### PR TITLE
bpf: use l4_load_ports() everywhere

### DIFF
--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -158,7 +158,7 @@ ipv4_handle_fragmentation(struct __ctx_buff *ctx,
 	}
 
 	/* load sport + dport into tuple */
-	ret = ctx_load_bytes(ctx, l4_off, ports, 4);
+	ret = l4_load_ports(ctx, l4_off, (__be16 *)ports);
 	if (ret < 0)
 		return ret;
 

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1551,7 +1551,7 @@ snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple, int off,
 #ifdef ENABLE_SCTP
 	case IPPROTO_SCTP:
 #endif  /* ENABLE_SCTP */
-		if (ctx_load_bytes(ctx, off, &l4hdr, sizeof(l4hdr)) < 0)
+		if (l4_load_ports(ctx, off, (__be16 *)&l4hdr) < 0)
 			return DROP_INVALID;
 
 		tuple->dport = l4hdr.dport;
@@ -1707,7 +1707,7 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 #ifdef ENABLE_SCTP
 	case IPPROTO_SCTP:
 #endif  /* ENABLE_SCTP */
-		if (ctx_load_bytes(ctx, off, &l4hdr, sizeof(l4hdr)) < 0)
+		if (l4_load_ports(ctx, off, (__be16 *)&l4hdr) < 0)
 			return DROP_INVALID;
 		tuple.dport = l4hdr.dport;
 		tuple.sport = l4hdr.sport;

--- a/bpf/lib/pcap.h
+++ b/bpf/lib/pcap.h
@@ -238,8 +238,7 @@ cilium_capture4_classify_wcard(struct __ctx_buff *ctx)
 	if (ip4->protocol != IPPROTO_TCP &&
 	    ip4->protocol != IPPROTO_UDP)
 		return NULL;
-	if (ctx_load_bytes(ctx, ETH_HLEN + ipv4_hdrlen(ip4),
-			   &okey.sport, 4) < 0)
+	if (l4_load_ports(ctx, ETH_HLEN + ipv4_hdrlen(ip4), &okey.sport) < 0)
 		return NULL;
 
 	okey.flags = 0;
@@ -363,8 +362,7 @@ cilium_capture6_classify_wcard(struct __ctx_buff *ctx)
 	if (okey.nexthdr != IPPROTO_TCP &&
 	    okey.nexthdr != IPPROTO_UDP)
 		return NULL;
-	if (ctx_load_bytes(ctx, l3_off + ret,
-			   &okey.sport, 4) < 0)
+	if (l4_load_ports(ctx, l3_off + ret, &okey.sport) < 0)
 		return NULL;
 
 	okey.flags = 0;

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -274,7 +274,7 @@ NAME(struct __ctx_buff *ctx, struct PREFIX ## _ct_tuple *tuple)		\
 	if (err != CTX_ACT_OK)						\
 		return err;						\
 									\
-	if (ctx_load_bytes(ctx, l4_off, &tuple->dport, 4) < 0)		\
+	if (l4_load_ports(ctx, l4_off, &tuple->dport) < 0)		\
 		return DROP_CT_INVALID_HDR;				\
 									\
 	__ ## PREFIX ## _ct_tuple_reverse(tuple);			\


### PR DESCRIPTION
Clean up all remaining open-coded occurences. No functional change, but this clarifies intent and should make it easier to spot areas that currently don't handle IPv4 fragmentation.