### PR TITLE
Bug: Fix module health status output

### DIFF
--- a/pkg/health/client/modules_test.go
+++ b/pkg/health/client/modules_test.go
@@ -40,10 +40,10 @@ agent
 ├── a
 │   └── b
 │       └── c
-│           ├── fred                                        [OK] yo (20s, x1)
-│           │   └── blee                                    [OK] doh (20s, x1)
-│           └── dork                                        [DEGRADED] bozo -- BOOM! (20s, x1)
-└── m1                                                      [OK] status nominal (2s, x0)`,
+│           ├── fred                                            [OK] yo (20s, x1)
+│           │   └── blee                                        [OK] doh (20s, x1)
+│           └── dork                                            [DEGRADED] bozo -- BOOM! (20s, x1)
+└── m1                                                          [OK] status nominal (2s, x0)`,
 			v: true,
 		},
 	}

--- a/pkg/health/client/tree_test.go
+++ b/pkg/health/client/tree_test.go
@@ -9,6 +9,49 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestComputeMaxLevel(t *testing.T) {
+	uu := map[string]struct {
+		n   *node
+		max int
+	}{
+		"empty": {},
+		"single": {
+			n: &node{val: "n1", meta: "m1"},
+		},
+		"flat": {
+			n: &node{val: "n1", meta: "m1", nodes: []*node{
+				{val: "n2", meta: "m2"},
+				{val: "n3", meta: "m3"},
+			}},
+			max: 1,
+		},
+		"multi": {
+			n: &node{val: "n1", meta: "m1", nodes: []*node{
+				{val: "n1_1", meta: "m1_1", nodes: []*node{
+					{val: "n1_1_1", meta: "m1_1_1", nodes: []*node{
+						{val: "n1_1_1_1", meta: "m1_1_1_1"},
+						{val: "n1_1_1_2", meta: "m1_1_1_2"},
+					}},
+				}},
+				{val: "n2", meta: "m2", nodes: []*node{
+					{val: "n2_1", meta: "m2_1", nodes: []*node{
+						{val: "n2_1_1", meta: "m2_1_1"},
+					}},
+				}},
+				{val: "n3", meta: "m3"},
+			}},
+			max: 3,
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.max, computeMaxLevel(0, u.n))
+		})
+	}
+}
+
 func TestTreeAddNode(t *testing.T) {
 	r := newRoot("fred")
 	r.addNode("a")
@@ -17,7 +60,13 @@ func TestTreeAddNode(t *testing.T) {
 	r.addNode("c")
 	r.addNodeWithMeta("d", "blee")
 
-	assert.Equal(t, "fred\n├── a\n├── b\n│   └── b1\n├── c\n└── d                                                       blee\n", r.String())
+	assert.Equal(t, `fred
+├── a
+├── b
+│   └── b1
+├── c
+└── d                                               blee
+`, r.String())
 }
 
 func TestTreeAddBranch(t *testing.T) {
@@ -29,7 +78,14 @@ func TestTreeAddBranch(t *testing.T) {
 	r.addBranch("c")
 	r.addBranchWithMeta("d", "blee")
 
-	assert.Equal(t, "fred\n├── a\n├── b\n│   └── b1\n│       └── b1_1\n├── c\n└── d                                                       blee\n", r.String())
+	assert.Equal(t, `fred
+├── a
+├── b
+│   └── b1
+│       └── b1_1
+├── c
+└── d                                                   blee
+`, r.String())
 }
 
 func TestTreeFind(t *testing.T) {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Add fall safe to ensure module health tree rendering does not panic when producing the output.

Note: This was a reported failure during ci testing where the cilium
status command failed with `panic: strings: negative Repeat count`

Fixes: #issue-number

Signed-off-by: Fernand Galiana <fernand.galiana@isovalent.com>