### PR TITLE
gateway-api: fix up for import rename

### DIFF
--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -34,11 +34,11 @@ var basicHTTP = Input{
 					Protocol: "HTTP",
 				},
 			},
-			Infrastructure: &gatewayv1beta1.GatewayInfrastructure{
-				Labels: map[gatewayv1beta1.AnnotationKey]gatewayv1beta1.AnnotationValue{
+			Infrastructure: &gatewayv1.GatewayInfrastructure{
+				Labels: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
 					"internal-loadbalancer-label": "true",
 				},
-				Annotations: map[gatewayv1beta1.AnnotationKey]gatewayv1beta1.AnnotationValue{
+				Annotations: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
 					"internal-loadbalancer-annotation": "true",
 				},
 			},


### PR DESCRIPTION
Fix up a conflict with
0b3611905cb5 ("gateway-api: Update import name in unit test").
