### PR TITLE
Fix source identity determination for DSR with Geneve-dispatch

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -173,7 +173,9 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 #ifdef ENABLE_NODEPORT
 	if (!from_host) {
 		if (!ctx_skip_nodeport(ctx)) {
-			ret = nodeport_lb6(ctx, ip6, secctx, ext_err);
+			bool is_dsr = false;
+
+			ret = nodeport_lb6(ctx, ip6, secctx, ext_err, &is_dsr);
 			/* nodeport_lb6() returns with TC_ACT_REDIRECT for
 			 * traffic to L7 LB. Policy enforcement needs to take
 			 * place after L7 LB has processed the packet, so we
@@ -564,7 +566,9 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 #ifdef ENABLE_NODEPORT
 	if (!from_host) {
 		if (!ctx_skip_nodeport(ctx)) {
-			int ret = nodeport_lb4(ctx, ip4, ETH_HLEN, secctx, ext_err);
+			bool __maybe_unused is_dsr = false;
+
+			int ret = nodeport_lb4(ctx, ip4, ETH_HLEN, secctx, ext_err, &is_dsr);
 
 			if (ret == NAT_46X64_RECIRC) {
 				ctx_store_meta(ctx, CB_SRC_LABEL, secctx);

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -104,6 +104,7 @@ int tail_lb_ipv4(struct __ctx_buff *ctx)
 		int l3_off = ETH_HLEN;
 		void *data, *data_end;
 		struct iphdr *ip4;
+		bool __maybe_unused is_dsr = false;
 
 		if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
 			ret = DROP_INVALID;
@@ -184,7 +185,7 @@ int tail_lb_ipv4(struct __ctx_buff *ctx)
 no_encap:
 #endif /* ENABLE_DSR && !ENABLE_DSR_HYBRID && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE */
 
-		ret = nodeport_lb4(ctx, ip4, l3_off, 0, &ext_err);
+		ret = nodeport_lb4(ctx, ip4, l3_off, 0, &ext_err, &is_dsr);
 		if (ret == NAT_46X64_RECIRC) {
 			ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_NETDEV);
 			return send_drop_notify_error(ctx, 0, DROP_MISSED_TAIL_CALL,
@@ -257,13 +258,14 @@ int tail_lb_ipv6(struct __ctx_buff *ctx)
 	if (!ctx_skip_nodeport(ctx)) {
 		void *data, *data_end;
 		struct ipv6hdr *ip6;
+		bool is_dsr = false;
 
 		if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
 			ret = DROP_INVALID;
 			goto drop_err;
 		}
 
-		ret = nodeport_lb6(ctx, ip6, 0, &ext_err);
+		ret = nodeport_lb6(ctx, ip6, 0, &ext_err, &is_dsr);
 		if (IS_ERR(ret))
 			goto drop_err;
 	}


### PR DESCRIPTION
<!-- Description of change -->

When DSR with Geneve is enabled, Cilium identity is not determined by the client's IP address and requests from outside cluster are dropped even though they are permitted by CiliumNetworkPolicy using `fromCIDR`.

This PR inputs identity that is from the client IP address.

Fixes: #29153


```release-note
Fix source identity determination for DSR with Geneve-dispatch, by looking it up from the ipcache.
```

---
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!
