### PR TITLE
Policy fix revert by only recording an "old" value if it existed before the changes

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -189,7 +189,7 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 
 	changes := policy.ChangeState{
 		Adds: make(policy.Keys),
-		Old:  policy.NewMapState(nil),
+		Old:  make(map[policy.Key]policy.MapStateEntry),
 	}
 
 	e.desiredPolicy.UpdateRedirects(ingress,
@@ -281,7 +281,7 @@ func (e *Endpoint) addVisibilityRedirects(ingress bool, desiredRedirects map[str
 		revertStack  revert.RevertStack
 		changes      = policy.ChangeState{
 			Adds: make(policy.Keys),
-			Old:  policy.NewMapState(nil),
+			Old:  make(map[policy.Key]policy.MapStateEntry),
 		}
 	)
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -417,7 +417,8 @@ func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
 		},
 	})
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
-		c.Fatal("desired policy map does not equal expected map")
+		c.Fatal("desired policy map does not equal expected map:\n",
+			ep.desiredPolicy.GetPolicyMap().Diff(c.T, expected))
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -461,7 +462,8 @@ func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
 	// Redirect for the HTTP port should have been added, but there should be a deny for Foo on
 	// that port, as it is shadowed by the deny rule
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected2) {
-		c.Fatal("desired policy map does not equal expected map")
+		c.Fatal("desired policy map does not equal expected map:\n",
+			ep.desiredPolicy.GetPolicyMap().Diff(c.T, expected2))
 	}
 
 	// Keep only desired redirects
@@ -476,7 +478,8 @@ func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
 
 	// Check that the state before addRedirects is restored
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
-		c.Fatal("desired policy map does not equal expected map")
+		c.Fatal("desired policy map does not equal expected map:\n",
+			ep.desiredPolicy.GetPolicyMap().Diff(c.T, expected))
 	}
 	c.Assert(len(ep.realizedRedirects), check.Equals, 0)
 	c.Assert(ep.desiredPolicy.GetPolicyMap().Len(), check.Equals, 2)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -476,9 +476,9 @@ type entryCallback func(key Key, value *MapStateEntry) bool
 
 // ChangeState allows caller to revert changes made by (multiple) toMapState call(s)
 type ChangeState struct {
-	Adds    Keys     // Added or modified keys, if not nil
-	Deletes Keys     // deleted keys, if not nil
-	Old     MapState // Old values of all modified or deleted keys, if not nil
+	Adds    Keys                  // Added or modified keys, if not nil
+	Deletes Keys                  // deleted keys, if not nil
+	Old     map[Key]MapStateEntry // Old values of all modified or deleted keys, if not nil
 }
 
 // toMapState converts a single filter into a MapState entries added to 'p.PolicyMapState'.

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -161,7 +161,7 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 		name                  string
 		ms, want              *mapState
 		wantAdds, wantDeletes Keys
-		wantOldValues         *mapState
+		wantOld               map[Key]MapStateEntry
 		args                  args
 	}{
 		{
@@ -194,9 +194,9 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					IsDeny:           false,
 				},
 			}),
-			wantAdds:      Keys{},
-			wantDeletes:   Keys{},
-			wantOldValues: newMapState(nil),
+			wantAdds:    Keys{},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
 			name: "test-2 - L3 allow KV should not overwrite deny entry",
@@ -255,8 +255,8 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
 			},
-			wantDeletes:   Keys{},
-			wantOldValues: newMapState(nil),
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
 			name: "test-3 - L3-L4 allow KV should not overwrite deny entry",
@@ -297,9 +297,9 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					IsDeny:           true,
 				},
 			}),
-			wantAdds:      Keys{},
-			wantDeletes:   Keys{},
-			wantOldValues: newMapState(nil),
+			wantAdds:    Keys{},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
 			name: "test-4 - L3-L4 deny KV should overwrite allow entry",
@@ -349,7 +349,7 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 				}: struct{}{},
 			},
 			wantDeletes: Keys{},
-			wantOldValues: newMapState(map[Key]MapStateEntry{
+			wantOld: map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -360,7 +360,7 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-			}),
+			},
 		},
 		{
 			name: "test-5 - L3 deny KV should overwrite all L3-L4 allow and L3 allow entries for the same L3",
@@ -467,7 +467,7 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
 			},
-			wantOldValues: newMapState(map[Key]MapStateEntry{
+			wantOld: map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         0,
@@ -488,7 +488,7 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-			}),
+			},
 		},
 		{
 			name: "test-6 - L3 egress deny KV should not overwrite any existing ingress allow",
@@ -607,8 +607,8 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					TrafficDirection: trafficdirection.Egress.Uint8(),
 				}: struct{}{},
 			},
-			wantDeletes:   Keys{},
-			wantOldValues: newMapState(nil),
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
 			name: "test-7 - L3 ingress deny KV should not be overwritten by a L3-L4 ingress allow",
@@ -649,9 +649,9 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					IsDeny:           true,
 				},
 			}),
-			wantAdds:      Keys{},
-			wantDeletes:   Keys{},
-			wantOldValues: newMapState(nil),
+			wantAdds:    Keys{},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
 			name: "test-8 - L3 ingress deny KV should not be overwritten by a L3-L4-L7 ingress allow",
@@ -692,9 +692,9 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					IsDeny:           true,
 				},
 			}),
-			wantAdds:      Keys{},
-			wantDeletes:   Keys{},
-			wantOldValues: newMapState(nil),
+			wantAdds:    Keys{},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
 			name: "test-9 - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow",
@@ -751,7 +751,7 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
 			},
-			wantOldValues: newMapState(map[Key]MapStateEntry{
+			wantOld: map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -762,7 +762,7 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-			}),
+			},
 		},
 		{
 			name: "test-10 - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow and a L3-L4 deny",
@@ -835,7 +835,7 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
 			},
-			wantOldValues: newMapState(map[Key]MapStateEntry{
+			wantOld: map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -856,7 +856,7 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			}),
+			},
 		},
 		{
 			name: "test-11 - L3 ingress allow should not be allowed if there is a L3 'all' deny",
@@ -917,9 +917,9 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					IsDeny:           true,
 				},
 			}),
-			wantAdds:      Keys{},
-			wantDeletes:   Keys{},
-			wantOldValues: newMapState(nil),
+			wantAdds:    Keys{},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
 		}, {
 			name: "test-12 - inserting a L3 'all' deny should delete all entries for that direction",
 			ms: newMapState(map[Key]MapStateEntry{
@@ -1011,7 +1011,7 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
 			},
-			wantOldValues: newMapState(map[Key]MapStateEntry{
+			wantOld: map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -1032,14 +1032,14 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-			}),
+			},
 		},
 	}
 	for _, tt := range tests {
 		changes := ChangeState{
 			Adds:    make(Keys),
 			Deletes: make(Keys),
-			Old:     newMapState(nil),
+			Old:     make(map[Key]MapStateEntry),
 		}
 		// copy the starging point
 		ms := newMapState(make(map[Key]MapStateEntry, tt.ms.Len()))
@@ -1054,12 +1054,7 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 		c.Assert(ms.denies, checker.DeepEquals, tt.want.denies, check.Commentf("%s: MapState mismatch denies", tt.name))
 		c.Assert(changes.Adds, checker.DeepEquals, tt.wantAdds, check.Commentf("%s: Adds mismatch", tt.name))
 		c.Assert(changes.Deletes, checker.DeepEquals, tt.wantDeletes, check.Commentf("%s: Deletes mismatch", tt.name))
-		oldMap, ok := changes.Old.(*mapState)
-		if !ok {
-			c.Fatal("Failed to coerce \"changes.Old\" to \"*mapState\"")
-		}
-		c.Assert(oldMap.allows, checker.DeepEquals, tt.wantOldValues.allows, check.Commentf("%s: OldValues mismatch allows", tt.name))
-		c.Assert(oldMap.denies, checker.DeepEquals, tt.wantOldValues.denies, check.Commentf("%s: OldValues mismatch denies", tt.name))
+		c.Assert(changes.Old, checker.DeepEquals, tt.wantOld, check.Commentf("%s: OldValues mismatch allows", tt.name))
 
 		// Revert changes and check that we get the original mapstate
 		ms.RevertChanges(changes)
@@ -1851,14 +1846,14 @@ func (ds *PolicyTestSuite) TestMapState_AddVisibilityKeys(c *check.C) {
 		},
 	}
 	for _, tt := range tests {
-		old := newMapState(nil)
+		old := make(map[Key]MapStateEntry)
 		tt.ms.ForEach(func(k Key, v MapStateEntry) bool {
-			old.InsertIfNotExists(k, v)
+			insertIfNotExists(old, k, v)
 			return true
 		})
 		changes := ChangeState{
 			Adds: make(Keys),
-			Old:  newMapState(nil),
+			Old:  make(map[Key]MapStateEntry),
 		}
 		tt.ms.AddVisibilityKeys(DummyOwner{}, tt.args.redirectPort, &tt.args.visMeta, changes)
 		tt.ms.validatePortProto(c)
@@ -1866,18 +1861,17 @@ func (ds *PolicyTestSuite) TestMapState_AddVisibilityKeys(c *check.C) {
 		c.Assert(tt.ms.denies, checker.DeepEquals, tt.want.denies, check.Commentf(tt.name))
 		// Find new and updated entries
 		wantAdds := make(Keys)
-		wantOld := newMapState(nil)
+		wantOld := make(map[Key]MapStateEntry)
 
-		old.ForEach(func(k Key, v MapStateEntry) bool {
+		for k, v := range old {
 			if _, ok := tt.ms.Get(k); !ok {
-				wantOld.Insert(k, v)
+				wantOld[k] = v
 			}
-			return true
-		})
+		}
 		tt.ms.ForEach(func(k Key, v MapStateEntry) bool {
-			if v2, ok := old.Get(k); ok {
+			if v2, ok := old[k]; ok {
 				if equals, _ := checker.DeepEqual(v2, v); !equals {
-					wantOld.Insert(k, v2)
+					wantOld[k] = v2
 				}
 			} else {
 				wantAdds[k] = struct{}{}
@@ -1913,7 +1907,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 		setup     *mapState
 		visArgs   []visArgs
 		visAdds   Keys
-		visOld    MapState
+		visOld    map[Key]MapStateEntry
 		args      []args // changes applied, in order
 		state     MapState
 		adds      Keys
@@ -1932,9 +1926,9 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			HttpIngressKey(0):   {},
 			HttpIngressKey(234): {},
 		},
-		visOld: newMapState(map[Key]MapStateEntry{
+		visOld: map[Key]MapStateEntry{
 			testIngressKey(234, 0, 0): denyEntry(0, csFoo),
-		}),
+		},
 		args: []args{
 			{cs: csFoo, adds: []int{235}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
@@ -2122,10 +2116,10 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 		visAdds: Keys{
 			HttpIngressKey(0): {},
 		},
-		visOld: newMapState(map[Key]MapStateEntry{
+		visOld: map[Key]MapStateEntry{
 			// Old value for the modified entry
 			HttpEgressKey(0): allowEntry(0),
-		}),
+		},
 		args: []args{
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
@@ -2206,7 +2200,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			tt.visAdds = make(Keys)
 		}
 		if tt.visOld == nil {
-			tt.visOld = newMapState(nil)
+			tt.visOld = make(map[Key]MapStateEntry)
 		}
 		if tt.adds == nil {
 			tt.adds = make(Keys)
@@ -2225,7 +2219,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 		changes := ChangeState{
 			Adds:    make(Keys),
 			Deletes: make(Keys),
-			Old:     newMapState(nil),
+			Old:     make(map[Key]MapStateEntry),
 		}
 		for _, arg := range tt.visArgs {
 			policyMapState.AddVisibilityKeys(DummyOwner{}, arg.redirectPort, &arg.visMeta, changes)
@@ -2250,17 +2244,16 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 		changes = ChangeState{
 			Adds:    adds,
 			Deletes: deletes,
-			Old:     newMapState(nil),
+			Old:     make(map[Key]MapStateEntry),
 		}
 
 		// Visibilty redirects need to be re-applied after consumeMapChanges()
 		for _, arg := range tt.visArgs {
 			policyMapState.AddVisibilityKeys(DummyOwner{}, arg.redirectPort, &arg.visMeta, changes)
 		}
-		changes.Old.ForEach(func(k Key, _ MapStateEntry) bool {
+		for k := range changes.Old {
 			changes.Deletes[k] = struct{}{}
-			return true
-		})
+		}
 		policyMapState.validatePortProto(c)
 		c.Assert(policyMapState, checker.DeepEquals, tt.state, check.Commentf(tt.name+" (MapState)"))
 		c.Assert(changes.Adds, checker.DeepEquals, tt.adds, check.Commentf(tt.name+" (adds)"))

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1846,9 +1846,11 @@ func (ds *PolicyTestSuite) TestMapState_AddVisibilityKeys(c *check.C) {
 		},
 	}
 	for _, tt := range tests {
-		old := make(map[Key]MapStateEntry)
+		old := ChangeState{
+			Old: make(map[Key]MapStateEntry),
+		}
 		tt.ms.ForEach(func(k Key, v MapStateEntry) bool {
-			insertIfNotExists(old, k, v)
+			old.insertOldIfNotExists(k, v)
 			return true
 		})
 		changes := ChangeState{
@@ -1863,13 +1865,13 @@ func (ds *PolicyTestSuite) TestMapState_AddVisibilityKeys(c *check.C) {
 		wantAdds := make(Keys)
 		wantOld := make(map[Key]MapStateEntry)
 
-		for k, v := range old {
+		for k, v := range old.Old {
 			if _, ok := tt.ms.Get(k); !ok {
 				wantOld[k] = v
 			}
 		}
 		tt.ms.ForEach(func(k Key, v MapStateEntry) bool {
-			if v2, ok := old[k]; ok {
+			if v2, ok := old.Old[k]; ok {
 				if equals, _ := checker.DeepEqual(v2, v); !equals {
 					wantOld[k] = v2
 				}
@@ -2138,10 +2140,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			DNSUDPEgressKey(42): {},
 			DNSTCPEgressKey(42): {},
 		},
-		deletes: Keys{
-			// AddVisibilityKeys() returns overwritten entries in 'deletes'
-			DNSUDPEgressKey(42): {},
-		},
+		deletes: Keys{},
 	}, {
 		continued: true,
 		name:      "test-3b - egress HTTP proxy (incremental update)",

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -198,9 +198,7 @@ func (l4policy L4DirectionPolicy) toMapState(p *EndpointPolicy) {
 				}
 			}
 			return true
-		}, ChangeState{
-			Old: newMapState(nil),
-		})
+		}, ChangeState{})
 	}
 }
 


### PR DESCRIPTION
Only record an old entry in `ChangeState` if it existed before this round of changes. We do this by testing if the entry is already in `Adds`. If not, then we record the old entry key and value. If the `Adds` entry exists, however, this entry may have only been added on this round of changes and we do not record the old value. This is safe due to the fact that when the `Adds` entry is created, the `Old` value is stored before adding the `Adds` entry, so for the first `Adds` entry the `Old` value does not yet exist and will be added.

This removes extraneous `Old` entries that did not actually originally exist. Before this change `ChangeState.Revert` could have restored entries the should not exists, based on these extraneous `Old` entries.

Note that the change in `TestMapState_AccumulateMapChangesOnVisibilityKeys` on the 3rd commit shows the effect of this change. Previously the test resulted in an entry in `ChangeState.Old` that did not exist before the changes started, but was recoded due to an entry being first added and then modified within the same set of changes.

> Note for backporting: Releases prior to 1.14 should only backport the last commit, as the changes addressed in first two are only in the main branch and are included to make the backports of the last commit easier.

```release-note
Policy revert used in rare error cases has been corrected.
```
