### PR TITLE
devices: fix busy loop

### DIFF
--- a/pkg/datapath/linux/devices.go
+++ b/pkg/datapath/linux/devices.go
@@ -116,14 +116,14 @@ func (dm *DeviceManager) Listen(ctx context.Context) (chan []string, error) {
 			devices, invalidated := tables.SelectedDevices(dm.params.DeviceTable, rxn)
 			newDevices := tables.DeviceNames(devices)
 
-			if slices.Equal(prevDevices, newDevices) {
-				continue
+			if !slices.Equal(prevDevices, newDevices) {
+				select {
+				case devs <- newDevices:
+				case <-ctx.Done():
+					return
+				}
 			}
-			select {
-			case devs <- newDevices:
-			case <-ctx.Done():
-				return
-			}
+
 			select {
 			case <-invalidated:
 			case <-ctx.Done():


### PR DESCRIPTION
If previous devices and new devices are equal, we don't wait for the invalidation of the query, and run into a busy loop until the devices change.

Fixes: 03ad61b6b3 (datapath/linux: Implement DevicesController) @joamaki - I've mentioned the bug to Jussi (who's on PTO atm), he agrees it's a bug, hence not pulling him in for review.

AFAIK this was never in a release thus not marking this a `release-note/bug`, but happy to be corrected on that.