### PR TITLE
health: Fix panic in tree formatter

### DIFF
--- a/pkg/health/client/modules_test.go
+++ b/pkg/health/client/modules_test.go
@@ -40,8 +40,10 @@ agent
 ├── a
 │   └── b
 │       └── c
-│           ├── fred                                        [OK] yo (20s, x1)
-│           │   └── blee                                    [OK] doh (20s, x1)
+│           ├── fred
+│           │   ├── blee                                    [OK] doh (20s, x1)
+│           │   └── qux
+│           │       └── bar                                     [STOPPED] bye! (20s, x1)
 │           └── dork                                        [DEGRADED] bozo -- BOOM! (20s, x1)
 └── m1                                                      [OK] status nominal (2s, x0)`,
 			v: true,
@@ -136,6 +138,25 @@ func makeComplexMsg(t time.Time) string {
 						Message:         "yo",
 						UpdateTimestamp: t,
 						Count:           1,
+						SubStatuses: []*cell.StatusNode{
+							{
+								Name:            "qux",
+								LastLevel:       cell.StatusOK,
+								Message:         "hi!",
+								UpdateTimestamp: t,
+								Count:           1,
+								SubStatuses: []*cell.StatusNode{
+									{
+										Name:            "bar",
+										LastLevel:       cell.StatusStopped,
+										Message:         "bye!",
+										UpdateTimestamp: t,
+										Count:           1,
+										SubStatuses:     nil,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/pkg/health/client/tree.go
+++ b/pkg/health/client/tree.go
@@ -140,7 +140,7 @@ func dumpVals(w io.Writer, level int, levelsEnded []int, edge decoration, node *
 
 	val := dumpVal(level, node)
 	if node.meta != "" {
-		c := 4 - level
+		c := max(4-level, 0)
 		fmt.Fprintf(w, "%s %-"+strconv.Itoa(leafMaxWidth+c*2)+"s%s%s\n", edge, val, strings.Repeat("  ", c), node.meta)
 		return
 	}


### PR DESCRIPTION
This commit fixes a panic for deeply nested status trees. In particular, the panic would fail because `strings.Repeat` was called with a negative count: `panic: strings: negative Repeat count`

This would occur when running `cilium status --verbose` on agents with deeply nested cells.

Fixes: 85d8e6ac604a ("Update cilium status command module health output")
