### PR TITLE
endpoint: fix removed code comment.

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1407,6 +1407,7 @@ func (e *Endpoint) startSyncPolicyMapController() {
 			Group:          syncPolicymapControllerGroup,
 			HealthReporter: e.GetReporter("policymap-sync"),
 			DoFunc: func(ctx context.Context) error {
+				// Failure to lock is not an error, it means
 				// that the endpoint was disconnected and we
 				// should exit gracefully.
 				if err := e.lockAlive(); err != nil {


### PR DESCRIPTION
Change in https://github.com/cilium/cilium/pull/27522 accidentally removed the first line in a code comment [1] explaining the significance of failure to get a mutex lock on an endpoint.

This undoes that change and fixes the comment.

[1] https://github.com/cilium/cilium/pull/27522#discussion_r1379146721

