### PR TITLE
release image: Allow arbitrary pre-release identifiers

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -4,9 +4,7 @@ on:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
-      - v[0-9]+.[0-9]+.[0-9]+-pre.[0-9]+
-      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-      - v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-*
 
 permissions:
   # To be able to access the repository with `actions/checkout`


### PR DESCRIPTION
Make the filter patterns for release image tags slightly more lenient to allow arbitrary pre-release identifiers beyond pre and rc.