### PR TITLE
CountUniqueIPsecKeys function fixed.

### DIFF
--- a/cilium-dbg/cmd/encrypt_status.go
+++ b/cilium-dbg/cmd/encrypt_status.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"reflect"
 	"regexp"
@@ -164,7 +165,10 @@ func dumpIPsecStatus() {
 	if err != nil {
 		Fatalf("Cannot get xfrm state: %s", err)
 	}
-	keys := ipsec.CountUniqueIPsecKeys(xfrmStates)
+	keys, err := ipsec.CountUniqueIPsecKeys(xfrmStates)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error counting IPsec keys: %s\n", err)
+	}
 	oseq := maxSequenceNumber()
 	interfaces := getDecryptionInterfaces()
 	fmt.Printf("Decryption interface(s): %s\n", strings.Join(interfaces, ", "))

--- a/pkg/common/ipsec/utils.go
+++ b/pkg/common/ipsec/utils.go
@@ -4,8 +4,8 @@
 package ipsec
 
 import (
+	"errors"
 	"fmt"
-	"os"
 
 	"github.com/vishvananda/netlink"
 
@@ -18,7 +18,7 @@ const (
 	markStateOut = 0xe00
 )
 
-func CountUniqueIPsecKeys(states []netlink.XfrmState) int {
+func CountUniqueIPsecKeys(states []netlink.XfrmState) (int, error) {
 	keys := make(map[string]bool)
 	invalidStateFound := false
 	for _, s := range states {
@@ -35,9 +35,9 @@ func CountUniqueIPsecKeys(states []netlink.XfrmState) int {
 		invalidStateFound = true
 	}
 	if invalidStateFound {
-		fmt.Fprintf(os.Stderr, "an unsupported XfrmStateAlgo combination has been found\n")
+		return len(keys), errors.New("an unsupported XfrmStateAlgo combination has been found")
 	}
-	return len(keys)
+	return len(keys), nil
 }
 
 func CountXfrmStatesByDir(states []netlink.XfrmState) (int, int) {

--- a/pkg/common/ipsec/utils_test.go
+++ b/pkg/common/ipsec/utils_test.go
@@ -65,35 +65,41 @@ func getXfrmPolicy(t *testing.T, src string, dst string, dir netlink.Dir) netlin
 func TestCountUniqueIPsecKeys(t *testing.T) {
 	var xfrmStates []netlink.XfrmState
 
-	keys := CountUniqueIPsecKeys(xfrmStates)
+	keys, err := CountUniqueIPsecKeys(xfrmStates)
+	require.NoError(t, err)
 	require.Equal(t, keys, 0)
 
 	xfrmStates = append(xfrmStates, getXfrmState(t, "10.0.0.1", "10.0.0.2", 2, "rfc4106(gcm(aes))", "611d0c8049dd88600ec4f9eded7b1ed540ea607f", 0x12343e00))
 	xfrmStates = append(xfrmStates, getXfrmState(t, "10.0.0.2", "10.0.0.1", 1, "rfc4106(gcm(aes))", "611d0c8049dd88600ec4f9eded7b1ed540ea607f", 0x12343d00))
 
-	keys = CountUniqueIPsecKeys(xfrmStates)
+	keys, err = CountUniqueIPsecKeys(xfrmStates)
+	require.NoError(t, err)
 	require.Equal(t, keys, 1)
 
 	xfrmStates = append(xfrmStates, getXfrmState(t, "10.0.0.1", "10.0.0.2", 1, "rfc4106(gcm(aes))", "383fa49ea57848c9e85af88a187321f81da54bb6", 0x12343e00))
 
-	keys = CountUniqueIPsecKeys(xfrmStates)
+	keys, err = CountUniqueIPsecKeys(xfrmStates)
+	require.NoError(t, err)
 	require.Equal(t, keys, 2)
 
 	xfrmStates = append(xfrmStates, getXfrmState(t, "10.0.0.1", "10.0.0.2", 1, "cbc(aes)", "a9d204b6c2df6f0b707bbfdb71b4bd44", 0x12343e00))
 
-	keys = CountUniqueIPsecKeys(xfrmStates)
+	keys, err = CountUniqueIPsecKeys(xfrmStates)
+	require.NoError(t, err)
 	require.Equal(t, keys, 3)
 
 	state := getXfrmState(t, "10.0.0.1", "10.0.0.2", 2, "cbc(aes)", "123d0c8049dd88600ec4f9eded7b1ed540ea607a", 0x12343e00)
 	state.Auth = nil // make it invalid
 	xfrmStates = append(xfrmStates, state)
-	keys = CountUniqueIPsecKeys(xfrmStates)
+	keys, err = CountUniqueIPsecKeys(xfrmStates)
+	require.Error(t, err)
 	require.Equal(t, keys, 3)
 
 	state = getXfrmState(t, "10.0.0.1", "10.0.0.2", 2, "cbc(aes)", "234d0c8049dd88600ec4f9eded7b1ed540ea607b", 0x12343e00)
 	state.Crypt = nil // make it invalid
 	xfrmStates = append(xfrmStates, state)
-	keys = CountUniqueIPsecKeys(xfrmStates)
+	keys, err = CountUniqueIPsecKeys(xfrmStates)
+	require.Error(t, err)
 	require.Equal(t, keys, 3)
 
 	state = getXfrmState(t, "10.0.0.1", "10.0.0.2", 2, "cbc(aes)", "345d0c8049dd88600ec4f9eded7b1ed540ea607c", 0x12343e00)
@@ -101,7 +107,8 @@ func TestCountUniqueIPsecKeys(t *testing.T) {
 	state.Auth = nil  // make it invalid
 	state.Crypt = nil // make it invalid
 	xfrmStates = append(xfrmStates, state)
-	keys = CountUniqueIPsecKeys(xfrmStates)
+	keys, err = CountUniqueIPsecKeys(xfrmStates)
+	require.Error(t, err)
 	require.Equal(t, keys, 3)
 }
 

--- a/pkg/common/ipsec/utils_test.go
+++ b/pkg/common/ipsec/utils_test.go
@@ -12,24 +12,41 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func getXfrmState(src string, dst string, spi int, key string, mark uint32) netlink.XfrmState {
+func getXfrmState(t *testing.T, src string, dst string, spi int, algoName string, key string, mark uint32) netlink.XfrmState {
 	k, _ := hex.DecodeString(key)
-	return netlink.XfrmState{
+	state := netlink.XfrmState{
 		Src:   net.ParseIP(src),
 		Dst:   net.ParseIP(dst),
 		Proto: netlink.XFRM_PROTO_ESP,
 		Mode:  netlink.XFRM_MODE_TUNNEL,
 		Spi:   spi,
-		Aead: &netlink.XfrmStateAlgo{
-			Name:   "rfc4106(gcm(aes))",
-			Key:    k,
-			ICVLen: 64,
-		},
 		Mark: &netlink.XfrmMark{
 			Value: mark,
 			Mask:  0xffffff00,
 		},
 	}
+	switch algoName {
+	case "cbc(aes)":
+		state.Auth = &netlink.XfrmStateAlgo{
+			Name:   "hmac(sha512)",
+			Key:    k,
+			ICVLen: 64,
+		}
+		state.Crypt = &netlink.XfrmStateAlgo{
+			Name:   "cbc(aes)",
+			Key:    k,
+			ICVLen: 64,
+		}
+	case "rfc4106(gcm(aes))":
+		state.Aead = &netlink.XfrmStateAlgo{
+			Name:   "rfc4106(gcm(aes))",
+			Key:    k,
+			ICVLen: 64,
+		}
+	default:
+		t.Errorf("Unsupported algorithm: %s", algoName)
+	}
+	return state
 }
 
 func getXfrmPolicy(t *testing.T, src string, dst string, dir netlink.Dir) netlink.XfrmPolicy {
@@ -51,16 +68,41 @@ func TestCountUniqueIPsecKeys(t *testing.T) {
 	keys := CountUniqueIPsecKeys(xfrmStates)
 	require.Equal(t, keys, 0)
 
-	xfrmStates = append(xfrmStates, getXfrmState("10.0.0.1", "10.0.0.2", 2, "611d0c8049dd88600ec4f9eded7b1ed540ea607f", 0x12343e00))
-	xfrmStates = append(xfrmStates, getXfrmState("10.0.0.2", "10.0.0.1", 1, "611d0c8049dd88600ec4f9eded7b1ed540ea607f", 0x12343d00))
+	xfrmStates = append(xfrmStates, getXfrmState(t, "10.0.0.1", "10.0.0.2", 2, "rfc4106(gcm(aes))", "611d0c8049dd88600ec4f9eded7b1ed540ea607f", 0x12343e00))
+	xfrmStates = append(xfrmStates, getXfrmState(t, "10.0.0.2", "10.0.0.1", 1, "rfc4106(gcm(aes))", "611d0c8049dd88600ec4f9eded7b1ed540ea607f", 0x12343d00))
 
 	keys = CountUniqueIPsecKeys(xfrmStates)
 	require.Equal(t, keys, 1)
 
-	xfrmStates = append(xfrmStates, getXfrmState("10.0.0.1", "10.0.0.2", 1, "383fa49ea57848c9e85af88a187321f81da54bb6", 0x12343e00))
+	xfrmStates = append(xfrmStates, getXfrmState(t, "10.0.0.1", "10.0.0.2", 1, "rfc4106(gcm(aes))", "383fa49ea57848c9e85af88a187321f81da54bb6", 0x12343e00))
 
 	keys = CountUniqueIPsecKeys(xfrmStates)
 	require.Equal(t, keys, 2)
+
+	xfrmStates = append(xfrmStates, getXfrmState(t, "10.0.0.1", "10.0.0.2", 1, "cbc(aes)", "a9d204b6c2df6f0b707bbfdb71b4bd44", 0x12343e00))
+
+	keys = CountUniqueIPsecKeys(xfrmStates)
+	require.Equal(t, keys, 3)
+
+	state := getXfrmState(t, "10.0.0.1", "10.0.0.2", 2, "cbc(aes)", "123d0c8049dd88600ec4f9eded7b1ed540ea607a", 0x12343e00)
+	state.Auth = nil // make it invalid
+	xfrmStates = append(xfrmStates, state)
+	keys = CountUniqueIPsecKeys(xfrmStates)
+	require.Equal(t, keys, 3)
+
+	state = getXfrmState(t, "10.0.0.1", "10.0.0.2", 2, "cbc(aes)", "234d0c8049dd88600ec4f9eded7b1ed540ea607b", 0x12343e00)
+	state.Crypt = nil // make it invalid
+	xfrmStates = append(xfrmStates, state)
+	keys = CountUniqueIPsecKeys(xfrmStates)
+	require.Equal(t, keys, 3)
+
+	state = getXfrmState(t, "10.0.0.1", "10.0.0.2", 2, "cbc(aes)", "345d0c8049dd88600ec4f9eded7b1ed540ea607c", 0x12343e00)
+	state.Aead = nil  // make it invalid
+	state.Auth = nil  // make it invalid
+	state.Crypt = nil // make it invalid
+	xfrmStates = append(xfrmStates, state)
+	keys = CountUniqueIPsecKeys(xfrmStates)
+	require.Equal(t, keys, 3)
 }
 
 func TestCountXfrmStatesByDir(t *testing.T) {
@@ -70,9 +112,9 @@ func TestCountXfrmStatesByDir(t *testing.T) {
 	require.Equal(t, nbIn, 0)
 	require.Equal(t, nbOut, 0)
 
-	xfrmStates = append(xfrmStates, getXfrmState("10.0.0.1", "10.0.0.2", 2, "611d0c8049dd88600ec4f9eded7b1ed540ea607f", 0x12343e00))
-	xfrmStates = append(xfrmStates, getXfrmState("10.0.0.2", "10.0.0.1", 1, "611d0c8049dd88600ec4f9eded7b1ed540ea607f", 0x12343d00))
-	xfrmStates = append(xfrmStates, getXfrmState("10.0.0.3", "10.0.0.1", 1, "611d0c8049dd88600ec4f9eded7b1ed540ea607f", 0x12343d00))
+	xfrmStates = append(xfrmStates, getXfrmState(t, "10.0.0.1", "10.0.0.2", 2, "rfc4106(gcm(aes))", "611d0c8049dd88600ec4f9eded7b1ed540ea607f", 0x12343e00))
+	xfrmStates = append(xfrmStates, getXfrmState(t, "10.0.0.2", "10.0.0.1", 1, "rfc4106(gcm(aes))", "611d0c8049dd88600ec4f9eded7b1ed540ea607f", 0x12343d00))
+	xfrmStates = append(xfrmStates, getXfrmState(t, "10.0.0.3", "10.0.0.1", 1, "rfc4106(gcm(aes))", "611d0c8049dd88600ec4f9eded7b1ed540ea607f", 0x12343d00))
 
 	nbIn, nbOut = CountXfrmStatesByDir(xfrmStates)
 	require.Equal(t, nbIn, 2)

--- a/pkg/datapath/linux/ipsec/xfrm_collector.go
+++ b/pkg/datapath/linux/ipsec/xfrm_collector.go
@@ -127,7 +127,10 @@ func (x *xfrmCollector) collectConfigStats(ch chan<- prometheus.Metric) {
 		log.WithError(err).Error("Failed to retrieve XFRM states to compute Prometheus metrics")
 		return
 	}
-	nbKeys := ipsec.CountUniqueIPsecKeys(states)
+	nbKeys, err := ipsec.CountUniqueIPsecKeys(states)
+	if err != nil {
+		log.WithError(err).Error("Error counting IPsec keys")
+	}
 	ch <- prometheus.MustNewConstMetric(x.nbKeysDesc, prometheus.GaugeValue, float64(nbKeys))
 
 	nbStatesIn, nbStatesOut := ipsec.CountXfrmStatesByDir(states)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Handle non-AEAD IPsec keys in `cilium encrypt status`.
```
