### PR TITLE
pkg/linux/bandwidth: don't start bandwidth manager in dry mode

### DIFF
--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -165,6 +165,7 @@ func newDatapath(params datapathParams) types.Datapath {
 		WGAgent:        params.WgAgent,
 		NodeMap:        params.NodeMap,
 		NodeAddressing: params.NodeAddressing,
+		BWManager:      params.BandwidthManager,
 	}, datapathConfig)
 
 	params.LC.Append(hive.Hook{
@@ -195,6 +196,8 @@ type datapathParams struct {
 	// This is required until option.Config.GetDevices() has been removed and
 	// uses of it converted to Table[Device].
 	DeviceManager *linuxdatapath.DeviceManager
+
+	BandwidthManager bandwidth.Manager
 
 	ModulesManager *modules.Manager
 

--- a/pkg/datapath/linux/bandwidth/cell.go
+++ b/pkg/datapath/linux/bandwidth/cell.go
@@ -41,7 +41,11 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 
 func newBandwidthManager(lc hive.Lifecycle, p bandwidthManagerParams) (Manager, defines.NodeFnOut) {
 	m := &manager{params: p}
-	lc.Append(m)
+
+	if !option.Config.DryMode {
+		lc.Append(m)
+	}
+
 	return m, defines.NewNodeFnOut(m.defines)
 }
 


### PR DESCRIPTION
When dry mode is enabled, we should not register the start hook. The start hook will probe and initialize the bandwidth manager, which should not happen in dry mode.

This was supposed to go into https://github.com/cilium/cilium/pull/28619 but due to a mistake it got merged without this change. So fixing that with this followup PR.

```release-note
do not start bandwidth manager in dry mode
```
