### PR TITLE
v1.14 Backports 2023-11-15

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -68,6 +68,10 @@
      - Enable SPIRE integration (beta)
      - bool
      - ``false``
+   * - :spelling:ignore:`authentication.mutual.spire.install.agent.affinity`
+     - SPIRE agent affinity configuration
+     - object
+     - ``{}``
    * - :spelling:ignore:`authentication.mutual.spire.install.agent.annotations`
      - SPIRE agent annotations
      - object
@@ -78,6 +82,18 @@
      - ``"ghcr.io/spiffe/spire-agent:1.6.3@sha256:8eef9857bf223181ecef10d9bbcd2f7838f3689e9bd2445bede35066a732e823"``
    * - :spelling:ignore:`authentication.mutual.spire.install.agent.labels`
      - SPIRE agent labels
+     - object
+     - ``{}``
+   * - :spelling:ignore:`authentication.mutual.spire.install.agent.nodeSelector`
+     - SPIRE agent nodeSelector configuration ref: ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+     - object
+     - ``{}``
+   * - :spelling:ignore:`authentication.mutual.spire.install.agent.podSecurityContext`
+     - Security context to be added to spire agent pods. SecurityContext holds pod-level security attributes and common container settings. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+     - object
+     - ``{}``
+   * - :spelling:ignore:`authentication.mutual.spire.install.agent.securityContext`
+     - Security context to be added to spire agent containers. SecurityContext holds pod-level security attributes and common container settings. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
      - object
      - ``{}``
    * - :spelling:ignore:`authentication.mutual.spire.install.agent.serviceAccount`

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -110,7 +110,7 @@ int tail_lb_ipv4(struct __ctx_buff *ctx)
 			goto out;
 		}
 
-#if defined(ENABLE_DSR) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+#if defined(ENABLE_DSR) && !defined(ENABLE_DSR_HYBRID) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
 		{
 			int l4_off, inner_l2_off;
 			struct genevehdr geneve;
@@ -182,7 +182,7 @@ int tail_lb_ipv4(struct __ctx_buff *ctx)
 			}
 		}
 no_encap:
-#endif /* ENABLE_DSR && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE */
+#endif /* ENABLE_DSR && !ENABLE_DSR_HYBRID && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE */
 
 		ret = nodeport_lb4(ctx, ip4, l3_off, 0, &ext_err);
 		if (ret == NAT_46X64_RECIRC) {

--- a/cilium/cmd/bpf_ct_list.go
+++ b/cilium/cmd/bpf_ct_list.go
@@ -104,7 +104,11 @@ func getMaps(t string, id uint32) []*ctmap.Map {
 func getClockSource() (*models.ClockSource, error) {
 	switch timeDiffClockSourceMode {
 	case "":
-		return timestamp.GetClockSourceFromAgent(client.Daemon)
+		clockSource, err := timestamp.GetClockSourceFromAgent(client.Daemon)
+		if err != nil {
+			return timestamp.GetClockSourceFromRuntimeConfig()
+		}
+		return clockSource, err
 	case models.ClockSourceModeKtime:
 		return &models.ClockSource{
 			Mode: models.ClockSourceModeKtime,

--- a/cilium/cmd/bpf_nat_list.go
+++ b/cilium/cmd/bpf_nat_list.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/maps/nat"
+	"github.com/cilium/cilium/pkg/maps/timestamp"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -93,7 +94,11 @@ func dumpNat(maps []interface{}, args ...interface{}) {
 				Fatalf("Error while collecting BPF map entries: %s", err)
 			}
 		} else {
-			out, err := m.(nat.NatMap).DumpEntries()
+			clockSource, err := timestamp.GetClockSourceFromAgent(client.Daemon)
+			if err != nil {
+				Fatalf("Error while dumping BPF Map: %s", err)
+			}
+			out, err := nat.DumpEntriesWithTimeDiff(m.(nat.NatMap), clockSource)
 			if err != nil {
 				Fatalf("Error while dumping BPF Map: %s", err)
 			}

--- a/cilium/cmd/bpf_nat_list.go
+++ b/cilium/cmd/bpf_nat_list.go
@@ -96,6 +96,10 @@ func dumpNat(maps []interface{}, args ...interface{}) {
 		} else {
 			clockSource, err := timestamp.GetClockSourceFromAgent(client.Daemon)
 			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to get clocksource from agent: %s", err)
+				clockSource, err = timestamp.GetClockSourceFromRuntimeConfig()
+			}
+			if err != nil {
 				Fatalf("Error while dumping BPF Map: %s", err)
 			}
 			out, err := nat.DumpEntriesWithTimeDiff(m.(nat.NatMap), clockSource)

--- a/clustermesh-apiserver/users_mgmt_test.go
+++ b/clustermesh-apiserver/users_mgmt_test.go
@@ -53,6 +53,9 @@ func TestMain(m *testing.M) {
 		// To ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go
 		// init function
 		goleak.IgnoreTopFunction("time.Sleep"),
+		// Delaying workqueues used by resource.Resource[T].Events leaks this waitingLoop goroutine.
+		// It does stop when shutting down but is not guaranteed to before we actually exit.
+		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop"),
 	)
 }
 

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
+	"github.com/cilium/cilium/pkg/maps/timestamp"
 	tunnelmap "github.com/cilium/cilium/pkg/maps/tunnel"
 	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -200,12 +201,7 @@ func (d *Daemon) getHostFirewallStatus() *models.HostFirewall {
 }
 
 func (d *Daemon) getClockSourceStatus() *models.ClockSource {
-	s := &models.ClockSource{Mode: models.ClockSourceModeKtime}
-	if option.Config.ClockSource == option.ClockSourceJiffies {
-		s.Mode = models.ClockSourceModeJiffies
-		s.Hertz = int64(option.Config.KernelHz)
-	}
-	return s
+	return timestamp.GetClockSourceFromOptions()
 }
 
 func (d *Daemon) getCNIChainingStatus() *models.CNIChainingStatus {

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -67,9 +67,13 @@ contributors across the globe, there is almost always someone available to help.
 | authentication.mutual.spire.agentSocketPath | string | `"/run/spire/sockets/agent/agent.sock"` | SPIRE socket path where the SPIRE workload agent is listening. Applies to both the Cilium Agent and Operator |
 | authentication.mutual.spire.connectionTimeout | string | `"30s"` | SPIRE connection timeout |
 | authentication.mutual.spire.enabled | bool | `false` | Enable SPIRE integration (beta) |
+| authentication.mutual.spire.install.agent.affinity | object | `{}` | SPIRE agent affinity configuration |
 | authentication.mutual.spire.install.agent.annotations | object | `{}` | SPIRE agent annotations |
 | authentication.mutual.spire.install.agent.image | string | `"ghcr.io/spiffe/spire-agent:1.6.3@sha256:8eef9857bf223181ecef10d9bbcd2f7838f3689e9bd2445bede35066a732e823"` | SPIRE agent image |
 | authentication.mutual.spire.install.agent.labels | object | `{}` | SPIRE agent labels |
+| authentication.mutual.spire.install.agent.nodeSelector | object | `{}` | SPIRE agent nodeSelector configuration ref: ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
+| authentication.mutual.spire.install.agent.podSecurityContext | object | `{}` | Security context to be added to spire agent pods. SecurityContext holds pod-level security attributes and common container settings. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod |
+| authentication.mutual.spire.install.agent.securityContext | object | `{}` | Security context to be added to spire agent containers. SecurityContext holds pod-level security attributes and common container settings. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container |
 | authentication.mutual.spire.install.agent.serviceAccount | object | `{"create":true,"name":"spire-agent"}` | SPIRE agent service account |
 | authentication.mutual.spire.install.agent.skipKubeletVerification | bool | `true` | SPIRE Workload Attestor kubelet verification. |
 | authentication.mutual.spire.install.agent.tolerations | list | `[]` | SPIRE agent tolerations configuration ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |

--- a/install/kubernetes/cilium/templates/spire/agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/daemonset.yaml
@@ -30,6 +30,10 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ .Values.authentication.mutual.spire.install.agent.serviceAccount.name }}
+      {{- with .Values.authentication.mutual.spire.install.agent.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init
           image: docker.io/library/busybox:1.35.0@sha256:223ae047b1065bd069aac01ae3ac8088b3ca4a527827e283b85112f29385fb1b
@@ -42,6 +46,10 @@ spec:
         - name: spire-agent
           image: {{ .Values.authentication.mutual.spire.install.agent.image }}
           args: ["-config", "/run/spire/config/agent.conf"]
+          {{- with .Values.authentication.mutual.spire.install.agent.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: spire-config
               mountPath: /run/spire/config
@@ -72,6 +80,14 @@ spec:
               port: 4251
             initialDelaySeconds: 5
             periodSeconds: 5
+      {{- with .Values.authentication.mutual.spire.install.agent.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.authentication.mutual.spire.install.agent.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.authentication.mutual.spire.install.agent.tolerations }}
       tolerations:
         {{- toYaml . | trim | nindent 8 }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3135,6 +3135,19 @@ authentication:
           # -- SPIRE agent tolerations configuration
           # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
           tolerations: []
+          # -- SPIRE agent affinity configuration
+          affinity: {}
+          # -- SPIRE agent nodeSelector configuration
+          # ref: ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+          nodeSelector: {}
+          # -- Security context to be added to spire agent pods.
+          # SecurityContext holds pod-level security attributes and common container settings.
+          # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+          podSecurityContext: {}
+          # -- Security context to be added to spire agent containers.
+          # SecurityContext holds pod-level security attributes and common container settings.
+          # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+          securityContext: {}
         server:
           # -- SPIRE server image
           image: ghcr.io/spiffe/spire-server:1.6.3@sha256:f4bc49fb0bd1d817a6c46204cc7ce943c73fb0a5496a78e0e4dc20c9a816ad7f

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3132,6 +3132,19 @@ authentication:
           # -- SPIRE agent tolerations configuration
           # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
           tolerations: []
+          # -- SPIRE agent affinity configuration
+          affinity: {}
+          # -- SPIRE agent nodeSelector configuration
+          # ref: ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+          nodeSelector: {}
+          # -- Security context to be added to spire agent pods.
+          # SecurityContext holds pod-level security attributes and common container settings.
+          # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+          podSecurityContext: {}
+          # -- Security context to be added to spire agent containers.
+          # SecurityContext holds pod-level security attributes and common container settings.
+          # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+          securityContext: {}
         server:
           # -- SPIRE server image
           image: ghcr.io/spiffe/spire-server:1.6.3@sha256:f4bc49fb0bd1d817a6c46204cc7ce943c73fb0a5496a78e0e4dc20c9a816ad7f

--- a/operator/pkg/gateway-api/httproute.go
+++ b/operator/pkg/gateway-api/httproute.go
@@ -91,7 +91,7 @@ func (r *httpRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch for changes to Backend services
 		Watches(&corev1.Service{}, r.enqueueRequestForBackendService()).
 		// Watch for changes to Reference Grants
-		Watches(&gatewayv1beta1.ReferenceGrant{}, r.enqueueRequestForRequestGrant()).
+		Watches(&gatewayv1beta1.ReferenceGrant{}, r.enqueueRequestForReferenceGrant()).
 		// Watch for changes to Gateways and enqueue HTTPRoutes that reference them,
 		Watches(&gatewayv1beta1.Gateway{}, r.enqueueRequestForGateway(),
 			builder.WithPredicates(
@@ -105,8 +105,9 @@ func (r *httpRouteReconciler) enqueueRequestForBackendService() handler.EventHan
 	return handler.EnqueueRequestsFromMapFunc(r.enqueueFromIndex(backendServiceIndex))
 }
 
-// enqueueRequestForRequestGrant makes sure that HTTP Routes in the same namespace are reconciled
-func (r *httpRouteReconciler) enqueueRequestForRequestGrant() handler.EventHandler {
+// enqueueRequestForReferenceGrant makes sure that all HTTP Routes are reconciled
+// if a ReferenceGrant changes
+func (r *httpRouteReconciler) enqueueRequestForReferenceGrant() handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(r.enqueueAll())
 }
 

--- a/operator/pkg/gateway-api/tlsroute.go
+++ b/operator/pkg/gateway-api/tlsroute.go
@@ -87,7 +87,7 @@ func (r *tlsRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch for changes to Backend services
 		Watches(&corev1.Service{}, r.enqueueRequestForBackendService()).
 		// Watch for changes to Reference Grants
-		Watches(&gatewayv1alpha2.ReferenceGrant{}, r.enqueueRequestForRequestGrant()).
+		Watches(&gatewayv1alpha2.ReferenceGrant{}, r.enqueueRequestForReferenceGrant()).
 		// Watch for changes to Gateways and enqueue TLSRoutes that reference them,
 		Watches(&gatewayv1beta1.Gateway{}, r.enqueueRequestForGateway(),
 			builder.WithPredicates(
@@ -102,8 +102,9 @@ func (r *tlsRouteReconciler) enqueueRequestForBackendService() handler.EventHand
 	return handler.EnqueueRequestsFromMapFunc(r.enqueueFromIndex(backendServiceIndex))
 }
 
-// enqueueRequestForRequestGrant makes sure that TLS Routes in the same namespace are reconciled
-func (r *tlsRouteReconciler) enqueueRequestForRequestGrant() handler.EventHandler {
+// enqueueRequestForReferenceGrant makes sure that all TLS Routes are reconciled
+// if a ReferenceGrant changes
+func (r *tlsRouteReconciler) enqueueRequestForReferenceGrant() handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(r.enqueueAll())
 }
 

--- a/operator/pkg/gateway-api/tlsroute.go
+++ b/operator/pkg/gateway-api/tlsroute.go
@@ -86,8 +86,8 @@ func (r *tlsRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&gatewayv1alpha2.TLSRoute{}).
 		// Watch for changes to Backend services
 		Watches(&corev1.Service{}, r.enqueueRequestForBackendService()).
-		// Watch for changes to Gateways and enqueue TLSRoutes that reference them
-		Watches(&gatewayv1beta1.Gateway{}, r.enqueueRequestForGateway()).
+		// Watch for changes to Reference Grants
+		Watches(&gatewayv1alpha2.ReferenceGrant{}, r.enqueueRequestForRequestGrant()).
 		// Watch for changes to Gateways and enqueue TLSRoutes that reference them,
 		Watches(&gatewayv1beta1.Gateway{}, r.enqueueRequestForGateway(),
 			builder.WithPredicates(
@@ -100,6 +100,11 @@ func (r *tlsRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // if the backend services are updated.
 func (r *tlsRouteReconciler) enqueueRequestForBackendService() handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(r.enqueueFromIndex(backendServiceIndex))
+}
+
+// enqueueRequestForRequestGrant makes sure that TLS Routes in the same namespace are reconciled
+func (r *tlsRouteReconciler) enqueueRequestForRequestGrant() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(r.enqueueAll())
 }
 
 func (r *tlsRouteReconciler) enqueueRequestForGateway() handler.EventHandler {
@@ -123,6 +128,34 @@ func (r *tlsRouteReconciler) enqueueFromIndex(index string) handler.MapFunc {
 
 		requests := make([]reconcile.Request, 0, len(rList.Items))
 		for _, item := range rList.Items {
+			route := client.ObjectKey{
+				Namespace: item.GetNamespace(),
+				Name:      item.GetName(),
+			}
+			requests = append(requests, reconcile.Request{
+				NamespacedName: route,
+			})
+			scopedLog.WithField("tlsRoute", route).Info("Enqueued TLSRoute for resource")
+		}
+		return requests
+	}
+}
+
+func (r *tlsRouteReconciler) enqueueAll() handler.MapFunc {
+	return func(ctx context.Context, o client.Object) []reconcile.Request {
+		scopedLog := log.WithFields(logrus.Fields{
+			logfields.Controller: "tlsRoute",
+			logfields.Resource:   client.ObjectKeyFromObject(o),
+		})
+		trList := &gatewayv1alpha2.TLSRouteList{}
+
+		if err := r.Client.List(ctx, trList, &client.ListOptions{}); err != nil {
+			scopedLog.WithError(err).Error("Failed to get TLSRoutes")
+			return []reconcile.Request{}
+		}
+
+		requests := make([]reconcile.Request, 0, len(trList.Items))
+		for _, item := range trList.Items {
 			route := client.ObjectKey{
 				Namespace: item.GetNamespace(),
 				Name:      item.GetName(),

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -20,7 +20,15 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(
+		m,
+		// To ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go
+		// init function
+		goleak.IgnoreTopFunction("time.Sleep"),
+		// Delaying workqueues used by resource.Resource[T].Events leaks this waitingLoop goroutine.
+		// It does stop when shutting down but is not guaranteed to before we actually exit.
+		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop"),
+	)
 }
 
 // TestConflictResolution tests that, upon initialization, LB IPAM will detect conflicts between pools,

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -996,7 +996,9 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 		}
 		fmt.Fprintf(fw, "#define DIRECT_ROUTING_DEV_IFINDEX %d\n", directRoutingIfIndex)
 		if len(option.Config.GetDevices()) == 1 {
-			fmt.Fprintf(fw, "#define ENABLE_SKIP_FIB 1\n")
+			if e.IsHost() || !option.Config.EnforceLXCFibLookup() {
+				fmt.Fprintf(fw, "#define ENABLE_SKIP_FIB 1\n")
+			}
 		}
 	}
 

--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -40,7 +40,12 @@ func TestMain(m *testing.M) {
 		// missing Event.Done() calls.
 		runtime.GC()
 	}
-	goleak.VerifyTestMain(m, goleak.Cleanup(cleanup))
+	goleak.VerifyTestMain(m,
+		goleak.Cleanup(cleanup),
+		// Delaying workqueues used by resource.Resource[T].Events leaks this waitingLoop goroutine.
+		// It does stop when shutting down but is not guaranteed to before we actually exit.
+		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop"),
+	)
 }
 
 func testStore(t *testing.T, node *corev1.Node, store resource.Store[*corev1.Node]) {

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -20,12 +20,12 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/bpf"
-	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/nat"
+	"github.com/cilium/cilium/pkg/maps/timestamp"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/tuple"
@@ -79,10 +79,6 @@ const (
 
 	// MaxTime specifies the last possible time for GCFilter.Time
 	MaxTime = math.MaxUint32
-
-	// The BPF CT implementation stores jiffies right-shifted by this value. Must
-	// correspond to BPF_MONO_SCALER in the datapath.
-	bpfMonoScaler = 8
 
 	metricsAlive   = "alive"
 	metricsDeleted = "deleted"
@@ -252,17 +248,6 @@ type GCFilter struct {
 // EmitCTEntryCBFunc is the type used for the EmitCTEntryCB callback in GCFilter
 type EmitCTEntryCBFunc func(srcIP, dstIP netip.Addr, srcPort, dstPort uint16, nextHdr, flags uint8, entry *CtEntry)
 
-// scaledJiffies returns the kernel's current jiffies, right-shifted by a
-// monotonic scaler value.
-func scaledJiffies() (uint64, error) {
-	j, err := probes.Jiffies()
-	if err != nil {
-		return 0, err
-	}
-
-	return j >> bpfMonoScaler, nil
-}
-
 // DumpEntriesWithTimeDiff iterates through Map m and writes the values of the
 // ct entries in m to a string. If clockSource is not nil, it uses it to
 // compute the time difference of each entry from now and prints that too.
@@ -271,32 +256,21 @@ func DumpEntriesWithTimeDiff(m CtMap, clockSource *models.ClockSource) (string, 
 
 	if clockSource == nil {
 		toRemSecs = nil
-	} else if clockSource.Mode == models.ClockSourceModeKtime {
-		now, err := bpf.GetMtime()
-		if err != nil {
-			return "", err
-		}
-		now = now / 1000000000
-		toRemSecs = func(t uint32) string {
-			diff := int64(t) - int64(now)
-			return fmt.Sprintf("remaining: %d sec(s)", diff)
-		}
-	} else if clockSource.Mode == models.ClockSourceModeJiffies {
-		now, err := scaledJiffies()
-		if err != nil {
-			return "", err
-		}
-		if clockSource.Hertz == 0 {
-			return "", fmt.Errorf("invalid clock Hertz value (0)")
-		}
-		toRemSecs = func(t uint32) string {
-			diff := int64(t) - int64(now)
-			diff = diff << 8
-			diff = diff / int64(clockSource.Hertz)
-			return fmt.Sprintf("remaining: %d sec(s)", diff)
-		}
 	} else {
-		return "", fmt.Errorf("unknown clock source: %s", clockSource.Mode)
+		now, err := timestamp.GetCTCurTime(clockSource)
+		if err != nil {
+			return "", err
+		}
+		tsConverter, err := timestamp.NewCTTimeToSecConverter(clockSource)
+		if err != nil {
+			return "", err
+		}
+		tsecNow := tsConverter(now)
+		toRemSecs = func(t uint32) string {
+			tsec := tsConverter(uint64(t))
+			diff := int64(tsec) - int64(tsecNow)
+			return fmt.Sprintf("remaining: %d sec(s)", diff)
+		}
 	}
 
 	var sb strings.Builder
@@ -620,13 +594,7 @@ func doGC(m *Map, filter *GCFilter) int {
 // It returns how many items were deleted from m.
 func GC(m *Map, filter *GCFilter) int {
 	if filter.RemoveExpired {
-		var t uint64
-		if option.Config.ClockSource == option.ClockSourceKtime {
-			t, _ = bpf.GetMtime()
-			t = t / 1000000000
-		} else {
-			t, _ = scaledJiffies()
-		}
+		t, _ := timestamp.GetCTCurTime(timestamp.GetClockSourceFromOptions())
 		filter.Time = uint32(t)
 	}
 

--- a/pkg/maps/nat/ipv4.go
+++ b/pkg/maps/nat/ipv4.go
@@ -33,7 +33,7 @@ func (n *NatEntry4) String() string {
 }
 
 // Dump dumps NAT entry to string.
-func (n *NatEntry4) Dump(key NatKey, start uint64) string {
+func (n *NatEntry4) Dump(key NatKey, toDeltaSecs func(uint64) string) string {
 	var which string
 
 	if key.GetFlags()&tuple.TUPLE_F_IN != 0 {
@@ -45,7 +45,7 @@ func (n *NatEntry4) Dump(key NatKey, start uint64) string {
 		which,
 		n.Addr,
 		n.Port,
-		NatDumpCreated(start, n.Created),
+		toDeltaSecs(n.Created),
 		n.NeedsCT)
 }
 

--- a/pkg/maps/nat/ipv6.go
+++ b/pkg/maps/nat/ipv6.go
@@ -37,7 +37,7 @@ func (n *NatEntry6) String() string {
 }
 
 // Dump dumps NAT entry to string.
-func (n *NatEntry6) Dump(key NatKey, start uint64) string {
+func (n *NatEntry6) Dump(key NatKey, toDeltaSecs func(uint64) string) string {
 	var which string
 
 	if key.GetFlags()&tuple.TUPLE_F_IN != 0 {
@@ -49,7 +49,7 @@ func (n *NatEntry6) Dump(key NatKey, start uint64) string {
 		which,
 		n.Addr,
 		n.Port,
-		NatDumpCreated(start, n.Created),
+		toDeltaSecs(n.Created),
 		n.NeedsCT)
 }
 

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/cilium/ebpf"
 
+	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/timestamp"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/tuple"
 )
@@ -47,7 +49,7 @@ type NatEntry interface {
 	ToHost() NatEntry
 
 	// Dumps the Nat entry as string.
-	Dump(key NatKey, start uint64) string
+	Dump(key NatKey, toDeltaSecs func(uint64) string) string
 }
 
 // A "Record" designates a map entry (key + value), but avoid "entry" because of
@@ -66,14 +68,6 @@ type NatMap interface {
 	Path() (string, error)
 	DumpEntries() (string, error)
 	DumpWithCallback(bpf.DumpCallback) error
-}
-
-// NatDumpCreated returns time in seconds when NAT entry was created.
-func NatDumpCreated(dumpStart, entryCreated uint64) string {
-	tsecCreated := entryCreated / 1000000000
-	tsecStart := dumpStart / 1000000000
-
-	return fmt.Sprintf("%dsec", tsecStart-tsecCreated)
 }
 
 // NewMap instantiates a Map.
@@ -115,22 +109,50 @@ func (m *Map) DumpReliablyWithCallback(cb bpf.DumpCallback, stats *bpf.DumpStats
 	return (&m.Map).DumpReliablyWithCallback(cb, stats)
 }
 
-// DoDumpEntries iterates through Map m and writes the values of the
-// nat entries in m to a string.
-func DoDumpEntries(m NatMap) (string, error) {
+// DumpEntriesWithTimeDiff iterates through Map m and writes the values of the
+// nat entries in m to a string. If clockSource is not nil, it uses it to
+// compute the time difference of each entry from now and prints that too.
+func DumpEntriesWithTimeDiff(m NatMap, clockSource *models.ClockSource) (string, error) {
+	var toDeltaSecs func(uint64) string
 	var sb strings.Builder
 
-	nsecStart, _ := bpf.GetMtime()
+	if clockSource == nil {
+		toDeltaSecs = func(t uint64) string {
+			return fmt.Sprintf("? (raw %d)", t)
+		}
+	} else {
+		now, err := timestamp.GetCTCurTime(clockSource)
+		if err != nil {
+			return "", err
+		}
+		tsConverter, err := timestamp.NewCTTimeToSecConverter(clockSource)
+		if err != nil {
+			return "", err
+		}
+		tsecNow := tsConverter(now)
+		toDeltaSecs = func(t uint64) string {
+			tsec := tsConverter(uint64(t))
+			diff := int64(tsecNow) - int64(tsec)
+			return fmt.Sprintf("%dsec ago", diff)
+		}
+	}
+
 	cb := func(k bpf.MapKey, v bpf.MapValue) {
 		key := k.(NatKey)
 		if !key.ToHost().Dump(&sb, false) {
 			return
 		}
 		val := v.(NatEntry)
-		sb.WriteString(val.ToHost().Dump(key, nsecStart))
+		sb.WriteString(val.ToHost().Dump(key, toDeltaSecs))
 	}
 	err := m.DumpWithCallback(cb)
 	return sb.String(), err
+}
+
+// DoDumpEntries iterates through Map m and writes the values of the
+// nat entries in m to a string.
+func DoDumpEntries(m NatMap) (string, error) {
+	return DumpEntriesWithTimeDiff(m, nil)
 }
 
 // DumpEntries iterates through Map m and writes the values of the

--- a/pkg/maps/timestamp/timestamp.go
+++ b/pkg/maps/timestamp/timestamp.go
@@ -4,13 +4,17 @@
 package timestamp
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/client/daemon"
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -20,14 +24,18 @@ const (
 	bpfMonoScaler = 8
 )
 
-// Get current clocksource - to be used in the agent context.
-func GetClockSourceFromOptions() *models.ClockSource {
+func getClockSourceFromConfig(config *option.DaemonConfig) *models.ClockSource {
 	clockSource := &models.ClockSource{Mode: models.ClockSourceModeKtime}
-	if option.Config.ClockSource == option.ClockSourceJiffies {
+	if config.ClockSource == option.ClockSourceJiffies {
 		clockSource.Mode = models.ClockSourceModeJiffies
-		clockSource.Hertz = int64(option.Config.KernelHz)
+		clockSource.Hertz = int64(config.KernelHz)
 	}
 	return clockSource
+}
+
+// Get current clocksource - to be used in the agent context.
+func GetClockSourceFromOptions() *models.ClockSource {
+	return getClockSourceFromConfig(option.Config)
 }
 
 // Connect to the agent via API and get its current clocksource.
@@ -45,6 +53,24 @@ func GetClockSourceFromAgent(svc daemon.ClientService) (*models.ClockSource, err
 	}
 
 	return resp.Payload.ClockSource, nil
+}
+
+// Get the clocksource from the agent config file in case agent is not running.
+func GetClockSourceFromRuntimeConfig() (*models.ClockSource, error) {
+	var config option.DaemonConfig
+
+	agentConfigFile := filepath.Join(defaults.RuntimePath, defaults.StateDir,
+		"agent-runtime-config.json")
+
+	if byteValue, err := os.ReadFile(agentConfigFile); err == nil {
+		err = json.Unmarshal(byteValue, &config)
+		if err != nil {
+			return nil, err
+		}
+		return getClockSourceFromConfig(&config), nil
+	} else {
+		return nil, err
+	}
 }
 
 // Returns current time in units that are used for timestamps in CT and NAT

--- a/pkg/maps/timestamp/timestamp.go
+++ b/pkg/maps/timestamp/timestamp.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package timestamp
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cilium/cilium/api/v1/client/daemon"
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/datapath/linux/probes"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+const (
+	// The BPF CT implementation stores jiffies right-shifted by this value. Must
+	// correspond to BPF_MONO_SCALER in the datapath.
+	bpfMonoScaler = 8
+)
+
+// Get current clocksource - to be used in the agent context.
+func GetClockSourceFromOptions() *models.ClockSource {
+	clockSource := &models.ClockSource{Mode: models.ClockSourceModeKtime}
+	if option.Config.ClockSource == option.ClockSourceJiffies {
+		clockSource.Mode = models.ClockSourceModeJiffies
+		clockSource.Hertz = int64(option.Config.KernelHz)
+	}
+	return clockSource
+}
+
+// Connect to the agent via API and get its current clocksource.
+func GetClockSourceFromAgent(svc daemon.ClientService) (*models.ClockSource, error) {
+	params := daemon.NewGetHealthzParamsWithTimeout(5 * time.Second)
+	brief := false
+	params.SetBrief(&brief)
+	resp, err := svc.GetHealthz(params)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Payload.ClockSource == nil {
+		return nil, fmt.Errorf("could not determine clocksource")
+	}
+
+	return resp.Payload.ClockSource, nil
+}
+
+// Returns current time in units that are used for timestamps in CT and NAT
+// maps (seconds for ClockSourceModeKtime and scaled jiffies for
+// ClockSourceModeJiffies).
+func GetCTCurTime(clockSource *models.ClockSource) (uint64, error) {
+	switch clockSource.Mode {
+	case models.ClockSourceModeKtime:
+		t, err := bpf.GetMtime()
+		if err != nil {
+			return 0, err
+		}
+		return t / 1000000000, nil
+	case models.ClockSourceModeJiffies:
+		j, err := probes.Jiffies()
+		if err != nil {
+			return 0, err
+		}
+		return j >> bpfMonoScaler, nil
+	default:
+		return 0, fmt.Errorf("invalid clocksource: %s", clockSource.Mode)
+	}
+}
+
+type TimestampConverter func(timestamp uint64) uint64
+
+// Returns a function that converts a CT timestamp from clocksource units into
+// seconds.
+func NewCTTimeToSecConverter(clockSource *models.ClockSource) (TimestampConverter, error) {
+	if clockSource == nil {
+		return nil, fmt.Errorf("clockSource is nil")
+	}
+	switch clockSource.Mode {
+	case models.ClockSourceModeKtime:
+		converter := func(timestamp uint64) uint64 {
+			return timestamp
+		}
+		return converter, nil
+	case models.ClockSourceModeJiffies:
+		hertz := clockSource.Hertz
+		if hertz == 0 {
+			return nil, fmt.Errorf("invalid clock Hertz value (0)")
+		}
+		converter := func(timestamp uint64) uint64 {
+			return (timestamp << bpfMonoScaler) / uint64(hertz)
+		}
+		return converter, nil
+	default:
+		return nil, fmt.Errorf("invalid clocksource: %s", clockSource.Mode)
+	}
+}

--- a/pkg/maps/timestamp/timestamp_test.go
+++ b/pkg/maps/timestamp/timestamp_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package timestamp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/api/v1/models"
+)
+
+func TestConvert(t *testing.T) {
+	tests := []struct {
+		name  string
+		mode  string
+		hertz int64
+		err   bool
+		inp   uint64
+		res   uint64
+	}{
+		{name: "ktime", mode: models.ClockSourceModeKtime, inp: uint64(0xff00ff0012345678), res: uint64(0xff00ff0012345678)},
+		{name: "jiffies_err", mode: models.ClockSourceModeJiffies, err: true},
+		{name: "jiffies_ok", mode: models.ClockSourceModeJiffies, hertz: 100, inp: uint64(0x00ffff0012345678), res: uint64(0x28f5999c834108f)},
+		{name: "invalid", mode: "", err: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clockSource := &models.ClockSource{Mode: tt.mode, Hertz: tt.hertz}
+			conv, err := NewCTTimeToSecConverter(clockSource)
+			if tt.err {
+				require.Error(t, err, "Invalid converter created")
+			} else {
+				require.NoError(t, err, "Failed to create converter")
+				res := conv(tt.inp)
+				require.Equal(t, tt.res, res)
+			}
+		})
+	}
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -4246,3 +4246,13 @@ func parseBPFMapEventConfigs(confs BPFEventBufferConfigs, confMap map[string]str
 	}
 	return nil
 }
+
+func (d *DaemonConfig) EnforceLXCFibLookup() bool {
+	// See https://github.com/cilium/cilium/issues/27343 for the symptoms.
+	//
+	// We want to enforce FIB lookup if EndpointRoutes are enabled, because
+	// this was a config dependency change which caused different behaviour
+	// since v1.14.0-snapshot.2. We will remove this hack later, once we
+	// have auto-device detection on by default.
+	return d.EnableEndpointRoutes
+}


### PR DESCRIPTION
 * [x] #28557 (@dylandreimerink)
    * :warning: Conflicts in the lbipam unit test, as it did not have any leak check before in v1.14
 * [x] #28959 (@julianwiedmann)
 * [x] #28264 (@aspsk)
 * [x] #29007 (@mhofstetter)
    *  :warning: Conflicts in the following files
    *  operator/pkg/gateway-api/tlsroute.go Conflicts due to Gateway resoruce version (v1 vs v1beta1)
    *  operator/pkg/gateway-api/httproute.go Conflicts due to Gateway resoruce version (v1 vs v1beta1)
    *  operator/pkg/gateway-api/grpcroute.go Conflicts because the file does not exist in v1.14
 * [x] #27062 (@gentoo-root)
    * :warning: Conflicts due to "cilium-dbg" and "pkg/time" rename
 * [ ] #29077 (@meyskens)

PRs skipped due to conflicts:

 * #28896 (@mhofstetter)
 * #29115 (@sayboras)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 28557 28959 28264 29007 27062 29077
```
