### PR TITLE
CODEOWNERS: Let IPsec team to own GH workflows for IPsec

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -229,6 +229,7 @@
 /.github/actions/ @cilium/github-sec @cilium/ci-structure
 /.github/workflows/ @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*datapath*.yaml @cilium/sig-datapath @cilium/github-sec @cilium/ci-structure
+/.github/workflows/*ipsec*.yaml @cilium/ipsec @cilium/github-sec @cilium/ci-structure
 /.gitignore @cilium/tophat
 /.golangci.yaml @cilium/ci-structure
 /.mailmap @cilium/tophat
@@ -410,7 +411,7 @@ Makefile* @cilium/build
 /pkg/datapath/linux/config/ @cilium/loader
 /pkg/datapath/linux/ipsec/ @cilium/ipsec
 /pkg/datapath/linux/ipsec/xfrm_collector* @cilium/ipsec @cilium/metrics
-/pkg/datapath/linux/ipsec.go @cilium/ipsec 
+/pkg/datapath/linux/ipsec.go @cilium/ipsec
 /pkg/datapath/linux/node.go @cilium/sig-datapath
 /pkg/datapath/linux/probes/ @cilium/loader
 /pkg/datapath/linux/requirements.go @cilium/loader


### PR DESCRIPTION
The IPsec team might be interested in reviewing changes happening in those workflow files (for example,
https://github.com/cilium/cilium/pull/29178).