### PR TITLE
Modularize ipcache BPF listener

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -419,7 +419,7 @@ func (d *Daemon) initMaps() error {
 	// used by syncEndpointsAndHostIPs()
 	// xDS cache will be added later by calling AddListener(), but only if necessary.
 	d.ipcache.SetListeners([]ipcache.IPIdentityMappingListener{
-		datapathIpcache.NewListener(d, d.ipcache),
+		datapathIpcache.NewListener(d.monitorAgent, d.ipcache),
 	})
 
 	if option.Config.EnableIPMasqAgent {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -419,7 +419,7 @@ func (d *Daemon) initMaps() error {
 	// used by syncEndpointsAndHostIPs()
 	// xDS cache will be added later by calling AddListener(), but only if necessary.
 	d.ipcache.SetListeners([]ipcache.IPIdentityMappingListener{
-		datapathIpcache.NewListener(d, d, d.ipcache),
+		datapathIpcache.NewListener(d, d.ipcache),
 	})
 
 	if option.Config.EnableIPMasqAgent {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -419,7 +419,7 @@ func (d *Daemon) initMaps() error {
 	// used by syncEndpointsAndHostIPs()
 	// xDS cache will be added later by calling AddListener(), but only if necessary.
 	d.ipcache.SetListeners([]ipcache.IPIdentityMappingListener{
-		datapathIpcache.NewListener(d.monitorAgent, d.ipcache),
+		datapathIpcache.NewListener(d.monitorAgent),
 	})
 
 	if option.Config.EnableIPMasqAgent {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -14,7 +14,6 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/cidr"
-	datapathIpcache "github.com/cilium/cilium/pkg/datapath/ipcache"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
@@ -23,7 +22,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	ippkg "github.com/cilium/cilium/pkg/ip"
-	"github.com/cilium/cilium/pkg/ipcache"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -414,13 +412,6 @@ func (d *Daemon) initMaps() error {
 			return fmt.Errorf("initializing fragments map: %w", err)
 		}
 	}
-
-	// Set up the list of IPCache listeners in the daemon, to be
-	// used by syncEndpointsAndHostIPs()
-	// xDS cache will be added later by calling AddListener(), but only if necessary.
-	d.ipcache.SetListeners([]ipcache.IPIdentityMappingListener{
-		datapathIpcache.NewListener(d.monitorAgent),
-	})
 
 	if option.Config.EnableIPMasqAgent {
 		if option.Config.EnableIPv4Masquerade {

--- a/daemon/cmd/ipcache.go
+++ b/daemon/cmd/ipcache.go
@@ -93,11 +93,6 @@ func (ipc *ipCacheDumpListener) OnIPIdentityCacheChange(modType ipcache.CacheMod
 	ipc.entries = append(ipc.entries, entry)
 }
 
-// OnIPIdentityCacheGC is required to implement IPIdentityMappingListener.
-func (ipc *ipCacheDumpListener) OnIPIdentityCacheGC() {
-	// Nothing to do.
-}
-
 // containsSubnet returns true if 'outer' contains 'inner'
 func containsSubnet(outer, inner net.IPNet) bool {
 	outerOnes, outerBits := outer.Mask.Size()

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -49,8 +49,7 @@ func (w *remoteEtcdClientWrapper) ListAndWatch(ctx context.Context, prefix strin
 
 type fakeIPCache struct{ updates atomic.Int32 }
 
-func (f *fakeIPCache) ForEachListener(func(listener ipcache.IPIdentityMappingListener)) {}
-func (f *fakeIPCache) Delete(string, source.Source) bool                                { return false }
+func (f *fakeIPCache) Delete(string, source.Source) bool { return false }
 func (f *fakeIPCache) Upsert(string, net.IP, uint8, *ipcache.K8sMetadata, ipcache.Identity) (bool, error) {
 	f.updates.Add(1)
 	return false, nil

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/agentliveness"
 	"github.com/cilium/cilium/pkg/datapath/garp"
+	"github.com/cilium/cilium/pkg/datapath/ipcache"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/l2responder"
 	"github.com/cilium/cilium/pkg/datapath/link"
@@ -105,6 +106,9 @@ var Cell = cell.Module(
 		// device-related configuration options.
 		return linuxdatapath.DevicesConfig{Devices: cfg.GetDevices()}
 	}),
+
+	// Synchronizes the userspace ipcache with the corresponding BPF map.
+	ipcache.Cell,
 )
 
 func newWireguardAgent(lc hive.Lifecycle, localNodeStore *node.LocalNodeStore) *wg.Agent {

--- a/pkg/datapath/ipcache/cell.go
+++ b/pkg/datapath/ipcache/cell.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import (
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/ipcache"
+	ipcacheMap "github.com/cilium/cilium/pkg/maps/ipcache"
+	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
+)
+
+// Cell is a cell that provides and registers the listener which synchronizes
+// the userspace ipcache with the corresponding BPF map.
+var Cell = cell.Module(
+	"ipcache-bpf-listener",
+	"IPCache BPF Listener",
+
+	cell.Provide(NewListener),
+	cell.ProvidePrivate(
+		func() Map { return ipcacheMap.IPCacheMap() },
+		func(agent monitorAgent.Agent) monitorNotify { return agent },
+	),
+
+	cell.Invoke(func(listener *BPFListener, ipc *ipcache.IPCache) { ipc.AddListener(listener) }),
+)

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -44,16 +44,12 @@ type BPFListener struct {
 	monitorNotify monitorNotify
 }
 
-func newListener(m Map, mn monitorNotify) *BPFListener {
+// NewListener returns a new listener to push IPCache entries into BPF maps.
+func NewListener(m Map, mn monitorNotify) *BPFListener {
 	return &BPFListener{
 		bpfMap:        m,
 		monitorNotify: mn,
 	}
-}
-
-// NewListener returns a new listener to push IPCache entries into BPF maps.
-func NewListener(mn monitorNotify) *BPFListener {
-	return newListener(ipcacheMap.IPCacheMap(), mn)
 }
 
 func (l *BPFListener) notifyMonitor(modType ipcache.CacheModification,

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -46,7 +46,7 @@ func newListener(m *ipcacheMap.Map, mn monitorNotify) *BPFListener {
 }
 
 // NewListener returns a new listener to push IPCache entries into BPF maps.
-func NewListener(mn monitorNotify, ipc *ipcache.IPCache) *BPFListener {
+func NewListener(mn monitorNotify) *BPFListener {
 	return newListener(ipcacheMap.IPCacheMap(), mn)
 }
 
@@ -160,5 +160,3 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 		scopedLog.Warning("cache modification type not supported")
 	}
 }
-
-func (l *BPFListener) OnIPIdentityCacheGC() {}

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -33,7 +33,7 @@ var (
 
 // monitorNotify is an interface to notify the monitor about ipcache changes.
 type monitorNotify interface {
-	SendNotification(msg monitorAPI.AgentNotifyMessage) error
+	SendEvent(typ int, event interface{}) error
 }
 
 // BPFListener implements the ipcache.IPIdentityMappingBPFListener
@@ -94,11 +94,11 @@ func (l *BPFListener) notifyMonitor(modType ipcache.CacheModification,
 	case ipcache.Upsert:
 		msg := monitorAPI.IPCacheUpsertedMessage(cidr.String(), newIdentity, oldIdentityPtr,
 			newHostIP, oldHostIP, encryptKey, k8sNamespace, k8sPodName)
-		l.monitorNotify.SendNotification(msg)
+		l.monitorNotify.SendEvent(monitorAPI.MessageTypeAgent, msg)
 	case ipcache.Delete:
 		msg := monitorAPI.IPCacheDeletedMessage(cidr.String(), newIdentity, oldIdentityPtr,
 			newHostIP, oldHostIP, encryptKey, k8sNamespace, k8sPodName)
-		l.monitorNotify.SendNotification(msg)
+		l.monitorNotify.SendEvent(monitorAPI.MessageTypeAgent, msg)
 	}
 }
 

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -4,16 +4,11 @@
 package ipcache
 
 import (
-	"context"
-	"fmt"
 	"net"
-	"sync"
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/cilium/cilium/pkg/bpf"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -21,14 +16,10 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/source"
-	"github.com/cilium/cilium/pkg/time"
 )
 
 var (
 	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "datapath-ipcache")
-
-	ipcacheBPFGCControllerGroup = controller.NewGroup("ipcache-bpf-garbage-collection")
 )
 
 // monitorNotify is an interface to notify the monitor about ipcache changes.
@@ -38,10 +29,6 @@ type monitorNotify interface {
 
 // BPFListener implements the ipcache.IPIdentityMappingBPFListener
 // interface with an IPCache store that is backed by BPF maps.
-//
-// One listener is shared between callers of OnIPIdentityCacheChange() and the
-// controller launched from OnIPIdentityCacheGC(). However, The listener is not
-// updated after initialization so no locking is provided for access.
 type BPFListener struct {
 	// bpfMap is the BPF map that this listener will update when events are
 	// received from the IPCache.
@@ -49,21 +36,18 @@ type BPFListener struct {
 
 	// monitorNotify is used to notify the monitor about ipcache updates
 	monitorNotify monitorNotify
-
-	ipcache *ipcache.IPCache
 }
 
-func newListener(m *ipcacheMap.Map, mn monitorNotify, ipc *ipcache.IPCache) *BPFListener {
+func newListener(m *ipcacheMap.Map, mn monitorNotify) *BPFListener {
 	return &BPFListener{
 		bpfMap:        m,
 		monitorNotify: mn,
-		ipcache:       ipc,
 	}
 }
 
 // NewListener returns a new listener to push IPCache entries into BPF maps.
 func NewListener(mn monitorNotify, ipc *ipcache.IPCache) *BPFListener {
-	return newListener(ipcacheMap.IPCacheMap(), mn, ipc)
+	return newListener(ipcacheMap.IPCacheMap(), mn)
 }
 
 func (l *BPFListener) notifyMonitor(modType ipcache.CacheModification,
@@ -177,86 +161,4 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 	}
 }
 
-// updateStaleEntriesFunction returns a DumpCallback that will update the
-// specified "keysToRemove" map with entries that exist in the BPF map which
-// do not exist in the in-memory ipcache.
-//
-// Must be called while holding l.ipcache.Lock for reading.
-func (l *BPFListener) updateStaleEntriesFunction(keysToRemove map[string]ipcacheMap.Key) bpf.DumpCallback {
-	return func(key bpf.MapKey, _ bpf.MapValue) {
-		k := key.(*ipcacheMap.Key)
-		keyToIP := k.String()
-
-		// Don't RLock as part of the same goroutine.
-		if i, exists := l.ipcache.LookupByPrefixRLocked(keyToIP); !exists {
-			switch i.Source {
-			case source.KVStore, source.Local:
-				// Cannot delete from map during callback because DumpWithCallback
-				// RLocks the map.
-				keysToRemove[keyToIP] = *k
-			}
-		}
-	}
-}
-
-// garbageCollect implements GC of the ipcache map in the following way:
-//
-//	Periodically sweep through every element in the BPF map and check it
-//	against the in-memory copy of the map. If it doesn't exist in memory,
-//	delete the entry.
-//
-// Returns an error if garbage collection failed to occur.
-func (l *BPFListener) garbageCollect(ctx context.Context) (*sync.WaitGroup, error) {
-	log.Debug("Running garbage collection for BPF IPCache")
-
-	// Since controllers run asynchronously, need to make sure
-	// IPIdentityCache is not being updated concurrently while we
-	// do GC;
-	l.ipcache.RLock()
-	defer l.ipcache.RUnlock()
-
-	keysToRemove := map[string]ipcacheMap.Key{}
-	if err := l.bpfMap.DumpWithCallback(l.updateStaleEntriesFunction(keysToRemove)); err != nil {
-		return nil, fmt.Errorf("error dumping ipcache BPF map: %s", err)
-	}
-
-	// Remove all keys which are not in in-memory cache from BPF map
-	// for consistency.
-	for _, k := range keysToRemove {
-		log.WithFields(logrus.Fields{logfields.BPFMapKey: k}).
-			Debug("deleting from ipcache BPF map")
-		if err := l.bpfMap.Delete(&k); err != nil {
-			return nil, fmt.Errorf("error deleting key %s from ipcache BPF map: %s", k, err)
-		}
-	}
-	return nil, nil
-}
-
-// OnIPIdentityCacheGC spawns a controller which synchronizes the BPF IPCache Map
-// with the in-memory IP-Identity cache.
-func (l *BPFListener) OnIPIdentityCacheGC() {
-	// This controller ensures that the in-memory IP-identity cache is in-sync
-	// with the BPF map on disk. These can get out of sync if the cilium-agent
-	// is offline for some time, as the maps persist on the BPF filesystem.
-	// In the case that there is some loss of event history in the key-value
-	// store (e.g., compaction in etcd), we cannot rely upon the key-value store
-	// fully to give us the history of all events. As such, periodically check
-	// for inconsistencies in the data-path with that in the agent to ensure
-	// consistent state.
-	l.ipcache.UpdateController("ipcache-bpf-garbage-collection",
-		controller.ControllerParams{
-			Group: ipcacheBPFGCControllerGroup,
-			DoFunc: func(ctx context.Context) error {
-				wg, err := l.garbageCollect(ctx)
-				if err != nil {
-					return err
-				}
-				if wg != nil {
-					wg.Wait()
-				}
-				return nil
-			},
-			RunInterval: 5 * time.Minute,
-		},
-	)
-}
+func (l *BPFListener) OnIPIdentityCacheGC() {}

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/cilium/cilium/pkg/bpf"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/logging"
@@ -27,18 +28,23 @@ type monitorNotify interface {
 	SendEvent(typ int, event interface{}) error
 }
 
+type Map interface {
+	Update(key bpf.MapKey, value bpf.MapValue) error
+	Delete(key bpf.MapKey) error
+}
+
 // BPFListener implements the ipcache.IPIdentityMappingBPFListener
 // interface with an IPCache store that is backed by BPF maps.
 type BPFListener struct {
 	// bpfMap is the BPF map that this listener will update when events are
 	// received from the IPCache.
-	bpfMap *ipcacheMap.Map
+	bpfMap Map
 
 	// monitorNotify is used to notify the monitor about ipcache updates
 	monitorNotify monitorNotify
 }
 
-func newListener(m *ipcacheMap.Map, mn monitorNotify) *BPFListener {
+func newListener(m Map, mn monitorNotify) *BPFListener {
 	return &BPFListener{
 		bpfMap:        m,
 		monitorNotify: mn,

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -90,11 +90,6 @@ func (cache *NPHDSCache) HandleResourceVersionAck(ackVersion uint64, nackVersion
 	})
 }
 
-// OnIPIdentityCacheGC is required to implement IPIdentityMappingListener.
-func (cache *NPHDSCache) OnIPIdentityCacheGC() {
-	// We don't have anything to synchronize in this case.
-}
-
 // OnIPIdentityCacheChange pushes modifications to the IP<->Identity mapping
 // into the Network Policy Host Discovery Service (NPHDS).
 //

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -179,13 +179,6 @@ func (ipc *IPCache) RUnlock() {
 	ipc.mutex.RUnlock()
 }
 
-// SetListeners sets the listeners for this IPCache.
-func (ipc *IPCache) SetListeners(listeners []IPIdentityMappingListener) {
-	ipc.mutex.Lock()
-	ipc.listeners = listeners
-	ipc.mutex.Unlock()
-}
-
 // AddListener adds a listener for this IPCache.
 func (ipc *IPCache) AddListener(listener IPIdentityMappingListener) {
 	// We need to acquire the semaphored mutex as we Write Lock as we are

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -891,11 +891,3 @@ func (m *K8sMetadata) Equal(o *K8sMetadata) bool {
 	}
 	return m.Namespace == o.Namespace && m.PodName == o.PodName
 }
-
-func (ipc *IPCache) ForEachListener(f func(listener IPIdentityMappingListener)) {
-	ipc.mutex.Lock()
-	defer ipc.mutex.Unlock()
-	for _, listener := range ipc.listeners {
-		f(listener)
-	}
-}

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -602,8 +602,6 @@ func (dl *dummyListener) OnIPIdentityCacheChange(modType CacheModification,
 	}
 }
 
-func (dl *dummyListener) OnIPIdentityCacheGC() {}
-
 func (dl *dummyListener) ExpectMapping(c *C, targetIP string, targetIdentity identityPkg.NumericIdentity) {
 	// Identity lookup directly shows the expected mapping
 	identity, exists := dl.ipc.LookupByPrefix(targetIP)

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -172,7 +172,6 @@ type IPIdentityWatcher struct {
 
 type IPCacher interface {
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8sMetadata, newIdentity Identity) (bool, error)
-	ForEachListener(f func(listener IPIdentityMappingListener))
 	Delete(IP string, source source.Source) (namedPortsChanged bool)
 }
 
@@ -374,9 +373,6 @@ func (iw *IPIdentityWatcher) OnDelete(k storepkg.NamedKey) {
 }
 
 func (iw *IPIdentityWatcher) onSync(context.Context) {
-	iw.ipcache.ForEachListener(func(listener IPIdentityMappingListener) {
-		listener.OnIPIdentityCacheGC()
-	})
 	close(iw.synced)
 }
 

--- a/pkg/ipcache/listener.go
+++ b/pkg/ipcache/listener.go
@@ -32,8 +32,4 @@ type IPIdentityMappingListener interface {
 	// and may be nil.
 	OnIPIdentityCacheChange(modType CacheModification, cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP,
 		oldID *Identity, newID Identity, encryptKey uint8, k8sMeta *K8sMetadata)
-
-	// OnIPIdentityCacheGC will be called to sync other components which are
-	// reliant upon the IPIdentityCache with the IPIdentityCache.
-	OnIPIdentityCacheGC()
 }

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -581,11 +581,6 @@ func (a *Agent) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrC
 	}
 }
 
-// OnIPIdentityCacheGC implements ipcache.IPIdentityMappingListener
-func (a *Agent) OnIPIdentityCacheGC() {
-	// ignored
-}
-
 // Status returns the state of the WireGuard tunnel managed by this instance.
 // If withPeers is true, then the details about each connected peer are
 // are populated as well.


### PR DESCRIPTION
Convert the ipcache BPF listener module into a cell. Additionally drop the existing ipcache map garbage collection logic, which turned out to be buggy and not really effective, as well as not necessary. Please review commit by commit, and refer to the individual commit messages for additional details.

Related: https://github.com/cilium/cilium/issues/28004