### PR TITLE
Report node source in `cilium-dbg node list`

### DIFF
--- a/api/v1/models/node_element.go
+++ b/api/v1/models/node_element.go
@@ -40,6 +40,9 @@ type NodeElement struct {
 
 	// Alternative addresses assigned to the node
 	SecondaryAddresses []*NodeAddressingElement `json:"secondary-addresses"`
+
+	// Source of the node configuration
+	Source string `json:"source,omitempty"`
 }
 
 // Validate validates this node element

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2835,6 +2835,9 @@ definitions:
       ingress-address:
         description: Source address for Ingress listener
         "$ref": "#/definitions/NodeAddressing"
+      source:
+        description: Source of the node configuration
+        type: string
   NodeAddressing:
     description: |-
       Addressing information of a node for all address families

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -4173,6 +4173,10 @@ func init() {
           "items": {
             "$ref": "#/definitions/NodeAddressingElement"
           }
+        },
+        "source": {
+          "description": "Source of the node configuration",
+          "type": "string"
         }
       }
     },
@@ -10206,6 +10210,10 @@ func init() {
           "items": {
             "$ref": "#/definitions/NodeAddressingElement"
           }
+        },
+        "source": {
+          "description": "Source of the node configuration",
+          "type": "string"
         }
       }
     },

--- a/cilium-dbg/cmd/node_list.go
+++ b/cilium-dbg/cmd/node_list.go
@@ -52,7 +52,7 @@ func init() {
 }
 
 func formatStatusResponse(w io.Writer, nodes []*models.NodeElement) {
-	nodesOutputHeader := "Name\tIPv4 Address\tEndpoint CIDR\tIPv6 Address\tEndpoint CIDR\n"
+	nodesOutputHeader := "Name\tIPv4 Address\tEndpoint CIDR\tIPv6 Address\tEndpoint CIDR\tSource\n"
 	nodesOutput := make([]string, len(nodes))
 
 	for _, node := range nodes {
@@ -68,8 +68,8 @@ func formatStatusResponse(w io.Writer, nodes []*models.NodeElement) {
 			}
 		}
 
-		nodesOutput = append(nodesOutput, fmt.Sprintf("%s\t%s\t%s\t%s\t%s\n",
-			node.Name, ipv4, ipv4Range, ipv6, ipv6Range))
+		nodesOutput = append(nodesOutput, fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\n",
+			node.Name, ipv4, ipv4Range, ipv6, ipv6Range, node.Source))
 	}
 
 	if len(nodesOutput) > 1 {

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -788,7 +788,7 @@ func (m *manager) GetNodes() map[nodeTypes.Identity]nodeTypes.Node {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 
-	nodes := make(map[nodeTypes.Identity]nodeTypes.Node)
+	nodes := make(map[nodeTypes.Identity]nodeTypes.Node, len(m.nodes))
 	for nodeIdentity, entry := range m.nodes {
 		entry.mutex.Lock()
 		nodes[nodeIdentity] = entry.node

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -572,6 +572,7 @@ func (n *Node) GetModel() *models.NodeElement {
 		SecondaryAddresses:    n.getSecondaryAddresses(),
 		HealthEndpointAddress: n.getHealthAddresses(),
 		IngressAddress:        n.getIngressAddresses(),
+		Source:                string(n.Source),
 	}
 }
 


### PR DESCRIPTION
In some cases it might be useful to know the source of a node's configuration for debugging purposes.

Example output:

    $ cilium-dbg node list
    Name                                                 IPv4 Address   Endpoint CIDR   IPv6 Address   Endpoint CIDR   Source
    cluster-1/ip-10-1-0-232.eu-west-1.compute.internal   10.1.0.232     10.201.2.0/24                                  kvstore
    cluster-1/ip-10-1-1-119.eu-west-1.compute.internal   10.1.1.119     10.201.1.0/24                                  kvstore
    cluster-1/ip-10-1-2-37.eu-west-1.compute.internal    10.1.2.37      10.201.0.0/24                                  local
    cluster-2/ip-10-2-0-237.eu-west-1.compute.internal   10.2.0.237     10.202.0.0/24                                  kvstore
    cluster-2/ip-10-2-1-31.eu-west-1.compute.internal    10.2.1.31      10.202.1.0/24                                  kvstore
    cluster-2/ip-10-2-2-150.eu-west-1.compute.internal   10.2.2.150     10.202.2.0/24                                  kvstore