### PR TITLE
metrics: fix issue where logging err/warn metric is never updated.

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
@@ -1157,7 +1156,7 @@ func restoreExecPermissions(searchDir string, patterns ...string) error {
 
 func initLogging() {
 	// add hooks after setting up metrics in the option.Config
-	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook(components.CiliumAgentName))
+	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook())
 
 	// Logging should always be bootstrapped first. Do not add any code above this!
 	if err := logging.SetupLogging(option.Config.LogDriver, logging.LogOptions(option.Config.LogOpt), "cilium-agent", option.Config.Debug); err != nil {

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cilium/cilium/operator/pkg/secretsync"
 	operatorWatchers "github.com/cilium/cilium/operator/watchers"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
@@ -321,8 +320,8 @@ func initEnv(vp *viper.Viper) {
 	option.Config.Populate(vp)
 	operatorOption.Config.Populate(vp)
 
-	// add hooks after setting up metrics in the option.Confog
-	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook(components.CiliumOperatortName))
+	// add hooks after setting up metrics in the option.Config
+	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook())
 
 	// Logging should always be bootstrapped first. Do not add any code above this!
 	if err := logging.SetupLogging(option.Config.LogDriver, logging.LogOptions(option.Config.LogOpt), binaryName, option.Config.Debug); err != nil {

--- a/pkg/metrics/cell.go
+++ b/pkg/metrics/cell.go
@@ -8,7 +8,14 @@ import "github.com/cilium/cilium/pkg/hive/cell"
 var Cell = cell.Module("metrics", "Metrics",
 	// Provide registry to hive, but also invoke if case no cells decide to use as dependency
 	cell.Provide(NewRegistry),
-	cell.Invoke(func(_ *Registry) {}),
 	cell.Metric(NewLegacyMetrics),
 	cell.Config(defaultRegistryConfig),
+	cell.Invoke(func(_ *Registry) {
+		// This is a hack to ensure that errors/warnings collected in the pre hive initialization
+		// phase are emitted as metrics.
+		if metricsInitialized != nil {
+			close(metricsInitialized)
+			metricsInitialized = nil
+		}
+	}),
 )

--- a/pkg/metrics/logging_hook.go
+++ b/pkg/metrics/logging_hook.go
@@ -24,10 +24,6 @@ type LoggingHook struct {
 // NewLoggingHook returns a new instance of LoggingHook for the given Cilium
 // component.
 func NewLoggingHook() *LoggingHook {
-	// NOTE(mrostecki): For now errors and warning metric exists only for Cilium
-	// daemon, but support of Prometheus metrics in some other components (i.e.
-	// cilium-health - GH-4268) is planned.
-
 	lh := &LoggingHook{}
 	go func() {
 		// This channel is closed after registry is created. At this point if the errs/warnings metric

--- a/pkg/metrics/logging_hook.go
+++ b/pkg/metrics/logging_hook.go
@@ -6,39 +6,42 @@ package metrics
 import (
 	"fmt"
 	"reflect"
+	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/metrics/metric"
 )
+
+var metricsInitialized chan struct{} = make(chan struct{})
 
 // LoggingHook is a hook for logrus which counts error and warning messages as a
 // Prometheus metric.
 type LoggingHook struct {
-	metric metric.Vec[metric.Counter]
+	errs, warn atomic.Uint64
 }
 
 // NewLoggingHook returns a new instance of LoggingHook for the given Cilium
 // component.
-func NewLoggingHook(component string) *LoggingHook {
+func NewLoggingHook() *LoggingHook {
 	// NOTE(mrostecki): For now errors and warning metric exists only for Cilium
 	// daemon, but support of Prometheus metrics in some other components (i.e.
 	// cilium-health - GH-4268) is planned.
 
-	// Pick a metric for the component.
-	var metric metric.Vec[metric.Counter]
-	switch component {
-	case components.CiliumAgentName:
-		metric = ErrorsWarnings
-	case components.CiliumOperatortName:
-		metric = ErrorsWarnings
-	default:
-		panic(fmt.Sprintf("component %s is unsupported by LoggingHook", component))
-	}
-
-	return &LoggingHook{metric: metric}
+	lh := &LoggingHook{}
+	go func() {
+		// This channel is closed after registry is created. At this point if the errs/warnings metric
+		// is enabled we flush counts of errors/warnings we collected before the registry was created.
+		// This is a hack to ensure that errors/warnings collected in the pre hive initialization
+		// phase are emitted as metrics.
+		// Because the ErrorsWarnings metric is a counter, this means that the rate of these errors won't be
+		// accurate, however init errors can only happen during initialization so it probably doesn't make
+		// a big difference in practice.
+		<-metricsInitialized
+		ErrorsWarnings.WithLabelValues(logrus.ErrorLevel.String(), "init").Add(float64(lh.errs.Load()))
+		ErrorsWarnings.WithLabelValues(logrus.WarnLevel.String(), "init").Add(float64(lh.warn.Load()))
+	}()
+	return lh
 }
 
 // Levels returns the list of logging levels on which the hook is triggered.
@@ -66,8 +69,16 @@ func (h *LoggingHook) Fire(entry *logrus.Entry) error {
 		return fmt.Errorf("type of the 'subsystem' log entry field is not string but %s", reflect.TypeOf(iSubsystem))
 	}
 
+	// We count errors/warnings outside of the prometheus metric.
+	switch entry.Level {
+	case logrus.ErrorLevel:
+		h.errs.Add(1)
+	case logrus.WarnLevel:
+		h.warn.Add(1)
+	}
+
 	// Increment the metric.
-	h.metric.WithLabelValues(entry.Level.String(), subsystem).Inc()
+	ErrorsWarnings.WithLabelValues(entry.Level.String(), subsystem).Inc()
 
 	return nil
 }


### PR DESCRIPTION
Because legacy metrics are now initialized in Hive, the logging hook was being set to the NoOpCounterVec instance.

This moves initializing the errors/warnings metric out of the NewLegacyMetrics function and provides a manual way to init metrics that must be initialized prior to Hive.

