### PR TITLE
test: Use previous in-pod CLI name for updates

### DIFF
--- a/test/k8s/updates.go
+++ b/test/k8s/updates.go
@@ -115,7 +115,8 @@ var _ = Describe("K8sUpdates", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport("cilium-dbg endpoint list")
+		// TODO(joe): Switch to cilium-dbg after v1.16-dev.
+		kubectl.CiliumReport("cilium endpoint list")
 	})
 
 	JustAfterEach(func() {


### PR DESCRIPTION
This command is not available in v1.14 which the current tests are
upgrading from, which means that upon failure developers do not get the
list of endpoints. Fix it for now.

Compile-tested only.

Reported-by: Sebastian Wicki <sebastian@isovalent.com>
Fixes: #29195
