### PR TITLE
Use Resource[T] to implement CiliumNode watcher

### DIFF
--- a/clustermesh-apiserver/clustermesh/k8s/resource_ctors.go
+++ b/clustermesh-apiserver/clustermesh/k8s/resource_ctors.go
@@ -31,3 +31,16 @@ func CiliumSlimEndpointResource(lc hive.Lifecycle, cs client.Clientset, opts ...
 		}, k8s.TransformToCiliumEndpoint),
 	), nil
 }
+
+func CiliumNodeResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumNode], error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](cs.CiliumV2().CiliumNodes()),
+		opts...,
+	)
+	return resource.New[*cilium_api_v2.CiliumNode](lc, lw,
+		resource.WithMetric("CiliumNode"),
+	), nil
+}

--- a/clustermesh-apiserver/clustermesh/k8s/resources.go
+++ b/clustermesh-apiserver/clustermesh/k8s/resources.go
@@ -26,7 +26,7 @@ var (
 		cell.Provide(
 			k8s.ServiceResource,
 			k8s.EndpointsResource,
-			k8s.CiliumNodeResource,
+			CiliumNodeResource,
 			k8s.CiliumIdentityResource,
 			// The CiliumSlimEndpoint resource constructor in the agent depends on the
 			// LocalNodeStore to index its cache. In the clustermesh-apiserver, there is no

--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -107,6 +107,7 @@ type Resources struct {
 	CiliumCIDRGroups                 resource.Resource[*cilium_api_v2alpha1.CiliumCIDRGroup]
 	CiliumSlimEndpoint               resource.Resource[*types.CiliumEndpoint]
 	CiliumEndpointSlice              resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice]
+	CiliumNode                       resource.Resource[*cilium_api_v2.CiliumNode]
 }
 
 // LocalNodeResources is a convenience struct to group CiliumNode and Node resources as cell constructor parameters.

--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -57,3 +57,16 @@ func CiliumEndpointSliceResource(lc hive.Lifecycle, cs client.Clientset, opts ..
 	)
 	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](lc, lw, resource.WithMetric("CiliumEndpointSlice")), nil
 }
+
+func CiliumNodeResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumNode], error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](cs.CiliumV2().CiliumNodes()),
+		opts...,
+	)
+	return resource.New[*cilium_api_v2.CiliumNode](lc, lw,
+		resource.WithMetric("CiliumNode"),
+	), nil
+}

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -35,7 +35,7 @@ var (
 			k8s.CiliumPodIPPoolResource,
 			CiliumEndpointResource,
 			CiliumEndpointSliceResource,
-			k8s.CiliumNodeResource,
+			CiliumNodeResource,
 			k8s.PodResource,
 		),
 	)

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -87,7 +87,10 @@ func CiliumNodeResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*me
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](cs.CiliumV2().CiliumNodes()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumNode](lc, lw, resource.WithMetric("CiliumNode")), nil
+	return resource.New[*cilium_api_v2.CiliumNode](lc, lw,
+		resource.WithMetric("CiliumNode"),
+		resource.WithStoppableInformer(),
+	), nil
 }
 
 func PodResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*slim_corev1.Pod], error) {

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -5,153 +5,165 @@ package watchers
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"maps"
 	"sync"
+	"sync/atomic"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/cache"
 
-	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	"github.com/cilium/cilium/pkg/k8s/client"
-	"github.com/cilium/cilium/pkg/k8s/informer"
-	"github.com/cilium/cilium/pkg/k8s/utils"
-	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
+	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/kvstore"
-	"github.com/cilium/cilium/pkg/lock"
-	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/node/types"
 )
 
-func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient client.Clientset, asyncControllers *sync.WaitGroup) {
+func (k *K8sWatcher) ciliumNodeInit(ctx context.Context, asyncControllers *sync.WaitGroup) {
 	// CiliumNode objects are used for node discovery until the key-value
 	// store is connected
 	var once sync.Once
 	apiGroup := k8sAPIGroupCiliumNodeV2
+
 	for {
-		swgNodes := lock.NewStoppableWaitGroup()
-		ciliumNodeStore, ciliumNodeInformer := informer.NewInformer(
-			utils.ListerWatcherFromTyped[*cilium_v2.CiliumNodeList](ciliumNPClient.CiliumV2().CiliumNodes()),
-			&cilium_v2.CiliumNode{},
-			0,
-			cache.ResourceEventHandlerFuncs{
-				AddFunc: func(obj interface{}) {
-					var valid, equal bool
-					defer func() { k.K8sEventReceived(apiGroup, metricCiliumNode, resources.MetricCreate, valid, equal) }()
-					if ciliumNode := k8s.CastInformerEvent[cilium_v2.CiliumNode](obj); ciliumNode != nil {
-						valid = true
-						n := nodeTypes.ParseCiliumNode(ciliumNode)
-						if n.IsLocal() {
-							return
-						}
-						k.nodeDiscoverManager.NodeUpdated(n)
-						k.K8sEventProcessed(metricCiliumNode, resources.MetricCreate, true)
-					}
-				},
-				UpdateFunc: func(oldObj, newObj interface{}) {
-					var valid, equal bool
-					defer func() { k.K8sEventReceived(apiGroup, metricCiliumNode, resources.MetricUpdate, valid, equal) }()
-					if oldCN := k8s.CastInformerEvent[cilium_v2.CiliumNode](oldObj); oldCN != nil {
-						if ciliumNode := k8s.CastInformerEvent[cilium_v2.CiliumNode](newObj); ciliumNode != nil {
-							valid = true
-							// Comparing Annotations here since wg-pub-key annotation is used to exchange rotated WireGuard keys.
-							if oldCN.DeepEqual(ciliumNode) &&
-								comparator.MapStringEquals(oldCN.ObjectMeta.Labels, ciliumNode.ObjectMeta.Labels) &&
-								comparator.MapStringEquals(oldCN.ObjectMeta.Annotations, ciliumNode.ObjectMeta.Annotations) {
-								equal = true
-								return
-							}
-							if k8s.IsLocalCiliumNode(ciliumNode) {
-								return
-							}
-							n := nodeTypes.ParseCiliumNode(ciliumNode)
-							k.nodeDiscoverManager.NodeUpdated(n)
-							k.K8sEventProcessed(metricCiliumNode, resources.MetricUpdate, true)
-						}
-					}
-				},
-				DeleteFunc: func(obj interface{}) {
-					var equal bool
-					defer func() { k.K8sEventReceived(apiGroup, metricCiliumNode, resources.MetricDelete, true, equal) }()
-					ciliumNode := k8s.CastInformerEvent[cilium_v2.CiliumNode](obj)
-					if ciliumNode == nil {
-						return
-					}
-					n := nodeTypes.ParseCiliumNode(ciliumNode)
-					k.nodeDiscoverManager.NodeDeleted(n)
-				},
-			},
+		var synced atomic.Bool
+		stop := make(chan struct{})
+
+		k.blockWaitGroupToSyncResources(
+			stop,
 			nil,
+			func() bool { return synced.Load() },
+			apiGroup,
 		)
-		isConnected := make(chan struct{})
-		// once isConnected is closed, it will stop waiting on caches to be
-		// synchronized.
-		k.blockWaitGroupToSyncResources(isConnected, swgNodes, ciliumNodeInformer.HasSynced, apiGroup)
-
-		k.ciliumNodeStoreMU.Lock()
-		k.ciliumNodeStore = ciliumNodeStore
-		k.ciliumNodeStoreMU.Unlock()
-
-		once.Do(func() {
-			// Signalize that we have put node controller in the wait group
-			// to sync resources.
-			asyncControllers.Done()
-		})
 		k.k8sAPIGroups.AddAPI(apiGroup)
-		go ciliumNodeInformer.Run(isConnected)
 
-		<-kvstore.Connected()
-		log.Info("Connected to key-value store, stopping CiliumNode watcher")
+		// Signalize that we have put node controller in the wait group to sync resources.
+		once.Do(asyncControllers.Done)
 
-		// Set the ciliumNodeStore as nil so that any attempts of getting the
-		// CiliumNode are performed with a request sent to kube-apiserver
-		// directly instead of relying on an outdated version of the CiliumNode
-		// in this cache.
-		k.ciliumNodeStoreMU.Lock()
-		k.ciliumNodeStore = nil
-		k.ciliumNodeStoreMU.Unlock()
+		// derive another context to signal Events() and Store() in case of kvstore connection
+		subCtx, cancel := context.WithCancel(ctx)
 
-		close(isConnected)
+		var wg sync.WaitGroup
 
-		k.cancelWaitGroupToSyncResources(apiGroup)
-		k.k8sAPIGroups.RemoveAPI(apiGroup)
-		// Create a new node controller when we are disconnected with the
-		// kvstore
-		<-kvstore.Client().Disconnected()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer close(stop)
 
-		log.Info("Disconnected from key-value store, restarting CiliumNode watcher")
+			events := k.resources.CiliumNode.Events(subCtx)
+			cache := make(map[resource.Key]*cilium_v2.CiliumNode)
+			for event := range events {
+				var err error
+				switch event.Kind {
+				case resource.Sync:
+					synced.Store(true)
+				case resource.Upsert:
+					var needUpdate bool
+					oldObj, ok := cache[event.Key]
+					if !ok {
+						needUpdate = k.onCiliumNodeInsert(event.Object)
+					} else {
+						needUpdate = k.onCiliumNodeUpdate(oldObj, event.Object)
+					}
+					if needUpdate {
+						cache[event.Key] = event.Object.DeepCopy()
+					}
+				case resource.Delete:
+					k.onCiliumNodeDelete(event.Object)
+					delete(cache, event.Key)
+				}
+				event.Done(err)
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			store, err := k.resources.CiliumNode.Store(subCtx)
+			if err != nil {
+				if !errors.Is(err, context.Canceled) {
+					log.WithError(err).Warning("unable to retrieve CiliumNode local store, going to query kube-apiserver directly")
+				}
+				return
+			}
+
+			k.ciliumNodeStore.Store(&store)
+
+			<-subCtx.Done()
+
+			store.Release()
+			k.ciliumNodeStore.Store(nil)
+		}()
+
+		select {
+		case <-kvstore.Connected():
+			log.Info("Connected to key-value store, stopping CiliumNode watcher")
+			cancel()
+			k.cancelWaitGroupToSyncResources(apiGroup)
+			k.k8sAPIGroups.RemoveAPI(apiGroup)
+			wg.Wait()
+		case <-ctx.Done():
+			cancel()
+			wg.Wait()
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-kvstore.Client().Disconnected():
+			log.Info("Disconnected from key-value store, restarting CiliumNode watcher")
+		}
 	}
 }
 
-// GetCiliumNode returns the CiliumNode "nodeName" from the local store. If the
-// local store is not initialized then it will fallback retrieving the node
-// from kube-apiserver.
-func (k *K8sWatcher) GetCiliumNode(ctx context.Context, nodeName string) (*cilium_v2.CiliumNode, error) {
-	var (
-		err                      error
-		nodeInterface            interface{}
-		exists, getFromAPIServer bool
-	)
-	k.ciliumNodeStoreMU.RLock()
-	// k.ciliumNodeStore might not be set in all invocations of GetCiliumNode,
-	// for example, during Cilium initialization GetCiliumNode is called from
-	// WaitForNodeInformation, which happens before ciliumNodeStore,
-	// so we will fallback to perform an API request to kube-apiserver.
-	if k.ciliumNodeStore == nil {
-		getFromAPIServer = true
-	} else {
-		nodeInterface, exists, err = k.ciliumNodeStore.GetByKey(nodeName)
+func (k *K8sWatcher) onCiliumNodeInsert(ciliumNode *cilium_v2.CiliumNode) bool {
+	if k8s.IsLocalCiliumNode(ciliumNode) {
+		return false
 	}
-	k.ciliumNodeStoreMU.RUnlock()
+	n := types.ParseCiliumNode(ciliumNode)
+	k.nodeDiscoverManager.NodeUpdated(n)
+	return true
+}
 
-	if !exists || getFromAPIServer {
-		// fallback to using the kube-apiserver
+func (k *K8sWatcher) onCiliumNodeUpdate(oldNode, newNode *cilium_v2.CiliumNode) bool {
+	// Comparing Annotations here since wg-pub-key annotation is used to exchange rotated WireGuard keys.
+	if oldNode.DeepEqual(newNode) &&
+		maps.Equal(oldNode.ObjectMeta.Labels, newNode.ObjectMeta.Labels) &&
+		maps.Equal(oldNode.ObjectMeta.Annotations, newNode.ObjectMeta.Annotations) {
+		return false
+	}
+	return k.onCiliumNodeInsert(newNode)
+}
+
+func (k *K8sWatcher) onCiliumNodeDelete(ciliumNode *cilium_v2.CiliumNode) {
+	if k8s.IsLocalCiliumNode(ciliumNode) {
+		return
+	}
+	n := types.ParseCiliumNode(ciliumNode)
+	k.nodeDiscoverManager.NodeDeleted(n)
+}
+
+// GetCiliumNode returns the CiliumNode "nodeName" from the local Resource[T] store. If the
+// local Resource[T] store is not initialized or the key value store is connected, then it will
+// retrieve the node from kube-apiserver.
+// Note that it may be possible (although rare) that the requested nodeName is not yet in the
+// store if the local cache is falling behind due to the high amount of CiliumNode events
+// received from the k8s API server. To mitigate this, the caller should retry GetCiliumNode
+// for a given interval to be sure that a CiliumNode with that name has not actually been created.
+func (k *K8sWatcher) GetCiliumNode(ctx context.Context, nodeName string) (*cilium_v2.CiliumNode, error) {
+	store := k.ciliumNodeStore.Load()
+	if store == nil {
 		return k.clientset.CiliumV2().CiliumNodes().Get(ctx, nodeName, v1.GetOptions{})
 	}
 
+	ciliumNode, exists, err := (*store).GetByKey(resource.Key{Name: nodeName})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to get CiliumNode %s from local store: %w", nodeName, err)
 	}
 	if !exists {
 		return nil, k8sErrors.NewNotFound(schema.GroupResource{
@@ -159,5 +171,5 @@ func (k *K8sWatcher) GetCiliumNode(ctx context.Context, nodeName string) (*ciliu
 			Resource: "CiliumNode",
 		}, nodeName)
 	}
-	return nodeInterface.(*cilium_v2.CiliumNode).DeepCopy(), nil
+	return ciliumNode.DeepCopy(), nil
 }


### PR DESCRIPTION
Use Resource[T] to implement the CiliumNode k8s watcher. This removes the additional informer previously used, reducing the queries to the kube-apiserver and reducing the memory needed for the additional local cache.

Please refer to the individual commits for further details.

Depends on: ~https://github.com/cilium/cilium/pull/29414~

Related: https://github.com/cilium/cilium/issues/28159