### PR TITLE
api: Allow middleware to be injected via Hive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,6 @@ endif
 # meaning 'all subpackages of the given package'.
 TESTPKGS ?= ./...
 
-SWAGGER_VERSION := v0.30.3
-SWAGGER := $(CONTAINER_ENGINE) run -u $(shell id -u):$(shell id -g) --rm -v $(CURDIR):$(CURDIR) -w $(CURDIR) --entrypoint swagger quay.io/goswagger/swagger:$(SWAGGER_VERSION)
-
 GOTEST_BASE := -timeout 600s
 GOTEST_COVER_OPTS += -coverprofile=coverage.out
 BENCH_EVAL := "."

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -68,6 +68,9 @@ CONSUL_IMAGE=consul:1.7.2
 export CILIUM_CLI ?= cilium
 export KUBECTL ?= kubectl
 
+SWAGGER_VERSION := v0.30.3
+SWAGGER := $(CONTAINER_ENGINE) run -u $(shell id -u):$(shell id -g) --rm -v $(ROOT_DIR):$(ROOT_DIR) -w $(ROOT_DIR) --entrypoint swagger quay.io/goswagger/swagger:$(SWAGGER_VERSION)
+
 # go build/test/clean flags
 # these are declared here so they are treated explicitly
 # as non-immediate variables

--- a/api/v1/operator/server/server.go
+++ b/api/v1/operator/server/server.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/loads"
+	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -54,6 +55,8 @@ type apiParams struct {
 
 	Spec *Spec
 
+	Middleware middleware.Builder `name:"cilium-operator-middleware" optional:"true"`
+
 	OperatorGetHealthzHandler operator.GetHealthzHandler
 	MetricsGetMetricsHandler  metrics.GetMetricsHandler
 }
@@ -65,6 +68,13 @@ func newAPI(p apiParams) *restapi.CiliumOperatorAPI {
 
 	api.OperatorGetHealthzHandler = p.OperatorGetHealthzHandler
 	api.MetricsGetMetricsHandler = p.MetricsGetMetricsHandler
+
+	// Inject custom middleware if provided by Hive
+	if p.Middleware != nil {
+		api.Middleware = func(builder middleware.Builder) http.Handler {
+			return p.Middleware(api.Context().APIHandler(builder))
+		}
+	}
 
 	return api
 }

--- a/api/v1/server.gotmpl
+++ b/api/v1/server.gotmpl
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/loads"
+	"github.com/go-openapi/runtime/middleware"
   "github.com/go-openapi/swag"
   {{ if .UsePFlags }}flag "github.com/spf13/pflag"
   {{ end -}}
@@ -54,6 +55,8 @@ type apiParams struct {
 
 	Spec       *Spec
 
+	Middleware middleware.Builder `name:"{{ dasherize .Name }}-middleware" optional:"true"`
+
 	{{- $package := .Package }}
 	{{ range .Operations }}
 		{{ if ne  .Package $package }}{{ pascalize .Package }}{{ end }}{{ pascalize .Name }}Handler {{ .PackageAlias }}.{{ pascalize .Name }}Handler
@@ -69,6 +72,13 @@ func newAPI(p apiParams) *{{ .Package }}.{{pascalize .Name}}API {
 	{{ range .Operations }}
 	  api.{{ if ne  .Package $package }}{{ pascalize .Package }}{{ end }}{{ pascalize .Name }}Handler = p.{{ if ne  .Package $package }}{{ pascalize .Package }}{{ end }}{{ pascalize .Name }}Handler
 	{{- end }}
+
+        // Inject custom middleware if provided by Hive
+	if p.Middleware != nil {
+		api.Middleware = func(builder middleware.Builder) http.Handler {
+                      return p.Middleware(api.Context().APIHandler(builder))
+		}
+	}
 
 	return api
 }

--- a/api/v1/server/server.go
+++ b/api/v1/server/server.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/loads"
+	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -61,6 +62,8 @@ type apiParams struct {
 	cell.In
 
 	Spec *Spec
+
+	Middleware middleware.Builder `name:"cilium-api-middleware" optional:"true"`
 
 	EndpointDeleteEndpointHandler        endpoint.DeleteEndpointHandler
 	EndpointDeleteEndpointIDHandler      endpoint.DeleteEndpointIDHandler
@@ -181,6 +184,13 @@ func newAPI(p apiParams) *restapi.CiliumAPIAPI {
 	api.PolicyPutPolicyHandler = p.PolicyPutPolicyHandler
 	api.RecorderPutRecorderIDHandler = p.RecorderPutRecorderIDHandler
 	api.ServicePutServiceIDHandler = p.ServicePutServiceIDHandler
+
+	// Inject custom middleware if provided by Hive
+	if p.Middleware != nil {
+		api.Middleware = func(builder middleware.Builder) http.Handler {
+			return p.Middleware(api.Context().APIHandler(builder))
+		}
+	}
 
 	return api
 }

--- a/cilium-dbg/cmd/map_event_list.go
+++ b/cilium-dbg/cmd/map_event_list.go
@@ -41,7 +41,7 @@ var mapEventListCmd = &cobra.Command{
 
 		var c *clientPkg.Client
 		var rt *runtime_client.Runtime
-		if r, err := clientPkg.NewRuntime(vp.GetString("host")); err != nil {
+		if r, err := clientPkg.NewRuntime(vp.GetString("host"), ""); err != nil {
 			Fatalf("Error while creating client: %s\n", err)
 		} else {
 			rt = r

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -107,13 +107,16 @@ func NewDefaultClientWithTimeout(timeout time.Duration) (*Client, error) {
 // If host is nil then use SockPath provided by CILIUM_SOCK
 // or the cilium default SockPath
 func NewClient(host string) (*Client, error) {
-	clientTrans, err := NewRuntime(host)
+	clientTrans, err := NewRuntime(host, "")
 	return &Client{*clientapi.New(clientTrans, strfmt.Default)}, err
 }
 
-func NewRuntime(host string) (*runtime_client.Runtime, error) {
+func NewRuntime(host, basePath string) (*runtime_client.Runtime, error) {
 	if host == "" {
 		host = DefaultSockPath()
+	}
+	if basePath == "" {
+		basePath = clientapi.DefaultBasePath
 	}
 	tmp := strings.SplitN(host, "://", 2)
 	if len(tmp) != 2 {
@@ -138,7 +141,7 @@ func NewRuntime(host string) (*runtime_client.Runtime, error) {
 
 	transport := configureTransport(nil, tmp[0], host)
 	httpClient := &http.Client{Transport: transport}
-	clientTrans := runtime_client.NewWithClient(hostHeader, clientapi.DefaultBasePath,
+	clientTrans := runtime_client.NewWithClient(hostHeader, basePath,
 		clientapi.DefaultSchemes, httpClient)
 	return clientTrans, nil
 }


### PR DESCRIPTION
This PR extends the Cilium API server cell with the ability to inject a global middleware. The middleware injected here is a global executed after the middlewares injected by `setupGlobalMiddleware`, but before the API method dispatch. See [1] for more details.

This allows the Hive-injected middleware to benefit from global middleware handlers such as our panic and metrics handlers, but before any swagger specific handlers are called. The middleware is optional, as it is intended to be used for out-of-tree API implementations. The middleware parameter is named, so it only applies to a particular
OpenAPI spec, thereby allowing for specialization of that API.

[1] https://goswagger.io/use/middleware.html

The other two commits in this PR are quality-of-life improvements for users with custom API extensions.