### PR TITLE
Fix Cilium Datapath Prometheus metric names

### DIFF
--- a/pkg/maps/metricsmap/metricsmap.go
+++ b/pkg/maps/metricsmap/metricsmap.go
@@ -174,22 +174,22 @@ func newMetricsMapCollector() prometheus.Collector {
 		droppedMetricsMap:   make(map[dropLabels]metricValues),
 		forwardedMetricsMap: make(map[forwardLabels]metricValues),
 		droppedByteDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(metrics.Namespace, metrics.SubsystemDatapath, "drop_bytes_total"),
+			prometheus.BuildFQName(metrics.Namespace, "", "drop_bytes_total"),
 			"Total dropped bytes, tagged by drop reason and ingress/egress direction",
 			[]string{metrics.LabelDropReason, metrics.LabelDirection}, nil,
 		),
 		droppedCountDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(metrics.Namespace, metrics.SubsystemDatapath, "drop_count_total"),
+			prometheus.BuildFQName(metrics.Namespace, "", "drop_count_total"),
 			"Total dropped packets, tagged by drop reason and ingress/egress direction",
 			[]string{metrics.LabelDropReason, metrics.LabelDirection}, nil,
 		),
 		forwardCountDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(metrics.Namespace, metrics.SubsystemDatapath, "forward_count_total"),
+			prometheus.BuildFQName(metrics.Namespace, "", "forward_count_total"),
 			"Total forwarded packets, tagged by ingress/egress direction",
 			[]string{metrics.LabelDirection}, nil,
 		),
 		forwardByteDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(metrics.Namespace, metrics.SubsystemDatapath, "forward_bytes_total"),
+			prometheus.BuildFQName(metrics.Namespace, "", "forward_bytes_total"),
 			"Total forwarded bytes, tagged by ingress/egress direction",
 			[]string{metrics.LabelDirection}, nil,
 		),


### PR DESCRIPTION
Commit [f8e9472](https://github.com/cilium/cilium/commit/f8e94721fcebe4f9e0d45d4d914949ffb7467ad1#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23) adds subsystem information to cilium_[forward|drop]_[count_bytes]_total metrics. This change was not intended. This commit removes subsystem info from metric names.

Fixes: #29213
Fixes: https://github.com/cilium/cilium/pull/27370.
