### PR TITLE
endpointstate: Add an interface to wait for endpoint restore

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -424,6 +424,7 @@ Makefile* @cilium/build
 /pkg/elf @cilium/sig-datapath
 /pkg/endpoint/ @cilium/endpoint
 /pkg/endpointmanager/ @cilium/endpoint
+/pkg/endpointstate/ @cilium/endpoint
 /pkg/envoy/ @cilium/proxy
 /pkg/flowdebug/ @cilium/proxy
 /pkg/fqdn/ @cilium/sig-agent @cilium/proxy

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -156,6 +156,8 @@ type Daemon struct {
 
 	endpointManager endpointmanager.EndpointManager
 
+	endpointRestoreComplete chan struct{}
+
 	identityAllocator CachingIdentityAllocator
 
 	ipcache *ipcache.IPCache

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/cilium/cilium/pkg/egressgateway"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/endpointstate"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/hive"
@@ -1605,6 +1606,7 @@ var daemonCell = cell.Module(
 	"Legacy Daemon",
 
 	cell.Provide(newDaemonPromise),
+	cell.Provide(newRestorerPromise),
 	cell.Provide(func() k8s.CacheStatus { return make(k8s.CacheStatus) }),
 	// Provide a read-only copy of the current daemon settings to be consumed
 	// by the debuginfo API
@@ -1730,7 +1732,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 		<-params.CacheStatus
 	}
 	bootstrapStats.k8sInit.End(true)
-	restoreComplete := d.initRestore(restoredEndpoints, params.EndpointRegenerator)
+	d.initRestore(restoredEndpoints, params.EndpointRegenerator)
 
 	if params.WGAgent != nil {
 		go func() {
@@ -1780,8 +1782,8 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 	}
 
 	go func() {
-		if restoreComplete != nil {
-			<-restoreComplete
+		if d.endpointRestoreComplete != nil {
+			<-d.endpointRestoreComplete
 		}
 		// Only attempt CEP cleanup if cilium endpoint CRD is enabled, otherwise the cep/ces
 		// watchers/indexers will not be initialized.
@@ -1820,8 +1822,8 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 	}()
 
 	go func() {
-		if restoreComplete != nil {
-			<-restoreComplete
+		if d.endpointRestoreComplete != nil {
+			<-d.endpointRestoreComplete
 		}
 		d.dnsNameManager.CompleteBootstrap()
 
@@ -1920,6 +1922,22 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 	if err != nil {
 		log.WithError(err).Error("Unable to store Viper's configuration")
 	}
+}
+
+func newRestorerPromise(lc hive.Lifecycle, daemonPromise promise.Promise[*Daemon]) promise.Promise[endpointstate.Restorer] {
+	resolver, promise := promise.New[endpointstate.Restorer]()
+	lc.Append(hive.Hook{
+		OnStart: func(ctx hive.HookContext) error {
+			daemon, err := daemonPromise.Await(context.Background())
+			if err != nil {
+				resolver.Reject(err)
+				return err
+			}
+			resolver.Resolve(daemon)
+			return nil
+		},
+	})
+	return promise
 }
 
 func initClockSourceOption() {

--- a/pkg/endpointstate/restorer.go
+++ b/pkg/endpointstate/restorer.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpointstate
+
+import "context"
+
+// Restorer wraps a method to wait for endpoints restoration.
+type Restorer interface {
+	// WaitForEndpointRestore blocks the caller until either the context is
+	// cancelled or all the endpoints have been restored from a previous run.
+	WaitForEndpointRestore(ctx context.Context)
+}


### PR DESCRIPTION
Provide an API to let callers wait for the endpoint restoration to be completed.  To avoid import cycles, the interface wrapping the API is defined outside of the `daemon/cmd` package where it is implemented. This allows cells to require an `endpointstate.Restorer` through Hive dependency injection without pulling in the `daemon/cmd` package.

This is a required step to migrate the k8s CEP watchers to Resource[T]. Refer to [this comment](https://github.com/cilium/cilium/issues/28159#issuecomment-1816498303) for more information.

Related: https://github.com/cilium/cilium/issues/28159
