### PR TITLE
Add CEP and CES resources

### DIFF
--- a/clustermesh-apiserver/clustermesh/k8s/resource_ctors.go
+++ b/clustermesh-apiserver/clustermesh/k8s/resource_ctors.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/k8s"
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+)
+
+func CiliumSlimEndpointResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*types.CiliumEndpoint], error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumEndpointList](cs.CiliumV2().CiliumEndpoints(slim_corev1.NamespaceAll)),
+		opts...,
+	)
+	return resource.New[*types.CiliumEndpoint](lc, lw,
+		resource.WithLazyTransform(func() runtime.Object {
+			return &cilium_api_v2.CiliumEndpoint{}
+		}, k8s.TransformToCiliumEndpoint),
+	), nil
+}

--- a/clustermesh-apiserver/clustermesh/k8s/resources.go
+++ b/clustermesh-apiserver/clustermesh/k8s/resources.go
@@ -28,7 +28,11 @@ var (
 			k8s.EndpointsResource,
 			k8s.CiliumNodeResource,
 			k8s.CiliumIdentityResource,
-			k8s.CiliumSlimEndpointResource,
+			// The CiliumSlimEndpoint resource constructor in the agent depends on the
+			// LocalNodeStore to index its cache. In the clustermesh-apiserver, there is no
+			// cell providing LocalNodeStore, so we provide the resource with a separate
+			// constructor.
+			CiliumSlimEndpointResource,
 			k8s.CiliumExternalWorkloads,
 		),
 	)

--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -41,6 +41,7 @@ var (
 			k8s.CiliumCIDRGroupResource,
 			k8s.CiliumNodeResource,
 			k8s.CiliumSlimEndpointResource,
+			k8s.CiliumEndpointSliceResource,
 		),
 	)
 

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -306,6 +306,7 @@ func CiliumSlimEndpointResource(lc hive.Lifecycle, cs client.Clientset, _ *node.
 		resource.WithLazyTransform(func() runtime.Object {
 			return &cilium_api_v2.CiliumEndpoint{}
 		}, TransformToCiliumEndpoint),
+		resource.WithMetric("CiliumEndpoint"),
 		resource.WithIndexers(indexers),
 	), nil
 }


### PR DESCRIPTION
This is a required step to migrate the k8s CEP watchers to Resource[T].

First, the PR adds a separate constructor for the CiliumSlimEndpoint resource in the clustermesh-apiserver. The apiserver is currently using the same constructor used by the agent and this limits the ability to add indexers that depend on agent-specific part.
Then, the PR adds the CES resource constructor and the same indexers already used by the informers in the CEP and CES k8s watchers.

Refer to [this comment](https://github.com/cilium/cilium/issues/28159#issuecomment-1816498303) and to the individual commit messages for more information.

Related: https://github.com/cilium/cilium/issues/28159
