### PR TITLE
Add cilium operator go runtime sched latency metrics

### DIFF
--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -6,6 +6,7 @@ package metrics
 import (
 	"errors"
 	"net/http"
+	"regexp"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -18,6 +19,9 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
 )
+
+// goCustomCollectorsRX tracks enabled go runtime metrics.
+var goCustomCollectorsRX = regexp.MustCompile(`^/sched/latencies:seconds`)
 
 type params struct {
 	cell.In
@@ -87,6 +91,10 @@ func registerMetricsManager(p params) {
 		Registry = controllerRuntimeMetrics.Registry
 	} else {
 		Registry = prometheus.NewPedanticRegistry()
+		Registry.MustRegister(collectors.NewGoCollector(
+			collectors.WithGoCollectorRuntimeMetrics(
+				collectors.GoRuntimeMetricsRule{Matcher: goCustomCollectorsRX},
+			)))
 	}
 
 	Registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{Namespace: metrics.CiliumOperatorNamespace}))


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

The operator depends on various goroutines being scheduled one time to perform critical tasks. Significatn scheduling lags could indicate potential issues with the operator functions.

- Added GO scheduler latency metrics tracking to the cilium operator.

```release-note
Expose Cilium operator go runtime scheduler latency prometheus metric `go_sched_latencies_seconds`
```

Signed-off-by: Fernand Galiana <fernand.galiana@gmail.com>