### PR TITLE
Fix labels synchronization issues on Cilium

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -344,7 +344,7 @@ func LaunchAsEndpoint(baseCtx context.Context,
 	// Give the endpoint a security identity
 	ctx, cancel := context.WithTimeout(baseCtx, LaunchTime)
 	defer cancel()
-	ep.UpdateLabels(ctx, labels.LabelHealth, nil, true)
+	ep.UpdateLabels(ctx, labels.LabelSourceAny, labels.LabelHealth, nil, true)
 
 	// Initialize the health client to talk to this instance.
 	client := &Client{host: "http://" + net.JoinHostPort(healthIP.String(), strconv.Itoa(option.Config.ClusterHealthPort))}

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -497,7 +497,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 		// and update the endpoint with these labels.
 		ep.RunMetadataResolver(d.bwManager, d.fetchK8sMetadataForEndpoint)
 	} else {
-		regenTriggered = ep.UpdateLabels(ctx, addLabels, infoLabels, true)
+		regenTriggered = ep.UpdateLabels(ctx, labels.LabelSourceAny, addLabels, infoLabels, true)
 	}
 
 	select {
@@ -989,7 +989,7 @@ func (d *Daemon) modifyEndpointIdentityLabelsFromAPI(id string, add, del labels.
 		return PatchEndpointIDInvalidCode, err
 	}
 
-	if err := ep.ModifyIdentityLabels(addLabels, delLabels); err != nil {
+	if err := ep.ModifyIdentityLabels(labels.LabelSourceAny, addLabels, delLabels); err != nil {
 		return PatchEndpointIDLabelsNotFoundCode, err
 	}
 

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"runtime"
@@ -411,16 +412,16 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 		return invalidDataError(ep, err)
 	}
 
-	addLabels := labels.NewLabelsFromModel(epTemplate.Labels)
+	apiLabels := labels.NewLabelsFromModel(epTemplate.Labels)
 	infoLabels := labels.NewLabelsFromModel([]string{})
 
-	if len(addLabels) > 0 {
-		if lbls := addLabels.FindReserved(); lbls != nil {
+	if len(apiLabels) > 0 {
+		if lbls := apiLabels.FindReserved(); lbls != nil {
 			return invalidDataError(ep, fmt.Errorf("not allowed to add reserved labels: %s", lbls))
 		}
 
-		addLabels, _ = labelsfilter.Filter(addLabels)
-		if len(addLabels) == 0 {
+		apiLabels, _ = labelsfilter.Filter(apiLabels)
+		if len(apiLabels) == 0 {
 			return invalidDataError(ep, fmt.Errorf("no valid labels provided"))
 		}
 	}
@@ -430,15 +431,17 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 	d.endpointCreations.NewCreateRequest(ep, cancel)
 	defer d.endpointCreations.EndCreateRequest(ep)
 
+	identityLbls := maps.Clone(apiLabels)
+
 	if ep.K8sNamespaceAndPodNameIsSet() && d.clientset.IsEnabled() {
-		pod, cp, identityLabels, info, annotations, err := d.fetchK8sMetadataForEndpoint(ep.K8sNamespace, ep.K8sPodName)
+		pod, cp, k8sIdentityLbls, k8sInfoLbls, annotations, err := d.fetchK8sMetadataForEndpoint(ep.K8sNamespace, ep.K8sPodName)
 		if err != nil {
 			ep.Logger("api").WithError(err).Warning("Unable to fetch kubernetes labels")
 		} else {
 			ep.SetPod(pod)
 			ep.SetK8sMetadata(cp)
-			addLabels.MergeLabels(identityLabels)
-			infoLabels.MergeLabels(info)
+			identityLbls.MergeLabels(k8sIdentityLbls)
+			infoLabels.MergeLabels(k8sInfoLbls)
 			if _, ok := annotations[bandwidth.IngressBandwidth]; ok {
 				log.WithFields(logrus.Fields{
 					logfields.K8sPodName:  epTemplate.K8sNamespace + "/" + epTemplate.K8sPodName,
@@ -458,11 +461,11 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 
 	// The following docs describe the cases where the init identity is used:
 	// http://docs.cilium.io/en/latest/policy/lifecycle/#init-identity
-	if len(addLabels) == 0 {
+	if len(identityLbls) == 0 {
 		// If the endpoint has no labels, give the endpoint a special identity with
 		// label reserved:init so we can generate a custom policy for it until we
 		// get its actual identity.
-		addLabels = labels.Labels{
+		identityLbls = labels.Labels{
 			labels.IDNameInit: labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved),
 		}
 	}
@@ -474,8 +477,8 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 	if ep.K8sNamespaceAndPodNameIsSet() && d.clientset.IsEnabled() {
 		// If there are labels, but no pod namespace, then it's
 		// likely that there are no k8s labels at all. Resolve.
-		if _, k8sLabelsConfigured := addLabels[k8sConst.PodNamespaceLabel]; !k8sLabelsConfigured {
-			ep.RunMetadataResolver(d.bwManager, d.fetchK8sMetadataForEndpoint)
+		if _, k8sLabelsConfigured := identityLbls[k8sConst.PodNamespaceLabel]; !k8sLabelsConfigured {
+			ep.RunMetadataResolver(false, false, apiLabels, d.bwManager, d.fetchK8sMetadataForEndpoint)
 		}
 	}
 
@@ -495,9 +498,10 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 		// since the pod event handler would not find the endpoint for that pod
 		// in the endpoint manager. Thus, we will fetch the labels again
 		// and update the endpoint with these labels.
-		ep.RunMetadataResolver(d.bwManager, d.fetchK8sMetadataForEndpoint)
+		// Wait for the regeneration to be triggered before continuing.
+		regenTriggered = ep.RunMetadataResolver(false, true, apiLabels, d.bwManager, d.fetchK8sMetadataForEndpoint)
 	} else {
-		regenTriggered = ep.UpdateLabels(ctx, labels.LabelSourceAny, addLabels, infoLabels, true)
+		regenTriggered = ep.UpdateLabels(ctx, labels.LabelSourceAny, identityLbls, infoLabels, true)
 	}
 
 	select {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -92,7 +92,7 @@ func (d *Daemon) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error)
 		// which the endpoint manager will begin processing the events off the
 		// queue.
 		ep.InitEventQueue()
-		ep.RunMetadataResolver(d.bwManager, d.fetchK8sMetadataForEndpoint)
+		ep.RunRestoredMetadataResolver(d.bwManager, d.fetchK8sMetadataForEndpoint)
 	}
 
 	if err := ep.ValidateConnectorPlumbing(checkLink); err != nil {
@@ -338,7 +338,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState, endpoi
 
 			if ep.IsHost() {
 				log.WithField(logfields.EndpointID, ep.ID).Info("Successfully restored endpoint. Scheduling regeneration")
-				if err := ep.RegenerateAfterRestore(endpointsRegenerator); err != nil {
+				if err := ep.RegenerateAfterRestore(endpointsRegenerator, d.bwManager, d.fetchK8sMetadataForEndpoint); err != nil {
 					log.WithField(logfields.EndpointID, ep.ID).WithError(err).Debug("error regenerating restored host endpoint")
 					epRegenerated <- false
 				} else {
@@ -356,7 +356,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState, endpoi
 		}
 		log.WithField(logfields.EndpointID, ep.ID).Info("Successfully restored endpoint. Scheduling regeneration")
 		go func(ep *endpoint.Endpoint, epRegenerated chan<- bool) {
-			if err := ep.RegenerateAfterRestore(endpointsRegenerator); err != nil {
+			if err := ep.RegenerateAfterRestore(endpointsRegenerator, d.bwManager, d.fetchK8sMetadataForEndpoint); err != nil {
 				log.WithField(logfields.EndpointID, ep.ID).WithError(err).Debug("error regenerating during restore")
 				epRegenerated <- false
 				return

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -525,8 +525,8 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 		// no need to set changed here
 	}
 
-	e.replaceInformationLabels(newEp.OpLabels.OrchestrationInfo)
-	rev := e.replaceIdentityLabels(newEp.OpLabels.IdentityLabels())
+	e.replaceInformationLabels(labels.LabelSourceAny, newEp.OpLabels.OrchestrationInfo)
+	rev := e.replaceIdentityLabels(labels.LabelSourceAny, newEp.OpLabels.IdentityLabels())
 	if rev != 0 {
 		// Run as a goroutine since the runIdentityResolver needs to get the lock
 		go e.runIdentityResolver(e.aliveCtx, rev, false)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1662,7 +1662,12 @@ func (e *Endpoint) RunMetadataResolver(bwm bandwidth.Manager, resolveMetadata Me
 		controller.ControllerParams{
 			Group: resolveLabelsControllerGroup,
 			DoFunc: func(ctx context.Context) error {
+				if e.K8sNamespaceAndPodNameIsSet() {
+					e.Logger(resolveLabels).Debug("Namespace and Pod are not set")
+					return nil
+				}
 				ns, podName := e.GetK8sNamespace(), e.GetK8sPodName()
+
 				pod, cp, identityLabels, info, _, err := resolveMetadata(ns, podName)
 				if err != nil {
 					e.Logger(resolveLabels).WithError(err).Warning("Unable to fetch kubernetes labels")

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1634,6 +1634,100 @@ func (e *Endpoint) APICanModifyConfig(n models.ConfigurationMap) error {
 	return nil
 }
 
+// metadataResolver will resolve the endpoint's metadata from a metadata
+// resolver.
+//
+//   - restoredEndpoint - should be set to 'true' if the endpoint is being
+//     restored.
+//
+//   - blocking - will block this function until the endpoint receives a new
+//     security identity, and it is regenerated. If 'false', this
+//     operation will be done in the background and 'regenTriggered'
+//     will always be 'false'.
+//
+//   - bwm - the bandwidth manager used to update the bandwidth policy for this
+//     endpoint.
+//
+//   - resolveMetadata - the metadata resolver that will be used to retrieve this
+//     endpoint's metadata.
+func (e *Endpoint) metadataResolver(ctx context.Context,
+	restoredEndpoint, blocking bool,
+	baseLabels labels.Labels,
+	bwm bandwidth.Manager,
+	resolveMetadata MetadataResolverCB) (regenTriggered bool, err error) {
+	if !e.K8sNamespaceAndPodNameIsSet() {
+		e.Logger(resolveLabels).Debug("Namespace and Pod are not set")
+		return false, nil
+	}
+
+	// copy the base labels into this local variable
+	// so that we don't override 'baseLabels'.
+	controllerBaseLabels := labels.NewFrom(baseLabels)
+
+	ns, podName := e.GetK8sNamespace(), e.GetK8sPodName()
+
+	pod, cp, identityLabels, info, _, err := resolveMetadata(ns, podName)
+	if err != nil {
+		e.Logger(resolveLabels).WithError(err).Warning("Unable to fetch kubernetes labels")
+		// If we were unable to fetch the k8s endpoints then
+		// we will mark the endpoint with the init identity.
+		if !restoredEndpoint {
+			// Only mark the endpoint with the 'init' identity if we are not
+			// restoring the endpoint from a restart.
+			identityLabels := labels.Labels{
+				labels.IDNameInit: labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved),
+			}
+			regenTriggered := e.UpdateLabels(ctx, labels.LabelSourceAny, identityLabels, nil, true)
+			if blocking {
+				return regenTriggered, err
+			}
+		}
+		return false, err
+	}
+
+	// Merge the labels retrieved from the 'resolveMetadata' into the base
+	// labels.
+	controllerBaseLabels.MergeLabels(identityLabels)
+
+	e.SetPod(pod)
+	e.SetK8sMetadata(cp)
+	e.UpdateNoTrackRules(func(_, _ string) (noTrackPort string, err error) {
+		po, _, _, _, _, err := resolveMetadata(ns, podName)
+		if err != nil {
+			return "", err
+		}
+		value, _ := annotation.Get(po, annotation.NoTrack, annotation.NoTrackAlias)
+		return value, nil
+	})
+	e.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
+		po, _, _, _, _, err := resolveMetadata(ns, podName)
+		if err != nil {
+			return "", err
+		}
+		value, _ := annotation.Get(po, annotation.ProxyVisibility, annotation.ProxyVisibilityAlias)
+		return value, nil
+	})
+	e.UpdateBandwidthPolicy(bwm, func(ns, podName string) (bandwidthEgress string, err error) {
+		_, _, _, _, annotations, err := resolveMetadata(ns, podName)
+		if err != nil {
+			return "", err
+		}
+		return annotations[bandwidth.EgressBandwidth], nil
+	})
+
+	// If 'baseLabels' are not set then 'controllerBaseLabels' only contains
+	// labels from k8s. Thus, we should only replace the labels that have their
+	// source as 'k8s' otherwise we will risk on replacing other labels that
+	// were added from other sources.
+	source := labels.LabelSourceK8s
+	if len(baseLabels) != 0 {
+		source = labels.LabelSourceAny
+	}
+	regenTriggered = e.UpdateLabels(ctx, source, controllerBaseLabels, info, blocking)
+
+	return regenTriggered, nil
+}
+
 // MetadataResolverCB provides an implementation for resolving the endpoint
 // metadata for an endpoint such as the associated labels and annotations.
 type MetadataResolverCB func(ns, podName string) (pod *slim_corev1.Pod, _ []slim_corev1.ContainerPort, identityLabels labels.Labels, infoLabels labels.Labels, annotations map[string]string, err error)
@@ -1644,10 +1738,30 @@ type MetadataResolverCB func(ns, podName string) (pod *slim_corev1.Pod, _ []slim
 // either the first successful metadata resolution or when the endpoint is
 // removed.
 //
+// baseLabels contains the list of labels use as "base" for the endpoint.
+// The labels retrieved from 'MetadataResolverCB' will be merged into the
+// baseLabels and put into the endpoint.
+// If this list is empty, the labels set on the endpoint will be
+// replaced by the labels returned 'MetadataResolverCB' as long their source
+// matches the source of the labels already present on the endpoint.
+//
+// restoredEndpoint should be set to 'true' if the endpoint is being restored.
+// If this is set to false and the resolver is unable to retrieve the endpoint
+// labels from k8s, the endpoint will be set with the 'init' identity.
+//
+// blocking - will block this function until the endpoint receives a new
+// security identity, and it is regenerated. If 'false', this
+// operation will be done in the background and 'regenTriggered'
+// will always be 'false'.
+//
 // This assumes that after the initial successful resolution, other mechanisms
 // will handle updates (such as pkg/k8s/watchers informers).
-func (e *Endpoint) RunMetadataResolver(bwm bandwidth.Manager, resolveMetadata MetadataResolverCB) {
-	done := make(chan struct{})
+func (e *Endpoint) RunMetadataResolver(restoredEndpoint, blocking bool, baseLabels labels.Labels, bwm bandwidth.Manager, resolveMetadata MetadataResolverCB) (regenTriggered bool) {
+	var regenTriggeredCh chan bool
+	if blocking {
+		regenTriggeredCh = make(chan bool)
+	}
+	done := make(chan bool)
 	controllerName := resolveLabels + "-" + e.GetK8sNamespaceAndPodName()
 	go func() {
 		select {
@@ -1662,49 +1776,50 @@ func (e *Endpoint) RunMetadataResolver(bwm bandwidth.Manager, resolveMetadata Me
 		controller.ControllerParams{
 			Group: resolveLabelsControllerGroup,
 			DoFunc: func(ctx context.Context) error {
-				if e.K8sNamespaceAndPodNameIsSet() {
-					e.Logger(resolveLabels).Debug("Namespace and Pod are not set")
-					return nil
+				regenTriggered, err := e.metadataResolver(ctx, restoredEndpoint, blocking, baseLabels, bwm, resolveMetadata)
+				if blocking {
+					select {
+					// Check if the channel was closed.
+					case <-regenTriggeredCh:
+					case <-e.aliveCtx.Done():
+					case regenTriggeredCh <- regenTriggered:
+						close(regenTriggeredCh)
+					}
 				}
-				ns, podName := e.GetK8sNamespace(), e.GetK8sPodName()
-
-				pod, cp, identityLabels, info, _, err := resolveMetadata(ns, podName)
 				if err != nil {
-					e.Logger(resolveLabels).WithError(err).Warning("Unable to fetch kubernetes labels")
 					return err
 				}
-				e.SetPod(pod)
-				e.SetK8sMetadata(cp)
-				e.UpdateNoTrackRules(func(_, _ string) (noTrackPort string, err error) {
-					po, _, _, _, _, err := resolveMetadata(ns, podName)
-					if err != nil {
-						return "", err
-					}
-					value, _ := annotation.Get(po, annotation.NoTrack, annotation.NoTrackAlias)
-					return value, nil
-				})
-				e.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
-					po, _, _, _, _, err := resolveMetadata(ns, podName)
-					if err != nil {
-						return "", err
-					}
-					value, _ := annotation.Get(po, annotation.ProxyVisibility, annotation.ProxyVisibilityAlias)
-					return value, nil
-				})
-				e.UpdateBandwidthPolicy(bwm, func(ns, podName string) (bandwidthEgress string, err error) {
-					_, _, _, _, annotations, err := resolveMetadata(ns, podName)
-					if err != nil {
-						return "", err
-					}
-					return annotations[bandwidth.EgressBandwidth], nil
-				})
-				e.UpdateLabels(ctx, labels.LabelSourceAny, identityLabels, info, true)
 				close(done)
 				return nil
 			},
 			Context: e.aliveCtx,
 		},
 	)
+
+	// If the caller wants this function to be blocking while resolving
+	// identities / regenerating then we will wait for the first result of
+	// `e.metadataResolver` before returning.
+	if blocking {
+		select {
+		case regenTriggered, ok := <-regenTriggeredCh:
+			return regenTriggered && ok
+		case <-e.aliveCtx.Done():
+			return false
+		}
+	}
+	return false
+}
+
+// RunRestoredMetadataResolver starts a controller associated with the received
+// endpoint which will periodically attempt to resolve the metadata for the
+// endpoint and update the endpoint with the related. It stops resolving after
+// either the first successful metadata resolution or when the endpoint is
+// removed.
+//
+// This assumes that after the initial successful resolution, other mechanisms
+// will handle updates (such as pkg/k8s/watchers informers).
+func (e *Endpoint) RunRestoredMetadataResolver(bwm bandwidth.Manager, resolveMetadata MetadataResolverCB) {
+	e.RunMetadataResolver(true, false, nil, bwm, resolveMetadata)
 }
 
 // ModifyIdentityLabels changes the custom and orchestration identity labels of an endpoint.

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -885,7 +885,7 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity, newEndpoint bool)
 		identitymanager.RemoveOldAddNew(e.SecurityIdentity, identity)
 	}
 	e.SecurityIdentity = identity
-	e.replaceIdentityLabels(identity.Labels)
+	e.replaceIdentityLabels(labels.LabelSourceAny, identity.Labels)
 
 	// Clear selectorPolicy. It will be determined at next regeneration.
 	e.selectorPolicy = nil

--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -96,7 +96,7 @@ func (u *namespaceUpdater) update(newNS *slim_corev1.Namespace) error {
 	for _, ep := range eps {
 		epNS := ep.GetK8sNamespace()
 		if newNS.Name == epNS {
-			err := ep.ModifyIdentityLabels(newIdtyLabels, oldIdtyLabels)
+			err := ep.ModifyIdentityLabels(labels.LabelSourceK8s, newIdtyLabels, oldIdtyLabels)
 			if err != nil {
 				log.WithError(err).WithField(logfields.EndpointID, ep.ID).
 					Warning("unable to update endpoint with new identity labels from namespace labels")

--- a/pkg/labels/oplabels.go
+++ b/pkg/labels/oplabels.go
@@ -202,11 +202,12 @@ func (o *OpLabels) ModifyIdentityLabels(addLabels, delLabels Labels) (changed bo
 // was not already in 'l'. Returns 'true' if a label was added, or an old label was
 // updated, 'false' otherwise.
 // The label is only updated if its source matches the provided 'sourceFilter'
-// or in case the provided sourceFilter is 'LabelSourceAny'.
+// or in case the provided sourceFilter is 'LabelSourceAny'. The new label must
+// also match the old label 'source' in order for it to be replaced.
 func (l Labels) upsertLabel(sourceFilter string, label Label) bool {
 	oldLabel, found := l[label.Key]
 	if found {
-		if sourceFilter != LabelSourceAny {
+		if sourceFilter != LabelSourceAny && sourceFilter != oldLabel.Source {
 			return false
 		}
 
@@ -214,7 +215,13 @@ func (l Labels) upsertLabel(sourceFilter string, label Label) bool {
 		if label.Value == oldLabel.Value && label.Source == oldLabel.Source {
 			return false // No change
 		}
+
+		// If the label is not from the same source, then don't replace it.
+		if oldLabel.Source != label.Source {
+			return false
+		}
 	}
+
 	// Insert or replace old label
 	l[label.Key] = label
 	return true

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -53,8 +53,8 @@ const (
 	// Labels are any label, they may not be relevant to the security identity.
 	Labels = "labels"
 
-	// Source is the label or node information source
-	Source = "source"
+	// SourceFilter is the label or node information source
+	SourceFilter = "sourceFilter"
 
 	// Controller is the name of the controller to log it.
 	Controller = "controller"


### PR DESCRIPTION
Read on a per commit basis.

```release-note
Fixed label synchronization issues in Cilium, ensuring accurate representation of endpoint labels during restoration and addressing out-of-sync problems caused by label changes while the Cilium agent is down.
```
