### PR TITLE
Use Resource[T] to implement CEP and CES watchers

### DIFF
--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -106,6 +106,7 @@ type Resources struct {
 	CiliumClusterwideNetworkPolicies resource.Resource[*cilium_api_v2.CiliumClusterwideNetworkPolicy]
 	CiliumCIDRGroups                 resource.Resource[*cilium_api_v2alpha1.CiliumCIDRGroup]
 	CiliumSlimEndpoint               resource.Resource[*types.CiliumEndpoint]
+	CiliumEndpointSlice              resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice]
 }
 
 // LocalNodeResources is a convenience struct to group CiliumNode and Node resources as cell constructor parameters.

--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
+	"github.com/cilium/cilium/pkg/k8s/types"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
 
@@ -104,6 +105,7 @@ type Resources struct {
 	CiliumNetworkPolicies            resource.Resource[*cilium_api_v2.CiliumNetworkPolicy]
 	CiliumClusterwideNetworkPolicies resource.Resource[*cilium_api_v2.CiliumClusterwideNetworkPolicy]
 	CiliumCIDRGroups                 resource.Resource[*cilium_api_v2alpha1.CiliumCIDRGroup]
+	CiliumSlimEndpoint               resource.Resource[*types.CiliumEndpoint]
 }
 
 // LocalNodeResources is a convenience struct to group CiliumNode and Node resources as cell constructor parameters.

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -350,6 +350,7 @@ func CiliumEndpointSliceResource(lc hive.Lifecycle, cs client.Clientset, _ *node
 	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](lc, lw,
 		resource.WithMetric("CiliumEndpointSlice"),
 		resource.WithIndexers(indexers),
+		resource.WithStoppableInformer(),
 	), nil
 }
 

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -308,6 +308,7 @@ func CiliumSlimEndpointResource(lc hive.Lifecycle, cs client.Clientset, _ *node.
 		}, TransformToCiliumEndpoint),
 		resource.WithMetric("CiliumEndpoint"),
 		resource.WithIndexers(indexers),
+		resource.WithStoppableInformer(),
 	), nil
 }
 

--- a/pkg/k8s/watchers/cilium_endpoint_slice.go
+++ b/pkg/k8s/watchers/cilium_endpoint_slice.go
@@ -4,113 +4,96 @@
 package watchers
 
 import (
-	"fmt"
+	"context"
 	"sync"
+	"sync/atomic"
 
-	"k8s.io/client-go/tools/cache"
-
-	"github.com/cilium/cilium/pkg/k8s"
-	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	"github.com/cilium/cilium/pkg/k8s/client"
-	"github.com/cilium/cilium/pkg/k8s/informer"
-	"github.com/cilium/cilium/pkg/k8s/utils"
+	cilium_api_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/k8s/watchers/subscriber"
 	"github.com/cilium/cilium/pkg/kvstore"
-	"github.com/cilium/cilium/pkg/node"
 )
 
 var (
 	cesNotify = subscriber.NewCES()
 )
 
-// CreateCiliumEndpointSliceLocalPodIndexFunc returns an IndexFunc that indexes CiliumEndpointSlices
-// by their corresponding Pod, which are running locally on this Node.
-func CreateCiliumEndpointSliceLocalPodIndexFunc() cache.IndexFunc {
-	nodeIP := node.GetCiliumEndpointNodeIP()
-	return func(obj interface{}) ([]string, error) {
-		ces, ok := obj.(*capi_v2a1.CiliumEndpointSlice)
-		if !ok {
-			return nil, fmt.Errorf("unexpected object type: %T", obj)
-		}
-		indices := []string{}
-		for _, ep := range ces.Endpoints {
-			if ep.Networking.NodeIP == nodeIP {
-				indices = append(indices, ep.Networking.NodeIP)
-				break
-			}
-		}
-		return indices, nil
-	}
-}
-
-func (k *K8sWatcher) ciliumEndpointSliceInit(client client.Clientset, asyncControllers *sync.WaitGroup) {
+func (k *K8sWatcher) ciliumEndpointSliceInit(ctx context.Context, asyncControllers *sync.WaitGroup) {
 	log.Info("Initializing CES controller")
+
 	var once sync.Once
+	apiGroup := k8sAPIGroupCiliumEndpointSliceV2Alpha1
 
 	// Register for all ces updates.
 	cesNotify.Register(newCESSubscriber(k))
 
 	for {
-		cesIndexer, cesInformer := informer.NewIndexerInformer(
-			utils.ListerWatcherFromTyped[*capi_v2a1.CiliumEndpointSliceList](
-				client.CiliumV2alpha1().CiliumEndpointSlices()),
-			&capi_v2a1.CiliumEndpointSlice{},
-			0,
-			cache.ResourceEventHandlerFuncs{
-				AddFunc: func(obj interface{}) {
-					if ces := k8s.CastInformerEvent[capi_v2a1.CiliumEndpointSlice](obj); ces != nil {
-						cesNotify.NotifyAdd(ces)
-					}
-				},
-				UpdateFunc: func(oldObj, newObj interface{}) {
-					if oldCES := k8s.CastInformerEvent[capi_v2a1.CiliumEndpointSlice](oldObj); oldCES != nil {
-						if newCES := k8s.CastInformerEvent[capi_v2a1.CiliumEndpointSlice](newObj); newCES != nil {
-							if oldCES.DeepEqual(newCES) {
-								return
-							}
-							cesNotify.NotifyUpdate(oldCES, newCES)
-						}
-					}
-				},
-				DeleteFunc: func(obj interface{}) {
-					if ces := k8s.CastInformerEvent[capi_v2a1.CiliumEndpointSlice](obj); ces != nil {
-						cesNotify.NotifyDelete(ces)
-					}
-				},
-			},
-			nil,
-			cache.Indexers{
-				"localNode": CreateCiliumEndpointSliceLocalPodIndexFunc(),
-			},
-		)
-		k.ciliumEndpointSliceIndexerMU.Lock()
-		k.ciliumEndpointSliceIndexer = cesIndexer
-		k.ciliumEndpointSliceIndexerMU.Unlock()
-		isConnected := make(chan struct{})
-		// once isConnected is closed, it will stop waiting on caches to be
-		// synchronized.
+		var synced atomic.Bool
+		stop := make(chan struct{})
+
 		k.blockWaitGroupToSyncResources(
-			isConnected,
+			stop,
 			nil,
-			cesInformer.HasSynced,
-			k8sAPIGroupCiliumEndpointSliceV2Alpha1,
+			func() bool { return synced.Load() },
+			apiGroup,
 		)
+		k.k8sAPIGroups.AddAPI(apiGroup)
 
-		once.Do(func() {
-			// Signalize that we have put node controller in the wait group
-			// to sync resources.
-			asyncControllers.Done()
-		})
-		k.k8sAPIGroups.AddAPI(k8sAPIGroupCiliumEndpointSliceV2Alpha1)
-		go cesInformer.Run(isConnected)
+		// Signalize that we have put node controller in the wait group to sync resources.
+		once.Do(asyncControllers.Done)
 
-		<-kvstore.Connected()
-		close(isConnected)
+		// derive another context to signal Events() in case of kvstore connection
+		eventsCtx, cancel := context.WithCancel(ctx)
 
-		log.Info("Connected to key-value store, stopping CiliumEndpointSlice watcher")
-		k.k8sAPIGroups.RemoveAPI(k8sAPIGroupCiliumEndpointSliceV2Alpha1)
-		k.cancelWaitGroupToSyncResources(k8sAPIGroupCiliumEndpointSliceV2Alpha1)
-		<-kvstore.Client().Disconnected()
-		log.Info("Disconnected from key-value store, restarting CiliumEndpointSlice watcher")
+		go func() {
+			defer close(stop)
+
+			events := k.resources.CiliumEndpointSlice.Events(eventsCtx)
+			cache := make(map[resource.Key]*cilium_api_v2a1.CiliumEndpointSlice)
+			for event := range events {
+				var err error
+				switch event.Kind {
+				case resource.Sync:
+					synced.Store(true)
+				case resource.Upsert:
+					var needUpdate bool
+					oldObj, ok := cache[event.Key]
+					if !ok {
+						cesNotify.NotifyAdd(event.Object)
+						needUpdate = true
+					} else if !oldObj.DeepEqual(event.Object) {
+						cesNotify.NotifyUpdate(oldObj, event.Object)
+						needUpdate = true
+					}
+					if needUpdate {
+						cache[event.Key] = event.Object
+					}
+				case resource.Delete:
+					cesNotify.NotifyDelete(event.Object)
+					delete(cache, event.Key)
+				}
+				event.Done(err)
+			}
+		}()
+
+		select {
+		case <-kvstore.Connected():
+			log.Info("Connected to key-value store, stopping CiliumEndpointSlice watcher")
+			cancel()
+			k.cancelWaitGroupToSyncResources(apiGroup)
+			k.k8sAPIGroups.RemoveAPI(apiGroup)
+			<-stop
+		case <-ctx.Done():
+			cancel()
+			<-stop
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-kvstore.Client().Disconnected():
+			log.Info("Disconnected from key-value store, restarting CiliumEndpointSlice watcher")
+		}
 	}
 }

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -1036,14 +1036,6 @@ func (k *K8sWatcher) GetStore(name string) cache.Store {
 		k.podStoreMU.RLock()
 		defer k.podStoreMU.RUnlock()
 		return k.podStore
-	case "ciliumendpoint":
-		k.ciliumEndpointIndexerMU.RLock()
-		defer k.ciliumEndpointIndexerMU.RUnlock()
-		return k.ciliumEndpointIndexer
-	case "ciliumendpointslice":
-		k.ciliumEndpointSliceIndexerMU.RLock()
-		defer k.ciliumEndpointSliceIndexerMU.RUnlock()
-		return k.ciliumEndpointSliceIndexer
 	default:
 		panic("no such store: " + name)
 	}


### PR DESCRIPTION
Use Resource[T] to implement the CiliumEndpoint and CiliumEndpointSlice k8s watchers. This removes the additional informers previously used, reducing the queries to the kube-apiserver and reducing the memory needed for the additional local caches.

Please refer to the individual commits for further details.

Depends on ~https://github.com/cilium/cilium/pull/29414~, ~https://github.com/cilium/cilium/pull/29243~, ~https://github.com/cilium/cilium/pull/29244~ and ~https://github.com/cilium/cilium/pull/29246~

Related: https://github.com/cilium/cilium/issues/28159