### PR TITLE
.github: use GitHub workflow from the same branch

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -286,7 +286,7 @@ jobs:
               --flush-ct
 
       - name: Rotate IPsec Key & Test (${{ join(matrix.*, ', ') }})
-        uses: cilium/cilium/.github/actions/conn-disrupt-test@d42be92482e5568f5899626b95df369b39d03276
+        uses: cilium/cilium/.github/actions/conn-disrupt-test@v1.14
         with:
           job-name: conformance-ipsec-e2e-key-rotation-${{ matrix.name }}
           operation-cmd: |

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -259,7 +259,7 @@ jobs:
             ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup
 
       - name: Upgrade Cilium & Test (${{ matrix.name }})
-        uses: cilium/cilium/.github/actions/conn-disrupt-test@d42be92482e5568f5899626b95df369b39d03276
+        uses: cilium/cilium/.github/actions/conn-disrupt-test@v1.14
         with:
           job-name: ipsec-upgrade-${{ matrix.name }}
           # Disable no-missed-tail-calls due to https://github.com/cilium/cilium/issues/26739
@@ -276,7 +276,7 @@ jobs:
             kubectl -n kube-system exec daemonset/cilium -- cilium status
 
       - name: Downgrade Cilium to ${{ env.cilium_stable_version }} & Test (${{ matrix.name }})
-        uses: cilium/cilium/.github/actions/conn-disrupt-test@d42be92482e5568f5899626b95df369b39d03276
+        uses: cilium/cilium/.github/actions/conn-disrupt-test@v1.14
         with:
           job-name: ipsec-downgrade-${{ matrix.name }}
           # Disable no-missed-tail-calls due to https://github.com/cilium/cilium/issues/26739


### PR DESCRIPTION
Prevent Renovate updates from main branch to avoid potential test failures due to divergent workflow behavior between main and current branch.

Suggested-by: Zhichuan Liang <gray.liang@isovalent.com>