### PR TITLE
.github: use GitHub workflow from the same branch

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -278,7 +278,7 @@ jobs:
               --flush-ct
 
       - name: Rotate IPsec Key & Test (${{ join(matrix.*, ', ') }})
-        uses: ./.github/actions/conn-disrupt-test
+        uses: cilium/cilium/.github/actions/conn-disrupt-test@v1.13
         with:
           job-name: conformance-ipsec-e2e-key-rotation-${{ matrix.name }}
           extra-connectivity-test-flags: --test '!check-log-errors'

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -251,7 +251,7 @@ jobs:
             ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup
 
       - name: Upgrade Cilium & Test (${{ matrix.name }})
-        uses: ./.github/actions/conn-disrupt-test
+        uses: cilium/cilium/.github/actions/conn-disrupt-test@v1.13
         with:
           job-name: ipsec-upgrade-${{ matrix.name }}
           # Disable no-missed-tail-calls due to https://github.com/cilium/cilium/issues/26739
@@ -268,7 +268,7 @@ jobs:
             kubectl -n kube-system exec daemonset/cilium -- cilium status
 
       - name: Downgrade Cilium to ${{ env.cilium_stable_version }} & Test (${{ matrix.name }})
-        uses: ./.github/actions/conn-disrupt-test
+        uses: cilium/cilium/.github/actions/conn-disrupt-test@v1.13
         with:
           job-name: ipsec-downgrade-${{ matrix.name }}
           # Disable no-missed-tail-calls due to https://github.com/cilium/cilium/issues/26739


### PR DESCRIPTION
Prevent Renovate updates from main branch to avoid potential test failures due to divergent workflow behavior between main and current branch.

Suggested-by: Zhichuan Liang <gray.liang@isovalent.com>