### PR TITLE
Update the Cilium OLM repo for the OKD installation guide

### DIFF
--- a/Documentation/installation/k8s-install-openshift-okd.rst
+++ b/Documentation/installation/k8s-install-openshift-okd.rst
@@ -134,7 +134,7 @@ Next, obtain Cilium manifest from ``cilium/cilium-olm`` repository and copy to `
    cilium_version="\ |release|\ "
    git_dir="/tmp/cilium-olm"
 
-   git clone https://github.com/cilium/cilium-olm.git ${git_dir}
+   git clone https://github.com/isovalent/olm-for-cilium.git ${git_dir}
    cp ${git_dir}/manifests/cilium.v${cilium_version}/* "${CLUSTER_NAME}/manifests"
 
    test -d ${git_dir} && rm -rf -- ${git_dir}


### PR DESCRIPTION
Update the Cilium OLM repo for the OKD installation guide to Isovalent repo instead.

In the latest/stable (1.14.4) version of the Cilium documentation, the installation guide for OKD points to a public archive of the Cilium OLM.

The docu was updated to point to the correct Git repo.

Fixes: #24270
