### PR TITLE
tunnel: add support for tunnel protocol defaulting

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2909,9 +2909,9 @@
      - int
      - Port 8472 for VXLAN, Port 6081 for Geneve
    * - :spelling:ignore:`tunnelProtocol`
-     - Tunneling protocol to use in tunneling mode and for ad-hoc tunnels. Possible values:   - ""   - vxlan   - geneve
+     - Tunneling protocol to use in tunneling mode and for ad-hoc tunnels. Possible values:   - ""   - vxlan   - geneve When not explicitly specified, Cilium can default the protocol to either vxlan or geneve depending on the additional features that are enabled.
      - string
-     - ``"vxlan"``
+     - ``""``
    * - :spelling:ignore:`updateStrategy`
      - Cilium agent update strategy
      - object

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -777,7 +777,7 @@ contributors across the globe, there is almost always someone available to help.
 | tls.secretsBackend | string | `"local"` | This configures how the Cilium agent loads the secrets used TLS-aware CiliumNetworkPolicies (namely the secrets referenced by terminatingTLS and originatingTLS). Possible values:   - local   - k8s |
 | tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for agent scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | tunnelPort | int | Port 8472 for VXLAN, Port 6081 for Geneve | Configure VXLAN and Geneve tunnel port. |
-| tunnelProtocol | string | `"vxlan"` | Tunneling protocol to use in tunneling mode and for ad-hoc tunnels. Possible values:   - ""   - vxlan   - geneve |
+| tunnelProtocol | string | `""` | Tunneling protocol to use in tunneling mode and for ad-hoc tunnels. Possible values:   - ""   - vxlan   - geneve When not explicitly specified, Cilium can default the protocol to either vxlan or geneve depending on the additional features that are enabled. |
 | updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":2},"type":"RollingUpdate"}` | Cilium agent update strategy |
 | vtep.cidr | string | `""` | A space separated list of VTEP device CIDRs, for example "1.1.1.0/24 1.1.2.0/24" |
 | vtep.enabled | bool | `false` | Enables VXLAN Tunnel Endpoint (VTEP) Integration (beta) to allow Cilium-managed pods to talk to third party VTEP devices over Cilium tunnel. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2264,7 +2264,8 @@ tls:
 #   - ""
 #   - vxlan
 #   - geneve
-# @default -- `"vxlan"`
+# When not explicitly specified, Cilium can default the protocol to either
+# vxlan or geneve depending on the additional features that are enabled.
 tunnelProtocol: ""
 
 # -- Enable native-routing mode or tunneling mode.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2261,7 +2261,8 @@ tls:
 #   - ""
 #   - vxlan
 #   - geneve
-# @default -- `"vxlan"`
+# When not explicitly specified, Cilium can default the protocol to either
+# vxlan or geneve depending on the additional features that are enabled.
 tunnelProtocol: ""
 
 # -- Enable native-routing mode or tunneling mode.

--- a/pkg/datapath/tunnel/cell.go
+++ b/pkg/datapath/tunnel/cell.go
@@ -4,6 +4,8 @@
 package tunnel
 
 import (
+	"fmt"
+
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/option"
@@ -37,6 +39,7 @@ var Cell = cell.Module(
 					dcfg.KubeProxyReplacement == option.KubeProxyReplacementTrue) &&
 					dcfg.LoadBalancerUsesDSR() &&
 					dcfg.LoadBalancerDSRDispatch == option.DSRDispatchGeneve,
+				WithProtocol(fmt.Sprintf("Node Port %q mode", option.DSRDispatchGeneve), Geneve),
 				// The datapath logic takes care of the MTU overhead. So no need to
 				// take it into account here.
 				// See encap_geneve_dsr_opt[4,6] in nodeport.h

--- a/pkg/datapath/tunnel/tunnel_test.go
+++ b/pkg/datapath/tunnel/tunnel_test.go
@@ -4,7 +4,6 @@
 package tunnel
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,6 +47,15 @@ func TestConfig(t *testing.T) {
 			proto:    Disabled,
 		},
 		{
+			name:           "tunnel enabled, auto",
+			ucfg:           userCfg{},
+			enablers:       []any{enabler(true), enabler(false)},
+			proto:          VXLAN,
+			port:           defaults.TunnelPortVXLAN,
+			deviceName:     defaults.VxlanDevice,
+			shouldAdaptMTU: true,
+		},
+		{
 			name:           "tunnel enabled, vxlan",
 			ucfg:           userCfg{TunnelProtocol: string(VXLAN)},
 			enablers:       []any{enabler(true), enabler(false)},
@@ -84,14 +92,27 @@ func TestConfig(t *testing.T) {
 			shouldAdaptMTU: true,
 		},
 		{
-			name: "tunnel enabled, validation function",
-			ucfg: userCfg{TunnelProtocol: string(Geneve)},
-			enablers: []any{enabler(true, WithValidator(func(proto Protocol) error {
-				if proto == Geneve {
-					return errors.New("invalid protocol")
-				}
-				return nil
-			}))},
+			name:           "tunnel enabled, auto, request geneve",
+			ucfg:           userCfg{},
+			enablers:       []any{enabler(true, WithProtocol("foo", Geneve))},
+			proto:          Geneve,
+			port:           defaults.TunnelPortGeneve,
+			deviceName:     defaults.GeneveDevice,
+			shouldAdaptMTU: true,
+		},
+		{
+			name:      "tunnel enabled, vxlan, request geneve",
+			ucfg:      userCfg{TunnelProtocol: string(VXLAN)},
+			enablers:  []any{enabler(true, WithProtocol("foo", Geneve))},
+			shallFail: true,
+		},
+		{
+			name: "tunnel enabled, auto, request vxlan, request geneve",
+			ucfg: userCfg{},
+			enablers: []any{
+				enabler(true, WithProtocol("foo", VXLAN)),
+				enabler(true, WithProtocol("bar", Geneve)),
+			},
 			shallFail: true,
 		},
 		{


### PR DESCRIPTION
Possible extension of https://github.com/cilium/cilium/pull/29051, which introduces again the possibility of defaulting the tunnel protocol to either vxlan or geneve, depending on additional features that are enabled (e.g., DSR Geneve). 
