### PR TITLE
v1.14 backports 2023-11-20

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -52,7 +52,7 @@ concurrency:
 
 env:
   # renovate: datasource=github-releases depName=cilium/cilium-cli
-  cilium_cli_version: v0.15.13
+  cilium_cli_version: v0.15.14
   cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   cilium_stable_version: 1.13
@@ -256,8 +256,7 @@ jobs:
         with:
           job-name: ipsec-upgrade-${{ matrix.name }}
           # Disable no-missed-tail-calls due to https://github.com/cilium/cilium/issues/26739
-          # Disable check-log-errors due to https://github.com/cilium/cilium-cli/issues/1858
-          extra-connectivity-test-flags: --test '!no-missed-tail-calls,!check-log-errors'
+          extra-connectivity-test-flags: --test '!no-missed-tail-calls'
           operation-cmd: |
             cd /host/
 
@@ -273,8 +272,7 @@ jobs:
         with:
           job-name: ipsec-downgrade-${{ matrix.name }}
           # Disable no-missed-tail-calls due to https://github.com/cilium/cilium/issues/26739
-          # Disable check-log-errors due to https://github.com/cilium/cilium-cli/issues/1858
-          extra-connectivity-test-flags: --test '!no-missed-tail-calls,!check-log-errors'
+          extra-connectivity-test-flags: --test '!no-missed-tail-calls'
           operation-cmd: |
             cd /host/
 

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -239,19 +239,12 @@ jobs:
             kubectl get pods --all-namespaces -o wide
             kubectl -n kube-system exec daemonset/cilium -- cilium status
 
-      - name: Test Cilium ${{ env.cilium_stable_version }} (${{ matrix.name }})
+      - name: Start conn-disrupt-test
         uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
         with:
           provision: 'false'
           cmd: |
             cd /host/
-
-            ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-              --flush-ct \
-              --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
-              --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
-              --junit-property github_job_step="Run tests upgrade 1 (${{ join(matrix.*, ', ') }})"
 
             # Create pods which establish long lived connections. It will be used by
             # subsequent connectivity tests with --include-conn-disrupt-test to catch any

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -93,13 +93,29 @@ func init() {
 		k8s.K8sErrorHandler,
 	}
 
-	k8s_metrics.Register(k8s_metrics.RegisterOpts{
+	// The client-go Register function can be called only once,
+	// but there's a possibility that another package calls it and
+	// registers the client-go metrics on its own registry.
+	// The metrics of one who called the init first will take effect,
+	// and which one wins depends on the order of package initialization.
+	// Currently, controller-runtime also calls it in its init function
+	// because there's an indirect dependency on controller-runtime.
+	// Given the possibility that controller-runtime wins, we should set
+	// the adapters directly to override the metrics registration of
+	// controller-runtime as well as calling Register function.
+	// Without calling Register function here, controller-runtime will have
+	// a chance to override our metrics registration.
+	registerOps := k8s_metrics.RegisterOpts{
 		ClientCertExpiry:      nil,
 		ClientCertRotationAge: nil,
 		RequestLatency:        &requestLatencyAdapter{},
 		RateLimiterLatency:    &rateLimiterLatencyAdapter{},
 		RequestResult:         &resultAdapter{},
-	})
+	}
+	k8s_metrics.Register(registerOps)
+	k8s_metrics.RequestLatency = registerOps.RequestLatency
+	k8s_metrics.RateLimiterLatency = registerOps.RateLimiterLatency
+	k8s_metrics.RequestResult = registerOps.RequestResult
 }
 
 var (


### PR DESCRIPTION
 - [x] #27007 -- metrics: fix potential conflict on metrics registration (@ysksuzuki)
 - [x] #29178 -- ci-ipsec-upgrade: Do not run conn tests after installing Cilium (@brb)
    - :warning: minor conflict 
 - [x] #29189 -- ci-ipsec-upgrade: Check for errors (@brb)
    - :warning: minor conflict 

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 27007 29178 29189; do contrib/backporting/set-labels.py $pr done 1.14; done
```
