### PR TITLE
client: Use options pattern for NewRuntime

### DIFF
--- a/cilium-dbg/cmd/map_event_list.go
+++ b/cilium-dbg/cmd/map_event_list.go
@@ -41,7 +41,7 @@ var mapEventListCmd = &cobra.Command{
 
 		var c *clientPkg.Client
 		var rt *runtime_client.Runtime
-		if r, err := clientPkg.NewRuntime(vp.GetString("host"), ""); err != nil {
+		if r, err := clientPkg.NewRuntime(clientPkg.WithHost(vp.GetString("host"))); err != nil {
 			Fatalf("Error while creating client: %s\n", err)
 		} else {
 			rt = r


### PR DESCRIPTION
Instead of passing in a list of strings, use an options pattern which makes call-sites easier to read.

Suggested-by: Marco Hofstetter <marco.hofstetter@isovalent.com>
