### PR TITLE
CI: Add merge_group trigger

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
       - ft/main/**
+  merge_group:
+    types: [checks_requested]
 
 permissions: read-all
 

--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
       - ft/main/**
+  merge_group:
+    types: [checks_requested]
 
 permissions: read-all
 

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
       - ft/main/**
+  merge_group:
+    types: [checks_requested]
 
 permissions: read-all
 
@@ -52,7 +54,7 @@ jobs:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.tested == 'true' }}
     runs-on: ubuntu-22.04
-    name: Installation and Conformance Test
+    name: Installation and Conformance Test (ipv6)
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
       - ft/main/**
+  merge_group:
+    types: [checks_requested]
 
 permissions: read-all
 


### PR DESCRIPTION
This PR adds merge_group trigger to workflows that have required checks. 
"Installation and Conformance Test" in smoke-test-ipv6 workflow is renamed as "Installation and Conformance Test (ipv6)" to distinguish the check from the one that is in smoke-test workflow. 
This way this check can also be added to required checks without mixup.
