### PR TITLE
Clarify `cilium_event_ts metric` description

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -428,6 +428,7 @@ Events external to Cilium
 Name                                     Labels                                             Default    Description
 ======================================== ================================================== ========== ========================================================
 ``event_ts``                             ``source``                                         Enabled    Last timestamp when Cilium received an event from a control plane source, per resource and per action
+``k8s_event_lag_seconds``                ``source``                                         Disabled   Lag for Kubernetes events - computed value between receiving a CNI ADD event from kubelet and a Pod event received from kube-api-server
 ======================================== ================================================== ========== ========================================================
 
 Controllers

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -427,7 +427,7 @@ Events external to Cilium
 ======================================== ================================================== ========== ========================================================
 Name                                     Labels                                             Default    Description
 ======================================== ================================================== ========== ========================================================
-``event_ts``                             ``source``                                         Enabled    Last timestamp when we received an event
+``event_ts``                             ``source``                                         Enabled    Last timestamp when Cilium received an event from a control plane source, per resource and per action
 ======================================== ================================================== ========== ========================================================
 
 Controllers

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -333,11 +333,9 @@ var (
 
 	// Events
 
-	// EventTS*is the time in seconds since epoch that we last received an
-	// event that we will handle
-	// source is one of k8s, docker or apia
-
-	// EventTS is the timestamp of k8s resource events.
+	// EventTS is the time in seconds since epoch that we last received an
+	// event that was handled by Cilium. This metric tracks the source of the
+	// event which can be one of K8s or Cilium's API.
 	EventTS = NoOpGaugeVec
 
 	// EventLagK8s is the lag calculation for k8s Pod events.
@@ -824,7 +822,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 			ConfigName: Namespace + "_event_ts",
 			Namespace:  Namespace,
 			Name:       "event_ts",
-			Help:       "Last timestamp when we received an event",
+			Help:       "Last timestamp when Cilium received an event from a control plane source, per resource and per action",
 		}, []string{LabelEventSource, LabelScope, LabelAction}),
 
 		EventLagK8s: metric.NewGauge(metric.GaugeOpts{


### PR DESCRIPTION
- metrics: Clarify cilium_event_ts metric description
- docs: Add missing cilium_k8s_event_lag_seconds metric from reference
