### PR TITLE
bpf: lxc: avoid upgrade/downgrade woes with CB_FROM_TUNNEL in IPv6 path

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1591,7 +1591,11 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 	ctx_store_meta(ctx, CB_FROM_HOST, 0);
 
 #ifdef HAVE_ENCAP
-	from_tunnel = ctx_load_meta(ctx, CB_FROM_TUNNEL);
+	/* TODO use CB_FROM_TUNNEL on v1.16, when we can trust that all
+	 * callers populate it (even after downgrade).
+	 */
+	/* from_tunnel = ctx_load_meta(ctx, CB_FROM_TUNNEL); */
+	from_tunnel = true;
 	ctx_store_meta(ctx, CB_FROM_TUNNEL, 0);
 #endif
 


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/28920 introduced usage of CB_FROM_TUNNEL in the IPv6 ingress tail-call. But unless all calling programs get upgraded/downgraded in *very* specific order (so that while this version of the tail-call is installed, *all* in-flight skbs have their CB_FROM_TUNNEL populated), some packets potentially miss the tunnel-specific processing that tail_ipv6_policy() is meant to apply. In particular their type might not get switched to PACKET_HOST, resulting in drops with SKB_DROP_REASON_OTHERHOST.

So we need to take a two-step approach - first roll out the support for CB_FROM_TUNNEL into all callers, but wait until a subsequent release (1.16) before tail_ipv6_policy() starts using it. Thus even on a downgrade to 1.15, all callers will continue to populate CB_FROM_TUNNEL.

Reported-by: Martynas Pumputis <m@lambda.lt>