### PR TITLE
iptables: remove logic to control non-existent net.ipv6.ip_early_demux

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -359,15 +359,9 @@ func (m *Manager) Start(ctx hive.HookContext) error {
 			m.logger.WithError(err).Warning("xt_socket kernel module could not be loaded")
 
 			if m.sharedCfg.EnableXTSocketFallback {
-				v4disabled := true
-				v6disabled := true
-				if m.sharedCfg.EnableIPv4 {
-					v4disabled = sysctl.Disable("net.ipv4.ip_early_demux") == nil
-				}
-				if m.sharedCfg.EnableIPv6 {
-					v6disabled = sysctl.Disable("net.ipv6.ip_early_demux") == nil
-				}
-				if v4disabled && v6disabled {
+				disabled := sysctl.Disable("net.ipv4.ip_early_demux") == nil
+
+				if disabled {
 					m.ipEarlyDemuxDisabled = true
 					m.logger.Warning("Disabled ip_early_demux to allow proxy redirection with original source/destination address without xt_socket support also in non-tunneled datapath modes.")
 				} else {


### PR DESCRIPTION
```
Early demux for both IP protocols is controlled by the IPv4 sysctl. Trying
to control net.ipv6.ip_early_demux would just result in awkward error
scenarios.
```