### PR TITLE
proxy: ignore EAFNOSUPPORT when deleting routing rules

### DIFF
--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -85,7 +85,8 @@ func installRoutesIPv6() error {
 
 // removeRoutesIPv6 ensures routes and rules for proxy traffic are removed.
 func removeRoutesIPv6() error {
-	if err := route.DeleteRule(netlink.FAMILY_V6, tproxyRule); err != nil && !errors.Is(err, syscall.ENOENT) {
+	if err := route.DeleteRule(netlink.FAMILY_V6, tproxyRule); err != nil &&
+		!errors.Is(err, syscall.ENOENT) && !errors.Is(err, syscall.EAFNOSUPPORT) {
 		return fmt.Errorf("removing ipv6 proxy routing rule: %w", err)
 	}
 	if err := route.DeleteRouteTable(linux_defaults.RouteTableProxy, netlink.FAMILY_V6); err != nil {


### PR DESCRIPTION
Fixes: https://github.com/cilium/cilium/issues/29302

```release-note
Ignore 'unknown address family' errors when deleting routing rules for the L7 proxy
```
