### PR TITLE
ci: Bump timeout of ci-runtime

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -225,7 +225,7 @@ jobs:
           - focus: "privileged"
             cliFocus: "RuntimeDatapathPrivilegedUnitTests"
 
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
We observed several timeout. Bump the timeout as a workaround.

```release-note
ci: Bump timeout of ci-runtime
```
