### PR TITLE
hubble-relay: Add support for peers joining during requests

### DIFF
--- a/pkg/hubble/relay/defaults/defaults.go
+++ b/pkg/hubble/relay/defaults/defaults.go
@@ -41,6 +41,9 @@ const (
 	// ErrorAggregationWindow is the time window during which errors with the
 	// same message are coalesced.
 	ErrorAggregationWindow = 10 * time.Second
+	// PeerUpdateInterval is the time interval in which relay is checking for
+	// newly joined peers for long running requests
+	PeerUpdateInterval = 2 * time.Second
 )
 
 var (

--- a/pkg/hubble/relay/observer/observer.go
+++ b/pkg/hubble/relay/observer/observer.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"io"
 
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/status"
@@ -17,6 +19,7 @@ import (
 	poolTypes "github.com/cilium/cilium/pkg/hubble/relay/pool/types"
 	"github.com/cilium/cilium/pkg/hubble/relay/queue"
 	"github.com/cilium/cilium/pkg/inctimer"
+	"github.com/cilium/cilium/pkg/lock"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -217,4 +220,85 @@ func aggregateErrors(
 
 	}()
 	return aggregated
+}
+
+func sendFlowsResponse(ctx context.Context, stream observerpb.Observer_GetFlowsServer, sortedFlows <-chan *observerpb.GetFlowsResponse) error {
+	for {
+		select {
+		case flow, ok := <-sortedFlows:
+			if !ok {
+				return nil
+			}
+			if err := stream.Send(flow); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func newFlowCollector(req *observerpb.GetFlowsRequest, opts options) *flowCollector {
+	fc := &flowCollector{
+		log: opts.log,
+		ocb: opts.ocb,
+
+		req: req,
+
+		connectedNodes: map[string]struct{}{},
+	}
+	return fc
+}
+
+type flowCollector struct {
+	log logrus.FieldLogger
+	ocb observerClientBuilder
+
+	req *observerpb.GetFlowsRequest
+
+	mu             lock.Mutex
+	connectedNodes map[string]struct{}
+}
+
+func (fc *flowCollector) collect(ctx context.Context, g *errgroup.Group, peers []poolTypes.Peer, flows chan *observerpb.GetFlowsResponse) ([]string, []string) {
+	var connected, unavailable []string
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	for _, p := range peers {
+		if _, ok := fc.connectedNodes[p.Name]; ok {
+			connected = append(connected, p.Name)
+			continue
+		}
+		if !isAvailable(p.Conn) {
+			fc.log.WithField("address", p.Address).Infof(
+				"No connection to peer %s, skipping", p.Name,
+			)
+			unavailable = append(unavailable, p.Name)
+			continue
+		}
+		connected = append(connected, p.Name)
+		fc.connectedNodes[p.Name] = struct{}{}
+		p := p
+		g.Go(func() error {
+			// retrieveFlowsFromPeer returns blocks until the peer finishes
+			// the request by closing the connection, an error occurs,
+			// or ctx expires.
+			err := retrieveFlowsFromPeer(ctx, fc.ocb.observerClient(&p), fc.req, flows)
+			if err != nil {
+				fc.log.WithFields(logrus.Fields{
+					"error": err,
+					"peer":  p,
+				}).Warning("Failed to retrieve flows from peer")
+				fc.mu.Lock()
+				delete(fc.connectedNodes, p.Name)
+				fc.mu.Unlock()
+				select {
+				case flows <- nodeStatusError(err, p.Name):
+				case <-ctx.Done():
+				}
+			}
+			return nil
+		})
+	}
+	return connected, unavailable
 }

--- a/pkg/hubble/relay/observer/option.go
+++ b/pkg/hubble/relay/observer/option.go
@@ -38,6 +38,7 @@ var defaultOptions = options{
 	sortBufferMaxLen:       defaults.SortBufferMaxLen,
 	sortBufferDrainTimeout: defaults.SortBufferDrainTimeout,
 	errorAggregationWindow: defaults.ErrorAggregationWindow,
+	peerUpdateInterval:     defaults.PeerUpdateInterval,
 	log:                    logging.DefaultLogger.WithField(logfields.LogSubsys, "hubble-relay"),
 	ocb:                    defaultObserverClientBuilder{},
 }
@@ -50,6 +51,7 @@ type options struct {
 	sortBufferMaxLen       int
 	sortBufferDrainTimeout time.Duration
 	errorAggregationWindow time.Duration
+	peerUpdateInterval     time.Duration
 	log                    logrus.FieldLogger
 
 	// this is not meant to be user configurable as it's only useful to


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)

With this change, if the request is in follow mode, we periodically re-list peers and send the request to newly joined or reconnected peers.

Fixes: #12833 

