### PR TITLE
datapath: Fix ENI egress routing table for cilium_host IP

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -330,6 +330,7 @@ func LaunchAsEndpoint(baseCtx context.Context,
 			healthIP,
 			mtuConfig.GetDeviceMTU(),
 			option.Config.EgressMultiHomeIPRuleCompat,
+			false,
 		); err != nil {
 
 			return nil, fmt.Errorf("Error while configuring health endpoint rules and routes: %s", err)
@@ -357,5 +358,5 @@ type policyRepoGetter interface {
 }
 
 type routingConfigurer interface {
-	Configure(ip net.IP, mtu int, compat bool) error
+	Configure(ip net.IP, mtu int, compat bool, host bool) error
 }

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -402,6 +402,7 @@ func (d *Daemon) allocateIngressIPs() error {
 						result.IP,
 						d.mtuConfig.GetDeviceMTU(),
 						option.Config.EgressMultiHomeIPRuleCompat,
+						false,
 					); err != nil {
 						log.WithError(err).Warn("Error while configuring ingress IP rules and routes.")
 					}

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -291,6 +291,15 @@ func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily, fromK8s,
 		if err != nil {
 			return nil, fmt.Errorf("failed to create router info %w", err)
 		}
+		if err = routingInfo.Configure(
+			result.IP,
+			d.mtuConfig.GetDeviceMTU(),
+			option.Config.EgressMultiHomeIPRuleCompat,
+			true,
+		); err != nil {
+			return nil, fmt.Errorf("failed to configure router IP rules and routes %w", err)
+		}
+
 		node.SetRouterInfo(routingInfo)
 	}
 

--- a/pkg/datapath/linux/routing/info.go
+++ b/pkg/datapath/linux/routing/info.go
@@ -48,14 +48,6 @@ func (info *RoutingInfo) GetIPv4CIDRs() []net.IPNet {
 	return info.IPv4CIDRs
 }
 
-func (info *RoutingInfo) GetMac() mac.MAC {
-	return info.MasterIfMAC
-}
-
-func (info *RoutingInfo) GetInterfaceNumber() int {
-	return info.InterfaceNumber
-}
-
 // NewRoutingInfo creates a new RoutingInfo struct, from data that will be
 // parsed and validated. Note, this code assumes IPv4 values because IPv4
 // (on either ENI or Azure interface) is the only supported path currently.

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -56,7 +56,7 @@ func (e *LinuxRoutingSuite) TestConfigure(c *C) {
 func (e *LinuxRoutingSuite) TestConfigureRoutewithIncompatibleIP(c *C) {
 	_, ri := getFakes(c, true)
 	ipv6 := netip.MustParseAddr("fd00::2").AsSlice()
-	err := ri.Configure(ipv6, 1500, false)
+	err := ri.Configure(ipv6, 1500, false, false)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, "IP not compatible")
 }
@@ -186,7 +186,7 @@ func runConfigureThenDelete(c *C, ri RoutingInfo, ip netip.Addr, mtu int) {
 }
 
 func runConfigure(c *C, ri RoutingInfo, ip netip.Addr, mtu int) {
-	err := ri.Configure(ip.AsSlice(), mtu, false)
+	err := ri.Configure(ip.AsSlice(), mtu, false, false)
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/ethtool"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
-	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -98,7 +97,7 @@ func writePreFilterHeader(preFilter *prefilter.PreFilter, dir string) error {
 	return fw.Flush()
 }
 
-func addENIRules(sysSettings []sysctl.Setting, nodeAddressing datapath.NodeAddressing) ([]sysctl.Setting, error) {
+func addENIRules(sysSettings []sysctl.Setting) ([]sysctl.Setting, error) {
 	// AWS ENI mode requires symmetric routing, see
 	// iptables.addCiliumENIRules().
 	// The default AWS daemonset installs the following rules that are used
@@ -138,20 +137,6 @@ func addENIRules(sysSettings []sysctl.Setting, nodeAddressing datapath.NodeAddre
 		Protocol: linux_defaults.RTProto,
 	}); err != nil {
 		return nil, fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
-	}
-
-	// Add rules for router (cilium_host).
-	info := node.GetRouterInfo()
-	cidrs := info.GetIPv4CIDRs()
-	routerIP := net.IPNet{
-		IP:   nodeAddressing.IPv4().Router(),
-		Mask: net.CIDRMask(32, 32),
-	}
-
-	for _, cidr := range cidrs {
-		if err = linuxrouting.SetupRules(&routerIP, &cidr, info.GetMac().String(), info.GetInterfaceNumber()); err != nil {
-			return nil, fmt.Errorf("unable to install ip rule for cilium_host: %w", err)
-		}
 	}
 
 	return retSettings, nil
@@ -327,7 +312,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 	if option.Config.IPAM == ipamOption.IPAMENI {
 		var err error
-		if sysSettings, err = addENIRules(sysSettings, o.Datapath().LocalNodeAddressing()); err != nil {
+		if sysSettings, err = addENIRules(sysSettings); err != nil {
 			return fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
 		}
 	}

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/option"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
@@ -66,8 +65,6 @@ type addresses struct {
 
 type RouterInfo interface {
 	GetIPv4CIDRs() []net.IPNet
-	GetMac() mac.MAC
-	GetInterfaceNumber() int
 }
 
 func makeIPv6HostIP() net.IP {

--- a/plugins/cilium-cni/interface.go
+++ b/plugins/cilium-cni/interface.go
@@ -60,6 +60,7 @@ func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, 
 		ipConfig.Address.IP,
 		int(conf.DeviceMTU),
 		conf.EgressMultiHomeIPRuleCompat,
+		false,
 	); err != nil {
 		return fmt.Errorf("unable to install ip rules and routes: %s", err)
 	}


### PR DESCRIPTION
On ENI, we install source-based egress routing rules that steer traffic from Cilium-mananged IPs (i.e. pods, but also the health IP, ingress IP and router IP) to the correct egress interface.

For pod IPs, this is done in the CNI plugin:

https://github.com/cilium/cilium/blob/7875f6acb5a2fd2b0e3e6c993c9995c0d322e55d/plugins/cilium-cni/interface.go#L59-L63

For ingress and health IP, this is done from cilium-agent:

https://github.com/cilium/cilium/blob/ed20c8acde8c76d405d6c9fac3c9de44aa3bb403/daemon/cmd/ipam.go#L401-L405 https://github.com/cilium/cilium/blob/e49430286b5d63b00062758a10a2b37458f94525/cilium-health/launch/endpoint.go#L329-L333

For the router (aka cilium_host) IP however, this was done differently. Commit f34371ce8f added a new `routing.SetupRules` function that duplicated parts of the `routing.RoutingInfo.Configure` logic, but missed a crucial part: Namely the creation of the per-ENI routing table that the source-based egress rule points towards.

This means that if the cilium_host IP address was allocated from a different ENI than the pod, health and ingress IP addresses, that the routing table for that ENI was never created. This led to connectivity issues, in particular in combination with IPSec.

This commit addresses that issue by having the router IP use the same code path as the other IP users: Using `RoutingInfo.Configure`. This not only fixes the bug, but removes some code that was otherwise only used for the router IP.

There is one major difference between other users of  `RoutingInfo.Configure` and the newly introduced use for the    `cilium_host` IP: For the `cilium_host` IP, we skip the creation of the ingress rule (by passing in `host=true`), as otherwise the `cilium_host` IP would not be considered a local address of the host network namespace. This is consistent with the old `SetupRules` function did also not create such an ingress rule.

Long-term, it remains questionable if the setup of egress rules in ENI mode should be left to IPAM clients, as every client seems to do it slightly differently. Maybe this is better done by either the IPAM subsystem or a separate device manager.

Fixes: f34371ce8f27 ("ipam: Add routes for cilium_host ENI address")
