### PR TITLE
ci: fix merge group required checks

### DIFF
--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -7,8 +7,6 @@ on:
     branches:
       - main
       - ft/main/**
-  merge_group:
-    types: [checks_requested]
 
 permissions: read-all
 

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -78,7 +78,7 @@ jobs:
 
   conformance-test:
     needs: check_changes
-    if: ${{ needs.check_changes.outputs.tested == 'true' }}
+    if: ${{ needs.check_changes.outputs.tested == 'true' && github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     name: Installation and Conformance Test
     steps:


### PR DESCRIPTION
This PR removes merge_group trigger from tests-smoke-ipv6.yaml workflow and adds a condition for `Installation and Conformance Test` in tests-smoke.yaml not to run on merge_group events.

These two tests require CI images and since merge_group creates a new branch with all other commits merged in the queue, SHA of the expected image is changed. Either we have to add Build Image CI to the required checks or disable these tests from running. Since Build Image CI takes a long time to run, on top of these two tests have to wait for the image to be available and run to completion. We implemented the second option.