### PR TITLE
images/cilium: copy the cilium-envoy binary into Cilium image

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -79,7 +79,8 @@ ARG TARGETOS
 ARG TARGETARCH
 LABEL maintainer="maintainer@cilium.io"
 RUN echo ". /etc/profile.d/bash_completion.sh" >> /etc/bash.bashrc
-COPY --from=cilium-envoy / /
+COPY --from=cilium-envoy /usr/lib/libcilium.so /usr/lib/libcilium.so
+COPY --from=cilium-envoy /usr/bin/cilium-envoy /usr/bin/cilium-envoy-starter /usr/bin/
 # When used within the Cilium container, Hubble CLI should target the
 # local unix domain socket instead of Hubble Relay.
 ENV HUBBLE_SERVER=unix:///var/run/cilium/hubble.sock


### PR DESCRIPTION
When we integrated cilium-envoy into Cilium's image we have made the assumption that the image only contained the cilium-envoy binary, which made it safe to copy the entire image into Cilium's. However, since 3698c40e878c, the cilium-envoy's base image was switched to Ubuntu's instead of "scratch". This had the consequence of overwriting the files of Cilium's Runtime image with Cilium-envoy's base image. To fix this, we should only copy the cilium-envoy binary available on the cilium-envoy image.

Fixes: 3698c40e878c ("cilium/proxy: updating proxy image to latest version")

```release-note
Replace Cilium's base image from ubuntu:22.04 with Cilium's Runtime image (also ubuntu:22.04 based).
```