### PR TITLE
docs: Add cluster install/prep guide for GKE-to-GKE clustermesh

### DIFF
--- a/Documentation/network/clustermesh/aks-clustermesh-prep.rst
+++ b/Documentation/network/clustermesh/aks-clustermesh-prep.rst
@@ -62,8 +62,8 @@ Install cluster one
 3.  We now have a virtual network and a subnet with the same CIDR. We can 
     create an AKS cluster without CNI and request to use our custom VNet and subnet.
 
-    During creation we also request to use ``"10.10.0.0/16`` as the pod CIDR and
-    ``"10.11.0.0/16`` as the services CIDR. These can be changed to any range
+    During creation we also request to use ``"10.10.0.0/16"`` as the pod CIDR and
+    ``"10.11.0.0/16"`` as the services CIDR. These can be changed to any range
     except for Azure reserved ranges and ranges used by other clusters we intend to
     add to the clustermesh.
 
@@ -151,8 +151,8 @@ arguments.
 3.  Create an AKS cluster without CNI and request to use our custom VNet and 
     subnet.
 
-    During creation we also request to use ``"10.20.0.0/16`` as the pod CIDR and
-    ``"10.21.0.0/16`` as the services CIDR. These can be changed to any range
+    During creation we also request to use ``"10.20.0.0/16"`` as the pod CIDR and
+    ``"10.21.0.0/16"`` as the services CIDR. These can be changed to any range
     except for Azure reserved ranges and ranges used by other clusters we intend to
     add to the clustermesh.
 

--- a/Documentation/network/clustermesh/clustermesh.rst
+++ b/Documentation/network/clustermesh/clustermesh.rst
@@ -42,6 +42,12 @@ Cluster Addressing Requirements
   you can follow the :ref:`gs_clustermesh_aks_prep` guide for instruction on
   how to meet the above requirements.
 
+.. note::
+  
+  If you intend to connect two Google Kubernetes Engine (GKE) clusters together
+  you can follow the :ref:`gs_clustermesh_gke_prep` guide for instruction on
+  how to meet the above requirements.
+
 Additional Requirements for Native-routed Datapath Modes
 --------------------------------------------------------
 

--- a/Documentation/network/clustermesh/clustermesh.rst
+++ b/Documentation/network/clustermesh/clustermesh.rst
@@ -38,14 +38,9 @@ Cluster Addressing Requirements
 
 .. note::
   
-  If you intend to connect two AKS (Azure Kubernetes Service) clusters together
-  you can follow the :ref:`gs_clustermesh_aks_prep` guide for instruction on
-  how to meet the above requirements.
-
-.. note::
-  
-  If you intend to connect two Google Kubernetes Engine (GKE) clusters together
-  you can follow the :ref:`gs_clustermesh_gke_prep` guide for instruction on
+  For cloud-specific deployments, you can check out the :ref:`gs_clustermesh_aks_prep`
+  guide for Azure Kubernetes Service (AKS) or the :ref:`gs_clustermesh_gke_prep` 
+  guide for Google Kubernetes Engine (GKE) clusters for instructions on
   how to meet the above requirements.
 
 Additional Requirements for Native-routed Datapath Modes

--- a/Documentation/network/clustermesh/gke-clustermesh-prep.rst
+++ b/Documentation/network/clustermesh/gke-clustermesh-prep.rst
@@ -21,7 +21,7 @@ Create VPC
 ##########
 
 1.  Create a VPC network in your GCP project. Environment variables are recommended as their
-    values will be references in later steps.
+    values will be referenced in later steps.
 
     .. code-block:: bash
 
@@ -58,9 +58,10 @@ Deploy clusters
 
     .. note::
 
-        During creation we also request to use ``"10.0.0.0/18"`` as the cluster (pod) CIDR
-        and ``"10.1.0.0/20"`` as the services CIDR. You may select change the CIDRs provided
-        they do not overlap with the pod and services CIDRs in your other cluster(s).
+        You can use different pod and services CIDRs than in the example, but make sure 
+        they meet the IP address range `rules <https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips#cluster_sizing>`__. But most
+        importantly, make sure they do not overlap with the pods and services CIDRs in
+        your other cluster(s).
 
     .. code-block:: bash
 

--- a/Documentation/network/clustermesh/gke-clustermesh-prep.rst
+++ b/Documentation/network/clustermesh/gke-clustermesh-prep.rst
@@ -1,0 +1,177 @@
+.. _gs_clustermesh_gke_prep:
+
+**********************************
+GKE-to-GKE Clustermesh Preparation
+**********************************
+
+This is a step-by-step guide on how to install and prepare 
+Google Kubernetes Engine (GKE) clusters to meet the requirements 
+for the clustermesh feature.
+
+In this guide we will deploy two zonal, single node GKE clusters
+in different regions for the express purpose of creating a
+cost-effective environment to deploy a clustermesh to. Ideal for
+development/learning purposes.
+
+.. note::
+
+        The steps below require the `gcloud <https://cloud.google.com/sdk/docs/install>`__ CLI tool
+
+Create VPC
+###################
+
+1.  Create a VPC network in your GCP project. Environment variables are recommended as their
+    values will be references in later steps.
+
+    .. code-block:: bash
+
+        #  feel free to choose your own VPC network name
+        export PROJECT_ID="[GCP_PROJECT_ID]"
+        export VPC_NETWORK="my-gke-network"
+
+        gcloud compute networks create ${VPC_NETWORK} \
+          --subnet-mode=auto \
+          --project ${PROJECT_ID}
+
+        gcloud compute firewall-rules create ${VPC_NETWORK}-allow-internal \
+          --network ${VPC_NETWORK} \
+          --allow tcp,udp,icmp \
+          --source-ranges "10.128.0.0/9"
+
+
+Deploy cluster one
+###################
+
+1.  We will once again set some environment variables for values that will be reused in 
+    later steps.
+
+    During creation we also request to use ``"10.0.0.0/18"`` as the cluster (pod) CIDR
+    and ``"10.1.0.0/20"`` as the services CIDR. You may select change the CIDRs provided
+    they do not overlap with the pod and services CIDRs in your other cluster(s).
+
+    .. code-block:: bash
+
+        #  us-west1-a can be changed to any available location (`gcloud compute zones list`)
+        export CLUSTER1="gke-1"
+        export ZONE1="us-west1-a"
+
+        gcloud container clusters create ${CLUSTER1} \
+          --zone ${ZONE1} \
+          --node-locations ${ZONE1} \
+          --network=${VPC_NETWORK} \
+          --enable-ip-alias \
+          --cluster-ipv4-cidr="10.0.0.0/18" \
+          --services-ipv4-cidr="10.1.0.0/20" \
+          --machine-type=e2-medium \
+          --max-nodes=1 \
+          --num-nodes=1 \
+          --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+          --project ${PROJECT_ID}
+
+        # Get kubectl credentials, the command will merge the new credentials
+        # with the existing ~/.kube/config
+        gcloud container clusters get-credentials ${CLUSTER1} \
+          --zone ${ZONE1} \
+          --project ${PROJECT_ID}
+ 
+    The node taint is used to prevent pods from being deployed/started until Cilium
+    has been installed.
+
+2.  Install Cilium. It is important to assign a unique ``cluster.id`` to each cluster.
+
+    .. code-block:: bash
+
+        cilium install \
+            --version |CHART_VERSION| \
+            --set cluster.id=1 \
+            --set cluster.name=${CLUSTER1}
+
+3.  Check the status of Cilium.
+
+    .. code-block:: bash
+
+        cilium status   
+
+4.  Save GKE cluster context in environment variable for use in the clustermesh setup process.
+    GKE cluster contexts is a combination of project ID, location, and cluster name..
+
+    .. code-block:: bash
+
+        export CONTEXT1="gke_${PROJECT_ID}_${ZONE1}_${CLUSTER1}"
+
+
+Deploy cluster two
+###################
+
+Installing the second cluster uses the same commands but with slightly different
+arguments.
+
+1.  We will once again set some environment variables for values that will be reused in 
+    later steps.
+
+    During creation we also request to use ``"10.10.0.0/18"`` as the cluster (pod) CIDR
+    and ``"10.11.0.0/20"`` as the services CIDR. You may select change the CIDRs provided
+    they do not overlap with the pod and services CIDRs in your other cluster(s).
+
+    .. code-block:: bash
+
+        #  us-east4-b can be changed to any available location (`gcloud compute zones list`)
+        export CLUSTER2="gke-2"
+        export ZONE2="us-east4-b"
+
+        gcloud container clusters create ${CLUSTER2} \
+          --zone ${ZONE2} \
+          --node-locations ${ZONE2} \
+          --network=${VPC_NETWORK} \
+          --enable-ip-alias \
+          --cluster-ipv4-cidr="10.10.0.0/18" \
+          --services-ipv4-cidr="10.11.0.0/20" \
+          --machine-type=e2-medium \
+          --max-nodes=1 \
+          --num-nodes=1 \
+          --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+          --project ${PROJECT_ID}
+
+        # Get kubectl credentials, the command will merge the new credentials
+        # with the existing ~/.kube/config
+        gcloud container clusters get-credentials ${CLUSTER2} \
+          --zone ${ZONE2} \
+          --project ${PROJECT_ID}
+
+    Once again, the node taint is used to prevent pods from being deployed/started
+    until Cilium has been installed.
+
+2.  Install Cilium. It is important to assign a unique ``cluster.id`` to each cluster.
+
+    .. code-block:: bash
+
+        cilium install \
+            --version |CHART_VERSION| \
+            --set cluster.id=2 \
+            --set cluster.name=${CLUSTER2}
+
+3.  Check the status of Cilium.
+
+    .. code-block:: bash
+
+        cilium status
+
+4.  Save GKE cluster context in environment variable for use in the clustermesh setup process.
+    GKE cluster contexts is a combination of project ID, location, and cluster name..
+
+    .. code-block:: bash
+
+        export CONTEXT2="gke_${PROJECT_ID}_${ZONE2}_${CLUSTER2}"
+
+
+Peering VPC networks
+########################
+
+Google Cloud's VPCs are global in scope, so subnets within the same VPC can already communicate with each
+other internally -- regardless of region. So there is no VPC peering required!
+
+Node-to-node traffic between clusters is now possible. All requirements for 
+clustermesh are met. Enabling clustermesh is explained in :ref:`gs_clustermesh`.
+
+Please reference environment variables ``CONTEXT1`` and ``CONTEXT2``
+for any steps that require the Kubernetes context.

--- a/Documentation/network/clustermesh/gke-clustermesh-prep.rst
+++ b/Documentation/network/clustermesh/gke-clustermesh-prep.rst
@@ -18,7 +18,7 @@ development/learning purposes.
         The steps below require the `gcloud <https://cloud.google.com/sdk/docs/install>`__ CLI tool
 
 Create VPC
-###################
+##########
 
 1.  Create a VPC network in your GCP project. Environment variables are recommended as their
     values will be references in later steps.
@@ -39,29 +39,38 @@ Create VPC
           --source-ranges "10.128.0.0/9"
 
 
-Deploy cluster one
-###################
+Deploy clusters
+###############
 
 1.  We will once again set some environment variables for values that will be reused in 
     later steps.
 
-    During creation we also request to use ``"10.0.0.0/18"`` as the cluster (pod) CIDR
-    and ``"10.1.0.0/20"`` as the services CIDR. You may select change the CIDRs provided
-    they do not overlap with the pod and services CIDRs in your other cluster(s).
-
     .. code-block:: bash
 
         #  us-west1-a can be changed to any available location (`gcloud compute zones list`)
-        export CLUSTER1="gke-1"
-        export ZONE1="us-west1-a"
+        export CLUSTER="gke-1"
+        export ZONE="us-west1-a"
+        export POD_CIDR="10.0.0.0/18"
+        export SERVICES_CIDR="10.1.0.0/20"
 
-        gcloud container clusters create ${CLUSTER1} \
-          --zone ${ZONE1} \
-          --node-locations ${ZONE1} \
+    Below is an example to deploy one GKE cluster. To create more clusters, follow the
+    steps again, using distinct cluster names, zones, pod CIDRs, and services CIDRs.
+
+    .. note::
+
+        During creation we also request to use ``"10.0.0.0/18"`` as the cluster (pod) CIDR
+        and ``"10.1.0.0/20"`` as the services CIDR. You may select change the CIDRs provided
+        they do not overlap with the pod and services CIDRs in your other cluster(s).
+
+    .. code-block:: bash
+
+        gcloud container clusters create ${CLUSTER} \
+          --zone ${ZONE} \
+          --node-locations ${ZONE} \
           --network=${VPC_NETWORK} \
           --enable-ip-alias \
-          --cluster-ipv4-cidr="10.0.0.0/18" \
-          --services-ipv4-cidr="10.1.0.0/20" \
+          --cluster-ipv4-cidr=${POD_CIDR} \
+          --services-ipv4-cidr=${SERVICES_CIDR} \
           --machine-type=e2-medium \
           --max-nodes=1 \
           --num-nodes=1 \
@@ -70,21 +79,25 @@ Deploy cluster one
 
         # Get kubectl credentials, the command will merge the new credentials
         # with the existing ~/.kube/config
-        gcloud container clusters get-credentials ${CLUSTER1} \
-          --zone ${ZONE1} \
+        gcloud container clusters get-credentials ${CLUSTER} \
+          --zone ${ZONE} \
           --project ${PROJECT_ID}
  
     The node taint is used to prevent pods from being deployed/started until Cilium
     has been installed.
 
-2.  Install Cilium. It is important to assign a unique ``cluster.id`` to each cluster.
+2.  Install Cilium.
+
+    .. important::
+
+        Be sure to assign a unique ``cluster.id`` to each cluster.
 
     .. code-block:: bash
 
         cilium install \
             --version |CHART_VERSION| \
             --set cluster.id=1 \
-            --set cluster.name=${CLUSTER1}
+            --set cluster.name=${CLUSTER}
 
 3.  Check the status of Cilium.
 
@@ -92,86 +105,24 @@ Deploy cluster one
 
         cilium status   
 
-4.  Save GKE cluster context in environment variable for use in the clustermesh setup process.
-    GKE cluster contexts is a combination of project ID, location, and cluster name..
+4.  For each GKE cluster, save its context in an environment variable for use in
+    the clustermesh setup process.
+
+    GKE cluster context is a combination of project ID, location, and cluster name.
 
     .. code-block:: bash
 
-        export CONTEXT1="gke_${PROJECT_ID}_${ZONE1}_${CLUSTER1}"
-
-
-Deploy cluster two
-###################
-
-Installing the second cluster uses the same commands but with slightly different
-arguments.
-
-1.  We will once again set some environment variables for values that will be reused in 
-    later steps.
-
-    During creation we also request to use ``"10.10.0.0/18"`` as the cluster (pod) CIDR
-    and ``"10.11.0.0/20"`` as the services CIDR. You may select change the CIDRs provided
-    they do not overlap with the pod and services CIDRs in your other cluster(s).
-
-    .. code-block:: bash
-
-        #  us-east4-b can be changed to any available location (`gcloud compute zones list`)
-        export CLUSTER2="gke-2"
-        export ZONE2="us-east4-b"
-
-        gcloud container clusters create ${CLUSTER2} \
-          --zone ${ZONE2} \
-          --node-locations ${ZONE2} \
-          --network=${VPC_NETWORK} \
-          --enable-ip-alias \
-          --cluster-ipv4-cidr="10.10.0.0/18" \
-          --services-ipv4-cidr="10.11.0.0/20" \
-          --machine-type=e2-medium \
-          --max-nodes=1 \
-          --num-nodes=1 \
-          --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
-          --project ${PROJECT_ID}
-
-        # Get kubectl credentials, the command will merge the new credentials
-        # with the existing ~/.kube/config
-        gcloud container clusters get-credentials ${CLUSTER2} \
-          --zone ${ZONE2} \
-          --project ${PROJECT_ID}
-
-    Once again, the node taint is used to prevent pods from being deployed/started
-    until Cilium has been installed.
-
-2.  Install Cilium. It is important to assign a unique ``cluster.id`` to each cluster.
-
-    .. code-block:: bash
-
-        cilium install \
-            --version |CHART_VERSION| \
-            --set cluster.id=2 \
-            --set cluster.name=${CLUSTER2}
-
-3.  Check the status of Cilium.
-
-    .. code-block:: bash
-
-        cilium status
-
-4.  Save GKE cluster context in environment variable for use in the clustermesh setup process.
-    GKE cluster contexts is a combination of project ID, location, and cluster name..
-
-    .. code-block:: bash
-
-        export CONTEXT2="gke_${PROJECT_ID}_${ZONE2}_${CLUSTER2}"
+        export CONTEXT1="gke_${PROJECT_ID}_${ZONE}_${CLUSTER}"
 
 
 Peering VPC networks
 ########################
 
-Google Cloud's VPCs are global in scope, so subnets within the same VPC can already communicate with each
-other internally -- regardless of region. So there is no VPC peering required!
+Google Cloud's VPCs are global in scope, so subnets within the same VPC can already communicate
+with each other internally -- regardless of region. So there is no VPC peering required!
 
 Node-to-node traffic between clusters is now possible. All requirements for 
 clustermesh are met. Enabling clustermesh is explained in :ref:`gs_clustermesh`.
 
-Please reference environment variables ``CONTEXT1`` and ``CONTEXT2``
-for any steps that require the Kubernetes context.
+Please reference environment variables exported in step 4 for any commands that require
+the Kubernetes context.

--- a/Documentation/network/clustermesh/index.rst
+++ b/Documentation/network/clustermesh/index.rst
@@ -20,3 +20,4 @@ Multi-cluster Networking
    policy
    affinity
    aks-clustermesh-prep
+   gke-clustermesh-prep

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -39,6 +39,8 @@ Fastabend
 Fosdem
 Freescale
 Fsnotify
+GCP
+GKE
 Gartrell
 Gbit
 GiB


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Using [AKS-to-AKS Clustermesh Preparation](https://docs.cilium.io/en/stable/network/clustermesh/aks-clustermesh-prep/) guide as a template, I create one for GKE-to-GKE.

Also fixed a minor typo in the AKS guide

This is strictly a website/documentation addition.  No changes to any Cilium code or functionality.