### PR TITLE
metrics: revert changes to pre-init kubernetes events metrics + improve metric logs

### DIFF
--- a/pkg/metrics/metric/metric_test.go
+++ b/pkg/metrics/metric/metric_test.go
@@ -53,7 +53,6 @@ func TestLabelsnamesToValues(t *testing.T) {
 		"3": {},
 		"4": {},
 	}, ntov["bar"])
-
 	assert.NoError(t, ls.checkLabels(map[string]string{
 		"foo": "0",
 		"bar": "2",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1009,51 +1009,19 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Help:       "Number of times that Cilium has started a subprocess, labeled by subsystem",
 		}, []string{LabelSubsystem}),
 
-		KubernetesEventProcessed: metric.NewCounterVecWithLabels(metric.CounterOpts{
+		KubernetesEventProcessed: metric.NewCounterVec(metric.CounterOpts{
 			ConfigName: Namespace + "_kubernetes_events_total",
 			Namespace:  Namespace,
 			Name:       "kubernetes_events_total",
 			Help:       "Number of Kubernetes events processed labeled by scope, action and execution result",
-		},
-			metric.Labels{
-				{
-					Name:   LabelScope,
-					Values: metric.NewValues("CiliumNetworkPolicy", "CiliumClusterwideNetworkPolicy", "NetworkPolicy"),
-				},
-				{
-					Name:   LabelAction,
-					Values: metric.NewValues("update", "delete"),
-				},
-				{
-					Name:   LabelStatus,
-					Values: metric.NewValues("success", "failed"),
-				},
-			},
-		),
+		}, []string{LabelScope, LabelAction, LabelStatus}),
 
-		KubernetesEventReceived: metric.NewCounterVecWithLabels(metric.CounterOpts{
+		KubernetesEventReceived: metric.NewCounterVec(metric.CounterOpts{
 			ConfigName: Namespace + "_kubernetes_events_received_total",
 			Namespace:  Namespace,
 			Name:       "kubernetes_events_received_total",
 			Help:       "Number of Kubernetes events received labeled by scope, action, valid data and equalness",
-		}, metric.Labels{
-			{
-				Name:   LabelScope,
-				Values: metric.NewValues("CiliumNetworkPolicy", "CiliumClusterwideNetworkPolicy", "NetworkPolicy"),
-			},
-			{
-				Name:   LabelAction,
-				Values: metric.NewValues("update", "delete"),
-			},
-			{
-				Name:   "valid",
-				Values: LabelValuesBool,
-			},
-			{
-				Name:   "equal",
-				Values: LabelValuesBool,
-			},
-		}),
+		}, []string{LabelScope, LabelAction, "valid", "equal"}),
 
 		KubernetesAPIInteractions: metric.NewHistogramVec(metric.HistogramOpts{
 			ConfigName: Namespace + "_" + SubsystemK8sClient + "_api_latency_time_seconds",


### PR DESCRIPTION
Commit bd5ec0b3070fb9536761ccb8245388624fdaffa9 introduced pre-declaring metrics label value ranges for k8s watcher metrics. This also performs a check when the metric is updated to check whether the metric label value is within the (optional) declared range.

However, k8s watchers would require declaring all possible CRD types in the scope.

We could make this change, but this list would be hard to maintain, and more importantly, we probably don't want to initialize metrics for CRDs that are not necessarily going to be used (i.e. CES if disabled).

This reverts this change, until a better solution for this type of metric is developed.

