### PR TITLE
ci-e2e: Use kernel 6.1 instead of 6.0

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -127,7 +127,7 @@ jobs:
 
           - name: '6'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.0-20231019.053646'
+            kernel: '6.1-20231026.065108'
             kube-proxy: 'none'
             kpr: 'true'
             tunnel: 'vxlan'
@@ -188,7 +188,7 @@ jobs:
 
           - name: '11'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.0-20231019.053646'
+            kernel: '6.1-20231026.065108'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -130,7 +130,7 @@ jobs:
 
           - name: '6'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.0-20231019.053646'
+            kernel: '6.1-20231026.065108'
             kube-proxy: 'none'
             kpr: 'true'
             tunnel: 'vxlan'
@@ -191,7 +191,7 @@ jobs:
 
           - name: '11'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.0-20231019.053646'
+            kernel: '6.1-20231026.065108'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'


### PR DESCRIPTION
The former is the long term stable - https://kernel.org
