### PR TITLE
gh: datapath-verifier: also run on 6.1 kernel

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -85,6 +85,9 @@ jobs:
           - kernel: '5.15-20231026.065108'
             ci-kernel: '510'
           # renovate: datasource=docker depName=quay.io/lvh-images/kind
+          - kernel: '6.1-20231026.065108'
+            ci-kernel: '510'
+          # renovate: datasource=docker depName=quay.io/lvh-images/kind
           - kernel: 'bpf-next-20231030.012704'
             ci-kernel: 'netnext'
     timeout-minutes: 60


### PR DESCRIPTION
We don't depend on any 6.1-specific features, so it's fine to run the 5.10 complexity configs.
