### PR TITLE
ipsec: Small refactorings on key loading and state creation

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -77,6 +77,34 @@ func (p *IPSecSuitePrivileged) TestLoadKeys(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (p *IPSecSuitePrivileged) TestParseSPI(c *C) {
+	testCases := []struct {
+		input    string
+		expSPI   uint8
+		expOff   int
+		expError bool
+	}{
+		{"254", 0, 0, true},
+		{"15", 15, 0, false},
+		{"abc", 1, -1, false},
+		{"0", 0, 0, true},
+	}
+	for _, tc := range testCases {
+		spi, off, err := parseSPI(tc.input)
+		if spi != tc.expSPI {
+			c.Fatalf("For input %q, expected SPI %d, but got %d", tc.input, tc.expSPI, spi)
+		}
+		if off != tc.expOff {
+			c.Fatalf("For input %q, expected base offset %d, but got %d", tc.input, tc.expOff, off)
+		}
+		if tc.expError {
+			c.Assert(err, NotNil)
+		} else {
+			c.Assert(err, IsNil)
+		}
+	}
+}
+
 func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(c *C) {
 	_, local, err := net.ParseCIDR("1.2.3.4/16")
 	c.Assert(err, IsNil)

--- a/pkg/datapath/linux/ipsec/probe_linux.go
+++ b/pkg/datapath/linux/ipsec/probe_linux.go
@@ -23,20 +23,21 @@ const (
 )
 
 func initDummyXfrmState() *netlink.XfrmState {
-	state := ipSecNewState()
-
 	k, _ := hex.DecodeString(aeadKey)
-	state.Aead = &netlink.XfrmStateAlgo{
-		Name:   aeadAlgo,
-		Key:    k,
-		ICVLen: 128,
+	return &netlink.XfrmState{
+		Mode:  netlink.XFRM_MODE_TUNNEL,
+		Proto: netlink.XFRM_PROTO_ESP,
+		ESN:   false,
+		Spi:   stateId,
+		Reqid: stateId,
+		Aead: &netlink.XfrmStateAlgo{
+			Name:   aeadAlgo,
+			Key:    k,
+			ICVLen: 128,
+		},
+		Src: net.ParseIP(dummyIP),
+		Dst: net.ParseIP(dummyIP),
 	}
-	state.Spi = stateId
-	state.Reqid = stateId
-
-	state.Src = net.ParseIP(dummyIP)
-	state.Dst = net.ParseIP(dummyIP)
-	return state
 }
 
 func createDummyXfrmState(state *netlink.XfrmState) error {


### PR DESCRIPTION
Two small bits of unrelated refactoring around the key loading (with new unit test) and the XFRM state creation. There should be no functional changes.