### PR TITLE
workflows: Add debug info to IPsec key rotation test

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -291,7 +291,7 @@ jobs:
               if [[ \$keys_in_use == 2 ]]; then
                 break
               fi
-              echo "Waiting until key rotation starts"
+              echo "Waiting until key rotation starts (seeing \$keys_in_use keys)"
               sleep 30s
             done
 
@@ -303,7 +303,7 @@ jobs:
               if [[ \$keys_in_use == 1 ]]; then
                 break
               fi
-              echo "Waiting until key rotation completes"
+              echo "Waiting until key rotation completes (seeing \$keys_in_use keys)"
               sleep 30s
             done
 


### PR DESCRIPTION
To detect that the key rotation began or that it successfully ended, we rely on the number of keys in use reported by
`cilium-dbg encrypt status`. When either of those steps times out, it would be good to have information on what the number of keys was.

This pull request adds that debug information to the test.