### PR TITLE
[v1.14] ci-ipsec-upgrade: Disable Linux 5.10-based configs

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -75,7 +75,8 @@ jobs:
       fail-fast: false
       max-parallel: 16
       matrix:
-        config: ['5.4', '5.10', 'bpf-next']
+        #config: ['5.4', '5.10', 'bpf-next']
+        config: ['5.4', 'bpf-next']
         mode: ['minor', 'patch']
         include:
           # Define three config sets
@@ -87,14 +88,14 @@ jobs:
             tunnel: 'disabled'
             encryption: 'ipsec'
 
-          - config: '5.10'
-            # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20231124.100406'
-            kube-proxy: 'iptables'
-            kpr: 'disabled'
-            tunnel: 'disabled'
-            encryption: 'ipsec'
-            endpoint-routes: 'true'
+          #- config: '5.10'
+          #  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+          #  kernel: '5.10-20231124.100406'
+          #  kube-proxy: 'iptables'
+          #  kpr: 'disabled'
+          #  tunnel: 'disabled'
+          #  encryption: 'ipsec'
+          #  endpoint-routes: 'true'
 
           - config: 'bpf-next'
             # We don't want to update bpf-next after branching
@@ -110,9 +111,9 @@ jobs:
             mode: 'minor'
             name: '1'
 
-          - config: '5.10'
-            mode: 'minor'
-            name: '2'
+          #- config: '5.10'
+          #  mode: 'minor'
+          #  name: '2'
 
           - config: 'bpf-next'
             mode: 'minor'
@@ -122,9 +123,9 @@ jobs:
             mode: 'patch'
             name: '4'
 
-          - config: '5.10'
-            mode: 'patch'
-            name: '5'
+          #- config: '5.10'
+          #  mode: 'patch'
+          #  name: '5'
 
           - config: 'bpf-next'
             mode: 'patch'


### PR DESCRIPTION
As reported in \[1\], the node-to-node-encryption tests are failing. It expects ICMP packets to be not encrypted.

Disable the config until we have resolved the issue.

\[1\]: https://github.com/cilium/cilium/issues/29351

Reported-by: Marcel Zieba <marcel.zieba@isovalent.com>