### PR TITLE
gateway-api: Use Gateway API definition to check Route condition

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -305,11 +305,11 @@ func isAttachable(_ context.Context, gw *gatewayv1.Gateway, route metav1.Object,
 		}
 
 		for _, cond := range rps.Conditions {
-			if cond.Type == conditionStatusAccepted && cond.Status == metav1.ConditionTrue {
+			if cond.Type == string(gatewayv1.RouteConditionAccepted) && cond.Status == metav1.ConditionTrue {
 				return true
 			}
 
-			if cond.Type == "ResolvedRefs" && cond.Status == metav1.ConditionFalse {
+			if cond.Type == string(gatewayv1.RouteConditionResolvedRefs) && cond.Status == metav1.ConditionFalse {
 				return true
 			}
 		}

--- a/operator/pkg/gateway-api/grpcroute_reconcile.go
+++ b/operator/pkg/gateway-api/grpcroute_reconcile.go
@@ -13,6 +13,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -78,9 +79,9 @@ func (r *grpcRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	for _, parent := range gr.Spec.ParentRefs {
 		// set acceptance to okay, this wil be overwritten in checks if needed
 		i.SetParentCondition(parent, metav1.Condition{
-			Type:    conditionStatusAccepted,
+			Type:    string(gatewayv1.RouteConditionAccepted),
 			Status:  metav1.ConditionTrue,
-			Reason:  conditionReasonAccepted,
+			Reason:  string(gatewayv1.RouteReasonAccepted),
 			Message: "Accepted GRPCRoute",
 		})
 

--- a/operator/pkg/gateway-api/httproute_reconcile.go
+++ b/operator/pkg/gateway-api/httproute_reconcile.go
@@ -75,9 +75,9 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		// set acceptance to okay, this wil be overwritten in checks if needed
 		i.SetParentCondition(parent, metav1.Condition{
-			Type:    conditionStatusAccepted,
+			Type:    string(gatewayv1.RouteConditionAccepted),
 			Status:  metav1.ConditionTrue,
-			Reason:  conditionReasonAccepted,
+			Reason:  string(gatewayv1.RouteReasonAccepted),
 			Message: "Accepted HTTPRoute",
 		})
 

--- a/operator/pkg/gateway-api/status.go
+++ b/operator/pkg/gateway-api/status.go
@@ -9,11 +9,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	conditionStatusAccepted = "Accepted"
-	conditionReasonAccepted = "Accepted"
-)
-
 func newCondition(conditionType string, status metav1.ConditionStatus, reason, msg string, lastTransitionTime time.Time, observedGeneration int64) metav1.Condition {
 	return metav1.Condition{
 		Type:               conditionType,

--- a/operator/pkg/gateway-api/tlsroute_reconcile.go
+++ b/operator/pkg/gateway-api/tlsroute_reconcile.go
@@ -76,9 +76,9 @@ func (r *tlsRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 		// set acceptance to okay, this wil be overwritten in checks if needed
 		i.SetParentCondition(parent, metav1.Condition{
-			Type:    conditionStatusAccepted,
+			Type:    string(gatewayv1.RouteConditionAccepted),
 			Status:  metav1.ConditionTrue,
-			Reason:  conditionReasonAccepted,
+			Reason:  string(gatewayv1.RouteReasonAccepted),
 			Message: "Accepted TLSRoute",
 		})
 


### PR DESCRIPTION
Replace the self defined Condition{Status/Reason}Accepted with the official specification definition.

No functional change.

```release-note
gateway-api: Use Gateway API definition to check Route condition
```
