### PR TITLE
CFP: Pod MAC Address Specification

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -209,8 +209,9 @@ include:
 
   ###
   # K8sKafkaPolicyTest Kafka Policy Tests KafkaPolicies
+  # K8sSpecificMACAddressTests Check whether the pod is created Checks the pod's mac address
   - focus: "f20-kafka"
-    cliFocus: "K8sKafkaPolicyTest"
+    cliFocus: "K8sKafkaPolicyTest|K8sSpecificMACAddressTests"
 
 exclude:
   # The bandwidth test is disabled and hubble tests are not meant

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -86,6 +86,7 @@ get started and experiment with Cilium.
    network/vtep
    network/l2-announcements
    network/node-ipam
+   network/pod-mac-address
 
 .. toctree::
    :maxdepth: 2

--- a/Documentation/network/pod-mac-address.rst
+++ b/Documentation/network/pod-mac-address.rst
@@ -1,0 +1,60 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _pod_mac_address:
+
+************************************
+Use a Specific MAC Address for a Pod
+************************************
+
+Some applications bind software licenses to network interface MAC addresses.
+Cilium provides the ability to specific MAC addresses for pods
+at deploy time instead of letting the operating system allocate them.
+
+
+Configuring the address
+#######################
+
+Cilium will configure the MAC address for the primary interface inside a
+Pod if you specify the MAC address in the ``cni.cilium.io/mac-address``
+annotation before deploying the Pod.
+This MAC address is isolated to the container so it will
+not collide with any other MAC addresses assigned to other Pods on the same
+node. The MAC address must be specified **before** deploying the Pod.
+
+Annotate the pod with ``cni.cilium.io/mac-address`` set to the desired MAC address.
+For example:
+
+.. code-block:: yaml
+
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      annotations:
+        cni.cilium.io/mac-address: e2:9c:30:38:52:61
+      labels:
+        app: busybox
+      name: busybox
+      namespace: default
+
+Deploy the Pod. Cilium will configure the mac address to the first interface in the Pod automatically.
+Check whether its mac address is the specified mac address.
+
+.. code-block:: shell-session
+
+    $ kubectl exec -it busybox -- ip addr
+    1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue qlen 1000
+        link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+        inet 127.0.0.1/8 scope host lo
+           valid_lft forever preferred_lft forever
+        inet6 ::1/128 scope host
+           valid_lft forever preferred_lft forever
+    7: eth0@if8: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue qlen 1000
+        link/ether e2:9c:30:38:52:61 brd ff:ff:ff:ff:ff:ff
+        inet 10.244.2.195/32 scope global eth0
+           valid_lft forever preferred_lft forever
+        inet6 fe80::e46d:f4ff:fe4d:ebca/64 scope link
+           valid_lft forever preferred_lft forever

--- a/api/v1/client/endpoint/put_endpoint_id_responses.go
+++ b/api/v1/client/endpoint/put_endpoint_id_responses.go
@@ -78,6 +78,7 @@ PutEndpointIDCreated describes a response with status code 201, with default hea
 Created
 */
 type PutEndpointIDCreated struct {
+	Payload *models.Endpoint
 }
 
 // IsSuccess returns true when this put endpoint Id created response has a 2xx status code
@@ -106,14 +107,25 @@ func (o *PutEndpointIDCreated) IsCode(code int) bool {
 }
 
 func (o *PutEndpointIDCreated) Error() string {
-	return fmt.Sprintf("[PUT /endpoint/{id}][%d] putEndpointIdCreated ", 201)
+	return fmt.Sprintf("[PUT /endpoint/{id}][%d] putEndpointIdCreated  %+v", 201, o.Payload)
 }
 
 func (o *PutEndpointIDCreated) String() string {
-	return fmt.Sprintf("[PUT /endpoint/{id}][%d] putEndpointIdCreated ", 201)
+	return fmt.Sprintf("[PUT /endpoint/{id}][%d] putEndpointIdCreated  %+v", 201, o.Payload)
+}
+
+func (o *PutEndpointIDCreated) GetPayload() *models.Endpoint {
+	return o.Payload
 }
 
 func (o *PutEndpointIDCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Endpoint)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -146,6 +146,8 @@ paths:
       responses:
         '201':
           description: Created
+          schema:
+            "$ref": "#/definitions/Endpoint"
         '400':
           description: Invalid endpoint in request
           x-go-name: Invalid

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -396,7 +396,10 @@ func init() {
         ],
         "responses": {
           "201": {
-            "description": "Created"
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/Endpoint"
+            }
           },
           "400": {
             "description": "Invalid endpoint in request",
@@ -5960,7 +5963,10 @@ func init() {
         ],
         "responses": {
           "201": {
-            "description": "Created"
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/Endpoint"
+            }
           },
           "400": {
             "description": "Invalid endpoint in request",

--- a/api/v1/server/restapi/endpoint/put_endpoint_id_responses.go
+++ b/api/v1/server/restapi/endpoint/put_endpoint_id_responses.go
@@ -25,6 +25,11 @@ PutEndpointIDCreated Created
 swagger:response putEndpointIdCreated
 */
 type PutEndpointIDCreated struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Endpoint `json:"body,omitempty"`
 }
 
 // NewPutEndpointIDCreated creates PutEndpointIDCreated with default headers values
@@ -33,12 +38,27 @@ func NewPutEndpointIDCreated() *PutEndpointIDCreated {
 	return &PutEndpointIDCreated{}
 }
 
+// WithPayload adds the payload to the put endpoint Id created response
+func (o *PutEndpointIDCreated) WithPayload(payload *models.Endpoint) *PutEndpointIDCreated {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the put endpoint Id created response
+func (o *PutEndpointIDCreated) SetPayload(payload *models.Endpoint) {
+	o.Payload = payload
+}
+
 // WriteResponse to the client
 func (o *PutEndpointIDCreated) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
 	rw.WriteHeader(201)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
 }
 
 // PutEndpointIDInvalidCode is the HTTP code returned for type PutEndpointIDInvalid

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -34,6 +34,12 @@ const (
 	// LBIPAMPrefix is the common prefix for LB IPAM related annotations.
 	LBIPAMPrefix = "lbipam.cilium.io"
 
+	// CNIPrefix is the common prefix for CNI related annotations.
+	CNIPrefix = "cni.cilium.io"
+
+	// PodAnnotationMAC is used to store the MAC address of the Pod.
+	PodAnnotationMAC = CNIPrefix + "/mac-address"
+
 	// PolicyName / PolicyNameAlias is an optional annotation to the NetworkPolicy
 	// resource which specifies the name of the policy node to which all
 	// rules should be applied to.

--- a/pkg/client/endpoint.go
+++ b/pkg/client/endpoint.go
@@ -41,11 +41,14 @@ func (c *Client) EndpointGet(id string) (*models.Endpoint, error) {
 }
 
 // EndpointCreate creates a new endpoint
-func (c *Client) EndpointCreate(ep *models.EndpointChangeRequest) error {
+func (c *Client) EndpointCreate(ep *models.EndpointChangeRequest) (*models.Endpoint, error) {
 	id := pkgEndpointID.NewCiliumID(ep.ID)
 	params := endpoint.NewPutEndpointIDParams().WithID(id).WithEndpoint(ep).WithTimeout(api.ClientTimeout)
-	_, err := c.Endpoint.PutEndpointID(params)
-	return Hint(err)
+	resp, err := c.Endpoint.PutEndpointID(params)
+	if err != nil {
+		return nil, Hint(err)
+	}
+	return resp.Payload, nil
 }
 
 // EndpointPatch modifies the endpoint

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1351,6 +1351,21 @@ func (e *Endpoint) SetState(toState State, reason string) bool {
 	return e.setState(toState, reason)
 }
 
+// SetMac modifies the endpoint's mac.
+func (e *Endpoint) SetMac(mac mac.MAC) {
+	e.unconditionalLock()
+	defer e.unlock()
+	e.mac = mac
+}
+
+// GetDisableLegacyIdentifiers returns the endpoint's disableLegacyIdentifiers.
+func (e *Endpoint) GetDisableLegacyIdentifiers() bool {
+	e.unconditionalRLock()
+	defer e.runlock()
+	return e.disableLegacyIdentifiers
+
+}
+
 func (e *Endpoint) setState(toState State, reason string) bool {
 	// Validate the state transition.
 	fromState := e.state

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -411,7 +411,7 @@ func (driver *driver) createEndpoint(w http.ResponseWriter, r *http.Request) {
 
 	// FIXME: Translate port mappings to RuleL4 policy elements
 
-	if err = driver.client.EndpointCreate(endpoint); err != nil {
+	if _, err = driver.client.EndpointCreate(endpoint); err != nil {
 		sendError(w, fmt.Sprintf("Error creating endpoint %s", err), http.StatusBadRequest)
 		return
 	}

--- a/test/k8s/manifests/pod_mac_address.yaml
+++ b/test/k8s/manifests/pod_mac_address.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: specific-mac-address
+  annotations:
+    cni.cilium.io/mac-address: e2:9c:30:38:52:61
+  labels:
+    specific-mac-address: specific-mac-address
+spec:
+  containers:
+    - name: specific-mac-address
+      image: busybox:1.36
+      command:
+        - sleep
+        - "3600"
+      imagePullPolicy: IfNotPresent

--- a/test/k8s/pod_mac_address.go
+++ b/test/k8s/pod_mac_address.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8sTest
+
+import (
+	"fmt"
+
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+)
+
+// The 5.4 CI job is intended to catch BPF complexity regressions and as such
+// doesn't need to execute this test suite.
+var _ = SkipDescribeIf(func() bool { return helpers.RunsOn54Kernel() && helpers.DoesNotRunOnAKS() }, "K8sSpecificMACAddressTests", func() {
+	var (
+		kubectl        *helpers.Kubectl
+		ciliumFilename string
+	)
+
+	BeforeAll(func() {
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+	})
+
+	JustAfterEach(func() {
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	AfterAll(func() {
+		UninstallCiliumFromManifest(kubectl, ciliumFilename)
+		kubectl.CloseSSHClient()
+	})
+
+	AfterFailed(func() {
+		kubectl.CiliumReport("cilium-dbg endpoint list -o jsonpath='{range [*]}{@.id}{\"=\"}{@.status.networking.mac}{\"\\n\"}{end}'")
+	})
+
+	SkipContextIf(func() bool { return !helpers.RunsOn419OrLaterKernel() && helpers.DoesNotRunOnAKS() }, "Check whether the pod is created", func() {
+		const specificMACAddress = "specific-mac-address=specific-mac-address"
+		var podYAML string
+
+		BeforeAll(func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{})
+			podYAML = helpers.ManifestGet(kubectl.BasePath(), "pod_mac_address.yaml")
+			res := kubectl.ApplyDefault(podYAML)
+			res.ExpectSuccess("Unable to apply %s", podYAML)
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", specificMACAddress), helpers.HelperTimeout)
+			Expect(err).Should(BeNil())
+		})
+
+		AfterAll(func() {
+			_ = kubectl.Delete(podYAML)
+			ExpectAllPodsTerminated(kubectl)
+		})
+		It("Checks the pod's mac address", func() {
+			var demoPods v1.PodList
+			kubectl.GetPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", specificMACAddress)).Unmarshal(&demoPods)
+			Expect(demoPods.Items).To(HaveLen(1))
+			By("Checking the pod's mac address")
+			kubectl.ExecPodCmd(helpers.DefaultNamespace, demoPods.Items[0].Name,
+				fmt.Sprintf("ip link show |grep \"%s\" | wc -l", demoPods.Items[0].Annotations[annotation.PodAnnotationMAC])).
+				ExpectSuccess("cannot find configured mac address %s in 'ip link show' output from pod %s",
+					demoPods.Items[0].Annotations[annotation.PodAnnotationMAC], demoPods.Items[0].Name)
+		})
+	})
+
+})


### PR DESCRIPTION

Specify the MAC address of the pod in the annotation, store the MAC address in the endpoint, and then cilium-cni obtains the specified MAC address by querying the endpoint and sets the MAC address of the interface inside the pod.



Fixes: #22119

```release-note
Add support for the `cni.cilium.io/mac-address` annotation on Pod resources to control the L2 address used for Pod communication.
```
