### PR TITLE
bpf: nodeport: phase out revDNAT support for local backends in bpf_lxc

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1545,17 +1545,8 @@ skip_policy_enforcement:
 		if (ret == CT_REOPENED && ct_state->dsr)
 			ct_update_dsr(get_ct_map6(tuple), tuple, false);
 # endif /* ENABLE_DSR */
-		{
-			bool node_port =
-				ct_has_nodeport_egress_entry6(get_ct_map6(tuple),
-							      tuple, NULL, false);
-
-			ct_state_new.node_port = node_port;
-			if (ret == CT_REOPENED &&
-			    ct_state->node_port != node_port)
-				ct_update_nodeport(get_ct_map6(tuple), tuple,
-						   node_port);
-		}
+		if (ret == CT_REOPENED && ct_state->node_port)
+			ct_update_nodeport(get_ct_map6(tuple), tuple, false);
 	}
 #endif /* ENABLE_NODEPORT */
 
@@ -1911,17 +1902,11 @@ skip_policy_enforcement:
 		if (ret == CT_REOPENED && ct_state->dsr)
 			ct_update_dsr(get_ct_map4(tuple), tuple, false);
 # endif /* ENABLE_DSR */
-		{
-			bool node_port =
-				ct_has_nodeport_egress_entry4(get_ct_map4(tuple),
-							      tuple, NULL, false);
-
-			ct_state_new.node_port = node_port;
-			if (ret == CT_REOPENED &&
-			    ct_state->node_port != node_port)
-				ct_update_nodeport(get_ct_map4(tuple), tuple,
-						   node_port);
-		}
+		/* Clear .node_port flag for old connections, nodeport.h
+		 * will handle their RevDNAT.
+		 */
+		if (ret == CT_REOPENED && ct_state->node_port)
+			ct_update_nodeport(get_ct_map4(tuple), tuple, false);
 	}
 #endif /* ENABLE_NODEPORT */
 


### PR DESCRIPTION
We recently added support for Service RevDNAT in to-netdev / to-overlay (https://github.com/cilium/cilium/pull/22756). This is currently only used as fall-back, for backends that are either in hostNetwork or bypass the revDNAT step in from-container.

With this patch we switch all new connections for local backends to the new RevDNAT mechanism. The code change in itself is simple: once to-container doesn't set the .node_port flag for a pod-level CT entry, from-container also doesn't apply revDNAT for this connection.

For new connections, replies by a local backend will now pass through the whole from-container path without being revDNATed. They eventually reach the revDNAT stage in handle_nat_fwd(), and get handled there.

To avoid any cause for disruption, old connections continue to receive their RevDNAT in from-container as before (unless they get reopened, which is a good point to stop their handling in bpf_lxc). We can pursue their transition in a subsequent patch.