### PR TITLE
Switch to on-demand instances for AWS tests on scheduled runs.

### DIFF
--- a/.github/actions/setup-eks-cluster/action.yml
+++ b/.github/actions/setup-eks-cluster/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: ''
     required: false
     default: ''
+  spot:
+    description: ''
+    required: false
+    default: 'true'
 runs:
   using: composite
   steps:
@@ -37,7 +41,7 @@ runs:
           instanceTypes:
            - t3.medium
           desiredCapacity: 1
-          spot: true
+          spot: ${{ inputs.spot }}
           privateNetworking: true
           volumeType: "gp3"
           volumeSize: 10
@@ -49,7 +53,7 @@ runs:
           instanceTypes:
            - t4g.medium
           desiredCapacity: 1
-          spot: true
+          spot: ${{ inputs.spot }}
           privateNetworking: true
           volumeType: "gp3"
           volumeSize: 10

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -199,6 +199,7 @@ jobs:
           region: ${{ matrix.region }}
           owner: "${{ steps.vars.outputs.owner }}"
           version: ${{ matrix.version }}
+          spot: ${{ github.event_name != 'schedule' }}
 
       - name: Wait for images to be available
         timeout-minutes: 30

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -192,6 +192,7 @@ jobs:
           region: ${{ matrix.region }}
           owner: "${{ steps.vars.outputs.owner }}"
           version: ${{ matrix.version }}
+          spot: ${{ github.event_name != 'schedule' }}
 
       # This is a workaround for flake #16938.
       - name: Remove AWS-CNI


### PR DESCRIPTION
More context in the issue.

Related: https://github.com/cilium/cilium/issues/29365