### PR TITLE
ingress: fix foreground deletion of Ingress

### DIFF
--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -593,7 +593,7 @@ func (ic *Controller) regenerate(ing *slim_networkingv1.Ingress, forceShared boo
 		translator = ic.sharedTranslator
 		for _, k := range ic.ingressStore.ListKeys() {
 			item, _ := ic.getByKey(k)
-			if !ic.isCiliumIngressEntry(item) || ic.isEffectiveLoadbalancerModeDedicated(item) || ing.GetDeletionTimestamp() != nil {
+			if !ic.isCiliumIngressEntry(item) || ic.isEffectiveLoadbalancerModeDedicated(item) || item.GetDeletionTimestamp() != nil {
 				continue
 			}
 			if annotations.GetAnnotationTLSPassthroughEnabled(item) {

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -303,9 +303,8 @@ func (ic *Controller) handleIngressUpdatedEvent(event ingressUpdatedEvent) error
 }
 
 func (ic *Controller) handleIngressDeletedEvent(event ingressDeletedEvent) error {
-	log.WithField(logfields.Ingress, event.ingress.Name).WithField(logfields.K8sNamespace, event.ingress.Namespace).Debug("Deleting CiliumEnvoyConfig for ingress")
-
 	if ic.isEffectiveLoadbalancerModeDedicated(event.ingress) {
+		log.WithField(logfields.Ingress, event.ingress.Name).WithField(logfields.K8sNamespace, event.ingress.Namespace).Debug("Deleting resources (CiliumEnvoyConfig, Service & Endpoints) for dedicated Ingress")
 		if err := ic.deleteResources(event.ingress); err != nil {
 			log.WithError(err).Warn("Failed to delete resources for ingress")
 			return err


### PR DESCRIPTION
Currently, when a shared Ingress resource (managed by Cilium) gets deleted via k8s foreground deletion (e.g. `kubectl delete ingress ... --cascade=foreground`) the corresponding shared CiliumEnvoyConfig in Ciliums namespace gets rewritten empty.

This breaks all shared Ingresses from working.

The reason is an error in the condition that checks which Ingresses should be taken into account when building the model for the shared CiliumEnvoyConfig.

The condition checks the `DeletionTimeStamp` (set via foreground deletion) from the modified Ingress instead of the the one within the loop. In case of the foreground deletion this always evaluates to `true` (exclude) - hence no entries in the CEC.

This commit fixes the condition to check for any ongoing deletion on the Ingress that gets checked within the loop.

Fixes: #21386
Fixes: #29306