### PR TITLE
statedb: Fix termination of string and IP keys

### DIFF
--- a/pkg/datapath/tables/device.go
+++ b/pkg/datapath/tables/device.go
@@ -20,10 +20,8 @@ var (
 		FromObject: func(d *Device) index.KeySet {
 			return index.NewKeySet(index.Int(d.Index))
 		},
-		FromKey: func(idx int) []byte {
-			return index.Int(idx)
-		},
-		Unique: true,
+		FromKey: index.Int,
+		Unique:  true,
 	}
 
 	DeviceNameIndex = statedb.Index[*Device, string]{
@@ -31,9 +29,7 @@ var (
 		FromObject: func(d *Device) index.KeySet {
 			return index.NewKeySet(index.String(d.Name))
 		},
-		FromKey: func(name string) []byte {
-			return index.String(name)
-		},
+		FromKey: index.String,
 	}
 
 	DeviceSelectedIndex = statedb.Index[*Device, bool]{
@@ -41,9 +37,7 @@ var (
 		FromObject: func(d *Device) index.KeySet {
 			return index.NewKeySet(index.Bool(d.Selected))
 		},
-		FromKey: func(selected bool) []byte {
-			return index.Bool(selected)
-		},
+		FromKey: index.Bool,
 	}
 )
 

--- a/pkg/datapath/tables/l2_announce.go
+++ b/pkg/datapath/tables/l2_announce.go
@@ -18,7 +18,7 @@ type L2AnnounceKey struct {
 	NetworkInterface string
 }
 
-func (k L2AnnounceKey) Key() []byte {
+func (k L2AnnounceKey) Key() index.Key {
 	key := append(index.NetIPAddr(k.IP), '+')
 	key = append(key, index.String(k.NetworkInterface)...)
 	return key
@@ -45,10 +45,8 @@ var (
 		FromObject: func(b *L2AnnounceEntry) index.KeySet {
 			return index.NewKeySet(b.Key())
 		},
-		FromKey: func(id L2AnnounceKey) []byte {
-			return id.Key()
-		},
-		Unique: true,
+		FromKey: L2AnnounceKey.Key,
+		Unique:  true,
 	}
 
 	L2AnnounceOriginIndex = statedb.Index[*L2AnnounceEntry, resource.Key]{
@@ -56,9 +54,7 @@ var (
 		FromObject: func(b *L2AnnounceEntry) index.KeySet {
 			return index.StringerSlice(b.Origins)
 		},
-		FromKey: func(id resource.Key) []byte {
-			return index.Stringer(id)
-		},
+		FromKey: index.Stringer[resource.Key],
 	}
 )
 

--- a/pkg/datapath/tables/node_address.go
+++ b/pkg/datapath/tables/node_address.go
@@ -72,10 +72,8 @@ var (
 		FromObject: func(a NodeAddress) index.KeySet {
 			return index.NewKeySet(index.NetIPAddr(a.Addr))
 		},
-		FromKey: func(addr netip.Addr) []byte {
-			return index.NetIPAddr(addr)
-		},
-		Unique: true,
+		FromKey: index.NetIPAddr,
+		Unique:  true,
 	}
 
 	NodeAddressDeviceNameIndex = statedb.Index[NodeAddress, string]{

--- a/pkg/datapath/tables/route.go
+++ b/pkg/datapath/tables/route.go
@@ -25,10 +25,8 @@ var (
 				}.Key(),
 			)
 		},
-		FromKey: func(id RouteID) []byte {
-			return id.Key()
-		},
-		Unique: true,
+		FromKey: RouteID.Key,
+		Unique:  true,
 	}
 
 	RouteLinkIndex = statedb.Index[*Route, int]{
@@ -36,9 +34,7 @@ var (
 		FromObject: func(r *Route) index.KeySet {
 			return index.NewKeySet(index.Int(r.LinkIndex))
 		},
-		FromKey: func(linkIndex int) []byte {
-			return index.Int(linkIndex)
-		},
+		FromKey: index.Int,
 	}
 )
 
@@ -56,11 +52,12 @@ type RouteID struct {
 	Dst       netip.Prefix
 }
 
-func (id RouteID) Key() []byte {
+func (id RouteID) Key() index.Key {
 	key := append(index.Uint64(uint64(id.Table)), '+')
 	key = append(key, index.Uint64(uint64(id.Table))...)
 	key = append(key, '+')
 	key = append(key, index.NetIPPrefix(id.Dst)...)
+	key = append(key, 0 /* termination */)
 	return key
 }
 

--- a/pkg/statedb/benchmarks_test.go
+++ b/pkg/statedb/benchmarks_test.go
@@ -243,10 +243,8 @@ var (
 		FromObject: func(t testObject2) index.KeySet {
 			return index.NewKeySet(index.Uint64(t.ID))
 		},
-		FromKey: func(n uint64) []byte {
-			return index.Uint64(n)
-		},
-		Unique: true,
+		FromKey: index.Uint64,
+		Unique:  true,
 	}
 )
 

--- a/pkg/statedb/db_test.go
+++ b/pkg/statedb/db_test.go
@@ -44,10 +44,8 @@ var (
 		FromObject: func(t testObject) index.KeySet {
 			return index.NewKeySet(index.Uint64(t.ID))
 		},
-		FromKey: func(n uint64) []byte {
-			return index.Uint64(n)
-		},
-		Unique: true,
+		FromKey: index.Uint64,
+		Unique:  true,
 	}
 
 	tagsIndex = Index[testObject, string]{
@@ -55,10 +53,8 @@ var (
 		FromObject: func(t testObject) index.KeySet {
 			return index.StringSlice(t.Tags)
 		},
-		FromKey: func(tag string) []byte {
-			return index.String(tag)
-		},
-		Unique: false,
+		FromKey: index.String,
+		Unique:  false,
 	}
 )
 

--- a/pkg/statedb/example/tables.go
+++ b/pkg/statedb/example/tables.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cilium/cilium/pkg/statedb/index"
 )
 
-type BackendID string
+type BackendID = string
 
 type Backend struct {
 	ID   BackendID
@@ -24,10 +24,8 @@ var (
 		FromObject: func(b Backend) index.KeySet {
 			return index.NewKeySet(index.String(string(b.ID)))
 		},
-		FromKey: func(id BackendID) []byte {
-			return index.String(string(id))
-		},
-		Unique: true,
+		FromKey: index.String,
+		Unique:  true,
 	}
 
 	BackendIPIndex = statedb.Index[Backend, netip.Addr]{

--- a/pkg/statedb/fuzz_test.go
+++ b/pkg/statedb/fuzz_test.go
@@ -65,10 +65,8 @@ var idIndex = statedb.Index[fuzzObj, uint64]{
 	FromObject: func(obj fuzzObj) index.KeySet {
 		return index.NewKeySet(index.Uint64(obj.id))
 	},
-	FromKey: func(n uint64) []byte {
-		return index.Uint64(n)
-	},
-	Unique: true,
+	FromKey: index.Uint64,
+	Unique:  true,
 }
 
 var (

--- a/pkg/statedb/index/keyset.go
+++ b/pkg/statedb/index/keyset.go
@@ -5,12 +5,20 @@ package index
 
 import "bytes"
 
-type Key = []byte
+// Key is a byte slice describing a key used in an index by statedb.
+// If a key is variable-sized, then it must be either terminated with
+// e.g. zero byte or it must be length-encoded. If it is not, then
+// a Get() may return results that don't match the query (e.g. objects
+// indexed with a key that has the same prefix but are longer).
+// The reason is that Get() is implemented as a prefix seek to avoid
+// full key comparison on iteration and also to support the
+// non-unique indexes which key on "secondary + primary" keys.
+type Key []byte
 
 // KeySet is a sequence of (length, byte slice) pairs.
 // length is encoded as 16-bit big-endian unsigned int.
 type KeySet struct {
-	buf Key
+	buf []byte
 }
 
 func NewKeySet(keys ...Key) KeySet {

--- a/pkg/statedb/index/keyset_test.go
+++ b/pkg/statedb/index/keyset_test.go
@@ -14,7 +14,7 @@ import (
 func TestKeySet_FromEmpty(t *testing.T) {
 	ks := index.NewKeySet()
 	require.Nil(t, ks.First())
-	ks.Foreach(func(_ []byte) {
+	ks.Foreach(func(_ index.Key) {
 		t.Fatalf("Foreach on NewKeySet called function")
 	})
 	require.False(t, ks.Exists(nil))
@@ -22,7 +22,7 @@ func TestKeySet_FromEmpty(t *testing.T) {
 
 	ks.Append([]byte("foo"))
 	require.EqualValues(t, "foo", ks.First())
-	ks.Foreach(func(bs []byte) {
+	ks.Foreach(func(bs index.Key) {
 		require.EqualValues(t, "foo", bs)
 	})
 	require.True(t, ks.Exists([]byte("foo")))
@@ -30,7 +30,7 @@ func TestKeySet_FromEmpty(t *testing.T) {
 	ks.Append([]byte("bar"))
 	require.EqualValues(t, "foo", ks.First())
 	vs := [][]byte{}
-	ks.Foreach(func(bs []byte) {
+	ks.Foreach(func(bs index.Key) {
 		vs = append(vs, bs)
 	})
 	require.ElementsMatch(t, vs, [][]byte{[]byte("foo"), []byte("bar")})
@@ -46,7 +46,7 @@ func TestKeySet_FromNonEmpty(t *testing.T) {
 	require.True(t, ks.Exists([]byte("quux")))
 	require.False(t, ks.Exists([]byte("foo")))
 	vs := [][]byte{}
-	ks.Foreach(func(bs []byte) {
+	ks.Foreach(func(bs index.Key) {
 		vs = append(vs, bs)
 	})
 	require.ElementsMatch(t, vs, [][]byte{[]byte("baz"), []byte("quux")})

--- a/pkg/statedb/index/netip.go
+++ b/pkg/statedb/index/netip.go
@@ -10,15 +10,18 @@ import (
 )
 
 func NetIP(ip net.IP) Key {
-	return bytes.Clone(ip)
+	// Use the 16-byte form to have a constant-size key.
+	return bytes.Clone(ip.To16())
 }
 
 func NetIPAddr(addr netip.Addr) Key {
-	buf, _ := addr.MarshalBinary()
-	return buf
+	// Use the 16-byte form to have a constant-size key.
+	buf := addr.As16()
+	return buf[:]
 }
 
 func NetIPPrefix(prefix netip.Prefix) Key {
-	buf, _ := prefix.MarshalBinary()
-	return buf
+	// Use the 16-byte form plus bits to have a constant-size key.
+	addrBytes := prefix.Addr().As16()
+	return append(addrBytes[:], uint8(prefix.Bits()))
 }

--- a/pkg/statedb/index/string.go
+++ b/pkg/statedb/index/string.go
@@ -5,12 +5,12 @@ package index
 
 import "fmt"
 
-func String(s string) []byte {
-	return []byte(s)
+func String(s string) Key {
+	return append([]byte(s), 0 /* termination */)
 }
 
-func Stringer(s fmt.Stringer) []byte {
-	return []byte(s.String())
+func Stringer[T fmt.Stringer](s T) Key {
+	return String(s.String())
 }
 
 func StringSlice(ss []string) KeySet {

--- a/pkg/statedb/regression_test.go
+++ b/pkg/statedb/regression_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/statedb/index"
+)
+
+// Test_Regression_29324 tests that Get() on a index.String-based
+// unique index only returns exact matches.
+// https://github.com/cilium/cilium/issues/29324
+func Test_Regression_29324(t *testing.T) {
+	type object struct {
+		ID string
+	}
+	idIndex := Index[object, string]{
+		Name: "id",
+		FromObject: func(t object) index.KeySet {
+			return index.NewKeySet(index.String(t.ID))
+		},
+		FromKey: index.String,
+		Unique:  true,
+	}
+
+	db, _, _ := newTestDB(t, tagsIndex)
+	table, err := NewTable[object]("objects", idIndex)
+	require.NoError(t, err)
+	require.NoError(t, db.RegisterTable(table))
+
+	wtxn := db.WriteTxn(table)
+	table.Insert(wtxn, object{"foo"})
+	table.Insert(wtxn, object{"foobar"})
+	table.Insert(wtxn, object{"baz"})
+	wtxn.Commit()
+
+	// Exact match should only return "foo"
+	txn := db.ReadTxn()
+	iter, _ := table.Get(txn, idIndex.Query("foo"))
+	items := Collect(iter)
+	if assert.Len(t, items, 1, "Get(\"foo\") should return one match") {
+		assert.EqualValues(t, "foo", items[0].ID)
+	}
+
+	// Partial match on prefix should not return anything
+	iter, _ = table.Get(txn, idIndex.Query("foob"))
+	items = Collect(iter)
+	assert.Len(t, items, 0, "Get(\"foob\") should return nothing")
+}

--- a/pkg/statedb/table.go
+++ b/pkg/statedb/table.go
@@ -92,8 +92,8 @@ type genTable[Obj any] struct {
 	secondaryAnyIndexers map[string]anyIndexer
 }
 
-func (t *genTable[Obj]) tableKey() index.Key {
-	return index.String(t.table)
+func (t *genTable[Obj]) tableKey() []byte {
+	return []byte(t.table)
 }
 
 func (t *genTable[Obj]) primaryIndexer() anyIndexer {

--- a/pkg/statedb/types.go
+++ b/pkg/statedb/types.go
@@ -143,7 +143,7 @@ type RWTable[Obj any] interface {
 // the object type (the 'Obj' constraint).
 type TableMeta interface {
 	Name() TableName                          // The name of the table
-	tableKey() index.Key                      // The radix key for the table in the root tree
+	tableKey() []byte                         // The radix key for the table in the root tree
 	primaryIndexer() anyIndexer               // The untyped primary indexer for the table
 	secondaryIndexers() map[string]anyIndexer // Secondary indexers (if any)
 	sortableMutex() lock.SortableMutex        // The sortable mutex for locking the table for writing
@@ -202,7 +202,7 @@ func ByRevision[Obj any](rev uint64) Query[Obj] {
 type Index[Obj any, Key any] struct {
 	Name       string
 	FromObject func(obj Obj) index.KeySet
-	FromKey    func(key Key) []byte
+	FromKey    func(key Key) index.Key
 	Unique     bool
 }
 


### PR DESCRIPTION
Due to missing zero byte termination in the keys returned by index.String and
index.Stringer the Get() method returned wrong results, e.g. Get("foo") would've returned both "foo" and "foobar" for a unique index. Fix by adding the termination.

Similar issue also existed for index.NetIP and index.NetIPAddr since they returned variable-sized keys (e.g. 4 bytes for IPv4 and 16 bytes for IPv6). Fix this by changing them to fixed-size keys.

While at it, make the construction of keys a bit more explicit by making index.Key a newtype over []byte and fix usages. Add documentation about the need for termination for variable sized keys to index.Key.

I did think about alternative ways to fix this. We can't just add "\x00" to keys since that may be a valid byte (e.g. in net.IP) and thus would not serve as termination. A more complex marker or adding e.g. length to beginning or end has the same issues (and breaks prefix searching). The only working alternative I can think of is to have a special iterator for Get() which does full key comparison, but that would be quite expensive for large keys, thus I opted for making the index functions carry the responsibility of properly either terminating the key or using fixed sizes.