### PR TITLE
Use a stoppable Resource[T] to implement CiliumNode watcher

### DIFF
--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -104,6 +104,7 @@ type Resources struct {
 	CiliumNetworkPolicies            resource.Resource[*cilium_api_v2.CiliumNetworkPolicy]
 	CiliumClusterwideNetworkPolicies resource.Resource[*cilium_api_v2.CiliumClusterwideNetworkPolicy]
 	CIDRGroups                       resource.Resource[*cilium_api_v2alpha1.CiliumCIDRGroup]
+	CiliumNode                       resource.Resource[*cilium_api_v2.CiliumNode]
 }
 
 // LocalNodeResources is a convenience struct to group CiliumNode and Node resources as cell contructor parameters.

--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -68,3 +68,16 @@ func IngressClassResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*
 	)
 	return resource.New[*slim_networkingv1.IngressClass](lc, lw, resource.WithMetric("IngressClass")), nil
 }
+
+func CiliumNodeResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumNode], error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](cs.CiliumV2().CiliumNodes()),
+		opts...,
+	)
+	return resource.New[*cilium_api_v2.CiliumNode](lc, lw,
+		resource.WithMetric("CiliumNode"),
+	), nil
+}

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -36,7 +36,7 @@ var (
 			k8s.CiliumPodIPPoolResource,
 			CiliumEndpointResource,
 			CiliumEndpointSliceResource,
-			k8s.CiliumNodeResource,
+			CiliumNodeResource,
 			k8s.PodResource,
 			IngressClassResource,
 		),

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -87,7 +87,10 @@ func CiliumNodeResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*me
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](cs.CiliumV2().CiliumNodes()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumNode](lc, lw, resource.WithMetric("CiliumNode")), nil
+	return resource.New[*cilium_api_v2.CiliumNode](lc, lw,
+		resource.WithMetric("CiliumNode"),
+		resource.WithStoppableInformer(),
+	), nil
 }
 
 func PodResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*slim_corev1.Pod], error) {


### PR DESCRIPTION
-- WORK IN PROGRESS --

Use a stoppable Resource[T] to implement the CiliumNode k8s watcher. This removes the additional informer previously used, reducing the queries to the kube-apiserver and reducing the memory needed for the additional local cache.

Please refer to the individual commits for further details.

Related: https://github.com/cilium/cilium/issues/28159