### PR TITLE
Fix external workloads not working with non-default ClusterID

### DIFF
--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -203,6 +203,16 @@ func (n *RegisterNode) DeepKeyCopy() store.LocalKey {
 	return n.DeepCopy()
 }
 
+func (n *RegisterNode) Unmarshal(_ string, data []byte) error {
+	newNode := Node{}
+	if err := json.Unmarshal(data, &newNode); err != nil {
+		return err
+	}
+
+	n.Node = newNode
+	return nil
+}
+
 // Node contains the nodes name, the list of addresses to this address
 //
 // +k8s:deepcopy-gen=true


### PR DESCRIPTION
https://github.com/cilium/cilium/commit/23e762cffd906e8ab88b367c170cf2adf792d014 ("node: add extra validation") introduced extra validation logic executed when unmarshalling node objects retrieved from the kvstore, ensuring in particular that the ClusterID is in the expected range and non-zero (unless the local ClusterID is zero).

Yet, this validation broke the external workloads support, if the ClusterID is set to a non-zero value. Indeed, the RegisterNode type used in this case is just a wrapper for the Node one, and reuses the same unmarshalling logic. Given that the RegisterNode object is initially created configuring the name only, it causes an unmarshalling failure when processed by the clustermesh-apiserver, due to the ClusterID being zero (only if that of the cluster is different from zero).

To fix this issue, let's override the Unmarshal function to skip the validation logic for the external workloads type, as used differently. Another possibility could be to explicitly configure the ClusterID; yet this would be trickier to backport to v1.14, as historically the ClusterID was not configured for external workloads agents, and inferred at runtime from that of the cluster it connected to.

Link to successful CI run, with non-default ClusterID: https://github.com/cilium/cilium/actions/runs/7002550345

Fixes https://github.com/cilium/cilium/issues/29355