### PR TITLE
egressgw: Redirect from bpf_overlay to egress gw SNAT netdev

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -32,6 +32,7 @@
 #include "lib/nodeport.h"
 #include "lib/clustermesh.h"
 #include "lib/wireguard.h"
+#include "lib/egress_gateway.h"
 
 #ifdef ENABLE_VTEP
 #include "lib/arp.h"
@@ -386,6 +387,35 @@ skip_vtep:
 	ctx->mark = 0;
 not_esp:
 #endif
+
+#if defined(ENABLE_EGRESS_GATEWAY_COMMON)
+	{
+		__be32 snat_addr, daddr;
+		int ret;
+		struct remote_endpoint_info *remote_ep;
+
+		remote_ep = lookup_ip4_remote_endpoint(ip4->daddr, 0);
+		/* If the packet is destined to an entity inside the cluster, either EP
+		 * or node, skip SNAT since only traffic leaving the cluster is supposed
+		 * to be masqueraded with an egress IP.
+		 */
+		if (remote_ep &&
+		    identity_is_cluster(remote_ep->sec_identity))
+			goto skip_egress_gateway;
+
+		daddr = ip4->daddr;
+		if (egress_gw_snat_needed_hook(ip4->saddr, daddr, &snat_addr)) {
+			ret = ipv4_l3(ctx, ETH_HLEN, NULL, NULL, ip4);
+			if (unlikely(ret != CTX_ACT_OK))
+				return ret;
+
+			/* to-netdev@bpf_host handles SNAT, so no need to do it here. */
+			return egress_gw_fib_lookup_and_redirect(ctx, snat_addr,
+								 daddr, ext_err);
+		}
+	}
+skip_egress_gateway:
+#endif /* ENABLE_EGRESS_GATEWAY_COMMON */
 
 	/* Deliver to local (non-host) endpoint: */
 	ep = lookup_ip4_endpoint(ip4);

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -392,16 +392,6 @@ not_esp:
 	{
 		__be32 snat_addr, daddr;
 		int ret;
-		struct remote_endpoint_info *remote_ep;
-
-		remote_ep = lookup_ip4_remote_endpoint(ip4->daddr, 0);
-		/* If the packet is destined to an entity inside the cluster, either EP
-		 * or node, skip SNAT since only traffic leaving the cluster is supposed
-		 * to be masqueraded with an egress IP.
-		 */
-		if (remote_ep &&
-		    identity_is_cluster(remote_ep->sec_identity))
-			goto skip_egress_gateway;
 
 		daddr = ip4->daddr;
 		if (egress_gw_snat_needed_hook(ip4->saddr, daddr, &snat_addr)) {
@@ -414,7 +404,6 @@ not_esp:
 								 daddr, ext_err);
 		}
 	}
-skip_egress_gateway:
 #endif /* ENABLE_EGRESS_GATEWAY_COMMON */
 
 	/* Deliver to local (non-host) endpoint: */

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -620,14 +620,6 @@ snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
  * always want to SNAT a packet if it's matched by an egress NAT policy.
  */
 #if defined(ENABLE_EGRESS_GATEWAY_COMMON)
-	/* If the packet is destined to an entity inside the cluster, either EP
-	 * or node, skip SNAT since only traffic leaving the cluster is supposed
-	 * to be masqueraded with an egress IP.
-	 */
-	if (remote_ep &&
-	    identity_is_cluster(remote_ep->sec_identity))
-		goto skip_egress_gateway;
-
 	/* If the packet is a reply it means that outside has initiated the
 	 * connection, so no need to SNAT the reply.
 	 */

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2415,10 +2415,10 @@ nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 			return ret;
 	}
 
-#if defined(ENABLE_EGRESS_GATEWAY_COMMON) && !defined(IS_BPF_OVERLAY) && !defined(TUNNEL_MODE)
-	/* If we are not using TUNNEL_MODE, the gateway node needs to manually steer
-	 * any reply traffic for a remote pod into the tunnel (to avoid iptables
-	 * potentially dropping the packets).
+#if defined(ENABLE_EGRESS_GATEWAY_COMMON) && !defined(IS_BPF_OVERLAY)
+	/* The gateway node needs to manually steer any reply traffic
+	 * for a remote pod into the tunnel (to avoid iptables potentially
+	 * dropping or accidentally SNATing the packets).
 	 */
 	if (egress_gw_reply_needs_redirect_hook(ip4, &tunnel_endpoint, &dst_sec_identity)) {
 		trace->reason = TRACE_REASON_CT_REPLY;
@@ -2572,7 +2572,7 @@ int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 	 * CALL_IPV4_FROM_NETDEV in the code above.
 	 */
 #if !defined(ENABLE_DSR) || (defined(ENABLE_DSR) && defined(ENABLE_DSR_HYBRID)) ||	\
-    (defined(ENABLE_EGRESS_GATEWAY_COMMON) && !defined(IS_BPF_OVERLAY) && !defined(TUNNEL_MODE))
+    (defined(ENABLE_EGRESS_GATEWAY_COMMON) && !defined(IS_BPF_OVERLAY))
 
 # if defined(ENABLE_HOST_FIREWALL) && defined(IS_BPF_HOST)
 	ret = ipv4_host_policy_ingress(ctx, &src_id, &trace, &ext_err);

--- a/bpf/tests/tc_egressgw_redirect_from_overlay.c
+++ b/bpf/tests/tc_egressgw_redirect_from_overlay.c
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+#define SECLABEL
+#define SECLABEL_IPV4
+#define SECLABEL_IPV6
+#include "config_replacement.h"
+#undef SECLABEL
+#undef SECLABEL_IPV4
+#undef SECLABEL_IPV6
+
+/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
+#define ETH_HLEN 14
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define ENABLE_EGRESS_GATEWAY
+#define ENABLE_MASQUERADE_IPV4
+#define ENCAP_IFINDEX	42
+#define IFACE_IFINDEX	44
+
+#define SECCTX_FROM_IPCACHE 1
+
+#define ctx_redirect mock_ctx_redirect
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused);
+
+#define fib_lookup mock_fib_lookup
+static __always_inline __maybe_unused long
+mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_unused,
+		int plen __maybe_unused, __u32 flags __maybe_unused);
+
+#define skb_get_tunnel_key mock_skb_get_tunnel_key
+static int mock_skb_get_tunnel_key(__maybe_unused struct __sk_buff *skb,
+				   struct bpf_tunnel_key *to,
+				   __maybe_unused __u32 size,
+				   __maybe_unused __u32 flags)
+{
+	to->remote_ipv4 = v4_node_one;
+	/* 0xfffff is the default SECLABEL */
+	to->tunnel_id = 0xfffff;
+	return 0;
+}
+
+#include "bpf_overlay.c"
+
+#include "lib/egressgw.h"
+#include "lib/ipcache.h"
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
+{
+	if (ifindex == IFACE_IFINDEX)
+		return CTX_ACT_REDIRECT;
+
+	return CTX_ACT_OK;
+}
+
+static __always_inline __maybe_unused long
+mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_unused,
+		int plen __maybe_unused, __u32 flags __maybe_unused)
+{
+	params->ifindex = IFACE_IFINDEX;
+	return 0;
+}
+
+#define FROM_OVERLAY 0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 2);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_OVERLAY] = &cil_from_overlay,
+	},
+};
+
+/* Test that a packet matching an egress gateway policy on the from-overlay program
+ * gets correctly redirected to the target netdev.
+ */
+PKTGEN("tc", "tc_egressgw_redirect_from_overlay")
+int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_REDIRECT,
+			.redirect = true,
+		});
+}
+
+SETUP("tc", "tc_egressgw_redirect_from_overlay")
+int egressgw_redirect_setup(struct __ctx_buff *ctx)
+{
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_OVERLAY);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_redirect_from_overlay")
+int egressgw_redirect_check(const struct __ctx_buff *ctx)
+{
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = TC_ACT_REDIRECT,
+	});
+
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24);
+
+	return ret;
+}
+
+/* Test that a packet matching an excluded CIDR egress gateway policy on the
+ * from-overlay program does not get redirected to the target netdev.
+ */
+PKTGEN("tc", "tc_egressgw_skip_excluded_cidr_redirect_from_overlay")
+int egressgw_skip_excluded_cidr_redirect_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_REDIRECT_EXCL_CIDR,
+		});
+}
+
+SETUP("tc", "tc_egressgw_skip_excluded_cidr_redirect_from_overlay")
+int egressgw_skip_excluded_cidr_redirect_setup(struct __ctx_buff *ctx)
+{
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP, 0);
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_EXCLUDED_CIDR, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_OVERLAY);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_skip_excluded_cidr_redirect_from_overlay")
+int egressgw_skip_excluded_cidr_redirect_check(const struct __ctx_buff *ctx)
+{
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = TC_ACT_OK,
+	});
+
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24);
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
+
+	return ret;
+}
+
+/* Test that a packet matching an egress gateway policy without a gateway on the
+ * from-overlay program does not get redirected to the target netdev.
+ */
+PKTGEN("tc", "tc_egressgw_skip_no_gateway_redirect_from_overlay")
+int egressgw_skip_no_gateway_redirect_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_REDIRECT_SKIP_NO_GATEWAY,
+		});
+}
+
+SETUP("tc", "tc_egressgw_skip_no_gateway_redirect_from_overlay")
+int egressgw_skip_no_gateway_redirect_setup(struct __ctx_buff *ctx)
+{
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_NO_GATEWAY, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_OVERLAY);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_skip_no_gateway_redirect_from_overlay")
+int egressgw_skip_no_gateway_redirect_check(const struct __ctx_buff *ctx)
+{
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = TC_ACT_OK,
+	});
+
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
+
+	return ret;
+}


### PR DESCRIPTION
This PR fixes the problem that an iptables SNAT rule in the host netns interferes with packets to egress gw by redirecting from bpf_overlay.

<!-- Description of change -->

Fixes: #17848

```release-note
egressgw: Fix the issue that an iptables SNAT rule in the host netns interferes packets to egress gw and bypass the egress GW policy
```
