### PR TITLE
Fix `ImplementationSpecific` path sorting for Ingress

### DIFF
--- a/operator/pkg/model/translation/envoy_virtual_host_test.go
+++ b/operator/pkg/model/translation/envoy_virtual_host_test.go
@@ -20,47 +20,31 @@ import (
 func TestSortableRoute(t *testing.T) {
 	arr := SortableRoute{
 		{
-			Name: "exact match 1",
-			Match: &envoy_config_route_v3.RouteMatch{
-				PathSpecifier: &envoy_config_route_v3.RouteMatch_Path{
-					Path: "/exact/match",
-				},
-			},
-		},
-		{
-			Name: "another exact match",
-			Match: &envoy_config_route_v3.RouteMatch{
-				PathSpecifier: &envoy_config_route_v3.RouteMatch_Path{
-					Path: "/exact/match/another",
-				},
-			},
-		},
-		{
-			Name: "prefix match",
+			Name: "regex match short",
 			Match: &envoy_config_route_v3.RouteMatch{
 				PathSpecifier: &envoy_config_route_v3.RouteMatch_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						Regex: "/prefix/match",
+						Regex: "/.*",
 					},
 				},
 			},
 		},
 		{
-			Name: "another prefix match",
+			Name: "regex match long",
 			Match: &envoy_config_route_v3.RouteMatch{
 				PathSpecifier: &envoy_config_route_v3.RouteMatch_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						Regex: "/prefix/match/another",
+						Regex: "/regex/.*/long",
 					},
 				},
 			},
 		},
 		{
-			Name: "prefix match with one header match",
+			Name: "regex match with one header",
 			Match: &envoy_config_route_v3.RouteMatch{
 				PathSpecifier: &envoy_config_route_v3.RouteMatch_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						Regex: "/header",
+						Regex: "/regex",
 					},
 				},
 				Headers: []*envoy_config_route_v3.HeaderMatcher{
@@ -78,12 +62,232 @@ func TestSortableRoute(t *testing.T) {
 			},
 		},
 		{
-			Name: "prefix match with two header matches",
+			Name: "regex match with one header and one query",
 			Match: &envoy_config_route_v3.RouteMatch{
 				PathSpecifier: &envoy_config_route_v3.RouteMatch_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						Regex: "/header",
+						Regex: "/regex",
 					},
+				},
+				Headers: []*envoy_config_route_v3.HeaderMatcher{
+					{
+						Name: "header1",
+						HeaderMatchSpecifier: &envoy_config_route_v3.HeaderMatcher_StringMatch{
+							StringMatch: &envoy_type_matcher_v3.StringMatcher{
+								MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+									Exact: "value1",
+								},
+							},
+						},
+					},
+				},
+				QueryParameters: []*envoy_config_route_v3.QueryParameterMatcher{
+					{
+						Name: "query1",
+						QueryParameterMatchSpecifier: &envoy_config_route_v3.QueryParameterMatcher_PresentMatch{
+							PresentMatch: true,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			Name: "regex match with two headers",
+			Match: &envoy_config_route_v3.RouteMatch{
+				PathSpecifier: &envoy_config_route_v3.RouteMatch_SafeRegex{
+					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
+						Regex: "/regex",
+					},
+				},
+				Headers: []*envoy_config_route_v3.HeaderMatcher{
+					{
+						Name: "header1",
+						HeaderMatchSpecifier: &envoy_config_route_v3.HeaderMatcher_StringMatch{
+							StringMatch: &envoy_type_matcher_v3.StringMatcher{
+								MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+									Exact: "value1",
+								},
+							},
+						},
+					},
+					{
+						Name: "header2",
+						HeaderMatchSpecifier: &envoy_config_route_v3.HeaderMatcher_StringMatch{
+							StringMatch: &envoy_type_matcher_v3.StringMatcher{
+								MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+									Exact: "value2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			Name: "exact match short",
+			Match: &envoy_config_route_v3.RouteMatch{
+				PathSpecifier: &envoy_config_route_v3.RouteMatch_Path{
+					Path: "/exact/match",
+				},
+			},
+		},
+		{
+			Name: "exact match long",
+			Match: &envoy_config_route_v3.RouteMatch{
+				PathSpecifier: &envoy_config_route_v3.RouteMatch_Path{
+					Path: "/exact/match/longest",
+				},
+			},
+		},
+		{
+			Name: "exact match with one header",
+			Match: &envoy_config_route_v3.RouteMatch{
+				PathSpecifier: &envoy_config_route_v3.RouteMatch_Path{
+					Path: "/exact/match/header",
+				},
+				Headers: []*envoy_config_route_v3.HeaderMatcher{
+					{
+						Name: "header1",
+						HeaderMatchSpecifier: &envoy_config_route_v3.HeaderMatcher_StringMatch{
+							StringMatch: &envoy_type_matcher_v3.StringMatcher{
+								MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+									Exact: "value1",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "exact match with one header and one query",
+			Match: &envoy_config_route_v3.RouteMatch{
+				PathSpecifier: &envoy_config_route_v3.RouteMatch_Path{
+					Path: "/exact/match/header",
+				},
+				Headers: []*envoy_config_route_v3.HeaderMatcher{
+					{
+						Name: "header1",
+						HeaderMatchSpecifier: &envoy_config_route_v3.HeaderMatcher_StringMatch{
+							StringMatch: &envoy_type_matcher_v3.StringMatcher{
+								MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+									Exact: "value1",
+								},
+							},
+						},
+					},
+				},
+				QueryParameters: []*envoy_config_route_v3.QueryParameterMatcher{
+					{
+						Name: "query1",
+						QueryParameterMatchSpecifier: &envoy_config_route_v3.QueryParameterMatcher_PresentMatch{
+							PresentMatch: true,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "exact match with two headers",
+			Match: &envoy_config_route_v3.RouteMatch{
+				PathSpecifier: &envoy_config_route_v3.RouteMatch_Path{
+					Path: "/exact/match/header",
+				},
+				Headers: []*envoy_config_route_v3.HeaderMatcher{
+					{
+						Name: "header1",
+						HeaderMatchSpecifier: &envoy_config_route_v3.HeaderMatcher_StringMatch{
+							StringMatch: &envoy_type_matcher_v3.StringMatcher{
+								MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+									Exact: "value1",
+								},
+							},
+						},
+					},
+					{
+						Name: "header2",
+						HeaderMatchSpecifier: &envoy_config_route_v3.HeaderMatcher_StringMatch{
+							StringMatch: &envoy_type_matcher_v3.StringMatcher{
+								MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+									Exact: "value2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "prefix match short",
+			Match: &envoy_config_route_v3.RouteMatch{
+				PathSpecifier: &envoy_config_route_v3.RouteMatch_PathSeparatedPrefix{
+					PathSeparatedPrefix: "/prefix/match",
+				},
+			},
+		},
+		{
+			Name: "prefix match long",
+			Match: &envoy_config_route_v3.RouteMatch{
+				PathSpecifier: &envoy_config_route_v3.RouteMatch_PathSeparatedPrefix{
+					PathSeparatedPrefix: "/prefix/match/long",
+				},
+			},
+		},
+		{
+			Name: "prefix match with one header",
+			Match: &envoy_config_route_v3.RouteMatch{
+				PathSpecifier: &envoy_config_route_v3.RouteMatch_PathSeparatedPrefix{
+					PathSeparatedPrefix: "/header",
+				},
+				Headers: []*envoy_config_route_v3.HeaderMatcher{
+					{
+						Name: "header1",
+						HeaderMatchSpecifier: &envoy_config_route_v3.HeaderMatcher_StringMatch{
+							StringMatch: &envoy_type_matcher_v3.StringMatcher{
+								MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+									Exact: "value1",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "prefix match with one header and one query",
+			Match: &envoy_config_route_v3.RouteMatch{
+				PathSpecifier: &envoy_config_route_v3.RouteMatch_PathSeparatedPrefix{
+					PathSeparatedPrefix: "/header",
+				},
+				Headers: []*envoy_config_route_v3.HeaderMatcher{
+					{
+						Name: "header1",
+						HeaderMatchSpecifier: &envoy_config_route_v3.HeaderMatcher_StringMatch{
+							StringMatch: &envoy_type_matcher_v3.StringMatcher{
+								MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+									Exact: "value1",
+								},
+							},
+						},
+					},
+				},
+				QueryParameters: []*envoy_config_route_v3.QueryParameterMatcher{
+					{
+						Name: "query1",
+						QueryParameterMatchSpecifier: &envoy_config_route_v3.QueryParameterMatcher_PresentMatch{
+							PresentMatch: true,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "prefix match with two headers",
+			Match: &envoy_config_route_v3.RouteMatch{
+				PathSpecifier: &envoy_config_route_v3.RouteMatch_PathSeparatedPrefix{
+					PathSeparatedPrefix: "/header",
 				},
 				Headers: []*envoy_config_route_v3.HeaderMatcher{
 					{
@@ -111,19 +315,61 @@ func TestSortableRoute(t *testing.T) {
 		},
 	}
 
+	// This assertion is to it easier to tell how
+	// the array is rearranged by the sorting.
+	// It also effectively ensures that buildNameSlice is
+	// working correctly.
+	namesBeforeSort := buildNameSlice(arr)
+	assert.Equal(t, []string{
+		"regex match short",
+		"regex match long",
+		"regex match with one header",
+		"regex match with one header and one query",
+		"regex match with two headers",
+		"exact match short",
+		"exact match long",
+		"exact match with one header",
+		"exact match with one header and one query",
+		"exact match with two headers",
+		"prefix match short",
+		"prefix match long",
+		"prefix match with one header",
+		"prefix match with one header and one query",
+		"prefix match with two headers",
+	}, namesBeforeSort)
+
 	sort.Sort(arr)
 
-	// Exact match comes first in any order
-	assert.True(t, len(arr[0].Match.GetPath()) != 0)
-	assert.True(t, len(arr[1].Match.GetPath()) != 0)
+	namesAfterSort := buildNameSlice(arr)
+	assert.Equal(t, []string{
+		"exact match long",
+		"exact match with two headers",
+		"exact match with one header and one query",
+		"exact match with one header",
+		"exact match short",
+		"regex match long",
+		"regex match with two headers",
+		"regex match with one header and one query",
+		"regex match with one header",
+		"regex match short",
+		"prefix match long",
+		"prefix match short",
+		"prefix match with two headers",
+		"prefix match with one header and one query",
+		"prefix match with one header",
+	}, namesAfterSort)
 
-	// Prefix match with longer path comes first
-	assert.Equal(t, "/prefix/match/another", arr[2].Match.GetSafeRegex().GetRegex())
-	assert.Equal(t, "/prefix/match", arr[3].Match.GetSafeRegex().GetRegex())
+}
 
-	// More Header match comes first
-	assert.True(t, len(arr[4].Match.GetHeaders()) == 2)
-	assert.True(t, len(arr[5].Match.GetHeaders()) == 1)
+func buildNameSlice(arr []*envoy_config_route_v3.Route) []string {
+
+	var names []string
+
+	for _, entry := range arr {
+		names = append(names, entry.Name)
+	}
+
+	return names
 }
 
 func Test_hostRewriteMutation(t *testing.T) {

--- a/operator/pkg/model/translation/fixture_test.go
+++ b/operator/pkg/model/translation/fixture_test.go
@@ -488,3 +488,70 @@ var complexIngressModel = &model.Model{
 		},
 	},
 }
+
+// multiplePathTypesModel is used to test that sorting of different path
+// types works correctly.
+//
+// It's based off of the output of the multiplePathTypes Ingress check in
+// operator/pkg/model/ingestion/ingress_test.go.
+var multiplePathTypesModel = &model.Model{
+	HTTP: []model.HTTPListener{
+		{
+			Sources: []model.FullyQualifiedResource{
+				{
+					Name:      "dummy-ingress",
+					Namespace: "dummy-namespace",
+					Version:   "v1",
+					Kind:      "Ingress",
+					UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+				},
+			},
+			Port:     80,
+			Hostname: "*",
+			Routes: []model.HTTPRoute{
+				{
+					PathMatch: model.StringMatch{
+						Regex: "/impl",
+					},
+					Backends: []model.Backend{
+						{
+							Name:      "dummy-backend",
+							Namespace: "dummy-namespace",
+							Port: &model.BackendPort{
+								Port: 8080,
+							},
+						},
+					},
+				},
+				{
+					PathMatch: model.StringMatch{
+						Prefix: "/",
+					},
+					Backends: []model.Backend{
+						{
+							Name:      "another-dummy-backend",
+							Namespace: "dummy-namespace",
+							Port: &model.BackendPort{
+								Port: 8081,
+							},
+						},
+					},
+				},
+				{
+					PathMatch: model.StringMatch{
+						Exact: "/exact",
+					},
+					Backends: []model.Backend{
+						{
+							Name:      "another-dummy-backend",
+							Namespace: "dummy-namespace",
+							Port: &model.BackendPort{
+								Port: 8081,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}


### PR DESCRIPTION
This PR fixes the sorting logic for Ingress (and, by extension, Gateway API), by fixing the model translation output step so that `ImplementationSpecific` (that is, regex) matches always come before `Prefix` matches, but after `Exact` matches.

It also updates the testing to ensure that changes here are caught, and updates some wording in the godoc to clarify the algorithm used for translation out of the model to Envoy config.

Fixes: #28852

```release-note
`ImplementationSpecific` Ingress paths (which for Cilium Ingress means regex path matches) are now sorted correctly in between `Exact` and `Prefix` matches.
```
