### PR TITLE
envoy: Bump envoy container image with golang 1.21 and latest grpc package

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -9,7 +9,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:b0a7b054e7d3a578f4c5c88dd
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.26-ff0d5d3f77d610040e93c7c7a430d61a0c0b90c1@sha256:6b0f2591fef922bf17a46517d5152ea7d6270524bb0e307c77986986677dbcea as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.26-5ec70a52b95e04ca7fb30c19855b20fc24da64d0@sha256:0f0b4bf9234b2b10d16cccabd31c3d2fe51a7d3a5fdfddb5a22e622cce2c87c2 as cilium-envoy
 
 #
 # Hubble CLI


### PR DESCRIPTION
The new build is with golang 1.21.4 and grpc v1.59.0, mainly for recent HTTP/2 related CVEs.

Related build: https://github.com/cilium/proxy/actions/runs/7002314626/job/19047286335
Relates: https://github.com/cilium/proxy/pull/439

```release-note
envoy: Bump envoy container image with golang 1.21 and latest grpc package
```
