### PR TITLE
bpf: Fix edge cases in new token bucket ratelimiting implementation

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1839,7 +1839,7 @@ int __tail_no_service_ipv4(struct __ctx_buff *ctx)
 		       (__u16)sample_len);
 	ip4->id = 0;
 	ip4->frag_off = 0;
-	ip4->ttl = 64;
+	ip4->ttl = IPDEFTTL;
 	ip4->protocol = IPPROTO_ICMP;
 	ip4->check = 0;
 	ip4->daddr = saddr;
@@ -2001,7 +2001,7 @@ int __tail_no_service_ipv6(struct __ctx_buff *ctx)
 	ip6->flow_lbl[2] = 0;
 	ip6->payload_len = bpf_htons(sizeof(struct icmp6hdr) + (__u16)sample_len);
 	ip6->nexthdr = IPPROTO_ICMPV6;
-	ip6->hop_limit = 64;
+	ip6->hop_limit = IPDEFTTL;
 	memcpy(&ip6->daddr, &saddr, sizeof(struct in6_addr));
 	memcpy(&ip6->saddr, &daddr, sizeof(struct in6_addr));
 

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -193,6 +193,7 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_snat_v6_external", bpffsMountpoint),
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_vtep_map", bpffsMountpoint),
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_l2_responder_v4", bpffsMountpoint),
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ratelimit", bpffsMountpoint),
 		}...)
 	}
 


### PR DESCRIPTION
This commit makes sure we reuse the same timestamp within the whole function instead of getting time multiple times.

It also adds logic to keep track of the time remainder of the interval when topping up the bucket. Before we discarded the remainder which could cause differences in the rate limit in certain edge cases.

Both changes improve the correctness of the rate limiting implementation in certain edge cases.

```release-note
improve the correctness of the rate limiting implementation in certain edge cases.
```
