### PR TITLE
workflows: Pin conn-disrupt-test GH action to main

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -275,7 +275,7 @@ jobs:
               --flush-ct
 
       - name: Rotate IPsec Key & Test (${{ join(matrix.*, ', ') }})
-        uses: cilium/cilium/.github/actions/conn-disrupt-test@614f2ddcc8fe93aeaf463b4535dcc0f1dcc373a3
+        uses: cilium/cilium/.github/actions/conn-disrupt-test@main
         with:
           job-name: conformance-ipsec-e2e-key-rotation-${{ matrix.name }}
           operation-cmd: |

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -311,7 +311,7 @@ jobs:
 
       - name: Upgrade Cilium & Test (${{ matrix.name }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
-        uses: cilium/cilium/.github/actions/conn-disrupt-test@614f2ddcc8fe93aeaf463b4535dcc0f1dcc373a3
+        uses: cilium/cilium/.github/actions/conn-disrupt-test@main
         with:
           job-name: ipsec-upgrade-${{ matrix.name }}
           operation-cmd: |
@@ -326,7 +326,7 @@ jobs:
 
       - name: Downgrade Cilium to ${{ steps.vars.outputs.downgrade_version }} & Test (${{ matrix.name }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
-        uses: cilium/cilium/.github/actions/conn-disrupt-test@614f2ddcc8fe93aeaf463b4535dcc0f1dcc373a3
+        uses: cilium/cilium/.github/actions/conn-disrupt-test@main
         with:
           job-name: ipsec-downgrade-${{ matrix.name }}
           operation-cmd: |


### PR DESCRIPTION
If we use a specific SHA, then Renovate will keep bothering us, trying to update it every time we push to main. The intent is for those workflows to use the main version of this action anyway.