### PR TITLE
ci: don't write github commit status on push event

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -67,6 +67,7 @@ env:
 
 jobs:
   commit-status-start:
+    if: ${{ github.event_name != 'push' }}
     name: Commit Status Start
     runs-on: ubuntu-latest
     steps:
@@ -287,7 +288,7 @@ jobs:
           retention-days: 5
 
   commit-status-final:
-    if: ${{ always() }}
+    if: ${{ github.event_name != 'push' }}
     name: Commit Status Final
     needs: gateway-api-conformance-test
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -65,6 +65,7 @@ env:
 
 jobs:
   commit-status-start:
+    if: ${{ github.event_name != 'push' }}
     name: Commit Status Start
     runs-on: ubuntu-latest
     steps:
@@ -289,7 +290,7 @@ jobs:
           retention-days: 5
 
   commit-status-final:
-    if: ${{ always() }}
+    if: ${{ github.event_name != 'push' }}
     name: Commit Status Final
     needs: ingress-conformance-test
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -55,6 +55,7 @@ concurrency:
 
 jobs:
   commit-status-start:
+    if: ${{ github.event_name != 'push' }}
     name: Commit Status Start
     runs-on: ubuntu-latest
     steps:
@@ -115,7 +116,7 @@ jobs:
           ./.travis/build.sh
 
   commit-status-final:
-    if: ${{ always() }}
+    if: ${{ github.event_name != 'push' }}
     name: Commit Status Final
     needs: integration-test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently, some GitHub workflows are reporting their status via GitHub Commit Status. The main reason is to link the status of the workflow run to a specific commit SHA. This is necessary for workflows that are triggered via Ariane (trigger `workflows_dispatch`).

However, if the same workflow is triggered via `push` (e.g. after a PR being merged), reporting the status via commit status is unnecessary, as the workflow is already linked to the correct commit SHA. it only results in displaying a duplicated check for the same workflow run.

Therefore, this commit suppresses the commit status reporting in case of a `push` trigger.