### PR TITLE
[v1.12] Backport of #26242 (don't hold EP lock while generating policy)

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -390,9 +390,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 			ep.Logger("api").WithError(err).Warning("Unable to fetch kubernetes labels")
 		} else {
 			ep.SetPod(pod)
-			if err := ep.SetK8sMetadata(cp); err != nil {
-				return invalidDataError(ep, fmt.Errorf("Invalid ContainerPorts %v: %s", cp, err))
-			}
+			ep.SetK8sMetadata(cp)
 			addLabels.MergeLabels(identityLabels)
 			infoLabels.MergeLabels(info)
 			if _, ok := annotations[bandwidth.IngressBandwidth]; ok {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -368,7 +368,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	var err error
 
 	if option.Config.EnableIPv6 && ep.IPv6 != nil {
-		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.IP(), ep.HumanStringLocked()+" [restored]")
+		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.IP(), ep.HumanString()+" [restored]")
 		if err != nil {
 			return fmt.Errorf("unable to reallocate %s IPv6 address: %w", ep.IPv6.IP(), err)
 		}
@@ -381,7 +381,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	}
 
 	if option.Config.EnableIPv4 && ep.IPv4 != nil {
-		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.IP(), ep.HumanStringLocked()+"[restored]")
+		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.IP(), ep.HumanString()+"[restored]")
 		switch {
 		// We only check for BypassIPAllocUponRestore for IPv4 because we
 		// assume that this flag is only turned on for IPv4-only IPAM modes

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -119,7 +119,7 @@ func (e *Endpoint) getModelEndpointIdentitiersRLocked() *models.EndpointIdentifi
 		ContainerName:    e.containerName,
 		DockerEndpointID: e.dockerEndpointID,
 		DockerNetworkID:  e.dockerNetworkID,
-		PodName:          e.getK8sNamespaceAndPodName(),
+		PodName:          e.GetK8sNamespaceAndPodName(),
 		K8sPodName:       e.K8sPodName,
 		K8sNamespace:     e.K8sNamespace,
 	}
@@ -437,6 +437,9 @@ func (e *Endpoint) policyStatus() models.EndpointPolicyEnabled {
 // purposes should a caller choose to try to regenerate this endpoint, as well
 // as an error if the Endpoint is being deleted, since there is no point in
 // changing an Endpoint if it is going to be deleted.
+//
+// Before adding any new fields here, check to see if they are assumed to be mutable after
+// endpoint creation!
 func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionState bool) (string, error) {
 	var (
 		changed bool

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -272,10 +272,12 @@ func (e *Endpoint) GetHealthModel() *models.EndpointHealth {
 }
 
 // getNamedPortsModel returns the endpoint's NamedPorts object.
-//
-// Must be called with e.mutex RLock()ed.
 func (e *Endpoint) getNamedPortsModel() (np models.NamedPorts) {
-	k8sPorts := e.k8sPorts
+	var k8sPorts policy.NamedPortMap
+	if p := e.k8sPorts.Load(); p != nil {
+		k8sPorts = p.(policy.NamedPortMap)
+	}
+
 	// keep named ports ordered to avoid the unnecessary updates to
 	// kube-apiserver
 	names := make([]string, 0, len(k8sPorts))

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -723,8 +723,18 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 	stats := &regenContext.Stats
 	datapathRegenCtxt := regenContext.datapathRegenerationContext
 
+	// regenerate policy without holding the lock.
+	// This is because policy generation needs the ipcache to make progress, and the ipcache needs to call
+	// endpoint.ApplyPolicyMapChanges()
+	stats.policyCalculation.Start()
+	policyResult, err := e.regeneratePolicy()
+	stats.policyCalculation.End(err == nil)
+	if err != nil {
+		return false, fmt.Errorf("unable to regenerate policy for '%s': %w", e.StringID(), err)
+	}
+
 	stats.waitingForLock.Start()
-	err := e.lockAlive()
+	err = e.lockAlive()
 	stats.waitingForLock.End(err == nil)
 	if err != nil {
 		return false, err
@@ -757,6 +767,12 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 		close(datapathRegenCtxt.ctCleaned)
 	}
 
+	// Set the computed policy as the "incoming" policy. This can fail if
+	// the endpoint's security identity changed during or after policy calculation.
+	if err := e.setDesiredPolicy(policyResult); err != nil {
+		return false, err
+	}
+
 	// We cannot obtain the rules while e.mutex is held, because obtaining
 	// fresh DNSRules requires the IPCache lock (which must not be taken while
 	// holding e.mutex to avoid deadlocks). Therefore, rules are obtained
@@ -765,12 +781,6 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 
 	// If dry mode is enabled, no further changes to BPF maps are performed
 	if option.Config.DryMode {
-
-		// Compute policy for this endpoint.
-		if err = e.regeneratePolicy(); err != nil {
-			return false, fmt.Errorf("Unable to regenerate policy: %s", err)
-		}
-
 		_ = e.updateAndOverrideEndpointOptions(nil)
 
 		// Dry mode needs Network Policy Updates, but the proxy wait group must
@@ -807,12 +817,6 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 	// Only generate & populate policy map if a security identity is set up for
 	// this endpoint.
 	if e.SecurityIdentity != nil {
-		stats.policyCalculation.Start()
-		err = e.regeneratePolicy()
-		stats.policyCalculation.End(err == nil)
-		if err != nil {
-			return false, fmt.Errorf("unable to regenerate policy for '%s': %s", e.StringID(), err)
-		}
 
 		_ = e.updateAndOverrideEndpointOptions(nil)
 
@@ -843,6 +847,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 		//
 		// Do this before updating the bpf policy maps below, so that the proxy listeners have a chance to be
 		// ready when new traffic is redirected to them.
+		// note: unlike regeneratePolicy, updateNetworkPolicy requires the endpoint read lock
 		stats.proxyPolicyCalculation.Start()
 		err, networkPolicyRevertFunc := e.updateNetworkPolicy(datapathRegenCtxt.proxyWaitGroup)
 		stats.proxyPolicyCalculation.End(err == nil)

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -70,7 +70,7 @@ func (e *Endpoint) Logger(subsystem string) *logrus.Entry {
 //
 // Note: You must hold Endpoint.mutex.Lock() to synchronize logger pointer
 // updates if the endpoint is already exposed. Callers that create new
-// endopoints do not need locks to call this.
+// endpoints do not need locks to call this.
 func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 	e.updatePolicyLogger(fields)
 	v := atomic.LoadPointer(&e.logger)
@@ -114,12 +114,12 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 	l := baseLogger.WithFields(logrus.Fields{
 		logfields.LogSubsys:              subsystem,
 		logfields.EndpointID:             e.ID,
-		logfields.ContainerID:            e.getShortContainerID(),
+		logfields.ContainerID:            e.getShortContainerIDLocked(),
 		logfields.DatapathPolicyRevision: e.policyRevision,
 		logfields.DesiredPolicyRevision:  e.nextPolicyRevision,
 		logfields.IPv4:                   e.IPv4.String(),
 		logfields.IPv6:                   e.IPv6.String(),
-		logfields.K8sPodName:             e.getK8sNamespaceAndPodName(),
+		logfields.K8sPodName:             e.GetK8sNamespaceAndPodName(),
 	})
 
 	if e.SecurityIdentity != nil {
@@ -173,12 +173,12 @@ func (e *Endpoint) updatePolicyLogger(fields map[string]interface{}) {
 		policyLogger = policyLogger.WithFields(logrus.Fields{
 			logfields.LogSubsys:              subsystem,
 			logfields.EndpointID:             e.ID,
-			logfields.ContainerID:            e.getShortContainerID(),
+			logfields.ContainerID:            e.getShortContainerIDLocked(),
 			logfields.DatapathPolicyRevision: e.policyRevision,
 			logfields.DesiredPolicyRevision:  e.nextPolicyRevision,
 			logfields.IPv4:                   e.IPv4.String(),
 			logfields.IPv6:                   e.IPv6.String(),
-			logfields.K8sPodName:             e.getK8sNamespaceAndPodName(),
+			logfields.K8sPodName:             e.GetK8sNamespaceAndPodName(),
 		})
 
 		if e.SecurityIdentity != nil {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -88,7 +88,7 @@ func (e *Endpoint) proxyID(l4 *policy.L4Filter) string {
 // lookupRedirectPort returns the redirect L4 proxy port for the given L4
 // policy map key, in host byte order. Returns 0 if not found or the
 // filter doesn't require a redirect.
-// Must be called with Endpoint.mutex held.
+// Must be called with either Endpoint.mutex or Endpoint.buildMutex held for reading.
 func (e *Endpoint) LookupRedirectPortLocked(ingress bool, protocol string, port uint16) uint16 {
 	return e.realizedRedirects[policy.ProxyID(e.ID, ingress, protocol, port)]
 }
@@ -128,6 +128,13 @@ func (e *Endpoint) setNextPolicyRevision(revision uint64) {
 	})
 }
 
+type policyGenerateResult struct {
+	policyRevision   uint64
+	selectorPolicy   policy.SelectorPolicy
+	endpointPolicy   *policy.EndpointPolicy
+	identityRevision int
+}
+
 // regeneratePolicy computes the policy for the given endpoint based off of the
 // rules in regeneration.Owner's policy repository.
 //
@@ -137,80 +144,166 @@ func (e *Endpoint) setNextPolicyRevision(revision uint64) {
 // however, and it is possible that policy update succeeds for some endpoints,
 // while it fails for other endpoints.
 //
-// Returns:
-//  - err: any error in obtaining information for computing policy, or if
-// policy could not be generated given the current set of rules in the
-// repository.
-// Must be called with endpoint mutex held.
-func (e *Endpoint) regeneratePolicy() (retErr error) {
-	var forceRegeneration bool
+// Failure may be due to any error in obtaining information for computing policy,
+// or if policy could not be generated given the current set of rules in the repository.
+//
+// endpoint lock must NOT be held. This is because the ipcache needs to be able to
+// make progress while generating policy, and *that* needs the endpoint unlocked to call
+// ep.ApplyPolicyMapChanges. Specifically, computing policy may cause identity allocation
+// which requires ipcache progress.
+//
+// buildMutex MUST be held, and not released until setDesiredPolicy and
+// updateRealizedState have been called
+//
+// There are a few fields that depend on this exact configuration of locking:
+//   - ep.desiredPolicy: ep.mutex must be locked between writing this and committing to
+//     the policy maps, or else policy drops may occur
+//   - ep.policyRevision: ep.mutex and ep.buildMutex must be held to write to this
+//   - ep.selectorPolicy: this may be nulled if the endpoints identity changes; we must
+//     check for this when committing. ep.mutex must be held
+//   - ep.realizedRedirects: this is read by external callers as part of policy generation,
+//     so ep.mutex must not be required to read this. Instead, both ep.mutex and ep.buildMutex
+//     must be held to write to this (i.e. we are deep in regeneration)
+//
+// Returns a result that should be passed to setDesiredPolicy after the endpoint's
+// write lock has been acquired, or err if recomputing policy failed.
+func (e *Endpoint) regeneratePolicy() (*policyGenerateResult, error) {
+	var err error
+
+	// lock the endpoint, read our values, then unlock
+	err = e.rlockAlive()
+	if err != nil {
+		return nil, err
+	}
 
 	// No point in calculating policy if endpoint does not have an identity yet.
 	if e.SecurityIdentity == nil {
 		e.getLogger().Warn("Endpoint lacks identity, skipping policy calculation")
-		return nil
+		e.runlock()
+		return nil, nil
 	}
+
+	// Copy out some values we care about, then unlock
+	forcePolicyCompute := e.forcePolicyCompute
+	securityIdentity := e.SecurityIdentity
+
+	// We are computing policy; set this to false.
+	// We do this now, not in setDesiredPolicy(), because if another caller
+	// comes in and forces computation, we should leave that for the *next*
+	// regeneration.
+	e.forcePolicyCompute = false
+
+	result := &policyGenerateResult{
+		selectorPolicy:   e.selectorPolicy,
+		endpointPolicy:   e.desiredPolicy,
+		identityRevision: e.identityRevision,
+	}
+	e.runlock()
 
 	e.getLogger().Debug("Starting policy recalculation...")
 	stats := &policyRegenerationStatistics{}
 	stats.totalTime.Start()
+	defer func() {
+		stats.totalTime.End(err == nil)
+		e.updatePolicyRegenerationStatistics(stats, forcePolicyCompute, err)
+	}()
 
 	stats.waitingForPolicyRepository.Start()
 	repo := e.policyGetter.GetPolicyRepository()
-	repo.Mutex.RLock()
-	revision := repo.GetRevision()
-	defer repo.Mutex.RUnlock()
+	repo.Mutex.RLock() // Be sure to release this lock!
 	stats.waitingForPolicyRepository.End(true)
 
-	// Recompute policy for this endpoint only if not already done for this revision.
-	if !e.forcePolicyCompute && e.nextPolicyRevision >= revision {
-		e.getLogger().WithFields(logrus.Fields{
-			"policyRevision.next": e.nextPolicyRevision,
-			"policyRevision.repo": revision,
-			"policyChanged":       e.nextPolicyRevision > e.policyRevision,
-		}).Debug("Skipping unnecessary endpoint policy recalculation")
+	result.policyRevision = repo.GetRevision()
 
-		return nil
+	// Recompute policy for this endpoint only if not already done for this revision
+	// and identity.
+	if e.nextPolicyRevision >= result.policyRevision &&
+		e.desiredPolicy != nil && result.selectorPolicy != nil {
+
+		if !forcePolicyCompute {
+			e.getLogger().WithFields(logrus.Fields{
+				"policyRevision.next": e.nextPolicyRevision,
+				"policyRevision.repo": result.policyRevision,
+				"policyChanged":       e.nextPolicyRevision > e.policyRevision,
+			}).Debug("Skipping unnecessary endpoint policy recalculation")
+			repo.Mutex.RUnlock()
+			return result, nil
+		} else {
+			e.getLogger().Debug("Forced policy recalculation")
+		}
 	}
 
 	stats.policyCalculation.Start()
-	if e.selectorPolicy == nil {
+	defer func() { stats.policyCalculation.End(err == nil) }()
+	if result.selectorPolicy == nil {
 		// Upon initial insertion or restore, there's currently no good
 		// trigger point to ensure that the security Identity is
 		// assigned after the endpoint is added to the endpointmanager
 		// (and hence also the identitymanager). In that case, detect
 		// that the selectorPolicy is not set and find it.
-		e.selectorPolicy = repo.GetPolicyCache().Lookup(e.SecurityIdentity)
-		if e.selectorPolicy == nil {
+		result.selectorPolicy = repo.GetPolicyCache().Lookup(securityIdentity)
+		if result.selectorPolicy == nil {
 			err := fmt.Errorf("no cached selectorPolicy found")
 			e.getLogger().WithError(err).Warning("Failed to regenerate from cached policy")
-			return err
+			repo.Mutex.RUnlock()
+			return result, err
 		}
 	}
-	// TODO: GH-7515: This should be triggered closer to policy change
-	// handlers, but for now let's just update it here.
-	if err := repo.GetPolicyCache().UpdatePolicy(e.SecurityIdentity); err != nil {
+
+	// UpdatePolicy ensures the SelectorPolicy is fully resolved.
+	// Endpoint lock must not be held!
+	// TODO: GH-7515: Consider ways to compute policy outside of the
+	// endpoint regeneration process, ideally as part of the policy change
+	// handler.
+	err = repo.GetPolicyCache().UpdatePolicy(securityIdentity)
+	if err != nil {
 		e.getLogger().WithError(err).Warning("Failed to update policy")
-		return err
+		repo.Mutex.RUnlock()
+		return nil, err
 	}
-	calculatedPolicy := e.selectorPolicy.Consume(e)
+	repo.Mutex.RUnlock() // Done with policy repository; release this now as Consume() can be slow
 
-	stats.policyCalculation.End(true)
+	// Consume converts a SelectorPolicy in to an EndpointPolicy
+	result.endpointPolicy = result.selectorPolicy.Consume(e)
+	return result, nil
+}
 
-	// This marks the e.desiredPolicy different from the previously realized policy
-	e.desiredPolicy = calculatedPolicy
+// setDesiredPolicy updates the endpoint with the results of a policy calculation.
+//
+// The endpoint write lock must be held and not released until the desired policy has
+// been pushed in to the policymaps via `syncPolicyMap`. This is so that we block
+// ApplyPolicyMapChanges, which has the effect of blocking the ipcache from updating
+// the ipcache bpf map. It is required that any pending changes are pushed in to
+// the policymap before the ipcache map, otherwise endpoints could experience transient
+// policy drops.
+//
+// Specifically, since policy is calculated asynchronously from the ipcacache's apply loop,
+// it is probable that the new policy diverges from the bpf PolicyMap. So, we cannot safely
+// consume incremental changes (and thus allow the ipcache to continue) until we have
+// successfully performed a full sync with the endpoints PolicyMap. Otherwise,
+// the ipcache may remove an identity from the ipcache that the bpf PolicyMap is still
+// relying on.
+func (e *Endpoint) setDesiredPolicy(res *policyGenerateResult) error {
+	// nil result means endpoint had no identity while policy was calculated
+	if res == nil {
+		if e.SecurityIdentity != nil {
+			e.getLogger().Info("Endpoint SecurityIdentity changed during policy regeneration")
+			return fmt.Errorf("endpoint %d SecurityIdentity changed during policy regeneration", e.ID)
+		}
 
-	if e.forcePolicyCompute {
-		forceRegeneration = true     // Options were changed by the caller.
-		e.forcePolicyCompute = false // Policies just computed
-		e.getLogger().Debug("Forced policy recalculation")
+		return nil
+	}
+	// if the security identity changed, reject the policy computation
+	if e.identityRevision != res.identityRevision {
+		e.getLogger().Info("Endpoint SecurityIdentity changed during policy regeneration")
+		return fmt.Errorf("endpoint %d SecurityIdentity changed during policy regeneration", e.ID)
 	}
 
 	// Set the revision of this endpoint to the current revision of the policy
 	// repository.
-	e.setNextPolicyRevision(revision)
-
-	e.updatePolicyRegenerationStatistics(stats, forceRegeneration, retErr)
+	e.setNextPolicyRevision(res.policyRevision)
+	e.selectorPolicy = res.selectorPolicy
+	e.desiredPolicy = res.endpointPolicy
 
 	return nil
 }

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -8,8 +8,23 @@ package endpoint
 import (
 	"gopkg.in/check.v1"
 
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -39,4 +54,166 @@ func (s *EndpointSuite) TestUpdateVisibilityPolicy(c *check.C) {
 		return "", nil
 	})
 	c.Assert(ep.visibilityPolicy, check.IsNil)
+}
+
+// This test fuzzes the incremental update engine from an end-to-end perspective
+// to ensure we don't ever miss an incremental update.
+//
+// It works by simulating a "churning" IPcache that is constantly allocating new identities.
+// There is a single policy that -- funnily enough -- selects all of the new identities.
+// We then continuously simulate endpoint regeneration and ensure the computed policy contains
+// all the generated identities.
+//
+// By default, we test 1000 identities, which should take less than 10 seconds. If this test fails,
+// please bump the factor to something massive and start debugging :-).
+func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
+	const testfactor = 1000 // bump this to stress-test
+
+	pe := policy.GetPolicyEnabled()
+	policy.SetPolicyEnabled("always")
+	defer policy.SetPolicyEnabled(pe)
+
+	idcache := make(cache.IdentityCache, testfactor)
+	fakeAllocator := testidentity.NewMockIdentityAllocator(idcache)
+	repo := policy.NewPolicyRepository(fakeAllocator, fakeAllocator.GetIdentityCache(), nil)
+
+	defer func() {
+		repo.RepositoryChangeQueue.Stop()
+		repo.RuleReactionQueue.Stop()
+		repo.RepositoryChangeQueue.WaitToBeDrained()
+		repo.RuleReactionQueue.WaitToBeDrained()
+	}()
+
+	addIdentity := func(labelKeys ...string) *identity.Identity {
+		t.Helper()
+		lbls := labels.Labels{}
+		for _, labelKey := range labelKeys {
+			lbls[labelKey] = labels.NewLabel("k8s:"+labelKey, "", "")
+		}
+		id, _, err := fakeAllocator.AllocateIdentity(context.Background(), lbls, false, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		//t.Logf("allocated label %s id %d", labelKeys, id.ID) // commented out for speed
+
+		wg := &sync.WaitGroup{}
+		repo.GetSelectorCache().UpdateIdentities(cache.IdentityCache{
+			id.ID: id.LabelArray,
+		}, nil, wg)
+		wg.Wait()
+		return id
+	}
+
+	podID := addIdentity("pod")
+	repo.GetPolicyCache().LocalEndpointIdentityAdded(podID)
+
+	ep := Endpoint{
+		SecurityIdentity: podID,
+		policyGetter:     &mockPolicyGetter{repo},
+	}
+	ep.UpdateLogger(nil)
+
+	podSelectLabel := labels.ParseSelectLabel("pod")
+	egressSelectLabel := labels.ParseSelectLabel("peer")
+
+	// Create a rule for our pod that selects all peer identities
+	egressDenyRule := &api.Rule{
+		EndpointSelector: api.NewESFromLabels(podSelectLabel),
+		EgressDeny: []api.EgressDenyRule{
+			{
+				EgressCommonRule: api.EgressCommonRule{
+					ToEndpoints: []api.EndpointSelector{
+						api.NewESFromLabels(egressSelectLabel),
+					},
+				},
+				ToPorts: []api.PortDenyRule{
+					{
+						Ports: []api.PortProtocol{
+							{
+								Port:     "80",
+								Protocol: "TCP",
+							},
+						},
+					},
+				},
+			},
+		},
+		Labels: labels.LabelArray{
+			labels.NewLabel(k8sConst.PolicyLabelName, "egressDenyRule", labels.LabelSourceAny),
+		},
+	}
+
+	_, _, err := repo.Add(*egressDenyRule, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Track all IDs we allocate so we can validate later that we never miss any
+	checkMutex := lock.Mutex{}
+	allocatedIDs := make(map[identity.NumericIdentity]struct{}, testfactor)
+	done := false
+
+	// simulate ipcache churn: continuously allocate IDs and push them to the policy engine.
+	go func() {
+		for i := 0; i < testfactor; i++ {
+			if i%100 == 0 {
+				t.Log(i)
+			}
+			id := addIdentity("peer", fmt.Sprintf("peer%d", i))
+
+			// note: we could stop checking here and the last ID would be missing from allocatedIDs
+			// so we will have to handle the case where we select one more ID than is in allocatedIDs
+			checkMutex.Lock()
+			allocatedIDs[id.ID] = struct{}{}
+			checkMutex.Unlock()
+
+		}
+		done = true
+	}()
+
+	// Continuously compute policy for the pod and ensure we never missed an incremental update.
+	for {
+		t.Log("Calculating policy...")
+		res, err := ep.regeneratePolicy()
+		assert.Nil(t, err)
+
+		// Sleep a random amount, so we accumulate some changes
+		// This does not slow down the test, since we always generate testFactor identities.
+		time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+
+		// Now, check that all the expected entries are there
+		checkMutex.Lock()
+		t.Log("Checking policy...")
+
+		// Apply any pending incremental changes
+		// This mirrors the existing code, where we consume map changes
+		// while holding the endpoint lock
+		res.endpointPolicy.ConsumeMapChanges()
+		haveIDs := make(map[identity.NumericIdentity]struct{}, testfactor)
+		for k := range res.endpointPolicy.PolicyMapState {
+			haveIDs[identity.NumericIdentity(k.Identity)] = struct{}{}
+		}
+
+		// It is okay if we have *more* IDs than allocatedIDs, since we may have propagated
+		// an ID change through the policy system but not yet added to the extra list we're
+		// keeping in this test.
+		//
+		// It is confusing, but this assertion checks that allocatedIDs is a subset of haveIDs,
+		// not the other way around.
+		assert.Subset(t, haveIDs, allocatedIDs, "stress-testing the incremental update system failed! DO NOT just retest, there is a race condition!")
+
+		checkMutex.Unlock()
+
+		if done {
+			break
+		}
+	}
+}
+
+type mockPolicyGetter struct {
+	repo *policy.Repository
+}
+
+func (m *mockPolicyGetter) GetPolicyRepository() *policy.Repository {
+	return m.repo
 }

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -174,7 +174,9 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return firstAnno, nil
 	})
-	err = ep.regeneratePolicy()
+	res, err := ep.regeneratePolicy()
+	c.Assert(err, check.IsNil)
+	err = ep.setDesiredPolicy(res)
 	c.Assert(err, check.IsNil)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -197,7 +199,11 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return secondAnno, nil
 	})
-	err = ep.regeneratePolicy()
+	res, err = ep.regeneratePolicy()
+	c.Assert(err, check.IsNil)
+	err = ep.setDesiredPolicy(res)
+	c.Assert(err, check.IsNil)
+
 	c.Assert(err, check.IsNil)
 	d, err, _, _ := ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
@@ -217,7 +223,11 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return thirdAnno, nil
 	})
-	err = ep.regeneratePolicy()
+	res, err = ep.regeneratePolicy()
+	c.Assert(err, check.IsNil)
+	err = ep.setDesiredPolicy(res)
+	c.Assert(err, check.IsNil)
+
 	c.Assert(err, check.IsNil)
 	_, err, _, _ = ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
@@ -264,7 +274,11 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return noAnno, nil
 	})
-	err = ep.regeneratePolicy()
+	res, err = ep.regeneratePolicy()
+	c.Assert(err, check.IsNil)
+	err = ep.setDesiredPolicy(res)
+	c.Assert(err, check.IsNil)
+
 	c.Assert(err, check.IsNil)
 	d, err, _, _ = ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
@@ -394,7 +408,9 @@ func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
 	}
 	do.repo.AddList(rules)
 
-	err = ep.regeneratePolicy()
+	res, err := ep.regeneratePolicy()
+	c.Assert(err, check.IsNil)
+	err = ep.setDesiredPolicy(res)
 	c.Assert(err, check.IsNil)
 
 	expected := policy.MapState{

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -1513,7 +1513,7 @@ func getDirectionNetworkPolicy(ep logger.EndpointUpdater, l4Policy policy.L4Poli
 
 		port := uint16(l4.Port)
 		if port == 0 && l4.PortName != "" {
-			port = ep.GetNamedPortLocked(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
+			port = ep.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
 			if port == 0 {
 				continue
 			}

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -342,7 +342,7 @@ func (l4Filter *L4Filter) ToMapState(policyOwner PolicyOwner, direction trafficd
 
 	// resolve named port
 	if port == 0 && l4Filter.PortName != "" {
-		port = policyOwner.GetNamedPortLocked(l4Filter.Ingress, l4Filter.PortName, proto)
+		port = policyOwner.GetNamedPort(l4Filter.Ingress, l4Filter.PortName, proto)
 		if port == 0 {
 			return keysToAdd
 		}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -818,7 +818,7 @@ func (keys MapState) DeniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
 
 	// resolve named port
 	if port == 0 && l4.PortName != "" {
-		port = policyOwner.GetNamedPortLocked(l4.Ingress, l4.PortName, proto)
+		port = policyOwner.GetNamedPort(l4.Ingress, l4.PortName, proto)
 		if port == 0 {
 			return true
 		}

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -68,7 +68,6 @@ type PolicyOwner interface {
 	GetID() uint64
 	LookupRedirectPortLocked(ingress bool, protocol string, port uint16) uint16
 	GetNamedPort(ingress bool, name string, proto uint8) uint16
-	GetNamedPortLocked(ingress bool, name string, proto uint8) uint16
 	PolicyDebug(fields logrus.Fields, msg string)
 }
 

--- a/pkg/proxy/endpoint/endpoint.go
+++ b/pkg/proxy/endpoint/endpoint.go
@@ -5,7 +5,6 @@ package endpoint
 
 import (
 	"github.com/cilium/cilium/pkg/fqdn/restore"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
 
@@ -15,15 +14,7 @@ type EndpointInfoSource interface {
 	GetID() uint64
 	GetIPv4Address() string
 	GetIPv6Address() string
-	GetIdentityLocked() identity.NumericIdentity
-	GetLabels() []string
 	HasSidecarProxy() bool
-	// ConntrackName assumes that the caller has *not* acquired any mutexes
-	// that may be associated with this EndpointInfoSource. It is (unfortunately)
-	// up to the caller to know when to use this vs. ConntrackNameLocked, which
-	// assumes that the caller has acquired any needed mutexes of the
-	// implementation.
-	ConntrackName() string
 	ConntrackNameLocked() string
 	GetNamedPort(ingress bool, name string, proto uint8) uint16
 }

--- a/pkg/proxy/endpoint/endpoint.go
+++ b/pkg/proxy/endpoint/endpoint.go
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package logger
+package endpoint
 
 import (
-	"net"
-
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
@@ -47,17 +45,4 @@ type EndpointUpdater interface {
 	// OnDNSPolicyUpdateLocked is called when the Endpoint's DNS policy has been updated.
 	// 'rules' is a fresh copy of the DNS rules passed to the callee.
 	OnDNSPolicyUpdateLocked(rules restore.DNSRules)
-}
-
-// EndpointInfoRegistry provides endpoint information lookup by endpoint IP
-// address.
-type EndpointInfoRegistry interface {
-	// FillEndpointInfo resolves the labels of the specified identity if known locally.
-	// If 'id' is passed as zero, will locate the EP by 'ip', and also fill info.ID, if found.
-	// Fills in the following info member fields:
-	//  - info.IPv4           (if 'ip' is IPv4)
-	//  - info.IPv6           (if 'ip' is not IPv4)
-	//  - info.Identity       (defaults to WORLD if not known)
-	//  - info.Labels         (only if identity is found)
-	FillEndpointInfo(info *accesslog.EndpointInfo, ip net.IP, id identity.NumericIdentity)
 }

--- a/pkg/proxy/endpoint/test/updater_mock.go
+++ b/pkg/proxy/endpoint/test/updater_mock.go
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-//go:build !privileged_tests
-
 package test
 
 import (

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -92,6 +92,7 @@ func (f *MockIdentityAllocator) AllocateIdentity(_ context.Context, lbls labels.
 		Labels:         lbls,
 		ReferenceCount: 1,
 	}
+	realID.Sanitize() // copy Labels to LabelArray
 	f.idToIdentity[id] = realID
 
 	return realID, true, nil


### PR DESCRIPTION
 * [x] #26242 (@squeed)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 26242
```


### Rationale

In the following, the notation SelectorCache > NameManager means that the selector cache lock is held while the NameManager lock is being acquired. When a lock is held when another is acquired, it creates an edge in the graph of lock dependencies. If there is a cycle in lock dependencies, a wait cycle (or deadlock) is possible.

In this case, the wait cycle in question is the following:

IPCache > EP > NameManager > IPCache

The IPCache > EP link stems from the following stack. Note that EP here stands for _any_ endpoint, as they are all locked in sequence. I believe this is related to replacing the kube API server.

```
github.com/cilium/cilium/pkg/endpointmanager.(*EndpointManager).UpdatePolicyMaps() <-- takes _all_ EP locks
github.com/cilium/cilium/pkg/ipcache.(*IPCache).UpdatePolicyMaps() <-- t
github.com/cilium/cilium/pkg/ipcache.(*IPCache).removeLabelsFromIPs(...) <-- takes IPCache lock
github.com/cilium/cilium/pkg/ipcache.(*IPCache).RemoveLabelsExcluded(...)
github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).handleKubeAPIServerServiceEPChanges(...)
github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).addKubeAPIServerServiceEPSliceV1(...)
github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).updateK8sEndpointSliceV1(...)
```

The next link in the chain, EP > NameManager, occurs in the path of EP regeneration when dealing with FQDN selectors. Specifically, the SelectorCache wants to lock NameManager early (due to lock ordering constraints, cf 0a07c9b0f43df871de97e0258518b487cf2642f0).

```
github.com/cilium/cilium/pkg/fqdn.(*NameManager).Lock() <--- NameManager lock
github.com/cilium/cilium/pkg/policy.(*SelectorCache).AddFQDNSelector(...)
github.com/cilium/cilium/pkg/policy.(*L4Filter).cacheFQDNSelector(...)
github.com/cilium/cilium/pkg/policy.(*L4Filter).cacheFQDNSelectors(...)
github.com/cilium/cilium/pkg/policy.createL4Filter(...)
github.com/cilium/cilium/pkg/policy.createL4EgressFilter(...)
github.com/cilium/cilium/pkg/policy.mergeEgressPortProto(...)
github.com/cilium/cilium/pkg/policy.mergeEgress.func1(...)
github.com/cilium/cilium/pkg/policy/api.PortRules.Iterate(...)
github.com/cilium/cilium/pkg/policy.mergeEgress(...)
github.com/cilium/cilium/pkg/policy.(*rule).resolveEgressPolicy(...)
github.com/cilium/cilium/pkg/policy.ruleSlice.resolveL4EgressPolicy(...)
github.com/cilium/cilium/pkg/policy.(*Repository).resolvePolicyLocked(...)
github.com/cilium/cilium/pkg/policy.(*PolicyCache).updateSelectorPolicy(...)
github.com/cilium/cilium/pkg/policy.(*PolicyCache).UpdatePolicy(...)
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regeneratePolicy(...)
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).runPreCompilationSteps(...) <--- takes EP lock
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerateBPF(...)
```

Finally, NameManager > IPCache stems from the incremental policy path used by FQDN. UpdateGenerateDNS locks the NameManager for the duration of the method, and calls into IPCache for CIDR allocation.

```
github.com/cilium/cilium/pkg/ipcache.(*IPCache).AllocateCIDRs(...) <--- rlocks metadata, locks IPCache
github.com/cilium/cilium/pkg/ipcache.(*IPCache).AllocateCIDRsForIPs(...)
github.com/cilium/cilium/daemon/cmd.cachingIdentityAllocator.AllocateCIDRsForIPs(...)
github.com/cilium/cilium/daemon/cmd.identitiesForFQDNSelectorIPs(...)
github.com/cilium/cilium/daemon/cmd.(*Daemon).updateSelectors(...)
github.com/cilium/cilium/pkg/fqdn.(*NameManager).UpdateGenerateDNS(...) <--- locks the NameManager
github.com/cilium/cilium/daemon/cmd.(*Daemon).notifyOnDNSMsg(...)
```


