### PR TITLE
Wait for downgrade images to be ready in GHA clustermesh upgrade/downgrade test

### DIFF
--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -295,14 +295,23 @@ jobs:
             --set=clustermesh.apiserver.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci:${SHA} \
             --set=clustermesh.apiserver.kvstoremesh.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/kvstoremesh-ci:${SHA} \
           "
+          echo "sha=${SHA}" >> $GITHUB_OUTPUT
           echo "cilium_image_settings=${CILIUM_IMAGE_SETTINGS}" >> $GITHUB_OUTPUT
 
-      - name: Wait for images to be available
+      - name: Wait for images to be available (newest)
         timeout-minutes: 10
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
             until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.newest-vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+          done
+
+      - name: Wait for images to be available (downgrade)
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.downgrade-vars.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
 


### PR DESCRIPTION
Currently, we only wait for the images from the current PR/main to be available in the clustermesh upgrade tests. Yet, it can happen that the ones from the stable branch are not available (either because they are being built, or something went wrong), leading to confusing failures (as the installation eventually fails due to ImagePullBackOff errors).

To prevent this, let's add an explicit step to additionally wait for downgrade images to be available before proceeding with the installation step, so that also the error message is clear.