### PR TITLE
k8s/resource: Add support for releasable Resource[T]

### DIFF
--- a/pkg/bgpv1/manager/store/diffstore_fake.go
+++ b/pkg/bgpv1/manager/store/diffstore_fake.go
@@ -113,6 +113,8 @@ func (mds *fakeDiffStore[T]) GetByKey(key resource.Key) (item T, exists bool, er
 	return item, exists, nil
 }
 
+func (mds *fakeDiffStore[T]) Release() {}
+
 type fakeKeyIter struct {
 	i    int
 	keys []resource.Key

--- a/pkg/bgpv1/manager/store/resource_store_mock.go
+++ b/pkg/bgpv1/manager/store/resource_store_mock.go
@@ -76,3 +76,6 @@ func (mds *mockBGPCPResourceStore[T]) GetByKey(key resource.Key) (item T, exists
 
 	return item, exists, nil
 }
+
+func (mds *mockBGPCPResourceStore[T]) Release() {
+}

--- a/pkg/ipam/metadata/manager_test.go
+++ b/pkg/ipam/metadata/manager_test.go
@@ -47,6 +47,10 @@ func (m mockStore[T]) CacheStore() cache.Store {
 	panic("not implemented")
 }
 
+func (m mockStore[T]) Release() {
+	panic("not implemented")
+}
+
 func podKey(ns, name string) resource.Key {
 	return resource.Key{
 		Namespace: ns,

--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -137,9 +137,7 @@ type Resource[T k8sRuntime.Object] interface {
 // See also pkg/k8s/resource/example/main.go for a runnable example.
 func New[T k8sRuntime.Object](lc hive.Lifecycle, lw cache.ListerWatcher, opts ...ResourceOption) Resource[T] {
 	r := &resource[T]{
-		subscribers: make(map[uint64]*subscriber[T]),
-		needed:      make(chan struct{}, 1),
-		lw:          lw,
+		lw: lw,
 	}
 	r.opts.sourceObj = func() k8sRuntime.Object {
 		var obj T
@@ -149,7 +147,7 @@ func New[T k8sRuntime.Object](lc hive.Lifecycle, lw cache.ListerWatcher, opts ..
 		o(&r.opts)
 	}
 	r.ctx, r.cancel = context.WithCancel(context.Background())
-	r.storeResolver, r.storePromise = promise.New[Store[T]]()
+	r.reset()
 	lc.Append(r)
 	return r
 }
@@ -160,6 +158,7 @@ type options struct {
 	indexers    cache.Indexers           // map of the optional custom indexers to be added to the underlying resource informer
 	metricScope string                   // the scope label used when recording metrics for the resource
 	name        string                   // the name label used for the workqueue metrics
+	releasable  bool                     // if true, the underlying informer will be stopped when the last subscriber cancels its subscription
 }
 
 type ResourceOption func(o *options)
@@ -213,6 +212,23 @@ func WithName(name string) ResourceOption {
 	}
 }
 
+// WithStoppableInformer marks the resource as releasable. A releasable resource stops
+// the underlying informer if the last active subscriber cancels its subscription.
+// In this case the resource is stopped and prepared again for a subsequent call to
+// either Events() or Store().
+// A subscriber is a consumer who has taken a reference to the store with Store() or that
+// is listening to the events stream channel with Events().
+// This option is meant to be used for very specific cases of resources with a high rate
+// of updates that can potentially hinder scalability in very large clusters, like
+// CiliumNode and CiliumEndpoint.
+// For this cases, stopping the informer is required when switching to other data sources
+// that scale better.
+func WithStoppableInformer() ResourceOption {
+	return func(o *options) {
+		o.releasable = true
+	}
+}
+
 type resource[T k8sRuntime.Object] struct {
 	mu     lock.RWMutex
 	ctx    context.Context
@@ -230,6 +246,12 @@ type resource[T k8sRuntime.Object] struct {
 
 	storePromise  promise.Promise[Store[T]]
 	storeResolver promise.Resolver[Store[T]]
+
+	// meaningful for releasable resources only
+	refsMu      lock.Mutex
+	refs        uint64
+	resetCtx    context.Context
+	resetCancel context.CancelFunc
 }
 
 var _ Resource[*corev1.Node] = &resource[*corev1.Node]{}
@@ -244,11 +266,14 @@ func (r *resource[T]) Store(ctx context.Context) (Store[T], error) {
 		defer r.mu.RUnlock()
 		return r.synchronized
 	}
-	if !cache.WaitForCacheSync(ctx.Done(), hasSynced) {
-		return nil, ctx.Err()
-	}
+	cache.WaitForCacheSync(ctx.Done(), hasSynced)
 
-	return r.storePromise.Await(ctx)
+	// use an error handler to release the resource if the store promise
+	// is rejected or the context is cancelled before the cache has synchronized.
+	return promise.MapError(r.storePromise, func(err error) error {
+		r.release()
+		return err
+	}).Await(ctx)
 }
 
 func (r *resource[T]) metricEventProcessed(eventKind EventKind, status bool) {
@@ -288,12 +313,26 @@ func (r *resource[T]) metricEventReceived(action string, valid, equal bool) {
 }
 
 func (r *resource[T]) Start(hive.HookContext) error {
-	r.wg.Add(1)
-	go r.startWhenNeeded()
+	r.start()
 	return nil
 }
 
+func (r *resource[T]) start() {
+	// Don't start the resource if it has been definitely stopped
+	if r.ctx.Err() != nil {
+		return
+	}
+	r.wg.Add(1)
+	go r.startWhenNeeded()
+}
+
 func (r *resource[T]) markNeeded() {
+	if r.opts.releasable {
+		r.refsMu.Lock()
+		r.refs++
+		r.refsMu.Unlock()
+	}
+
 	select {
 	case r.needed <- struct{}{}:
 	default:
@@ -316,16 +355,19 @@ func (r *resource[T]) startWhenNeeded() {
 	}
 
 	store, informer := r.newInformer()
-	r.storeResolver.Resolve(&typedStore[T]{store})
+	r.storeResolver.Resolve(&typedStore[T]{
+		store:   store,
+		release: r.release,
+	})
 
 	r.wg.Add(1)
 	go func() {
 		defer r.wg.Done()
-		informer.Run(r.ctx.Done())
+		informer.Run(merge(r.ctx.Done(), r.resetCtx.Done()))
 	}()
 
 	// Wait for cache to be synced before emitting the sync event.
-	if cache.WaitForCacheSync(r.ctx.Done(), informer.HasSynced) {
+	if cache.WaitForCacheSync(merge(r.ctx.Done(), r.resetCtx.Done()), informer.HasSynced) {
 		// Emit the sync event for all subscribers. Subscribers
 		// that subscribe afterwards will emit it by checking
 		// r.synchronized.
@@ -339,6 +381,12 @@ func (r *resource[T]) startWhenNeeded() {
 }
 
 func (r *resource[T]) Stop(stopCtx hive.HookContext) error {
+	if r.opts.releasable {
+		// grab the refs lock to avoid a concurrent restart for releasable resource
+		r.refsMu.Lock()
+		defer r.refsMu.Unlock()
+	}
+
 	r.cancel()
 	r.wg.Wait()
 	return nil
@@ -414,6 +462,7 @@ func (r *resource[T]) Events(ctx context.Context, opts ...EventsOpt) <-chan Even
 	// Fork a goroutine to process the queued keys and pass them to the subscriber.
 	r.wg.Add(1)
 	go func() {
+		defer r.release()
 		defer r.wg.Done()
 		defer close(out)
 
@@ -460,6 +509,7 @@ func (r *resource[T]) Events(ctx context.Context, opts ...EventsOpt) <-chan Even
 		defer r.wg.Done()
 		select {
 		case <-r.ctx.Done():
+		case <-r.resetCtx.Done():
 		case <-ctx.Done():
 		}
 		subCancel()
@@ -467,6 +517,39 @@ func (r *resource[T]) Events(ctx context.Context, opts ...EventsOpt) <-chan Even
 	}()
 
 	return out
+}
+
+func (r *resource[T]) release() {
+	if !r.opts.releasable {
+		return
+	}
+
+	// in case of a releasable resource, stop the underlying informer when the last
+	// reference to it is released. The resource is restarted to be
+	// ready again in case of a subsequent call to either Events() or Store().
+
+	r.refsMu.Lock()
+	defer r.refsMu.Unlock()
+
+	r.refs--
+	if r.refs > 0 {
+		return
+	}
+
+	r.resetCancel()
+	r.wg.Wait()
+	close(r.needed)
+
+	r.reset()
+	r.start()
+}
+
+func (r *resource[T]) reset() {
+	r.subscribers = make(map[uint64]*subscriber[T])
+	r.needed = make(chan struct{}, 1)
+	r.synchronized = false
+	r.storeResolver, r.storePromise = promise.New[Store[T]]()
+	r.resetCtx, r.resetCancel = context.WithCancel(context.Background())
 }
 
 func (r *resource[T]) resourceName() string {
@@ -814,4 +897,16 @@ func getUID(obj k8sRuntime.Object) types.UID {
 		panic(fmt.Sprintf("BUG: meta.Accessor() failed on %T: %s", obj, err))
 	}
 	return meta.GetUID()
+}
+
+func merge[T any](c1, c2 <-chan T) <-chan T {
+	m := make(chan T)
+	go func() {
+		select {
+		case <-c1:
+		case <-c2:
+		}
+		close(m)
+	}()
+	return m
 }

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -128,6 +128,7 @@ func (fs *fakeStore[T]) ByIndex(indexName, indexedValue string) ([]T, error) {
 	return nil, nil
 }
 func (fs *fakeStore[T]) CacheStore() cache.Store { return nil }
+func (fs *fakeStore[T]) Release()                {}
 
 var _ resource.Resource[runtime.Object] = (*fakeResource[runtime.Object])(nil)
 

--- a/pkg/promise/promise.go
+++ b/pkg/promise/promise.go
@@ -130,3 +130,14 @@ func Map[A, B any](p Promise[A], transform func(A) B) Promise[B] {
 		return transform(v), nil
 	})
 }
+
+// MapError transforms the error of a rejected promise with the provided function.
+func MapError[A any](p Promise[A], transform func(error) error) Promise[A] {
+	return wrappedPromise[A](func(ctx context.Context) (out A, err error) {
+		v, err := p.Await(ctx)
+		if err != nil {
+			err = transform(err)
+		}
+		return v, err
+	})
+}

--- a/pkg/redirectpolicy/manager_test.go
+++ b/pkg/redirectpolicy/manager_test.go
@@ -86,6 +86,8 @@ func (ps *fakePodStore) IndexKeys(indexName, indexedValue string) ([]string, err
 func (ps *fakePodStore) ByIndex(indexName, indexedValue string) ([]*slimcorev1.Pod, error) {
 	return nil, nil
 }
+func (ps *fakePodStore) Release() {
+}
 
 var (
 	tcpStr    = "TCP"


### PR DESCRIPTION
```
Add support for resources that can be stopped and restarted dynamically.
This is needed to stop the underlying informer for all the resource
kinds that may stream too many events in large scale clusters, like
CiliumEndpoint and CiliumNode. In these cases, we want to preserve the
current agent behavior, thus switching to the key-value store and
disabling the k8s resource informer.

With a releasable resource, the resource informer is stopped when the
last active subscriber cancels its subscription. A subscriber is a
consumer who has taken a reference to the store with Store() or that is
listening to the events stream channel with Events().  In the former
case, the subscriber should explicitly call the Release method on the
Store, to signal that the informer can be stopped. In the latter case,
cancelling the context passed to Events is enough.

When the informer stops, any reference to the store previously taken
remains valid, but it might return stale data.  After being stopped, the
resource can be started again with a subsequent call to either Store or
Events.
```

This is a prerequisite to migrate CiliumNode, CiliumEndpoint and CiliumEndpointSlices to Resource[T] (see https://github.com/cilium/cilium/issues/28159#issuecomment-1827900645 for more info).

Related: https://github.com/cilium/cilium/issues/28159