### PR TITLE
Improve insertNodeNeighbor behavior to report health

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1871,6 +1871,9 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 		log.WithError(err).Warn("Failed to send agent start monitor message")
 	}
 
+	// Watches for node neighbors link updates.
+	d.nodeDiscovery.Manager.StartNodeNeighborLinkUpdater(d.datapath.NodeNeighbors())
+
 	if option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
 		if !d.datapath.NodeNeighbors().NodeNeighDiscoveryEnabled() {
 			// Remove all non-GC'ed neighbor entries that might have previously set

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -542,8 +542,8 @@ func (c *clusterNodesClient) NodeNeighDiscoveryEnabled() bool {
 	return false
 }
 
-func (c *clusterNodesClient) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) {
-	// no-op
+func (c *clusterNodesClient) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) error {
+	return nil
 }
 
 func (c *clusterNodesClient) NodeCleanNeighbors(migrateOnly bool) {

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -542,7 +542,7 @@ func (c *clusterNodesClient) NodeNeighDiscoveryEnabled() bool {
 	return false
 }
 
-func (c *clusterNodesClient) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) error {
+func (c *clusterNodesClient) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node, refresh bool) error {
 	return nil
 }
 

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/nodemap"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/mtu"
+	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/option"
 	wg "github.com/cilium/cilium/pkg/wireguard/agent"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
@@ -173,6 +174,7 @@ func newDatapath(params datapathParams) types.Datapath {
 		NodeAddressing: params.NodeAddressing,
 		BWManager:      params.BandwidthManager,
 		Loader:         params.Loader,
+		NodeManager:    params.NodeManager,
 	}, datapathConfig)
 
 	params.LC.Append(cell.Hook{
@@ -215,4 +217,6 @@ type datapathParams struct {
 	TunnelConfig tunnel.Config
 
 	Loader loaderTypes.Loader
+
+	NodeManager nodeManager.NodeManager
 }

--- a/pkg/datapath/fake/types/node.go
+++ b/pkg/datapath/fake/types/node.go
@@ -68,7 +68,7 @@ func (n *FakeNodeHandler) NodeNeighDiscoveryEnabled() bool {
 	return false
 }
 
-func (n *FakeNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) error {
+func (n *FakeNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node, refresh bool) error {
 	return nil
 }
 

--- a/pkg/datapath/fake/types/node.go
+++ b/pkg/datapath/fake/types/node.go
@@ -68,7 +68,8 @@ func (n *FakeNodeHandler) NodeNeighDiscoveryEnabled() bool {
 	return false
 }
 
-func (n *FakeNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) {
+func (n *FakeNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) error {
+	return nil
 }
 
 func (n *FakeNodeHandler) NodeCleanNeighbors(migrateOnly bool) {

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -8,6 +8,7 @@ import (
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
+	"github.com/cilium/cilium/pkg/node/manager"
 )
 
 // DatapathConfiguration is the static configuration of the datapath. The
@@ -41,6 +42,7 @@ type DatapathParams struct {
 	NodeAddressing datapath.NodeAddressing
 	MTU            datapath.MTUConfiguration
 	Loader         loader.Loader
+	NodeManager    manager.NodeManager
 }
 
 // NewDatapath creates a new Linux datapath
@@ -56,7 +58,7 @@ func NewDatapath(p DatapathParams, cfg DatapathConfiguration) datapath.Datapath 
 		bwmgr:           p.BWManager,
 	}
 
-	dp.node = NewNodeHandler(cfg, dp.nodeAddressing, p.NodeMap, p.MTU)
+	dp.node = NewNodeHandler(cfg, dp.nodeAddressing, p.NodeMap, p.MTU, p.NodeManager)
 	return dp
 }
 

--- a/pkg/datapath/linux/fuzz_test.go
+++ b/pkg/datapath/linux/fuzz_test.go
@@ -23,7 +23,7 @@ func FuzzNodeHandler(f *testing.F) {
 		}
 		dpConfig := DatapathConfiguration{HostDevice: "veth0"}
 		fakeNodeAddressing := fakeTypes.NewNodeAddressing()
-		linuxNodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil, &fakeTypes.MTU{})
+		linuxNodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil, &fakeTypes.MTU{}, new(mockEnqueuer))
 		if linuxNodeHandler == nil {
 			panic("Should not be nil")
 		}
@@ -31,8 +31,20 @@ func FuzzNodeHandler(f *testing.F) {
 		if err != nil {
 			t.Skip()
 		}
-		linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev1)
+		linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev1, true)
 		linuxNodeHandler.NodeDelete(nodev1)
-		linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev1)
+		linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev1, true)
 	})
+}
+
+type mockEnqueuer struct {
+	nh *linuxNodeHandler
+}
+
+func (q *mockEnqueuer) Enqueue(n *nodeTypes.Node, refresh bool) {
+	if q.nh != nil {
+		if err := q.nh.insertNeighbor(context.Background(), n, refresh); err != nil {
+			log.Errorf("MockQ NodeNeighborRefresh failed: %s", err)
+		}
+	}
 }

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -208,7 +208,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestUpdateNodeRoute(c *check.C) {
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig, new(mockEnqueuer))
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4: s.enableIPv4,
@@ -259,7 +259,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestAuxiliaryPrefixes(c *check.C) {
 	net2 := cidr.MustParseCIDR("cafe:f00d::/112")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil, &s.mtuConfig)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil, &s.mtuConfig, new(mockEnqueuer))
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4:        s.enableIPv4,
@@ -344,7 +344,7 @@ func (s *linuxPrivilegedBaseTestSuite) commonNodeUpdateEncapsulation(c *check.C,
 	externalNodeIP2 := net.ParseIP("8.8.8.8")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig, new(mockEnqueuer))
 	linuxNodeHandler.OverrideEnableEncapsulation(override)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
@@ -614,7 +614,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateIDs(c *check.C) {
 	nodeMap := nodemapfake.NewFakeNodeMap()
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodeMap, &s.mtuConfig)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodeMap, &s.mtuConfig, new(mockEnqueuer))
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err := linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -763,7 +763,7 @@ func (s *linuxPrivilegedBaseTestSuite) testNodeChurnXFRMLeaksWithConfig(c *check
 	c.Assert(err, check.IsNil)
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig, new(mockEnqueuer))
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(config)
@@ -850,7 +850,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateDirectRouting(c *check.C) {
 	defer removeDevice(externalNode2Device)
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig, new(mockEnqueuer))
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4:              s.enableIPv4,
@@ -1066,7 +1066,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestAgentRestartOptionChanges(c *check.C)
 	underlayIP := net.ParseIP("4.4.4.4")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig, new(mockEnqueuer))
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4:          s.enableIPv4,
@@ -1176,7 +1176,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeValidationDirectRouting(c *check.
 	ip4Alloc1 := cidr.MustParseCIDR("5.5.5.0/24")
 	ip6Alloc1 := cidr.MustParseCIDR("2001:aaaa::/96")
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig, new(mockEnqueuer))
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	if s.enableIPv4 {
@@ -1347,7 +1347,9 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
 	option.Config.ARPPingRefreshPeriod = time.Duration(1 * time.Nanosecond)
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig)
+	mq := new(mockEnqueuer)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig, mq)
+	mq.nh = linuxNodeHandler
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -1436,7 +1438,7 @@ refetch1:
 	err = netlink.LinkSetHardwareAddr(veth0, veth1HwAddr)
 	c.Assert(err, check.IsNil)
 
-	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1)
+	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1, true)
 	wait(nodev1.Identity(), "veth0", &now, false)
 refetch2:
 	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
@@ -1888,8 +1890,8 @@ refetch6:
 
 	// insertNeighbor is invoked async, so thus this wait based on last ping
 	now = time.Now()
-	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev2)
-	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev3)
+	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev2, true)
+	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev3, true)
 	waitGw("f00d::251", nodev2.Identity(), "veth0", &now)
 	waitGw("f00d::250", nodev3.Identity(), "veth0", &now)
 
@@ -1942,8 +1944,8 @@ refetch8:
 
 	// insertNeighbor is invoked async, so thus this wait based on last ping
 	now = time.Now()
-	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev2)
-	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev3)
+	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev2, true)
+	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev3, true)
 	waitGw("f00d::251", nodev2.Identity(), "veth0", &now)
 	waitGw("f00d::251", nodev3.Identity(), "veth0", &now)
 
@@ -2286,7 +2288,9 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
 	option.Config.ARPPingRefreshPeriod = 1 * time.Nanosecond
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig)
+	mq := new(mockEnqueuer)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig, mq)
+	mq.nh = linuxNodeHandler
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -2426,7 +2430,7 @@ refetch2:
 	err = netlink.LinkSetHardwareAddr(veth2, veth3HwAddr)
 	c.Assert(err, check.IsNil)
 
-	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1)
+	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1, true)
 	wait(nodev1.Identity(), "veth0", &now, false)
 	wait(nodev1.Identity(), "veth2", &now, false)
 refetch3:
@@ -2593,7 +2597,9 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
 	option.Config.ARPPingRefreshPeriod = time.Duration(1 * time.Nanosecond)
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig)
+	mq := new(mockEnqueuer)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig, mq)
+	mq.nh = linuxNodeHandler
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -2682,7 +2688,7 @@ refetch1:
 	err = netlink.LinkSetHardwareAddr(veth0, veth1HwAddr)
 	c.Assert(err, check.IsNil)
 
-	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1)
+	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1, true)
 	wait(nodev1.Identity(), "veth0", &now, false)
 refetch2:
 	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
@@ -3135,8 +3141,8 @@ refetch6:
 
 	// insertNeighbor is invoked async, so thus this wait based on last ping
 	now = time.Now()
-	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev2)
-	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev3)
+	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev2, true)
+	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev3, true)
 	waitGw("9.9.9.251", nodev2.Identity(), "veth0", &now)
 	waitGw("9.9.9.250", nodev3.Identity(), "veth0", &now)
 
@@ -3189,8 +3195,8 @@ refetch8:
 
 	// insertNeighbor is invoked async, so thus this wait based on last ping
 	now = time.Now()
-	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev2)
-	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev3)
+	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev2, true)
+	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev3, true)
 	waitGw("9.9.9.251", nodev2.Identity(), "veth0", &now)
 	waitGw("9.9.9.251", nodev3.Identity(), "veth0", &now)
 
@@ -3534,7 +3540,9 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
 	option.Config.ARPPingRefreshPeriod = 1 * time.Nanosecond
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig)
+	mq := new(mockEnqueuer)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig, mq)
+	mq.nh = linuxNodeHandler
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -3674,7 +3682,7 @@ refetch2:
 	err = netlink.LinkSetHardwareAddr(veth2, veth3HwAddr)
 	c.Assert(err, check.IsNil)
 
-	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1)
+	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1, true)
 	wait(nodev1.Identity(), "veth0", &now, false)
 	wait(nodev1.Identity(), "veth2", &now, false)
 refetch3:
@@ -3754,7 +3762,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdate(c *check.C, config da
 	ip6Alloc2 := cidr.MustParseCIDR("2001:bbbb::/96")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig, new(mockEnqueuer))
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err := linuxNodeHandler.NodeConfigurationChanged(config)
@@ -3851,7 +3859,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdateNOP(c *check.C, config
 	ip6Alloc1 := cidr.MustParseCIDR("2001:aaaa::/96")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig, new(mockEnqueuer))
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err := linuxNodeHandler.NodeConfigurationChanged(config)
@@ -3920,7 +3928,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeValidateImplementation(c *ch
 	ip6Alloc1 := cidr.MustParseCIDR("2001:aaaa::/96")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap(), &s.mtuConfig, new(mockEnqueuer))
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err := linuxNodeHandler.NodeConfigurationChanged(config)

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -77,7 +77,7 @@ func (s *linuxTestSuite) TestCreateNodeRoute(c *check.C) {
 
 	fakeNodeAddressing := fakeTypes.NewNodeAddressing()
 
-	nodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil, &mtuConfig)
+	nodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil, &mtuConfig, new(mockEnqueuer))
 
 	c1 := cidr.MustParseCIDR("10.10.0.0/16")
 	generatedRoute, err := nodeHandler.createNodeRouteSpec(c1, false)

--- a/pkg/datapath/types/config.go
+++ b/pkg/datapath/types/config.go
@@ -11,8 +11,16 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/node"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 )
+
+// NodeNeighborEnqueuer provides an interface for clients to push node updates
+// for further processing.
+type NodeNeighborEnqueuer interface {
+	// Enqueue enqueues a node for processing node neighbors updates.
+	Enqueue(*nodeTypes.Node, bool)
+}
 
 // DeviceConfiguration is an interface for injecting configuration of datapath
 // options that affect lookups and logic applied at a per-device level, whether

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -130,7 +130,7 @@ type NodeNeighbors interface {
 	NodeNeighDiscoveryEnabled() bool
 
 	// NodeNeighborRefresh is called to refresh node neighbor table
-	NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node)
+	NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) error
 
 	// NodeCleanNeighbors cleans all neighbor entries for the direct routing device
 	// and the encrypt interface.

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -130,7 +130,7 @@ type NodeNeighbors interface {
 	NodeNeighDiscoveryEnabled() bool
 
 	// NodeNeighborRefresh is called to refresh node neighbor table
-	NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) error
+	NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node, refresh bool) error
 
 	// NodeCleanNeighbors cleans all neighbor entries for the direct routing device
 	// and the encrypt interface.

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -42,6 +42,8 @@ type Notifier interface {
 }
 
 type NodeManager interface {
+	datapath.NodeNeighborEnqueuer
+
 	Notifier
 
 	// GetNodes returns a copy of all the nodes as a map from Identity to Node.
@@ -67,6 +69,10 @@ type NodeManager interface {
 	// StartNeighborRefresh spawns a controller which refreshes neighbor table
 	// by sending arping periodically.
 	StartNeighborRefresh(nh datapath.NodeNeighbors)
+
+	// StartNodeNeighborLinkUpdater spawns a controller that watches a queue
+	// for node neighbor link updates.
+	StartNodeNeighborLinkUpdater(nh datapath.NodeNeighbors)
 }
 
 type ipsetManager interface {

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -43,8 +43,10 @@ import (
 var (
 	randGen                    = rand.NewSafeRand(time.Now().UnixNano())
 	baseBackgroundSyncInterval = time.Minute
+	defaultNodeUpdateInterval  = 10 * time.Second
 
 	neighborTableRefreshControllerGroup = controller.NewGroup("neighbor-table-refresh")
+	neighborTableUpdateControllerGroup  = controller.NewGroup("neighbor-table-update")
 )
 
 const (
@@ -127,6 +129,24 @@ type manager struct {
 
 	// healthScope reports on the current health status of the node manager module.
 	healthScope cell.Scope
+
+	// nodeNeighborQueue tracks node neighbor link updates.
+	nodeNeighborQueue queue[nodeQueueEntry]
+}
+
+type nodeQueueEntry struct {
+	node    *nodeTypes.Node
+	refresh bool
+}
+
+// Enqueue add a node to a controller managed queue which sets up the neighbor link.
+func (m *manager) Enqueue(n *nodeTypes.Node, refresh bool) {
+	if n == nil {
+		log.WithFields(logrus.Fields{
+			logfields.LogSubsys: "enqueue",
+		}).Warn("Skipping nodeNeighbor insert: No node given")
+	}
+	m.nodeNeighborQueue.push(&nodeQueueEntry{node: n, refresh: refresh})
 }
 
 // Subscribe subscribes the given node handler to node events.
@@ -326,19 +346,21 @@ func (m *manager) backgroundSync(ctx context.Context) error {
 				m.mutex.RUnlock()
 				continue
 			}
+			m.mutex.RUnlock()
 
 			entry.mutex.Lock()
-			m.mutex.RUnlock()
-			m.Iter(func(nh datapath.NodeHandler) {
-				if err := nh.NodeValidateImplementation(entry.node); err != nil {
-					log.WithFields(logrus.Fields{
-						"handler": nh.Name(),
-						"node":    entry.node.Name,
-					}).WithError(err).
-						Error("Failed to apply node handler during background sync. Cilium may have degraded functionality. See error message for details.")
-					errs = errors.Join(errs, fmt.Errorf("failed while handling %s on node %s: %w", nh.Name(), entry.node.Name, err))
-				}
-			})
+			{
+				m.Iter(func(nh datapath.NodeHandler) {
+					if err := nh.NodeValidateImplementation(entry.node); err != nil {
+						log.WithFields(logrus.Fields{
+							"handler": nh.Name(),
+							"node":    entry.node.Name,
+						}).WithError(err).
+							Error("Failed to apply node handler during background sync. Cilium may have degraded functionality. See error message for details.")
+						errs = errors.Join(errs, fmt.Errorf("failed while handling %s on node %s: %w", nh.Name(), entry.node.Name, err))
+					}
+				})
+			}
 			entry.mutex.Unlock()
 
 			m.metrics.DatapathValidations.Inc()
@@ -833,8 +855,47 @@ func (m *manager) GetNodes() map[nodeTypes.Identity]nodeTypes.Node {
 	return nodes
 }
 
+// StartNodeNeighborLinkUpdater manages node neighbors links sync.
+// This provides a central location for all node neighbor link updates.
+// Under proper conditions, publisher enqueues the node which requires a link update.
+// This controller is agnostic of the condition under which the links must be established, thus
+// that responsibility lies on the publishers.
+// This controller also provides for module health to be reported in a single central location.
+func (m *manager) StartNodeNeighborLinkUpdater(nh datapath.NodeNeighbors) {
+	sc := cell.GetSubScope(m.healthScope, "neighbor-link-updater")
+	controller.NewManager().UpdateController(
+		"node-neighbor-link-updater",
+		controller.ControllerParams{
+			Group: neighborTableUpdateControllerGroup,
+			DoFunc: func(ctx context.Context) error {
+				if m.nodeNeighborQueue.isEmpty() {
+					return nil
+				}
+				var errs error
+				for {
+					e := m.nodeNeighborQueue.pop()
+					if e == nil || e.node == nil {
+						errs = errors.Join(errs, fmt.Errorf("invalid node spec found in queue: %#v", e))
+						break
+					}
+
+					log.Debugf("Refreshing node neighbor link for %s", e.node.Name)
+					hr := cell.GetHealthReporter(sc, e.node.Name)
+					if errs = errors.Join(errs, nh.NodeNeighborRefresh(ctx, *e.node, e.refresh)); errs != nil {
+						hr.Degraded("Failed node neighbor link update", errs)
+					} else {
+						hr.OK("Node neighbor link update successful")
+					}
+				}
+				return errs
+			},
+			RunInterval: defaultNodeUpdateInterval,
+		},
+	)
+}
+
 // StartNeighborRefresh spawns a controller which refreshes neighbor table
-// by sending arping periodically.
+// by forcing node neighbors refresh periodically based on the arping settings.
 func (m *manager) StartNeighborRefresh(nh datapath.NodeNeighbors) {
 	ctx, cancel := context.WithCancel(context.Background())
 	controller.NewManager().UpdateController(
@@ -854,14 +915,15 @@ func (m *manager) StartNeighborRefresh(nh datapath.NodeNeighbors) {
 					if entryNode.IsLocal() {
 						continue
 					}
-					go func(c context.Context, e nodeTypes.Node) {
+					go func(ctx context.Context, e *nodeTypes.Node) {
+						// TODO Should this be moved to dequeue instead?
 						// To avoid flooding network with arping requests
 						// at the same time, spread them over the
 						// [0; ARPPingRefreshPeriod/2) period.
 						n := randGen.Int63n(int64(m.conf.ARPPingRefreshPeriod / 2))
 						time.Sleep(time.Duration(n))
-						nh.NodeNeighborRefresh(c, e)
-					}(ctx, entryNode)
+						m.Enqueue(e, false)
+					}(ctx, &entryNode)
 				}
 				return nil
 			},

--- a/pkg/node/manager/queue.go
+++ b/pkg/node/manager/queue.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package manager
+
+import "github.com/cilium/cilium/pkg/lock"
+
+type queue[T any] struct {
+	mx    lock.RWMutex
+	items []*T
+}
+
+func (q *queue[T]) push(t *T) {
+	q.mx.Lock()
+	defer q.mx.Unlock()
+
+	q.items = append(q.items, t)
+}
+
+func (q *queue[T]) isEmpty() bool {
+	q.mx.RLock()
+	defer q.mx.RUnlock()
+
+	return len(q.items) == 0
+}
+
+func (q *queue[T]) pop() *T {
+	if q.isEmpty() {
+		return nil
+	}
+
+	q.mx.Lock()
+	defer q.mx.Unlock()
+	t := q.items[0]
+	q.items = q.items[1:]
+
+	return t
+}

--- a/pkg/node/manager/queue_test.go
+++ b/pkg/node/manager/queue_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package manager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQPush(t *testing.T) {
+	uu := map[string]struct {
+		items, e []string
+	}{
+		"empty": {},
+		"happy": {
+			items: []string{"a", "b", "c"},
+			e:     []string{"a", "b", "c"},
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			var q queue[string]
+
+			for i := range u.items {
+				q.push(&u.items[i])
+			}
+			for i := 0; i < len(u.items); i++ {
+				v := q.pop()
+				assert.Less(t, i, len(u.e))
+				assert.Equal(t, u.e[i], *v)
+			}
+			assert.True(t, q.isEmpty())
+		})
+	}
+}
+
+func TestQPop(t *testing.T) {
+	uu := map[string]struct {
+		items, e []string
+	}{
+		"empty": {},
+		"happy": {
+			items: []string{"a", "b", "c"},
+			e:     []string{"a", "b", "c"},
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			var q queue[string]
+
+			for i := range u.items {
+				q.push(&u.items[i])
+			}
+			for q.pop() != nil {
+			}
+			assert.True(t, q.isEmpty())
+		})
+	}
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2341,6 +2341,7 @@ type DaemonConfig struct {
 
 	// ARPPingRefreshPeriod is the ARP entries refresher period.
 	ARPPingRefreshPeriod time.Duration
+
 	// EnableCiliumEndpointSlice enables the cilium endpoint slicing feature.
 	EnableCiliumEndpointSlice bool
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

Currently insertNodeNeighbor does not return any errors. When the behavior is enabled and node neighbor inserts fail we simply log the issue. 
This PR is an attempt to make node neighbor insertions failures more visible and report health.  
To achieve this we've opted to introduce a new controller that monitors node neighbors insertions and gather health status so that they can be surfaced in the cilium cli.

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```

 Signed-off-by: Fernand Galiana <fernand.galiana@isovalent.com>