### PR TITLE
Fix unchecked error in datapath/linux/ipsec

### DIFF
--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -178,7 +178,9 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, nodeID uint1
 			}
 		} else {
 			remoteCIDR := newNode.IPv4AllocCIDR.IPNet
-			n.replaceNodeIPSecOutRoute(remoteCIDR)
+			if err := n.replaceNodeIPSecOutRoute(remoteCIDR); err != nil {
+				errs = errors.Join(errs, fmt.Errorf("failed to replace ipsec OUT (%q): %w", remoteCIDR.IP, err))
+			}
 			spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, remoteCIDR, localIP, remoteIP, nodeID, ipsec.IPSecDirOut, false)
 			errs = errors.Join(errs, upsertIPsecLog(err, "out IPv4", wildcardCIDR, remoteCIDR, spi, nodeID))
 		}
@@ -261,7 +263,9 @@ func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, nodeID uint1
 			}
 		} else {
 			remoteCIDR := newNode.IPv6AllocCIDR.IPNet
-			n.replaceNodeIPSecOutRoute(remoteCIDR)
+			if err := n.replaceNodeIPSecOutRoute(remoteCIDR); err != nil {
+				errs = errors.Join(errs, fmt.Errorf("failed to replace ipsec OUT (%q): %w", remoteCIDR.IP, err))
+			}
 			spi, err := ipsec.UpsertIPsecEndpoint(wildcardCIDR, remoteCIDR, localIP, remoteIP, nodeID, ipsec.IPSecDirOut, false)
 			errs = errors.Join(errs, upsertIPsecLog(err, "out IPv6", wildcardCIDR, remoteCIDR, spi, nodeID))
 		}
@@ -430,7 +434,7 @@ func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) error {
 		old6RouteNet := &net.IPNet{IP: oldNode.IPv6AllocCIDR.IP, Mask: oldNode.IPv6AllocCIDR.Mask}
 		// See IPv4 case above.
 		if !n.subnetEncryption() {
-			n.deleteNodeIPSecOutRoute(old6RouteNet)
+			errs = errors.Join(errs, n.deleteNodeIPSecOutRoute(old6RouteNet))
 		}
 	}
 	return errs


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

Fix unchecked error in datapath/linux/ipsec.go

The following calls are unchecked:

- deleteNodeIPSecOutRoute
- replaceNodeIPSecOutRoute

Fixes: #issue-number

Signed-off-by: Fernand Galiana <fernand.galiana@isovalent.com>

```release-note
Fix bug that could cause IPsec route change failures to be silent.
```