### PR TITLE
images: Fix init-container script for cilium-dbg

### DIFF
--- a/images/cilium/init-container.sh
+++ b/images/cilium/init-container.sh
@@ -6,10 +6,10 @@
 
 if [ "${CILIUM_BPF_STATE}" = "true" ] \
    || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then
-	cilium cleanup -f --bpf-state
+	cilium-dbg cleanup -f --bpf-state
 fi
 
 if [ "${CILIUM_ALL_STATE}" = "true" ] \
     || [ "${CLEAN_CILIUM_STATE}" = "true" ]; then
-	cilium cleanup -f --all-state
+	cilium-dbg cleanup -f --all-state
 fi


### PR DESCRIPTION
Commit 328a98f2bbae ("images: Switch CLI references to cilium-dbg")
started using the newly renamed cilium CLI name in images/ artifacts,
but that commit missed the update to the cleanup script. Fix it.

Fixes: 328a98f2bbae ("images: Switch CLI references to cilium-dbg")
Fixes: https://github.com/cilium/cilium/pull/28085
