### PR TITLE
lbipam: Fix off-by-one error in rangeFromPrefix

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"go4.org/netipx"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -1945,25 +1946,5 @@ func isIPv6(ip netip.Addr) bool {
 
 func rangeFromPrefix(prefix netip.Prefix) (netip.Addr, netip.Addr) {
 	prefix = prefix.Masked()
-	from := prefix.Addr()
-	bitLen := from.BitLen()
-	varBits := bitLen - prefix.Bits()
-	toSlice := from.AsSlice()
-
-	i := len(toSlice) - 1
-	for varBits > 0 {
-		if varBits >= 8 {
-			toSlice[i] = 0xFF
-			varBits -= 8
-			i--
-			continue
-		}
-
-		mask := byte(1) << varBits
-		toSlice[i] |= mask
-		break
-	}
-
-	to, _ := netip.AddrFromSlice(toSlice)
-	return from, to
+	return prefix.Addr(), netipx.PrefixLastIP(prefix)
 }

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -3024,7 +3024,7 @@ func TestRangeFromPrefix(t *testing.T) {
 			name:   "/25",
 			prefix: "10.0.0.0/25",
 			from:   "10.0.0.0",
-			to:     "10.0.0.128",
+			to:     "10.0.0.127",
 		},
 		{
 			name:   "offset prefix",


### PR DESCRIPTION
There's an off-by-one error in rangeFromPrefix that miscalculates the end of the allocatable IP range when the prefix length is not byte-aligned. We couldn't catch this bug with the test because the expected value in the test was wrong.

netipx package provides a convenient function netipx.PrefixLastIP which does what we want. Rely on that instead of calculating it by ourselves.

Fixes: #29410
Fixes: 32feef5d
Fixes: 27322f39

```release-note
lbipam: Fix off-by-one error in LBIPAM range allocation
```
