### PR TITLE
ci: fix deployment issue with multiple clusters in same region

### DIFF
--- a/.github/actions/aws/k8s-versions.yaml
+++ b/.github/actions/aws/k8s-versions.yaml
@@ -4,7 +4,7 @@ include:
   - version: "1.23"
     region: eu-central-1
   - version: "1.24"
-    region: eu-central-1
+    region: eu-west-1
   - version: "1.25"
     region: ap-northeast-1
   - version: "1.26"


### PR DESCRIPTION
Currently, the tests `ci-eks` & `ci-aws-cni` fail due to issues deploying multiple clusters with the same name in the same region.

Therefore, this commit uses a different region for k8s version v1.24 to ensure that only one cluster gets deployed per region.

Note: This is the quick fix. As mentioned in the related issue, it might be better to ensure a unique name via other measures.

Fixes: #29004
Fixes: #29426