### PR TITLE
.github/workflows: only cancel concurrent jobs if not in merge_group

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -14,7 +14,7 @@ permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !github.event.merge_group }}
 
 jobs:
   check_changes:

--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -14,7 +14,7 @@ permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !github.event.merge_group }}
 
 jobs:
   check_changes:

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -14,7 +14,7 @@ permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !github.event.merge_group }}
 
 jobs:
   go-mod:

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -14,7 +14,7 @@ permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !github.event.merge_group }}
 
 env:
   cilium_cli_ci_version:


### PR DESCRIPTION
If we cancel concurrent jobs, regardless of them being in merge_group or not, we will not be able to have concurrent runs for the same workflow in the merge groups events. Thus, we should detect if the event is not from a merge_group and only cancel the concurrent jobs on that case.