### PR TITLE
[v1.13] ci-ipsec-upgrade: Drop no-missed-tail-calls exclusion

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -349,8 +349,6 @@ jobs:
         uses: cilium/cilium/.github/actions/conn-disrupt-test@v1.13
         with:
           job-name: ipsec-downgrade-${{ matrix.name }}
-          # Disable no-missed-tail-calls due to https://github.com/cilium/cilium/issues/26739
-          extra-connectivity-test-flags: --test '!no-missed-tail-calls'
           operation-cmd: |
             cd /host/
 


### PR DESCRIPTION
- [ ] #29325

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 29325; do contrib/backporting/set-labels.py $pr done 1.13; done
```
or with
```
make add-labels BRANCH=v1.13 ISSUES=29325
```
