### PR TITLE
gateway-api: don't register secretsync if required CRDs aren't present

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -96,6 +96,10 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 // registerSecretSync registers the Gateway API for secret synchronization based on TLS secrets referenced
 // by a Cilium Gateway resource.
 func registerSecretSync(params gatewayAPIParams) secretsync.SecretSyncRegistrationOut {
+	if err := checkRequiredCRDs(context.Background(), params.K8sClient); err != nil {
+		return secretsync.SecretSyncRegistrationOut{}
+	}
+
 	if !operatorOption.Config.EnableGatewayAPI || !params.Config.EnableGatewayAPISecretsSync {
 		return secretsync.SecretSyncRegistrationOut{}
 	}


### PR DESCRIPTION
With #28982 a check got introduced that disables the Gateway API functionality if the required Gateway API CRDs aren't installed in the cluster.

But this check is not executed when the secret sync registrations is performed.

This leads to situations where the CRD isn't registered to the schema, but secretsync registering watches for this CRD. This results in failures in the secret-sync:

```
level=error msg="kind must be registered to the Scheme" error="no kind is registered for the type v1.Gateway in scheme \"k8s.io/client-go/kubernetes/scheme/register.go:80\"" logger=controller-runtime.source.EventHandler subsys=controller-runtime
```

Therefore, this commit adds the check to the secret sync registration too.

Fixes: #29100
