### PR TITLE
statedb: Allow non-terminated keys

### DIFF
--- a/pkg/statedb/api_client.go
+++ b/pkg/statedb/api_client.go
@@ -71,7 +71,7 @@ func (t *RemoteTable[Obj]) query(ctx context.Context, lowerBound bool, q Query[O
 		errChan <- err
 	}()
 
-	return &getIterator[Obj]{gob.NewDecoder(r)}, errChan
+	return &remoteGetIterator[Obj]{gob.NewDecoder(r)}, errChan
 }
 func (t *RemoteTable[Obj]) Get(ctx context.Context, q Query[Obj]) (Iterator[Obj], <-chan error) {
 	return t.query(ctx, false, q)
@@ -81,11 +81,11 @@ func (t *RemoteTable[Obj]) LowerBound(ctx context.Context, q Query[Obj]) (Iterat
 	return t.query(ctx, true, q)
 }
 
-type getIterator[Obj any] struct {
+type remoteGetIterator[Obj any] struct {
 	decoder *gob.Decoder
 }
 
-func (it *getIterator[Obj]) Next() (obj Obj, revision Revision, ok bool) {
+func (it *remoteGetIterator[Obj]) Next() (obj Obj, revision Revision, ok bool) {
 	err := it.decoder.Decode(&revision)
 	if err != nil {
 		return

--- a/pkg/statedb/api_handler.go
+++ b/pkg/statedb/api_handler.go
@@ -56,7 +56,7 @@ func (h *queryHandler) Handle(params GetStatedbQueryTableParams) middleware.Resp
 		return api.Error(GetStatedbQueryTableNotFoundCode, err)
 	}
 
-	iter := indexTxn.Root().Iterator()
+	iter := indexTxn.txn.Root().Iterator()
 	if params.Lowerbound {
 		iter.SeekLowerBound(key)
 	} else {

--- a/pkg/statedb/api_handler_test.go
+++ b/pkg/statedb/api_handler_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/statedb/index"
+)
+
+func Test_runQuery(t *testing.T) {
+	db, table, _ := newTestDB(t, tagsIndex)
+
+	wtxn := db.WriteTxn(table)
+	table.Insert(wtxn, testObject{1, []string{"foo"}})
+	table.Insert(wtxn, testObject{2, []string{"foo"}})
+	table.Insert(wtxn, testObject{3, []string{"foobar"}})
+	table.Insert(wtxn, testObject{4, []string{"baz"}})
+	wtxn.Commit()
+
+	txn := db.ReadTxn()
+
+	// idIndex, unique
+	indexTxn, err := txn.getTxn().indexReadTxn(table.Name(), idIndex.Name)
+	require.NoError(t, err)
+	items := []object{}
+	onObject := func(obj object) error {
+		items = append(items, obj)
+		return nil
+	}
+	runQuery(indexTxn, false, index.Uint64(1), onObject)
+	if assert.Len(t, items, 1) {
+		assert.EqualValues(t, items[0].data.(testObject).ID, 1)
+	}
+
+	// tagsIndex, non-unique
+	indexTxn, err = txn.getTxn().indexReadTxn(table.Name(), tagsIndex.Name)
+	require.NoError(t, err)
+	items = nil
+	runQuery(indexTxn, false, index.String("foo"), onObject)
+
+	if assert.Len(t, items, 2) {
+		assert.EqualValues(t, items[0].data.(testObject).ID, 1)
+		assert.EqualValues(t, items[1].data.(testObject).ID, 2)
+	}
+
+}

--- a/pkg/statedb/benchmarks_test.go
+++ b/pkg/statedb/benchmarks_test.go
@@ -216,7 +216,7 @@ func BenchmarkDB_SequentialLookup(b *testing.B) {
 	}
 }
 
-func BenchmarkDB_FullIteration(b *testing.B) {
+func BenchmarkDB_FullIteration_All(b *testing.B) {
 	db, table, _ := newTestDB(b)
 	wtxn := db.WriteTxn(table)
 	for i := 0; i < b.N; i++ {
@@ -228,6 +228,25 @@ func BenchmarkDB_FullIteration(b *testing.B) {
 
 	txn := db.ReadTxn()
 	iter, _ := table.All(txn)
+	i := uint64(0)
+	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+		require.Equal(b, obj.ID, i)
+		i++
+	}
+}
+
+func BenchmarkDB_FullIteration_Get(b *testing.B) {
+	db, table, _ := newTestDB(b, tagsIndex)
+	wtxn := db.WriteTxn(table)
+	for i := 0; i < b.N; i++ {
+		_, _, err := table.Insert(wtxn, testObject{ID: uint64(i), Tags: []string{"foo"}})
+		require.NoError(b, err)
+	}
+	wtxn.Commit()
+	b.ResetTimer()
+
+	txn := db.ReadTxn()
+	iter, _ := table.Get(txn, tagsIndex.Query("foo"))
 	i := uint64(0)
 	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
 		require.Equal(b, obj.ID, i)

--- a/pkg/statedb/db_test.go
+++ b/pkg/statedb/db_test.go
@@ -676,6 +676,7 @@ func TestWriteJSON(t *testing.T) {
 	}
 	txn.Commit()
 }
+
 func Test_callerPackage(t *testing.T) {
 	t.Parallel()
 
@@ -683,6 +684,32 @@ func Test_callerPackage(t *testing.T) {
 		return callerPackage()
 	}()
 	require.Equal(t, "pkg/statedb", pkg)
+}
+
+func Test_nonUniqueKey(t *testing.T) {
+	// empty keys
+	key := encodeNonUniqueKey(nil, nil)
+	primary, secondary := decodeNonUniqueKey(key)
+	assert.Len(t, primary, 0)
+	assert.Len(t, secondary, 0)
+
+	// empty primary
+	key = encodeNonUniqueKey(nil, []byte("foo"))
+	primary, secondary = decodeNonUniqueKey(key)
+	assert.Len(t, primary, 0)
+	assert.Equal(t, string(secondary), "foo")
+
+	// empty secondary
+	key = encodeNonUniqueKey([]byte("quux"), []byte{})
+	primary, secondary = decodeNonUniqueKey(key)
+	assert.Equal(t, string(primary), "quux")
+	assert.Len(t, secondary, 0)
+
+	// non-empty
+	key = encodeNonUniqueKey([]byte("foo"), []byte("quux"))
+	primary, secondary = decodeNonUniqueKey(key)
+	assert.EqualValues(t, primary, "foo")
+	assert.EqualValues(t, secondary, "quux")
 }
 
 func eventuallyGraveyardIsEmpty(t testing.TB, db *DB) {

--- a/pkg/statedb/deletetracker.go
+++ b/pkg/statedb/deletetracker.go
@@ -35,7 +35,7 @@ func (dt *DeleteTracker[Obj]) getRevision() uint64 {
 // called!
 func (dt *DeleteTracker[Obj]) Deleted(txn ReadTxn, minRevision Revision) Iterator[Obj] {
 	indexTxn := txn.getTxn().mustIndexReadTxn(dt.table.Name(), GraveyardRevisionIndex)
-	iter := indexTxn.Root().Iterator()
+	iter := indexTxn.txn.Root().Iterator()
 	iter.SeekLowerBound(index.Uint64(minRevision))
 	return &iterator[Obj]{iter}
 }

--- a/pkg/statedb/iterator.go
+++ b/pkg/statedb/iterator.go
@@ -4,6 +4,7 @@
 package statedb
 
 import (
+	"bytes"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -47,6 +48,64 @@ type iterator[Obj any] struct {
 
 func (it *iterator[Obj]) Next() (obj Obj, revision uint64, ok bool) {
 	_, iobj, ok := it.iter.Next()
+	if ok {
+		obj = iobj.data.(Obj)
+		revision = iobj.revision
+	}
+	return
+}
+
+// uniqueIterator iterates over objects in a unique index. Since
+// we find the node by prefix search, we may see a key that shares
+// the search prefix but is longer. We skip those objects.
+type uniqueIterator[Obj any] struct {
+	iter interface{ Next() ([]byte, object, bool) }
+	key  []byte
+}
+
+func (it *uniqueIterator[Obj]) Next() (obj Obj, revision uint64, ok bool) {
+	var iobj object
+	for {
+		var key []byte
+		key, iobj, ok = it.iter.Next()
+		if !ok || bytes.Equal(key, it.key) {
+			break
+		}
+	}
+	if ok {
+		obj = iobj.data.(Obj)
+		revision = iobj.revision
+	}
+	return
+}
+
+// nonUniqueIterator iterates over a non-unique index. Since we seek by prefix and don't
+// require that indexers terminate the keys, the iterator checks that the prefix
+// has the right length.
+type nonUniqueIterator[Obj any] struct {
+	iter interface{ Next() ([]byte, object, bool) }
+	key  []byte
+}
+
+func (it *nonUniqueIterator[Obj]) Next() (obj Obj, revision uint64, ok bool) {
+	var iobj object
+	for {
+		var key []byte
+		key, iobj, ok = it.iter.Next()
+		if !ok {
+			return
+		}
+		_, secondary := decodeNonUniqueKey(key)
+
+		// Equal length implies equal key since we got here via
+		// prefix search and all child nodes share the same prefix.
+		if len(secondary) == len(it.key) {
+			break
+		}
+
+		// This node has a longer secondary key that shares our search
+		// prefix, skip it.
+	}
 	if ok {
 		obj = iobj.data.(Obj)
 		revision = iobj.revision

--- a/pkg/statedb/regression_test.go
+++ b/pkg/statedb/regression_test.go
@@ -17,7 +17,8 @@ import (
 // https://github.com/cilium/cilium/issues/29324
 func Test_Regression_29324(t *testing.T) {
 	type object struct {
-		ID string
+		ID  string
+		Tag string
 	}
 	idIndex := Index[object, string]{
 		Name: "id",
@@ -27,16 +28,24 @@ func Test_Regression_29324(t *testing.T) {
 		FromKey: index.String,
 		Unique:  true,
 	}
+	tagIndex := Index[object, string]{
+		Name: "tag",
+		FromObject: func(t object) index.KeySet {
+			return index.NewKeySet(index.String(t.Tag))
+		},
+		FromKey: index.String,
+		Unique:  false,
+	}
 
-	db, _, _ := newTestDB(t, tagsIndex)
-	table, err := NewTable[object]("objects", idIndex)
+	db, _, _ := newTestDB(t)
+	table, err := NewTable[object]("objects", idIndex, tagIndex)
 	require.NoError(t, err)
 	require.NoError(t, db.RegisterTable(table))
 
 	wtxn := db.WriteTxn(table)
-	table.Insert(wtxn, object{"foo"})
-	table.Insert(wtxn, object{"foobar"})
-	table.Insert(wtxn, object{"baz"})
+	table.Insert(wtxn, object{"foo", "aa"})
+	table.Insert(wtxn, object{"foobar", "aaa"})
+	table.Insert(wtxn, object{"baz", "aaaa"})
 	wtxn.Commit()
 
 	// Exact match should only return "foo"
@@ -51,4 +60,17 @@ func Test_Regression_29324(t *testing.T) {
 	iter, _ = table.Get(txn, idIndex.Query("foob"))
 	items = Collect(iter)
 	assert.Len(t, items, 0, "Get(\"foob\") should return nothing")
+
+	// Query on non-unique index should only return exact match
+	iter, _ = table.Get(txn, tagIndex.Query("aa"))
+	items = Collect(iter)
+	if assert.Len(t, items, 1, "Get(\"aa\") on tags should return one match") {
+		assert.EqualValues(t, "foo", items[0].ID)
+	}
+
+	// Partial match on prefix should not return anything on non-unique index
+	iter, _ = table.Get(txn, idIndex.Query("a"))
+	items = Collect(iter)
+	assert.Len(t, items, 0, "Get(\"a\") should return nothing")
+
 }

--- a/pkg/statedb/table.go
+++ b/pkg/statedb/table.go
@@ -123,7 +123,7 @@ func (t *genTable[Obj]) First(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint
 
 func (t *genTable[Obj]) FirstWatch(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, watch <-chan struct{}, ok bool) {
 	indexTxn := txn.getTxn().mustIndexReadTxn(t.table, q.index)
-	iter := indexTxn.Root().Iterator()
+	iter := indexTxn.txn.Root().Iterator()
 	watch = iter.SeekPrefixWatch(q.key)
 	_, iobj, ok := iter.Next()
 	if ok {
@@ -140,7 +140,7 @@ func (t *genTable[Obj]) Last(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint6
 
 func (t *genTable[Obj]) LastWatch(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, watch <-chan struct{}, ok bool) {
 	indexTxn := txn.getTxn().mustIndexReadTxn(t.table, q.index)
-	iter := indexTxn.Root().ReverseIterator()
+	iter := indexTxn.txn.Root().ReverseIterator()
 	watch = iter.SeekPrefixWatch(q.key)
 	_, iobj, ok := iter.Previous()
 	if ok {
@@ -152,7 +152,7 @@ func (t *genTable[Obj]) LastWatch(txn ReadTxn, q Query[Obj]) (obj Obj, revision 
 
 func (t *genTable[Obj]) LowerBound(txn ReadTxn, q Query[Obj]) (Iterator[Obj], <-chan struct{}) {
 	indexTxn := txn.getTxn().mustIndexReadTxn(t.table, q.index)
-	root := indexTxn.Root()
+	root := indexTxn.txn.Root()
 
 	// Since LowerBound query may be invalidated by changes in another branch
 	// of the tree, we cannot just simply watch the node we seeked to. Instead
@@ -165,7 +165,7 @@ func (t *genTable[Obj]) LowerBound(txn ReadTxn, q Query[Obj]) (Iterator[Obj], <-
 
 func (t *genTable[Obj]) All(txn ReadTxn) (Iterator[Obj], <-chan struct{}) {
 	indexTxn := txn.getTxn().mustIndexReadTxn(t.table, t.primaryAnyIndexer.name)
-	root := indexTxn.Root()
+	root := indexTxn.txn.Root()
 	// Grab the watch channel for the root node
 	watchCh, _, _ := root.GetWatch(nil)
 	return &iterator[Obj]{root.Iterator()}, watchCh
@@ -173,7 +173,7 @@ func (t *genTable[Obj]) All(txn ReadTxn) (Iterator[Obj], <-chan struct{}) {
 
 func (t *genTable[Obj]) Get(txn ReadTxn, q Query[Obj]) (Iterator[Obj], <-chan struct{}) {
 	indexTxn := txn.getTxn().mustIndexReadTxn(t.table, q.index)
-	iter := indexTxn.Root().Iterator()
+	iter := indexTxn.txn.Root().Iterator()
 	watchCh := iter.SeekPrefixWatch(q.key)
 	return &iterator[Obj]{iter}, watchCh
 }

--- a/pkg/statedb/types.go
+++ b/pkg/statedb/types.go
@@ -289,27 +289,30 @@ type deleteTracker interface {
 	getRevision() uint64
 }
 
-type indexTree = *iradix.Tree[object]
+type indexEntry struct {
+	tree   *iradix.Tree[object]
+	unique bool
+}
 
 type tableEntry struct {
 	meta           TableMeta
-	indexes        *iradix.Tree[indexTree]
+	indexes        *iradix.Tree[indexEntry]
 	deleteTrackers *iradix.Tree[deleteTracker]
 	revision       uint64
 }
 
 func (t *tableEntry) numObjects() int {
-	indexTree, ok := t.indexes.Get([]byte(RevisionIndex))
+	indexEntry, ok := t.indexes.Get([]byte(RevisionIndex))
 	if ok {
-		return indexTree.Len()
+		return indexEntry.tree.Len()
 	}
 	return 0
 }
 
 func (t *tableEntry) numDeletedObjects() int {
-	indexTree, ok := t.indexes.Get([]byte(GraveyardIndex))
+	indexEntry, ok := t.indexes.Get([]byte(GraveyardIndex))
 	if ok {
-		return indexTree.Len()
+		return indexEntry.tree.Len()
 	}
 	return 0
 }

--- a/pkg/statedb/types.go
+++ b/pkg/statedb/types.go
@@ -184,17 +184,15 @@ type WriteTxn interface {
 }
 
 type Query[Obj any] struct {
-	index  IndexName
-	unique bool
-	key    []byte
+	index IndexName
+	key   []byte
 }
 
 // ByRevision constructs a revision query. Applicable to any table.
 func ByRevision[Obj any](rev uint64) Query[Obj] {
 	return Query[Obj]{
-		index:  RevisionIndex,
-		unique: false,
-		key:    index.Uint64(rev),
+		index: RevisionIndex,
+		key:   index.Uint64(rev),
 	}
 }
 
@@ -229,9 +227,8 @@ func (i Index[Obj, Key]) isUnique() bool {
 // Query constructs a query against this index from a key.
 func (i Index[Obj, Key]) Query(key Key) Query[Obj] {
 	return Query[Obj]{
-		index:  i.Name,
-		unique: i.isUnique(),
-		key:    i.FromKey(key),
+		index: i.Name,
+		key:   i.FromKey(key),
 	}
 }
 


### PR DESCRIPTION
Allow use of indexers that are not fixed-size or which don't terminate the key by checking that the key
length matches exactly with the used search prefix. For unique indexes this is as simple as checking
the key lengths in the iterator and for multi-index we need to extract the length of the secondary key
and compare against that.

E.g. now `struct{A, B string}` with multi-index on `B` will be indexed internally with concatenated key `B + A + <len>`, where `<len>` is 16-bit unsigned big endian int (the KeySet limits key sizes to 16-bits). A `Get` against a multi-index will
return an iterator which will check that the node's key matches with the query, for example `Get("foo")` against
`{"foo", "bar"}` and `{"foob", "ar"}` (assuming no terminating `\0`) will return an iterator which has been
seeked to key "foobar3". The iterator will extract length (3) and compare against search key length (len("foo")) 
and since length matches the object is returned. Next the iterator would advance to "foobar4" which would be
skipped since `4 != len("foo")`. 

In effect this allows statedb to work with indexers that do not terminate the keys, but at the performance cost of
potentially traversing over non-matching tree nodes. The actual length extraction and comparison adds no measurable
time to the iteration (the Get benchmark that was added showed no difference).

This PR additionally extends the tests to cover queries against multi-indexes with overlapping prefixes.
