### PR TITLE
ipam: Fix bug where IP lease did not expire

### DIFF
--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -251,7 +251,7 @@ func (ipam *IPAM) AllocateNextWithExpiration(family, owner string, pool Pool, ti
 	if timeout != time.Duration(0) {
 		for _, result := range []*AllocationResult{ipv4Result, ipv6Result} {
 			if result != nil {
-				result.ExpirationUUID, err = ipam.StartExpirationTimer(result.IP, pool, timeout)
+				result.ExpirationUUID, err = ipam.StartExpirationTimer(result.IP, result.IPPoolName, timeout)
 				if err != nil {
 					if ipv4Result != nil {
 						ipam.ReleaseIP(ipv4Result.IP, ipv4Result.IPPoolName)

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -296,7 +296,12 @@ func (ipam *IPAM) releaseIPLocked(ip net.IP, pool Pool) error {
 		"ip":    ip.String(),
 		"owner": owner,
 	}).Debugf("Released IP")
-	delete(ipam.expirationTimers, ip.String())
+
+	key := timerKey{ip: ip.String(), pool: pool}
+	if t, ok := ipam.expirationTimers[key]; ok {
+		close(t.stop)
+		delete(ipam.expirationTimers, key)
+	}
 
 	metrics.IPAMEvent.WithLabelValues(metricRelease, string(family)).Inc()
 	metrics.IPAMEvent.WithLabelValues(metricRelease, string(family)).Inc()
@@ -377,24 +382,35 @@ func (ipam *IPAM) StartExpirationTimer(ip net.IP, pool Pool, timeout time.Durati
 	ipam.allocatorMutex.Lock()
 	defer ipam.allocatorMutex.Unlock()
 
-	ipString := ip.String()
-	if _, ok := ipam.expirationTimers[ipString]; ok {
+	key := timerKey{ip: ip.String(), pool: pool}
+	if _, ok := ipam.expirationTimers[key]; ok {
 		return "", fmt.Errorf("expiration timer already registered")
 	}
 
 	allocationUUID := uuid.New().String()
-	ipam.expirationTimers[ipString] = allocationUUID
+	stop := make(chan struct{})
+	ipam.expirationTimers[key] = expirationTimer{
+		uuid: allocationUUID,
+		stop: stop,
+	}
 
-	go func(ip net.IP, allocationUUID string, timeout time.Duration) {
-		ipString := ip.String()
-		time.Sleep(timeout)
+	go func(key timerKey, ip net.IP, pool Pool, allocationUUID string, timeout time.Duration, stop <-chan struct{}) {
+		timer := time.NewTimerWithoutMaxDelay(timeout)
+		select {
+		case <-stop:
+			// Expiration timer was explicitly stopped before timeout.
+			// Ensure time.Timer can be garbage collected and exit
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
 
 		ipam.allocatorMutex.Lock()
 		defer ipam.allocatorMutex.Unlock()
 
-		if currentUUID, ok := ipam.expirationTimers[ipString]; ok {
-			if currentUUID == allocationUUID {
-				scopedLog := log.WithFields(logrus.Fields{"ip": ipString, "uuid": allocationUUID})
+		if t, ok := ipam.expirationTimers[key]; ok {
+			if t.uuid == allocationUUID {
+				scopedLog := log.WithFields(logrus.Fields{"ip": ip, "pool": pool, "uuid": allocationUUID})
 				if err := ipam.releaseIPLocked(ip, pool); err != nil {
 					scopedLog.WithError(err).Warning("Unable to release IP after expiration")
 				} else {
@@ -408,7 +424,7 @@ func (ipam *IPAM) StartExpirationTimer(ip net.IP, pool Pool, timeout time.Durati
 		} else {
 			// Expiration timer was removed. No action is required
 		}
-	}(ip, allocationUUID, timeout)
+	}(key, ip, pool, allocationUUID, timeout, stop)
 
 	return allocationUUID, nil
 }
@@ -421,14 +437,16 @@ func (ipam *IPAM) StopExpirationTimer(ip net.IP, pool Pool, allocationUUID strin
 	ipam.allocatorMutex.Lock()
 	defer ipam.allocatorMutex.Unlock()
 
-	ipString := ip.String()
-	if currentUUID, ok := ipam.expirationTimers[ipString]; !ok {
+	key := timerKey{ip: ip.String(), pool: pool}
+	t, ok := ipam.expirationTimers[key]
+	if !ok {
 		return fmt.Errorf("no expiration timer registered")
-	} else if currentUUID != allocationUUID {
+	} else if t.uuid != allocationUUID {
 		return fmt.Errorf("UUID mismatch, not stopping expiration timer")
 	}
 
-	delete(ipam.expirationTimers, ipString)
+	close(t.stop)
+	delete(ipam.expirationTimers, key)
 
 	return nil
 }

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -128,7 +128,9 @@ func (s *IPAMSuite) TestAllocateNextWithExpiration(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()
 	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
-	ipv4, ipv6, err := ipam.AllocateNextWithExpiration("", "foo", PoolDefault(), timeout)
+	// Allocate IPs and test expiration timer. 'pool' is empty in order to test
+	// that the allocated pool is passed to StartExpirationTimer
+	ipv4, ipv6, err := ipam.AllocateNextWithExpiration("", "foo", "", timeout)
 	c.Assert(err, IsNil)
 
 	// IPv4 address must be in use

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -104,7 +104,7 @@ func NewIPAM(nodeAddressing types.NodeAddressing, c Configuration, owner Owner, 
 		nodeAddressing:   nodeAddressing,
 		config:           c,
 		owner:            map[Pool]map[string]string{},
-		expirationTimers: map[string]string{},
+		expirationTimers: map[timerKey]expirationTimer{},
 		excludedIPs:      map[string]string{},
 	}
 

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -97,7 +97,7 @@ type IPAM struct {
 	// expirationTimers is a map of all expiration timers. Each entry
 	// represents a IP allocation which is protected by an expiration
 	// timer.
-	expirationTimers map[string]string
+	expirationTimers map[timerKey]expirationTimer
 
 	// mutex covers access to all members of this struct
 	allocatorMutex lock.RWMutex
@@ -125,4 +125,14 @@ type Pool string
 
 func (p Pool) String() string {
 	return string(p)
+}
+
+type timerKey struct {
+	ip   string
+	pool Pool
+}
+
+type expirationTimer struct {
+	uuid string
+	stop chan<- struct{}
 }

--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -105,11 +105,18 @@ func NewTicker(d Duration) *time.Ticker {
 }
 
 // NewTimer overrides the stdlib time.NewTimer to enforce maximum sleepiness
-// va option.MaxInternalTimerDelay.
+// via option.MaxInternalTimerDelay.
 func NewTimer(d Duration) *time.Timer {
 	if MaxInternalTimerDelay > 0 && d > MaxInternalTimerDelay {
 		d = MaxInternalTimerDelay
 	}
+	return time.NewTimer(d)
+}
+
+// NewTimerWithoutMaxDelay returns a time.NewTimer without enforcing maximum
+// sleepiness. This function should only be used in cases where the timer firing
+// early impacts correctness. If in doubt, you probably should use NewTimer.
+func NewTimerWithoutMaxDelay(d Duration) *time.Timer {
 	return time.NewTimer(d)
 }
 


### PR DESCRIPTION
The [`AllocateNextWithExpiration`](https://github.com/cilium/cilium/blob/0fcd1c86e347b2701880c9034e7ea3a74cd6b13e/daemon/cmd/ipam.go#L46) function is used to allocate an IP via API from the CNI plugin. Such IPs are always allocated with an expiration timer, which means that if the CNI ADD fails later on and is never retried, the IP is automatically released. Only once an endpoint is created, do we stop the expiration timer [during the endpoint creation request](https://github.com/cilium/cilium/blob/95a7d1288d5a13a5a216dcdb09383f1f483e5ac1/daemon/cmd/endpoint.go#L536), making the allocation of the IP permanent until it is explicitly freed.

The current expiration implementation however has a bug: Instead of releasing the IP back into the IPAM pool from where the IP was actually allocated from, we forwarded the desired pool, which can be empty and is later overwritten with the actual pool.

Because we passed in an empty pool into `StartExpirationTimer`, this led to IP expiration being broken in almost all cases:

```
2023-11-24T06:24:37.089657953Z level=warning msg="Unable to release IP after expiration" error="no IPAM pool provided for IP release of 10.0.1.41" ip=10.0.1.41 subsys=ipam uuid=2320c5c1-b4c0-4a2e-8f3d-2b906330ab55
```

This commit fixes that by using the realized pool (from the result) instead of the desired pool from the request. In addition, the unit tests are also adapted to cover this case to ensure we don't regress.

Reported-by: Yutaro Hayakawa <yutaro.hayakawa@isovalent.com>
