### PR TITLE
Increase client-go qps and burst to 10/20 for k8s 1.27+

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2135,15 +2135,15 @@
    * - :spelling:ignore:`k8sClientRateLimit`
      - Configure the client side rate limit for the agent and operator  If the amount of requests to the Kubernetes API server exceeds the configured rate limit, the agent and operator will start to throttle requests by delaying them until there is budget or the request times out.
      - object
-     - ``{"burst":10,"qps":5}``
+     - ``{"burst":null,"qps":null}``
    * - :spelling:ignore:`k8sClientRateLimit.burst`
      - The burst request rate in requests per second. The rate limiter will allow short bursts with a higher rate.
      - int
-     - ``10``
+     - 10 for k8s up to 1.26. 20 for k8s version 1.27+
    * - :spelling:ignore:`k8sClientRateLimit.qps`
      - The sustained request rate in requests per second.
      - int
-     - ``5``
+     - 5 for k8s up to 1.26. 10 for k8s version 1.27+
    * - :spelling:ignore:`k8sNetworkPolicy.enabled`
      - Enable support for K8s NetworkPolicy
      - bool

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -583,9 +583,9 @@ contributors across the globe, there is almost always someone available to help.
 | ipv6.enabled | bool | `false` | Enable IPv6 support. |
 | ipv6NativeRoutingCIDR | string | `""` | Allows to explicitly specify the IPv6 CIDR for native routing. When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. To offer a concrete example, if Cilium is configured to use direct routing and the Kubernetes CIDR is included in the native routing CIDR, the user must configure the routes to reach pods, either manually or by setting the auto-direct-node-routes flag. |
 | k8s | object | `{}` | Configure Kubernetes specific configuration |
-| k8sClientRateLimit | object | `{"burst":10,"qps":5}` | Configure the client side rate limit for the agent and operator  If the amount of requests to the Kubernetes API server exceeds the configured rate limit, the agent and operator will start to throttle requests by delaying them until there is budget or the request times out. |
-| k8sClientRateLimit.burst | int | `10` | The burst request rate in requests per second. The rate limiter will allow short bursts with a higher rate. |
-| k8sClientRateLimit.qps | int | `5` | The sustained request rate in requests per second. |
+| k8sClientRateLimit | object | `{"burst":null,"qps":null}` | Configure the client side rate limit for the agent and operator  If the amount of requests to the Kubernetes API server exceeds the configured rate limit, the agent and operator will start to throttle requests by delaying them until there is budget or the request times out. |
+| k8sClientRateLimit.burst | int | 10 for k8s up to 1.26. 20 for k8s version 1.27+ | The burst request rate in requests per second. The rate limiter will allow short bursts with a higher rate. |
+| k8sClientRateLimit.qps | int | 5 for k8s up to 1.26. 10 for k8s version 1.27+ | The sustained request rate in requests per second. |
 | k8sNetworkPolicy.enabled | bool | `true` | Enable support for K8s NetworkPolicy |
 | k8sServiceHost | string | `""` | Kubernetes service host |
 | k8sServicePort | string | `""` | Kubernetes service port |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -13,6 +13,8 @@
 {{- $fragmentTracking := "true" -}}
 {{- $defaultKubeProxyReplacement := "false" -}}
 {{- $azureUsePrimaryAddress := "true" -}}
+{{- $defaultK8sClientQPS := 5 -}}
+{{- $defaultK8sClientBurst := 10 -}}
 
 {{- /* Default values when 1.8 was initially deployed */ -}}
 {{- if semverCompare ">=1.8" (default "1.8" .Values.upgradeCompatibility) -}}
@@ -75,6 +77,11 @@
   {{- $cniChainingMode = .Values.cni.chainingMode  -}}
 {{- else if (not (kindIs "invalid" .Values.cni.chainingTarget)) -}}
   {{- $cniChainingMode = "generic-veth" -}}
+{{- end -}}
+
+{{- if semverCompare ">=1.27-0" .Capabilities.KubeVersion.Version -}}
+  {{- $defaultK8sClientQPS = 10 -}}
+  {{- $defaultK8sClientBurst = 20 -}}
 {{- end -}}
 ---
 apiVersion: v1
@@ -1118,10 +1125,8 @@ data:
   annotate-k8s-node: "true"
 {{- end }}
 
-{{- if hasKey .Values "k8sClientRateLimit" }}
-  k8s-client-qps: {{ .Values.k8sClientRateLimit.qps | quote }}
-  k8s-client-burst: {{ .Values.k8sClientRateLimit.burst | quote }}
-{{- end }}
+  k8s-client-qps: {{ .Values.k8sClientRateLimit.qps | default $defaultK8sClientQPS | quote}}
+  k8s-client-burst: {{ .Values.k8sClientRateLimit.burst | default $defaultK8sClientBurst | quote }}
 
 {{- if and .Values.operator.setNodeTaints (not .Values.operator.removeNodeTaints) -}}
   {{ fail "Cannot have operator.setNodeTaintsMaxNodes and not operator.removeNodeTaints = false" }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -47,11 +47,13 @@ k8sServicePort: ""
 # rate limit, the agent and operator will start to throttle requests by delaying
 # them until there is budget or the request times out.
 k8sClientRateLimit:
-  # -- The sustained request rate in requests per second.
-  qps: 5
-  # -- The burst request rate in requests per second.
+  # -- (int) The sustained request rate in requests per second.
+  # @default -- 5 for k8s up to 1.26. 10 for k8s version 1.27+
+  qps:
+  # -- (int) The burst request rate in requests per second.
   # The rate limiter will allow short bursts with a higher rate.
-  burst: 10
+  # @default -- 10 for k8s up to 1.26. 20 for k8s version 1.27+
+  burst:
 
 cluster:
   # -- Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -44,11 +44,13 @@ k8sServicePort: ""
 # rate limit, the agent and operator will start to throttle requests by delaying
 # them until there is budget or the request times out.
 k8sClientRateLimit:
-  # -- The sustained request rate in requests per second.
-  qps: 5
-  # -- The burst request rate in requests per second.
+  # -- (int) The sustained request rate in requests per second.
+  # @default -- 5 for k8s up to 1.26. 10 for k8s version 1.27+
+  qps:
+  # -- (int) The burst request rate in requests per second.
   # The rate limiter will allow short bursts with a higher rate.
-  burst: 10
+  # @default -- 10 for k8s up to 1.26. 20 for k8s version 1.27+
+  burst:
 
 cluster:
   # -- Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE.


### PR DESCRIPTION
Default QPS for kubelet has been increased in 1.27 k8s to 50 QPS. https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md under "Bump default API QPS limits for Kubelet.
Before kubelet had 5 QPS the same as agent.
Still when agent needs to create CEP and Identity for a pod, it has to make two API calls so potentially pod startup latency was higher than expected if node was experiancing high churn of pods with new identities.
Now with recent change of kubelet, there is even higher chance of that to happen - therefore we should increase QPS.

```release-note
Default client-go QPS and burst in agent and operator have been increased to 10 and 20 respectively for k8s versions 1.27+
```
