### PR TITLE
Fix cleanup of AWS-related leftover iptables chains

### DIFF
--- a/install/kubernetes/cilium/files/agent/poststart-eni.bash
+++ b/install/kubernetes/cilium/files/agent/poststart-eni.bash
@@ -11,9 +11,9 @@ set -o nounset
 # dependencies on anything that is part of the startup script
 # itself, and can be safely run multiple times per node (e.g. in
 # case of a restart).
-if [[ "$(iptables-save | grep -c 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN')" != "0" ]];
+if [[ "$(iptables-save | grep -E -c 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN')" != "0" ]];
 then
     echo 'Deleting iptables rules created by the AWS CNI VPC plugin'
-    iptables-save | grep -v 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN' | iptables-restore
+    iptables-save | grep -E -v 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN' | iptables-restore
 fi
 echo 'Done!'


### PR DESCRIPTION
The poststart-eni.sh script got recently modified to delete both AWS-SNAT and AWS-CONNMARK related chains. Yet, the filter is now a regular expression, and does not return any match with plain grep. Let's fix this by setting the `-E` (--extended-regexp) flag.