### PR TITLE
[v1.14] bgpv1: Fix BGP component tests using the same VirtualRouter config

### DIFF
--- a/pkg/bgpv1/test/adverts_test.go
+++ b/pkg/bgpv1/test/adverts_test.go
@@ -139,7 +139,7 @@ func Test_PodCIDRAdvert(t *testing.T) {
 	defer testDone()
 
 	// setup topology
-	gobgpPeers, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, fixtureConf)
+	gobgpPeers, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, newFixtureConf())
 	require.NoError(t, err)
 	require.Len(t, gobgpPeers, 1)
 	defer cleanup()
@@ -316,7 +316,7 @@ func Test_LBEgressAdvertisement(t *testing.T) {
 	defer testDone()
 
 	// setup topology
-	gobgpPeers, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, fixtureConf)
+	gobgpPeers, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, newFixtureConf())
 	require.NoError(t, err)
 	require.Len(t, gobgpPeers, 1)
 	defer cleanup()

--- a/pkg/bgpv1/test/neighbor_test.go
+++ b/pkg/bgpv1/test/neighbor_test.go
@@ -127,7 +127,7 @@ func Test_NeighborAddDel(t *testing.T) {
 	defer testDone()
 
 	// test setup, we configure two gobgp instances here.
-	gobgpInstances, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf, gobgpConf2}, fixtureConf)
+	gobgpInstances, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf, gobgpConf2}, newFixtureConf())
 	require.NoError(t, err)
 	require.Len(t, gobgpInstances, 2)
 	defer cleanup()
@@ -272,7 +272,7 @@ func Test_NeighborGracefulRestart(t *testing.T) {
 	defer testDone()
 
 	// test setup, we configure single gobgp instance here.
-	gobgpInstances, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, fixtureConf)
+	gobgpInstances, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, newFixtureConf())
 	require.NoError(t, err)
 	require.Len(t, gobgpInstances, 1)
 	defer cleanup()


### PR DESCRIPTION
This is an author's backport of https://github.com/cilium/cilium/pull/28420 potentially fixing the CI issue https://github.com/cilium/cilium/issues/28415