### PR TITLE
ci: add nameserver 1.1.1.1 to conformance-runtime test LVM

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -288,7 +288,6 @@ jobs:
           image-version: ${{ matrix.kernel }}
           host-mount: ./
           cpu: 4
-          dns-resolver: '1.1.1.1'
           install-dependencies: 'true'
           cmd: |
             git config --global --add safe.directory /host

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -281,7 +281,6 @@ jobs:
           host-mount: ./
           cpu: 4
           mem: 12G
-          dns-resolver: '1.1.1.1'
           cmd: |
             git config --global --add safe.directory /host
             mv /host/helm /usr/bin

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -231,7 +231,6 @@ jobs:
           image-version: ${{ matrix.kernel }}
           host-mount: ./
           cpu: 4
-          dns-resolver: '1.1.1.1'
           install-dependencies: 'true'
           cmd: |
             git config --global --add safe.directory /host

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -266,7 +266,6 @@ jobs:
           host-mount: ./
           cpu: 4
           mem: 12G
-          dns-resolver: '1.1.1.1'
 
       # Load Ginkgo build from GitHub
       - name: Load ${{ matrix.name }} Ginkgo build from GitHub

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -333,6 +333,7 @@ jobs:
             export VMUSER=root
             echo '127.0.0.1 localhost' >> /etc/hosts
             echo '::1 localhost' >> /etc/hosts
+            sed -i '1s/^/nameserver 1.1.1.1\n/' /etc/resolv.conf
             /tmp/provision/runtime_install.sh
             service docker restart
 

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -108,7 +108,6 @@ jobs:
           image-version: ${{ matrix.kernel }}
           host-mount: ./
           cpu: 4
-          dns-resolver: '1.1.1.1'
           install-dependencies: 'true'
           cmd: |
             git config --global --add safe.directory /host

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -312,7 +312,6 @@ jobs:
           host-mount: ./
           cpu: 4
           mem: '12G'
-          dns-resolver: '1.1.1.1'
           install-dependencies: 'true'
           cmd: |
             git config --global --add safe.directory /host

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -247,7 +247,6 @@ jobs:
           host-mount: ./
           cpu: 4
           mem: '12G'
-          dns-resolver: '1.1.1.1'
           install-dependencies: 'true'
           cmd: |
             git config --global --add safe.directory /host


### PR DESCRIPTION
With the [removal of the property](https://github.com/cilium/little-vm-helper/pull/118) `dns-resolver` to set a nameserver via the little-vm-helper GitHub action, [conformance-runtime tests are failing quite often with the following error.](https://github.com/cilium/cilium/actions/workflows/conformance-runtime.yaml?query=branch%3Amain+event%3Apush)

```
dial tcp: lookup quay.io on 127.0.0.53:53: read udp 127.0.0.1:40553->127.0.0.53:53: read: connection refused
```

The assumption is that the local DNS resolver isn't ready at that time when pulling the cilium docker plugin image (rather early after startup).

Therefore, this commit temporarily re-adds the nameserver `1.1.1.1` manually in the runtime test - at the beginning of `/etc/resolv.conf` - and therefore prioritized.

See: https://github.com/cilium/little-vm-helper/pull/118