### PR TITLE
[v1.12] Author Backport of 27001 (Add support for tracking map pressure for NAT map)

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -258,7 +258,7 @@ func (m *Map) WithPressureMetric() *Map {
 	return m.WithPressureMetricThreshold(0.0)
 }
 
-func (m *Map) updatePressureMetric() {
+func (m *Map) UpdatePressureMetricWithSize(size int32) {
 	if m.pressureGauge == nil {
 		return
 	}
@@ -273,8 +273,18 @@ func (m *Map) updatePressureMetric() {
 		return
 	}
 
-	pvalue := float64(len(m.cache)) / float64(m.MaxEntries)
+	pvalue := float64(size) / float64(m.MaxEntries)
 	m.pressureGauge.Set(pvalue)
+}
+
+func (m *Map) updatePressureMetric() {
+	// Skipping pressure metric gauge updates for LRU map as the cache size
+	// does not accurately represent the actual map sie.
+	if m.MapType == MapTypeLRUHash {
+		return
+	}
+
+	m.UpdatePressureMetricWithSize(int32(len(m.cache)))
 }
 
 func (m *Map) GetFd() int {

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -632,7 +632,11 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 		}
 	}
 
-	natMap.DumpReliablyWithCallback(cb, stats.DumpStats)
+	if err := natMap.DumpReliablyWithCallback(cb, stats.DumpStats); err != nil {
+		log.WithError(err).Error("NATmap dump failed during GC")
+	} else {
+		natMap.UpdatePressureMetricWithSize(int32(stats.IngressAlive + stats.EgressAlive))
+	}
 
 	return &stats
 }

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -103,7 +103,8 @@ func NewMap(name string, v4 bool, entries int) *Map {
 			entries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache(),
+		).WithCache().
+			WithPressureMetric(),
 		v4: v4,
 	}
 }


### PR DESCRIPTION
- [ ] #27001 -- Add support for tracking map pressure for NAT map (@derailed)
    
Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 27001; do contrib/backporting/set-labels.py $pr done 1.12; done
```
