### PR TITLE
bpf: do not invoke llc from Makefiles

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -5,7 +5,6 @@ include ../Makefile.defs
 
 SUBDIRS = custom
 BPF_SIMPLE = bpf_network.o bpf_alignchecker.o
-BPF_SIMPLE_LL = $(patsubst %.o,%.ll,${BPF_SIMPLE})
 BPF = bpf_lxc.o bpf_overlay.o bpf_sock.o bpf_host.o bpf_xdp.o $(BPF_SIMPLE)
 
 KERNEL ?= netnext
@@ -197,13 +196,9 @@ testdata:
 	-c ../pkg/alignchecker/testdata/bpf_foo.c \
 	-o ../pkg/alignchecker/testdata/bpf_foo.o
 
-$(BPF_SIMPLE_LL): %.ll: %.c
+$(BPF_SIMPLE): %.o: %.c
 	@$(ECHO_CC)
 	$(QUIET) ${CLANG} ${BPF_SIMPLE_OPTIONS} ${CLANG_FLAGS} -c $< -o $@
-
-$(BPF_SIMPLE): %.o: %.ll
-	@$(ECHO_CC)
-	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $<
 
 # Hack to get make to replace : with a space
 null :=
@@ -213,59 +208,39 @@ ifneq ($(BUILD_PERMUTATIONS),)
 define PERMUTATION_template =
 $(1)::
 	@$$(ECHO_CC) " [$(subst :,=1$(space),$(2))]"
-	$$(QUIET) $${CLANG} $(subst :,=1$(space),$(2)) $${CLANG_FLAGS} -c $(patsubst %.ll,%.c,$(1)) -o- | $${LLC} $${LLC_FLAGS} -o /dev/null -
+	$$(QUIET) $${CLANG} $(subst :,=1$(space),$(2)) $${CLANG_FLAGS} -c $(patsubst %.o,%.c,$(1)) -o /dev/null
 endef
 endif
 
-bpf_sock.ll:: bpf_sock.c $(LIB)
+bpf_sock.o:: bpf_sock.c $(LIB)
 	@$(ECHO_CC)
 	$(QUIET) ${CLANG} ${MAX_LB_OPTIONS} ${CLANG_FLAGS} -c $< -o $@
 
-$(foreach OPTS,$(LB_OPTIONS),$(eval $(call PERMUTATION_template,bpf_sock.ll,$(OPTS))))
+$(foreach OPTS,$(LB_OPTIONS),$(eval $(call PERMUTATION_template,bpf_sock.o,$(OPTS))))
 
-bpf_sock.o: bpf_sock.ll
-	@$(ECHO_CC)
-	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)
-
-bpf_overlay.ll:: bpf_overlay.c $(LIB)
+bpf_overlay.o:: bpf_overlay.c $(LIB)
 	@$(ECHO_CC)
 	$(QUIET) ${CLANG} ${MAX_OVERLAY_OPTIONS} ${CLANG_FLAGS} -c $< -o $@
 
-$(foreach OPTS,$(LB_OPTIONS),$(eval $(call PERMUTATION_template,bpf_overlay.ll,$(OPTS) -DENCAP_IFINDEX=1)))
+$(foreach OPTS,$(LB_OPTIONS),$(eval $(call PERMUTATION_template,bpf_overlay.o,$(OPTS) -DENCAP_IFINDEX=1)))
 
-bpf_overlay.o: bpf_overlay.ll
-	@$(ECHO_CC)
-	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)
-
-bpf_host.ll:: bpf_host.c $(LIB)
+bpf_host.o:: bpf_host.c $(LIB)
 	@$(ECHO_CC)
 	$(QUIET) ${CLANG} ${MAX_HOST_OPTIONS} ${CLANG_FLAGS} -c $< -o $@
 
-$(foreach OPTS,$(HOST_OPTIONS),$(eval $(call PERMUTATION_template,bpf_host.ll,$(OPTS) -DENCAP_IFINDEX=1)))
+$(foreach OPTS,$(HOST_OPTIONS),$(eval $(call PERMUTATION_template,bpf_host.o,$(OPTS) -DENCAP_IFINDEX=1)))
 
-bpf_host.o: bpf_host.ll
-	@$(ECHO_CC)
-	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)
-
-bpf_xdp.ll:: bpf_xdp.c $(LIB)
+bpf_xdp.o:: bpf_xdp.c $(LIB)
 	@$(ECHO_CC)
 	$(QUIET) ${CLANG} ${MAX_XDP_OPTIONS} ${CLANG_FLAGS} -c $< -o $@
 
-$(foreach OPTS,$(XDP_OPTIONS),$(eval $(call PERMUTATION_template,bpf_xdp.ll,$(OPTS))))
+$(foreach OPTS,$(XDP_OPTIONS),$(eval $(call PERMUTATION_template,bpf_xdp.o,$(OPTS))))
 
-bpf_xdp.o: bpf_xdp.ll
-	@$(ECHO_CC)
-	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)
-
-bpf_lxc.ll:: bpf_lxc.c $(LIB)
+bpf_lxc.o:: bpf_lxc.c $(LIB)
 	@$(ECHO_CC)
 	$(QUIET) ${CLANG} ${MAX_LXC_OPTIONS} ${CLANG_FLAGS} -c $< -o $@
 
-$(foreach OPTS,$(LXC_OPTIONS),$(eval $(call PERMUTATION_template,bpf_lxc.ll,$(OPTS))))
-
-bpf_lxc.o: bpf_lxc.ll
-	@$(ECHO_CC)
-	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)
+$(foreach OPTS,$(LXC_OPTIONS),$(eval $(call PERMUTATION_template,bpf_lxc.o,$(OPTS))))
 
 subdirs: $(SUBDIRS)
 	$(QUIET) $(foreach TARGET,$(SUBDIRS), \

--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -3,7 +3,7 @@
 
 FLAGS := -I$(ROOT_DIR)/bpf/include -I$(ROOT_DIR)/bpf -D__NR_CPUS__=$(shell nproc --all) -O2 -g
 
-CLANG_FLAGS := ${FLAGS} --target=bpf -std=gnu89 -nostdinc -emit-llvm
+CLANG_FLAGS := ${FLAGS} --target=bpf -std=gnu89 -nostdinc
 # eBPF verifier enforces unaligned access checks where necessary, so don't
 # let clang complain too early.
 CLANG_FLAGS += -Wall -Wextra -Werror -Wshadow
@@ -13,21 +13,18 @@ CLANG_FLAGS += -Wno-gnu-variable-sized-type-not-at-end
 CLANG_FLAGS += -Wdeclaration-after-statement
 CLANG_FLAGS += -Wimplicit-int-conversion -Wenum-conversion
 CLANG_FLAGS += -Wimplicit-fallthrough
-LLC_FLAGS := -march=bpf
 # Mimics the mcpu values set by cilium-agent. See GetBPFCPU().
 ifeq ("$(KERNEL)","netnext")
-LLC_FLAGS += -mcpu=v3
+CLANG_FLAGS += -mcpu=v3
 else
-LLC_FLAGS += -mcpu=v2
+CLANG_FLAGS += -mcpu=v2
 endif
 
 LIB := $(shell find $(ROOT_DIR)/bpf -name '*.h')
 BPF_C := $(patsubst %.o,%.c,$(BPF))
 BPF_ASM := $(patsubst %.o,%.s,$(BPF))
 
-CLANG ?= clang
-LLC   ?= llc
-
+CLANG      ?= clang
 HOST_CC    ?= gcc
 HOST_STRIP ?= strip
 
@@ -47,11 +44,11 @@ force:
 
 %.ll: %.c $(LIB)
 	@$(ECHO_CC)
-	$(QUIET) ${CLANG} ${CLANG_FLAGS} -c $< -o $@
+	$(QUIET) ${CLANG} ${CLANG_FLAGS} -emit-llvm -c $< -o $@
 
-%.s: %.ll
+%.o: %.c $(LIB)
 	@$(ECHO_CC)
-	$(QUIET) ${LLC} $(LLC_FLAGS) -filetype=asm -o $@ $(patsubst %.s,%.ll,$@)
+	$(QUIET) ${CLANG} ${CLANG_FLAGS} -c $< -o $@
 
 #
 # TODO: revert addition of ignore MACRO_ARG_REUSE below once cilium-checkpatch

--- a/bpf/custom/Makefile
+++ b/bpf/custom/Makefile
@@ -25,16 +25,12 @@ include ../Makefile.bpf
 
 all: $(PROGS)
 
-%.ll: %.h $(BASE_PROG) $(LIB)
+%.o: %.h $(BASE_PROG) $(LIB)
 	@$(ECHO_CC)
 	$(QUIET) ${CLANG} ${CLANG_FLAGS} \
 		-DBPF_CUSTOM_PROG_FILE=$< \
 		-DBPF_CUSTOM_PROG_NAME=$(call sec_name,$<) \
 		-c $(BASE_PROG) -o $@
-
-$(PROGS): %.o: %.ll
-	@$(ECHO_CC)
-	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)
 
 clean:
 	@$(ECHO_CLEAN)

--- a/bpf/tests/Makefile
+++ b/bpf/tests/Makefile
@@ -6,11 +6,10 @@ include ../../Makefile.defs
 MAKEFLAGS += -r
 
 CLANG ?= clang
-LLC   ?= llc
 
 FLAGS := -I$(ROOT_DIR)/bpf/include -I$(ROOT_DIR)/bpf -D__NR_CPUS__=$(shell nproc --all) -O2 -g
 
-CLANG_FLAGS := ${FLAGS} --target=bpf -std=gnu99 -nostdinc -emit-llvm
+CLANG_FLAGS := ${FLAGS} --target=bpf -std=gnu99 -nostdinc
 # eBPF verifier enforces unaligned access checks where necessary, so don't
 # let clang complain too early.
 CLANG_FLAGS += -Wall -Wextra -Werror -Wshadow
@@ -21,29 +20,28 @@ CLANG_FLAGS += -Wimplicit-int-conversion -Wenum-conversion
 CLANG_FLAGS += -Wimplicit-fallthrough
 # Create dependency files for each .o file.
 CLANG_FLAGS += -MD
-LLC_FLAGS := -march=bpf
 # Mimics the mcpu values set by cilium-agent. See GetBPFCPU().
 ifeq ("$(KERNEL)","netnext")
-LLC_FLAGS += -mcpu=v3
+CLANG_FLAGS += -mcpu=v3
 else
-LLC_FLAGS += -mcpu=v2
+CLANG_FLAGS += -mcpu=v2
 endif
 
 .PHONY: all clean
 
 TEST_OBJECTS = $(patsubst %.c, %.o, $(wildcard *.c))
 
-%.o: %.ll %.i $(LIB)
+%.o: %.c $(LIB)
 	$(ECHO_CC)
 	# Remove the .o file to force recompilation, only rely on make's caching, not clangs
 	rm -f $@
-	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $<
-
-%.ll: %.c
-	$(ECHO_CC)
 	$(QUIET) ${CLANG} ${CLANG_FLAGS} -c $< -o $@
 
-%.i: %.c
+%.ll: %.c $(LIB)
+	$(ECHO_CC)
+	$(QUIET) ${CLANG} ${CLANG_FLAGS} -c -emit-llvm $< -o $@
+
+%.i: %.c $(LIB)
 	$(ECHO_CC)
 	$(QUIET) ${CLANG} ${CLANG_FLAGS} -E -c $< -o $@
 

--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -12,13 +12,11 @@ FLAGS_CLANG += -Wno-gnu-variable-sized-type-not-at-end
 FLAGS_CLANG += -Wdeclaration-after-statement
 FLAGS_CLANG += -g
 
-BPF_CC_FLAGS := ${FLAGS} --target=bpf -std=gnu89 -nostdinc -emit-llvm
-BPF_LLC_FLAGS := -march=bpf -mcpu=probe -filetype=obj
+BPF_CC_FLAGS := ${FLAGS} --target=bpf -mcpu=probe -std=gnu89 -nostdinc
 
 LIB := $(shell find ../../bpf/ -name '*.h')
 
 CLANG ?= clang
-LLC ?= llc
 
 BPF_TARGETS := elf-demo.o
 ALL_TESTS := unit-test
@@ -28,7 +26,7 @@ all: $(TARGETS) unit-tests
 
 elf-demo.o: elf-demo.c
 	@$(ECHO_CC)
-	$(QUIET) $(CLANG) ${FLAGS_CLANG} ${BPF_CC_FLAGS} -c $< -o - | $(LLC) ${BPF_LLC_FLAGS} -o $@
+	$(QUIET) $(CLANG) ${FLAGS_CLANG} ${BPF_CC_FLAGS} -c $< -o $@
 
 %: %.c $(LIB)
 	@$(ECHO_CC)

--- a/tools/dev-doctor/rootcmd.go
+++ b/tools/dev-doctor/rootcmd.go
@@ -156,13 +156,6 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 			minVersion:    &semver.Version{Major: 3, Minor: 6, Patch: 0},
 		},
 		&binaryCheck{
-			name:          "llc",
-			ifNotFound:    checkWarning,
-			versionArgs:   []string{"--version"},
-			versionRegexp: regexp.MustCompile(`LLVM\s+version\s+(\d+\.\d+\S*)`),
-			minVersion:    &semver.Version{Major: 10, Minor: 0, Patch: 0},
-		},
-		&binaryCheck{
 			name:          "vagrant",
 			ifNotFound:    checkInfo,
 			versionArgs:   []string{"--version"},


### PR DESCRIPTION
bpf: do not invoke llc separately

    Update the various bpf Makefiles to not invoke llc anymore. This matches 
    what the loader does now.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

tools/dev-doctor: do not check for llc

    Compiling bpf doesn't invoke llc directly anymore, stop checking for its
    presence.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
