### PR TITLE
daemon: use local CiliumNode resource to populate CiliumInternalIP.

### DIFF
--- a/daemon/cmd/local_node_sync_test.go
+++ b/daemon/cmd/local_node_sync_test.go
@@ -8,14 +8,20 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	k8sLabels "k8s.io/apimachinery/pkg/labels"
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/node/addressing"
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/stream"
@@ -84,6 +90,14 @@ func TestLocalNodeSync(t *testing.T) {
 				NodeEncryptionOptOutLabels: labels.Nothing(),
 			},
 			K8sLocalNode: fln,
+			K8sCiliumLocalNode: &mockResource[*v2.CiliumNode]{
+				items: []resource.Event[*v2.CiliumNode]{
+					{
+						Kind: resource.Sync,
+						Done: func(err error) {},
+					},
+				},
+			},
 		})
 	)
 
@@ -115,4 +129,91 @@ func TestLocalNodeSync(t *testing.T) {
 	update = <-updates
 	require.Equal(t, k8stypes.UID("uid2"), update.UID)
 	require.Equal(t, "provider://foobaz", update.ProviderID)
+}
+func TestInitLocalNode_initFromK8s(t *testing.T) {
+	lni := &localNodeSynchronizer{
+		localNodeSynchronizerParams: localNodeSynchronizerParams{
+			Config: &option.DaemonConfig{
+				IPv4NodeAddr:               "auto",
+				IPv6NodeAddr:               "auto",
+				NodeEncryptionOptOutLabels: k8sLabels.NewSelector(),
+			},
+			K8sLocalNode: &mockResource[*slim_corev1.Node]{
+				items: []resource.Event[*slim_corev1.Node]{
+					{
+						Kind: resource.Upsert,
+						Object: &slim_corev1.Node{
+							ObjectMeta: slim_metav1.ObjectMeta{
+								Labels: map[string]string{
+									"x": "y",
+								},
+								Name:      "test-node",
+								Namespace: "test-namespace",
+							},
+						},
+						Done: func(err error) {},
+					},
+				},
+			},
+			K8sCiliumLocalNode: &mockResource[*v2.CiliumNode]{
+				items: []resource.Event[*v2.CiliumNode]{
+					{
+						Kind: resource.Upsert,
+						Object: &v2.CiliumNode{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-node",
+								Namespace: "test-namespace",
+								Labels: map[string]string{
+									"x": "y",
+								},
+							},
+							Spec: v2.NodeSpec{
+								Addresses: []v2.NodeAddress{
+									{
+										Type: addressing.NodeCiliumInternalIP,
+										IP:   "10.0.0.1",
+									},
+									{
+										Type: addressing.NodeCiliumInternalIP,
+										IP:   "fd00:10:244:1::aaa6",
+									},
+								},
+							},
+						},
+						Done: func(err error) {},
+					},
+				},
+			},
+		},
+	}
+	n := &node.LocalNode{
+		Node: types.Node{
+			Labels: map[string]string{},
+		},
+	}
+	err := lni.InitLocalNode(context.Background(), n)
+	assert.NoError(t, err)
+	assert.Equal(t, "10.0.0.1", n.GetCiliumInternalIP(false).String())
+	assert.Equal(t, "fd00:10:244:1::aaa6", n.GetCiliumInternalIP(true).String())
+	assert.Equal(t, n.Name, "test-node")
+}
+
+type mockResource[T k8sRuntime.Object] struct {
+	items []resource.Event[T]
+}
+
+func (mr *mockResource[T]) Observe(ctx context.Context, next func(resource.Event[T]), complete func(error)) {
+	panic("observe not impl")
+}
+
+func (mr *mockResource[T]) Events(ctx context.Context, opts ...resource.EventsOpt) <-chan resource.Event[T] {
+	ch := make(chan resource.Event[T], len(mr.items))
+	for _, item := range mr.items {
+		ch <- item
+	}
+	return ch
+}
+
+func (mr *mockResource[T]) Store(context.Context) (resource.Store[T], error) {
+	panic("store not impl")
 }

--- a/pkg/node/addressing/addresstype.go
+++ b/pkg/node/addressing/addresstype.go
@@ -9,7 +9,7 @@ import (
 
 // AddressType represents a type of IP address for a node. They are copied
 // from k8s.io/api/core/v1/types.go to avoid pulling in a lot of Kubernetes
-// imports into this package.s
+// imports into this package.
 type AddressType string
 
 const (

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/k8s/apis"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/version"
@@ -523,6 +524,14 @@ func filterList(obj k8sRuntime.Object, restrictions k8sTesting.ListRestrictions)
 		obj.Items = items
 	case *slim_corev1.PodList:
 		items := make([]slim_corev1.Pod, 0, len(obj.Items))
+		for i := range obj.Items {
+			if matchFieldSelector(&obj.Items[i], selector) {
+				items = append(items, obj.Items[i])
+			}
+		}
+		obj.Items = items
+	case *v2.CiliumNodeList:
+		items := make([]v2.CiliumNode, 0, len(obj.Items))
 		for i := range obj.Items {
 			if matchFieldSelector(&obj.Items[i], selector) {
 				items = append(items, obj.Items[i])


### PR DESCRIPTION
It appears that during recent refactors, restoring cilium addresses from k8s node objects would only use k8s Node types.

However, in order to restore cilium_host router interface IP from k8s, the agent needs to find an IP of type CiliumInternalIP.

This type is only enumerated on CN types, not K8s Nodes so in it's current state all attempts to restore from k8s would return a nil IP.


```release-note
Fix issue where agent attempting to restore local node information (such as cilium_host ip) would fail on k8s fallback method.  
```
