### PR TITLE
plugins/cilium-cni: Install loopback atomically

### DIFF
--- a/plugins/cilium-cni/install-plugin.sh
+++ b/plugins/cilium-cni/install-plugin.sh
@@ -13,20 +13,23 @@ if [ ! -d "${CNI_DIR}/bin" ]; then
 	mkdir -p "${CNI_DIR}/bin"
 fi
 
+# Copy the binary and then rename so the move is atomic
+install_cni() {
+	src="$1"
+	bin_name="$(basename $src)"
+	tmp_dst="${CNI_DIR}/bin/.$bin_name.new"
+	dst="${CNI_DIR}/bin/$bin_name"
+
+	echo "Installing $bin_name to $dst ..."
+	cp $src $tmp_dst && \
+	mv $tmp_dst $dst && \
+	echo "Wrote $dst"
+}
+
 # Install the CNI loopback driver if not installed already
 if [ ! -f "${CNI_DIR}/bin/loopback" ]; then
-	echo "Installing loopback driver..."
-
 	# Don't fail hard if this fails as it is usually not required
-	cp /cni/loopback "${CNI_DIR}/bin/" || true
+	install_cni /cni/loopback || true
 fi
 
-echo "Installing ${BIN_NAME} to ${CNI_DIR}/bin/ ..."
-
-# Copy the binary, then do a rename
-# so the move is atomic
-rm -f "${CNI_DIR}/bin/${BIN_NAME}.new" || true
-cp "/opt/cni/bin/${BIN_NAME}" "${CNI_DIR}/bin/.${BIN_NAME}.new"
-mv "${CNI_DIR}/bin/.${BIN_NAME}.new" "${CNI_DIR}/bin/${BIN_NAME}"
-
-echo "wrote ${CNI_DIR}/bin/${BIN_NAME}"
+install_cni "/opt/cni/bin/${BIN_NAME}"


### PR DESCRIPTION
If copying of the loopback binary is interrupted, then a truncated version will exist on the node. The node can't recover from this state even if the pod is restarted because install-plugin.sh won't overwrite the existing loopback file.

To fix, install loopback atomically using a cp + mv.

This change also removes the unnecessary deletion of "${BIN_NAME}.new". This is a no-op because the temporary copy destination is prefixed with a dot: ".${BIN_NAME}.new".

Fixes: #29461

```release-note
Install loopback CNI atomically to protect against aborted copy
```
