### PR TITLE
docs: Drop references to Helm v2

### DIFF
--- a/Documentation/installation/k8s-install-download-release.rst
+++ b/Documentation/installation/k8s-install-download-release.rst
@@ -4,11 +4,6 @@
     Please use the official rendered version released here:
     https://docs.cilium.io
 
-.. note::
-
-   Make sure you have Helm 3 `installed <https://helm.sh/docs/intro/install/>`_.
-   Helm 2 is `no longer supported <https://helm.sh/blog/helm-v2-deprecation-timeline/>`_.
-
 .. only:: stable
 
    Setup Helm repository:


### PR DESCRIPTION
Helm v2 has been out of support for around three years now, no need to
continue to reference this outdated version in the docs.
