### PR TITLE
bgpv1: Use kube-system namespace by default for MD5 secret

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -267,7 +267,7 @@
    * - :spelling:ignore:`bgpControlPlane`
      - This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs.
      - object
-     - ``{"enabled":false,"secretsNamespace":{"create":true,"name":"cilium-bgp-secrets"}}``
+     - ``{"enabled":false,"secretsNamespace":{"create":false,"name":"kube-system"}}``
    * - :spelling:ignore:`bgpControlPlane.enabled`
      - Enables the BGP control plane.
      - bool
@@ -275,15 +275,15 @@
    * - :spelling:ignore:`bgpControlPlane.secretsNamespace`
      - SecretsNamespace is the namespace which BGP support will retrieve secrets from.
      - object
-     - ``{"create":true,"name":"cilium-bgp-secrets"}``
+     - ``{"create":false,"name":"kube-system"}``
    * - :spelling:ignore:`bgpControlPlane.secretsNamespace.create`
      - Create secrets namespace for BGP secrets.
      - bool
-     - ``true``
+     - ``false``
    * - :spelling:ignore:`bgpControlPlane.secretsNamespace.name`
      - The name of the secret namespace to which Cilium agents are given read access
      - string
-     - ``"cilium-bgp-secrets"``
+     - ``"kube-system"``
    * - :spelling:ignore:`bpf.authMapMax`
      - Configure the maximum number of entries in auth map.
      - int

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -116,11 +116,11 @@ contributors across the globe, there is almost always someone available to help.
 | bgp.announce.loadbalancerIP | bool | `false` | Enable allocation and announcement of service LoadBalancer IPs |
 | bgp.announce.podCIDR | bool | `false` | Enable announcement of node pod CIDR |
 | bgp.enabled | bool | `false` | Enable BGP support inside Cilium; embeds a new ConfigMap for BGP inside cilium-agent and cilium-operator |
-| bgpControlPlane | object | `{"enabled":false,"secretsNamespace":{"create":true,"name":"cilium-bgp-secrets"}}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs. |
+| bgpControlPlane | object | `{"enabled":false,"secretsNamespace":{"create":false,"name":"kube-system"}}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs. |
 | bgpControlPlane.enabled | bool | `false` | Enables the BGP control plane. |
-| bgpControlPlane.secretsNamespace | object | `{"create":true,"name":"cilium-bgp-secrets"}` | SecretsNamespace is the namespace which BGP support will retrieve secrets from. |
-| bgpControlPlane.secretsNamespace.create | bool | `true` | Create secrets namespace for BGP secrets. |
-| bgpControlPlane.secretsNamespace.name | string | `"cilium-bgp-secrets"` | The name of the secret namespace to which Cilium agents are given read access |
+| bgpControlPlane.secretsNamespace | object | `{"create":false,"name":"kube-system"}` | SecretsNamespace is the namespace which BGP support will retrieve secrets from. |
+| bgpControlPlane.secretsNamespace.create | bool | `false` | Create secrets namespace for BGP secrets. |
+| bgpControlPlane.secretsNamespace.name | string | `"kube-system"` | The name of the secret namespace to which Cilium agents are given read access |
 | bpf.authMapMax | int | `524288` | Configure the maximum number of entries in auth map. |
 | bpf.autoMount.enabled | bool | `true` | Enable automatic mount of BPF filesystem When `autoMount` is enabled, the BPF filesystem is mounted at `bpf.root` path on the underlying host and inside the cilium agent pod. If users disable `autoMount`, it's expected that users have mounted bpffs filesystem at the specified `bpf.root` volume, and then the volume will be mounted inside the cilium agent pod at the same path. |
 | bpf.ctAnyMax | int | `262144` | Configure the maximum number of entries for the non-TCP connection tracking table. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -412,9 +412,9 @@ bgpControlPlane:
   # -- SecretsNamespace is the namespace which BGP support will retrieve secrets from.
   secretsNamespace:
     # -- Create secrets namespace for BGP secrets.
-    create: true
+    create: false
     # -- The name of the secret namespace to which Cilium agents are given read access
-    name: cilium-bgp-secrets
+    name: kube-system
 
 pmtuDiscovery:
   # -- Enable path MTU discovery to send ICMP fragmentation-needed replies to

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -409,9 +409,9 @@ bgpControlPlane:
   # -- SecretsNamespace is the namespace which BGP support will retrieve secrets from.
   secretsNamespace:
     # -- Create secrets namespace for BGP secrets.
-    create: true
+    create: false
     # -- The name of the secret namespace to which Cilium agents are given read access
-    name: cilium-bgp-secrets
+    name: kube-system
 
 pmtuDiscovery:
   # -- Enable path MTU discovery to send ICMP fragmentation-needed replies to


### PR DESCRIPTION
Currently, BGP Control Plane uses cilium-bgp-secrets namespace by default to fetch MD5 password authentication. Also, if not specified, it creates a new namespace by default.

However, the rest of the cilium-related secrets such as cilium-ca, hubble certificates, or clustermesh certificates are in kube-system namespace. So, having a new namespace is inconsistent with rest of the system, and also inconvenient since users need to manage one more namespace.

This commit addresses the issue by changing the default value of `bgpControlPlane.secretNamespace.name` to `kube-system` and `bgpControlPlane.secretNamespace.create` to `false`. Users can always change the namespace if they wish to have an isolation.

I put `release-note/minor` because this BGP MD5 feature is only released in `v1.15-pre` releases.

```release-note
bgpv1: Use kube-system namespace by default for MD5 secret
```
