### PR TITLE
mountinfo: fix build on linux/386

### DIFF
--- a/pkg/mountinfo/mountinfo_linux.go
+++ b/pkg/mountinfo/mountinfo_linux.go
@@ -53,6 +53,6 @@ func IsMountFS(mntType int64, path string) (bool, bool, error) {
 		return true, false, &os.PathError{Op: "statfs", Path: path, Err: err}
 	}
 
-	return true, fst.Type == mntType, nil
+	return true, int64(fst.Type) == mntType, nil
 
 }


### PR DESCRIPTION
Due to a recent change cilium-cli started pulling in this package. We currently still build release binaries for linux/386, but these are failing with

    # github.com/cilium/cilium/pkg/mountinfo
    Error: ../../pkg/mountinfo/mountinfo_linux.go:56:27: invalid operation: fst.Type == mntType (mismatched types int32 and int64)

because fst.Type has a different type depending on GOARCH (e.g. int32 on linux/386). Fix this issue by converting fst.Type to int64 for comparison.

Related #16843