### PR TITLE
gh/workflows: Add lvh-kind action and use it in ci-e2e

### DIFF
--- a/.github/actions/lvh-kind/action.yaml
+++ b/.github/actions/lvh-kind/action.yaml
@@ -1,0 +1,42 @@
+name: K8s on LVH
+description: Creates K8s cluster inside LVH VM, and then exposes K8s cluster to GHA runner.
+
+inputs:
+  kernel:
+    required: true
+    type: string
+  kind-params:
+    required: true
+    type: string
+  test-name:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Provision LVH VMs
+      uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
+      with:
+        test-name: ${{ inputs.test-name }}
+        image-version: ${{ inputs.kernel }}
+        host-mount: ./
+        cpu: 4
+        install-dependencies: 'true'
+        port-forward: '6443:6443'
+        cmd: |
+          git config --global --add safe.directory /host
+
+    - name: Create K8s cluster
+      uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
+      with:
+        provision: 'false'
+        cmd: |
+          cd /host
+          ./contrib/scripts/kind.sh ${{ inputs.kind-params }} 0.0.0.0 6443
+
+    - name: Copy kubeconfig
+      shell: bash
+      run: |
+        mkdir ~/.kube
+        scp -o StrictHostKeyChecking=no -P 2222 root@localhost:/root/.kube/config ~/.kube/config

--- a/.github/actions/lvh-kind/action.yaml
+++ b/.github/actions/lvh-kind/action.yaml
@@ -22,6 +22,7 @@ runs:
         image-version: ${{ inputs.kernel }}
         host-mount: ./
         cpu: 4
+        mem: 12G
         install-dependencies: 'true'
         port-forward: '6443:6443'
         cmd: |

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -281,17 +281,22 @@ jobs:
           binary-name: cilium-cli
           binary-dir: ./
 
-      - name: Provision LVH VMs
-        uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
+      - name: Set Kind params
+        id: kind-params
+        shell: bash
+        run: |
+          IP_FAM="dual"
+          if [ "${{ matrix.ipv6 }}" == "false" ]; then
+            IP_FAM="ipv4"
+          fi
+          echo params="--xdp --secondary-network \"\" 3 \"\" \"\" ${{ matrix.kube-proxy }} $IP_FAM" >> $GITHUB_OUTPUT
+
+      - name: Provision K8s on LVH VM
+        uses: ./.github/actions/lvh-kind
         with:
           test-name: e2e-conformance
-          image-version: ${{ matrix.kernel }}
-          host-mount: ./
-          cpu: 4
-          mem: 12G
-          install-dependencies: 'true'
-          cmd: |
-            git config --global --add safe.directory /host
+          kernel: ${{ matrix.kernel }}
+          kind-params: "${{ steps.kind-params.outputs.params }}"
 
       - name: Wait for images to be available
         timeout-minutes: 30
@@ -301,73 +306,47 @@ jobs:
             until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
-      - name: Setup K8s cluster
-        uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
-
-            IP_FAM="dual"
-            if [ "${{ matrix.ipv6 }}" == "false" ]; then
-              IP_FAM="ipv4"
-            fi
-            ./contrib/scripts/kind.sh --xdp --secondary-network "" 3 "" "" "${{ matrix.kube-proxy }}" \$IP_FAM
-
-            kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
-
       - name: Install Cilium
-        uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
+        shell: bash
+        run: |
+          kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
 
-            export CILIUM_CLI_MODE=helm
-            ./cilium-cli install ${{ steps.cilium-config.outputs.config }}
-            kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-server --timeout=300s
-            kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-agent --timeout=300s
+          export CILIUM_CLI_MODE=helm
+          ./cilium-cli install ${{ steps.cilium-config.outputs.config }}
+          kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-server --timeout=300s
+          kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-agent --timeout=300s
 
-            ./cilium-cli status --wait
-            kubectl get pods --all-namespaces -o wide
-            kubectl -n kube-system exec daemonset/cilium -- cilium-dbg status
+          ./cilium-cli status --wait
+          kubectl get pods --all-namespaces -o wide
+          kubectl -n kube-system exec daemonset/cilium -- cilium-dbg status
 
-            mkdir -p cilium-junits
+          mkdir -p cilium-junits
 
       - name: Run tests
-        uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
+        shell: bash
+        run: |
+          EXTRA=""
+          if [ "${{ matrix.secondary-network }}" = "true" ]; then
+            EXTRA="--secondary-network-iface=eth1"
+          fi
 
-            EXTRA=""
-            if [ "${{ matrix.secondary-network }}" = "true" ]; then
-              EXTRA="--secondary-network-iface=eth1"
-            fi
-
-            ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-              --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
-              --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
-              --junit-property github_job_step="Run tests (${{ matrix.name }})" \
-              \$EXTRA
-
-            ./contrib/scripts/kind-down.sh
+          ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
+            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+            --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
+            --junit-property github_job_step="Run tests (${{ matrix.name }})" \
+            $EXTRA
 
       - name: Fetch artifacts
         if: ${{ !success() && steps.run-tests.outcome != 'skipped' }}
-        uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host
-            kubectl get pods --all-namespaces -o wide
-            ./cilium-cli status
-            mkdir -p cilium-sysdumps
-            ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
-            # To debug https://github.com/cilium/cilium/issues/26062
-            head -n -0 /proc/buddyinfo /proc/pagetypeinfo
+        shell: bash
+        run: |
+          kubectl get pods --all-namespaces -o wide
+          ./cilium-cli status
+          mkdir -p cilium-sysdumps
+          ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
+          # To debug https://github.com/cilium/cilium/issues/26062
+          head -n -0 /proc/buddyinfo /proc/pagetypeinfo
 
       - name: Upload artifacts
         if: ${{ !success() }}

--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -15,6 +15,8 @@ default_service_subnet=""
 default_agent_port_prefix="234"
 default_operator_port_prefix="235"
 default_network="kind-cilium"
+default_apiserver_addr="127.0.0.1"
+default_apiserver_port=0 # kind will randomly select
 secondary_network="${default_network}-secondary"
 
 PROG=${0}
@@ -42,6 +44,8 @@ cluster_name="${3:-${CLUSTER_NAME:=${default_cluster_name}}}"
 image="${4:-${IMAGE:=${default_image}}}"
 kubeproxy_mode="${5:-${KUBEPROXY_MODE:=${default_kubeproxy_mode}}}"
 ipfamily="${6:-${IPFAMILY:=${default_ipfamily}}}"
+apiserver_addr="${7:-${APISERVER_ADDR:=${default_apiserver_addr}}}"
+apiserver_port="${8:-${APISERVER_PORT:=${default_apiserver_port}}}"
 pod_subnet="${PODSUBNET:=${default_pod_subnet}}"
 service_subnet="${SERVICESUBNET:=${default_service_subnet}}"
 agent_port_prefix="${AGENTPORTPREFIX:=${default_agent_port_prefix}}"
@@ -56,7 +60,7 @@ v6_prefix_secondary="fc00:c112::/64"
 CILIUM_ROOT="$(git rev-parse --show-toplevel)"
 
 usage() {
-  echo "Usage: ${PROG} [--xdp] [--secondary-network] [control-plane node count] [worker node count] [cluster-name] [node image] [kube-proxy mode] [ip-family]"
+  echo "Usage: ${PROG} [--xdp] [--secondary-network] [control-plane node count] [worker node count] [cluster-name] [node image] [kube-proxy mode] [ip-family] [apiserver-addr] [apiserver-port]"
 }
 
 have_kind() {
@@ -79,7 +83,7 @@ if ! have_kubectl; then
     exit 1
 fi
 
-if [ ${#} -gt 6 ]; then
+if [ ${#} -gt 8 ]; then
   usage
   exit 1
 fi
@@ -163,6 +167,9 @@ networking:
   ipFamily: ${ipfamily}
   ${pod_subnet:+"podSubnet: "$pod_subnet}
   ${service_subnet:+"serviceSubnet: "$service_subnet}
+  apiServerAddress: ${apiserver_addr}
+  apiServerPort: ${apiserver_port}
+
 kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration


### PR DESCRIPTION
This will allow us to create more reusable workflows for testing. E.g., ci-ipsec-e2e will be reused by ci-eks, ci-aks, etc.