### PR TITLE
endpoint: avoid an unnecessary error log

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -307,7 +307,9 @@ func (e *Endpoint) setDesiredPolicy(res *policyGenerateResult) error {
 	if res == nil {
 		if e.SecurityIdentity != nil {
 			e.getLogger().Info("Endpoint SecurityIdentity changed during policy regeneration")
-			return fmt.Errorf("endpoint %d SecurityIdentity changed during policy regeneration", e.ID)
+			// Wrap context.Cancelled here, so that the upper layers have a signal that
+			// this failure is a cancellation, not an error.
+			return fmt.Errorf("endpoint %d SecurityIdentity changed during policy regeneration: %w", e.ID, context.Canceled)
 		}
 
 		return nil
@@ -315,7 +317,9 @@ func (e *Endpoint) setDesiredPolicy(res *policyGenerateResult) error {
 	// if the security identity changed, reject the policy computation
 	if e.identityRevision != res.identityRevision {
 		e.getLogger().Info("Endpoint SecurityIdentity changed during policy regeneration")
-		return fmt.Errorf("endpoint %d SecurityIdentity changed during policy regeneration", e.ID)
+		// Wrap context.Cancelled here, so that the upper layers have a signal that this
+		// failure is a cancellation, not an error.
+		return fmt.Errorf("endpoint %d SecurityIdentity changed during policy regeneration: %w", e.ID, context.Canceled)
 	}
 
 	// Set the revision of this endpoint to the current revision of the policy


### PR DESCRIPTION
If the endpoint policy regeneration is interrupted because the SecurityIdentity changed or the endpoint revision doesn't match the code's expectation, the agent would log an error. Specifically, the log-line would say (abbreviated for clarity):

level=error msg="endpoint regeneration failed" error="endpoint 42 SecurityIdentity changed during policy regeneration"

This is misleading, as this does _not_ signify a problem with endpoint regeneration. If this interruption occurs, we simply give up on the current attempt, but will retry.

This patch does so by wrapping the context.Cancelled error in the returned error. That way, the upper layers can check with errors.Is(err, context.Cancelled) whether we hit this condition, and act accordingly.

