### PR TITLE
ariane: Disable ci-e2e-upgrade

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -18,7 +18,6 @@ triggers:
     - tests-clustermesh-upgrade.yaml
     - tests-datapath-verifier.yaml
     - tests-l4lb.yaml
-    - tests-e2e-upgrade.yaml
     - tests-ipsec-upgrade.yaml
   /ci-aks:
     workflows:


### PR DESCRIPTION
Two issues are nagging us (investigations are WIP):

* allow-all-except-world
* no-missed-tail-calls

Once they have been resolved, we can re-enable the GHA.