### PR TITLE
ci: Bump up the memory of LVH in conformance-e2e

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -288,6 +288,7 @@ jobs:
           image-version: ${{ matrix.kernel }}
           host-mount: ./
           cpu: 4
+          mem: 12G
           install-dependencies: 'true'
           cmd: |
             git config --global --add safe.directory /host


### PR DESCRIPTION
There have been some failures with out-of-memory in conformance-e2e. Bump up the memory to 12G to fix that.