### PR TITLE
Make logging.InitializeDefaultLogger private

### DIFF
--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/cilium/checkmate"
 	"github.com/sirupsen/logrus"
 
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
@@ -26,7 +27,10 @@ func (s *EndpointSuite) TestEndpointLogFormat(c *C) {
 	c.Assert(ok, Equals, true)
 
 	// Log format is JSON when configured
-	option.Config.LogOpt["format"] = "json"
+	logging.SetLogFormat(logging.LogFormatJSON)
+	defer func() {
+		logging.SetLogFormat(logging.LogFormatText)
+	}()
 	do = &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
 	ep = NewEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -41,7 +41,7 @@ const (
 
 // DefaultLogger is the base logrus logger. It is different from the logrus
 // default to avoid external dependencies from writing out unexpectedly
-var DefaultLogger = InitializeDefaultLogger()
+var DefaultLogger = initializeDefaultLogger()
 
 func initializeKLog() {
 	log := DefaultLogger.WithField(logfields.LogSubsys, "klog")
@@ -73,8 +73,9 @@ func initializeKLog() {
 // LogOptions maps configuration key-value pairs related to logging.
 type LogOptions map[string]string
 
-// InitializeDefaultLogger returns a logrus Logger with a custom text formatter.
-func InitializeDefaultLogger() (logger *logrus.Logger) {
+// initializeDefaultLogger returns a logrus Logger with the default logging
+// settings.
+func initializeDefaultLogger() (logger *logrus.Logger) {
 	logger = logrus.New()
 	logger.SetFormatter(GetFormatter(DefaultLogFormat))
 	logger.SetLevel(DefaultLogLevel)

--- a/test/controlplane/suite/flags.go
+++ b/test/controlplane/suite/flags.go
@@ -20,5 +20,4 @@ func ParseFlags() {
 	if *FlagDebug {
 		logging.SetLogLevelToDebug()
 	}
-	logging.InitializeDefaultLogger()
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

This PR renames the function `logging.InitializeDefaultLogger` to `logging.initializeDefaultLogger` in order to make it private to the logging module. This function should only be used to initialize the `logging.DefaultLogger` variable, and should not be used by users as a parent logger. This is because the logger returned by `logging.InitializeDefaultLogger` will always use the hard-coded default logging settings, while `logging.DefaultLogger` is adjusted based on the user configuration.

The changes in `pkg/endpoint/log.go` remove the use of `logging.InitializeDefaultLogger` while also fixing #29215.

Fixes: #29215

```release-note
Fix bug preventing endpoint-related debug logs from being emitted
```
