### PR TITLE
tests-e2e-upgrade: Use CILIUM_CLI_VERSION

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -51,8 +51,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # renovate: datasource=github-releases depName=cilium/cilium-cli
-  cilium_cli_version: v0.15.16
   cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   # renovate: datasource=docker depName=quay.io/cilium/kindest-node
@@ -299,7 +297,7 @@ jobs:
         uses: cilium/cilium-cli@beceead2bece1d174e2c11f36e6bfac8ce3f8e7d # v0.15.16
         with:
           repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
-          release-version: ${{ env.cilium_cli_version }}
+          release-version: ${{ env.CILIUM_CLI_VERSION }}
           ci-version: ${{ env.cilium_cli_ci_version }}
           binary-name: cilium-cli
           binary-dir: ./


### PR DESCRIPTION
Looks like #29237 missed tests-e2e-upgrade.yaml.

Fixes: 42e1a4a129b9 ("workflows: move cilium_cli_version definition to set-env-variables action")