### PR TITLE
bpf: ct: simplify create & lookup code flow

### DIFF
--- a/bpf/tests/conntrack_test.c
+++ b/bpf/tests/conntrack_test.c
@@ -112,7 +112,6 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		if (!entry)
 			test_fatal("ct entry lookup failed");
 
-		struct ct_state ct_state;
 		union tcp_flags seen_flags = {0};
 		__u32 monitor;
 
@@ -121,7 +120,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		/* First packet is monitored */
 		entry = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				    ct_tcp_select_action(seen_flags), CT_INGRESS,
-				    CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				    CT_ENTRY_ANY, true, seen_flags, &monitor);
 		assert(entry);
 		assert(monitor == TRACE_PAYLOAD_LEN);
 		assert(timeout_in(entry, CT_SYN_TIMEOUT));
@@ -132,7 +131,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		advance_time();
 		entry = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				    ct_tcp_select_action(seen_flags), CT_INGRESS,
-				    CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				    CT_ENTRY_ANY, true, seen_flags, &monitor);
 		assert(entry);
 		assert(monitor == 0);
 		assert(timeout_in(entry, CT_SYN_TIMEOUT));
@@ -142,7 +141,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value &= ~TCP_FLAG_SYN;
 		entry = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				    ct_tcp_select_action(seen_flags), CT_INGRESS,
-				    CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				    CT_ENTRY_ANY, true, seen_flags, &monitor);
 		assert(entry);
 		assert(monitor == 0);
 		assert(timeout_in(entry, CT_CONNECTION_LIFETIME_TCP));
@@ -152,7 +151,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value |= TCP_FLAG_FIN;
 		entry = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				    ct_tcp_select_action(seen_flags), CT_INGRESS,
-				    CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				    CT_ENTRY_ANY, true, seen_flags, &monitor);
 		assert(entry);
 		assert(monitor == TRACE_PAYLOAD_LEN);
 		assert(timeout_in(entry, CT_CONNECTION_LIFETIME_TCP));
@@ -162,7 +161,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value &= ~TCP_FLAG_FIN;
 		entry = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				    ct_tcp_select_action(seen_flags), CT_INGRESS,
-				    CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				    CT_ENTRY_ANY, true, seen_flags, &monitor);
 		assert(entry);
 		assert(monitor == 0);
 		assert(timeout_in(entry, CT_CONNECTION_LIFETIME_TCP));
@@ -175,7 +174,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value |= TCP_FLAG_FIN;
 		entry = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				    ct_tcp_select_action(seen_flags), CT_EGRESS,
-				    CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				    CT_ENTRY_ANY, true, seen_flags, &monitor);
 		assert(entry);
 		assert(monitor == TRACE_PAYLOAD_LEN);
 		assert(timeout_in(entry, CT_CLOSE_TIMEOUT));
@@ -186,7 +185,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value &= ~TCP_FLAG_FIN;
 		entry = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				    ct_tcp_select_action(seen_flags), CT_EGRESS,
-				    CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				    CT_ENTRY_ANY, true, seen_flags, &monitor);
 		assert(entry);
 		assert(monitor == 0);
 		assert(timeout_in(entry, CT_CLOSE_TIMEOUT - 1));
@@ -197,7 +196,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value = TCP_FLAG_SYN;
 		entry = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				    ct_tcp_select_action(seen_flags), CT_EGRESS,
-				    CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				    CT_ENTRY_ANY, true, seen_flags, &monitor);
 		assert(entry);
 		assert(ct_entry_closing(entry));
 		assert(monitor == TRACE_PAYLOAD_LEN);
@@ -208,7 +207,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value = TCP_FLAG_SYN;
 		entry = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				    ct_tcp_select_action(seen_flags), CT_INGRESS,
-				    CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				    CT_ENTRY_ANY, true, seen_flags, &monitor);
 		assert(!entry);
 		assert(monitor == TRACE_PAYLOAD_LEN);
 	});


### PR DESCRIPTION
For both CT entry creation and CT lookup we currently allow a `ct_state` parameter, which provides detailed information about the CT entry. But some callers don't need this level of detail. Simplify these callers by making the `ct_state` parameter optional.

Also start to de-duplicate the __ct_lookup() path, so we can trust that only the strictly needed parts are included twice.