### PR TITLE
ci: fix dns issue when pulling cilium-docker-plugin in ci-runtime

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -332,7 +332,6 @@ jobs:
             export VMUSER=root
             echo '127.0.0.1 localhost' >> /etc/hosts
             echo '::1 localhost' >> /etc/hosts
-            sed -i '1s/^/nameserver 1.1.1.1\n/' /etc/resolv.conf
             /tmp/provision/runtime_install.sh
             service docker restart
 

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -17,6 +17,19 @@ sudo systemctl restart ssh
 
 "${PROVISIONSRC}"/dns.sh
 
+sudo systemctl status systemd-resolved.service || true
+# Remove symlinked resolv.conf to systemd-resolved
+rm /etc/resolv.conf
+# Remove systemd-resolvd resolv.conf to avoid being read by docker
+rm /run/systemd/resolve/stub-resolv.conf || true
+# Explicitly set nameserver 1.1.1.1 for runtime tests
+# to avoid chases with Cilium DNS
+echo "nameserver 1.1.1.1" > /etc/resolv.conf
+cat /etc/resolv.conf
+
+# Restarting docker to use correct nameserver
+service docker restart
+
 if [[ "${PROVISION_EXTERNAL_WORKLOAD}" == "false" ]]; then
     "${PROVISIONSRC}"/compile.sh
     "${PROVISIONSRC}"/wait-cilium-in-docker.sh


### PR DESCRIPTION
It seems that even though we're setting the nameserver at the top of `/etc/resolv.conf` (#29455), in some cases docker still uses 127.0.0.53 to resolve names while pulling the cilium docker plugin in the ci-runtime test (e.g. https://github.com/cilium/cilium/actions/runs/7044583579/job/19172666548).

[In one specific test-run](https://github.com/cilium/cilium/actions/runs/7043951835/job/19170888281) even if `etc/resolv.conf` only contains nameserver 1.1.1.1.

It seems as docker tries to use nameserver information from `systemd-resolved`.

Therefore, this commit tries to force docker to use the nameserver 1.1.1.1, by removing the resolv.conf symlink, deleting the resolv.conf from systemd-resolved and restarting the docker service after applying the changes.

Follow up of https://github.com/cilium/cilium/pull/29455