### PR TITLE
[v1.14] bpf: Fix identity determination in bpf_overlay.c

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -750,6 +750,7 @@ static __always_inline __u32 or_encrypt_key(__u8 key)
 #define TC_INDEX_F_SKIP_NODEPORT	4
 #define TC_INDEX_F_SKIP_RECIRCULATION	8
 #define TC_INDEX_F_SKIP_HOST_FIREWALL	16
+#define TC_INDEX_F_IS_DSR	32
 
 /*
  * For use in ctx_{load,store}_meta(), which operates on sk_buff->cb or

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -772,6 +772,9 @@ create_ct:
 	}
 
 	ctx_skip_nodeport_set(ctx);
+#if defined(IS_BPF_OVERLAY) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+	ctx_is_dsr_set(ctx);
+#endif
 	ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_NETDEV);
 	ret = DROP_MISSED_TAIL_CALL;
 
@@ -2231,6 +2234,9 @@ create_ct:
 
 	/* Recircle, so packet can continue on its way to the local backend: */
 	ctx_skip_nodeport_set(ctx);
+#if defined(IS_BPF_OVERLAY) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+	ctx_is_dsr_set(ctx);
+#endif
 	ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_NETDEV);
 	ret = DROP_MISSED_TAIL_CALL;
 

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -145,6 +145,35 @@ ctx_skip_host_fw(struct __sk_buff *ctx)
 }
 #endif /* ENABLE_HOST_FIREWALL */
 
+static __always_inline __maybe_unused void
+ctx_is_dsr_clear(struct __sk_buff *ctx __maybe_unused)
+{
+#if defined(ENABLE_DSR) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+	ctx->tc_index &= ~TC_INDEX_F_IS_DSR;
+#endif
+}
+
+static __always_inline __maybe_unused void
+ctx_is_dsr_set(struct __sk_buff *ctx __maybe_unused)
+{
+#if defined(ENABLE_DSR) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+	ctx->tc_index |= TC_INDEX_F_IS_DSR;
+#endif
+}
+
+static __always_inline __maybe_unused bool
+ctx_is_dsr(struct __sk_buff *ctx __maybe_unused)
+{
+#if defined(ENABLE_DSR) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+	volatile __u32 tc_index = ctx->tc_index;
+
+	ctx->tc_index &= ~TC_INDEX_F_IS_DSR;
+	return tc_index & TC_INDEX_F_IS_DSR;
+#else
+	return false;
+#endif
+}
+
 static __always_inline __maybe_unused __u32 ctx_get_xfer(struct __sk_buff *ctx,
 							 __u32 off)
 {


### PR DESCRIPTION
This PR is the custom backport for v1.14.
Upstream commit: 895630ba293dc0e40197bbc23ce188ba1557f27f

When DSR with Geneve is enabled, Cilium identity is not determined by the client's IP address and requests from outside cluster are dropped even though they are permitted by CiliumNetworkPolicy using `fromCIDR`.

This commit inputs identity that is from the client IP address.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #29153

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
