### PR TITLE
k8s: Fix envoyConfig description on CNP/CCNP CRDs

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -368,7 +368,7 @@ spec:
                             properties:
                               envoyConfig:
                                 description: EnvoyConfig is a reference to the CEC
-                                  or CCNP resource in which the listener is defined.
+                                  or CCEC resource in which the listener is defined.
                                 properties:
                                   kind:
                                     description: Kind is the resource type being referred
@@ -1737,7 +1737,7 @@ spec:
                             properties:
                               envoyConfig:
                                 description: EnvoyConfig is a reference to the CEC
-                                  or CCNP resource in which the listener is defined.
+                                  or CCEC resource in which the listener is defined.
                                 properties:
                                   kind:
                                     description: Kind is the resource type being referred
@@ -2900,7 +2900,7 @@ spec:
                               properties:
                                 envoyConfig:
                                   description: EnvoyConfig is a reference to the CEC
-                                    or CCNP resource in which the listener is defined.
+                                    or CCEC resource in which the listener is defined.
                                   properties:
                                     kind:
                                       description: Kind is the resource type being
@@ -4290,7 +4290,7 @@ spec:
                               properties:
                                 envoyConfig:
                                   description: EnvoyConfig is a reference to the CEC
-                                    or CCNP resource in which the listener is defined.
+                                    or CCEC resource in which the listener is defined.
                                   properties:
                                     kind:
                                       description: Kind is the resource type being

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -372,7 +372,7 @@ spec:
                             properties:
                               envoyConfig:
                                 description: EnvoyConfig is a reference to the CEC
-                                  or CCNP resource in which the listener is defined.
+                                  or CCEC resource in which the listener is defined.
                                 properties:
                                   kind:
                                     description: Kind is the resource type being referred
@@ -1741,7 +1741,7 @@ spec:
                             properties:
                               envoyConfig:
                                 description: EnvoyConfig is a reference to the CEC
-                                  or CCNP resource in which the listener is defined.
+                                  or CCEC resource in which the listener is defined.
                                 properties:
                                   kind:
                                     description: Kind is the resource type being referred
@@ -2904,7 +2904,7 @@ spec:
                               properties:
                                 envoyConfig:
                                   description: EnvoyConfig is a reference to the CEC
-                                    or CCNP resource in which the listener is defined.
+                                    or CCEC resource in which the listener is defined.
                                   properties:
                                     kind:
                                       description: Kind is the resource type being
@@ -4294,7 +4294,7 @@ spec:
                               properties:
                                 envoyConfig:
                                   description: EnvoyConfig is a reference to the CEC
-                                    or CCNP resource in which the listener is defined.
+                                    or CCEC resource in which the listener is defined.
                                   properties:
                                     kind:
                                       description: Kind is the resource type being

--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -139,7 +139,7 @@ type EnvoyConfig struct {
 
 // Listener defines a reference to an Envoy listener specified in a CEC or CCEC resource.
 type Listener struct {
-	// EnvoyConfig is a reference to the CEC or CCNP resource in which
+	// EnvoyConfig is a reference to the CEC or CCEC resource in which
 	// the listener is defined.
 	//
 	// +kubebuilder:validation:Required


### PR DESCRIPTION
Fixes a typo on the `envoyConfig` description of `CiliumNetworkPolicy` and `CiliumClusterwideNetworkPolicy` K8s CRDs definitions.