### PR TITLE
envoy: perform version check directly on envoy binary (not starter)

### DIFF
--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -22,7 +22,6 @@ import (
 	envoy_config_endpoint "github.com/cilium/proxy/go/envoy/config/endpoint/v3"
 	envoy_extensions_bootstrap_internal_listener_v3 "github.com/cilium/proxy/go/envoy/extensions/bootstrap/internal_listener/v3"
 	envoy_config_upstream "github.com/cilium/proxy/go/envoy/extensions/upstreams/http/v3"
-
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -56,7 +55,8 @@ var (
 )
 
 const (
-	ciliumEnvoy = "cilium-envoy-starter"
+	ciliumEnvoyStarter = "cilium-envoy-starter"
+	ciliumEnvoy        = "cilium-envoy"
 )
 
 // EnableTracing changes Envoy log level to "trace", producing the most logs.
@@ -118,7 +118,7 @@ func startEmbeddedEnvoy(runDir, logPath string, baseID uint64) (*EmbeddedEnvoy, 
 				Filename:   logPath,
 				MaxSize:    100, // megabytes
 				MaxBackups: 3,
-				MaxAge:     28,   //days
+				MaxAge:     28,   // days
 				Compress:   true, // disabled by default
 			}
 			logWriter = logger
@@ -137,7 +137,7 @@ func startEmbeddedEnvoy(runDir, logPath string, baseID uint64) (*EmbeddedEnvoy, 
 
 		for {
 			logLevel := logging.GetLevel(logging.DefaultLogger)
-			cmd := exec.Command(ciliumEnvoy, "-l", mapLogLevel(logLevel), "-c", bootstrapPath, "--base-id", strconv.FormatUint(baseID, 10), "--log-format", logFormat)
+			cmd := exec.Command(ciliumEnvoyStarter, "-l", mapLogLevel(logLevel), "-c", bootstrapPath, "--base-id", strconv.FormatUint(baseID, 10), "--log-format", logFormat)
 			cmd.Stderr = logWriter
 			cmd.Stdout = logWriter
 
@@ -156,7 +156,7 @@ func startEmbeddedEnvoy(runDir, logPath string, baseID uint64) (*EmbeddedEnvoy, 
 			}
 
 			log.Infof("Envoy: Proxy started with pid %d", cmd.Process.Pid)
-			metrics.SubprocessStart.WithLabelValues(ciliumEnvoy).Inc()
+			metrics.SubprocessStart.WithLabelValues(ciliumEnvoyStarter).Inc()
 
 			// We do not return after a successful start, but watch the Envoy process
 			// and restart it if it crashes.
@@ -393,7 +393,8 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 									Endpoint: &envoy_config_endpoint.Endpoint{
 										Address: &envoy_config_core.Address{
 											Address: &envoy_config_core.Address_Pipe{
-												Pipe: &envoy_config_core.Pipe{Path: xdsSock}},
+												Pipe: &envoy_config_core.Pipe{Path: xdsSock},
+											},
 										},
 									},
 								},
@@ -415,7 +416,8 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 									Endpoint: &envoy_config_endpoint.Endpoint{
 										Address: &envoy_config_core.Address{
 											Address: &envoy_config_core.Address_Pipe{
-												Pipe: &envoy_config_core.Pipe{Path: adminPath}},
+												Pipe: &envoy_config_core.Pipe{Path: adminPath},
+											},
 										},
 									},
 								},


### PR DESCRIPTION
With the introduction of the envoy starter (#27498), the Envoy version check of the embedded mode calls out to the starter binary instead of the envoy binary directly.

Depending on the permissions the agent runs with, the capabilities check within the starter might fail.

To prevent unexpected errors, this commit re-introduces that the Envoy version check is performed on the Envoy binary directly.