### PR TITLE
ci-ipsec-{e2e,upgrade}: Use lvh-kind

### DIFF
--- a/.github/actions/conn-disrupt-test/action.yaml
+++ b/.github/actions/conn-disrupt-test/action.yaml
@@ -16,34 +16,26 @@ runs:
   using: composite
   steps:
     - name: Setup Conn Disrupt Test
-      uses: cilium/little-vm-helper@0fcaa3fed17811fcd8b6f1b0dc1f24e5f4ff6b13 # v0.0.7
-      with:
-        provision: 'false'
-        cmd: |
-          cd /host/
-          # Create pods which establish long lived connections. It will be used by
-          # subsequent connectivity tests with --include-conn-disrupt-test to catch any
-          # interruption in such flows.
-          ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup
+      shell: bash
+      run: |
+        # Create pods which establish long lived connections. It will be used by
+        # subsequent connectivity tests with --include-conn-disrupt-test to catch any
+        # interruption in such flows.
+        ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup
 
     - name: Operate Cilium
-      uses: cilium/little-vm-helper@0fcaa3fed17811fcd8b6f1b0dc1f24e5f4ff6b13 # v0.0.7
-      with:
-        provision: 'false'
-        cmd: |
-          ${{ inputs.operation-cmd }}
+      shell: bash
+      run: |
+        ${{ inputs.operation-cmd }}
 
     - name: Perform Conn Disrupt Test
-      uses: cilium/little-vm-helper@0fcaa3fed17811fcd8b6f1b0dc1f24e5f4ff6b13 # v0.0.7
-      with:
-        provision: 'false'
-        cmd: |
-          cd /host/
-          ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-            --include-conn-disrupt-test \
-            --flush-ct \
-            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-            --sysdump-output-filename "cilium-sysdump-${{ inputs.job-name }}-<ts>" \
-            --junit-file "cilium-junits/${{ inputs.job-name }}.xml" \
-            ${{ inputs.extra-connectivity-test-flags }} \
-            --junit-property github_job_step="Run conn disrupt tests (${{ inputs.job-name }})"
+      shell: bash
+      run: |
+        ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+          --include-conn-disrupt-test \
+          --flush-ct \
+          --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
+          --sysdump-output-filename "cilium-sysdump-${{ inputs.job-name }}-<ts>" \
+          --junit-file "cilium-junits/${{ inputs.job-name }}.xml" \
+          ${{ inputs.extra-connectivity-test-flags }} \
+          --junit-property github_job_step="Run conn disrupt tests (${{ inputs.job-name }})"

--- a/.github/actions/lvh-kind/action.yaml
+++ b/.github/actions/lvh-kind/action.yaml
@@ -8,6 +8,8 @@ inputs:
   kind-params:
     required: true
     type: string
+  kind-image-vsn:
+    type: string
   test-name:
     required: true
     type: string
@@ -34,6 +36,9 @@ runs:
         provision: 'false'
         cmd: |
           cd /host
+          if [ "${{ inputs.kind-image-vsn }}" != "" ]; then
+            export IMAGE=quay.io/cilium/kindest-node:${{ inputs.kind-image-vsn }}
+          fi
           ./contrib/scripts/kind.sh ${{ inputs.kind-params }} 0.0.0.0 6443
 
     - name: Copy kubeconfig

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -292,7 +292,7 @@ jobs:
           echo params="--xdp --secondary-network \"\" 3 \"\" \"\" ${{ matrix.kube-proxy }} $IP_FAM" >> $GITHUB_OUTPUT
 
       - name: Provision K8s on LVH VM
-        uses: ./.github/actions/lvh-kind
+        uses: cilium/cilium/.github/actions/lvh-kind@main
         with:
           test-name: e2e-conformance
           kernel: ${{ matrix.kernel }}

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -224,16 +224,22 @@ jobs:
           binary-name: cilium-cli
           binary-dir: ./
 
-      - name: Provision LVH VMs
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
+      - name: Set Kind params
+        id: kind-params
+        shell: bash
+        run: |
+          IP_FAM="dual"
+          if [ "${{ matrix.ipv6 }}" == "false" ]; then
+            IP_FAM="ipv4"
+          fi
+          echo params="--xdp --secondary-network \"\" 3 \"\" \"\" ${{ matrix.kube-proxy }} $IP_FAM" >> $GITHUB_OUTPUT
+
+      - name: Provision K8s on LVH VM
+        uses: cilium/cilium/.github/actions/lvh-kind@main
         with:
           test-name: e2e-conformance
-          image-version: ${{ matrix.kernel }}
-          host-mount: ./
-          cpu: 4
-          install-dependencies: 'true'
-          cmd: |
-            git config --global --add safe.directory /host
+          kernel: ${{ matrix.kernel }}
+          kind-params: "${{ steps.kind-params.outputs.params }}"
 
       - name: Wait for images to be available
         timeout-minutes: 30
@@ -244,82 +250,72 @@ jobs:
           done
 
       - name: Run tests (${{ join(matrix.*, ', ') }})
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
-            ./contrib/scripts/kind.sh --xdp "" 3 "" "" "${{ matrix.kube-proxy }}" "dual"
+        shell: bash
+        run: |
+          kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
+          kubectl create -n kube-system secret generic cilium-ipsec-keys \
+            --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 
-            kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
-            kubectl create -n kube-system secret generic cilium-ipsec-keys \
-              --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
+          export CILIUM_CLI_MODE=helm
+          ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }}
+          kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-server --timeout=300s
+          kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-agent --timeout=300s
 
-            export CILIUM_CLI_MODE=helm
-            ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }}
-            kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-server --timeout=300s
-            kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-agent --timeout=300s
+          ./cilium-cli status --wait
+          kubectl get pods --all-namespaces -o wide
+          kubectl -n kube-system exec daemonset/cilium -- cilium-dbg status
 
-            ./cilium-cli status --wait
-            kubectl get pods --all-namespaces -o wide
-            kubectl -n kube-system exec daemonset/cilium -- cilium-dbg status
+          mkdir -p cilium-junits
 
-            mkdir -p cilium-junits
-
-            ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-              --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
-              --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
-              --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-              --flush-ct
+          ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
+            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+            --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
+            --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
+            --flush-ct
 
       - name: Rotate IPsec Key & Test (${{ join(matrix.*, ', ') }})
         uses: cilium/cilium/.github/actions/conn-disrupt-test@main
         with:
           job-name: conformance-ipsec-e2e-key-rotation-${{ matrix.name }}
           operation-cmd: |
-            cd /host/
-
-            KEYID=\$(kubectl get secret -n kube-system cilium-ipsec-keys -o go-template --template={{.data.keys}} | base64 -d | cut -c 1)
-            if [[ \$KEYID -ge 15 ]]; then KEYID=0; fi
-            data=\$(echo "{\"stringData\":{\"keys\":\"\$(((\$KEYID+1))) "rfc4106\(gcm\(aes\)\)" 59f4d92cccede1b1abc920104ca61cd552782e12 128\"}}")
-            kubectl patch secret -n kube-system cilium-ipsec-keys -p="\$data" -v=1
+            KEYID=$(kubectl get secret -n kube-system cilium-ipsec-keys -o go-template --template={{.data.keys}} | base64 -d | cut -c 1)
+            if [[ $KEYID -ge 15 ]]; then KEYID=0; fi
+            data=$(echo "{\"stringData\":{\"keys\":\"$((($KEYID+1))) "rfc4106\(gcm\(aes\)\)" 59f4d92cccede1b1abc920104ca61cd552782e12 128\"}}")
+            kubectl patch secret -n kube-system cilium-ipsec-keys -p="$data" -v=1
 
             # Wait until key rotation starts
             while true; do
-              keys_in_use=\$(kubectl -n kube-system exec daemonset/cilium -- cilium-dbg encrypt status | awk '/Keys in use/ {print \$NF}')
-              if [[ \$keys_in_use == 2 ]]; then
+              keys_in_use=$(kubectl -n kube-system exec daemonset/cilium -- cilium-dbg encrypt status | awk '/Keys in use/ {print $NF}')
+              if [[ $keys_in_use == 2 ]]; then
                 break
               fi
-              echo "Waiting until key rotation starts (seeing \$keys_in_use keys)"
+              echo "Waiting until key rotation starts (seeing $keys_in_use keys)"
               sleep 30s
             done
 
             # Wait until key rotation completes
             # By default the key rotation cleanup delay is 5min, let's sleep 4min before actively polling
-            sleep \$((4*60))
+            sleep $((4*60))
             while true; do
-              keys_in_use=\$(kubectl -n kube-system exec daemonset/cilium -- cilium-dbg encrypt status | awk '/Keys in use/ {print \$NF}')
-              if [[ \$keys_in_use == 1 ]]; then
+              keys_in_use=$(kubectl -n kube-system exec daemonset/cilium -- cilium-dbg encrypt status | awk '/Keys in use/ {print $NF}')
+              if [[ $keys_in_use == 1 ]]; then
                 break
               fi
-              echo "Waiting until key rotation completes (seeing \$keys_in_use keys)"
+              echo "Waiting until key rotation completes (seeing $keys_in_use keys)"
               sleep 30s
             done
 
       - name: Fetch artifacts
         if: ${{ !success() }}
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host
-            kubectl get pods --all-namespaces -o wide
-            ./cilium-cli status
-            mkdir -p cilium-sysdumps
-            ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
-            # To debug https://github.com/cilium/cilium/issues/26062
-            head -n -0 /proc/buddyinfo /proc/pagetypeinfo
+        shell: bash
+        run: |
+          kubectl get pods --all-namespaces -o wide
+          ./cilium-cli status
+          mkdir -p cilium-sysdumps
+          ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
+          # To debug https://github.com/cilium/cilium/issues/26062
+          head -n -0 /proc/buddyinfo /proc/pagetypeinfo
 
       - name: Upload artifacts
         if: ${{ !success() }}

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -238,38 +238,24 @@ jobs:
           binary-name: cilium-cli
           binary-dir: ./
 
-      - name: Provision LVH VMs
+      - name: Set Kind params
+        id: kind-params
+        shell: bash
+        run: |
+          IP_FAM="dual"
+          if [ "${{ matrix.ipv6 }}" == "false" ]; then
+            IP_FAM="ipv4"
+          fi
+          echo params="\"\" 3 \"\" \"\" ${{ matrix.kube-proxy }} $IP_FAM" >> $GITHUB_OUTPUT
+
+      - name: Provision K8s on LVH VM
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
+        uses: cilium/cilium/.github/actions/lvh-kind@main
         with:
-          test-name: ipsec-upgrade
-          image-version: ${{ matrix.kernel }}
-          host-mount: ./
-          cpu: 4
-          mem: '12G'
-          install-dependencies: 'true'
-          cmd: |
-            git config --global --add safe.directory /host
-
-      - name: Setup K8s cluster (${{ matrix.name }})
-        if: ${{ steps.vars.outputs.downgrade_version != '' }}
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
-
-            IP_FAM="dual"
-            if [ "${{ matrix.ipv6 }}" == "false" ]; then
-              IP_FAM="ipv4"
-            fi
-            IMAGE=quay.io/cilium/kindest-node:${k8s_version} ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}" \$IP_FAM
-
-            kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
-            kubectl create -n kube-system secret generic cilium-ipsec-keys \
-                --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
-
-            mkdir -p cilium-junits
+          test-name: e2e-conformance
+          kernel: ${{ matrix.kernel }}
+          kind-params: "${{ steps.kind-params.outputs.params }}"
+          kind-image-vsn: ${k8s_version}
 
       - name: Wait for images to be available
         timeout-minutes: 30
@@ -281,32 +267,30 @@ jobs:
 
       - name: Install Cilium ${{ steps.vars.outputs.downgrade_version }} (${{ matrix.name }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
+        shell: bash
+        run: |
+          kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
+          kubectl create -n kube-system secret generic cilium-ipsec-keys \
+              --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 
-            CILIUM_CLI_MODE=helm ./cilium-cli install \
-              ${{ steps.cilium-stable-config.outputs.config }}
+          mkdir -p cilium-junits
 
-            ./cilium-cli status --wait
-            kubectl get pods --all-namespaces -o wide
-            # TODO: After Cilium 1.15 release, update to cilium-dbg
-            kubectl -n kube-system exec daemonset/cilium -- cilium status
+          CILIUM_CLI_MODE=helm ./cilium-cli install \
+            ${{ steps.cilium-stable-config.outputs.config }}
+
+          ./cilium-cli status --wait
+          kubectl get pods --all-namespaces -o wide
+          # TODO: After Cilium 1.15 release, update to cilium-dbg
+          kubectl -n kube-system exec daemonset/cilium -- cilium status
 
       - name: Start conn-disrupt-test
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
-
-            # Create pods which establish long lived connections. It will be used by
-            # subsequent connectivity tests with --include-conn-disrupt-test to catch any
-            # interruption in such flows.
-            ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup
+        shell: bash
+        run: |
+          # Create pods which establish long lived connections. It will be used by
+          # subsequent connectivity tests with --include-conn-disrupt-test to catch any
+          # interruption in such flows.
+          ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup
 
       - name: Upgrade Cilium & Test (${{ matrix.name }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
@@ -314,8 +298,6 @@ jobs:
         with:
           job-name: ipsec-upgrade-${{ matrix.name }}
           operation-cmd: |
-            cd /host/
-
             CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
               ${{ steps.cilium-newest-config.outputs.config }}
 
@@ -329,8 +311,6 @@ jobs:
         with:
           job-name: ipsec-downgrade-${{ matrix.name }}
           operation-cmd: |
-            cd /host/
-
             CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
               ${{ steps.cilium-stable-config.outputs.config }}
 
@@ -341,17 +321,14 @@ jobs:
 
       - name: Fetch artifacts
         if: ${{ steps.vars.outputs.downgrade_version != '' && !success() }}
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host
-            kubectl get pods --all-namespaces -o wide
-            ./cilium-cli status
-            mkdir -p cilium-sysdumps
-            ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
-            # To debug https://github.com/cilium/cilium/issues/26062
-            head -n -0 /proc/buddyinfo /proc/pagetypeinfo
+        shell: bash
+        run: |
+          kubectl get pods --all-namespaces -o wide
+          ./cilium-cli status
+          mkdir -p cilium-sysdumps
+          ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
+          # To debug https://github.com/cilium/cilium/issues/26062
+          head -n -0 /proc/buddyinfo /proc/pagetypeinfo
 
       - name: Upload artifacts
         if: ${{ steps.vars.outputs.downgrade_version != '' && !success() }}


### PR DESCRIPTION
Preparatory work before refactoring ci-ipsec-{e2e,upgrade} testing part into a separate GH action.

Successful runs:
- ci-ipsec-e2e: https://github.com/cilium/cilium/actions/runs/7084438203
- ci-ipsec-upgrade: https://github.com/cilium/cilium/actions/runs/7084851807