### PR TITLE
chore: rename CIDRGroups resource to CiliumCIDRGroups

### DIFF
--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -103,7 +103,7 @@ type Resources struct {
 	NetworkPolicies                  resource.Resource[*slim_networkingv1.NetworkPolicy]
 	CiliumNetworkPolicies            resource.Resource[*cilium_api_v2.CiliumNetworkPolicy]
 	CiliumClusterwideNetworkPolicies resource.Resource[*cilium_api_v2.CiliumClusterwideNetworkPolicy]
-	CIDRGroups                       resource.Resource[*cilium_api_v2alpha1.CiliumCIDRGroup]
+	CiliumCIDRGroups                 resource.Resource[*cilium_api_v2alpha1.CiliumCIDRGroup]
 }
 
 // LocalNodeResources is a convenience struct to group CiliumNode and Node resources as cell constructor parameters.

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -84,7 +84,7 @@ func (k *K8sWatcher) ciliumNetworkPoliciesInit(ctx context.Context, cs client.Cl
 		cnpCache := make(map[resource.Key]*types.SlimCNP)
 
 		cidrGroupCache := make(map[string]*cilium_v2_alpha1.CiliumCIDRGroup)
-		cidrGroupEvents := k.resources.CIDRGroups.Events(ctx)
+		cidrGroupEvents := k.resources.CiliumCIDRGroups.Events(ctx)
 
 		// cidrGroupPolicies is the set of policies that are referencing CiliumCIDRGroup objects.
 		cidrGroupPolicies := make(map[resource.Key]struct{})


### PR DESCRIPTION
To be consistent with other Cilium resources, rename `CIDRGroups` to `CiliumCIDRGroups`.