### PR TITLE
ipam: Fix duplicate metric ipam_event release

### DIFF
--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -299,7 +299,6 @@ func (ipam *IPAM) releaseIPLocked(ip net.IP, pool Pool) error {
 	delete(ipam.expirationTimers, ip.String())
 
 	metrics.IPAMEvent.WithLabelValues(metricRelease, string(family)).Inc()
-	metrics.IPAMEvent.WithLabelValues(metricRelease, string(family)).Inc()
 	return nil
 }
 


### PR DESCRIPTION
Fixes: 788d1aa82b ("ipam, metrics: Add new capacity metric")

Signed-off-by: Chris Tarazi <chris@isovalent.com>
