### PR TITLE
Service load-balancing differentiates between protocols

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -294,9 +294,11 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	struct lb4_service *svc;
 	__u16 dst_port = ctx_dst_port(ctx);
 	__u32 dst_ip = ctx->user_ip4;
+	__u32 proto = ctx->protocol;
 	struct lb4_key key = {
 		.address	= dst_ip,
 		.dport		= dst_port,
+		.proto		= (__u8)ctx->protocol,
 	}, orig_key = key;
 	struct lb4_service *backend_slot;
 	bool backend_from_affinity = false;
@@ -308,7 +310,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	if (is_defined(ENABLE_SOCKET_LB_HOST_ONLY) && !in_hostns)
 		return -ENXIO;
 
-	if (!udp_only && !sock_proto_enabled(ctx->protocol))
+	if (!udp_only && !sock_proto_enabled(proto))
 		return -ENOTSUP;
 
 	/* In case a direct match fails, we try to look-up surrogate
@@ -480,6 +482,7 @@ static __always_inline int __sock4_post_bind(struct bpf_sock *ctx,
 	struct lb4_key key = {
 		.address	= ctx->src_ip4,
 		.dport		= ctx_src_port(ctx),
+		.proto		= (__u8)ctx->protocol,
 	};
 
 	if (!sock_proto_enabled(ctx->protocol) ||
@@ -587,6 +590,7 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 		struct lb4_key svc_key = {
 			.address	= val->address,
 			.dport		= val->port,
+			.proto		= (__u8)ctx->protocol,
 		};
 
 		svc = lb4_lookup_service(&svc_key, true, false);
@@ -852,6 +856,7 @@ static __always_inline int __sock6_post_bind(struct bpf_sock *ctx)
 	struct lb6_service *svc;
 	struct lb6_key key = {
 		.dport		= ctx_src_port(ctx),
+		.proto		= (__u8)ctx->protocol,
 	};
 
 	if (!sock_proto_enabled(ctx->protocol) ||
@@ -976,8 +981,10 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	struct lb6_backend *backend;
 	struct lb6_service *svc;
 	__u16 dst_port = ctx_dst_port(ctx);
+	__u32 proto = ctx->protocol;
 	struct lb6_key key = {
 		.dport		= dst_port,
+		.proto		= (__u8)ctx->protocol,
 	}, orig_key;
 	struct lb6_service *backend_slot;
 	bool backend_from_affinity = false;
@@ -989,7 +996,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	if (is_defined(ENABLE_SOCKET_LB_HOST_ONLY) && !in_hostns)
 		return -ENXIO;
 
-	if (!udp_only && !sock_proto_enabled(ctx->protocol))
+	if (!udp_only && !sock_proto_enabled(proto))
 		return -ENOTSUP;
 
 	ctx_get_v6_address(ctx, &key.address);
@@ -1179,6 +1186,7 @@ static __always_inline int __sock6_xlate_rev(struct bpf_sock_addr *ctx)
 		struct lb6_key svc_key = {
 			.address	= val->address,
 			.dport		= val->port,
+			.proto		= (__u8)ctx->protocol,
 		};
 
 		svc = lb6_lookup_service(&svc_key, true, false);

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -975,7 +975,7 @@ struct lb6_key {
 	union v6addr address;	/* Service virtual IPv6 address */
 	__be16 dport;		/* L4 port filter, if unset, all ports apply */
 	__u16 backend_slot;	/* Backend iterator, 0 indicates the svc frontend */
-	__u8 proto;		/* L4 protocol, currently not used (set to 0) */
+	__u8 proto;		/* L4 protocol, 0 indicates any protocol */
 	__u8 scope;		/* LB_LOOKUP_SCOPE_* for externalTrafficPolicy=Local */
 	__u8 pad[2];
 };
@@ -1033,7 +1033,7 @@ struct lb4_key {
 	__be32 address;		/* Service virtual IPv4 address */
 	__be16 dport;		/* L4 port filter, if unset, all ports apply */
 	__u16 backend_slot;	/* Backend iterator, 0 indicates the svc frontend */
-	__u8 proto;		/* L4 protocol, currently not used (set to 0) */
+	__u8 proto;		/* L4 protocol, 0 indicates any protocol */
 	__u8 scope;		/* LB_LOOKUP_SCOPE_* for externalTrafficPolicy=Local */
 	__u8 pad[2];
 };

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -509,8 +509,7 @@ static __always_inline int lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 static __always_inline void
 lb6_fill_key(struct lb6_key *key, struct ipv6_ct_tuple *tuple)
 {
-	/* FIXME: set after adding support for different L4 protocols in LB */
-	key->proto = 0;
+	key->proto = tuple->nexthdr;
 	ipv6_addr_copy(&key->address, &tuple->daddr);
 	key->dport = tuple->sport;
 }
@@ -604,7 +603,13 @@ struct lb6_service *lb6_lookup_service(struct lb6_key *key,
 
 	key->scope = LB_LOOKUP_SCOPE_EXT;
 	key->backend_slot = 0;
+	/* Keys may look for an explicit protocol or ANY if key is 0. */
 	svc = map_lookup_elem(&LB6_SERVICES_MAP_V2, key);
+	/* If there are no elements for an specific protocol check for ANY entries. */
+	if (!svc && key->proto != 0) {
+		key->proto = 0;
+		svc = map_lookup_elem(&LB6_SERVICES_MAP_V2, key);
+	}
 	if (svc) {
 		if (!scope_switch || !lb6_svc_is_two_scopes(svc))
 			/* Packets for L7 LB are redirected even when there are no backends. */
@@ -1161,8 +1166,7 @@ static __always_inline int lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l
 static __always_inline void
 lb4_fill_key(struct lb4_key *key, const struct ipv4_ct_tuple *tuple)
 {
-	/* FIXME: set after adding support for different L4 protocols in LB */
-	key->proto = 0;
+	key->proto = tuple->nexthdr;
 	key->address = tuple->daddr;
 	/* CT tuple has ports in reverse order: */
 	key->dport = tuple->sport;
@@ -1254,7 +1258,13 @@ struct lb4_service *lb4_lookup_service(struct lb4_key *key,
 
 	key->scope = LB_LOOKUP_SCOPE_EXT;
 	key->backend_slot = 0;
+	/* Keys may look for an explicit protocol or ANY if key is 0. */
 	svc = map_lookup_elem(&LB4_SERVICES_MAP_V2, key);
+	/* If there are no elements for an specific protocol check for ANY entries. */
+	if (!svc && key->proto != 0) {
+		key->proto = 0;
+		svc = map_lookup_elem(&LB4_SERVICES_MAP_V2, key);
+	}
 	if (svc) {
 		if (!scope_switch || !lb4_svc_is_two_scopes(svc))
 			/* Packets for L7 LB are redirected even when there are no backends. */

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -111,6 +111,8 @@ static volatile const __u8 v6_node_three[] = {0xfd, 0x07, 0, 0, 0, 0, 0, 0,
 
 #define NEXTHDR_MAX             255
 
+#define PROTO_ANY               0       /* ANY protocol. */
+
 /* Define SCTP header here because this is all we need. */
 struct sctphdr {
 	__be16 source;

--- a/bpf/tests/tc_lxc_lb4_proto_aware.c
+++ b/bpf/tests/tc_lxc_lb4_proto_aware.c
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_HOST_ROUTING
+
+#define CLIENT_IP			v4_pod_one
+#define CLIENT_PORT			__bpf_htons(33000)
+
+#define FRONTEND_IP			v4_svc_one
+#define FRONTEND_PORT		__bpf_htons(53)
+
+#define BACKEND_PORT		__bpf_htons(8080)
+#define BACKEND_IDENTITY	112233
+
+#include <bpf_lxc.c>
+
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+#include "lib/policy.h"
+
+#define FROM_CONTAINER	0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 2);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_CONTAINER] = &cil_from_container,
+	},
+};
+
+static __always_inline int setup(struct __ctx_buff *ctx)
+{
+	lb_v4_add_service_with_proto(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, 1);
+	lb_v4_add_service_with_proto(FRONTEND_IP, FRONTEND_PORT, IPPROTO_UDP, 1, 2);
+
+	/* TCP -> pod_two */
+	/* UDP -> pod_three */
+
+	lb_v4_add_backend_with_proto(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP,
+				     1, 124, v4_pod_two, BACKEND_PORT, IPPROTO_TCP, 0);
+	lb_v4_add_backend_with_proto(FRONTEND_IP, FRONTEND_PORT, IPPROTO_UDP,
+				     1, 125, v4_pod_three, BACKEND_PORT, IPPROTO_UDP, 0);
+
+	ipcache_v4_add_entry(v4_pod_two, 0, BACKEND_IDENTITY, 0, 0);
+	ipcache_v4_add_entry(v4_pod_three, 0, BACKEND_IDENTITY, 0, 0);
+
+	policy_add_egress_allow_entry(BACKEND_IDENTITY, IPPROTO_TCP, BACKEND_PORT);
+	policy_add_egress_allow_entry(BACKEND_IDENTITY, IPPROTO_UDP, BACKEND_PORT);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_CONTAINER);
+
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+static __always_inline int check(const struct __ctx_buff *ctx, __be32 addr, __u8 proto)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	test_log("Status code: %d", *status_code);
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->daddr != addr)
+		test_fatal("dst IP isn't the right backend IP");
+
+	if (l3->protocol != proto)
+		test_fatal("doesn't have correct L4 protocol");
+
+	test_finish();
+}
+
+SETUP("tc", "tc_lxc_lb4_tcp")
+int lxc_lb4_tcp_setup(struct __ctx_buff *ctx)
+{
+	return setup(ctx);
+}
+
+PKTGEN("tc", "tc_lxc_lb4_tcp")
+int lxc_lb4_tcp_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_two,
+					  CLIENT_IP, FRONTEND_IP,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+CHECK("tc", "tc_lxc_lb4_tcp")
+int lxc_lb4_tcp_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	return check(ctx, v4_pod_two, IPPROTO_TCP);
+}
+
+SETUP("tc", "tc_lxc_lb4_udp")
+int lxc_lb4_udp_setup(struct __ctx_buff *ctx)
+{
+	return setup(ctx);
+}
+
+PKTGEN("tc", "tc_lxc_lb4_udp")
+int lxc_lb4_udp_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_udp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_two,
+					  CLIENT_IP, FRONTEND_IP,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+CHECK("tc", "tc_lxc_lb4_udp")
+int lxc_lb4_udp_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	return check(ctx, v4_pod_three, IPPROTO_UDP);
+}

--- a/bpf/tests/tc_nodeport_lb4_proto_aware.c
+++ b/bpf/tests/tc_nodeport_lb4_proto_aware.c
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+
+/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
+#define ETH_HLEN 14
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define ENABLE_HOST_ROUTING
+
+#define DISABLE_LOOPBACK_LB
+
+/* Skip ingress policy checks, not needed to validate hairpin flow */
+#define USE_BPF_PROG_FOR_INGRESS_POLICY
+#undef FORCE_LOCAL_POLICY_EVAL_AT_SOURCE
+
+#define CLIENT_IP		v4_ext_one
+#define CLIENT_PORT		__bpf_htons(111)
+
+#define FRONTEND_IP	v4_svc_one
+#define FRONTEND_PORT		tcp_svc_one
+
+#define LB_IP			v4_node_one
+#define IPV4_DIRECT_ROUTING	LB_IP
+
+#define BACKEND_PORT		__bpf_htons(8080)
+
+#define NATIVE_DEV_IFINDEX	24
+#define DEFAULT_IFACE		NATIVE_DEV_IFINDEX
+#define BACKEND_IFACE		25
+#define SVC_EGRESS_IFACE	26
+
+static volatile const __u8 *client_mac = mac_one;
+/* this matches the default node_config.h: */
+static volatile const __u8 lb_mac[ETH_ALEN]	= { 0xce, 0x72, 0xa7, 0x03, 0x88, 0x56 };
+static volatile const __u8 *node_mac = mac_three;
+static volatile const __u8 *local_backend_mac = mac_four;
+
+#define SECCTX_FROM_IPCACHE 1
+
+#include "bpf_host.c"
+
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+
+#define FROM_NETDEV	0
+#define TO_NETDEV	1
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 2);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_from_netdev,
+		[TO_NETDEV] = &cil_to_netdev,
+	},
+};
+
+static __always_inline int setup(struct __ctx_buff *ctx)
+{
+	lb_v4_add_service_with_proto(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, 1);
+	lb_v4_add_service_with_proto(FRONTEND_IP, FRONTEND_PORT, IPPROTO_UDP, 1, 2);
+
+	lb_v4_add_backend_with_proto(FRONTEND_IP, FRONTEND_PORT, IPPROTO_UDP,
+				     1, 125, v4_pod_one, BACKEND_PORT, IPPROTO_UDP, 0);
+
+	/* add local backend */
+	endpoint_v4_add_entry(v4_pod_one, BACKEND_IFACE, 0, 0,
+			      (__u8 *)local_backend_mac, (__u8 *)node_mac);
+
+	ipcache_v4_add_entry(v4_pod_one, 0, 112233, 0, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+/* Test that a SVC request (UDP) to a local backend
+ * - gets DNATed (but not SNATed)
+ * - gets redirected by TC (as ENABLE_HOST_ROUTING is set)
+ */
+PKTGEN("tc", "tc_nodeport_lb4_udp")
+int nodeport_udp_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_udp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)lb_mac,
+					  CLIENT_IP, FRONTEND_IP,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb4_udp")
+int nodeport_udp_setup(struct __ctx_buff *ctx)
+{
+	return setup(ctx);
+}
+
+CHECK("tc", "tc_nodeport_lb4_udp")
+int nodeport_udp_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct udphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(*l4) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)node_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the node MAC")
+	if (memcmp(l2->h_dest, (__u8 *)local_backend_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the endpoint MAC")
+
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != v4_pod_one)
+		test_fatal("dst IP hasn't been NATed to local backend IP");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been NATed to backend port");
+
+	test_finish();
+}


### PR DESCRIPTION
Builds off the work started by @aojea in https://github.com/cilium/cilium/pull/26399.

TODO:
- [x] Add double lookup in datapath to preserve compat
- [ ] TC eBPF unit tests
- [ ] XDP eBPF unit tests
- [ ] Add agent support for setting protocol in services map
- [ ] Add a feature flag that's disabled by default
- [ ] Update backend address API spec
- [ ] Update docs
- [ ] Integration tests
- [ ] Update `cilium-dbg` CLI

Fixes: #9207

```release-note
Service load-balancing differentiates between protocols
```
