### PR TITLE
daemon: Fix incorrect node and ciliumnode resource type in annotations

### DIFF
--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -78,11 +78,11 @@ var (
 	)
 )
 
-// LocalNodeResource is a resource.Resource[*corev1.Node] but one which will only stream updates for the node object
+// LocalNodeResource is a resource.Resource[*slim_corev1.Node] but one which will only stream updates for the node object
 // associated with the node we are currently running on.
 type LocalNodeResource resource.Resource[*slim_corev1.Node]
 
-// LocalCiliumNodeResource is a resource.Resource[*cilium_api_v2.Node] but one which will only stream updates for the
+// LocalCiliumNodeResource is a resource.Resource[*cilium_api_v2.CiliumNode] but one which will only stream updates for the
 // CiliumNode object associated with the node we are currently running on.
 type LocalCiliumNodeResource resource.Resource[*cilium_api_v2.CiliumNode]
 
@@ -106,7 +106,7 @@ type Resources struct {
 	CIDRGroups                       resource.Resource[*cilium_api_v2alpha1.CiliumCIDRGroup]
 }
 
-// LocalNodeResources is a convenience struct to group CiliumNode and Node resources as cell contructor parameters.
+// LocalNodeResources is a convenience struct to group CiliumNode and Node resources as cell constructor parameters.
 type LocalNodeResources struct {
 	cell.In
 


### PR DESCRIPTION
Fix incorrect node and ciliumnode resource types in annotations, along with a typo.
