### PR TITLE
ci: increase disk size for GKE clusters (ci-gke & ci-external-workloads)

### DIFF
--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -228,7 +228,7 @@ jobs:
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
-            --disk-size 10GB \
+            --disk-size 20GB \
             --preemptible
 
       - name: Get cluster credentials

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -211,7 +211,7 @@ jobs:
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
-            --disk-size 10GB \
+            --disk-size 20GB \
             --node-taints ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready=true:NoExecute \
             --preemptible
 


### PR DESCRIPTION
Some tests are failing due to PodEviction due to DiskPressure.

Therefore, this commit is increasing the disk size of a GKE node from 10GB to 20GB.

Fixes: #29312
