### PR TITLE
Re-introduce 2005 route table to fix L7 proxy issues

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -384,7 +384,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	/* See IPv4 comment. */
 	if (from_ingress_proxy && info->tunnel_endpoint && encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
-					 info->sec_identity);
+					 info->sec_identity, true);
 #endif
 
 	return CTX_ACT_OK;
@@ -828,7 +828,7 @@ skip_vtep:
 	/* We encrypt host to remote pod packets only if they are from ingress proxy. */
 	if (from_ingress_proxy && info->tunnel_endpoint && encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
-					 info->sec_identity);
+					 info->sec_identity, true);
 #endif
 
 	return CTX_ACT_OK;
@@ -1455,7 +1455,10 @@ int cil_to_host(struct __ctx_buff *ctx)
 	__u32 src_id = 0;
 	__s8 ext_err = 0;
 
-	if ((magic & 0xFFFF) == MARK_MAGIC_TO_PROXY) {
+	if ((magic & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT) {
+		ctx->mark = magic; /* CB_ENCRYPT_MAGIC */
+		src_id = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);
+	} else if ((magic & 0xFFFF) == MARK_MAGIC_TO_PROXY) {
 		/* Upper 16 bits may carry proxy port number */
 		__be16 port = magic >> 16;
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -366,7 +366,8 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	}
 #endif
 
-	if (!info || identity_is_world_ipv6(info->sec_identity)) {
+	if (!info || (!tc_index_from_ingress_proxy(ctx) &&
+		      identity_is_world_ipv6(info->sec_identity))) {
 		/* See IPv4 comment. */
 		return DROP_UNROUTABLE;
 	}
@@ -781,7 +782,8 @@ skip_vtep:
 	}
 #endif
 
-	if (!info || identity_is_world_ipv4(info->sec_identity)) {
+	if (!info || (!tc_index_from_ingress_proxy(ctx) &&
+		      identity_is_world_ipv4(info->sec_identity))) {
 		/* We have received a packet for which no ipcache entry exists,
 		 * we do not know what to do with this packet, drop it.
 		 *
@@ -790,6 +792,10 @@ skip_vtep:
 		 * entry. Therefore we need to test for WORLD_ID. It is clearly
 		 * wrong to route a ctx to cilium_host for which we don't know
 		 * anything about it as otherwise we'll run into a routing loop.
+		 *
+		 * Note that we do not drop packets from ingress proxy even if
+		 * they are going to WORLD_ID. This is to avoid
+		 * https://github.com/cilium/cilium/issues/21954.
 		 */
 		return DROP_UNROUTABLE;
 	}

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1465,7 +1465,7 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, int ifindex, __u32 src_
 	/* If packet is coming from the ingress proxy we have to skip
 	 * redirection to the ingress proxy as we would loop forever.
 	 */
-	skip_ingress_proxy = tc_index_skip_ingress_proxy(ctx);
+	skip_ingress_proxy = tc_index_from_ingress_proxy(ctx);
 
 	ct_buffer = map_lookup_elem(&CT_TAIL_CALL_BUFFER6, &zero);
 	if (!ct_buffer)
@@ -1488,7 +1488,7 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, int ifindex, __u32 src_
 		 * Always redirect connections that originated from L7 LB.
 		 */
 		if (ct_state_is_from_l7lb(ct_state) ||
-		    (ct_state->proxy_redirect && !tc_index_skip_egress_proxy(ctx))) {
+		    (ct_state->proxy_redirect && !tc_index_from_egress_proxy(ctx))) {
 			/* This is a reply, the proxy port does not need to be embedded
 			 * into ctx->mark and *proxy_port can be left unset.
 			 */
@@ -1792,7 +1792,7 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, int ifindex, __u32 src_la
 	/* If packet is coming from the ingress proxy we have to skip
 	 * redirection to the ingress proxy as we would loop forever.
 	 */
-	skip_ingress_proxy = tc_index_skip_ingress_proxy(ctx);
+	skip_ingress_proxy = tc_index_from_ingress_proxy(ctx);
 
 	orig_sip = ip4->saddr;
 
@@ -1825,7 +1825,7 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, int ifindex, __u32 src_la
 	/* Skip policy enforcement for return traffic. */
 	if (ret == CT_REPLY || ret == CT_RELATED) {
 		if (ct_state_is_from_l7lb(ct_state) ||
-		    (ct_state->proxy_redirect && !tc_index_skip_egress_proxy(ctx))) {
+		    (ct_state->proxy_redirect && !tc_index_from_egress_proxy(ctx))) {
 			/* This is a reply, the proxy port does not need to be embedded
 			 * into ctx->mark and *proxy_port can be left unset.
 			 */

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -692,10 +692,9 @@ pass_to_stack:
 #ifndef TUNNEL_MODE
 # ifdef ENABLE_IPSEC
 	if (encrypt_key && tunnel_endpoint) {
-		ret = set_ipsec_encrypt_mark(ctx, encrypt_key, tunnel_endpoint);
+		ret = set_ipsec_encrypt(ctx, encrypt_key, tunnel_endpoint, SECLABEL_IPV6, false);
 		if (unlikely(ret != CTX_ACT_OK))
 			return ret;
-		set_identity_meta(ctx, SECLABEL_IPV6);
 	} else
 # endif /* ENABLE_IPSEC */
 #endif /* TUNNEL_MODE */
@@ -1251,10 +1250,9 @@ pass_to_stack:
 #ifndef TUNNEL_MODE
 # ifdef ENABLE_IPSEC
 	if (encrypt_key && tunnel_endpoint) {
-		ret = set_ipsec_encrypt_mark(ctx, encrypt_key, tunnel_endpoint);
+		ret = set_ipsec_encrypt(ctx, encrypt_key, tunnel_endpoint, SECLABEL_IPV4, false);
 		if (unlikely(ret != CTX_ACT_OK))
 			return ret;
-		set_identity_meta(ctx, SECLABEL_IPV4);
 	} else
 # endif /* ENABLE_IPSEC */
 #endif /* TUNNEL_MODE */

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -797,6 +797,7 @@ enum {
 #define	CB_PORT			CB_SRC_LABEL	/* Alias, non-overlapping */
 #define	CB_HINT			CB_SRC_LABEL	/* Alias, non-overlapping */
 #define	CB_PROXY_MAGIC		CB_SRC_LABEL	/* Alias, non-overlapping */
+#define	CB_ENCRYPT_MAGIC	CB_SRC_LABEL	/* Alias, non-overlapping */
 #define	CB_DST_ENDPOINT_ID	CB_SRC_LABEL    /* Alias, non-overlapping */
 #define CB_SRV6_SID_1		CB_SRC_LABEL	/* Alias, non-overlapping */
 	CB_IFINDEX,

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -776,8 +776,8 @@ static __always_inline __u32 or_encrypt_key(__u8 key)
  * cilium_host @egress
  *   bpf_host -> bpf_lxc
  */
-#define TC_INDEX_F_SKIP_INGRESS_PROXY	1
-#define TC_INDEX_F_SKIP_EGRESS_PROXY	2
+#define TC_INDEX_F_FROM_INGRESS_PROXY	1
+#define TC_INDEX_F_FROM_EGRESS_PROXY	2
 #define TC_INDEX_F_SKIP_NODEPORT	4
 #define TC_INDEX_F_SKIP_RECIRCULATION	8
 #define TC_INDEX_F_SKIP_HOST_FIREWALL	16

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -75,7 +75,7 @@ encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 #ifdef ENABLE_IPSEC
 	if (encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, tunnel_endpoint,
-					 seclabel);
+					 seclabel, true);
 #endif
 
 	return __encap_and_redirect_with_nodeid(ctx, 0, tunnel_endpoint,
@@ -97,7 +97,7 @@ __encap_and_redirect_lxc(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 #ifdef ENABLE_IPSEC
 	if (encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, tunnel_endpoint,
-					 seclabel);
+					 seclabel, false);
 #endif
 
 #if !defined(ENABLE_NODEPORT) && defined(ENABLE_HOST_FIREWALL)
@@ -165,7 +165,7 @@ encap_and_redirect_lxc(struct __ctx_buff *ctx,
 		__u8 min_encrypt_key = get_min_encrypt_key(tunnel->key);
 
 		return set_ipsec_encrypt(ctx, min_encrypt_key, tunnel->ip4,
-					 seclabel);
+					 seclabel, false);
 	}
 # endif
 	return encap_and_redirect_with_nodeid(ctx, tunnel->ip4, 0, seclabel, dstid,
@@ -187,7 +187,7 @@ encap_and_redirect_netdev(struct __ctx_buff *ctx, struct tunnel_key *k,
 #ifdef ENABLE_IPSEC
 	if (encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, tunnel->ip4,
-					 seclabel);
+					 seclabel, true);
 #endif
 
 	return encap_and_redirect_with_nodeid(ctx, tunnel->ip4, 0, seclabel, 0,

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -68,9 +68,16 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip __maybe_un
  */
 static __always_inline int
 encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
+			       __u8 encrypt_key __maybe_unused,
 			       __u32 seclabel, __u32 dstid,
 			       const struct trace_ctx *trace)
 {
+#ifdef ENABLE_IPSEC
+	if (encrypt_key)
+		return set_ipsec_encrypt(ctx, encrypt_key, tunnel_endpoint,
+					 seclabel);
+#endif
+
 	return __encap_and_redirect_with_nodeid(ctx, 0, tunnel_endpoint,
 						seclabel, dstid, NOT_VTEP_DST,
 						trace);
@@ -110,7 +117,7 @@ __encap_and_redirect_lxc(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 	/* tell caller that this packet needs to go through the stack: */
 	return CTX_ACT_OK;
 #else
-	return encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, seclabel,
+	return encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, 0, seclabel,
 					      dstid, trace);
 #endif /* !ENABLE_NODEPORT && ENABLE_HOST_FIREWALL */
 }
@@ -161,13 +168,14 @@ encap_and_redirect_lxc(struct __ctx_buff *ctx,
 					 seclabel);
 	}
 # endif
-	return encap_and_redirect_with_nodeid(ctx, tunnel->ip4, seclabel, dstid,
+	return encap_and_redirect_with_nodeid(ctx, tunnel->ip4, 0, seclabel, dstid,
 					      trace);
 #endif /* ENABLE_HIGH_SCALE_IPCACHE */
 }
 
 static __always_inline int
 encap_and_redirect_netdev(struct __ctx_buff *ctx, struct tunnel_key *k,
+			  __u8 encrypt_key __maybe_unused,
 			  __u32 seclabel, const struct trace_ctx *trace)
 {
 	struct tunnel_value *tunnel;
@@ -176,7 +184,13 @@ encap_and_redirect_netdev(struct __ctx_buff *ctx, struct tunnel_key *k,
 	if (!tunnel)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
-	return encap_and_redirect_with_nodeid(ctx, tunnel->ip4, seclabel, 0,
+#ifdef ENABLE_IPSEC
+	if (encrypt_key)
+		return set_ipsec_encrypt(ctx, encrypt_key, tunnel->ip4,
+					 seclabel);
+#endif
+
+	return encap_and_redirect_with_nodeid(ctx, tunnel->ip4, 0, seclabel, 0,
 					      trace);
 }
 #endif /* TUNNEL_MODE || ENABLE_HIGH_SCALE_IPCACHE */

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -157,14 +157,14 @@ static __always_inline __u32 inherit_identity_from_host(struct __ctx_buff *ctx, 
 	 */
 	if (magic == MARK_MAGIC_PROXY_INGRESS) {
 		*identity = get_identity(ctx);
-		ctx->tc_index |= TC_INDEX_F_SKIP_INGRESS_PROXY;
+		ctx->tc_index |= TC_INDEX_F_FROM_INGRESS_PROXY;
 	/* (Return) packets from the egress proxy must skip the redirection to
 	 * the proxy, as the packet would loop and/or the connection be reset
 	 * otherwise.
 	 */
 	} else if (magic == MARK_MAGIC_PROXY_EGRESS) {
 		*identity = get_identity(ctx);
-		ctx->tc_index |= TC_INDEX_F_SKIP_EGRESS_PROXY;
+		ctx->tc_index |= TC_INDEX_F_FROM_EGRESS_PROXY;
 	} else if (magic == MARK_MAGIC_IDENTITY) {
 		*identity = get_identity(ctx);
 	} else if (magic == MARK_MAGIC_HOST) {

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -102,6 +102,12 @@ set_encrypt_key_mark(struct __sk_buff *ctx, __u8 key, __u32 node_id)
 	ctx->mark = or_encrypt_key(key) | node_id << 16;
 }
 
+static __always_inline __maybe_unused void
+set_encrypt_key_meta(struct __sk_buff *ctx, __u8 key, __u32 node_id)
+{
+	ctx->cb[CB_ENCRYPT_MAGIC] = or_encrypt_key(key) | node_id << 16;
+}
+
 /**
  * set_cluster_id_mark - sets the cluster_id mark.
  */

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -42,6 +42,12 @@ set_encrypt_key_mark(struct xdp_md *ctx __maybe_unused, __u8 key __maybe_unused,
 }
 
 static __always_inline __maybe_unused void
+set_encrypt_key_meta(struct __sk_buff *ctx __maybe_unused, __u8 key __maybe_unused,
+		     __u32 node_id __maybe_unused)
+{
+}
+
+static __always_inline __maybe_unused void
 ctx_set_cluster_id_mark(struct xdp_md *ctx __maybe_unused, __u32 cluster_id __maybe_unused)
 {
 }

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -362,30 +362,30 @@ out: __maybe_unused;
 }
 
 /**
- * tc_index_skip_ingress_proxy - returns true if packet originates from ingress proxy
+ * tc_index_from_ingress_proxy - returns true if packet originates from ingress proxy
  */
-static __always_inline bool tc_index_skip_ingress_proxy(struct __ctx_buff *ctx)
+static __always_inline bool tc_index_from_ingress_proxy(struct __ctx_buff *ctx)
 {
 	volatile __u32 tc_index = ctx->tc_index;
 #ifdef DEBUG
-	if (tc_index & TC_INDEX_F_SKIP_INGRESS_PROXY)
+	if (tc_index & TC_INDEX_F_FROM_INGRESS_PROXY)
 		cilium_dbg(ctx, DBG_SKIP_PROXY, tc_index, 0);
 #endif
 
-	return tc_index & TC_INDEX_F_SKIP_INGRESS_PROXY;
+	return tc_index & TC_INDEX_F_FROM_INGRESS_PROXY;
 }
 
 /**
- * tc_index_skip_egress_proxy - returns true if packet originates from egress proxy
+ * tc_index_from_egress_proxy - returns true if packet originates from egress proxy
  */
-static __always_inline bool tc_index_skip_egress_proxy(struct __ctx_buff *ctx)
+static __always_inline bool tc_index_from_egress_proxy(struct __ctx_buff *ctx)
 {
 	volatile __u32 tc_index = ctx->tc_index;
 #ifdef DEBUG
-	if (tc_index & TC_INDEX_F_SKIP_EGRESS_PROXY)
+	if (tc_index & TC_INDEX_F_FROM_EGRESS_PROXY)
 		cilium_dbg(ctx, DBG_SKIP_PROXY, tc_index, 0);
 #endif
 
-	return tc_index & TC_INDEX_F_SKIP_EGRESS_PROXY;
+	return tc_index & TC_INDEX_F_FROM_EGRESS_PROXY;
 }
 #endif /* __LIB_PROXY_H_ */

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -19,8 +19,11 @@ const (
 	// RouteTableVtep is the default table ID to use for VTEP routing rules
 	RouteTableVtep = 202
 
-	// RouteTableProxy is the default table ID to use for proxy routing rules.
-	RouteTableProxy = 2004
+	// RouteTableToProxy is the default table ID to use routing rules to the proxy.
+	RouteTableToProxy = 2004
+
+	// RouteTableFromProxy is the default table ID to use routing rules from the proxy.
+	RouteTableFromProxy = 2005
 
 	// RouteTableInterfacesOffset is the offset for the per-ENI routing tables.
 	// Each ENI interface will have its own table starting with this offset. It
@@ -70,11 +73,13 @@ const (
 	// RulePriorityWireguard is the priority of the rule used for routing packets to WireGuard device for encryption
 	RulePriorityWireguard = 1
 
-	// RulePriorityProxyIngress is the priority of the routing rule installed by
-	// the proxy package for redirecting inbound packets to the proxy. Priority 10
-	// used to be for outgoing packets from the proxy (see PROXY_RT_TABLE in older
-	// versions), but is no longer used.
-	RulePriorityProxyIngress = 9
+	// RulePriorityToProxyIngress is the priority of the routing rule installed by
+	// the proxy package for redirecting inbound packets to the proxy.
+	RulePriorityToProxyIngress = 9
+
+	// RulePriorityFromProxyIngress is the priority of the routing rule installed by
+	// the proxy package for redirecting inbound packets from the proxy.
+	RulePriorityFromProxyIngress = 10
 
 	// RulePriorityIngress is the priority of the rule used for ingress routing
 	// of endpoints. This priority is after encryption and proxy rules, and

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -17,19 +17,19 @@ import (
 
 var (
 	// Routing rule for traffic to proxy.
-	tproxyRule = route.Rule{
+	toProxyRule = route.Rule{
 		// Cilium bumps the default catch-all pref 0 routing rule that points at
 		// table 255 to pref 100 during startup, to create space to insert its own
 		// rules between 0-99.
-		Priority: linux_defaults.RulePriorityProxyIngress,
+		Priority: linux_defaults.RulePriorityToProxyIngress,
 		Mark:     int(linux_defaults.MagicMarkIsToProxy),
 		Mask:     linux_defaults.MagicMarkHostMask,
-		Table:    linux_defaults.RouteTableProxy,
+		Table:    linux_defaults.RouteTableToProxy,
 	}
 
 	// Default IPv4 route for local delivery.
 	route4 = route.Route{
-		Table:  linux_defaults.RouteTableProxy,
+		Table:  linux_defaults.RouteTableToProxy,
 		Type:   route.RTN_LOCAL,
 		Local:  net.IPv4zero,
 		Device: "lo",
@@ -37,7 +37,7 @@ var (
 
 	// Default IPv6 route for local delivery.
 	route6 = route.Route{
-		Table:  linux_defaults.RouteTableProxy,
+		Table:  linux_defaults.RouteTableToProxy,
 		Type:   route.RTN_LOCAL,
 		Local:  net.IPv6zero,
 		Device: "lo",
@@ -45,51 +45,149 @@ var (
 	}
 )
 
-// installRoutesIPv4 configures routes and rules needed to redirect ingress
+// installToProxyRoutesIPv4 configures routes and rules needed to redirect ingress
 // packets to the proxy.
-func installRoutesIPv4() error {
+func installToProxyRoutesIPv4() error {
 	if err := route.Upsert(route4); err != nil {
 		return fmt.Errorf("inserting ipv4 proxy route %v: %w", route4, err)
 	}
-	if err := route.ReplaceRule(tproxyRule); err != nil {
-		return fmt.Errorf("inserting ipv4 proxy routing rule %v: %w", tproxyRule, err)
+	if err := route.ReplaceRule(toProxyRule); err != nil {
+		return fmt.Errorf("inserting ipv4 proxy routing rule %v: %w", toProxyRule, err)
 	}
 
 	return nil
 }
 
-// removeRoutesIPv4 ensures routes and rules for proxy traffic are removed.
-func removeRoutesIPv4() error {
-	if err := route.DeleteRule(netlink.FAMILY_V4, tproxyRule); err != nil && !errors.Is(err, syscall.ENOENT) {
+// removeToProxyRoutesIPv4 ensures routes and rules for proxy traffic are removed.
+func removeToProxyRoutesIPv4() error {
+	if err := route.DeleteRule(netlink.FAMILY_V4, toProxyRule); err != nil && !errors.Is(err, syscall.ENOENT) {
 		return fmt.Errorf("removing ipv4 proxy routing rule: %w", err)
 	}
-	if err := route.DeleteRouteTable(linux_defaults.RouteTableProxy, netlink.FAMILY_V4); err != nil {
+	if err := route.DeleteRouteTable(linux_defaults.RouteTableToProxy, netlink.FAMILY_V4); err != nil {
 		return fmt.Errorf("removing ipv4 proxy route table: %w", err)
 	}
 
 	return nil
 }
 
-// installRoutesIPv6 configures routes and rules needed to redirect ingress
+// installToProxyRoutesIPv6 configures routes and rules needed to redirect ingress
 // packets to the proxy.
-func installRoutesIPv6() error {
+func installToProxyRoutesIPv6() error {
 	if err := route.Upsert(route6); err != nil {
 		return fmt.Errorf("inserting ipv6 proxy route %v: %w", route6, err)
 	}
-	if err := route.ReplaceRuleIPv6(tproxyRule); err != nil {
-		return fmt.Errorf("inserting ipv6 proxy routing rule %v: %w", tproxyRule, err)
+	if err := route.ReplaceRuleIPv6(toProxyRule); err != nil {
+		return fmt.Errorf("inserting ipv6 proxy routing rule %v: %w", toProxyRule, err)
 	}
 
 	return nil
 }
 
-// removeRoutesIPv6 ensures routes and rules for proxy traffic are removed.
-func removeRoutesIPv6() error {
-	if err := route.DeleteRule(netlink.FAMILY_V6, tproxyRule); err != nil && !errors.Is(err, syscall.ENOENT) {
+// removeToProxyRoutesIPv6 ensures routes and rules for proxy traffic are removed.
+func removeToProxyRoutesIPv6() error {
+	if err := route.DeleteRule(netlink.FAMILY_V6, toProxyRule); err != nil && !errors.Is(err, syscall.ENOENT) {
 		return fmt.Errorf("removing ipv6 proxy routing rule: %w", err)
 	}
-	if err := route.DeleteRouteTable(linux_defaults.RouteTableProxy, netlink.FAMILY_V6); err != nil {
+	if err := route.DeleteRouteTable(linux_defaults.RouteTableToProxy, netlink.FAMILY_V6); err != nil {
 		return fmt.Errorf("removing ipv6 proxy route table: %w", err)
+	}
+
+	return nil
+}
+
+var (
+	// Routing rule for traffic from proxy.
+	fromProxyRule = route.Rule{
+		Priority: linux_defaults.RulePriorityFromProxyIngress,
+		Mark:     linux_defaults.MagicMarkIsProxy,
+		Mask:     linux_defaults.MagicMarkHostMask,
+		Table:    linux_defaults.RouteTableFromProxy,
+	}
+)
+
+// installFromProxyRoutesIPv4 configures routes and rules needed to redirect ingress
+// packets from the proxy.
+func installFromProxyRoutesIPv4(ipv4 net.IP, device string) error {
+	fromProxyToCiliumHostRoute4 := route.Route{
+		Table: linux_defaults.RouteTableFromProxy,
+		Prefix: net.IPNet{
+			IP:   ipv4,
+			Mask: net.CIDRMask(32, 32),
+		},
+		Device: device,
+		Type:   route.RTN_LOCAL,
+		Proto:  linux_defaults.RTProto,
+	}
+	fromProxyDefaultRoute4 := route.Route{
+		Table:   linux_defaults.RouteTableFromProxy,
+		Nexthop: &ipv4,
+		Device:  device,
+	}
+
+	if err := route.ReplaceRule(fromProxyRule); err != nil {
+		return fmt.Errorf("inserting ipv4 from proxy routing rule %v: %w", fromProxyRule, err)
+	}
+	if err := route.Upsert(fromProxyToCiliumHostRoute4); err != nil {
+		return fmt.Errorf("inserting ipv4 from proxy to cilium_host route %v: %w", fromProxyToCiliumHostRoute4, err)
+	}
+	if err := route.Upsert(fromProxyDefaultRoute4); err != nil {
+		return fmt.Errorf("inserting ipv4 from proxy default route %v: %w", fromProxyDefaultRoute4, err)
+	}
+
+	return nil
+}
+
+// removeFromProxyRoutesIPv4 ensures routes and rules for traffic from the proxy are removed.
+func removeFromProxyRoutesIPv4() error {
+	if err := route.DeleteRule(netlink.FAMILY_V4, fromProxyRule); err != nil && !errors.Is(err, syscall.ENOENT) {
+		return fmt.Errorf("removing ipv4 from proxy routing rule: %w", err)
+	}
+	if err := route.DeleteRouteTable(linux_defaults.RouteTableFromProxy, netlink.FAMILY_V4); err != nil {
+		return fmt.Errorf("removing ipv4 from proxy route table: %w", err)
+	}
+
+	return nil
+}
+
+// installFromProxyRoutesIPv6 configures routes and rules needed to redirect ingress
+// packets from the proxy.
+func installFromProxyRoutesIPv6(ipv6 net.IP, device string) error {
+	fromProxyToCiliumHostRoute6 := route.Route{
+		Table: linux_defaults.RouteTableFromProxy,
+		Prefix: net.IPNet{
+			IP:   ipv6,
+			Mask: net.CIDRMask(128, 128),
+		},
+		Device: device,
+		Proto:  linux_defaults.RTProto,
+	}
+
+	fromProxyDefaultRoute6 := route.Route{
+		Table:   linux_defaults.RouteTableFromProxy,
+		Nexthop: &ipv6,
+		Device:  device,
+	}
+
+	if err := route.ReplaceRuleIPv6(fromProxyRule); err != nil {
+		return fmt.Errorf("inserting ipv6 from proxy routing rule %v: %w", fromProxyRule, err)
+	}
+	if err := route.Upsert(fromProxyToCiliumHostRoute6); err != nil {
+		return fmt.Errorf("inserting ipv6 from proxy to cilium_host route %v: %w", fromProxyToCiliumHostRoute6, err)
+	}
+	if err := route.Upsert(fromProxyDefaultRoute6); err != nil {
+		return fmt.Errorf("inserting ipv6 from proxy default route %v: %w", fromProxyDefaultRoute6, err)
+	}
+
+	return nil
+}
+
+// removeFromProxyRoutesIPv6 ensures routes and rules for traffic from the proxy are removed.
+func removeFromProxyRoutesIPv6() error {
+	if err := route.DeleteRule(netlink.FAMILY_V6, fromProxyRule); err != nil && !errors.Is(err, syscall.ENOENT) {
+		return fmt.Errorf("removing ipv6 from proxy routing rule: %w", err)
+	}
+	if err := route.DeleteRouteTable(linux_defaults.RouteTableFromProxy, netlink.FAMILY_V6); err != nil {
+		return fmt.Errorf("removing ipv6 from proxy route table: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
See commit messages for details.

```release-note
Fixes an L7 proxy issue by re-introducing 2005 route table.
```
