### PR TITLE
docs: specify which further release for fqdn option removal.

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -376,7 +376,7 @@ Removed Options
 * The long defunct and undocumented ``single-cluster-route`` flag has been removed.
 
 * The ``dnsproxy-lock-count`` and ``dnsproxy-lock-timeout`` flags no longer have
-  any effect and are deprecated. They will be removed in a future release.
+  any effect and are deprecated. They will be removed in v1.16.
 
 Helm Options
 ~~~~~~~~~~~~


### PR DESCRIPTION
This should have been made explicit. @tklauser observed this in a [comment](https://github.com/cilium/cilium/pull/29036#discussion_r1411153578) on a ready-to-merge PR, hence, the new PR.