### PR TITLE
ci: increase cilium wait timeout to 10m on cloud providers

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -229,7 +229,7 @@ jobs:
 
       - name: Wait for Cilium status to be ready
         run: |
-          cilium status --wait
+          cilium status --wait --wait-duration=10m
 
       - name: Port forward Relay
         run: |
@@ -268,7 +268,7 @@ jobs:
 
       - name: Wait for Cilium status to be ready
         run: |
-          cilium status --wait
+          cilium status --wait --wait-duration=10m
 
       - name: Port forward Relay
         run: |

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -224,7 +224,7 @@ jobs:
 
       - name: Wait for Cilium to be ready
         run: |
-          cilium status --wait
+          cilium status --wait --wait-duration=10m
           kubectl get pods -n kube-system
 
       - name: Port forward Relay

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -222,7 +222,7 @@ jobs:
 
       - name: Wait for Cilium to be ready
         run: |
-          cilium status --wait
+          cilium status --wait --wait-duration=10m
           kubectl get pods -n kube-system
 
       - name: Port forward Relay
@@ -258,7 +258,7 @@ jobs:
 
       - name: Wait for Cilium to be ready
         run: |
-          cilium status --wait
+          cilium status --wait --wait-duration=10m
           kubectl get pods -n kube-system
 
       - name: Port forward Relay

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -239,7 +239,7 @@ jobs:
 
       - name: Wait for Cilium to be ready
         run: |
-          cilium status --wait
+          cilium status --wait --wait-duration=10m
           kubectl get pods -n kube-system
 
       - name: Wait for Cilium status to be ready


### PR DESCRIPTION
There are cases where image pulling isn't successful within 5 minutes (default wait time of `cilium status --wait`).

Especially on public cloud providers, it might takes longer in some cases.

What's interesting, it's never a >=1.27 k8s cluster. Good indication that parallel image pull introduced with 1.27 will help here: https://kubernetes.io/blog/2023/05/15/speed-up-pod-startup/

Therefore, this commit increases the wait timeout to 10m.

* Google GKE: https://github.com/cilium/cilium/actions/runs/7057359357/job/19210904763 (Image Pull ongoing)
* Google GKE: https://github.com/cilium/cilium/actions/runs/7057359357/job/19210905203 (Image Pull ongoing)
* Google GKE: https://github.com/cilium/cilium/actions/runs/7054868274/job/19204419890 (Image Pull ongoing)
* Amazon EKS: https://github.com/cilium/cilium/actions/runs/7051040283/job/19193093297 (Cilium Agents image pull back off -> 502 quay -> more time should help to retry)
* Amazon EKS: https://github.com/cilium/cilium/actions/runs/7051040283/job/19193094020 (Hubble Relay image pull back off -> 502 quay -> more time should help to retry)
* ...

I'm aware that this might introduce follow up issues (due to overall timeout) if more time is spent in this wait. But would be interesting to know if this helps.
