### PR TITLE
ci-gke: remove duplicated wait for cilium

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -242,10 +242,6 @@ jobs:
           cilium status --wait
           kubectl get pods -n kube-system
 
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
-
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&


### PR DESCRIPTION
This commit removes the duplicated step to wait for Cilium to become ready.