### PR TITLE
Fix JSON logging for the endpoint logger

### DIFF
--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -96,7 +96,7 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 	}
 
 	// default to a new default logger
-	baseLogger := logging.InitializeDefaultLogger()
+	baseLogger := logging.DefaultLogger
 
 	// Set log format based on daemon config
 	baseLogger.SetFormatter(logging.GetFormatter(


### PR DESCRIPTION
# Description

Tiny change to ensure that JSON logging can be enabled consistently everywhere. Similar issue to https://github.com/cilium/cilium/issues/14028.

The problem was that directly calling [logging.InitializeDefaultLogger()](https://github.com/cilium/cilium/blob/c311616158faa44f274f38c634b9d7d7fae903e3/pkg/logging/logging.go#L77-L82) was not taking into account the user-passed parameters which are initialized in [logging.SetupLogging() 
](https://github.com/cilium/cilium/blob/c311616158faa44f274f38c634b9d7d7fae903e3/pkg/logging/logging.go#L155)

# Testing
## Previous behaviour
Ran the the Cilium Agent v1.13.9 with `--log-opt=format=json`. Here is a sample of logs that were produced:
```
level=info msg="Rewrote endpoint BPF program" containerID= datapathPolicyRevision=0 desiredPolicyRevision=4 endpointID=3107 identity=5860823 ipv4= ipv6= k8sPodName=/ subsys=endpoint
level=info msg="Successful endpoint creation" containerID= datapathPolicyRevision=4 desiredPolicyRevision=4 endpointID=3107 identity=5860823 ipv4= ipv6= k8sPodName=/ subsys=daemon
{"level":"info","msg":"regenerating all endpoints","reason":"one or more identities created or deleted","subsys":"endpoint-manager"}
{"level":"info","msg":"regenerating all endpoints","reason":"one or more identities created or deleted","subsys":"endpoint-manager"}
```
As you can see there was a mix of JSON and non-JSON logs. I noticed that all improperly formatted logs were coming from the logger in `pkg/endpoint/log.go`.

## Fixed behaviour
After rebuilding the agent from this PR, the logs are now properly formatted, here is a small sample:
```
{"containerID":"","datapathPolicyRevision":4,"desiredPolicyRevision":4,"endpointID":664,"identity":"5860823","ipv4":"","ipv6":"","k8sPodName":"/","level":"info","msg":"Successful endpoint creation","subsys":"daemon"}
{"endpointID":2466,"level":"info","msg":"Successfully restored endpoint. Scheduling regeneration","subsys":"daemon"}
{"containerID":"","datapathPolicyRevision":0,"desiredPolicyRevision":4,"endpointID":336,"identity":"1","ipv4":"","ipv6":"","k8sPodName":"/","level":"info","msg":"Rewrote endpoint BPF program","subsys":"endpoint"}
{"endpointID":336,"ipAddr":["10.18.2.114",""],"level":"info","msg":"Restored endpoint","subsys":"endpoint"}
{"containerID":"a10ffce455","datapathPolicyRevision":0,"desiredPolicyRevision":4,"endpointID":237,"identity":"5862152","ipv4":"10.19.2.114","ipv6":"","k8sPodName":"namespace/pod-name-7ccd4bb498-847jx","level":"info","msg":"Rewrote endpoint BPF program","subsys":"endpoint"}
```