### PR TITLE
ipcache: refactor controller initialization

### DIFF
--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -61,10 +61,15 @@ func (ds *DaemonFQDNSuite) SetUpTest(c *C) {
 	})
 	d.endpointManager = endpointmanager.New(&dummyEpSyncher{}, nil)
 	d.policy.GetSelectorCache().SetLocalIdentityNotifier(d.dnsNameManager)
+	d.ipcache.Start()
 
 	ds.d = d
 
 	logger.SetEndpointInfoRegistry(&dummyInfoRegistry{})
+}
+
+func (ds *DaemonFQDNSuite) TearDownTest(c *C) {
+	ds.d.ipcache.Shutdown()
 }
 
 type dummyInfoRegistry struct{}

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -126,6 +126,7 @@ func newPolicyTrifecta(params policyParams) (policyOut, error) {
 	params.Lifecycle.Append(hive.Hook{
 		OnStart: func(hc hive.HookContext) error {
 			iao.policy.Start()
+			ipc.Start()
 			return nil
 		},
 		OnStop: func(hc hive.HookContext) error {

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -135,6 +135,7 @@ func TestClusterMesh(t *testing.T) {
 	ipc := ipcache.NewIPCache(&ipcache.Configuration{
 		Context: ctx,
 	})
+	ipc.Start()
 	t.Cleanup(func() { ipc.Shutdown() })
 
 	usedIDs := NewClusterMeshUsedIDs()

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -156,7 +156,7 @@ func NewIPCache(c *Configuration) *IPCache {
 // Shutdown cleans up asynchronous routines associated with the IPCache.
 func (ipc *IPCache) Shutdown() error {
 	ipc.deferredPrefixRelease.Shutdown()
-	return ipc.ShutdownLabelInjection()
+	return ipc.controllers.RemoveControllerAndWait(LabelInjectorName)
 }
 
 // Lock locks the IPCache's mutex.

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -132,6 +132,8 @@ type IPCache struct {
 	// prefixLengths tracks the unique set of prefix lengths for IPv4 and
 	// IPv6 addresses in order to optimize longest prefix match lookups.
 	prefixLengths *counter.PrefixLengthCounter
+
+	started bool
 }
 
 // NewIPCache returns a new IPCache with the mappings of endpoint IP to security
@@ -166,6 +168,7 @@ func (ipc *IPCache) Start() {
 			MaxRetryInterval: 1 * time.Minute,
 		},
 	)
+	ipc.started = true
 }
 
 // Shutdown cleans up asynchronous routines associated with the IPCache.

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -480,7 +480,7 @@ func (ipc *IPCache) UpsertMetadataBatch(updates ...MU) (revision uint64) {
 	}
 	ipc.metadata.Unlock()
 	revision = ipc.metadata.enqueuePrefixUpdates(prefixes...)
-	ipc.TriggerLabelInjection()
+	ipc.triggerLabelInjection()
 	return
 }
 
@@ -510,7 +510,7 @@ func (ipc *IPCache) RemoveMetadataBatch(updates ...MU) (revision uint64) {
 	}
 	ipc.metadata.Unlock()
 	revision = ipc.metadata.enqueuePrefixUpdates(prefixes...)
-	ipc.TriggerLabelInjection()
+	ipc.triggerLabelInjection()
 	return
 }
 
@@ -529,7 +529,7 @@ func (ipc *IPCache) UpsertPrefixes(prefixes []netip.Prefix, src source.Source, r
 	}
 	ipc.metadata.Unlock()
 	revision = ipc.metadata.enqueuePrefixUpdates(prefixes...)
-	ipc.TriggerLabelInjection()
+	ipc.triggerLabelInjection()
 	return
 }
 
@@ -551,7 +551,7 @@ func (ipc *IPCache) RemovePrefixes(prefixes []netip.Prefix, src source.Source, r
 	}
 	ipc.metadata.Unlock()
 	ipc.metadata.enqueuePrefixUpdates(prefixes...)
-	ipc.TriggerLabelInjection()
+	ipc.triggerLabelInjection()
 }
 
 // UpsertLabels upserts a given IP and its corresponding labels associated

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -53,6 +53,7 @@ func (s *IPCacheTestSuite) SetUpTest(c *C) {
 		PolicyHandler:     PolicyHandler,
 		DatapathHandler:   &mockTriggerer{},
 	})
+	IPIdentityCache.Start()
 
 	s.cleanup = func() {
 		cancel()

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -208,7 +208,7 @@ func (m *metadata) getLocked(prefix netip.Prefix) PrefixInfo {
 	return m.m[prefix]
 }
 
-// InjectLabels injects labels from the ipcache metadata (IDMD) map into the
+// injectLabels injects labels from the ipcache metadata (IDMD) map into the
 // identities used for the prefixes in the IPCache. The given source is the
 // source of the caller, as inserting into the IPCache requires knowing where
 // this updated information comes from. Conversely, RemoveLabelsExcluded()
@@ -224,7 +224,7 @@ func (m *metadata) getLocked(prefix netip.Prefix) PrefixInfo {
 // Returns the CIDRs that were not yet processed, for example due to an
 // unexpected error while processing the identity updates for those CIDRs
 // The caller should attempt to retry injecting labels for those CIDRs.
-func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.Prefix) (remainingPrefixes []netip.Prefix, err error) {
+func (ipc *IPCache) injectLabels(ctx context.Context, modifiedPrefixes []netip.Prefix) (remainingPrefixes []netip.Prefix, err error) {
 	if ipc.IdentityAllocator == nil {
 		return modifiedPrefixes, ErrLocalIdentityAllocatorUninitialized
 	}
@@ -666,7 +666,7 @@ func (m *metadata) remove(prefix netip.Prefix, resource types.ResourceID, aux ..
 	m.enqueuePrefixUpdates(prefix)
 }
 
-// TriggerLabelInjection triggers the label injection controller to iterate
+// triggerLabelInjection triggers the label injection controller to iterate
 // through the IDMD and potentially allocate new identities based on any label
 // changes.
 //
@@ -697,7 +697,7 @@ func (m *metadata) remove(prefix netip.Prefix, resource types.ResourceID, aux ..
 //	legend:
 //	* W means write
 //	* R means read
-func (ipc *IPCache) TriggerLabelInjection() {
+func (ipc *IPCache) triggerLabelInjection() {
 	// GH-17829: Would also be nice to have an end-to-end test to validate
 	//           on upgrade that there are no connectivity drops when this
 	//           channel is preventing transient BPF entries.
@@ -711,7 +711,7 @@ func (ipc *IPCache) TriggerLabelInjection() {
 			Context: ipc.Configuration.Context,
 			DoFunc: func(ctx context.Context) error {
 				idsToModify, rev := ipc.metadata.dequeuePrefixUpdates()
-				remaining, err := ipc.InjectLabels(ctx, idsToModify)
+				remaining, err := ipc.injectLabels(ctx, idsToModify)
 				if len(remaining) > 0 {
 					ipc.metadata.enqueuePrefixUpdates(remaining...)
 				} else {

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -724,8 +724,3 @@ func (ipc *IPCache) triggerLabelInjection() {
 		},
 	)
 }
-
-// ShutdownLabelInjection shuts down the controller in TriggerLabelInjection().
-func (ipc *IPCache) ShutdownLabelInjection() error {
-	return ipc.controllers.RemoveControllerAndWait(LabelInjectorName)
-}

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -714,5 +714,8 @@ func (ipc *IPCache) triggerLabelInjection() {
 	// GH-17829: Would also be nice to have an end-to-end test to validate
 	//           on upgrade that there are no connectivity drops when this
 	//           channel is preventing transient BPF entries.
+	if !ipc.started {
+		panic("triggerLabelInjection of stopped ipcache")
+	}
 	ipc.controllers.TriggerController(labelInjectorName)
 }

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -50,7 +50,7 @@ func TestInjectLabels(t *testing.T) {
 	option.Config.PolicyCIDRMatchMode = []string{}
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	remaining, err := IPIdentityCache.InjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, err := IPIdentityCache.injectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.Len(t, remaining, 0)
 	assert.NoError(t, err)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
@@ -59,7 +59,7 @@ func TestInjectLabels(t *testing.T) {
 	// a CIDR ID for this IP.
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.KubeAPIServer, "kube-uid", labels.LabelKubeAPIServer)
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{inClusterPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
@@ -70,7 +70,7 @@ func TestInjectLabels(t *testing.T) {
 	// IP now (unless we are enabling policy-cidr-match-mode=remote-node).
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.CustomResource, "node-uid", labels.LabelRemoteNode)
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{inClusterPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
@@ -80,7 +80,7 @@ func TestInjectLabels(t *testing.T) {
 	// Insert another node, see that it gets the RemoteNode ID but not kube-apiserver
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix2, source.CustomResource, "node-uid", labels.LabelRemoteNode)
 	assert.Len(t, IPIdentityCache.metadata.m, 3)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix2})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{inClusterPrefix2})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 3)
@@ -93,7 +93,7 @@ func TestInjectLabels(t *testing.T) {
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.CustomResource, "node-uid-cidr", labels.GetCIDRLabels(inClusterPrefix))
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix2, source.CustomResource, "node-uid-cidr", labels.GetCIDRLabels(inClusterPrefix2))
 
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix, inClusterPrefix2})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{inClusterPrefix, inClusterPrefix2})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 3)
@@ -122,7 +122,7 @@ func TestInjectLabels(t *testing.T) {
 	// Remove remote-node label, ensure transition to local cidr identity space
 	IPIdentityCache.metadata.remove(inClusterPrefix, "node-uid", overrideIdentity(false), labels.LabelRemoteNode)
 	IPIdentityCache.metadata.remove(inClusterPrefix2, "node-uid", overrideIdentity(false), labels.LabelRemoteNode)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix, inClusterPrefix2})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{inClusterPrefix, inClusterPrefix2})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 
@@ -149,7 +149,7 @@ func TestInjectLabels(t *testing.T) {
 	IPIdentityCache.metadata.remove(inClusterPrefix, "node-uid-cidr", overrideIdentity(false), labels.Labels{})
 	IPIdentityCache.metadata.remove(inClusterPrefix2, "node-uid-cidr", overrideIdentity(false), labels.Labels{})
 	IPIdentityCache.metadata.remove(inClusterPrefix, "kube-uid", overrideIdentity(false), labels.LabelKubeAPIServer)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix, inClusterPrefix2})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{inClusterPrefix, inClusterPrefix2})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
@@ -158,7 +158,7 @@ func TestInjectLabels(t *testing.T) {
 	// reserved health ID.
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.Local, "node-uid", labels.LabelHealth)
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{inClusterPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
@@ -169,7 +169,7 @@ func TestInjectLabels(t *testing.T) {
 	// reserved ingress ID.
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix2, source.Local, "node-uid", labels.LabelIngress)
 	assert.Len(t, IPIdentityCache.metadata.m, 3)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix2})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{inClusterPrefix2})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 3)
@@ -177,7 +177,7 @@ func TestInjectLabels(t *testing.T) {
 	assert.Equal(t, identity.ReservedIdentityIngress, IPIdentityCache.ipToIdentityCache["10.0.0.5/32"].ID)
 	// Clean up.
 	IPIdentityCache.metadata.remove(inClusterPrefix2, "node-uid", overrideIdentity(false), labels.LabelIngress)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix2})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{inClusterPrefix2})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
@@ -187,13 +187,13 @@ func TestInjectLabels(t *testing.T) {
 	// within the cluster.
 	IPIdentityCache.metadata.upsertLocked(aPrefix, source.Generated, "cnp-uid", labels.LabelWorld)
 	assert.Len(t, IPIdentityCache.metadata.m, 3)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{aPrefix})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{aPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 3)
 	assert.True(t, IPIdentityCache.ipToIdentityCache["100.4.16.32/32"].ID.HasLocalScope())
 	IPIdentityCache.metadata.upsertLocked(aPrefix, source.CustomResource, "node-uid", labels.LabelRemoteNode)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{aPrefix})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{aPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 3)
@@ -203,7 +203,7 @@ func TestInjectLabels(t *testing.T) {
 	// reserved world-ipv4 ID.
 	IPIdentityCache.metadata.upsertLocked(allIPv4CIDRsPrefix, source.Local, "daemon-uid", labels.LabelWorldIPv4)
 	assert.Len(t, IPIdentityCache.metadata.m, 4)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{allIPv4CIDRsPrefix})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{allIPv4CIDRsPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 4)
@@ -214,7 +214,7 @@ func TestInjectLabels(t *testing.T) {
 	// reserved world-ipv6 ID.
 	IPIdentityCache.metadata.upsertLocked(allIPv6CIDRsPrefix, source.Local, "daemon-uid", labels.LabelWorldIPv6)
 	assert.Len(t, IPIdentityCache.metadata.m, 5)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{allIPv6CIDRsPrefix})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{allIPv6CIDRsPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 5)
@@ -226,7 +226,7 @@ func TestInjectLabels(t *testing.T) {
 	option.Config.EnableIPv6 = false
 	IPIdentityCache.metadata.upsertLocked(allIPv4CIDRsPrefix, source.Local, "daemon-uid", labels.LabelWorld)
 	assert.Len(t, IPIdentityCache.metadata.m, 5)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{allIPv4CIDRsPrefix})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{allIPv4CIDRsPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 5)
@@ -257,7 +257,7 @@ func TestUpdateLocalNode(t *testing.T) {
 
 	injectLabels := func(ip netip.Prefix) {
 		t.Helper()
-		remaining, err := IPIdentityCache.InjectLabels(ctx, []netip.Prefix{ip})
+		remaining, err := IPIdentityCache.injectLabels(ctx, []netip.Prefix{ip})
 		assert.NoError(t, err)
 		assert.Len(t, remaining, 0)
 	}
@@ -354,7 +354,7 @@ func TestInjectExisting(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Now, the second half of UpsertLabels -- identity injection
-	remaining, err := IPIdentityCache.InjectLabels(context.Background(), []netip.Prefix{prefix})
+	remaining, err := IPIdentityCache.injectLabels(context.Background(), []netip.Prefix{prefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 
@@ -472,7 +472,7 @@ func TestInjectLegacySecond(t *testing.T) {
 	labels := labels.GetCIDRLabels(prefix)
 
 	IPIdentityCache.metadata.upsertLocked(prefix, source.Generated, resource, labels)
-	remaining, err := IPIdentityCache.InjectLabels(context.Background(), []netip.Prefix{prefix})
+	remaining, err := IPIdentityCache.injectLabels(context.Background(), []netip.Prefix{prefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 
@@ -491,7 +491,7 @@ func TestInjectLegacySecond(t *testing.T) {
 
 	// Remove via new APIs
 	IPIdentityCache.metadata.remove(prefix, resource, labels)
-	remaining, err = IPIdentityCache.InjectLabels(context.Background(), []netip.Prefix{prefix})
+	remaining, err = IPIdentityCache.injectLabels(context.Background(), []netip.Prefix{prefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 
@@ -518,7 +518,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	ctx := context.Background()
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	remaining, err := IPIdentityCache.InjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, err := IPIdentityCache.injectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
@@ -546,7 +546,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	// the cluster, and thus will have a CIDR identity when InjectLabels() is
 	// called.
 	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.CustomResource, "kube-uid", labels.LabelKubeAPIServer)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	id := IPIdentityCache.IdentityAllocator.LookupIdentityByID(
@@ -563,7 +563,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	IPIdentityCache.RemoveLabelsExcluded(
 		labels.LabelKubeAPIServer, map[netip.Prefix]struct{}{},
 		"kube-uid")
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.NotContains(t, IPIdentityCache.metadata.m[worldPrefix].ToLabels(), labels.IDNameKubeAPIServer)
@@ -595,7 +595,7 @@ func TestOverrideIdentity(t *testing.T) {
 
 	// Create CIDR identity from labels
 	ipc.metadata.upsertLocked(worldPrefix, source.KubeAPIServer, "kube-uid", labels.LabelKubeAPIServer)
-	remaining, err := ipc.InjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, err := ipc.injectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 
@@ -606,7 +606,7 @@ func TestOverrideIdentity(t *testing.T) {
 
 	// Force an identity override
 	ipc.metadata.upsertLocked(worldPrefix, source.CustomResource, "cep-uid", overrideIdentity(true), fooLabels)
-	remaining, err = ipc.InjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, err = ipc.injectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 
@@ -617,7 +617,7 @@ func TestOverrideIdentity(t *testing.T) {
 
 	// Remove identity override from prefix, should assign a CIDR identity again
 	ipc.metadata.remove(worldPrefix, "cep-uid", overrideIdentity(true), fooLabels)
-	remaining, err = ipc.InjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, err = ipc.injectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 
@@ -629,7 +629,7 @@ func TestOverrideIdentity(t *testing.T) {
 
 	// Remove remaining labels from prefix, this should remove the entry
 	ipc.metadata.remove(worldPrefix, "kube-uid", labels.LabelKubeAPIServer)
-	remaining, err = ipc.InjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, err = ipc.injectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 
@@ -638,13 +638,13 @@ func TestOverrideIdentity(t *testing.T) {
 
 	// Create a new entry again via override
 	ipc.metadata.upsertLocked(worldPrefix, source.CustomResource, "cep-uid", overrideIdentity(true), barLabels)
-	remaining, err = ipc.InjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, err = ipc.injectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 
 	// Add labels, those will be ignored due to override
 	ipc.metadata.upsertLocked(worldPrefix, source.KubeAPIServer, "kube-uid", labels.LabelKubeAPIServer)
-	remaining, err = ipc.InjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, err = ipc.injectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 
@@ -656,7 +656,7 @@ func TestOverrideIdentity(t *testing.T) {
 	// Remove all metadata at once, this should remove the whole entry
 	ipc.metadata.remove(worldPrefix, "kube-uid", labels.LabelKubeAPIServer)
 	ipc.metadata.remove(worldPrefix, "cep-uid", overrideIdentity(true), barLabels)
-	remaining, err = ipc.InjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, err = ipc.injectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 
@@ -674,7 +674,7 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.CustomResource, "node-uid",
 		types.TunnelPeer{Addr: netip.MustParseAddr("192.168.1.100")},
 		types.EncryptKey(7))
-	remaining, err := IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix})
+	remaining, err := IPIdentityCache.injectLabels(ctx, []netip.Prefix{inClusterPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 
@@ -688,7 +688,7 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.Generated, "generated-uid",
 		types.TunnelPeer{Addr: netip.MustParseAddr("192.168.1.101")},
 		types.EncryptKey(6))
-	_, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix})
+	_, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{inClusterPrefix})
 	assert.NoError(t, err)
 	ip, key = IPIdentityCache.getHostIPCache(inClusterPrefix.String())
 	assert.Equal(t, "192.168.1.100", ip.String())
@@ -697,7 +697,7 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 	// Remove the entry with the encryptKey=7 and encryptKey=6.
 	IPIdentityCache.metadata.remove(inClusterPrefix, "node-uid", types.EncryptKey(7))
 	IPIdentityCache.metadata.remove(inClusterPrefix, "generated-uid", types.EncryptKey(6))
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{inClusterPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 
@@ -714,7 +714,7 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.KubeAPIServer, "kube-uid",
 		labels.LabelKubeAPIServer,
 	)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix})
+	remaining, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{inClusterPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 
@@ -724,7 +724,7 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 		types.TunnelPeer{Addr: netip.MustParseAddr("192.168.1.101")},
 		types.EncryptKey(6),
 	)
-	_, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix})
+	_, err = IPIdentityCache.injectLabels(ctx, []netip.Prefix{inClusterPrefix})
 	assert.NoError(t, err)
 	ip, key = IPIdentityCache.getHostIPCache(inClusterPrefix.String())
 	assert.Equal(t, "192.168.1.101", ip.String())
@@ -740,7 +740,7 @@ func TestRequestIdentity(t *testing.T) {
 
 	injectLabels := func(prefixes ...netip.Prefix) {
 		t.Helper()
-		remaining, err := IPIdentityCache.InjectLabels(context.Background(), prefixes)
+		remaining, err := IPIdentityCache.injectLabels(context.Background(), prefixes)
 		assert.NoError(t, err)
 		assert.Len(t, remaining, 0)
 	}

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -829,6 +829,8 @@ func setupTest(t *testing.T) (cleanup func()) {
 		PolicyHandler:     PolicyHandler,
 		DatapathHandler:   &mockTriggerer{},
 	})
+	// Don't start the ipcache here, as we don't want the controller stepping on our toes.
+	// A lot of the tests recreate specific interleaving of actions.
 
 	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.KubeAPIServer, "kube-uid", labels.LabelKubeAPIServer)
 	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.Local, "host-uid", labels.LabelHost)

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -416,9 +416,10 @@ func TestInjectWithLegacyAPIOverlap(t *testing.T) {
 	// It should only allocate once, even if we run it multiple times.
 	identityReferences++
 	for i := 0; i < 2; i++ {
-		IPIdentityCache.UpsertLabels(prefix, labels, source.CustomResource, resource)
-		// Need to wait for the label injector to finish; easiest just to remove it
-		IPIdentityCache.controllers.RemoveControllerAndWait(LabelInjectorName)
+		IPIdentityCache.metadata.upsertLocked(prefix, source.CustomResource, resource, labels)
+		remaining, err := IPIdentityCache.injectLabels(context.Background(), []netip.Prefix{prefix})
+		assert.NoError(t, err)
+		assert.Len(t, remaining, 0)
 	}
 
 	// Ensure the source is now correctly understood in the ipcache
@@ -450,8 +451,10 @@ func TestInjectWithLegacyAPIOverlap(t *testing.T) {
 	assert.Equal(t, id.ID.Uint32(), uint32(realID.ID))
 
 	// Remove the identity allocation via newer APIs
-	IPIdentityCache.RemoveLabels(prefix, labels, resource)
-	IPIdentityCache.controllers.RemoveControllerAndWait(LabelInjectorName)
+	IPIdentityCache.metadata.remove(prefix, resource, labels)
+	remaining, err := IPIdentityCache.injectLabels(context.Background(), []netip.Prefix{prefix})
+	assert.NoError(t, err)
+	assert.Len(t, remaining, 0)
 	identityReferences--
 	assert.Equal(t, identityReferences, 0)
 


### PR DESCRIPTION
The relevant change in this PR refactors the ipcache to explicitly start the label injection controller, rather than lazily on first prefix update. It also adjusts some tests that relied in this behavior.

It also switches to using `TriggerController` rather than `UpdateController` to trigger the controller, which is actually a bug, since `UpdateController` can drop triggers ([issue](https://github.com/cilium/cilium/issues/29015))

A mechanical commit also un-exports some methods that should not have been exported.