### PR TITLE
ipcache: use TriggerController, not UpdateController

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -156,7 +156,7 @@ func NewIPCache(c *Configuration) *IPCache {
 // Shutdown cleans up asynchronous routines associated with the IPCache.
 func (ipc *IPCache) Shutdown() error {
 	ipc.deferredPrefixRelease.Shutdown()
-	return ipc.ShutdownLabelInjection()
+	return ipc.controllers.RemoveControllerAndWait(LabelInjectorName)
 }
 
 // Lock locks the IPCache's mutex.

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net"
 	"net/netip"
+	"sync"
 	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
@@ -132,6 +133,10 @@ type IPCache struct {
 	// prefixLengths tracks the unique set of prefix lengths for IPv4 and
 	// IPv6 addresses in order to optimize longest prefix match lookups.
 	prefixLengths *counter.PrefixLengthCounter
+
+	// injectionStarted is a sync.Once so we can lazily start the prefix injection controller,
+	// but only once
+	injectionStarted sync.Once
 }
 
 // NewIPCache returns a new IPCache with the mappings of endpoint IP to security

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -724,8 +724,3 @@ func (ipc *IPCache) TriggerLabelInjection() {
 		},
 	)
 }
-
-// ShutdownLabelInjection shuts down the controller in TriggerLabelInjection().
-func (ipc *IPCache) ShutdownLabelInjection() error {
-	return ipc.controllers.RemoveControllerAndWait(LabelInjectorName)
-}

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -704,23 +704,26 @@ func (ipc *IPCache) TriggerLabelInjection() {
 
 	// This controller is for retrying this operation in case it fails. It
 	// should eventually succeed.
-	ipc.UpdateController(
-		LabelInjectorName,
-		controller.ControllerParams{
-			Group:   injectLabelsControllerGroup,
-			Context: ipc.Configuration.Context,
-			DoFunc: func(ctx context.Context) error {
-				idsToModify, rev := ipc.metadata.dequeuePrefixUpdates()
-				remaining, err := ipc.InjectLabels(ctx, idsToModify)
-				if len(remaining) > 0 {
-					ipc.metadata.enqueuePrefixUpdates(remaining...)
-				} else {
-					ipc.metadata.setInjectedRevision(rev)
-				}
+	ipc.injectionStarted.Do(func() {
+		ipc.UpdateController(
+			LabelInjectorName,
+			controller.ControllerParams{
+				Group:   injectLabelsControllerGroup,
+				Context: ipc.Configuration.Context,
+				DoFunc: func(ctx context.Context) error {
+					idsToModify, rev := ipc.metadata.dequeuePrefixUpdates()
+					remaining, err := ipc.InjectLabels(ctx, idsToModify)
+					if len(remaining) > 0 {
+						ipc.metadata.enqueuePrefixUpdates(remaining...)
+					} else {
+						ipc.metadata.setInjectedRevision(rev)
+					}
 
-				return err
+					return err
+				},
+				MaxRetryInterval: 1 * time.Minute,
 			},
-			MaxRetryInterval: 1 * time.Minute,
-		},
-	)
+		)
+	})
+	ipc.controllers.TriggerController(LabelInjectorName)
 }

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -416,9 +416,10 @@ func TestInjectWithLegacyAPIOverlap(t *testing.T) {
 	// It should only allocate once, even if we run it multiple times.
 	identityReferences++
 	for i := 0; i < 2; i++ {
-		IPIdentityCache.UpsertLabels(prefix, labels, source.CustomResource, resource)
-		// Need to wait for the label injector to finish; easiest just to remove it
-		IPIdentityCache.controllers.RemoveControllerAndWait(LabelInjectorName)
+		IPIdentityCache.metadata.upsertLocked(prefix, source.CustomResource, resource, labels)
+		remaining, err := IPIdentityCache.InjectLabels(context.Background(), []netip.Prefix{prefix})
+		assert.NoError(t, err)
+		assert.Len(t, remaining, 0)
 	}
 
 	// Ensure the source is now correctly understood in the ipcache
@@ -450,8 +451,10 @@ func TestInjectWithLegacyAPIOverlap(t *testing.T) {
 	assert.Equal(t, id.ID.Uint32(), uint32(realID.ID))
 
 	// Remove the identity allocation via newer APIs
-	IPIdentityCache.RemoveLabels(prefix, labels, resource)
-	IPIdentityCache.controllers.RemoveControllerAndWait(LabelInjectorName)
+	IPIdentityCache.metadata.remove(prefix, resource, labels)
+	remaining, err := IPIdentityCache.InjectLabels(context.Background(), []netip.Prefix{prefix})
+	assert.NoError(t, err)
+	assert.Len(t, remaining, 0)
 	identityReferences--
 	assert.Equal(t, identityReferences, 0)
 


### PR DESCRIPTION
There was an issue discovered in #29015 where using `UpdateController()` to trigger a controller caused that trigger to be lost. There is already an existing `TriggerController()` method; switch to that.

(This also fixes a test that wants to use the ipcache synchronously; rather than stoppping the controller, the convention is to just call the synchronous methods).