### PR TITLE
Makefile: fix make bench not invoking checkmate tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ TESTPKGS ?= ./...
 
 GOTEST_BASE := -timeout 600s
 GOTEST_COVER_OPTS += -coverprofile=coverage.out
-BENCH_EVAL := "."
+BENCH_EVAL := .
 BENCH ?= $(BENCH_EVAL)
-BENCHFLAGS_EVAL := -bench=$(BENCH) -run=^$ -benchtime=10s
+BENCHFLAGS_EVAL := -bench='$(BENCH)' -run='^Test$$/.+Suite/^Benchmark$(BENCH)' -benchtime=10s
 BENCHFLAGS ?= $(BENCHFLAGS_EVAL)
 SKIP_KVSTORES ?= "false"
 SKIP_K8S_CODE_GEN_CHECK ?= "true"
@@ -129,11 +129,11 @@ integration-tests: start-kvstores ## Run Go tests including ones that are marked
 	$(MAKE) stop-kvstores
 
 bench: start-kvstores ## Run benchmarks for Cilium integration-tests in the repository.
-	$(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $(GOTEST_BASE) $(BENCHFLAGS) $(TESTPKGS)
+	INTEGRATION_TESTS=y $(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $(GOTEST_BASE) $(BENCHFLAGS) $(TESTPKGS) -check.b
 	$(MAKE) stop-kvstores
 
 bench-privileged: ## Run benchmarks for privileged tests.
-	PRIVILEGED_TESTS=true $(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $(GOTEST_BASE) $(BENCHFLAGS) $(TESTPKGS)
+	PRIVILEGED_TESTS=true $(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $(GOTEST_BASE) $(BENCHFLAGS) $(TESTPKGS) -check.b
 
 clean-tags: ## Remove all the tags files from the repository.
 	@$(ECHO_CLEAN) tags


### PR DESCRIPTION
Executing make bench doesn't invoke checkmate-style tests, and from what I can tell never has. Fixing it to run our benchmarks isn't straightforward however.

gocheck made the unfortunate decision that benchmarks are just tests with a special name. This means that checkmate can't distinguish between tests and benchmarks and the -bench flag has no effect on checkmate benchmarks. Instead a separate -check.b flag has to be passed, and filtering benchmarks is just filtering tests.

Make the go test runner invoke checkmate tests by specifying a special regex. Pass -check.b as the last argument, since the test runner stops processing arguments on the first unknown flag.

Fixes: #29546