### PR TITLE
.github: do not group jobs on merge queues

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -13,7 +13,7 @@ on:
 permissions: read-all
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || github.event.merge_group && github.run_id }}
   cancel-in-progress: ${{ !github.event.merge_group }}
 
 jobs:

--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -13,7 +13,7 @@ on:
 permissions: read-all
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || github.event.merge_group && github.run_id }}
   cancel-in-progress: ${{ !github.event.merge_group }}
 
 jobs:

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -13,7 +13,7 @@ on:
 permissions: read-all
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || github.event.merge_group && github.run_id }}
   cancel-in-progress: ${{ !github.event.merge_group }}
 
 jobs:

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -13,7 +13,7 @@ on:
 permissions: read-all
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || github.event.merge_group && github.run_id }}
   cancel-in-progress: ${{ !github.event.merge_group }}
 
 env:


### PR DESCRIPTION
During merge queues we don't want to group the concurrent jobs together since they are supposed to run in parallel. Thus, we should suffix the concurrency group with with the `github.run_id` which is unique per each run but only when the event type is a merge_group.

Concurrent jobs are still canceled for PRs, tested in https://github.com/cilium/cilium/actions/runs/7060613961/job/19220496966?pr=29551