### PR TITLE
endpointmanager: unmap ip for lookup

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -325,7 +325,7 @@ func (mgr *endpointManager) LookupIPv6(ipv6 string) *endpoint.Endpoint {
 
 // LookupIP looks up endpoint by IP address
 func (mgr *endpointManager) LookupIP(ip netip.Addr) (ep *endpoint.Endpoint) {
-	ipStr := ip.String()
+	ipStr := ip.Unmap().String()
 	mgr.mutex.RLock()
 	if ip.Is4() {
 		ep = mgr.lookupIPv4(ipStr)


### PR DESCRIPTION
In case of an IPv4-mapped IPv6 address we'd lookup the address as an IPv4 address with a ::ffff: prefix, leading to endpoint lookup errors such as

    cannot find endpoint with IP ::ffff:10.0.1.19

Fix this by explicitly unmapping the address before lookup which leads to 10.0.1.19 to be looked up (and found) in the above case.

Fixes: 54a896c5ab9a ("endpointmanager: Use netip.Addr instead of net.IP in LookupIP")
