### PR TITLE
ci-clustermesh-upgrade: Increment timeout between rollouts to 5min

### DIFF
--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -426,8 +426,8 @@ jobs:
           kubectl --context ${{ env.contextName2 }} rollout restart -n kube-system ds/cilium
 
           # Wait until all agents successfully restarted before scaling the replicas again
-          kubectl --context ${{ env.contextName1 }} rollout status -n kube-system ds/cilium --timeout=1m
-          kubectl --context ${{ env.contextName2 }} rollout status -n kube-system ds/cilium --timeout=1m
+          kubectl --context ${{ env.contextName1 }} rollout status -n kube-system ds/cilium --timeout=5m
+          kubectl --context ${{ env.contextName2 }} rollout status -n kube-system ds/cilium --timeout=5m
 
       - name: Scale the clustermesh-apiserver replicas back to 1
         run: |


### PR DESCRIPTION
Currently, the ClusterMesh upgrade test sets an explicit timeout of 1min to wait for the Cilium Agent DaemonSet to become ready between the rollouts.

In some cases, the Pods aren't ready after 1min. Therefore, this commit increases the timeout to 5min.

I think the most important part is that we set an explicit timeout on the command `kubectl rollout status` - as the default is wait forever.

Spotted on `main`: https://github.com/cilium/cilium/actions/runs/7061558462/job/19223486069

Sysdump analysis: The last missing agent pod on cluster 1 was soon about to become ready. (`Init 3/6`)

Cluster 1 / Context 1:

```
NAMESPACE            NAME                                             READY   STATUS     RESTARTS   AGE     IP             NODE                     NOMINATED NODE   READINESS GATES
...
kube-system          cilium-7vbtb                                     1/1     Running    0          60s     172.18.0.2     cluster1-worker          <none>           <none>
kube-system          cilium-gbd6v                                     0/1     Init:3/6   0          60s     172.18.0.3     cluster1-control-plane   <none>           <none>...
```

Cluster2 / Context 2:

```
kube-system          cilium-fr7mn                                     1/1     Running   0          92s     172.18.0.5     cluster2-control-plane   <none>           <none>
kube-system          cilium-wndch                                     1/1     Running   0          92s     172.18.0.4     cluster2-worker          <none>           <none>
```