### PR TITLE
ipset: ignore not found errors on entry removal

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1204,7 +1204,7 @@ func (m *Manager) RemoveFromNodeIpset(nodeIP net.IP) {
 	if ip.IsIPv6(nodeIP) {
 		ciliumNodeIpset = ciliumNodeIpsetV6
 	}
-	progArgs := []string{"del", ciliumNodeIpset, nodeIP.String()}
+	progArgs := []string{"del", ciliumNodeIpset, nodeIP.String(), "-exist"}
 	if err := ipset.runProg(progArgs); err != nil {
 		scopedLog.WithError(err).Errorf("Failed to remove IP from ipset %s", ciliumNodeIpset)
 	}


### PR DESCRIPTION
Configure the extra flag to prevent the ipset command from returning an error if the entry that we are trying to remove is already not present. This change brings consistency with the add command (which already sets the same flag), and enables us to attempt to remove an entry even if it may not exist, e.g., to cleanup possible stale entries.

<!-- Description of change -->

Fixes: #issue-number

```release-note
Don't log an error if the to be deleted ipset entry does not exist
```
