### PR TITLE
scale-test-100-gce: Use CILIUM_CLI_VERSION

### DIFF
--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -28,8 +28,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # renovate: datasource=github-releases depName=cilium/cilium-cli
-  cilium_cli_version: v0.15.11
   # renovate: datasource=github-releases depName=kubernetes/kops
   kops_version: v1.28.1
   # renovate: datasource=golang-version depName=go
@@ -39,7 +37,6 @@ env:
   test_name: scale-100
   cluster_base_name: ${{ github.run_id }}-${{ github.run_attempt }}.k8s.local
   GCP_PERF_RESULTS_BUCKET: gs://cilium-scale-results
-  CILIUM_CLI_MODE: helm
 
 jobs:
   install-and-scaletest:
@@ -91,9 +88,10 @@ jobs:
           go-version: ${{ env.go_version }}
 
       - name: Install Cilium CLI
-        uses: cilium/cilium-cli@951eb9108277f4ffeb86d047bd492b6b96a52542 # v0.15.11
+        uses: cilium/cilium-cli@beceead2bece1d174e2c11f36e6bfac8ce3f8e7d # v0.15.16
         with:
-          release-version: ${{ env.cilium_cli_version }}
+          repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
+          release-version: ${{ env.CILIUM_CLI_VERSION }}
 
       - name: Install Kops
         uses: cilium/scale-tests-action/install-kops@8a522b9d71254b6f6615c296e41a70610c9615ea # main


### PR DESCRIPTION
- Remove cilium_cli_version variable and use CILIUM_CLI_VERSION instead.
- Remove CILIUM_CLI_MODE environment variable. The Helm mode became the default in v0.15.

Fixes: 42e1a4a129b9 ("workflows: move cilium_cli_version definition to set-env-variables action")