### PR TITLE
helm: fix prometheus.metrics not correctly configuring metrics.

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -206,9 +206,7 @@ data:
   # Metrics that should be enabled or disabled from the default metric
   # list. (+metric_foo to enable metric_foo , -metric_bar to disable
   # metric_bar).
-  metrics: {{- range .Values.prometheus.metrics }}
-    {{ . }}
-  {{- end }}
+  metrics: {{ join "," .Values.prometheus.metrics | quote }}
   {{- end }}
   {{- if .Values.prometheus.controllerGroupMetrics }}
   # A space-separated list of controller groups for which to enable metrics.

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1950,8 +1950,6 @@ prometheus:
     trustCRDsExist: false
 
   # -- Metrics that should be enabled or disabled from the default metric list.
-  # The list is expected to be separated by a space. (+metric_foo to enable
-  # metric_foo , -metric_bar to disable metric_bar).
   # ref: https://docs.cilium.io/en/stable/observability/metrics/
   metrics: ~
 


### PR DESCRIPTION
The prometheus.metrics field in helm input values takes an array object, and in the cilium-config ConfigMap creates config such as:

```
metrics: +metric1 +metric2 -metric
```

This [is then parsed by a StringSlice flag](https://github.com/cilium/cilium/blob/main/pkg/metrics/registry.go#L39) in pkg/metrics/registry.go.

StringSlice is supposed to be a comma-seperated value, however the configmap value is a whitespace seperated.

This changes the helm template to do a join creating a comma seperated array.

Suggested-by: Michi Mutsuzaki <michi@isovalent.com>