### PR TITLE
Hubble: Emit v1.Event on packet drop

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -185,6 +185,9 @@ cilium-agent [flags]
       --http-retry-count uint                                     Number of retries performed after a forwarded request attempt fails (default 3)
       --http-retry-timeout uint                                   Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --hubble-disable-tls                                        Allow Hubble server to run on the given listen address without TLS.
+      --hubble-drop-events                                        Emit packet drop Events related to pods
+      --hubble-drop-events-interval duration                      Minimum time between emitting same events (default 2m0s)
+      --hubble-drop-events-reasons string                         Drop reasons to emit events for (default "auth_required,policy_denied")
       --hubble-event-buffer-capacity int                          Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)
       --hubble-event-queue-size int                               Buffer size of the channel to receive monitor events.
       --hubble-export-allowlist strings                           Specify allowlist as JSON encoded FlowFilters to Hubble exporter.

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1468,6 +1468,18 @@
      - Annotations to be added to all top-level hubble objects (resources under templates/hubble)
      - object
      - ``{}``
+   * - :spelling:ignore:`hubble.dropEventEmitter`
+     - Emit v1.Events related to pods on detection of packet drops.
+     - object
+     - ``{"enabled":false,"interval":"2m","reasons":["auth_required","policy_denied"]}``
+   * - :spelling:ignore:`hubble.dropEventEmitter.interval`
+     - - Minimum time between emitting same events.
+     - string
+     - ``"2m"``
+   * - :spelling:ignore:`hubble.dropEventEmitter.reasons`
+     - - Drop reasons to emit events for. ref: https://docs.cilium.io/en/stable/_api/v1/flow/README/#dropreason
+     - list
+     - ``["auth_required","policy_denied"]``
    * - :spelling:ignore:`hubble.enabled`
      - Enable Hubble (true by default).
      - bool

--- a/USERS.md
+++ b/USERS.md
@@ -235,6 +235,12 @@ Users (Alphabetically)
       L: https://metal.equinix.com/
       Q: @matoszz
 
+    * N: Equinix
+      D: Equinix NL Managed Services is using Cilium with their Managed Kubernetes offering
+      U: CNI, network policies, visibility
+      L: https://www.equinix.nl/products/support-services/managed-services/netherlands
+      Q: @jonkerj
+
     * N: Exoscale
       D: Exoscale is offering Cilium as a CNI option on its managed Kubernetes service named SKS (Scalable Kubernetes Service)
       U: CNI, Networking

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -986,6 +986,15 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.StringSlice(option.HubbleRedactHttpHeadersDeny, []string{}, "HTTP headers to redact from flows")
 	option.BindEnv(vp, option.HubbleRedactHttpHeadersDeny)
 
+	flags.Bool(option.HubbleDropEvents, defaults.HubbleDropEventsEnabled, "Emit packet drop Events related to pods")
+	option.BindEnv(vp, option.HubbleDropEvents)
+
+	flags.Duration(option.HubbleDropEventsInterval, defaults.HubbleDropEventsInterval, "Minimum time between emitting same events")
+	option.BindEnv(vp, option.HubbleDropEventsInterval)
+
+	flags.String(option.HubbleDropEventsReasons, defaults.HubbleDropEventsReasons, "Drop reasons to emit events for")
+	option.BindEnv(vp, option.HubbleDropEventsReasons)
+
 	flags.Bool(option.EnableIPv4FragmentsTrackingName, defaults.EnableIPv4FragmentsTracking, "Enable IPv4 fragments tracking for L4-based lookups")
 	option.BindEnv(vp, option.EnableIPv4FragmentsTrackingName)
 

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/link"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/container"
+	"github.com/cilium/cilium/pkg/hubble/dropeventemitter"
 	"github.com/cilium/cilium/pkg/hubble/exporter"
 	"github.com/cilium/cilium/pkg/hubble/exporter/exporteroption"
 	"github.com/cilium/cilium/pkg/hubble/metrics"
@@ -108,6 +109,29 @@ func (d *Daemon) launchHubble() {
 		} else {
 			observerOpts = append(observerOpts, observeroption.WithOnMonitorEvent(monitorFilter))
 		}
+	}
+
+	if option.Config.HubbleDropEvents {
+		logger.
+			WithField("interval", option.Config.HubbleDropEventsInterval).
+			WithField("reasons", option.Config.HubbleDropEventsReasons).
+			Info("Starting packet drop events emitter")
+
+		dropEventEmitter := dropeventemitter.NewDropEventEmitter(
+			option.Config.HubbleDropEventsInterval,
+			option.Config.HubbleDropEventsReasons,
+			d.clientset,
+		)
+
+		observerOpts = append(observerOpts,
+			observeroption.WithOnDecodedFlowFunc(func(ctx context.Context, flow *flowpb.Flow) (bool, error) {
+				err := dropEventEmitter.ProcessFlow(ctx, flow)
+				if err != nil {
+					logger.WithError(err).Error("Failed to ProcessFlow in drop events handler")
+				}
+				return false, nil
+			}),
+		)
 	}
 
 	if option.Config.HubbleMetricsServer != "" {

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -417,6 +417,9 @@ contributors across the globe, there is almost always someone available to help.
 | hostFirewall.enabled | bool | `false` | Enables the enforcement of host policies in the eBPF datapath. |
 | hostPort.enabled | bool | `false` | Enable hostPort service support. |
 | hubble.annotations | object | `{}` | Annotations to be added to all top-level hubble objects (resources under templates/hubble) |
+| hubble.dropEventEmitter | object | `{"enabled":false,"interval":"2m","reasons":["auth_required","policy_denied"]}` | Emit v1.Events related to pods on detection of packet drops. |
+| hubble.dropEventEmitter.interval | string | `"2m"` | - Minimum time between emitting same events. |
+| hubble.dropEventEmitter.reasons | list | `["auth_required","policy_denied"]` | - Drop reasons to emit events for. ref: https://docs.cilium.io/en/stable/_api/v1/flow/README/#dropreason |
 | hubble.enabled | bool | `true` | Enable Hubble (true by default). |
 | hubble.export | object | `{"dynamic":{"config":{"configMapName":"cilium-flowlog-config","content":[{"excludeFilters":[],"fieldMask":[],"filePath":"/var/run/cilium/hubble/events.log","includeFilters":[],"name":"all"}],"createConfigMap":true},"enabled":false},"fileMaxBackups":5,"fileMaxSizeMb":10,"static":{"allowList":[],"denyList":[],"enabled":false,"fieldMask":[],"filePath":"/var/run/cilium/hubble/events.log"}}` | Hubble flows export. |
 | hubble.export.dynamic | object | `{"config":{"configMapName":"cilium-flowlog-config","content":[{"excludeFilters":[],"fieldMask":[],"filePath":"/var/run/cilium/hubble/events.log","includeFilters":[],"name":"all"}],"createConfigMap":true},"enabled":false}` | - Dynamic exporters configuration. Dynamic exporters may be reconfigured without a need of agent restarts. |

--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -41,6 +41,7 @@ rules:
   - get
   - list
   - watch
+{{- if and .Values.hubble.enabled .Values.hubble.dropEventEmitter.enabled }}
 - apiGroups:
   - ""
   resources:
@@ -48,6 +49,7 @@ rules:
   verbs:
   - create
   - patch
+{{- end }}
 {{- if .Values.annotateK8sNode }}
 - apiGroups:
   - ""

--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -41,6 +41,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 {{- if .Values.annotateK8sNode }}
 - apiGroups:
   - ""

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -929,6 +929,11 @@ data:
   hubble-disable-tls: "true"
 {{- end }}
 {{- end }}
+{{- if .Values.hubble.dropEventEmitter.enabled }}
+  hubble-drop-events: "true"
+  hubble-drop-events-interval: {{ .Values.hubble.dropEventEmitter.interval | quote }}
+  hubble-drop-events-reasons: {{ .Values.hubble.dropEventEmitter.reasons | join "," | quote }}
+{{- end }}
 {{- if .Values.hubble.preferIpv6 }}
   hubble-prefer-ipv6: "true"
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -41,6 +41,7 @@ rules:
   - get
   - list
   - watch
+{{- if and .Values.hubble.enabled .Values.hubble.dropEventEmitter.enabled }}
 - apiGroups:
   - ""
   resources:
@@ -48,6 +49,7 @@ rules:
   verbs:
   - create
   - patch
+{{- end }}
 {{- if .Values.annotateK8sNode }}
 - apiGroups:
   - ""

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -41,6 +41,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 {{- if .Values.annotateK8sNode }}
 - apiGroups:
   - ""

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1434,6 +1434,16 @@ hubble:
             #     - destination_pod: ["frontend/nginx-975996d4c-7hhgt"]
             #     excludeFilters: []
             #     end: "2023-10-09T23:59:59-07:00"
+  # -- Emit v1.Events related to pods on detection of packet drops.
+  dropEventEmitter:
+    enabled: false
+    # --- Minimum time between emitting same events.
+    interval: 2m
+    # --- Drop reasons to emit events for.
+    # ref: https://docs.cilium.io/en/stable/_api/v1/flow/README/#dropreason
+    reasons:
+      - auth_required
+      - policy_denied
 # -- Method to use for identity allocation (`crd` or `kvstore`).
 identityAllocationMode: "crd"
 # -- (string) Time to wait before using new identity on endpoint identity change.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1431,6 +1431,18 @@ hubble:
             #     - destination_pod: ["frontend/nginx-975996d4c-7hhgt"]
             #     excludeFilters: []
             #     end: "2023-10-09T23:59:59-07:00"
+
+  # -- Emit v1.Events related to pods on detection of packet drops.
+  dropEventEmitter:
+    enabled: false
+    # --- Minimum time between emitting same events.
+    interval: 2m
+    # --- Drop reasons to emit events for.
+    # ref: https://docs.cilium.io/en/stable/_api/v1/flow/README/#dropreason
+    reasons:
+      - auth_required
+      - policy_denied
+
 # -- Method to use for identity allocation (`crd` or `kvstore`).
 identityAllocationMode: "crd"
 # -- (string) Time to wait before using new identity on endpoint identity change.

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -98,6 +98,17 @@ const (
 	// HubbleRedactKafkaApiKey controls if the Kafka API key will be redacted from flows
 	HubbleRedactKafkaApiKey = false
 
+	// HubbleDropEventsEnabled controls whether Hubble should create v1.Events
+	// for packet drops related to pods
+	HubbleDropEventsEnabled = false
+
+	// HubbleDropEventsInterval controls the minimum time between emitting events
+	// with the same source and destination IP
+	HubbleDropEventsInterval = 2 * time.Minute
+
+	// HubbleDropEventsReasons controls which drop reasons to emit events for
+	HubbleDropEventsReasons = "auth_required,policy_denied"
+
 	// MonitorSockPath1_2 is the path to the UNIX domain socket used to
 	// distribute BPF and agent events to listeners.
 	// This is the 1.2 protocol version.

--- a/pkg/hubble/dropeventemitter/dropeventemitter.go
+++ b/pkg/hubble/dropeventemitter/dropeventemitter.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dropeventemitter
+
+import (
+	"context"
+	"slices"
+	"strconv"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	metaslimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	slimscheme "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/scheme"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/identity"
+	client "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type DropEventEmitter struct {
+	reasons  []string
+	recorder record.EventRecorder
+}
+
+func NewDropEventEmitter(interval time.Duration, reasons []string, k8s client.Clientset) *DropEventEmitter {
+	broadcaster := record.NewBroadcasterWithCorrelatorOptions(record.CorrelatorOptions{
+		BurstSize:            1,
+		QPS:                  1 / float32(interval.Seconds()),
+		MaxEvents:            1,
+		MaxIntervalInSeconds: int(interval.Seconds()),
+		MessageFunc:          func(event *v1.Event) string { return event.Message },
+	})
+	broadcaster.StartRecordingToSink(&typedv1.EventSinkImpl{Interface: k8s.CoreV1().Events("")})
+
+	return &DropEventEmitter{
+		reasons:  reasons,
+		recorder: broadcaster.NewRecorder(slimscheme.Scheme, v1.EventSource{Component: "cilium"}),
+	}
+}
+
+func (e *DropEventEmitter) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
+	reason := strings.ToLower(flow.DropReasonDesc.String())
+
+	// Only handle packet drops due to policy related to a Pod
+	if flow.Verdict != flowpb.Verdict_DROPPED ||
+		!slices.Contains(e.reasons, reason) ||
+		(flow.TrafficDirection == flowpb.TrafficDirection_INGRESS &&
+			flow.Destination.PodName == "") ||
+		(flow.TrafficDirection == flowpb.TrafficDirection_EGRESS &&
+			flow.Source.PodName == "") {
+		return nil
+	}
+
+	if flow.TrafficDirection == flowpb.TrafficDirection_INGRESS {
+		message := "Incoming packet dropped (" + reason + ") from " +
+			e.endpointToString(flow.IP.Source, flow.Source) + " " +
+			e.l4protocolToString(flow.L4)
+		e.recorder.Event(&slimv1.Pod{
+			TypeMeta: metaslimv1.TypeMeta{
+				Kind:       "Pod",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metaslimv1.ObjectMeta{
+				Name:      flow.Destination.PodName,
+				Namespace: flow.Destination.Namespace,
+			},
+		}, v1.EventTypeWarning, "PacketDrop", message)
+	} else {
+		message := "Outgoing packet dropped (" + reason + ") to " +
+			e.endpointToString(flow.IP.Destination, flow.Destination) + " " +
+			e.l4protocolToString(flow.L4)
+		e.recorder.Event(&slimv1.Pod{
+			TypeMeta: metaslimv1.TypeMeta{
+				Kind:       "Pod",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metaslimv1.ObjectMeta{
+				Name:      flow.Source.PodName,
+				Namespace: flow.Source.Namespace,
+			},
+		}, v1.EventTypeWarning, "PacketDrop", message)
+	}
+
+	return nil
+}
+
+func (e *DropEventEmitter) endpointToString(ip string, endpoint *flowpb.Endpoint) string {
+	if endpoint.PodName != "" {
+		return endpoint.Namespace + "/" + endpoint.PodName + " (" + ip + ")"
+	} else if identity.NumericIdentity(endpoint.Identity).IsReservedIdentity() {
+		return identity.NumericIdentity(endpoint.Identity).String() + " (" + ip + ")"
+	} else {
+		return ip
+	}
+}
+
+func (e *DropEventEmitter) l4protocolToString(l4 *flowpb.Layer4) string {
+	switch l4.Protocol.(type) {
+	case *flowpb.Layer4_TCP:
+		return "TCP/" + strconv.Itoa(int(l4.GetTCP().DestinationPort))
+	case *flowpb.Layer4_UDP:
+		return "UDP/" + strconv.Itoa(int(l4.GetUDP().DestinationPort))
+	case *flowpb.Layer4_ICMPv4:
+		return "ICMPv4"
+	case *flowpb.Layer4_ICMPv6:
+		return "ICMPv6"
+	case *flowpb.Layer4_SCTP:
+		return "SCTP"
+	}
+	return ""
+}

--- a/pkg/hubble/dropeventemitter/dropeventemitter_test.go
+++ b/pkg/hubble/dropeventemitter/dropeventemitter_test.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dropeventemitter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/tools/record"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/identity"
+)
+
+func TestEndpointToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip       string
+		endpoint *flowpb.Endpoint
+		expect   string
+	}{
+		{
+			name:     "pod",
+			ip:       "1.2.3.4",
+			endpoint: &flowpb.Endpoint{PodName: "pod", Namespace: "namespace"},
+			expect:   "namespace/pod (1.2.3.4)",
+		},
+		{
+			name:     "node",
+			ip:       "1.2.3.4",
+			endpoint: &flowpb.Endpoint{Identity: identity.ReservedIdentityRemoteNode.Uint32()},
+			expect:   identity.ReservedIdentityRemoteNode.String() + " (1.2.3.4)",
+		},
+		{
+			name:     "unknown",
+			ip:       "1.2.3.4",
+			endpoint: &flowpb.Endpoint{Identity: identity.MaxLocalIdentity.Uint32() + 1},
+			expect:   "1.2.3.4",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &DropEventEmitter{}
+			str := e.endpointToString(tt.ip, tt.endpoint)
+			assert.Equal(t, str, tt.expect)
+		})
+	}
+}
+
+func TestL4protocolToString(t *testing.T) {
+	tests := []struct {
+		name   string
+		l4     *flowpb.Layer4
+		expect string
+	}{
+		{
+			name:   "udp/512",
+			l4:     &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{DestinationPort: 512}}},
+			expect: "UDP/512",
+		},
+		{
+			name:   "tcp/443",
+			l4:     &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+			expect: "TCP/443",
+		},
+		{
+			name:   "unknown",
+			l4:     &flowpb.Layer4{},
+			expect: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &DropEventEmitter{}
+			str := e.l4protocolToString(tt.l4)
+			assert.Equal(t, str, tt.expect)
+		})
+	}
+}
+
+func TestProcessFlow(t *testing.T) {
+	tests := []struct {
+		name   string
+		flow   *flowpb.Flow
+		expect string
+	}{
+		{
+			name: "valid ingress drop event",
+			flow: &flowpb.Flow{
+				Verdict:          flowpb.Verdict_DROPPED,
+				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
+				TrafficDirection: flowpb.TrafficDirection_INGRESS,
+				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Source:           &flowpb.Endpoint{},
+				Destination:      &flowpb.Endpoint{Namespace: "namespace", PodName: "pod"},
+				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+			},
+			expect: "Incoming packet dropped (policy_denied) from unknown (1.2.3.4) TCP/443",
+		},
+		{
+			name: "valid egress drop event to node",
+			flow: &flowpb.Flow{
+				Verdict:          flowpb.Verdict_DROPPED,
+				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
+				TrafficDirection: flowpb.TrafficDirection_EGRESS,
+				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Source:           &flowpb.Endpoint{Namespace: "namespace", PodName: "pod"},
+				Destination:      &flowpb.Endpoint{Identity: identity.ReservedIdentityRemoteNode.Uint32()},
+				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{DestinationPort: 512}}},
+			},
+			expect: "Outgoing packet dropped (policy_denied) to remote-node (5.6.7.8) UDP/512",
+		},
+		{
+			name: "ingress drop event not matching reason",
+			flow: &flowpb.Flow{
+				Verdict:          flowpb.Verdict_DROPPED,
+				DropReasonDesc:   flowpb.DropReason_AUTH_REQUIRED,
+				TrafficDirection: flowpb.TrafficDirection_INGRESS,
+				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Source:           &flowpb.Endpoint{},
+				Destination:      &flowpb.Endpoint{Namespace: "namespace", PodName: "pod"},
+				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+			},
+			expect: "",
+		},
+		{
+			name: "ingress verdict is not dropped",
+			flow: &flowpb.Flow{
+				Verdict:          flowpb.Verdict_ERROR,
+				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
+				TrafficDirection: flowpb.TrafficDirection_INGRESS,
+				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Source:           &flowpb.Endpoint{},
+				Destination:      &flowpb.Endpoint{Namespace: "namespace", PodName: "pod"},
+				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+			},
+			expect: "",
+		},
+		{
+			name: "ingress but no destination pod",
+			flow: &flowpb.Flow{
+				Verdict:          flowpb.Verdict_DROPPED,
+				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
+				TrafficDirection: flowpb.TrafficDirection_INGRESS,
+				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Source:           &flowpb.Endpoint{Namespace: "namespace", PodName: "pod"},
+				Destination:      &flowpb.Endpoint{},
+				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+			},
+			expect: "",
+		},
+		{
+			name: "egress but no source pod",
+			flow: &flowpb.Flow{
+				Verdict:          flowpb.Verdict_DROPPED,
+				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
+				TrafficDirection: flowpb.TrafficDirection_EGRESS,
+				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Source:           &flowpb.Endpoint{},
+				Destination:      &flowpb.Endpoint{},
+				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+			},
+			expect: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeRecorder := record.NewFakeRecorder(3)
+			e := &DropEventEmitter{
+				reasons:  []string{"policy_denied"},
+				recorder: fakeRecorder,
+			}
+			if err := e.ProcessFlow(context.Background(), tt.flow); err != nil {
+				t.Errorf("DropEventEmitter.ProcessFlow() error = %v", err)
+			}
+			if tt.expect == "" {
+				assert.Len(t, fakeRecorder.Events, 0)
+			} else {
+				assert.Len(t, fakeRecorder.Events, 1)
+				event := <-fakeRecorder.Events
+				assert.Contains(t, event, tt.expect)
+			}
+		})
+	}
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1037,6 +1037,17 @@ const (
 	// HubbleRedactHttpHeadersDeny controls which http headers will be redacted from flows
 	HubbleRedactHttpHeadersDeny = "hubble-redact-http-headers-deny"
 
+	// HubbleDropEvents controls whether Hubble should create v1.Events
+	// for packet drops related to pods
+	HubbleDropEvents = "hubble-drop-events"
+
+	// HubbleDropEventsInterval controls the minimum time between emitting events
+	// with the same source and destination IP
+	HubbleDropEventsInterval = "hubble-drop-events-interval"
+
+	// HubbleDropEventsReasons controls which drop reasons to emit events for
+	HubbleDropEventsReasons = "hubble-drop-events-reasons"
+
 	// K8sHeartbeatTimeout configures the timeout for apiserver heartbeat
 	K8sHeartbeatTimeout = "k8s-heartbeat-timeout"
 
@@ -2247,6 +2258,17 @@ type DaemonConfig struct {
 
 	// HubbleRedactHttpHeadersDeny controls which http headers will be redacted from flows
 	HubbleRedactHttpHeadersDeny []string
+
+	// HubbleDropEvents controls whether Hubble should create v1.Events
+	// for packet drops related to pods
+	HubbleDropEvents bool
+
+	// HubbleDropEventsInterval controls the minimum time between emitting events
+	// with the same source and destination IP
+	HubbleDropEventsInterval time.Duration
+
+	// HubbleDropEventsReasons controls which drop reasons to emit events for
+	HubbleDropEventsReasons []string
 
 	// EndpointStatus enables population of information in the
 	// CiliumEndpoint.Status resource
@@ -3512,6 +3534,9 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.HubbleRedactKafkaApiKey = vp.GetBool(HubbleRedactKafkaApiKey)
 	c.HubbleRedactHttpHeadersAllow = vp.GetStringSlice(HubbleRedactHttpHeadersAllow)
 	c.HubbleRedactHttpHeadersDeny = vp.GetStringSlice(HubbleRedactHttpHeadersDeny)
+	c.HubbleDropEvents = vp.GetBool(HubbleDropEvents)
+	c.HubbleDropEventsInterval = vp.GetDuration(HubbleDropEventsInterval)
+	c.HubbleDropEventsReasons = vp.GetStringSlice(HubbleDropEventsReasons)
 
 	// Hidden options
 	c.CompilerFlags = vp.GetStringSlice(CompilerFlags)


### PR DESCRIPTION
This adds the option to hubble to emit v1.Events related to v1.Pods when a packet drop to or from that pod is detected.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #29399

```release-note
Hubble now has an option to emit v1.Events related to pods on detection of packet drops.
```
