### PR TITLE
Fix stale references to old nodes during health probe

### DIFF
--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -338,14 +338,14 @@ func (s *Server) runActiveServices() error {
 	prober := newProber(s, nodesAdded)
 	prober.MaxRTT = s.ProbeInterval
 	prober.OnIdle = func() {
-		// Fetch results and update set of nodes to probe every
-		// ProbeInterval
-		s.updateCluster(prober.getResults())
+		// Update set of nodes to probe every ProbeInterval and then fetch
+		// results
 		if nodesAdded, nodesRemoved, err := s.getNodes(); err != nil {
 			log.WithError(err).Error("unable to get cluster nodes")
 		} else {
 			prober.setNodes(nodesAdded, nodesRemoved)
 		}
+		s.updateCluster(prober.getResults())
 	}
 	prober.RunLoop()
 	defer prober.Stop()

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -28,6 +28,7 @@ import (
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
 	"github.com/cilium/cilium/pkg/node"
@@ -448,7 +449,13 @@ func (m *manager) nodeIdentityLabels(n nodeTypes.Node) (nodeLabels labels.Labels
 // the node. If an update or addition has occurred, NodeUpdate() of the datapath
 // interface is invoked.
 func (m *manager) NodeUpdated(n nodeTypes.Node) {
-	log.Debugf("Received node update event from %s: %#v", n.Source, n)
+	log.WithFields(logrus.Fields{
+		logfields.ClusterName: n.Cluster,
+		logfields.NodeName:    n.Name,
+	}).Info("Node updated")
+	if log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		log.Debugf("Received node update event from %s: %#v", n.Source, n)
+	}
 
 	nodeIdentifier := n.Identity()
 	dpUpdate := true
@@ -707,9 +714,15 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 // origins from. If the node was removed, NodeDelete() is invoked of the
 // datapath interface.
 func (m *manager) NodeDeleted(n nodeTypes.Node) {
-	m.metrics.EventsReceived.WithLabelValues("delete", string(n.Source)).Inc()
+	log.WithFields(logrus.Fields{
+		logfields.ClusterName: n.Cluster,
+		logfields.NodeName:    n.Name,
+	}).Info("Node deleted")
+	if log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		log.Debugf("Received node delete event from %s", n.Source)
+	}
 
-	log.Debugf("Received node delete event from %s", n.Source)
+	m.metrics.EventsReceived.WithLabelValues("delete", string(n.Source)).Inc()
 
 	nodeIdentifier := n.Identity()
 


### PR DESCRIPTION
- node/manager: Add info logs for added and deleted nodes
- health/server: Fix stale references to old nodes during health probe

Related: https://github.com/cilium/cilium/pull/28382

```release-note
Fix bug where deleted nodes would reappear in the cilium_node_connectivity_* metrics
```