### PR TITLE
daemon: add BackendSlot to Service6Key.String and Service4Key.String

### DIFF
--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -253,6 +253,7 @@ func (k *Service4Key) String() string {
 	if kHost.Scope == loadbalancer.ScopeInternal {
 		addr += "/i"
 	}
+	addr = fmt.Sprintf("%s (%d)", addr, kHost.BackendSlot)
 	return addr
 }
 

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -149,9 +149,9 @@ func NewService6Key(ip net.IP, port uint16, proto u8proto.U8proto, scope uint8, 
 func (k *Service6Key) String() string {
 	kHost := k.ToHost().(*Service6Key)
 	if kHost.Scope == loadbalancer.ScopeInternal {
-		return fmt.Sprintf("[%s]:%d/i", kHost.Address, kHost.Port)
+		return fmt.Sprintf("[%s]:%d/i (%d)", kHost.Address, kHost.Port, kHost.BackendSlot)
 	} else {
-		return fmt.Sprintf("[%s]:%d", kHost.Address, kHost.Port)
+		return fmt.Sprintf("[%s]:%d (%d)", kHost.Address, kHost.Port, kHost.BackendSlot)
 	}
 }
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1894,8 +1894,7 @@ func (kub *Kubectl) validateServicePlumbingInCiliumPod(fullName, ciliumPod strin
 		return fmt.Errorf("unable to validate cilium service by running '%s': %s", cmd, res.OutputPrettyPrint())
 	}
 
-	var lbMap map[string][]string
-	err = res.Unmarshal(&lbMap)
+	lbMap, err := parseLBList(res)
 	if err != nil {
 		return fmt.Errorf("unable to unmarshal cilium bpf lb list output: %s", err)
 	}
@@ -4013,14 +4012,40 @@ func (kub *Kubectl) fillServiceCache() error {
 			return err
 		}
 
-		err = ciliumLbRes.Unmarshal(&podCache.loadBalancers)
+		lbMap, err := parseLBList(ciliumLbRes)
 		if err != nil {
 			return fmt.Errorf("Unable to unmarshal Cilium bpf lb list: %s", err.Error())
 		}
+
+		podCache.loadBalancers = lbMap
 		cache.pods = append(cache.pods, podCache)
 	}
 	kub.serviceCache = &cache
 	return nil
+}
+
+func parseLBList(res *CmdRes) (map[string][]string, error) {
+	var resMap map[string][]string
+	err := res.Unmarshal(&resMap)
+	if err != nil {
+		return nil, err
+	}
+	// A service for example:
+	// 10.96.0.10:9153 (1)      10.0.1.251:9153 (7) (1)
+	// 172.18.0.4:32686/i (1)   10.0.0.179:69 (32) (1)
+	lbMap := make(map[string][]string)
+	for frontend, backends := range resMap {
+		// strip the space and parentheses
+		index := strings.Index(frontend, " ")
+		if index > 0 {
+			frontend = frontend[:index]
+		}
+		if len(backends) > 0 {
+			lbMap[frontend] = append(lbMap[frontend], backends...)
+		}
+	}
+
+	return lbMap, nil
 }
 
 // KubeDNSPreFlightCheck makes sure that kube-dns is plumbed into Cilium.


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #29580

```release-note
Fix overlapping keys in agent-side service BPF map cache used for retries. In rare cases this bug may have caused retrying of a failed BPF map update for a services entry to be skipped leading to a missing entry. This may have, for example, adversely affected recovering from a full BPF service map after excess services were removed.
```
