### PR TITLE
bpf: clean up some IPv4 header validations

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -280,7 +280,7 @@ int NAME(struct __ctx_buff *ctx)						\
 	if (!map)								\
 		return drop_for_direction(ctx, DIR, DROP_CT_NO_MAP_FOUND);	\
 										\
-	ct_buffer.ret = ct_lookup4(map, tuple, ctx, ct_buffer.l4_off,		\
+	ct_buffer.ret = ct_lookup4(map, tuple, ctx, ip4, ct_buffer.l4_off,	\
 				   DIR, ct_state, &ct_buffer.monitor);		\
 	if (ct_buffer.ret < 0)							\
 		return drop_for_direction(ctx, DIR, ct_buffer.ret);		\

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -871,25 +871,15 @@ ct_lazy_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff 
 /* Offset must point to IPv4 header */
 static __always_inline int ct_lookup4(const void *map,
 				      struct ipv4_ct_tuple *tuple,
-				      struct __ctx_buff *ctx, int off, enum ct_dir dir,
+				      struct __ctx_buff *ctx, struct iphdr *ip4,
+				      int off, enum ct_dir dir,
 				      struct ct_state *ct_state, __u32 *monitor)
 {
+	bool is_fragment = ipv4_is_fragment(ip4);
 	bool has_l4_header = true;
-	bool is_fragment = false;
-	struct iphdr *ip4 = NULL;
-#ifdef ENABLE_IPV4_FRAGMENTS
-	void *data, *data_end;
-#endif
 	int ret;
 
 	tuple->flags = ct_lookup_select_tuple_type(dir, SCOPE_BIDIR);
-
-#ifdef ENABLE_IPV4_FRAGMENTS
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
-		return DROP_CT_INVALID_HDR;
-
-	is_fragment = ipv4_is_fragment(ip4);
-#endif
 
 	ret = ct_extract_ports4(ctx, ip4, off, dir, tuple, &has_l4_header);
 	if (ret < 0)

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -706,8 +706,8 @@ ipv4_ct_reverse_tuple_daddr(const struct ipv4_ct_tuple *rtuple)
 }
 
 static __always_inline int
-ct_extract_ports4(struct __ctx_buff *ctx, int off, enum ct_dir dir,
-		  struct ipv4_ct_tuple *tuple, bool *has_l4_header)
+ct_extract_ports4(struct __ctx_buff *ctx, struct iphdr *ip4, int off,
+		  enum ct_dir dir, struct ipv4_ct_tuple *tuple, bool *has_l4_header)
 {
 	int err;
 
@@ -752,7 +752,7 @@ ct_extract_ports4(struct __ctx_buff *ctx, int off, enum ct_dir dir,
 #ifdef ENABLE_SCTP
 	case IPPROTO_SCTP:
 #endif  /* ENABLE_SCTP */
-		err = ipv4_load_l4_ports(ctx, NULL, off, dir, &tuple->dport,
+		err = ipv4_load_l4_ports(ctx, ip4, off, dir, &tuple->dport,
 					 has_l4_header);
 		if (err < 0)
 			return err;
@@ -876,9 +876,9 @@ static __always_inline int ct_lookup4(const void *map,
 {
 	bool has_l4_header = true;
 	bool is_fragment = false;
+	struct iphdr *ip4 = NULL;
 #ifdef ENABLE_IPV4_FRAGMENTS
 	void *data, *data_end;
-	struct iphdr *ip4;
 #endif
 	int ret;
 
@@ -891,7 +891,7 @@ static __always_inline int ct_lookup4(const void *map,
 	is_fragment = ipv4_is_fragment(ip4);
 #endif
 
-	ret = ct_extract_ports4(ctx, off, dir, tuple, &has_l4_header);
+	ret = ct_extract_ports4(ctx, ip4, off, dir, tuple, &has_l4_header);
 	if (ret < 0)
 		return ret;
 

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -346,7 +346,7 @@ ipv4_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 	tuple->daddr = ip4->daddr;
 	tuple->saddr = ip4->saddr;
 	ct_buffer->l4_off = l3_off + ipv4_hdrlen(ip4);
-	ct_buffer->ret = ct_lookup4(get_ct_map4(tuple), tuple, ctx, ct_buffer->l4_off,
+	ct_buffer->ret = ct_lookup4(get_ct_map4(tuple), tuple, ctx, ip4, ct_buffer->l4_off,
 				    CT_EGRESS, &ct_buffer->ct_state, &ct_buffer->monitor);
 	return true;
 }
@@ -465,7 +465,7 @@ ipv4_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct iphdr *ip4,
 	tuple->daddr = ip4->daddr;
 	tuple->saddr = ip4->saddr;
 	ct_buffer->l4_off = l3_off + ipv4_hdrlen(ip4);
-	ct_buffer->ret = ct_lookup4(get_ct_map4(tuple), tuple, ctx, ct_buffer->l4_off,
+	ct_buffer->ret = ct_lookup4(get_ct_map4(tuple), tuple, ctx, ip4, ct_buffer->l4_off,
 				    CT_INGRESS, &ct_buffer->ct_state, &ct_buffer->monitor);
 
 	return true;

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -185,16 +185,6 @@ ipv4_load_l4_ports(struct __ctx_buff *ctx, struct iphdr *ip4 __maybe_unused,
 		   __be16 *ports, bool *has_l4_header __maybe_unused)
 {
 #ifdef ENABLE_IPV4_FRAGMENTS
-	if (!ip4) {
-		void *data, *data_end;
-
-		/* This function is called from ct_lookup4(), which is sometimes called
-		 * after data has been invalidated (see handle_ipv4_from_lxc())
-		 */
-		if (!revalidate_data(ctx, &data, &data_end, &ip4))
-			return DROP_CT_INVALID_HDR;
-	}
-
 	return ipv4_handle_fragmentation(ctx, ip4, l4_off, dir,
 					 (struct ipv4_frag_l4ports *)ports,
 					 has_l4_header);

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -501,6 +501,7 @@ static __always_inline void snat_v4_init_tuple(const struct iphdr *ip4,
 static __always_inline int
 snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 			 struct ipv4_ct_tuple *tuple __maybe_unused,
+			 struct iphdr *ip4 __maybe_unused,
 			 int l4_off __maybe_unused,
 			 struct ipv4_nat_target *target __maybe_unused)
 {
@@ -544,7 +545,7 @@ snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 
 		target->from_local_endpoint = true;
 
-		err = ct_extract_ports4(ctx, l4_off, CT_EGRESS, tuple, NULL);
+		err = ct_extract_ports4(ctx, ip4, l4_off, CT_EGRESS, tuple, NULL);
 		if (err < 0)
 			return err;
 
@@ -753,7 +754,7 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 #ifdef ENABLE_SCTP
 	case IPPROTO_SCTP:
 #endif  /* ENABLE_SCTP */
-		if (ipv4_load_l4_ports(ctx, NULL, off, CT_EGRESS,
+		if (ipv4_load_l4_ports(ctx, ip4, off, CT_EGRESS,
 				       &tuple->dport, &has_l4_header) < 0)
 			return DROP_INVALID;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1682,7 +1682,7 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 	    nodeport_has_nat_conflict_ipv4(ip4, &target))
 		goto apply_snat;
 
-	ret = snat_v4_needs_masquerade(ctx, &tuple, l4_off, &target);
+	ret = snat_v4_needs_masquerade(ctx, &tuple, ip4, l4_off, &target);
 	if (IS_ERR(ret))
 		goto out;
 

--- a/bpf/tests/bpf_ct_tests.c
+++ b/bpf/tests/bpf_ct_tests.c
@@ -126,8 +126,8 @@ int test_ct4_rst1_check(__maybe_unused struct __ctx_buff *ctx)
 		tuple.saddr = ip4->saddr;
 		l4_off = l3_off + ipv4_hdrlen(ip4);
 
-		ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_EGRESS,
-				 &ct_state, &monitor);
+		ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, ip4, l4_off,
+				 CT_EGRESS, &ct_state, &monitor);
 		switch (ret) {
 		case CT_NEW:
 			ct_state_new.node_port = ct_state.node_port;
@@ -186,8 +186,8 @@ int test_ct4_rst1_check(__maybe_unused struct __ctx_buff *ctx)
 		tuple.saddr = ip4->saddr;
 		l4_off = l3_off + ipv4_hdrlen(ip4);
 
-		ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_INGRESS,
-			   &ct_state, &monitor);
+		ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, ip4, l4_off,
+			   CT_INGRESS, &ct_state, &monitor);
 
 		if (data + pkt_size > data_end)
 			test_fatal("packet shrank");


### PR DESCRIPTION
`ct_lookup4()` and `ipv4_load_l4_ports()` currently each contain a call to `revalidate_data()`. Replace them by passing a validated IPv4 header as parameter.