### PR TITLE
Makefile: Fix variable override not working in all cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,18 +12,24 @@ debug: all
 
 include Makefile.defs
 
-SUBDIRS_CILIUM_CONTAINER := cilium-dbg daemon cilium-health bugtool tools/mount tools/sysctlfix
+SUBDIRS_CILIUM_CONTAINER := cilium-dbg daemon cilium-health bugtool tools/mount tools/sysctlfix plugins/cilium-cni
 SUBDIR_OPERATOR_CONTAINER := operator
+
+ifdef LIBNETWORK_PLUGIN
+SUBDIRS_CILIUM_CONTAINER += plugins/cilium-docker
+endif
 
 # Add the ability to override variables
 -include Makefile.override
 
+# List of subdirectories used for global "make build", "make clean", etc
 SUBDIRS := $(SUBDIRS_CILIUM_CONTAINER) $(SUBDIR_OPERATOR_CONTAINER) plugins tools hubble-relay bpf
 
-SUBDIRS_CILIUM_CONTAINER += plugins/cilium-cni
-ifdef LIBNETWORK_PLUGIN
-SUBDIRS_CILIUM_CONTAINER += plugins/cilium-docker
-endif
+# Filter out any directories where the parent directory is also present, to avoid
+# building or cleaning a subdirectory twice.
+# For example: The directory "tools" is transformed into a match pattern "tools/%",
+# which is then used to filter out items such as "tools/mount" and "tools/sysctlfx"
+SUBDIRS := $(filter-out $(foreach dir,$(SUBDIRS),$(dir)/%),$(SUBDIRS))
 
 # Space-separated list of Go packages to test, equivalent to 'go test' package patterns.
 # Because is treated as a Go package pattern, the special '...' sequence is supported,


### PR DESCRIPTION
Commit b256fbd8 introduced the ability to override certain Makefile variables, such as `SUBDIRS_CILIUM_CONTAINER`, which controls which targets are built for the Cilium container.

However, due to 1fcbe96bf88e ("make: avoid building plugins/cni twice"), the Makefile would then still append additional entries to the variable, thus not allowing the override to e.g. override the CNI plugin build.

This commit addresses this issue by moving any modification to `SUBDIRS_CILIUM_CONTAINER` to before the override Makefile is included. This ensures that the override Makefile has full control over the variables it overrides.

To compensate for the fact that SUBDIRS would then cause the CNI plugin to be built twice (e.g. once via "make -C plugins/cilium-cni", but then once again via "make -C plugins"), a new filter is introduced which filters out any subdirectories already covered by parent directories. This incidentally also fixes a bug where certain tools (e.g. "tools/mount") were built twice.
