### PR TITLE
[v1.12] Author Backport of 29603 (examples: update guestbook example & test with new image registry)

### DIFF
--- a/examples/misc/guestbook/1-redis-leader-controller.json
+++ b/examples/misc/guestbook/1-redis-leader-controller.json
@@ -2,30 +2,29 @@
     "kind":"ReplicationController",
     "apiVersion":"v1",
     "metadata":{
-        "name":"redis-slave",
+        "name":"redis-leader",
         "labels":{
             "k8s-app.guestbook":"redis",
-            "role":"slave"
+            "role":"leader"
         }
     },
     "spec":{
         "replicas":1,
         "selector":{
             "k8s-app.guestbook":"redis",
-            "role":"slave"
+            "role":"leader"
         },
         "template":{
             "metadata":{
                 "labels":{
                     "k8s-app.guestbook":"redis",
-                    "role":"slave"
+                    "role":"leader"
                 }
             },
             "spec":{
                 "containers":[{
-                    "name":"redis-slave",
+                    "name":"redis-leader",
                     "image":"docker.io/library/redis:4.0.1",
-                    "command": ["redis-server","--loglevel","verbose","--slaveof","redis-master","6379"],
                     "ports":[{
                         "name":"redis-server",
                         "containerPort":6379

--- a/examples/misc/guestbook/2-redis-leader-service.json
+++ b/examples/misc/guestbook/2-redis-leader-service.json
@@ -2,10 +2,10 @@
     "kind":"Service",
     "apiVersion":"v1",
     "metadata":{
-        "name":"redis-master",
+        "name":"redis-leader",
         "labels":{
             "k8s-app.guestbook":"redis",
-            "role":"master"
+            "role":"leader"
         }
     },
     "spec":{
@@ -15,7 +15,7 @@
         }],
         "selector":{
             "k8s-app.guestbook":"redis",
-            "role":"master"
+            "role":"leader"
         }
     }
 }

--- a/examples/misc/guestbook/3-redis-follower-controller.json
+++ b/examples/misc/guestbook/3-redis-follower-controller.json
@@ -2,29 +2,30 @@
     "kind":"ReplicationController",
     "apiVersion":"v1",
     "metadata":{
-        "name":"redis-master",
+        "name":"redis-follower",
         "labels":{
             "k8s-app.guestbook":"redis",
-            "role":"master"
+            "role":"follower"
         }
     },
     "spec":{
         "replicas":1,
         "selector":{
             "k8s-app.guestbook":"redis",
-            "role":"master"
+            "role":"follower"
         },
         "template":{
             "metadata":{
                 "labels":{
                     "k8s-app.guestbook":"redis",
-                    "role":"master"
+                    "role":"follower"
                 }
             },
             "spec":{
                 "containers":[{
-                    "name":"redis-master",
+                    "name":"redis-follower",
                     "image":"docker.io/library/redis:4.0.1",
+                    "command": ["redis-server","--loglevel","verbose","--slaveof","redis-leader","6379"],
                     "ports":[{
                         "name":"redis-server",
                         "containerPort":6379

--- a/examples/misc/guestbook/4-redis-follower-service.json
+++ b/examples/misc/guestbook/4-redis-follower-service.json
@@ -2,10 +2,10 @@
     "kind":"Service",
     "apiVersion":"v1",
     "metadata":{
-        "name":"redis-slave",
+        "name":"redis-follower",
         "labels":{
             "k8s-app.guestbook":"redis",
-            "role":"slave"
+            "role":"follower"
         }
     },
     "spec":{
@@ -15,7 +15,7 @@
         }],
         "selector":{
             "k8s-app.guestbook":"redis",
-            "role":"slave"
+            "role":"follower"
         }
     }
 }

--- a/examples/misc/guestbook/5-guestbook-controller.json
+++ b/examples/misc/guestbook/5-guestbook-controller.json
@@ -21,7 +21,7 @@
             "spec":{
                 "containers":[{
                     "name":"guestbook",
-                    "image":"gcr.io/google-samples/gb-frontend:v6",
+                    "image":"us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5",
                     "ports":[{
                         "name":"http-server",
                         "containerPort": 80

--- a/test/k8s/manifests/guestbook_deployment.yaml
+++ b/test/k8s/manifests/guestbook_deployment.yaml
@@ -68,7 +68,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: follower
-        image: gcr.io/google_samples/gb-redis-follower:v2
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-redis-follower:v2
         imagePullPolicy: IfNotPresent
         ports:
         - name: redis-server
@@ -111,7 +111,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google-samples/gb-frontend:v6
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5
         resources:
           requests:
             cpu: 100m

--- a/test/k8s/manifests/guestbook_deployment.yaml
+++ b/test/k8s/manifests/guestbook_deployment.yaml
@@ -2,7 +2,7 @@
 kind: ReplicationController
 apiVersion: v1
 metadata:
-  name: redis-master
+  name: redis-leader
   labels:
     app: redis
     role: leader
@@ -32,7 +32,7 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: redis-master
+  name: redis-leader
   labels:
     app: redis
     role: leader

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -1975,8 +1975,8 @@ var _ = SkipDescribeIf(func() bool {
 			err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l tier=frontend", helpers.HelperTimeout)
 			ExpectWithOffset(1, err).Should(BeNil(), "Frontend pods are not ready after timeout")
 
-			err = kubectl.WaitForServiceEndpoints(helpers.DefaultNamespace, "", "redis-master", helpers.HelperTimeout)
-			ExpectWithOffset(1, err).Should(BeNil(), "error waiting for redis-master service to be ready")
+			err = kubectl.WaitForServiceEndpoints(helpers.DefaultNamespace, "", "redis-leader", helpers.HelperTimeout)
+			ExpectWithOffset(1, err).Should(BeNil(), "error waiting for redis-leader service to be ready")
 
 			err = kubectl.WaitForServiceEndpoints(helpers.DefaultNamespace, "", "redis-follower", helpers.HelperTimeout)
 			ExpectWithOffset(1, err).Should(BeNil(), "error waiting for redis-follower service to be ready")


### PR DESCRIPTION
The GCP Kubernetes Engine Samples migrated their image registry from Google Container Registry to Google Artifact Registry. Hence, the image gb-frontend from the guestbook example is no longer available.

Therefore, this commit changes the example to use the new registry. In addition it adopts the "leader/follower" naming.

Issue: GoogleCloudPlatform/kubernetes-engine-samples#209
Guestbook PR: GoogleCloudPlatform/kubernetes-engine-samples#194

PR from `main`: https://github.com/cilium/cilium/pull/29603