### PR TITLE
examples: update guestbook example with new image registry

### DIFF
--- a/examples/misc/guestbook/5-guestbook-controller.json
+++ b/examples/misc/guestbook/5-guestbook-controller.json
@@ -21,7 +21,7 @@
             "spec":{
                 "containers":[{
                     "name":"guestbook",
-                    "image":"gcr.io/google-samples/gb-frontend:v6",
+                    "image":"us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5",
                     "ports":[{
                         "name":"http-server",
                         "containerPort": 80


### PR DESCRIPTION
The GCP Kubernetes Engine Samples migrated their image registry from Google Container Registry to Google Artifact Registry. Hence, the image gb-frontend from the guestbook example is no longer available.

Therefore, this commit changes the example to use the new registry. In addition it adopts the "leader/follower" naming.

Issue: https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/issues/209
Guestbook PR: https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/194

Relevant backport to v1.12 where this image is used in CI: https://github.com/cilium/cilium/pull/29600