### PR TITLE
ci: disable preemptible VM & GKE clusters on tests based on GKE

### DIFF
--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -111,6 +111,7 @@ jobs:
     timeout-minutes: 45
     env:
       job_name: "Installation and Connectivity Test"
+      preemptible: ${{ github.event_name != 'schedule' && '--preemptible' || '' }}
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
@@ -208,7 +209,7 @@ jobs:
               --machine-type e2-custom-2-4096 \
               --boot-disk-type pd-standard \
               --boot-disk-size 10GB \
-              --preemptible \
+              ${{ env.preemptible }} \
               --image-project ubuntu-os-cloud \
               --image-family ubuntu-2004-lts \
               --metadata hostname=${{ env.vmName }}-${{ matrix.vmIndex }} \
@@ -229,7 +230,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 20GB \
-            --preemptible
+            ${{ env.preemptible }}
 
       - name: Get cluster credentials
         run: |

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -116,6 +116,7 @@ jobs:
     timeout-minutes: 75
     env:
       job_name: "Installation and Connectivity Test"
+      preemptible: ${{ github.event_name != 'schedule' && '--preemptible' || '' }}
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
@@ -213,7 +214,7 @@ jobs:
             --disk-type pd-standard \
             --disk-size 20GB \
             --node-taints ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready=true:NoExecute \
-            --preemptible
+            ${{ env.preemptible }}
 
       - name: Get cluster credentials
         run: |


### PR DESCRIPTION
This commit introduces the usage of normal VMs and GKE clusters for tests based on GCP running on a schedule basis.

Preemptible machines & clusters are still used for PR tests.

This should reduce the flakyness.

Unfortunately the flag `--preemptible` doesn't allow for explicit value (`true` / `false`)

Related PR for AWS: https://github.com/cilium/cilium/pull/29366