### PR TITLE
policy: Do not select any identity with empty slices

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -342,6 +342,12 @@ Annotations:
 * The ``CILIUM_PREPEND_IPTABLES_CHAIN`` environment variable has been renamed
   to ``CILIUM_PREPEND_IPTABLES_CHAINS`` (note the trailing ``S``) to more accurately
   match the name of the associated command line flag ``--prepend-iptables-chains``.
+* ``CiliumNetworkPolicy`` changed the semantic of the empty non-nil slice.
+  For an Ingress CNP, an empty slice in one of the fields ``fromEndpoints``, ``fromCIDR``,
+  ``fromCIDRSet`` and ``fromEntities`` will not select any identity, thus falling back
+  to default deny for an allow policy. Similarly, for an Egress CNP, an empty slice in
+  one of the fields ``toEndpoints``, ``toCIDR``, ``toCIDRSet`` and ``toEntities`` will
+  not select any identity either.
 
 .. _upgrade_cilium_cli_helm_mode:
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -322,10 +322,8 @@ var (
 	ruleL4L7Allow = api.NewRule().
 			WithLabels(lblsL4L7Allow).
 			WithIngressRules([]api.IngressRule{{
-			IngressCommonRule: api.IngressCommonRule{
-				FromEndpoints: []api.EndpointSelector{},
-			},
-			ToPorts: combineL4L7(allowPort80, allowHTTPRoot),
+			IngressCommonRule: api.IngressCommonRule{},
+			ToPorts:           combineL4L7(allowPort80, allowHTTPRoot),
 		}})
 
 	AllowAnyEgressLabels = labels.LabelArray{labels.NewLabel(policy.LabelKeyPolicyDerivedFrom,

--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -219,6 +219,13 @@ type EgressDenyRule struct {
 // ToEndpoints is not aggregated due to requirement folding in
 // GetDestinationEndpointSelectorsWithRequirements()
 func (e *EgressCommonRule) getAggregatedSelectors() EndpointSelectorSlice {
+	// explicitly check for empty non-nil slices, it should not result in any identity being selected.
+	if (e.ToEntities != nil && len(e.ToEntities) == 0) ||
+		(e.ToCIDR != nil && len(e.ToCIDR) == 0) ||
+		(e.ToCIDRSet != nil && len(e.ToCIDRSet) == 0) {
+		return nil
+	}
+
 	res := make(EndpointSelectorSlice, 0, len(e.ToEntities)+len(e.ToCIDR)+len(e.ToCIDRSet))
 	res = append(res, e.ToEntities.GetAsEndpointSelectors()...)
 	res = append(res, e.ToCIDR.GetAsEndpointSelectors()...)
@@ -281,6 +288,11 @@ func (e *EgressDenyRule) GetDestinationEndpointSelectorsWithRequirements(require
 func (e *EgressCommonRule) getDestinationEndpointSelectorsWithRequirements(
 	requirements []slim_metav1.LabelSelectorRequirement,
 ) EndpointSelectorSlice {
+
+	// explicitly check for empty non-nil slices, it should not result in any identity being selected.
+	if e.aggregatedSelectors == nil || (e.ToEndpoints != nil && len(e.ToEndpoints) == 0) {
+		return nil
+	}
 
 	res := make(EndpointSelectorSlice, 0, len(e.ToEndpoints)+len(e.aggregatedSelectors))
 

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -359,6 +359,11 @@ func rulePortsCoverSearchContext(ports []api.PortProtocol, ctx *SearchContext) b
 func mergeIngress(policyCtx PolicyContext, ctx *SearchContext, fromEndpoints api.EndpointSelectorSlice, auth *api.Authentication, toPorts, icmp api.PortsIterator, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
 	found := 0
 
+	// short-circuit if no endpoint is selected
+	if fromEndpoints == nil {
+		return found, nil
+	}
+
 	if ctx.From != nil && len(fromEndpoints) > 0 {
 		if ctx.TraceEnabled() {
 			traceL3(ctx, fromEndpoints, "from", policyCtx.IsDeny())
@@ -469,6 +474,7 @@ func mergeIngress(policyCtx PolicyContext, ctx *SearchContext, fromEndpoints api
 		if len(fromEndpoints) == 0 {
 			fromEndpoints = api.EndpointSelectorSlice{api.WildcardEndpointSelector}
 		}
+
 		if !policyCtx.IsDeny() {
 			ctx.PolicyTrace("      Allows ICMP type %v\n", r.GetPortProtocols())
 		} else {

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -603,6 +603,11 @@ func (r *rule) matches(securityIdentity *identity.Identity) bool {
 func mergeEgress(policyCtx PolicyContext, ctx *SearchContext, toEndpoints api.EndpointSelectorSlice, auth *api.Authentication, toPorts, icmp api.PortsIterator, ruleLabels labels.LabelArray, resMap L4PolicyMap, fqdns api.FQDNSelectorSlice) (int, error) {
 	found := 0
 
+	// short-circuit if no endpoint is selected
+	if toEndpoints == nil {
+		return found, nil
+	}
+
 	if ctx.To != nil && len(toEndpoints) > 0 {
 		if ctx.TraceEnabled() {
 			traceL3(ctx, toEndpoints, "to", policyCtx.IsDeny())


### PR DESCRIPTION
This PR aims to redefine the semantic of a non-nil empty slice in CNP/CCNP. Specifically, In case of egress/ingress policies with an explicit (non-nil) empty slice in one of:

- toEndpoints/fromEndpoints
- toCIDR/fromCIDR
- toCIDRSet/fromCIDRSet
- toEntities/fromEntities
    
no identities should be selected, thus falling back to default deny for an allow policy.

An example of the different behavior introduced with this PR can be seen with the following two L4 ingress policies:

```yaml
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  ...
spec:
  endpointSelector:
    ...
  ingress:
    - fromCIDR: []
      toPorts:
        - ports:
            - port: "80"
```

```yaml
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  ...
spec:
  endpointSelector:
    ...
  ingress:
    - toPorts:
        - ports:
            - port: "80"
```

The first one, with an explicit empty `fromCIDR` slice, does not select any identity (thus resulting in default deny) while the second one keeps the current behavior and allow traffic to port 80 for all identities.

This behavior also fixes a bug in policies referencing a CiliumCIDRGroup in the `fromCIDRSet/cidrGroupRef` field. If the referenced CIDR Group is empty or non-existent, the policy is equivalent to the first one, and therefore it won't select any identities.