### PR TITLE
bpf/Makefile: remove gen_compile_commands make target

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -288,7 +288,6 @@ BEAR_CLI   = $(shell which bear 2> /dev/null)
 gen_compile_commands:
 ifeq (, $(BEAR_CLI))
 	@echo 'Bear cli must be in $$PATH to generate json compilation database'
-	@echo 'See: https://github.com/rizsotto/Bear'
 else
 	bear -- make
 endif


### PR DESCRIPTION
The presence of the GitHub project URL for Bear got flagged in a GPL license
check. Remove the gen_compile_commands make target as it simply resolves to
`bear --make`. It doesn't seem to be referenced by any GH workflows, so it
could be invoked by personal scripts/configuration instead.

@ldelossa Could you live with this?