### PR TITLE
Fix possible disruption of long running, cross-cluster, pod to node traffic on agent restart 

### DIFF
--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -260,9 +260,11 @@ func (s *synced) Services(ctx context.Context) error {
 // IPIdentities returns after that the initial list of ipcache entries and
 // identities has been received from the remote cluster, and synchronized
 // with the BPF datapath, the remote cluster is disconnected, or the given
-// context is canceled.
+// context is canceled. We additionally need to explicitly wait for nodes
+// synchronization because they also trigger the insertion of ipcache entries
+// (i.e., node addresses, health, ingress, ...).
 func (s *synced) IPIdentities(ctx context.Context) error {
-	return s.wait(ctx, s.ipcache, s.identities.WaitChannel())
+	return s.wait(ctx, s.ipcache, s.identities.WaitChannel(), s.nodes)
 }
 
 func (s *synced) wait(ctx context.Context, chs ...<-chan struct{}) error {


### PR DESCRIPTION
8de7707a706c ("endpoint: wait for clustermesh IPs/identities sync before regeneration") modified the endpoint regeneration logic to explicitly wait for ipcache and identities synchronization from all remote clusters (in addition to the local one) before starting the regeneration process, to avoid disrupting long running connections.

Yet, that fix is not enough in case of pod-to-node connectivity, because the ipcache entries corresponding to the addresses of remote nodes (as well as the health and ingress IPs) are configured upon reception of the relevant node entry. Hence, let's extend the wait function to also wait for nodes synchronization in addition to IPs and identities, in order to ensure that the ipcache is fully synchronized before triggering the endpoint regeneration process.

Related: https://github.com/cilium/cilium/pull/27575

<!-- Description of change -->

```release-note
Fix possible disruption of long running, cross-cluster, pod to node traffic on agent restart 
```
