### PR TITLE
workflows: Make the conn-disrupt test more sensitive

### DIFF
--- a/.github/actions/conn-disrupt-test/action.yaml
+++ b/.github/actions/conn-disrupt-test/action.yaml
@@ -21,7 +21,8 @@ runs:
         # Create pods which establish long lived connections. It will be used by
         # subsequent connectivity tests with --include-conn-disrupt-test to catch any
         # interruption in such flows.
-        ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup
+        ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup \
+          --conn-disrupt-dispatch-interval 0ms
 
     - name: Operate Cilium
       shell: bash

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -364,7 +364,8 @@ jobs:
           # interruption in such flows.
           cilium --context ${{ env.contextName1 }} connectivity test \
             --multi-cluster=${{ env.contextName2 }} --hubble=false \
-            --include-conn-disrupt-test --conn-disrupt-test-setup
+            --include-conn-disrupt-test --conn-disrupt-test-setup \
+            --conn-disrupt-dispatch-interval 0ms
 
 
       - name: Upgrade Cilium in cluster1 and enable kvstoremesh
@@ -410,7 +411,8 @@ jobs:
           # interruption in such flows.
           cilium --context ${{ env.contextName1 }} connectivity test \
             --multi-cluster=${{ env.contextName2 }} --hubble=false \
-            --include-conn-disrupt-test --conn-disrupt-test-setup
+            --include-conn-disrupt-test --conn-disrupt-test-setup \
+            --conn-disrupt-dispatch-interval 0ms
 
 
       # Perform an additional "stress" test, scaling the clustermesh-apiservers in both clusters
@@ -467,7 +469,8 @@ jobs:
           # interruption in such flows.
           cilium --context ${{ env.contextName1 }} connectivity test \
             --multi-cluster=${{ env.contextName2 }} --hubble=false \
-            --include-conn-disrupt-test --conn-disrupt-test-setup
+            --include-conn-disrupt-test --conn-disrupt-test-setup \
+            --conn-disrupt-dispatch-interval 0ms
 
 
       - name: Downgrade Cilium in cluster1 and disable kvstoremesh

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -362,7 +362,8 @@ jobs:
             # Create pods which establish long lived connections. It will be used by
             # subsequent connectivity tests with --include-conn-disrupt-test to catch any
             # interruption in such flows.
-            ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup
+            ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup \
+              --conn-disrupt-dispatch-interval 0ms
 
       - name: Upgrade Cilium
         uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
@@ -401,7 +402,8 @@ jobs:
               \$EXTRA
 
             # --flush-ct interrupts the flows, so we need to set up again.
-            ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup
+            ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup \
+              --conn-disrupt-dispatch-interval 0ms
 
       - name: Downgrade Cilium ${{ env.cilium_stable_version }}
         uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -290,7 +290,8 @@ jobs:
           # Create pods which establish long lived connections. It will be used by
           # subsequent connectivity tests with --include-conn-disrupt-test to catch any
           # interruption in such flows.
-          ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup
+          ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup \
+            --conn-disrupt-dispatch-interval 0ms
 
       - name: Upgrade Cilium & Test (${{ matrix.name }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}


### PR DESCRIPTION
By reducing the interval between two sent packets to 0ms, we are making the conn-disrupt test more sensitive to drops. That should help us identify remaining bugs in upgrades, key rotations, etc.

Fixes: https://github.com/cilium/cilium/issues/27916.