### PR TITLE
test: Fail ginkgo tests on warnings

### DIFF
--- a/test/bigtcp/test.sh
+++ b/test/bigtcp/test.sh
@@ -33,7 +33,7 @@ helm install cilium ${HELM_CHART_DIR} \
     --set ipv6.enabled=true \
     --set routingMode='native' \
     --set bpf.masquerade=true \
-    --set kubeProxyReplacement=strict \
+    --set kubeProxyReplacement=true \
     --set ipam.mode=kubernetes \
     --set autoDirectNodeRoutes=true \
     --set hostLegacyRouting=false \

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -244,7 +244,33 @@ const (
 	failedToUpdateLock         = "Failed to update lock:"
 	failedToReleaseLock        = "Failed to release lock:"
 	errorCreatingInitialLeader = "error initially creating leader election record:"
-	cantEnableJIT              = "bpf_jit_enable: no such file or directory" // Because we run tests in Kind.
+	cantEnableJIT              = "bpf_jit_enable: no such file or directory"                               // Because we run tests in Kind.
+	delMissingService          = "Deleting no longer present service"                                      // cf. https://github.com/cilium/cilium/issues/29679
+	failedIpcacheRestore       = "Failed to restore existing identities from the previous ipcache"         // cf. https://github.com/cilium/cilium/issues/29328
+	podCIDRUnavailable         = " PodCIDR not available"                                                  // cf. https://github.com/cilium/cilium/issues/29680
+	delMissingIdentity         = "Skipping Delete of a non-existing identity"                              // cf. https://github.com/cilium/cilium/issues/29681
+	wipEnvoyFeature            = "envoy/extensions/bootstrap/internal_listener/v3/internal_listener.proto" // cf. https://github.com/cilium/cilium/issues/29682
+	unableGetNode              = "Unable to get node resource"                                             // cf. https://github.com/cilium/cilium/issues/29710
+	disableSocketLBTracing     = "Disabling socket-LB tracing"                                             // cf. https://github.com/cilium/cilium/issues/29734
+	sessionAffinitySocketLB    = "Session affinity for host reachable services needs kernel"               // cf. https://github.com/cilium/cilium/issues/29736
+	objectHasBeenModified      = "the object has been modified; please apply your changes"                 // cf. https://github.com/cilium/cilium/issues/29712
+	noBackendResponse          = "The kernel does not support --service-no-backend-response=reject"        // cf. https://github.com/cilium/cilium/issues/29733
+	unsupportedSocketLookup    = "Without socket lookup kernel functionality"                              // cf. https://github.com/cilium/cilium/issues/29735
+	legacyBGPFeature           = "You are using the legacy BGP feature"                                    // Expected when testing the legacy BGP feature.
+	etcdTimeout                = "etcd client timeout exceeded"                                            // cf. https://github.com/cilium/cilium/issues/29714
+	endpointRestoreFailed      = "Unable to restore endpoint, ignoring"                                    // cf. https://github.com/cilium/cilium/issues/29716
+	failedPeerSync             = "Failed to create peer client for peers synchronization"                  // cf. https://github.com/cilium/cilium/issues/29726
+	policyMapSyncFix           = "Policy map sync fixed errors"                                            // cf. https://github.com/cilium/cilium/issues/29727
+	unableRestoreRouterIP      = "Unable to restore router IP from filesystem"                             // cf. https://github.com/cilium/cilium/issues/29715
+	routerIPReallocated        = "Router IP could not be re-allocated"                                     // cf. https://github.com/cilium/cilium/issues/29715
+	cantFindIdentityInCache    = "unable to release identity: unable to find key in local cache"           // cf. https://github.com/cilium/cilium/issues/29732
+	kubeApiserverConnLost1     = ":6443/version\\\": http2: client connection lost"                        // cf. https://github.com/cilium/cilium/issues/29737
+	kubeApiserverConnLost2     = ":6443/healthz\\\": http2: client connection lost"                        // cf. https://github.com/cilium/cilium/issues/29737
+	heartbeatTimedOut          = "Heartbeat timed out, restarting client connections"                      // cf. https://github.com/cilium/cilium/issues/29737
+	keyAllocFailedFoundMaster  = "Found master key after proceeding with new allocation"                   // cf. https://github.com/cilium/cilium/issues/29738
+	cantRecreateMasterKey      = "unable to re-create missing master key"                                  // cf. https://github.com/cilium/cilium/issues/29738
+	cantUpdateCRDIdentity      = "Unable update CRD identity information with a reference for this node"   // cf. https://github.com/cilium/cilium/issues/29739
+	cantDeleteFromPolicyMap    = "cilium_call_policy: delete: key does not exist"                          // cf. https://github.com/cilium/cilium/issues/29754
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -311,7 +337,14 @@ var badLogMessages = map[string][]string{
 	logutils.ErrorLogs: {opCantBeFulfilled, initLeaderElection, globalDataSupport,
 		removeInexistentID, failedToListCRDs, retrieveResLock, failedToRelLockEmptyName,
 		failedToUpdateLock, failedToReleaseLock, errorCreatingInitialLeader},
-	logutils.WarningLogs: {cantEnableJIT},
+	logutils.WarningLogs: {cantEnableJIT, delMissingService, failedIpcacheRestore,
+		podCIDRUnavailable, delMissingIdentity, wipEnvoyFeature, unableGetNode,
+		disableSocketLBTracing, sessionAffinitySocketLB, objectHasBeenModified, noBackendResponse,
+		unsupportedSocketLookup, legacyBGPFeature, etcdTimeout, endpointRestoreFailed,
+		failedPeerSync, policyMapSyncFix, unableRestoreRouterIP, routerIPReallocated,
+		cantFindIdentityInCache, kubeApiserverConnLost1, kubeApiserverConnLost2, heartbeatTimedOut,
+		keyAllocFailedFoundMaster, cantRecreateMasterKey, cantUpdateCRDIdentity,
+		cantDeleteFromPolicyMap},
 }
 
 var ciliumCLICommands = map[string]string{

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -244,6 +244,7 @@ const (
 	failedToUpdateLock         = "Failed to update lock:"
 	failedToReleaseLock        = "Failed to release lock:"
 	errorCreatingInitialLeader = "error initially creating leader election record:"
+	cantEnableJIT              = "bpf_jit_enable: no such file or directory" // Because we run tests in Kind.
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -307,7 +308,10 @@ var badLogMessages = map[string][]string{
 	"DATA RACE":         nil,
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.
-	logutils.ErrorLogs:   {opCantBeFulfilled, initLeaderElection, globalDataSupport, removeInexistentID, failedToListCRDs, retrieveResLock, failedToRelLockEmptyName, failedToUpdateLock, failedToReleaseLock, errorCreatingInitialLeader},
+	logutils.ErrorLogs: {opCantBeFulfilled, initLeaderElection, globalDataSupport,
+		removeInexistentID, failedToListCRDs, retrieveResLock, failedToRelLockEmptyName,
+		failedToUpdateLock, failedToReleaseLock, errorCreatingInitialLeader},
+	logutils.WarningLogs: {cantEnableJIT},
 }
 
 var ciliumCLICommands = map[string]string{

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -12,6 +12,7 @@ import (
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/versioncheck"
 	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers/logutils"
 )
 
 var (
@@ -306,7 +307,7 @@ var badLogMessages = map[string][]string{
 	"DATA RACE":         nil,
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.
-	"level=error": {opCantBeFulfilled, initLeaderElection, globalDataSupport, removeInexistentID, failedToListCRDs, retrieveResLock, failedToRelLockEmptyName, failedToUpdateLock, failedToReleaseLock, errorCreatingInitialLeader},
+	logutils.ErrorLogs:   {opCantBeFulfilled, initLeaderElection, globalDataSupport, removeInexistentID, failedToListCRDs, retrieveResLock, failedToRelLockEmptyName, failedToUpdateLock, failedToReleaseLock, errorCreatingInitialLeader},
 }
 
 var ciliumCLICommands = map[string]string{

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -170,7 +170,7 @@ var (
 		"install-no-conntrack-iptables-rules": "false",
 		"l7Proxy":                             "false",
 		"hubble.enabled":                      "false",
-		"kubeProxyReplacement":                "strict",
+		"kubeProxyReplacement":                "true",
 		"endpointHealthChecking.enabled":      "false",
 		"cni.install":                         "true",
 		"cni.customConf":                      "true",
@@ -2499,7 +2499,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 
 	if RunsWithKubeProxyReplacement() {
 		opts := map[string]string{
-			"kubeProxyReplacement": "strict",
+			"kubeProxyReplacement": "true",
 		}
 
 		if RunsWithKubeProxy() {
@@ -2534,7 +2534,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 	// Disable unsupported features that will just generated unnecessary
 	// warnings otherwise.
 	if DoesNotRunOnNetNextKernel() {
-		addIfNotOverwritten(options, "kubeProxyReplacement", "disabled")
+		addIfNotOverwritten(options, "kubeProxyReplacement", "false")
 		addIfNotOverwritten(options, "bpf.masquerade", "false")
 		addIfNotOverwritten(options, "sessionAffinity", "false")
 		addIfNotOverwritten(options, "bandwidthManager.enabled", "false")

--- a/test/helpers/logutils/utils.go
+++ b/test/helpers/logutils/utils.go
@@ -14,12 +14,12 @@ const (
 	selfishThresholdMsg = "Goroutine took lock for more than" // from https://github.com/cilium/cilium/pull/5268
 
 	contextDeadlineExceeded = "context deadline exceeded"
-	errorLogs               = "level=error"
-	warningLogs             = "level=warning"
+	ErrorLogs               = "level=error"
+	WarningLogs             = "level=warning"
 	aPIPanicked             = "Cilium API handler panicked"
 )
 
-var countLogsMessages = []string{contextDeadlineExceeded, errorLogs, warningLogs, aPIPanicked, selfishThresholdMsg}
+var countLogsMessages = []string{contextDeadlineExceeded, ErrorLogs, WarningLogs, aPIPanicked, selfishThresholdMsg}
 
 // LogErrorsSummary returns error and warning summary for given logs
 func LogErrorsSummary(logs string) string {
@@ -52,10 +52,10 @@ func getErrorWarningMsgs(logs string, n int) []string {
 	errors := map[string]int{}
 	warnings := map[string]int{}
 	for _, line := range strings.Split(logs, "\n") {
-		if strings.Contains(line, errorLogs) {
+		if strings.Contains(line, ErrorLogs) {
 			msg := getMsg(line)
 			errors[msg]++
-		} else if strings.Contains(line, warningLogs) {
+		} else if strings.Contains(line, WarningLogs) {
 			msg := getMsg(line)
 			warnings[msg]++
 		}

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -587,6 +587,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"devices":                    devices,
 				"hostFirewall.enabled":       "false",
 				"kubeProxyReplacement":       "false",
+				"bpf.masquerade":             "false",
 			}, DeployCiliumOptionsAndDNS)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -586,7 +586,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"encryption.ipsec.interface": privateIface,
 				"devices":                    devices,
 				"hostFirewall.enabled":       "false",
-				"kubeProxyReplacement":       "disabled",
+				"kubeProxyReplacement":       "false",
 			}, DeployCiliumOptionsAndDNS)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})
@@ -759,7 +759,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 				options["autoDirectNodeRoutes"] = "true"
 			}
 			if helpers.RunsWithKubeProxy() {
-				options["kubeProxyReplacement"] = "disabled"
+				options["kubeProxyReplacement"] = "false"
 			}
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -1477,7 +1477,7 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn54OrLaterKernel,
 					// https://github.com/cilium/cilium/issues/16197.
 					"routingMode":          "native",
 					"autoDirectNodeRoutes": "true",
-					"kubeProxyReplacement": "strict",
+					"kubeProxyReplacement": "true",
 				})
 
 				By("Deploying demo local daemonset")


### PR DESCRIPTION
This pull request makes the ginkgo tests fail on any level=warning agent or operator log. See commits for details.

I had to allowlist a bunch of warnings so we can at least stop the bleeding before we fix them. I ran the full ginkgo suite 12 times without any new warnings popping up so we should be good to go.

<!-- https://github.com/cilium/cilium/actions/runs/7150774784 -->