### PR TITLE
fqdn: avoid converting from `netip.Addr` to `net.IP` and back

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -73,15 +73,14 @@ type nameEntries map[string]*cacheEntry
 
 // getIPs returns a sorted list of non-expired unique IPs.
 // This needs a read-lock
-func (s ipEntries) getIPs(now time.Time) []net.IP {
-	ips := make([]net.IP, 0, len(s)) // worst case size
+func (s ipEntries) getIPs(now time.Time) []netip.Addr {
+	ips := make([]netip.Addr, 0, len(s)) // worst case size
 	for ip, entry := range s {
 		if entry != nil && !entry.isExpiredBy(now) {
-			ips = append(ips, ip.Unmap().AsSlice())
+			ips = append(ips, ip.Unmap())
 		}
 	}
-
-	return ippkg.KeepUniqueIPs(ips) // sorts IPs
+	return ippkg.KeepUniqueAddrs(ips) // sorts IPs
 }
 
 // DNSCache manages DNS data that will expire after a certain TTL. Information
@@ -399,7 +398,7 @@ func (c *DNSCache) ReplaceFromCacheByNames(namesToUpdate []string, updates ...*D
 // Lookup returns a set of unique IPs that are currently unexpired for name, if
 // any exist. An empty list indicates no valid records exist. The IPs are
 // returned sorted.
-func (c *DNSCache) Lookup(name string) (ips []net.IP) {
+func (c *DNSCache) Lookup(name string) (ips []netip.Addr) {
 	c.RLock()
 	defer c.RUnlock()
 
@@ -408,7 +407,7 @@ func (c *DNSCache) Lookup(name string) (ips []net.IP) {
 
 // lookupByTime takes a timestamp for expiration comparisons, and is only
 // intended for testing.
-func (c *DNSCache) lookupByTime(now time.Time, name string) (ips []net.IP) {
+func (c *DNSCache) lookupByTime(now time.Time, name string) (ips []netip.Addr) {
 	entries, found := c.forward[name]
 	if !found {
 		return nil
@@ -419,14 +418,14 @@ func (c *DNSCache) lookupByTime(now time.Time, name string) (ips []net.IP) {
 
 // LookupByRegexp returns all non-expired cache entries that match re as a map
 // of name -> IPs
-func (c *DNSCache) LookupByRegexp(re *regexp.Regexp) (matches map[string][]net.IP) {
+func (c *DNSCache) LookupByRegexp(re *regexp.Regexp) (matches map[string][]netip.Addr) {
 	return c.lookupByRegexpByTime(c.lastCleanup, re)
 }
 
 // lookupByRegexpByTime takes a timestamp for expiration comparisons, and is
 // only intended for testing.
-func (c *DNSCache) lookupByRegexpByTime(now time.Time, re *regexp.Regexp) (matches map[string][]net.IP) {
-	matches = make(map[string][]net.IP)
+func (c *DNSCache) lookupByRegexpByTime(now time.Time, re *regexp.Regexp) (matches map[string][]netip.Addr) {
+	matches = make(map[string][]netip.Addr)
 
 	c.RLock()
 	defer c.RUnlock()

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/fqdn/re"
-	ippkg "github.com/cilium/cilium/pkg/ip"
 )
 
 type DNSCacheTestSuite struct{}
@@ -107,7 +106,7 @@ func (ds *DNSCacheTestSuite) TestDelete(c *C) {
 		c.Assert(len(ips), Equals, 2, Commentf("Wrong count of IPs returned (%v) for non-deleted name '%s'", ips, name))
 		c.Assert(cache.forward, checker.HasKey, name, Commentf("Expired name '%s' not deleted from forward", name))
 		for _, ip := range ips {
-			c.Assert(cache.reverse, checker.HasKey, ippkg.MustAddrFromIP(ip), Commentf("Expired IP '%s' not deleted from reverse", ip))
+			c.Assert(cache.reverse, checker.HasKey, ip, Commentf("Expired IP '%s' not deleted from reverse", ip))
 		}
 	}
 
@@ -130,7 +129,7 @@ func (ds *DNSCacheTestSuite) TestDelete(c *C) {
 		c.Assert(len(ips), Equals, 2, Commentf("Wrong count of IPs returned (%v) for non-deleted name '%s'", ips, name))
 		c.Assert(cache.forward, checker.HasKey, name, Commentf("Expired name '%s' not deleted from forward", name))
 		for _, ip := range ips {
-			c.Assert(cache.reverse, checker.HasKey, ippkg.MustAddrFromIP(ip), Commentf("Expired IP '%s' not deleted from reverse", ip))
+			c.Assert(cache.reverse, checker.HasKey, ip, Commentf("Expired IP '%s' not deleted from reverse", ip))
 		}
 	}
 

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -4,7 +4,6 @@
 package fqdn
 
 import (
-	"net"
 	"net/netip"
 	"regexp"
 
@@ -30,7 +29,7 @@ func (n *NameManager) mapSelectorsToIPsLocked(fqdnSelectors sets.Set[api.FQDNSel
 
 	// Map each FQDNSelector to set of CIDRs
 	for ToFQDN := range fqdnSelectors {
-		ipsSelected := make([]net.IP, 0)
+		ipsSelected := make([]netip.Addr, 0)
 		// lookup matching DNS names
 		if len(ToFQDN.MatchName) > 0 {
 			dnsName := prepareMatchName(ToFQDN.MatchName)
@@ -70,8 +69,7 @@ func (n *NameManager) mapSelectorsToIPsLocked(fqdnSelectors sets.Set[api.FQDNSel
 			}
 		}
 
-		ips := ip.KeepUniqueIPs(ipsSelected)
-		selectorIPMapping[ToFQDN] = ip.MustAddrsFromIPs(ips)
+		selectorIPMapping[ToFQDN] = ip.KeepUniqueAddrs(ipsSelected)
 	}
 
 	return selectorIPMapping

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/netip"
 	"regexp"
+	"slices"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -264,7 +265,7 @@ func (n *NameManager) updateIPsForName(lookupTime time.Time, dnsName string, new
 	// The 0 checks below account for an unlike race condition where this
 	// function is called with already expired data and if other cache data
 	// from before also expired.
-	return (len(cacheIPs) == 0 && len(sortedNewIPs) == 0) || !ip.SortedIPListsAreEqual(sortedNewIPs, cacheIPs)
+	return (len(cacheIPs) == 0 && len(sortedNewIPs) == 0) || !slices.Equal(sortedNewIPs, cacheIPs)
 }
 
 var ipcacheResource = ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindDaemon, "", "fqdn-name-manager")

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -739,22 +739,6 @@ func PartitionCIDR(targetCIDR net.IPNet, excludeCIDR net.IPNet) ([]*net.IPNet, [
 	return left, excludeList, right
 }
 
-// KeepUniqueIPs transforms the provided multiset of IPs into a single set,
-// lexicographically sorted via a byte-wise comparison of the IP slices (i.e.
-// IPv4 addresses show up before IPv6).
-// The slice is manipulated in-place destructively.
-func KeepUniqueIPs(ips []net.IP) []net.IP {
-	return slices.SortedUniqueFunc(
-		ips,
-		func(i, j int) bool {
-			return bytes.Compare(ips[i], ips[j]) == -1
-		},
-		func(a, b net.IP) bool {
-			return a.Equal(b)
-		},
-	)
-}
-
 // KeepUniqueAddrs transforms the provided multiset of IP addresses into a
 // single set, lexicographically sorted via comparison of the addresses using
 // netip.Addr.Compare (i.e. IPv4 addresses show up before IPv6).

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -852,24 +852,6 @@ func getSortedIPList(ipList []net.IP) []net.IP {
 	return sortedIPList
 }
 
-// SortedIPListsAreEqual compares two lists of sorted IPs. If any differ it returns
-// false.
-func SortedIPListsAreEqual(a, b []net.IP) bool {
-	// The IP set is definitely different if the lengths are different.
-	if len(a) != len(b) {
-		return false
-	}
-
-	// Lengths are equal, so each member in one set must be in the other
-	// If any IPs at the same index differ the sorted IP list are not equal.
-	for i := range a {
-		if !a[i].Equal(b[i]) {
-			return false
-		}
-	}
-	return true
-}
-
 // UnsortedIPListsAreEqual returns true if the list of net.IP provided is same
 // without considering the order of the IPs in the list. The function will first
 // attempt to sort both the IP lists and then validate equality for sorted lists.
@@ -879,10 +861,17 @@ func UnsortedIPListsAreEqual(ipList1, ipList2 []net.IP) bool {
 		return false
 	}
 
-	sortedIPList1 := getSortedIPList(ipList1)
-	sortedIPList2 := getSortedIPList(ipList2)
+	a := getSortedIPList(ipList1)
+	b := getSortedIPList(ipList2)
 
-	return SortedIPListsAreEqual(sortedIPList1, sortedIPList2)
+	// Lengths are equal, so each member in one set must be in the other
+	// If any IPs at the same index differ the sorted IP list are not equal.
+	for i := range a {
+		if !a[i].Equal(b[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // GetIPFromListByFamily returns a single IP address of the provided family from a list

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -883,9 +883,6 @@ func (s *IPTestSuite) TestIPListEquals(c *C) {
 	ips := []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("fd00::1"), net.ParseIP("8.8.8.8")}
 	sorted := []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("8.8.8.8"), net.ParseIP("fd00::1")}
 
-	sortedIPs := getSortedIPList(ips)
-	c.Assert(SortedIPListsAreEqual(sorted, sortedIPs), checker.Equals, true)
-
 	c.Assert(UnsortedIPListsAreEqual(ips, sorted), checker.Equals, true)
 }
 

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -722,34 +722,6 @@ func (s *IPTestSuite) TestPartitionCIDR(c *C) {
 	s.testIPNetsEqual([]*net.IPNet{excludeCIDR}, exclude, c)
 }
 
-// TestKeepUniqueIPs tests that KeepUniqueIPs returns a slice with only the unique IPs
-func (s *IPTestSuite) TestKeepUniqueIPs(c *C) {
-	// test nil/empty handling
-	ips := KeepUniqueIPs(nil)
-	c.Assert(len(ips), Equals, 0, Commentf("Non-empty slice returned with empty input"))
-
-	// test all duplicate
-	ips = KeepUniqueIPs([]net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("1.1.1.1"), net.ParseIP("1.1.1.1")})
-	c.Assert(len(ips), Equals, 1, Commentf("Too many IPs returned for only 1 unique"))
-	c.Assert(ips[0].String(), Equals, "1.1.1.1", Commentf("Incorrect unique IP returned"))
-
-	// test all unique
-	ipSource := []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2"), net.ParseIP("3.3.3.3")}
-	ips = KeepUniqueIPs(ipSource)
-	c.Assert(len(ips), Equals, 3, Commentf("Too few IPs returned for only 3 uniques"))
-	for i := range ipSource {
-		c.Assert(ips[i].String(), Equals, ipSource[i].String(), Commentf("Incorrect unique IP returned"))
-	}
-
-	// test mixed
-	ipSource = []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2"), net.ParseIP("3.3.3.3"), net.ParseIP("2.2.2.2")}
-	ips = KeepUniqueIPs(ipSource)
-	c.Assert(len(ips), Equals, 3, Commentf("Too few IPs returned for only 3 uniques"))
-	for i := range ipSource[:3] {
-		c.Assert(ips[i].String(), Equals, ipSource[i].String(), Commentf("Incorrect unique IP returned"))
-	}
-}
-
 func TestKeepUniqueAddrs(t *testing.T) {
 	for _, tc := range []struct {
 		name  string


### PR DESCRIPTION
Change `(*DNSCache).Lookup` and `(*DNSCache).LookupByRegex` to return `netip.Addr`. This avoids a back-and-forth conversion to `net.IP` and allows to drop some now unused helper functions in `pkg/ip`.

See commits for details.

Towards: #24246

