### PR TITLE
proxy: only divert outbound traffic from Ingress proxy to cilium_host

### DIFF
--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -96,11 +96,13 @@ func removeToProxyRoutesIPv6() error {
 }
 
 var (
-	// Routing rule for traffic from proxy.
+	// Routing rule for reply traffic from ingress proxy.
+	// Reply traffic has only the Ingress-Proxy mark, while forward traffic
+	// also embeds an identity. So we match against *exactly* the Ingress-Proxy mark.
 	fromProxyRule = route.Rule{
 		Priority: linux_defaults.RulePriorityFromProxyIngress,
 		Mark:     linux_defaults.MagicMarkIngress,
-		Mask:     linux_defaults.MagicMarkHostMask,
+		Mask:     0xFFFFFFFF,
 		Table:    linux_defaults.RouteTableFromProxy,
 	}
 )

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -99,7 +99,7 @@ var (
 	// Routing rule for traffic from proxy.
 	fromProxyRule = route.Rule{
 		Priority: linux_defaults.RulePriorityFromProxyIngress,
-		Mark:     linux_defaults.MagicMarkIsProxy,
+		Mark:     linux_defaults.MagicMarkIngress,
 		Mask:     linux_defaults.MagicMarkHostMask,
 		Table:    linux_defaults.RouteTableFromProxy,
 	}


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/29530 re-introduced the custom routing of Ingress proxy traffic to `cilium_host`. But we actually don't need to route *all* Ingress proxy traffic - it's sufficient to divert traffic that is in direction from the connection's source to destination.