### PR TITLE
ci datapath-verifier: add connectivity test

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -110,6 +110,8 @@ jobs:
           cpu: 4
           install-dependencies: 'true'
           cmd: |
+            for i in {1..5}; do curl "https://golang.org" > /dev/null 2>&1 && break || sleep 5; echo "Waiting for systemd-resolved to be ready..."; done
+
             git config --global --add safe.directory /host
             uname -a
             # The LVH image might ship with an arbitrary Go toolchain version,


### PR DESCRIPTION
This commit adds a temporary connectivity test to the LVH GitHub Action command.

This checks whether golang.org is resolvable - and therefore `systemd-resolved` ready.

This prevents the actual download of Go from failing.

Fixes: https://github.com/cilium/cilium/issues/29543
Should unblock: https://github.com/cilium/cilium/pull/29556