### PR TITLE
dockerfile: define Envoy image using ARG

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -119,7 +119,7 @@ ifeq ($(NOSTRIP),)
 endif
 
 ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/images/cilium/Dockerfile),)
-    CILIUM_ENVOY_REF=$(shell sed -E -e 's/^FROM (--[^ ]* )*([^ ]*) as cilium-envoy/\2/p;d' < $(ROOT_DIR)/images/cilium/Dockerfile)
+    CILIUM_ENVOY_REF=$(shell sed -E -e 's/^ARG CILIUM_ENVOY_IMAGE=([^ ]*)/\1/p;d' < $(ROOT_DIR)/images/cilium/Dockerfile)
     CILIUM_ENVOY_SHA=$(shell echo $(CILIUM_ENVOY_REF) | sed -E -e 's/[^/]*\/[^:]*:(.*-)?([^:@]*).*/\2/p;d')
     GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/envoy.requiredEnvoyVersionSHA=$(CILIUM_ENVOY_SHA)"
 endif

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -3,10 +3,11 @@
 
 ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:e2dc02fe9b2871b1f9a7468698abd536531af086@sha256:8eb964e2da3ffdaa92189d4e3161cf31c4e72300378411b69d99ff1121ced6bf
 ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:98dea50d165d236ffd2c829196ab58df9326c495@sha256:5e307ffbdc5552dc3d6f94d7ba1e5afe6a22c19af765777f4ea48f0522baf147
+ARG CILIUM_ENVOY_IMAGE=quay.io/cilium/cilium-envoy:v1.27.2-6d609cf1559365fe9e8db5a7774a313f1861e143@sha256:90c280221e269952b0fe70c2e0c7fcafe7b51e713c8a4b60eb318c5d626f0553
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.27.2-6d609cf1559365fe9e8db5a7774a313f1861e143@sha256:90c280221e269952b0fe70c2e0c7fcafe7b51e713c8a4b60eb318c5d626f0553 as cilium-envoy
+FROM ${CILIUM_ENVOY_IMAGE} as cilium-envoy
 
 #
 # Hubble CLI

--- a/images/scripts/check-cilium-envoy-image.sh
+++ b/images/scripts/check-cilium-envoy-image.sh
@@ -17,9 +17,9 @@ image_tag="$(yq '.envoy.image.tag' ./install/kubernetes/cilium/values.yaml)"
 image_sha256="$(yq '.envoy.image.digest' ./install/kubernetes/cilium/values.yaml)"
 
 # pre-check for sed, in case that this script may fail to detect change when the `sed` command fails to replace the string and return code 0
-image_regular="(FROM ${image}:)(.*)(@sha256:[0-9a-z]*)( as cilium-envoy)"
+image_regular="(ARG CILIUM_ENVOY_IMAGE=${image}:)(.*)(@sha256:[0-9a-z]*)"
 grep -E "${image_regular}" ./images/cilium/Dockerfile &>/dev/null || exit 1
-sed -i -E "s|${image_regular}|\1${image_tag}@${image_sha256}\4|" ./images/cilium/Dockerfile
+sed -i -E "s|${image_regular}|\1${image_tag}@${image_sha256}|" ./images/cilium/Dockerfile
 
 echo "Checking for different Cilium Envoy images"
 git diff --exit-code ./images/cilium/Dockerfile

--- a/images/scripts/update-cilium-envoy-image.sh
+++ b/images/scripts/update-cilium-envoy-image.sh
@@ -39,7 +39,7 @@ echo "Latest image from branch ${github_branch}: ${image_full}"
 
 DOCKERFILEPATH="./images/cilium/Dockerfile"
 echo "Updating image in ${DOCKERFILEPATH}"
-sed -i -E "s|FROM quay.io/cilium/cilium-envoy.*:.*@sha256:[0-9a-z]* as cilium-envoy|FROM ${image}:${image_tag}@${image_sha256} as cilium-envoy|" ${DOCKERFILEPATH}
+sed -i -E "s|ARG CILIUM_ENVOY_IMAGE=quay.io/cilium/cilium-envoy.*:.*@sha256:[0-9a-z]*|ARG CILIUM_ENVOY_IMAGE=${image}:${image_tag}@${image_sha256}|" ${DOCKERFILEPATH}
 
 MAKEFILEPATH="./install/kubernetes/Makefile.values"
 echo "Updating image in ${MAKEFILEPATH}"


### PR DESCRIPTION

<!-- Description of change -->

Move the cilium-envoy image reference to an ARG so that it can be overridden via build-args.

This allows overrides using mirrored images for instance and is useful in build environments without Internet access as well as avoiding API throttling on public registries.


```release-note
Defines the cilium-envoy image used in the build Dockerfile using ARG to allow overrides. 
```
