### PR TITLE
guestbook: update example with leader/follower naming

### DIFF
--- a/examples/misc/guestbook/1-redis-leader-controller.json
+++ b/examples/misc/guestbook/1-redis-leader-controller.json
@@ -2,29 +2,29 @@
     "kind":"ReplicationController",
     "apiVersion":"v1",
     "metadata":{
-        "name":"redis-master",
+        "name":"redis-leader",
         "labels":{
             "k8s-app.guestbook":"redis",
-            "role":"master"
+            "role":"leader"
         }
     },
     "spec":{
         "replicas":1,
         "selector":{
             "k8s-app.guestbook":"redis",
-            "role":"master"
+            "role":"leader"
         },
         "template":{
             "metadata":{
                 "labels":{
                     "k8s-app.guestbook":"redis",
-                    "role":"master"
+                    "role":"leader"
                 }
             },
             "spec":{
                 "containers":[{
-                    "name":"redis-master",
-                    "image":"docker.io/library/redis:4.0.1",
+                    "name":"redis-leader",
+                    "image":"docker.io/redis:6.0.5",
                     "ports":[{
                         "name":"redis-server",
                         "containerPort":6379

--- a/examples/misc/guestbook/2-redis-leader-service.json
+++ b/examples/misc/guestbook/2-redis-leader-service.json
@@ -2,10 +2,10 @@
     "kind":"Service",
     "apiVersion":"v1",
     "metadata":{
-        "name":"redis-master",
+        "name":"redis-leader",
         "labels":{
             "k8s-app.guestbook":"redis",
-            "role":"master"
+            "role":"leader"
         }
     },
     "spec":{
@@ -15,7 +15,7 @@
         }],
         "selector":{
             "k8s-app.guestbook":"redis",
-            "role":"master"
+            "role":"leader"
         }
     }
 }

--- a/examples/misc/guestbook/3-redis-follower-controller.json
+++ b/examples/misc/guestbook/3-redis-follower-controller.json
@@ -2,30 +2,30 @@
     "kind":"ReplicationController",
     "apiVersion":"v1",
     "metadata":{
-        "name":"redis-slave",
+        "name":"redis-follower",
         "labels":{
             "k8s-app.guestbook":"redis",
-            "role":"slave"
+            "role":"follower"
         }
     },
     "spec":{
         "replicas":1,
         "selector":{
             "k8s-app.guestbook":"redis",
-            "role":"slave"
+            "role":"follower"
         },
         "template":{
             "metadata":{
                 "labels":{
                     "k8s-app.guestbook":"redis",
-                    "role":"slave"
+                    "role":"follower"
                 }
             },
             "spec":{
                 "containers":[{
-                    "name":"redis-slave",
-                    "image":"docker.io/library/redis:4.0.1",
-                    "command": ["redis-server","--loglevel","verbose","--slaveof","redis-master","6379"],
+                    "name":"redis-follower",
+                    "image":"docker.io/redis:6.0.5",
+                    "command": ["redis-server","--loglevel","verbose","--slaveof","redis-leader","6379"],
                     "ports":[{
                         "name":"redis-server",
                         "containerPort":6379

--- a/examples/misc/guestbook/4-redis-follower-service.json
+++ b/examples/misc/guestbook/4-redis-follower-service.json
@@ -2,10 +2,10 @@
     "kind":"Service",
     "apiVersion":"v1",
     "metadata":{
-        "name":"redis-slave",
+        "name":"redis-follower",
         "labels":{
             "k8s-app.guestbook":"redis",
-            "role":"slave"
+            "role":"follower"
         }
     },
     "spec":{
@@ -15,7 +15,7 @@
         }],
         "selector":{
             "k8s-app.guestbook":"redis",
-            "role":"slave"
+            "role":"follower"
         }
     }
 }


### PR DESCRIPTION
The guestbook in version v5 fails trying to connect to `redis-leader`. The reason is that the deployment is still named `redis-master`.

Therefore, this commit renames the guestbook example deployments to use the leader/follower naming.

I forgot to commit this to the main PR where the guestbook is only used as an example: https://github.com/cilium/cilium/pull/29603 
It only landed on the v1.12 backport (https://github.com/cilium/cilium/pull/29600) where it was more important anyway (because it was used in an automated CI test)