### PR TITLE
Add readinessProbe to clustermesh-apiserver

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -480,6 +480,10 @@
      - Additional clustermesh-apiserver volumes.
      - list
      - ``[]``
+   * - :spelling:ignore:`clustermesh.apiserver.healthPort`
+     - TCP port for the clustermesh-apiserver health API.
+     - int
+     - ``9880``
    * - :spelling:ignore:`clustermesh.apiserver.image`
      - Clustermesh API server image.
      - object

--- a/clustermesh-apiserver/clustermesh/root.go
+++ b/clustermesh-apiserver/clustermesh/root.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -78,6 +79,7 @@ type parameters struct {
 	Resources      cmk8s.Resources
 	BackendPromise promise.Promise[kvstore.BackendOperations]
 	StoreFactory   store.Factory
+	SyncState      *SyncState
 }
 
 func registerHooks(lc hive.Lifecycle, params parameters) error {
@@ -92,25 +94,55 @@ func registerHooks(lc hive.Lifecycle, params parameters) error {
 				return err
 			}
 
-			startServer(ctx, params.ClusterInfo, params.EnableExternalWorkloads, params.Clientset, backend, params.Resources, params.StoreFactory)
+			startServer(ctx, params.ClusterInfo, params.EnableExternalWorkloads, params.Clientset, backend, params.Resources, params.StoreFactory, params.SyncState)
 			return nil
 		},
 	})
 	return nil
 }
 
-type identitySynchronizer struct {
-	store   store.SyncStore
-	encoder func([]byte) string
+func NewSyncState() *SyncState {
+	return &SyncState{StoppableWaitGroup: *lock.NewStoppableWaitGroup()}
 }
 
-func newIdentitySynchronizer(ctx context.Context, cinfo cmtypes.ClusterInfo, backend kvstore.BackendOperations, factory store.Factory) synchronizer {
+// SyncState is a wrapper around lock.StoppableWaitGroup used to keep track of the synchronization
+// of various resources to the kvstore.
+type SyncState struct {
+	lock.StoppableWaitGroup
+}
+
+// Complete returns true if all resources have been synchronized to the kvstore.
+func (ss *SyncState) Complete() bool {
+	select {
+	case <-ss.WaitChannel():
+		return true
+	default:
+		return false
+	}
+}
+
+// WaitForResource adds a resource to the SyncState and returns a callback function that should be
+// called when the resource has been synchronized.
+func (ss *SyncState) WaitForResource() func(context.Context) {
+	ss.Add()
+	return func(_ context.Context) {
+		ss.Done()
+	}
+}
+
+type identitySynchronizer struct {
+	store        store.SyncStore
+	encoder      func([]byte) string
+	syncCallback func(context.Context)
+}
+
+func newIdentitySynchronizer(ctx context.Context, cinfo cmtypes.ClusterInfo, backend kvstore.BackendOperations, factory store.Factory, syncCallback func(context.Context)) synchronizer {
 	identitiesStore := factory.NewSyncStore(cinfo.Name, backend,
 		path.Join(identityCache.IdentitiesPath, "id"),
 		store.WSSWithSyncedKeyOverride(identityCache.IdentitiesPath))
 	go identitiesStore.Run(ctx)
 
-	return &identitySynchronizer{store: identitiesStore, encoder: backend.Encode}
+	return &identitySynchronizer{store: identitiesStore, encoder: backend.Encode, syncCallback: syncCallback}
 }
 
 func parseLabelArrayFromMap(base map[string]string) labels.LabelArray {
@@ -162,7 +194,7 @@ func (is *identitySynchronizer) delete(ctx context.Context, key resource.Key) er
 
 func (is *identitySynchronizer) synced(ctx context.Context) error {
 	log.Info("Initial list of identities successfully received from Kubernetes")
-	return is.store.Synced(ctx)
+	return is.store.Synced(ctx, is.syncCallback)
 }
 
 type nodeStub struct {
@@ -175,15 +207,16 @@ func (n *nodeStub) GetKeyName() string {
 }
 
 type nodeSynchronizer struct {
-	clusterInfo cmtypes.ClusterInfo
-	store       store.SyncStore
+	clusterInfo  cmtypes.ClusterInfo
+	store        store.SyncStore
+	syncCallback func(context.Context)
 }
 
-func newNodeSynchronizer(ctx context.Context, cinfo cmtypes.ClusterInfo, backend kvstore.BackendOperations, factory store.Factory) synchronizer {
+func newNodeSynchronizer(ctx context.Context, cinfo cmtypes.ClusterInfo, backend kvstore.BackendOperations, factory store.Factory, syncCallback func(context.Context)) synchronizer {
 	nodesStore := factory.NewSyncStore(cinfo.Name, backend, nodeStore.NodeStorePrefix)
 	go nodesStore.Run(ctx)
 
-	return &nodeSynchronizer{clusterInfo: cinfo, store: nodesStore}
+	return &nodeSynchronizer{clusterInfo: cinfo, store: nodesStore, syncCallback: syncCallback}
 }
 
 func (ns *nodeSynchronizer) upsert(ctx context.Context, _ resource.Key, obj runtime.Object) error {
@@ -221,25 +254,27 @@ func (ns *nodeSynchronizer) delete(ctx context.Context, key resource.Key) error 
 
 func (ns *nodeSynchronizer) synced(ctx context.Context) error {
 	log.Info("Initial list of nodes successfully received from Kubernetes")
-	return ns.store.Synced(ctx)
+	return ns.store.Synced(ctx, ns.syncCallback)
 }
 
 type ipmap map[string]struct{}
 
 type endpointSynchronizer struct {
-	store store.SyncStore
-	cache map[string]ipmap
+	store        store.SyncStore
+	cache        map[string]ipmap
+	syncCallback func(context.Context)
 }
 
-func newEndpointSynchronizer(ctx context.Context, cinfo cmtypes.ClusterInfo, backend kvstore.BackendOperations, factory store.Factory) synchronizer {
+func newEndpointSynchronizer(ctx context.Context, cinfo cmtypes.ClusterInfo, backend kvstore.BackendOperations, factory store.Factory, syncCallback func(context.Context)) synchronizer {
 	endpointsStore := factory.NewSyncStore(cinfo.Name, backend,
 		path.Join(ipcache.IPIdentitiesPath, ipcache.DefaultAddressSpace),
 		store.WSSWithSyncedKeyOverride(ipcache.IPIdentitiesPath))
 	go endpointsStore.Run(ctx)
 
 	return &endpointSynchronizer{
-		store: endpointsStore,
-		cache: make(map[string]ipmap),
+		store:        endpointsStore,
+		cache:        make(map[string]ipmap),
+		syncCallback: syncCallback,
 	}
 }
 
@@ -299,7 +334,7 @@ func (es *endpointSynchronizer) delete(ctx context.Context, key resource.Key) er
 
 func (es *endpointSynchronizer) synced(ctx context.Context) error {
 	log.Info("Initial list of endpoints successfully received from Kubernetes")
-	return es.store.Synced(ctx)
+	return es.store.Synced(ctx, es.syncCallback)
 }
 
 func (es *endpointSynchronizer) deleteEndpoints(ctx context.Context, key resource.Key, ips ipmap) {
@@ -342,6 +377,7 @@ func startServer(
 	backend kvstore.BackendOperations,
 	resources cmk8s.Resources,
 	factory store.Factory,
+	syncState *SyncState,
 ) {
 	log.WithFields(logrus.Fields{
 		"cluster-name": cinfo.Name,
@@ -363,9 +399,9 @@ func startServer(
 	}
 
 	ctx := context.Background()
-	go synchronize(ctx, resources.CiliumIdentities, newIdentitySynchronizer(ctx, cinfo, backend, factory))
-	go synchronize(ctx, resources.CiliumNodes, newNodeSynchronizer(ctx, cinfo, backend, factory))
-	go synchronize(ctx, resources.CiliumSlimEndpoints, newEndpointSynchronizer(ctx, cinfo, backend, factory))
+	go synchronize(ctx, resources.CiliumIdentities, newIdentitySynchronizer(ctx, cinfo, backend, factory, syncState.WaitForResource()))
+	go synchronize(ctx, resources.CiliumNodes, newNodeSynchronizer(ctx, cinfo, backend, factory, syncState.WaitForResource()))
+	go synchronize(ctx, resources.CiliumSlimEndpoints, newEndpointSynchronizer(ctx, cinfo, backend, factory, syncState.WaitForResource()))
 	operatorWatchers.StartSynchronizingServices(ctx, &sync.WaitGroup{}, operatorWatchers.ServiceSyncParameters{
 		ClusterInfo:  cinfo,
 		Clientset:    clientset,
@@ -374,7 +410,9 @@ func startServer(
 		Backend:      backend,
 		SharedOnly:   !allServices,
 		StoreFactory: factory,
+		SyncCallback: syncState.WaitForResource(),
 	})
+	syncState.Stop()
 
 	log.Info("Initialization complete")
 }

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -170,6 +170,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.extraEnv | list | `[]` | Additional clustermesh-apiserver environment variables. |
 | clustermesh.apiserver.extraVolumeMounts | list | `[]` | Additional clustermesh-apiserver volumeMounts. |
 | clustermesh.apiserver.extraVolumes | list | `[]` | Additional clustermesh-apiserver volumes. |
+| clustermesh.apiserver.healthPort | int | `9880` | TCP port for the clustermesh-apiserver health API. |
 | clustermesh.apiserver.image | object | `{"digest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/clustermesh-apiserver-ci","tag":"latest","useDigest":false}` | Clustermesh API server image. |
 | clustermesh.apiserver.kvstoremesh.enabled | bool | `false` | Enable KVStoreMesh. KVStoreMesh caches the information retrieved from the remote clusters in the local etcd instance. |
 | clustermesh.apiserver.kvstoremesh.extraArgs | list | `[]` | Additional KVStoreMesh arguments. |

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -169,6 +169,7 @@ spec:
         {{- if hasKey .Values.clustermesh "maxConnectedClusters" }}
         - --max-connected-clusters={{ .Values.clustermesh.maxConnectedClusters }}
         {{- end }}
+        - --clustermesh-health-port={{ .Values.clustermesh.apiserver.healthPort }}
         {{- if ne .Values.clustermesh.apiserver.tls.authMode "legacy" }}
         - --cluster-users-enabled
         - --cluster-users-config-path=/var/lib/cilium/etcd-config/users.yaml
@@ -204,11 +205,21 @@ spec:
               name: cilium-config
               key: enable-k8s-endpoint-slice
               optional: true
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: apiserv-health
+          periodSeconds: 30
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
         {{- with .Values.clustermesh.apiserver.extraEnv }}
         {{- toYaml . | trim | nindent 8 }}
         {{- end }}
-        {{- if .Values.clustermesh.apiserver.metrics.enabled }}
         ports:
+        - name: apiserv-health
+          containerPort: {{ .Values.clustermesh.apiserver.healthPort }}
+          protocol: TCP
+        {{- if .Values.clustermesh.apiserver.metrics.enabled }}
         - name: apiserv-metrics
           containerPort: {{ .Values.clustermesh.apiserver.metrics.port }}
           protocol: TCP

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2928,6 +2928,9 @@ clustermesh:
       useDigest: false
       pullPolicy: "Always"
 
+    # -- TCP port for the clustermesh-apiserver health API.
+    healthPort: 9880
+
     etcd:
       # The etcd binary is included in the clustermesh API server image, so the same image from above is reused.
       # Independent override isn't supported, because clustermesh-apiserver is tested against the etcd version it is

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2925,6 +2925,9 @@ clustermesh:
       useDigest: ${USE_DIGESTS}
       pullPolicy: "${PULL_POLICY}"
 
+    # -- TCP port for the clustermesh-apiserver health API.
+    healthPort: 9880
+
     etcd:
       # The etcd binary is included in the clustermesh API server image, so the same image from above is reused.
       # Independent override isn't supported, because clustermesh-apiserver is tested against the etcd version it is

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -563,6 +563,7 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 				Endpoints:    legacy.resources.Endpoints,
 				SharedOnly:   true,
 				StoreFactory: legacy.storeFactory,
+				SyncCallback: func(_ context.Context) {},
 			})
 			// If K8s is enabled we can do the service translation automagically by
 			// looking at services from k8s and retrieve the service IP from that.

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -90,6 +90,7 @@ type ServiceSyncParameters struct {
 	Backend      store.SyncStoreBackend
 	SharedOnly   bool
 	StoreFactory store.Factory
+	SyncCallback func(context.Context)
 }
 
 // StartSynchronizingServices starts a controller for synchronizing services from k8s to kvstore
@@ -150,7 +151,7 @@ func StartSynchronizingServices(ctx context.Context, wg *sync.WaitGroup, cfg Ser
 			close(k8sSvcCacheSynced)
 
 			log.Info("Initial list of services successfully received from Kubernetes")
-			kvs.Synced(ctx)
+			kvs.Synced(ctx, cfg.SyncCallback)
 		}
 
 		for serviceEvents != nil || endpointEvents != nil {


### PR DESCRIPTION
This adds a `/readyz` endpoint to the clustermesh-apiserver to report the status of the synchronization of nodes, identities, services, and endpoints to the kvstore, and configures a readinessProbe on the clustermesh-apiserver deployment.

```
Adds a /readyz endpoint to be used with a readiness probe. The endpoint
will return 200 if nodes, identities, services, and endpoints have been
synchronized to the kvstore. If any resources have not finished
synchronizing, the endpoint returns 500.
```

```
Add a readinessProbe to the clustermesh-apiserver deployment utilizing
the '/readyz' endpoint of the health API.

clustermesh-apiserver accepts a healthPort via the option
`--clustermesh-health-port` that was not previously included in the helm
chart. This was added with a default of 9880 to ensure the
readinessProbe could be configured correctly.
```

Release-note:
```release-note
add readinessProbe to clustermesh-apiserver indicating kvstore sync status
```
