### PR TITLE
[v1.14] gh: datapath-verifier: also run on 6.1 kernel

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -82,6 +82,9 @@ jobs:
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
           - kernel: '5.15-20231124.100406'
             ci-kernel: '510'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+          - kernel: '6.1-20231124.100406'
+            ci-kernel: '510'
             # We don't want to update bpf-next after branching
           - kernel: 'bpf-next-20230420.212204'
             ci-kernel: 'netnext'


### PR DESCRIPTION
Backport of

* https://github.com/cilium/cilium/pull/29349
