### PR TITLE
envoy: Bump cilium-envoy with golang 1.21.5

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -9,7 +9,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:dfd010f8d8720731961aecdf9
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.26-5ec70a52b95e04ca7fb30c19855b20fc24da64d0@sha256:0f0b4bf9234b2b10d16cccabd31c3d2fe51a7d3a5fdfddb5a22e622cce2c87c2 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.26-ad82c7c56e88989992fd25d8d67747de865c823b@sha256:992998398dadfff7117bfa9fdb7c9474fefab7f0237263f7c8114e106c67baca as cilium-envoy
 
 #
 # Hubble CLI


### PR DESCRIPTION
This is mainly for recently golang version v1.21.5

Relates build: https://github.com/cilium/proxy/actions/runs/7113088396/job/19364351580

