### PR TITLE
envoy: Bump cilium-envoy with golang 1.21.5

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -7,7 +7,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:76c96fc643c701fa5c822e507
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.26-5ec70a52b95e04ca7fb30c19855b20fc24da64d0@sha256:0f0b4bf9234b2b10d16cccabd31c3d2fe51a7d3a5fdfddb5a22e622cce2c87c2 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.26-ad82c7c56e88989992fd25d8d67747de865c823b@sha256:992998398dadfff7117bfa9fdb7c9474fefab7f0237263f7c8114e106c67baca as cilium-envoy
 
 #
 # Hubble CLI

--- a/pkg/k8s/watchers/cilium_clusterwide_envoy_config.go
+++ b/pkg/k8s/watchers/cilium_clusterwide_envoy_config.go
@@ -94,7 +94,7 @@ func (k *K8sWatcher) addCiliumClusterwideEnvoyConfig(ccec *cilium_v2.CiliumClust
 		true,
 		k.envoyConfigManager,
 		len(ccec.Spec.Services) > 0,
-		!isIngressKind(&ccec.ObjectMeta),
+		!isCiliumIngress(&ccec.ObjectMeta),
 	)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to add CiliumClusterwideEnvoyConfig: malformed Envoy config")
@@ -140,7 +140,7 @@ func (k *K8sWatcher) updateCiliumClusterwideEnvoyConfig(oldCCEC *cilium_v2.Ciliu
 		false,
 		k.envoyConfigManager,
 		len(oldCCEC.Spec.Services) > 0,
-		!isIngressKind(&oldCCEC.ObjectMeta),
+		!isCiliumIngress(&oldCCEC.ObjectMeta),
 	)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to update CiliumClusterwideEnvoyConfig: malformed old Envoy config")
@@ -153,7 +153,7 @@ func (k *K8sWatcher) updateCiliumClusterwideEnvoyConfig(oldCCEC *cilium_v2.Ciliu
 		true,
 		k.envoyConfigManager,
 		len(newCCEC.Spec.Services) > 0,
-		!isIngressKind(&newCCEC.ObjectMeta),
+		!isCiliumIngress(&newCCEC.ObjectMeta),
 	)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to update CiliumClusterwideEnvoyConfig: malformed new Envoy config")
@@ -199,7 +199,7 @@ func (k *K8sWatcher) deleteCiliumClusterwideEnvoyConfig(ccec *cilium_v2.CiliumCl
 		false,
 		k.envoyConfigManager,
 		len(ccec.Spec.Services) > 0,
-		!isIngressKind(&ccec.ObjectMeta),
+		!isCiliumIngress(&ccec.ObjectMeta),
 	)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to delete CiliumClusterwideEnvoyConfig: parsing rersource names failed")

--- a/pkg/k8s/watchers/cilium_envoy_config.go
+++ b/pkg/k8s/watchers/cilium_envoy_config.go
@@ -85,10 +85,10 @@ func (k *K8sWatcher) ciliumEnvoyConfigInit(ciliumNPClient client.Clientset) {
 	k.k8sAPIGroups.AddAPI(k8sAPIGroupCiliumEnvoyConfigV2)
 }
 
-// isIngressKind returns true if any of the OwnerReferences is Kind "Ingress"
-func isIngressKind(meta *meta_v1.ObjectMeta) bool {
+// isCiliumIngress returns true if the given object metadata indicates that the owner needs the Envoy listener to assume the identity of Cilium Ingress. Currently this is the case when any of the OwnerReferences is Kind "Ingress" or "Gateway".
+func isCiliumIngress(meta *meta_v1.ObjectMeta) bool {
 	for _, owner := range meta.OwnerReferences {
-		if owner.Kind == "Ingress" {
+		if owner.Kind == "Ingress" || owner.Kind == "Gateway" {
 			return true
 		}
 	}
@@ -110,7 +110,7 @@ func (k *K8sWatcher) addCiliumEnvoyConfig(cec *cilium_v2.CiliumEnvoyConfig) erro
 		true,
 		k.envoyConfigManager,
 		len(cec.Spec.Services) > 0,
-		!isIngressKind(&cec.ObjectMeta),
+		!isCiliumIngress(&cec.ObjectMeta),
 	)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to add CiliumEnvoyConfig: malformed Envoy config")
@@ -219,7 +219,7 @@ func (k *K8sWatcher) updateCiliumEnvoyConfig(oldCEC *cilium_v2.CiliumEnvoyConfig
 		false,
 		k.envoyConfigManager,
 		len(oldCEC.Spec.Services) > 0,
-		!isIngressKind(&oldCEC.ObjectMeta),
+		!isCiliumIngress(&oldCEC.ObjectMeta),
 	)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to update CiliumEnvoyConfig: malformed old Envoy config")
@@ -232,7 +232,7 @@ func (k *K8sWatcher) updateCiliumEnvoyConfig(oldCEC *cilium_v2.CiliumEnvoyConfig
 		true,
 		k.envoyConfigManager,
 		len(newCEC.Spec.Services) > 0,
-		!isIngressKind(&newCEC.ObjectMeta),
+		!isCiliumIngress(&newCEC.ObjectMeta),
 	)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to update CiliumEnvoyConfig: malformed new Envoy config")
@@ -338,7 +338,7 @@ func (k *K8sWatcher) deleteCiliumEnvoyConfig(cec *cilium_v2.CiliumEnvoyConfig) e
 		false,
 		k.envoyConfigManager,
 		len(cec.Spec.Services) > 0,
-		!isIngressKind(&cec.ObjectMeta),
+		!isCiliumIngress(&cec.ObjectMeta),
 	)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to delete CiliumEnvoyConfig: parsing rersource names failed")


### PR DESCRIPTION
This is mainly for recently golang version v1.21.5

Relates build: https://github.com/cilium/proxy/actions/runs/7113088396/job/19364351580

