### PR TITLE
Clean up deprecated and unused IPCache APIs after FQDN transition to asynchronous APIs

### DIFF
--- a/daemon/cmd/identity.go
+++ b/daemon/cmd/identity.go
@@ -4,10 +4,6 @@
 package cmd
 
 import (
-	"context"
-	"net"
-	"net/netip"
-
 	"github.com/go-openapi/runtime/middleware"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -17,7 +13,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	identitymodel "github.com/cilium/cilium/pkg/identity/model"
-	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -78,17 +73,4 @@ type CachingIdentityAllocator interface {
 
 	InitIdentityAllocator(versioned.Interface) <-chan struct{}
 	Close()
-}
-
-type cachingIdentityAllocator struct {
-	*cache.CachingIdentityAllocator
-	ipcache *ipcache.IPCache
-}
-
-func (c cachingIdentityAllocator) AllocateCIDRsForIPs(ips []net.IP, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity) ([]*identity.Identity, error) {
-	return c.ipcache.AllocateCIDRsForIPs(ips, newlyAllocatedIdentities)
-}
-
-func (c cachingIdentityAllocator) ReleaseCIDRIdentitiesByID(ctx context.Context, identities []identity.NumericIdentity) {
-	c.ipcache.ReleaseCIDRIdentitiesByID(ctx, identities)
 }

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -93,10 +93,7 @@ type policyOut struct {
 // special care.
 func newPolicyTrifecta(params policyParams) (policyOut, error) {
 	iao := &identityAllocatorOwner{}
-	idAlloc := &cachingIdentityAllocator{
-		cache.NewCachingIdentityAllocator(iao),
-		nil,
-	}
+	idAlloc := cache.NewCachingIdentityAllocator(iao)
 
 	iao.policy = policy.NewStoppedPolicyRepository(
 		idAlloc,
@@ -121,7 +118,6 @@ func newPolicyTrifecta(params policyParams) (policyOut, error) {
 		DatapathHandler:   params.EndpointManager,
 		CacheStatus:       params.CacheStatus,
 	})
-	idAlloc.ipcache = ipc
 
 	params.Lifecycle.Append(hive.Hook{
 		OnStart: func(hc hive.HookContext) error {

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -136,7 +136,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 
 	idAllocatorOwner := &DummyIdentityAllocatorOwner{}
 
-	mgr := NewCachingIdentityAllocator(idAllocatorOwner)
+	mgr := cache.NewCachingIdentityAllocator(idAllocatorOwner)
 	<-mgr.InitIdentityAllocator(nil)
 	defer mgr.Close()
 
@@ -363,7 +363,7 @@ func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
 
 	idAllocatorOwner := &DummyIdentityAllocatorOwner{}
 
-	mgr := NewCachingIdentityAllocator(idAllocatorOwner)
+	mgr := cache.NewCachingIdentityAllocator(idAllocatorOwner)
 	<-mgr.InitIdentityAllocator(nil)
 	defer mgr.Close()
 

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
-	"net/netip"
 	"path"
 
 	"github.com/sirupsen/logrus"
@@ -117,24 +115,6 @@ type IdentityAllocator interface {
 
 	// GetIdentities returns a copy of the current cache of identities.
 	GetIdentities() IdentitiesModel
-
-	// AllocateCIDRsForIPs attempts to allocate identities for a list of
-	// CIDRs. If any allocation fails, all allocations are rolled back and
-	// the error is returned. When an identity is freshly allocated for a
-	// CIDR, it is added to the ipcache if 'newlyAllocatedIdentities' is
-	// 'nil', otherwise the newly allocated identities are placed in
-	// 'newlyAllocatedIdentities' and it is the caller's responsibility to
-	// upsert them into ipcache by calling UpsertGeneratedIdentities().
-	//
-	// Upon success, the caller must also arrange for the resulting identities to
-	// be released via a subsequent call to ReleaseCIDRIdentitiesByID().
-	//
-	// The implementation for this function currently lives in pkg/ipcache.
-	AllocateCIDRsForIPs(ips []net.IP, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity) ([]*identity.Identity, error)
-
-	// ReleaseCIDRIdentitiesByID() is a wrapper for ReleaseSlice() that
-	// also handles ipcache entries.
-	ReleaseCIDRIdentitiesByID(context.Context, []identity.NumericIdentity)
 
 	// WithholdLocalIdentities holds a set of numeric identities out of the local
 	// allocation pool(s). Once withheld, a numeric identity can only be used

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -5,14 +5,12 @@ package ipcache
 
 import (
 	"context"
-	"net"
 	"net/netip"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -83,19 +81,6 @@ func (ipc *IPCache) AllocateCIDRs(
 		identities = append(identities, id)
 	}
 	return identities, nil
-}
-
-// AllocateCIDRsForIPs performs the same action as AllocateCIDRs but for IP
-// addresses instead of CIDRs.
-//
-// Upon success, the caller must also arrange for the resulting identities to
-// be released via a subsequent call to ReleaseCIDRIdentitiesByID().
-//
-// Deprecated: Prefer UpsertLabels() instead.
-func (ipc *IPCache) AllocateCIDRsForIPs(
-	prefixes []net.IP, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity,
-) ([]*identity.Identity, error) {
-	return ipc.AllocateCIDRs(ip.IPsToNetPrefixes(prefixes), newlyAllocatedIdentities)
 }
 
 func cidrLabelToPrefix(id *identity.Identity) (prefix netip.Prefix, ok bool) {
@@ -237,43 +222,4 @@ func (ipc *IPCache) releaseCIDRIdentities(ctx context.Context, prefixes []netip.
 // Deprecated: Prefer RemoveLabels() or RemoveIdentity() instead.
 func (ipc *IPCache) ReleaseCIDRIdentitiesByCIDR(prefixes []netip.Prefix) {
 	ipc.deferredPrefixRelease.enqueue(prefixes, "cidr-prefix-release")
-}
-
-// ReleaseCIDRIdentitiesByID releases the specified identities.
-// When the last use of the identity is released, the ipcache entry is deleted.
-//
-// Deprecated: Prefer RemoveLabels() or RemoveIdentity() instead.
-func (ipc *IPCache) ReleaseCIDRIdentitiesByID(ctx context.Context, identities []identity.NumericIdentity) {
-	prefixes := make([]netip.Prefix, 0, len(identities))
-	for _, nid := range identities {
-		if id := ipc.IdentityAllocator.LookupIdentityByID(ctx, nid); id != nil {
-			prefix, ok := cidrLabelToPrefix(id)
-			if !ok {
-				lgr := log.WithFields(logrus.Fields{
-					logfields.Identity: nid,
-					logfields.Labels:   id.Labels,
-				})
-
-				if !id.IsReserved() {
-					lgr.Warn("Unexpected release of non-CIDR identity, will leak this identity. Please report this issue to the developers.")
-				} else {
-					// If we have arrived here because the identity is a
-					// reserved identity, then the caller was mistaken. This
-					// currently has a number of occurrences, in which case we
-					// debug log here because this has caused excessive log
-					// pressure. https://github.com/cilium/cilium/issues/23192
-					lgr.Debug("Unexpected release of Reserved identity. Please report this issue to the developers.")
-				}
-
-				continue
-			}
-			prefixes = append(prefixes, prefix)
-		} else {
-			log.WithFields(logrus.Fields{
-				logfields.Identity: nid,
-			}).Warn("Unexpected release of numeric identity that is no longer allocated")
-		}
-	}
-
-	ipc.deferredPrefixRelease.enqueue(prefixes, "selector-prefix-release")
 }

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -646,7 +646,7 @@ func (m *metadata) filterByLabels(filter labels.Labels) []netip.Prefix {
 	return matching
 }
 
-// removeLabels asynchronously removes the labels association for a prefix.
+// remove asynchronously removes the labels association for a prefix.
 //
 // This function assumes that the ipcache metadata lock is held for writing.
 func (m *metadata) remove(prefix netip.Prefix, resource types.ResourceID, aux ...IPMetadata) {

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -329,13 +329,13 @@ func TestInjectExisting(t *testing.T) {
 
 	// mimic fqdn policy:
 	// - identitiesForFQDNSelectorIPs calls AllocateCIDRsForIPs()
-	// - notifyOnDNSMsg calls UpsertGeneratedIdentities())
+	// - notifyOnDNSMsg calls upsertGeneratedIdentities())
 	newlyAllocatedIdentities := make(map[netip.Prefix]*identity.Identity)
 	prefix := netip.MustParsePrefix("172.19.0.5/32")
 	_, err := IPIdentityCache.AllocateCIDRsForIPs([]net.IP{prefix.Addr().AsSlice()}, newlyAllocatedIdentities)
 	assert.NoError(t, err)
 
-	IPIdentityCache.UpsertGeneratedIdentities(newlyAllocatedIdentities, nil)
+	IPIdentityCache.upsertGeneratedIdentities(newlyAllocatedIdentities, nil)
 
 	// sanity check: ensure the cidr is correctly in the ipcache
 	wantID := identity.IdentityScopeLocal
@@ -383,7 +383,7 @@ func TestInjectWithLegacyAPIOverlap(t *testing.T) {
 
 	// mimic fqdn policy:
 	// - identitiesForFQDNSelectorIPs calls AllocateCIDRsForIPs()
-	// - notifyOnDNSMsg calls UpsertGeneratedIdentities())
+	// - notifyOnDNSMsg calls upsertGeneratedIdentities())
 	newlyAllocatedIdentities := make(map[netip.Prefix]*identity.Identity)
 	prefix := netip.MustParsePrefix("172.19.0.5/32")
 	_, err := IPIdentityCache.AllocateCIDRsForIPs([]net.IP{prefix.Addr().AsSlice()}, newlyAllocatedIdentities)
@@ -392,7 +392,7 @@ func TestInjectWithLegacyAPIOverlap(t *testing.T) {
 
 	wantID := newlyAllocatedIdentities[prefix].ID
 
-	IPIdentityCache.UpsertGeneratedIdentities(newlyAllocatedIdentities, nil)
+	IPIdentityCache.upsertGeneratedIdentities(newlyAllocatedIdentities, nil)
 
 	// sanity check: ensure the cidr is correctly in the ipcache
 	id, ok := IPIdentityCache.LookupByIP(prefix.String())
@@ -487,7 +487,7 @@ func TestInjectLegacySecond(t *testing.T) {
 	assert.Len(t, newlyAllocatedIdentities, 0)
 	assert.Len(t, currentlyAllocatedIdentities, 1)
 	assert.Equal(t, wantID, currentlyAllocatedIdentities[0].ID)
-	IPIdentityCache.UpsertGeneratedIdentities(newlyAllocatedIdentities, currentlyAllocatedIdentities)
+	IPIdentityCache.upsertGeneratedIdentities(newlyAllocatedIdentities, currentlyAllocatedIdentities)
 
 	// Remove via new APIs
 	IPIdentityCache.metadata.remove(prefix, resource, labels)

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -5,7 +5,6 @@ package ipcache
 
 import (
 	"context"
-	"net"
 	"net/netip"
 	"sync"
 	"testing"
@@ -328,11 +327,11 @@ func TestInjectExisting(t *testing.T) {
 	defer cancel()
 
 	// mimic fqdn policy:
-	// - identitiesForFQDNSelectorIPs calls AllocateCIDRsForIPs()
+	// - identitiesForFQDNSelectorIPs calls AllocateCIDRs()
 	// - notifyOnDNSMsg calls upsertGeneratedIdentities())
 	newlyAllocatedIdentities := make(map[netip.Prefix]*identity.Identity)
 	prefix := netip.MustParsePrefix("172.19.0.5/32")
-	_, err := IPIdentityCache.AllocateCIDRsForIPs([]net.IP{prefix.Addr().AsSlice()}, newlyAllocatedIdentities)
+	_, err := IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix}, newlyAllocatedIdentities)
 	assert.NoError(t, err)
 
 	IPIdentityCache.upsertGeneratedIdentities(newlyAllocatedIdentities, nil)
@@ -382,11 +381,11 @@ func TestInjectWithLegacyAPIOverlap(t *testing.T) {
 	defer cancel()
 
 	// mimic fqdn policy:
-	// - identitiesForFQDNSelectorIPs calls AllocateCIDRsForIPs()
+	// - identitiesForFQDNSelectorIPs calls AllocateCIDRs()
 	// - notifyOnDNSMsg calls upsertGeneratedIdentities())
 	newlyAllocatedIdentities := make(map[netip.Prefix]*identity.Identity)
 	prefix := netip.MustParsePrefix("172.19.0.5/32")
-	_, err := IPIdentityCache.AllocateCIDRsForIPs([]net.IP{prefix.Addr().AsSlice()}, newlyAllocatedIdentities)
+	_, err := IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix}, newlyAllocatedIdentities)
 	assert.NoError(t, err)
 	identityReferences := 1
 
@@ -482,7 +481,7 @@ func TestInjectLegacySecond(t *testing.T) {
 
 	// Allocate via old APIs
 	newlyAllocatedIdentities := make(map[netip.Prefix]*identity.Identity)
-	currentlyAllocatedIdentities, err := IPIdentityCache.AllocateCIDRsForIPs([]net.IP{prefix.Addr().AsSlice()}, newlyAllocatedIdentities)
+	currentlyAllocatedIdentities, err := IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix}, newlyAllocatedIdentities)
 	assert.NoError(t, err)
 	assert.Len(t, newlyAllocatedIdentities, 0)
 	assert.Len(t, currentlyAllocatedIdentities, 1)
@@ -556,7 +555,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	assert.NotNil(t, id)
 	assert.Equal(t, 1, id.ReferenceCount)
 	// Simulate adding CIDR policy.
-	ids, err := IPIdentityCache.AllocateCIDRsForIPs([]net.IP{net.ParseIP("1.1.1.1").To4()}, nil)
+	ids, err := IPIdentityCache.AllocateCIDRs([]netip.Prefix{netip.MustParsePrefix("1.1.1.1/32")}, nil)
 	assert.Nil(t, err)
 	assert.Len(t, ids, 1)
 	assert.Equal(t, 2, id.ReferenceCount)


### PR DESCRIPTION
Clean up some deprecated/unused ipcache API following #29036 (fixing issue #28930). I've noticed these could be dropped while re-reviewing that PR after merge.

See commits for details.