### PR TITLE
gha: add step to ensure presence/absence of the AWS iptables chains

### DIFF
--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -230,6 +230,16 @@ jobs:
           cilium status --wait --wait-duration=10m
           kubectl get pods -n kube-system
 
+      - name: Check that AWS iptables chains have not been removed
+        run: |
+          for pod in $(kubectl get po -n kube-system -l app.kubernetes.io/name=cilium-agent -o name); do
+            echo "Checking ${pod}"
+            if ! kubectl exec -n kube-system  ${pod} -c cilium-agent -- iptables-save | grep --silent ':AWS'; then
+              echo "Expected AWS iptables chains are not present"
+              exit 1
+            fi
+          done
+
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -228,6 +228,17 @@ jobs:
           cilium status --wait --wait-duration=10m
           kubectl get pods -n kube-system
 
+      - name: Check that AWS leftover iptables chains have been removed
+        run: |
+          for pod in $(kubectl get po -n kube-system -l app.kubernetes.io/name=cilium-agent -o name); do
+            echo "Checking ${pod}"
+            if kubectl exec -n kube-system  ${pod} -c cilium-agent -- iptables-save | grep --silent ':AWS'; then
+              echo "Unexpected AWS leftover iptables chains"
+              kubectl exec -n kube-system ds/cilium -- iptables-save | grep ':AWS'
+              exit 1
+            fi
+          done
+
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&


### PR DESCRIPTION
Recently, a regression of the poststart-eni.sh script got unnoticed, as we are not explicitly testing it as part of the E2E pipelines.

Let's add a step to the Conformance EKS and Conformance AWS-CNI workflows to assert that, in the former case, the stale AWS iptables chains are removed, and in the latter they are not modified.

Link to failing run (without the fix):
* https://github.com/cilium/cilium/actions/runs/7116844494/job/19376214534

Link to successful runs (with the fix):
* https://github.com/cilium/cilium/actions/runs/7117161237/job/19377715059
* https://github.com/cilium/cilium/actions/runs/7117164187/job/19377306203

