### PR TITLE
Helm: enforce routing mode when either gke.enabled or aksbyocni.enabled are set

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -448,9 +448,15 @@ data:
   #   - vxlan (default)
   #   - geneve
 {{- if .Values.gke.enabled }}
+  {{- if ne (.Values.routingMode | default "native") "native" }}
+    {{- fail (printf "RoutingMode must be set to native when gke.enabled=true" )}}
+  {{- end }}
   routing-mode: "native"
   enable-endpoint-routes: "true"
 {{- else if .Values.aksbyocni.enabled }}
+  {{- if ne (.Values.routingMode | default "tunnel") "tunnel" }}
+    {{- fail (printf "RoutingMode must be set to tunnel when aksbyocni.enabled=true" )}}
+  {{- end }}
   routing-mode: "tunnel"
   tunnel-protocol: "vxlan"
 {{- else if .Values.routingMode }}


### PR DESCRIPTION
Historically, the Cilium helm chart allowed to override the routing mode leveraged in combination with {gke,aksbyocni}.enabled. This is no longer possible since aff16b2e404d ("Change routing-mode and tunnel interaction.").

According to the Cilium documentation [1,2], this appears to be the correct behavior, as the routing mode must be respectively set to native and tunnel in these cases. Hence, let's validate that users didn't configure a different routing mode, to avoid falling back silently, which may be confusing.

aff16b2e404d could be considered a breaking change. However, it got backported to v1.14, and we haven't sees bug reports (at least AFAIK) about the behavioral difference. Which means that users are not overriding the routing mode in these cases, as documented. Still, better being pedantic and prevent possible issues (our CI was affected, as apparently we were overriding the routing mode in the external workloads workflow, and it took a while to discover the underlying cause).

I'm marking this PR for backport to v1.14 for consistency with the above commit which introduced the behavioral change.

Related: https://github.com/cilium/cilium/pull/27841#discussion_r1383699775

\[1\]: https://docs.cilium.io/en/stable/network/concepts/routing/#id6
\[2\]: https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/#install-cilium (AKS tab)