### PR TITLE
gha: enable IPv6 in clustermesh upgrade/downgrade workflow

### DIFF
--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -137,9 +137,6 @@ jobs:
           echo "downgrade_version=${CILIUM_DOWNGRADE_VERSION}" >> $GITHUB_OUTPUT
 
           # * bpf.masquerade is disabled due to #23283
-          # * IPv6 is disabled because an issue under investigation (#28088) seems
-          #   to possibly cause seldom and brief connection disruptions on agent
-          #   restart in dual stack clusters, independently of clustermesh.
           # * Hubble is disabled to avoid the performance penalty in the testing
           #   environment due to the relatively high traffic load.
           # * We explicitly configure the sync timeout to a higher value to
@@ -153,7 +150,7 @@ jobs:
             --set=routingMode=tunnel \
             --set=tunnelProtocol=vxlan \
             --set=ipv4.enabled=true \
-            --set=ipv6.enabled=false \
+            --set=ipv6.enabled=true \
             --set=clustermesh.useAPIServer=true \
             --set=clustermesh.config.enabled=true \
             --set=extraConfig.clustermesh-ip-identities-sync-timeout=5m"


### PR DESCRIPTION
Now that known issues causing connection disruption (which appeared to mostly affect dual stack clusters) have been fixed, let's enable IPv6 again in the clustermesh upgrade/downgrade workflow.

Link to three successful runs: https://github.com/cilium/cilium/actions/runs/7117112225