### PR TITLE
[v1.12] ctmap: consider CT entry's .dsr flag in PurgeOrphanNATEntries()

### DIFF
--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -383,6 +383,7 @@ func (k *CTMapTestSuite) TestOrphanNatGC(c *C) {
 		TxPackets: 1,
 		TxBytes:   216,
 		Lifetime:  37459,
+		Flags:     DSR,
 	}
 	err = bpf.UpdateElement(ctMapTCP.Map.GetFd(), ctMapTCP.Map.Name(), unsafe.Pointer(ctKey),
 		unsafe.Pointer(ctVal), 0)

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -522,6 +522,10 @@ const (
 	MaxFlags
 )
 
+func (c *CtEntry) isDsrEntry() bool {
+	return c.Flags&DSR != 0
+}
+
 func (c *CtEntry) flagsString() string {
 	var sb strings.Builder
 


### PR DESCRIPTION
Manual backport of

* https://github.com/cilium/cilium/pull/28857 (partial)
* https://github.com/cilium/cilium/pull/29098