### PR TITLE
Validate code owners in documentation in lint-codeowners CI workflow

### DIFF
--- a/.github/workflows/lint-codeowners.yaml
+++ b/.github/workflows/lint-codeowners.yaml
@@ -34,6 +34,7 @@ jobs:
             codeowners-changed:
               - 'CODEOWNERS'
               - '.github/workflows/lint-codeowners.yaml'
+              - 'Documentation/codeowners.rst'
 
   codeowners:
     needs: check_changes
@@ -127,3 +128,9 @@ jobs:
               echo '::error title=missing_team::The teams above are not documented in CODEOWNERS. Typo?'
               exit ${EXIT_STATUS}
           fi
+
+      - name: Check if code owners list in contributor guide matches CODEOWNERS
+        if: ${{ needs.check_changes.outputs.codeowners-changed == 'true' }}
+        run: |
+          cd src/github.com/cilium/cilium
+          make -C Documentation check-codeowners

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -107,15 +107,17 @@ $(HELM_VALUES): FORCE
 	$(QUIET)printf '..\n  %s\n\n%s\n' "AUTO-GENERATED. Please DO NOT edit manually." "$$(cat $(TMP_FILE_3))" > $@
 	$(QUIET)$(RM) -- $(TMP_FILE_1) $(TMP_FILE_2) $(TMP_FILE_3)
 
-check: builder-image api-flaggen update-cmdref update-crdlist update-helm-values update-codeowners ## Validate command and Helm references, policy examples, and others.
+check-codeowners: builder-image update-codeowners ## Validate code owners list in contributor guide
+	@$(ECHO_CHECK) codeowners.rst
+	$(QUIET) ./check-codeowners.sh
+
+check: builder-image api-flaggen update-cmdref update-crdlist update-helm-values check-codeowners ## Validate command and Helm references, policy examples, and others.
 	@$(ECHO_CHECK) cmdref
 	$(QUIET) ./check-cmdref.sh
 	@$(ECHO_CHECK) $(HELM_VALUES)
 	$(QUIET) ./check-helmvalues.sh
 	@$(ECHO_CHECK) examples
 	$(QUIET)$(DOCKER_RUN) ./check-examples.sh
-	@$(ECHO_CHECK) codeowners.rst
-	$(QUIET) ./check-codeowners.sh
 	@$(ECHO_CHECK) configuration/api-restrictions-table.rst
 	$(QUIET) ./check-flaggen.sh
 	@$(ECHO_CHECK) crdlist.rst

--- a/Documentation/codeowners.rst
+++ b/Documentation/codeowners.rst
@@ -143,8 +143,14 @@ external software and protocols:
   Provide background on how the Cilium Endpoint package fits into the overall
   agent architecture, relationship with generation of policy / datapath
   constructs, serialization and restore from disk.
+- `@cilium/envoy <https://github.com/orgs/cilium/teams/envoy>`__:
+  Maintain the L7 proxy integration with Envoy. This includes the
+  configurations for Envoy via xDS protocols as well as the extensible
+  proxylib framework for Go-based layer 7 filters.
 - `@cilium/egress-gateway <https://github.com/orgs/cilium/teams/egress-gateway>`__:
   Maintain the egress gateway control plane and datapath logic.
+- `@cilium/fqdn <https://github.com/orgs/cilium/teams/fqdn>`__:
+  Maintain the L7 DNS proxy integration.
 - `@cilium/ipcache <https://github.com/orgs/cilium/teams/ipcache>`__:
   Provide background on how the userspace IPCache structure fits into the
   overall agent architecture, ordering constraints with respect to network
@@ -166,10 +172,8 @@ external software and protocols:
   component. Take care of the corresponding garbage collection and leader
   election logic.
 - `@cilium/proxy <https://github.com/orgs/cilium/teams/proxy>`__:
-  Review low-level implementations used to redirect and process traffic at
-  Layer 7, including via the Cilium DNS proxy and Envoy. Maintain the
-  configurations for Envoy via xDS protocols as well as the extensible
-  proxylib framework for Go-based layer 7 filters.
+  Review low-level implementations used to redirect L7 traffic to the actual
+  proxy implementations (FQDN, Envoy, ...).
 - `@cilium/sig-agent <https://github.com/orgs/cilium/teams/sig-agent>`__:
   Provide Cilium (agent) general Go review. Internal architecture, core data
   structures and daemon startup.


### PR DESCRIPTION
This makes sure they are checked to be consistent on every PR modifying
either Documentation/codeowners.rst or CODEOWNERS, regardless of
whether the documentation build/check are run or skipped.

See commits for details.