### PR TITLE
gha: align ci-ipsec-e2e workflow name to main

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -1,4 +1,4 @@
-name: Cilium Conformance IPsec E2E (ci-ipsec-e2e)
+name: Conformance IPsec E2E (ci-ipsec-e2e)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:


### PR DESCRIPTION
Otherwise the name of the workflow displayed by GitHub bounces depending on which one is executed last. This specific change seems to have been lost while backporting e9e43fe3f8c7 ("ci: rename name fields").