### PR TITLE
FQDN: pick some low-hanging performance fruit

### DIFF
--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/fqdn/re"
+	"github.com/cilium/cilium/pkg/ip"
 )
 
 type DNSCacheTestSuite struct{}
@@ -60,6 +61,9 @@ func (ds *DNSCacheTestSuite) TestUpdateLookup(c *C) {
 	for secondsPastNow := 1; secondsPastNow <= endTimeSeconds; secondsPastNow++ {
 		ips := cache.lookupByTime(now.Add(time.Duration(secondsPastNow)*time.Second), name)
 		c.Assert(len(ips), Equals, 2*(endTimeSeconds-secondsPastNow+1), Commentf("Incorrect number of IPs returned"))
+
+		// This test expects ips sorted
+		ip.SortAddrList(ips)
 
 		// Check that we returned each 1.1.1.x entry where x={1..endTimeSeconds}
 		// These are sorted, and are in the first half of the array
@@ -276,6 +280,7 @@ func (ds *DNSCacheTestSuite) TestJSONMarshal(c *C) {
 	currentTime := now
 	for name := range names {
 		IPs := cache.lookupByTime(currentTime, name)
+		ip.SortAddrList(IPs)
 		c.Assert(len(IPs), Equals, 2, Commentf("Incorrect number of IPs returned for %s", name))
 		c.Assert(IPs[0].String(), Equals, sharedIP.String(), Commentf("Returned an IP that doesn't match %s", name))
 		c.Assert(IPs[1].String(), Equals, names[name].String(), Commentf("Returned an IP name that doesn't match %s", name))

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -59,11 +59,13 @@ func (n *NameManager) mapSelectorsToIPsLocked(fqdnSelectors sets.Set[api.FQDNSel
 
 			for name, ips := range lookupIPs {
 				if len(ips) > 0 {
-					log.WithFields(logrus.Fields{
-						"DNSName":      name,
-						"IPs":          ips,
-						"matchPattern": ToFQDN.MatchPattern,
-					}).Debug("Emitting matching DNS Name -> IPs for FQDNSelector")
+					if log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+						log.WithFields(logrus.Fields{
+							"DNSName":      name,
+							"IPs":          ips,
+							"matchPattern": ToFQDN.MatchPattern,
+						}).Debug("Emitting matching DNS Name -> IPs for FQDNSelector")
+					}
 					if ipsSelected == nil {
 						ipsSelected = ips
 					} else {

--- a/pkg/fqdn/helpers_test.go
+++ b/pkg/fqdn/helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
 
@@ -71,6 +72,7 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	ciliumIPs, ok = selIPMapping[ciliumIOSel]
 	c.Assert(ok, Equals, true)
 	c.Assert(len(ciliumIPs), Equals, 2)
+	ip.SortAddrList(ciliumIPs)
 	c.Assert(ciliumIPs[0], Equals, ciliumIP1)
 	c.Assert(ciliumIPs[1], Equals, ciliumIP2)
 
@@ -82,6 +84,7 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	ciliumIPs, ok = selIPMapping[ciliumIOSelMatchPattern]
 	c.Assert(ok, Equals, true)
 	c.Assert(len(ciliumIPs), Equals, 2)
+	ip.SortAddrList(ciliumIPs)
 	c.Assert(ciliumIPs[0], Equals, ciliumIP1)
 	c.Assert(ciliumIPs[1], Equals, ciliumIP2)
 
@@ -92,11 +95,13 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	ciliumIPs, ok = selIPMapping[ciliumIOSelMatchPattern]
 	c.Assert(ok, Equals, true)
 	c.Assert(len(ciliumIPs), Equals, 2)
+	ip.SortAddrList(ciliumIPs)
 	c.Assert(ciliumIPs[0], Equals, ciliumIP1)
 	c.Assert(ciliumIPs[1], Equals, ciliumIP2)
 	ciliumIPs, ok = selIPMapping[ciliumIOSel]
 	c.Assert(ok, Equals, true)
 	c.Assert(len(ciliumIPs), Equals, 2)
+	ip.SortAddrList(ciliumIPs)
 	c.Assert(ciliumIPs[0], Equals, ciliumIP1)
 	c.Assert(ciliumIPs[1], Equals, ciliumIP2)
 }

--- a/pkg/fqdn/name_manager_bench_test.go
+++ b/pkg/fqdn/name_manager_bench_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package fqdn
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/fqdn/dns"
+	"github.com/cilium/cilium/pkg/fqdn/re"
+	"github.com/cilium/cilium/pkg/policy/api"
+	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// BenchmarkUpdateGenerateDNS tests updating a large number of selectors.
+//
+// Run it like
+// go test -benchmem -run=^$ -bench ^BenchmarkUpdateGeneratedDNS$ github.com/cilium/cilium/pkg/fqdn -benchtime=4x -count=10
+func BenchmarkUpdateGenerateDNS(b *testing.B) {
+
+	// For every i in range 1 .. K, create selectors
+	// - "$K.example.com"
+	// - "*.$K.example.com"
+	// as well as *.example.com.
+	//
+	// Then, update the generated DNS N * K times, setting i to N % K, and updating
+	// - $i.example.com
+	// - foo.$i.example.com
+	// with a random new IP
+
+	numSelectors := 1000
+
+	re.InitRegexCompileLRU(defaults.FQDNRegexCompileLRUSize)
+
+	nameManager := NewNameManager(Config{
+		MinTTL:  1,
+		Cache:   NewDNSCache(0),
+		IPCache: testipcache.NewMockIPCache(),
+	})
+
+	for i := 0; i < numSelectors; i++ {
+		nameManager.RegisterForIPUpdatesLocked(api.FQDNSelector{
+			MatchName: fmt.Sprintf("%d.example.com", i),
+		})
+		nameManager.RegisterForIPUpdatesLocked(api.FQDNSelector{
+			MatchPattern: fmt.Sprintf("*.%d.example.com", i),
+		})
+	}
+	nameManager.RegisterForIPUpdatesLocked(api.FQDNSelector{
+		MatchPattern: "*.example.com",
+	})
+
+	t := time.Now() // doesn't matter, just need a stable base
+	ip := netip.MustParseAddr("10.0.0.0")
+
+	b.ResetTimer() // Don't benchmark adding selectors, just evaluating them
+	for i := 0; i < b.N*numSelectors; i++ {
+		t = t.Add(1 * time.Second)
+		ip = ip.Next()
+
+		k := i % numSelectors
+		nameManager.UpdateGenerateDNS(context.Background(), t, map[string]*DNSIPRecords{
+			dns.FQDN(fmt.Sprintf("%d.example.com", k)): {
+				TTL: 60,
+				IPs: []net.IP{ip.AsSlice()},
+			}})
+
+		nameManager.UpdateGenerateDNS(context.Background(), t, map[string]*DNSIPRecords{
+			dns.FQDN(fmt.Sprintf("example.%d.example.com", k)): {
+				TTL: 60,
+				IPs: []net.IP{ip.AsSlice()},
+			}})
+	}
+}

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -843,6 +843,12 @@ func SortIPList(ipList []net.IP) {
 	})
 }
 
+func SortAddrList(ipList []netip.Addr) {
+	sort.Slice(ipList, func(i, j int) bool {
+		return ipList[i].Compare(ipList[j]) < 0
+	})
+}
+
 // getSortedIPList returns a new net.IP slice in which the IPs are sorted.
 func getSortedIPList(ipList []net.IP) []net.IP {
 	sortedIPList := make([]net.IP, len(ipList))


### PR DESCRIPTION
This fixes some low-hanging-fruit, performance-wise, of the FQDN subsystem. It introduces a benchmark that stresses `NameManager.UpdateGeneratedDNS()`, which is in the critical path (and behind a lock!) for returning DNS responses.

The changes are:
1. Use sets.Set for determining IP uniqueness. This allocates a bit more memory, but has the advantage of many fewer allocations
2. Don't sort unnecessarily. We were doing a lot of unnecessary sorts in the DNSCache. These are only needed for tests, so just axe 'em.
3. Don't build an expensive `logrus.Fields` object just to skip at non-Debug level.

Benchmark results:
```
                     │ bench/00.out │            bench/01.out            │
                     │    sec/op    │   sec/op    vs base                │
UpdateGenerateDNS-12     3.558 ± 1%   2.157 ± 1%  -39.37% (p=0.000 n=10)

                     │ bench/00.out │             bench/01.out             │
                     │     B/op     │     B/op      vs base                │
UpdateGenerateDNS-12   902.9Mi ± 0%   532.1Mi ± 0%  -41.06% (p=0.000 n=10)

                     │ bench/00.out │            bench/01.out             │
                     │  allocs/op   │  allocs/op   vs base                │
UpdateGenerateDNS-12    9.034M ± 0%   1.009M ± 0%  -88.83% (p=0.000 n=10)
```

```release-note
Optimize IP/FQDN management in the DNSCache
```