### PR TITLE
policy: batch UpdateFQDNPolicies

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -84,13 +84,7 @@ func (d *Daemon) updateSelectors(ctx context.Context, selectors map[policyApi.FQ
 	notifyWg := &sync.WaitGroup{}
 	updateResult := policy.UpdateResultUnchanged
 	// Update mapping of selector to set of IPs in selector cache.
-	for selector, ips := range selectors {
-		logger.WithFields(logrus.Fields{
-			"fqdnSelectorString": selector,
-			"ips":                ips}).Debug("updating FQDN selector")
-		res := d.policy.GetSelectorCache().UpdateFQDNSelector(selector, ips, notifyWg)
-		updateResult |= res
-	}
+	updateResult |= d.policy.GetSelectorCache().UpdateFQDNSelectors(selectors, notifyWg)
 
 	// UpdatePolicyMaps consumes notifyWG, and returns its own WaitGroup
 	// that is Done() when all endpoints have pushed their incremental changes

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -451,7 +451,7 @@ func (ds *SelectorCacheTestSuite) TestFQDNSelectorUpdates(c *C) {
 	// Add an additional IP to the selector (for which the identity exists)
 	user1.Reset()
 	wg := &sync.WaitGroup{}
-	sc.UpdateFQDNSelector(ciliumSel, ciliumIPs, wg)
+	sc.UpdateFQDNSelectors(map[api.FQDNSelector][]netip.Addr{ciliumSel: ciliumIPs}, wg)
 	wg.Wait()
 
 	adds, deletes := user1.WaitForUpdate()
@@ -466,7 +466,7 @@ func (ds *SelectorCacheTestSuite) TestFQDNSelectorUpdates(c *C) {
 	// Change to a different IP that does not yet exist
 	user1.Reset()
 	wg = &sync.WaitGroup{}
-	sc.UpdateFQDNSelector(ciliumSel, []netip.Addr{netip.MustParseAddr("4.4.4.4")}, wg)
+	sc.UpdateFQDNSelectors(map[api.FQDNSelector][]netip.Addr{ciliumSel: {netip.MustParseAddr("4.4.4.4")}}, wg)
 	wg.Wait()
 
 	adds, deletes = user1.WaitForUpdate()


### PR DESCRIPTION
Rather than taking and dropping the lock multiple times, add a batch method that allows for many updates in a single transaction.
