### PR TITLE
ci: always use full matrix for scheduled cloud-provider workflows

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -94,7 +94,10 @@ jobs:
         run: |
           cd /tmp/generated/azure
 
-          if [ "${{ github.event_name }}" == "schedule" ];then
+          # Use complete matrix in case of scheduled run
+          # main -> event_name = schedule
+          # other stable branches -> PR-number starting with v (e.g. v1.14)
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
             cp azure.json /tmp/matrix.json
           else
             jq '{ "include": [ .include[] | select(.default) ] }' azure.json > /tmp/matrix.json

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -95,7 +95,10 @@ jobs:
         run: |
           cd /tmp/generated/aws
 
-          if [ "${{ github.event_name }}" == "schedule" ];then
+          # Use complete matrix in case of scheduled run
+          # main -> event_name = schedule
+          # other stable branches -> PR-number starting with v (e.g. v1.14)
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
             cp aws.json /tmp/matrix.json
           else
             jq '{ "include": [ .include[] | select(.default) ] }' aws.json > /tmp/matrix.json

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -95,7 +95,10 @@ jobs:
         run: |
           cd /tmp/generated/aws
 
-          if [ "${{ github.event_name }}" == "schedule" ];then
+          # Use complete matrix in case of scheduled run
+          # main -> event_name = schedule
+          # other stable branches -> PR-number starting with v (e.g. v1.14)
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
             cp aws.json /tmp/matrix.json
           else
             jq '{ "include": [ .include[] | select(.default) ] }' aws.json > /tmp/matrix.json

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -94,7 +94,10 @@ jobs:
         run: |
           cd /tmp/generated/gke
 
-          if [ "${{ github.event_name }}" == "schedule" ];then
+          # Use complete matrix in case of scheduled run
+          # main -> event_name = schedule
+          # other stable branches -> PR-number starting with v (e.g. v1.14)
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
             jq '{ "include": [ .k8s[] ] }' gke.json > /tmp/matrix.json
           else
             jq '{ "include": [ .k8s[] | select(.default) ] }' gke.json > /tmp/matrix.json

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -99,7 +99,10 @@ jobs:
         run: |
           cd /tmp/generated/gke
 
-          if [ "${{ github.event_name }}" == "schedule" ];then
+          # Use complete matrix in case of scheduled run
+          # main -> event_name = schedule
+          # other stable branches -> PR-number starting with v (e.g. v1.14)
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
             cp gke.json /tmp/matrix.json
           else
             jq '{ "k8s": [ .k8s[] | select(.default) ], "config": .config}' gke.json > /tmp/matrix.json


### PR DESCRIPTION
Cloud provider related workflows use the full configuration as matrix when being executed on a scheduled basis on stable branches, whereas only the default configuration is used on PR workflows.

Currently, this decision checks whether the workflow is triggered via `event_name == schedule`.

This is working fine on `main`, but not on all other stable branches where the workflows are triggered via workflow_dispatch event (called by a scheduled workflow (ariane-scheduled.yaml) on main).

Therefore, this commit extends the decision to check for the input `PR-number` starting with a "v". This is the case for Ariane triggered runs - as [they pass the branch name as PR-number](https://github.com/cilium/cilium/blob/main/.github/workflows/ariane-scheduled.yaml#L45) (PR runs pass the actual numeric PR number).

Note: It may look at little bit strange to use the input `pr-number` for this decision. But IMO it should be up to another PR to rename this input field from `pr-number` to something like `owner` - because that's the actual use of it. I assume it was kept for historical reasons because this was introduced with PR / Ariane based workflows first - before using it for scheduled workflows on non-main stable branches too.

Fixes: #28353