### PR TITLE
ginkgo: Switch --kpr to boolean

### DIFF
--- a/test/bigtcp/test.sh
+++ b/test/bigtcp/test.sh
@@ -33,7 +33,7 @@ helm install cilium ${HELM_CHART_DIR} \
     --set ipv6.enabled=true \
     --set routingMode='native' \
     --set bpf.masquerade=true \
-    --set kubeProxyReplacement=strict \
+    --set kubeProxyReplacement=true \
     --set ipam.mode=kubernetes \
     --set autoDirectNodeRoutes=true \
     --set hostLegacyRouting=false \

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -170,7 +170,7 @@ var (
 		"install-no-conntrack-iptables-rules": "false",
 		"l7Proxy":                             "false",
 		"hubble.enabled":                      "false",
-		"kubeProxyReplacement":                "strict",
+		"kubeProxyReplacement":                "true",
 		"endpointHealthChecking.enabled":      "false",
 		"cni.install":                         "true",
 		"cni.customConf":                      "true",
@@ -2499,7 +2499,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 
 	if RunsWithKubeProxyReplacement() {
 		opts := map[string]string{
-			"kubeProxyReplacement": "strict",
+			"kubeProxyReplacement": "true",
 		}
 
 		if RunsWithKubeProxy() {
@@ -2534,7 +2534,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 	// Disable unsupported features that will just generated unnecessary
 	// warnings otherwise.
 	if DoesNotRunOnNetNextKernel() {
-		addIfNotOverwritten(options, "kubeProxyReplacement", "disabled")
+		addIfNotOverwritten(options, "kubeProxyReplacement", "false")
 		addIfNotOverwritten(options, "bpf.masquerade", "false")
 		addIfNotOverwritten(options, "sessionAffinity", "false")
 		addIfNotOverwritten(options, "bandwidthManager.enabled", "false")

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -1477,7 +1477,7 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn54OrLaterKernel,
 					// https://github.com/cilium/cilium/issues/16197.
 					"routingMode":          "native",
 					"autoDirectNodeRoutes": "true",
-					"kubeProxyReplacement": "strict",
+					"kubeProxyReplacement": "true",
 				})
 
 				By("Deploying demo local daemonset")


### PR DESCRIPTION
"strict" and "disabled" were deprecated in
https://github.com/cilium/cilium/pull/26496.

Reported-by: Paul Chaignon <paul.chaignon@gmail.com>