### PR TITLE
[v1.13] Make logging.InitializeDefaultLogger private

### DIFF
--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -13,11 +13,32 @@ import (
 	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
+
+func (s *EndpointSuite) TestEndpointLogFormat(c *C) {
+	// Default log format is text
+	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil)}
+	ep := NewEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+
+	_, ok := ep.getLogger().Logger.Formatter.(*logrus.TextFormatter)
+	c.Assert(ok, Equals, true)
+
+	// Log format is JSON when configured
+	logging.SetLogFormat(logging.LogFormatJSON)
+	defer func() {
+		logging.SetLogFormat(logging.LogFormatText)
+	}()
+	do = &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil)}
+	ep = NewEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+
+	_, ok = ep.getLogger().Logger.Formatter.(*logrus.JSONFormatter)
+	c.Assert(ok, Equals, true)
+}
 
 func (s *EndpointSuite) TestPolicyLog(c *C) {
 	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil)}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -39,7 +39,7 @@ const (
 
 // DefaultLogger is the base logrus logger. It is different from the logrus
 // default to avoid external dependencies from writing out unexpectedly
-var DefaultLogger = InitializeDefaultLogger()
+var DefaultLogger = initializeDefaultLogger()
 
 func initializeKLog() {
 	log := DefaultLogger.WithField(logfields.LogSubsys, "klog")
@@ -71,8 +71,9 @@ func initializeKLog() {
 // LogOptions maps configuration key-value pairs related to logging.
 type LogOptions map[string]string
 
-// InitializeDefaultLogger returns a logrus Logger with a custom text formatter.
-func InitializeDefaultLogger() (logger *logrus.Logger) {
+// initializeDefaultLogger returns a logrus Logger with the default logging
+// settings.
+func initializeDefaultLogger() (logger *logrus.Logger) {
 	logger = logrus.New()
 	logger.SetFormatter(GetFormatter(DefaultLogFormat))
 	logger.SetLevel(DefaultLogLevel)

--- a/test/controlplane/suite/flags.go
+++ b/test/controlplane/suite/flags.go
@@ -20,5 +20,4 @@ func ParseFlags() {
 	if *FlagDebug {
 		logging.SetLogLevelToDebug()
 	}
-	logging.InitializeDefaultLogger()
 }


### PR DESCRIPTION
1.13 backport for https://github.com/cilium/cilium/pull/29495

As mentioned in https://github.com/cilium/cilium/pull/29495#issuecomment-1841187772, the original PR contained code which relied on changes made in https://github.com/cilium/cilium/pull/26327 and https://github.com/cilium/cilium/pull/23971. I tried to workaround this as much as possible to make the backport as minimal and self-contained as possible:
- For https://github.com/cilium/cilium/pull/23971, I kept the usage of `atomic.StorePointer` + `unsafe.Pointer` in `pkg/endpoint/log.go` and didn't touch other files changed in that PR
- For https://github.com/cilium/cilium/pull/26327, I tried to minimize the refactoring of the code in `pkg/endpoint/log.go` and didn't touch other files changed in that PR

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 29495
```