### PR TITLE
hubble-relay: fix panic during server shutdown

### DIFF
--- a/pkg/hubble/relay/server/server.go
+++ b/pkg/hubble/relay/server/server.go
@@ -201,9 +201,10 @@ func (s *Server) Stop() {
 	s.opts.log.Info("Stopping server...")
 	close(s.stop)
 	s.server.Stop()
-	err := s.metricsServer.Shutdown(context.Background())
-	if err != nil {
-		s.opts.log.WithError(err).Info("Failed to gracefully stop metrics server")
+	if s.metricsServer != nil {
+		if err := s.metricsServer.Shutdown(context.Background()); err != nil {
+			s.opts.log.WithError(err).Info("Failed to gracefully stop metrics server")
+		}
 	}
 	s.pm.Stop()
 	s.healthServer.stop()


### PR DESCRIPTION
Currently, stopping the Hubble Relay server panics when trying to stop the metrics server in case the metrics listen address isn't configured (and therefore the metrics server not set).

Therefore, this commit adds a check whether metrics server needs to be stopped.