### PR TITLE
plugins/cilium-cni: Introduce endpoint customization

### DIFF
--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -57,6 +57,16 @@ var (
 	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "cilium-cni")
 )
 
+// Cmd provides methods for the CNI ADD, DEL and CHECK commands.
+type Cmd struct{}
+
+// NewCmd creates a new Cmd instance, whose Add, Del and Check methods can be
+// passed to skel.PluginMain
+func NewCmd() *Cmd {
+	cmd := &Cmd{}
+	return cmd
+}
+
 type CmdState struct {
 	IP6       netip.Addr
 	IP6routes []route.Route
@@ -347,7 +357,7 @@ func setupLogging(n *types.NetConf) error {
 	return nil
 }
 
-func Add(args *skel.CmdArgs) (err error) {
+func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 	n, err := types.LoadNetConf(args.StdinData)
 	if err != nil {
 		return fmt.Errorf("unable to parse CNI configuration %q: %w", string(args.StdinData), err)
@@ -591,7 +601,7 @@ func Add(args *skel.CmdArgs) (err error) {
 //
 // Note: ENI specific attributes do not need to be released as the ENIs and ENI
 // IPs can be reused and are not released until the node terminates.
-func Del(args *skel.CmdArgs) error {
+func (cmd *Cmd) Del(args *skel.CmdArgs) error {
 	// Note about when to return errors: kubelet will retry the deletion
 	// for a long time. Therefore, only return an error for errors which
 	// are guaranteed to be recoverable.
@@ -694,7 +704,7 @@ func Del(args *skel.CmdArgs) error {
 // Currently, it verifies that
 // - endpoint exists in the agent and is healthy
 // - the interface in the container is sane
-func Check(args *skel.CmdArgs) error {
+func (cmd *Cmd) Check(args *skel.CmdArgs) error {
 	n, err := types.LoadNetConf(args.StdinData)
 	if err != nil {
 		return cniTypes.NewError(cniTypes.ErrInvalidNetworkConfig, "InvalidNetworkConfig",

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -490,7 +490,8 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 
 	switch conf.DatapathMode {
 	case datapathOption.DatapathModeVeth:
-		veth, peer, tmpIfName, err := connector.SetupVeth(ep.ContainerID, int(conf.DeviceMTU),
+		cniID := ep.ContainerID + ":" + ep.ContainerInterfaceName
+		veth, peer, tmpIfName, err := connector.SetupVeth(cniID, int(conf.DeviceMTU),
 			int(conf.GROMaxSize), int(conf.GSOMaxSize),
 			int(conf.GROIPV4MaxSize), int(conf.GSOIPV4MaxSize), ep)
 		if err != nil {

--- a/plugins/cilium-cni/cmd/endpoint.go
+++ b/plugins/cilium-cni/cmd/endpoint.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/plugins/cilium-cni/types"
+)
+
+// EndpointConfigurator returns a list of endpoint configurations for a given
+// CNI ADD invocation. If the CNI ADD invocation should result in multiple endpoints
+// being created, it may return multiple endpoint configurations, one for each endpoint.
+type EndpointConfigurator interface {
+	GetConfigurations(p ConfigurationParams) ([]EndpointConfiguration, error)
+}
+
+// EndpointConfiguration determines the configuration of an endpoint to be
+// created duing a CNI ADD invocation.
+type EndpointConfiguration interface {
+	// IfName specifies the container interface name to be used for this endpoint
+	IfName() string
+	// IPAMPool specifies which IPAM pool the endpoint's IP should be allocated from
+	IPAMPool() string
+}
+
+// ConfigurationParams contains the arguments and Cilium configuration of a CNI
+// invocation. Those fields may be used by custom implementations of the
+// EndpointConfigurator interface to customize the CNI ADD call.
+type ConfigurationParams struct {
+	Log     *logrus.Entry
+	Conf    *models.DaemonConfigurationStatus
+	Args    *skel.CmdArgs
+	CniArgs *types.ArgsSpec
+}
+
+// DefaultConfigurator is the default endpoint configurator. It configures a
+// single endpoint for the interface name provided by the CNI ADD invocation,
+// using an auto-selected IPAM pool.
+type DefaultConfigurator struct{}
+
+// GetConfigurations returns a single a default configuration
+func (c *DefaultConfigurator) GetConfigurations(p ConfigurationParams) ([]EndpointConfiguration, error) {
+	return []EndpointConfiguration{
+		&defaultEndpointConfiguration{
+			ConfigurationParams: p,
+		},
+	}, nil
+}
+
+// defaultEndpointConfiguration is the default configuration when a single endpoint
+// is to be created
+type defaultEndpointConfiguration struct {
+	ConfigurationParams
+}
+
+func (c *defaultEndpointConfiguration) IfName() string {
+	return c.Args.IfName
+}
+
+func (c *defaultEndpointConfiguration) IPAMPool() string {
+	return "" // auto-select
+}

--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -18,9 +18,10 @@ func init() {
 }
 
 func main() {
-	skel.PluginMain(cmd.Add,
-		cmd.Check,
-		cmd.Del,
+	c := cmd.NewCmd()
+	skel.PluginMain(c.Add,
+		c.Check,
+		c.Del,
 		cniVersion.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0"),
 		"Cilium CNI plugin "+version.Version)
 }


### PR DESCRIPTION
This PR adds the ability for out-of-tree customization of the Cilium CNI plugin. This is done by introducing the concept of an `EndpointConfigurator` which allows for the customization of the container interface name, container namespace rules and routes, and the endpoint creation request template.

This PR contains technically no functional changes, it merely allows out-of-tree modifications to the Cilium CNI plugin.

Tip: **Review per commit and enable the "Hide whitespace" checkmark in GitHub:**

![image](https://github.com/cilium/cilium/assets/50564/00668007-f2b8-44e8-92ba-945100f9ab98)
