### PR TITLE
bpf: l3: restore MARK_MAGIC_PROXY_INGRESS for from-proxy traffic

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -241,6 +241,8 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	int ret;
 	__u8 encrypt_key __maybe_unused = 0;
 	bool from_ingress_proxy = tc_index_from_ingress_proxy(ctx);
+	__u32 magic = from_ingress_proxy ? MARK_MAGIC_PROXY_INGRESS :
+					   MARK_MAGIC_IDENTITY;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
@@ -334,7 +336,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 			l3_off += __ETH_HLEN;
 		}
 #endif
-		return ipv6_local_delivery(ctx, l3_off, secctx, ep,
+		return ipv6_local_delivery(ctx, l3_off, secctx, magic, ep,
 					   METRIC_INGRESS, from_host, false);
 	}
 
@@ -657,6 +659,8 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	int ret;
 	__u8 encrypt_key __maybe_unused = 0;
 	bool from_ingress_proxy = tc_index_from_ingress_proxy(ctx);
+	__u32 magic = from_ingress_proxy ? MARK_MAGIC_PROXY_INGRESS :
+					   MARK_MAGIC_IDENTITY;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
@@ -744,7 +748,7 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		}
 #endif
 
-		return ipv4_local_delivery(ctx, l3_off, secctx, ip4, ep,
+		return ipv4_local_delivery(ctx, l3_off, secctx, magic, ip4, ep,
 					   METRIC_INGRESS, from_host, false,
 					   false, 0);
 	}

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -705,7 +705,7 @@ pass_to_stack:
 		 * source identity can still be derived even if SNAT is
 		 * performed by a component such as portmap.
 		 */
-		set_identity_mark(ctx, SECLABEL_IPV6);
+		set_identity_mark(ctx, SECLABEL_IPV6, MARK_MAGIC_IDENTITY);
 #endif
 	}
 
@@ -1263,7 +1263,7 @@ pass_to_stack:
 		 * source identity can still be derived even if SNAT is
 		 * performed by a component such as portmap.
 		 */
-		set_identity_mark(ctx, SECLABEL_IPV4);
+		set_identity_mark(ctx, SECLABEL_IPV4, MARK_MAGIC_IDENTITY);
 #endif
 	}
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -621,7 +621,8 @@ ct_recreate6:
 #endif /* ENABLE_HOST_ROUTING || ENABLE_ROUTING */
 			policy_clear_mark(ctx);
 			/* If the packet is from L7 LB it is coming from the host */
-			return ipv6_local_delivery(ctx, ETH_HLEN, SECLABEL_IPV6, ep,
+			return ipv6_local_delivery(ctx, ETH_HLEN, SECLABEL_IPV6,
+						   MARK_MAGIC_IDENTITY, ep,
 						   METRIC_EGRESS, from_l7lb, false);
 		}
 	}
@@ -1109,7 +1110,8 @@ ct_recreate4:
 #endif /* ENABLE_HOST_ROUTING || ENABLE_ROUTING */
 			policy_clear_mark(ctx);
 			/* If the packet is from L7 LB it is coming from the host */
-			return ipv4_local_delivery(ctx, ETH_HLEN, SECLABEL_IPV4, ip4,
+			return ipv4_local_delivery(ctx, ETH_HLEN, SECLABEL_IPV4,
+						   MARK_MAGIC_IDENTITY, ip4,
 						   ep, METRIC_EGRESS, from_l7lb,
 						   bypass_ingress_policy, false, 0);
 		}

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -132,8 +132,8 @@ not_esp:
 	/* Deliver to local (non-host) endpoint: */
 	ep = lookup_ip6_endpoint(ip6);
 	if (ep && !(ep->flags & ENDPOINT_F_HOST))
-		return ipv6_local_delivery(ctx, l3_off, *identity, ep,
-					   METRIC_INGRESS, false, true);
+		return ipv6_local_delivery(ctx, l3_off, *identity, MARK_MAGIC_IDENTITY,
+					   ep, METRIC_INGRESS, false, true);
 
 	/* A packet entering the node from the tunnel and not going to a local
 	 * endpoint has to be going to the local host.
@@ -243,7 +243,8 @@ static __always_inline int handle_inter_cluster_revsnat(struct __ctx_buff *ctx,
 		if (ep->flags & ENDPOINT_F_HOST)
 			return ipv4_host_delivery(ctx, ip4);
 
-		return ipv4_local_delivery(ctx, ETH_HLEN, src_sec_identity, ip4, ep,
+		return ipv4_local_delivery(ctx, ETH_HLEN, src_sec_identity,
+					   MARK_MAGIC_IDENTITY, ip4, ep,
 					   METRIC_INGRESS, false, false, true,
 					   cluster_id);
 	}
@@ -416,8 +417,8 @@ not_esp:
 	/* Deliver to local (non-host) endpoint: */
 	ep = lookup_ip4_endpoint(ip4);
 	if (ep && !(ep->flags & ENDPOINT_F_HOST))
-		return ipv4_local_delivery(ctx, ETH_HLEN, *identity, ip4, ep,
-					   METRIC_INGRESS, false, false, true,
+		return ipv4_local_delivery(ctx, ETH_HLEN, *identity, MARK_MAGIC_IDENTITY,
+					   ip4, ep, METRIC_INGRESS, false, false, true,
 					   0);
 
 	/* A packet entering the node from the tunnel and not going to a local

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -71,6 +71,7 @@ static __always_inline int ipv4_l3(struct __ctx_buff *ctx, int l3_off,
 #ifndef SKIP_POLICY_MAP
 static __always_inline int
 l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
+		  __u32 magic __maybe_unused,
 		  const struct endpoint_info *ep __maybe_unused,
 		  __u8 direction __maybe_unused,
 		  bool from_host __maybe_unused, bool hairpin_flow __maybe_unused,
@@ -87,7 +88,7 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 
 #if defined(USE_BPF_PROG_FOR_INGRESS_POLICY) && \
 	!defined(FORCE_LOCAL_POLICY_EVAL_AT_SOURCE)
-	set_identity_mark(ctx, seclabel, MARK_MAGIC_IDENTITY);
+	set_identity_mark(ctx, seclabel, magic);
 
 # if !defined(ENABLE_NODEPORT)
 	/* In tunneling mode, we execute this code to send the packet from
@@ -134,7 +135,7 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
  * destination pod via a tail call.
  */
 static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_off,
-					       __u32 seclabel,
+					       __u32 seclabel, __u32 magic,
 					       const struct endpoint_info *ep,
 					       __u8 direction, bool from_host,
 					       bool from_tunnel)
@@ -149,8 +150,8 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 	if (ret != CTX_ACT_OK)
 		return ret;
 
-	return l3_local_delivery(ctx, seclabel, ep, direction, from_host, false,
-				 from_tunnel, 0);
+	return l3_local_delivery(ctx, seclabel, magic, ep, direction, from_host,
+				 false, from_tunnel, 0);
 }
 #endif /* ENABLE_IPV6 */
 
@@ -160,7 +161,8 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
  * destination pod via a tail call.
  */
 static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_off,
-					       __u32 seclabel, struct iphdr *ip4,
+					       __u32 seclabel, __u32 magic,
+					       struct iphdr *ip4,
 					       const struct endpoint_info *ep,
 					       __u8 direction, bool from_host,
 					       bool hairpin_flow, bool from_tunnel,
@@ -176,8 +178,8 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 	if (ret != CTX_ACT_OK)
 		return ret;
 
-	return l3_local_delivery(ctx, seclabel, ep, direction, from_host, hairpin_flow,
-				 from_tunnel, cluster_id);
+	return l3_local_delivery(ctx, seclabel, magic, ep, direction, from_host,
+				 hairpin_flow, from_tunnel, cluster_id);
 }
 #endif /* SKIP_POLICY_MAP */
 

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -87,7 +87,7 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 
 #if defined(USE_BPF_PROG_FOR_INGRESS_POLICY) && \
 	!defined(FORCE_LOCAL_POLICY_EVAL_AT_SOURCE)
-	set_identity_mark(ctx, seclabel);
+	set_identity_mark(ctx, seclabel, MARK_MAGIC_IDENTITY);
 
 # if !defined(ENABLE_NODEPORT)
 	/* In tunneling mode, we execute this code to send the packet from

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -76,13 +76,13 @@ get_epid(const struct __sk_buff *ctx)
  * CIIIIIII IIIIIIII XXXXXXXX CCCCCCCC
  */
 static __always_inline __maybe_unused void
-set_identity_mark(struct __sk_buff *ctx, __u32 identity)
+set_identity_mark(struct __sk_buff *ctx, __u32 identity, __u32 magic)
 {
 	__u32 cluster_id = (identity >> IDENTITY_LEN) & CLUSTER_ID_MAX;
 	__u32 cluster_id_lower = cluster_id & 0xFF;
 	__u32 cluster_id_upper = ((cluster_id & 0xFFFFFF00) << (8 + IDENTITY_LEN));
 
-	ctx->mark |= MARK_MAGIC_IDENTITY;
+	ctx->mark |= magic;
 	ctx->mark &= MARK_MAGIC_KEY_MASK;
 	ctx->mark |= (identity & IDENTITY_MAX) << 16 | cluster_id_lower | cluster_id_upper;
 }

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -25,7 +25,8 @@ set_encrypt_dip(struct xdp_md *ctx __maybe_unused,
 }
 
 static __always_inline __maybe_unused void
-set_identity_mark(struct xdp_md *ctx __maybe_unused, __u32 identity __maybe_unused)
+set_identity_mark(struct xdp_md *ctx __maybe_unused, __u32 identity __maybe_unused,
+		  __u32 magic __maybe_unused)
 {
 }
 

--- a/bpf/tests/bpf_skb_255_tests.c
+++ b/bpf/tests/bpf_skb_255_tests.c
@@ -30,7 +30,7 @@ int check_get_identity(struct __ctx_buff *ctx)
 
 	test_init();
 
-	set_identity_mark(ctx, IDENTITY);
+	set_identity_mark(ctx, IDENTITY, MARK_MAGIC_IDENTITY);
 
 	identity = get_identity(ctx);
 	if (identity != IDENTITY)

--- a/bpf/tests/bpf_skb_511_tests.c
+++ b/bpf/tests/bpf_skb_511_tests.c
@@ -30,7 +30,7 @@ int check_get_identity(struct __ctx_buff *ctx)
 
 	test_init();
 
-	set_identity_mark(ctx, IDENTITY);
+	set_identity_mark(ctx, IDENTITY, MARK_MAGIC_IDENTITY);
 
 	identity = get_identity(ctx);
 	if (identity != IDENTITY)


### PR DESCRIPTION
> With https://github.com/cilium/cilium/pull/29530 in place, we now also
> divert proxy traffic to cilium_host when per-EP routes are enabled. But we
> potentially still need to deliver this traffic to a local endpoint - say
> for a pod-to-pod connection on the same node, with L7 proxy inbetween.
> 
> In a configuration with per-EP routes but no BPF Host-Routing,
> l3_local_delivery() transfers the source identity to the skb->mark and
> redirects to bpf_lxc, where the to-container program handles the packet.
> 
> If we transfer the packet with MARK_MAGIC_IDENTITY, to-container will
> look up the network policy and redirect to the L7 proxy *again*. Thus we
> need to fully restore the proxy's actual mark, so that to-container's
> inherit_identity_from_host() call finds the expected magic ID. It then
> sets the TC_INDEX_F_FROM_INGRESS_PROXY flag, and skips the redirect to
> L7 proxy.
