### PR TITLE
monitor/payload: remove bitrotted benchmark

### DIFF
--- a/pkg/monitor/payload/monitor_payload_test.go
+++ b/pkg/monitor/payload/monitor_payload_test.go
@@ -4,8 +4,6 @@
 package payload
 
 import (
-	"bytes"
-	"encoding/gob"
 	"testing"
 
 	. "github.com/cilium/checkmate"
@@ -46,49 +44,4 @@ func (s *PayloadSuite) TestPayload_UnMarshalBinary(c *C) {
 	c.Assert(err, Equals, nil)
 
 	c.Assert(payload1, checker.DeepEquals, payload2)
-}
-
-func (s *PayloadSuite) BenchmarkWritePayloadReuseEncoder(c *C) {
-	payload := Payload{
-		Data: []byte{1, 2, 3, 4},
-		Lost: 5243,
-		CPU:  12,
-		Type: 9,
-	}
-
-	// Do a first dry run to pre-allocate the buffer capacity.
-	var buf bytes.Buffer
-	enc := gob.NewEncoder(&buf)
-	err := payload.EncodeBinary(enc)
-	c.Assert(err, Equals, nil)
-
-	for i := 0; i < c.N; i++ {
-		buf.Reset()
-		err := payload.EncodeBinary(enc)
-		c.Assert(err, Equals, nil)
-	}
-}
-
-func (s *PayloadSuite) BenchmarkReadPayloadRuseEncoder(c *C) {
-	payload := Payload{
-		Data: []byte{1, 2, 3, 4},
-		Lost: 5243,
-		CPU:  12,
-		Type: 9,
-	}
-
-	var buf bytes.Buffer
-
-	// prefill an encoded stream
-	enc := gob.NewEncoder(&buf)
-	for i := 0; i < c.N; i++ {
-		err := payload.EncodeBinary(enc)
-		c.Assert(err, Equals, nil)
-	}
-
-	dec := gob.NewDecoder(&buf)
-	for i := 0; i < c.N; i++ {
-		err := payload.DecodeBinary(dec)
-		c.Assert(err, Equals, nil)
-	}
 }


### PR DESCRIPTION
Benchmarks written against gocheck / checkmate can't be invoked easily and lack integration with the normal go test runner. They also aren't executed by CI and therefore tend to rot away.

Remove the gocheck benchmark.

Updates #29546