### PR TITLE
cilium: Do not warn on socket tracing if EnableSocketLBTracing was not set

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -348,12 +348,11 @@ func probeKubeProxyReplacementOptions() error {
 			}
 		}
 
-		if !option.Config.EnableSocketLB {
-			option.Config.EnableSocketLBTracing = false
-		}
-		if probes.HaveProgramHelper(ebpf.CGroupSockAddr, asm.FnPerfEventOutput) != nil {
-			option.Config.EnableSocketLBTracing = false
-			log.Warn("Disabling socket-LB tracing as it requires kernel 5.7 or newer")
+		if option.Config.EnableSocketLBTracing {
+			if probes.HaveProgramHelper(ebpf.CGroupSockAddr, asm.FnPerfEventOutput) != nil {
+				option.Config.EnableSocketLBTracing = false
+				log.Warn("Disabling socket-LB tracing as it requires kernel 5.7 or newer")
+			}
 		}
 	} else {
 		option.Config.EnableSocketLBTracing = false


### PR DESCRIPTION
(see commit msg)