### PR TITLE
bpf,tests: Mock out time for ratelimit test to make it more stable

### DIFF
--- a/bpf/tests/ratelimit.c
+++ b/bpf/tests/ratelimit.c
@@ -5,6 +5,14 @@
 #include "node_config.h"
 #include "common.h"
 #include "lib/maps.h"
+
+static __u64 mock_ktime_get_ns(void)
+{
+	return 3000 * NSEC_PER_SEC;
+}
+
+#define ktime_get_ns mock_ktime_get_ns
+
 #include "lib/ratelimit.h"
 
 CHECK("xdp", "ratelimit") int test_ratelimit(void)
@@ -56,7 +64,7 @@ CHECK("xdp", "ratelimit") int test_ratelimit(void)
 
 		/* Set last topup to 1 interval ago */
 		value->tokens = 0;
-		value->last_topup = ktime_get_ns() - settings.topup_interval_ns;
+		value->last_topup = ktime_get_ns() - (settings.topup_interval_ns + 1);
 
 		if (!ratelimit_check_and_take(&key, &settings))
 			test_fatal("Rate limit not allowed after topup");


### PR DESCRIPTION
In CI the ratelimit test would sometimes fail, the only real variable that could cause this is time. So this commit updates the test, mocking out `ktime_get_ns` so that time appears frozen.

```release-note
Mock out time for BPF ratelimit test to make it more stable
```
