### PR TITLE
[v1.14] ci: In conn-disrupt-test action, disable node-to-node-encryption check

### DIFF
--- a/.github/actions/conn-disrupt-test/action.yaml
+++ b/.github/actions/conn-disrupt-test/action.yaml
@@ -37,10 +37,12 @@ runs:
       uses: cilium/little-vm-helper@0fcaa3fed17811fcd8b6f1b0dc1f24e5f4ff6b13 # v0.0.7
       with:
         provision: 'false'
+        # Skip test node-to-node-encryption until we've solved https://github.com/cilium/cilium/issues/29351
         cmd: |
           cd /host/
           ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
             --include-conn-disrupt-test \
+            --test '!node-to-node-encryption' \
             --flush-ct \
             --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
             --sysdump-output-filename "cilium-sysdump-${{ inputs.job-name }}-<ts>" \

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -75,8 +75,7 @@ jobs:
       fail-fast: false
       max-parallel: 16
       matrix:
-        #config: ['5.4', '5.10', 'bpf-next']
-        config: ['5.4', 'bpf-next']
+        config: ['5.4', '5.10', 'bpf-next']
         mode: ['minor', 'patch']
         include:
           # Define three config sets
@@ -88,14 +87,14 @@ jobs:
             tunnel: 'disabled'
             encryption: 'ipsec'
 
-          #- config: '5.10'
-          #  # renovate: datasource=docker depName=quay.io/lvh-images/kind
-          #  kernel: '5.10-20231128.100518'
-          #  kube-proxy: 'iptables'
-          #  kpr: 'disabled'
-          #  tunnel: 'disabled'
-          #  encryption: 'ipsec'
-          #  endpoint-routes: 'true'
+          - config: '5.10'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: '5.10-20231128.100518'
+            kube-proxy: 'iptables'
+            kpr: 'disabled'
+            tunnel: 'disabled'
+            encryption: 'ipsec'
+            endpoint-routes: 'true'
 
           - config: 'bpf-next'
             # We don't want to update bpf-next after branching
@@ -111,9 +110,9 @@ jobs:
             mode: 'minor'
             name: '1'
 
-          #- config: '5.10'
-          #  mode: 'minor'
-          #  name: '2'
+          - config: '5.10'
+            mode: 'minor'
+            name: '2'
 
           - config: 'bpf-next'
             mode: 'minor'
@@ -123,9 +122,9 @@ jobs:
             mode: 'patch'
             name: '4'
 
-          #- config: '5.10'
-          #  mode: 'patch'
-          #  name: '5'
+          - config: '5.10'
+            mode: 'patch'
+            name: '5'
 
           - config: 'bpf-next'
             mode: 'patch'


### PR DESCRIPTION
The node-to-node-encryption test is known to fail often on branches v1.13 and v1.14 with jobs running on kernels 5.4 and 5.10, and so far we haven't been able to figure out why. The test brings little value anyway, so we disable it on the branches.

Link: https://github.com/cilium/cilium/issues/29351
