### PR TITLE
health-server prober bugfixes

### DIFF
--- a/pkg/health/server/prober.go
+++ b/pkg/health/server/prober.go
@@ -162,7 +162,7 @@ func resolveIP(n *healthNode, addr *ciliumModels.NodeAddressingElement, proto st
 	}
 
 	ra, err := net.ResolveIPAddr(network, addr.IP)
-	if err != nil {
+	if err != nil || ra.String() == "" {
 		scopedLog.Debug("Unable to resolve address")
 		return "", nil
 	}

--- a/pkg/health/server/prober_test.go
+++ b/pkg/health/server/prober_test.go
@@ -192,4 +192,29 @@ func (s *HealthServerTestSuite) TestProbersetNodes(c *check.C) {
 		}},
 	}
 	c.Assert(sortNodes(nodes3), checker.DeepEquals, sortNodes(expected3))
+
+	// node4 has a PrimaryAddress with IPV4 enabled but an empty IP address.
+	// It should not show up in the prober.
+	node4, _, node4HealthIP := makeHealthNodeNil(4, 4)
+	node4.PrimaryAddress = &models.NodeAddressing{
+		IPV4: &models.NodeAddressingElement{
+			IP:      "",
+			Enabled: true,
+		},
+		IPV6: &models.NodeAddressingElement{
+			Enabled: false,
+		},
+	}
+
+	newNodes4 := nodeMap{
+		ipString(node4.Name): node4,
+	}
+	prober4 := newProber(&Server{}, newNodes4)
+	nodes4 := prober4.getIPsByNode()
+	expected4 := map[string][]*net.IPAddr{
+		node4.Name: {{
+			IP: node4HealthIP,
+		}},
+	}
+	c.Assert(sortNodes(nodes4), checker.DeepEquals, sortNodes(expected4))
 }

--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -341,11 +341,15 @@ func (s *Server) runActiveServices() error {
 		// Update set of nodes to probe every ProbeInterval and then fetch
 		// results
 		if nodesAdded, nodesRemoved, err := s.getNodes(); err != nil {
+			// reset the cache by setting clientID to 0 and removing all current nodes
+			s.clientID = 0
+			prober.setNodes(nil, prober.nodes)
 			log.WithError(err).Error("unable to get cluster nodes")
+			return
 		} else {
 			prober.setNodes(nodesAdded, nodesRemoved)
+			s.updateCluster(prober.getResults())
 		}
-		s.updateCluster(prober.getResults())
 	}
 	prober.RunLoop()
 	defer prober.Stop()


### PR DESCRIPTION
This PR fixes 2 separate bugs in the health-server prober:

The 1st commit resets the cache if a client-side error is encountered:
```
    reset health-server's node cache on error
    
    The health-server prober maintains a cache of the nodes in the cluster
    to avoid requesting the entire list of cluster nodes on each interval.
    When calling the daemon API's /cluster/nodes endpoint, it subscribes as
    a client so that it only receives a diff since the last request, which
    it applies to the cache.
    
    If a client-side error is encountered when making this request, the
    cache is not updated and events are lost since the server is unaware.
    
    This commit flushes the prober's node cache if any error occurs and sets
    its clientID to 0. On the subsequent request, the prober will be
    subscribed as a new client and receive the full list of nodes.
```

The 2nd commit ensures we actually skip adding empty IP addresses to the prober's node cache:
```
    prevent adding empty IPs to health-server cache
    
    The logic in the prober.setNodes function should skip adding nodes to
    the prober's cache if the IP address is empty. This is dependant on
    resolveIP() returning a nil address if it is unable to resolve the IP,
    however this will only happen if net.ResolveIPAddr returns an error. In
    the case that the address is an empty string, net.ResolveIPAddr will
    return a pointer to an empty net.IPAddr{} and error will be nil. This
    allows a node with no IP addresses to be added to the cache.
    
    server.resolveIP() has been updated to skip the address if it is empty.
    This prevents the prober from trying to probe and report on the empty
    addresses.
    
    The following is the output of `cilium-health status` for a faux
    CiliumNode with no addresses before and after this commit (snipped for
    brevity):
    
    Before:
    ---
    root@kind-worker:/home/cilium# cilium-health status
    Probe time:   2023-12-08T14:58:11Z
    Nodes:
      kind-kind/kind-worker2:
        Host connectivity to :
          ICMP to stack:   Connection timed out
          Secondary connectivity to :
            ICMP to stack:   Connection timed out
        Endpoint connectivity to 10.244.1.202:
          ICMP to stack:   Connection timed out
          Secondary connectivity to fd00:10:244:1::c879:
            ICMP to stack:   Connection timed out
    ---
    
    After:
    ---
    root@kind-control-plane:/home/cilium# cilium-health status
    Probe time:   2023-12-08T14:44:35Z
    Nodes:
      kind-kind/kind-worker2:
        Endpoint connectivity to 10.244.1.202:
          ICMP to stack:   Connection timed out
          Secondary connectivity to fd00:10:244:1::c879:
            ICMP to stack:   Connection timed out
    ---
```

```release-note
Fix bugs in health-server that cause the state in the prober's cache to drift and allow nodes with empty IP addresses to be added.
```
