### PR TITLE
complexity-tests: fix copying verifier log output to artifacts

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -136,7 +136,7 @@ jobs:
           cmd: |
             cd /host
             mkdir datapath-verifier
-            find test/verifier -name "*.log" -o -name "*.o" -exec cp {} datapath-verifier/ \;
+            find test/verifier \( -name "*.log" -o -name "*.o" \) -exec cp -v {} datapath-verifier/ \;
 
       - name: Upload artifacts
         if: ${{ !success() }}


### PR DESCRIPTION
It turns out that the following find command is subtle:

    find . -name foo -o -name bar -exec ...

This means: execute the command for bar. It doesn't execute the command for foo. For this reason verifier logs are currently not being copied correctly into GH artifacts.

Fixes: 735807fb16 ("test/verifier: fix complexity tests not being recompiled")

```release-note
Fix collecting of verifier logs in ci-verifier
```
