### PR TITLE
bpf: proxy: add IPv4 fragmentation support in ctx_redirect_to_proxy_first()

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -415,9 +415,6 @@ ipv6_extract_tuple(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 		     tuple->nexthdr != IPPROTO_UDP))
 		return DROP_CT_UNKNOWN_PROTO;
 
-	if (ret < 0)
-		return ret;
-
 	*l4_off = l3_off + ret;
 	return CTX_ACT_OK;
 }

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -268,14 +268,11 @@ ctx_redirect_to_proxy6(struct __ctx_buff *ctx, void *tuple __maybe_unused,
 static __always_inline int						\
 NAME(struct __ctx_buff *ctx, struct PREFIX ## _ct_tuple *tuple)		\
 {									\
-	int err, l4_off;						\
+	int err;							\
 									\
-	err = PREFIX ## _extract_tuple(ctx, tuple, &l4_off);		\
+	err = PREFIX ## _extract_tuple(ctx, tuple);			\
 	if (err != CTX_ACT_OK)						\
 		return err;						\
-									\
-	if (l4_load_ports(ctx, l4_off, &tuple->dport) < 0)		\
-		return DROP_CT_INVALID_HDR;				\
 									\
 	__ ## PREFIX ## _ct_tuple_reverse(tuple);			\
 									\


### PR DESCRIPTION
Instead of unconditionally accessing the first few bytes of the L3 payload to extract L4 ports, teach `ctx_redirect_to_proxy_first()` to respect IPv4 fragmentation.