### PR TITLE
pkg: proxy: only install from-proxy rules/routes for native routing

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -425,7 +425,7 @@ func (p *Proxy) ReinstallRoutingRules() error {
 			return err
 		}
 
-		if !option.Config.EnableIPSec {
+		if !option.Config.EnableIPSec || option.Config.TunnelingEnabled() {
 			if err := removeFromProxyRoutesIPv4(); err != nil {
 				return err
 			}
@@ -448,7 +448,7 @@ func (p *Proxy) ReinstallRoutingRules() error {
 			return err
 		}
 
-		if !option.Config.EnableIPSec {
+		if !option.Config.EnableIPSec || option.Config.TunnelingEnabled() {
 			if err := removeFromProxyRoutesIPv6(); err != nil {
 				return err
 			}


### PR DESCRIPTION
With tunnel routing, traffic to remote pods already flows via cilium_host. This is sufficient for what IPsec requires. Thus currently only native routing requires the custom redirect logic for from-ingress proxy traffic.