### PR TITLE
bpf: improve metadata initialization

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1088,8 +1088,6 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 				  TRACE_REASON_UNKNOWN, TRACE_PAYLOAD_LEN);
 	}
 
-	bpf_clear_meta(ctx);
-
 	switch (proto) {
 # if defined ENABLE_ARP_PASSTHROUGH || defined ENABLE_ARP_RESPONDER || \
      defined ENABLE_L2_ANNOUNCEMENTS
@@ -1246,6 +1244,7 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 		}
 	}
 
+	bpf_clear_meta(ctx);
 	ctx_skip_nodeport_clear(ctx);
 
 #ifdef ENABLE_NODEPORT_ACCELERATION
@@ -1280,6 +1279,8 @@ drop_err:
 __section_entry
 int cil_from_host(struct __ctx_buff *ctx)
 {
+	bpf_clear_meta(ctx);
+
 	/* Traffic from the host ns going through cilium_host device must
 	 * not be subject to EDT rate-limiting.
 	 */

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -545,6 +545,12 @@ int cil_from_overlay(struct __ctx_buff *ctx)
 	__u16 proto;
 	int ret;
 
+#ifndef ENABLE_HIGH_SCALE_IPCACHE
+	/* For hs-ipcache we rely on from-netdev to clear the metadata,
+	 * and need to preserve the information that gets passed via skb->cb.
+	 */
+	bpf_clear_meta(ctx);
+#endif
 	ctx_skip_nodeport_clear(ctx);
 
 	if (!validate_ethertype(ctx, &proto)) {

--- a/bpf/lib/high_scale_ipcache.h
+++ b/bpf/lib/high_scale_ipcache.h
@@ -90,8 +90,6 @@ decapsulate_overlay(struct __ctx_buff *ctx, __u32 *src_id)
 		memcpy(src_id, &geneve.vni, sizeof(__u32));
 
 #if defined(ENABLE_DSR) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-		ctx_store_meta(ctx, CB_HSIPC_ADDR_V4, 0);
-
 		if (opt_len && opt_len >= sizeof(dsr_opt)) {
 			if (ctx_load_bytes(ctx, off + sizeof(geneve), &dsr_opt,
 					   sizeof(dsr_opt)) < 0)


### PR DESCRIPTION
Improve the robustness of the `skb->cb` clearing in `from-netdev` / `from-host`. Also sort out the custom hs-ipcache path into `from-overlay`, until https://github.com/cilium/cilium/issues/29762 is sorted.