### PR TITLE
daemon: Fail init if requirements for BPF masquerade are not met

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -348,6 +348,10 @@ Annotations:
   to default deny for an allow policy. Similarly, for an Egress CNP, an empty slice in
   one of the fields ``toEndpoints``, ``toCIDR``, ``toCIDRSet`` and ``toEntities`` will
   not select any identity either.
+* If Cilium is configured with BPF masquerade support but the requirements are not
+  met (e.g: NodePort service implementation in BPF is disabled or socket load-balancing
+  is disabled), it will fail to initialize and will log an error instead of silently
+  fall back to iptables based masquerading.
 
 .. _upgrade_cilium_cli_helm_mode:
 

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -678,6 +678,7 @@ var _ = SkipDescribeIf(func() bool {
 					map[string]string{
 						"enableIPv4Masquerade": "false",
 						"enableIPv6Masquerade": "false",
+						"bpf.masquerade":       "false",
 					})
 
 			})
@@ -756,6 +757,7 @@ var _ = SkipDescribeIf(func() bool {
 							"remoteNodeIdentity":   "false",
 							"enableIPv4Masquerade": "false",
 							"enableIPv6Masquerade": "false",
+							"bpf.masquerade":       "false",
 						})
 				})
 
@@ -777,6 +779,7 @@ var _ = SkipDescribeIf(func() bool {
 							"remoteNodeIdentity":   "true",
 							"enableIPv4Masquerade": "false",
 							"enableIPv6Masquerade": "false",
+							"bpf.masquerade":       "false",
 						})
 				})
 


### PR DESCRIPTION
In case the requirements for BPF masquerade are not met, fail the daemon initialization instead of silently fall back to iptables based masquerading.

This is needed because the iptables cell does not support runtime configuration changes.

Fixes: https://github.com/cilium/cilium/issues/29663
