### PR TITLE
Envoy silence expected internal listener warning

### DIFF
--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -248,11 +248,6 @@ func newEnvoyLogPiper() io.WriteCloser {
 			case "off", "critical", "error":
 				scopedLog.Error(msg)
 			case "warning":
-				// Silently drop expected warnings if flowdebug is not enabled
-				// TODO: Remove this special case when https://github.com/envoyproxy/envoy/issues/13504 is fixed.
-				if !flowdebug.Enabled() && strings.Contains(msg, "Unable to use runtime singleton for feature envoy.http.headermap.lazy_map_min_size") {
-					continue
-				}
 				scopedLog.Warn(msg)
 			case "info":
 				scopedLog.Info(msg)

--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -248,6 +248,12 @@ func newEnvoyLogPiper() io.WriteCloser {
 			case "off", "critical", "error":
 				scopedLog.Error(msg)
 			case "warning":
+				// Silently drop expected warnings if Envoy tracing is not enabled
+				// TODO: Remove this what at Envoy 1.28, as this warning is no
+				// longer be issued then.
+				if !tracing && strings.Contains(msg, "message 'envoy.extensions.bootstrap.internal_listener.v3.InternalListener' is contained in proto file 'envoy/extensions/bootstrap/internal_listener/v3/internal_listener.proto' marked as work-in-progress.") {
+					continue
+				}
 				scopedLog.Warn(msg)
 			case "info":
 				scopedLog.Info(msg)


### PR DESCRIPTION
Silence the expected warning about internal listener being
work-in-progress. This special case can be removed when at Envoy 1.28,
as internal listener is a stable feature in Envoy 1.28.

This warning is not silenced if debug-verbose=envoy (which enables Envoy
trace logs). Due to this the warning still needs to be allow-listed for
tests, as some tests run with debug-verbose=envoy.

Fixes: #29682
