### PR TITLE
FQDN: incrementally update selectors on DNS message

### DIFF
--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/fqdn/re"
+	"github.com/cilium/cilium/pkg/ip"
 )
 
 type DNSCacheTestSuite struct{}
@@ -60,6 +61,9 @@ func (ds *DNSCacheTestSuite) TestUpdateLookup(c *C) {
 	for secondsPastNow := 1; secondsPastNow <= endTimeSeconds; secondsPastNow++ {
 		ips := cache.lookupByTime(now.Add(time.Duration(secondsPastNow)*time.Second), name)
 		c.Assert(len(ips), Equals, 2*(endTimeSeconds-secondsPastNow+1), Commentf("Incorrect number of IPs returned"))
+
+		// This test expects ips sorted
+		ip.SortAddrList(ips)
 
 		// Check that we returned each 1.1.1.x entry where x={1..endTimeSeconds}
 		// These are sorted, and are in the first half of the array
@@ -276,6 +280,7 @@ func (ds *DNSCacheTestSuite) TestJSONMarshal(c *C) {
 	currentTime := now
 	for name := range names {
 		IPs := cache.lookupByTime(currentTime, name)
+		ip.SortAddrList(IPs)
 		c.Assert(len(IPs), Equals, 2, Commentf("Incorrect number of IPs returned for %s", name))
 		c.Assert(IPs[0].String(), Equals, sharedIP.String(), Commentf("Returned an IP that doesn't match %s", name))
 		c.Assert(IPs[1].String(), Equals, names[name].String(), Commentf("Returned an IP name that doesn't match %s", name))

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -25,7 +25,7 @@ type Config struct {
 
 	// UpdateSelectors is a callback to update the mapping of FQDNSelector to
 	// sets of IPs.
-	UpdateSelectors func(ctx context.Context, selectorsToIPs map[api.FQDNSelector][]netip.Addr, ipcacheRevision uint64) *sync.WaitGroup
+	UpdateSelectors func(ctx context.Context, selectorsToIPs map[api.FQDNSelector][]netip.Addr, incremental bool, ipcacheRevision uint64) *sync.WaitGroup
 
 	// GetEndpointsDNSInfo is a function that returns a list of fqdn-relevant fields from all Endpoints known to the agent.
 	// The endpoint's DNSHistory and DNSZombies are used as part of the garbage collection and restoration processes.

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -59,11 +59,13 @@ func (n *NameManager) mapSelectorsToIPsLocked(fqdnSelectors sets.Set[api.FQDNSel
 
 			for name, ips := range lookupIPs {
 				if len(ips) > 0 {
-					log.WithFields(logrus.Fields{
-						"DNSName":      name,
-						"IPs":          ips,
-						"matchPattern": ToFQDN.MatchPattern,
-					}).Debug("Emitting matching DNS Name -> IPs for FQDNSelector")
+					if log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+						log.WithFields(logrus.Fields{
+							"DNSName":      name,
+							"IPs":          ips,
+							"matchPattern": ToFQDN.MatchPattern,
+						}).Debug("Emitting matching DNS Name -> IPs for FQDNSelector")
+					}
 					if ipsSelected == nil {
 						ipsSelected = ips
 					} else {

--- a/pkg/fqdn/helpers_test.go
+++ b/pkg/fqdn/helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
 
@@ -71,6 +72,7 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	ciliumIPs, ok = selIPMapping[ciliumIOSel]
 	c.Assert(ok, Equals, true)
 	c.Assert(len(ciliumIPs), Equals, 2)
+	ip.SortAddrList(ciliumIPs)
 	c.Assert(ciliumIPs[0], Equals, ciliumIP1)
 	c.Assert(ciliumIPs[1], Equals, ciliumIP2)
 
@@ -82,6 +84,7 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	ciliumIPs, ok = selIPMapping[ciliumIOSelMatchPattern]
 	c.Assert(ok, Equals, true)
 	c.Assert(len(ciliumIPs), Equals, 2)
+	ip.SortAddrList(ciliumIPs)
 	c.Assert(ciliumIPs[0], Equals, ciliumIP1)
 	c.Assert(ciliumIPs[1], Equals, ciliumIP2)
 
@@ -92,11 +95,13 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	ciliumIPs, ok = selIPMapping[ciliumIOSelMatchPattern]
 	c.Assert(ok, Equals, true)
 	c.Assert(len(ciliumIPs), Equals, 2)
+	ip.SortAddrList(ciliumIPs)
 	c.Assert(ciliumIPs[0], Equals, ciliumIP1)
 	c.Assert(ciliumIPs[1], Equals, ciliumIP2)
 	ciliumIPs, ok = selIPMapping[ciliumIOSel]
 	c.Assert(ok, Equals, true)
 	c.Assert(len(ciliumIPs), Equals, 2)
+	ip.SortAddrList(ciliumIPs)
 	c.Assert(ciliumIPs[0], Equals, ciliumIP1)
 	c.Assert(ciliumIPs[1], Equals, ciliumIP2)
 }

--- a/pkg/fqdn/name_manager_bench_test.go
+++ b/pkg/fqdn/name_manager_bench_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package fqdn
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/fqdn/dns"
+	"github.com/cilium/cilium/pkg/fqdn/re"
+	"github.com/cilium/cilium/pkg/policy/api"
+	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// BenchmarkUpdateGenerateDNS tests updating a large number of selectors.
+//
+// Run it like
+// go test -benchmem -run=^$ -bench ^BenchmarkUpdateGeneratedDNS$ github.com/cilium/cilium/pkg/fqdn -benchtime=4x -count=10
+func BenchmarkUpdateGenerateDNS(b *testing.B) {
+
+	// For every i in range 1 .. K, create selectors
+	// - "$K.example.com"
+	// - "*.$K.example.com"
+	// as well as *.example.com.
+	//
+	// Then, update the generated DNS N * K times, setting i to N % K, and updating
+	// - $i.example.com
+	// - foo.$i.example.com
+	// with a random new IP
+
+	numSelectors := 1000
+
+	re.InitRegexCompileLRU(defaults.FQDNRegexCompileLRUSize)
+
+	nameManager := NewNameManager(Config{
+		MinTTL:  1,
+		Cache:   NewDNSCache(0),
+		IPCache: testipcache.NewMockIPCache(),
+	})
+
+	for i := 0; i < numSelectors; i++ {
+		nameManager.RegisterForIPUpdatesLocked(api.FQDNSelector{
+			MatchName: fmt.Sprintf("%d.example.com", i),
+		})
+		nameManager.RegisterForIPUpdatesLocked(api.FQDNSelector{
+			MatchPattern: fmt.Sprintf("*.%d.example.com", i),
+		})
+	}
+	nameManager.RegisterForIPUpdatesLocked(api.FQDNSelector{
+		MatchPattern: "*.example.com",
+	})
+
+	t := time.Now() // doesn't matter, just need a stable base
+	ip := netip.MustParseAddr("10.0.0.0")
+
+	b.ResetTimer() // Don't benchmark adding selectors, just evaluating them
+	for i := 0; i < b.N*numSelectors; i++ {
+		t = t.Add(1 * time.Second)
+		ip = ip.Next()
+
+		k := i % numSelectors
+		nameManager.UpdateGenerateDNS(context.Background(), t, map[string]*DNSIPRecords{
+			dns.FQDN(fmt.Sprintf("%d.example.com", k)): {
+				TTL: 60,
+				IPs: []net.IP{ip.AsSlice()},
+			}})
+
+		nameManager.UpdateGenerateDNS(context.Background(), t, map[string]*DNSIPRecords{
+			dns.FQDN(fmt.Sprintf("example.%d.example.com", k)): {
+				TTL: 60,
+				IPs: []net.IP{ip.AsSlice()},
+			}})
+	}
+}

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -843,6 +843,12 @@ func SortIPList(ipList []net.IP) {
 	})
 }
 
+func SortAddrList(ipList []netip.Addr) {
+	sort.Slice(ipList, func(i, j int) bool {
+		return ipList[i].Compare(ipList[j]) < 0
+	})
+}
+
 // getSortedIPList returns a new net.IP slice in which the IPs are sorted.
 func getSortedIPList(ipList []net.IP) []net.IP {
 	sortedIPList := make([]net.IP, len(ipList))

--- a/pkg/policy/selectorcache_selector.go
+++ b/pkg/policy/selectorcache_selector.go
@@ -178,6 +178,26 @@ func (f *fqdnSelector) setSelectorIPs(ips []netip.Addr) {
 	f.wantLabels = lbls
 }
 
+// addSelectorIPs is the same as setSelectorIPs, but preserves existing IPs.
+// returns true if the set of labels has changed
+func (f *fqdnSelector) addSelectorIPs(ips []netip.Addr) bool {
+	lbls := labels.FromSlice(f.wantLabels)
+	for _, ip := range ips {
+		l, err := labels.IPStringToLabel(ip.String())
+		if err != nil {
+			// not possible
+			continue
+		}
+		lbls[l.Key] = l
+	}
+
+	if len(lbls) == len(f.wantLabels) {
+		return false
+	}
+	f.wantLabels = lbls.LabelArray()
+	return true
+}
+
 // matches returns true if the identity contains at least one label
 // that is in wantLabels.
 // This is reasonably efficient, as it relies on both arrays being sorted.

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -451,7 +451,8 @@ func (ds *SelectorCacheTestSuite) TestFQDNSelectorUpdates(c *C) {
 	// Add an additional IP to the selector (for which the identity exists)
 	user1.Reset()
 	wg := &sync.WaitGroup{}
-	sc.UpdateFQDNSelector(ciliumSel, ciliumIPs, wg)
+	res := sc.UpdateFQDNSelectorsIncremental(map[api.FQDNSelector][]netip.Addr{ciliumSel: ciliumIPs[1:]}, wg)
+	c.Assert(res, Equals, UpdateResultUpdatePolicyMaps)
 	wg.Wait()
 
 	adds, deletes := user1.WaitForUpdate()
@@ -466,7 +467,8 @@ func (ds *SelectorCacheTestSuite) TestFQDNSelectorUpdates(c *C) {
 	// Change to a different IP that does not yet exist
 	user1.Reset()
 	wg = &sync.WaitGroup{}
-	sc.UpdateFQDNSelector(ciliumSel, []netip.Addr{netip.MustParseAddr("4.4.4.4")}, wg)
+	res = sc.UpdateFQDNSelector(ciliumSel, []netip.Addr{netip.MustParseAddr("4.4.4.4")}, wg)
+	c.Assert(res, Equals, UpdateResultIdentitiesNeeded|UpdateResultUpdatePolicyMaps) // should be both, as we have deleted identities as well as an unknown one
 	wg.Wait()
 
 	adds, deletes = user1.WaitForUpdate()


### PR DESCRIPTION
(Note: This is based on #29691, but does not actually rely on that PR. It's based on that just for a meaningful performance comparison. Only the last commit is new.)

This change removes a full recalculcation of FQDN policy when a DNS response is received.
    
When a response is received, one of two things can occur:
1. One or more selectors select additional IPs / identities
2. Nothing has changed
    
Not possible is the case that selectors **lose** IP addresses; that happens only upon gabage collection / entry expiration. This means we can skip a full recalculation of selectors in the critical path.
    
This change is relatively small; it adds an incremental update method to the SelectorCache, and then changes the NameManager to utilize that. It does a bit of bookkeeping to compute the delta, and passes those directly to the selectors.
    
This results in a 70% improvement in benchmark speed, as well as a 99% reduction in memory usage.

```
                     │  0_main.out  │            1_pr-29691.out            │          2_incremental.out          │
                     │    sec/op    │    sec/op     vs base                │   sec/op     vs base                │
UpdateGenerateDNS-12   3558.2m ± 1%   2157.2m ± 1%  -39.37% (p=0.000 n=10)   606.4m ± 1%  -82.96% (p=0.000 n=10)

                     │   0_main.out   │             1_pr-29691.out             │          2_incremental.out           │
                     │      B/op      │      B/op       vs base                │     B/op      vs base                │
UpdateGenerateDNS-12   902.866Mi ± 0%   532.115Mi ± 0%  -41.06% (p=0.000 n=10)   3.914Mi ± 0%  -99.57% (p=0.000 n=10)

                     │  0_main.out   │            1_pr-29691.out             │          2_incremental.out          │
                     │   allocs/op   │   allocs/op    vs base                │  allocs/op   vs base                │
UpdateGenerateDNS-12   9033.94k ± 0%   1008.96k ± 0%  -88.83% (p=0.000 n=10)   49.02k ± 0%  -99.46% (p=0.000 n=10)
```


```release-note
The latency when updating the FQDN policy subsystem in response to a DNS packet has been significantly reduced.
```