### PR TITLE
ci/ipsec: Skip waiting for images when skipping upgrade/dowgrade

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -256,6 +256,7 @@ jobs:
           binary-dir: ./
 
       - name: Set Kind params
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
         id: kind-params
         shell: bash
         run: |
@@ -275,6 +276,7 @@ jobs:
           kind-image-vsn: ${k8s_version}
 
       - name: Wait for images to be available
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
         timeout-minutes: 30
         shell: bash
         run: |


### PR DESCRIPTION
The workflow to test upgrades/downgrades with IPsec supports two cases: upgrading from the last minor version, or from the last patch release. In the case of patch releases, there are instances where we are not able to determine the latest patch releases. This is the case on the current development branch, where no patch releases have been created yet, for example. In such a case, we skip most of the steps in the job.

When implementing the check on the patch release value and the bypass of the relevant steps, we omitted to skip the step where we wait for the CI images to be available, potentially causing unnecessary wait time for the job. Let's skip this step as well.

Fixes: c9dedb49f5a6 ("ci/ipsec: Skip upgrade/downgrade test to patch release on main branch")
Reported at https://github.com/cilium/cilium/pull/28815#discussion_r1421717650
