### PR TITLE
renovate: enable Cilium CLI patch updates for Cilium <v1.14

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -351,22 +351,23 @@
       "matchDepNames": [
         "cilium/cilium-cli"
       ],
-      "matchBaseBranches": [
-        "main",
-        "v1.14"
-      ]
     },
     {
+      // Do not bump the minor version for Cilium <v1.14. Certain workflows
+      // are already using Cilium CLI v0.15.*, so let's enable patch versions.
+      "enabled": false,
       "groupName": "Cilium CLI",
       "groupSlug": "cilium-cli",
       "matchDepNames": [
         "cilium/cilium-cli"
       ],
-      "allowedVersions": "/^v0\\.14\\.[0-9]+$/",
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
       "matchBaseBranches": [
         "v1.13",
         "v1.12",
-        "v1.11"
       ]
     },
     {


### PR DESCRIPTION
Cilium versions earlier that v1.14 are officially compatible with the Cilium CLI v0.14 series only. Still, some workflows in stable branches are already using one of the v0.15 releases, to benefit from newer functionalities. Let's enable renovate to bump patch versions for them, so that we automatically pick new fixes and improvements.

I'm far from an expert about renovate, but the approach resembles the one already used for other dependencies (e.g., `kindest/node`), and I hope it will work as expected. 