### PR TITLE
bpf, ipcache: Add skip_tunnel field to remote_endpoint_info

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -356,6 +356,8 @@ struct remote_endpoint_info {
 	__u32		tunnel_endpoint;
 	__u16		pad;
 	__u8		key;
+	__u8		flag_skip_tunnel:1,
+			pad2:7;
 };
 
 /*

--- a/pkg/maps/ipcache/ipcache_test.go
+++ b/pkg/maps/ipcache/ipcache_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import (
+	"testing"
+)
+
+func TestRemoteEndpointInfoFlagsStringReturnsCorrectValue(t *testing.T) {
+	type stringTest struct {
+		name string
+		in   RemoteEndpointInfoFlags
+		out  string
+	}
+
+	tests := []stringTest{
+		{
+			name: "no flags",
+			in:   0,
+			out:  "<none>",
+		},
+		{
+			name: "FlagSkipTunnel",
+			in:   FlagSkipTunnel,
+			out:  "skiptunnel",
+		},
+	}
+
+	for _, test := range tests {
+		if s := test.in.String(); s != test.out {
+			t.Errorf(
+				"Expected '%s' for string representation of %s, instead got '%s'",
+				test.out, test.name, s,
+			)
+		}
+	}
+}


### PR DESCRIPTION
Consume 8 bits of padding from the ipcache remote_endpoint_info struct and reserve them for optional flags. This commit adds a single new flag, `flag_skip_tunnel`, to signal that the attached endpoint shall not be forwarded through a VXLAN/Geneve tunnel, regardless of the Cilium configuration.

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

```release-note
Add a new flag to endpoints in the IPCache to allow for overriding tunnel configuration
```
