### PR TITLE
Revert "cilium: Ensure xfrm state is initialized for route IP before …

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -34,7 +34,6 @@ import (
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/datapath/linux/bandwidth"
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
-	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/datapath/loader"
@@ -914,16 +913,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	// K8s resources have been synced.
 	if err := d.allocateIPs(ctx, restoredRouterIPs); err != nil { // will log errors/fatal internally
 		return nil, nil, err
-	}
-
-	// allocateIPs got us the routerIP so now we can create ipsec endpoint
-	// we must do this before publishing the router IP otherwise remote
-	// nodes could pick up the IP and send us outer headers we do not yet
-	// have xfrm rules for.
-	if option.Config.EnableIPSec {
-		if err := ipsec.Init(); err != nil {
-			log.WithError(err).Error("IPSec init failed")
-		}
 	}
 
 	// Must occur after d.allocateIPs(), see GH-14245 and its fix.

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -1162,20 +1162,3 @@ func staleKeyReclaimer(ctx context.Context) error {
 
 	return nil
 }
-
-// We need to install xfrm state for the local router (cilium_host) early
-// in daemon init path. This is to ensure that we have the xfrm state in
-// place before we advertise the routerIP where other nodes may potentially
-// pick it up and start sending traffic to us. This was previously racing
-// and creating XfrmInNoState errors because other nodes picked up node
-// update before Xfrm config logic was in place. So special case init the
-// rule we need early in init flow.
-func Init() error {
-	outerLocalIP := node.GetInternalIPv4Router()
-	wildcardIP := net.ParseIP("0.0.0.0")
-	localCIDR := node.GetIPv4AllocRange().IPNet
-	localWildcardIP := &net.IPNet{IP: wildcardIP, Mask: net.IPv4Mask(0, 0, 0, 0)}
-
-	_, err := UpsertIPsecEndpoint(localCIDR, localWildcardIP, outerLocalIP, wildcardIP, 0, IPSecDirIn, false)
-	return err
-}


### PR DESCRIPTION
This reverts commit https://github.com/cilium/cilium/commit/c9ea7a52bd59c167c6e7611d4976e3c041f4e7f0.

This works around a condition where restarting the agent uses a new
IP for Cilium Internal IP. But, it turns out this is because of an
incorrect set helm chart option in our reproducer. When configured
correctly we require CiliumInternalIP to reused so this patch is not
necessary. In fact it complicates the code so lets drop it.

The helm option is cleanState. It must be set to false

  cleanState=false

Note that cleanState="false" is a string type and will default to
true because of bool typing. Creating a subtle and broke config.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>