### PR TITLE
preflight: fix overriding node name env variable

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -70,8 +70,13 @@ spec:
               - /tmp/ready
             initialDelaySeconds: 5
             periodSeconds: 5
-          {{- with .Values.preflight.extraEnv }}
           env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
+          {{- with .Values.preflight.extraEnv }}
             {{- toYaml . | trim | nindent 12 }}
           {{- end }}
           volumeMounts:


### PR DESCRIPTION
Cilium-agent is overriding K8S_NODE_NAME env variable based on [node
name](https://github.com/cilium/cilium/blob/f51bc04630f7260817b9947b1a7ae0aeec455579/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml#L188). Cilium-preflight was not overriding it so in case the hostname
did not match the node name, the preflight was stuck waiting for node
information.

```release-note
cilium-preflight: use the k8s node name instead of relying on hostname
```
