### PR TITLE
gha: sig-servicemesh owns Ingress or Gateway API related workflows

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -235,8 +235,10 @@
 /.github/workflows/ @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*clustermesh*.yaml @cilium/sig-clustermesh @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*datapath*.yaml @cilium/sig-datapath @cilium/github-sec @cilium/ci-structure
+/.github/workflows/*gateway-api*.yaml @cilium/sig-servicemesh @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*externalworkloads*.yaml @cilium/sig-clustermesh @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*ipsec*.yaml @cilium/ipsec @cilium/github-sec @cilium/ci-structure
+/.github/workflows/*ingress*.yaml @cilium/sig-servicemesh @cilium/github-sec @cilium/ci-structure
 /.gitignore @cilium/tophat
 /.golangci.yaml @cilium/ci-structure
 /.mailmap @cilium/tophat


### PR DESCRIPTION
The servicemesh team may be interested in reviewing changes of these
workflows.

Signed-off-by: Tam Mach <tam.mach@cilium.io>
