### PR TITLE
endpoint: Use resolved named port also in the proxy stats

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -266,7 +266,7 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 				// Update the endpoint API model to report that Cilium manages a
 				// redirect for that port.
 				e.proxyStatisticsMutex.Lock()
-				proxyStats := e.getProxyStatisticsLocked(proxyID, string(l4.L7Parser), uint16(l4.Port), l4.Ingress)
+				proxyStats := e.getProxyStatisticsLocked(proxyID, string(l4.L7Parser), dstPort, l4.Ingress)
 				proxyStats.AllocatedProxyPort = int64(redirectPort)
 				e.proxyStatisticsMutex.Unlock()
 


### PR DESCRIPTION
Commit 10f04fd98a5fb17c745aa4363aa331128ab0698c (endpoint: Resolve named ports for redirects) fixed redirect creation for L7 policies using a named port, but failed to use the resolved destination port also in proxy stats. This commit does that.

Fixes: #29023
