### PR TITLE
bpf: compile with debug info enabled

### DIFF
--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -3,7 +3,7 @@
 
 FLAGS := -I$(ROOT_DIR)/bpf/include -I$(ROOT_DIR)/bpf -D__NR_CPUS__=$(shell nproc --all) -O2 -g
 
-CLANG_FLAGS := ${FLAGS} --target=bpf -std=gnu89 -nostdinc -emit-llvm
+CLANG_FLAGS := ${FLAGS} --target=bpf -std=gnu89 -nostdinc -emit-llvm -g
 # eBPF verifier enforces unaligned access checks where necessary, so don't
 # let clang complain too early.
 CLANG_FLAGS += -Wall -Wextra -Werror -Wshadow


### PR DESCRIPTION
Compiling bpf objects via make -C bpf/ currently doesn't include debug information in the ELF. This means that line information isn't preserved which makes inspecting the ELF via llvm-objdump much harder.

Always compile with -g to enable debug information.

```release-note
Compile BPF object with debug info on CI
```
