### PR TITLE
[v1.13] go.mod: bump Go to 1.20

### DIFF
--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           # renovate: datasource=golang-version depName=go
-          go-version: 1.19.4
+          go-version: 1.20.11
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
@@ -61,7 +61,7 @@ jobs:
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           # renovate: datasource=golang-version depName=go
-          go-version: 1.19.4
+          go-version: 1.20.11
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: focal
 sudo: required
 
 # renovate: datasource=golang-version depName=go
-go: "1.19.4"
+go: "1.20.11"
 
 jobs:
   include:

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ BENCH_EVAL := "."
 BENCH ?= $(BENCH_EVAL)
 BENCHFLAGS_EVAL := -bench=$(BENCH) -run=^$ -benchtime=10s
 BENCHFLAGS ?= $(BENCHFLAGS_EVAL)
-SKIP_VET ?= "false"
 SKIP_KVSTORES ?= "false"
 SKIP_K8S_CODE_GEN_CHECK ?= "true"
 SKIP_CUSTOMVET_CHECK ?= "false"
@@ -170,9 +169,6 @@ generate-cov: ## Generate HTML coverage report at coverage-all.html.
 integration-tests: GO_TAGS_FLAGS+=integration_tests
 integration-tests: start-kvstores ## Runs all integration tests.
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C test/bpf/
-ifeq ($(SKIP_VET),"false")
-	$(MAKE) govet
-endif
 	$(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $(TESTPKGS) $(GOTEST_BASE) $(GOTEST_COVER_OPTS) | $(GOTEST_FORMATTER)
 	$(MAKE) generate-cov
 	$(MAKE) stop-kvstores

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -133,7 +133,7 @@ CILIUM_DATAPATH_SHA256=$(shell cd $(ROOT_DIR); cat $(BPF_SRCFILES) | sha256sum |
 GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/datapath/loader.DatapathSHA256=$(CILIUM_DATAPATH_SHA256)"
 
 GO_BUILD_FLAGS += -mod=vendor
-GO_TEST_FLAGS += -mod=vendor
+GO_TEST_FLAGS += -mod=vendor -vet=all
 GO_CLEAN_FLAGS += -mod=vendor
 
 GO_BUILD = CGO_ENABLED=0 $(GO) build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/cilium
 
-go 1.19
+go 1.20
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20221118232415-3345c89a7c72


### PR DESCRIPTION
We've switched to use Go 1.20 for the v1.13 branch, see commit 6c0d4787f0f2 ("Bump Golang to v1.20 on Cilium v1.12 and v1.13"). Use that version in go.mod as well so `make check-go-version` passes when using Go 1.20 in local development on v1.13.

Follow-up for https://github.com/cilium/cilium/pull/29743