### PR TITLE
loader: refactor/cleanup replaceNetworkDatapath

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -6,6 +6,7 @@ package loader
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -195,17 +196,33 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 	}
 
 	// No interfaces is valid in tunnel disabled case
-	if len(interfaces) != 0 {
-		for _, iface := range interfaces {
-			if err := connector.DisableRpFilter(iface); err != nil {
-				log.WithError(err).WithField(logfields.Interface, iface).Warn("Rpfilter could not be disabled, node to node encryption may fail")
-			}
+	if len(interfaces) == 0 {
+		return nil
+	}
+
+	progs := []progDefinition{{progName: symbolFromNetwork, direction: dirIngress}}
+	var errs error
+	for _, iface := range interfaces {
+		if err := connector.DisableRpFilter(iface); err != nil {
+			log.WithError(err).WithField(logfields.Interface, iface).Warn("Rpfilter could not be disabled, node to node encryption may fail")
 		}
 
-		if err := l.replaceNetworkDatapath(ctx, interfaces); err != nil {
-			return fmt.Errorf("failed to load encryption program: %w", err)
+		finalize, err := replaceDatapath(ctx, iface, networkObj, progs, "")
+		if err != nil {
+			log.WithField(logfields.Interface, iface).WithError(err).Error("Load encryption network failed")
+			// collect errors, but keep trying replacing other interfaces.
+			errs = errors.Join(errs, err)
+		} else {
+			log.WithField(logfields.Interface, iface).Info("Encryption network program (re)loaded")
+			// Defer map removal until all interfaces' progs have been replaced.
+			defer finalize()
 		}
 	}
+
+	if errs != nil {
+		return fmt.Errorf("failed to load encryption program: %w", errs)
+	}
+
 	return nil
 }
 

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -467,23 +467,6 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 	return nil
 }
 
-func (l *Loader) replaceNetworkDatapath(ctx context.Context, interfaces []string) (err error) {
-	progs := []progDefinition{{progName: symbolFromNetwork, direction: dirIngress}}
-	for _, iface := range option.Config.EncryptInterface {
-		finalize, replaceErr := replaceDatapath(ctx, iface, networkObj, progs, "")
-		if replaceErr != nil {
-			log.WithField(logfields.Interface, iface).WithError(replaceErr).Error("Load encryption network failed")
-			// Return the error to the caller, but keep trying replacing other interfaces.
-			err = replaceErr
-		} else {
-			log.WithField(logfields.Interface, iface).Info("Encryption network program (re)loaded")
-			// Defer map removal until all interfaces' progs have been replaced.
-			defer finalize()
-		}
-	}
-	return
-}
-
 func (l *Loader) replaceOverlayDatapath(ctx context.Context, cArgs []string, iface string) error {
 	if err := compileOverlay(ctx, cArgs); err != nil {
 		log.WithError(err).Fatal("failed to compile overlay programs")


### PR DESCRIPTION
replaceNetworkDatapath() is only called from one place and adds an additional loop over the encryption devices. This commit removes the function and calls replaceDatapath() from reinitializeIPSec() directly.

There are no functional changes.
