### PR TITLE
Fix regression causing a 10x increase in the duration of endpoint integration tests

### DIFF
--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -119,11 +119,11 @@ func (s *EndpointSuite) SetUpTest(c *C) {
 	<-mgr.InitIdentityAllocator(nil)
 	s.mgr = mgr
 	node.SetTestLocalNodeStore()
-}
 
-func (s *EndpointSuite) TearDownTest(c *C) {
-	s.mgr.Close()
-	node.UnsetTestLocalNodeStore()
+	c.Cleanup(func() {
+		s.mgr.Close()
+		node.UnsetTestLocalNodeStore()
+	})
 }
 
 func (s *EndpointSuite) TestEndpointStatus(c *C) {


### PR DESCRIPTION
d9a4594b2048 ("etcd: rework lease manager to additionally create sessions") appears to have caused a regression in the duration of the endpoint tests, due to a slightly different implementation of the isConnectedAndHasQuorum() etcd client method, which is in turn executed before starting a Watcher (through Connected()).

The regression is the combination of multiple causes:

* Incorrect endpoint tests tear down ordering, due to the interplay of TearDownTest and Cleanup; specifically, the identity allocator manager (which internally starts the watch operation) is stopped after closing the kvstore client;
* The identity allocator does not propagate a context to the watch operation, but instead relies on a external channel to stop it;
* The etcd Connected() function does no longer terminate immediately when the client is closed (i.e., when the session gets closed). The reason is that the session is no longer guaranteed to be unique.
* The etcd client appears to retry multiple times certain operations if it is closing, but the given context is not canceled (as in this case, as the given context is never canceled). This is the reason for the extra delay, and comes with 100 repetitions of the warning:

{"level":"warn","ts":"...","logger":"etcd-client","caller":"v3/retry_interceptor.go:62",
 "msg":"retrying of unary invoker failed","target":"...","attempt":0,
 "error":"rpc error: code = Canceled desc = grpc: the client connection is closing"}

Let's adopt the easiest fix here, and make sure that the client is closed after closing the manager. This ensures correct tear down ordering and prevents the etcd client retry process.