### PR TITLE
proxy: export ProxyConfig fields

### DIFF
--- a/pkg/proxy/cell.go
+++ b/pkg/proxy/cell.go
@@ -29,16 +29,16 @@ var Cell = cell.Module(
 )
 
 type ProxyConfig struct {
-	minPort, maxPort uint16
-	dnsProxyPort     uint16
+	MinPort, MaxPort uint16
+	DNSProxyPort     uint16
 }
 
 var DefaultProxyConfig = ProxyConfig{
-	minPort: 10000,
-	maxPort: 20000,
+	MinPort: 10000,
+	MaxPort: 20000,
 	// The default value for the DNS proxy port is set to 0 to allocate a random
 	// port.
-	dnsProxyPort: 0,
+	DNSProxyPort: 0,
 }
 
 type proxyParams struct {
@@ -63,7 +63,7 @@ func newProxy(params proxyParams, cfg ProxyConfig) *Proxy {
 
 	configureProxyLogger(params.EndpointInfoRegistry, params.MonitorAgent, option.Config.AgentLabels)
 
-	return createProxy(cfg.minPort, cfg.maxPort, cfg.dnsProxyPort, params.Datapath, params.EnvoyProxyIntegration, params.DNSProxyIntegration, params.XdsServer)
+	return createProxy(cfg.MinPort, cfg.MaxPort, cfg.DNSProxyPort, params.Datapath, params.EnvoyProxyIntegration, params.DNSProxyIntegration, params.XdsServer)
 }
 
 type envoyProxyIntegrationParams struct {


### PR DESCRIPTION
Otherwise there is no way to set them from outside the proxy package. No functional change as currently always the DefaultProxyConfig is applied.

Fixes: f8befdf48003 ("proxy: allow to provide fixed port for DNS proxy via cell")
