### PR TITLE
[v1.14] Make logging.InitializeDefaultLogger private

### DIFF
--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -91,22 +91,9 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 		return
 	}
 
-	// default to a new default logger
-	baseLogger := logging.InitializeDefaultLogger()
-
-	// If this endpoint is set to debug ensure it will print debug by giving it
-	// an independent logger
-	if e.Options != nil && e.Options.IsEnabled(option.Debug) {
-		baseLogger.SetLevel(logrus.DebugLevel)
-	} else {
-		// Debug mode takes priority; if not in debug, check what log level user
-		// has set and set the endpoint's log to log at that level.
-		baseLogger.SetLevel(logging.DefaultLogger.Level)
-	}
-
 	// When adding new fields, make sure they are abstracted by a setter
 	// and update the logger when the value is set.
-	l := baseLogger.WithFields(logrus.Fields{
+	f := logrus.Fields{
 		logfields.LogSubsys:              subsystem,
 		logfields.EndpointID:             e.ID,
 		logfields.ContainerID:            e.getShortContainerIDLocked(),
@@ -115,13 +102,23 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 		logfields.IPv4:                   e.GetIPv4Address(),
 		logfields.IPv6:                   e.GetIPv6Address(),
 		logfields.K8sPodName:             e.GetK8sNamespaceAndPodName(),
-	})
-
-	if e.SecurityIdentity != nil {
-		l = l.WithField(logfields.Identity, e.SecurityIdentity.ID.StringID())
 	}
 
-	e.logger.Store(l)
+	if e.SecurityIdentity != nil {
+		f[logfields.Identity] = e.SecurityIdentity.ID.StringID()
+	}
+
+	// Inherit properties from default logger.
+	baseLogger := logging.DefaultLogger.WithFields(f)
+
+	// If this endpoint is set to debug ensure it will print debug by giving it
+	// an independent logger.
+	// If this endpoint is not set to debug, it will use the log level set by the user.
+	if e.Options != nil && e.Options.IsEnabled(option.Debug) {
+		baseLogger.Logger.SetLevel(logrus.DebugLevel)
+	}
+
+	e.logger.Store(baseLogger)
 }
 
 // Only to be called from UpdateLogger() above

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -11,11 +11,32 @@ import (
 	. "github.com/cilium/checkmate"
 	"github.com/sirupsen/logrus"
 
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
+
+func (s *EndpointSuite) TestEndpointLogFormat(c *C) {
+	// Default log format is text
+	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
+	ep := NewEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+
+	_, ok := ep.getLogger().Logger.Formatter.(*logrus.TextFormatter)
+	c.Assert(ok, Equals, true)
+
+	// Log format is JSON when configured
+	logging.SetLogFormat(logging.LogFormatJSON)
+	defer func() {
+		logging.SetLogFormat(logging.LogFormatText)
+	}()
+	do = &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
+	ep = NewEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+
+	_, ok = ep.getLogger().Logger.Formatter.(*logrus.JSONFormatter)
+	c.Assert(ok, Equals, true)
+}
 
 func (s *EndpointSuite) TestPolicyLog(c *C) {
 	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -41,7 +41,7 @@ const (
 
 // DefaultLogger is the base logrus logger. It is different from the logrus
 // default to avoid external dependencies from writing out unexpectedly
-var DefaultLogger = InitializeDefaultLogger()
+var DefaultLogger = initializeDefaultLogger()
 
 func initializeKLog() {
 	log := DefaultLogger.WithField(logfields.LogSubsys, "klog")
@@ -73,8 +73,8 @@ func initializeKLog() {
 // LogOptions maps configuration key-value pairs related to logging.
 type LogOptions map[string]string
 
-// InitializeDefaultLogger returns a logrus Logger with a custom text formatter.
-func InitializeDefaultLogger() (logger *logrus.Logger) {
+// initializeDefaultLogger returns a logrus Logger with a custom text formatter.
+func initializeDefaultLogger() (logger *logrus.Logger) {
 	logger = logrus.New()
 	logger.SetFormatter(GetFormatter(DefaultLogFormat))
 	logger.SetLevel(DefaultLogLevel)

--- a/test/controlplane/suite/flags.go
+++ b/test/controlplane/suite/flags.go
@@ -20,5 +20,4 @@ func ParseFlags() {
 	if *FlagDebug {
 		logging.SetLogLevelToDebug()
 	}
-	logging.InitializeDefaultLogger()
 }


### PR DESCRIPTION
1.14 backport for #29495

The original PR relied on code from changes made in https://github.com/cilium/cilium/pull/26327. This backport incorporates minimal changes from said PR in `pkg/endpoint/log.go`.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 29495
```