### PR TITLE
.github: Don't update LVH bpf-next images on stable branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -423,16 +423,29 @@
       "versioning": "regex:^((?<compatibility>[a-z-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
     },
     {
-      "groupName": "all lvh-images main",
-      "groupSlug": "all-lvh-images-main",
+      "groupName": "stable lvh-images",
+      "groupSlug": "stable-lvh-images",
       "matchPackageNames": [
         "quay.io/lvh-images/kind"
       ],
-      "matchUpdateTypes": [
-        "digest",
-        "patch",
-        "pin",
-        "pinDigest"
+      "allowedVersions": "!/bpf-next-.*/",
+      "matchBaseBranches": [
+        "main",
+        "v1.15",
+        "v1.14",
+        "v1.13",
+        "v1.12",
+      ],
+    },
+    {
+      "groupName": "bpf-next lvh-images main",
+      "groupSlug": "bpf-next-lvh-images-main",
+      "matchPackageNames": [
+        "quay.io/lvh-images/kind"
+      ],
+      "allowedVersions": "/bpf-next-.*/",
+      "matchBaseBranches": [
+        "main"
       ],
     },
     {


### PR DESCRIPTION
The v1.14 workflows have obtained tweaks to avoid renovate from updating
the dependencies. Rather than editing each workflow on each stable
branch, configure the renovate config to avoid updating those
dependencies on the stable branches.

The motivation for this PR can be seen in comments like this in older workflows:

https://github.com/cilium/cilium/blob/77f0d11dc13cd7153aaa14237573b49bb25f784d/.github/workflows/tests-ipsec-upgrade.yaml#L101

When creating a new stable branch like v1.15, it is difficult to assess how to make the right changes to various workflow files rather than controlling the updates centrally in the renovate config.

Tested here:
https://github.com/joestringer/cilium/commit/70884e50fd2e8234278390e839074270b23d7939
https://github.com/joestringer/cilium/pull/7
https://github.com/joestringer/cilium/pull/9