### PR TITLE
bpf: nat: pass back ipv4_load_l4_ports()'s actual drop reason

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -745,6 +745,7 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 {
 	struct icmphdr icmphdr __align_stack_8;
 	__u16 port_off;
+	int ret;
 
 	build_bug_on(sizeof(struct ipv4_nat_entry) > 64);
 
@@ -754,9 +755,10 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 #ifdef ENABLE_SCTP
 	case IPPROTO_SCTP:
 #endif  /* ENABLE_SCTP */
-		if (ipv4_load_l4_ports(ctx, ip4, off, CT_EGRESS,
-				       &tuple->dport, &has_l4_header) < 0)
-			return DROP_INVALID;
+		ret = ipv4_load_l4_ports(ctx, ip4, off, CT_EGRESS,
+					 &tuple->dport, &has_l4_header);
+		if (ret < 0)
+			return ret;
 
 		ipv4_ct_tuple_swap_ports(tuple);
 		port_off = TCP_SPORT_OFF;
@@ -890,9 +892,11 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 #ifdef ENABLE_SCTP
 	case IPPROTO_SCTP:
 #endif  /* ENABLE_SCTP */
-		if (ipv4_load_l4_ports(ctx, ip4, off, CT_INGRESS,
-				       &tuple.dport, &has_l4_header) < 0)
-			return DROP_INVALID;
+		ret = ipv4_load_l4_ports(ctx, ip4, off, CT_INGRESS,
+					 &tuple.dport, &has_l4_header);
+		if (ret < 0)
+			return ret;
+
 		ipv4_ct_tuple_swap_ports(&tuple);
 		port_off = TCP_DPORT_OFF;
 		break;


### PR DESCRIPTION
ipv4_load_l4_ports() is now consistently returning a drop reason on error,
so we can return that instead of DROP_INVALID.