### PR TITLE
statedb: Fix revision indexing

### DIFF
--- a/pkg/statedb/api_handler.go
+++ b/pkg/statedb/api_handler.go
@@ -76,11 +76,13 @@ func runQuery(indexTxn indexReadTxn, lowerbound bool, queryKey []byte, onObject 
 	} else {
 		iter.SeekPrefixWatch(queryKey)
 	}
-
 	var match func([]byte) bool
-	if indexTxn.entry.unique {
+	switch {
+	case lowerbound:
+		match = func([]byte) bool { return true }
+	case indexTxn.entry.unique:
 		match = func(k []byte) bool { return len(k) == len(queryKey) }
-	} else {
+	default:
 		match = func(k []byte) bool {
 			_, secondary := decodeNonUniqueKey(k)
 			return len(secondary) == len(queryKey)

--- a/pkg/statedb/api_handler_test.go
+++ b/pkg/statedb/api_handler_test.go
@@ -48,4 +48,16 @@ func Test_runQuery(t *testing.T) {
 		assert.EqualValues(t, items[1].data.(testObject).ID, 2)
 	}
 
+	// lower-bound on revision index
+	indexTxn, err = txn.getTxn().indexReadTxn(table.Name(), RevisionIndex)
+	require.NoError(t, err)
+	items = nil
+	runQuery(indexTxn, true, index.Uint64(0), onObject)
+	if assert.Len(t, items, 4) {
+		// Items are in revision (creation) order
+		assert.EqualValues(t, items[0].data.(testObject).ID, 1)
+		assert.EqualValues(t, items[1].data.(testObject).ID, 2)
+		assert.EqualValues(t, items[2].data.(testObject).ID, 3)
+		assert.EqualValues(t, items[3].data.(testObject).ID, 4)
+	}
 }


### PR DESCRIPTION
Revision index was marked unique, but encoded the key as `<revision> <primary key>`. This was an accidental leftover from when revision was per-transaction rather than per insert/delete. The key can now be simplified to just `<revision>`.

This issue combined with "statedb: Allow non-terminated keys" broke revision queries via the statedb REST API handler as the lowerbound iteration terminated when the key length did not match. Fix the REST API handler as well to not check result keys when doing lowerbound search.

Fixes: aa15ba7ad8 ("statedb: Allow non-terminated keys")