### PR TITLE
v1.13 Backports 2023-12-13

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -95,7 +95,10 @@ jobs:
         run: |
           cd /tmp/generated/azure
 
-          if [ "${{ github.event_name }}" == "schedule" ];then
+          # Use complete matrix in case of scheduled run
+          # main -> event_name = schedule
+          # other stable branches -> PR-number starting with v (e.g. v1.14)
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
             cp azure.json /tmp/matrix.json
           else
             jq '{ "include": [ .include[] | select(.default) ] }' azure.json > /tmp/matrix.json

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -94,7 +94,10 @@ jobs:
         run: |
           cd /tmp/generated/aws
 
-          if [ "${{ github.event_name }}" == "schedule" ];then
+          # Use complete matrix in case of scheduled run
+          # main -> event_name = schedule
+          # other stable branches -> PR-number starting with v (e.g. v1.14)
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
             cp aws.json /tmp/matrix.json
           else
             jq '{ "include": [ .include[] | select(.default) ] }' aws.json > /tmp/matrix.json

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -255,7 +255,6 @@ jobs:
           image-version: ${{ matrix.kernel }}
           host-mount: ./
           cpu: 4
-          dns-resolver: '1.1.1.1'
           install-dependencies: 'true'
           cmd: |
             git config --global --add safe.directory /host

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -94,7 +94,10 @@ jobs:
         run: |
           cd /tmp/generated/aws
 
-          if [ "${{ github.event_name }}" == "schedule" ];then
+          # Use complete matrix in case of scheduled run
+          # main -> event_name = schedule
+          # other stable branches -> PR-number starting with v (e.g. v1.14)
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
             cp aws.json /tmp/matrix.json
           else
             jq '{ "include": [ .include[] | select(.default) ] }' aws.json > /tmp/matrix.json

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -95,7 +95,10 @@ jobs:
         run: |
           cd /tmp/generated/gke
 
-          if [ "${{ github.event_name }}" == "schedule" ];then
+          # Use complete matrix in case of scheduled run
+          # main -> event_name = schedule
+          # other stable branches -> PR-number starting with v (e.g. v1.14)
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
             jq '{ "include": [ .k8s[] ] }' gke.json > /tmp/matrix.json
           else
             jq '{ "include": [ .k8s[] | select(.default) ] }' gke.json > /tmp/matrix.json

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -100,7 +100,10 @@ jobs:
         run: |
           cd /tmp/generated/gke
 
-          if [ "${{ github.event_name }}" == "schedule" ];then
+          # Use complete matrix in case of scheduled run
+          # main -> event_name = schedule
+          # other stable branches -> PR-number starting with v (e.g. v1.14)
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
             cp gke.json /tmp/matrix.json
           else
             jq '{ "k8s": [ .k8s[] | select(.default) ], "config": .config}' gke.json > /tmp/matrix.json

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -235,7 +235,6 @@ jobs:
           image-version: ${{ matrix.kernel }}
           host-mount: ./
           cpu: 4
-          dns-resolver: '1.1.1.1'
           install-dependencies: 'true'
           cmd: |
             git config --global --add safe.directory /host

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -118,9 +118,6 @@ jobs:
           "
 
           # * bpf.masquerade is disabled due to #23283
-          # * IPv6 is disabled because an issue under investigation seems to
-          #   possibly cause seldom and brief connection disruptions on agent
-          #   restart in dual stack clusters, independently of clustermesh.
           # * Hubble is disabled to avoid the performance penalty in the testing
           #   environment due to the relatively high traffic load.
           CILIUM_INSTALL_DEFAULTS=" \
@@ -130,7 +127,7 @@ jobs:
             --set=hubble.enabled=false \
             --set=tunnel=vxlan \
             --set=ipv4.enabled=true \
-            --set=ipv6.enabled=false \
+            --set=ipv6.enabled=true \
             --set=clustermesh.useAPIServer=true \
             --set=clustermesh.config.enabled=true"
 

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -249,7 +249,6 @@ jobs:
           host-mount: ./
           cpu: 4
           mem: '12G'
-          dns-resolver: '1.1.1.1'
           install-dependencies: 'true'
           cmd: |
             git config --global --add safe.directory /host


### PR DESCRIPTION
 * [x] #29455 (@mhofstetter)
    - :information_source: Skipped cac433cd41ba9fc37fa894974416f4c31a14d3be, as conformance-runtime is not present in v1.13.
    - :information_source: Skipped changes in conformance-ginkgo.yaml, conformance-runtime.yaml, tests-datapath-verifier.yaml and tests-e2e-upgrade.yaml, as not present in v1.13.
 * [x] #29694 (@mhofstetter)
 * [x] #29675 (@giorio94)
 * [ ] ~~#29793 (@qmonnet)~~ Dropped, as it depends on https://github.com/cilium/cilium/pull/29514 (backport/author)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 29455 29694 29675
```
