### PR TITLE
hive: Unify parsing of string slices

### DIFF
--- a/pkg/hive/cell/config.go
+++ b/pkg/hive/cell/config.go
@@ -104,8 +104,24 @@ func decoderConfig(target any) *mapstructure.DecoderConfig {
 		Result:           target,
 		WeaklyTypedInput: true,
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			// To unify the splitting of fields of a []string field across the input coming
+			// from environment, configmap and pflag (command-line), we first split a string
+			// (env/configmap) by comma, and then for all input methods we split a single
+			// value []string by whitespace. Thus the following all result in the same slice:
+			//
+			// --string-slice=foo,bar,baz
+			// --string-slice="foo bar baz"
+			// CILIUM_STRING_SLICE="foo,bar,baz"
+			// CILIUM_STRING_SLICE="foo bar baz"
+			// /.../configmap/string_slice: "foo bar baz"
+			// /.../configmap/string_slice: "foo,bar,baz"
+			//
+			// If both commas and whitespaces are present the commas take precedence:
+			// "foo,bar baz" => []string{"foo", "bar baz"}
+			mapstructure.StringToSliceHookFunc(","), // string->[]string is split by comma
+			fixupStringSliceHookFunc,                // []string of length 1 is split again by whitespace
+
 			mapstructure.StringToTimeDurationHookFunc(),
-			mapstructure.StringToSliceHookFunc(","),
 			stringToCIDRHookFunc,
 			stringToMapHookFunc,
 		),
@@ -164,4 +180,24 @@ func stringToCIDRHookFunc(from reflect.Type, to reflect.Type, data interface{}) 
 		return data, nil
 	}
 	return cidr.ParseCIDR(s)
+}
+
+// fixupStringSliceHookFunc takes a []string and if it's a single element splits it again
+// by whitespace. This unifies the flag parsing behavior with StringSlice
+// values coming from environment or configmap where both spaces or commas can be used to split.
+func fixupStringSliceHookFunc(from reflect.Type, to reflect.Type, data interface{}) (interface{}, error) {
+	if from.Kind() != reflect.Slice || to.Kind() != reflect.Slice {
+		return data, nil
+	}
+	if from.Elem().Kind() != reflect.String || to.Elem().Kind() != reflect.String {
+		return data, nil
+	}
+
+	raw := data.([]string)
+	if len(raw) == 1 {
+		// Flag was already split by commas (the default behavior), so split it
+		// now by spaces.
+		return strings.Fields(raw[0]), nil
+	}
+	return raw, nil
 }


### PR DESCRIPTION
Hive uses pflag and viper to parse configuration flags from multiple sources. If a flag is set via command-line then the pflag parser is invoked to get to the destination type as defined in the FlagSet ("flags.StringSlice" [1]), however if the flag comes from enviroment or config-map, then the parsing was done by a mapstructure hook [2].

This is all well and good as long as these two ways of parsing into say []string are aligned with each other. And they were. Unfortunately these were not aligned with the pre-Hive way of parsing which used viper.GetStringSlice and similar methods. Specifically viper.GetStringSlice is implemented ([3]) via cast.ToStringSlice, which uses strings.Fields that splits by whitespace instead of by commas.

So to summarize the different ways a StringSlice can be parsed:

- [1]: flags.StringSlice: parses with csv.Reader (split by comma)
- [2]: stringToSliceHookFunc: splits by comma
- [3]: viper.GetStringSlice: splits by whitespaces

So while arguably the first two are more consistent, we can't just flip from splitting by spaces to splitting by commas as that creates a huge foot-gun when fields are moved from option.Config to individual hive.Config structs.

To solve this we allow splitting both ways by using two mapstructure hooks that process the values before they're pushed to the config struct:

- stringToSliceHookFunc now splits first by commas and if it doesn't produce multiple values it will split by commas. This handles the values going to []string and coming from "flags.String", config file, config map and the environment.

- fixupStringSliceHookFunc takes []string coming from flags.StringSlice that was split by comma and resplits it if splitting by comma resulted in a single value.

With this, we have unified the parsing of []string across all the config input methods:

-  `"foo,bar,baz" => []string{"foo", "bar", "baz"}`
- `"foo bar baz" => []string{"foo", "bar", "baz"}`
- `"foo bar,baz" => []string{"foo bar", "baz"}`

[1]: https://github.com/spf13/pflag/blob/master/string_slice.go#L27
[2]: https://github.com/mitchellh/mapstructure/blob/main/decode_hooks.go#L104
[3]: https://github.com/spf13/viper/blob/9154b900c34ad9d88897f7e5288ce43f457f698b/viper.go#L1067

Fixes: #29210
Fixes: b407ffce15 ("hive: Reimplement on top of dig")

```release-note
Unify parsing of StringSlice flags and allow splitting by commas (preferably) or by spaces. This fixes parsing of 'prometheus.metrics'.
```