### PR TITLE
gha: Removed metal LB references

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -62,7 +62,6 @@ env:
   kind_version: v0.20.0
   kind_config: .github/kind-config.yaml
   gateway_api_version: v1.0.0
-  metallb_version: 0.12.1
   timeout: 5m
 
 jobs:

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -60,7 +60,6 @@ env:
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   kind_version: v0.20.0
   kind_config: .github/kind-config.yaml
-  metallb_version: 0.12.1
   timeout: 5m
 
 jobs:


### PR DESCRIPTION

```release-note
removing reference to Metal LB in GHA now that MetalLB has been replaced with Cilium L2 Announcement (https://github.com/cilium/cilium/pull/28926)
```
