### PR TITLE
gh/workflows: Drop rading /proc in case of failure

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -357,8 +357,6 @@ jobs:
           ./cilium-cli status
           mkdir -p cilium-sysdumps
           ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
-          # To debug https://github.com/cilium/cilium/issues/26062
-          head -n -0 /proc/buddyinfo /proc/pagetypeinfo
 
       - name: Upload artifacts
         if: ${{ !success() }}

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -286,8 +286,6 @@ jobs:
           ./cilium-cli status
           mkdir -p cilium-sysdumps
           ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
-          # To debug https://github.com/cilium/cilium/issues/26062
-          head -n -0 /proc/buddyinfo /proc/pagetypeinfo
 
       - name: Upload artifacts
         if: ${{ !success() }}

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -345,8 +345,6 @@ jobs:
           ./cilium-cli status
           mkdir -p cilium-sysdumps
           ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
-          # To debug https://github.com/cilium/cilium/issues/26062
-          head -n -0 /proc/buddyinfo /proc/pagetypeinfo
 
       - name: Upload artifacts
         if: ${{ steps.vars.outputs.downgrade_version != '' && !success() }}


### PR DESCRIPTION
The [1] changed the execution context of test commands (i.e., kubectl, cilium-cli, etc) in a way that instead of ssh'ing and then running a cmd, we communicate with a target test cluster via kube-apiserver.

This makes the dropped reading from /proc to fail. As we haven't heard about #26062 occurrences, let's remove it. We can always add it to Cilium's bugtool.

Fixes: 936c8ae01f8 ("ci-e2e: Use lvh-kind action instead of c/little-vm-helper")
Fixes: cd93d377495 ("ci-ipsec-upgrade: Use lvh-kind")
Fixes: f8e61f3c740 ("ci-ipsec-e2e: Use lvh-kind")
Reported-by:  Paul Chaignon <paul.chaignon@gmail.com>

Fix #29851 