### PR TITLE
operator: Implement CES Controller dynamic rate limiting

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -16,10 +16,14 @@ cilium-operator-alibabacloud [flags]
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
+      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -12,10 +12,14 @@ cilium-operator-alibabacloud hive [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
+      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -18,10 +18,14 @@ cilium-operator-alibabacloud hive dot-graph [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
+      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -19,10 +19,14 @@ cilium-operator-aws [flags]
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
+      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -12,10 +12,14 @@ cilium-operator-aws hive [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
+      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -18,10 +18,14 @@ cilium-operator-aws hive dot-graph [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
+      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -19,10 +19,14 @@ cilium-operator-azure [flags]
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
+      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -12,10 +12,14 @@ cilium-operator-azure hive [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
+      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -18,10 +18,14 @@ cilium-operator-azure hive dot-graph [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
+      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -15,10 +15,14 @@ cilium-operator-generic [flags]
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
+      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -12,10 +12,14 @@ cilium-operator-generic hive [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
+      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -18,10 +18,14 @@ cilium-operator-generic hive dot-graph [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
+      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -24,10 +24,14 @@ cilium-operator [flags]
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
+      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -12,10 +12,14 @@ cilium-operator hive [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
+      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -18,10 +18,14 @@ cilium-operator hive dot-graph [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
+      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/operator/pkg/ciliumendpointslice/cell.go
+++ b/operator/pkg/ciliumendpointslice/cell.go
@@ -26,6 +26,22 @@ const (
 	// for the CES work queue to process CES events that result in CES write
 	// (Create, Update, Delete) requests to the kube-apiserver.
 	CESWriteQPSBurst = "ces-write-qps-burst"
+
+	// CESEnableDynamicRateLimit is used to ignore static QPS Limit and Burst
+	// and use dynamic limit, burst and nodes instead.
+	CESEnableDynamicRateLimit = "ces-enable-dynamic-rate-limit"
+
+	// CESDynamicRateLimitNodes is used to specify the list of nodes used for the
+	// dynamic rate limit steps.
+	CESDynamicRateLimitNodes = "ces-dynamic-rate-limit-nodes"
+
+	// CESDynamicRateLimitQPSLimit is used to specify the list of qps limits for the
+	// dynamic rate limit steps.
+	CESDynamicRateLimitQPSLimit = "ces-dynamic-rate-limit-qps-limit"
+
+	// CESDynamicRateLimitQPSBurst is used to specify the list of qps bursts for the
+	// dynamic rate limit steps.
+	CESDynamicRateLimitQPSBurst = "ces-dynamic-rate-limit-qps-burst"
 )
 
 // Cell is a cell that implements a Cilium Endpoint Slice Controller.
@@ -40,24 +56,37 @@ var Cell = cell.Module(
 )
 
 type Config struct {
-	CESMaxCEPsInCES  int     `mapstructure:"ces-max-ciliumendpoints-per-ces"`
-	CESSlicingMode   string  `mapstructure:"ces-slice-mode"`
-	CESWriteQPSLimit float64 `mapstructure:"ces-write-qps-limit"`
-	CESWriteQPSBurst int     `mapstructure:"ces-write-qps-burst"`
+	CESMaxCEPsInCES             int      `mapstructure:"ces-max-ciliumendpoints-per-ces"`
+	CESSlicingMode              string   `mapstructure:"ces-slice-mode"`
+	CESWriteQPSLimit            float64  `mapstructure:"ces-write-qps-limit"`
+	CESWriteQPSBurst            int      `mapstructure:"ces-write-qps-burst"`
+	CESEnableDynamicRateLimit   bool     `mapstructure:"ces-enable-dynamic-rate-limit"`
+	CESDynamicRateLimitNodes    []string `mapstructure:"ces-dynamic-rate-limit-nodes"`
+	CESDynamicRateLimitQPSLimit []string `mapstructure:"ces-dynamic-rate-limit-qps-limit"`
+	CESDynamicRateLimitQPSBurst []string `mapstructure:"ces-dynamic-rate-limit-qps-burst"`
 }
 
 var defaultConfig = Config{
-	CESMaxCEPsInCES:  100,
-	CESSlicingMode:   "cesSliceModeIdentity",
-	CESWriteQPSLimit: 10,
-	CESWriteQPSBurst: 20,
+	CESMaxCEPsInCES:             100,
+	CESSlicingMode:              "cesSliceModeIdentity",
+	CESWriteQPSLimit:            10,
+	CESWriteQPSBurst:            20,
+	CESEnableDynamicRateLimit:   false,
+	CESDynamicRateLimitNodes:    []string{},
+	CESDynamicRateLimitQPSLimit: []string{},
+	CESDynamicRateLimitQPSBurst: []string{},
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {
 	flags.Int(CESMaxCEPsInCES, def.CESMaxCEPsInCES, "Maximum number of CiliumEndpoints allowed in a CES")
 	flags.String(CESSlicingMode, def.CESSlicingMode, "Slicing mode define how ceps are grouped into a CES")
-	flags.Float64(CESWriteQPSLimit, def.CESWriteQPSLimit, "CES work queue rate limit")
-	flags.Int(CESWriteQPSBurst, def.CESWriteQPSBurst, "CES work queue burst rate")
+	flags.Float64(CESWriteQPSLimit, def.CESWriteQPSLimit, "CES work queue rate limit. Ignored when "+CESEnableDynamicRateLimit+" is set")
+	flags.Int(CESWriteQPSBurst, def.CESWriteQPSBurst, "CES work queue burst rate. Ignored when "+CESEnableDynamicRateLimit+" is set")
+
+	flags.Bool(CESEnableDynamicRateLimit, def.CESEnableDynamicRateLimit, "Flag to enable dynamic rate limit specified in separate fields instead of the static one")
+	flags.StringSlice(CESDynamicRateLimitNodes, def.CESDynamicRateLimitNodes, "List of nodes used for the dynamic rate limit steps")
+	flags.StringSlice(CESDynamicRateLimitQPSLimit, def.CESDynamicRateLimitQPSLimit, "List of qps limits used for the dynamic rate limit steps")
+	flags.StringSlice(CESDynamicRateLimitQPSBurst, def.CESDynamicRateLimitQPSBurst, "List of qps burst used for the dynamic rate limit steps")
 }
 
 // SharedConfig contains the configuration that is shared between

--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cilium/workerpool"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/time/rate"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/hive"
@@ -32,6 +31,7 @@ type params struct {
 	Clientset           k8sClient.Clientset
 	CiliumEndpoint      resource.Resource[*v2.CiliumEndpoint]
 	CiliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice]
+	CiliumNodes         resource.Resource[*v2.CiliumNode]
 
 	Cfg       Config
 	SharedCfg SharedConfig
@@ -48,6 +48,7 @@ type Controller struct {
 	clientset           k8sClient.Clientset
 	ciliumEndpoint      resource.Resource[*v2.CiliumEndpoint]
 	ciliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice]
+	ciliumNodes         resource.Resource[*v2.CiliumNode]
 
 	// reconciler is an util used to reconcile CiliumEndpointSlice changes.
 	reconciler *reconciler
@@ -63,10 +64,8 @@ type Controller struct {
 	// CES requests going to api-server, ensures a single CES will not be proccessed
 	// multiple times concurrently, and if CES is added multiple times before it
 	// can be processed, this will only be processed only once.
-	queue            workqueue.RateLimitingInterface
-	queueRateLimiter *rate.Limiter
-	writeQPSLimit    float64
-	writeQPSBurst    int
+	queue     workqueue.RateLimitingInterface
+	rateLimit rateLimitConfig
 
 	enqueuedAt     map[CESName]time.Time
 	enqueuedAtLock lock.Mutex
@@ -87,10 +86,10 @@ func registerController(p params) {
 		clientset:           p.Clientset,
 		ciliumEndpoint:      p.CiliumEndpoint,
 		ciliumEndpointSlice: p.CiliumEndpointSlice,
+		ciliumNodes:         p.CiliumNodes,
 		slicingMode:         p.Cfg.CESSlicingMode,
 		maxCEPsInCES:        p.Cfg.CESMaxCEPsInCES,
-		writeQPSLimit:       p.Cfg.CESWriteQPSLimit,
-		writeQPSBurst:       p.Cfg.CESWriteQPSBurst,
+		rateLimit:           getRateLimitConfig(p),
 		enqueuedAt:          make(map[CESName]time.Time),
 		metrics:             p.Metrics,
 	}

--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cilium/workerpool"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/time/rate"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/util/workqueue"
 
@@ -48,28 +47,14 @@ const (
 )
 
 func (c *Controller) initializeQueue() {
-	if c.writeQPSLimit == 0 {
-		c.writeQPSLimit = CESControllerWorkQueueQPSLimit
-	} else if c.writeQPSLimit > CESWriteQPSLimitMax {
-		c.writeQPSLimit = CESWriteQPSLimitMax
-	}
-
-	if c.writeQPSBurst == 0 {
-		c.writeQPSBurst = CESControllerWorkQueueBurstLimit
-	} else if c.writeQPSBurst > CESWriteQPSBurstMax {
-		c.writeQPSBurst = CESWriteQPSBurstMax
-	}
-
 	c.logger.WithFields(logrus.Fields{
-		logfields.WorkQueueQPSLimit:    c.writeQPSLimit,
-		logfields.WorkQueueBurstLimit:  c.writeQPSBurst,
+		logfields.WorkQueueQPSLimit:    c.rateLimit.current.Limit,
+		logfields.WorkQueueBurstLimit:  c.rateLimit.current.Burst,
 		logfields.WorkQueueSyncBackOff: defaultSyncBackOff,
 	}).Info("CES controller workqueue configuration")
-
 	c.queue = workqueue.NewRateLimitingQueueWithConfig(
 		workqueue.NewItemExponentialFailureRateLimiter(defaultSyncBackOff, maxSyncBackOff),
 		workqueue.RateLimitingQueueConfig{Name: "cilium_endpoint_slice"})
-	c.queueRateLimiter = rate.NewLimiter(rate.Limit(c.writeQPSLimit), c.writeQPSBurst)
 }
 
 func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
@@ -143,9 +128,12 @@ func (c *Controller) Start(ctx hive.HookContext) error {
 	}
 
 	// Start the work pools processing CEP events only after syncing CES in local cache.
-	c.wp = workerpool.New(2)
+	c.wp = workerpool.New(3)
 	c.wp.Submit("cilium-endpoints-updater", c.runCiliumEndpointsUpdater)
 	c.wp.Submit("cilium-endpoint-slices-updater", c.runCiliumEndpointSliceUpdater)
+	if c.rateLimit.hasDynamicRateLimiting() {
+		c.wp.Submit("cilium-nodes-updater", c.runCiliumNodesUpdater)
+	}
 
 	c.logger.Info("Starting CES controller reconciler.")
 	go c.worker()
@@ -194,6 +182,25 @@ func (c *Controller) runCiliumEndpointSliceUpdater(ctx context.Context) error {
 	return nil
 }
 
+func (c *Controller) runCiliumNodesUpdater(ctx context.Context) error {
+	ciliumNodesStore, err := c.ciliumNodes.Store(ctx)
+	if err != nil {
+		c.logger.WithError(err).Warn("Couldn't get CiliumNodes store")
+		return err
+	}
+	for event := range c.ciliumNodes.Events(ctx) {
+		event.Done(nil)
+		totalNodes := len(ciliumNodesStore.List())
+		if c.rateLimit.updateRateLimiterWithNodes(totalNodes) {
+			c.logger.WithFields(logrus.Fields{
+				logfields.WorkQueueQPSLimit:   c.rateLimit.current.Limit,
+				logfields.WorkQueueBurstLimit: c.rateLimit.current.Burst,
+			}).Info("Updated CES controller workqueue configuration")
+		}
+	}
+	return nil
+}
+
 // Sync all CESs from cesStore to manager cache.
 // Note: CESs are synced locally before CES controller running and this is required.
 func (c *Controller) syncCESsInLocalCache(ctx context.Context) error {
@@ -220,7 +227,7 @@ func (c *Controller) worker() {
 }
 
 func (c *Controller) rateLimitProcessing() {
-	delay := c.queueRateLimiter.Reserve().Delay()
+	delay := c.rateLimit.getDelay()
 	select {
 	case <-c.context.Done():
 	case <-time.After(delay):

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -86,8 +86,7 @@ func TestSyncCESsInLocalCache(t *testing.T) {
 		ciliumEndpointSlice: ciliumEndpointSlice,
 		reconciler:          r,
 		manager:             m,
-		writeQPSBurst:       2,
-		writeQPSLimit:       1,
+		rateLimit:           getRateLimitConfig(params{Cfg: Config{CESWriteQPSLimit: 2, CESWriteQPSBurst: 1}}),
 		enqueuedAt:          make(map[CESName]time.Time),
 	}
 	cesController.initializeQueue()

--- a/operator/pkg/ciliumendpointslice/rate_limit.go
+++ b/operator/pkg/ciliumendpointslice/rate_limit.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumendpointslice
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
+	"k8s.io/client-go/util/workqueue"
+)
+
+type rateLimit struct {
+	Nodes int
+	Limit float64
+	Burst int
+}
+
+type rateLimitConfig struct {
+	current          rateLimit
+	dynamicRateLimit []rateLimit
+
+	rateLimiter *workqueue.BucketRateLimiter
+
+	logger logrus.FieldLogger
+}
+
+func getRateLimitConfig(p params) rateLimitConfig {
+	var dynamicRateLimit []rateLimit
+	if p.Cfg.CESEnableDynamicRateLimit {
+		var err error
+		dynamicRateLimit, err = parseDynamicRateLimit(p.Cfg.CESDynamicRateLimitNodes, p.Cfg.CESDynamicRateLimitQPSLimit, p.Cfg.CESDynamicRateLimitQPSBurst)
+		if err != nil {
+			p.Logger.WithError(err).Warn("Couldn't parse dynamic rate limit config")
+		}
+	}
+	rlc := rateLimitConfig{
+		current: rateLimit{
+			Limit: p.Cfg.CESWriteQPSLimit,
+			Burst: p.Cfg.CESWriteQPSBurst,
+		},
+		dynamicRateLimit: dynamicRateLimit,
+		logger:           p.Logger,
+	}
+
+	if rlc.hasDynamicRateLimiting() {
+		rlc.updateRateLimitWithNodes(0, true)
+	}
+	rlc.rateLimiter = &workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(rlc.current.Limit), rlc.current.Burst)}
+	return rlc
+}
+
+func parseDynamicRateLimit(nodes []string, limits []string, bursts []string) ([]rateLimit, error) {
+	if len(nodes) != len(limits) || len(nodes) != len(bursts) {
+		return nil, fmt.Errorf("Length of the %s, %s and %s needs to be the same", CESDynamicRateLimitNodes, CESDynamicRateLimitQPSLimit, CESDynamicRateLimitQPSBurst)
+	}
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("Dynamic rate limit is enabled but the flags specifying it are not set")
+	}
+	dynamicRateLimit := make([]rateLimit, len(nodes))
+	for i := 0; i < len(nodes); i++ {
+		node, err := strconv.Atoi(nodes[i])
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert node value %q to int", nodes[i])
+		}
+		dynamicRateLimit[i].Nodes = node
+
+		limit, err := strconv.ParseFloat(limits[i], 64)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert limit value %q to float", limits[i])
+		}
+		dynamicRateLimit[i].Limit = limit
+
+		burst, err := strconv.Atoi(bursts[i])
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert burst value %q to int", bursts[i])
+		}
+		dynamicRateLimit[i].Burst = burst
+	}
+	sort.Slice(dynamicRateLimit, func(i, j int) bool {
+		return dynamicRateLimit[i].Nodes < dynamicRateLimit[j].Nodes
+	})
+	return dynamicRateLimit, nil
+}
+
+func (rlc *rateLimitConfig) hasDynamicRateLimiting() bool {
+	return rlc.dynamicRateLimit != nil
+}
+
+func (rlc *rateLimitConfig) getDelay() time.Duration {
+	return rlc.rateLimiter.Reserve().Delay()
+}
+
+func (rlc *rateLimitConfig) updateRateLimiterWithNodes(nodes int) bool {
+	rlc.logger.Info("Updating rate limit with nodes: ", nodes)
+	changed := rlc.updateRateLimitWithNodes(nodes, false)
+	if changed {
+		rlc.rateLimiter.SetBurst(rlc.current.Burst)
+		rlc.rateLimiter.SetLimit(rate.Limit(rlc.current.Limit))
+	}
+	return changed
+}
+
+func (rlc *rateLimitConfig) updateRateLimitWithNodes(nodes int, force bool) bool {
+	if !rlc.hasDynamicRateLimiting() {
+		return false
+	}
+
+	index := 0
+	for ; index < len(rlc.dynamicRateLimit)-1; index++ {
+		if rlc.dynamicRateLimit[index+1].Nodes > nodes {
+			break
+		}
+	}
+	changed := rlc.current.Nodes != rlc.dynamicRateLimit[index].Nodes
+
+	if changed || force {
+		rlc.current = rateLimit{
+			Nodes: rlc.dynamicRateLimit[index].Nodes,
+			Limit: rlc.dynamicRateLimit[index].Limit,
+			Burst: rlc.dynamicRateLimit[index].Burst,
+		}
+		if rlc.current.Limit == 0 {
+			rlc.current.Limit = CESControllerWorkQueueQPSLimit
+		} else if rlc.current.Limit > CESWriteQPSLimitMax {
+			rlc.current.Limit = CESWriteQPSLimitMax
+		}
+		if rlc.current.Burst == 0 {
+			rlc.current.Burst = CESControllerWorkQueueBurstLimit
+		} else if rlc.current.Burst > CESWriteQPSBurstMax {
+			rlc.current.Burst = CESWriteQPSBurstMax
+		}
+		return true
+	}
+	return false
+}

--- a/operator/pkg/ciliumendpointslice/rate_limit_test.go
+++ b/operator/pkg/ciliumendpointslice/rate_limit_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumendpointslice
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoDynamicRateLimit(t *testing.T) {
+	limit := 10.0
+	burst := 20
+	p := params{
+		Logger: log,
+		Cfg: Config{
+			CESWriteQPSLimit: limit,
+			CESWriteQPSBurst: burst,
+		},
+	}
+	config := getRateLimitConfig(p)
+	assert.False(t, config.hasDynamicRateLimiting())
+	assert.Equal(t, limit, config.current.Limit)
+	assert.Equal(t, burst, config.current.Burst)
+	assert.False(t, config.updateRateLimiterWithNodes(1000))
+	assert.Equal(t, limit, config.current.Limit)
+	assert.Equal(t, burst, config.current.Burst)
+	assert.False(t, config.updateRateLimiterWithNodes(0))
+	assert.Equal(t, limit, config.current.Limit)
+	assert.Equal(t, burst, config.current.Burst)
+	assert.False(t, config.updateRateLimiterWithNodes(-100))
+	assert.Equal(t, limit, config.current.Limit)
+	assert.Equal(t, burst, config.current.Burst)
+}
+
+func TestSingleDynamicRateLimit(t *testing.T) {
+	limit := 15.0
+	burst := 30
+	p := params{
+		Logger: log,
+		Cfg: Config{
+			CESEnableDynamicRateLimit:   true,
+			CESDynamicRateLimitNodes:    []string{"5"},
+			CESDynamicRateLimitQPSLimit: []string{strconv.FormatFloat(limit, 'g', -1, 64)},
+			CESDynamicRateLimitQPSBurst: []string{strconv.Itoa(burst)},
+		},
+	}
+	config := getRateLimitConfig(p)
+	assert.True(t, config.hasDynamicRateLimiting())
+	assert.Equal(t, limit, config.current.Limit)
+	assert.Equal(t, burst, config.current.Burst)
+	assert.False(t, config.updateRateLimiterWithNodes(1000))
+	assert.Equal(t, limit, config.current.Limit)
+	assert.Equal(t, burst, config.current.Burst)
+	assert.False(t, config.updateRateLimiterWithNodes(0))
+	assert.Equal(t, limit, config.current.Limit)
+	assert.Equal(t, burst, config.current.Burst)
+	assert.False(t, config.updateRateLimiterWithNodes(-100))
+	assert.Equal(t, limit, config.current.Limit)
+	assert.Equal(t, burst, config.current.Burst)
+}
+
+func TestMultipleUnsortedDynamicRateLimit(t *testing.T) {
+	limit0 := 5.0
+	burst0 := 10
+	limit1 := 11.0
+	burst1 := 22
+	limit2 := 16.0
+	burst2 := 32
+	p := params{
+		Logger: log,
+		Cfg: Config{
+			CESEnableDynamicRateLimit: true,
+			CESDynamicRateLimitNodes:  []string{"15", "5", "25"},
+			CESDynamicRateLimitQPSLimit: []string{
+				strconv.FormatFloat(limit1, 'g', -1, 64),
+				strconv.FormatFloat(limit0, 'g', -1, 64),
+				strconv.FormatFloat(limit2, 'g', -1, 64),
+			},
+			CESDynamicRateLimitQPSBurst: []string{
+				strconv.Itoa(burst1),
+				strconv.Itoa(burst0),
+				strconv.Itoa(burst2),
+			},
+		},
+	}
+	config := getRateLimitConfig(p)
+	assert.True(t, config.hasDynamicRateLimiting())
+	assert.Equal(t, limit0, config.current.Limit)
+	assert.Equal(t, burst0, config.current.Burst)
+	assert.True(t, config.updateRateLimiterWithNodes(1000))
+	assert.Equal(t, limit2, config.current.Limit)
+	assert.Equal(t, burst2, config.current.Burst)
+	assert.True(t, config.updateRateLimiterWithNodes(0))
+	assert.Equal(t, limit0, config.current.Limit)
+	assert.Equal(t, burst0, config.current.Burst)
+	assert.True(t, config.updateRateLimiterWithNodes(24))
+	assert.Equal(t, limit1, config.current.Limit)
+	assert.Equal(t, burst1, config.current.Burst)
+	assert.True(t, config.updateRateLimiterWithNodes(25))
+	assert.Equal(t, limit2, config.current.Limit)
+	assert.Equal(t, burst2, config.current.Burst)
+	assert.True(t, config.updateRateLimiterWithNodes(-100))
+	assert.Equal(t, limit0, config.current.Limit)
+	assert.Equal(t, burst0, config.current.Burst)
+	assert.True(t, config.updateRateLimiterWithNodes(16))
+	assert.Equal(t, limit1, config.current.Limit)
+	assert.Equal(t, burst1, config.current.Burst)
+	assert.False(t, config.updateRateLimiterWithNodes(23))
+	assert.Equal(t, limit1, config.current.Limit)
+	assert.Equal(t, burst1, config.current.Burst)
+}


### PR DESCRIPTION
Support dynamic rate limiting in the CES Controller similar to the cluster-proportional-autoscaler ladder mode. Operator accepts new JSON parameter with a map of nodes number and rate limit and burst.


```release-note
Supports for dynamic CES Controller throttling configuration based on the number of nodes
```
