### PR TITLE
add missing kustomization.yaml

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/kustomization.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./v2
+  - ./v2alpha1

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/kustomization.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./ciliumclusterwideenvoyconfigs.yaml
+  - ./ciliumclusterwidenetworkpolicies.yaml
+  - ./ciliumegressgatewaypolicies.yaml
+  - ./ciliumendpoints.yaml
+  - ./ciliumenvoyconfigs.yaml
+  - ./ciliumexternalworkloads.yaml
+  - ./ciliumidentities.yaml
+  - ./ciliumlocalredirectpolicies.yaml
+  - ./ciliumnetworkpolicies.yaml
+  - ./ciliumnodes.yaml
+

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/kustomization.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./ciliumbgpadvertisements.yaml
+  - ./ciliumbgpclusterconfigs.yaml
+  - ./ciliumbgpnodeconfigoverrides.yaml
+  - ./ciliumbgpnodeconfigs.yaml
+  - ./ciliumbgppeerconfigs.yaml
+  - ./ciliumbgppeeringpolicies.yaml
+  - ./ciliumcidrgroups.yaml
+  - ./ciliumendpointslices.yaml
+  - ./ciliuml2announcementpolicies.yaml
+  - ./ciliumloadbalancerippools.yaml
+  - ./ciliumnodeconfigs.yaml
+  - ./ciliumpodippools.yaml
+


### PR DESCRIPTION
kustomization.yaml: access custom resource definitions from within kustomization and related files via a simple url.
the simplicity makes the repository more approachable.
    
add missing kustomization.yaml at keypoints in the repository.