### PR TITLE
v1.14 Backports 2023-12-13

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -96,7 +96,10 @@ jobs:
         run: |
           cd /tmp/generated/azure
 
-          if [ "${{ github.event_name }}" == "schedule" ];then
+          # Use complete matrix in case of scheduled run
+          # main -> event_name = schedule
+          # other stable branches -> PR-number starting with v (e.g. v1.14)
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
             cp azure.json /tmp/matrix.json
           else
             jq '{ "include": [ .include[] | select(.default) ] }' azure.json > /tmp/matrix.json

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -96,7 +96,10 @@ jobs:
         run: |
           cd /tmp/generated/aws
 
-          if [ "${{ github.event_name }}" == "schedule" ];then
+          # Use complete matrix in case of scheduled run
+          # main -> event_name = schedule
+          # other stable branches -> PR-number starting with v (e.g. v1.14)
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
             cp aws.json /tmp/matrix.json
           else
             jq '{ "include": [ .include[] | select(.default) ] }' aws.json > /tmp/matrix.json

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -238,6 +238,16 @@ jobs:
           cilium status --wait
           kubectl get pods -n kube-system
 
+      - name: Check that AWS iptables chains have not been removed
+        run: |
+          for pod in $(kubectl get po -n kube-system -l app.kubernetes.io/name=cilium-agent -o name); do
+            echo "Checking ${pod}"
+            if ! kubectl exec -n kube-system  ${pod} -c cilium-agent -- iptables-save | grep --silent ':AWS'; then
+              echo "Expected AWS iptables chains are not present"
+              exit 1
+            fi
+          done
+
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -300,7 +300,6 @@ jobs:
           image-version: ${{ matrix.kernel }}
           host-mount: ./
           cpu: 4
-          dns-resolver: '1.1.1.1'
           install-dependencies: 'true'
           cmd: |
             git config --global --add safe.directory /host

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -96,7 +96,10 @@ jobs:
         run: |
           cd /tmp/generated/aws
 
-          if [ "${{ github.event_name }}" == "schedule" ];then
+          # Use complete matrix in case of scheduled run
+          # main -> event_name = schedule
+          # other stable branches -> PR-number starting with v (e.g. v1.14)
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
             cp aws.json /tmp/matrix.json
           else
             jq '{ "include": [ .include[] | select(.default) ] }' aws.json > /tmp/matrix.json

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -235,6 +235,17 @@ jobs:
           cilium status --wait
           kubectl get pods -n kube-system
 
+      - name: Check that AWS leftover iptables chains have been removed
+        run: |
+          for pod in $(kubectl get po -n kube-system -l app.kubernetes.io/name=cilium-agent -o name); do
+            echo "Checking ${pod}"
+            if kubectl exec -n kube-system  ${pod} -c cilium-agent -- iptables-save | grep --silent ':AWS'; then
+              echo "Unexpected AWS leftover iptables chains"
+              kubectl exec -n kube-system ds/cilium -- iptables-save | grep ':AWS'
+              exit 1
+            fi
+          done
+
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -96,7 +96,10 @@ jobs:
         run: |
           cd /tmp/generated/gke
 
-          if [ "${{ github.event_name }}" == "schedule" ];then
+          # Use complete matrix in case of scheduled run
+          # main -> event_name = schedule
+          # other stable branches -> PR-number starting with v (e.g. v1.14)
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
             jq '{ "include": [ .k8s[] ] }' gke.json > /tmp/matrix.json
           else
             jq '{ "include": [ .k8s[] | select(.default) ] }' gke.json > /tmp/matrix.json

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -280,7 +280,6 @@ jobs:
           host-mount: ./
           cpu: 4
           mem: 12G
-          dns-resolver: '1.1.1.1'
           cmd: |
             git config --global --add safe.directory /host
             mv /host/helm /usr/bin

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -101,7 +101,10 @@ jobs:
         run: |
           cd /tmp/generated/gke
 
-          if [ "${{ github.event_name }}" == "schedule" ];then
+          # Use complete matrix in case of scheduled run
+          # main -> event_name = schedule
+          # other stable branches -> PR-number starting with v (e.g. v1.14)
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
             cp gke.json /tmp/matrix.json
           else
             jq '{ "k8s": [ .k8s[] | select(.default) ], "config": .config}' gke.json > /tmp/matrix.json

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -242,7 +242,6 @@ jobs:
           image-version: ${{ matrix.kernel }}
           host-mount: ./
           cpu: 4
-          dns-resolver: '1.1.1.1'
           install-dependencies: 'true'
           cmd: |
             git config --global --add safe.directory /host

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -326,7 +326,6 @@ jobs:
             export VMUSER=root
             echo '127.0.0.1 localhost' >> /etc/hosts
             echo '::1 localhost' >> /etc/hosts
-            sed -i '1s/^/nameserver 1.1.1.1\n/' /etc/resolv.conf
             /tmp/provision/runtime_install.sh
             service docker restart
 

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -327,6 +327,7 @@ jobs:
             export VMUSER=root
             echo '127.0.0.1 localhost' >> /etc/hosts
             echo '::1 localhost' >> /etc/hosts
+            sed -i '1s/^/nameserver 1.1.1.1\n/' /etc/resolv.conf
             /tmp/provision/runtime_install.sh
             service docker restart
 

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -260,7 +260,6 @@ jobs:
           host-mount: ./
           cpu: 4
           mem: 12G
-          dns-resolver: '1.1.1.1'
 
       # Load Ginkgo build from GitHub
       - name: Load ${{ matrix.name }} Ginkgo build from GitHub

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -119,9 +119,6 @@ jobs:
           "
 
           # * bpf.masquerade is disabled due to #23283
-          # * IPv6 is disabled because an issue under investigation seems to
-          #   possibly cause seldom and brief connection disruptions on agent
-          #   restart in dual stack clusters, independently of clustermesh.
           # * Hubble is disabled to avoid the performance penalty in the testing
           #   environment due to the relatively high traffic load.
           CILIUM_INSTALL_DEFAULTS=" \
@@ -131,7 +128,7 @@ jobs:
             --set=hubble.enabled=false \
             --set=tunnel=vxlan \
             --set=ipv4.enabled=true \
-            --set=ipv6.enabled=false \
+            --set=ipv6.enabled=true \
             --set=clustermesh.useAPIServer=true \
             --set=clustermesh.config.enabled=true"
 

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -128,7 +128,7 @@ jobs:
           cmd: |
             cd /host
             mkdir datapath-verifier
-            find test/verifier -name "*.log" -o -name "*.o" -exec cp {} datapath-verifier/ \;
+            find test/verifier \( -name "*.log" -o -name "*.o" \) -exec cp -v {} datapath-verifier/ \;
 
       - name: Upload artifacts
         if: ${{ !success() }}

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -106,7 +106,6 @@ jobs:
           image-version: ${{ matrix.kernel }}
           host-mount: ./
           cpu: 4
-          dns-resolver: '1.1.1.1'
           install-dependencies: 'true'
           cmd: |
             git config --global --add safe.directory /host

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -248,7 +248,6 @@ jobs:
           host-mount: ./
           cpu: 4
           mem: '12G'
-          dns-resolver: '1.1.1.1'
           install-dependencies: 'true'
           cmd: |
             git config --global --add safe.directory /host

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
@@ -1148,7 +1147,7 @@ func restoreExecPermissions(searchDir string, patterns ...string) error {
 
 func initLogging() {
 	// add hooks after setting up metrics in the option.Config
-	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook(components.CiliumAgentName))
+	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook())
 
 	// Logging should always be bootstrapped first. Do not add any code above this!
 	if err := logging.SetupLogging(option.Config.LogDriver, logging.LogOptions(option.Config.LogOpt), "cilium-agent", option.Config.Debug); err != nil {

--- a/install/kubernetes/cilium/files/agent/poststart-eni.bash
+++ b/install/kubernetes/cilium/files/agent/poststart-eni.bash
@@ -11,9 +11,9 @@ set -o nounset
 # dependencies on anything that is part of the startup script
 # itself, and can be safely run multiple times per node (e.g. in
 # case of a restart).
-if [[ "$(iptables-save | grep -c 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN')" != "0" ]];
+if [[ "$(iptables-save | grep -E -c 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN')" != "0" ]];
 then
     echo 'Deleting iptables rules created by the AWS CNI VPC plugin'
-    iptables-save | grep -v 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN' | iptables-restore
+    iptables-save | grep -E -v 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN' | iptables-restore
 fi
 echo 'Done!'

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cilium/cilium/operator/pkg/ingress"
 	"github.com/cilium/cilium/operator/pkg/lbipam"
 	operatorWatchers "github.com/cilium/cilium/operator/watchers"
-	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/hive"
@@ -228,8 +227,8 @@ func initEnv() {
 	option.Config.Populate(vp)
 	operatorOption.Config.Populate(vp)
 
-	// add hooks after setting up metrics in the option.Confog
-	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook(components.CiliumOperatortName))
+	// add hooks after setting up metrics in the option.Config
+	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook())
 
 	// Logging should always be bootstrapped first. Do not add any code above this!
 	if err := logging.SetupLogging(option.Config.LogDriver, logging.LogOptions(option.Config.LogOpt), binaryName, option.Config.Debug); err != nil {

--- a/pkg/hubble/parser/common/endpoint.go
+++ b/pkg/hubble/parser/common/endpoint.go
@@ -15,6 +15,14 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
+type DatapathContext struct {
+	SrcIP                 netip.Addr
+	SrcLabelID            uint32
+	DstIP                 netip.Addr
+	DstLabelID            uint32
+	TraceObservationPoint pb.TraceObservationPoint
+}
+
 type EndpointResolver struct {
 	log            logrus.FieldLogger
 	endpointGetter getters.EndpointGetter
@@ -36,7 +44,7 @@ func NewEndpointResolver(
 	}
 }
 
-func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdentity uint32) *pb.Endpoint {
+func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdentity uint32, context DatapathContext) *pb.Endpoint {
 	// The datapathSecurityIdentity parameter is the numeric security identity
 	// obtained from the datapath.
 	// The numeric identity from the datapath can differ from the one we obtain
@@ -45,29 +53,76 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 	// created and the time the event reaches the Hubble parser.
 	// To aid in troubleshooting, we want to preserve what the datapath observed
 	// when it made the policy decision.
-	resolveIdentityConflict := func(identity identity.NumericIdentity) uint32 {
+	resolveIdentityConflict := func(userspaceID identity.NumericIdentity, isLocalEndpoint bool) uint32 {
 		// if the datapath did not provide an identity (e.g. FROM_LXC trace
 		// points), use what we have in the user-space cache
-		userspaceSecurityIdentity := identity.Uint32()
-		if datapathSecurityIdentity == 0 {
-			return userspaceSecurityIdentity
+		datapathID := identity.NumericIdentity(datapathSecurityIdentity)
+		if datapathID == identity.IdentityUnknown {
+			return userspaceID.Uint32()
 		}
 
-		if datapathSecurityIdentity != userspaceSecurityIdentity {
-			r.log.WithFields(logrus.Fields{
-				logfields.Identity:    datapathSecurityIdentity,
-				logfields.OldIdentity: userspaceSecurityIdentity,
-				logfields.IPAddr:      ip,
-			}).Debugf("stale identity observed")
+		if datapathID != userspaceID {
+			if context.TraceObservationPoint == pb.TraceObservationPoint_TO_OVERLAY &&
+				ip == context.SrcIP && datapathID.Uint32() == context.SrcLabelID &&
+				datapathID == identity.ReservedIdentityRemoteNode &&
+				userspaceID == identity.ReservedIdentityHost {
+				// Ignore
+				//
+				// When encapsulating a packet for sending via the overlay network, if the source
+				// seclabel = HOST_ID, then we reassign seclabel with LOCAL_NODE_ID and then send
+				// a trace notify.
+			} else if context.TraceObservationPoint == pb.TraceObservationPoint_FROM_ENDPOINT &&
+				ip == context.SrcIP && datapathID.Uint32() == context.SrcLabelID &&
+				(datapathID == identity.ReservedIdentityHealth || !datapathID.IsReservedIdentity()) &&
+				userspaceID.IsWorld() {
+				// Ignore
+				//
+				// Sometimes packets from endpoint link-local addresses are intercepted by
+				// cil_from_container. Because link-local addresses are not stored in the IP cache,
+				// Hubble assigns them WORLD_ID.
+			} else if context.TraceObservationPoint == pb.TraceObservationPoint_FROM_HOST &&
+				ip == context.SrcIP && datapathID.Uint32() == context.SrcLabelID &&
+				datapathID.IsWorld() && userspaceID == identity.ReservedIdentityKubeAPIServer {
+				// Ignore
+				//
+				// When a pod sends a packet to the Kubernetes API, its IP is masqueraded and then
+				// when it receives a response and the masquerade is reversed, cil_from_host
+				// determines that the source ID is WORLD_ID because there is no packet mark.
+			} else if (context.TraceObservationPoint == pb.TraceObservationPoint_FROM_HOST ||
+				context.TraceObservationPoint == pb.TraceObservationPoint_TO_OVERLAY) &&
+				ip == context.SrcIP && datapathID.Uint32() == context.SrcLabelID &&
+				isLocalEndpoint && userspaceID == identity.ReservedIdentityHost {
+				// Ignore
+				//
+				// When proxied packets (via Cilium DNS proxy) are sent from the host their source
+				// IP is that of the host, yet their security identity is retained from the
+				// original source pod.
+			} else if context.TraceObservationPoint == pb.TraceObservationPoint_TO_ENDPOINT &&
+				ip == context.SrcIP && datapathID.Uint32() == context.SrcLabelID &&
+				!datapathID.IsReservedIdentity() &&
+				(userspaceID == identity.ReservedIdentityHost || userspaceID == identity.ReservedIdentityRemoteNode) {
+				// Ignore
+				//
+				// When proxied packets (via Cilium DNS proxy) are received by the destination
+				// host their source IP is that of the proxy, yet their security identity is
+				// retained from the original source pod. This is a similar case to #4, but on the
+				// receiving side.
+			} else {
+				r.log.WithFields(logrus.Fields{
+					logfields.Identity:    datapathID.Uint32(),
+					logfields.OldIdentity: userspaceID.Uint32(),
+					logfields.IPAddr:      ip,
+				}).Debugf("stale identity observed")
+			}
 		}
 
-		return datapathSecurityIdentity
+		return datapathID.Uint32()
 	}
 
 	// for local endpoints, use the available endpoint information
 	if r.endpointGetter != nil {
 		if ep, ok := r.endpointGetter.GetEndpointInfo(ip); ok {
-			epIdentity := resolveIdentityConflict(ep.GetIdentity())
+			epIdentity := resolveIdentityConflict(ep.GetIdentity(), true)
 			e := &pb.Endpoint{
 				ID:        uint32(ep.GetID()),
 				Identity:  epIdentity,
@@ -90,7 +145,7 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 	var namespace, podName string
 	if r.ipGetter != nil {
 		if ipIdentity, ok := r.ipGetter.LookupSecIDByIP(ip); ok {
-			numericIdentity = resolveIdentityConflict(ipIdentity.ID)
+			numericIdentity = resolveIdentityConflict(ipIdentity.ID, false)
 		}
 		if meta := r.ipGetter.GetK8sMetadata(ip); meta != nil {
 			namespace, podName = meta.Namespace, meta.PodName

--- a/pkg/hubble/parser/sock/parser.go
+++ b/pkg/hubble/parser/sock/parser.go
@@ -94,8 +94,14 @@ func (p *Parser) Decode(data []byte, decoded *flowpb.Flow) error {
 	srcIP, _ := ippkg.AddrFromIP(epIP)
 	srcPort := uint16(0) // source port is not known for TraceSock events
 
-	srcEndpoint := p.epResolver.ResolveEndpoint(srcIP, 0)
-	dstEndpoint := p.epResolver.ResolveEndpoint(dstIP, 0)
+	datapathContext := common.DatapathContext{
+		SrcIP:      srcIP,
+		SrcLabelID: 0,
+		DstIP:      dstIP,
+		DstLabelID: 0,
+	}
+	srcEndpoint := p.epResolver.ResolveEndpoint(srcIP, 0, datapathContext)
+	dstEndpoint := p.epResolver.ResolveEndpoint(dstIP, 0, datapathContext)
 
 	// On the reverse path, source and destination IP of the packet are reversed
 	isRevNat := decodeRevNat(sock.XlatePoint)

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -186,8 +186,15 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	}
 
 	srcLabelID, dstLabelID := decodeSecurityIdentities(dn, tn, pvn)
-	srcEndpoint := p.epResolver.ResolveEndpoint(srcIP, srcLabelID)
-	dstEndpoint := p.epResolver.ResolveEndpoint(dstIP, dstLabelID)
+	datapathContext := common.DatapathContext{
+		SrcIP:                 srcIP,
+		SrcLabelID:            srcLabelID,
+		DstIP:                 dstIP,
+		DstLabelID:            dstLabelID,
+		TraceObservationPoint: decoded.TraceObservationPoint,
+	}
+	srcEndpoint := p.epResolver.ResolveEndpoint(srcIP, srcLabelID, datapathContext)
+	dstEndpoint := p.epResolver.ResolveEndpoint(dstIP, dstLabelID, datapathContext)
 	var sourceService, destinationService *pb.Service
 	if p.serviceGetter != nil {
 		sourceService = p.serviceGetter.GetServiceByAddr(srcIP, srcPort)

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -556,3 +556,8 @@ func iterateReservedIdentityLabels(f func(_ NumericIdentity, _ labels.Labels)) {
 func (id NumericIdentity) HasLocalScope() bool {
 	return (id & LocalIdentityFlag) != 0
 }
+
+// IsWorld returns true if the identity is the world identity
+func (id NumericIdentity) IsWorld() bool {
+	return id == ReservedIdentityWorld
+}

--- a/pkg/metrics/cell.go
+++ b/pkg/metrics/cell.go
@@ -9,4 +9,12 @@ var Cell = cell.Module("metrics", "Metrics",
 	cell.Invoke(NewRegistry),
 	cell.Metric(NewLegacyMetrics),
 	cell.Config(defaultRegistryConfig),
+	cell.Invoke(func() {
+		// This is a hack to ensure that errors/warnings collected in the pre hive initialization
+		// phase are emitted as metrics.
+		if metricsInitialized != nil {
+			close(metricsInitialized)
+			metricsInitialized = nil
+		}
+	}),
 )

--- a/pkg/metrics/logging_hook.go
+++ b/pkg/metrics/logging_hook.go
@@ -24,10 +24,6 @@ type LoggingHook struct {
 // NewLoggingHook returns a new instance of LoggingHook for the given Cilium
 // component.
 func NewLoggingHook() *LoggingHook {
-	// NOTE(mrostecki): For now errors and warning metric exists only for Cilium
-	// daemon, but support of Prometheus metrics in some other components (i.e.
-	// cilium-health - GH-4268) is planned.
-
 	lh := &LoggingHook{}
 	go func() {
 		// This channel is closed after registry is created. At this point if the errs/warnings metric

--- a/pkg/metrics/logging_hook.go
+++ b/pkg/metrics/logging_hook.go
@@ -6,39 +6,42 @@ package metrics
 import (
 	"fmt"
 	"reflect"
+	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/metrics/metric"
 )
+
+var metricsInitialized chan struct{} = make(chan struct{})
 
 // LoggingHook is a hook for logrus which counts error and warning messages as a
 // Prometheus metric.
 type LoggingHook struct {
-	metric metric.Vec[metric.Counter]
+	errs, warn atomic.Uint64
 }
 
 // NewLoggingHook returns a new instance of LoggingHook for the given Cilium
 // component.
-func NewLoggingHook(component string) *LoggingHook {
+func NewLoggingHook() *LoggingHook {
 	// NOTE(mrostecki): For now errors and warning metric exists only for Cilium
 	// daemon, but support of Prometheus metrics in some other components (i.e.
 	// cilium-health - GH-4268) is planned.
 
-	// Pick a metric for the component.
-	var metric metric.Vec[metric.Counter]
-	switch component {
-	case components.CiliumAgentName:
-		metric = ErrorsWarnings
-	case components.CiliumOperatortName:
-		metric = ErrorsWarnings
-	default:
-		panic(fmt.Sprintf("component %s is unsupported by LoggingHook", component))
-	}
-
-	return &LoggingHook{metric: metric}
+	lh := &LoggingHook{}
+	go func() {
+		// This channel is closed after registry is created. At this point if the errs/warnings metric
+		// is enabled we flush counts of errors/warnings we collected before the registry was created.
+		// This is a hack to ensure that errors/warnings collected in the pre hive initialization
+		// phase are emitted as metrics.
+		// Because the ErrorsWarnings metric is a counter, this means that the rate of these errors won't be
+		// accurate, however init errors can only happen during initialization so it probably doesn't make
+		// a big difference in practice.
+		<-metricsInitialized
+		ErrorsWarnings.WithLabelValues(logrus.ErrorLevel.String(), "init").Add(float64(lh.errs.Load()))
+		ErrorsWarnings.WithLabelValues(logrus.WarnLevel.String(), "init").Add(float64(lh.warn.Load()))
+	}()
+	return lh
 }
 
 // Levels returns the list of logging levels on which the hook is triggered.
@@ -66,8 +69,16 @@ func (h *LoggingHook) Fire(entry *logrus.Entry) error {
 		return fmt.Errorf("type of the 'subsystem' log entry field is not string but %s", reflect.TypeOf(iSubsystem))
 	}
 
+	// We count errors/warnings outside of the prometheus metric.
+	switch entry.Level {
+	case logrus.ErrorLevel:
+		h.errs.Add(1)
+	case logrus.WarnLevel:
+		h.warn.Add(1)
+	}
+
 	// Increment the metric.
-	h.metric.WithLabelValues(entry.Level.String(), subsystem).Inc()
+	ErrorsWarnings.WithLabelValues(entry.Level.String(), subsystem).Inc()
 
 	return nil
 }

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -17,6 +17,19 @@ sudo systemctl restart ssh
 
 "${PROVISIONSRC}"/dns.sh
 
+sudo systemctl status systemd-resolved.service || true
+# Remove symlinked resolv.conf to systemd-resolved
+rm /etc/resolv.conf
+# Remove systemd-resolvd resolv.conf to avoid being read by docker
+rm /run/systemd/resolve/stub-resolv.conf || true
+# Explicitly set nameserver 1.1.1.1 for runtime tests
+# to avoid chases with Cilium DNS
+echo "nameserver 1.1.1.1" > /etc/resolv.conf
+cat /etc/resolv.conf
+
+# Restarting docker to use correct nameserver
+service docker restart
+
 if [[ "${PROVISION_EXTERNAL_WORKLOAD}" == "false" ]]; then
     "${PROVISIONSRC}"/compile.sh
     "${PROVISIONSRC}"/wait-cilium-in-docker.sh


### PR DESCRIPTION
 * [x] #27894 (@leblowl)
    - :information_source: Introduced a simplified version of the `identity.IsWorld()` method, which was not present in v1.14, as added in a94fa56f6713 ("Fix CIDR to World Entity Conversion Bug")
 * [x] #29455 (@mhofstetter)
   - :information_source: Skipped changes in tests-e2e-upgrade.yaml, as not present in v1.14.
 * [ ] ~~#29625 (@tklauser)~~ 
   - :x: Dropped based on https://github.com/cilium/cilium/pull/29863#issuecomment-1854108601.
 * [x] #29694 (@mhofstetter)
 * [x] #29201 (@tommyp1ckles)
   - :information_source: Dropped the Registry parameter from the new invoke function in `pkg/metrics/cell.go`, as it is not provided.
 * [x] #29448 (@giorio94)
 * [x] #29675 (@giorio94)
 * [x] #29670 (@giorio94)
 * [x] #29752 (@lmb)
 * [x] #29502 (@mhofstetter)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 27894 29455 29694 29201 29448 29675 29670 29752 29502
```
