### PR TITLE
identity: stop double-update of selector cache and regenerate when a local identity is allocated

### DIFF
--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -339,7 +339,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	defer mgr.Close()
 	defer mgr.IdentityAllocator.DeleteAllKeys()
 
-	id, isNew, err := mgr.AllocateIdentity(context.Background(), lbls1, false, identity.InvalidIdentity)
+	id, isNew, err := mgr.AllocateIdentity(context.Background(), lbls1, true, identity.InvalidIdentity)
 	c.Assert(id, Not(IsNil))
 	c.Assert(err, IsNil)
 	c.Assert(isNew, Equals, true)
@@ -349,7 +349,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	c.Assert(owner.GetIdentity(id.ID), checker.DeepEquals, lbls1.LabelArray())
 
 	// reuse the same identity
-	id, isNew, err = mgr.AllocateIdentity(context.Background(), lbls1, false, identity.InvalidIdentity)
+	id, isNew, err = mgr.AllocateIdentity(context.Background(), lbls1, true, identity.InvalidIdentity)
 	c.Assert(id, Not(IsNil))
 	c.Assert(err, IsNil)
 	c.Assert(isNew, Equals, false)
@@ -358,7 +358,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	c.Assert(cache[id.ID], Not(IsNil))
 
 	// 1st Release, not released
-	released, err := mgr.Release(context.Background(), id, false)
+	released, err := mgr.Release(context.Background(), id, true)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, false)
 
@@ -366,7 +366,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	c.Assert(owner.GetIdentity(id.ID), checker.DeepEquals, lbls1.LabelArray())
 
 	// 2nd Release, released
-	released, err = mgr.Release(context.Background(), id, false)
+	released, err = mgr.Release(context.Background(), id, true)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
 
@@ -378,13 +378,13 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	cache = mgr.GetIdentityCache()
 	c.Assert(cache[id.ID], IsNil)
 
-	id, isNew, err = mgr.AllocateIdentity(context.Background(), lbls1, false, identity.InvalidIdentity)
+	id, isNew, err = mgr.AllocateIdentity(context.Background(), lbls1, true, identity.InvalidIdentity)
 	c.Assert(id, Not(IsNil))
 	c.Assert(err, IsNil)
 	c.Assert(isNew, Equals, true)
 	c.Assert(id.ID.HasLocalScope(), Equals, true)
 
-	released, err = mgr.Release(context.Background(), id, false)
+	released, err = mgr.Release(context.Background(), id, true)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
 

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -347,9 +347,9 @@ func (m *CachingIdentityAllocator) AllocateIdentity(ctx context.Context, lbls la
 	// then allocate with the appropriate local allocator and return.
 	switch identity.ScopeForLabels(lbls) {
 	case identity.IdentityScopeLocal:
-		return m.localIdentities.lookupOrCreate(lbls, oldNID)
+		return m.localIdentities.lookupOrCreate(lbls, oldNID, notifyOwner)
 	case identity.IdentityScopeRemoteNode:
-		return m.localNodeIdentities.lookupOrCreate(lbls, oldNID)
+		return m.localNodeIdentities.lookupOrCreate(lbls, oldNID, notifyOwner)
 	}
 
 	// This will block until the kvstore can be accessed and all identities
@@ -433,9 +433,9 @@ func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Ide
 
 	switch identity.ScopeForLabels(id.Labels) {
 	case identity.IdentityScopeLocal:
-		return m.localIdentities.release(id), nil
+		return m.localIdentities.release(id, notifyOwner), nil
 	case identity.IdentityScopeRemoteNode:
-		return m.localNodeIdentities.release(id), nil
+		return m.localNodeIdentities.release(id, notifyOwner), nil
 	}
 
 	// This will block until the kvstore can be accessed and all identities

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -248,7 +248,6 @@ const (
 	delMissingService          = "Deleting no longer present service"                                      // cf. https://github.com/cilium/cilium/issues/29679
 	failedIpcacheRestore       = "Failed to restore existing identities from the previous ipcache"         // cf. https://github.com/cilium/cilium/issues/29328
 	podCIDRUnavailable         = " PodCIDR not available"                                                  // cf. https://github.com/cilium/cilium/issues/29680
-	delMissingIdentity         = "Skipping Delete of a non-existing identity"                              // cf. https://github.com/cilium/cilium/issues/29681
 	wipEnvoyFeature            = "envoy/extensions/bootstrap/internal_listener/v3/internal_listener.proto" // cf. https://github.com/cilium/cilium/issues/29682
 	unableGetNode              = "Unable to get node resource"                                             // cf. https://github.com/cilium/cilium/issues/29710
 	disableSocketLBTracing     = "Disabling socket-LB tracing"                                             // cf. https://github.com/cilium/cilium/issues/29734
@@ -338,7 +337,7 @@ var badLogMessages = map[string][]string{
 		removeInexistentID, failedToListCRDs, retrieveResLock, failedToRelLockEmptyName,
 		failedToUpdateLock, failedToReleaseLock, errorCreatingInitialLeader},
 	logutils.WarningLogs: {cantEnableJIT, delMissingService, failedIpcacheRestore,
-		podCIDRUnavailable, delMissingIdentity, wipEnvoyFeature, unableGetNode,
+		podCIDRUnavailable, wipEnvoyFeature, unableGetNode,
 		disableSocketLBTracing, sessionAffinitySocketLB, objectHasBeenModified, noBackendResponse,
 		unsupportedSocketLookup, legacyBGPFeature, etcdTimeout, endpointRestoreFailed,
 		failedPeerSync, policyMapSyncFix, unableRestoreRouterIP, routerIPReallocated,


### PR DESCRIPTION
As I was looking in to some issues, I discovered that we are still regenerating all endpoints whenever we allocated a new local identity. This is not necessary, since we already have an incremental policy update engine.

This has been the case for some time, but it is a lot more relevant since #29036, which moved FQDN policy over to this code-path.

### Background:
The `AllocateIdentity()` function takes a parameter, `notifyOwner`. When this is `true`, any newly allocated identities are passed to the policy engine by the identity allocator and an endpoint regeneration is triggered. However, there is a funny inconsistency: if the identity is local (i.e. a CIDR identity), then `notifyOwner` is ignored and the policy engine is always updated. Incidentally, as part of updating the policy engine, **all endpoints are regenerated**.

However, the only source of local (CIDR) identities now is the IPCache, which already has its own policy update mechanism. There is one missed case -- fixed in this PR -- so there really is no need to ignore `notifyOwner`. This is, also, the only caller where `AllocateIdentity(notifyOwner = false)`.

### The fix:

1. Push allocated identities in to the policy engine with the legacy / synchronous ipcache `AllocateCIDRs()` / `releaseCIDRIdentities()` calls too. These methods are only have one caller: the ServiceHandler that translates `toServices:` policy rules to a CIDR selector.
2. Make the local identity allocator respect `notifyOwner`, and don't pass policy updates when it is `false`.

### What's changed?
It's useful to look at the flow, just to understand the full context of what's changed

#### Before:
1. Something calls `ipcache.UpsertMetadata(prefix, ...`)
2. The ipcache calls `AllocateIdentity(labels, notifyOwner = false)`
3. The allocator calls `SelectorCache.UpdateIdentities(...)` and `RegenerateAllEndpoints()`
4. The ipcache *also* calls `SelectorCache.UpdateIdentities()` and `UpdatePolicyMaps()`

#### After:
1. Something calls `ipcache.UpsertMetadata(prefix, ...`)
2. The ipcache calls `AllocateIdentity(labels, notifyOwner = false)`
3. The ipcache calls `SelectorCache.UpdateIdentities()` and `UpdatePolicyMaps()`

So, this change is safe, in that it is not possible for a new identity to be missed.

Fixes: #29681
Fixes: #29846
