### PR TITLE
hubble: Add an interface for Parser struct

### DIFF
--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -53,7 +53,7 @@ type LocalObserverServer struct {
 	log logrus.FieldLogger
 
 	// payloadParser decodes flowpb.Payload into flowpb.Flow
-	payloadParser *parser.Parser
+	payloadParser parser.Decoder
 
 	opts observeroption.Options
 
@@ -68,7 +68,7 @@ type LocalObserverServer struct {
 
 // NewLocalServer returns a new local observer server.
 func NewLocalServer(
-	payloadParser *parser.Parser,
+	payloadParser parser.Decoder,
 	namespaceManager NamespaceManager,
 	logger logrus.FieldLogger,
 	options ...observeroption.Option,
@@ -197,7 +197,7 @@ func (s *LocalObserverServer) GetStopped() chan struct{} {
 }
 
 // GetPayloadParser implements GRPCServer.GetPayloadParser.
-func (s *LocalObserverServer) GetPayloadParser() *parser.Parser {
+func (s *LocalObserverServer) GetPayloadParser() parser.Decoder {
 	return s.payloadParser
 }
 

--- a/pkg/hubble/parser/parser.go
+++ b/pkg/hubble/parser/parser.go
@@ -25,6 +25,12 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
 
+// Decoder is an interface for the parser.
+// It decodes a monitor event into a hubble event.
+type Decoder interface {
+	Decode(monitorEvent *observerTypes.MonitorEvent) (*v1.Event, error)
+}
+
 // Parser for all flows
 type Parser struct {
 	l34  *threefour.Parser

--- a/pkg/hubble/parser/parser.go
+++ b/pkg/hubble/parser/parser.go
@@ -28,6 +28,7 @@ import (
 // Decoder is an interface for the parser.
 // It decodes a monitor event into a hubble event.
 type Decoder interface {
+	// Decode transforms a monitor event into a hubble event.
 	Decode(monitorEvent *observerTypes.MonitorEvent) (*v1.Event, error)
 }
 


### PR DESCRIPTION
# Description

Currently
- the `Parser` module is missing an interface
- The `LocalObserverServer` struct uses the `Parser` struct directly, instead of using an interface. This is in contrast to the other parameters it accepts like `NamespaceManager`, which is an interface.

# What this change does?

Submitting a minor fix to
- add an interface called `Decoder` for the `Parser` module
- use the `Decoder` interface instead of the `Parser` struct

# Testing done

```bash
$ make build-container
...
<succeeds>
```

Ran unit tests locally.

Fixes: N/A

Signed-off-by: Anubhab Majumdar <anmajumdar@microsoft.com>
