### PR TITLE
bpf: ipv4: always return drop reason from ipv4_handle_fragmentation()

### DIFF
--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -160,7 +160,7 @@ ipv4_handle_fragmentation(struct __ctx_buff *ctx,
 	/* load sport + dport into tuple */
 	ret = l4_load_ports(ctx, l4_off, (__be16 *)ports);
 	if (ret < 0)
-		return ret;
+		return DROP_CT_INVALID_HDR;
 
 	if (unlikely(is_fragment)) {
 		/* First logical fragment for this datagram (not necessarily the first


### PR DESCRIPTION
To make it easy for callers, ipv4_handle_fragmentation() should always return a DROP_* reason on error. But for errors from l4_load_ports() we're currently just propagating those raw errors back.

Return a drop reason instead. This also makes us consistent with the non-fragment path in ipv4_load_l4_ports().