### PR TITLE
CI: Fix Artifact Creation Failure Due to Invalid Character in Name

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -401,7 +401,11 @@ jobs:
         if: ${{ !success() && (matrix.focus == 'agent' || matrix.focus == 'datapath') }}
         shell: bash
         run: |
-          tar -zcf test_results-${{ join(matrix.*, '-') }}.tar.gz ./test/test_results
+          if [ -e ./test/test_results ];then
+            tar -zcf 'test_results-${{ matrix.focus }}.tar.gz' ./test/test_results
+          else
+            echo "::warning::test results directory is not exist!"
+          fi
 
       - name: Upload artifacts
         if: ${{ !success() && (matrix.focus == 'agent' || matrix.focus == 'datapath') }}


### PR DESCRIPTION
Resolved an issue where the creation of tar archives was failing. The failure was caused by the presence of an invalid '|' character in the archive name. This update modifies the archive naming process to only use 'matrix.focus', ensuring the name is valid and the archive creation succeeds.

Fixes: #29852

[Example run](https://github.com/cilium/cilium/actions/runs/7208058270/job/19636307803) that show changes works
