### PR TITLE
helm: Allow unsupported K8s versions for now

### DIFF
--- a/install/kubernetes/cilium/Chart.yaml
+++ b/install/kubernetes/cilium/Chart.yaml
@@ -4,7 +4,7 @@ displayName: Cilium
 home: https://cilium.io/
 version: 1.16.0-dev
 appVersion: 1.16.0-dev
-kubeVersion: ">= 1.26.0-0"
+kubeVersion: ">= 1.16.0-0"
 icon: https://cdn.jsdelivr.net/gh/cilium/cilium@main/Documentation/images/logo-solo.svg
 description: eBPF-based Networking, Security, and Observability
 keywords:

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -18,7 +18,7 @@ efficient and flexible.
 
 ## Prerequisites
 
-* Kubernetes: `>= 1.26.0-0`
+* Kubernetes: `>= 1.16.0-0`
 * Helm: `>= 3.0`
 
 ## Getting Started


### PR DESCRIPTION
Commit 9b016904f8aa7db90ab8fc3539933562d80c022f bumped the `kubeVersion` in the Helm chart to K8s 1.26, which is effectively the oldest Kubernetes version we officially supported.

However, this change now prevents the installation of Cilium against Kubernetes versions which we don't officially support, but are still used in CI (e.g. ci-eks, ci-aks, ci-gke, ext-workload). To unbreak CI, let's relax that restriction for now.

Reported-by: Marco Hofstetter <marco.hofstetter@isovalent.com>
