### PR TITLE
Conformance AKS: wait for cilium-test namespace deletion during uninstallation 

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -253,7 +253,7 @@ jobs:
       - name: Clean up Cilium
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" || test $? -eq 1
-          cilium uninstall
+          cilium uninstall --wait
 
       - name: Create custom IPsec secret
         run: |


### PR DESCRIPTION
Add the wait flag to cilium uninstall in Conformance AKS, so that we ensure that the cilium-test namespace gets effectively deleted before uninstalling and reinstalling Cilium. This ensures that the connectivity tests can then be started correctly (i.e., that the namespace can be created) and prevents Cilium errors such as:

>   msg="Cannot create CEP" error="... forbidden: unable to create new content  in namespace cilium-test because it is being terminated"

Finally, it brings also consistency with what we already do in the other workflows.

For https://github.com/cilium/cilium-cli/pull/2184