### PR TITLE
gateway-api: fix status reconcile error handling

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -60,11 +60,6 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	gw := original.DeepCopy()
-	defer func() {
-		if err := r.updateStatus(ctx, original, gw); err != nil {
-			scopedLog.WithError(err).Error("Unable to update Gateway status")
-		}
-	}()
 
 	// Step 2: Gather all required information for the ingestion model
 	gwc := &gatewayv1.GatewayClass{}
@@ -74,41 +69,41 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			Error("Unable to get GatewayClass")
 		if k8serrors.IsNotFound(err) {
 			setGatewayAccepted(gw, false, "GatewayClass does not exist")
-			return controllerruntime.Fail(err)
+			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 		}
 		setGatewayAccepted(gw, false, "Unable to get GatewayClass")
-		return controllerruntime.Fail(err)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
 	httpRouteList := &gatewayv1.HTTPRouteList{}
 	if err := r.Client.List(ctx, httpRouteList); err != nil {
 		scopedLog.WithError(err).Error("Unable to list HTTPRoutes")
-		return controllerruntime.Fail(err)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
 	grpcRouteList := &gatewayv1alpha2.GRPCRouteList{}
 	if err := r.Client.List(ctx, grpcRouteList); err != nil {
 		scopedLog.WithError(err).Error("Unable to list GRPCRoutes")
-		return controllerruntime.Fail(err)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
 	tlsRouteList := &gatewayv1alpha2.TLSRouteList{}
 	if err := r.Client.List(ctx, tlsRouteList); err != nil {
 		scopedLog.WithError(err).Error("Unable to list TLSRoutes")
-		return controllerruntime.Fail(err)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
 	// TODO(tam): Only list the services used by accepted Routes
 	servicesList := &corev1.ServiceList{}
 	if err := r.Client.List(ctx, servicesList); err != nil {
 		scopedLog.WithError(err).Error("Unable to list Services")
-		return controllerruntime.Fail(err)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
 	grants := &gatewayv1beta1.ReferenceGrantList{}
 	if err := r.Client.List(ctx, grants); err != nil {
 		scopedLog.WithError(err).Error("Unable to list ReferenceGrants")
-		return controllerruntime.Fail(err)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
 	httpListeners, tlsListeners := ingestion.GatewayAPI(ingestion.Input{
@@ -124,7 +119,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err := r.setListenerStatus(ctx, gw, httpRouteList, tlsRouteList); err != nil {
 		scopedLog.WithError(err).Error("Unable to set listener status")
 		setGatewayAccepted(gw, false, "Unable to set listener status")
-		return controllerruntime.Fail(err)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 	setGatewayAccepted(gw, true, "Gateway successfully scheduled")
 
@@ -133,35 +128,39 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err != nil {
 		scopedLog.WithError(err).Error("Unable to translate resources")
 		setGatewayAccepted(gw, false, "Unable to translate resources")
-		return controllerruntime.Fail(err)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
 	if err = r.ensureService(ctx, svc); err != nil {
 		scopedLog.WithError(err).Error("Unable to create Service")
 		setGatewayAccepted(gw, false, "Unable to create Service resource")
-		return controllerruntime.Fail(err)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
 	if err = r.ensureEndpoints(ctx, ep); err != nil {
 		scopedLog.WithError(err).Error("Unable to ensure Endpoints")
 		setGatewayAccepted(gw, false, "Unable to ensure Endpoints resource")
-		return controllerruntime.Fail(err)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
 	if err = r.ensureEnvoyConfig(ctx, cec); err != nil {
 		scopedLog.WithError(err).Error("Unable to ensure CiliumEnvoyConfig")
 		setGatewayAccepted(gw, false, "Unable to ensure CEC resource")
-		return controllerruntime.Fail(err)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
 	// Step 4: Update the status of the Gateway
 	if err = r.setAddressStatus(ctx, gw); err != nil {
 		scopedLog.WithError(err).Error("Address is not ready")
 		setGatewayProgrammed(gw, false, "Address is not ready")
-		return controllerruntime.Fail(err)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
 	setGatewayProgrammed(gw, true, "Gateway successfully reconciled")
+	if err := r.updateStatus(ctx, original, gw); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update Gateway status: %w", err)
+	}
+
 	scopedLog.Info("Successfully reconciled Gateway")
 	return controllerruntime.Success()
 }
@@ -515,4 +514,12 @@ func isValidPemFormat(b []byte) bool {
 		return true
 	}
 	return isValidPemFormat(rest)
+}
+
+func (r *gatewayReconciler) handleReconcileErrorWithStatus(ctx context.Context, reconcileErr error, original *gatewayv1.Gateway, modified *gatewayv1.Gateway) (ctrl.Result, error) {
+	if err := r.updateStatus(ctx, original, modified); err != nil {
+		return controllerruntime.Fail(fmt.Errorf("failed to update Gateway status while handling the reconcile error %w: %w", reconcileErr, err))
+	}
+
+	return controllerruntime.Fail(reconcileErr)
 }

--- a/operator/pkg/gateway-api/httproute_reconcile.go
+++ b/operator/pkg/gateway-api/httproute_reconcile.go
@@ -49,16 +49,11 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	hr := original.DeepCopy()
-	defer func() {
-		if err := r.updateStatus(ctx, original, hr); err != nil {
-			scopedLog.WithError(err).Error("Failed to update HTTPRoute status")
-		}
-	}()
 
 	// check if this cert is allowed to be used by this gateway
 	grants := &gatewayv1beta1.ReferenceGrantList{}
 	if err := r.Client.List(ctx, grants); err != nil {
-		return controllerruntime.Fail(fmt.Errorf("failed to retrieve reference grants: %w", err))
+		return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to retrieve reference grants: %w", err), original, hr)
 	}
 
 	// input for the validators
@@ -99,7 +94,7 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		} {
 			continueCheck, err := fn(i, parent)
 			if err != nil {
-				return ctrl.Result{}, err
+				return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to apply Gateway check: %w", err), original, hr)
 			}
 
 			if !continueCheck {
@@ -113,9 +108,18 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		routechecks.CheckBackendIsService,
 		routechecks.CheckBackendIsExistingService,
 	} {
-		if continueCheck, err := fn(i); err != nil || !continueCheck {
-			return ctrl.Result{}, err
+		continueCheck, err := fn(i)
+		if err != nil {
+			return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to apply Backend check: %w", err), original, hr)
 		}
+
+		if !continueCheck {
+			break
+		}
+	}
+
+	if err := r.updateStatus(ctx, original, hr); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update HTTPRoute status: %w", err)
 	}
 
 	scopedLog.Info("Successfully reconciled HTTPRoute")
@@ -131,4 +135,12 @@ func (r *httpRouteReconciler) updateStatus(ctx context.Context, original *gatewa
 		return nil
 	}
 	return r.Client.Status().Update(ctx, new)
+}
+
+func (r *httpRouteReconciler) handleReconcileErrorWithStatus(ctx context.Context, reconcileErr error, original *gatewayv1.HTTPRoute, modified *gatewayv1.HTTPRoute) (ctrl.Result, error) {
+	if err := r.updateStatus(ctx, original, modified); err != nil {
+		return controllerruntime.Fail(fmt.Errorf("failed to update HTTPRoute status while handling the reconcile error %w: %w", reconcileErr, err))
+	}
+
+	return controllerruntime.Fail(reconcileErr)
 }

--- a/operator/pkg/gateway-api/tlsroute_reconcile.go
+++ b/operator/pkg/gateway-api/tlsroute_reconcile.go
@@ -50,16 +50,11 @@ func (r *tlsRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	tr := original.DeepCopy()
-	defer func() {
-		if err := r.updateStatus(ctx, original, tr); err != nil {
-			scopedLog.WithError(err).Error("Failed to update TLSRoute status")
-		}
-	}()
 
 	// check if this cert is allowed to be used by this gateway
 	grants := &gatewayv1beta1.ReferenceGrantList{}
 	if err := r.Client.List(ctx, grants); err != nil {
-		return controllerruntime.Fail(fmt.Errorf("failed to retrieve reference grants: %w", err))
+		return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to retrieve reference grants: %w", err), original, tr)
 	}
 
 	// input for the validators
@@ -100,7 +95,7 @@ func (r *tlsRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		} {
 			continueCheck, err := fn(i, parent)
 			if err != nil {
-				return ctrl.Result{}, err
+				return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to apply route check: %w", err), original, tr)
 			}
 
 			if !continueCheck {
@@ -116,9 +111,18 @@ func (r *tlsRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		routechecks.CheckBackendIsService,
 		routechecks.CheckBackendIsExistingService,
 	} {
-		if continueCheck, err := fn(i); err != nil || !continueCheck {
-			return ctrl.Result{}, err
+		continueCheck, err := fn(i)
+		if err != nil {
+			return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to apply Gateway check: %w", err), original, tr)
 		}
+
+		if !continueCheck {
+			break
+		}
+	}
+
+	if err := r.updateStatus(ctx, original, tr); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update TLSRoute status: %w", err)
 	}
 
 	scopedLog.Info("Successfully reconciled TLSRoute")
@@ -134,4 +138,12 @@ func (r *tlsRouteReconciler) updateStatus(ctx context.Context, original *gateway
 		return nil
 	}
 	return r.Client.Status().Update(ctx, new)
+}
+
+func (r *tlsRouteReconciler) handleReconcileErrorWithStatus(ctx context.Context, reconcileErr error, original *gatewayv1alpha2.TLSRoute, modified *gatewayv1alpha2.TLSRoute) (ctrl.Result, error) {
+	if err := r.updateStatus(ctx, original, modified); err != nil {
+		return controllerruntime.Fail(fmt.Errorf("failed to update TLSRoute status while handling the reconcile error %w: %w", reconcileErr, err))
+	}
+
+	return controllerruntime.Fail(reconcileErr)
 }


### PR DESCRIPTION
Currently, errors during writing the status in the defer function aren't returned to the caller (controller-runtime). Hence, a successful reconciliation (error = nil) but a failure during writing the status would result in a non-updated status (because it wouldn't result in an additional reconciliation).

To avoid having to introduce named return params (to let the defer function modifying the returned error), this commit gets rid of the defer statement at all and replaced it with explicit calls to a newly introduced function `handleReconcileErrorWithStatus` that tries to update the resource status and reflects any errors during updating the status in the returned error.

Info: it's not that uncommon to hit this issue that the status can't be written. At least during the execution of the Gateway API Conformance tests (that's were i detected this error message). Hence, it's important to ensure a proper reconcile and logging in these cases too.