### PR TITLE
Fix log error in clustermesh-apiserver when connecting external workloads 

### DIFF
--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -177,6 +177,8 @@ func (n *NodeDiscovery) JoinCluster(nodeName string) error {
 		if resp.IPv6AllocCIDR != nil {
 			ln.IPv6AllocCIDR = resp.IPv6AllocCIDR
 		}
+
+		ln.NodeIdentity = resp.NodeIdentity
 	})
 
 	identity.SetLocalNodeID(resp.NodeIdentity)


### PR DESCRIPTION
During external workloads initialization, the clustermesh-apiserver allocates a new identity for the external workload, which is then propagated through etcd to the agent running on the external workload; yet, the agent eventually overrides it with the default value (1).

While this appears to be harmless from a functional point of view, as the clustermesh-apiserver configures the original identity as part of the associated the CiliumNode and CiliumEndpoint resources (which are then watched by the other agents), it also triggers an error, due to the unexpected mismatch:

>   CEW: Invalid identity 1 in ...

Let's fix this by avoiding to override the originally assigned identity from the external workload agent.

For https://github.com/cilium/cilium-cli/pull/2184