### PR TITLE
[v1.13] node: Fix IP removal from ipset on node updates

### DIFF
--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -54,8 +54,9 @@ function update_docker_and_buildx() {
 
   sudo apt-get update
   sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  sudo apt-get -y install ipset
   mkdir -vp ~/.docker/cli-plugins/
-  
+
   case `uname -m` in
     'x86_64' )
       curl --silent -L "https://github.com/docker/buildx/releases/download/v0.12.0/buildx-v0.12.0.linux-amd64" > ~/.docker/cli-plugins/docker-buildx

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -51,8 +51,8 @@ const (
 	ciliumForwardChain    = "CILIUM_FORWARD"
 	feederDescription     = "cilium-feeder:"
 	xfrmDescription       = "cilium-xfrm-notrack:"
-	ciliumNodeIpsetV4     = "cilium_node_set_v4"
-	ciliumNodeIpsetV6     = "cilium_node_set_v6"
+	CiliumNodeIpsetV4     = "cilium_node_set_v4"
+	CiliumNodeIpsetV6     = "cilium_node_set_v6"
 )
 
 // Minimum iptables versions supporting the -w and -w<seconds> flags
@@ -105,8 +105,8 @@ func (ipt *ipt) initArgs(waitSeconds int) {
 
 // package name is iptables so we use ip4tables internally for "iptables"
 var (
-	ip4tables = &ipt{prog: "iptables", ipset: ciliumNodeIpsetV4}
-	ip6tables = &ipt{prog: "ip6tables", ipset: ciliumNodeIpsetV6}
+	ip4tables = &ipt{prog: "iptables", ipset: CiliumNodeIpsetV4}
+	ip6tables = &ipt{prog: "ip6tables", ipset: CiliumNodeIpsetV6}
 	ipset     = &ipt{prog: "ipset"}
 )
 
@@ -1067,9 +1067,9 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 // or the IP already exist.
 func AddToNodeIpset(nodeIP net.IP) {
 	scopedLog := log.WithField(logfields.IPAddr, nodeIP.String())
-	ciliumNodeIpset := ciliumNodeIpsetV4
+	ciliumNodeIpset := CiliumNodeIpsetV4
 	if ip.IsIPv6(nodeIP) {
-		ciliumNodeIpset = ciliumNodeIpsetV6
+		ciliumNodeIpset = CiliumNodeIpsetV6
 	}
 	if err := createIpset(ciliumNodeIpset, ip.IsIPv6(nodeIP)); err != nil {
 		scopedLog.WithError(err).Errorf("Failed to create ipset %s", ciliumNodeIpset)
@@ -1084,9 +1084,9 @@ func AddToNodeIpset(nodeIP net.IP) {
 // RemoveFromBodeIpset removes an IP address from the ipset for cluster nodes.
 func RemoveFromNodeIpset(nodeIP net.IP) {
 	scopedLog := log.WithField(logfields.IPAddr, nodeIP.String())
-	ciliumNodeIpset := ciliumNodeIpsetV4
+	ciliumNodeIpset := CiliumNodeIpsetV4
 	if ip.IsIPv6(nodeIP) {
-		ciliumNodeIpset = ciliumNodeIpsetV6
+		ciliumNodeIpset = CiliumNodeIpsetV6
 	}
 	progArgs := []string{"del", ciliumNodeIpset, nodeIP.String()}
 	if err := ipset.runProg(progArgs); err != nil {
@@ -1253,7 +1253,7 @@ func createIpset(name string, ipv6 bool) error {
 	return ipset.runProg(progArgs)
 }
 
-func removeIpset(name string) error {
+func RemoveIpset(name string) error {
 	if !ipsetExists(name) {
 		return nil
 	}
@@ -1265,6 +1265,22 @@ func ipsetExists(name string) bool {
 	progArgs := []string{"list", name}
 	err := ipset.runProg(progArgs)
 	return err == nil
+}
+
+func IpsetContains(setName string, ip string) bool {
+	progArgs := []string{"list", setName}
+	set, err := ipset.runProgOutput(progArgs)
+	if err != nil {
+		log.WithError(err).Warningf("Failed to dump ipset %s", setName)
+		return false
+	}
+	lines := strings.Split(set, "\n")
+	for _, line := range lines {
+		if line == ip {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *IptablesManager) installHostTrafficMarkRule(prog iptablesInterface) error {
@@ -1373,20 +1389,20 @@ func (m *IptablesManager) doInstallRules(ifName string, firstInitialization, ins
 	// needed depends on the configuration, but the content doesn't.
 	if option.Config.NodeIpsetNeeded() {
 		if option.Config.IptablesMasqueradingIPv4Enabled() {
-			if err := createIpset(ciliumNodeIpsetV4, false); err != nil {
+			if err := createIpset(CiliumNodeIpsetV4, false); err != nil {
 				return err
 			}
 		}
 		if option.Config.IptablesMasqueradingIPv6Enabled() {
-			if err := createIpset(ciliumNodeIpsetV6, true); err != nil {
+			if err := createIpset(CiliumNodeIpsetV6, true); err != nil {
 				return err
 			}
 		}
 	} else {
-		if err := removeIpset(ciliumNodeIpsetV4); err != nil {
+		if err := RemoveIpset(CiliumNodeIpsetV4); err != nil {
 			return err
 		}
-		if err := removeIpset(ciliumNodeIpsetV6); err != nil {
+		if err := RemoveIpset(CiliumNodeIpsetV6); err != nil {
 			return err
 		}
 	}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -527,18 +527,18 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		// Delete the old node IP addresses if they have changed in this node.
 		var oldNodeIPAddrs []string
 		for _, address := range oldNode.IPAddresses {
-			if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP &&
-				!slices.Contains(ipsAdded, address.IP.String()) {
-				iptables.RemoveFromNodeIpset(address.IP)
-			}
-			if skipIPCache(address) {
-				continue
-			}
 			var prefix netip.Prefix
 			if v4 := address.IP.To4(); v4 != nil {
 				prefix = ip.IPToNetPrefix(v4)
 			} else {
 				prefix = ip.IPToNetPrefix(address.IP.To16())
+			}
+			if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP &&
+				!slices.Contains(ipsAdded, prefix.String()) {
+				iptables.RemoveFromNodeIpset(address.IP)
+			}
+			if skipIPCache(address) {
+				continue
 			}
 			oldNodeIPAddrs = append(oldNodeIPAddrs, prefix.String())
 		}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -68,6 +68,7 @@ type Configuration interface {
 	TunnelingEnabled() bool
 	RemoteNodeIdentitiesEnabled() bool
 	NodeEncryptionEnabled() bool
+	NodeIpsetNeeded() bool
 }
 
 // Notifier is the interface the wraps Subscribe and Unsubscribe. An
@@ -419,7 +420,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			tunnelIP = nodeIP
 		}
 
-		if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
+		if m.conf.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
 			iptables.AddToNodeIpset(address.IP)
 		}
 
@@ -533,7 +534,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			} else {
 				prefix = ip.IPToNetPrefix(address.IP.To16())
 			}
-			if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP &&
+			if m.conf.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP &&
 				!slices.Contains(ipsAdded, prefix.String()) {
 				iptables.RemoveFromNodeIpset(address.IP)
 			}
@@ -679,7 +680,7 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 	}
 
 	for _, address := range entry.node.IPAddresses {
-		if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
+		if m.conf.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
 			iptables.RemoveFromNodeIpset(address.IP)
 		}
 

--- a/pkg/node/manager/manager_privileged_test.go
+++ b/pkg/node/manager/manager_privileged_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build linux
+
+package manager
+
+import (
+	"net"
+	"strings"
+	"time"
+
+	"gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/datapath/iptables"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+type managerPrivilegedTestSuite struct{}
+
+var _ = check.Suite(&managerPrivilegedTestSuite{})
+
+func (s *managerPrivilegedTestSuite) SetUpSuite(c *check.C) {
+	testutils.PrivilegedCheck(c)
+}
+
+func (c *configMock) NodeIpsetNeeded() bool {
+	return !c.Tunneling && (c.EnableIPv4Masquerade || c.EnableIPv6Masquerade)
+}
+
+// TestNodeIpset tests that the ipset entries on the node are updated correctly
+// when a node is updated or removed.
+// It is inspired from TestNode() in manager_test.go.
+func (s *managerPrivilegedTestSuite) TestNodeIpset(c *check.C) {
+	ipcacheMock := newIPcacheMock()
+	ipsetExpect := func(ip string, expected bool) {
+		setName := iptables.CiliumNodeIpsetV6
+		if v4 := net.ParseIP(ip).To4(); v4 != nil {
+			setName = iptables.CiliumNodeIpsetV4
+		}
+		found := iptables.IpsetContains(setName, strings.ToLower(ip))
+		if found && !expected {
+			c.Errorf("ipset %s contains IP %s but it should not", setName, ip)
+		}
+		if !found && expected {
+			c.Errorf("ipset %s does not contain expected IP %s", setName, ip)
+		}
+	}
+
+	dp := newSignalNodeHandler()
+	dp.EnableNodeAddEvent = true
+	dp.EnableNodeUpdateEvent = true
+	dp.EnableNodeDeleteEvent = true
+	mngr, err := NewManager("test", dp, &configMock{
+		// Tunneling and EnableIPv4Masquerade are disabled and enabled,
+		// respectively, to make sure we update the ipset in the
+		// manager (see NodeIpsetNeeded()).
+		Tunneling:            false,
+		EnableIPv4Masquerade: true,
+		// RemoteNodeIdentity is enabled to make sure we don't skip the
+		// ipcache update in NodeUpdated(), and in particular, the
+		// update to ipsAdded.
+		//
+		// Note: If we don't updated ipsAdded, NodeUpdated() will
+		// remove the ipset entry it just added. I'm not sure whether
+		// this is intended or not, if the ipset entry is not needed in
+		// that case we should check before adding it; if it is needed
+		// even without the ipcache update, then we might have a bug.
+		// Bug this has changed and works differently on the "main'
+		// branch, so I didn't want to change the code too much here.
+		// So we just enable RemoteNodeIdentity for our test.
+		RemoteNodeIdentity: true,
+	}, nil, nil)
+	mngr = mngr.WithIPCache(ipcacheMock)
+	c.Assert(err, check.IsNil)
+	defer mngr.Close()
+	defer iptables.RemoveIpset(iptables.CiliumNodeIpsetV4)
+	defer iptables.RemoveIpset(iptables.CiliumNodeIpsetV6)
+
+	n1 := nodeTypes.Node{
+		Name:    "node1",
+		Cluster: "c1",
+		IPAddresses: []nodeTypes.Address{
+			{
+				Type: addressing.NodeCiliumInternalIP,
+				IP:   net.ParseIP("192.0.2.1"),
+			},
+			{
+				Type: addressing.NodeCiliumInternalIP,
+				IP:   net.ParseIP("2001:DB8::1"),
+			},
+			{
+				Type: addressing.NodeInternalIP,
+				IP:   net.ParseIP("10.0.0.1"),
+			},
+			{
+				Type: addressing.NodeInternalIP,
+				IP:   net.ParseIP("2001:ABCD::1"),
+			},
+		},
+		IPv4HealthIP: net.ParseIP("192.0.2.2"),
+		IPv6HealthIP: net.ParseIP("2001:DB8::2"),
+		Source:       source.KVStore,
+	}
+	mngr.NodeUpdated(n1)
+
+	select {
+	case nodeEvent := <-dp.NodeAddEvent:
+		c.Assert(nodeEvent, checker.DeepEquals, n1)
+	case nodeEvent := <-dp.NodeUpdateEvent:
+		c.Errorf("Unexpected NodeUpdate() event %#v", nodeEvent)
+	case nodeEvent := <-dp.NodeDeleteEvent:
+		c.Errorf("Unexpected NodeDelete() event %#v", nodeEvent)
+	case <-time.After(3 * time.Second):
+		c.Errorf("timeout while waiting for NodeAdd() event")
+	}
+
+	ipsetExpect("192.0.2.1", false)
+	ipsetExpect("2001:DB8::1", false)
+	ipsetExpect("10.0.0.1", true)
+	ipsetExpect("2001:ABCD::1", true)
+
+	n1.IPv4HealthIP = net.ParseIP("192.0.2.20")
+	mngr.NodeUpdated(n1)
+
+	select {
+	case nodeEvent := <-dp.NodeAddEvent:
+		c.Errorf("Unexpected NodeAdd() event %#v", nodeEvent)
+	case nodeEvent := <-dp.NodeUpdateEvent:
+		c.Assert(nodeEvent, checker.DeepEquals, n1)
+	case nodeEvent := <-dp.NodeDeleteEvent:
+		c.Errorf("Unexpected NodeDelete() event %#v", nodeEvent)
+	case <-time.After(3 * time.Second):
+		c.Errorf("timeout while waiting for NodeUpdate() event")
+	}
+
+	ipsetExpect("192.0.2.1", false)
+	ipsetExpect("2001:DB8::1", false)
+	ipsetExpect("10.0.0.1", true)
+	ipsetExpect("2001:ABCD::1", true)
+
+	mngr.NodeDeleted(n1)
+	select {
+	case nodeEvent := <-dp.NodeDeleteEvent:
+		c.Assert(nodeEvent, checker.DeepEquals, n1)
+	case nodeEvent := <-dp.NodeAddEvent:
+		c.Errorf("Unexpected NodeAdd() event %#v", nodeEvent)
+	case nodeEvent := <-dp.NodeUpdateEvent:
+		c.Errorf("Unexpected NodeUpdate() event %#v", nodeEvent)
+	case <-time.After(3 * time.Second):
+		c.Errorf("timeout while waiting for NodeDelete() event")
+	}
+
+	ipsetExpect("192.0.2.1", false)
+	ipsetExpect("2001:DB8::1", false)
+	ipsetExpect("10.0.0.1", false)
+	ipsetExpect("2001:ABCD::1", false)
+}

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -34,10 +34,12 @@ type managerTestSuite struct{}
 var _ = check.Suite(&managerTestSuite{})
 
 type configMock struct {
-	Tunneling          bool
-	RemoteNodeIdentity bool
-	NodeEncryption     bool
-	Encryption         bool
+	Tunneling            bool
+	RemoteNodeIdentity   bool
+	NodeEncryption       bool
+	Encryption           bool
+	EnableIPv4Masquerade bool
+	EnableIPv6Masquerade bool
 }
 
 func (c *configMock) TunnelingEnabled() bool {

--- a/pkg/option/fake/config.go
+++ b/pkg/option/fake/config.go
@@ -32,6 +32,12 @@ func (f *Config) EncryptionEnabled() bool {
 	return true
 }
 
+// NodeIpsetNeeded returns true if masquerading rules require entries to be
+// added to an ipset for this node
+func (f *Config) NodeIpsetNeeded() bool {
+	return false
+}
+
 // NodeEncryptionEnabled returns true if node encryption is enabled
 func (f *Config) NodeEncryptionEnabled() bool {
 	return true


### PR DESCRIPTION
In CI, on upgrade/downgrade tests for IPsec, we have observed regular failures on some workflows for the node-to-node-encryption test. In this test, we look for some unencrypted packets from a client pod to a host on a distinct node; but sometimes, these packets do not show up.

Investigation showed that the packets do show up, but not with the expected IP address, thus failing to be caught by the tcpdump filter in use. In the failure state, instead of having the client pod IP as source address, packets have the origin host IP as source address. This is not supposed to happen: we use an iptables rule to exclude packets from masquerading in such case. Why then masquerading still occur? This is because the rule doesn't apply, the relevant host IP being missing in the ipset used by the rule.

Looking at the agent, the relevant node IP is missing from the ipset because on node updates, we sometimes remove it, when we should not. And the reason for that is that we're not comparing the right values to decide whether this removal should happen. Indeed, in the following:

    !slices.Contains(ipsAdded, address.IP.String())

The `address.IP.String()` represents a mere IP address, when the values added to ipsAdded are `netip.Prefix.String()`, containing the IP followed by a CIDR mask with the slash notation. For an example, `ipsAdded` can be `[172.19.0.2/32 fc00:c111::2/128]`, and `address.IP.String()` can be `172.19.0.2` (no CIDR mask): the search fails and we do remove the IP from the ipset, even if we just added it above in the function.

This commit fixes the comparison to ensure that we're looking for the relevant values in the slice, which in turns fixes the set of IPs contained in the ipset, and applies the masquerading exclusion to the relevant packets.

Related: https://github.com/cilium/cilium/issues/29351
