### PR TITLE
contrib: Autodetect GITHUB_TOKEN during release

### DIFF
--- a/contrib/release/prep-changelog.sh
+++ b/contrib/release/prep-changelog.sh
@@ -58,6 +58,7 @@ main() {
     local ersion="$(echo $2 | sed 's/^v//')"
     local version="v$ersion"
     local old_branch="$(echo $3 | sed 's/^v//')"
+    local GITHUB_TOKEN=${GITHUB_TOKEN:-"$(gh auth token)"}
 
     logecho "Generating CHANGELOG.md"
     rm -f $RELNOTESCACHE

--- a/contrib/release/prep-changelog.sh
+++ b/contrib/release/prep-changelog.sh
@@ -45,6 +45,10 @@ handle_args() {
         usage 2>&1
         common::exit 1 "Invalid OLD-BRANCH ARG \"$3\"; Expected X.Y"
     fi
+
+    if ! gh auth status >/dev/null; then
+        common::exit 1 "Failed to authenticate with GitHub"
+    fi
 }
 
 main() {

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -56,6 +56,10 @@ handle_args() {
         git status -s | grep -v "^??"
         common::exit 1 "Unmerged changes in tree prevent preparing release PR."
     fi
+
+    if ! gh auth status >/dev/null; then
+        common::exit 1 "Failed to authenticate with GitHub"
+    fi
 }
 
 main() {


### PR DESCRIPTION
If the GITHUB_TOKEN variable is not set, try to create it via local CLI.
