### PR TITLE
ci: Add a call to the update label backport action

### DIFF
--- a/.github/workflows/call-backport-label-updater.yaml
+++ b/.github/workflows/call-backport-label-updater.yaml
@@ -1,0 +1,39 @@
+---
+  name: Call Backport Label Updater
+  on:
+    pull_request_target:
+      types:
+        - closed
+      branches:
+        - v[0-9]+.[0-9]+
+
+  jobs:
+    get-branch:
+      name: Detect base branch
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          branch: ["1.12", "1.13", "1.14", "1.15"]
+      outputs:
+          version: ${{ steps.get-branch.outputs.version }}
+      if: |
+        github.event.pull_request.merged == true &&
+        contains(github.event.pull_request.body, 'upstream-prs') &&
+        contains(join(github.event.pull_request.labels.*.name, ', '), 'backport/')
+      steps:
+        - name: Get Branch
+          id: get-branch
+          run: |
+            if echo ",${{ github.event.pull_request.labels.*.name }}," | grep -q ",backport/${{ matrix.branch }},"; then
+              echo "version=${{ matrix.branch }}" >> "$GITHUB_OUTPUT"
+            fi
+
+    call-backport-label-updater:
+      name: Update backport labels for upstream PR
+      needs: get-branch
+      if: ${{needs.get-branch.outputs.version}} != ''
+      uses: cilium/cilium/.github/workflows/update-label-backport-pr.yaml@main
+      with:
+        pr-body: ${{ github.event.pull_request.body }}
+        branch: ${{needs.get-branch.outputs.version}}
+      secrets: inherit


### PR DESCRIPTION
Add an action to call the workflow that update the labels of backported
PRs in all stable branches.

This commit is based on the following commits by Fabio from v1.14 branch:
- 81ade5f693b8 ("ci: Call the workflow to update labels of backported PRs")
- a5a047f2fa84 ("ci: Use pull_request_target in update label workflow")

The primary change here is to list all maintained branches in a single
workflow on main in order to simplify the maintenance burden when
creating new stable branches (eg, during v1.15 stable branch creation).

This action will not trigger from the main branch for PRs targeted to
stable branches. However, when we copy this workflow to stable branches,
it will run for PRs targeted to that stable branch (assuming that the
versions referenced in this file are kept in sync with the branch
version).

Related: https://github.com/cilium/cilium/pull/27875

Tested here: https://github.com/pippolo84/gh-action-label-test/actions/runs/6773033350/job/18406926291