### PR TITLE
docs: Add stubs for v1.16 upgrade notes

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -302,6 +302,40 @@ Annotations:
 
 .. _current_release_required_changes:
 
+.. _1.16_upgrade_notes:
+
+1.16 Upgrade Notes
+------------------
+
+* To be determined during v1.16 development.
+
+Removed Options
+~~~~~~~~~~~~~~~
+
+* TBD
+
+Helm Options
+~~~~~~~~~~~~
+
+* TBD
+
+Added Metrics
+~~~~~~~~~~~~~
+
+* TBD
+
+Removed Metrics
+~~~~~~~~~~~~~~~
+
+The following deprecated metrics were removed:
+
+* TBD
+
+Changed Metrics
+~~~~~~~~~~~~~~~
+
+* TBD
+
 .. _1.15_upgrade_notes:
 
 1.15 Upgrade Notes


### PR DESCRIPTION
Add stubs in the upgrade docs so that developers can add new upgrade
notes here for the later v1.16 release. Until v1.15.0 is out, it makes
sense to keep the existing 1.15 section around to simplify backports.
After v1.15.0 we can delete that section.

Fixes: 9b016904f8aa ("Prepare for v1.16 development cycle")
Fixes: #29802
