### PR TITLE
contrib: Fix post-release.sh for branch candidates

### DIFF
--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -94,3 +94,15 @@ version_is_prerelease() {
             ;;
     esac
 }
+
+# $1 - VERSION
+version_is_rc() {
+    case "$1" in
+        *rc*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}

--- a/contrib/release/post-release.sh
+++ b/contrib/release/post-release.sh
@@ -75,7 +75,7 @@ main() {
     logrun hub release create -d -F $version-release-summary.txt $version
     logecho "Browse to $RELEASES_URL to see the draft release"
 
-    if version_is_prerelease "$version"; then
+    if version_is_prerelease "$version" && ! version_is_rc "$version"; then
         # No digest updates for main branch for prereleases.
         return
     fi


### PR DESCRIPTION
When we prepare release candidates on branches, we need to update the
helm values and submit a PR to update the branch. Make sure that
happens.
