### PR TITLE
k8s: Bump CRD schema version to 1.27.x

### DIFF
--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.26.11"
+	CustomResourceDefinitionSchemaVersion = "1.27.0"
 )


### PR DESCRIPTION
Somehow we missed bumping the minor schema version release during the
v1.14 dev cycle. This creates a mild danger for conflict with 1.26.x
that is currently used by Cilium 1.13.x releases. Bump this up to 1.27.0
to reduce the risk of conflicting CRD schema versions between branches.
