### PR TITLE
statedb: Add Kubernetes StateDB reflector

### DIFF
--- a/pkg/statedb/observable.go
+++ b/pkg/statedb/observable.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/stream"
+)
+
+type Event[Obj any] struct {
+	Object   Obj
+	Revision Revision
+	Deleted  bool
+}
+
+// Observable creates an observable from the given table for observing the changes
+// to the table as a stream of events.
+//
+// For high-churn tables it's advisable to apply rate-limiting to the stream to
+// decrease overhead (stream.Throttle).
+func Observable[Obj any](db *DB, table Table[Obj]) stream.Observable[Event[Obj]] {
+	return &observable[Obj]{db, table}
+}
+
+type observable[Obj any] struct {
+	db    *DB
+	table Table[Obj]
+}
+
+func (to *observable[Obj]) Observe(ctx context.Context, next func(Event[Obj]), complete func(error)) {
+	go func() {
+		wtxn := to.db.WriteTxn(to.table)
+		dt, err := to.table.DeleteTracker(wtxn, "Observe")
+		wtxn.Commit()
+		if err != nil {
+			complete(err)
+			return
+		}
+
+		revision := Revision(0)
+		for {
+			var watch <-chan struct{}
+			revision, watch, _ = dt.Process(to.db.ReadTxn(), revision,
+				func(obj Obj, deleted bool, rev uint64) error {
+					next(Event[Obj]{
+						Object:   obj,
+						Revision: rev,
+						Deleted:  deleted,
+					})
+					return nil
+				})
+
+			select {
+			case <-ctx.Done():
+				dt.Close()
+				complete(nil)
+				return
+			case <-watch:
+			}
+		}
+	}()
+}

--- a/pkg/statedb/reflector/common.go
+++ b/pkg/statedb/reflector/common.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reflector
+
+import "github.com/cilium/cilium/pkg/hive"
+
+// Reflector reflects external data into a statedb table
+type Reflector[Obj any] interface {
+	hive.HookInterface // Can be started and stopped.
+}

--- a/pkg/statedb/reflector/doc.go
+++ b/pkg/statedb/reflector/doc.go
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// The reflector package provides a set of utilities to reflect external data into a statedb table.
+package reflector

--- a/pkg/statedb/reflector/k8s.go
+++ b/pkg/statedb/reflector/k8s.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reflector
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/stream"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type KubernetesConfig[Obj any] struct {
+	BufferSize     int                  // Maximum number of objects to commit in one transaction. Uses default if left zero.
+	BufferWaitTime time.Duration        // The amount of time to wait for the buffer to fill. Uses default if left zero.
+	ListerWatcher  cache.ListerWatcher  // The ListerWatcher to use to retrieve the objects
+	Transform      TransformFunc[Obj]   // Optional function to transform the objects given by the ListerWatcher
+	Table          statedb.RWTable[Obj] // The table to populate
+}
+
+// TransformFunc is an optional function to give to the Kubernetes source
+// to transform the object returned by the ListerWatcher to the desired
+// target object. If the function returns false the object is silently
+// skipped.
+type TransformFunc[Obj any] func(any) (obj Obj, ok bool)
+
+const (
+	DefaultBufferSize     = 64
+	DefaultBufferWaitTime = 50 * time.Millisecond
+)
+
+func (cfg KubernetesConfig[Obj]) getBufferSize() int {
+	if cfg.BufferSize == 0 {
+		return DefaultBufferSize
+	}
+	return cfg.BufferSize
+}
+
+func (cfg KubernetesConfig[Obj]) getWaitTime() time.Duration {
+	if cfg.BufferWaitTime == 0 {
+		return DefaultBufferWaitTime
+	}
+	return cfg.BufferWaitTime
+}
+
+type KubernetesParams[Obj any] struct {
+	cell.In
+
+	Config KubernetesConfig[Obj]
+	Jobs   job.Registry
+	Scope  cell.Scope
+	DB     *statedb.DB
+}
+
+// Kubernetes synchronizes statedb table with an external Kubernetes resource.
+// Returns a 'Source' for starting and stopping it. If the source can be started
+// unconditionally, consider using [KubernetesCell] instead.
+func Kubernetes[Obj any](p KubernetesParams[Obj]) Reflector[Obj] {
+	tr := &k8sSource[Obj]{
+		KubernetesConfig: p.Config,
+		db:               p.DB,
+	}
+	g := p.Jobs.NewGroup(p.Scope)
+	g.Add(job.OneShot("run", tr.run))
+	return g
+}
+
+// KubernetesCell returns a cell that constructs the Kubernetes source and
+// adds it to the the application lifecycle.
+// For dependencies see [KubernetesParams].
+func KubernetesCell[Obj any]() cell.Cell {
+	return cell.Group(
+		cell.ProvidePrivate(Kubernetes[Obj]),
+		cell.Invoke(func(s Reflector[Obj], lc hive.Lifecycle) { lc.Append(s) }),
+	)
+}
+
+type k8sSource[Obj any] struct {
+	KubernetesConfig[Obj]
+
+	db *statedb.DB
+}
+
+func (s *k8sSource[Obj]) run(ctx context.Context, health cell.HealthReporter) error {
+	type entry struct {
+		deleted   bool
+		name      string
+		namespace string
+		obj       Obj
+	}
+	type buffer map[string]entry
+	bufferSize := s.getBufferSize()
+	waitTime := s.getWaitTime()
+	table := s.Table
+
+	transform := s.Transform
+	if transform == nil {
+		// No provided transform function, use the identity function instead.
+		transform = TransformFunc[Obj](func(obj any) (Obj, bool) { return obj.(Obj), true })
+	}
+
+	// Construct a stream of K8s objects, buffered into chunks every 100 milliseconds.
+	// This reduces the number of write transactions required and thus the number of times
+	// readers get woken up, which results in much better overall throughput.
+	src := stream.Buffer(
+		k8sEventObservable(s.ListerWatcher),
+		bufferSize,
+		waitTime,
+
+		// Buffer the events into a map, coalescing them by key.
+		func(buf buffer, ev cacheStoreEvent) buffer {
+			if buf == nil {
+				buf = make(buffer, bufferSize)
+			}
+			var entry entry
+			entry.deleted = ev.Type == cacheStoreDelete
+
+			var key string
+			if d, ok := ev.Obj.(cache.DeletedFinalStateUnknown); ok {
+				key = d.Key
+				entry.namespace, entry.name, _ = cache.SplitMetaNamespaceKey(d.Key)
+
+				entry.obj, ok = transform(d.Obj)
+				if !ok {
+					return buf
+				}
+			} else {
+				meta, err := meta.Accessor(ev.Obj)
+				if err != nil {
+					panic(fmt.Sprintf("%T internal error: meta.Accessor failed: %s", s, err))
+				}
+				entry.name = meta.GetName()
+				if ns := meta.GetNamespace(); ns != "" {
+					key = ns + "/" + meta.GetName()
+					entry.namespace = ns
+				} else {
+					key = meta.GetName()
+				}
+
+				var ok bool
+				entry.obj, ok = transform(ev.Obj)
+				if !ok {
+					return buf
+				}
+			}
+			buf[key] = entry
+			return buf
+		},
+	)
+
+	commitBuffer := func(buf buffer) {
+		txn := s.db.WriteTxn(s.Table)
+		defer txn.Commit()
+
+		for _, entry := range buf {
+			if !entry.deleted {
+				table.Insert(txn, entry.obj)
+			} else {
+				table.Delete(txn, entry.obj)
+			}
+		}
+	}
+
+	errs := make(chan error)
+	src.Observe(
+		ctx,
+		commitBuffer,
+		func(err error) {
+			errs <- err
+			close(errs)
+		},
+	)
+	return <-errs
+}
+
+// k8sEventObservable turns a ListerWatcher into an observable using the client-go's Reflector.
+func k8sEventObservable(lw cache.ListerWatcher) stream.Observable[cacheStoreEvent] {
+	return stream.FuncObservable[cacheStoreEvent](
+		func(ctx context.Context, next func(cacheStoreEvent), complete func(err error)) {
+			store := &cacheStoreListener{
+				onAdd: func(obj any) {
+					next(cacheStoreEvent{cacheStoreAdd, obj})
+				},
+				onUpdate: func(obj any) { next(cacheStoreEvent{cacheStoreUpdate, obj}) },
+				onDelete: func(obj any) { next(cacheStoreEvent{cacheStoreDelete, obj}) },
+			}
+			reflector := cache.NewReflector(lw, nil, store, 0)
+			go func() {
+				reflector.Run(ctx.Done())
+				complete(nil)
+			}()
+		})
+}
+
+const (
+	cacheStoreAdd = iota
+	cacheStoreUpdate
+	cacheStoreDelete
+)
+
+type cacheStoreEvent struct {
+	Type int
+	Obj  any
+}
+
+// cacheStoreListener implements the methods used by the cache reflector and
+// calls the given handlers for added, updated and deleted objects.
+type cacheStoreListener struct {
+	onAdd, onUpdate, onDelete func(any)
+}
+
+func (s *cacheStoreListener) Add(obj interface{}) error {
+	s.onAdd(obj)
+	return nil
+}
+
+func (s *cacheStoreListener) Update(obj interface{}) error {
+	s.onUpdate(obj)
+	return nil
+}
+
+func (s *cacheStoreListener) Delete(obj interface{}) error {
+	s.onDelete(obj)
+	return nil
+}
+
+func (s *cacheStoreListener) Replace(items []interface{}, resourceVersion string) error {
+	for _, item := range items {
+		s.onAdd(item)
+	}
+	return nil
+}
+
+// These methods are never called by cache.Reflector:
+
+func (*cacheStoreListener) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	panic("unimplemented")
+}
+func (*cacheStoreListener) GetByKey(key string) (item interface{}, exists bool, err error) {
+	panic("unimplemented")
+}
+func (*cacheStoreListener) List() []interface{} { panic("unimplemented") }
+func (*cacheStoreListener) ListKeys() []string  { panic("unimplemented") }
+func (*cacheStoreListener) Resync() error       { panic("unimplemented") }
+
+var _ cache.Store = &cacheStoreListener{}

--- a/pkg/statedb/reflector/k8s_test.go
+++ b/pkg/statedb/reflector/k8s_test.go
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reflector_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/index"
+	"github.com/cilium/cilium/pkg/statedb/reflector"
+)
+
+func TestKubernetes(t *testing.T) {
+	podNameIndex := statedb.Index[*v1.Pod, string]{
+		Name: "name",
+		FromObject: func(p *v1.Pod) index.KeySet {
+			return index.NewKeySet(index.String(p.Namespace + "/" + p.Name))
+		},
+		FromKey: index.String,
+		Unique:  true,
+	}
+
+	table, err := statedb.NewTable[*v1.Pod]("pods", podNameIndex)
+	require.NoError(t, err, "NewTable")
+
+	type params struct {
+		cell.In
+
+		DB        *statedb.DB
+		Clientset client.Clientset
+	}
+	var p params
+
+	sourceConfig := func(cs client.Clientset) reflector.KubernetesConfig[*v1.Pod] {
+		lw := utils.ListerWatcherFromTyped[*v1.PodList](
+			cs.CoreV1().Pods(""),
+		)
+
+		return reflector.KubernetesConfig[*v1.Pod]{
+			ListerWatcher: lw,
+			Table:         table,
+		}
+	}
+
+	h := hive.New(
+		statedb.Cell,
+		job.Cell,
+		client.FakeClientCell,
+
+		cell.Module("test", "Test",
+			cell.ProvidePrivate(sourceConfig),
+			reflector.KubernetesCell[*v1.Pod](),
+
+			cell.Invoke(
+				func(db *statedb.DB) error {
+					return db.RegisterTable(table)
+				}),
+
+			cell.Invoke(func(p_ params) { p = p_ }),
+		),
+	)
+
+	require.NoError(t, h.Start(context.TODO()))
+
+	// Table is empty when starting.
+	txn := p.DB.ReadTxn()
+	iter, watch := table.All(txn)
+	objs := statedb.Collect[*v1.Pod](iter)
+	assert.Len(t, objs, 0)
+
+	// Insert a new pod and wait for table to update.
+	expectedPod := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod1", Namespace: "test1",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+	_, err = p.Clientset.CoreV1().Pods("test1").Create(
+		context.Background(), expectedPod, metav1.CreateOptions{})
+	require.NoError(t, err, "Create pod")
+
+	<-watch
+
+	// Table should now contain the new pod
+	txn = p.DB.ReadTxn()
+	iter, _ = table.All(txn)
+	objs = statedb.Collect[*v1.Pod](iter)
+	assert.Len(t, objs, 1)
+
+	// Pod can be retrieved by name
+	pod, _, ok := table.First(txn, podNameIndex.Query(expectedPod.Namespace+"/"+expectedPod.Name))
+	if assert.True(t, ok) && assert.NotNil(t, pod) {
+		assert.Equal(t, expectedPod.Name, pod.Name)
+	}
+
+	// Pod deletion can be observed
+	_, watch = table.All(txn)
+	err = p.Clientset.CoreV1().Pods("test1").Delete(context.Background(), "pod1", metav1.DeleteOptions{})
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	<-watch
+
+	iter, _ = table.All(p.DB.ReadTxn())
+	objs = statedb.Collect[*v1.Pod](iter)
+	assert.Len(t, objs, 0)
+
+	assert.NoError(t, h.Stop(context.TODO()))
+}
+
+func BenchmarkKubernetes(b *testing.B) {
+	logging.SetLogLevel(logrus.WarnLevel)
+
+	podNameIndex := statedb.Index[*v1.Pod, string]{
+		Name: "name",
+		FromObject: func(p *v1.Pod) index.KeySet {
+			return index.NewKeySet(index.String(p.Namespace + "/" + p.Name))
+		},
+		FromKey: index.String,
+		Unique:  true,
+	}
+
+	table, err := statedb.NewTable[*v1.Pod]("pods", podNameIndex)
+	require.NoError(b, err, "NewTable")
+
+	type params struct {
+		cell.In
+
+		DB        *statedb.DB
+		Clientset client.Clientset
+	}
+	var p params
+
+	// Don't use a buffer size larger than 100 since that's the limit
+	// for how much the fake client wants to buffer.
+	batchSize := 100
+
+	sourceConfig := func(cs client.Clientset) reflector.KubernetesConfig[*v1.Pod] {
+		lw := utils.ListerWatcherFromTyped[*v1.PodList](
+			cs.CoreV1().Pods(""),
+		)
+
+		return reflector.KubernetesConfig[*v1.Pod]{
+			BufferSize:     batchSize,
+			BufferWaitTime: time.Hour, // We want to only emit on full buffer
+			ListerWatcher:  lw,
+			Table:          table,
+		}
+	}
+
+	// Insert a new pod and wait for table to update.
+	expectedPod := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod1", Namespace: "test1",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	h := hive.New(
+		statedb.Cell,
+		job.Cell,
+		client.FakeClientCell,
+
+		cell.Invoke(func(cs client.Clientset) {
+			// Create the initial pods before anything starts. The fake client
+			// doesn't know how to "Watch" from a specific ResourceVersion so we
+			// need to make sure that we've added everything before Watch() gets called.
+			for j := 0; j < batchSize; j++ {
+				expectedPod.ObjectMeta.Name = fmt.Sprintf("pod%d", j)
+				expectedPod.ObjectMeta.ResourceVersion = "1"
+				expectedPod.ObjectMeta.Generation = 1
+				expectedPod.UID = types.UID(expectedPod.Name)
+				_, err = cs.CoreV1().Pods("test1").Create(
+					context.Background(), expectedPod.DeepCopy(), metav1.CreateOptions{})
+				require.NoError(b, err, "Create pod")
+			}
+		}),
+
+		cell.Module("test", "Test",
+			cell.ProvidePrivate(sourceConfig),
+			reflector.KubernetesCell[*v1.Pod](),
+
+			cell.Invoke(
+				func(db *statedb.DB) error {
+					return db.RegisterTable(table)
+				}),
+
+			cell.Invoke(func(p_ params) { p = p_ }),
+		),
+	)
+
+	require.NoError(b, h.Start(context.TODO()))
+
+	// Wait for pods to be created
+	iter, watch := table.All(p.DB.ReadTxn())
+	for {
+		objs := statedb.Collect[*v1.Pod](iter)
+		if len(objs) == batchSize {
+			break
+		}
+		<-watch
+		iter, watch = table.All(p.DB.ReadTxn())
+	}
+
+	// Benchmark updating a batch of objects and checking that the table
+	// has updated. Actual throughput is 'batchSize' * the number of iterations
+	// in a second. On my i5 laptop I'm getting ~120k/s with batchSize of 100.
+
+	b.Logf("batchSize=%d, multiple the ops/sec with it for per-object throughput", batchSize)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		expectedPod.ResourceVersion = fmt.Sprintf("%d", i+2)
+		expectedPod.Generation = int64(i + 1)
+		expectedPod.Labels["i"] = fmt.Sprintf("%d", i)
+		for j := 0; j < batchSize; j++ {
+			expectedPod.Name = fmt.Sprintf("pod%d", j)
+			expectedPod.UID = types.UID(expectedPod.Name)
+			_, err = p.Clientset.CoreV1().Pods("test1").Update(
+				context.Background(), expectedPod.DeepCopy(), metav1.UpdateOptions{})
+			require.NoError(b, err, "Update pod")
+		}
+
+		// Wait until the batch has committed.
+		<-watch
+
+		// Check that all objects are from the new round
+		iter, watch1 := table.All(p.DB.ReadTxn())
+		watch = watch1
+		objs := statedb.Collect[*v1.Pod](iter)
+		require.Len(b, objs, batchSize)
+		for _, obj := range objs {
+			require.Equal(b, obj.Labels["i"], fmt.Sprintf("%d", i))
+		}
+
+	}
+}


### PR DESCRIPTION
Adds the reflector package and the `Kubernetes` reflector which essentially takes a `cache.ListerWatcher` and writes the changing objects into the given table.

Also adds `statedb.Observable[Obj any](*DB, Table[Obj) stream.Observable[Event[Obj]]` for `Resource[T]` style stream of events to make it easier to migrate from `Resource[T]` to `Table[T]`. Won't support workqueue for retries, for that we'd implement the workqueue directly and perhaps use the stream to queue the work and then query the table (though when retrying is needed it's better to use the generic reconciler).