### PR TITLE
make cilium/loader owner of pkg/elf

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -435,7 +435,7 @@ Makefile* @cilium/build
 /pkg/defaults @cilium/sig-agent
 /pkg/ebpf @cilium/sig-datapath
 /pkg/egressgateway/ @cilium/egress-gateway
-/pkg/elf @cilium/sig-datapath
+/pkg/elf @cilium/loader
 /pkg/endpoint/ @cilium/endpoint
 /pkg/endpointmanager/ @cilium/endpoint
 /pkg/endpointstate/ @cilium/endpoint


### PR DESCRIPTION
pkg/loader is the only consumer of pkg/elf. Let's make cilium/loader the owner of the package instead of sig-datapath.