### PR TITLE
ci: check kvstoremesh for vulnerabilities only on v1.14

### DIFF
--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -18,15 +18,12 @@ jobs:
           {name: clustermesh-apiserver, dockerfile: ./images/clustermesh-apiserver/Dockerfile},
           {name: docker-plugin, dockerfile: ./images/cilium-docker-plugin/Dockerfile},
           {name: hubble-relay, dockerfile: ./images/hubble-relay/Dockerfile},
-          {name: kvstoremesh, dockerfile: ./images/kvstoremesh/Dockerfile},
           {name: operator-generic, dockerfile: ./images/operator/Dockerfile},
         ]
         branch: [v1.12, v1.13, v1.14, v1.15]
-        exclude:
+        include:
           - image: {name: kvstoremesh, dockerfile: ./images/kvstoremesh/Dockerfile}
-            branch: v1.12
-          - image: {name: kvstoremesh, dockerfile: ./images/kvstoremesh/Dockerfile}
-            branch: v1.13
+            branch: v1.14
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
Currently, vulnerability scanning fails because kvstoremesh no longer exists on v1.15. It has been removed with #28961

https://github.com/cilium/cilium/actions/workflows/container-scan.yaml

There are already kvstoremesh exclusions for v1.12 & v1.13. This commit inverts the exclusion to an inclusion for v1.14, as this is the only branch that contains the kvstoremesh.

cc @giorio94 & @ferozsalam 

Fixes: #28961