### PR TITLE
Fix log error in clustermesh-apiserver when connecting external workloads

### DIFF
--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -245,6 +245,12 @@ func (n *NodeDiscovery) fillLocalNode() {
 	n.localNode.Labels = node.GetLabels()
 	n.localNode.NodeIdentity = uint32(identity.ReservedIdentityHost)
 
+	if option.Config.JoinCluster {
+		// Ensure that we propagate the identity allocated by the clustermesh-apiserver
+		// when the agent is running on an external workload.
+		n.localNode.NodeIdentity = identity.GetLocalNodeID().Uint32()
+	}
+
 	if node.GetK8sExternalIPv4() != nil {
 		n.localNode.IPAddresses = append(n.localNode.IPAddresses, nodeTypes.Address{
 			Type: addressing.NodeExternalIP,


### PR DESCRIPTION
During external workloads initialization, the clustermesh-apiserver allocates a new identity for the external workload, which is then propagated through etcd to the agent running on the external workload; yet, the agent eventually overrides it with the default value (1).

While this appears to be harmless from a functional point of view, as the clustermesh-apiserver configures the original identity as part of the associated the CiliumNode and CiliumEndpoint resources (which are then watched by the other agents), it also triggers an error, due to the unexpected mismatch:

> CEW: Invalid identity 1 in ...

Let's fix this by ensuring that we correctly propagate the identity assigned to the external workloads agent by the clustermesh-apiserver.

For https://github.com/cilium/cilium-cli/pull/2184
This is a custom backport of https://github.com/cilium/cilium/pull/29896 due to the different node discovery logic.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 29896
```