### PR TITLE
ci: continue container scanning on error

### DIFF
--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -11,6 +11,7 @@ jobs:
     if: github.repository_owner == 'cilium'
     name: Scan Containers
     runs-on: ubuntu-22.04
+    continue-on-error: true
     strategy:
       matrix:
         image: [


### PR DESCRIPTION
Stopping scanning if a single image shows CVEs stops us from seeing the entire results and being able to resolve multiple issues at the same time.

