### PR TITLE
Enable additional tests as part of the conformance-clustermesh workflow

### DIFF
--- a/.github/kind-config.yaml.tmpl
+++ b/.github/kind-config.yaml.tmpl
@@ -13,6 +13,8 @@ nodes:
           taints: []
   - role: worker
     image: quay.io/cilium/kindest-node:${K8S_VERSION}
+  - role: worker
+    image: quay.io/cilium/kindest-node:${K8S_VERSION}
 networking:
   disableDefaultCNI: true
   ipFamily: ${IPFAMILY}

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -213,7 +213,6 @@ jobs:
           # bpf.masquerade is disabled due to #23283
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=bpf.masquerade=false \
-            --helm-set=bpf.monitorAggregation=none \
             --helm-set=hubble.enabled=true \
             --helm-set=hubble.relay.enabled=true \
             --helm-set=clustermesh.useAPIServer=${{ matrix.mode != 'external' }} \

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -261,10 +261,17 @@ jobs:
               --helm-set=encryption.type=${{ matrix.encryption }}"
           fi
 
+          CILIUM_INSTALL_INGRESS=""
+          if [ "${{ matrix.kube-proxy }}" == "none" ]; then
+            # The ingress controller requires KPR to be enabled.
+            CILIUM_INSTALL_INGRESS="--helm-set=ingressController.enabled=true"
+          fi
+
           CONNECTIVITY_TEST_DEFAULTS="--hubble=false \
             --flow-validation=disabled \
             --multi-cluster=${{ env.contextName2 }} \
             --external-target=google.com \
+            --include-unsafe-tests \
             --collect-sysdump-on-failure"
 
           # Skip external traffic (e.g. 1.1.1.1 and www.google.com) tests as IPv6 is not supported
@@ -276,7 +283,7 @@ jobs:
           fi
 
           echo cilium_install_defaults="${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_TUNNEL} \
-            ${CILIUM_INSTALL_IPFAMILY} ${CILIUM_INSTALL_ENCRYPTION}" >> $GITHUB_OUTPUT
+            ${CILIUM_INSTALL_IPFAMILY} ${CILIUM_INSTALL_ENCRYPTION} ${CILIUM_INSTALL_INGRESS}" >> $GITHUB_OUTPUT
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
 
@@ -325,6 +332,11 @@ jobs:
           kubectl_version: ${{ env.k8s_version }}
           config: ./.github/kind-config-cluster2.yaml
           wait: 0 # The control-plane never becomes ready, since no CNI is present
+
+      - name: Label one of the nodes as external to the cluster
+        run: |
+          kubectl --context ${{ env.contextName1 }} label node \
+            ${{ env.clusterName1 }}-worker2 cilium.io/no-schedule=true
 
       # Make sure that coredns uses IPv4-only upstream DNS servers also in case of clusters
       # with IP family dual, since IPv6 ones are not reachable and cause spurious failures.
@@ -406,7 +418,8 @@ jobs:
             --helm-set clustermesh.apiserver.service.nodePort=32379 \
             --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.cm-auth-mode-1 }} \
             ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
-            ${{ steps.clustermesh-vars.outputs.cilium_install_clustermesh }}
+            ${{ steps.clustermesh-vars.outputs.cilium_install_clustermesh }} \
+            --nodes-without-cilium=${{ env.clusterName1 }}-worker2
 
       - name: Copy the Cilium CA secret to cluster2, as they must match
         run: |

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -422,7 +422,7 @@ jobs:
           cilium --context ${{ env.contextName2 }} install \
             ${{ steps.vars.outputs.cilium_install_defaults }} \
             --helm-set cluster.name=${{ env.clusterName2 }} \
-            --helm-set cluster.id=255 \
+            --helm-set cluster.id=${{ matrix.maxConnectedClusters }} \
             --helm-set clustermesh.apiserver.service.nodePort=32380 \
             --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.cm-auth-mode-2 }} \
             ${{ steps.kvstore.outputs.cilium_install_kvstore }} \

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -158,7 +158,7 @@ jobs:
             --set=ipv6.enabled=true \
             --set=clustermesh.useAPIServer=${{ !matrix.external-kvstore }} \
             --set=clustermesh.config.enabled=true \
-            --set=extraConfig.clustermesh-ip-identities-sync-timeout=5m"
+            --set=extraConfig.clustermesh-ip-identities-sync-timeout=10m"
 
           # Run only a limited subset of tests to reduce the amount of time
           # required. The full suite is run in conformance-clustermesh.

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -456,11 +456,16 @@ jobs:
 
       # Perform an additional "stress" test, scaling the clustermesh-apiservers in both clusters
       # to zero replicas, and restarting all agents. Existing connections should not be disrupted.
+      # One exception to this is represented by Cilium being in charge of handling NodePort
+      # traffic, as the simultaneous restart of the clustermesh-apiserver pods in both clusters
+      # after rolling out all agents can lead to a circular dependency (#30156).
       - name: Scale the clustermesh-apiserver replicas to 0
         if: ${{ !matrix.external-kvstore }}
         run: |
           kubectl --context ${{ env.contextName1 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
-          kubectl --context ${{ env.contextName2 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
+          if [ ${{ matrix.kube-proxy }} != "none" ]; then
+            kubectl --context ${{ env.contextName2 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
+          fi
 
       - name: Rollout Cilium agents in both clusters
         run: |


### PR DESCRIPTION
Extend the conformance-clustermesh workflow coverage:
* Always assign the first and last ClusterID to the two clusters;
* Enable north/south loadbalancing tests from external node;
* Enable ingress-related tests.

```release-note
Improve Conformance Cluster Mesh workflow coverage 
```

Requires https://github.com/cilium/cilium-cli/pull/2191
