### PR TITLE
Add OpenSSF Scorecard badge to Cilium README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
       <img src="https://cdn.jsdelivr.net/gh/cilium/cilium@main/Documentation/images/logo-dark.png" width="350" alt="Cilium Logo">
    </picture>
 
-|cii| |go-report| |clomonitor| |artifacthub| |slack| |go-doc| |rtd| |apache| |bsd| |gpl| |fossa| |gateway-api| |codespaces|
+|cii| |openssf-scorecard| |go-report| |clomonitor| |artifacthub| |slack| |go-doc| |rtd| |apache| |bsd| |gpl| |fossa| |gateway-api| |codespaces|
 
 Cilium is a networking, observability, and security solution with an eBPF-based
 dataplane. It provides a simple flat Layer 3 network with the ability to span
@@ -372,6 +372,10 @@ and the `2-Clause BSD License <bsd-license_>`__
 .. |cii| image:: https://bestpractices.coreinfrastructure.org/projects/1269/badge
     :alt: CII Best Practices
     :target: https://bestpractices.coreinfrastructure.org/projects/1269
+
+.. |openssf-scorecard| image:: https://api.securityscorecards.dev/projects/github.com/cilium/cilium/badge
+    :alt: OpenSSF Scorecard badge
+    :target: https://securityscorecards.dev/viewer/?uri=github.com/cilium/cilium
 
 .. |clomonitor| image:: https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/cilium/badge
     :alt: CLOMonitor


### PR DESCRIPTION

<!-- Description of change -->
OpenSSF Scorecard assesses open source projects for security risks through a series of automated checks.  It performs a series of checks and scores the overall security posture on a scale from 1-10. Adding the OpenSSF Scorecard badge to the README would increase transparency on the overall security posture of the project as recommended in Cilium security audit, 2022. This would also increase the [CLOMonitor score](https://clomonitor.io/projects/cncf/cilium) of Cilium.

Fixes: #23287 #21760