### PR TITLE
workflows: Increase IPsec upgrade test's timeout

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -147,7 +147,7 @@ jobs:
             mode: 'patch'
             name: '8'
 
-    timeout-minutes: 60
+    timeout-minutes: 70
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
The IPsec upgrade test started timing out from time to time on main's CI. This commit bumps the timeout a bit to avoid such failures.