### PR TITLE
daemon: Retrieve k8s info before updating local CiliumNode

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -688,16 +688,16 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 			}
 		}
 
+		if err := agentK8s.WaitForNodeInformation(d.ctx, log, params.Resources.LocalNode, params.Resources.LocalCiliumNode); err != nil {
+			log.WithError(err).Error("unable to connect to get node spec from apiserver")
+			return nil, nil, fmt.Errorf("unable to connect to get node spec from apiserver: %w", err)
+		}
+
 		if option.Config.IPAM == ipamOption.IPAMClusterPool ||
 			option.Config.IPAM == ipamOption.IPAMMultiPool {
 			// Create the CiliumNode custom resource. This call will block until
 			// the custom resource has been created
 			d.nodeDiscovery.UpdateCiliumNodeResource()
-		}
-
-		if err := agentK8s.WaitForNodeInformation(d.ctx, log, params.Resources.LocalNode, params.Resources.LocalCiliumNode); err != nil {
-			log.WithError(err).Error("unable to connect to get node spec from apiserver")
-			return nil, nil, fmt.Errorf("unable to connect to get node spec from apiserver: %w", err)
 		}
 
 		// Kubernetes demands that the localhost can always reach local


### PR DESCRIPTION
This commit fixes a bug that causes the CiliumInternalIP of the local node to be temporarily removed on up/downgrades [1]. This removal is then propagated to all nodes in the cluster and can cause the removal of related state (ex. node IDs) and connectivity issues.

On a kind cluster with cluster-pool IPAM, the following logs were collected, all on the same node "kind-worker":

    14:18:46.118170271Z level=info msg="Node updated" clusterName=default nodeName=kind-worker2 subsys=nodemanager
    14:18:46.118390271Z level=debug msg="Received node update event from custom-resource: types.Node{Name:\"kind-worker2\", Cluster:\"default\", IPAddresses:[]types.Address{types.Address{Type:\"InternalIP\", IP:net.IP{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xac, 0x12, 0x0, 0x4}}, types.Address{Type:\"InternalIP\", IP:net.IP{0xfc, 0x0, 0xc1, 0x11, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x4}}, types.Address{Type:\"CiliumInternalIP\", IP:net.IP{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xa, 0xf4, 0x2, 0x4f}}, types.Address{Type:\"CiliumInternalIP\", IP:net.IP{0xfd, 0x0, 0x0, 0x10, 0x2, 0x44, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xaa, 0x53}}}, IPv4AllocCIDR:(*cidr.CIDR)(0xc000b502b0), IPv4SecondaryAllocCIDRs:[]*cidr.CIDR(nil), IPv6AllocCIDR:(*cidr.CIDR)(0xc000b502b8), IPv6SecondaryAllocCIDRs:[]*cidr.CIDR(nil), IPv4HealthIP:net.IP{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xa, 0xf4, 0x2, 0x4a}, IPv6HealthIP:net.IP{0xfd, 0x0, 0x0, 0x10, 0x2, 0x44, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfe, 0x8}, IPv4IngressIP:net.IP(nil), IPv6IngressIP:net.IP(nil), ClusterID:0x0, Source:\"custom-resource\", EncryptionKey:0x3, Labels:map[string]string{\"beta.kubernetes.io/arch\":\"amd64\", \"beta.kubernetes.io/os\":\"linux\", \"kubernetes.io/arch\":\"amd64\", \"kubernetes.io/hostname\":\"kind-worker2\", \"kubernetes.io/os\":\"linux\"}, Annotations:map[string]string(nil), NodeIdentity:0x0, WireguardPubKey:\"\", BootID:\"\"}" subsys=nodemanager
    [...]
    14:19:30.884679838Z level=info msg="Node updated" clusterName=default nodeName=kind-worker2 subsys=nodemanager
    14:19:30.884909987Z level=debug msg="Received node update event from custom-resource: types.Node{Name:\"kind-worker2\", Cluster:\"default\", IPAddresses:[]types.Address{types.Address{Type:\"InternalIP\", IP:net.IP{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xac, 0x12, 0x0, 0x4}}, types.Address{Type:\"InternalIP\", IP:net.IP{0xfc, 0x0, 0xc1, 0x11, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x4}}}, IPv4AllocCIDR:(*cidr.CIDR)(0xc001106320), IPv4SecondaryAllocCIDRs:[]*cidr.CIDR(nil), IPv6AllocCIDR:(*cidr.CIDR)(0xc001106328), IPv6SecondaryAllocCIDRs:[]*cidr.CIDR(nil), IPv4HealthIP:net.IP(nil), IPv6HealthIP:net.IP(nil), IPv4IngressIP:net.IP(nil), IPv6IngressIP:net.IP(nil), ClusterID:0x0, Source:\"custom-resource\", EncryptionKey:0x3, Labels:map[string]string{\"beta.kubernetes.io/arch\":\"amd64\", \"beta.kubernetes.io/os\":\"linux\", \"kubernetes.io/arch\":\"amd64\", \"kubernetes.io/hostname\":\"kind-worker2\", \"kubernetes.io/os\":\"linux\"}, Annotations:map[string]string(nil), NodeIdentity:0x0, WireguardPubKey:\"\", BootID:\"\"}" subsys=nodemanager
    [...]
    14:19:31.134547701Z level=info msg="Node updated" clusterName=default nodeName=kind-worker2 subsys=nodemanager
    14:19:31.135434243Z level=debug msg="Received node update event from custom-resource: types.Node{Name:\"kind-worker2\", Cluster:\"default\", IPAddresses:[]types.Address{types.Address{Type:\"InternalIP\", IP:net.IP{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xac, 0x12, 0x0, 0x4}}, types.Address{Type:\"InternalIP\", IP:net.IP{0xfc, 0x0, 0xc1, 0x11, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x4}}, types.Address{Type:\"CiliumInternalIP\", IP:net.IP{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xa, 0xf4, 0x2, 0x4f}}, types.Address{Type:\"CiliumInternalIP\", IP:net.IP{0xfd, 0x0, 0x0, 0x10, 0x2, 0x44, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xaa, 0x53}}}, IPv4AllocCIDR:(*cidr.CIDR)(0xc000e9efa8), IPv4SecondaryAllocCIDRs:[]*cidr.CIDR(nil), IPv6AllocCIDR:(*cidr.CIDR)(0xc000e9efb0), IPv6SecondaryAllocCIDRs:[]*cidr.CIDR(nil), IPv4HealthIP:net.IP{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xa, 0xf4, 0x2, 0x57}, IPv6HealthIP:net.IP{0xfd, 0x0, 0x0, 0x10, 0x2, 0x44, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x89, 0xc6}, IPv4IngressIP:net.IP(nil), IPv6IngressIP:net.IP(nil), ClusterID:0x0, Source:\"custom-resource\", EncryptionKey:0x3, Labels:map[string]string{\"beta.kubernetes.io/arch\":\"amd64\", \"beta.kubernetes.io/os\":\"linux\", \"kubernetes.io/arch\":\"amd64\", \"kubernetes.io/hostname\":\"kind-worker2\", \"kubernetes.io/os\":\"linux\"}, Annotations:map[string]string(nil), NodeIdentity:0x0, WireguardPubKey:\"\", BootID:\"\"}" subsys=nodemanager

We observe that three updates of the remote node kind-worker2 were received. In the second update, the CiliumInternalIP appears to have been removed and it is readded in the third update, ~0.25s later.

This pull request fixes the bug by reordering operations on agent startup, to pull the information from k8s before updating (and propagating) the local node information. That ensures that have the CiliumInternalIP when we update the local node.

1 - The bug may affect all agent restarts, but has only been noticed on up/downgrades so far.
