### PR TITLE
Optimize make update-authors

### DIFF
--- a/contrib/scripts/extract_authors.sh
+++ b/contrib/scripts/extract_authors.sh
@@ -5,16 +5,7 @@ export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 
 function extract_authors() {
-	authors=$(git shortlog --summary \
-		  | awk '{$1=""; print $0}' \
-		  | sed -e 's/^ //' \
-			-e '/vagrant/d')
-
-	# Iterate $authors by line
-	IFS=$'\n'
-	for i in $authors; do
-		git log --use-mailmap --author="$i" --format="%<|(40)%aN%aE" | head -1
-	done
+	git log --use-mailmap --format="%<|(40)%aN%aE" | sort -f | uniq
 }
 
-extract_authors | sort -u
+extract_authors


### PR DESCRIPTION
Previously, running make update-authors took about 3.5 minutes to run. Now, it runs in seconds.

Fixes: #29882 