### PR TITLE
bpf: fix wrong loopback address mask value

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -28,7 +28,7 @@
 static __always_inline __maybe_unused bool is_v4_loopback(__be32 daddr)
 {
 	/* Check for 127.0.0.0/8 range, RFC3330. */
-	return (daddr & bpf_htonl(0x7f000000)) == bpf_htonl(0x7f000000);
+	return (daddr & bpf_htonl(0xff000000)) == bpf_htonl(0x7f000000);
 }
 
 static __always_inline __maybe_unused bool is_v6_loopback(const union v6addr *daddr)


### PR DESCRIPTION
The loopback address mask value should be '0xff000000':

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/in.h?h=v6.7-rc6#n38

	static inline bool ipv4_is_loopback(__be32 addr)
	{
		return (addr & htonl(0xff000000)) == htonl(0x7f000000);
	}

Fixes: 50c947d5286d ("bpf: refine wild card lookup for node port services from host")
