### PR TITLE
bgpv1: Avoid creating `resource.Store` in `Start()` hive hooks of BGP CP

### DIFF
--- a/pkg/bgpv1/manager/reconciler/neighbor_test.go
+++ b/pkg/bgpv1/manager/reconciler/neighbor_test.go
@@ -16,13 +16,12 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/manager/store"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/option"
 )
 
-func FakeSecretStore(secrets map[string][]byte) resource.Store[*slim_corev1.Secret] {
+func FakeSecretStore(secrets map[string][]byte) store.BGPCPResourceStore[*slim_corev1.Secret] {
 	store := store.NewMockBGPCPResourceStore[*slim_corev1.Secret]()
 	for k, v := range secrets {
 		store.Upsert(&slim_corev1.Secret{
@@ -56,7 +55,7 @@ func TestNeighborReconciler(t *testing.T) {
 		// this is the resulting neighbors we expect on the BgpServer.
 		newNeighbors []v2alpha1api.CiliumBGPNeighbor
 		// secretStore passed to the test, provides a way to fetch secrets (use FakeSecretStore above).
-		secretStore resource.Store[*slim_corev1.Secret]
+		secretStore store.BGPCPResourceStore[*slim_corev1.Secret]
 		// checks validates set timer values
 		checks checkTimers
 		// expected secret if set.

--- a/pkg/bgpv1/manager/reconciler/pod_ip_pool.go
+++ b/pkg/bgpv1/manager/reconciler/pod_ip_pool.go
@@ -131,7 +131,10 @@ func (r *PodIPPoolReconciler) fullReconciliation(ctx context.Context,
 	}
 
 	// Loop over all pod ip pools, reconcile any updates to the pool.
-	pools := r.poolStore.List()
+	pools, err := r.poolStore.List()
+	if err != nil {
+		return fmt.Errorf("failed to list ip pools from store: %w", err)
+	}
 	for _, pool := range pools {
 		if err := r.reconcilePodIPPool(ctx, sc, newc, pool, localPools); err != nil {
 			return fmt.Errorf("failed to reconcile pod ip pool: %w", err)

--- a/pkg/bgpv1/manager/reconciler/route_policy.go
+++ b/pkg/bgpv1/manager/reconciler/route_policy.go
@@ -196,7 +196,11 @@ func (r *RoutePolicyReconciler) pathAttributesToPolicy(attrs v2alpha1api.CiliumB
 	switch attrs.SelectorType {
 	case v2alpha1api.CPIPKindDefinition:
 		localPools := r.populateLocalPools(params.CiliumNode)
-		for _, pool := range r.podPoolStore.List() {
+		podPoolList, err := r.podPoolStore.List()
+		if err != nil {
+			return nil, fmt.Errorf("failed to list pod ip pools from store: %w", err)
+		}
+		for _, pool := range podPoolList {
 			if attrs.Selector != nil && !labelSelector.Matches(labels.Set(pool.Labels)) {
 				continue
 			}
@@ -214,7 +218,11 @@ func (r *RoutePolicyReconciler) pathAttributesToPolicy(attrs v2alpha1api.CiliumB
 			}
 		}
 	case v2alpha1api.CiliumLoadBalancerIPPoolSelectorName:
-		for _, pool := range r.lbPoolStore.List() {
+		lbPoolList, err := r.lbPoolStore.List()
+		if err != nil {
+			return nil, fmt.Errorf("failed to list lb ip pools from store: %w", err)
+		}
+		for _, pool := range lbPoolList {
 			if pool.Spec.Disabled {
 				continue
 			}

--- a/pkg/bgpv1/manager/store/diffstore_fake.go
+++ b/pkg/bgpv1/manager/store/diffstore_fake.go
@@ -6,7 +6,6 @@ package store
 import (
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/lock"
@@ -52,17 +51,20 @@ func (mds *fakeDiffStore[T]) Diff() (upserted []T, deleted []resource.Key, err e
 }
 
 // List returns all items currently in the store.
-func (mds *fakeDiffStore[T]) List() []T {
+func (mds *fakeDiffStore[T]) List() ([]T, error) {
 	mds.objMu.Lock()
 	defer mds.objMu.Unlock()
-	return maps.Values(mds.objects)
+	return maps.Values(mds.objects), nil
 }
 
-// IterKeys returns a key iterator.
-func (mds *fakeDiffStore[T]) IterKeys() resource.KeyIter {
+// GetByKey returns the latest version of the object with given key.
+func (mds *fakeDiffStore[T]) GetByKey(key resource.Key) (item T, exists bool, err error) {
 	mds.objMu.Lock()
 	defer mds.objMu.Unlock()
-	return newMockKeyIter(maps.Keys(mds.objects))
+
+	item, exists = mds.objects[key]
+
+	return item, exists, nil
 }
 
 func (mds *fakeDiffStore[T]) Upsert(obj T) {
@@ -84,56 +86,4 @@ func (mds *fakeDiffStore[T]) Delete(key resource.Key) {
 
 	delete(mds.objects, key)
 	mds.changed[key] = true
-}
-
-func (mds *fakeDiffStore[T]) IndexKeys(indexName, indexedValue string) ([]string, error) {
-	return nil, nil
-}
-
-func (mds *fakeDiffStore[T]) ByIndex(indexName, indexedValue string) ([]T, error) {
-	return nil, nil
-}
-
-func (mds *fakeDiffStore[T]) CacheStore() cache.Store {
-	return nil
-}
-
-// Get returns the latest version by deriving the key from the given object.
-func (mds *fakeDiffStore[T]) Get(obj T) (item T, exists bool, err error) {
-	return mds.GetByKey(resource.NewKey(obj))
-}
-
-// GetByKey returns the latest version of the object with given key.
-func (mds *fakeDiffStore[T]) GetByKey(key resource.Key) (item T, exists bool, err error) {
-	mds.objMu.Lock()
-	defer mds.objMu.Unlock()
-
-	item, exists = mds.objects[key]
-
-	return item, exists, nil
-}
-
-func (mds *fakeDiffStore[T]) Release() {}
-
-type fakeKeyIter struct {
-	i    int
-	keys []resource.Key
-}
-
-func newMockKeyIter(keys []resource.Key) *fakeKeyIter {
-	return &fakeKeyIter{
-		i:    -1,
-		keys: keys,
-	}
-}
-
-// Next returns true if there is a key, false if iteration has finished.
-func (mki *fakeKeyIter) Next() bool {
-	mki.i++
-	return mki.i < len(mki.keys)
-}
-
-func (mki *fakeKeyIter) Key() resource.Key {
-	key := mki.keys[mki.i]
-	return key
 }

--- a/pkg/bgpv1/manager/store/diffstore_test.go
+++ b/pkg/bgpv1/manager/store/diffstore_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/agent/signaler"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -60,6 +61,11 @@ func newDiffStoreFixture() *DiffStoreFixture {
 		}),
 
 		cell.Provide(NewDiffStore[*slimv1.Service]),
+
+		job.Cell,
+		cell.Provide(func() cell.Scope {
+			return cell.TestScope()
+		}),
 	)
 
 	return fixture

--- a/pkg/bgpv1/manager/store/resource_store_mock.go
+++ b/pkg/bgpv1/manager/store/resource_store_mock.go
@@ -6,7 +6,6 @@ package store
 import (
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/lock"
@@ -25,16 +24,19 @@ func NewMockBGPCPResourceStore[T runtime.Object]() *mockBGPCPResourceStore[T] {
 	}
 }
 
-func (mds *mockBGPCPResourceStore[T]) List() []T {
+func (mds *mockBGPCPResourceStore[T]) List() ([]T, error) {
 	mds.objMu.Lock()
 	defer mds.objMu.Unlock()
-	return maps.Values(mds.objects)
+	return maps.Values(mds.objects), nil
 }
 
-func (mds *mockBGPCPResourceStore[T]) IterKeys() resource.KeyIter {
+func (mds *mockBGPCPResourceStore[T]) GetByKey(key resource.Key) (item T, exists bool, err error) {
 	mds.objMu.Lock()
 	defer mds.objMu.Unlock()
-	return newMockKeyIter(maps.Keys(mds.objects))
+
+	item, exists = mds.objects[key]
+
+	return item, exists, nil
 }
 
 func (mds *mockBGPCPResourceStore[T]) Upsert(obj T) {
@@ -50,32 +52,4 @@ func (mds *mockBGPCPResourceStore[T]) Delete(key resource.Key) {
 	defer mds.objMu.Unlock()
 
 	delete(mds.objects, key)
-}
-
-func (mds *mockBGPCPResourceStore[T]) IndexKeys(indexName, indexedValue string) ([]string, error) {
-	return nil, nil
-}
-
-func (mds *mockBGPCPResourceStore[T]) ByIndex(indexName, indexedValue string) ([]T, error) {
-	return nil, nil
-}
-
-func (mds *mockBGPCPResourceStore[T]) CacheStore() cache.Store {
-	return nil
-}
-
-func (mds *mockBGPCPResourceStore[T]) Get(obj T) (item T, exists bool, err error) {
-	return mds.GetByKey(resource.NewKey(obj))
-}
-
-func (mds *mockBGPCPResourceStore[T]) GetByKey(key resource.Key) (item T, exists bool, err error) {
-	mds.objMu.Lock()
-	defer mds.objMu.Unlock()
-
-	item, exists = mds.objects[key]
-
-	return item, exists, nil
-}
-
-func (mds *mockBGPCPResourceStore[T]) Release() {
 }


### PR DESCRIPTION
This PR ensures that `resource.Store` is not created in `Start()` hive hooks of the BGP CP. The motivation is:
 - If CRDs are not yet installed, this blocks the agent initialization, which can lead to issues in case of non-default `operator.tolerations` (see https://github.com/cilium/cilium/issues/29371#issuecomment-1842841350)
 - To not slow down the agent startup process (see https://github.com/cilium/cilium/pull/28593#discussion_r1363589573).

Please also see commit messages for some more details.

Fixes: #29371

```release-note
bgpv1: Avoid creating `resource.Store` in `Start()` hive hooks of BGP CP to ensure proper BGP CP initialization.
```
