### PR TITLE
[backport-1.15]  policy: expand "world" entity selector to select all address families

### DIFF
--- a/pkg/policy/api/entity.go
+++ b/pkg/policy/api/entity.go
@@ -89,7 +89,7 @@ var (
 	// policies to selectors
 	EntitySelectorMapping = map[Entity]EndpointSelectorSlice{
 		EntityAll:           {WildcardEndpointSelector},
-		EntityWorld:         {endpointSelectorWorld},
+		EntityWorld:         {endpointSelectorWorld, endpointSelectorWorldIPv4, endpointSelectorWorldIPv6},
 		EntityWorldIPv4:     {endpointSelectorWorldIPv4},
 		EntityWorldIPv6:     {endpointSelectorWorldIPv6},
 		EntityHost:          {endpointSelectorHost},

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -1169,6 +1169,12 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDenyFromEntities(c *C) {
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(selWorld)
 	c.Assert(cachedSelectorWorld, Not(IsNil))
 
+	cachedSelectorWorldV4 := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv4])
+	c.Assert(cachedSelectorWorldV4, Not(IsNil))
+
+	cachedSelectorWorldV6 := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv6])
+	c.Assert(cachedSelectorWorldV6, Not(IsNil))
+
 	expectedPolicy := L4PolicyMap{
 		"0/ANY": {
 			Port:     0,
@@ -1176,10 +1182,16 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDenyFromEntities(c *C) {
 			U8Proto:  0x0,
 			L7Parser: "",
 			PerSelectorPolicies: L7DataMap{
-				cachedSelectorWorld: &PerSelectorPolicy{IsDeny: true},
+				cachedSelectorWorld:   &PerSelectorPolicy{IsDeny: true},
+				cachedSelectorWorldV4: &PerSelectorPolicy{IsDeny: true},
+				cachedSelectorWorldV6: &PerSelectorPolicy{IsDeny: true},
 			},
-			Ingress:    true,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectorWorld: {labelsL3}},
+			Ingress: true,
+			RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+				cachedSelectorWorld:   {labelsL3},
+				cachedSelectorWorldV4: {labelsL3},
+				cachedSelectorWorldV6: {labelsL3},
+			},
 		},
 	}
 
@@ -1224,6 +1236,12 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDenyToEntities(c *C) {
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(selWorld)
 	c.Assert(cachedSelectorWorld, Not(IsNil))
 
+	cachedSelectorWorldV4 := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv4])
+	c.Assert(cachedSelectorWorldV4, Not(IsNil))
+
+	cachedSelectorWorldV6 := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv6])
+	c.Assert(cachedSelectorWorldV6, Not(IsNil))
+
 	// We should expect an empty deny policy because the policy does not
 	// contain any rules with the label 'id=foo'.
 	expectedDenyPolicy := L4PolicyMap{
@@ -1233,10 +1251,16 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDenyToEntities(c *C) {
 			U8Proto:  0x0,
 			L7Parser: "",
 			PerSelectorPolicies: L7DataMap{
-				cachedSelectorWorld: &PerSelectorPolicy{IsDeny: true},
+				cachedSelectorWorld:   &PerSelectorPolicy{IsDeny: true},
+				cachedSelectorWorldV4: &PerSelectorPolicy{IsDeny: true},
+				cachedSelectorWorldV6: &PerSelectorPolicy{IsDeny: true},
 			},
-			Ingress:    false,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectorWorld: {labelsL3}},
+			Ingress: false,
+			RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+				cachedSelectorWorld:   {labelsL3},
+				cachedSelectorWorldV4: {labelsL3},
+				cachedSelectorWorldV6: {labelsL3},
+			},
 		},
 	}
 

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -1698,6 +1698,12 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(selWorld)
 	c.Assert(cachedSelectorWorld, Not(IsNil))
 
+	cachedSelectorWorldV4 := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv4])
+	c.Assert(cachedSelectorWorldV4, Not(IsNil))
+
+	cachedSelectorWorldV6 := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv6])
+	c.Assert(cachedSelectorWorldV6, Not(IsNil))
+
 	expectedPolicy := L4PolicyMap{
 		"0/ANY": {
 			Port:     0,
@@ -1705,10 +1711,16 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 			U8Proto:  0x0,
 			L7Parser: "",
 			PerSelectorPolicies: L7DataMap{
-				cachedSelectorWorld: nil,
+				cachedSelectorWorld:   nil,
+				cachedSelectorWorldV4: nil,
+				cachedSelectorWorldV6: nil,
 			},
-			Ingress:    true,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectorWorld: {labelsL3}},
+			Ingress: true,
+			RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+				cachedSelectorWorld:   {labelsL3},
+				cachedSelectorWorldV4: {labelsL3},
+				cachedSelectorWorldV6: {labelsL3},
+			},
 		},
 		"9092/TCP": {
 			Port:     9092,
@@ -1838,6 +1850,12 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(selWorld)
 	c.Assert(cachedSelectorWorld, Not(IsNil))
 
+	cachedSelectorWorldV4 := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv4])
+	c.Assert(cachedSelectorWorldV4, Not(IsNil))
+
+	cachedSelectorWorldV6 := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv6])
+	c.Assert(cachedSelectorWorldV6, Not(IsNil))
+
 	expectedPolicy := L4PolicyMap{
 		"0/ANY": {
 			Port:     0,
@@ -1845,10 +1863,16 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 			U8Proto:  0x0,
 			L7Parser: "",
 			PerSelectorPolicies: L7DataMap{
-				cachedSelectorWorld: nil,
+				cachedSelectorWorld:   nil,
+				cachedSelectorWorldV4: nil,
+				cachedSelectorWorldV6: nil,
 			},
-			Ingress:    false,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectorWorld: {labelsL3}},
+			Ingress: false,
+			RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+				cachedSelectorWorld:   {labelsL3},
+				cachedSelectorWorldV4: {labelsL3},
+				cachedSelectorWorldV6: {labelsL3},
+			},
 		},
 		"53/UDP": {
 			Port:     53,

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -442,6 +442,12 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorld])
 	c.Assert(cachedSelectorWorld, Not(IsNil))
 
+	cachedSelectorWorldV4 := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv4])
+	c.Assert(cachedSelectorWorldV4, Not(IsNil))
+
+	cachedSelectorWorldV6 := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv6])
+	c.Assert(cachedSelectorWorldV6, Not(IsNil))
+
 	cachedSelectorTest := testSelectorCache.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
 	c.Assert(cachedSelectorTest, Not(IsNil))
 
@@ -462,12 +468,16 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 						L7Parser: ParserTypeNone,
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
-							cachedSelectorWorld: &PerSelectorPolicy{IsDeny: true},
-							cachedSelectorTest:  &PerSelectorPolicy{IsDeny: true},
+							cachedSelectorWorld:   &PerSelectorPolicy{IsDeny: true},
+							cachedSelectorWorldV4: &PerSelectorPolicy{IsDeny: true},
+							cachedSelectorWorldV6: &PerSelectorPolicy{IsDeny: true},
+							cachedSelectorTest:    &PerSelectorPolicy{IsDeny: true},
 						},
 						RuleOrigin: map[CachedSelector]labels.LabelArrayList{
-							cachedSelectorWorld: {ruleLabel},
-							cachedSelectorTest:  {ruleLabel},
+							cachedSelectorWorld:   {ruleLabel},
+							cachedSelectorWorldV4: {ruleLabel},
+							cachedSelectorWorldV6: {ruleLabel},
+							cachedSelectorTest:    {ruleLabel},
 						},
 					},
 				},
@@ -483,8 +493,8 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 			// will still allow egress to world.
 			{TrafficDirection: trafficdirection.Egress.Uint8()}:                              allowEgressMapStateEntry,
 			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}:     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
-			{Identity: uint32(identity.ReservedIdentityWorldIPv4), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
-			{Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
+			{Identity: uint32(identity.ReservedIdentityWorldIPv4), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorldV4, cachedSelectorWorld),
+			{Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorldV6, cachedSelectorWorld),
 			{Identity: 192, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry,
 			{Identity: 194, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry,
 		}),

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -626,6 +626,12 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorld])
 	c.Assert(cachedSelectorWorld, Not(IsNil))
 
+	cachedSelectorWorldV4 := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv4])
+	c.Assert(cachedSelectorWorldV4, Not(IsNil))
+
+	cachedSelectorWorldV6 := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv6])
+	c.Assert(cachedSelectorWorldV6, Not(IsNil))
+
 	cachedSelectorTest := testSelectorCache.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
 	c.Assert(cachedSelectorTest, Not(IsNil))
 
@@ -646,7 +652,9 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 						L7Parser: ParserTypeNone,
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
-							cachedSelectorWorld: nil,
+							cachedSelectorWorld:   nil,
+							cachedSelectorWorldV4: nil,
+							cachedSelectorWorldV6: nil,
 							cachedSelectorTest: &PerSelectorPolicy{
 								Authentication: &api.Authentication{
 									Mode: api.AuthenticationModeDisabled,
@@ -655,8 +663,10 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 							},
 						},
 						RuleOrigin: map[CachedSelector]labels.LabelArrayList{
-							cachedSelectorWorld: {ruleLabel},
-							cachedSelectorTest:  {ruleLabel},
+							cachedSelectorWorld:   {ruleLabel},
+							cachedSelectorWorldV4: {ruleLabel},
+							cachedSelectorWorldV6: {ruleLabel},
+							cachedSelectorTest:    {ruleLabel},
 						},
 					},
 				},
@@ -671,8 +681,8 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 		policyMapState: newMapState(map[Key]MapStateEntry{
 			{TrafficDirection: trafficdirection.Egress.Uint8()}:                              allowEgressMapStateEntry,
 			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}:     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
-			{Identity: uint32(identity.ReservedIdentityWorldIPv4), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
-			{Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
+			{Identity: uint32(identity.ReservedIdentityWorldIPv4), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld, cachedSelectorWorldV4),
+			{Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld, cachedSelectorWorldV6),
 			{Identity: 192, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry.WithAuthType(AuthTypeDisabled),
 			{Identity: 194, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry.WithAuthType(AuthTypeDisabled),
 		}),

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1961,7 +1961,7 @@ func (ds *PolicyTestSuite) TestEgressL4AllowWorld(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, false)
 
-	c.Assert(len(filter.PerSelectorPolicies), Equals, 1)
+	c.Assert(len(filter.PerSelectorPolicies), Equals, 3)
 	l4EgressPolicy.Detach(repo.GetSelectorCache())
 }
 


### PR DESCRIPTION
- [x] #29958 -- policy: expand "world" entity selector to select all address families (@squeed)

Fixes: #29666

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
29958
```