### PR TITLE
bpf: host: skip from-proxy handling in from-netdev

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -240,9 +240,13 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	struct endpoint_info *ep;
 	int ret;
 	__u8 encrypt_key __maybe_unused = 0;
-	bool from_ingress_proxy = tc_index_from_ingress_proxy(ctx);
-	__u32 magic = from_ingress_proxy ? MARK_MAGIC_PROXY_INGRESS :
-					   MARK_MAGIC_IDENTITY;
+	__u32 magic = MARK_MAGIC_IDENTITY;
+	bool from_ingress_proxy = false;
+
+	if (from_host && tc_index_from_ingress_proxy(ctx)) {
+		from_ingress_proxy = true;
+		magic = MARK_MAGIC_PROXY_INGRESS;
+	}
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
@@ -658,9 +662,13 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	struct endpoint_info *ep;
 	int ret;
 	__u8 encrypt_key __maybe_unused = 0;
-	bool from_ingress_proxy = tc_index_from_ingress_proxy(ctx);
-	__u32 magic = from_ingress_proxy ? MARK_MAGIC_PROXY_INGRESS :
-					   MARK_MAGIC_IDENTITY;
+	__u32 magic = MARK_MAGIC_IDENTITY;
+	bool from_ingress_proxy = false;
+
+	if (from_host && tc_index_from_ingress_proxy(ctx)) {
+		from_ingress_proxy = true;
+		magic = MARK_MAGIC_PROXY_INGRESS;
+	}
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;


### PR DESCRIPTION
`from-proxy` traffic gets redirected to `cilium_host`. Skip the proxy paths when `handle_ipv*_cont()` is included by `from-netdev`.