### PR TITLE
v1.15: nodediscovery: Fix bug where CiliumInternalIP was flapping

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-
 	"slices"
 
 	"github.com/cilium/workerpool"
@@ -455,7 +454,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		logfields.NodeName:    n.Name,
 	}).Info("Node updated")
 	if log.Logger.IsLevelEnabled(logrus.DebugLevel) {
-		log.Debugf("Received node update event from %s: %#v", n.Source, n)
+		log.WithField(logfields.Node, n.LogRepr()).Debugf("Received node update event from %s", n.Source)
 	}
 
 	nodeIdentifier := n.Identity()

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"path"
 	"slices"
@@ -634,6 +635,15 @@ func (n *Node) Unmarshal(_ string, data []byte) error {
 	*n = newNode
 
 	return nil
+}
+
+// LogRepr returns a representation of the node to be used for logging
+func (n *Node) LogRepr() string {
+	b, err := n.Marshal()
+	if err != nil {
+		return fmt.Sprintf("%#v", n)
+	}
+	return string(b)
 }
 
 func (n *Node) validate() error {


### PR DESCRIPTION
Manual backport of https://github.com/cilium/cilium/pull/29964. There were no conflicts.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 29964; do contrib/backporting/set-labels.py $pr done 1.15; done
```
