### PR TITLE
v1.13: nodediscovery: Fix bug where CiliumInternalIP was flapping

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -383,7 +383,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		logfields.NodeName:    n.Name,
 	}).Info("Node updated")
 	if log.Logger.IsLevelEnabled(logrus.DebugLevel) {
-		log.Debugf("Received node update event from %s: %#v", n.Source, n)
+		log.WithField(logfields.Node, n.LogRepr()).Debugf("Received node update event from %s", n.Source)
 	}
 
 	nodeIdentity := n.Identity()

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"path"
 	"strings"
@@ -602,4 +603,13 @@ func (n *Node) Unmarshal(data []byte) error {
 	*n = newNode
 
 	return nil
+}
+
+// LogRepr returns a representation of the node to be used for logging
+func (n *Node) LogRepr() string {
+	b, err := n.Marshal()
+	if err != nil {
+		return fmt.Sprintf("%#v", n)
+	}
+	return string(b)
 }

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/net"
 
 	alibabaCloudTypes "github.com/cilium/cilium/pkg/alibabacloud/eni/types"
 	alibabaCloudMetadata "github.com/cilium/cilium/pkg/alibabacloud/metadata"
@@ -42,6 +43,7 @@ import (
 	nodestore "github.com/cilium/cilium/pkg/node/store"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/slices"
 	"github.com/cilium/cilium/pkg/source"
 	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 )
@@ -412,8 +414,6 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 		k8sNodeAddresses []nodeTypes.Address
 	)
 
-	nodeResource.Spec.Addresses = []ciliumv2.NodeAddress{}
-
 	// If we are unable to fetch the K8s Node resource and the CiliumNode does
 	// not have an OwnerReference set, then somehow we are running in an
 	// environment where only the CiliumNode exists. Do not proceed as this is
@@ -461,6 +461,27 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 	// This is for syncing relevant node annotations from the k8s node to the
 	// CiliumNode object
 	nodeResource.ObjectMeta.Annotations = k8sNodeParsed.GetCiliumAnnotations()
+
+	// This function can be called before we have restored the CiliumInternalIP.
+	// In that case, we do not want to remove the old CiliumInternalIP, as this
+	// would lead to the IP address flapping. Therefore, this code preserves any
+	// CiliumInternalIP if (and only if) the local node store does not yet
+	// include the restored CiliumInternalIP.
+	nodeResource.Spec.Addresses = slices.DeleteFunc(nodeResource.Spec.Addresses, func(address ciliumv2.NodeAddress) bool {
+		if address.Type == addressing.NodeCiliumInternalIP {
+			// Only delete a CiliumInternalIP if
+			// a) its IP family is disabled,
+			// and/or
+			// b) the LocalNode store contains an IP address which we can use instead
+			if v4 := net.ParseIPSloppy(address.IP).To4(); v4 != nil {
+				return !n.LocalConfig.EnableIPv4 || n.localNode.GetCiliumInternalIP(false) != nil
+			} else {
+				return !n.LocalConfig.EnableIPv6 || n.localNode.GetCiliumInternalIP(true) != nil
+			}
+		}
+
+		return true // delete all other node addresses
+	})
 
 	for _, k8sAddress := range k8sNodeAddresses {
 		// Do not add CiliumNodeInternalIP from the k8sNodeAddress. The source

--- a/pkg/slices/doc.go
+++ b/pkg/slices/doc.go
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package slices contains common utilities to work on slices of any type.
+package slices

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package slices
+
+import (
+	"golang.org/x/exp/slices"
+)
+
+// DeleteFunc removes any elements from s for which del returns true,
+// returning the modified slice.
+// When DeleteFunc removes m elements, it might not modify the elements
+// s[len(s)-m:len(s)]. If those elements contain pointers you might consider
+// zeroing those elements so that objects they reference can be garbage
+// collected.
+func DeleteFunc[S ~[]E, E any](s S, del func(E) bool) S {
+	i := slices.IndexFunc(s, del)
+	if i == -1 {
+		return s
+	}
+	// Don't start copying elements until we find one to delete.
+	for j := i + 1; j < len(s); j++ {
+		if v := s[j]; !del(v) {
+			s[i] = v
+			i++
+		}
+	}
+	return s[:i]
+}


### PR DESCRIPTION
Manual backport of https://github.com/cilium/cilium/pull/29964. See commits for conflict notes.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 29964; do contrib/backporting/set-labels.py $pr done 1.13; done
```
