### PR TITLE
v1.12: nodediscovery: Fix bug where CiliumInternalIP was flapping

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -388,7 +388,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		logfields.NodeName:    n.Name,
 	}).Info("Node updated")
 	if log.Logger.IsLevelEnabled(logrus.DebugLevel) {
-		log.Debugf("Received node update event from %s: %#v", n.Source, n)
+		log.WithField(logfields.Node, n.LogRepr()).Debugf("Received node update event from %s", n.Source)
 	}
 
 	nodeIdentity := n.Identity()

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"path"
 
@@ -533,4 +534,13 @@ func (n *Node) Unmarshal(data []byte) error {
 	*n = newNode
 
 	return nil
+}
+
+// LogRepr returns a representation of the node to be used for logging
+func (n *Node) LogRepr() string {
+	b, err := n.Marshal()
+	if err != nil {
+		return fmt.Sprintf("%#v", n)
+	}
+	return string(b)
 }

--- a/pkg/slices/doc.go
+++ b/pkg/slices/doc.go
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package slices contains common utilities to work on slices of any type.
+package slices

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package slices
+
+import (
+	"golang.org/x/exp/slices"
+)
+
+// DeleteFunc removes any elements from s for which del returns true,
+// returning the modified slice.
+// When DeleteFunc removes m elements, it might not modify the elements
+// s[len(s)-m:len(s)]. If those elements contain pointers you might consider
+// zeroing those elements so that objects they reference can be garbage
+// collected.
+func DeleteFunc[S ~[]E, E any](s S, del func(E) bool) S {
+	i := slices.IndexFunc(s, del)
+	if i == -1 {
+		return s
+	}
+	// Don't start copying elements until we find one to delete.
+	for j := i + 1; j < len(s); j++ {
+		if v := s[j]; !del(v) {
+			s[i] = v
+			i++
+		}
+	}
+	return s[:i]
+}


### PR DESCRIPTION
Manual backport of https://github.com/cilium/cilium/pull/29964. See commits for conflict notes (same ones as for v1.13).

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 29964; do contrib/backporting/set-labels.py $pr done 1.12; done
```
