### PR TITLE
Extend the clustermesh workflows to additionally cover the external kvstore case

### DIFF
--- a/.github/actions/kvstore/action.yaml
+++ b/.github/actions/kvstore/action.yaml
@@ -1,0 +1,120 @@
+name: Setup external etcd clusters for Cilium
+description: Generates the appropriate TLS certificates and starts the given number of single replica etcd clusters
+
+inputs:
+  clusters:
+    description: "Number of etcd single replica clusters to create"
+    default: "1"
+  etcd-image:
+    description: "etcd docker image"
+    default: gcr.io/etcd-development/etcd:v3.5.11@sha256:8eff25cf636711fb48426005b55fc9f4d6ffa4f38f483fa87c8cc82976347bbb
+  name:
+    description: "Base name of the etcd containers (to which the index is appended)"
+    default: kvstore
+  network:
+    description: "The Docker network the etcd containers are attached to"
+    default: kind
+
+outputs:
+  cilium_etcd_secrets_path:
+    description: "Path to the generated cilium-etcd-secrets Kubernetes secret"
+    value: ${{ steps.kvstore-vars.outputs.cilium_etcd_secrets_path }}
+  cilium_install_kvstore:
+    description: "The Cilium configuration to connect to the etcd cluster (parametrized by $KVSTORE_ID)"
+    value: ${{ steps.kvstore-vars.outputs.settings }}
+  cilium_install_clustermesh:
+    description: "The Cluster Mesh configuration to connect to the other clusters"
+    value: ${{ steps.clustermesh-vars.outputs.settings }}
+
+runs:
+  using: composite
+  steps:
+    - name: Generate certificates
+      id: generate-certs
+      shell: bash
+      run: |
+        DIR=$(mktemp -d)
+        echo "certs_dir=$DIR" >> $GITHUB_OUTPUT
+
+        # Generate the TLS certificates
+        openssl genrsa 4096 > $DIR/kvstore-ca-key.pem
+        openssl genrsa 4096 > $DIR/kvstore-server-key.pem
+        openssl genrsa 4096 > $DIR/kvstore-client-key.pem
+
+        # We reuse the same certificates for all etcd clusters for simplicity,
+        # as we are interested in a working setup, not a production-ready one.
+        openssl req -new -x509 -nodes -days 1 -subj "/CN=KVStore CA/" \
+          -key $DIR/kvstore-ca-key.pem -out $DIR/kvstore-ca-crt.pem
+        openssl req -new -x509 -nodes -days 1 -subj "/CN=server/" \
+          -addext "subjectAltName=$(printf DNS:${{ inputs.name }}%d, {1..${{ inputs.clusters }}})DNS:*.mesh.cilium.io" \
+          -key $DIR/kvstore-server-key.pem -out $DIR/kvstore-server-crt.pem \
+          -CA $DIR/kvstore-ca-crt.pem -CAkey $DIR/kvstore-ca-key.pem
+        openssl req -new -x509 -nodes -days 1 -subj "/CN=client/" \
+          -key $DIR/kvstore-client-key.pem -out $DIR/kvstore-client-crt.pem \
+          -CA $DIR/kvstore-ca-crt.pem -CAkey $DIR/kvstore-ca-key.pem
+
+    - name: Start kvstore containers
+      shell: bash
+      run: |
+        DIR=${{ steps.generate-certs.outputs.certs_dir }}
+
+        ETCD_VOLUMES=" \
+          --volume=$DIR/kvstore-ca-crt.pem:/tmp/tls/ca.crt:ro \
+          --volume=$DIR/kvstore-server-crt.pem:/tmp/tls/tls.crt:ro \
+          --volume=$DIR/kvstore-server-key.pem:/tmp/tls/tls.key:ro \
+        "
+
+        ETCD_FLAGS=" \
+          --client-cert-auth \
+          --trusted-ca-file=/tmp/tls/ca.crt \
+          --cert-file=/tmp/tls/tls.crt \
+          --key-file=/tmp/tls/tls.key \
+          --listen-client-urls=https://0.0.0.0:2379 \
+          --advertise-client-urls=https://0.0.0.0:2379 \
+        "
+
+        for i in {1..${{ inputs.clusters }}}; do
+          docker run --name ${{ inputs.name }}$i --detach --network=${{ inputs.network }} \
+            ${ETCD_VOLUMES} ${{ inputs.etcd-image }} etcd ${ETCD_FLAGS}
+        done
+
+    - name: Set kvstore connection parameters
+      shell: bash
+      id: kvstore-vars
+      run: |
+        DIR=${{ steps.generate-certs.outputs.certs_dir }}
+
+        echo "settings= \
+          --set etcd.enabled=true \
+          --set etcd.endpoints={https://${{ inputs.name }}\${KVSTORE_ID}:2379} \
+          --set etcd.ssl=true \
+          --set identityAllocationMode=kvstore \
+        " >> $GITHUB_OUTPUT
+
+        SECRET_PATH=$DIR/cilium-etcd-secrets.yaml
+        echo "cilium_etcd_secrets_path=$SECRET_PATH" >> $GITHUB_OUTPUT
+        kubectl create secret generic cilium-etcd-secrets --dry-run=client -o yaml \
+          --from-file etcd-client-ca.crt=$DIR/kvstore-ca-crt.pem \
+          --from-file etcd-client.crt=$DIR/kvstore-client-crt.pem \
+          --from-file etcd-client.key=$DIR/kvstore-client-key.pem \
+          > $SECRET_PATH
+
+    - name: Set clustermesh connection parameters
+      shell: bash
+      id: clustermesh-vars
+      run: |
+        DIR=${{ steps.generate-certs.outputs.certs_dir }}
+        SETTINGS=""
+
+        for i in {1..${{ inputs.clusters }}}; do
+          IP=$(docker inspect --format '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${{ inputs.name }}$i)
+          SETTINGS="$SETTINGS \
+            --set clustermesh.config.clusters[$(( i-1 ))].ips={$IP} \
+            --set clustermesh.config.clusters[$(( i-1 ))].port=2379 \
+            --set clustermesh.config.clusters[$(( i-1 ))].tls.caCert=$(base64 -w0 $DIR/kvstore-ca-crt.pem) \
+            --set clustermesh.config.clusters[$(( i-1 ))].tls.cert=$(base64 -w0 $DIR/kvstore-client-crt.pem) \
+            --set clustermesh.config.clusters[$(( i-1 ))].tls.key=$(base64 -w0 $DIR/kvstore-client-key.pem) \
+          "
+        done
+
+        echo "settings=$SETTINGS" >> $GITHUB_OUTPUT

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,7 @@
   // This ensures that the gitAuthor and gitSignOff fields match
   "gitAuthor": "renovate[bot] <bot@renovateapp.com>",
   "includePaths": [
+    ".github/actions/kvstore/**",
     ".github/actions/ginkgo/**",
     ".github/actions/set-env-variables/action.yml",
     ".github/workflows/**",
@@ -545,6 +546,15 @@
       "matchStrings": [
         "// renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+go (?<currentValue>.*)"
       ]
+    },
+    {
+      "fileMatch": [
+        ".github/actions/kvstore/action.yaml"
+      ],
+      "matchStrings": [
+        "default: (?<depName>.*?):(?<currentValue>.*?)@(?<currentDigest>.*?)\\s"
+      ],
+      "datasourceTemplate": "docker"
     }
   ]
 }

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -94,17 +94,17 @@ jobs:
             ipfamily: 'ipv4'
             encryption: 'disabled'
             kube-proxy: 'iptables'
-            kvstoremesh: true
+            mode: 'kvstoremesh'
             cm-auth-mode-1: 'legacy'
             cm-auth-mode-2: 'legacy'
             maxConnectedClusters: '255'
 
           - name: '2'
             tunnel: 'disabled'
-            ipfamily: 'ipv4'
+            ipfamily: 'dual'
             encryption: 'wireguard'
             kube-proxy: 'none'
-            kvstoremesh: false
+            mode: 'clustermesh'
             cm-auth-mode-1: 'migration'
             cm-auth-mode-2: 'migration'
             maxConnectedClusters: '511'
@@ -112,10 +112,10 @@ jobs:
           # IPsec encryption cannot be used with BPF NodePort.
           - name: '3'
             tunnel: 'disabled'
-            ipfamily: 'ipv4'
+            ipfamily: 'dual'
             encryption: 'ipsec'
             kube-proxy: 'iptables'
-            kvstoremesh: true
+            mode: 'kvstoremesh'
             cm-auth-mode-1: 'cluster'
             cm-auth-mode-2: 'cluster'
             maxConnectedClusters: '255'
@@ -127,7 +127,7 @@ jobs:
             ipfamily: 'ipv6'
             encryption: 'disabled'
             kube-proxy: 'none'
-            kvstoremesh: false
+            mode: 'clustermesh'
             cm-auth-mode-1: 'legacy'
             cm-auth-mode-2: 'migration'
             maxConnectedClusters: '255'
@@ -138,8 +138,8 @@ jobs:
             ipfamily: 'dual'
             encryption: 'ipsec'
             kube-proxy: 'iptables'
-            kvstoremesh: true
-            cm-auth-mode-1: 'migration'
+            mode: 'kvstoremesh'
+            cm-auth-mode-1: 'cluster'
             cm-auth-mode-2: 'cluster'
             maxConnectedClusters: '255'
 
@@ -148,28 +148,28 @@ jobs:
             ipfamily: 'ipv4'
             encryption: 'disabled'
             kube-proxy: 'none'
-            kvstoremesh: false
+            mode: 'clustermesh'
             cm-auth-mode-1: 'cluster'
             cm-auth-mode-2: 'cluster'
             maxConnectedClusters: '511'
 
           - name: '7'
             tunnel: 'geneve'
-            ipfamily: 'ipv4'
+            ipfamily: 'dual'
             encryption: 'wireguard'
             kube-proxy: 'iptables'
-            kvstoremesh: true
-            cm-auth-mode-1: 'cluster'
+            mode: 'kvstoremesh'
+            cm-auth-mode-1: 'migration'
             cm-auth-mode-2: 'cluster'
             maxConnectedClusters: '255'
 
           # IPsec encryption cannot be used with BPF NodePort.
           - name: '8'
             tunnel: 'vxlan'
-            ipfamily: 'ipv4'
+            ipfamily: 'dual'
             encryption: 'ipsec'
             kube-proxy: 'iptables'
-            kvstoremesh: false
+            mode: 'clustermesh'
             cm-auth-mode-1: 'cluster'
             cm-auth-mode-2: 'cluster'
             maxConnectedClusters: '255'
@@ -180,7 +180,7 @@ jobs:
         #    ipfamily: 'ipv6'
         #    encryption: 'disabled'
         #    kube-proxy: 'none'
-        #    kvstoremesh: true
+        #    mode: 'kvstoremesh'
         #    cm-auth-mode-1: 'cluster'
         #    cm-auth-mode-2: 'cluster'
 
@@ -189,7 +189,7 @@ jobs:
             ipfamily: 'dual'
             encryption: 'wireguard'
             kube-proxy: 'iptables'
-            kvstoremesh: false
+            mode: 'clustermesh'
             cm-auth-mode-1: 'cluster'
             cm-auth-mode-2: 'cluster'
             maxConnectedClusters: '255'
@@ -221,7 +221,7 @@ jobs:
             --helm-set=hubble.enabled=true \
             --helm-set=hubble.relay.enabled=true \
             --helm-set=clustermesh.useAPIServer=true \
-            --helm-set=clustermesh.apiserver.kvstoremesh.enabled=${{ matrix.kvstoremesh }} \
+            --helm-set=clustermesh.apiserver.kvstoremesh.enabled=${{ matrix.mode == 'kvstoremesh' }} \
             --helm-set=clustermesh.maxConnectedClusters=${{ matrix.maxConnectedClusters }} \
             "
 

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -149,7 +149,7 @@ jobs:
             mode: 'clustermesh'
             cm-auth-mode-1: 'cluster'
             cm-auth-mode-2: 'cluster'
-            maxConnectedClusters: '511'
+            maxConnectedClusters: '255'
 
           - name: '7'
             tunnel: 'geneve'
@@ -159,7 +159,7 @@ jobs:
             mode: 'kvstoremesh'
             cm-auth-mode-1: 'migration'
             cm-auth-mode-2: 'cluster'
-            maxConnectedClusters: '255'
+            maxConnectedClusters: '511'
 
           # IPsec encryption cannot be used with BPF NodePort.
           - name: '8'
@@ -188,7 +188,7 @@ jobs:
             encryption: 'wireguard'
             kube-proxy: 'iptables'
             mode: 'external'
-            maxConnectedClusters: '255'
+            maxConnectedClusters: '511'
 
     steps:
       - name: Checkout context ref (trusted)

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -138,9 +138,7 @@ jobs:
             ipfamily: 'dual'
             encryption: 'ipsec'
             kube-proxy: 'iptables'
-            mode: 'kvstoremesh'
-            cm-auth-mode-1: 'cluster'
-            cm-auth-mode-2: 'cluster'
+            mode: 'external'
             maxConnectedClusters: '255'
 
           - name: '6'
@@ -189,9 +187,7 @@ jobs:
             ipfamily: 'dual'
             encryption: 'wireguard'
             kube-proxy: 'iptables'
-            mode: 'clustermesh'
-            cm-auth-mode-1: 'cluster'
-            cm-auth-mode-2: 'cluster'
+            mode: 'external'
             maxConnectedClusters: '255'
 
     steps:
@@ -220,7 +216,7 @@ jobs:
             --helm-set=bpf.monitorAggregation=none \
             --helm-set=hubble.enabled=true \
             --helm-set=hubble.relay.enabled=true \
-            --helm-set=clustermesh.useAPIServer=true \
+            --helm-set=clustermesh.useAPIServer=${{ matrix.mode != 'external' }} \
             --helm-set=clustermesh.apiserver.kvstoremesh.enabled=${{ matrix.mode == 'kvstoremesh' }} \
             --helm-set=clustermesh.maxConnectedClusters=${{ matrix.maxConnectedClusters }} \
             "
@@ -350,6 +346,30 @@ jobs:
           kubectl --context ${{ env.contextName1 }} patch deployment -n kube-system coredns --patch="$COREDNS_PATCH"
           kubectl --context ${{ env.contextName2 }} patch deployment -n kube-system coredns --patch="$COREDNS_PATCH"
 
+      - name: Start kvstore clusters
+        id: kvstore
+        if: matrix.mode == 'external'
+        uses: ./.github/actions/kvstore
+        with:
+          clusters: 2
+
+      - name: Create the secret containing the kvstore credentials
+        if: matrix.mode == 'external'
+        run: |
+          kubectl --context ${{ env.contextName1 }} create -n kube-system -f ${{ steps.kvstore.outputs.cilium_etcd_secrets_path }}
+          kubectl --context ${{ env.contextName2 }} create -n kube-system -f ${{ steps.kvstore.outputs.cilium_etcd_secrets_path }}
+
+      - name: Set clustermesh connection parameters
+        if: matrix.mode == 'external'
+        id: clustermesh-vars
+        run: |
+          echo "cilium_install_clustermesh= \
+            --set=clustermesh.config.enabled=true \
+            --set clustermesh.config.clusters[0].name=${{ env.clusterName1 }} \
+            --set clustermesh.config.clusters[1].name=${{ env.clusterName2 }} \
+            ${{ steps.kvstore.outputs.cilium_install_clustermesh }} \
+          " >> $GITHUB_OUTPUT
+
       - name: Wait for images to be available
         timeout-minutes: 30
         shell: bash
@@ -375,6 +395,8 @@ jobs:
 
       - name: Install Cilium in cluster1
         id: install-cilium-cluster1
+        env:
+          KVSTORE_ID: 1
         run: |
           # Explicitly configure the NodePort to make sure that it is different in
           # each cluster, to workaround #24692
@@ -383,7 +405,9 @@ jobs:
             --helm-set cluster.name=${{ env.clusterName1 }} \
             --helm-set cluster.id=1 \
             --helm-set clustermesh.apiserver.service.nodePort=32379 \
-            --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.cm-auth-mode-1 }}
+            --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.cm-auth-mode-1 }} \
+            ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
+            ${{ steps.clustermesh-vars.outputs.cilium_install_clustermesh }}
 
       - name: Copy the Cilium CA secret to cluster2, as they must match
         run: |
@@ -391,6 +415,8 @@ jobs:
             kubectl --context ${{ env.contextName2 }} create -f -
 
       - name: Install Cilium in cluster2
+        env:
+          KVSTORE_ID: 2
         run: |
           # Explicitly configure the NodePort to make sure that it is different in
           # each cluster, to workaround #24692
@@ -399,7 +425,9 @@ jobs:
             --helm-set cluster.name=${{ env.clusterName2 }} \
             --helm-set cluster.id=255 \
             --helm-set clustermesh.apiserver.service.nodePort=32380 \
-            --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.cm-auth-mode-2 }}
+            --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.cm-auth-mode-2 }} \
+            ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
+            ${{ steps.clustermesh-vars.outputs.cilium_install_clustermesh }}
 
       - name: Wait for cluster mesh status to be ready
         run: |
@@ -409,10 +437,12 @@ jobs:
           cilium --context ${{ env.contextName2 }} clustermesh status --wait
 
       - name: Connect clusters
+        if: matrix.mode != 'external'
         run: |
           cilium --context ${{ env.contextName1 }} clustermesh connect --destination-context ${{ env.contextName2 }}
 
       - name: Wait for cluster mesh status to be ready
+        if: matrix.mode != 'external'
         run: |
           cilium --context ${{ env.contextName1 }} status --wait
           cilium --context ${{ env.contextName2 }} status --wait
@@ -450,6 +480,14 @@ jobs:
           kubectl config use-context ${{ env.contextName2 }}
           kubectl get pods --all-namespaces -o wide
           cilium sysdump --output-filename cilium-sysdump-context2-final-${{ join(matrix.*, '-') }}
+
+          if [ "${{ matrix.mode }}" == "external" ]; then
+            for i in {1..2}; do
+              echo
+              echo "# Retrieving logs from kvstore$i docker container"
+              docker logs kvstore$i
+            done
+          fi
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload artifacts

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -91,10 +91,12 @@ jobs:
           - name: '1'
             encryption: 'disabled'
             kube-proxy: 'iptables'
+            external-kvstore: false
 
           - name: '2'
             encryption: 'disabled'
             kube-proxy: 'none'
+            external-kvstore: false
 
           # Currently, ipsec requires to synchronously regenerate the host
           # endpoint to ensure ordering (#25735). Given that this is a blocking
@@ -104,14 +106,17 @@ jobs:
           # experience cross-cluster connection drops during upgrades/downgrades,
           # given that the timeout is too low to account for the initialization
           # of a new clustermesh-apiserver replica (while it is enough to prevent
-          # issues in case of agent restarts, if all remote clusters are ready).
-          # - name: '3'
-          #   encryption: 'ipsec'
-          #   kube-proxy: 'iptables'
+          # issues in case of agent restarts, if all remote clusters are ready,
+          # as well as when connecting to an external kvstore as in this case).
+          - name: '3'
+            encryption: 'ipsec'
+            kube-proxy: 'iptables'
+            external-kvstore: true
 
           - name: '4'
             encryption: 'wireguard'
             kube-proxy: 'iptables'
+            external-kvstore: false
 
     steps:
       - name: Checkout context ref (trusted)
@@ -151,7 +156,7 @@ jobs:
             --set=tunnelProtocol=vxlan \
             --set=ipv4.enabled=true \
             --set=ipv6.enabled=true \
-            --set=clustermesh.useAPIServer=true \
+            --set=clustermesh.useAPIServer=${{ !matrix.external-kvstore }} \
             --set=clustermesh.config.enabled=true \
             --set=extraConfig.clustermesh-ip-identities-sync-timeout=5m"
 
@@ -230,17 +235,25 @@ jobs:
           kubectl --context ${{ env.contextName1 }} create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="${SECRET}"
           kubectl --context ${{ env.contextName2 }} create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="${SECRET}"
 
+      - name: Start kvstore clusters
+        id: kvstore
+        if: matrix.external-kvstore
+        uses: ./.github/actions/kvstore
+        with:
+          clusters: 2
+
+      - name: Create the secret containing the kvstore credentials
+        if: matrix.external-kvstore
+        run: |
+          kubectl --context ${{ env.contextName1 }} create -n kube-system -f ${{ steps.kvstore.outputs.cilium_etcd_secrets_path }}
+          kubectl --context ${{ env.contextName2 }} create -n kube-system -f ${{ steps.kvstore.outputs.cilium_etcd_secrets_path }}
+
       - name: Set clustermesh connection parameters
         id: clustermesh-vars
         run: |
           # Let's retrieve in advance the parameters to mesh the two clusters, so
           # that we don't need to do that through the CLI in a second step, as it
           # would be reset during upgrade (as we are resetting the values).
-
-          IP1=$(kubectl --context ${{ env.contextName1 }} get nodes \
-            ${{ env.clusterName1 }}-worker -o wide --no-headers | awk '{ print $6 }')
-          IP2=$(kubectl --context ${{ env.contextName2 }} get nodes \
-            ${{ env.clusterName2 }}-worker -o wide --no-headers | awk '{ print $6 }')
 
           # Explicitly configure the NodePorts to make sure that they are different
           # in each cluster, to workaround #24692
@@ -251,20 +264,38 @@ jobs:
             --set cluster.name=${{ env.clusterName1 }} \
             --set cluster.id=1 \
             --set clustermesh.apiserver.service.nodePort=$PORT1 \
-            --set clustermesh.config.clusters[0].name=${{ env.clusterName2 }} \
-            --set clustermesh.config.clusters[0].ips={$IP2} \
-            --set clustermesh.config.clusters[0].port=$PORT2"
+          "
 
           CILIUM_INSTALL_CLUSTER2=" \
             --set cluster.name=${{ env.clusterName2 }} \
             --set cluster.id=255 \
             --set clustermesh.apiserver.service.nodePort=$PORT2 \
-            --set clustermesh.config.clusters[0].name=${{ env.clusterName1 }} \
-            --set clustermesh.config.clusters[0].ips={$IP1} \
-            --set clustermesh.config.clusters[0].port=$PORT1"
+          "
 
-          echo cilium_install_cluster1=$CILIUM_INSTALL_CLUSTER1 >> $GITHUB_OUTPUT
-          echo cilium_install_cluster2=$CILIUM_INSTALL_CLUSTER2 >> $GITHUB_OUTPUT
+          CILIUM_INSTALL_COMMON=" \
+            --set clustermesh.config.clusters[0].name=${{ env.clusterName1 }} \
+            --set clustermesh.config.clusters[1].name=${{ env.clusterName2 }} \
+          "
+
+          if [ "${{ matrix.external-kvstore }}" == "true" ]; then
+            CILIUM_INSTALL_COMMON="$CILIUM_INSTALL_COMMON \
+              ${{ steps.kvstore.outputs.cilium_install_clustermesh }}"
+          else
+            IP1=$(kubectl --context ${{ env.contextName1 }} get nodes \
+              ${{ env.clusterName1 }}-worker -o wide --no-headers | awk '{ print $6 }')
+            IP2=$(kubectl --context ${{ env.contextName2 }} get nodes \
+              ${{ env.clusterName2 }}-worker -o wide --no-headers | awk '{ print $6 }')
+
+            CILIUM_INSTALL_COMMON="$CILIUM_INSTALL_COMMON \
+              --set clustermesh.config.clusters[0].ips={$IP1} \
+              --set clustermesh.config.clusters[0].port=$PORT1 \
+              --set clustermesh.config.clusters[1].ips={$IP2} \
+              --set clustermesh.config.clusters[1].port=$PORT2 \
+            "
+          fi
+
+          echo cilium_install_cluster1="$CILIUM_INSTALL_CLUSTER1 $CILIUM_INSTALL_COMMON" >> $GITHUB_OUTPUT
+          echo cilium_install_cluster2="$CILIUM_INSTALL_CLUSTER2 $CILIUM_INSTALL_COMMON" >> $GITHUB_OUTPUT
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
@@ -319,22 +350,29 @@ jobs:
 
       - name: Install Cilium in cluster1
         id: install-cilium-cluster1
+        env:
+          KVSTORE_ID: 1
         run: |
           cilium --context ${{ env.contextName1 }} install \
             ${{ steps.downgrade-vars.outputs.cilium_image_settings }} \
             ${{ steps.vars.outputs.cilium_install_defaults }} \
+            ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
             ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }}
 
       - name: Copy the Cilium CA secret to cluster2, as they must match
+        if: ${{ !matrix.external-kvstore }}
         run: |
           kubectl --context ${{ env.contextName1 }} get secret -n kube-system cilium-ca -o yaml |
             kubectl --context ${{ env.contextName2 }} create -f -
 
       - name: Install Cilium in cluster2
+        env:
+          KVSTORE_ID: 2
         run: |
           cilium --context ${{ env.contextName2 }} install \
             ${{ steps.newest-vars.outputs.cilium_install_defaults }} \
             ${{ steps.vars.outputs.cilium_install_defaults }} \
+            ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
             ${{ steps.clustermesh-vars.outputs.cilium_install_cluster2 }}
 
       - name: Wait for cluster mesh status to be ready
@@ -366,14 +404,18 @@ jobs:
 
 
       - name: Upgrade Cilium in cluster1 and enable kvstoremesh
+        env:
+          KVSTORE_ID: 1
         run: |
           cilium --context ${{ env.contextName1 }} upgrade --reset-values \
             ${{ steps.newest-vars.outputs.cilium_install_defaults }} \
             ${{ steps.vars.outputs.cilium_install_defaults }} \
+            ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
             ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }} \
             --set clustermesh.apiserver.kvstoremesh.enabled=true
 
       - name: Rollout Cilium agents in cluster2
+        if: ${{ !matrix.external-kvstore }}
         run: |
           # This makes sure that the remote agents reconnect to the new instance of the
           # clustermesh-apiserver, without waiting for the watchdog mechanism to kick in.
@@ -415,6 +457,7 @@ jobs:
       # Perform an additional "stress" test, scaling the clustermesh-apiservers in both clusters
       # to zero replicas, and restarting all agents. Existing connections should not be disrupted.
       - name: Scale the clustermesh-apiserver replicas to 0
+        if: ${{ !matrix.external-kvstore }}
         run: |
           kubectl --context ${{ env.contextName1 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
           kubectl --context ${{ env.contextName2 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
@@ -429,6 +472,7 @@ jobs:
           kubectl --context ${{ env.contextName2 }} rollout status -n kube-system ds/cilium --timeout=5m
 
       - name: Scale the clustermesh-apiserver replicas back to 1
+        if: ${{ !matrix.external-kvstore }}
         run: |
           kubectl --context ${{ env.contextName1 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 1
           kubectl --context ${{ env.contextName2 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 1
@@ -471,13 +515,17 @@ jobs:
 
 
       - name: Downgrade Cilium in cluster1 and disable kvstoremesh
+        env:
+          KVSTORE_ID: 1
         run: |
           cilium --context ${{ env.contextName1 }} upgrade --reset-values \
             ${{ steps.downgrade-vars.outputs.cilium_image_settings }} \
             ${{ steps.vars.outputs.cilium_install_defaults }} \
+            ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
             ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }}
 
       - name: Rollout Cilium agents in cluster2
+        if: ${{ !matrix.external-kvstore }}
         run: |
           # This makes sure that the remote agents reconnect to the new instance of the
           # clustermesh-apiserver, without waiting for the watchdog mechanism to kick in.
@@ -523,6 +571,14 @@ jobs:
           kubectl config use-context ${{ env.contextName2 }}
           kubectl get pods --all-namespaces -o wide
           cilium sysdump --output-filename cilium-sysdump-context2-final-${{ join(matrix.*, '-') }}
+
+          if [ "${{ matrix.external-kvstore }}" == "true" ]; then
+            for i in {1..2}; do
+              echo
+              echo "# Retrieving logs from kvstore$i docker container"
+              docker logs kvstore$i
+            done
+          fi
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload artifacts

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -232,6 +232,7 @@
 /.github/ @cilium/contributing
 /.github/renovate.json5 @cilium/github-sec @cilium/ci-structure
 /.github/actions/ @cilium/github-sec @cilium/ci-structure
+/.github/actions/kvstore/ @cilium/sig-clustermesh @cilium/kvstore @cilium/github-sec @cilium/ci-structure
 /.github/workflows/ @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*clustermesh*.yaml @cilium/sig-clustermesh @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*datapath*.yaml @cilium/sig-datapath @cilium/github-sec @cilium/ci-structure


### PR DESCRIPTION
Let's extend the conformance clustermesh and clustermesh upgrade/downgrade workflows to additionally cover the external kvstores configuration, in addition to plain clustermesh and kvstoremesh, to prevent possible regressions associated with that setup.

Please review commit by commit, and refer to the respective messages for additional details.

Depends on https://github.com/cilium/cilium-cli/pull/2199

<!-- Description of change -->

```release-note
Extend the clustermesh workflows to additionally cover the external kvstore case
```
