### PR TITLE
pkg/metrics/bpf: new bpf_maps & bpf_progs metrics

### DIFF
--- a/pkg/metrics/bpf.go
+++ b/pkg/metrics/bpf.go
@@ -8,26 +8,52 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"slices"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/cilium/cilium/pkg/time"
 )
 
 type bpfCollector struct {
-	bpfMapsMemory *prometheus.Desc
-	bpfProgMemory *prometheus.Desc
+	sfg singleflight.Group
+
+	bpfMapsCount      *prometheus.Desc
+	bpfMapsMemory     *prometheus.Desc
+	bpfProgramsCount  *prometheus.Desc
+	bpfProgramsMemory *prometheus.Desc
+}
+
+type bpfUsage struct {
+	ids                   []uint64
+	virtualMemoryMaxBytes float64
+}
+
+func (bu bpfUsage) count() float64 {
+	return float64(len(bu.ids))
 }
 
 func newbpfCollector() *bpfCollector {
 	return &bpfCollector{
+		bpfMapsCount: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "bpf_maps"),
+			"Total count of BPF maps.",
+			nil, nil,
+		),
 		bpfMapsMemory: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, "", "bpf_maps_virtual_memory_max_bytes"),
 			"BPF maps kernel max memory usage size in bytes.",
 			nil, nil,
 		),
-		bpfProgMemory: prometheus.NewDesc(
+		bpfProgramsCount: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "bpf_progs"),
+			"Total count of BPF programs.",
+			nil, nil,
+		),
+		bpfProgramsMemory: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, "", "bpf_progs_virtual_memory_max_bytes"),
 			"BPF programs kernel max memory usage size in bytes.",
 			nil, nil,
@@ -36,55 +62,111 @@ func newbpfCollector() *bpfCollector {
 }
 
 func (s *bpfCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- s.bpfMapsMemory
-	ch <- s.bpfProgMemory
+	prometheus.DescribeByCollect(s, ch)
 }
 
 type memoryEntry struct {
+	ID           uint64 `json:"id"`
+	Name         string `json:"name"`
 	BytesMemlock uint64 `json:"bytes_memlock"`
+
+	// (returned only for programs)
+	MapIDs []uint64 `json:"map_ids"`
 }
 
-func getMemoryUsage(typ string) (uint64, error) {
+func getBPFUsage(typ string, filter func(memoryEntry) bool) (bpfUsage, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "bpftool", "-j", typ, "show")
 	out, err := cmd.Output()
 	if err != nil {
-		return 0, fmt.Errorf("unable to get bpftool output: %w", err)
+		return bpfUsage{}, fmt.Errorf("unable to get bpftool output: %w", err)
 	}
 
-	var memoryEntries []memoryEntry
+	var (
+		memoryEntries []memoryEntry
+		usage         bpfUsage
+	)
+
 	err = json.Unmarshal(out, &memoryEntries)
 	if err != nil {
-		return 0, fmt.Errorf("unable to unmarshal bpftool output: %w", err)
+		return usage, fmt.Errorf("unable to unmarshal bpftool output: %w", err)
 	}
-	var totalMem uint64
+
 	for _, entry := range memoryEntries {
-		totalMem += entry.BytesMemlock
+		if !filter(entry) {
+			continue
+		}
+
+		usage.ids = append(usage.ids, entry.ID)
+		usage.virtualMemoryMaxBytes += float64(entry.BytesMemlock)
 	}
-	return totalMem, nil
+
+	return usage, nil
 }
 
 func (s *bpfCollector) Collect(ch chan<- prometheus.Metric) {
-	mapMem, err := getMemoryUsage("map")
-	if err != nil {
-		logrus.WithError(err).Error("Error while getting BPF maps memory usage")
-	} else {
-		ch <- prometheus.MustNewConstMetric(
-			s.bpfMapsMemory,
-			prometheus.GaugeValue,
-			float64(mapMem),
-		)
+	type bpfUsageResults struct {
+		maps     bpfUsage
+		programs bpfUsage
 	}
 
-	progMem, err := getMemoryUsage("prog")
-	if err != nil {
-		logrus.WithError(err).Error("Error while getting BPF progs memory usage")
-	} else {
-		ch <- prometheus.MustNewConstMetric(
-			s.bpfProgMemory,
-			prometheus.GaugeValue,
-			float64(progMem),
+	// Avoid querying BPF multiple times concurrently, if it happens, additional callers will wait for the
+	// first one to finish and reuse its resulting values.
+	results, err, _ := s.sfg.Do("collect", func() (interface{}, error) {
+		var (
+			results = bpfUsageResults{}
+			err     error
 		)
+
+		if results.maps, err = getBPFUsage("map", func(entry memoryEntry) bool {
+			// Filter on maps prefixed with cilium_
+			return strings.HasPrefix(entry.Name, "cilium_")
+		}); err != nil {
+			return results, err
+		}
+
+		if results.programs, err = getBPFUsage("prog", func(entry memoryEntry) bool {
+			// Filter on programs related to cilium maps
+			for i := 0; i < len(entry.MapIDs); i++ {
+				if slices.Contains(results.maps.ids, entry.MapIDs[i]) {
+					return true
+				}
+			}
+			return false
+		}); err != nil {
+			return results, err
+		}
+
+		return results, nil
+	})
+
+	if err != nil {
+		logrus.WithError(err).Error("retrieving BPF maps & programs usage")
+		return
 	}
+
+	ch <- prometheus.MustNewConstMetric(
+		s.bpfMapsCount,
+		prometheus.GaugeValue,
+		results.(bpfUsageResults).maps.count(),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		s.bpfMapsMemory,
+		prometheus.GaugeValue,
+		results.(bpfUsageResults).maps.virtualMemoryMaxBytes,
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		s.bpfProgramsCount,
+		prometheus.GaugeValue,
+		results.(bpfUsageResults).programs.count(),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		s.bpfProgramsMemory,
+		prometheus.GaugeValue,
+		results.(bpfUsageResults).programs.virtualMemoryMaxBytes,
+	)
 }

--- a/vendor/golang.org/x/sync/singleflight/singleflight.go
+++ b/vendor/golang.org/x/sync/singleflight/singleflight.go
@@ -1,0 +1,214 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package singleflight provides a duplicate function call suppression
+// mechanism.
+package singleflight // import "golang.org/x/sync/singleflight"
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"sync"
+)
+
+// errGoexit indicates the runtime.Goexit was called in
+// the user given function.
+var errGoexit = errors.New("runtime.Goexit was called")
+
+// A panicError is an arbitrary value recovered from a panic
+// with the stack trace during the execution of given function.
+type panicError struct {
+	value interface{}
+	stack []byte
+}
+
+// Error implements error interface.
+func (p *panicError) Error() string {
+	return fmt.Sprintf("%v\n\n%s", p.value, p.stack)
+}
+
+func (p *panicError) Unwrap() error {
+	err, ok := p.value.(error)
+	if !ok {
+		return nil
+	}
+
+	return err
+}
+
+func newPanicError(v interface{}) error {
+	stack := debug.Stack()
+
+	// The first line of the stack trace is of the form "goroutine N [status]:"
+	// but by the time the panic reaches Do the goroutine may no longer exist
+	// and its status will have changed. Trim out the misleading line.
+	if line := bytes.IndexByte(stack[:], '\n'); line >= 0 {
+		stack = stack[line+1:]
+	}
+	return &panicError{value: v, stack: stack}
+}
+
+// call is an in-flight or completed singleflight.Do call
+type call struct {
+	wg sync.WaitGroup
+
+	// These fields are written once before the WaitGroup is done
+	// and are only read after the WaitGroup is done.
+	val interface{}
+	err error
+
+	// These fields are read and written with the singleflight
+	// mutex held before the WaitGroup is done, and are read but
+	// not written after the WaitGroup is done.
+	dups  int
+	chans []chan<- Result
+}
+
+// Group represents a class of work and forms a namespace in
+// which units of work can be executed with duplicate suppression.
+type Group struct {
+	mu sync.Mutex       // protects m
+	m  map[string]*call // lazily initialized
+}
+
+// Result holds the results of Do, so they can be passed
+// on a channel.
+type Result struct {
+	Val    interface{}
+	Err    error
+	Shared bool
+}
+
+// Do executes and returns the results of the given function, making
+// sure that only one execution is in-flight for a given key at a
+// time. If a duplicate comes in, the duplicate caller waits for the
+// original to complete and receives the same results.
+// The return value shared indicates whether v was given to multiple callers.
+func (g *Group) Do(key string, fn func() (interface{}, error)) (v interface{}, err error, shared bool) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		g.mu.Unlock()
+		c.wg.Wait()
+
+		if e, ok := c.err.(*panicError); ok {
+			panic(e)
+		} else if c.err == errGoexit {
+			runtime.Goexit()
+		}
+		return c.val, c.err, true
+	}
+	c := new(call)
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	g.doCall(c, key, fn)
+	return c.val, c.err, c.dups > 0
+}
+
+// DoChan is like Do but returns a channel that will receive the
+// results when they are ready.
+//
+// The returned channel will not be closed.
+func (g *Group) DoChan(key string, fn func() (interface{}, error)) <-chan Result {
+	ch := make(chan Result, 1)
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		c.chans = append(c.chans, ch)
+		g.mu.Unlock()
+		return ch
+	}
+	c := &call{chans: []chan<- Result{ch}}
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	go g.doCall(c, key, fn)
+
+	return ch
+}
+
+// doCall handles the single call for a key.
+func (g *Group) doCall(c *call, key string, fn func() (interface{}, error)) {
+	normalReturn := false
+	recovered := false
+
+	// use double-defer to distinguish panic from runtime.Goexit,
+	// more details see https://golang.org/cl/134395
+	defer func() {
+		// the given function invoked runtime.Goexit
+		if !normalReturn && !recovered {
+			c.err = errGoexit
+		}
+
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		c.wg.Done()
+		if g.m[key] == c {
+			delete(g.m, key)
+		}
+
+		if e, ok := c.err.(*panicError); ok {
+			// In order to prevent the waiting channels from being blocked forever,
+			// needs to ensure that this panic cannot be recovered.
+			if len(c.chans) > 0 {
+				go panic(e)
+				select {} // Keep this goroutine around so that it will appear in the crash dump.
+			} else {
+				panic(e)
+			}
+		} else if c.err == errGoexit {
+			// Already in the process of goexit, no need to call again
+		} else {
+			// Normal return
+			for _, ch := range c.chans {
+				ch <- Result{c.val, c.err, c.dups > 0}
+			}
+		}
+	}()
+
+	func() {
+		defer func() {
+			if !normalReturn {
+				// Ideally, we would wait to take a stack trace until we've determined
+				// whether this is a panic or a runtime.Goexit.
+				//
+				// Unfortunately, the only way we can distinguish the two is to see
+				// whether the recover stopped the goroutine from terminating, and by
+				// the time we know that, the part of the stack trace relevant to the
+				// panic has been discarded.
+				if r := recover(); r != nil {
+					c.err = newPanicError(r)
+				}
+			}
+		}()
+
+		c.val, c.err = fn()
+		normalReturn = true
+	}()
+
+	if !normalReturn {
+		recovered = true
+	}
+}
+
+// Forget tells the singleflight to forget about a key.  Future calls
+// to Do for this key will call the function rather than waiting for
+// an earlier call to complete.
+func (g *Group) Forget(key string) {
+	g.mu.Lock()
+	delete(g.m, key)
+	g.mu.Unlock()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1691,6 +1691,7 @@ golang.org/x/oauth2/internal
 ## explicit; go 1.18
 golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
+golang.org/x/sync/singleflight
 # golang.org/x/sys v0.27.0
 ## explicit; go 1.18
 golang.org/x/sys/cpu


### PR DESCRIPTION
This change introduces two new metrics to monitor the amount of bpf maps and programs currently defined on the system.

We recently discovered that abnormally large amounts of maps could be found on some of our nodes.

Additionally, this change introduces request concurrency limit as well as dynamic definition of the metrics list throughout the Describe() function.

```release-note
pkg/metrics/bpf: new bpf_maps & bpf_progs metrics
```
