### PR TITLE
pkg/node/manager: Fix inconsistent ipset entries handling on node update, add test non-regression test

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -55,8 +55,8 @@ const (
 	ciliumForwardChain    = "CILIUM_FORWARD"
 	feederDescription     = "cilium-feeder:"
 	xfrmDescription       = "cilium-xfrm-notrack:"
-	ciliumNodeIpsetV4     = "cilium_node_set_v4"
-	ciliumNodeIpsetV6     = "cilium_node_set_v6"
+	CiliumNodeIpsetV4     = "cilium_node_set_v4"
+	CiliumNodeIpsetV6     = "cilium_node_set_v6"
 )
 
 // Minimum iptables versions supporting the -w and -w<seconds> flags
@@ -109,8 +109,8 @@ func (ipt *ipt) initArgs(waitSeconds int) {
 
 // package name is iptables so we use ip4tables internally for "iptables"
 var (
-	ip4tables = &ipt{prog: "iptables", ipset: ciliumNodeIpsetV4}
-	ip6tables = &ipt{prog: "ip6tables", ipset: ciliumNodeIpsetV6}
+	ip4tables = &ipt{prog: "iptables", ipset: CiliumNodeIpsetV4}
+	ip6tables = &ipt{prog: "ip6tables", ipset: CiliumNodeIpsetV6}
 	ipset     = &ipt{prog: "ipset"}
 )
 
@@ -1198,9 +1198,9 @@ func (m *Manager) installForwardChainRulesIpX(prog iptablesInterface, ifName, lo
 // or the IP already exist.
 func (m *Manager) AddToNodeIpset(nodeIP net.IP) {
 	scopedLog := log.WithField(logfields.IPAddr, nodeIP.String())
-	ciliumNodeIpset := ciliumNodeIpsetV4
+	ciliumNodeIpset := CiliumNodeIpsetV4
 	if ip.IsIPv6(nodeIP) {
-		ciliumNodeIpset = ciliumNodeIpsetV6
+		ciliumNodeIpset = CiliumNodeIpsetV6
 	}
 	if err := createIpset(ciliumNodeIpset, ip.IsIPv6(nodeIP)); err != nil {
 		scopedLog.WithError(err).Errorf("Failed to create ipset %s", ciliumNodeIpset)
@@ -1215,9 +1215,9 @@ func (m *Manager) AddToNodeIpset(nodeIP net.IP) {
 // RemoveFromBodeIpset removes an IP address from the ipset for cluster nodes.
 func (m *Manager) RemoveFromNodeIpset(nodeIP net.IP) {
 	scopedLog := log.WithField(logfields.IPAddr, nodeIP.String())
-	ciliumNodeIpset := ciliumNodeIpsetV4
+	ciliumNodeIpset := CiliumNodeIpsetV4
 	if ip.IsIPv6(nodeIP) {
-		ciliumNodeIpset = ciliumNodeIpsetV6
+		ciliumNodeIpset = CiliumNodeIpsetV6
 	}
 	progArgs := []string{"del", ciliumNodeIpset, nodeIP.String(), "-exist"}
 	if err := ipset.runProg(progArgs); err != nil {
@@ -1613,20 +1613,20 @@ func (m *Manager) doInstallRules(ifName string, firstInitialization, install boo
 	// needed depends on the configuration, but the content doesn't.
 	if m.sharedCfg.NodeIpsetNeeded {
 		if m.sharedCfg.IptablesMasqueradingIPv4Enabled {
-			if err := createIpset(ciliumNodeIpsetV4, false); err != nil {
+			if err := createIpset(CiliumNodeIpsetV4, false); err != nil {
 				return err
 			}
 		}
 		if m.sharedCfg.IptablesMasqueradingIPv6Enabled {
-			if err := createIpset(ciliumNodeIpsetV6, true); err != nil {
+			if err := createIpset(CiliumNodeIpsetV6, true); err != nil {
 				return err
 			}
 		}
 	} else {
-		if err := removeIpset(ciliumNodeIpsetV4); err != nil {
+		if err := removeIpset(CiliumNodeIpsetV4); err != nil {
 			return err
 		}
-		if err := removeIpset(ciliumNodeIpsetV6); err != nil {
+		if err := removeIpset(CiliumNodeIpsetV6); err != nil {
 			return err
 		}
 	}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -79,6 +79,7 @@ type Configuration interface {
 	RemoteNodeIdentitiesEnabled() bool
 	NodeEncryptionEnabled() bool
 	IsLocalRouterIP(string) bool
+	NodeIpsetNeeded() bool
 }
 
 var _ Notifier = (*manager)(nil)
@@ -476,7 +477,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 	var nodeIPsAdded, healthIPsAdded, ingressIPsAdded []netip.Prefix
 
 	for _, address := range n.IPAddresses {
-		if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
+		if m.conf.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
 			m.ipsetMgr.AddToNodeIpset(address.IP)
 		}
 
@@ -660,7 +661,7 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 			continue
 		}
 
-		if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
+		if m.conf.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
 			m.ipsetMgr.RemoveFromNodeIpset(address.IP)
 		}
 

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -1081,12 +1081,6 @@ func (s *managerTestSuite) TestNodeIpset(c *check.C) {
 		// manager (see NodeIpsetNeeded()).
 		Tunneling:            false,
 		EnableIPv4Masquerade: true,
-		// RemoteNodeIdentity is enabled to make sure we don't skip the
-		// ipcache update in NodeUpdated(), and in particular, the
-		// update to nodeIpsAdded. If we skip that part, and an old
-		// node existed, then Nodeupdated() will remove the ipset entry
-		// it just added when calling removenodeFromIPCache().
-		RemoteNodeIdentity: true,
 	}, newIPcacheMock(), newIPSetMock(), NewNodeMetrics(), cell.TestScope())
 	mngr.Subscribe(dp)
 	c.Assert(err, check.IsNil)

--- a/pkg/option/fake/config.go
+++ b/pkg/option/fake/config.go
@@ -27,6 +27,12 @@ func (f *Config) EncryptionEnabled() bool {
 	return true
 }
 
+// NodeIpsetNeeded returns true if masquerading rules require entries to be
+// added to an ipset for this node
+func (f *Config) NodeIpsetNeeded() bool {
+	return false
+}
+
 // NodeEncryptionEnabled returns true if node encryption is enabled
 func (f *Config) NodeEncryptionEnabled() bool {
 	return true


### PR DESCRIPTION
Following a bug on the v1.13 branch in the way we update the list of ipset entries in the node manager, add a test to ensure that entries are added or removed as we expect on node updates.

This is a forward port of the test added first to branch v1.13, commit 9ec163aff6f ("pkg/node/manager: Add test to validate ipset entries"), although the test has been reworked to use a mock ipset manager instead of checking the real ipset (which required privileges).

Related: https://github.com/cilium/cilium/pull/29898

[EDIT] Added an additional commit to fix the inconsistent behaviour on ipset entry handling in the node manager.

```release-note
Fix a bug that may cause traffic to the node internal IP addresses to be incorrectly masqueraded when node encryption and remote node identities are both disabled, due to an inconsistency in the node manager when handling ipset entries insertions and deletions on node updates.
```