### PR TITLE
Don't GC CT and NAT entries for host-network

### DIFF
--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -301,26 +301,21 @@ func (gc *GC) createGCFilter(initialScan bool, restoredEndpoints []*endpoint.End
 			}
 		}
 
-		// Once the host firewall is enabled, we will start tracking (and
-		// potentially enforcing policies) on all connections to and from the
-		// host IP addresses. Thus, we also need to avoid GCing the host IPs.
-		if option.Config.EnableHostFirewall {
-			addrs, err := nodeAddressing.IPv4().LocalAddresses()
-			if err != nil {
-				gc.logger.WithError(err).Warning("Unable to list local IPv4 addresses")
-			}
-			addrsV6, err := nodeAddressing.IPv6().LocalAddresses()
-			if err != nil {
-				gc.logger.WithError(err).Warning("Unable to list local IPv6 addresses")
-			}
-			addrs = append(addrs, addrsV6...)
+		addrs, err := nodeAddressing.IPv4().LocalAddresses()
+		if err != nil {
+			gc.logger.WithError(err).Warning("Unable to list local IPv4 addresses")
+		}
+		addrsV6, err := nodeAddressing.IPv6().LocalAddresses()
+		if err != nil {
+			gc.logger.WithError(err).Warning("Unable to list local IPv6 addresses")
+		}
+		addrs = append(addrs, addrsV6...)
 
-			for _, ip := range addrs {
-				if option.Config.IsExcludedLocalAddress(ip) {
-					continue
-				}
-				filter.ValidIPs[iputil.MustAddrFromIP(ip)] = struct{}{}
+		for _, ip := range addrs {
+			if option.Config.IsExcludedLocalAddress(ip) {
+				continue
 			}
+			filter.ValidIPs[iputil.MustAddrFromIP(ip)] = struct{}{}
 		}
 	}
 


### PR DESCRIPTION
host node IPs are not added into filter.ValidIPs unless EnableHostFirewall. This doesn't make sense because SNAT still happens for host network traffic to avoid port conflict with existing NAT sessions.

This change adds all node IPs into filter.ValidIPs without EnableHostFirewall to make sure the CT
and NAT entries are not cleared by GC.

A detailed sequence of events are described below:

1. node A (port 39714) talks to node B (port 39722) with TCP (A:39714 -> B:39722)
2. Two nat entries are created on both nodes. Take A as example:
```
TCP OUT A:39714 -> B:39722 XLATE_SRC A:39714 Created=18732805sec HostLocal=1
TCP IN B:39722 -> A:39714 XLATE_DST A:39714 Created=18732805sec HostLocal=1
```

3. The first entry is for egress and the second is for ingress (reply) traffic. The port is not changed because bpf masquerading tries to keep the port if it’s not used.
4. cilium-agent is restarted on A
5. The NAT entries are removed in order.
6. During the short gap where the first entry is removed, traffic triggers bpf masquerading. It looks for the first entry to test if there is existing entry. Because it’s GCed, it moves on to create a new mapping
7. Because the 2nd entry is not removed yet, it considers 39714 as taken and will allocate a new port. 
8. Traffic will be SNATed with the new port, that triggers TCP reset from B

```release-note
Fix TCP reset for host-network traffic on cilium-agent restart
```
