### PR TITLE
bpf: add improved helper for program-internal tail-call

### DIFF
--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -186,11 +186,9 @@ no_encap:
 #endif /* ENABLE_DSR && !ENABLE_DSR_HYBRID && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE */
 
 		ret = nodeport_lb4(ctx, ip4, l3_off, 0, &ext_err, &is_dsr);
-		if (ret == NAT_46X64_RECIRC) {
-			ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_NETDEV);
-			return send_drop_notify_error(ctx, 0, DROP_MISSED_TAIL_CALL,
-						      CTX_ACT_DROP, METRIC_INGRESS);
-		}
+		if (ret == NAT_46X64_RECIRC)
+			ret = tail_call_internal(ctx, CILIUM_CALL_IPV6_FROM_NETDEV,
+						 &ext_err);
 	}
 
 out:
@@ -203,9 +201,12 @@ out:
 
 static __always_inline int check_v4_lb(struct __ctx_buff *ctx)
 {
-	ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_NETDEV);
-	return send_drop_notify_error(ctx, 0, DROP_MISSED_TAIL_CALL, CTX_ACT_DROP,
-				      METRIC_INGRESS);
+	__s8 ext_err = 0;
+	int ret;
+
+	ret = tail_call_internal(ctx, CILIUM_CALL_IPV4_FROM_NETDEV, &ext_err);
+	return send_drop_notify_error_ext(ctx, 0, ret, ext_err, CTX_ACT_DROP,
+					  METRIC_INGRESS);
 }
 #else
 static __always_inline int check_v4_lb(struct __ctx_buff *ctx __maybe_unused)
@@ -279,9 +280,12 @@ drop_err:
 
 static __always_inline int check_v6_lb(struct __ctx_buff *ctx)
 {
-	ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_NETDEV);
-	return send_drop_notify_error(ctx, 0, DROP_MISSED_TAIL_CALL, CTX_ACT_DROP,
-				      METRIC_INGRESS);
+	__s8 ext_err = 0;
+	int ret;
+
+	ret = tail_call_internal(ctx, CILIUM_CALL_IPV6_FROM_NETDEV, &ext_err);
+	return send_drop_notify_error_ext(ctx, 0, ret, ext_err, CTX_ACT_DROP,
+					  METRIC_INGRESS);
 }
 #else
 static __always_inline int check_v6_lb(struct __ctx_buff *ctx __maybe_unused)

--- a/bpf/lib/config.h
+++ b/bpf/lib/config.h
@@ -13,4 +13,6 @@
 
 #define is_defined(option)           __is_defined(option)
 
+#define __must_check		     __attribute__((warn_unused_result))
+
 #endif /* _H_LIB_CONFIG_H_ */

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -99,6 +99,8 @@ _send_drop_notify(__u8 file, __u16 line, struct __ctx_buff *ctx,
 		  __u32 src, __u32 dst, __u32 dst_id,
 		  __u32 reason, __u32 exitcode, enum metric_dir direction)
 {
+	int ret __maybe_unused;
+
 	/* These fields should be constants and fit (together) in 32 bits */
 	if (!__builtin_constant_p(exitcode) || exitcode > 0xff ||
 	    !__builtin_constant_p(file) || file > 0xff ||
@@ -116,7 +118,8 @@ _send_drop_notify(__u8 file, __u16 line, struct __ctx_buff *ctx,
 	ctx_store_meta(ctx, 4, exitcode | file << 8 | line << 16);
 
 	update_metrics(ctx_full_len(ctx), direction, (__u8)reason);
-	ep_tail_call(ctx, CILIUM_CALL_DROP_NOTIFY);
+	ret = tail_call_internal(ctx, CILIUM_CALL_DROP_NOTIFY, NULL);
+	/* ignore the returned error, use caller-provided exitcode */
 
 	return exitcode;
 }

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -293,9 +293,7 @@ static __always_inline int icmp6_send_time_exceeded(struct __ctx_buff *ctx,
 	ctx_store_meta(ctx, 0, nh_off);
 	ctx_store_meta(ctx, 1, direction);
 
-	ep_tail_call(ctx, CILIUM_CALL_SEND_ICMP6_TIME_EXCEEDED);
-
-	return DROP_MISSED_TAIL_CALL;
+	return tail_call_internal(ctx, CILIUM_CALL_SEND_ICMP6_TIME_EXCEEDED, NULL);
 }
 
 static __always_inline int __icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off)
@@ -359,9 +357,7 @@ static __always_inline int icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off,
 	ctx_store_meta(ctx, 0, nh_off);
 	ctx_store_meta(ctx, 1, direction);
 
-	ep_tail_call(ctx, CILIUM_CALL_HANDLE_ICMP6_NS);
-
-	return DROP_MISSED_TAIL_CALL;
+	return tail_call_internal(ctx, CILIUM_CALL_HANDLE_ICMP6_NS, NULL);
 }
 
 static __always_inline bool

--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -314,10 +314,21 @@ struct {
 #endif /* ENABLE_HIGH_SCALE_IPCACHE */
 
 #ifndef SKIP_CALLS_MAP
+/* Deprecated, use tail_call_internal() instead. */
 static __always_inline void ep_tail_call(struct __ctx_buff *ctx __maybe_unused,
 					 const __u32 index __maybe_unused)
 {
 	tail_call_static(ctx, &CALLS_MAP, index);
+}
+
+static __always_inline __must_check int
+tail_call_internal(struct __ctx_buff *ctx, const __u32 index, __s8 *ext_err)
+{
+	tail_call_static(ctx, &CALLS_MAP, index);
+
+	if (ext_err)
+		*ext_err = (__s8)index;
+	return DROP_MISSED_TAIL_CALL;
 }
 #endif /* SKIP_CALLS_MAP */
 #endif

--- a/bpf/lib/tailcall.h
+++ b/bpf/lib/tailcall.h
@@ -103,10 +103,9 @@
 
 #define __invoke_tailcall_if_0(NAME, FUNC)    \
 	FUNC(ctx)
-#define __invoke_tailcall_if_1(NAME, FUNC)    \
-	({				      \
-		ep_tail_call(ctx, NAME);      \
-		DROP_MISSED_TAIL_CALL;        \
+#define __invoke_tailcall_if_1(NAME, FUNC)				\
+	({								\
+		tail_call_internal(ctx, NAME, NULL);			\
 	})
 #define invoke_tailcall_if(COND, NAME, FUNC)  \
 	__eval(__invoke_tailcall_if_, COND)(NAME, FUNC)
@@ -115,8 +114,7 @@
 	FUNC(ctx, TRACE, EXT_ERR)
 #define __invoke_traced_tailcall_if_1(NAME, FUNC, TRACE, EXT_ERR)	\
 	({								\
-		ep_tail_call(ctx, NAME);				\
-		DROP_MISSED_TAIL_CALL;					\
+		tail_call_internal(ctx, NAME, EXT_ERR);			\
 	})
 #define invoke_traced_tailcall_if(COND, NAME, FUNC, TRACE, EXT_ERR)	\
 	__eval(__invoke_traced_tailcall_if_, COND)(NAME, FUNC, TRACE,	\

--- a/bpf/tests/drop_notify_test.c
+++ b/bpf/tests/drop_notify_test.c
@@ -20,35 +20,36 @@
 #include "bpf/ctx/skb.h"
 #include "node_config.h"
 
-/* Include lib/metrics.h which contains the definition of ep_tail_call first to */
+/* Include lib/metrics.h which contains the definition of tail_call_internal first to */
 /* avoid it to be included again in lib/drop.h. */
 #include "lib/metrics.h"
 
 /* Forward declare the mock func */
-void mock_tail_call(void *ctx, const void *map, __u32 index);
+int mock_tail_call(void *ctx, const void *map, __u32 index);
 
 /* Define macros like the following to make sure the original tailcall is redirected */
 /* to the mock tailcall function, the last 0 does not matter because we do not */
 /* actually use the arguments. */
-#define ep_tail_call(a, b) mock_tail_call(a, NULL, 0)
+#define tail_call_internal(a, b, c) mock_tail_call(a, NULL, 0)
 
 /* The file containing the functions to be tested must be included after */
 /* defining the above macros. */
 #include "lib/drop.h"
 
-/* Undefine ep_tail_call to stop redirecting to the mock. It is not necessary */
+/* Undefine tail_call_internal to stop redirecting to the mock. It is not necessary */
 /* unless you would like to include something else that might conflict with the */
 /* redirection. */
-#undef ep_tail_call
+#undef tail_call_internal
 
 static int __send_drop_notify_res;
 
 /* This is the function we use as the callback when stubbing the tailcall. */
-void mock_tail_call(void *ctx, __maybe_unused const void *map, __maybe_unused __u32 index)
+int mock_tail_call(void *ctx, __maybe_unused const void *map, __maybe_unused __u32 index)
 {
   /* We can even unit-test the function which is actually called by the tailcall */
   /* within the callback. */
   __send_drop_notify_res = __send_drop_notify(ctx);
+  return 0;
 }
 
 /* A sample test for function send_drop_notify */


### PR DESCRIPTION
The naming of ep_tail_call() is very misleading - it *doesn't* call to an endpoint's policy tail-call (in POLICY_CALL_MAP), and it's also used by programs that are *not* associated with an endpoint (eg. bpf_xdp and bpf_overlay). Instead it's used for a tail-call in the program's internal tail-call map.

So start off with introducing a new helper with improved naming. Then let this helper return DROP_MISSED_TAIL_CALL (instead of every caller open-coding the same value), and also setting the index of the missed tail-call in `ext_err` where available.

Finally steal a bit of compiler magic from the kernel, and enforce that callers check for returned errors. We've had too many cases in the past where we forgot to return the DROP_MISSED_TAIL_CALL.

Then convert a few initial callers to demonstrate the usage.