### PR TITLE
labels: small optimization in NewFrom and various cleanups

### DIFF
--- a/clustermesh-apiserver/clustermesh/vmmanager.go
+++ b/clustermesh-apiserver/clustermesh/vmmanager.go
@@ -271,7 +271,7 @@ func (m *VMManager) OnDelete(k store.NamedKey) {
 }
 
 func (m *VMManager) AllocateNodeIdentity(n *nodeTypes.RegisterNode) *identity.Identity {
-	vmLabels := labels.Map2Labels(n.Labels, "k8s")
+	vmLabels := labels.Map2Labels(n.Labels, labels.LabelSourceK8s)
 
 	log.Debug("Resolving identity for VM labels")
 	ctx, cancel := context.WithTimeout(context.TODO(), option.Config.KVstoreConnectivityTimeout)
@@ -296,7 +296,7 @@ func (m *VMManager) AllocateNodeIdentity(n *nodeTypes.RegisterNode) *identity.Id
 }
 
 func (m *VMManager) LookupNodeIdentity(n *nodeTypes.RegisterNode) *identity.Identity {
-	vmLabels := labels.Map2Labels(n.Labels, "k8s")
+	vmLabels := labels.Map2Labels(n.Labels, labels.LabelSourceK8s)
 
 	log.Debug("Looking up identity for VM labels")
 	ctx, cancel := context.WithTimeout(context.TODO(), option.Config.KVstoreConnectivityTimeout)

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -69,7 +69,7 @@ func (s *K8sSuite) Test_EqualV2CNP(c *C) {
 							Name: "rule1",
 						},
 						Spec: &api.Rule{
-							EndpointSelector: api.NewESFromLabels(labels.NewLabel("foo", "bar", "k8s")),
+							EndpointSelector: api.NewESFromLabels(labels.NewLabel("foo", "bar", labels.LabelSourceK8s)),
 						},
 					},
 				},

--- a/pkg/k8s/resource/example/main.go
+++ b/pkg/k8s/resource/example/main.go
@@ -138,7 +138,7 @@ func (ps *PrintServices) printServices(ctx context.Context) {
 
 	log.Info("Services:")
 	for _, svc := range store.List() {
-		labels := labels.Map2Labels(svc.Spec.Selector, "k8s")
+		labels := labels.Map2Labels(svc.Spec.Selector, labels.LabelSourceK8s)
 		log.Infof("  - %s/%s\ttype=%s\tselector=%s", svc.Namespace, svc.Name, svc.Spec.Type, labels)
 	}
 
@@ -195,7 +195,7 @@ func (ps *PrintServices) processLoop(ctx context.Context) error {
 				// data of pods that are not part of this set.
 			case resource.Upsert:
 				log.Infof("Pod %s updated", ev.Key)
-				podLabels[ev.Key] = labels.Map2Labels(ev.Object.Labels, "k8s")
+				podLabels[ev.Key] = labels.Map2Labels(ev.Object.Labels, labels.LabelSourceK8s)
 			case resource.Delete:
 				log.Infof("Pod %s deleted", ev.Key)
 				delete(podLabels, ev.Key)
@@ -226,7 +226,7 @@ func (ps *PrintServices) processLoop(ctx context.Context) error {
 			case resource.Upsert:
 				log.Infof("Service %s updated", ev.Key)
 				if len(ev.Object.Spec.Selector) > 0 {
-					serviceSelectors[ev.Key] = labels.Map2Labels(ev.Object.Spec.Selector, "k8s")
+					serviceSelectors[ev.Key] = labels.Map2Labels(ev.Object.Spec.Selector, labels.LabelSourceK8s)
 				}
 			case resource.Delete:
 				log.Infof("Service %s deleted", ev.Key)

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -424,7 +424,7 @@ func NewSelectLabelArrayFromModel(base []string) LabelArray {
 
 // NewFrom creates a new Labels from the given labels by creating a copy.
 func NewFrom(l Labels) Labels {
-	nl := NewLabelsFromModel(nil)
+	nl := make(Labels, len(l))
 	nl.MergeLabels(l)
 	return nl
 }

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -176,20 +176,6 @@ func (l Labels) String() string {
 	return strings.Join(l.GetPrintableModel(), ",")
 }
 
-// AppendPrefixInKey appends the given prefix to all the Key's of the map and the
-// respective Labels' Key.
-func (l Labels) AppendPrefixInKey(prefix string) Labels {
-	newLabels := Labels{}
-	for k, v := range l {
-		newLabels[prefix+k] = Label{
-			Key:    prefix + v.Key,
-			Value:  v.Value,
-			Source: v.Source,
-		}
-	}
-	return newLabels
-}
-
 // Equals returns true if the two Labels contain the same set of labels.
 func (l Labels) Equals(other Labels) bool {
 	if len(l) != len(other) {

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -41,6 +41,38 @@ var (
 	DefaultLabelSourceKeyPrefix = LabelSourceAny + "."
 )
 
+func TestNewFrom(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		lbls Labels
+		want Labels
+	}{
+		{
+			name: "non-empty labels",
+			lbls: lbls,
+			want: lbls,
+		},
+		{
+			name: "empty labels",
+			lbls: Labels{},
+			want: Labels{},
+		},
+		{
+			name: "nil labels",
+			lbls: nil,
+			want: Labels{},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			newLbls := NewFrom(tt.lbls)
+			// Verify that underlying maps are different
+			assert.NotSame(t, tt.lbls, newLbls)
+			// Verify that the map contents are equal
+			assert.EqualValues(t, tt.want, newLbls)
+		})
+	}
+}
+
 func (s *LabelsSuite) TestSortMap(c *C) {
 	lblsString := strings.Join(lblsArray, ";")
 	lblsString += ";"
@@ -396,6 +428,14 @@ func TestLabels_GetFromSource(t *testing.T) {
 				t.Errorf("Labels.GetFromSource() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func BenchmarkNewFrom(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = NewFrom(lbls)
 	}
 }
 

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -108,7 +108,7 @@ func (s *LabelsSuite) TestParseLabel(c *C) {
 		{"5blah::foo=", NewLabel("::foo", "", "5blah")},
 		{"6foo==", NewLabel("6foo", "=", LabelSourceUnspec)},
 		{"7foo=bar", NewLabel("7foo", "bar", LabelSourceUnspec)},
-		{"k8s:foo=bar:", NewLabel("foo", "bar:", "k8s")},
+		{"k8s:foo=bar:", NewLabel("foo", "bar:", LabelSourceK8s)},
 		{"reservedz=host", NewLabel("reservedz", "host", LabelSourceUnspec)},
 		{":", NewLabel("", "", LabelSourceUnspec)},
 		{LabelSourceReservedKeyPrefix + "host", NewLabel("host", "", LabelSourceReserved)},
@@ -139,7 +139,7 @@ func BenchmarkParseLabel(b *testing.B) {
 		{"5blah::foo=", NewLabel("::foo", "", "5blah")},
 		{"6foo==", NewLabel("6foo", "=", LabelSourceUnspec)},
 		{"7foo=bar", NewLabel("7foo", "bar", LabelSourceUnspec)},
-		{"k8s:foo=bar:", NewLabel("foo", "bar:", "k8s")},
+		{"k8s:foo=bar:", NewLabel("foo", "bar:", LabelSourceK8s)},
 		{"reservedz=host", NewLabel("reservedz", "host", LabelSourceUnspec)},
 		{":", NewLabel("", "", LabelSourceUnspec)},
 		{LabelSourceReservedKeyPrefix + "host", NewLabel("host", "", LabelSourceReserved)},
@@ -174,7 +174,7 @@ func (s *LabelsSuite) TestParseSelectLabel(c *C) {
 		{"5blah::foo=", NewLabel("::foo", "", "5blah")},
 		{"6foo==", NewLabel("6foo", "=", LabelSourceAny)},
 		{"7foo=bar", NewLabel("7foo", "bar", LabelSourceAny)},
-		{"k8s:foo=bar:", NewLabel("foo", "bar:", "k8s")},
+		{"k8s:foo=bar:", NewLabel("foo", "bar:", LabelSourceK8s)},
 		{LabelSourceReservedKeyPrefix + "host", NewLabel("host", "", LabelSourceReserved)},
 	}
 	for _, test := range tests {
@@ -408,7 +408,7 @@ func BenchmarkLabels_SortedList(b *testing.B) {
 }
 
 func BenchmarkLabel_FormatForKVStore(b *testing.B) {
-	l := NewLabel("io.kubernetes.pod.namespace", "kube-system", "k8s")
+	l := NewLabel("io.kubernetes.pod.namespace", "kube-system", LabelSourceK8s)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -417,7 +417,7 @@ func BenchmarkLabel_FormatForKVStore(b *testing.B) {
 }
 
 func BenchmarkLabel_String(b *testing.B) {
-	l := NewLabel("io.kubernetes.pod.namespace", "kube-system", "k8s")
+	l := NewLabel("io.kubernetes.pod.namespace", "kube-system", LabelSourceK8s)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -435,9 +435,9 @@ func BenchmarkGenerateLabelString(b *testing.B) {
 
 func TestLabel_String(t *testing.T) {
 	// with value
-	l := NewLabel("io.kubernetes.pod.namespace", "kube-system", "k8s")
+	l := NewLabel("io.kubernetes.pod.namespace", "kube-system", LabelSourceK8s)
 	assert.Equal(t, "k8s:io.kubernetes.pod.namespace=kube-system", l.String())
 	// without value
-	l = NewLabel("io.kubernetes.pod.namespace", "", "k8s")
+	l = NewLabel("io.kubernetes.pod.namespace", "", LabelSourceK8s)
 	assert.Equal(t, "k8s:io.kubernetes.pod.namespace", l.String())
 }


### PR DESCRIPTION
- Avoid re-allocation in NewFrom
- Use labels.LabelSourceK8s const instead of open-coding it
- Remove unused AppendPrefixInKey

See commits for details.
