### PR TITLE
helm: don't create remote-users ConfigMap when the clustermesh-apiserver is not enabled

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
@@ -1,4 +1,7 @@
-{{- if ne .Values.clustermesh.apiserver.tls.authMode "legacy" }}
+{{- if and
+  (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer)
+  (ne .Values.clustermesh.apiserver.tls.authMode "legacy")
+}}
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
The clustermesh-remote-users ConfigMap is used only by the clustermesh-apiserver when the authMode is set to either migration or cluster. Hence, let's avoid creating it when the clustermesh-apiserver is not enabled.