### PR TITLE
compile: avoid nil deref of Cmd.ProcessState if compileCmd fails to start

### DIFF
--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -202,20 +202,12 @@ func compile(ctx context.Context, prog *progInfo, dir *directoryInfo) (string, e
 	var compilerStderr bytes.Buffer
 	compileCmd.Stderr = &compilerStderr
 
-	err = compileCmd.Run()
-
-	var maxRSS int64
-	if usage, ok := compileCmd.ProcessState.SysUsage().(*syscall.Rusage); ok {
-		maxRSS = usage.Maxrss
-	}
-
-	if err != nil {
+	if err := compileCmd.Run(); err != nil {
 		err = fmt.Errorf("Failed to compile %s: %w", prog.Output, err)
 
 		if !errors.Is(err, context.Canceled) {
 			log.WithFields(logrus.Fields{
 				"compiler-pid": pidFromProcess(compileCmd.Process),
-				"max-rss":      maxRSS,
 			}).Error(err)
 		}
 
@@ -227,11 +219,14 @@ func compile(ctx context.Context, prog *progInfo, dir *directoryInfo) (string, e
 		return "", err
 	}
 
-	if maxRSS > 0 {
+	// Cmd.ProcessState is populated by Cmd.Wait(). Cmd.Run() bails out if
+	// Cmd.Start() fails, which will leave Cmd.ProcessState nil. Only log peak
+	// RSS if the compilation succeeded, which will be the majority of cases.
+	if usage, ok := compileCmd.ProcessState.SysUsage().(*syscall.Rusage); ok {
 		log.WithFields(logrus.Fields{
 			"compiler-pid": compileCmd.Process.Pid,
 			"output":       output.Name(),
-		}).Debugf("Compilation had peak RSS of %d bytes", maxRSS)
+		}).Debugf("Compilation had peak RSS of %d bytes", usage.Maxrss)
 	}
 
 	return output.Name(), nil


### PR DESCRIPTION
The gotcha with Cmd.ProcessState is documented in comments. I'm not sure if we're really interested in Maxrss of failed compilations, or if it really needs to be debug-logged.

For troubleshooting something like this, we'd want to reproduce this locally anyway, at which point we can hack in a few log lines. I didn't want to switch to a separate Cmd.Start() and Cmd.Wait(), so the maxrss logic was consolidated into a single block, only executed when compilation was successful, where Cmd.ProcessState is guaranteed to be set.

Fixes #29989 

```release-note
Avoid panic during BPF program compilation when clang command fails to start
```
