### PR TITLE
[v1.13] CI IPsec backports

### DIFF
--- a/.github/actions/conn-disrupt-test/action.yaml
+++ b/.github/actions/conn-disrupt-test/action.yaml
@@ -16,37 +16,29 @@ runs:
   using: composite
   steps:
     - name: Setup Conn Disrupt Test
-      uses: cilium/little-vm-helper@0fcaa3fed17811fcd8b6f1b0dc1f24e5f4ff6b13 # v0.0.7
-      with:
-        provision: 'false'
-        cmd: |
-          cd /host/
-          # Create pods which establish long lived connections. It will be used by
-          # subsequent connectivity tests with --include-conn-disrupt-test to catch any
-          # interruption in such flows.
-          ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup \
-            --conn-disrupt-dispatch-interval 0ms
+      shell: bash
+      run: |
+        # Create pods which establish long lived connections. It will be used by
+        # subsequent connectivity tests with --include-conn-disrupt-test to catch any
+        # interruption in such flows.
+        ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup \
+          --conn-disrupt-dispatch-interval 0ms
 
     - name: Operate Cilium
-      uses: cilium/little-vm-helper@0fcaa3fed17811fcd8b6f1b0dc1f24e5f4ff6b13 # v0.0.7
-      with:
-        provision: 'false'
-        cmd: |
-          ${{ inputs.operation-cmd }}
+      shell: bash
+      run: |
+        ${{ inputs.operation-cmd }}
 
     - name: Perform Conn Disrupt Test
-      uses: cilium/little-vm-helper@0fcaa3fed17811fcd8b6f1b0dc1f24e5f4ff6b13 # v0.0.7
-      with:
-        provision: 'false'
+      shell: bash
+      run: |
         # Skip test node-to-node-encryption until we've solved https://github.com/cilium/cilium/issues/29351
-        cmd: |
-          cd /host/
-          ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-            --include-conn-disrupt-test \
-            --test '!node-to-node-encryption' \
-            --flush-ct \
-            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-            --sysdump-output-filename "cilium-sysdump-${{ inputs.job-name }}-<ts>" \
-            --junit-file "cilium-junits/${{ inputs.job-name }}.xml" \
-            ${{ inputs.extra-connectivity-test-flags }} \
-            --junit-property github_job_step="Run conn disrupt tests (${{ inputs.job-name }})"
+        ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+          --include-conn-disrupt-test \
+          --test '!node-to-node-encryption' \
+          --flush-ct \
+          --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
+          --sysdump-output-filename "cilium-sysdump-${{ inputs.job-name }}-<ts>" \
+          --junit-file "cilium-junits/${{ inputs.job-name }}.xml" \
+          ${{ inputs.extra-connectivity-test-flags }} \
+          --junit-property github_job_step="Run conn disrupt tests (${{ inputs.job-name }})"

--- a/.github/actions/lvh-kind/action.yaml
+++ b/.github/actions/lvh-kind/action.yaml
@@ -8,6 +8,8 @@ inputs:
   kind-params:
     required: true
     type: string
+  kind-image-vsn:
+    type: string
   test-name:
     required: true
     type: string
@@ -34,6 +36,9 @@ runs:
         provision: 'false'
         cmd: |
           cd /host
+          if [ "${{ inputs.kind-image-vsn }}" != "" ]; then
+            export IMAGE=quay.io/cilium/kindest-node:${{ inputs.kind-image-vsn }}
+          fi
           ./contrib/scripts/kind.sh ${{ inputs.kind-params }} 0.0.0.0 6443
 
     - name: Copy kubeconfig

--- a/.github/actions/lvh-kind/action.yaml
+++ b/.github/actions/lvh-kind/action.yaml
@@ -1,0 +1,42 @@
+name: K8s on LVH
+description: Creates K8s cluster inside LVH VM, and then exposes K8s cluster to GHA runner.
+
+inputs:
+  kernel:
+    required: true
+    type: string
+  kind-params:
+    required: true
+    type: string
+  test-name:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Provision LVH VMs
+      uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
+      with:
+        test-name: ${{ inputs.test-name }}
+        image-version: ${{ inputs.kernel }}
+        host-mount: ./
+        cpu: 4
+        install-dependencies: 'true'
+        port-forward: '6443:6443'
+        cmd: |
+          git config --global --add safe.directory /host
+
+    - name: Create K8s cluster
+      uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
+      with:
+        provision: 'false'
+        cmd: |
+          cd /host
+          ./contrib/scripts/kind.sh ${{ inputs.kind-params }} 0.0.0.0 6443
+
+    - name: Copy kubeconfig
+      shell: bash
+      run: |
+        mkdir ~/.kube
+        scp -o StrictHostKeyChecking=no -P 2222 root@localhost:/root/.kube/config ~/.kube/config

--- a/.github/actions/lvh-kind/action.yaml
+++ b/.github/actions/lvh-kind/action.yaml
@@ -22,6 +22,7 @@ runs:
         image-version: ${{ inputs.kernel }}
         host-mount: ./
         cpu: 4
+        mem: 12G
         install-dependencies: 'true'
         port-forward: '6443:6443'
         cmd: |

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -259,7 +259,7 @@ jobs:
           echo params="--xdp --secondary-network \"\" 3 \"\" \"\" ${{ matrix.kube-proxy }} $IP_FAM" >> $GITHUB_OUTPUT
 
       - name: Provision K8s on LVH VM
-        uses: ./.github/actions/lvh-kind
+        uses: cilium/cilium/.github/actions/lvh-kind@v1.13
         with:
           test-name: e2e-conformance
           kernel: ${{ matrix.kernel }}

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -248,31 +248,22 @@ jobs:
           binary-name: cilium-cli
           binary-dir: ./
 
-      - name: Provision LVH VMs
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
+      - name: Set Kind params
+        id: kind-params
+        shell: bash
+        run: |
+          IP_FAM="dual"
+          if [ "${{ matrix.ipv6 }}" == "false" ]; then
+            IP_FAM="ipv4"
+          fi
+          echo params="--xdp --secondary-network \"\" 3 \"\" \"\" ${{ matrix.kube-proxy }} $IP_FAM" >> $GITHUB_OUTPUT
+
+      - name: Provision K8s on LVH VM
+        uses: ./.github/actions/lvh-kind
         with:
           test-name: e2e-conformance
-          image-version: ${{ matrix.kernel }}
-          host-mount: ./
-          cpu: 4
-          install-dependencies: 'true'
-          cmd: |
-            git config --global --add safe.directory /host
-
-      - name: Setup K8s cluster (${{ join(matrix.*, ', ') }})
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
-
-            IP_FAM="dual"
-            if [ "${{ matrix.ipv6 }}" == "false" ]; then
-              IP_FAM="ipv4"
-            fi
-            ./contrib/scripts/kind.sh --xdp --secondary-network "" 3 "" "" "${{ matrix.kube-proxy }}" \$IP_FAM
-
-            kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
+          kernel: ${{ matrix.kernel }}
+          kind-params: "${{ steps.kind-params.outputs.params }}"
 
       - name: Wait for images to be available
         timeout-minutes: 30
@@ -282,63 +273,57 @@ jobs:
             until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
-      - name: Install Cilium (${{ join(matrix.*, ', ') }})
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
+      - name: Install Cilium
+        shell: bash
+        run: |
+          kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
 
-            export CILIUM_CLI_MODE=helm
-            ./cilium-cli install ${{ steps.cilium-config.outputs.config }}
+          export CILIUM_CLI_MODE=helm
+          ./cilium-cli install ${{ steps.cilium-config.outputs.config }}
 
-            ./cilium-cli status --wait
-            kubectl -n kube-system exec daemonset/cilium -- cilium status
+          ./cilium-cli status --wait
+          kubectl get pods --all-namespaces -o wide
+          kubectl -n kube-system exec daemonset/cilium -- cilium status
 
-            mkdir -p cilium-junits
+          mkdir -p cilium-junits
 
-      - name: Run tests (${{ join(matrix.*, ', ') }})
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
+      - name: Run tests
+        shell: bash
+        run: |
+          EXTRA=()
+          if [ "${{ matrix.secondary-network }}" = "true" ]; then
+            EXTRA+=("--secondary-network-iface=eth1")
+          fi
 
-            EXTRA=()
-            if [ "${{ matrix.host-fw }}" == "true" ]; then
-              # Until https://github.com/cilium/cilium/issues/28088 is fixed
-              EXTRA+=("--expected-drop-reasons=+Missed tail call")
-            fi
+          if [ "${{ matrix.host-fw }}" == "true" ]; then
+            # Until https://github.com/cilium/cilium/issues/28088 is fixed
+            EXTRA+=("--expected-drop-reasons=+Missed tail call")
+          fi
 
-            if [ "${{ matrix.tunnel }}" != "disabled" ]; then
-              # node-to-node-encryption test with tunneling is broken on this
-              # branch. It was skipped before we bumped cilium_cli_version from
-              # v0.15.3 to v0.15.19, because we don't have encryption enabled,
-              # but cilium-cli changed it in
-              # https://github.com/cilium/cilium-cli/commit/32e12a8e5ab25c54ffe5366825e420a30ea4c3fe
-              EXTRA+=('--test=!node-to-node-encryption')
-            fi
+          if [ "${{ matrix.tunnel }}" != "disabled" ]; then
+            # node-to-node-encryption test with tunneling is broken on this
+            # branch. It was skipped before we bumped cilium_cli_version from
+            # v0.15.3 to v0.15.19, because we don't have encryption enabled,
+            # but cilium-cli changed it in
+            # https://github.com/cilium/cilium-cli/commit/32e12a8e5ab25c54ffe5366825e420a30ea4c3fe
+            EXTRA+=('--test=!node-to-node-encryption')
+          fi
 
-            ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-              "\${EXTRA[@]}" \
-              --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
-              --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
-              --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})"
-
-            ./contrib/scripts/kind-down.sh
+          ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+            "${EXTRA[@]}" \
+            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
+            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+            --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
+            --junit-property github_job_step="Run tests (${{ matrix.name }})"
 
       - name: Fetch artifacts
-        if: ${{ !success() }}
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host
-            kubectl get pods --all-namespaces -o wide
-            ./cilium-cli status
-            mkdir -p cilium-sysdumps
-            ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
+        if: ${{ !success() && steps.run-tests.outcome != 'skipped' }}
+        shell: bash
+        run: |
+          kubectl get pods --all-namespaces -o wide
+          ./cilium-cli status
+          mkdir -p cilium-sysdumps
+          ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
 
       - name: Upload artifacts
         if: ${{ !success() }}

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -270,7 +270,7 @@ jobs:
             if [ "${{ matrix.ipv6 }}" == "false" ]; then
               IP_FAM="ipv4"
             fi
-            ./contrib/scripts/kind.sh --xdp "" 3 "" "" "${{ matrix.kube-proxy }}" \$IP_FAM
+            ./contrib/scripts/kind.sh --xdp --secondary-network "" 3 "" "" "${{ matrix.kube-proxy }}" \$IP_FAM
 
             kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
 

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -52,7 +52,7 @@ concurrency:
 
 env:
   # renovate: datasource=github-releases depName=cilium/cilium-cli
-  cilium_cli_version: v0.15.3
+  cilium_cli_version: v0.15.19
   cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -310,8 +310,17 @@ jobs:
               EXTRA+=("--expected-drop-reasons=+Missed tail call")
             fi
 
+            if [ "${{ matrix.tunnel }}" != "disabled" ]; then
+              # node-to-node-encryption test with tunneling is broken on this
+              # branch. It was skipped before we bumped cilium_cli_version from
+              # v0.15.3 to v0.15.19, because we don't have encryption enabled,
+              # but cilium-cli changed it in
+              # https://github.com/cilium/cilium-cli/commit/32e12a8e5ab25c54ffe5366825e420a30ea4c3fe
+              EXTRA+=('--test=!node-to-node-encryption')
+            fi
+
             ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-              "${EXTRA[@]}" \
+              "\${EXTRA[@]}" \
               --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
               --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -228,16 +228,22 @@ jobs:
           binary-name: cilium-cli
           binary-dir: ./
 
-      - name: Provision LVH VMs
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
+      - name: Set Kind params
+        id: kind-params
+        shell: bash
+        run: |
+          IP_FAM="dual"
+          if [ "${{ matrix.ipv6 }}" == "false" ]; then
+            IP_FAM="ipv4"
+          fi
+          echo params="--xdp --secondary-network \"\" 3 \"\" \"\" ${{ matrix.kube-proxy }} $IP_FAM" >> $GITHUB_OUTPUT
+
+      - name: Provision K8s on LVH VM
+        uses: cilium/cilium/.github/actions/lvh-kind@v1.13
         with:
           test-name: e2e-conformance
-          image-version: ${{ matrix.kernel }}
-          host-mount: ./
-          cpu: 4
-          install-dependencies: 'true'
-          cmd: |
-            git config --global --add safe.directory /host
+          kernel: ${{ matrix.kernel }}
+          kind-params: "${{ steps.kind-params.outputs.params }}"
 
       - name: Wait for images to be available
         timeout-minutes: 10
@@ -248,33 +254,28 @@ jobs:
           done
 
       - name: Run tests (${{ join(matrix.*, ', ') }})
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
-            ./contrib/scripts/kind.sh --xdp "" 3 "" "" "${{ matrix.kube-proxy }}" "dual"
+        shell: bash
+        run: |
+          kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
+          kubectl create -n kube-system secret generic cilium-ipsec-keys \
+            --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 
-            kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
-            kubectl create -n kube-system secret generic cilium-ipsec-keys \
-              --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
+          export CILIUM_CLI_MODE=helm
+          ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }}
 
-            export CILIUM_CLI_MODE=helm
-            ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }}
+          ./cilium-cli status --wait
+          kubectl get pods --all-namespaces -o wide
+          kubectl -n kube-system exec daemonset/cilium -- cilium status
 
-            ./cilium-cli status --wait
-            kubectl get pods --all-namespaces -o wide
-            kubectl -n kube-system exec daemonset/cilium -- cilium status
+          mkdir -p cilium-junits
 
-            mkdir -p cilium-junits
-
-            ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-              --test '!check-log-errors' \
-              --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
-              --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
-              --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-              --flush-ct
+          ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+            --test '!check-log-errors' \
+            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
+            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+            --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
+            --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
+            --flush-ct
 
       - name: Rotate IPsec Key & Test (${{ join(matrix.*, ', ') }})
         uses: cilium/cilium/.github/actions/conn-disrupt-test@v1.13
@@ -282,48 +283,41 @@ jobs:
           job-name: conformance-ipsec-e2e-key-rotation-${{ matrix.name }}
           extra-connectivity-test-flags: --test '!check-log-errors'
           operation-cmd: |
-            cd /host/
-
-            KEYID=\$(kubectl get secret -n kube-system cilium-ipsec-keys -o go-template --template={{.data.keys}} | base64 -d | cut -c 1)
-            if [[ \$KEYID -ge 15 ]]; then KEYID=0; fi
-            data=\$(echo "{\"stringData\":{\"keys\":\"\$(((\$KEYID+1))) "rfc4106\(gcm\(aes\)\)" 59f4d92cccede1b1abc920104ca61cd552782e12 128\"}}")
-            kubectl patch secret -n kube-system cilium-ipsec-keys -p="\$data" -v=1
+            KEYID=$(kubectl get secret -n kube-system cilium-ipsec-keys -o go-template --template={{.data.keys}} | base64 -d | cut -c 1)
+            if [[ $KEYID -ge 15 ]]; then KEYID=0; fi
+            data=$(echo "{\"stringData\":{\"keys\":\"$((($KEYID+1))) "rfc4106\(gcm\(aes\)\)" 59f4d92cccede1b1abc920104ca61cd552782e12 128\"}}")
+            kubectl patch secret -n kube-system cilium-ipsec-keys -p="$data" -v=1
 
             # Wait until key rotation starts
             while true; do
-              keys_in_use=\$(kubectl -n kube-system exec daemonset/cilium -- cilium encrypt status | awk '/Keys in use/ {print \$NF}')
-              if [[ \$keys_in_use == 2 ]]; then
+              keys_in_use=$(kubectl -n kube-system exec daemonset/cilium -- cilium encrypt status | awk '/Keys in use/ {print $NF}')
+              if [[ $keys_in_use == 2 ]]; then
                 break
               fi
-              echo "Waiting until key rotation starts (seeing \$keys_in_use keys)"
+              echo "Waiting until key rotation starts (seeing $keys_in_use keys)"
               sleep 30s
             done
 
             # Wait until key rotation completes
             # By default the key rotation cleanup delay is 5min, let's sleep 4min before actively polling
-            sleep \$((4*60))
+            sleep $((4*60))
             while true; do
-              keys_in_use=\$(kubectl -n kube-system exec daemonset/cilium -- cilium encrypt status | awk '/Keys in use/ {print \$NF}')
-              if [[ \$keys_in_use == 1 ]]; then
+              keys_in_use=$(kubectl -n kube-system exec daemonset/cilium -- cilium encrypt status | awk '/Keys in use/ {print $NF}')
+              if [[ $keys_in_use == 1 ]]; then
                 break
               fi
-              echo "Waiting until key rotation completes (seeing \$keys_in_use keys)"
+              echo "Waiting until key rotation completes (seeing $keys_in_use keys)"
               sleep 30s
             done
 
       - name: Fetch artifacts
         if: ${{ !success() }}
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host
-            kubectl get pods --all-namespaces -o wide
-            ./cilium-cli status
-            mkdir -p cilium-sysdumps
-            ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
-            # To debug https://github.com/cilium/cilium/issues/26062
-            head -n -0 /proc/buddyinfo /proc/pagetypeinfo
+        shell: bash
+        run: |
+          kubectl get pods --all-namespaces -o wide
+          ./cilium-cli status
+          mkdir -p cilium-sysdumps
+          ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
 
       - name: Upload artifacts
         if: ${{ !success() }}

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -260,6 +260,7 @@ jobs:
           binary-dir: ./
 
       - name: Set Kind params
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
         id: kind-params
         shell: bash
         run: |
@@ -279,6 +280,7 @@ jobs:
           kind-image-vsn: ${k8s_version}
 
       - name: Wait for images to be available
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
         timeout-minutes: 30
         shell: bash
         run: |

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -349,8 +349,9 @@ jobs:
         uses: cilium/cilium/.github/actions/conn-disrupt-test@v1.13
         with:
           job-name: ipsec-downgrade-${{ matrix.name }}
-          # Disable no-missed-tail-calls due to https://github.com/cilium/cilium/issues/26739
-          extra-connectivity-test-flags: --test '!no-missed-tail-calls'
+          # Disable no-unexpected-packet-drops (formerly no-missed-tail-calls)
+          # due to https://github.com/cilium/cilium/issues/26739
+          extra-connectivity-test-flags: --test '!no-unexpected-packet-drops'
           operation-cmd: |
             cd /host/
 

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -259,38 +259,24 @@ jobs:
           binary-name: cilium-cli
           binary-dir: ./
 
-      - name: Provision LVH VMs
+      - name: Set Kind params
+        id: kind-params
+        shell: bash
+        run: |
+          IP_FAM="dual"
+          if [ "${{ matrix.ipv6 }}" == "false" ]; then
+            IP_FAM="ipv4"
+          fi
+          echo params="\"\" 3 \"\" \"\" ${{ matrix.kube-proxy }} $IP_FAM" >> $GITHUB_OUTPUT
+
+      - name: Provision K8s on LVH VM
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
+        uses: cilium/cilium/.github/actions/lvh-kind@v1.13
         with:
-          test-name: ipsec-upgrade
-          image-version: ${{ matrix.kernel }}
-          host-mount: ./
-          cpu: 4
-          mem: '12G'
-          install-dependencies: 'true'
-          cmd: |
-            git config --global --add safe.directory /host
-
-      - name: Setup K8s cluster (${{ matrix.name }})
-        if: ${{ steps.vars.outputs.downgrade_version != '' }}
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
-
-            IP_FAM="dual"
-            if [ "${{ matrix.ipv6 }}" == "false" ]; then
-              IP_FAM="ipv4"
-            fi
-            ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}" \$IP_FAM
-
-            kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
-            kubectl create -n kube-system secret generic cilium-ipsec-keys \
-                --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
-
-            mkdir -p cilium-junits
+          test-name: e2e-conformance
+          kernel: ${{ matrix.kernel }}
+          kind-params: "${{ steps.kind-params.outputs.params }}"
+          kind-image-vsn: ${k8s_version}
 
       - name: Wait for images to be available
         timeout-minutes: 30
@@ -302,32 +288,30 @@ jobs:
 
       - name: Install Cilium ${{ steps.vars.outputs.downgrade_version }} (${{ matrix.name }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
+        shell: bash
+        run: |
+          kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
+          kubectl create -n kube-system secret generic cilium-ipsec-keys \
+              --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 
-            CILIUM_CLI_MODE=helm ./cilium-cli install \
-              ${{ steps.cilium-stable-config.outputs.config }}
+          mkdir -p cilium-junits
 
-            ./cilium-cli status --wait
-            kubectl get pods --all-namespaces -o wide
-            kubectl -n kube-system exec daemonset/cilium -- cilium status
+          CILIUM_CLI_MODE=helm ./cilium-cli install \
+            ${{ steps.cilium-stable-config.outputs.config }}
+
+          ./cilium-cli status --wait
+          kubectl get pods --all-namespaces -o wide
+          kubectl -n kube-system exec daemonset/cilium -- cilium status
 
       - name: Start conn-disrupt-test
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
-
-            # Create pods which establish long lived connections. It will be used by
-            # subsequent connectivity tests with --include-conn-disrupt-test to catch any
-            # interruption in such flows.
-            ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup \
-              --conn-disrupt-dispatch-interval 0ms
+        shell: bash
+        run: |
+          # Create pods which establish long lived connections. It will be used by
+          # subsequent connectivity tests with --include-conn-disrupt-test to catch any
+          # interruption in such flows.
+          ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup \
+            --conn-disrupt-dispatch-interval 0ms
 
       - name: Upgrade Cilium & Test (${{ matrix.name }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
@@ -335,8 +319,6 @@ jobs:
         with:
           job-name: ipsec-upgrade-${{ matrix.name }}
           operation-cmd: |
-            cd /host/
-
             CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
               ${{ steps.cilium-newest-config.outputs.config }}
 
@@ -353,8 +335,6 @@ jobs:
           # due to https://github.com/cilium/cilium/issues/26739
           extra-connectivity-test-flags: --test '!no-unexpected-packet-drops'
           operation-cmd: |
-            cd /host/
-
             CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
               ${{ steps.cilium-stable-config.outputs.config }}
 
@@ -364,17 +344,12 @@ jobs:
 
       - name: Fetch artifacts
         if: ${{ steps.vars.outputs.downgrade_version != '' && !success() }}
-        uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host
-            kubectl get pods --all-namespaces -o wide
-            ./cilium-cli status
-            mkdir -p cilium-sysdumps
-            ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
-            # To debug https://github.com/cilium/cilium/issues/26062
-            head -n -0 /proc/buddyinfo /proc/pagetypeinfo
+        shell: bash
+        run: |
+          kubectl get pods --all-namespaces -o wide
+          ./cilium-cli status
+          mkdir -p cilium-sysdumps
+          ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
 
       - name: Upload artifacts
         if: ${{ steps.vars.outputs.downgrade_version != '' && !success() }}

--- a/Makefile
+++ b/Makefile
@@ -459,7 +459,7 @@ microk8s: check-microk8s ## Build cilium-dev docker image and import to microk8s
 	$(QUIET)./contrib/scripts/microk8s-import.sh $(LOCAL_OPERATOR_IMAGE)
 
 kind: ## Create a kind cluster for Cilium development.
-	$(QUIET)./contrib/scripts/kind.sh
+	SED=$(SED) $(QUIET)./contrib/scripts/kind.sh
 
 kind-down: ## Destroy a kind cluster for Cilium development.
 	$(QUIET)./contrib/scripts/kind-down.sh

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -34,7 +34,7 @@ DOCKER_BUILD_FLAGS?=
 
 # use gsed if available, otherwise use sed.
 # gsed is needed for MacOS to make in-place replacement work correctly.
-SED ?= $(if $(shell command -v gsed), gsed, sed)
+SED ?= $(if $(shell command -v gsed),gsed,sed)
 
 # Set DOCKER_DEV_ACCOUNT with "cilium" by default
 ifeq ($(DOCKER_DEV_ACCOUNT),)

--- a/contrib/scripts/kind-down.sh
+++ b/contrib/scripts/kind-down.sh
@@ -16,3 +16,8 @@ fi
 
 kind delete clusters kind && \
     docker network rm kind-cilium
+
+secondary_network="kind-cilium-secondary"
+if docker network inspect "${secondary_network}" >/dev/null 2>&1; then
+  docker network rm ${secondary_network}
+fi

--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -11,6 +11,8 @@ default_image=""
 default_kubeproxy_mode="iptables"
 default_ipfamily="ipv4"
 default_network="kind-cilium"
+default_apiserver_addr="127.0.0.1"
+default_apiserver_port=0 # kind will randomly select
 secondary_network="${default_network}-secondary"
 
 PROG=${0}
@@ -38,6 +40,8 @@ cluster_name="${3:-${CLUSTER_NAME:=${default_cluster_name}}}"
 image="${4:-${IMAGE:=${default_image}}}"
 kubeproxy_mode="${5:-${KUBEPROXY_MODE:=${default_kubeproxy_mode}}}"
 ipfamily="${6:-${IPFAMILY:=${default_ipfamily}}}"
+apiserver_addr="${7:-${APISERVER_ADDR:=${default_apiserver_addr}}}"
+apiserver_port="${8:-${APISERVER_PORT:=${default_apiserver_port}}}"
 
 bridge_dev="br-${default_network}"
 bridge_dev_secondary="${bridge_dev}2"
@@ -46,7 +50,7 @@ v6_prefix_secondary="fc00:c112::/64"
 CILIUM_ROOT="$(git rev-parse --show-toplevel)"
 
 usage() {
-  echo "Usage: ${PROG} [--xdp] [--secondary-network] [control-plane node count] [worker node count] [cluster-name] [node image] [kube-proxy mode] [ip-family]"
+  echo "Usage: ${PROG} [--xdp] [--secondary-network] [control-plane node count] [worker node count] [cluster-name] [node image] [kube-proxy mode] [ip-family] [apiserver-addr] [apiserver-port]"
 }
 
 have_kind() {
@@ -58,7 +62,7 @@ if ! have_kind; then
     echo "  https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
 fi
 
-if [ ${#} -gt 6 ]; then
+if [ ${#} -gt 8 ]; then
   usage
   exit 1
 fi
@@ -149,6 +153,8 @@ networking:
   disableDefaultCNI: true
   kubeProxyMode: ${kubeproxy_mode}
   ipFamily: ${ipfamily}
+  apiServerAddress: ${apiserver_addr}
+  apiServerPort: ${apiserver_port}
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]

--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -14,6 +14,8 @@ default_network="kind-cilium"
 
 PROG=${0}
 
+SED="${SED:-sed}"
+
 xdp=false
 if [ "${1:-}" = "--xdp" ]; then
   xdp=true
@@ -172,7 +174,7 @@ done
 # Replace "forward . /etc/resolv.conf" in the coredns cm with "forward . 8.8.8.8".
 # This is required because in case of BPF Host Routing we bypass iptables thus
 # breaking DNS. See https://github.com/cilium/cilium/issues/23330
-NewCoreFile=$(kubectl get cm -n kube-system coredns -o jsonpath='{.data.Corefile}' | sed 's,forward . /etc/resolv.conf,forward . 8.8.8.8,' | sed -z 's/\n/\\n/g')
+NewCoreFile=$(kubectl get cm -n kube-system coredns -o jsonpath='{.data.Corefile}' | "${SED}" 's,forward . /etc/resolv.conf,forward . 8.8.8.8,' | "${SED}" -z 's/\n/\\n/g')
 kubectl patch configmap/coredns -n kube-system --type merge -p '{"data":{"Corefile": "'"$NewCoreFile"'"}}'
 
 set +e


### PR DESCRIPTION
Here's a bunch of IPsec CI backports labelled as `backport/author`, before the workflows diverge too much.

Should be similar to [the v1.14 equivalent](https://github.com/cilium/cilium/pull/29966), although I needed to backport two preparatory commits to make `kind.sh` behave.

 * [x] #25317 (@chancez)
 * [ ] #26338 (@ysksuzuki)
 * [x] #29485 (@brb)
 * [x] #29514 (@brb)
 * [x] #29793 (@qmonnet)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 25317 26338 29485 29514 29793; do contrib/backporting/set-labels.py $pr done 1.13; done
```
or with
```
make add-labels BRANCH=v1.13 ISSUES=25317,26338,29485,29514,29793
```
