### PR TITLE
bgpv1: set running flag in manager

### DIFF
--- a/pkg/bgpv1/manager/manager_test.go
+++ b/pkg/bgpv1/manager/manager_test.go
@@ -171,6 +171,7 @@ func TestGetRoutes(t *testing.T) {
 				Servers: map[int64]*instance.ServerWithConfig{
 					int64(testRouterASN): testSC,
 				},
+				running: true,
 			}
 
 			// add a neighbor


### PR DESCRIPTION
BGP Manager to unset running flag when Stop is called. This is to fix flaky tests where reconcile gets called after Stop, which recreates BGP servers at shutdown stage.

Fixes: #28415
