### PR TITLE
helm: Fix envoy servicemonitor annotations

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-envoy/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/servicemonitor.yaml
@@ -10,12 +10,12 @@ metadata:
     {{- with .Values.envoy.prometheus.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- if or .Values.envoy.prometheus.serviceMonitor .Values.envoy.annotations }}
+  {{- if or .Values.envoy.prometheus.serviceMonitor.annotations .Values.envoy.annotations }}
   annotations:
     {{- with .Values.envoy.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.envoy.prometheus.serviceMonitor }}
+    {{- with .Values.envoy.prometheus.serviceMonitor.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
Currently does not use the annotations field and templating fails 

Adding the missing serviceMonitor.annotations field for envoy's serviceMonitor annotation population

Fixes: #30015