### PR TITLE
ci: Add "forcetypeassert" to golint-ci

### DIFF
--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -55,7 +55,7 @@ jobs:
           # renovate: datasource=docker depName=golangci/golangci-lint
           version: v1.55.2
           skip-cache: true
-          args: "--out-${NO_FUTURE}format colored-line-number --verbose --modules-download-mode=vendor"
+          args: "--out-${NO_FUTURE}format colored-line-number --verbose --modules-download-mode=vendor -E forcetypeassert"
 
   precheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Unchecked type assertions are potential security
vulnerabilities and should not be allowed.

```release-note
ci: CI now enforces type check assertions in all Golang code PR submissions.
```
