### PR TITLE
Refactor getEnvoyHTTPRouteConfiguration test

### DIFF
--- a/operator/pkg/model/translation/fixture_test.go
+++ b/operator/pkg/model/translation/fixture_test.go
@@ -4,8 +4,9 @@
 package translation
 
 import (
-	"github.com/cilium/cilium/operator/pkg/model"
 	envoy_config_route_v3 "github.com/cilium/proxy/go/envoy/config/route/v3"
+
+	"github.com/cilium/cilium/operator/pkg/model"
 )
 
 // This file contains text fixtures and expected configs for the
@@ -188,6 +189,49 @@ var hostRulesExpectedConfig = []*envoy_config_route_v3.RouteConfiguration{
 					{
 						Match:  envoyRouteMatchRootPath(),
 						Action: envoyRouteAction("random-namespace", "foo-bar-com", "http"),
+					},
+				},
+			},
+		},
+	},
+	{
+		Name: "listener-secure",
+		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+			{
+				Name:    "foo.bar.com",
+				Domains: domainsHelper("foo.bar.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("random-namespace", "foo-bar-com", "http"),
+					},
+				},
+			},
+		},
+	},
+}
+
+var hostRulesExpectedConfigEnforceHTTPS = []*envoy_config_route_v3.RouteConfiguration{
+	{
+		Name: "listener-insecure",
+		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+			{
+				Name:    "foo.bar.com",
+				Domains: domainsHelper("foo.bar.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyHTTPSRouteRedirect(),
+					},
+				},
+			},
+			{
+				Name:    "*.foo.com",
+				Domains: domainsHelper("*.foo.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  withAuthority(envoyRouteMatchRootPath(), "^[^.]+[.]foo[.]com$"),
+						Action: envoyRouteAction("random-namespace", "wildcard-foo-com", "8080"),
 					},
 				},
 			},
@@ -630,6 +674,109 @@ var complexIngressExpectedConfig = []*envoy_config_route_v3.RouteConfiguration{
 	{
 		Name: "listener-insecure",
 		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+			{
+				Name:    "*",
+				Domains: domainsHelper("*"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchExactPath("/dummy-path"),
+						Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
+					},
+					{
+						Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
+						Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
+					},
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("dummy-namespace", "default-backend", "8080"),
+					},
+				},
+			},
+		},
+	},
+	{
+		Name: "listener-secure",
+		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+			{
+				Name:    "another-very-secure.server.com",
+				Domains: domainsHelper("another-very-secure.server.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchExactPath("/dummy-path"),
+						Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
+					},
+					{
+						Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
+						Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
+					},
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("dummy-namespace", "default-backend", "8080"),
+					},
+				},
+			},
+			{
+				Name:    "very-secure.server.com",
+				Domains: domainsHelper("very-secure.server.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchExactPath("/dummy-path"),
+						Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
+					},
+					{
+						Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
+						Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
+					},
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("dummy-namespace", "default-backend", "8080"),
+					},
+				},
+			},
+		},
+	},
+}
+
+var complexIngressExpectedConfigEnforceHTTPS = []*envoy_config_route_v3.RouteConfiguration{
+	{
+		Name: "listener-insecure",
+		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+			{
+				Name:    "another-very-secure.server.com",
+				Domains: domainsHelper("another-very-secure.server.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchExactPath("/dummy-path"),
+						Action: envoyHTTPSRouteRedirect(),
+					},
+					{
+						Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
+						Action: envoyHTTPSRouteRedirect(),
+					},
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyHTTPSRouteRedirect(),
+					},
+				},
+			},
+			{
+				Name:    "very-secure.server.com",
+				Domains: domainsHelper("very-secure.server.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchExactPath("/dummy-path"),
+						Action: envoyHTTPSRouteRedirect(),
+					},
+					{
+						Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
+						Action: envoyHTTPSRouteRedirect(),
+					},
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyHTTPSRouteRedirect(),
+					},
+				},
+			},
 			{
 				Name:    "*",
 				Domains: domainsHelper("*"),

--- a/operator/pkg/model/translation/fixture_test.go
+++ b/operator/pkg/model/translation/fixture_test.go
@@ -3,9 +3,22 @@
 
 package translation
 
-import "github.com/cilium/cilium/operator/pkg/model"
+import (
+	"github.com/cilium/cilium/operator/pkg/model"
+	envoy_config_route_v3 "github.com/cilium/proxy/go/envoy/config/route/v3"
+)
 
-// The test fixtures are coming from Conformance Suite for Ingress API.
+// This file contains text fixtures and expected configs for the
+// TestSharedIngressTranslator_getEnvoyHTTPRouteConfiguration test.
+//
+// The format is a model.Model representing the input, and a
+// []*envoy_config_route_v3.RouteConfiguration representing the output.
+//
+// NOTE: For models that have some TLS config - anything with an insecure *and*
+// secure listener in the resultant RouteConfiguration, you _must_ make sure
+// you test with enforceHTTPS true and false.
+
+// Some of these test fixtures are coming from Conformance Suite for Ingress API.
 // https://github.com/kubernetes-sigs/ingress-controller-conformance/tree/master/features
 
 var defaultBackendModel = &model.Model{
@@ -31,6 +44,24 @@ var defaultBackendModel = &model.Model{
 								Port: 8080,
 							},
 						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var defaultBackendExpectedConfig = []*envoy_config_route_v3.RouteConfiguration{
+	{
+		Name: "listener-insecure",
+		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+			{
+				Name:    "*",
+				Domains: domainsHelper("*"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("random-namespace", "default-backend", "8080"),
 					},
 				},
 			},
@@ -129,6 +160,49 @@ var hostRulesModel = &model.Model{
 								Name: "http",
 							},
 						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var hostRulesExpectedConfig = []*envoy_config_route_v3.RouteConfiguration{
+	{
+		Name: "listener-insecure",
+		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+			{
+				Name:    "*.foo.com",
+				Domains: domainsHelper("*.foo.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  withAuthority(envoyRouteMatchRootPath(), "^[^.]+[.]foo[.]com$"),
+						Action: envoyRouteAction("random-namespace", "wildcard-foo-com", "8080"),
+					},
+				},
+			},
+			{
+				Name:    "foo.bar.com",
+				Domains: domainsHelper("foo.bar.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("random-namespace", "foo-bar-com", "http"),
+					},
+				},
+			},
+		},
+	},
+	{
+		Name: "listener-secure",
+		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+			{
+				Name:    "foo.bar.com",
+				Domains: domainsHelper("foo.bar.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("random-namespace", "foo-bar-com", "http"),
 					},
 				},
 			},
@@ -313,6 +387,69 @@ var pathRulesModel = &model.Model{
 	},
 }
 
+var pathRulesExpectedConfig = []*envoy_config_route_v3.RouteConfiguration{
+	{
+		Name: "listener-insecure",
+		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+			{
+				Name:    "exact-path-rules",
+				Domains: domainsHelper("exact-path-rules"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchExactPath("/foo"),
+						Action: envoyRouteAction("random-namespace", "foo-exact", "8080"),
+					},
+				},
+			},
+			{
+				Name:    "mixed-path-rules",
+				Domains: domainsHelper("mixed-path-rules"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchExactPath("/foo"),
+						Action: envoyRouteAction("random-namespace", "foo-exact", "8080"),
+					},
+					{
+						Match:  envoyRouteMatchPrefixPath("/foo"),
+						Action: envoyRouteAction("random-namespace", "foo-prefix", "8080"),
+					},
+				},
+			},
+			{
+				Name:    "prefix-path-rules",
+				Domains: domainsHelper("prefix-path-rules"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchPrefixPath("/aaa/bbb"),
+						Action: envoyRouteAction("random-namespace", "aaa-slash-bbb-prefix", "8080"),
+					},
+					{
+						Match:  envoyRouteMatchPrefixPath("/foo"),
+						Action: envoyRouteAction("random-namespace", "foo-prefix", "8080"),
+					},
+					{
+						Match:  envoyRouteMatchPrefixPath("/aaa"),
+						Action: envoyRouteAction("random-namespace", "aaa-prefix", "8080"),
+					}},
+			},
+			{
+				Name:    "trailing-slash-path-rules",
+				Domains: domainsHelper("trailing-slash-path-rules"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchExactPath("/foo/"),
+						Action: envoyRouteAction("random-namespace", "foo-slash-exact", "8080"),
+					},
+					{
+						Match:  envoyRouteMatchPrefixPath("/aaa/bbb"),
+						Action: envoyRouteAction("random-namespace", "aaa-slash-bbb-slash-prefix", "8080"),
+					},
+				},
+			},
+		},
+	},
+}
+
 var complexIngressModel = &model.Model{
 	HTTP: []model.HTTPListener{
 		{
@@ -489,6 +626,73 @@ var complexIngressModel = &model.Model{
 	},
 }
 
+var complexIngressExpectedConfig = []*envoy_config_route_v3.RouteConfiguration{
+	{
+		Name: "listener-insecure",
+		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+			{
+				Name:    "*",
+				Domains: domainsHelper("*"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchExactPath("/dummy-path"),
+						Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
+					},
+					{
+						Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
+						Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
+					},
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("dummy-namespace", "default-backend", "8080"),
+					},
+				},
+			},
+		},
+	},
+	{
+		Name: "listener-secure",
+		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+			{
+				Name:    "another-very-secure.server.com",
+				Domains: domainsHelper("another-very-secure.server.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchExactPath("/dummy-path"),
+						Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
+					},
+					{
+						Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
+						Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
+					},
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("dummy-namespace", "default-backend", "8080"),
+					},
+				},
+			},
+			{
+				Name:    "very-secure.server.com",
+				Domains: domainsHelper("very-secure.server.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchExactPath("/dummy-path"),
+						Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
+					},
+					{
+						Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
+						Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
+					},
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("dummy-namespace", "default-backend", "8080"),
+					},
+				},
+			},
+		},
+	},
+}
+
 // multiplePathTypesModel is used to test that sorting of different path
 // types works correctly.
 //
@@ -549,6 +753,135 @@ var multiplePathTypesModel = &model.Model{
 								Port: 8081,
 							},
 						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var multiplePathTypesExpectedConfig = []*envoy_config_route_v3.RouteConfiguration{
+	{
+		Name: "listener-insecure",
+		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+			{
+				Name:    "*",
+				Domains: domainsHelper("*"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchExactPath("/exact"),
+						Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
+					},
+					{
+						Match:  envoyRouteMatchImplementationSpecific("/impl"),
+						Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
+					},
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
+					},
+				},
+			},
+		},
+	},
+}
+
+// multiplePathTypesModel is used to test that sorting of different path
+// types works correctly.
+//
+// It's based off of the output of the multiplePathTypes Ingress check in
+// operator/pkg/model/ingestion/ingress_test.go.
+var multipleRouteHostnamesModel = &model.Model{
+	HTTP: []model.HTTPListener{
+		{
+			Sources: []model.FullyQualifiedResource{
+				{
+					Name:      "dummy-ingress",
+					Namespace: "dummy-namespace",
+					Version:   "v1",
+					Kind:      "Ingress",
+					UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+				},
+			},
+			Port:     80,
+			Hostname: "*",
+			Routes: []model.HTTPRoute{
+				{
+					Hostnames: []string{
+						"foo.example.com",
+						"bar.example.com",
+					},
+					Backends: []model.Backend{
+						{
+							Name:      "dummy-backend",
+							Namespace: "dummy-namespace",
+							Port: &model.BackendPort{
+								Port: 8080,
+							},
+						},
+					},
+				},
+				{
+					Hostnames: []string{
+						"baz.example.com",
+						"quux.example.com",
+					},
+					Backends: []model.Backend{
+						{
+							Name:      "another-dummy-backend",
+							Namespace: "dummy-namespace",
+							Port: &model.BackendPort{
+								Port: 8081,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var multipleRouteHostnamesExpectedConfig = []*envoy_config_route_v3.RouteConfiguration{
+	{
+		Name: "listener-insecure",
+		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+			{
+				Name:    "foo.example.com",
+				Domains: domainsHelper("foo.example.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
+					},
+				},
+			},
+			{
+				Name:    "bar.example.com",
+				Domains: domainsHelper("bar.example.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
+					},
+				},
+			},
+			{
+				Name:    "baz.example.com",
+				Domains: domainsHelper("baz.example.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
+					},
+				},
+			},
+			{
+				Name:    "quux.example.com",
+				Domains: domainsHelper("quux.example.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
 					},
 				},
 			},

--- a/operator/pkg/model/translation/translator_test.go
+++ b/operator/pkg/model/translation/translator_test.go
@@ -373,230 +373,42 @@ func TestSharedIngressTranslator_getEnvoyHTTPRouteConfiguration(t *testing.T) {
 			args: args{
 				m: defaultBackendModel,
 			},
-			expectedRouteConfigs: []*envoy_config_route_v3.RouteConfiguration{
-				{
-					Name: "listener-insecure",
-					VirtualHosts: []*envoy_config_route_v3.VirtualHost{
-						{
-							Name: "*",
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match:  envoyRouteMatchRootPath(),
-									Action: envoyRouteAction("random-namespace", "default-backend", "8080"),
-								},
-							},
-						},
-					},
-				},
-			},
+			expectedRouteConfigs: defaultBackendExpectedConfig,
 		},
 		{
 			name: "host rule",
 			args: args{
 				m: hostRulesModel,
 			},
-			expectedRouteConfigs: []*envoy_config_route_v3.RouteConfiguration{
-				{
-					Name: "listener-insecure",
-					VirtualHosts: []*envoy_config_route_v3.VirtualHost{
-						{
-							Name: "*.foo.com",
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match:  withAuthority(envoyRouteMatchRootPath(), "^[^.]+[.]foo[.]com$"),
-									Action: envoyRouteAction("random-namespace", "wildcard-foo-com", "8080"),
-								},
-							},
-						},
-						{
-							Name: "foo.bar.com",
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match:  envoyRouteMatchRootPath(),
-									Action: envoyRouteAction("random-namespace", "foo-bar-com", "http"),
-								},
-							},
-						},
-					},
-				},
-				{
-					Name: "listener-secure",
-					VirtualHosts: []*envoy_config_route_v3.VirtualHost{
-						{
-							Name: "foo.bar.com",
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match:  envoyRouteMatchRootPath(),
-									Action: envoyRouteAction("random-namespace", "foo-bar-com", "http"),
-								},
-							},
-						},
-					},
-				},
-			},
+			expectedRouteConfigs: hostRulesExpectedConfig,
 		},
 		{
 			name: "path rules",
 			args: args{
 				m: pathRulesModel,
 			},
-			expectedRouteConfigs: []*envoy_config_route_v3.RouteConfiguration{
-				{
-					Name: "listener-insecure",
-					VirtualHosts: []*envoy_config_route_v3.VirtualHost{
-						{
-							Name: "exact-path-rules",
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match:  envoyRouteMatchExactPath("/foo"),
-									Action: envoyRouteAction("random-namespace", "foo-exact", "8080"),
-								},
-							},
-						},
-						{
-							Name: "mixed-path-rules",
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match:  envoyRouteMatchExactPath("/foo"),
-									Action: envoyRouteAction("random-namespace", "foo-exact", "8080"),
-								},
-								{
-									Match:  envoyRouteMatchPrefixPath("/foo"),
-									Action: envoyRouteAction("random-namespace", "foo-prefix", "8080"),
-								},
-							},
-						},
-						{
-							Name: "prefix-path-rules",
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match:  envoyRouteMatchPrefixPath("/aaa/bbb"),
-									Action: envoyRouteAction("random-namespace", "aaa-slash-bbb-prefix", "8080"),
-								},
-								{
-									Match:  envoyRouteMatchPrefixPath("/foo"),
-									Action: envoyRouteAction("random-namespace", "foo-prefix", "8080"),
-								},
-								{
-									Match:  envoyRouteMatchPrefixPath("/aaa"),
-									Action: envoyRouteAction("random-namespace", "aaa-prefix", "8080"),
-								}},
-						},
-						{
-							Name: "trailing-slash-path-rules",
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match:  envoyRouteMatchExactPath("/foo/"),
-									Action: envoyRouteAction("random-namespace", "foo-slash-exact", "8080"),
-								},
-								{
-									Match:  envoyRouteMatchPrefixPath("/aaa/bbb"),
-									Action: envoyRouteAction("random-namespace", "aaa-slash-bbb-slash-prefix", "8080"),
-								},
-							},
-						},
-					},
-				},
-			},
+			expectedRouteConfigs: pathRulesExpectedConfig,
 		},
 		{
 			name: "complex ingress",
 			args: args{
 				m: complexIngressModel,
 			},
-			expectedRouteConfigs: []*envoy_config_route_v3.RouteConfiguration{
-				{
-					Name: "listener-insecure",
-					VirtualHosts: []*envoy_config_route_v3.VirtualHost{
-						{
-							Name: "*",
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match:  envoyRouteMatchExactPath("/dummy-path"),
-									Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
-								},
-								{
-									Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
-									Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
-								},
-								{
-									Match:  envoyRouteMatchRootPath(),
-									Action: envoyRouteAction("dummy-namespace", "default-backend", "8080"),
-								},
-							},
-						},
-					},
-				},
-				{
-					Name: "listener-secure",
-					VirtualHosts: []*envoy_config_route_v3.VirtualHost{
-						{
-							Name: "another-very-secure.server.com",
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match:  envoyRouteMatchExactPath("/dummy-path"),
-									Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
-								},
-								{
-									Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
-									Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
-								},
-								{
-									Match:  envoyRouteMatchRootPath(),
-									Action: envoyRouteAction("dummy-namespace", "default-backend", "8080"),
-								},
-							},
-						},
-						{
-							Name: "very-secure.server.com",
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match:  envoyRouteMatchExactPath("/dummy-path"),
-									Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
-								},
-								{
-									Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
-									Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
-								},
-								{
-									Match:  envoyRouteMatchRootPath(),
-									Action: envoyRouteAction("dummy-namespace", "default-backend", "8080"),
-								},
-							},
-						},
-					},
-				},
-			},
+			expectedRouteConfigs: complexIngressExpectedConfig,
 		},
 		{
 			name: "multiple path types in one listener",
 			args: args{
 				m: multiplePathTypesModel,
 			},
-			expectedRouteConfigs: []*envoy_config_route_v3.RouteConfiguration{
-				{
-					Name: "listener-insecure",
-					VirtualHosts: []*envoy_config_route_v3.VirtualHost{
-						{
-							Name: "*",
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match:  envoyRouteMatchExactPath("/exact"),
-									Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
-								},
-								{
-									Match:  envoyRouteMatchImplementationSpecific("/impl"),
-									Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
-								},
-								{
-									Match:  envoyRouteMatchRootPath(),
-									Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
-								},
-							},
-						},
-					},
-				},
+			expectedRouteConfigs: multiplePathTypesExpectedConfig,
+		},
+		{
+			name: "routes with multiple hostnames in one listener",
+			args: args{
+				m: multipleRouteHostnamesModel,
 			},
+			expectedRouteConfigs: multipleRouteHostnamesExpectedConfig,
 		},
 	}
 
@@ -611,33 +423,48 @@ func TestSharedIngressTranslator_getEnvoyHTTPRouteConfiguration(t *testing.T) {
 			require.Len(t, res, len(tt.expectedRouteConfigs), "Number of Listeners did not match")
 
 			for i, rawRoute := range res {
-				listener := tt.expectedRouteConfigs[i]
-				route := &envoy_config_route_v3.RouteConfiguration{}
-				err := proto.Unmarshal(rawRoute.Value, route)
+				ttListener := tt.expectedRouteConfigs[i]
+				listener := &envoy_config_route_v3.RouteConfiguration{}
+				err := proto.Unmarshal(rawRoute.Value, listener)
 				require.NoError(t, err)
 
-				// first, check that the outermost listener name matches
-				require.Equal(t, listener.Name, route.Name, "Listener Names did not match")
-
-				require.Len(t, listener.VirtualHosts, len(route.VirtualHosts), "Number of virtualhosts did not match for %s", listener.Name)
-
-				for j, vhost := range route.VirtualHosts {
-					ttVhost := listener.VirtualHosts[j]
-					require.Equal(t, ttVhost.Name, vhost.Name, "VirtualHost name did not match for %s", listener.Name)
-
-					if len(ttVhost.Routes) != len(vhost.Routes) {
-						t.Fatalf("Length of the Routes stanzas are different for Listener %s and VirtualHost %s, want %d and have %d: %s", listener.Name, vhost.Name, len(ttVhost.Routes), len(vhost.Routes), cmp.Diff(ttVhost.Routes, vhost.Routes, protocmp.Transform()))
+				for j, vhost := range listener.VirtualHosts {
+					if j >= len(ttListener.VirtualHosts) {
+						t.Errorf("More VirtualHosts in the actual than the expected for actual Listener name %s", listener.Name)
+						continue
 					}
 
+					ttVhost := ttListener.VirtualHosts[j]
+
 					for k, route := range vhost.Routes {
+						if k >= len(ttVhost.Routes) {
+							t.Errorf("More Routes in the actual than the expected for actual VirtualHost name %s in actual Listener %s", vhost.Name, listener.Name)
+							continue
+						}
+
 						ttRoute := ttVhost.Routes[k]
 
 						diffOutput := cmp.Diff(ttRoute, route, protocmp.Transform())
 						if len(diffOutput) != 0 {
-							t.Fatalf("Routes did not match for Listener %s and VirtualHost %s, route number %d:\n%s\n", listener.Name, vhost.Name, k, diffOutput)
+							t.Errorf("Routes did not match for Listener %s and VirtualHost %s, route number %d:\n%s\n", ttListener.Name, ttVhost.Name, k, diffOutput)
+						}
+					}
+					// If there were no errors at the Route level, check for errors at the VirtualHost level
+					if !t.Failed() {
+						diffOutput := cmp.Diff(ttVhost, vhost, protocmp.Transform())
+						if len(diffOutput) != 0 {
+							t.Errorf("VirtualHosts did not match:\n %s\n", diffOutput)
 						}
 					}
 				}
+				// If there were no errors anywhere else, check for errors at the Listener level
+				if !t.Failed() {
+					diffOutput := cmp.Diff(ttListener, listener, protocmp.Transform())
+					if len(diffOutput) != 0 {
+						t.Errorf("VirtualHosts did not match:\n %s\n", diffOutput)
+					}
+				}
+
 			}
 		})
 	}
@@ -709,6 +536,14 @@ func withAuthority(match *envoy_config_route_v3.RouteMatch, regex string) *envoy
 	match.Headers = append(match.Headers, authorityHeader)
 
 	return match
+}
+
+func domainsHelper(domain string) []string {
+	if domain == "*" {
+		return []string{domain}
+	}
+
+	return []string{domain, fmt.Sprintf("%s:*", domain)}
 }
 
 func TestSharedIngressTranslator_getResources(t *testing.T) {


### PR DESCRIPTION
I was looking at if we could add an equivalent to the nginx `ssl-redirect` annotation for Ingres, when I realized that:
* our Ingress translation has an `enforceHTTPS` paramenter, set based on the Helm `ingress.enforceHTTPS` param, which defaults to `true`.
* our translation tests never check what happens if that is true though.

Oops.

This PR refactors the tests of the `operator/pkg/model/translation` package to increase readability and make it easier to add new tests, and then adds tests for `enforceHTTPS` behavior when it's relevant (when the model contains both insecure and secure listeners).

I'll build on this for when I figure out how to handle a new `ssl-redirect` equivalent annotation.