### PR TITLE
bpf: add ext_err for more callers of tail_call_internal()

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -441,11 +441,13 @@ tail_handle_ipv6(struct __ctx_buff *ctx, __u32 ipcache_srcid, const bool from_ho
 		if (from_host)
 			ret = invoke_tailcall_if(is_defined(ENABLE_HOST_FIREWALL),
 						 CILIUM_CALL_IPV6_CONT_FROM_HOST,
-						 tail_handle_ipv6_cont_from_host);
+						 tail_handle_ipv6_cont_from_host,
+						 &ext_err);
 		else
 			ret = invoke_tailcall_if(is_defined(ENABLE_HOST_FIREWALL),
 						 CILIUM_CALL_IPV6_CONT_FROM_NETDEV,
-						 tail_handle_ipv6_cont_from_netdev);
+						 tail_handle_ipv6_cont_from_netdev,
+						 &ext_err);
 	}
 
 	/* Catch errors from both handle_ipv6 and invoke_tailcall_if here. */
@@ -891,11 +893,13 @@ tail_handle_ipv4(struct __ctx_buff *ctx, __u32 ipcache_srcid, const bool from_ho
 		if (from_host)
 			ret = invoke_tailcall_if(is_defined(ENABLE_HOST_FIREWALL),
 						 CILIUM_CALL_IPV4_CONT_FROM_HOST,
-						 tail_handle_ipv4_cont_from_host);
+						 tail_handle_ipv4_cont_from_host,
+						 &ext_err);
 		else
 			ret = invoke_tailcall_if(is_defined(ENABLE_HOST_FIREWALL),
 						 CILIUM_CALL_IPV4_CONT_FROM_NETDEV,
-						 tail_handle_ipv4_cont_from_netdev);
+						 tail_handle_ipv4_cont_from_netdev,
+						 &ext_err);
 	}
 
 	/* Catch errors from both handle_ipv4 and invoke_tailcall_if here. */
@@ -1575,6 +1579,7 @@ static __always_inline int
 to_host_from_lxc(struct __ctx_buff *ctx __maybe_unused)
 {
 	int ret = CTX_ACT_OK;
+	__s8 ext_err = 0;
 	__u16 proto = 0;
 
 	if (!validate_ethertype(ctx, &proto)) {
@@ -1594,7 +1599,8 @@ to_host_from_lxc(struct __ctx_buff *ctx __maybe_unused)
 						    is_defined(ENABLE_IPV6)),
 					      is_defined(DEBUG)),
 					 CILIUM_CALL_IPV6_TO_HOST_POLICY_ONLY,
-					 tail_ipv6_host_policy_ingress);
+					 tail_ipv6_host_policy_ingress,
+					 &ext_err);
 		break;
 # endif
 # ifdef ENABLE_IPV4
@@ -1603,7 +1609,8 @@ to_host_from_lxc(struct __ctx_buff *ctx __maybe_unused)
 						    is_defined(ENABLE_IPV6)),
 					      is_defined(DEBUG)),
 					 CILIUM_CALL_IPV4_TO_HOST_POLICY_ONLY,
-					 tail_ipv4_host_policy_ingress);
+					 tail_ipv4_host_policy_ingress,
+					 &ext_err);
 		break;
 # endif
 	default:
@@ -1613,8 +1620,8 @@ to_host_from_lxc(struct __ctx_buff *ctx __maybe_unused)
 
 out:
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
-					      METRIC_INGRESS);
+		return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
+						  CTX_ACT_DROP, METRIC_INGRESS);
 	return ret;
 }
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -768,7 +768,7 @@ static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx,
 	 * are subjected to forwarding into the container.
 	 */
 	if (unlikely(is_icmp6_ndp(ctx, ip6, ETH_HLEN)))
-		return icmp6_ndp_handle(ctx, ETH_HLEN, METRIC_EGRESS);
+		return icmp6_ndp_handle(ctx, ETH_HLEN, METRIC_EGRESS, ext_err);
 
 	if (unlikely(!is_valid_lxc_src_ip(ip6)))
 		return DROP_INVALID_SIP;

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -346,18 +346,20 @@ int tail_icmp6_handle_ns(struct __ctx_buff *ctx)
  * @ctx:	socket buffer
  * @nh_off:	offset to the IPv6 header
  * @direction:  direction of packet(ingress or egress)
+ * @ext_err:	extended error value
  *
  * Respond to ICMPv6 Neighbour Solicitation
  *
  * NOTE: This is terminal function and will cause the BPF program to exit
  */
 static __always_inline int icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off,
-					   enum metric_dir direction)
+					   enum metric_dir direction,
+					   __s8 *ext_err)
 {
 	ctx_store_meta(ctx, 0, nh_off);
 	ctx_store_meta(ctx, 1, direction);
 
-	return tail_call_internal(ctx, CILIUM_CALL_HANDLE_ICMP6_NS, NULL);
+	return tail_call_internal(ctx, CILIUM_CALL_HANDLE_ICMP6_NS, ext_err);
 }
 
 static __always_inline bool
@@ -373,7 +375,8 @@ is_icmp6_ndp(struct __ctx_buff *ctx, const struct ipv6hdr *ip6, int nh_off)
 }
 
 static __always_inline int icmp6_ndp_handle(struct __ctx_buff *ctx, int nh_off,
-					    enum metric_dir direction)
+					    enum metric_dir direction,
+					    __s8 *ext_err)
 {
 	__u8 type;
 
@@ -382,7 +385,7 @@ static __always_inline int icmp6_ndp_handle(struct __ctx_buff *ctx, int nh_off,
 
 	cilium_dbg(ctx, DBG_ICMP6_HANDLE, type, 0);
 	if (type == ICMP6_NS_MSG_TYPE)
-		return icmp6_handle_ns(ctx, nh_off, direction);
+		return icmp6_handle_ns(ctx, nh_off, direction, ext_err);
 
 	/* All branching above will have issued a tail call, all
 	 * remaining traffic is subject to forwarding to containers.

--- a/bpf/lib/tailcall.h
+++ b/bpf/lib/tailcall.h
@@ -101,14 +101,14 @@
 #define declare_tailcall_if(COND, NAME)       \
 	__eval(__declare_tailcall_if_, COND)(NAME)
 
-#define __invoke_tailcall_if_0(NAME, FUNC)    \
+#define __invoke_tailcall_if_0(NAME, FUNC, EXT_ERR)			\
 	FUNC(ctx)
-#define __invoke_tailcall_if_1(NAME, FUNC)				\
+#define __invoke_tailcall_if_1(NAME, FUNC, EXT_ERR)			\
 	({								\
-		tail_call_internal(ctx, NAME, NULL);			\
+		tail_call_internal(ctx, NAME, EXT_ERR);			\
 	})
-#define invoke_tailcall_if(COND, NAME, FUNC)  \
-	__eval(__invoke_tailcall_if_, COND)(NAME, FUNC)
+#define invoke_tailcall_if(COND, NAME, FUNC, EXT_ERR)			\
+	__eval(__invoke_tailcall_if_, COND)(NAME, FUNC, EXT_ERR)
 
 #define __invoke_traced_tailcall_if_0(NAME, FUNC, TRACE, EXT_ERR)	\
 	FUNC(ctx, TRACE, EXT_ERR)


### PR DESCRIPTION
As follow-on to https://github.com/cilium/cilium/pull/30001, improve some users of `tail_call_internal()` to pass an `ext_err` parameter.