### PR TITLE
statedb: replace the buffer based KeySet with simpler implementation

### DIFF
--- a/pkg/statedb/graveyard.go
+++ b/pkg/statedb/graveyard.go
@@ -90,7 +90,7 @@ func graveyardWorker(db *DB, ctx context.Context, gcRateLimitInterval time.Durat
 				if existed {
 					// The dead object still existed (and wasn't replaced by a create->delete),
 					// delete it from the primary index.
-					key = meta.primary().fromObject(oldObj).First()
+					key = []byte(meta.primary().fromObject(oldObj).First())
 					txn.mustIndexWriteTxn(tableName, GraveyardIndex).txn.Delete(key)
 				}
 			}

--- a/pkg/statedb/index/keyset.go
+++ b/pkg/statedb/index/keyset.go
@@ -3,7 +3,9 @@
 
 package index
 
-import "bytes"
+import (
+	"bytes"
+)
 
 // Key is a byte slice describing a key used in an index by statedb.
 // If a key is variable-sized, then it must be either terminated with
@@ -15,56 +17,44 @@ import "bytes"
 // non-unique indexes which key on "secondary + primary" keys.
 type Key []byte
 
-// KeySet is a sequence of (length, byte slice) pairs.
-// length is encoded as 16-bit big-endian unsigned int.
-type KeySet struct {
-	buf []byte
+func (k Key) Equal(k2 Key) bool {
+	return bytes.Equal(k, k2)
 }
 
-func NewKeySet(keys ...Key) KeySet {
-	size := 2 * len(keys)
-	for _, k := range keys {
-		size += len(k)
-	}
-	ks := KeySet{make([]byte, 0, size)}
-	for _, k := range keys {
-		ks.Append(k)
-	}
-	return ks
+type KeySet struct {
+	head Key
+	tail []Key
 }
 
 func (ks KeySet) First() Key {
-	if len(ks.buf) < 2 {
-		return nil
-	}
-	length := uint16(ks.buf[0])<<8 | uint16(ks.buf[1])
-	return ks.buf[2 : 2+length]
-}
-
-func (ks *KeySet) Append(k Key) {
-	if len(k) > 2<<16 {
-		panic("keyset.Append: key too long, maximum is 64kB")
-	}
-	ks.buf = append(append(ks.buf, byte(len(k)>>8), byte(len(k)&0xff)), k...)
+	return ks.head
 }
 
 func (ks KeySet) Foreach(fn func(Key)) {
-	for len(ks.buf) >= 2 {
-		length := uint16(ks.buf[0])<<8 | uint16(ks.buf[1])
-		fn(append([]byte(nil), ks.buf[2:2+length]...))
-		ks.buf = ks.buf[2+length:]
+	if ks.head == nil {
+		return
+	}
+	fn(ks.head)
+	for _, k := range ks.tail {
+		fn(k)
 	}
 }
 
 func (ks KeySet) Exists(k Key) bool {
-	buf := ks.buf
-	for len(buf) >= 2 {
-		length := uint16(buf[0])<<8 | uint16(buf[1])
-		k2 := buf[2 : 2+length]
-		if bytes.Equal(k, k2) {
+	if ks.head.Equal(k) {
+		return true
+	}
+	for _, k2 := range ks.tail {
+		if k2.Equal(k) {
 			return true
 		}
-		buf = buf[2+length:]
 	}
 	return false
+}
+
+func NewKeySet(keys ...Key) KeySet {
+	if len(keys) == 0 {
+		return KeySet{}
+	}
+	return KeySet{keys[0], keys[1:]}
 }

--- a/pkg/statedb/index/keyset_test.go
+++ b/pkg/statedb/index/keyset_test.go
@@ -11,35 +11,19 @@ import (
 	"github.com/cilium/cilium/pkg/statedb/index"
 )
 
-func TestKeySet_FromEmpty(t *testing.T) {
-	ks := index.NewKeySet()
-	require.Nil(t, ks.First())
-	ks.Foreach(func(_ index.Key) {
-		t.Fatalf("Foreach on NewKeySet called function")
-	})
-	require.False(t, ks.Exists(nil))
-	require.False(t, ks.Exists([]byte{1, 2, 3}))
-
-	ks.Append([]byte("foo"))
-	require.EqualValues(t, "foo", ks.First())
-	ks.Foreach(func(bs index.Key) {
-		require.EqualValues(t, "foo", bs)
-	})
-	require.True(t, ks.Exists([]byte("foo")))
-
-	ks.Append([]byte("bar"))
-	require.EqualValues(t, "foo", ks.First())
-	vs := [][]byte{}
+func TestKeySet_Single(t *testing.T) {
+	ks := index.NewKeySet([]byte("baz"))
+	require.EqualValues(t, "baz", ks.First())
+	require.True(t, ks.Exists([]byte("baz")))
+	require.False(t, ks.Exists([]byte("foo")))
+	vs := []index.Key{}
 	ks.Foreach(func(bs index.Key) {
 		vs = append(vs, bs)
 	})
-	require.ElementsMatch(t, vs, [][]byte{[]byte("foo"), []byte("bar")})
-	require.True(t, ks.Exists([]byte("foo")))
-	require.True(t, ks.Exists([]byte("bar")))
-	require.False(t, ks.Exists([]byte("baz")))
+	require.ElementsMatch(t, vs, []index.Key{index.Key("baz")})
 }
 
-func TestKeySet_FromNonEmpty(t *testing.T) {
+func TestKeySet_Multi(t *testing.T) {
 	ks := index.NewKeySet([]byte("baz"), []byte("quux"))
 	require.EqualValues(t, "baz", ks.First())
 	require.True(t, ks.Exists([]byte("baz")))

--- a/pkg/statedb/index/map.go
+++ b/pkg/statedb/index/map.go
@@ -4,9 +4,9 @@
 package index
 
 func StringMap[V any](m map[string]V) KeySet {
-	ks := KeySet{}
+	keys := make([]Key, 0, len(m))
 	for k := range m {
-		ks.Append(String(k))
+		keys = append(keys, String(k))
 	}
-	return ks
+	return NewKeySet(keys...)
 }

--- a/pkg/statedb/index/string.go
+++ b/pkg/statedb/index/string.go
@@ -14,17 +14,17 @@ func Stringer[T fmt.Stringer](s T) Key {
 }
 
 func StringSlice(ss []string) KeySet {
-	ks := KeySet{}
+	keys := make([]Key, 0, len(ss))
 	for _, s := range ss {
-		ks.Append(String(s))
+		keys = append(keys, String(s))
 	}
-	return ks
+	return NewKeySet(keys...)
 }
 
 func StringerSlice[T fmt.Stringer](ss []T) KeySet {
-	ks := KeySet{}
+	keys := make([]Key, 0, len(ss))
 	for _, s := range ss {
-		ks.Append(Stringer(s))
+		keys = append(keys, Stringer(s))
 	}
-	return ks
+	return NewKeySet(keys...)
 }

--- a/pkg/statedb/reconciler/reconciler.go
+++ b/pkg/statedb/reconciler/reconciler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/index"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -35,7 +36,7 @@ func New[Obj comparable](p Params[Obj]) (Reconciler[Obj], error) {
 	}
 
 	idx := p.Table.PrimaryIndexer()
-	objectToKey := func(o any) []byte {
+	objectToKey := func(o any) index.Key {
 		return idx.ObjectToKey(o.(Obj))
 	}
 	r := &reconciler[Obj]{

--- a/pkg/statedb/reconciler/retries_test.go
+++ b/pkg/statedb/reconciler/retries_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestRetries(t *testing.T) {
-	objectToKey := func(o any) []byte {
+	objectToKey := func(o any) index.Key {
 		return index.Uint64(o.(uint64))
 	}
 	rq := newRetries(time.Millisecond, 100*time.Millisecond, objectToKey)

--- a/pkg/statedb/txn.go
+++ b/pkg/statedb/txn.go
@@ -202,19 +202,19 @@ func (txn *txn) Insert(meta TableMeta, guardRevision Revision, data any) (any, b
 	// Update revision index
 	revIndexTxn := txn.mustIndexWriteTxn(tableName, RevisionIndex)
 	if oldExists {
-		_, ok := revIndexTxn.txn.Delete(index.Uint64(oldObj.revision))
+		_, ok := revIndexTxn.txn.Delete([]byte(index.Uint64(oldObj.revision)))
 		if !ok {
 			panic("BUG: Old revision index entry not found")
 		}
 
 	}
-	revIndexTxn.txn.Insert(index.Uint64(revision), obj)
+	revIndexTxn.txn.Insert([]byte(index.Uint64(revision)), obj)
 
 	// If it's new, possibly remove an older deleted object with the same
 	// primary key from the graveyard.
 	if !oldExists && txn.hasDeleteTrackers(tableName) {
 		if old, existed := txn.mustIndexWriteTxn(tableName, GraveyardIndex).txn.Delete(idKey); existed {
-			txn.mustIndexWriteTxn(tableName, GraveyardRevisionIndex).txn.Delete(index.Uint64(old.revision))
+			txn.mustIndexWriteTxn(tableName, GraveyardRevisionIndex).txn.Delete([]byte(index.Uint64(old.revision)))
 		}
 	}
 
@@ -351,7 +351,7 @@ func (txn *txn) Delete(meta TableMeta, guardRevision Revision, data any) (any, b
 // This allows looking up from the non-unique index with the secondary key by doing a prefix
 // search. The length is used to safe-guard against indexers that don't terminate the key
 // properly (e.g. if secondary key is "foo", then we don't want "foobar" to match).
-func encodeNonUniqueKey(primary, secondary []byte) []byte {
+func encodeNonUniqueKey(primary, secondary index.Key) []byte {
 	key := make([]byte, 0, len(secondary)+len(primary)+2)
 	key = append(key, secondary...)
 	key = append(key, primary...)

--- a/pkg/statedb/types.go
+++ b/pkg/statedb/types.go
@@ -193,7 +193,7 @@ type WriteTxn interface {
 
 type Query[Obj any] struct {
 	index IndexName
-	key   []byte
+	key   index.Key
 }
 
 // ByRevision constructs a revision query. Applicable to any table.


### PR DESCRIPTION
Memory profiling showed that we were allocating fair bit in NewKeySet. This can be avoided in cases where the indexer only returns a single key by using a special case implementation.

This replaces KeySet with keySetSingle and keySetMulti implementations which optimizes for the case where only single argument is given to NewKeySet. This allows writing indexers that can return a constant and avoid all memory allocation for the key.
