### PR TITLE
bpf: ipv6: optimize ipv6_addr_copy()

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -372,9 +372,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		struct tunnel_key key = {};
 
 		/* IPv6 lookup key: daddr/96 */
-		key.ip6.p1 = dst->p1;
-		key.ip6.p2 = dst->p2;
-		key.ip6.p3 = dst->p3;
+		ipv6_addr_copy(&key.ip6, dst);
 		key.ip6.p4 = 0;
 		key.family = ENDPOINT_KEY_IPV6;
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -642,9 +642,8 @@ ct_recreate6:
 		 *
 		 * IPv6 lookup key: daddr/96
 		 */
-		key.ip6.p1 = daddr->p1;
-		key.ip6.p2 = daddr->p2;
-		key.ip6.p3 = daddr->p3;
+		ipv6_addr_copy(&key.ip6, daddr);
+		key.ip6.p4 = 0;
 		key.family = ENDPOINT_KEY_IPV6;
 
 		/* Three cases exist here either (a) the encap and redirect could

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -267,7 +267,8 @@ set_geneve_dsr_opt6(__be16 port, const union v6addr *addr,
 	gopt->hdr.opt_class = bpf_htons(DSR_GENEVE_OPT_CLASS);
 	gopt->hdr.type = DSR_GENEVE_OPT_TYPE;
 	gopt->hdr.length = DSR_IPV6_GENEVE_OPT_LEN;
-	ipv6_addr_copy((union v6addr *)&gopt->addr, addr);
+	ipv6_addr_copy_unaligned((union v6addr *)&gopt->addr, addr);
+
 	gopt->port = port;
 }
 #endif

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -89,6 +89,12 @@ static __always_inline int ipv6_hdrlen(struct __ctx_buff *ctx, __u8 *nexthdr)
 static __always_inline void ipv6_addr_copy(union v6addr *dst,
 					   const union v6addr *src)
 {
+	memcpy(dst, src, sizeof(*dst));
+}
+
+static __always_inline void ipv6_addr_copy_unaligned(union v6addr *dst,
+						     const union v6addr *src)
+{
 	dst->d1 = src->d1;
 	dst->d2 = src->d2;
 }

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -751,7 +751,7 @@ __lb6_affinity_backend_id(const struct lb6_service *svc, bool netns_cookie,
 	};
 	struct lb_affinity_val *val;
 
-	ipv6_addr_copy(&key.client_id.client_ip, &id->client_ip);
+	ipv6_addr_copy_unaligned(&key.client_id.client_ip, &id->client_ip);
 
 	val = map_lookup_elem(&LB6_AFFINITY_MAP, &key);
 	if (val != NULL) {
@@ -800,7 +800,7 @@ __lb6_update_affinity(const struct lb6_service *svc, bool netns_cookie,
 		.last_used	= now,
 	};
 
-	ipv6_addr_copy(&key.client_id.client_ip, &id->client_ip);
+	ipv6_addr_copy_unaligned(&key.client_id.client_ip, &id->client_ip);
 
 	map_update_elem(&LB6_AFFINITY_MAP, &key, &val, 0);
 }

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -346,7 +346,7 @@ static __always_inline int dsr_set_ext6(struct __ctx_buff *ctx,
 	opt.hdr.hdrlen = DSR_IPV6_EXT_LEN;
 	opt.opt_type = DSR_IPV6_OPT_TYPE;
 	opt.opt_len = DSR_IPV6_OPT_LEN;
-	ipv6_addr_copy(&opt.addr, svc_addr);
+	ipv6_addr_copy_unaligned(&opt.addr, svc_addr);
 	opt.port = svc_port;
 
 	if (ctx_adjust_hroom(ctx, sizeof(opt), BPF_ADJ_ROOM_NET,
@@ -526,7 +526,8 @@ nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 			    gopt.hdr.type == DSR_GENEVE_OPT_TYPE) {
 				*dsr = true;
 				*port = gopt.port;
-				ipv6_addr_copy(addr, (union v6addr *)&gopt.addr);
+				ipv6_addr_copy_unaligned(addr,
+							 (union v6addr *)&gopt.addr);
 				return 0;
 			}
 		}

--- a/bpf/lib/trace_sock.h
+++ b/bpf/lib/trace_sock.h
@@ -120,7 +120,7 @@ send_trace_sock_notify6(struct __ctx_sock *ctx,
 		.l4_proto	= parse_protocol(ctx->protocol),
 		.ipv6		= 1,
 	};
-	ipv6_addr_copy(&msg.dst_ip.ip6, dst_addr);
+	ipv6_addr_copy_unaligned(&msg.dst_ip.ip6, dst_addr);
 
 	ctx_event_output(ctx, &EVENTS_MAP, BPF_F_CURRENT_CPU, &msg, sizeof(msg));
 }

--- a/bpf/tests/tc_nodeport_lb6_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb6_dsr_backend.c
@@ -102,7 +102,7 @@ int nodeport_dsr_backend_pktgen(struct __ctx_buff *ctx)
 
 	opt->opt_type = DSR_IPV6_OPT_TYPE;
 	opt->opt_len = DSR_IPV6_OPT_LEN;
-	ipv6_addr_copy((union v6addr *)&opt->addr, &frontend_ip);
+	ipv6_addr_copy_unaligned((union v6addr *)&opt->addr, &frontend_ip);
 	opt->port = FRONTEND_PORT;
 
 	/* Push TCP header */


### PR DESCRIPTION
Refresh the optimization from https://github.com/cilium/cilium/pull/24341, it's a nice gain for IPv6 already.