### PR TITLE
[config] Make TraceNotification configurable

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -329,6 +329,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableSocketLBTracing, true, "Enable tracing for socket-based LB")
 	option.BindEnv(vp, option.EnableSocketLBTracing)
 
+	flags.Bool(option.EnableTraceNotification, true, "Enable trace notifications")
+	option.BindEnv(vp, option.EnableTraceNotification)
+
 	flags.Bool(option.EnableAutoDirectRoutingName, defaults.EnableAutoDirectRouting, "Enable automatic L2 routing between nodes")
 	option.BindEnv(vp, option.EnableAutoDirectRoutingName)
 
@@ -1308,7 +1311,7 @@ func initEnv(vp *viper.Viper) {
 	option.Config.Opts.SetBool(option.Debug, debugDatapath)
 	option.Config.Opts.SetBool(option.DebugLB, debugDatapath)
 	option.Config.Opts.SetBool(option.DropNotify, true)
-	option.Config.Opts.SetBool(option.TraceNotify, true)
+	option.Config.Opts.SetBool(option.TraceNotify, option.Config.EnableTraceNotifications)
 	option.Config.Opts.SetBool(option.PolicyVerdictNotify, true)
 	option.Config.Opts.SetBool(option.PolicyTracing, option.Config.EnableTracing)
 	option.Config.Opts.SetBool(option.ConntrackAccounting, true)

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1218,6 +1218,10 @@ data:
   max-connected-clusters: {{ .Values.clustermesh.maxConnectedClusters | quote }}
 {{- end }}
 
+{{- if and (.Values.trace) (hasKey .Values.trace "notification") (hasKey .Values.trace.notification "enabled") }}
+  trace-notification: {{ .Values.trace.notification.enabled | quote }}
+{{- end }}
+
 # Extra config allows adding arbitrary properties to the cilium config.
 # By putting it at the end of the ConfigMap, it's also possible to override existing properties.
 {{- if .Values.extraConfig }}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -50,7 +50,7 @@ const (
 	// StateDirRights are the default access rights of the state directory
 	StateDirRights = 0770
 
-	//StateDir is the default path for the state directory relative to RuntimePath
+	// StateDir is the default path for the state directory relative to RuntimePath
 	StateDir = "state"
 
 	// TemplatesDir is the default path for the compiled template objects relative to StateDir
@@ -158,7 +158,7 @@ const (
 
 	// FQDNProxyResponseMaxDelay The maximum time the DNS proxy holds an allowed
 	// DNS response before sending it along. Responses are sent as soon as the
-	//datapath is updated with the new IP information.
+	// datapath is updated with the new IP information.
 	FQDNProxyResponseMaxDelay = 100 * time.Millisecond
 
 	// ToFQDNsPreCache is a path to a file with DNS cache data to insert into the
@@ -546,6 +546,9 @@ const (
 
 	// EnableK8sNetworkPolicy enables support for K8s NetworkPolicy.
 	EnableK8sNetworkPolicy = true
+
+	// EnableTraceNotification enables trace notifications by default.
+	EnableTraceNotification = true
 
 	// MaxConnectedClusters sets the maximum number of clusters that can be
 	// connected in a clustermesh.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -499,6 +499,9 @@ const (
 	// BPFSocketLBHostnsOnly is the name of the BPFSocketLBHostnsOnly option
 	BPFSocketLBHostnsOnly = "bpf-lb-sock-hostns-only"
 
+	// EnableTraceNotification is the name of the option to enable trace notifications
+	EnableTraceNotification = "trace-notification"
+
 	// RoutingMode is the name of the option to choose between native routing and tunneling mode
 	RoutingMode = "routing-mode"
 
@@ -1750,6 +1753,7 @@ type DaemonConfig struct {
 	EnableSocketLB                bool
 	EnableSocketLBTracing         bool
 	EnableSocketLBPeer            bool
+	EnableTraceNotifications      bool
 	EnablePolicy                  string
 	EnableTracing                 bool
 	EnableUnreachableRoutes       bool
@@ -2477,6 +2481,8 @@ var (
 		EnableK8sNetworkPolicy: defaults.EnableK8sNetworkPolicy,
 		PolicyCIDRMatchMode:    defaults.PolicyCIDRMatchMode,
 		MaxConnectedClusters:   defaults.MaxConnectedClusters,
+
+		EnableTraceNotifications: defaults.EnableTraceNotification,
 	}
 )
 
@@ -3024,6 +3030,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.BPFSocketLBHostnsOnly = vp.GetBool(BPFSocketLBHostnsOnly)
 	c.EnableSocketLB = vp.GetBool(EnableSocketLB)
 	c.EnableSocketLBTracing = vp.GetBool(EnableSocketLBTracing)
+	c.EnableTraceNotifications = vp.GetBool(EnableTraceNotification)
 	c.EnableRemoteNodeIdentity = vp.GetBool(EnableRemoteNodeIdentity)
 	c.EnableBPFTProxy = vp.GetBool(EnableBPFTProxy)
 	c.EnableXTSocketFallback = vp.GetBool(EnableXTSocketFallbackName)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Makes TraceNotification configurable.

When enabled, trace notifications (`send_trace_notify()`) consume CPU in proportion to the volume of traffic on an instance. This makes the use of Hubble or other perf event consumers such as `cilium monitor` prohibitive on high-traffic nodes.

TraceNotification is only configurable via the agent API (e.g. `cilium config TraceNotification=Disabled`) and defaults to `Enabled`. This change makes this setting configurable at agent startup.


Fixes: #issue-number

```release-note
TraceNotification is now configurable via `--trace-notification=true|false`.
```
