### PR TITLE
bgpv1: Enable `cilium-dbg bgp routes advertised` command without specifying a peer

### DIFF
--- a/api/v1/models/bgp_route.go
+++ b/api/v1/models/bgp_route.go
@@ -22,6 +22,9 @@ import (
 // swagger:model BgpRoute
 type BgpRoute struct {
 
+	// IP address specifying a BGP neighbor if the source table type is adj-rib-in or adj-rib-out
+	Neighbor string `json:"neighbor,omitempty"`
+
 	// List of routing paths leading towards the prefix
 	Paths []*BgpPath `json:"paths"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -4042,6 +4042,9 @@ definitions:
       router-asn:
         description: Autonomous System Number (ASN) identifying a BGP virtual router instance
         type: integer
+      neighbor:
+        description: IP address specifying a BGP neighbor if the source table type is adj-rib-in or adj-rib-out
+        type: string
       prefix:
         description: IP prefix of the route
         type: string

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2201,6 +2201,10 @@ func init() {
     "BgpRoute": {
       "description": "Single BGP route retrieved from the RIB of underlying router",
       "properties": {
+        "neighbor": {
+          "description": "IP address specifying a BGP neighbor if the source table type is adj-rib-in or adj-rib-out",
+          "type": "string"
+        },
         "paths": {
           "description": "List of routing paths leading towards the prefix",
           "type": "array",
@@ -7951,6 +7955,10 @@ func init() {
     "BgpRoute": {
       "description": "Single BGP route retrieved from the RIB of underlying router",
       "properties": {
+        "neighbor": {
+          "description": "IP address specifying a BGP neighbor if the source table type is adj-rib-in or adj-rib-out",
+          "type": "string"
+        },
         "paths": {
           "description": "List of routing paths leading towards the prefix",
           "type": "array",

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -436,6 +436,8 @@ func copyCiliumInfoCommands(cmdDir string, k8sPods []string) []string {
 		"cilium-dbg bgp peers",
 		"cilium-dbg bgp routes available ipv4 unicast",
 		"cilium-dbg bgp routes available ipv6 unicast",
+		"cilium-dbg bgp routes advertised ipv4 unicast",
+		"cilium-dbg bgp routes advertised ipv6 unicast",
 		"cilium-dbg bgp route-policies",
 	}
 	var commands []string

--- a/pkg/bgpv1/api/conversions.go
+++ b/pkg/bgpv1/api/conversions.go
@@ -208,13 +208,14 @@ func ToAgentPaths(ms []*models.BgpPath) ([]*types.Path, error) {
 	return ret, nil
 }
 
-func ToAPIRoute(r *types.Route, routerASN int64) (*models.BgpRoute, error) {
+func ToAPIRoute(r *types.Route, routerASN int64, neighbor string) (*models.BgpRoute, error) {
 	paths, err := ToAPIPaths(r.Paths)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize Paths: %w", err)
 	}
 	return &models.BgpRoute{
 		RouterAsn: routerASN,
+		Neighbor:  neighbor,
 		Prefix:    r.Prefix,
 		Paths:     paths,
 	}, nil
@@ -231,12 +232,12 @@ func ToAgentRoute(m *models.BgpRoute) (*types.Route, error) {
 	}, nil
 }
 
-func ToAPIRoutes(rs []*types.Route, routerASN int64) ([]*models.BgpRoute, error) {
+func ToAPIRoutes(rs []*types.Route, routerASN int64, neighbor string) ([]*models.BgpRoute, error) {
 	errs := []error{}
 	ret := []*models.BgpRoute{}
 
 	for _, r := range rs {
-		route, err := ToAPIRoute(r, routerASN)
+		route, err := ToAPIRoute(r, routerASN, neighbor)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/pkg/bgpv1/api/conversions_test.go
+++ b/pkg/bgpv1/api/conversions_test.go
@@ -22,7 +22,7 @@ func TestRouteConversions(t *testing.T) {
 				Paths:  []*types.Path{&tt.Path},
 			}
 
-			apiRoutes, err := ToAPIRoutes([]*types.Route{expectedRoute}, testRouterASN)
+			apiRoutes, err := ToAPIRoutes([]*types.Route{expectedRoute}, testRouterASN, "")
 			require.NoError(t, err)
 			require.NotZero(t, apiRoutes)
 

--- a/pkg/bgpv1/manager/manager_test.go
+++ b/pkg/bgpv1/manager/manager_test.go
@@ -116,15 +116,15 @@ func TestGetRoutes(t *testing.T) {
 			expectedErr:        fmt.Errorf(""),
 		},
 		{
-			name:               "missing neighbor for adj-rib-out",
+			name:               "unspecified neighbor for adj-rib-out",
 			advertisedPrefixes: testSingleIPv4Prefix,
-			expectedPrefixes:   nil,
+			expectedPrefixes:   nil, // nil as the neighbor never goes UP
 			routerASN:          nil,
 			tableType:          tableTypeLocAdjRibOut,
 			afi:                afiIPv4,
 			safi:               safiUnicast,
 			neighbor:           nil,
-			expectedErr:        fmt.Errorf(""),
+			expectedErr:        nil,
 		},
 		{
 			name:               "valid neighbor",


### PR DESCRIPTION
This PR enhances the `cilium-dbg bgp routes advertised` CLI command to allow dumping advertised routes without the need to specify an exact peer IP. In this case, the CLI will dump the advertised routes for each configured peer. 

This also allows to include the dump of advertised BGP routes in the bugtool, what is part of this PR as well.

Additionally, this PR adds defaulting of table type and AFI / SAFI to the CLI, to allow simple use with even less typing.

## Examples

Simplest dump of all advertised routes of all peers on all vrouters:
```
$ cilium bgp routes advertised
(Defaulting to `ipv4 unicast` AFI & SAFI, please see help for more options)

VRouter   Peer       Prefix        NextHop    Age     Attrs
65001     10.0.1.1   10.1.0.0/24   10.0.1.2   35m7s   [{Origin: i} {AsPath: 65001} {Nexthop: 10.0.1.2}] 
```

The same as yaml:
```
$ cilium bgp routes advertised -o yaml
- neighbor: 10.0.1.1
  paths:
    - agenanoseconds: 111065296279
      best: false
      family:
        afi: ipv4
        safi: unicast
      nlri:
        base64: GAoBAA==
      pathattributes:
        - base64: QAEBAA==
        - base64: QAIGAgEAAP3p
        - base64: QAMECgABAg==
      stale: false
  prefix: 10.1.0.0/24
  routerasn: 65001
```

Before this change, the only option to dump  advertised routes was to provide AFI & SAFI + peer IP:
```
$ cilium bgp routes advertised ipv4 unicast peer 10.0.1.1
VRouter   Prefix        NextHop    Age     Attrs
65001     10.1.0.0/24   10.0.1.2   4m10s   [{Origin: i} {AsPath: 65001} {Nexthop: 10.0.1.2}]   
```

Simplest use of the `routes` command:
```
$ cilium bgp routes                   
(Defaulting to `available ipv4 unicast` routes, please see help for more options)

VRouter   Prefix        NextHop    Age     Attrs
65001     10.1.0.0/24   0.0.0.0    2m19s   [{Origin: i} {Nexthop: 0.0.0.0}]                          
65001     10.1.1.0/24   10.0.1.1   2m12s   [{Origin: i} {AsPath: 65000 65002} {Nexthop: 10.0.1.1}]   

```