### PR TITLE
envoy: Default to daemon set deployment from 1.16

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1091,7 +1091,7 @@
    * - :spelling:ignore:`envoy.enabled`
      - Enable Envoy Proxy in standalone DaemonSet.
      - bool
-     - ``false``
+     - ``true``
    * - :spelling:ignore:`envoy.extraArgs`
      - Additional envoy container arguments.
      - list

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -306,7 +306,10 @@ Annotations:
 1.16 Upgrade Notes
 ------------------
 
-* To be determined during v1.16 development.
+* Cilium Envoy DaemonSet is now enabled by default, and existing in-container installs
+  will be changed to DaemonSet mode unless specifically opted out of. This can be done by
+  disabling it manually by setting ``envoy.enabled=false`` accordingly.
+
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -322,7 +322,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.baseID | int | `0` |  Set Envoy'--base-id' to use when allocating shared memory regions. Only needs to be changed if multiple Envoy instances will run on the same node and may have conflicts. Supported values: 0 - 4294967295. Defaults to '0' |
 | envoy.connectTimeoutSeconds | int | `2` | Time in seconds after which a TCP connection attempt times out |
 | envoy.dnsPolicy | string | `nil` | DNS policy for Cilium envoy pods. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
-| envoy.enabled | bool | `false` | Enable Envoy Proxy in standalone DaemonSet. |
+| envoy.enabled | bool | `true` | Enable Envoy Proxy in standalone DaemonSet. |
 | envoy.extraArgs | list | `[]` | Additional envoy container arguments. |
 | envoy.extraContainers | list | `[]` | Additional containers added to the cilium Envoy DaemonSet. |
 | envoy.extraEnv | list | `[]` | Additional envoy container environment variables. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1795,7 +1795,7 @@ dashboards:
 # Configure Cilium Envoy options.
 envoy:
   # -- Enable Envoy Proxy in standalone DaemonSet.
-  enabled: false
+  enabled: true
   # -- (int)
   # Set Envoy'--base-id' to use when allocating shared memory regions.
   # Only needs to be changed if multiple Envoy instances will run on the same node and may have conflicts. Supported values: 0 - 4294967295. Defaults to '0'

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1795,7 +1795,7 @@ dashboards:
 # Configure Cilium Envoy options.
 envoy:
   # -- Enable Envoy Proxy in standalone DaemonSet.
-  enabled: false
+  enabled: true
   # -- (int)
   # Set Envoy'--base-id' to use when allocating shared memory regions.
   # Only needs to be changed if multiple Envoy instances will run on the same node and may have conflicts. Supported values: 0 - 4294967295. Defaults to '0'

--- a/test/k8s/updates.go
+++ b/test/k8s/updates.go
@@ -453,6 +453,8 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 			"hubble.relay.image.tag": newImageVersion,
 			"cluster.name":           clusterName,
 			"cluster.id":             clusterID,
+			// Remove this after 1.16 is released
+			"envoy.enabled": "false",
 		}
 
 		upgradeCompatibilityVer := strings.TrimSuffix(oldHelmChartVersion, "-dev")


### PR DESCRIPTION
This is to set the default envoy deployment to daemon set mode for new installation.

```release-note
Deploy Envoy as a separate DaemonSet by default rather than running it inside the Cilium Pod
```

