### PR TITLE
nodeipam: add a Service LoadBalancer node ipam

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2308,6 +2308,10 @@
      - Enable RFC8215-prefixed translation
      - bool
      - ``false``
+   * - :spelling:ignore:`nodeIPAM.enabled`
+     - Configure Node IPAM ref: https://docs.cilium.io/en/stable/network/node-ipam/
+     - bool
+     - ``false``
    * - :spelling:ignore:`nodePort`
      - Configure N-S k8s service loadbalancing
      - object

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -85,6 +85,7 @@ get started and experiment with Cilium.
    network/servicemesh/index
    network/vtep
    network/l2-announcements
+   network/node-ipam
 
 .. toctree::
    :maxdepth: 2

--- a/Documentation/network/node-ipam.rst
+++ b/Documentation/network/node-ipam.rst
@@ -1,0 +1,25 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _node_ipam:
+
+************
+Node IPAM LB
+************
+
+Node IPAM LoadBalancer is a feature inspired by k3s "ServiceLB" that allows you
+to "advertise" the node's IPs directly inside a Service LoadBalancer. This feature
+is especially useful if you don't control the network you are running on and can't
+use either the L2 or BGP capabilities of Cilium.
+
+It works by getting the Node addresses of the selected pods and advertising them.
+It will respect the ``.spec.ipFamilies`` to decide if IPv4 or IPv6 addresses
+shall be used and will use the ``ExternalIP`` addresses if any or the
+``InternalIP`` addresses otherwise.
+
+To use this feature your service must be of type ``LoadBalancer`` and have the
+`loadBalancerClass <https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class>`__
+set to ``io.cilium/node``.

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -627,6 +627,7 @@ contributors across the globe, there is almost always someone available to help.
 | name | string | `"cilium"` | Agent container name. |
 | nat46x64Gateway | object | `{"enabled":false}` | Configure standalone NAT46/NAT64 gateway |
 | nat46x64Gateway.enabled | bool | `false` | Enable RFC8215-prefixed translation |
+| nodeIPAM.enabled | bool | `false` | Configure Node IPAM ref: https://docs.cilium.io/en/stable/network/node-ipam/ |
 | nodePort | object | `{"autoProtectPortRange":true,"bindProtection":true,"enableHealthCheck":true,"enableHealthCheckLoadBalancerIP":false,"enabled":false}` | Configure N-S k8s service loadbalancing |
 | nodePort.autoProtectPortRange | bool | `true` | Append NodePort range to ip_local_reserved_ports if clash with ephemeral ports is detected. |
 | nodePort.bindProtection | bool | `true` | Set to true to prevent applications binding to service ports. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1000,6 +1000,10 @@ data:
   limit-ipam-api-qps: {{ .Values.ipam.operator.externalAPILimitQPS | quote }}
 {{- end }}
 
+{{- if .Values.nodeIPAM.enabled }}
+  enable-node-ipam: "true"
+{{- end }}
+
 {{- if .Values.apiRateLimit }}
   api-rate-limit: {{ .Values.apiRateLimit | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1714,6 +1714,11 @@ ipam:
     # @default -- `4.0`
     externalAPILimitQPS: ~
 
+nodeIPAM:
+  # -- Configure Node IPAM
+  # ref: https://docs.cilium.io/en/stable/network/node-ipam/
+  enabled: false
+
 # -- The api-rate-limit option can be used to overwrite individual settings of the default configuration for rate limiting calls to the Cilium Agent API
 apiRateLimit: ~
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1711,6 +1711,11 @@ ipam:
     # @default -- `4.0`
     externalAPILimitQPS: ~
 
+nodeIPAM:
+  # -- Configure Node IPAM
+  # ref: https://docs.cilium.io/en/stable/network/node-ipam/
+  enabled: false
+
 # -- The api-rate-limit option can be used to overwrite individual settings of the default configuration for rate limiting calls to the Cilium Agent API
 apiRateLimit: ~
 

--- a/operator/pkg/nodeipam/cell.go
+++ b/operator/pkg/nodeipam/cell.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nodeipam
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+	ctrlRuntime "sigs.k8s.io/controller-runtime"
+
+	"github.com/cilium/cilium/pkg/hive/cell"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+)
+
+var Cell = cell.Module(
+	"nodeipam",
+	"Node-IPAM",
+
+	cell.Config(nodeIpamConfig{}),
+	cell.Invoke(registerNodeSvcLBReconciler),
+)
+
+type nodeipamCellParams struct {
+	cell.In
+
+	Logger             logrus.FieldLogger
+	Clientset          k8sClient.Clientset
+	CtrlRuntimeManager ctrlRuntime.Manager
+	Config             nodeIpamConfig
+}
+
+type nodeIpamConfig struct {
+	EnableNodeIPAM bool
+}
+
+func (r nodeIpamConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool("enable-node-ipam", r.EnableNodeIPAM, "Enable Node IPAM")
+}
+
+func registerNodeSvcLBReconciler(params nodeipamCellParams) error {
+	if !params.Clientset.IsEnabled() || !params.Config.EnableNodeIPAM {
+		return nil
+	}
+
+	if err := newNodeSvcLBReconciler(params.CtrlRuntimeManager, params.Logger).SetupWithManager(params.CtrlRuntimeManager); err != nil {
+		return fmt.Errorf("Failed to register NodeSvcLBReconciler: %s", err)
+	}
+
+	return nil
+}

--- a/operator/pkg/nodeipam/nodesvclb.go
+++ b/operator/pkg/nodeipam/nodesvclb.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nodeipam
+
+import (
+	"context"
+	"slices"
+	"sort"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/sets"
+	utilsnet "k8s.io/utils/net"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	controllerruntime "github.com/cilium/cilium/operator/pkg/controller-runtime"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var nodeSvcLBClass = "io.cilium/node"
+
+type nodeSvcLBReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	Logger logrus.FieldLogger
+}
+
+func newNodeSvcLBReconciler(mgr ctrl.Manager, logger logrus.FieldLogger) *nodeSvcLBReconciler {
+	return &nodeSvcLBReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Logger: logger,
+	}
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *nodeSvcLBReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	filter := func(obj client.Object) bool {
+		svc, ok := obj.(*corev1.Service)
+		return ok && r.isServiceSupported(svc)
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		// Watch for changes to Services supported by the controller
+		For(&corev1.Service{}, builder.WithPredicates(predicate.NewPredicateFuncs(filter))).
+		// Watch for changes to EndpointSlices
+		Watches(&discoveryv1.EndpointSlice{}, r.enqueueRequestForEndpointSlice()).
+		// Watch for changes to Nodes
+		Watches(&corev1.Node{}, handler.EnqueueRequestsFromMapFunc(r.enqueueAll())).
+		Complete(r)
+}
+
+// enqueueRequestForEndpointSlice enqueue the service if a corresponding Enndpoint Slice is updated
+func (r *nodeSvcLBReconciler) enqueueRequestForEndpointSlice() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+		scopedLog := r.Logger.WithFields(logrus.Fields{
+			logfields.Controller: "node-service-lb",
+			logfields.Resource:   client.ObjectKeyFromObject(o),
+		})
+		epSlice, ok := o.(*discoveryv1.EndpointSlice)
+		if !ok {
+			return []ctrl.Request{}
+		}
+		svcName, ok := epSlice.Labels[discoveryv1.LabelServiceName]
+		if !ok {
+			return []ctrl.Request{}
+		}
+		svc := client.ObjectKey{
+			Namespace: epSlice.GetNamespace(),
+			Name:      svcName,
+		}
+		scopedLog.WithField("service", svc).Info("Enqueued Service")
+		return []ctrl.Request{{NamespacedName: svc}}
+	})
+}
+
+// enqueueAll enqueue every services of supported type
+func (r *nodeSvcLBReconciler) enqueueAll() handler.MapFunc {
+	return func(ctx context.Context, o client.Object) []reconcile.Request {
+		scopedLog := r.Logger.WithFields(logrus.Fields{
+			logfields.Controller: "node-service-lb",
+			logfields.Resource:   client.ObjectKeyFromObject(o),
+		})
+		svcList := &corev1.ServiceList{}
+
+		if err := r.Client.List(ctx, svcList, &client.ListOptions{}); err != nil {
+			scopedLog.WithError(err).Error("Failed to get Services")
+			return []reconcile.Request{}
+		}
+
+		requests := make([]reconcile.Request, 0, len(svcList.Items))
+		for _, item := range svcList.Items {
+			if !r.isServiceSupported(&item) {
+				continue
+			}
+			svc := client.ObjectKey{
+				Namespace: item.GetNamespace(),
+				Name:      item.GetName(),
+			}
+			requests = append(requests, reconcile.Request{NamespacedName: svc})
+			scopedLog.WithField("service", svc).Info("Enqueued Service")
+		}
+		return requests
+	}
+}
+
+func (r *nodeSvcLBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	scopedLog := r.Logger.WithFields(logrus.Fields{
+		logfields.Controller: "node-service-lb",
+		logfields.Resource:   req.NamespacedName,
+	})
+	scopedLog.Info("Reconciling Service")
+
+	svc := corev1.Service{}
+	err := r.Get(ctx, req.NamespacedName, &svc)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return controllerruntime.Success()
+		}
+		return controllerruntime.Fail(err)
+	}
+
+	// Ignore deleted Service, this can happen when foregroundDeletion is enabled
+	if svc.GetDeletionTimestamp() != nil {
+		return controllerruntime.Success()
+	}
+
+	if !r.isServiceSupported(&svc) {
+		return controllerruntime.Success()
+	}
+
+	nodes, err := r.getRelevantNodes(ctx, &svc)
+	if err != nil {
+		return controllerruntime.Fail(err)
+	}
+	svc.Status.LoadBalancer.Ingress = getNodeLoadBalancerIngresses(nodes, svc.Spec.IPFamilies)
+	return controllerruntime.Fail(r.Status().Update(ctx, &svc))
+}
+
+// isServiceSupported returns true if the service is supported by the controller
+func (r nodeSvcLBReconciler) isServiceSupported(service *corev1.Service) bool {
+	if !service.DeletionTimestamp.IsZero() {
+		return false
+	}
+	if service.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return false
+	}
+	return service.Spec.LoadBalancerClass != nil && *service.Spec.LoadBalancerClass == nodeSvcLBClass
+}
+
+// getRelevantNodes get all the nodes in the matching EndpointSlices for a specified service
+func (r *nodeSvcLBReconciler) getRelevantNodes(ctx context.Context, svc *corev1.Service) ([]corev1.Node, error) {
+	selectedNodes := sets.Set[string]{}
+	serviceReq, _ := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{svc.Name})
+
+	selector := labels.NewSelector()
+	selector = selector.Add(*serviceReq)
+
+	var epSliceList discoveryv1.EndpointSliceList
+	if err := r.List(ctx, &epSliceList, &client.ListOptions{Namespace: svc.Namespace, LabelSelector: selector}); err != nil && !k8serrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	for _, item := range epSliceList.Items {
+		for _, endpoint := range item.Endpoints {
+			if endpoint.NodeName != nil {
+				selectedNodes.Insert(*endpoint.NodeName)
+			}
+		}
+	}
+
+	var nodes corev1.NodeList
+	if err := r.List(ctx, &nodes); err != nil {
+		return []corev1.Node{}, err
+	}
+
+	relevantsNodes := []corev1.Node{}
+	for _, node := range nodes.Items {
+		if !selectedNodes.Has(node.Name) {
+			continue
+		}
+
+		relevantsNodes = append(relevantsNodes, node)
+	}
+	return relevantsNodes, nil
+}
+
+// getNodeLoadBalancerIngresses get all the load balancer ingresses with the specified nodes
+// and IPFamilies. It will prioritize external IPs of the nodes if it can find some
+// or internal IPs otherwise.
+func getNodeLoadBalancerIngresses(nodes []corev1.Node, ipFamilies []corev1.IPFamily) []corev1.LoadBalancerIngress {
+	hasV4 := slices.Contains(ipFamilies, corev1.IPv4Protocol)
+	hasV6 := slices.Contains(ipFamilies, corev1.IPv6Protocol)
+	extIPs := sets.Set[string]{}
+	intIPs := sets.Set[string]{}
+	for _, node := range nodes {
+		for _, addr := range node.Status.Addresses {
+			var currentIps *sets.Set[string]
+			switch addr.Type {
+			case corev1.NodeExternalIP:
+				currentIps = &extIPs
+			case corev1.NodeInternalIP:
+				currentIps = &intIPs
+			default:
+				continue
+			}
+
+			switch {
+			case hasV4 && utilsnet.IsIPv4String(addr.Address):
+				currentIps.Insert(addr.Address)
+			case hasV6 && utilsnet.IsIPv6String(addr.Address):
+				currentIps.Insert(addr.Address)
+			}
+		}
+	}
+
+	var ips []string
+	if extIPs.Len() > 0 {
+		ips = extIPs.UnsortedList()
+	} else {
+		ips = intIPs.UnsortedList()
+	}
+	sort.Strings(ips)
+
+	ingresses := make([]corev1.LoadBalancerIngress, len(ips))
+	for i, ip := range ips {
+		ingresses[i] = corev1.LoadBalancerIngress{IP: ip}
+	}
+
+	return ingresses
+}

--- a/operator/pkg/nodeipam/nodesvclb.go
+++ b/operator/pkg/nodeipam/nodesvclb.go
@@ -174,9 +174,14 @@ func (r *nodeSvcLBReconciler) getRelevantNodes(ctx context.Context, svc *corev1.
 
 	for _, item := range epSliceList.Items {
 		for _, endpoint := range item.Endpoints {
-			if endpoint.NodeName != nil {
-				selectedNodes.Insert(*endpoint.NodeName)
+			if endpoint.Conditions.Ready != nil && !*endpoint.Conditions.Ready {
+				continue
 			}
+			if endpoint.NodeName == nil {
+				continue
+			}
+
+			selectedNodes.Insert(*endpoint.NodeName)
 		}
 	}
 

--- a/operator/pkg/nodeipam/nodesvclb_test.go
+++ b/operator/pkg/nodeipam/nodesvclb_test.go
@@ -52,6 +52,7 @@ var (
 			},
 			Endpoints: []discoveryv1.Endpoint{
 				{NodeName: stringPtr("node-1")},
+				{NodeName: stringPtr("node-2"), Conditions: discoveryv1.EndpointConditions{Ready: boolPtr(false)}},
 			},
 		},
 		&corev1.Service{
@@ -212,6 +213,9 @@ var (
 
 func stringPtr(str string) *string {
 	return &str
+}
+func boolPtr(boolean bool) *bool {
+	return &boolean
 }
 
 func Test_httpRouteReconciler_Reconcile(t *testing.T) {

--- a/operator/pkg/nodeipam/nodesvclb_test.go
+++ b/operator/pkg/nodeipam/nodesvclb_test.go
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nodeipam
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/cilium/cilium/pkg/logging"
+)
+
+var (
+	nodeSvcLbFixtures = []client.Object{
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-1",
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+					{Type: corev1.NodeExternalIP, Address: "2001:0000::1"},
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-2",
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: "fc00::2"},
+					{Type: corev1.NodeExternalIP, Address: "42.0.0.2"},
+				},
+			},
+		},
+
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ipv4-internal",
+				Namespace: "default",
+				Labels:    map[string]string{discoveryv1.LabelServiceName: "ipv4-internal"},
+			},
+			Endpoints: []discoveryv1.Endpoint{
+				{NodeName: stringPtr("node-1")},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ipv4-internal",
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				Type:              corev1.ServiceTypeLoadBalancer,
+				IPFamilies:        []corev1.IPFamily{corev1.IPv4Protocol},
+				LoadBalancerClass: &nodeSvcLBClass,
+			},
+		},
+
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ipv4-external",
+				Namespace: "default",
+				Labels:    map[string]string{discoveryv1.LabelServiceName: "ipv4-external"},
+			},
+			Endpoints: []discoveryv1.Endpoint{
+				{NodeName: stringPtr("node-1")},
+				{NodeName: stringPtr("node-2")},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ipv4-external",
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				Type:              corev1.ServiceTypeLoadBalancer,
+				IPFamilies:        []corev1.IPFamily{corev1.IPv4Protocol},
+				LoadBalancerClass: &nodeSvcLBClass,
+			},
+		},
+
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ipv6-internal",
+				Namespace: "default",
+				Labels:    map[string]string{discoveryv1.LabelServiceName: "ipv6-internal"},
+			},
+			Endpoints: []discoveryv1.Endpoint{
+				{NodeName: stringPtr("node-2")},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ipv6-internal",
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				Type:              corev1.ServiceTypeLoadBalancer,
+				IPFamilies:        []corev1.IPFamily{corev1.IPv6Protocol},
+				LoadBalancerClass: &nodeSvcLBClass,
+			},
+		},
+
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ipv6-external",
+				Namespace: "default",
+				Labels:    map[string]string{discoveryv1.LabelServiceName: "ipv6-external"},
+			},
+			Endpoints: []discoveryv1.Endpoint{
+				{NodeName: stringPtr("node-1")},
+				{NodeName: stringPtr("node-2")},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ipv6-external",
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				Type:              corev1.ServiceTypeLoadBalancer,
+				IPFamilies:        []corev1.IPFamily{corev1.IPv6Protocol},
+				LoadBalancerClass: &nodeSvcLBClass,
+			},
+		},
+
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dualstack-external",
+				Namespace: "default",
+				Labels:    map[string]string{discoveryv1.LabelServiceName: "dualstack-external"},
+			},
+			Endpoints: []discoveryv1.Endpoint{
+				{NodeName: stringPtr("node-1")},
+				{NodeName: stringPtr("node-2")},
+				{NodeName: stringPtr("does-not-exist")},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dualstack-external",
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				Type:              corev1.ServiceTypeLoadBalancer,
+				IPFamilies:        []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+				LoadBalancerClass: &nodeSvcLBClass,
+			},
+		},
+
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "not-supported-1",
+				Namespace: "default",
+				Labels:    map[string]string{discoveryv1.LabelServiceName: "not-supported-1"},
+			},
+			Endpoints: []discoveryv1.Endpoint{
+				{NodeName: stringPtr("node-1")},
+				{NodeName: stringPtr("node-2")},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "not-supported-1",
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				Type:       corev1.ServiceTypeLoadBalancer,
+				IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+			},
+			Status: corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{IP: "100.100.100.100"}},
+			}},
+		},
+
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "not-supported-2",
+				Namespace: "default",
+				Labels:    map[string]string{discoveryv1.LabelServiceName: "not-supported-2"},
+			},
+			Endpoints: []discoveryv1.Endpoint{
+				{NodeName: stringPtr("node-1")},
+				{NodeName: stringPtr("node-2")},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "not-supported-2",
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				IPFamilies:        []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+				LoadBalancerClass: &nodeSvcLBClass,
+			},
+			Status: corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{IP: "100.100.100.100"}},
+			}},
+		},
+	}
+)
+
+func stringPtr(str string) *string {
+	return &str
+}
+
+func Test_httpRouteReconciler_Reconcile(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithObjects(nodeSvcLbFixtures...).
+		WithStatusSubresource(&corev1.Service{}).
+		Build()
+	r := &nodeSvcLBReconciler{Client: c, Logger: logging.DefaultLogger}
+
+	t.Run("unsupported service reset", func(t *testing.T) {
+		for _, name := range []string{"not-supported-1", "not-supported-2"} {
+			key := types.NamespacedName{
+				Name:      name,
+				Namespace: "default",
+			}
+			result, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: key,
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+			svc := &corev1.Service{}
+			err = c.Get(context.Background(), key, svc)
+
+			require.NoError(t, err)
+			// It did not change the IPs already advertised
+			require.Len(t, svc.Status.LoadBalancer.Ingress, 1)
+			require.Equal(t, svc.Status.LoadBalancer.Ingress[0].IP, "100.100.100.100")
+		}
+	})
+
+	t.Run("single address test in single stack", func(t *testing.T) {
+		for _, param := range []struct {
+			name    string
+			address string
+		}{
+			{name: "ipv4-internal", address: "10.0.0.1"},
+			{name: "ipv4-external", address: "42.0.0.2"},
+			{name: "ipv6-internal", address: "fc00::2"},
+			{name: "ipv6-external", address: "2001:0000::1"},
+		} {
+			key := types.NamespacedName{
+				Name:      param.name,
+				Namespace: "default",
+			}
+			result, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: key,
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+			svc := &corev1.Service{}
+			err = c.Get(context.Background(), key, svc)
+
+			require.NoError(t, err)
+			require.Len(t, svc.Status.LoadBalancer.Ingress, 1)
+			require.Equal(t, svc.Status.LoadBalancer.Ingress[0].IP, param.address)
+		}
+	})
+
+	t.Run("dual stack", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "dualstack-external",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		svc := &corev1.Service{}
+		err = c.Get(context.Background(), key, svc)
+
+		require.NoError(t, err)
+		require.Len(t, svc.Status.LoadBalancer.Ingress, 2)
+		require.Equal(t, svc.Status.LoadBalancer.Ingress[0].IP, "2001:0000::1")
+		require.Equal(t, svc.Status.LoadBalancer.Ingress[1].IP, "42.0.0.2")
+	})
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Add a new Node IPAM to Cilium controlled by the loadBalancer class `io.cilium/node`. This works similarly to k3s ServiceLB and allow users to advertise node IPs. It is especially useful in context where users don't have control over the networks and can't advertise IPs using L2 or BGP.

It simply works by getting the addresses of the nodes of the selected pods and advertising those in the Service status. Node IPAM will also respect `.spec.ipFamilies` and use `ExternalIP` if it can find any or `InternalIP` otherwise.

Fixes: #30037

```release-note
Add a simple node IPAM to allow using LoadBalancer Service type on "uncontrolled" networks
```
