### PR TITLE
Add a description to the default GatewayClass

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-gateway-api-class.yaml
+++ b/install/kubernetes/cilium/templates/cilium-gateway-api-class.yaml
@@ -6,5 +6,6 @@ metadata:
   name: cilium
 spec:
   controllerName: io.cilium/gateway-controller
+  description: The default Cilium GatewayClass
 {{- end}}
 {{- end}}


### PR DESCRIPTION


<!-- Description of change -->

Adding a description to the default GatewayClass so that some command line UI tools like `k9s` can display description information to help users quickly identify these default resources.

Fixes: #issue-number

```release-note
Add a description to the default GatewayClass.
```
