### PR TITLE
init well-known identity before new policy repository

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -411,11 +411,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	identity.IterateReservedIdentities(func(_ identity.NumericIdentity, _ *identity.Identity) {
 		metrics.Identity.WithLabelValues(identity.ReservedIdentityType).Inc()
 	})
-	if option.Config.EnableWellKnownIdentities {
-		// Must be done before calling policy.NewPolicyRepository() below.
-		num := identity.InitWellKnownIdentities(option.Config, params.ClusterInfo)
-		metrics.Identity.WithLabelValues(identity.WellKnownIdentityType).Add(float64(num))
-	}
 
 	nd := nodediscovery.NewNodeDiscovery(params.NodeManager, params.Clientset, params.LocalNodeStore, params.MTU, params.CNIConfigManager.GetCustomNetConf())
 


### PR DESCRIPTION
<!-- Description of change -->

Fixes: #30051 

```release-note
init well-known identity before new policy repository to fix the fqdn policy issue when enable well-known identity.
```
