### PR TITLE
lbipam: allow cross namespace IP sharing

### DIFF
--- a/Documentation/network/lb-ipam.rst
+++ b/Documentation/network/lb-ipam.rst
@@ -477,3 +477,5 @@ Services that have the same sharing key annotation will share the same IP or set
 
 As long as the services do not have conflicting ports, they will be allocated the same IP. If the services have conflicting ports, they will be allocated different IPs, which will be added to the set of IPs belonging to the sharing key.
 If a service has a sharing key and also requests a specific IP, the service will be allocated the requested IP and it will be added to the set of IPs belonging to that sharing key.
+
+By default, sharing IPs across namespaces is not allowed. To allow sharing across a namespace, set the ``io.cilium/lb-ipam-sharing-cross-namespace`` annotation to the namespaces the service can be shared with. The value must be a comma-separated list of namespaces. The annotation must be present on both services. You can allow all namespaces with ``*``.


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

Follow-up of #28806 to allow sharing an IP across namespaces.

The previous changes to allow sharing an IP between several services forbid to do so across namespaces because a service is a namespaced resource and doing so could cause security issues.

However, for non-tenanted clusters needing to really reduce IP usage, it still makes sense to allow users to share IPs across namespaces.

This change thus re-introduces that ability by having the user specify an annotation on both services, thus granting sharing.

cc. @usiegl00 @dylandreimerink that implemented/reviewed the initial change allowing sharing.