### PR TITLE
v1.14 Backports 2024-01-02

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -149,7 +149,7 @@ jobs:
             mode: 'patch'
             name: '8'
 
-    timeout-minutes: 60
+    timeout-minutes: 70
     steps:
       - name: Checkout context ref
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -166,7 +166,7 @@ To replace cilium-ipsec-keys secret with a new key:
 
 .. code-block:: shell-session
 
-    KEYID=$(kubectl get secret -n kube-system cilium-ipsec-keys -o go-template --template={{.data.keys}} | base64 -d | cut -c 1)
+    KEYID=$(kubectl get secret -n kube-system cilium-ipsec-keys -o go-template --template={{.data.keys}} | base64 -d | cut -d' ' -f1)
     if [[ $KEYID -ge 15 ]]; then KEYID=0; fi
     data=$(echo "{\"stringData\":{\"keys\":\"$((($KEYID+1))) "rfc4106\(gcm\(aes\)\)" $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64)) 128\"}}")
     kubectl patch secret -n kube-system cilium-ipsec-keys -p="${data}" -v=1

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -430,10 +430,16 @@ data:
   #   - vxlan (default)
   #   - geneve
 {{- if .Values.gke.enabled }}
+  {{- if ne (.Values.routingMode | default "native") "native" }}
+    {{- fail (printf "RoutingMode must be set to native when gke.enabled=true" )}}
+  {{- end }}
   routing-mode: "native"
   enable-endpoint-routes: "true"
   enable-local-node-route: "false"
 {{- else if .Values.aksbyocni.enabled }}
+  {{- if ne (.Values.routingMode | default "tunnel") "tunnel" }}
+    {{- fail (printf "RoutingMode must be set to tunnel when aksbyocni.enabled=true" )}}
+  {{- end }}
   routing-mode: "tunnel"
   tunnel-protocol: "vxlan"
 {{- else if .Values.routingMode }}

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -83,7 +83,7 @@ var (
 
 	// ipSecKeysGlobal can be accessed by multiple subsystems concurrently,
 	// so it should be accessed only through the getIPSecKeys and
-	// loadIPSecKeys functions, which will ensure the proper lock is held
+	// LoadIPSecKeys functions, which will ensure the proper lock is held
 	ipSecKeysGlobal = make(map[string]*ipSecKey)
 
 	// ipSecCurrentKeySPI is the SPI of the IPSec currently in use
@@ -761,10 +761,10 @@ func LoadIPSecKeysFile(path string) (int, uint8, error) {
 		return 0, 0, err
 	}
 	defer file.Close()
-	return loadIPSecKeys(file)
+	return LoadIPSecKeys(file)
 }
 
-func loadIPSecKeys(r io.Reader) (int, uint8, error) {
+func LoadIPSecKeys(r io.Reader) (int, uint8, error) {
 	var spi uint8
 	var keyLen int
 

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -52,7 +52,7 @@ func (p *IPSecSuitePrivileged) TestLoadKeysNoFile(c *C) {
 
 func (p *IPSecSuitePrivileged) TestInvalidLoadKeys(c *C) {
 	keys := bytes.NewReader(invalidKeysDat)
-	_, _, err := loadIPSecKeys(keys)
+	_, _, err := LoadIPSecKeys(keys)
 	c.Assert(err, NotNil)
 
 	_, local, err := net.ParseCIDR("1.1.3.4/16")
@@ -66,12 +66,12 @@ func (p *IPSecSuitePrivileged) TestInvalidLoadKeys(c *C) {
 
 func (p *IPSecSuitePrivileged) TestLoadKeys(c *C) {
 	keys := bytes.NewReader(keysDat)
-	_, spi, err := loadIPSecKeys(keys)
+	_, spi, err := LoadIPSecKeys(keys)
 	c.Assert(err, IsNil)
 	err = SetIPSecSPI(spi)
 	c.Assert(err, IsNil)
 	keys = bytes.NewReader(keysAeadDat)
-	_, spi, err = loadIPSecKeys(keys)
+	_, spi, err = LoadIPSecKeys(keys)
 	c.Assert(err, IsNil)
 	err = SetIPSecSPI(spi)
 	c.Assert(err, IsNil)

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -757,7 +757,6 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateIDs(c *check.C) {
 
 // Tests that we don't leak XFRM policies and states as nodes come and go.
 func (s *linuxPrivilegedBaseTestSuite) TestNodeChurnXFRMLeaks(c *check.C) {
-	externalNodeDevice := "ipsec_interface"
 
 	// Cover the XFRM configuration for IPAM modes cluster-pool, kubernetes, etc.
 	config := datapath.LocalNodeConfiguration{
@@ -765,7 +764,20 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeChurnXFRMLeaks(c *check.C) {
 		EnableIPv6:  s.enableIPv6,
 		EnableIPSec: true,
 	}
-	//s.testNodeChurnXFRMLeaksWithConfig(c, config)
+	s.testNodeChurnXFRMLeaksWithConfig(c, config)
+}
+
+// Tests the same as linuxPrivilegedBaseTestSuite.TestNodeChurnXFRMLeaks just
+// for the subnet encryption. IPv4-only because of https://github.com/cilium/cilium/issues/27280.
+func (s *linuxPrivilegedIPv4OnlyTestSuite) TestNodeChurnXFRMLeaks(c *check.C) {
+	externalNodeDevice := "ipsec_interface"
+
+	// Cover the XFRM configuration for IPAM modes cluster-pool, kubernetes, etc.
+	config := datapath.LocalNodeConfiguration{
+		EnableIPv4:  s.enableIPv4,
+		EnableIPSec: true,
+	}
+	s.testNodeChurnXFRMLeaksWithConfig(c, config)
 
 	// In the case of subnet encryption (tested below), the IPsec logic
 	// retrieves the IP address of the encryption interface directly so we need

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -757,6 +757,38 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateIDs(c *check.C) {
 
 // Tests that we don't leak XFRM policies and states as nodes come and go.
 func (s *linuxPrivilegedBaseTestSuite) TestNodeChurnXFRMLeaks(c *check.C) {
+	externalNodeDevice := "ipsec_interface"
+
+	// Cover the XFRM configuration for IPAM modes cluster-pool, kubernetes, etc.
+	config := datapath.LocalNodeConfiguration{
+		EnableIPv4:  s.enableIPv4,
+		EnableIPv6:  s.enableIPv6,
+		EnableIPSec: true,
+	}
+	//s.testNodeChurnXFRMLeaksWithConfig(c, config)
+
+	// In the case of subnet encryption (tested below), the IPsec logic
+	// retrieves the IP address of the encryption interface directly so we need
+	// a dummy interface.
+	removeDevice(externalNodeDevice)
+	err := setupDummyDevice(externalNodeDevice, net.ParseIP("1.1.1.1"), net.ParseIP("face::1"))
+	c.Assert(err, check.IsNil)
+	defer removeDevice(externalNodeDevice)
+	option.Config.EncryptInterface = []string{externalNodeDevice}
+
+	// Cover the XFRM configuration for subnet encryption: IPAM modes AKS and EKS.
+	_, ipv4PodSubnets, err := net.ParseCIDR("4.4.0.0/16")
+	c.Assert(err, check.IsNil)
+	c.Assert(ipv4PodSubnets, check.Not(check.IsNil))
+	config.IPv4PodSubnets = []*net.IPNet{ipv4PodSubnets}
+	_, ipv6PodSubnets, err := net.ParseCIDR("2001:aaaa::/64")
+	c.Assert(err, check.IsNil)
+	c.Assert(ipv6PodSubnets, check.Not(check.IsNil))
+	config.IPv6PodSubnets = []*net.IPNet{ipv6PodSubnets}
+	s.testNodeChurnXFRMLeaksWithConfig(c, config)
+}
+
+func (s *linuxPrivilegedBaseTestSuite) testNodeChurnXFRMLeaksWithConfig(c *check.C, config datapath.LocalNodeConfiguration) {
 	keys := bytes.NewReader([]byte("6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n"))
 	_, _, err := ipsec.LoadIPSecKeys(keys)
 	c.Assert(err, check.IsNil)
@@ -765,11 +797,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeChurnXFRMLeaks(c *check.C) {
 	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap())
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
-	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
-		EnableIPv4:  s.enableIPv4,
-		EnableIPv6:  s.enableIPv6,
-		EnableIPSec: true,
-	})
+	err = linuxNodeHandler.NodeConfigurationChanged(config)
 	c.Assert(err, check.IsNil)
 
 	// Adding a node adds some XFRM states and policies.

--- a/pkg/hive/cell/config.go
+++ b/pkg/hive/cell/config.go
@@ -103,8 +103,24 @@ func decoderConfig(target any) *mapstructure.DecoderConfig {
 		Result:           target,
 		WeaklyTypedInput: true,
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			// To unify the splitting of fields of a []string field across the input coming
+			// from environment, configmap and pflag (command-line), we first split a string
+			// (env/configmap) by comma, and then for all input methods we split a single
+			// value []string by whitespace. Thus the following all result in the same slice:
+			//
+			// --string-slice=foo,bar,baz
+			// --string-slice="foo bar baz"
+			// CILIUM_STRING_SLICE="foo,bar,baz"
+			// CILIUM_STRING_SLICE="foo bar baz"
+			// /.../configmap/string_slice: "foo bar baz"
+			// /.../configmap/string_slice: "foo,bar,baz"
+			//
+			// If both commas and whitespaces are present the commas take precedence:
+			// "foo,bar baz" => []string{"foo", "bar baz"}
+			mapstructure.StringToSliceHookFunc(","), // string->[]string is split by comma
+			fixupStringSliceHookFunc,                // []string of length 1 is split again by whitespace
+
 			mapstructure.StringToTimeDurationHookFunc(),
-			mapstructure.StringToSliceHookFunc(","),
 			stringToMapHookFunc(),
 		),
 		ZeroFields: true,
@@ -153,4 +169,24 @@ func stringToMapHookFunc() mapstructure.DecodeHookFunc {
 
 		return command.ToStringMapStringE(data.(string))
 	}
+}
+
+// fixupStringSliceHookFunc takes a []string and if it's a single element splits it again
+// by whitespace. This unifies the flag parsing behavior with StringSlice
+// values coming from environment or configmap where both spaces or commas can be used to split.
+func fixupStringSliceHookFunc(from reflect.Type, to reflect.Type, data interface{}) (interface{}, error) {
+	if from.Kind() != reflect.Slice || to.Kind() != reflect.Slice {
+		return data, nil
+	}
+	if from.Elem().Kind() != reflect.String || to.Elem().Kind() != reflect.String {
+		return data, nil
+	}
+
+	raw := data.([]string)
+	if len(raw) == 1 {
+		// Flag was already split by commas (the default behavior), so split it
+		// now by spaces.
+		return strings.Fields(raw[0]), nil
+	}
+	return raw, nil
 }

--- a/pkg/hive/hive_test.go
+++ b/pkg/hive/hive_test.go
@@ -197,6 +197,78 @@ func TestHiveConfigOverride(t *testing.T) {
 	assert.Equal(t, "override", cfg.Foo, "Config.Foo not set correctly")
 }
 
+type StringSliceConfig struct {
+	SpacesFlag, CommasFlag []string
+	SpacesMap, CommasMap   []string
+	Mixed                  []string
+	StringFlag             string
+}
+
+func (StringSliceConfig) Flags(flags *pflag.FlagSet) {
+	flags.StringSlice("spaces-flag", nil, "split by spaces via pflag")
+	flags.StringSlice("commas-flag", nil, "split by commas via pflag")
+	flags.StringSlice("spaces-map", nil, "split by spaces via configmap")
+	flags.StringSlice("commas-map", nil, "split by commas via configmap")
+
+	// One can also use just flags.String against a []string config field and
+	// it will be parsed the same way as via configmap.
+	flags.String("mixed", "", "mixed")
+
+	flags.String("string-flag", "", "plain string untouched")
+}
+
+func TestHiveStringSlice(t *testing.T) {
+	var cfg StringSliceConfig
+	testCell := cell.Module(
+		"test",
+		"Test Module",
+		cell.Config(StringSliceConfig{}),
+		cell.Invoke(func(c StringSliceConfig) {
+			cfg = c
+		}),
+	)
+	hive := hive.New(testCell)
+
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	hive.RegisterFlags(flags)
+
+	spaces := "foo bar baz"
+	commas := "foo,bar,baz"
+	expected := []string{"foo", "bar", "baz"}
+
+	// When the values are provided via the flags then the value given
+	// to Viper is already a []string as parsed by pflag. This will be
+	// processed by stringSliceToStringSliceHookFunc to re-split if needed.
+	flags.Set("spaces-flag", spaces)
+	flags.Set("commas-flag", commas)
+
+	// Plain string flags are not split in any way.
+	flags.Set("string-flag", "foo, bar, baz")
+
+	// If spaces and commas are mixed then commas take precedence.
+	flags.Set("mixed", "foo bar,baz")
+
+	// When the values are provided via the configmap or environment they're
+	// given to Viper as plain strings that will be processed by stringToSliceHookFunc.
+	hive.Viper().MergeConfigMap(
+		map[string]any{
+			"spaces-map": spaces,
+			"commas-map": commas,
+		})
+
+	err := hive.Start(context.TODO())
+	require.NoError(t, err, "expected Start to succeed")
+	err = hive.Stop(context.TODO())
+	require.NoError(t, err, "expected Stop to succeed")
+
+	assert.ElementsMatch(t, cfg.SpacesFlag, expected, "unexpected SpacesFlag")
+	assert.ElementsMatch(t, cfg.SpacesMap, expected, "unexpected SpacesMap")
+	assert.ElementsMatch(t, cfg.CommasFlag, expected, "unexpected CommasFlag")
+	assert.ElementsMatch(t, cfg.CommasMap, expected, "unexpected CommasMap")
+	assert.ElementsMatch(t, cfg.Mixed, []string{"foo bar", "baz"}, "unexpected Mixed")
+	assert.Equal(t, cfg.StringFlag, "foo, bar, baz", "unexpected StringFlag")
+}
+
 type SomeObject struct {
 	X int
 }


### PR DESCRIPTION
 * [x] #27187 (@pchaigno)
  ⚠️ Conflict due to `TestLoadKeys` slightly different in v1.14
 * [x] #27212 (@pchaigno)
 * [x] #27274 (@brb)
 * [x] #29934 (@pchaigno)
 * [x] #29674 (@giorio94)
 * [x] #30000 (@brb)
 * [x] #29848 (@joamaki)
   ⚠️ Conflict in `decoderConfig` (`stringToCIDRHookFunc` not present in v1.14)
 * [x] #30013 (@harsimran-pabla)
   ⚠️ Conflict due to `manager_test.go` not present in v1.14

⚠️ Skipped
- #27427 (@tklauser)
  - Dependency commit ced01f6 doesn't exist on v1.14 branch
- #29849 (@brb)
  - There's no workflow using `CILIUM_CLI_VERSION`

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 27187 27212 27274 29934 29674 30000 29848 30013
```
