### PR TITLE
Bump allowed Golang version to v1.21

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -300,7 +300,7 @@
         "docker.io/library/golang",
         "go"
       ],
-      "allowedVersions": "<1.21",
+      "allowedVersions": "<1.22",
       "matchBaseBranches": [
         "v1.14",
         "v1.13",


### PR DESCRIPTION
v1.20 will see its last patch release in January, so this change will allow us to keep on top of security fixes in maintained branches past that point.
