### PR TITLE
datapath/loader: fix nil deref in compile

### DIFF
--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -200,8 +200,10 @@ func compile(ctx context.Context, prog *progInfo, dir *directoryInfo) (string, e
 	err = compileCmd.Run()
 
 	var maxRSS int64
-	if usage, ok := compileCmd.ProcessState.SysUsage().(*syscall.Rusage); ok {
-		maxRSS = usage.Maxrss
+	if compileCmd.ProcessState != nil {
+		if usage, ok := compileCmd.ProcessState.SysUsage().(*syscall.Rusage); ok {
+			maxRSS = usage.Maxrss
+		}
 	}
 
 	if err != nil {

--- a/pkg/datapath/loader/compile_test.go
+++ b/pkg/datapath/loader/compile_test.go
@@ -43,3 +43,11 @@ func TestCompile(t *testing.T) {
 		})
 	}
 }
+
+func TestCompileError(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	t.Setenv("PATH", "")
+	_, err := compile(context.Background(), epProg, getDirs(t))
+	require.Error(t, err)
+}


### PR DESCRIPTION
exec.Cmd.ProcessState is populated by Cmd.Wait(). Cmd.Run() does invoke Wait(), but only if Start() was successful. If start fails (for example because the clang binary is missing) we never execute Wait and therefore ProcessState is nil. Trying to retrieve rusage then panics due to a nil deref. Ensure that ProcessState is not nil before retrieving rusage.

Fixes #29989

Fixes: d2ee07e805 ("loader: log maximum RSS used by clang for compilation")

```release-note
Fix a nil pointer deref when invoking clang fails
```
