### PR TITLE
bgpv1: Some test coverage improvements for bgpv1/agent package

### DIFF
--- a/pkg/bgpv1/agent/annotations.go
+++ b/pkg/bgpv1/agent/annotations.go
@@ -90,19 +90,6 @@ type Attributes struct {
 // ASN its annotating.
 type AnnotationMap map[int64]Attributes
 
-// ErrMulti holds multiple errors and formats them sanely when printed.
-type ErrMulti struct {
-	errs []error
-}
-
-func (e ErrMulti) Error() string {
-	s := strings.Builder{}
-	for _, err := range e.errs {
-		s.WriteString(err.Error() + ",")
-	}
-	return s.String()
-}
-
 func (a AnnotationMap) ResolveRouterID(localASN int64) (string, error) {
 	if attr, ok := a[localASN]; ok && attr.RouterID != "" {
 		return attr.RouterID, nil
@@ -130,7 +117,7 @@ func NewAnnotationMap(a map[string]string) (AnnotationMap, error) {
 		am[asn] = attrs
 	}
 	if len(errs) > 0 {
-		return am, ErrMulti{errs}
+		return am, errors.Join(errs...)
 	}
 	return am, nil
 }

--- a/pkg/bgpv1/agent/annotations.go
+++ b/pkg/bgpv1/agent/annotations.go
@@ -6,7 +6,6 @@ package agent
 import (
 	"errors"
 	"fmt"
-	"math"
 	"net/netip"
 	"strconv"
 	"strings"
@@ -157,11 +156,11 @@ func parseAnnotation(key string, value string) (int64, Attributes, error) {
 	if anno := strings.Split(key, "."); len(anno) != 3 {
 		return 0, out, ErrNoASNAnno{key}
 	} else {
-		var err error
-		asn, err = strconv.ParseInt(anno[2], 10, 64)
+		asn64, err := strconv.ParseUint(anno[2], 10, 32)
 		if err != nil {
-			return 0, out, ErrASNAnno{}
+			return 0, out, ErrASNAnno{"could not parse ASN as a 32bit integer", anno[2], key}
 		}
+		asn = int64(asn64)
 	}
 	out.ASN = asn
 
@@ -178,18 +177,18 @@ func parseAnnotation(key string, value string) (int64, Attributes, error) {
 		}
 		switch kv[0] {
 		case "router-id":
-			addr, _ := netip.ParseAddr(kv[1])
-			if addr.IsUnspecified() {
-				return 0, out, ErrAttrib{key, kv[0], "could not parse in an IPv4 address"}
+			addr, err := netip.ParseAddr(kv[1])
+			if err != nil {
+				return 0, out, ErrAttrib{key, kv[0], "could not parse router-id as an IPv4 address"}
+			}
+			if !addr.Is4() {
+				return 0, out, ErrAttrib{key, kv[0], "router-id must be a valid IPv4 address"}
 			}
 			out.RouterID = kv[1]
 		case "local-port":
-			port, err := strconv.ParseInt(kv[1], 10, 0)
+			port, err := strconv.ParseInt(kv[1], 10, 16)
 			if err != nil {
-				return 0, out, ErrAttrib{key, kv[0], "could not parse into port number"}
-			}
-			if port > math.MaxUint16 {
-				return 0, out, ErrAttrib{key, kv[0], "local port must be smaller then 65535"}
+				return 0, out, ErrAttrib{key, kv[0], "could not parse into port number as 16bit integer"}
 			}
 			out.LocalPort = int32(port)
 		}

--- a/pkg/bgpv1/agent/annotations.go
+++ b/pkg/bgpv1/agent/annotations.go
@@ -104,13 +104,8 @@ func (e ErrMulti) Error() string {
 }
 
 func (a AnnotationMap) ResolveRouterID(localASN int64) (string, error) {
-	if _, ok := a[localASN]; ok {
-		var err error
-		var parsed netip.Addr
-		if parsed, err = netip.ParseAddr(a[localASN].RouterID); err == nil && !parsed.IsUnspecified() {
-			return parsed.String(), nil
-		}
-		return "", fmt.Errorf("failed to parse RouterID for local ASN %v: %w", localASN, err)
+	if attr, ok := a[localASN]; ok && attr.RouterID != "" {
+		return attr.RouterID, nil
 	}
 	return "", fmt.Errorf("router id not specified by annotation, cannot resolve router id for local ASN %v", localASN)
 }

--- a/pkg/bgpv1/agent/annotations_test.go
+++ b/pkg/bgpv1/agent/annotations_test.go
@@ -124,6 +124,37 @@ func TestAnnotation(t *testing.T) {
 	}
 }
 
+func TestResolveRouterID(t *testing.T) {
+	t.Run("RouterID specified", func(t *testing.T) {
+		annoMap, err := NewAnnotationMap(map[string]string{
+			"cilium.io/bgp-virtual-router.123": "router-id=127.0.0.1",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		routerID, err := annoMap.ResolveRouterID(123)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if routerID != "127.0.0.1" {
+			t.Fatalf("got: %v, want: %v", routerID, "127.0.0.1")
+		}
+	})
+
+	t.Run("RouterID unspecified", func(t *testing.T) {
+		annoMap, err := NewAnnotationMap(map[string]string{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = annoMap.ResolveRouterID(123)
+		if err == nil {
+			t.Fatal("expected error, got no error")
+		}
+	})
+}
+
 func BenchmarkErrNotVRouterAnnoError(b *testing.B) {
 	e := &ErrNotVRouterAnno{
 		a: "foo error",

--- a/pkg/bgpv1/agent/signaler/signaler_test.go
+++ b/pkg/bgpv1/agent/signaler/signaler_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+package signaler
+
+import "testing"
+
+// Make sure that the receiver only observes a single event even if multiple
+// events are sent.
+func TestEventCorrelation(t *testing.T) {
+	s := NewBGPCPSignaler()
+
+	// Send two events
+	s.Event(nil)
+	s.Event(nil)
+
+	// One event should be received
+	select {
+	case <-s.Sig:
+	default:
+		t.Fatal("expected event to be received")
+	}
+
+	// The second event should be correlated and shouldn't received
+	select {
+	case <-s.Sig:
+		t.Fatal("expected event to be correlated")
+	default:
+	}
+}


### PR DESCRIPTION
This PR improves unit testing coverage for the `bgpv1/agent` package.

Before

```
ok  	github.com/cilium/cilium/pkg/bgpv1/agent	0.878s	coverage: 41.4% of statements
?   	github.com/cilium/cilium/pkg/bgpv1/agent/signaler	[no test files]
```

After

```
ok  	github.com/cilium/cilium/pkg/bgpv1/agent	0.908s	coverage: 65.0% of statements
ok  	github.com/cilium/cilium/pkg/bgpv1/agent/signaler	0.889s	coverage: 100.0% of statements
```

```release-note
bgpv1: Some test coverage improvements for bgpv1/agent
```
