### PR TITLE
fqdn: serialize requests per-name

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -384,9 +384,6 @@ Removed Options
 
 * The long defunct and undocumented ``single-cluster-route`` flag has been removed.
 
-* The ``dnsproxy-lock-count`` and ``dnsproxy-lock-timeout`` flags no longer have
-  any effect and are deprecated. They will be removed in v1.16.
-
 * Deprecated options ``enable-k8s-event-handover`` and ``cnp-status-update-interval`` has been removed.
 
 Helm Options

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -871,12 +871,12 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Duration(option.DNSProxyConcurrencyProcessingGracePeriod, 0, "Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing")
 	option.BindEnv(vp, option.DNSProxyConcurrencyProcessingGracePeriod)
 
-	flags.Int(option.DNSProxyLockCount, 131, "Array size containing mutexes which protect against parallel handling of DNS response IPs. Preferably use prime numbers")
-	flags.MarkDeprecated(option.DNSProxyLockCount, "This option no longer has any effect, and will be removed in v1.16")
+	flags.Int(option.DNSProxyLockCount, 131, "Array size containing mutexes which protect against parallel handling of DNS response names. Preferably use prime numbers")
+	flags.MarkHidden(option.DNSProxyLockCount)
 	option.BindEnv(vp, option.DNSProxyLockCount)
 
 	flags.Duration(option.DNSProxyLockTimeout, 500*time.Millisecond, fmt.Sprintf("Timeout when acquiring the locks controlled by --%s", option.DNSProxyLockCount))
-	flags.MarkDeprecated(option.DNSProxyLockTimeout, "This option no longer has any effect, and will be removed in v1.16")
+	flags.MarkHidden(option.DNSProxyLockTimeout)
 	option.BindEnv(vp, option.DNSProxyLockTimeout)
 
 	flags.Int(option.PolicyQueueSize, defaults.PolicyQueueSize, "Size of queues for policy-related events")

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1853,6 +1853,14 @@ type DaemonConfig struct {
 	// been reached.
 	DNSProxyConcurrencyProcessingGracePeriod time.Duration
 
+	// DNSProxyLockCount is the array size containing mutexes which protect
+	// against parallel handling of DNS response names.
+	DNSProxyLockCount int
+
+	// DNSProxyLockTimeout is timeout when acquiring the locks controlled by
+	// DNSProxyLockCount.
+	DNSProxyLockTimeout time.Duration
+
 	// EnableXTSocketFallback allows disabling of kernel's ip_early_demux
 	// sysctl option if `xt_socket` kernel module is not available.
 	EnableXTSocketFallback bool
@@ -3290,6 +3298,8 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.FQDNProxyResponseMaxDelay = vp.GetDuration(FQDNProxyResponseMaxDelay)
 	c.DNSProxyConcurrencyLimit = vp.GetInt(DNSProxyConcurrencyLimit)
 	c.DNSProxyConcurrencyProcessingGracePeriod = vp.GetDuration(DNSProxyConcurrencyProcessingGracePeriod)
+	c.DNSProxyLockCount = vp.GetInt(DNSProxyLockCount)
+	c.DNSProxyLockTimeout = vp.GetDuration(DNSProxyLockTimeout)
 	c.FQDNRejectResponse = vp.GetString(FQDNRejectResponseCode)
 
 	// Convert IP strings into net.IPNet types


### PR DESCRIPTION
This re-creates similar behavior as in v1.14 - FQDN requests are serialized on a per-name basis. This was removed as part of the larger fqdn refactor but, it turns out, that was premature. The difference between v1.14 and now is that this locks per-name, rather than per-IP. It preserves the prime-sized count of bucketed locks.

This is needed because we release the lock on the NameManager before policy updates have been fully pushed out to all endpoints. If another endpoint requests the same name, it may have the DNS response returned to it before policy updates are complete. However, the NameManager will detect the noop case, take a shortcut, and release the DNS response before policy updates are potentially complete.

For precise details, see the comment in fqdn.go.

Fixes: #30014
Fixes: 507259fd