### PR TITLE
fqdn: skip ipcache insertion for names without fqdn selectors

### DIFF
--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -110,6 +110,11 @@ func (n *NameManager) RegisterForIPUpdatesLocked(selector api.FQDNSelector) []ne
 	}
 
 	selectorIPMapping := n.mapSelectorsToIPsLocked(sets.New(selector))
+
+	// We may have skipped inserting these IPs in to the ipcache earlier, if they
+	// were not previously selected. Upsert them now.
+	n.upsertMetadata(selectorIPMapping[selector])
+
 	return selectorIPMapping[selector]
 }
 
@@ -242,7 +247,13 @@ func (n *NameManager) updateDNSIPs(lookupTime time.Time, updatedDNSIPs map[strin
 			}
 		}
 	}
-	if len(addrsToUpsert) > 0 {
+
+	// If new IPs were detected, and these IPs are selected by selectors,
+	// then ensure they have an identity allocated to them via the ipcache.
+	//
+	// If no selectors care about this name, then skip this step. If any selectors
+	// are added later, ipcache insertion will happen then.
+	if len(addrsToUpsert) > 0 && affectedSelectors.Len() > 0 {
 		ipcacheRevision = n.upsertMetadata(addrsToUpsert.UnsortedList())
 	}
 


### PR DESCRIPTION
This small fix prevents allocating a local identity for IPs with names that are not selected by a toFQDN selector. Without this change, an identity is allocated for every IP included in an intercepted DNS response. For the (common) case where all DNS requests are proxied, this could potentially lead to a waste of resources and thus a performance regression.

Previously (v1.14 and before), we did not allocate identities for un-selected IPs. That was inadvertently changed in #29036.
