### PR TITLE
Cilium should accepts any value that is not "disabled" for svc topology mode

### DIFF
--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -74,7 +74,7 @@ func getAnnotationTopologyAwareHints(svc *slim_corev1.Service) bool {
 	if !ok {
 		value = svc.ObjectMeta.Annotations[v1.AnnotationTopologyMode]
 	}
-	return strings.ToLower(value) == "auto"
+	return !(value == "" || value == "disabled" || value == "Disabled")
 }
 
 // isValidServiceFrontendIP returns true if the provided service frontend IP address type

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -134,6 +134,13 @@ func (s *K8sSuite) TestGetAnnotationTopologyAwareHints(c *check.C) {
 	}}
 	c.Assert(getAnnotationTopologyAwareHints(svc), check.Equals, true)
 
+	svc = &slim_corev1.Service{ObjectMeta: slim_metav1.ObjectMeta{
+		Annotations: map[string]string{
+			corev1.AnnotationTopologyMode: "PreferZone",
+		},
+	}}
+	c.Assert(getAnnotationTopologyAwareHints(svc), check.Equals, true)
+
 	// v1.DeprecatedAnnotationTopologyAwareHints has precedence over v1.AnnotationTopologyMode.
 	svc = &slim_corev1.Service{ObjectMeta: slim_metav1.ObjectMeta{
 		Annotations: map[string]string{


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->
k8s will support multiple topologies type in service annotations: Auto, PreferZone, ProportionalZoneCPU and etc., https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/2433-topology-aware-hints/README.md.
So cilium should allow more configurability on topology mode annotation.
The kube-proxy has changed in https://github.com/kubernetes/kubernetes/pull/116522/commits. 

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
Accept any service topology mode values that is not "disabled".  
```
