### PR TITLE
test: standalone l4lb add test to verify that rqs to service do not fail when agent is starting

### DIFF
--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -144,6 +144,22 @@ for i in $(seq 1 10); do
     fi
 done
 
+# Stop on error
+set -e
+docker exec -t lb-node docker exec -t cilium-lb \
+    cilium-dbg service update --id 1 --frontend "${LB_VIP}:80" --backends "${WORKER_IP}:80" --backend-weights "1" --k8s-node-port
+
+curl -o /dev/null "${LB_VIP}:80" -m1 || (echo "Failed"; exit -1)
+
+# Restart cilium-agent and issue 50 requests to LB
+docker exec -d lb-node docker restart cilium-lb
+
+# Requests should not timeout when agent is starting up
+for i in $(seq 1 50); do
+    curl -o /dev/null "${LB_VIP}:80" -m1 || (echo "Failed"; exit -1)
+    sleep 0.2
+done
+
 # Cleanup
 docker rm -f lb-node
 docker rm -f nginx


### PR DESCRIPTION
Related slack thread: https://cilium.slack.com/archives/CDKG8NNHK/p1704378628377709

[Fix](https://github.com/cilium/cilium/pull/30163) was merged yesterday, so it's already present in the cilium-ci release, tested locally that it now works as expected. 

```release-note
test: add standalone l4lb test to verify that traffic works even when cilium agent is restarted
```

Signed-off-by: Ondrej Blazek <ondrej.blazek@firma.seznam.cz>
