### PR TITLE
bpf: fib: fix issues with L2 resolution

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -668,7 +668,7 @@ ct_recreate6:
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif = 0;
 
-		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, ext_err, &oif);
+		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, false, ext_err, &oif);
 		if (fib_ok(ret))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV6,
 					  *dst_sec_identity, 0, oif,
@@ -1229,7 +1229,7 @@ skip_vtep:
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif = 0;
 
-		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, ext_err, &oif);
+		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, false, ext_err, &oif);
 		if (fib_ok(ret))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV4,
 					  *dst_sec_identity, 0, oif,

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -39,7 +39,7 @@ int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, 
 	if (old_oif == fib_params.l.ifindex)
 		return CTX_ACT_OK;
 
-	return fib_do_redirect(ctx, true, &fib_params, ext_err, (int *)&old_oif);
+	return fib_do_redirect(ctx, true, &fib_params, false, ext_err, (int *)&old_oif);
 }
 
 #ifdef ENABLE_EGRESS_GATEWAY

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -932,6 +932,7 @@ nodeport_rev_dnat_ingress_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	__u32 tunnel_endpoint __maybe_unused = 0;
 	__u32 dst_sec_identity __maybe_unused = 0;
 	__be16 src_port __maybe_unused = 0;
+	bool allow_neigh_map = true;
 	int ifindex = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
@@ -998,6 +999,8 @@ encap_redirect:
 	if (ret == CTX_ACT_REDIRECT && ifindex)
 		return ctx_redirect(ctx, ifindex, 0);
 
+	/* neigh map doesn't contain DMACs for other nodes */
+	allow_neigh_map = false;
 	goto fib_ipv4;
 #endif
 
@@ -1024,7 +1027,7 @@ fib_ipv4:
 		ipv6_addr_copy((union v6addr *)&fib_params.l.ipv6_dst,
 			       (union v6addr *)&ip6->daddr);
 	}
-	return fib_redirect(ctx, true, &fib_params, true, ext_err, &ifindex);
+	return fib_redirect(ctx, true, &fib_params, allow_neigh_map, ext_err, &ifindex);
 }
 
 declare_tailcall_if(__or(__not(is_defined(HAVE_LARGE_INSN_LIMIT)),
@@ -2398,6 +2401,7 @@ nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	struct iphdr *ip4;
 	__u32 tunnel_endpoint __maybe_unused = 0;
 	__u32 dst_sec_identity __maybe_unused = 0;
+	bool allow_neigh_map = true;
 	bool check_revdnat = true;
 	bool has_l4_header;
 
@@ -2478,6 +2482,9 @@ redirect:
 
 		if (ret == CTX_ACT_REDIRECT && ifindex)
 			return ctx_redirect(ctx, ifindex, 0);
+
+		/* neigh map doesn't contain DMACs for other nodes */
+		allow_neigh_map = false;
 	}
 #endif
 
@@ -2487,7 +2494,7 @@ redirect:
 	fib_params.l.ipv4_src = ip4->saddr;
 	fib_params.l.ipv4_dst = ip4->daddr;
 
-	return fib_redirect(ctx, true, &fib_params, true, ext_err, &ifindex);
+	return fib_redirect(ctx, true, &fib_params, allow_neigh_map, ext_err, &ifindex);
 }
 
 declare_tailcall_if(__or(__not(is_defined(HAVE_LARGE_INSN_LIMIT)),

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -141,7 +141,7 @@ nodeport_fib_lookup_and_redirect(struct __ctx_buff *ctx,
 		if ((__u32)oif == fib_params->l.ifindex)
 			return CTX_ACT_OK;
 
-		return fib_do_redirect(ctx, true, fib_params, ext_err, &oif);
+		return fib_do_redirect(ctx, true, fib_params, true, ext_err, &oif);
 	default:
 		return DROP_NO_FIB;
 	}
@@ -762,7 +762,7 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 			       (union v6addr *)&ip6->daddr);
 	}
 
-	ret = fib_redirect(ctx, true, &fib_params, &ext_err, &oif);
+	ret = fib_redirect(ctx, true, &fib_params, false, &ext_err, &oif);
 	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
@@ -869,7 +869,7 @@ int tail_nat_ipv46(struct __ctx_buff *ctx)
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
-	ret = fib_redirect_v6(ctx, l3_off, ip6, false, &ext_err, &oif);
+	ret = fib_redirect_v6(ctx, l3_off, ip6, false, true, &ext_err, &oif);
 	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
@@ -900,7 +900,7 @@ int tail_nat_ipv64(struct __ctx_buff *ctx)
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
-	ret = fib_redirect_v4(ctx, l3_off, ip4, false, &ext_err, &oif);
+	ret = fib_redirect_v4(ctx, l3_off, ip4, false, true, &ext_err, &oif);
 	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
@@ -1024,7 +1024,7 @@ fib_ipv4:
 		ipv6_addr_copy((union v6addr *)&fib_params.l.ipv6_dst,
 			       (union v6addr *)&ip6->daddr);
 	}
-	return fib_redirect(ctx, true, &fib_params, ext_err, &ifindex);
+	return fib_redirect(ctx, true, &fib_params, true, ext_err, &ifindex);
 }
 
 declare_tailcall_if(__or(__not(is_defined(HAVE_LARGE_INSN_LIMIT)),
@@ -1257,7 +1257,7 @@ fib_ipv4:
 		ipv6_addr_copy((union v6addr *)&fib_params.l.ipv6_dst,
 			       (union v6addr *)&ip6->daddr);
 	}
-	ret = fib_redirect(ctx, true, &fib_params, &ext_err, &oif);
+	ret = fib_redirect(ctx, true, &fib_params, false, &ext_err, &oif);
 	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
@@ -2273,7 +2273,7 @@ int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
-	ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, true, &ext_err, &oif);
+	ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, true, false, &ext_err, &oif);
 	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
@@ -2487,7 +2487,7 @@ redirect:
 	fib_params.l.ipv4_src = ip4->saddr;
 	fib_params.l.ipv4_dst = ip4->daddr;
 
-	return fib_redirect(ctx, true, &fib_params, ext_err, &ifindex);
+	return fib_redirect(ctx, true, &fib_params, true, ext_err, &ifindex);
 }
 
 declare_tailcall_if(__or(__not(is_defined(HAVE_LARGE_INSN_LIMIT)),
@@ -2729,7 +2729,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 	fib_params.l.ipv4_src = ip4->saddr;
 	fib_params.l.ipv4_dst = ip4->daddr;
 
-	ret = fib_redirect(ctx, true, &fib_params, &ext_err, &oif);
+	ret = fib_redirect(ctx, true, &fib_params, false, &ext_err, &oif);
 	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;

--- a/bpf/tests/fib_tests.c
+++ b/bpf/tests/fib_tests.c
@@ -90,7 +90,7 @@ int test1_check(struct __ctx_buff *ctx)
 
 		params.l.ifindex = ifindex_good;
 
-		ret = fib_do_redirect(ctx, false, &params, &flags,
+		ret = fib_do_redirect(ctx, false, &params, true, &flags,
 				      (int *)&ifindex_bad);
 		if (ret != CTX_REDIRECT_ENTERED)
 			test_fatal("did not enter ctx_redirect");
@@ -124,7 +124,7 @@ int test1_check(struct __ctx_buff *ctx)
 		if (!neigh_resolver_available())
 			test_fatal("expected neigh_resolver_available true");
 
-		ret = fib_do_redirect(ctx, false, &params, &flags, (int *)&ifindex_bad);
+		ret = fib_do_redirect(ctx, false, &params, true, &flags, (int *)&ifindex_bad);
 		if (ret != REDIR_NEIGH_ENTERED)
 			test_fatal("did not enter redirect_neigh");
 
@@ -158,7 +158,7 @@ int test1_check(struct __ctx_buff *ctx)
 		if (!neigh_resolver_available())
 			test_fatal("expected neigh_resolver_available true");
 
-		ret = fib_do_redirect(ctx, false, NULL, &flags, (int *)&ifindex_good);
+		ret = fib_do_redirect(ctx, false, NULL, true, &flags, (int *)&ifindex_good);
 		if (ret != REDIR_NEIGH_ENTERED)
 			test_fatal("did not enter redirect_neigh");
 
@@ -193,7 +193,7 @@ int test2_check(__maybe_unused struct __ctx_buff *ctx)
 			if (flag == BPF_FIB_LKUP_RET_NO_NEIGH)
 				continue;
 
-			if (fib_do_redirect(NULL, false, NULL, &flag, NULL) != DROP_NO_FIB)
+			if (fib_do_redirect(NULL, false, NULL, true, &flag, NULL) != DROP_NO_FIB)
 				test_fatal("expected DROP_NO_FIB with flag %d", flag);
 		}
 	});


### PR DESCRIPTION
Clarify in which scenarios the fallback to the neigh-map makes sense.

Then fix a recent regression where some code paths are no longer able to obtain a L2 resolution on BPF redirect. This would for instance affect the forwarding of LBed requests to remote backends, when running in XDP or on a pre-5.10 kernel.