### PR TITLE
cleanup: Remove cilium_isitio sidecar configuration

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -313,7 +313,6 @@ cilium-agent [flags]
       --route-metric int                                          Overwrite the metric used by cilium when adding routes to its 'cilium_host' device
       --routing-mode string                                       Routing mode ("native" or "tunnel") (default "tunnel")
       --service-no-backend-response string                        Response to traffic for a service without backends (default "reject")
-      --sidecar-istio-proxy-image string                          Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
       --socket-path string                                        Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
       --state-dir string                                          Directory path to store runtime state (default "/var/run/cilium")
       --tofqdns-dns-reject-response-code string                   DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2784,14 +2784,6 @@
      - Set to ``true`` and helm will not check for monitoring.coreos.com/v1 CRDs before deploying
      - bool
      - ``false``
-   * - :spelling:ignore:`proxy`
-     - Configure Istio proxy options.
-     - object
-     - ``{"sidecarImageRegex":"cilium/istio_proxy"}``
-   * - :spelling:ignore:`proxy.sidecarImageRegex`
-     - Regular expression matching compatible Istio sidecar istio-proxy container image names
-     - string
-     - ``"cilium/istio_proxy"``
    * - :spelling:ignore:`rbac.create`
      - Enable creation of Resource-Based Access Control configuration.
      - bool

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -311,7 +311,7 @@ Annotations:
 Removed Options
 ~~~~~~~~~~~~~~~
 
-* TBD
+* The unused flag ``sidecar-istio-proxy-image`` has been removed.
 
 Helm Options
 ~~~~~~~~~~~~
@@ -320,7 +320,7 @@ Helm Options
   in favor of encryption.ipsec.*.
 * Deprecated options ``proxy.prometheus.enabled`` and ``proxy.prometheus.port`` have been removed.
   Please use ``envoy.prometheus.enabled`` and ``envoy.prometheus.port`` instead.
-
+* The unused helm option ``proxy.sidecarImageRegex`` has been removed.
 
 Added Metrics
 ~~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -730,10 +730,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.Restore, true, "Restores state, if possible, from previous daemon")
 	option.BindEnv(vp, option.Restore)
 
-	flags.String(option.SidecarIstioProxyImage, k8s.DefaultSidecarIstioProxyImageRegexp,
-		"Regular expression matching compatible Istio sidecar istio-proxy container image names")
-	option.BindEnv(vp, option.SidecarIstioProxyImage)
-
 	flags.String(option.SocketPath, defaults.SockPath, "Sets daemon's socket path to listen for connections")
 	option.BindEnv(vp, option.SocketPath)
 
@@ -1444,12 +1440,6 @@ func initEnv(vp *viper.Viper) {
 			log.Warn("The kernel does not support --service-no-backend-response=reject, falling back to --service-no-backend-response=drop")
 			option.Config.ServiceNoBackendResponse = option.ServiceNoBackendResponseDrop
 		}
-	}
-
-	k8s.SidecarIstioProxyImageRegexp, err = regexp.Compile(option.Config.SidecarIstioProxyImage)
-	if err != nil {
-		log.WithError(err).Fatal("Invalid sidecar-istio-proxy-image regular expression")
-		return
 	}
 
 	if option.Config.EnableIPv4FragmentsTracking {

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -746,8 +746,6 @@ contributors across the globe, there is almost always someone available to help.
 | prometheus.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor cilium-agent |
 | prometheus.serviceMonitor.relabelings | list | `[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]` | Relabeling configs for the ServiceMonitor cilium-agent |
 | prometheus.serviceMonitor.trustCRDsExist | bool | `false` | Set to `true` and helm will not check for monitoring.coreos.com/v1 CRDs before deploying |
-| proxy | object | `{"sidecarImageRegex":"cilium/istio_proxy"}` | Configure Istio proxy options. |
-| proxy.sidecarImageRegex | string | `"cilium/istio_proxy"` | Regular expression matching compatible Istio sidecar istio-proxy container image names |
 | rbac.create | bool | `true` | Enable creation of Resource-Based Access Control configuration. |
 | readinessProbe.failureThreshold | int | `3` | failure threshold of readiness probe |
 | readinessProbe.periodSeconds | int | `30` | interval between checks of the readiness probe |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -427,10 +427,6 @@ data:
   # 1.4 or later, then it may cause one-time disruptions during the upgrade.
   preallocate-bpf-maps: "{{ .Values.bpf.preallocateMaps }}"
 
-  # Regular expression matching compatible Istio sidecar istio-proxy
-  # container image names
-  sidecar-istio-proxy-image: "{{ .Values.proxy.sidecarImageRegex }}"
-
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: {{ .Values.cluster.name }}
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1756,11 +1756,6 @@ dashboards:
   namespace: ~
   labelValue: "1"
   annotations: {}
-# -- Configure Istio proxy options.
-proxy:
-  # -- Regular expression matching compatible Istio sidecar istio-proxy
-  # container image names
-  sidecarImageRegex: "cilium/istio_proxy"
 # Configure Cilium Envoy options.
 envoy:
   # -- Enable Envoy Proxy in standalone DaemonSet.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1753,11 +1753,6 @@ dashboards:
   namespace: ~
   labelValue: "1"
   annotations: {}
-# -- Configure Istio proxy options.
-proxy:
-  # -- Regular expression matching compatible Istio sidecar istio-proxy
-  # container image names
-  sidecarImageRegex: "cilium/istio_proxy"
 # Configure Cilium Envoy options.
 envoy:
   # -- Enable Envoy Proxy in standalone DaemonSet.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -213,13 +213,6 @@ type Endpoint struct {
 	// the endpoint's labels.
 	SecurityIdentity *identity.Identity `json:"SecLabel"`
 
-	// hasSidecarProxy indicates whether the endpoint has been injected by
-	// Istio with a Cilium-compatible sidecar proxy. If true, the sidecar proxy
-	// will be used to apply L7 policy rules. Otherwise, Cilium's node-wide
-	// proxy will be used.
-	// TODO: Currently this applies only to HTTP L7 rules. Kafka L7 rules are still enforced by Cilium's node-wide Kafka proxy.
-	hasSidecarProxy bool
-
 	// policyMap is the policy related state of the datapath including
 	// reference to all policy related BPF
 	policyMap *policymap.PolicyMap
@@ -474,17 +467,6 @@ func (e *Endpoint) closeBPFProgramChannel() {
 	}
 }
 
-// bpfProgramInstalled returns whether a BPF program has been generated for this
-// endpoint.
-func (e *Endpoint) bpfProgramInstalled() bool {
-	select {
-	case <-e.hasBPFProgram:
-		return true
-	default:
-		return false
-	}
-}
-
 // waitForProxyCompletions blocks until all proxy changes have been completed.
 // Called with buildMutex held.
 func (e *Endpoint) waitForProxyCompletions(proxyWaitGroup *completion.WaitGroup) error {
@@ -688,10 +670,6 @@ func (e *Endpoint) IPv6Address() netip.Addr {
 // GetNodeMAC returns the MAC address of the node from this endpoint's perspective.
 func (e *Endpoint) GetNodeMAC() mac.MAC {
 	return e.nodeMAC
-}
-
-func (e *Endpoint) HasSidecarProxy() bool {
-	return e.hasSidecarProxy
 }
 
 // ConntrackName returns the name suffix for the endpoint-specific bpf
@@ -2501,15 +2479,7 @@ func (e *Endpoint) WaitForFirstRegeneration(ctx context.Context) error {
 			if err := e.rlockAlive(); err != nil {
 				return fmt.Errorf("endpoint was deleted while waiting for initial endpoint generation to complete")
 			}
-			hasSidecarProxy := e.HasSidecarProxy()
 			e.runlock()
-			if hasSidecarProxy && e.bpfProgramInstalled() {
-				// If the endpoint is determined to have a sidecar proxy,
-				// return immediately to let the sidecar container start,
-				// in case it is required to enforce L7 rules.
-				e.getLogger().Info("Endpoint has sidecar proxy, returning from synchronous creation request before regeneration has succeeded")
-				return nil
-			}
 		}
 
 		if ctx.Err() != nil {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
-	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -870,14 +869,6 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 // Caller triggers policy regeneration if needed.
 // Called with e.mutex Lock()ed
 func (e *Endpoint) SetIdentity(identity *identityPkg.Identity, newEndpoint bool) {
-
-	// Set a boolean flag to indicate whether the endpoint has been injected by
-	// Istio with a Cilium-compatible sidecar proxy.
-	istioSidecarProxyLabel, found := identity.Labels[k8sConst.PolicyLabelIstioSidecarProxy]
-	e.hasSidecarProxy = found &&
-		istioSidecarProxyLabel.Source == labels.LabelSourceK8s &&
-		strings.ToLower(istioSidecarProxyLabel.Value) == "true"
-
 	oldIdentity := "no identity"
 	if e.SecurityIdentity != nil {
 		oldIdentity = e.SecurityIdentity.StringID()

--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -30,12 +30,6 @@ const (
 	// running in
 	PolicyLabelCluster = LabelPrefix + ".policy.cluster"
 
-	// PolicyLabelIstioSidecarProxy is the label key added to the identity of
-	// any pod that has been injected by Istio with a Cilium-compatible sidecar
-	// proxy. The value of this label is expected to be a boolean, i.e. "true"
-	// or "false".
-	PolicyLabelIstioSidecarProxy = LabelPrefix + ".policy.istiosidecarproxy"
-
 	// PodNamespaceMetaLabels is the label used to store the labels of the
 	// kubernetes namespace's labels.
 	PodNamespaceMetaLabels = LabelPrefix + ".namespace.labels"

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -4,7 +4,6 @@
 package k8s
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -21,71 +20,6 @@ import (
 // to use the original source address when extracting the metadata for a request.
 const UseOriginalSourceAddressLabel = "cilium.io/use-original-source-address"
 
-const (
-	// AnnotationIstioSidecarStatus is the annotation added by Istio into a pod
-	// when it is injected with a sidecar proxy.
-	// Since Istio 0.5.0, the value of this annotation is a serialized JSON object
-	// with the following structure ("imagePullSecrets" was added in Istio 0.8.0):
-	//
-	//     {
-	//         "version": "0213afe1274259d2f23feb4820ad2f8eb8609b84a5538e5f51f711545b6bde88",
-	//         "initContainers": ["sleep", "istio-init"],
-	//         "containers": ["istio-proxy"],
-	//         "volumes": ["cilium-unix-sock-dir", "istio-envoy", "istio-certs"],
-	//         "imagePullSecrets": null
-	//     }
-	AnnotationIstioSidecarStatus = "sidecar.istio.io/status"
-
-	// DefaultSidecarIstioProxyImageRegexp is the default regexp compiled into
-	// SidecarIstioProxyImageRegexp.
-	DefaultSidecarIstioProxyImageRegexp = "cilium/istio_proxy"
-)
-
-// SidecarIstioProxyImageRegexp is the regular expression matching
-// compatible Istio sidecar istio-proxy container image names.
-// This is set by the "sidecar-istio-proxy-image" configuration flag.
-var SidecarIstioProxyImageRegexp = regexp.MustCompile(DefaultSidecarIstioProxyImageRegexp)
-
-// isInjectedWithIstioSidecarProxy returns whether the given pod has been
-// injected by Istio with a sidecar proxy that is compatible with Cilium.
-func isInjectedWithIstioSidecarProxy(scopedLog *logrus.Entry, pod *slim_corev1.Pod) bool {
-	istioStatusString, ok := pod.Annotations[AnnotationIstioSidecarStatus]
-	if !ok {
-		// Istio's injection annotation was not found.
-		scopedLog.Debugf("No %s annotation", AnnotationIstioSidecarStatus)
-		return false
-	}
-
-	scopedLog.Debugf("Found %s annotation with value: %s",
-		AnnotationIstioSidecarStatus, istioStatusString)
-
-	// Check that there's an "istio-proxy" container that uses an image
-	// compatible with Cilium.
-	for _, container := range pod.Spec.Containers {
-		if container.Name != "istio-proxy" {
-			continue
-		}
-		scopedLog.Debug("Found istio-proxy container in pod")
-
-		if !SidecarIstioProxyImageRegexp.MatchString(container.Image) {
-			continue
-		}
-		scopedLog.Debugf("istio-proxy container runs Cilium-compatible image: %s", container.Image)
-
-		for _, mountPath := range container.VolumeMounts {
-			if mountPath.MountPath != "/var/run/cilium" {
-				continue
-			}
-			scopedLog.Debug("istio-proxy container has volume mounted into /var/run/cilium")
-
-			return true
-		}
-	}
-
-	scopedLog.Debug("No Cilium-compatible istio-proxy container found")
-	return false
-}
-
 // GetPodMetadata returns the labels and annotations of the pod with the given
 // namespace / name.
 func GetPodMetadata(k8sNs *slim_corev1.Namespace, pod *slim_corev1.Pod) (containerPorts []slim_corev1.ContainerPort, lbls map[string]string, retAnno map[string]string, retErr error) {
@@ -99,16 +33,6 @@ func GetPodMetadata(k8sNs *slim_corev1.Namespace, pod *slim_corev1.Pod) (contain
 	objMetaCpy := pod.ObjectMeta.DeepCopy()
 	annotations := objMetaCpy.Annotations
 	k8sLabels := filterPodLabels(objMetaCpy.Labels)
-
-	// If the pod has been injected with an Istio sidecar proxy compatible with
-	// Cilium, add a label to notify that.
-	// If the pod already contains that label to explicitly enable or disable
-	// the sidecar proxy mode, keep it as is.
-	if val, ok := objMetaCpy.Labels[k8sConst.PolicyLabelIstioSidecarProxy]; ok {
-		k8sLabels[k8sConst.PolicyLabelIstioSidecarProxy] = val
-	} else if isInjectedWithIstioSidecarProxy(scopedLog, pod) {
-		k8sLabels[k8sConst.PolicyLabelIstioSidecarProxy] = "true"
-	}
 
 	for _, containers := range pod.Spec.Containers {
 		containerPorts = append(containerPorts, containers.Ports...)

--- a/pkg/k8s/labels_test.go
+++ b/pkg/k8s/labels_test.go
@@ -73,53 +73,6 @@ func TestGetPodMetadata(t *testing.T) {
 			require.Equal(t, expectedLabels, labels)
 		})
 	})
-
-	t.Run("istio sidecar label", func(t *testing.T) {
-		t.Run("with istio sidecar label", func(t *testing.T) {
-			pod := pod.DeepCopy()
-			pod.Labels["io.cilium.k8s.policy.istiosidecarproxy"] = "true"
-
-			_, labels, _, err := GetPodMetadata(ns, pod)
-
-			require.NoError(t, err)
-			require.Equal(t, map[string]string{
-				"app":                          "test",
-				"io.cilium.k8s.policy.cluster": "",
-				"io.kubernetes.pod.namespace":  "default",
-				"io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name": "default",
-				"io.cilium.k8s.namespace.labels.namespace-level-key":         "namespace-level-value",
-				"io.cilium.k8s.policy.istiosidecarproxy":                     "true",
-			}, labels)
-		})
-
-		t.Run("with istio sidecar injection", func(t *testing.T) {
-			pod := pod.DeepCopy()
-			pod.Annotations["sidecar.istio.io/status"] = "true"
-			pod.Spec.Containers = []slim_corev1.Container{
-				{
-					Name:  "istio-proxy",
-					Image: "cilium/istio_proxy:1.0.0",
-					VolumeMounts: []slim_corev1.VolumeMount{
-						{
-							MountPath: "/var/run/cilium",
-						},
-					},
-				},
-			}
-
-			_, labels, _, err := GetPodMetadata(ns, pod)
-
-			require.NoError(t, err)
-			require.Equal(t, map[string]string{
-				"app":                          "test",
-				"io.cilium.k8s.policy.cluster": "",
-				"io.kubernetes.pod.namespace":  "default",
-				"io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name": "default",
-				"io.cilium.k8s.namespace.labels.namespace-level-key":         "namespace-level-value",
-				"io.cilium.k8s.policy.istiosidecarproxy":                     "true",
-			}, labels)
-		})
-	})
 }
 
 func Test_filterPodLabels(t *testing.T) {
@@ -161,15 +114,14 @@ func Test_filterPodLabels(t *testing.T) {
 			name: "having cilium owned policy labels",
 			args: args{
 				labels: map[string]string{
-					"app":                                    "test",
-					"io.kubernetes.pod.namespace":            "default",
-					"io.cilium.k8s.policy.name":              "admin",
-					"io.cilium.k8s.policy.cluster":           "admin-cluster",
-					"io.cilium.k8s.policy.derived-from":      "admin",
-					"io.cilium.k8s.policy.namespace":         "kube-system",
-					"io.cilium.k8s.policy.istiosidecarproxy": "false",
-					"io.cilium.k8s.policy.serviceaccount":    "admin-serviceaccount",
-					"io.cilium.k8s.policy.uuid":              "6eadee3e-0121-11ed-b58d-fc3497a92ef6",
+					"app":                                 "test",
+					"io.kubernetes.pod.namespace":         "default",
+					"io.cilium.k8s.policy.name":           "admin",
+					"io.cilium.k8s.policy.cluster":        "admin-cluster",
+					"io.cilium.k8s.policy.derived-from":   "admin",
+					"io.cilium.k8s.policy.namespace":      "kube-system",
+					"io.cilium.k8s.policy.serviceaccount": "admin-serviceaccount",
+					"io.cilium.k8s.policy.uuid":           "6eadee3e-0121-11ed-b58d-fc3497a92ef6",
 				},
 			},
 			want: map[string]string{

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -397,9 +397,6 @@ const (
 	// Restore restores state, if possible, from previous daemon
 	Restore = "restore"
 
-	// SidecarIstioProxyImage regular expression matching compatible Istio sidecar istio-proxy container image names
-	SidecarIstioProxyImage = "sidecar-istio-proxy-image"
-
 	// SocketPath sets daemon's socket path to listen for connections
 	SocketPath = "socket-path"
 
@@ -3128,7 +3125,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.RouteMetric = vp.GetInt(RouteMetric)
 	c.RunDir = vp.GetString(StateDir)
 	c.ExternalEnvoyProxy = vp.GetBool(ExternalEnvoyProxy)
-	c.SidecarIstioProxyImage = vp.GetString(SidecarIstioProxyImage)
 	c.SocketPath = vp.GetString(SocketPath)
 	c.TracePayloadlen = vp.GetInt(TracePayloadlen)
 	c.Version = vp.GetString(Version)

--- a/pkg/proxy/endpoint/endpoint.go
+++ b/pkg/proxy/endpoint/endpoint.go
@@ -14,7 +14,6 @@ type EndpointInfoSource interface {
 	GetID() uint64
 	GetIPv4Address() string
 	GetIPv6Address() string
-	HasSidecarProxy() bool
 	ConntrackNameLocked() string
 	GetNamedPort(ingress bool, name string, proto uint8) uint16
 }


### PR DESCRIPTION
The last cilium istio image was unmaintained for a long time, it's worth mentioning that cilium/proxy repo is no longer building cilium_istio image. This commit is to remove istio sidecar related configuration in cilium codebase.

Related: https://github.com/cilium/proxy/pull/448
Related: https://github.com/cilium/cilium/pull/25722

