### PR TITLE
helm: Add extraVolumeMounts to cilium config init container

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -457,6 +457,9 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        {{- with .Values.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
       {{- if .Values.cgroup.autoMount.enabled }}
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.


### PR DESCRIPTION
Follow-up to https://github.com/cilium/cilium/pull/29511 to add extraVolumeMounts to config init container

```release-note
helm: Add extraVolumeMounts to cilium config init container
```
