### PR TITLE
Fix leaked health reporter updates

### DIFF
--- a/pkg/hive/cell/structured.go
+++ b/pkg/hive/cell/structured.go
@@ -212,9 +212,7 @@ type scope struct {
 func (s *scope) Close() {
 	s.base.Lock()
 	s.base.removeRefLocked(s.id)
-	if s.base.canRemoveTreeLocked(s.id) {
-		s.base.removeTreeLocked(s.id)
-	}
+	s.base.removeTreeLocked(s.id)
 	s.base.Unlock()
 	s.scheduleRealize()
 }


### PR DESCRIPTION
This fixes leaking health reporters on internal Endpoints by changing the behavior of `cell.Scope.Close()`.

Previously, this would recurse the reporter tree and only close out the scope if all subscopes/reporters where also closed.

From a usability perspective this is difficult to achieve as you'd need to unwind closing the health reporters and scopes, from the reporter-leaves up order, to successfully clean out a scope.

Thus, this changes the default behaviour to unequivocally close out reporter trees and children, any referenced reporters still in use will emit warnings - so hopefully we can catch these in our testing.

```release-note
Fix instances of leaked health reporter updates.
```
