### PR TITLE
v1.12: ipam: Fix invalid PodCIDR in CiliumNode in ENI/Azure/MultiPool mode

### DIFF
--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -150,11 +150,10 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node, nodeID uint16) {
 func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, nodeID uint16, zeroMark bool) {
 	var spi uint8
 
-	if !n.nodeConfig.EnableIPv4 || newNode.IPv4AllocCIDR == nil {
+	if !n.nodeConfig.EnableIPv4 || (newNode.IPv4AllocCIDR == nil && !n.subnetEncryption()) {
 		return
 	}
 
-	new4Net := newNode.IPv4AllocCIDR.IPNet
 	wildcardIP := net.ParseIP(wildcardIPv4)
 	wildcardCIDR := &net.IPNet{IP: wildcardIP, Mask: net.IPv4Mask(0, 0, 0, 0)}
 
@@ -162,14 +161,18 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, nodeID uint1
 	upsertIPsecLog(err, "default-drop IPv4", wildcardCIDR, wildcardCIDR, spi, 0)
 
 	if newNode.IsLocal() {
-		n.replaceNodeIPSecInRoute(new4Net)
-
 		localIP := newNode.GetCiliumInternalIP(false)
 		if localIP == nil {
 			return
 		}
 
 		if n.subnetEncryption() {
+			// FIXME: Remove the following four lines in Cilium v1.16
+			if localCIDR := n.nodeAddressing.IPv4().AllocationCIDR(); localCIDR != nil {
+				// This removes a bogus route that Cilium installed prior to v1.15
+				_ = route.Delete(n.createNodeIPSecInRoute(localCIDR.IPNet))
+			}
+
 			localNodeInternalIP, err := getV4LinkLocalIP()
 			if err != nil {
 				log.WithError(err).Error("Failed to get local IPv4 for IPsec configuration")
@@ -194,6 +197,7 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, nodeID uint1
 			}
 
 			localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
+			n.replaceNodeIPSecInRoute(localCIDR)
 			spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localIP, wildcardIP, 0, ipsec.IPSecDirIn, false)
 			upsertIPsecLog(err, "in IPv4", localCIDR, wildcardCIDR, spi, 0)
 		}
@@ -222,7 +226,7 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, nodeID uint1
 			}
 		} else {
 			remoteCIDR := newNode.IPv4AllocCIDR.IPNet
-			n.replaceNodeIPSecOutRoute(new4Net)
+			n.replaceNodeIPSecOutRoute(remoteCIDR)
 			spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, remoteCIDR, localIP, remoteIP, nodeID, ipsec.IPSecDirOut, false)
 			upsertIPsecLog(err, "out IPv4", wildcardCIDR, remoteCIDR, spi, nodeID)
 		}
@@ -232,11 +236,10 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, nodeID uint1
 func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, nodeID uint16, zeroMark bool) {
 	var spi uint8
 
-	if !n.nodeConfig.EnableIPv6 || newNode.IPv6AllocCIDR == nil {
+	if !n.nodeConfig.EnableIPv6 || (newNode.IPv6AllocCIDR == nil && !n.subnetEncryption()) {
 		return
 	}
 
-	new6Net := newNode.IPv6AllocCIDR.IPNet
 	wildcardIP := net.ParseIP(wildcardIPv6)
 	wildcardCIDR := &net.IPNet{IP: wildcardIP, Mask: net.CIDRMask(0, 128)}
 
@@ -244,14 +247,18 @@ func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, nodeID uint1
 	upsertIPsecLog(err, "default-drop IPv6", wildcardCIDR, wildcardCIDR, spi, 0)
 
 	if newNode.IsLocal() {
-		n.replaceNodeIPSecInRoute(new6Net)
-
 		localIP := newNode.GetCiliumInternalIP(true)
 		if localIP == nil {
 			return
 		}
 
 		if n.subnetEncryption() {
+			// FIXME: Remove the following four lines in Cilium v1.16
+			if localCIDR := n.nodeAddressing.IPv6().AllocationCIDR(); localCIDR != nil {
+				// This removes a bogus route that Cilium installed prior to v1.15
+				_ = route.Delete(n.createNodeIPSecInRoute(localCIDR.IPNet))
+			}
+
 			localNodeInternalIP, err := getV6LinkLocalIP()
 			if err != nil {
 				log.WithError(err).Error("Failed to get local IPv6 for IPsec configuration")
@@ -266,6 +273,7 @@ func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, nodeID uint1
 			}
 		} else {
 			localCIDR := n.nodeAddressing.IPv6().AllocationCIDR().IPNet
+			n.replaceNodeIPSecInRoute(localCIDR)
 			spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localIP, wildcardIP, 0, ipsec.IPSecDirIn, false)
 			upsertIPsecLog(err, "in IPv6", localCIDR, wildcardCIDR, spi, 0)
 		}
@@ -294,7 +302,7 @@ func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, nodeID uint1
 			}
 		} else {
 			remoteCIDR := newNode.IPv6AllocCIDR.IPNet
-			n.replaceNodeIPSecOutRoute(new6Net)
+			n.replaceNodeIPSecOutRoute(remoteCIDR)
 			spi, err := ipsec.UpsertIPsecEndpoint(wildcardCIDR, remoteCIDR, localIP, remoteIP, nodeID, ipsec.IPSecDirOut, false)
 			upsertIPsecLog(err, "out IPv6", wildcardCIDR, remoteCIDR, spi, nodeID)
 		}

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -512,17 +512,16 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 		}
 	}
 
-	switch option.Config.IPAM {
-	case ipamOption.IPAMClusterPool, ipamOption.IPAMClusterPoolV2:
-		// We want to keep the podCIDRs untouched in these IPAM modes because
-		// the operator will verify if it can assign such podCIDRs.
-		// If the user was running in non-IPAM Operator mode and then switched
-		// to IPAM Operator, then it is possible that the previous cluster CIDR
-		// from the old IPAM mode differs from the current cluster CIDR set in
-		// the operator.
-		// There is a chance that the operator won't be able to allocate these
-		// podCIDRs, resulting in an error in the CiliumNode status.
-	default:
+	if option.Config.IPAM == ipamOption.IPAMKubernetes {
+		// We only want to copy the PodCIDR from the Kubernetes Node resource to
+		// the CiliumNode resource in IPAM Kubernetes mode. In other PodCIDR
+		// based IPAM modes (such as ClusterPool or MultiPool), the operator
+		// will set the PodCIDRs of the CiliumNode and those might be different
+		// from the ones assigned by Kubernetes.
+		// For non-podCIDR based IPAM modes (e.g. ENI, Azure, AlibabaCloud), there
+		// is no such thing as a podCIDR to begin with. In those cases, the
+		// IPv4/IPv6AllocRange is auto-generated and otherwise unused, so it does not
+		// make sense to copy it into the CiliumNode it either.
 		nodeResource.Spec.IPAM.PodCIDRs = []string{}
 		if cidr := node.GetIPv4AllocRange(); cidr != nil {
 			nodeResource.Spec.IPAM.PodCIDRs = append(nodeResource.Spec.IPAM.PodCIDRs, cidr.String())


### PR DESCRIPTION
Manual backport of https://github.com/cilium/cilium/pull/26663.