### PR TITLE
docs: Document XfrmInStateInvalid errors

### DIFF
--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -218,10 +218,10 @@ Troubleshooting
    receive pod traffic (for example, ENI interfaces).
 
  * All XFRM errors correspond to a packet drop in the kernel. Except for
-   ``XfrmFwdHdrError`` and ``XfrmInError``, all XFRM errors indicate a bug in
-   Cilium or an operational mistake. ``XfrmOutStateSeqError``,
-   ``XfrmInStateProtoError``, and ``XfrmInNoStates`` may be caused by
-   operational mistakes, as detailed in the following points.
+   ``XfrmFwdHdrError``, ``XfrmInError``, and ``XfrmInStateInvalid``, all XFRM
+   errors indicate a bug in Cilium or an operational mistake.
+   ``XfrmOutStateSeqError``, ``XfrmInStateProtoError``, and ``XfrmInNoStates``
+   may be caused by operational mistakes, as detailed in the following points.
 
  * If the sequence number reaches its maximum value for any XFRM OUT state, it
    will result in packet drops and XFRM errors of type
@@ -249,6 +249,10 @@ Troubleshooting
    errors can also happen under memory pressure when the kernel fails to
    allocate memory.
 
+ * ``XfrmInStateInvalid`` can happen on rare occasions if packets are received
+   while an XFRM state is being deleted. XFRM states get deleted as part of
+   node scale-downs and for some upgrades and downgrades.
+
  * The following table documents the known explanations for several XFRM errors
    that were observed in the past. Many other error types exist, but they are
    usually for Linux subfeatures that Cilium doesn't use (e.g., XFRM
@@ -262,6 +266,8 @@ Troubleshooting
                             allocate memory.
    XfrmInNoStates           Bug in the XFRM configuration for decryption.
    XfrmInStateProtoError    There is a key mismatch between nodes.
+   XfrmInStateInvalid       A received packet matched an XFRM state that is
+                            being deleted.
    XfrmInTmplMismatch       Bug in the XFRM configuration for decryption.
    XfrmInNoPols             Bug in the XFRM configuration for decryption.
    XfrmInPolBlock           Explicit drop, not used by Cilium.


### PR DESCRIPTION
This error can happen if a state is being destroyed while packets are in flight. It should be rare as the window in the kernel where it can happen is very short.