### PR TITLE
Correct Istio Integration Documentation for Cilium CLI Flag Usage

### DIFF
--- a/Documentation/network/servicemesh/istio.rst
+++ b/Documentation/network/servicemesh/istio.rst
@@ -25,8 +25,9 @@ Istio's `sidecar proxies <https://istio.io/latest/docs/ops/deployment/architectu
 Disruptions can happen when you enable Cilium's ``kubeProxyReplacement`` feature  (see :ref:`kubeproxy-free` docs), 
 which enables socket based load balancing inside a Pod.
 
+
 To ensure that Cilium does not interfere with Istio, Cilium must be deployed
-with the ``--config bpf-lb-sock-hostns-only=true`` cilium CLI flag or with the ``socketLB.hostNamespaceOnly`` Helm value.
+with the ``--set socketLB.hostNamespaceOnly=true`` cilium CLI flag, or with the ``socketLB.hostNamespaceOnly`` Helm value.
 You can confirm the result with the following command:
 
 .. code-block:: shell-session

--- a/Documentation/network/servicemesh/istio.rst
+++ b/Documentation/network/servicemesh/istio.rst
@@ -26,8 +26,9 @@ Disruptions can happen when you enable Cilium's ``kubeProxyReplacement`` feature
 which enables socket based load balancing inside a Pod.
 
 
-To ensure that Cilium does not interfere with Istio, Cilium must be deployed
-with the ``--set socketLB.hostNamespaceOnly=true`` cilium CLI flag, or with the ``socketLB.hostNamespaceOnly`` Helm value.
+To ensure that Cilium does not interfere with Istio, it is important to set the
+``bpf-lb-sock-hostns-only`` parameter in the Cilium ConfigMap to ``true``. This can be achieved by using the
+``--set`` flag with the ``socketLB.hostNamespaceOnly`` Helm value set to ``true``.
 You can confirm the result with the following command:
 
 .. code-block:: shell-session


### PR DESCRIPTION
I recently followed the instructions in the [Cilium Documentation](https://docs.cilium.io/en/latest/network/servicemesh/istio/#cilium-configuration) for installing Istio alongside Cilium. The documentation suggests using the `--config bpf-lb-sock-hostns-only=true` CLI flag with Cilium to ensure compatibility with Istio. However, I noticed that the cilium CLI does not have a --config flag. Instead, it appears that the correct usage should be `--set socketLB.hostNamespaceOnly=true`.

I know that the `cilium` CLI in the Cilium Agent has the `--config` flag, but in the context of this document, I think the one to use would be the Cilium Installation CLI.