### PR TITLE
[test] Add validation on change of Renovate config

### DIFF
--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -1,0 +1,20 @@
+name: Validate Renovate configuration
+
+on:
+  pull_request:
+    paths:
+      - '.github/renovate.json5'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout configuration
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      # this step uses latest renovate slim release
+      - name: Validate configuration
+        run: >
+          docker run --rm --entrypoint "renovate-config-validator"
+          -v "${{ github.workspace }}/.github/renovate.json5":"/renovate.json5"
+          renovate/renovate:slim "/renovate.json5"


### PR DESCRIPTION
This change adds a GHA to validate the Renovate configuration when it is changed inside a PR.
This is analog to the one in the Tetragon repository

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
