### PR TITLE
Ldelossa/srv6 monitor logging

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -48,7 +48,7 @@
 #include "lib/eps.h"
 #include "lib/host_firewall.h"
 #include "lib/egress_gateway.h"
-#include "lib/egress_policies.h"
+#include "lib/srv6.h"
 #include "lib/overloadable.h"
 #include "lib/encrypt.h"
 #include "lib/wireguard.h"

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -49,7 +49,7 @@
 #include "lib/trace.h"
 #include "lib/csum.h"
 #include "lib/egress_gateway.h"
-#include "lib/egress_policies.h"
+#include "lib/srv6.h"
 #include "lib/encap.h"
 #include "lib/eps.h"
 #include "lib/nat.h"

--- a/bpf/lib/srv6.h
+++ b/bpf/lib/srv6.h
@@ -490,7 +490,7 @@ int tail_srv6_encap(struct __ctx_buff *ctx)
 					      METRIC_EGRESS);
 
 	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL_IPV6, 0, 0, 0,
-			  TRACE_REASON_UNKNOWN, 0);
+			  TRACE_REASON_SRV6_ENCAP, 0);
 
 	return ret;
 }
@@ -509,7 +509,7 @@ int tail_srv6_decap(struct __ctx_buff *ctx)
 		goto error_drop;
 
 	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL_IPV6, 0, 0, 0,
-			  TRACE_REASON_UNKNOWN, 0);
+			  TRACE_REASON_SRV6_DECAP, 0);
 	return CTX_ACT_OK;
 error_drop:
 		return send_drop_notify_error(ctx, SECLABEL_IPV6, ret, CTX_ACT_DROP,

--- a/bpf/lib/srv6.h
+++ b/bpf/lib/srv6.h
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
-#ifndef __LIB_EGRESS_POLICIES_H_
-#define __LIB_EGRESS_POLICIES_H_
+#ifndef __LIB_SRV6_H_
+#define __LIB_SRV6_H_
 
 #include "lib/common.h"
 #include "lib/fib.h"
@@ -529,4 +529,4 @@ int tail_srv6_reply(struct __ctx_buff *ctx)
 }
 # endif /* SKIP_SRV6_HANDLING */
 #endif /* ENABLE_SRV6 */
-#endif /* __LIB_EGRESS_POLICIES_H_ */
+#endif /* __LIB_SRV6_H_ */

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -52,6 +52,8 @@ enum trace_reason {
 	TRACE_REASON_CT_RELATED = CT_RELATED,
 	TRACE_REASON_CT_REOPENED = CT_REOPENED,
 	TRACE_REASON_UNKNOWN,
+	TRACE_REASON_SRV6_ENCAP,
+	TRACE_REASON_SRV6_DECAP,
 	/* Note: TRACE_REASON_ENCRYPTED is used as a mask. Beware if you add
 	 * new values below it, they would match with that mask.
 	 */

--- a/bpf/source_names_to_ids.h
+++ b/bpf/source_names_to_ids.h
@@ -28,7 +28,7 @@ __source_file_name_to_id(const char *const header_name)
 	/* header files from bpf/lib/ */
 	_strcase_(101, "arp.h");
 	_strcase_(102, "drop.h");
-	_strcase_(103, "egress_policies.h");
+	_strcase_(103, "srv6.h");
 	_strcase_(104, "icmp6.h");
 	_strcase_(105, "nodeport.h");
 	_strcase_(106, "lb.h");

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -410,6 +410,9 @@ func isReply(reason uint8) bool {
 func decodeIsReply(tn *monitor.TraceNotify, pvn *monitor.PolicyVerdictNotify) *wrapperspb.BoolValue {
 	switch {
 	case tn != nil && monitor.TraceReasonIsKnown(tn.Reason):
+		if monitor.TraceReasonIsEncap(tn.Reason) || monitor.TraceReasonIsDecap(tn.Reason) {
+			return nil
+		}
 		// Reason was specified by the datapath, just reuse it.
 		return &wrapperspb.BoolValue{
 			Value: isReply(tn.Reason),

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -540,6 +540,7 @@ func TestDecodeLocalIdentity(t *testing.T) {
 func TestDecodeTrafficDirection(t *testing.T) {
 	localIP := "1.2.3.4"
 	localEP := uint16(1234)
+	hostEP := uint16(0x1092)
 	remoteIP := "5.6.7.8"
 	remoteID := uint32(5678)
 
@@ -681,6 +682,28 @@ func TestDecodeTrafficDirection(t *testing.T) {
 	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.GetTrafficDirection())
 	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
 
+	// TRACE_TO_STACK SRV6 decap Ingress
+	tn = monitor.TraceNotifyV0{
+		Type:     byte(monitorAPI.MessageTypeTrace),
+		Source:   hostEP,
+		ObsPoint: monitorAPI.TraceToStack,
+		Reason:   monitor.TraceReasonSRv6Decap,
+	}
+	f = parseFlow(tn, remoteIP, localIP)
+	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.GetTrafficDirection())
+	assert.Equal(t, uint32(localEP), f.GetDestination().GetID())
+
+	// TRACE_TO_STACK SRV6 encap Egress
+	tn = monitor.TraceNotifyV0{
+		Type:     byte(monitorAPI.MessageTypeTrace),
+		Source:   localEP,
+		ObsPoint: monitorAPI.TraceToStack,
+		Reason:   monitor.TraceReasonSRv6Encap,
+	}
+	f = parseFlow(tn, localIP, remoteIP)
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
+	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+
 	// PolicyVerdictNotify Egress
 	pvn := monitor.PolicyVerdictNotify{
 		Type:        byte(monitorAPI.MessageTypePolicyVerdict),
@@ -715,6 +738,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 
 func TestDecodeIsReply(t *testing.T) {
 	localIP := net.ParseIP("1.2.3.4")
+	localEP := uint16(1234)
+	hostEP := uint16(0x1092)
 	remoteIP := net.ParseIP("5.6.7.8")
 
 	parser, err := New(log, nil, nil, nil, nil, nil, nil)
@@ -750,6 +775,28 @@ func TestDecodeIsReply(t *testing.T) {
 		Type:     byte(monitorAPI.MessageTypeTrace),
 		ObsPoint: monitorAPI.TraceFromLxc,
 		Reason:   monitor.TraceReasonUnknown,
+	}
+	f = parseFlow(tn, localIP, remoteIP)
+	assert.Nil(t, f.GetIsReply())
+	assert.Equal(t, false, f.GetReply())
+
+	// TRACE_TO_STACK SRV6 decap
+	tn = monitor.TraceNotifyV0{
+		Type:     byte(monitorAPI.MessageTypeTrace),
+		Source:   hostEP,
+		ObsPoint: monitorAPI.TraceToStack,
+		Reason:   monitor.TraceReasonSRv6Decap,
+	}
+	f = parseFlow(tn, remoteIP, localIP)
+	assert.Nil(t, f.GetIsReply())
+	assert.Equal(t, false, f.GetReply())
+
+	// TRACE_TO_STACK SRV6 encap
+	tn = monitor.TraceNotifyV0{
+		Type:     byte(monitorAPI.MessageTypeTrace),
+		Source:   localEP,
+		ObsPoint: monitorAPI.TraceToStack,
+		Reason:   monitor.TraceReasonSRv6Encap,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
 	assert.Nil(t, f.GetIsReply())

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -57,7 +57,7 @@ var sourceFileNames = map[int]string{
 	// header files from bpf/lib/
 	101: "arp.h",
 	102: "drop.h",
-	103: "egress_policies.h",
+	103: "srv6.h",
 	104: "icmp6.h",
 	105: "nodeport.h",
 	106: "lb.h",

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -128,6 +128,8 @@ const (
 	TraceReasonCtRelated
 	TraceReasonCtReopened
 	TraceReasonUnknown
+	TraceReasonSRv6Encap
+	TraceReasonSRv6Decap
 )
 
 var traceReasons = map[uint8]string{
@@ -137,6 +139,8 @@ var traceReasons = map[uint8]string{
 	TraceReasonCtRelated:     "related",
 	TraceReasonCtReopened:    "reopened",
 	TraceReasonUnknown:       "unknown",
+	TraceReasonSRv6Encap:     "srv6-encap",
+	TraceReasonSRv6Decap:     "srv6-decap",
 }
 
 func connState(reason uint8) string {

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -160,6 +160,24 @@ func TraceReasonIsKnown(reason uint8) bool {
 	}
 }
 
+func TraceReasonIsEncap(reason uint8) bool {
+	switch reason {
+	case TraceReasonSRv6Encap:
+		return true
+	default:
+		return false
+	}
+}
+
+func TraceReasonIsDecap(reason uint8) bool {
+	switch reason {
+	case TraceReasonSRv6Decap:
+		return true
+	default:
+		return false
+	}
+}
+
 // DecodeTraceNotify will decode 'data' into the provided TraceNotify structure
 func DecodeTraceNotify(data []byte, tn *TraceNotify) error {
 	if len(data) < traceNotifyCommonLen {


### PR DESCRIPTION
This PR renames "egress_policies.h" to "srv6.h" since only SRv6 related logic was left in this file.
Moving forward "srv6.h" will be the canonical file for SRv6 related datapath functionality. 

This PR also adds "srv6-encap" and "srv6-decap" monitor events, explaining to a debugger that SRv6 encap/decap successfully occurred and the subsequent packet is heading to the stack. 
This will cut down the time it takes to debug whether the SRv6 datapath processed an SRv6 VPN related packet. 

```release-note
Rename egress_policies.h to srv6.h and add SRv6 related trace reasons. 
```
