### PR TITLE
loader: fix obsolete XDP program removal

### DIFF
--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -205,7 +205,7 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 			}
 
 			scopedLog.Debug("Attaching XDP program to interface")
-			err = attachXDPProgram(link, coll.Programs[prog.progName], prog.progName, linkDir, xdpModeToFlag(xdpMode))
+			err = attachXDPProgram(link, coll.Programs[prog.progName], prog.progName, linkDir, xdpConfigModeToFlag(xdpMode))
 		} else {
 			scopedLog.Debug("Attaching TC program to interface")
 			err = attachTCProgram(link, coll.Programs[prog.progName], prog.progName, directionToParent(prog.direction))


### PR DESCRIPTION
This commit fixes a bug where `maybeUnloadObsoleteXDPPrograms()` removes XDP programs after a restart that are still in use and should remain in place. This can cause intermittent connectivity issues.

The issue is that the kernel returns different values when it is queried for the attach mode of a netlink device compared to the values used when configuring the attach mode. E.g. when attaching with `XDPDriverMode` which evaluates to '4' in the input flags, querying it will return `XDP_ATTACHED_DRV` which evaluates to '1'. So when `maybeUnloadObsoleteXDPPrograms()` compares the queried values to the used input values there can be a mismatch which leads to cilium removing still needed XDP programs.

This commit also changes the test, to be a suitable regression test for this fix. Previously the test was using `XDPGenericMode`. Unfortunately in this case the returned value from the kernel when querying netlink devices is `XDP_ATTACHED_SKB`, and both constants evaluate to '2' which is why this bug wasn't caught by the test in the first place.

Fixes: #30132
