### PR TITLE
Egress Gateway Policies CRD validations

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumegressgatewaypolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumegressgatewaypolicies.yaml
@@ -134,6 +134,9 @@ spec:
                 required:
                 - nodeSelector
                 type: object
+                x-kubernetes-validations:
+                - message: Egress Gateway cannot contain both egressIP and interface
+                  rule: '!((has(self.egressIP)) && (has(self.interface)))'
               excludedCIDRs:
                 description: ExcludedCIDRs is a list of destination CIDRs that will
                   be excluded from the egress gateway redirection and SNAT logic.


### PR DESCRIPTION
This commit adds validation to the `ciliumegressgatewaypolicies` CRD to ensure `egressIP` and `interface` are not configured at the same time.

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
There is a known limitation with Egress Gateway Policies where `egressIP` and `interface` values cannot be both have values, Egress Gateway will only allow either of those values or none. This PR adds validation to the `egressGateway` object of the CRD that will fail to apply if both fields are specified. The message exposed to users will look like this:

```
The CiliumEgressGatewayPolicy "egress-hello-world" is invalid: spec.egressGateway: Invalid value: "object": Egress Gateway cannot contain both egressIP and interface
```

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
Egress Gateway: CRD validation for Egress Gateway Policies
```
