### PR TITLE
lb-ipam: Add annotation alias with lbipam.cilium.io prefix

### DIFF
--- a/Documentation/network/lb-ipam.rst
+++ b/Documentation/network/lb-ipam.rst
@@ -400,7 +400,7 @@ Services can request specific IPs. The legacy way of doing so is via ``.spec.loa
 which takes a single IP address. This method has been deprecated in k8s v1.24 but is supported
 until its future removal.
 
-The new way of requesting specific IPs is to use annotations, ``io.cilium/lb-ipam-ips`` in the case
+The new way of requesting specific IPs is to use annotations, ``lbipam.cilium.io/ips`` in the case
 of Cilium LB IPAM. This annotation takes a comma-separated list of IP addresses, allowing for
 multiple IPs to be requested at once.
 
@@ -420,7 +420,7 @@ for the network and broadcast addresses respectively.
       labels:
         color: blue
       annotations:
-        "io.cilium/lb-ipam-ips": "20.0.10.100,20.0.10.200"
+        "lbipam.cilium.io/ips": "20.0.10.100,20.0.10.200"
     spec:
       type: LoadBalancer
       ports:
@@ -435,7 +435,7 @@ for the network and broadcast addresses respectively.
 Sharing Keys
 ------------
 
-Services can share the same IP or set of IPs with other services. This is done by setting the ``io.cilium/lb-ipam-sharing-key`` annotation on the service.
+Services can share the same IP or set of IPs with other services. This is done by setting the ``lbipam.cilium.io/sharing-key`` annotation on the service.
 Services that have the same sharing key annotation will share the same IP or set of IPs. The sharing key is a string that can be any value.
 
 .. code-block:: yaml
@@ -448,7 +448,7 @@ Services that have the same sharing key annotation will share the same IP or set
     labels:
       color: blue
     annotations:
-      "io.cilium/lb-ipam-sharing-key": "1234"
+      "lbipam.cilium.io/sharing-key": "1234"
   spec:
     type: LoadBalancer
     ports:
@@ -462,7 +462,7 @@ Services that have the same sharing key annotation will share the same IP or set
     labels:
       color: red
     annotations:
-      "io.cilium/lb-ipam-sharing-key": "1234"
+      "lbipam.cilium.io/sharing-key": "1234"
   spec:
     type: LoadBalancer
     ports:
@@ -478,4 +478,4 @@ Services that have the same sharing key annotation will share the same IP or set
 As long as the services do not have conflicting ports, they will be allocated the same IP. If the services have conflicting ports, they will be allocated different IPs, which will be added to the set of IPs belonging to the sharing key.
 If a service has a sharing key and also requests a specific IP, the service will be allocated the requested IP and it will be added to the set of IPs belonging to that sharing key.
 
-By default, sharing IPs across namespaces is not allowed. To allow sharing across a namespace, set the ``io.cilium/lb-ipam-sharing-cross-namespace`` annotation to the namespaces the service can be shared with. The value must be a comma-separated list of namespaces. The annotation must be present on both services. You can allow all namespaces with ``*``.
+By default, sharing IPs across namespaces is not allowed. To allow sharing across a namespace, set the ``lbipam.cilium.io/sharing-cross-namespace`` annotation to the namespaces the service can be shared with. The value must be a comma-separated list of namespaces. The annotation must be present on both services. You can allow all namespaces with ``*``.

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/ipalloc"
@@ -45,11 +46,7 @@ const (
 	ciliumPoolIPsUsedCondition      = "cilium.io/IPsUsed"
 	ciliumPoolConflict              = "cilium.io/PoolConflict"
 
-	// The annotation LB IPAM will look for when searching for requested IPs
-	ciliumSvcLBIPSAnnotation   = "io.cilium/lb-ipam-ips"
-	ciliumSvcLBISKAnnotation   = "io.cilium/lb-ipam-sharing-key"
-	ciliumSvcLBISKCNAnnotation = "io.cilium/lb-ipam-sharing-cross-namespace"
-	ciliumSvcLBISKCNWildward   = "*"
+	ciliumSvcLBISKCNWildward = "*"
 
 	// The string used in the FieldManager field on update options
 	ciliumFieldManager = "cilium-operator-lb-ipam"
@@ -685,8 +682,8 @@ func getSVCRequestedIPs(log logrus.FieldLogger, svc *slim_core_v1.Service) []net
 		}
 	}
 
-	if annotation := svc.Annotations[ciliumSvcLBIPSAnnotation]; annotation != "" {
-		for _, ipStr := range strings.Split(annotation, ",") {
+	if value, _ := annotation.Get(svc, annotation.LBIPAMIPsKey, annotation.LBIPAMIPKeyAlias); value != "" {
+		for _, ipStr := range strings.Split(value, ",") {
 			ip, err := netip.ParseAddr(strings.TrimSpace(ipStr))
 			if err == nil {
 				ips = append(ips, ip)
@@ -702,15 +699,15 @@ func getSVCRequestedIPs(log logrus.FieldLogger, svc *slim_core_v1.Service) []net
 }
 
 func getSVCSharingKey(log logrus.FieldLogger, svc *slim_core_v1.Service) string {
-	if annotation := svc.Annotations[ciliumSvcLBISKAnnotation]; annotation != "" {
-		return annotation
+	if val, _ := annotation.Get(svc, annotation.LBIPAMSharingKey, annotation.LBIPAMSharingKeyAlias); val != "" {
+		return val
 	}
 	return ""
 }
 
 func getSVCSharingCrossNamespace(log logrus.FieldLogger, svc *slim_core_v1.Service) []string {
-	if annotation := svc.Annotations[ciliumSvcLBISKCNAnnotation]; annotation != "" {
-		return strings.Split(annotation, ",")
+	if val, _ := annotation.Get(svc, annotation.LBIPAMSharingAcrossNamespace, annotation.LBIPAMSharingAcrossNamespaceAlias); val != "" {
+		return strings.Split(val, ",")
 	}
 	return []string{}
 }

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -13,6 +13,7 @@ import (
 
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -179,7 +180,7 @@ func TestSharedServiceUpdatedSharingKey(t *testing.T) {
 			Namespace: "default",
 			UID:       serviceAUID,
 			Annotations: map[string]string{
-				ciliumSvcLBISKAnnotation: "key-1",
+				annotation.LBIPAMSharingKeyAlias: "key-1",
 			},
 		},
 		Spec: slim_core_v1.ServiceSpec{
@@ -200,7 +201,7 @@ func TestSharedServiceUpdatedSharingKey(t *testing.T) {
 			Namespace: "default",
 			UID:       serviceAUID,
 			Annotations: map[string]string{
-				ciliumSvcLBISKAnnotation: "key-1",
+				annotation.LBIPAMSharingKeyAlias: "key-1",
 			},
 		},
 		Spec: slim_core_v1.ServiceSpec{
@@ -222,7 +223,7 @@ func TestSharedServiceUpdatedSharingKey(t *testing.T) {
 		t.Fatal("IPs should be the same")
 	}
 
-	svcB.Annotations[ciliumSvcLBISKAnnotation] = "key-2"
+	svcB.Annotations[annotation.LBIPAMSharingKeyAlias] = "key-2"
 	fixture.UpsertSvc(t, svcB)
 	svcB = fixture.GetSvc("default", "service-b")
 
@@ -248,7 +249,7 @@ func TestSharedServiceUpdatedPorts(t *testing.T) {
 			Namespace: "default",
 			UID:       serviceAUID,
 			Annotations: map[string]string{
-				ciliumSvcLBISKAnnotation: "key-1",
+				annotation.LBIPAMSharingKeyAlias: "key-1",
 			},
 		},
 		Spec: slim_core_v1.ServiceSpec{
@@ -269,7 +270,7 @@ func TestSharedServiceUpdatedPorts(t *testing.T) {
 			Namespace: "default",
 			UID:       serviceAUID,
 			Annotations: map[string]string{
-				ciliumSvcLBISKAnnotation: "key-1",
+				annotation.LBIPAMSharingKeyAlias: "key-1",
 			},
 		},
 		Spec: slim_core_v1.ServiceSpec{
@@ -1216,7 +1217,7 @@ func TestRequestIPs(t *testing.T) {
 			Namespace: "default",
 			UID:       serviceBUID,
 			Annotations: map[string]string{
-				ciliumSvcLBIPSAnnotation: "10.0.10.22,10.0.10.23",
+				annotation.LBIPAMIPKeyAlias: "10.0.10.22,10.0.10.23",
 			},
 		},
 		Spec: slim_core_v1.ServiceSpec{

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -31,6 +31,9 @@ const (
 	// IPAMPrefix is the common prefix for IPAM related annotations.
 	IPAMPrefix = "ipam.cilium.io"
 
+	// LBIPAMPrefix is the common prefix for LB IPAM related annotations.
+	LBIPAMPrefix = "lbipam.cilium.io"
+
 	// PolicyName / PolicyNameAlias is an optional annotation to the NetworkPolicy
 	// resource which specifies the name of the policy node to which all
 	// rules should be applied to.
@@ -138,6 +141,14 @@ const (
 	// IPAMIPv6PoolKey is the annotation name used to store the IPAM IPv6 pool name from
 	// which workloads should allocate their IP from
 	IPAMIPv6PoolKey = IPAMPrefix + "/ipv6-pool"
+
+	LBIPAMIPsKey     = LBIPAMPrefix + "/ips"
+	LBIPAMIPKeyAlias = Prefix + "/lb-ipam-ips"
+
+	LBIPAMSharingKey                  = LBIPAMPrefix + "/sharing-key"
+	LBIPAMSharingKeyAlias             = Prefix + "/lb-ipam-sharing-key"
+	LBIPAMSharingAcrossNamespace      = LBIPAMPrefix + "/sharing-cross-namespace"
+	LBIPAMSharingAcrossNamespaceAlias = Prefix + "/lb-ipam-sharing-cross-namespace"
 )
 
 var (


### PR DESCRIPTION
Recently, we are going with a new convention for annotation name (e.g. service.cilium.io) instead of cilium.io/service-xxx. This commit is to support the same for LB-IPAM module.

