### PR TITLE
gateway: Add GRPCRoute support for status changed predicate

### DIFF
--- a/operator/pkg/gateway-api/controller.go
+++ b/operator/pkg/gateway-api/controller.go
@@ -139,7 +139,7 @@ func getGatewaysForNamespace(ctx context.Context, c client.Client, ns client.Obj
 }
 
 // onlyStatusChanged returns true if and only if there is status change for underlying objects.
-// Supported objects are GatewayClass, Gateway, and HTTPRoute.
+// Supported objects are GatewayClass, Gateway, HTTPRoute and GRPCRoute
 func onlyStatusChanged() predicate.Predicate {
 	option := cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")
 	return predicate.Funcs{
@@ -169,6 +169,13 @@ func onlyStatusChanged() predicate.Predicate {
 			case *gatewayv1alpha2.TLSRoute:
 				o, _ := e.ObjectOld.(*gatewayv1alpha2.TLSRoute)
 				n, ok := e.ObjectNew.(*gatewayv1alpha2.TLSRoute)
+				if !ok {
+					return false
+				}
+				return !cmp.Equal(o.Status, n.Status, option)
+			case *gatewayv1alpha2.GRPCRoute:
+				o, _ := e.ObjectOld.(*gatewayv1alpha2.GRPCRoute)
+				n, ok := e.ObjectNew.(*gatewayv1alpha2.GRPCRoute)
 				if !ok {
 					return false
 				}


### PR DESCRIPTION
This was missed in the previous commit 8a421e7.

