### PR TITLE
ipam/crd: remove redundant `len` and `nil` check

### DIFF
--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -202,30 +202,26 @@ func newNodeStore(nodeName string, conf Configuration, owner Owner, clientset cl
 }
 
 func deriveVpcCIDRs(node *ciliumv2.CiliumNode) (primaryCIDR *cidr.CIDR, secondaryCIDRs []*cidr.CIDR) {
-	if len(node.Status.ENI.ENIs) > 0 {
-		// A node belongs to a single VPC so we can pick the first ENI
-		// in the list and derive the VPC CIDR from it.
-		for _, eni := range node.Status.ENI.ENIs {
-			c, err := cidr.ParseCIDR(eni.VPC.PrimaryCIDR)
-			if err == nil {
-				primaryCIDR = c
-				for _, sc := range eni.VPC.CIDRs {
-					c, err = cidr.ParseCIDR(sc)
-					if err == nil {
-						secondaryCIDRs = append(secondaryCIDRs, c)
-					}
+	// A node belongs to a single VPC so we can pick the first ENI
+	// in the list and derive the VPC CIDR from it.
+	for _, eni := range node.Status.ENI.ENIs {
+		c, err := cidr.ParseCIDR(eni.VPC.PrimaryCIDR)
+		if err == nil {
+			primaryCIDR = c
+			for _, sc := range eni.VPC.CIDRs {
+				c, err = cidr.ParseCIDR(sc)
+				if err == nil {
+					secondaryCIDRs = append(secondaryCIDRs, c)
 				}
-				return
 			}
+			return
 		}
 	}
-	if len(node.Status.Azure.Interfaces) > 0 {
-		for _, azif := range node.Status.Azure.Interfaces {
-			c, err := cidr.ParseCIDR(azif.CIDR)
-			if err == nil {
-				primaryCIDR = c
-				return
-			}
+	for _, azif := range node.Status.Azure.Interfaces {
+		c, err := cidr.ParseCIDR(azif.CIDR)
+		if err == nil {
+			primaryCIDR = c
+			return
 		}
 	}
 	// return AlibabaCloud vpc CIDR
@@ -349,14 +345,12 @@ func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 	n.ownNode = node
 	n.allocationPoolSize[IPv4] = 0
 	n.allocationPoolSize[IPv6] = 0
-	if node.Spec.IPAM.Pool != nil {
-		for ipString := range node.Spec.IPAM.Pool {
-			if ip := net.ParseIP(ipString); ip != nil {
-				if ip.To4() != nil {
-					n.allocationPoolSize[IPv4]++
-				} else {
-					n.allocationPoolSize[IPv6]++
-				}
+	for ipString := range node.Spec.IPAM.Pool {
+		if ip := net.ParseIP(ipString); ip != nil {
+			if ip.To4() != nil {
+				n.allocationPoolSize[IPv4]++
+			} else {
+				n.allocationPoolSize[IPv6]++
 			}
 		}
 	}


### PR DESCRIPTION
- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/master/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

From the Go specification (https://go.dev/ref/spec#For_range):

> "1. For a nil slice, the number of iterations is 0."
> "3. If the map is nil, the number of iterations is 0."

`len` returns 0 if the slice or map is `nil` (https://pkg.go.dev/builtin#len). Therefore, checking `len(v) > 0` around a loop is unnecessary.