### PR TITLE
Switch to self-hosted Renovate in GHA

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,8 +5,21 @@
     ":gitSignOff",
     "helpers:pinGitHubActionDigests"
   ],
+  // self-hosted configuration
+  "username": "cilium-renovate[bot]",
+  "repositories": ["cilium/cilium"],
+  // renovate first reads this configuration, then reads the repository
+  // configuration, since we don't split between the self-hosted and the
+  // repository configuration, this can lead to duplicate of some areas of the
+  // config, for example the regex. See:
+  // https://docs.renovatebot.com/self-hosted-configuration/#requireconfig
+  "requireConfig": "ignored",
+  "allowedPostUpgradeCommands": [
+    "^make -C install/kubernetes$",
+    "^go mod vendor$",
+  ],
   // This ensures that the gitAuthor and gitSignOff fields match
-  "gitAuthor": "renovate[bot] <bot@renovateapp.com>",
+  "gitAuthor": "cilium-renovate[bot] <134692979+cilium-renovate[bot]@users.noreply.github.com>",
   "includePaths": [
     ".github/actions/kvstore/**",
     ".github/actions/ginkgo/**",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -211,7 +211,27 @@
     {
       "groupName": "spire-images",
       "matchFiles": [
-        "install/kubernetes/cilium/values.yaml.tmpl"
+        "install/kubernetes/Makefile.values"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/spiffe/spire-agent",
+        "ghcr.io/spiffe/spire-server"
+      ],
+      "matchBaseBranches": [
+        "main"
+      ],
+      "allowedVersions": ">1.6",
+      // generate files for helm chart
+      "postUpgradeTasks": {
+        "commands": ["make -C install/kubernetes"],
+        "fileFilters": ["**/**"],
+        "executionMode": "branch"
+      }
+    },
+    {
+      "groupName": "spire-images",
+      "matchFiles": [
+        "install/kubernetes/Makefile.values"
       ],
       "matchPackageNames": [
         "ghcr.io/spiffe/spire-agent",
@@ -220,7 +240,13 @@
       "matchBaseBranches": [
         "v1.14"
       ],
-      "allowedVersions": "<1.7"
+      "allowedVersions": "<1.7",
+      // generate files for helm chart
+      "postUpgradeTasks": {
+        "commands": ["make -C install/kubernetes"],
+        "fileFilters": ["**/**"],
+        "executionMode": "branch"
+      }
     },
     {
       "matchPackageNames": [

--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -1,0 +1,21 @@
+name: Validate Renovate configuration
+
+on:
+  pull_request:
+    paths:
+      - '.github/renovate.json5'
+
+jobs:
+  validate:
+    name: Validate Renovate configuration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout configuration
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      # this step uses latest renovate slim release
+      - name: Validate configuration
+        run: >
+          docker run --rm --entrypoint "renovate-config-validator"
+          -v "${{ github.workspace }}/.github/renovate.json5":"/renovate.json5"
+          renovate/renovate:slim "/renovate.json5"

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,41 @@
+name: Renovate
+on:
+  # running every two hours from 9h to 19h UTC on every working day
+  schedule:
+    - cron: '0 9-19/2 * * 1-5'
+  # allow to manually trigger this workflow
+  workflow_dispatch:
+    inputs:
+      renovate_log_level_debug:
+        type: boolean
+        default: true
+
+jobs:
+  renovate:
+    name: Run self-hosted Renovate
+    runs-on: ubuntu-latest
+    steps:
+      # we need special permission to be able to operate renovate (view, list,
+      # create issues, PR, etc.) and we use a GitHub application with fine
+      # grained permissions installed in the repository for that.
+      - name: Get token
+        id: get_token
+        uses: cilium/actions-app-token@61a6271ce92ba02f49bf81c755685d59fb25a59a # v0.21.1
+        with:
+          APP_PEM: ${{ secrets.CILIUM_RENOVATE_PEM }}
+          APP_ID: ${{ secrets.CILIUM_RENOVATE_APP_ID }}
+
+      # renovate clones the repository again in its container fs but it needs
+      # the renovate configuration to start.
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@f9c81dddc9b589e4e6ae0326d1e36f6bc415d230 # v39.2.4
+        env:
+          # default to DEBUG log level, this is always useful
+          LOG_LEVEL: ${{ github.event.inputs.renovate_log_level_debug == 'false' && 'INFO' || 'DEBUG' }}
+        with:
+          configurationFile: .github/renovate.json5
+          token: '${{ steps.get_token.outputs.app_token }}'
+          mount-docker-socket: true

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,8 +1,10 @@
 name: Renovate
 on:
-  # running every two hours from 9h to 19h UTC on every working day
+  # running every hour every working day
+  # running every two hours outside of those hours
   schedule:
-    - cron: '0 9-19/2 * * 1-5'
+    - cron: '0 * * * 1-5'
+    - cron: '0 */2 * * 6-7'
   # allow to manually trigger this workflow
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This change moves the Renovate bot from the hosted version to be running as a scheduled job in GHA.
This will allow us to run any post-upgrade command in our set up environment and allow us to use our tooling to update versions we use in variables that generate code or documentation like the Helm chart.

It does come with a downside that any actions with the bot (eg. asking for a rebase) does come with a delay as the bot runs every two hours (like on the tetragon repo).


Fixes: https://github.com/cilium/cilium/issues/25457

