### PR TITLE
tests: check for pending maps after network policy tests finish

### DIFF
--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -368,6 +368,9 @@ var _ = SkipDescribeIf(func() bool {
 			By("Cleaning up after the test")
 			cmd := fmt.Sprintf("%s delete --all cnp,ccnp,netpol -n %s", helpers.KubectlCmd, testNamespace)
 			_ = kubectl.Exec(cmd)
+
+			By("Checking for pending maps")
+			kubectl.CiliumExecMustSucceedOnAll(context.Background(), "sh -c '! ls /sys/fs/bpf/tc/globals/*:pending'")
 		})
 
 		SkipContextIf(helpers.DoesNotExistNodeWithoutCilium, "validates ingress CIDR-dependent L4", func() {


### PR DESCRIPTION
tests: check for pending maps after network policy tests finish

    There is a flaky test failure due to

        Removed pending pinned map, did the agent die unexpectedly?

    being logged by the cilium agent when it finds remains of a previous cilium
    agent. As far as I can tell this comes about since the testsuite 
    reconfigures cilium between test runs, and that reconfiguration happens 
    while the old agent is applying some config.

    Right now it's almost impossible to debug the issue since we get the logs 
    for the wrong test. Try to make the "correct" test fail by adding an 
    assertion to test cleanup which checks that there are no maps pending. 
    Adding this check seems to make the problem occur a lot less frequently, 
    which suggests a race of some sort.

    Updates https://github.com/cilium/cilium/issues/30101

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

Updates #30101