### PR TITLE
pkg/ipcache: Updates IPListEntrySlice.Less() to Use netip Pkg

### DIFF
--- a/pkg/ipcache/types/entries.go
+++ b/pkg/ipcache/types/entries.go
@@ -4,8 +4,7 @@
 package types
 
 import (
-	"bytes"
-	"net"
+	"net/netip"
 
 	"github.com/cilium/cilium/api/v1/models"
 )
@@ -20,12 +19,12 @@ func (s IPListEntrySlice) Swap(i, j int) {
 // Given that the same IP cannot map to more than one identity, no further
 // sorting is performed.
 func (s IPListEntrySlice) Less(i, j int) bool {
-	_, iNet, _ := net.ParseCIDR(*s[i].Cidr)
-	_, jNet, _ := net.ParseCIDR(*s[j].Cidr)
-	iPrefixSize, _ := iNet.Mask.Size()
-	jPrefixSize, _ := jNet.Mask.Size()
+	iNet, _ := netip.ParsePrefix(*s[i].Cidr)
+	jNet, _ := netip.ParsePrefix(*s[j].Cidr)
+	iPrefixSize := iNet.Bits()
+	jPrefixSize := jNet.Bits()
 	if iPrefixSize == jPrefixSize {
-		return bytes.Compare(iNet.IP, jNet.IP) < 0
+		return iNet.Addr().Less(jNet.Addr())
 	}
 	return iPrefixSize < jPrefixSize
 }

--- a/pkg/ipcache/types/entries_test.go
+++ b/pkg/ipcache/types/entries_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"testing"
+)
+
+func TestIPListEntrySliceSwap(t *testing.T) {
+	entries := IPListEntrySlice{
+		{Cidr: strPtr("192.168.1.1/32")},
+		{Cidr: strPtr("10.0.0.1/32")},
+	}
+	entries.Swap(0, 1)
+	if *entries[0].Cidr != "10.0.0.1/32" || *entries[1].Cidr != "192.168.1.1/32" {
+		t.Errorf("Swap did not swap elements correctly")
+	}
+}
+
+func TestIPListEntrySliceLess(t *testing.T) {
+	entries := IPListEntrySlice{
+		{Cidr: strPtr("192.168.1.1/32")},
+		{Cidr: strPtr("10.0.0.1/32")},
+	}
+	if !entries.Less(1, 0) {
+		t.Errorf("Expected 10.0.0.1/32 to be less than 192.168.1.1/32")
+	}
+}
+
+func TestIPListEntrySliceLen(t *testing.T) {
+	entries := IPListEntrySlice{
+		{Cidr: strPtr("192.168.1.1/32")},
+		{Cidr: strPtr("10.0.0.1/32")},
+	}
+	if entries.Len() != 2 {
+		t.Errorf("Expected length 2, got %d", entries.Len())
+	}
+}
+
+// Helper function to create *string from string
+func strPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
Previously, the Less() method used the net/ip and bytes packages to sort the IPListEntry objects by CIDR prefix and then IP address. This PR updates the method to remove both packages in favor of the net/netip package.

Related: #24246