### PR TITLE
ci conformance e2e: increase request timeout from 10s to 30s.

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -353,6 +353,7 @@ jobs:
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
             --junit-property github_job_step="Run tests (${{ matrix.name }})" \
+            --request-timeout 30s
 
       - name: Fetch artifacts
         if: ${{ !success() && steps.run-tests.outcome != 'skipped' }}


### PR DESCRIPTION
Based on investigation here: https://github.com/cilium/cilium/issues/27762#issuecomment-1886329997

I'd like to increase the response timeout for the request, to see if the json-mock application is hanging or if this is some kind of proxy related issue.

Addresses: #27762
