### PR TITLE
workflows: Increase IPsec e2e test's timeout

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -122,7 +122,7 @@ jobs:
             key-one: 'cbc(aes)'
             key-two: 'gcm(aes)'
 
-    timeout-minutes: 60
+    timeout-minutes: 70
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
Bump the timeout to fix cancelled test runs that have started to pop up in CI.