### PR TITLE
renovate: don't separate minor/patch updates of Go modules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -109,6 +109,7 @@
         // update source import paths on major updates
         "gomodUpdateImportPaths"
       ],
+      "separateMinorPatch": false,
       "matchUpdateTypes": [
         "major",
         "minor",


### PR DESCRIPTION
In its current configuration, renovate will create separate branches for major, minor and patch version updates of all dependencies due to the top-level separate* configuration settings. In the case of Go modules which update the go.mod and go.sum files this often leads to conflict which requires rebasing PRs. Avoid parts of the conflicts by combining minor and patch updates for all Go module. For major version updates we'll still want a separate PR as these might introduce API breakage which need to be scrutinized.