### PR TITLE
operator/identitygc: remove unused GC.allocationCfg

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -140,7 +140,6 @@ var (
 		) identitygc.SharedConfig {
 			return identitygc.SharedConfig{
 				IdentityAllocationMode: daemonCfg.IdentityAllocationMode,
-				K8sNamespace:           daemonCfg.CiliumNamespaceName(),
 			}
 		}),
 

--- a/operator/identitygc/cell.go
+++ b/operator/identitygc/cell.go
@@ -80,8 +80,4 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 type SharedConfig struct {
 	// IdentityAllocationMode specifies what mode to use for identity allocation
 	IdentityAllocationMode string
-
-	// K8sNamespace is the name of the namespace in which Cilium is
-	// deployed in when running in Kubernetes mode
-	K8sNamespace string
 }

--- a/operator/identitygc/gc.go
+++ b/operator/identitygc/gc.go
@@ -80,8 +80,7 @@ type GC struct {
 	// processing each one individually.
 	rateLimiter *rate.Limiter
 
-	allocationCfg identityAllocationConfig
-	allocator     *allocator.Allocator
+	allocator *allocator.Allocator
 
 	// counters for GC failed/successful runs
 	failedRuns     int
@@ -114,9 +113,6 @@ func registerGC(p params) {
 			p.Cfg.RateInterval,
 			p.Cfg.RateLimit,
 		),
-		allocationCfg: identityAllocationConfig{
-			k8sNamespace: p.SharedCfg.K8sNamespace,
-		},
 		metrics: p.Metrics,
 	}
 	p.Lifecycle.Append(hive.Hook{
@@ -143,13 +139,4 @@ func registerGC(p params) {
 			return nil
 		},
 	})
-}
-
-// identityAllocationConfig is a helper struct that satisfies the Configuration interface.
-type identityAllocationConfig struct {
-	k8sNamespace string
-}
-
-func (cfg identityAllocationConfig) CiliumNamespaceName() string {
-	return cfg.k8sNamespace
 }

--- a/operator/identitygc/gc_test.go
+++ b/operator/identitygc/gc_test.go
@@ -59,7 +59,6 @@ func TestIdentitiesGC(t *testing.T) {
 		cell.Provide(func() SharedConfig {
 			return SharedConfig{
 				IdentityAllocationMode: option.IdentityAllocationModeCRD,
-				K8sNamespace:           "",
 			}
 		}),
 


### PR DESCRIPTION
It is unsed since commit 0f323a0feb4a ("refactor: replace identity allocation globals"). Removing it also allows to drop SharedConfig.K8sNamespace which was only used to initialize GC.allocationCfg.k8sNamespace.
