### PR TITLE
v1.12: Ignore packet drops of type `Failed to update or lookup TC buffer`

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -336,6 +336,7 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test
         with:
           job-name: ipsec-upgrade-${{ matrix.name }}
+          extra-connectivity-test-flags: --expected-drop-reasons "+Failed to update or lookup TC buffer"
           operation-cmd: |
             cd /host/
 


### PR DESCRIPTION
Commit 94ec45a6bdcc ("bpf: unconditionally migrate cilium_calls_* maps during ELF load") in main fixed a set of packet drops that can happen during a short time on agent restarts. Now that our CI is more sensitive to such drops, we are noticing them on all stable branches.

Unfortunately, the fix is too invasive to confidently backport to v1.12. Instead, this commit allowlist the CT buffer drops we are seeing in CI.