### PR TITLE
[v1.15] docs: add deprecation notice for enable-remote-node-identity for v1.15

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2801,7 +2801,7 @@
      - int
      - ``30``
    * - :spelling:ignore:`remoteNodeIdentity`
-     - Enable use of the remote node identity. ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity
+     - Enable use of the remote node identity. ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity Deprecated without replacement in 1.15. To be removed in 1.16.
      - bool
      - ``true``
    * - :spelling:ignore:`resourceQuotas`

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -383,6 +383,13 @@ Removed Options
 
 * Deprecated options ``enable-k8s-event-handover`` and ``cnp-status-update-interval`` has been removed.
 
+Deprecated Options
+~~~~~~~~~~~~~~~~~~
+
+* The ``enable-remote-node-identity`` flag has been deprecated and will be removed in Cilium 1.16.
+  This flag is needed for various features to work correctly and has been enabled by default since
+  Cilium 1.7. There is no benefit in disabling it anymore.
+
 Helm Options
 ~~~~~~~~~~~~
 
@@ -405,6 +412,9 @@ Helm Options
   ``tunnelProtocol``, and has been removed.
 
 * Values  ``enableK8sEventHandover`` and ``enableCnpStatusUpdates`` have been removed.
+
+* Value ``remoteNodeIdentity`` has been deprecated and will be removed in Cilium 1.16. See
+  deprecation notice for the ``enable-remote-node-identity`` for details.
 
 Added Metrics
 ~~~~~~~~~~~~~

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -750,7 +750,7 @@ contributors across the globe, there is almost always someone available to help.
 | rbac.create | bool | `true` | Enable creation of Resource-Based Access Control configuration. |
 | readinessProbe.failureThreshold | int | `3` | failure threshold of readiness probe |
 | readinessProbe.periodSeconds | int | `30` | interval between checks of the readiness probe |
-| remoteNodeIdentity | bool | `true` | Enable use of the remote node identity. ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity |
+| remoteNodeIdentity | bool | `true` | Enable use of the remote node identity. ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity Deprecated without replacement in 1.15. To be removed in 1.16. |
 | resourceQuotas | object | `{"cilium":{"hard":{"pods":"10k"}},"enabled":false,"operator":{"hard":{"pods":"15"}}}` | Enable resource quotas for priority classes used in the cluster. |
 | resources | object | `{}` | Agent resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | rollOutCiliumPods | bool | `false` | Roll out cilium agent pods automatically when configmap is updated. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2232,6 +2232,7 @@ envoy:
 
 # -- Enable use of the remote node identity.
 # ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity
+# Deprecated without replacement in 1.15. To be removed in 1.16.
 remoteNodeIdentity: true
 
 # -- Enable resource quotas for priority classes used in the cluster.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2229,6 +2229,7 @@ envoy:
 
 # -- Enable use of the remote node identity.
 # ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity
+# Deprecated without replacement in 1.15. To be removed in 1.16.
 remoteNodeIdentity: true
 
 # -- Enable resource quotas for priority classes used in the cluster.


### PR DESCRIPTION
The enable-remote-node-identity agent flag was marked as deprecated for 1.15 in commit cf472ef90f61 ("daemon: Deprecate EnableRemoteNodeIdentity"). Add an upgrade note about the flag and the corresponding remoteNodeIdentity helm value being deprecated.
