### PR TITLE
docs: fix chained veth plugin example

### DIFF
--- a/Documentation/installation/cni-chaining-generic-veth.rst
+++ b/Documentation/installation/cni-chaining-generic-veth.rst
@@ -62,7 +62,8 @@ desired CNI chaining configuration:
 	      [...]
             },
             {
-              "type": "cilium-cni"
+              "type": "cilium-cni",
+              "chaining-mode": "generic-veth"
             }
           ]
         }


### PR DESCRIPTION
We previously looked up the chaining mode by name, but this is non-obvious and unnecessary. So, we added the CNI chaining-mode parameter. But, we failed to update the docs to reference this.

Fixes: #28714
