### PR TITLE
Revert "renovate: don't separate minor/patch updates of Go modules"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -109,7 +109,6 @@
         // update source import paths on major updates
         "gomodUpdateImportPaths"
       ],
-      "separateMinorPatch": false,
       "matchUpdateTypes": [
         "major",
         "minor",


### PR DESCRIPTION
This reverts commit fece63cd2e171cf2be68c95e8d7f5e35e81e6a4f.

Reason for revert: breaks renovate
