### PR TITLE
ci-clustermesh-upgrade: Adjust name of test to run, to match cilium-cli's renaming

### DIFF
--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -161,7 +161,7 @@ jobs:
             --hubble=false \
             --flow-validation=disabled \
             --test='no-interrupted-connections' \
-            --test='no-missed-tail-calls' \
+            --test='no-unexpected-packet-drops' \
             --test='no-policies/' \
             --test='no-policies-extra/' \
             --test='allow-all-except-world/' \
@@ -456,7 +456,7 @@ jobs:
             --hubble=false \
             --flow-validation=disabled \
             --test='no-interrupted-connections' \
-            --test='no-missed-tail-calls' \
+            --test='no-unexpected-packet-drops' \
             --include-conn-disrupt-test \
             --junit-file "cilium-junits/${{ env.job_name }} - stress test (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests stess-test (${{ join(matrix.*, ', ') }})"


### PR DESCRIPTION
At some point (v0.15.18), connectivity test `no-missed-tail-calls` was renamed as `no-unexpected-packet-drops` in cilium-cli ([reference]). We now use a cilium-cli version that contain the change, but we've omitted to update the name of the test to run in the workflow. Let's adjust it now.

[reference]: cilium/cilium-cli@4880c91a726d ("connectivity: Check for unexpected packet drops")
Fixes: 16fe16637833 ("gh/workflows: Bump CLI to v0.15.18")
