### PR TITLE
loader, bpf: remove context cancellation check, lower pending map removal Warning to Info

### DIFF
--- a/pkg/bpf/bpffs_migrate.go
+++ b/pkg/bpf/bpffs_migrate.go
@@ -122,7 +122,7 @@ func RepinMap(bpffsPath string, name string, spec *ebpf.MapSpec) error {
 		log.WithFields(logrus.Fields{
 			logfields.BPFMapName: name,
 			logfields.BPFMapPath: dest,
-		}).Warn("Removed pending pinned map, did the agent die unexpectedly?")
+		}).Info("Removed pending pinned map, did the agent die unexpectedly?")
 	}
 
 	// Atomically re-pin the map to its new path.

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -191,11 +191,6 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 	}
 	defer coll.Close()
 
-	// Avoid attaching a prog to a stale interface.
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
 	for _, prog := range progs {
 		scopedLog := l.WithField("progName", prog.progName).WithField("direction", prog.direction)
 		if xdpMode != "" {


### PR DESCRIPTION
```
loader: ignore context cancellations during map migration

Allowing replaceDatapath() to be cancelled in the middle of an ongoing map
migration is a potential source of chaos. We've recently seen some flakes
with errors like `Removed pending pinned map, did the agent die unexpectedly?`,
so let's remove this context check to reduce the likelyhood of that happening.
```

```
bpf: lower pending map removal warning to info level

This has been making ci-ginkgo fail recently. With the removal of map
migrations around the corner (https://github.com/cilium/cilium/issues/29333),
and having declared bankruptcy on the Ginkgo test suite, let's not waste more
time chasing this bugbear.
```

Contributes to https://github.com/cilium/cilium/issues/29350.
Fixes https://github.com/cilium/cilium/issues/30101.