### PR TITLE
Introducing `stylecheck` linter to detect duplicate package imports in Go code

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -80,6 +80,9 @@ linters-settings:
               - errors
             reason: "Go 1.20+ has support for combining multiple errors, see https://go.dev/doc/go1.20#errors"
 
+  stylecheck:
+    checks: ["ST1019"]
+
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
@@ -110,6 +113,7 @@ linters:
     - ineffassign
     - misspell
     - staticcheck
+    - stylecheck
     - unused
     - goheader
     - gosec

--- a/daemon/cmd/local_node_sync_test.go
+++ b/daemon/cmd/local_node_sync_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	k8sLabels "k8s.io/apimachinery/pkg/labels"
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -87,7 +86,7 @@ func TestLocalNodeSync(t *testing.T) {
 			Config: &option.DaemonConfig{
 				IPv4NodeAddr:               "1.2.3.4",
 				IPv6NodeAddr:               "fd00::1",
-				NodeEncryptionOptOutLabels: labels.Nothing(),
+				NodeEncryptionOptOutLabels: k8sLabels.Nothing(),
 			},
 			K8sLocalNode: fln,
 			K8sCiliumLocalNode: &mockResource[*v2.CiliumNode]{

--- a/operator/cmd/kvstore_watchdog.go
+++ b/operator/cmd/kvstore_watchdog.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/allocator"
-	"github.com/cilium/cilium/pkg/clustermesh/types"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -107,7 +106,7 @@ func startKvstoreWatchdog() {
 				// insertion to prevent issues in case of, e.g., unexpected lease expiration.
 				cfg := cmtypes.CiliumClusterConfig{
 					ID:           option.Config.ClusterID,
-					Capabilities: types.CiliumClusterConfigCapabilities{MaxConnectedClusters: option.Config.MaxConnectedClusters}}
+					Capabilities: cmtypes.CiliumClusterConfigCapabilities{MaxConnectedClusters: option.Config.MaxConnectedClusters}}
 				if err := cmutils.SetClusterConfig(ctx, option.Config.ClusterName, &cfg, kvstore.Client()); err != nil {
 					log.WithError(err).Warning("Unable to set local cluster config")
 				}

--- a/operator/endpointgc/gc.go
+++ b/operator/endpointgc/gc.go
@@ -8,15 +8,12 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	k8sconstv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -111,11 +108,11 @@ func (g *GC) Stop(ctx cell.HookContext) error {
 
 func (g *GC) checkForCiliumEndpointCRD(ctx cell.HookContext) bool {
 	_, err := g.clientset.ApiextensionsV1().CustomResourceDefinitions().Get(
-		ctx, k8sconstv2.CEPName, metav1.GetOptions{ResourceVersion: "0"},
+		ctx, cilium_api_v2.CEPName, metav1.GetOptions{ResourceVersion: "0"},
 	)
 	if err == nil {
 		return true
-	} else if k8sErrors.IsNotFound(err) {
+	} else if k8serrors.IsNotFound(err) {
 		g.logger.WithError(err).Info("CiliumEndpoint CRD cannot be found, skipping garbage collection")
 	} else {
 		g.logger.WithError(err).Error(
@@ -243,15 +240,15 @@ func (g *GC) deleteCEP(cep *cilium_api_v2.CiliumEndpoint, scopedLog *logrus.Entr
 		logfields.EndpointID: cep.Status.ID,
 	})
 	scopedLog.Debug("Orphaned CiliumEndpoint is being garbage collected")
-	propagationPolicy := meta_v1.DeletePropagationBackground // because these are const strings but the API wants pointers
+	propagationPolicy := metav1.DeletePropagationBackground // because these are const strings but the API wants pointers
 	err := ciliumClient.CiliumEndpoints(cep.Namespace).Delete(
 		ctx,
 		cep.Name,
-		meta_v1.DeleteOptions{
+		metav1.DeleteOptions{
 			PropagationPolicy: &propagationPolicy,
 			// Set precondition to ensure we are only deleting CEPs owned by
 			// this agent.
-			Preconditions: &meta_v1.Preconditions{
+			Preconditions: &metav1.Preconditions{
 				UID: &cep.UID,
 			},
 		})

--- a/operator/endpointgc/gc_test.go
+++ b/operator/endpointgc/gc_test.go
@@ -20,7 +20,6 @@ import (
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
-	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/testutils"
 )
@@ -212,19 +211,19 @@ func createOwnerReference(kind, name string) meta_v1.OwnerReference {
 	}
 }
 
-func createPod(name, namespace string, isRunning bool) *v1.Pod {
+func createPod(name, namespace string, isRunning bool) *slim_corev1.Pod {
 	var phase slim_corev1.PodPhase
 	if isRunning {
 		phase = slim_corev1.PodRunning
 	} else {
 		phase = slim_corev1.PodSucceeded
 	}
-	return &v1.Pod{
+	return &slim_corev1.Pod{
 		ObjectMeta: slim_metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Status: v1.PodStatus{
+		Status: slim_corev1.PodStatus{
 			Phase: phase,
 		},
 	}

--- a/operator/pkg/bgpv2/cluster_test.go
+++ b/operator/pkg/bgpv2/cluster_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/api/errors"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -634,7 +633,7 @@ func Test_Cleanup(t *testing.T) {
 
 func upsertNode(req *require.Assertions, ctx context.Context, f *fixture, node *cilium_api_v2.CiliumNode) {
 	_, err := f.nodeClient.Get(ctx, node.Name, meta_v1.GetOptions{})
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && k8sErrors.IsNotFound(err) {
 		_, err = f.nodeClient.Create(ctx, node, meta_v1.CreateOptions{})
 	} else if err != nil {
 		req.Fail(err.Error())
@@ -650,7 +649,7 @@ func upsertBGPCC(req *require.Assertions, ctx context.Context, f *fixture, bgpcc
 	}
 
 	_, err := f.bgpcClient.Get(ctx, bgpcc.Name, meta_v1.GetOptions{})
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && k8sErrors.IsNotFound(err) {
 		_, err = f.bgpcClient.Create(ctx, bgpcc, meta_v1.CreateOptions{})
 	} else if err != nil {
 		req.Fail(err.Error())
@@ -662,7 +661,7 @@ func upsertBGPCC(req *require.Assertions, ctx context.Context, f *fixture, bgpcc
 
 func deleteBGPCC(req *require.Assertions, ctx context.Context, f *fixture, name string) {
 	_, err := f.bgpcClient.Get(ctx, name, meta_v1.GetOptions{})
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && k8sErrors.IsNotFound(err) {
 		return // already deleted
 	} else if err != nil {
 		req.Fail(err.Error())
@@ -674,7 +673,7 @@ func deleteBGPCC(req *require.Assertions, ctx context.Context, f *fixture, name 
 
 func upsertNodeOverrides(req *require.Assertions, ctx context.Context, f *fixture, nodeOverride *cilium_api_v2alpha1.CiliumBGPNodeConfigOverride) {
 	_, err := f.bgpncoClient.Get(ctx, nodeOverride.Name, meta_v1.GetOptions{})
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && k8sErrors.IsNotFound(err) {
 		_, err = f.bgpncoClient.Create(ctx, nodeOverride, meta_v1.CreateOptions{})
 	} else {
 		_, err = f.bgpncoClient.Update(ctx, nodeOverride, meta_v1.UpdateOptions{})

--- a/operator/pkg/ciliumendpointslice/reconciler_test.go
+++ b/operator/pkg/ciliumendpointslice/reconciler_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -53,10 +52,10 @@ func TestReconcileCreate(t *testing.T) {
 	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cepStore, _ := ciliumEndpoint.Store(context.Background())
 
-	var createdSlice *v2alpha1.CiliumEndpointSlice
+	var createdSlice *cilium_v2a1.CiliumEndpointSlice
 	fakeClient.CiliumFakeClientset.PrependReactor("create", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
 		pa := action.(k8sTesting.CreateAction)
-		createdSlice = pa.GetObject().(*v2alpha1.CiliumEndpointSlice)
+		createdSlice = pa.GetObject().(*cilium_v2a1.CiliumEndpointSlice)
 		return true, nil, nil
 	})
 
@@ -112,10 +111,10 @@ func TestReconcileUpdate(t *testing.T) {
 	cepStore, _ := ciliumEndpoint.Store(context.Background())
 	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
 
-	var updatedSlice *v2alpha1.CiliumEndpointSlice
+	var updatedSlice *cilium_v2a1.CiliumEndpointSlice
 	fakeClient.CiliumFakeClientset.PrependReactor("update", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
 		pa := action.(k8sTesting.UpdateAction)
-		updatedSlice = pa.GetObject().(*v2alpha1.CiliumEndpointSlice)
+		updatedSlice = pa.GetObject().(*cilium_v2a1.CiliumEndpointSlice)
 		return true, nil, nil
 	})
 
@@ -125,7 +124,7 @@ func TestReconcileUpdate(t *testing.T) {
 	cepStore.CacheStore().Add(cep2)
 	cep3 := createStoreEndpoint("cep3", "ns", 2)
 	cepStore.CacheStore().Add(cep3)
-	ces1 := createStoreEndpointSlice("ces1", "ns", []v2alpha1.CoreCiliumEndpoint{createManagerEndpoint("cep1", 1), createManagerEndpoint("cep3", 2)})
+	ces1 := createStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{createManagerEndpoint("cep1", 1), createManagerEndpoint("cep3", 2)})
 	cesStore.CacheStore().Add(ces1)
 	m.mapping.insertCES(NewCESName("ces1"), "ns")
 	m.mapping.insertCES(NewCESName("ces2"), "ns")
@@ -188,7 +187,7 @@ func TestReconcileDelete(t *testing.T) {
 	cepStore.CacheStore().Add(cep2)
 	cep3 := createStoreEndpoint("cep3", "ns", 2)
 	cepStore.CacheStore().Add(cep3)
-	ces1 := createStoreEndpointSlice("ces1", "ns", []v2alpha1.CoreCiliumEndpoint{createManagerEndpoint("cep1", 1), createManagerEndpoint("cep3", 2)})
+	ces1 := createStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{createManagerEndpoint("cep1", 1), createManagerEndpoint("cep3", 2)})
 	cesStore.CacheStore().Add(ces1)
 	m.mapping.insertCES(NewCESName("ces1"), "ns")
 	m.mapping.insertCES(NewCESName("ces2"), "ns")

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -19,7 +19,6 @@ import (
 	"go4.org/netipx"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 
@@ -28,7 +27,6 @@ import (
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/ipalloc"
 	"github.com/cilium/cilium/pkg/k8s"
-	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -65,7 +63,7 @@ var (
 )
 
 type poolClient interface {
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v2alpha1.CiliumLoadBalancerIPPool, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts meta_v1.PatchOptions, subresources ...string) (result *cilium_api_v2alpha1.CiliumLoadBalancerIPPool, err error)
 }
 
 type lbIPAMParams struct {

--- a/pkg/bgp/manager/manager_test.go
+++ b/pkg/bgp/manager/manager_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	metallbk8s "go.universe.tf/metallb/pkg/k8s"
-	mlbk8s "go.universe.tf/metallb/pkg/k8s"
 	"go.universe.tf/metallb/pkg/k8s/types"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/workqueue"
@@ -26,7 +25,7 @@ const (
 
 var (
 	errTimeout = errors.New("timeout occurred before mock received event")
-	emptyEps   = mlbk8s.EpsOrSlices{
+	emptyEps   = metallbk8s.EpsOrSlices{
 		Type: metallbk8s.Eps,
 	}
 )
@@ -44,11 +43,11 @@ func TestManagerEventNoService(t *testing.T) {
 		lock.Mutex
 		name  string
 		srvRo *v1.Service
-		eps   mlbk8s.EpsOrSlices
+		eps   metallbk8s.EpsOrSlices
 	}
 
 	mockCtrl := &mock.MockMetalLBController{
-		SetBalancer_: func(name string, srvRo *v1.Service, eps mlbk8s.EpsOrSlices) types.SyncState {
+		SetBalancer_: func(name string, srvRo *v1.Service, eps metallbk8s.EpsOrSlices) types.SyncState {
 			rr.Lock()
 			rr.name, rr.srvRo, rr.eps = name, srvRo, eps
 			rr.Unlock()
@@ -114,11 +113,11 @@ func TestManagerEvent(t *testing.T) {
 		lock.Mutex
 		name  string
 		srvRo *v1.Service
-		eps   mlbk8s.EpsOrSlices
+		eps   metallbk8s.EpsOrSlices
 	}
 
 	mockCtrl := &mock.MockMetalLBController{
-		SetBalancer_: func(name string, srvRo *v1.Service, eps mlbk8s.EpsOrSlices) types.SyncState {
+		SetBalancer_: func(name string, srvRo *v1.Service, eps metallbk8s.EpsOrSlices) types.SyncState {
 			rr.Lock()
 			rr.name, rr.srvRo, rr.eps = name, srvRo, eps
 			rr.Unlock()

--- a/pkg/bgpv1/test/gobgp.go
+++ b/pkg/bgpv1/test/gobgp.go
@@ -11,7 +11,6 @@ import (
 
 	gobgpapi "github.com/osrg/gobgp/v3/api"
 	"github.com/osrg/gobgp/v3/pkg/apiutil"
-	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
 	gobgpb "github.com/osrg/gobgp/v3/pkg/packet/bgp"
 	"github.com/osrg/gobgp/v3/pkg/server"
 )
@@ -151,7 +150,7 @@ type routeEvent struct {
 	prefix              string
 	prefixLen           uint8
 	isWithdrawn         bool
-	extraPathAttributes []bgp.PathAttributeInterface // non-standard path attributes (other than Origin / ASPath / NextHop / MpReachNLRI)
+	extraPathAttributes []gobgpb.PathAttributeInterface // non-standard path attributes (other than Origin / ASPath / NextHop / MpReachNLRI)
 }
 
 // peerEvent contains information about peer state change of gobgp
@@ -350,17 +349,17 @@ func (g *goBGP) getRouteEvents(ctx context.Context, numExpectedEvents int) ([]ro
 
 // filterStandardPathAttributes filters standard path attributes (usually present on all routes) from the
 // provided list of the path attributes.
-func (g *goBGP) filterStandardPathAttributes(attrs []bgp.PathAttributeInterface) []bgp.PathAttributeInterface {
-	var res []bgp.PathAttributeInterface
+func (g *goBGP) filterStandardPathAttributes(attrs []gobgpb.PathAttributeInterface) []gobgpb.PathAttributeInterface {
+	var res []gobgpb.PathAttributeInterface
 	for _, a := range attrs {
 		switch a.(type) {
-		case *bgp.PathAttributeOrigin:
+		case *gobgpb.PathAttributeOrigin:
 			continue
-		case *bgp.PathAttributeAsPath:
+		case *gobgpb.PathAttributeAsPath:
 			continue
-		case *bgp.PathAttributeNextHop:
+		case *gobgpb.PathAttributeNextHop:
 			continue
-		case *bgp.PathAttributeMpReachNLRI:
+		case *gobgpb.PathAttributeMpReachNLRI:
 			continue
 		}
 		res = append(res, a)

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
-	"github.com/cilium/cilium/pkg/clustermesh/types"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -35,7 +34,7 @@ type Configuration struct {
 	common.Config
 
 	// ClusterInfo is the id/name of the local cluster. This is used for logging and metrics
-	ClusterInfo types.ClusterInfo
+	ClusterInfo cmtypes.ClusterInfo
 
 	// NodeKeyCreator is the function used to create node instances as
 	// nodes are being discovered in remote clusters
@@ -62,7 +61,7 @@ type Configuration struct {
 
 	// ConfigValidationMode defines whether the CiliumClusterConfig is always
 	// expected to be exposed by remote clusters.
-	ConfigValidationMode types.ValidationMode `optional:"true"`
+	ConfigValidationMode cmtypes.ValidationMode `optional:"true"`
 
 	// IPCacheWatcherExtraOpts returns extra options for watching ipcache entries.
 	IPCacheWatcherExtraOpts IPCacheWatcherOptsFn `optional:"true"`

--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -16,7 +16,6 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/clustermesh/types"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
 	"github.com/cilium/cilium/pkg/controller"
@@ -35,7 +34,7 @@ var (
 type RemoteCluster interface {
 	// Run implements the actual business logic once the connection to the remote cluster has been established.
 	// The ready channel shall be closed when the initialization tasks completed, possibly returning an error.
-	Run(ctx context.Context, backend kvstore.BackendOperations, config *types.CiliumClusterConfig, ready chan<- error)
+	Run(ctx context.Context, backend kvstore.BackendOperations, config *cmtypes.CiliumClusterConfig, ready chan<- error)
 
 	// ClusterConfigRequired returns whether the CiliumClusterConfig is always
 	// expected to be exposed by remote clusters.
@@ -254,7 +253,7 @@ func (rc *remoteCluster) getClusterConfig(ctx context.Context, backend kvstore.B
 	rc.config = &models.RemoteClusterConfig{Required: requireConfig}
 	rc.mutex.Unlock()
 
-	cfgch := make(chan *types.CiliumClusterConfig)
+	cfgch := make(chan *cmtypes.CiliumClusterConfig)
 	defer close(cfgch)
 
 	// We retry here rather than simply returning an error and relying on the external

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
-	"github.com/cilium/cilium/pkg/clustermesh/types"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	identityCache "github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -81,7 +80,7 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 		return
 	}
 
-	var capabilities types.CiliumClusterConfigCapabilities
+	var capabilities cmtypes.CiliumClusterConfigCapabilities
 	if config != nil {
 		capabilities = config.Capabilities
 	}
@@ -175,7 +174,7 @@ func (rc *remoteCluster) Status() *models.RemoteCluster {
 }
 
 func (rc *remoteCluster) ClusterConfigRequired() bool {
-	return rc.mesh.conf.ConfigValidationMode == types.Strict
+	return rc.mesh.conf.ConfigValidationMode == cmtypes.Strict
 }
 
 func (rc *remoteCluster) onUpdateConfig(newConfig *cmtypes.CiliumClusterConfig) error {

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
-	"github.com/cilium/cilium/pkg/clustermesh/types"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
@@ -85,7 +84,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	for i, cluster := range []string{clusterName1, clusterName2} {
 		config := cmtypes.CiliumClusterConfig{
 			ID: uint32(i + 1),
-			Capabilities: types.CiliumClusterConfigCapabilities{
+			Capabilities: cmtypes.CiliumClusterConfigCapabilities{
 				MaxConnectedClusters: 255,
 			},
 		}
@@ -108,7 +107,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	store := store.NewFactory(store.MetricsProvider())
 	s.mesh = NewClusterMesh(hivetest.Lifecycle(c), Configuration{
 		Config:                common.Config{ClusterMeshConfig: dir},
-		ClusterInfo:           types.ClusterInfo{ID: 255, Name: "test2", MaxConnectedClusters: 255},
+		ClusterInfo:           cmtypes.ClusterInfo{ID: 255, Name: "test2", MaxConnectedClusters: 255},
 		NodeKeyCreator:        testNodeCreator,
 		NodeObserver:          &testObserver{},
 		ServiceMerger:         s.svcCache,

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/nodemap"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
 	"github.com/cilium/cilium/pkg/node"
-	"github.com/cilium/cilium/pkg/node/types"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
@@ -81,8 +80,8 @@ type linuxNodeHandler struct {
 	ipsecMetricCollector prometheus.Collector
 	ipsecMetricOnce      sync.Once
 
-	prefixClusterMutatorFn func(node *types.Node) []cmtypes.PrefixClusterOpts
-	enableEncapsulation    func(node *types.Node) bool
+	prefixClusterMutatorFn func(node *nodeTypes.Node) []cmtypes.PrefixClusterOpts
+	enableEncapsulation    func(node *nodeTypes.Node) bool
 }
 
 var (

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/netns"
 	nodeaddressing "github.com/cilium/cilium/pkg/node/addressing"
-	"github.com/cilium/cilium/pkg/node/types"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/sysctl"
@@ -329,10 +328,10 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 }
 
 func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulationWithOverride(c *check.C) {
-	s.commonNodeUpdateEncapsulation(c, false, func(*types.Node) bool { return true })
+	s.commonNodeUpdateEncapsulation(c, false, func(*nodeTypes.Node) bool { return true })
 }
 
-func (s *linuxPrivilegedBaseTestSuite) commonNodeUpdateEncapsulation(c *check.C, encap bool, override func(*types.Node) bool) {
+func (s *linuxPrivilegedBaseTestSuite) commonNodeUpdateEncapsulation(c *check.C, encap bool, override func(*nodeTypes.Node) bool) {
 	ip4Alloc1 := cidr.MustParseCIDR("5.5.5.0/24")
 	ip4Alloc2 := cidr.MustParseCIDR("6.6.6.0/24")
 	ip6Alloc1 := cidr.MustParseCIDR("2001:aaaa::/96")

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	"github.com/cilium/cilium/api/v1/flow"
 	pb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/hubble/parser/common"
@@ -105,7 +104,7 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	var pvn *monitor.PolicyVerdictNotify
 	var dbg *monitor.DebugCapture
 	var eventSubType uint8
-	var authType flow.AuthType
+	var authType pb.AuthType
 
 	switch eventType {
 	case monitorAPI.MessageTypeDrop:
@@ -138,7 +137,7 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 		}
 		eventSubType = pvn.SubType
 		packetOffset = monitor.PolicyVerdictNotifyLen
-		authType = flow.AuthType(pvn.GetAuthType())
+		authType = pb.AuthType(pvn.GetAuthType())
 	case monitorAPI.MessageTypeCapture:
 		dbg = &monitor.DebugCapture{}
 		if err := monitor.DecodeDebugCapture(data, dbg); err != nil {

--- a/pkg/identity/numericidentity_test.go
+++ b/pkg/identity/numericidentity_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/clustermesh/types"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 )
 
@@ -20,7 +19,7 @@ func (s *IdentityTestSuite) TestLocalIdentity(c *C) {
 	localID := NumericIdentity(IdentityScopeLocal | 1)
 	c.Assert(localID.HasLocalScope(), Equals, true)
 
-	maxClusterID := NumericIdentity(types.ClusterIDMax | 1)
+	maxClusterID := NumericIdentity(cmtypes.ClusterIDMax | 1)
 	c.Assert(maxClusterID.HasLocalScope(), Equals, false)
 
 	c.Assert(ReservedIdentityWorld.HasLocalScope(), Equals, false)
@@ -48,12 +47,12 @@ func (s *IdentityTestSuite) TestClusterID(c *C) {
 			clusterID: 255,
 		},
 		{ // make sure we support min/max configuration values
-			identity:  types.ClusterIDMin << 16,
-			clusterID: types.ClusterIDMin,
+			identity:  cmtypes.ClusterIDMin << 16,
+			clusterID: cmtypes.ClusterIDMin,
 		},
 		{
-			identity:  types.ClusterIDMax << 16,
-			clusterID: types.ClusterIDMax,
+			identity:  cmtypes.ClusterIDMax << 16,
+			clusterID: cmtypes.ClusterIDMax,
 		},
 	}
 

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/ipam/service/ipallocator"
@@ -477,12 +476,12 @@ type fakeK8sCiliumNodeAPIResource struct {
 	onDeleteEvent func(err error)
 }
 
-func (f *fakeK8sCiliumNodeAPIResource) Update(ctx context.Context, ciliumNode *ciliumv2.CiliumNode, _ v1.UpdateOptions) (*ciliumv2.CiliumNode, error) {
+func (f *fakeK8sCiliumNodeAPIResource) Update(ctx context.Context, ciliumNode *ciliumv2.CiliumNode, _ metav1.UpdateOptions) (*ciliumv2.CiliumNode, error) {
 	err := f.updateNode(ciliumNode)
 	return ciliumNode, err
 }
 
-func (f *fakeK8sCiliumNodeAPIResource) UpdateStatus(ctx context.Context, ciliumNode *ciliumv2.CiliumNode, _ v1.UpdateOptions) (*ciliumv2.CiliumNode, error) {
+func (f *fakeK8sCiliumNodeAPIResource) UpdateStatus(ctx context.Context, ciliumNode *ciliumv2.CiliumNode, _ metav1.UpdateOptions) (*ciliumv2.CiliumNode, error) {
 	err := f.updateNode(ciliumNode)
 	return ciliumNode, err
 }

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
@@ -62,7 +61,7 @@ func updateNodeAnnotation(c kubernetes.Interface, nodeName string, annotation no
 	}
 	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":%s}}`, raw))
 
-	_, err = c.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "status")
+	_, err = c.CoreV1().Nodes().Patch(context.TODO(), nodeName, k8sTypes.StrategicMergePatchType, patch, metav1.PatchOptions{}, "status")
 
 	return err
 }

--- a/pkg/k8s/apis/crdhelpers/register_test.go
+++ b/pkg/k8s/apis/crdhelpers/register_test.go
@@ -14,7 +14,6 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 
@@ -129,7 +128,7 @@ func (s *CiliumV2RegisterSuite) TestCreateUpdateCRD(c *C) {
 				_, err = client.ApiextensionsV1beta1().CustomResourceDefinitions().Create(
 					context.TODO(),
 					oldCRD,
-					v1.CreateOptions{},
+					metav1.CreateOptions{},
 				)
 				c.Assert(err, IsNil)
 
@@ -158,7 +157,7 @@ func (s *CiliumV2RegisterSuite) TestCreateUpdateCRD(c *C) {
 				_, err = client.ApiextensionsV1().CustomResourceDefinitions().Create(
 					context.TODO(),
 					oldCRD,
-					v1.CreateOptions{},
+					metav1.CreateOptions{},
 				)
 				c.Assert(err, IsNil)
 

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
@@ -354,7 +353,7 @@ func CiliumSlimEndpointResource(lc cell.Lifecycle, cs client.Clientset, _ *node.
 		"localNode": ciliumEndpointLocalPodIndexFunc,
 	}
 	return resource.New[*types.CiliumEndpoint](lc, lw,
-		resource.WithLazyTransform(func() runtime.Object {
+		resource.WithLazyTransform(func() k8sRuntime.Object {
 			return &cilium_api_v2.CiliumEndpoint{}
 		}, TransformToCiliumEndpoint),
 		resource.WithMetric("CiliumEndpoint"),

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -32,7 +32,6 @@ import (
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	k8smetrics "github.com/cilium/cilium/pkg/k8s/metrics"
@@ -409,17 +408,17 @@ type watcherInfo struct {
 }
 
 var ciliumResourceToGroupMapping = map[string]watcherInfo{
-	synced.CRDResourceName(v2.CNPName):                  {start, k8sAPIGroupCiliumNetworkPolicyV2},
-	synced.CRDResourceName(v2.CCNPName):                 {start, k8sAPIGroupCiliumClusterwideNetworkPolicyV2},
-	synced.CRDResourceName(v2.CEPName):                  {start, k8sAPIGroupCiliumEndpointV2}, // ipcache
-	synced.CRDResourceName(v2.CNName):                   {start, k8sAPIGroupCiliumNodeV2},
-	synced.CRDResourceName(v2.CIDName):                  {skip, ""}, // Handled in pkg/k8s/identitybackend/
-	synced.CRDResourceName(v2.CLRPName):                 {start, k8sAPIGroupCiliumLocalRedirectPolicyV2},
-	synced.CRDResourceName(v2.CEWName):                  {skip, ""}, // Handled in clustermesh-apiserver/
-	synced.CRDResourceName(v2.CEGPName):                 {skip, ""}, // Handled via Resource[T].
+	synced.CRDResourceName(cilium_v2.CNPName):           {start, k8sAPIGroupCiliumNetworkPolicyV2},
+	synced.CRDResourceName(cilium_v2.CCNPName):          {start, k8sAPIGroupCiliumClusterwideNetworkPolicyV2},
+	synced.CRDResourceName(cilium_v2.CEPName):           {start, k8sAPIGroupCiliumEndpointV2}, // ipcache
+	synced.CRDResourceName(cilium_v2.CNName):            {start, k8sAPIGroupCiliumNodeV2},
+	synced.CRDResourceName(cilium_v2.CIDName):           {skip, ""}, // Handled in pkg/k8s/identitybackend/
+	synced.CRDResourceName(cilium_v2.CLRPName):          {start, k8sAPIGroupCiliumLocalRedirectPolicyV2},
+	synced.CRDResourceName(cilium_v2.CEWName):           {skip, ""}, // Handled in clustermesh-apiserver/
+	synced.CRDResourceName(cilium_v2.CEGPName):          {skip, ""}, // Handled via Resource[T].
 	synced.CRDResourceName(v2alpha1.CESName):            {start, k8sAPIGroupCiliumEndpointSliceV2Alpha1},
-	synced.CRDResourceName(v2.CCECName):                 {skip, ""}, // Handled via CiliumEnvoyConfig watcher via Resource[T]
-	synced.CRDResourceName(v2.CECName):                  {skip, ""}, // Handled via CiliumEnvoyConfig watcher via Resource[T]
+	synced.CRDResourceName(cilium_v2.CCECName):          {skip, ""}, // Handled via CiliumEnvoyConfig watcher via Resource[T]
+	synced.CRDResourceName(cilium_v2.CECName):           {skip, ""}, // Handled via CiliumEnvoyConfig watcher via Resource[T]
 	synced.CRDResourceName(v2alpha1.BGPPName):           {skip, ""}, // Handled in BGP control plane
 	synced.CRDResourceName(v2alpha1.BGPCCName):          {skip, ""}, // Handled in BGP control plane
 	synced.CRDResourceName(v2alpha1.BGPAName):           {skip, ""}, // Handled in BGP control plane

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	"github.com/cilium/cilium/pkg/k8s/client"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -37,7 +36,6 @@ import (
 	"golang.org/x/exp/maps"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -51,7 +49,7 @@ var Cell = cell.Module(
 	cell.Provide(l2AnnouncementPolicyResource),
 )
 
-func l2AnnouncementPolicyResource(lc cell.Lifecycle, cs client.Clientset) (resource.Resource[*cilium_api_v2alpha1.CiliumL2AnnouncementPolicy], error) {
+func l2AnnouncementPolicyResource(lc cell.Lifecycle, cs k8sClient.Clientset) (resource.Resource[*cilium_api_v2alpha1.CiliumL2AnnouncementPolicy], error) {
 	if !cs.IsEnabled() {
 		return nil, nil
 	}
@@ -641,7 +639,7 @@ func (l2a *L2Announcer) updatePolicyStatus(
 	}
 
 	_, err = policyClient.Patch(ctx, policy.Name,
-		types.JSONPatchType, createStatusPatch, v1.PatchOptions{
+		types.JSONPatchType, createStatusPatch, metav1.PatchOptions{
 			FieldManager: ciliumFieldManager,
 		}, "status")
 

--- a/pkg/pprof/cell.go
+++ b/pkg/pprof/cell.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
-	_ "net/http/pprof"
 	"strconv"
 
 	"github.com/sirupsen/logrus"

--- a/pkg/redirectpolicy/redirectpolicy.go
+++ b/pkg/redirectpolicy/redirectpolicy.go
@@ -14,7 +14,6 @@ import (
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
-	"github.com/cilium/cilium/pkg/loadbalancer"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
@@ -69,14 +68,14 @@ type LRPConfig struct {
 	backendPortsByPortName map[portName]*bePortInfo
 }
 
-type frontend = loadbalancer.L3n4Addr
+type frontend = lb.L3n4Addr
 
 // backend encapsulates loadbalancer.L3n4Addr for a pod along with podID (pod
 // name and namespace). There can be multiple backend pods for an LRP frontend,
 // in such cases, the podID will be used to keep track of updates related to
 // a pod.
 type backend struct {
-	loadbalancer.L3n4Addr
+	lb.L3n4Addr
 	podID podID
 }
 
@@ -194,7 +193,7 @@ func getSanitizedLRPConfig(name, namespace string, uid types.UID, spec v2.Cilium
 				return nil, fmt.Errorf("invalid address matcher port %v", err)
 			}
 			// Set the scope to ScopeExternal as the externalTrafficPolicy is set to Cluster.
-			fe = loadbalancer.NewL3n4Addr(proto, addrCluster, p, loadbalancer.ScopeExternal)
+			fe = lb.NewL3n4Addr(proto, addrCluster, p, lb.ScopeExternal)
 			feM := &feMapping{
 				feAddr: fe,
 				fePort: pName,
@@ -233,7 +232,7 @@ func getSanitizedLRPConfig(name, namespace string, uid types.UID, spec v2.Cilium
 			}
 			// Set the scope to ScopeExternal as the externalTrafficPolicy is set to Cluster.
 			// frontend ip will later be populated with the clusterIP of the service.
-			fe = loadbalancer.NewL3n4Addr(proto, cmtypes.AddrCluster{}, p, loadbalancer.ScopeExternal)
+			fe = lb.NewL3n4Addr(proto, cmtypes.AddrCluster{}, p, lb.ScopeExternal)
 			feM := &feMapping{
 				feAddr: fe,
 				fePort: pName,

--- a/pkg/statedb/api_handler.go
+++ b/pkg/statedb/api_handler.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 
-	. "github.com/cilium/cilium/api/v1/server/restapi/statedb"
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/statedb"
 	"github.com/cilium/cilium/pkg/api"
 )
@@ -27,7 +26,7 @@ type dumpHandler struct {
 	db *DB
 }
 
-func (h *dumpHandler) Handle(params GetStatedbDumpParams) middleware.Responder {
+func (h *dumpHandler) Handle(params restapi.GetStatedbDumpParams) middleware.Responder {
 	return middleware.ResponderFunc(func(w http.ResponseWriter, _ runtime.Producer) {
 		h.db.ReadTxn().WriteJSON(w)
 	})
@@ -44,20 +43,20 @@ type queryHandler struct {
 }
 
 // /statedb/query
-func (h *queryHandler) Handle(params GetStatedbQueryTableParams) middleware.Responder {
+func (h *queryHandler) Handle(params restapi.GetStatedbQueryTableParams) middleware.Responder {
 	queryKey, err := base64.StdEncoding.DecodeString(params.Key)
 	if err != nil {
-		return api.Error(GetStatedbQueryTableBadRequestCode, fmt.Errorf("Invalid key: %w", err))
+		return api.Error(restapi.GetStatedbQueryTableBadRequestCode, fmt.Errorf("Invalid key: %w", err))
 	}
 
 	txn := h.db.ReadTxn()
 	indexTxn, err := txn.getTxn().indexReadTxn(params.Table, params.Index)
 	if err != nil {
-		return api.Error(GetStatedbQueryTableNotFoundCode, err)
+		return api.Error(restapi.GetStatedbQueryTableNotFoundCode, err)
 	}
 
 	return middleware.ResponderFunc(func(w http.ResponseWriter, _ runtime.Producer) {
-		w.WriteHeader(GetStatedbDumpOKCode)
+		w.WriteHeader(restapi.GetStatedbDumpOKCode)
 		enc := gob.NewEncoder(w)
 		onObject := func(obj object) error {
 			if err := enc.Encode(obj.revision); err != nil {

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/k8s/apis"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/version"
@@ -530,8 +529,8 @@ func filterList(obj k8sRuntime.Object, restrictions k8sTesting.ListRestrictions)
 			}
 		}
 		obj.Items = items
-	case *v2.CiliumNodeList:
-		items := make([]v2.CiliumNode, 0, len(obj.Items))
+	case *cilium_v2.CiliumNodeList:
+		items := make([]cilium_v2.CiliumNode, 0, len(obj.Items))
 		for i := range obj.Items {
 			if matchFieldSelector(&obj.Items[i], selector) {
 				items = append(items, obj.Items[i])


### PR DESCRIPTION
We introduce `stylecheck` linter in `.golangci.yaml`, but enable it only for duplicate imports (ST1019)

Then this PR fixes all the duplicate go imports found by running:
```
make golangci-lint
```

This is a re-spin of the original (abandoned) https://github.com/cilium/cilium/pull/28062 by @Archisman-Mridha

Fixes: #27676
