### PR TITLE
daemon/cmd: Updates restoreIPCache() to use errors.Is()

### DIFF
--- a/daemon/cmd/ipcache.go
+++ b/daemon/cmd/ipcache.go
@@ -4,10 +4,11 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"net/netip"
-	"os"
 
 	"github.com/go-openapi/runtime/middleware"
 
@@ -144,7 +145,7 @@ func (d *Daemon) restoreIPCache() error {
 	ipcachemap.IPCacheMap().Close()
 
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 		return fmt.Errorf("error dumping ipcache: %w", err)


### PR DESCRIPTION
Previously, the restoreIPCache() method would return an error on new installs because it was checking for the presence of the "file or dir missing" error but this error was being wrapped by another method in the call chain.

This PR updates the restoreIPCache() method to use errors.Is() that reports whether any error in err's chain matches the target and thus reports a nil error on new installs when the "cilium_ipcache" file does not exist.

Fixes: #29328