### PR TITLE
[v1.14] pkg/node/manager: Fix inconsistent ipset entries handling on node update, add test non-regression test 

### DIFF
--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -35,7 +35,7 @@ func (g *GetNodesSuite) SetUpTest(c *C) {
 
 func (g *GetNodesSuite) SetUpSuite(c *C) {
 	var err error
-	nm, err = manager.New(&fakeConfig.Config{}, nil, manager.NewNodeMetrics())
+	nm, err = manager.New(&fakeConfig.Config{}, nil, nil, manager.NewNodeMetrics())
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1156,7 +1156,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 // AddToNodeIpset adds an IP address to the ipset for cluster nodes. It creates
 // the ipset if it doesn't already exist and doesn't error if either the ipset
 // or the IP already exist.
-func AddToNodeIpset(nodeIP net.IP) {
+func (m *IptablesManager) AddToNodeIpset(nodeIP net.IP) {
 	scopedLog := log.WithField(logfields.IPAddr, nodeIP.String())
 	ciliumNodeIpset := ciliumNodeIpsetV4
 	if ip.IsIPv6(nodeIP) {
@@ -1173,7 +1173,7 @@ func AddToNodeIpset(nodeIP net.IP) {
 }
 
 // RemoveFromBodeIpset removes an IP address from the ipset for cluster nodes.
-func RemoveFromNodeIpset(nodeIP net.IP) {
+func (m *IptablesManager) RemoveFromNodeIpset(nodeIP net.IP) {
 	scopedLog := log.WithField(logfields.IPAddr, nodeIP.String())
 	ciliumNodeIpset := ciliumNodeIpsetV4
 	if ip.IsIPv6(nodeIP) {

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -52,8 +52,8 @@ const (
 	ciliumForwardChain    = "CILIUM_FORWARD"
 	feederDescription     = "cilium-feeder:"
 	xfrmDescription       = "cilium-xfrm-notrack:"
-	ciliumNodeIpsetV4     = "cilium_node_set_v4"
-	ciliumNodeIpsetV6     = "cilium_node_set_v6"
+	CiliumNodeIpsetV4     = "cilium_node_set_v4"
+	CiliumNodeIpsetV6     = "cilium_node_set_v6"
 )
 
 // Minimum iptables versions supporting the -w and -w<seconds> flags
@@ -106,8 +106,8 @@ func (ipt *ipt) initArgs(waitSeconds int) {
 
 // package name is iptables so we use ip4tables internally for "iptables"
 var (
-	ip4tables = &ipt{prog: "iptables", ipset: ciliumNodeIpsetV4}
-	ip6tables = &ipt{prog: "ip6tables", ipset: ciliumNodeIpsetV6}
+	ip4tables = &ipt{prog: "iptables", ipset: CiliumNodeIpsetV4}
+	ip6tables = &ipt{prog: "ip6tables", ipset: CiliumNodeIpsetV6}
 	ipset     = &ipt{prog: "ipset"}
 )
 
@@ -1158,9 +1158,9 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 // or the IP already exist.
 func (m *IptablesManager) AddToNodeIpset(nodeIP net.IP) {
 	scopedLog := log.WithField(logfields.IPAddr, nodeIP.String())
-	ciliumNodeIpset := ciliumNodeIpsetV4
+	ciliumNodeIpset := CiliumNodeIpsetV4
 	if ip.IsIPv6(nodeIP) {
-		ciliumNodeIpset = ciliumNodeIpsetV6
+		ciliumNodeIpset = CiliumNodeIpsetV6
 	}
 	if err := createIpset(ciliumNodeIpset, ip.IsIPv6(nodeIP)); err != nil {
 		scopedLog.WithError(err).Errorf("Failed to create ipset %s", ciliumNodeIpset)
@@ -1175,9 +1175,9 @@ func (m *IptablesManager) AddToNodeIpset(nodeIP net.IP) {
 // RemoveFromBodeIpset removes an IP address from the ipset for cluster nodes.
 func (m *IptablesManager) RemoveFromNodeIpset(nodeIP net.IP) {
 	scopedLog := log.WithField(logfields.IPAddr, nodeIP.String())
-	ciliumNodeIpset := ciliumNodeIpsetV4
+	ciliumNodeIpset := CiliumNodeIpsetV4
 	if ip.IsIPv6(nodeIP) {
-		ciliumNodeIpset = ciliumNodeIpsetV6
+		ciliumNodeIpset = CiliumNodeIpsetV6
 	}
 	progArgs := []string{"del", ciliumNodeIpset, nodeIP.String()}
 	if err := ipset.runProg(progArgs); err != nil {
@@ -1477,20 +1477,20 @@ func (m *IptablesManager) doInstallRules(ifName string, firstInitialization, ins
 	// needed depends on the configuration, but the content doesn't.
 	if option.Config.NodeIpsetNeeded() {
 		if option.Config.IptablesMasqueradingIPv4Enabled() {
-			if err := createIpset(ciliumNodeIpsetV4, false); err != nil {
+			if err := createIpset(CiliumNodeIpsetV4, false); err != nil {
 				return err
 			}
 		}
 		if option.Config.IptablesMasqueradingIPv6Enabled() {
-			if err := createIpset(ciliumNodeIpsetV6, true); err != nil {
+			if err := createIpset(CiliumNodeIpsetV6, true); err != nil {
 				return err
 			}
 		}
 	} else {
-		if err := removeIpset(ciliumNodeIpsetV4); err != nil {
+		if err := removeIpset(CiliumNodeIpsetV4); err != nil {
 			return err
 		}
-		if err := removeIpset(ciliumNodeIpsetV6); err != nil {
+		if err := removeIpset(CiliumNodeIpsetV6); err != nil {
 			return err
 		}
 	}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -73,6 +73,7 @@ type Configuration interface {
 	TunnelingEnabled() bool
 	RemoteNodeIdentitiesEnabled() bool
 	NodeEncryptionEnabled() bool
+	NodeIpsetNeeded() bool
 }
 
 var _ Notifier = (*manager)(nil)
@@ -430,7 +431,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 	var nodeIPsAdded, healthIPsAdded, ingressIPsAdded []netip.Prefix
 
 	for _, address := range n.IPAddresses {
-		if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
+		if m.conf.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
 			m.ipsetMgr.AddToNodeIpset(address.IP)
 		}
 
@@ -572,7 +573,7 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 			continue
 		}
 
-		if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
+		if m.conf.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
 			m.ipsetMgr.RemoveFromNodeIpset(address.IP)
 		}
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -428,11 +428,15 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 	resource := ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindNode, "", n.Name)
 	nodeLabels, nodeIdentityOverride := m.nodeIdentityLabels(n)
 
+	var ipsetEntries []netip.Prefix
 	var nodeIPsAdded, healthIPsAdded, ingressIPsAdded []netip.Prefix
 
 	for _, address := range n.IPAddresses {
+		prefix := ip.IPToNetPrefix(address.IP)
+
 		if m.conf.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
 			m.ipsetMgr.AddToNodeIpset(address.IP)
+			ipsetEntries = append(ipsetEntries, prefix)
 		}
 
 		if m.nodeAddressSkipsIPCache(address) {
@@ -449,7 +453,6 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 			key = n.EncryptionKey
 		}
 
-		prefix := ip.IPToNetPrefix(address.IP)
 		// We expect the node manager to have a source of either Kubernetes,
 		// CustomResource, or KVStore. Prioritize the KVStore source over the
 		// rest as it is the strongest source, i.e. only trigger datapath
@@ -532,7 +535,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 			})
 		}
 
-		m.removeNodeFromIPCache(oldNode, resource, nodeIPsAdded, healthIPsAdded, ingressIPsAdded)
+		m.removeNodeFromIPCache(oldNode, resource, ipsetEntries, nodeIPsAdded, healthIPsAdded, ingressIPsAdded)
 
 		entry.mutex.Unlock()
 	} else {
@@ -554,10 +557,11 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 
 // removeNodeFromIPCache removes all addresses associated with oldNode from the IPCache,
 // unless they are present in the nodeIPsAdded, healthIPsAdded, ingressIPsAdded lists.
+// Removes ipset entry associated with oldNode if it is not present in ipsetEntries.
 //
 // The removal logic in this function should mirror the upsert logic in NodeUpdated.
 func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcacheTypes.ResourceID,
-	nodeIPsAdded, healthIPsAdded, ingressIPsAdded []netip.Prefix) {
+	ipsetEntries, nodeIPsAdded, healthIPsAdded, ingressIPsAdded []netip.Prefix) {
 
 	var oldNodeIP netip.Addr
 	if nIP := oldNode.GetNodeIP(false); nIP != nil {
@@ -573,7 +577,8 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 			continue
 		}
 
-		if m.conf.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
+		if m.conf.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP &&
+			!slices.Contains(ipsetEntries, oldPrefix) {
 			m.ipsetMgr.RemoveFromNodeIpset(address.IP)
 		}
 
@@ -668,7 +673,7 @@ func (m *manager) NodeDeleted(n nodeTypes.Node) {
 		return
 	}
 
-	m.removeNodeFromIPCache(entry.node, resource, nil, nil, nil)
+	m.removeNodeFromIPCache(entry.node, resource, nil, nil, nil, nil)
 
 	m.metrics.NumNodes.Dec()
 	m.metrics.ProcessNodeDeletion(n.Cluster, n.Name)

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/controller"
-	"github.com/cilium/cilium/pkg/datapath/iptables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity"
@@ -120,6 +119,9 @@ type manager struct {
 
 	// ipcache is the set operations performed against the ipcache
 	ipcache IPCache
+
+	// ipsetMgr is the ipset cluster nodes configuration manager
+	ipsetMgr ipsetManager
 
 	// controllerManager manages the controllers that are launched within the
 	// Manager.
@@ -226,13 +228,14 @@ func NewNodeMetrics() *nodeMetrics {
 }
 
 // New returns a new node manager
-func New(c Configuration, ipCache IPCache, nodeMetrics *nodeMetrics) (*manager, error) {
+func New(c Configuration, ipCache IPCache, ipsetMgr ipsetManager, nodeMetrics *nodeMetrics) (*manager, error) {
 	m := &manager{
 		nodes:             map[nodeTypes.Identity]*nodeEntry{},
 		conf:              c,
 		controllerManager: controller.NewManager(),
 		nodeHandlers:      map[datapath.NodeHandler]struct{}{},
 		ipcache:           ipCache,
+		ipsetMgr:          ipsetMgr,
 		metrics:           nodeMetrics,
 	}
 
@@ -428,7 +431,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 
 	for _, address := range n.IPAddresses {
 		if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
-			iptables.AddToNodeIpset(address.IP)
+			m.ipsetMgr.AddToNodeIpset(address.IP)
 		}
 
 		if m.nodeAddressSkipsIPCache(address) {
@@ -570,7 +573,7 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 		}
 
 		if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
-			iptables.RemoveFromNodeIpset(address.IP)
+			m.ipsetMgr.RemoveFromNodeIpset(address.IP)
 		}
 
 		if m.nodeAddressSkipsIPCache(address) {

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -924,12 +924,6 @@ func (s *managerTestSuite) TestNodeIpset(c *check.C) {
 		// manager (see NodeIpsetNeeded()).
 		Tunneling:            false,
 		EnableIPv4Masquerade: true,
-		// RemoteNodeIdentity is enabled to make sure we don't skip the
-		// ipcache update in NodeUpdated(), and in particular, the
-		// update to nodeIpsAdded. If we skip that part, and an old
-		// node existed, then Nodeupdated() will remove the ipset entry
-		// it just added when calling removenodeFromIPCache().
-		RemoteNodeIdentity: true,
 	}, newIPcacheMock(), newIPSetMock(), NewNodeMetrics())
 	mngr.Subscribe(dp)
 	c.Assert(err, check.IsNil)

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -14,11 +14,14 @@ import (
 	"time"
 
 	check "github.com/cilium/checkmate"
+	"golang.org/x/exp/slices"
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/datapath/fake"
+	"github.com/cilium/cilium/pkg/datapath/iptables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/inctimer"
+	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
@@ -41,6 +44,9 @@ type configMock struct {
 	RemoteNodeIdentity bool
 	NodeEncryption     bool
 	Encryption         bool
+
+	EnableIPv4Masquerade bool
+	EnableIPv6Masquerade bool
 }
 
 func (c *configMock) TunnelingEnabled() bool {
@@ -57,6 +63,10 @@ func (c *configMock) NodeEncryptionEnabled() bool {
 
 func (c *configMock) EncryptionEnabled() bool {
 	return c.Encryption
+}
+
+func (c *configMock) NodeIpsetNeeded() bool {
+	return !c.Tunneling && (c.EnableIPv4Masquerade || c.EnableIPv6Masquerade)
 }
 
 type nodeEvent struct {
@@ -125,14 +135,55 @@ func (i *ipcacheMock) RemoveIdentityOverride(prefix netip.Prefix, identityLabels
 	i.Delete(prefix.String(), source.CustomResource)
 }
 
-type ipsetMock struct{}
+type ipsetMock struct {
+	v4 []string
+	v6 []string
+}
 
 func newIPSetMock() *ipsetMock {
 	return &ipsetMock{}
 }
 
-func (i *ipsetMock) AddToNodeIpset(nodeIP net.IP)      {}
-func (i *ipsetMock) RemoveFromNodeIpset(nodeIP net.IP) {}
+func (i *ipsetMock) AddToNodeIpset(nodeIP net.IP) {
+	entry := nodeIP.String()
+	if ip.IsIPv6(nodeIP) {
+		if slices.Contains(i.v6, entry) {
+			return
+		}
+		i.v6 = append(i.v6, strings.ToLower(entry))
+	} else {
+		if slices.Contains(i.v4, entry) {
+			return
+		}
+		i.v4 = append(i.v4, entry)
+	}
+}
+
+func (i *ipsetMock) RemoveFromNodeIpset(nodeIP net.IP) {
+	entry := nodeIP.String()
+	if ip.IsIPv6(nodeIP) {
+		idx := slices.Index(i.v6, entry)
+		if idx != -1 {
+			i.v6 = slices.Delete(i.v6, idx, idx+1)
+		}
+	} else {
+		idx := slices.Index(i.v4, entry)
+		if idx != -1 {
+			i.v4 = slices.Delete(i.v4, idx, idx+1)
+		}
+	}
+}
+
+func ipsetContains(ipsetMgr *ipsetMock, setName string, nodeIP string) (bool, error) {
+	switch setName {
+	case iptables.CiliumNodeIpsetV4:
+		return slices.Index(ipsetMgr.v4, nodeIP) != -1, nil
+	case iptables.CiliumNodeIpsetV6:
+		return slices.Index(ipsetMgr.v6, nodeIP) != -1, nil
+	default:
+		return false, fmt.Errorf("unexpected ipset name %s", setName)
+	}
+}
 
 type signalNodeHandler struct {
 	EnableNodeAddEvent                    bool
@@ -840,4 +891,126 @@ func (s *managerTestSuite) TestNode(c *check.C) {
 	c.Assert(ok, check.Equals, true)
 	// Needs to be the same as n2
 	c.Assert(n, checker.DeepEquals, *n1V2)
+}
+
+// TestNodeIpset tests that the ipset entries on the node are updated correctly
+// when a node is updated or removed.
+// It is inspired from TestNode() in manager_test.go.
+func (s *managerTestSuite) TestNodeIpset(c *check.C) {
+	ipsetExpect := func(ipsetMgr *ipsetMock, ip string, expected bool) {
+		setName := iptables.CiliumNodeIpsetV6
+		if v4 := net.ParseIP(ip).To4(); v4 != nil {
+			setName = iptables.CiliumNodeIpsetV4
+		}
+
+		found, err := ipsetContains(ipsetMgr, setName, strings.ToLower(ip))
+		c.Assert(err, check.IsNil)
+
+		if found && !expected {
+			c.Errorf("ipset %s contains IP %s but it should not", setName, ip)
+		}
+		if !found && expected {
+			c.Errorf("ipset %s does not contain expected IP %s", setName, ip)
+		}
+	}
+
+	dp := newSignalNodeHandler()
+	dp.EnableNodeAddEvent = true
+	dp.EnableNodeUpdateEvent = true
+	dp.EnableNodeDeleteEvent = true
+	mngr, err := New(&configMock{
+		// Tunneling and EnableIPv4Masquerade are disabled and enabled,
+		// respectively, to make sure we update the ipset in the
+		// manager (see NodeIpsetNeeded()).
+		Tunneling:            false,
+		EnableIPv4Masquerade: true,
+		// RemoteNodeIdentity is enabled to make sure we don't skip the
+		// ipcache update in NodeUpdated(), and in particular, the
+		// update to nodeIpsAdded. If we skip that part, and an old
+		// node existed, then Nodeupdated() will remove the ipset entry
+		// it just added when calling removenodeFromIPCache().
+		RemoteNodeIdentity: true,
+	}, newIPcacheMock(), newIPSetMock(), NewNodeMetrics())
+	mngr.Subscribe(dp)
+	c.Assert(err, check.IsNil)
+	defer mngr.Stop(context.TODO())
+
+	n1 := nodeTypes.Node{
+		Name:    "node1",
+		Cluster: "c1",
+		IPAddresses: []nodeTypes.Address{
+			{
+				Type: addressing.NodeCiliumInternalIP,
+				IP:   net.ParseIP("192.0.2.1"),
+			},
+			{
+				Type: addressing.NodeCiliumInternalIP,
+				IP:   net.ParseIP("2001:DB8::1"),
+			},
+			{
+				Type: addressing.NodeInternalIP,
+				IP:   net.ParseIP("10.0.0.1"),
+			},
+			{
+				Type: addressing.NodeInternalIP,
+				IP:   net.ParseIP("2001:ABCD::1"),
+			},
+		},
+		IPv4HealthIP: net.ParseIP("192.0.2.2"),
+		IPv6HealthIP: net.ParseIP("2001:DB8::2"),
+		Source:       source.KVStore,
+	}
+	mngr.NodeUpdated(n1)
+
+	select {
+	case nodeEvent := <-dp.NodeAddEvent:
+		c.Assert(nodeEvent, checker.DeepEquals, n1)
+	case nodeEvent := <-dp.NodeUpdateEvent:
+		c.Errorf("Unexpected NodeUpdate() event %#v", nodeEvent)
+	case nodeEvent := <-dp.NodeDeleteEvent:
+		c.Errorf("Unexpected NodeDelete() event %#v", nodeEvent)
+	case <-time.After(3 * time.Second):
+		c.Errorf("timeout while waiting for NodeAdd() event")
+	}
+
+	ipsetExpect(mngr.ipsetMgr.(*ipsetMock), "192.0.2.1", false)
+	ipsetExpect(mngr.ipsetMgr.(*ipsetMock), "2001:DB8::1", false)
+	ipsetExpect(mngr.ipsetMgr.(*ipsetMock), "10.0.0.1", true)
+	ipsetExpect(mngr.ipsetMgr.(*ipsetMock), "2001:ABCD::1", true)
+
+	n1.IPv4HealthIP = net.ParseIP("192.0.2.20")
+	mngr.NodeUpdated(n1)
+
+	select {
+	case nodeEvent := <-dp.NodeAddEvent:
+		c.Errorf("Unexpected NodeAdd() event %#v", nodeEvent)
+	case nodeEvent := <-dp.NodeUpdateEvent:
+		c.Assert(nodeEvent, checker.DeepEquals, n1)
+	case nodeEvent := <-dp.NodeDeleteEvent:
+		c.Errorf("Unexpected NodeDelete() event %#v", nodeEvent)
+	case <-time.After(3 * time.Second):
+		c.Errorf("timeout while waiting for NodeUpdate() event")
+	}
+
+	ipsetExpect(mngr.ipsetMgr.(*ipsetMock), "192.0.2.1", false)
+	ipsetExpect(mngr.ipsetMgr.(*ipsetMock), "2001:DB8::1", false)
+	ipsetExpect(mngr.ipsetMgr.(*ipsetMock), "10.0.0.1", true)
+	ipsetExpect(mngr.ipsetMgr.(*ipsetMock), "2001:ABCD::1", true)
+
+	mngr.NodeDeleted(n1)
+	select {
+	case nodeEvent := <-dp.NodeDeleteEvent:
+		c.Assert(nodeEvent, checker.DeepEquals, n1)
+	case nodeEvent := <-dp.NodeAddEvent:
+		c.Errorf("Unexpected NodeAdd() event %#v", nodeEvent)
+	case nodeEvent := <-dp.NodeUpdateEvent:
+		c.Errorf("Unexpected NodeUpdate() event %#v", nodeEvent)
+	case <-time.After(3 * time.Second):
+		c.Errorf("timeout while waiting for NodeDelete() event")
+	}
+
+	ipsetExpect(mngr.ipsetMgr.(*ipsetMock), "192.0.2.1", false)
+	ipsetExpect(mngr.ipsetMgr.(*ipsetMock), "2001:DB8::1", false)
+	ipsetExpect(mngr.ipsetMgr.(*ipsetMock), "10.0.0.1", false)
+	ipsetExpect(mngr.ipsetMgr.(*ipsetMock), "2001:ABCD::1", false)
 }

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -125,6 +125,15 @@ func (i *ipcacheMock) RemoveIdentityOverride(prefix netip.Prefix, identityLabels
 	i.Delete(prefix.String(), source.CustomResource)
 }
 
+type ipsetMock struct{}
+
+func newIPSetMock() *ipsetMock {
+	return &ipsetMock{}
+}
+
+func (i *ipsetMock) AddToNodeIpset(nodeIP net.IP)      {}
+func (i *ipsetMock) RemoveFromNodeIpset(nodeIP net.IP) {}
+
 type signalNodeHandler struct {
 	EnableNodeAddEvent                    bool
 	NodeAddEvent                          chan nodeTypes.Node
@@ -197,7 +206,7 @@ func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics())
+	mngr, err := New(&configMock{}, ipcacheMock, newIPSetMock(), NewNodeMetrics())
 	mngr.Subscribe(dp)
 	c.Assert(err, check.IsNil)
 
@@ -269,7 +278,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics())
+	mngr, err := New(&configMock{}, ipcacheMock, newIPSetMock(), NewNodeMetrics())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -351,7 +360,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := fake.NewNodeHandler()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics())
+	mngr, err := New(&configMock{}, ipcacheMock, newIPSetMock(), NewNodeMetrics())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -372,7 +381,7 @@ func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 func (s *managerTestSuite) TestClusterSizeDependantInterval(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := fake.NewNodeHandler()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics())
+	mngr, err := New(&configMock{}, ipcacheMock, newIPSetMock(), NewNodeMetrics())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -404,7 +413,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 	signalNodeHandler := newSignalNodeHandler()
 	signalNodeHandler.EnableNodeValidateImplementationEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics())
+	mngr, err := New(&configMock{}, ipcacheMock, newIPSetMock(), NewNodeMetrics())
 	mngr.Subscribe(signalNodeHandler)
 	c.Assert(err, check.IsNil)
 	defer mngr.Stop(context.TODO())
@@ -448,7 +457,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 func (s *managerTestSuite) TestIpcache(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics())
+	mngr, err := New(&configMock{}, ipcacheMock, newIPSetMock(), NewNodeMetrics())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -496,7 +505,7 @@ func (s *managerTestSuite) TestIpcache(c *check.C) {
 func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics())
+	mngr, err := New(&configMock{}, ipcacheMock, newIPSetMock(), NewNodeMetrics())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -572,7 +581,7 @@ func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New(&configMock{RemoteNodeIdentity: true}, ipcacheMock, NewNodeMetrics())
+	mngr, err := New(&configMock{RemoteNodeIdentity: true}, ipcacheMock, newIPSetMock(), NewNodeMetrics())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -648,7 +657,7 @@ func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New(&configMock{NodeEncryption: true, Encryption: true}, ipcacheMock, NewNodeMetrics())
+	mngr, err := New(&configMock{NodeEncryption: true, Encryption: true}, ipcacheMock, newIPSetMock(), NewNodeMetrics())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -743,7 +752,7 @@ func (s *managerTestSuite) TestNode(c *check.C) {
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics())
+	mngr, err := New(&configMock{}, ipcacheMock, newIPSetMock(), NewNodeMetrics())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())

--- a/pkg/option/fake/config.go
+++ b/pkg/option/fake/config.go
@@ -32,6 +32,12 @@ func (f *Config) EncryptionEnabled() bool {
 	return true
 }
 
+// NodeIpsetNeeded returns true if masquerading rules require entries to be
+// added to an ipset for this node
+func (f *Config) NodeIpsetNeeded() bool {
+	return false
+}
+
 // NodeEncryptionEnabled returns true if node encryption is enabled
 func (f *Config) NodeEncryptionEnabled() bool {
 	return true


### PR DESCRIPTION
 * [x] #28746 (@pippolo84)
 * [x] #29986 (@qmonnet)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
28746 29986
```
