### PR TITLE
[1.14] loader: fix obsolete XDP program removal

### DIFF
--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -200,7 +200,7 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 	for _, prog := range progs {
 		scopedLog := l.WithField("progName", prog.progName).WithField("direction", prog.direction)
 		scopedLog.Debug("Attaching program to interface")
-		if err := attachProgram(link, coll.Programs[prog.progName], prog.progName, directionToParent(prog.direction), xdpModeToFlag(xdpMode)); err != nil {
+		if err := attachProgram(link, coll.Programs[prog.progName], prog.progName, directionToParent(prog.direction), xdpConfigModeToFlag(xdpMode)); err != nil {
 			revert()
 			return nil, fmt.Errorf("program %s: %w", prog.progName, err)
 		}

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -257,7 +258,7 @@ func resolveAndInsertCalls(coll *ebpf.Collection, mapName string, calls []ebpf.M
 
 // attachProgram attaches prog to link.
 // If xdpFlags is non-zero, attaches prog to XDP.
-func attachProgram(link netlink.Link, prog *ebpf.Program, progName string, qdiscParent uint32, xdpFlags uint32) error {
+func attachProgram(link netlink.Link, prog *ebpf.Program, progName string, qdiscParent uint32, xdpFlags link.XDPAttachFlags) error {
 	if prog == nil {
 		return errors.New("cannot attach a nil program")
 	}

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -22,11 +22,32 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 )
 
-func xdpModeToFlag(xdpMode string) link.XDPAttachFlags {
+func xdpConfigModeToFlag(xdpMode string) link.XDPAttachFlags {
 	switch xdpMode {
 	case option.XDPModeNative, option.XDPModeLinkDriver:
 		return link.XDPDriverMode
 	case option.XDPModeGeneric, option.XDPModeLinkGeneric:
+		return link.XDPGenericMode
+	}
+	return 0
+}
+
+// These constant values are returned by the kernel when querying the XDP program attach mode.
+// Important: they differ from constants that are used when attaching an XDP program to a netlink device.
+const (
+	XDPAttachedNone uint32 = iota
+	XDPAttachedDriver
+	XDPAttachedGeneric
+)
+
+// xdpAttachedModeToFlag maps the attach mode that is returned in the metadata when
+// querying netlink devices to the attach flags that were used to configure the
+// xdp program attachement.
+func xdpAttachedModeToFlag(mode uint32) link.XDPAttachFlags {
+	switch mode {
+	case XDPAttachedDriver:
+		return link.XDPDriverMode
+	case XDPAttachedGeneric:
 		return link.XDPGenericMode
 	}
 	return 0
@@ -53,7 +74,7 @@ func maybeUnloadObsoleteXDPPrograms(xdpDevs []string, xdpMode string) {
 		used := false
 		for _, xdpDev := range xdpDevs {
 			if link.Attrs().Name == xdpDev &&
-				linkxdp.AttachMode == uint32(xdpModeToFlag(xdpMode)) {
+				xdpAttachedModeToFlag(linkxdp.AttachMode) == xdpConfigModeToFlag(xdpMode) {
 				// XDP mode matches; don't unload, otherwise we might introduce
 				// intermittent connectivity problems
 				used = true
@@ -61,8 +82,8 @@ func maybeUnloadObsoleteXDPPrograms(xdpDevs []string, xdpMode string) {
 			}
 		}
 		if !used {
-			netlink.LinkSetXdpFdWithFlags(link, -1, int(xdpModeToFlag(option.XDPModeLinkGeneric)))
-			netlink.LinkSetXdpFdWithFlags(link, -1, int(xdpModeToFlag(option.XDPModeLinkDriver)))
+			netlink.LinkSetXdpFdWithFlags(link, -1, int(xdpConfigModeToFlag(option.XDPModeLinkGeneric)))
+			netlink.LinkSetXdpFdWithFlags(link, -1, int(xdpConfigModeToFlag(option.XDPModeLinkDriver)))
 		}
 	}
 }

--- a/pkg/datapath/loader/xdp_test.go
+++ b/pkg/datapath/loader/xdp_test.go
@@ -65,13 +65,13 @@ func TestMaybeUnloadObsoleteXDPPrograms(t *testing.T) {
 
 		prog := mustXDPProgram(t)
 
-		err = attachProgram(veth0, prog, "test", 0, xdpModeToFlag(option.XDPModeLinkGeneric))
+		err = attachProgram(veth0, prog, "test", 0, xdpConfigModeToFlag(option.XDPModeLinkDriver))
 		require.NoError(t, err)
 
-		err = attachProgram(veth1, prog, "test", 0, xdpModeToFlag(option.XDPModeLinkGeneric))
+		err = attachProgram(veth1, prog, "test", 0, xdpConfigModeToFlag(option.XDPModeLinkDriver))
 		require.NoError(t, err)
 
-		maybeUnloadObsoleteXDPPrograms([]string{"veth0"}, option.XDPModeLinkGeneric)
+		maybeUnloadObsoleteXDPPrograms([]string{"veth0"}, option.XDPModeLinkDriver)
 
 		v0, err := netlink.LinkByName("veth0")
 		require.NoError(t, err)


### PR DESCRIPTION
This is a manual backport of #30163. 
Additionally, I had to backport https://github.com/cilium/cilium/commit/de46ed8a6ff22b287658c05b8207a02444554b8c because the upstream PR depends on it.