### PR TITLE
 endpoint: pause policymap-sync controller during regeneration 

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1435,6 +1435,11 @@ func (e *Endpoint) startSyncPolicyMapController() {
 					return controller.NewExitReason("Endpoint disappeared")
 				}
 				defer e.unlock()
+				if e.desiredPolicy != e.realizedPolicy {
+					// Currently in the middle of a regeneration; do not execute
+					// at this time.
+					return nil
+				}
 				return e.syncPolicyMapWithDump()
 			},
 			RunInterval: option.Config.PolicyMapFullReconciliationInterval,

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -259,7 +259,6 @@ const (
 	etcdTimeout                = "etcd client timeout exceeded"                                            // cf. https://github.com/cilium/cilium/issues/29714
 	endpointRestoreFailed      = "Unable to restore endpoint, ignoring"                                    // cf. https://github.com/cilium/cilium/issues/29716
 	failedPeerSync             = "Failed to create peer client for peers synchronization"                  // cf. https://github.com/cilium/cilium/issues/29726
-	policyMapSyncFix           = "Policy map sync fixed errors"                                            // cf. https://github.com/cilium/cilium/issues/29727
 	unableRestoreRouterIP      = "Unable to restore router IP from filesystem"                             // cf. https://github.com/cilium/cilium/issues/29715
 	routerIPReallocated        = "Router IP could not be re-allocated"                                     // cf. https://github.com/cilium/cilium/issues/29715
 	cantFindIdentityInCache    = "unable to release identity: unable to find key in local cache"           // cf. https://github.com/cilium/cilium/issues/29732
@@ -340,7 +339,7 @@ var badLogMessages = map[string][]string{
 		podCIDRUnavailable, wipEnvoyFeature, unableGetNode,
 		disableSocketLBTracing, sessionAffinitySocketLB, objectHasBeenModified, noBackendResponse,
 		unsupportedSocketLookup, legacyBGPFeature, etcdTimeout, endpointRestoreFailed,
-		failedPeerSync, policyMapSyncFix, unableRestoreRouterIP, routerIPReallocated,
+		failedPeerSync, unableRestoreRouterIP, routerIPReallocated,
 		cantFindIdentityInCache, kubeApiserverConnLost1, kubeApiserverConnLost2, heartbeatTimedOut,
 		keyAllocFailedFoundMaster, cantRecreateMasterKey, cantUpdateCRDIdentity,
 		cantDeleteFromPolicyMap},


### PR DESCRIPTION
During regeneration, we don't consistently hold the endpoint lock. This
leaves some windows wherein an updated policy may be partially applied.
as a side effect, the periodic policymap-sync reconciler occasionally
complains (rather rudely) about benign inconsistencies. (This warning
shows up in the logs and can cause CI failures).

So, don't run the controller while we're in a half-applied state. This
state will be quickly resolved, so the controller should succeed on the
next round. Additionally, regeneration performs the equivalent
synchronization *anyways*, so we're not actually missing a
synchronization.

Fixes: #29727