### PR TITLE
doc: Add Egress Gateway Policy warning

### DIFF
--- a/Documentation/network/egress-gateway.rst
+++ b/Documentation/network/egress-gateway.rst
@@ -278,6 +278,10 @@ Regardless of which way the egress IP is configured, the user must ensure that
 Cilium is running on the device that has the egress IP assigned to it, by
 setting the ``--devices`` agent option accordingly.
 
+.. warning::
+
+   The ``egressIP`` and ``interface`` properties cannot both be specified in the ``egressGateway`` spec. Egress Gateway Policies that contain both of these properties will be ignored by Cilium.
+           
 Example policy
 --------------
 


### PR DESCRIPTION
This commit adds a warning to the Egress Gateway documentation to help user avoid deploying a known bad configuration.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
docs: Add Egress Gateway Policy warning on `egressIP` and `interface` being mutually exclusive in the `egressGateway` spec.
```
