### PR TITLE
v1.12: workflow/ipsec-e2e: bump CLI to v0.15.19

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -52,7 +52,7 @@ concurrency:
 
 env:
   # renovate: datasource=github-releases depName=cilium/cilium-cli
-  cilium_cli_version: v0.15.17
+  cilium_cli_version: v0.15.19
   cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -210,7 +210,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Cilium CLI-cli
-        uses: cilium/cilium-cli@5362f383942260c0aed4f3876e09c3452435577a # v0.14.8
+        uses: cilium/cilium-cli@32109b32259a487c803648a3c9463cdcafa4c0c3 # v0.15.19
         with:
           release-version: ${{ env.cilium_cli_version }}
           ci-version: ${{ env.cilium_cli_ci_version }}


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/30146 already bumped the CLI to v0.15.19 for several workflows of v1.12. For some reason, I skipped the update for the IPsec end-to-end test, even though we need this to be able to skip a bunch of expected packet drops and XFRM errors.

This pull request therefore bumps the CLI to v0.15.19 for that workflow.