### PR TITLE
If source address is remote node then we should treat it as ouside traffic.

### DIFF
--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -133,6 +133,12 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 	if (!src || !identity_is_cluster(src->sec_identity))
 		goto out;
 
+	/* If source is remote node we should treat it like outside traffic.
+	 * This is possible when connection is done from pod to load balancer with DSR enabled.
+	 */
+	if (identity_is_remote_node(src->sec_identity))
+		goto out;
+
 	/* Redirect to the WireGuard tunnel device if the encryption is
 	 * required.
 	 */


### PR DESCRIPTION
If source address is remote node then we should treat it as ouside traffic. In other way traffic will be dropped by wireguard. And such traffic may exist in case some pod will connect to load balancer's external address with DSR enabled.

Fixes: #28492
