### PR TITLE
bpf: lxc: remove CB_FROM_TUNNEL upgrade toleration for IPv6

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1632,11 +1632,7 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 	ctx_store_meta(ctx, CB_FROM_HOST, 0);
 
 #ifdef HAVE_ENCAP
-	/* TODO use CB_FROM_TUNNEL on v1.16, when we can trust that all
-	 * callers populate it (even after downgrade).
-	 */
-	/* from_tunnel = ctx_load_meta(ctx, CB_FROM_TUNNEL); */
-	from_tunnel = true;
+	from_tunnel = ctx_load_meta(ctx, CB_FROM_TUNNEL);
 	ctx_store_meta(ctx, CB_FROM_TUNNEL, 0);
 #endif
 


### PR DESCRIPTION
This workaround was added by https://github.com/cilium/cilium/pull/29304 to deal with up-/downgrade troubles between v1.14 and v1.15.

As the comment says, we can now remove this workaround for the 1.16 devel cycle.