### PR TITLE
statedb: Derive, Observable and Map

### DIFF
--- a/pkg/statedb/db.go
+++ b/pkg/statedb/db.go
@@ -150,11 +150,11 @@ func (db *DB) registerTable(table TableMeta, txn *iradix.Txn[tableEntry]) error 
 	entry.meta = table
 	entry.deleteTrackers = iradix.New[deleteTracker]()
 	indexTxn := iradix.New[indexEntry]().Txn()
-	indexTxn.Insert([]byte(table.primaryIndexer().name), indexEntry{iradix.New[object](), true})
+	indexTxn.Insert([]byte(table.primary().name), indexEntry{iradix.New[object](), true})
 	indexTxn.Insert([]byte(RevisionIndex), indexEntry{iradix.New[object](), true})
 	indexTxn.Insert([]byte(GraveyardIndex), indexEntry{iradix.New[object](), true})
 	indexTxn.Insert([]byte(GraveyardRevisionIndex), indexEntry{iradix.New[object](), true})
-	for index, indexer := range table.secondaryIndexers() {
+	for index, indexer := range table.secondary() {
 		indexTxn.Insert([]byte(index), indexEntry{iradix.New[object](), indexer.unique})
 	}
 	entry.indexes = indexTxn.CommitOnly()

--- a/pkg/statedb/derive.go
+++ b/pkg/statedb/derive.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+)
+
+type DeriveResult int
+
+const (
+	DeriveInsert DeriveResult = 0 // Insert the object
+	DeriveUpdate DeriveResult = 1 // Update the object (if it exists)
+	DeriveDelete DeriveResult = 2 // Delete the object
+	DeriveSkip   DeriveResult = 3 // Skip
+)
+
+type DeriveParams[In, Out any] struct {
+	cell.In
+
+	Lifecycle hive.Lifecycle
+	Jobs      job.Registry
+	Scope     cell.Scope
+	DB        *DB
+	InTable   Table[In]
+	OutTable  RWTable[Out]
+}
+
+// Derive constructs and registers a job to transform objects from the input table to the
+// output table, e.g. derive the output table from the input table. Useful when constructing
+// a reconciler that has its desired state solely derived from a single table. For example
+// the bandwidth manager's desired state is directly derived from the devices table.
+//
+// Derive is parametrized with the transform function that transforms the input object
+// into the output object. If the transform function returns false, then the object
+// is skipped.
+//
+// Example use:
+//
+//	cell.Invoke(
+//	  statedb.Derive[*tables.Device, *Foo](
+//	    func(d *Device, deleted bool) (*Foo, DeriveResult) {
+//	      if deleted {
+//	        return &Foo{Index: d.Index}, DeriveDelete
+//	      }
+//	      return &Foo{Index: d.Index}, DeriveInsert
+//	    }),
+//	)
+func Derive[In, Out any](jobName string, transform func(obj In, deleted bool) (Out, DeriveResult)) func(DeriveParams[In, Out]) {
+	return func(p DeriveParams[In, Out]) {
+		g := p.Jobs.NewGroup(p.Scope)
+		g.Add(job.OneShot(
+			jobName,
+			derive[In, Out]{p, jobName, transform}.loop),
+		)
+		p.Lifecycle.Append(g)
+	}
+
+}
+
+type derive[In, Out any] struct {
+	DeriveParams[In, Out]
+	jobName   string
+	transform func(obj In, deleted bool) (Out, DeriveResult)
+}
+
+func (d derive[In, Out]) loop(ctx context.Context, health cell.HealthReporter) error {
+	out := d.OutTable
+	wtxn := d.DB.WriteTxn(d.InTable)
+	tracker, err := d.InTable.DeleteTracker(wtxn, d.jobName)
+	if err != nil {
+		wtxn.Abort()
+		return err
+	}
+	wtxn.Commit()
+	defer tracker.Close()
+	revision := Revision(0)
+	for {
+		wtxn := d.DB.WriteTxn(out)
+
+		var watch <-chan struct{}
+		revision, watch, err = tracker.Process(
+			wtxn,
+			revision,
+			func(obj In, deleted bool, rev Revision) (err error) {
+				outObj, result := d.transform(obj, deleted)
+				switch result {
+				case DeriveInsert:
+					_, _, err = out.Insert(wtxn, outObj)
+				case DeriveUpdate:
+					_, _, found := out.First(wtxn, out.PrimaryIndexer().QueryFromObject(outObj))
+					if found {
+						_, _, err = out.Insert(wtxn, outObj)
+					}
+				case DeriveDelete:
+					_, _, err = out.Delete(wtxn, outObj)
+				case DeriveSkip:
+				}
+				return err
+			},
+		)
+		wtxn.Commit()
+
+		if err != nil {
+			return err
+		}
+
+		select {
+		case <-watch:
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}

--- a/pkg/statedb/derive_test.go
+++ b/pkg/statedb/derive_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/statedb/index"
+)
+
+type derived struct {
+	ID      uint64
+	Deleted bool
+}
+
+var derivedIdIndex = Index[derived, uint64]{
+	Name: "id",
+	FromObject: func(t derived) index.KeySet {
+		return index.NewKeySet(index.Uint64(t.ID))
+	},
+	FromKey: index.Uint64,
+	Unique:  true,
+}
+
+func TestDerive(t *testing.T) {
+	var db *DB
+	inTable, err := NewTable[testObject]("test", idIndex)
+	require.NoError(t, err)
+	outTable, err := NewTable[derived]("derived", derivedIdIndex)
+	require.NoError(t, err)
+
+	transform := func(obj testObject, deleted bool) (derived, DeriveResult) {
+		t.Logf("transform(%v, %v)", obj, deleted)
+
+		if len(obj.Tags) > 0 && obj.Tags[0] == "skip" {
+			return derived{}, DeriveSkip
+		}
+		if deleted {
+			if len(obj.Tags) > 0 && obj.Tags[0] == "delete" {
+				return derived{ID: obj.ID}, DeriveDelete
+			}
+			return derived{ID: obj.ID, Deleted: true}, DeriveUpdate
+		}
+		return derived{ID: obj.ID, Deleted: false}, DeriveInsert
+	}
+
+	h := hive.New(
+		Cell, // DB
+		job.Cell,
+
+		cell.Module(
+			"test", "Test",
+
+			cell.Provide(func(db_ *DB) (Table[testObject], RWTable[derived], error) {
+				db = db_
+				if err := db.RegisterTable(inTable); err != nil {
+					return nil, nil, err
+				}
+				if err := db.RegisterTable(outTable); err != nil {
+					return nil, nil, err
+				}
+				return inTable, outTable, nil
+			}),
+
+			cell.Invoke(Derive[testObject, derived]("testObject-to-derived", transform)),
+		),
+	)
+	require.NoError(t, h.Start(context.TODO()), "Start")
+
+	getDerived := func() []derived {
+		txn := db.ReadTxn()
+		iter, _ := outTable.All(txn)
+		objs := Collect(iter)
+		// Log so we can trace the failed eventually calls
+		t.Logf("derived: %+v", objs)
+		return objs
+	}
+
+	// Insert 1, 2 and 3 (skipped) and validate.
+	wtxn := db.WriteTxn(inTable)
+	inTable.Insert(wtxn, testObject{ID: 1})
+	inTable.Insert(wtxn, testObject{ID: 2})
+	inTable.Insert(wtxn, testObject{ID: 3, Tags: []string{"skip"}})
+	wtxn.Commit()
+
+	require.Eventually(t,
+		func() bool {
+			objs := getDerived()
+			return len(objs) == 2 && // 3 is skipped
+				objs[0].ID == 1 && objs[1].ID == 2
+		},
+		time.Second,
+		10*time.Millisecond,
+		"expected 1 & 2 to be derived",
+	)
+
+	// Delete 2 (testing DeriveUpdate)
+	wtxn = db.WriteTxn(inTable)
+	inTable.Delete(wtxn, testObject{ID: 2})
+	wtxn.Commit()
+
+	require.Eventually(t,
+		func() bool {
+			objs := getDerived()
+			return len(objs) == 2 && // 3 is skipped
+				objs[0].ID == 1 && !objs[0].Deleted &&
+				objs[1].ID == 2 && objs[1].Deleted
+		},
+		time.Second,
+		10*time.Millisecond,
+		"expected 1 & 2, with 2 marked deleted",
+	)
+
+	// Delete 1 (testing DeriveDelete)
+	wtxn = db.WriteTxn(inTable)
+	inTable.Insert(wtxn, testObject{ID: 1, Tags: []string{"delete"}})
+	wtxn.Commit()
+	wtxn = db.WriteTxn(inTable)
+	inTable.Delete(wtxn, testObject{ID: 1})
+	wtxn.Commit()
+
+	require.Eventually(t,
+		func() bool {
+			objs := getDerived()
+			return len(objs) == 1 &&
+				objs[0].ID == 2 && objs[0].Deleted
+		},
+		time.Second,
+		10*time.Millisecond,
+		"expected 1 to be gone, and 2 mark deleted",
+	)
+
+	require.NoError(t, h.Stop(context.TODO()), "Stop")
+}

--- a/pkg/statedb/graveyard.go
+++ b/pkg/statedb/graveyard.go
@@ -90,7 +90,7 @@ func graveyardWorker(db *DB, ctx context.Context, gcRateLimitInterval time.Durat
 				if existed {
 					// The dead object still existed (and wasn't replaced by a create->delete),
 					// delete it from the primary index.
-					key = meta.primaryIndexer().fromObject(oldObj).First()
+					key = meta.primary().fromObject(oldObj).First()
 					txn.mustIndexWriteTxn(tableName, GraveyardIndex).txn.Delete(key)
 				}
 			}

--- a/pkg/statedb/index/keyset.go
+++ b/pkg/statedb/index/keyset.go
@@ -3,7 +3,9 @@
 
 package index
 
-import "bytes"
+import (
+	"bytes"
+)
 
 // Key is a byte slice describing a key used in an index by statedb.
 // If a key is variable-sized, then it must be either terminated with
@@ -15,56 +17,44 @@ import "bytes"
 // non-unique indexes which key on "secondary + primary" keys.
 type Key []byte
 
-// KeySet is a sequence of (length, byte slice) pairs.
-// length is encoded as 16-bit big-endian unsigned int.
-type KeySet struct {
-	buf []byte
+func (k Key) Equal(k2 Key) bool {
+	return bytes.Equal(k, k2)
 }
 
-func NewKeySet(keys ...Key) KeySet {
-	size := 2 * len(keys)
-	for _, k := range keys {
-		size += len(k)
-	}
-	ks := KeySet{make([]byte, 0, size)}
-	for _, k := range keys {
-		ks.Append(k)
-	}
-	return ks
+type KeySet struct {
+	head Key
+	tail []Key
 }
 
 func (ks KeySet) First() Key {
-	if len(ks.buf) < 2 {
-		return nil
-	}
-	length := uint16(ks.buf[0])<<8 | uint16(ks.buf[1])
-	return ks.buf[2 : 2+length]
-}
-
-func (ks *KeySet) Append(k Key) {
-	if len(k) > 2<<16 {
-		panic("keyset.Append: key too long, maximum is 64kB")
-	}
-	ks.buf = append(append(ks.buf, byte(len(k)>>8), byte(len(k)&0xff)), k...)
+	return ks.head
 }
 
 func (ks KeySet) Foreach(fn func(Key)) {
-	for len(ks.buf) >= 2 {
-		length := uint16(ks.buf[0])<<8 | uint16(ks.buf[1])
-		fn(append([]byte(nil), ks.buf[2:2+length]...))
-		ks.buf = ks.buf[2+length:]
+	if ks.head == nil {
+		return
+	}
+	fn(ks.head)
+	for _, k := range ks.tail {
+		fn(k)
 	}
 }
 
 func (ks KeySet) Exists(k Key) bool {
-	buf := ks.buf
-	for len(buf) >= 2 {
-		length := uint16(buf[0])<<8 | uint16(buf[1])
-		k2 := buf[2 : 2+length]
-		if bytes.Equal(k, k2) {
+	if ks.head.Equal(k) {
+		return true
+	}
+	for _, k2 := range ks.tail {
+		if k2.Equal(k) {
 			return true
 		}
-		buf = buf[2+length:]
 	}
 	return false
+}
+
+func NewKeySet(keys ...Key) KeySet {
+	if len(keys) == 0 {
+		return KeySet{}
+	}
+	return KeySet{keys[0], keys[1:]}
 }

--- a/pkg/statedb/index/keyset_test.go
+++ b/pkg/statedb/index/keyset_test.go
@@ -11,35 +11,19 @@ import (
 	"github.com/cilium/cilium/pkg/statedb/index"
 )
 
-func TestKeySet_FromEmpty(t *testing.T) {
-	ks := index.NewKeySet()
-	require.Nil(t, ks.First())
-	ks.Foreach(func(_ index.Key) {
-		t.Fatalf("Foreach on NewKeySet called function")
-	})
-	require.False(t, ks.Exists(nil))
-	require.False(t, ks.Exists([]byte{1, 2, 3}))
-
-	ks.Append([]byte("foo"))
-	require.EqualValues(t, "foo", ks.First())
-	ks.Foreach(func(bs index.Key) {
-		require.EqualValues(t, "foo", bs)
-	})
-	require.True(t, ks.Exists([]byte("foo")))
-
-	ks.Append([]byte("bar"))
-	require.EqualValues(t, "foo", ks.First())
-	vs := [][]byte{}
+func TestKeySet_Single(t *testing.T) {
+	ks := index.NewKeySet([]byte("baz"))
+	require.EqualValues(t, "baz", ks.First())
+	require.True(t, ks.Exists([]byte("baz")))
+	require.False(t, ks.Exists([]byte("foo")))
+	vs := []index.Key{}
 	ks.Foreach(func(bs index.Key) {
 		vs = append(vs, bs)
 	})
-	require.ElementsMatch(t, vs, [][]byte{[]byte("foo"), []byte("bar")})
-	require.True(t, ks.Exists([]byte("foo")))
-	require.True(t, ks.Exists([]byte("bar")))
-	require.False(t, ks.Exists([]byte("baz")))
+	require.ElementsMatch(t, vs, []index.Key{index.Key("baz")})
 }
 
-func TestKeySet_FromNonEmpty(t *testing.T) {
+func TestKeySet_Multi(t *testing.T) {
 	ks := index.NewKeySet([]byte("baz"), []byte("quux"))
 	require.EqualValues(t, "baz", ks.First())
 	require.True(t, ks.Exists([]byte("baz")))

--- a/pkg/statedb/index/map.go
+++ b/pkg/statedb/index/map.go
@@ -4,9 +4,9 @@
 package index
 
 func StringMap[V any](m map[string]V) KeySet {
-	ks := KeySet{}
+	keys := make([]Key, 0, len(m))
 	for k := range m {
-		ks.Append(String(k))
+		keys = append(keys, String(k))
 	}
-	return ks
+	return NewKeySet(keys...)
 }

--- a/pkg/statedb/index/string.go
+++ b/pkg/statedb/index/string.go
@@ -14,17 +14,17 @@ func Stringer[T fmt.Stringer](s T) Key {
 }
 
 func StringSlice(ss []string) KeySet {
-	ks := KeySet{}
+	keys := make([]Key, 0, len(ss))
 	for _, s := range ss {
-		ks.Append(String(s))
+		keys = append(keys, String(s))
 	}
-	return ks
+	return NewKeySet(keys...)
 }
 
 func StringerSlice[T fmt.Stringer](ss []T) KeySet {
-	ks := KeySet{}
+	keys := make([]Key, 0, len(ss))
 	for _, s := range ss {
-		ks.Append(Stringer(s))
+		keys = append(keys, Stringer(s))
 	}
-	return ks
+	return NewKeySet(keys...)
 }

--- a/pkg/statedb/iterator.go
+++ b/pkg/statedb/iterator.go
@@ -55,6 +55,27 @@ func (it *iterator[Obj]) Next() (obj Obj, revision uint64, ok bool) {
 	return
 }
 
+func Map[In, Out any, It Iterator[In]](iter It, transform func(In) Out) Iterator[Out] {
+	return &mapIterator[In, Out]{
+		iter:      iter,
+		transform: transform,
+	}
+}
+
+// mapIterator transforms the objects
+type mapIterator[In, Out any] struct {
+	iter      Iterator[In]
+	transform func(In) Out
+}
+
+func (it *mapIterator[In, Out]) Next() (out Out, revision Revision, ok bool) {
+	obj, rev, ok := it.iter.Next()
+	if ok {
+		return it.transform(obj), rev, true
+	}
+	return
+}
+
 // uniqueIterator iterates over objects in a unique index. Since
 // we find the node by prefix search, we may see a key that shares
 // the search prefix but is longer. We skip those objects.

--- a/pkg/statedb/observable.go
+++ b/pkg/statedb/observable.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/stream"
+)
+
+type Event[Obj any] struct {
+	Object   Obj
+	Revision Revision
+	Deleted  bool
+}
+
+// Observable creates an observable from the given table for observing the changes
+// to the table as a stream of events.
+//
+// For high-churn tables it's advisable to apply rate-limiting to the stream to
+// decrease overhead (stream.Throttle).
+func Observable[Obj any](db *DB, table Table[Obj]) stream.Observable[Event[Obj]] {
+	return &observable[Obj]{db, table}
+}
+
+type observable[Obj any] struct {
+	db    *DB
+	table Table[Obj]
+}
+
+func (to *observable[Obj]) Observe(ctx context.Context, next func(Event[Obj]), complete func(error)) {
+	go func() {
+		wtxn := to.db.WriteTxn(to.table)
+		dt, err := to.table.DeleteTracker(wtxn, "Observe")
+		wtxn.Commit()
+		if err != nil {
+			complete(err)
+			return
+		}
+
+		revision := Revision(0)
+		for {
+			var watch <-chan struct{}
+			revision, watch, _ = dt.Process(to.db.ReadTxn(), revision,
+				func(obj Obj, deleted bool, rev uint64) error {
+					next(Event[Obj]{
+						Object:   obj,
+						Revision: rev,
+						Deleted:  deleted,
+					})
+					return nil
+				})
+
+			select {
+			case <-ctx.Done():
+				dt.Close()
+				complete(nil)
+				return
+			case <-watch:
+			}
+		}
+	}()
+}

--- a/pkg/statedb/txn.go
+++ b/pkg/statedb/txn.go
@@ -202,19 +202,19 @@ func (txn *txn) Insert(meta TableMeta, guardRevision Revision, data any) (any, b
 	// Update revision index
 	revIndexTxn := txn.mustIndexWriteTxn(tableName, RevisionIndex)
 	if oldExists {
-		_, ok := revIndexTxn.txn.Delete(index.Uint64(oldObj.revision))
+		_, ok := revIndexTxn.txn.Delete([]byte(index.Uint64(oldObj.revision)))
 		if !ok {
 			panic("BUG: Old revision index entry not found")
 		}
 
 	}
-	revIndexTxn.txn.Insert(index.Uint64(revision), obj)
+	revIndexTxn.txn.Insert([]byte(index.Uint64(revision)), obj)
 
 	// If it's new, possibly remove an older deleted object with the same
 	// primary key from the graveyard.
 	if !oldExists && txn.hasDeleteTrackers(tableName) {
 		if old, existed := txn.mustIndexWriteTxn(tableName, GraveyardIndex).txn.Delete(idKey); existed {
-			txn.mustIndexWriteTxn(tableName, GraveyardRevisionIndex).txn.Delete(index.Uint64(old.revision))
+			txn.mustIndexWriteTxn(tableName, GraveyardRevisionIndex).txn.Delete([]byte(index.Uint64(old.revision)))
 		}
 	}
 
@@ -351,7 +351,7 @@ func (txn *txn) Delete(meta TableMeta, guardRevision Revision, data any) (any, b
 // This allows looking up from the non-unique index with the secondary key by doing a prefix
 // search. The length is used to safe-guard against indexers that don't terminate the key
 // properly (e.g. if secondary key is "foo", then we don't want "foobar" to match).
-func encodeNonUniqueKey(primary, secondary []byte) []byte {
+func encodeNonUniqueKey(primary, secondary index.Key) []byte {
 	key := make([]byte, 0, len(secondary)+len(primary)+2)
 	key = append(key, secondary...)
 	key = append(key, primary...)

--- a/pkg/statedb/types.go
+++ b/pkg/statedb/types.go
@@ -192,7 +192,7 @@ type WriteTxn interface {
 
 type Query[Obj any] struct {
 	index IndexName
-	key   []byte
+	key   index.Key
 }
 
 // ByRevision constructs a revision query. Applicable to any table.

--- a/pkg/statedb/types.go
+++ b/pkg/statedb/types.go
@@ -24,6 +24,13 @@ type Table[Obj any] interface {
 	// 'Obj' type.
 	TableMeta
 
+	// PrimaryIndexer returns the primary indexer for the table.
+	// Useful for generic utilities that need access to the primary key.
+	PrimaryIndexer() Indexer[Obj]
+
+	// NumObjects returns the number of objects stored in the table.
+	NumObjects(ReadTxn) int
+
 	// Revision of the table. Constant for a read transaction, but
 	// increments in a write transaction on each Insert and Delete.
 	Revision(ReadTxn) Revision
@@ -142,11 +149,11 @@ type RWTable[Obj any] interface {
 // TableMeta provides information about the table that is independent of
 // the object type (the 'Obj' constraint).
 type TableMeta interface {
-	Name() TableName                          // The name of the table
-	tableKey() []byte                         // The radix key for the table in the root tree
-	primaryIndexer() anyIndexer               // The untyped primary indexer for the table
-	secondaryIndexers() map[string]anyIndexer // Secondary indexers (if any)
-	sortableMutex() lock.SortableMutex        // The sortable mutex for locking the table for writing
+	Name() TableName                   // The name of the table
+	tableKey() []byte                  // The radix key for the table in the root tree
+	primary() anyIndexer               // The untyped primary indexer for the table
+	secondary() map[string]anyIndexer  // Secondary indexers (if any)
+	sortableMutex() lock.SortableMutex // The sortable mutex for locking the table for writing
 }
 
 // Iterator for iterating objects returned from queries.
@@ -232,12 +239,26 @@ func (i Index[Obj, Key]) Query(key Key) Query[Obj] {
 	}
 }
 
+func (i Index[Obj, Key]) QueryFromObject(obj Obj) Query[Obj] {
+	return Query[Obj]{
+		index: i.Name,
+		key:   i.FromObject(obj).First(),
+	}
+}
+
+func (i Index[Obj, Key]) ObjectToKey(obj Obj) index.Key {
+	return i.FromObject(obj).First()
+}
+
 // Indexer is the "FromObject" subset of Index[Obj, Key]
 // without the 'Key' constraint.
 type Indexer[Obj any] interface {
 	indexName() string
 	isUnique() bool
-	fromObject(obj Obj) index.KeySet
+	fromObject(Obj) index.KeySet
+
+	ObjectToKey(Obj) index.Key
+	QueryFromObject(Obj) Query[Obj]
 }
 
 // TableWritable is a constraint for objects that implement tabular


### PR DESCRIPTION
This upstreams the improvements to pkg/statedb that arose as part of https://github.com/cilium/cilium/pull/30024.

* `statedb.Map` function for transforming iterators
* `statedb.Observable` function for making a `stream.Observable` out of a table
* `statedb.Derive` function for deriving one table from another with a transform function
* simplifying `index.KeySet` to reduce amount of allocation