### PR TITLE
loader: insert policy programs before attaching bpf entrypoints, enforce missed tail calls in ci-e2e

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -345,12 +345,7 @@ jobs:
             EXTRA+=("--secondary-network-iface=eth1")
           fi
 
-          if [ "${{ matrix.host-fw }}" == "true" ]; then
-            # Missed tail calls until https://github.com/cilium/cilium/issues/28088 is fixed,
-            # host datapath once cilium-cli is upgraded to a version that includes 
-            # https://github.com/cilium/cilium-cli/pull/2206.
-            EXTRA+=("--expected-drop-reasons=+Missed tail call,+Host datapath not ready")
-          fi
+          # EXTRA+=("--expected-drop-reasons=+Host datapath not ready")
 
           ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
             "${EXTRA[@]}" \

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -191,6 +191,35 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 	}
 	defer coll.Close()
 
+	// If an ELF contains one of the policy call maps, resolve and insert the
+	// programs it refers to into the map. This always needs to happen _before_
+	// attaching the ELF's entrypoint(s), but after the ELF's internal tail call
+	// map (cilium_calls) has been populated, as doing so means the ELF's programs
+	// become reachable through its policy programs, which hold references to the
+	// endpoint's cilium_calls. Therefore, inserting policy programs is considered
+	// an 'attachment', just not through the typical bpf hooks.
+	//
+	// For example, a packet can enter to-container, jump into the bpf_host policy
+	// program, which then jumps into the endpoint's policy program that are
+	// installed by the loops below. If we allow packets to enter the endpoint's
+	// bpf programs through its tc hook(s), _all_ this plumbing needs to be done
+	// first, or we risk missing tail calls.
+	if len(policyProgs) != 0 {
+		if err := resolveAndInsertCalls(coll, policymap.PolicyCallMapName, policyProgs); err != nil {
+			revert()
+			return nil, fmt.Errorf("inserting policy programs: %w", err)
+		}
+	}
+
+	if len(egressPolicyProgs) != 0 {
+		if err := resolveAndInsertCalls(coll, policymap.PolicyEgressCallMapName, egressPolicyProgs); err != nil {
+			revert()
+			return nil, fmt.Errorf("inserting egress policy programs: %w", err)
+		}
+	}
+
+	// Finally, attach the endpoint's tc or xdp entry points to allow traffic to
+	// flow in.
 	for _, prog := range progs {
 		scopedLog := l.WithField("progName", prog.progName).WithField("direction", prog.direction)
 		if xdpMode != "" {
@@ -211,23 +240,6 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 			return nil, fmt.Errorf("program %s: %w", prog.progName, err)
 		}
 		scopedLog.Debug("Successfully attached program to interface")
-	}
-
-	// If an ELF contains one of the policy call maps, resolve and insert the
-	// programs it refers to into the map.
-
-	if len(policyProgs) != 0 {
-		if err := resolveAndInsertCalls(coll, policymap.PolicyCallMapName, policyProgs); err != nil {
-			revert()
-			return nil, fmt.Errorf("inserting policy programs: %w", err)
-		}
-	}
-
-	if len(egressPolicyProgs) != 0 {
-		if err := resolveAndInsertCalls(coll, policymap.PolicyEgressCallMapName, egressPolicyProgs); err != nil {
-			revert()
-			return nil, fmt.Errorf("inserting egress policy programs: %w", err)
-		}
 	}
 
 	return finalize, nil


### PR DESCRIPTION
Since the early days of Cilium, we would miss tail calls in CI and not really monitor when or how these happened. Many improvements have been made in recent months to make these a thing of the past, but they were still occurring with host-fw enabled.

After the most recent round of fixes, most of these errors disappeared, but one bugbear remained. This PR addresses the final outstanding error in ordering prog array insertions:

```
loader: install an ELF's policy programs before attaching tc/xdp hooks

See code comments for a detailed description of the problem. This commit
installs policy programs before attaching tc/xdp hooks since doing things
in the wrong order means dropping tail calls when handling traffic if the
policy programs aren't inserted.
```

Finally, strictly enforce no missed tail calls in all ci-e2e scenarios.

Fixes: https://github.com/cilium/cilium/issues/29476

```release-note
Fix all packet drops due to missed tail calls, enable zero tolerance for these errors in CI
```
