### PR TITLE
[1.13] Ignore packet drops of type Failed to update or lookup TC buffer

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -335,7 +335,7 @@ jobs:
           job-name: ipsec-downgrade-${{ matrix.name }}
           # Disable no-unexpected-packet-drops (formerly no-missed-tail-calls)
           # due to https://github.com/cilium/cilium/issues/26739
-          extra-connectivity-test-flags: --expected-drop-reasons "+Missed tail call"
+          extra-connectivity-test-flags: --expected-drop-reasons "+Missed tail call,+Failed to update or lookup TC buffer"
           operation-cmd: |
             CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
               ${{ steps.cilium-stable-config.outputs.config }}

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -335,7 +335,7 @@ jobs:
           job-name: ipsec-downgrade-${{ matrix.name }}
           # Disable no-unexpected-packet-drops (formerly no-missed-tail-calls)
           # due to https://github.com/cilium/cilium/issues/26739
-          extra-connectivity-test-flags: --test '!no-unexpected-packet-drops'
+          extra-connectivity-test-flags: --expected-drop-reasons "+Missed tail call"
           operation-cmd: |
             CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
               ${{ steps.cilium-stable-config.outputs.config }}


### PR DESCRIPTION
First commit is a bit of a drive-by fixing some unwanted changes from https://github.com/cilium/cilium/pull/30010 in order to avoid conflicts with the second commit that ports https://github.com/cilium/cilium/pull/30202 to the downgrade scenario 1.13 -> 1.12.

cc @pchaigno 
