### PR TITLE
gateway: Add SectionName and Port filter in Route namespace checks

### DIFF
--- a/operator/pkg/gateway-api/routechecks/gateway_checks.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks.go
@@ -35,6 +35,18 @@ func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentRefe
 			continue
 		}
 
+		if parentRef.SectionName != nil {
+			if listener.Name != *parentRef.SectionName {
+				continue
+			}
+		}
+
+		if parentRef.Port != nil {
+			if listener.Port != *parentRef.Port {
+				continue
+			}
+		}
+
 		// if gateway allows all namespaces, we do not need to check anything here
 		if *listener.AllowedRoutes.Namespaces.From == gatewayv1.NamespacesFromAll {
 			continue


### PR DESCRIPTION
The current Gateway check for Route attachment is done sequentially, without giving the priority for SectionName and Port. Hence, depending on Listener ordering in Gateway spec, some routes might be rejected for attachment despite it has specified parent SectionName or Port number. This commit is to make sure that SectionName and Port number is used for Gateway listener validation.

Fixes: #30138 
