### PR TITLE
pkg/nodediscovery: Updates updateCiliumNodeResource() Warning Message

### DIFF
--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -316,7 +316,9 @@ func (n *NodeDiscovery) updateCiliumNodeResource(ln *node.LocalNode) {
 			var err error
 			nodeResource, err = n.k8sGetters.GetCiliumNode(context.TODO(), nodeTypes.GetName())
 			if err != nil {
-				log.WithError(err).Warning("Unable to get node resource")
+				if retryCount == maxRetryCount {
+					log.WithError(err).Warningf("Unable to get CiliumNode resource after %d retries", maxRetryCount)
+				}
 				performUpdate = false
 				nodeResource = &ciliumv2.CiliumNode{
 					ObjectMeta: metav1.ObjectMeta{
@@ -362,7 +364,7 @@ func (n *NodeDiscovery) updateCiliumNodeResource(ln *node.LocalNode) {
 			}
 		}
 	}
-	log.Fatal("Could not create or update CiliumNode resource, despite retries")
+	log.Fatalf("Could not create or update CiliumNode resource, despite %d retries", maxRetryCount)
 }
 
 func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode, ln *node.LocalNode) error {


### PR DESCRIPTION
Previously, updateCiliumNodeResource() would emit a warning message whenever the k8s client could not get the local CiliumNode resource from the k8s api server. This caused the following benign log message for new installations since the CiliumNode resource has yet to be created:

`level=warning msg="Unable to get node resource" error="ciliumnodes.cilium.io \"kind-control-plane\" not found" subsys=nodediscovery`

This PR updates updateCiliumNodeResource() to only generate the warning message when the maximum number of attempts has been reached.

Fixes: #29330