### PR TITLE
Docs: add warning for the latest version

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
 .. versionadded::HEAD
 .. note::
 
@@ -5,13 +11,6 @@
     For the latest stable release, please refer to the `official documentation`_
     
 .. _official documentation: https://docs.cilium.io/en/stable/
-
-.. only:: not (epub or latex or html)
-
-    WARNING: You are looking at unreleased Cilium documentation.
-    Please use the official rendered version released here:
-    https://docs.cilium.io
-
 
 Welcome to Cilium's documentation!
 ==================================

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -1,8 +1,17 @@
+.. versionadded::HEAD
+.. note::
+
+    WARNING: This documentation is for the development version and may not be stable.
+    For the latest stable release, please refer to the `official documentation`_
+    
+.. _official documentation: https://docs.cilium.io/en/stable/
+
 .. only:: not (epub or latex or html)
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
     https://docs.cilium.io
+
 
 Welcome to Cilium's documentation!
 ==================================


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
For latest version of cilium there is no warning specifying in the documentation regarding it as a unstable/development version. The issue focuses on fixes it for the latest version by adding warning at the top of documentation.

Fixes:  #29969 

