### PR TITLE
bgpv1: Fix GoBGP Server leak on initial reconciliation failure

### DIFF
--- a/pkg/bgpv1/manager/manager.go
+++ b/pkg/bgpv1/manager/manager.go
@@ -277,6 +277,7 @@ func (m *BGPRouterManager) registerBGPServer(ctx context.Context,
 	}
 
 	if err = m.reconcileBGPConfig(ctx, s, c, ciliumNode); err != nil {
+		s.Server.Stop()
 		return fmt.Errorf("failed initial reconciliation for peer config with local ASN %v: %w", c.LocalASN, err)
 	}
 


### PR DESCRIPTION
Please see the commit message for more details

```release-note
bgpv1: Fix GoBGP Server leak on initial reconciliation failure
```
