### PR TITLE
doc(global-svc): fix legacy nginx version which doesn't support ipv6 only env

### DIFF
--- a/examples/kubernetes/clustermesh/global-service-example/cluster2.yaml
+++ b/examples/kubernetes/clustermesh/global-service-example/cluster2.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: rebel-base
-        image: docker.io/nginx:1.15.8
+        image: docker.io/nginx:1.25.3
         volumeMounts:
           - name: html
             mountPath: /usr/share/nginx/html/

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2139,7 +2139,6 @@ func (e *Endpoint) SyncEndpointHeaderFile() {
 // * removal from the endpointmanager, resulting in new events not taking effect
 // on this endpoint
 // * cleanup of datapath state (BPF maps, proxy configuration, directories)
-// * releasing IP addresses allocated for the endpoint
 // * releasing of the reference to its allocated security identity
 func (e *Endpoint) Delete(conf DeleteConfig) []error {
 	errs := []error{}


### PR DESCRIPTION
The legacy version will not start in ipv6 only env.


Signed-off-by: Simon Wu <simon.wu@smartnews.com>