### PR TITLE
workflows: conformance-eks: use env.QUAY_ORGANIZATION_DEV

### DIFF
--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -219,7 +219,7 @@ jobs:
               spec:
                 containers:
                 - name: wait-for-images
-                  image: quay.io/cilium/cilium-ci:${{ steps.vars.outputs.sha }}
+                  image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci:${{ steps.vars.outputs.sha }}
                   command: ["true"]
                 tolerations:
                 - key: "node.cilium.io/agent-not-ready"


### PR DESCRIPTION
Enable the usual customization of the quay repo location.

Fixes: c26c55b1b724 ("ci: fix eks image pull flake")