### PR TITLE
v1.14 Backports 2024-01-16

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -114,7 +114,7 @@ jobs:
             encryption-node: 'false'
             endpoint-routes: 'true'
 
-    timeout-minutes: 60
+    timeout-minutes: 70
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/Documentation/installation/cni-chaining-generic-veth.rst
+++ b/Documentation/installation/cni-chaining-generic-veth.rst
@@ -62,7 +62,8 @@ desired CNI chaining configuration:
 	      [...]
             },
             {
-              "type": "cilium-cni"
+              "type": "cilium-cni",
+              "chaining-mode": "generic-veth"
             }
           ]
         }

--- a/cilium/cmd/build-config.go
+++ b/cilium/cmd/build-config.go
@@ -36,9 +36,11 @@ var buildConfigHive = hive.New(
 var buildConfigCmd = &cobra.Command{
 	Use:   "build-config --node-name $K8S_NODE_NAME",
 	Short: "Resolve all of the configuration sources that apply to this node",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Running")
-		return buildConfigHive.Run()
+		if err := buildConfigHive.Run(); err != nil {
+			Fatalf("Build config failed: %v\n", err)
+		}
 	},
 }
 

--- a/operator/auth/spire/client.go
+++ b/operator/auth/spire/client.go
@@ -135,7 +135,7 @@ func (c *Client) onStart(_ hive.HookContext) error {
 				c.entry = entryv1.NewEntryClient(conn)
 				break
 			}
-			c.log.WithError(err).Errorf("Unable to connect to SPIRE server, attempt %d", attempts+1)
+			c.log.WithError(err).Warnf("Unable to connect to SPIRE server, attempt %d", attempts+1)
 			time.Sleep(backoffTime.Duration(attempts))
 		}
 		c.log.Info("Initialized SPIRE client")
@@ -159,7 +159,7 @@ func (c *Client) connect(ctx context.Context) (*grpc.ClientConn, error) {
 	source, err := workloadapi.NewX509Source(timeoutCtx,
 		workloadapi.WithClientOptions(
 			workloadapi.WithAddr(fmt.Sprintf("unix://%s", c.cfg.SpireAgentSocketPath)),
-			workloadapi.WithLogger(c.log),
+			workloadapi.WithLogger(newSpiffeLogWrapper(c.log)),
 		),
 	)
 	if err != nil {

--- a/operator/auth/spire/log_wrapper.go
+++ b/operator/auth/spire/log_wrapper.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package spire
+
+import "github.com/sirupsen/logrus"
+
+// spiffeLogWrapper is a log wrapper for the SPIRE client logs
+// the log levels of this library do not match those from Cilium
+// this will be used to convert the log levels.
+type spiffeLogWrapper struct {
+	log logrus.FieldLogger
+}
+
+// newSpiffeLogWrapper returns a new spiffeLogWrapper
+func newSpiffeLogWrapper(log logrus.FieldLogger) *spiffeLogWrapper {
+	return &spiffeLogWrapper{
+		log: log,
+	}
+}
+
+// Debugf logs a debug message
+func (l *spiffeLogWrapper) Debugf(format string, args ...interface{}) {
+	l.log.Debugf(format, args...)
+}
+
+// Infof logs an info message
+func (l *spiffeLogWrapper) Infof(format string, args ...interface{}) {
+	l.log.Infof(format, args...)
+}
+
+// Warnf logs a warning message
+func (l *spiffeLogWrapper) Warnf(format string, args ...interface{}) {
+	l.log.Warnf(format, args...)
+}
+
+// Errorf logs an error message downgraded to a warning as in our case
+// a connection error on startups is expected on initial start of the oprator
+// while the SPIRE server is still starting up. Any errors given by spire will
+// result in an error passed back to the function caller which then is logged
+// as an error.
+func (l *spiffeLogWrapper) Errorf(format string, args ...interface{}) {
+	l.log.Warnf(format, args...)
+}

--- a/pkg/auth/authmap_cache_test.go
+++ b/pkg/auth/authmap_cache_test.go
@@ -19,8 +19,8 @@ func Test_authMapCache_restoreCache(t *testing.T) {
 		authmap: &fakeAuthMap{
 			entries: map[authKey]authInfo{
 				{
-					localIdentity:  1,
-					remoteIdentity: 2,
+					localIdentity:  1000,
+					remoteIdentity: 2000,
 					remoteNodeID:   10,
 					authType:       policy.AuthTypeDisabled,
 				}: {
@@ -37,8 +37,8 @@ func Test_authMapCache_restoreCache(t *testing.T) {
 	assert.Len(t, am.cacheEntries, 1)
 
 	val, err := am.Get(authKey{
-		localIdentity:  1,
-		remoteIdentity: 2,
+		localIdentity:  1000,
+		remoteIdentity: 2000,
 		remoteNodeID:   10,
 		authType:       policy.AuthTypeDisabled,
 	})
@@ -54,8 +54,8 @@ func Test_authMapCache_allReturnsCopy(t *testing.T) {
 		},
 		cacheEntries: map[authKey]authInfoCache{
 			{
-				localIdentity:  1,
-				remoteIdentity: 2,
+				localIdentity:  1000,
+				remoteIdentity: 2000,
 				remoteNodeID:   10,
 				authType:       policy.AuthTypeDisabled,
 			}: {
@@ -70,8 +70,8 @@ func Test_authMapCache_allReturnsCopy(t *testing.T) {
 	assert.Len(t, all, 1)
 
 	all[authKey{
-		localIdentity:  10,
-		remoteIdentity: 20,
+		localIdentity:  10000,
+		remoteIdentity: 20000,
 		remoteNodeID:   100,
 		authType:       policy.AuthTypeDisabled,
 	}] = authInfo{
@@ -85,8 +85,8 @@ func Test_authMapCache_Delete(t *testing.T) {
 	fakeMap := &fakeAuthMap{
 		entries: map[authKey]authInfo{
 			{
-				localIdentity:  1,
-				remoteIdentity: 2,
+				localIdentity:  1000,
+				remoteIdentity: 2000,
 				remoteNodeID:   10,
 				authType:       policy.AuthTypeDisabled,
 			}: {
@@ -99,8 +99,8 @@ func Test_authMapCache_Delete(t *testing.T) {
 		authmap: fakeMap,
 		cacheEntries: map[authKey]authInfoCache{
 			{
-				localIdentity:  1,
-				remoteIdentity: 2,
+				localIdentity:  1000,
+				remoteIdentity: 2000,
 				remoteNodeID:   10,
 				authType:       policy.AuthTypeDisabled,
 			}: {
@@ -108,8 +108,8 @@ func Test_authMapCache_Delete(t *testing.T) {
 				storedAt: time.Now().Add(-10 * time.Minute),
 			},
 			{
-				localIdentity:  3,
-				remoteIdentity: 2,
+				localIdentity:  3000,
+				remoteIdentity: 2000,
 				remoteNodeID:   10,
 				authType:       policy.AuthTypeDisabled,
 			}: {
@@ -117,8 +117,8 @@ func Test_authMapCache_Delete(t *testing.T) {
 				storedAt: time.Now().Add(-10 * time.Minute),
 			},
 			{
-				localIdentity:  4,
-				remoteIdentity: 2,
+				localIdentity:  4000,
+				remoteIdentity: 2000,
 				remoteNodeID:   10,
 				authType:       policy.AuthTypeDisabled,
 			}: {
@@ -131,8 +131,8 @@ func Test_authMapCache_Delete(t *testing.T) {
 	assert.Len(t, am.cacheEntries, 3)
 
 	err := am.Delete(authKey{
-		localIdentity:  1,
-		remoteIdentity: 2,
+		localIdentity:  1000,
+		remoteIdentity: 2000,
 		remoteNodeID:   10,
 		authType:       policy.AuthTypeDisabled,
 	})
@@ -140,8 +140,8 @@ func Test_authMapCache_Delete(t *testing.T) {
 	assert.Len(t, am.cacheEntries, 2)
 
 	err = am.Delete(authKey{
-		localIdentity:  3,
-		remoteIdentity: 2,
+		localIdentity:  3000,
+		remoteIdentity: 2000,
 		remoteNodeID:   10,
 		authType:       policy.AuthTypeDisabled,
 	})
@@ -150,8 +150,8 @@ func Test_authMapCache_Delete(t *testing.T) {
 
 	fakeMap.failDelete = true
 	err = am.Delete(authKey{
-		localIdentity:  4,
-		remoteIdentity: 2,
+		localIdentity:  4000,
+		remoteIdentity: 2000,
 		remoteNodeID:   10,
 		authType:       policy.AuthTypeDisabled,
 	})
@@ -163,8 +163,8 @@ func Test_authMapCache_DeleteIf(t *testing.T) {
 	fakeMap := &fakeAuthMap{
 		entries: map[authKey]authInfo{
 			{
-				localIdentity:  1,
-				remoteIdentity: 2,
+				localIdentity:  1000,
+				remoteIdentity: 2000,
 				remoteNodeID:   10,
 				authType:       policy.AuthTypeDisabled,
 			}: {
@@ -177,8 +177,8 @@ func Test_authMapCache_DeleteIf(t *testing.T) {
 		authmap: fakeMap,
 		cacheEntries: map[authKey]authInfoCache{
 			{
-				localIdentity:  1,
-				remoteIdentity: 2,
+				localIdentity:  1000,
+				remoteIdentity: 2000,
 				remoteNodeID:   10,
 				authType:       policy.AuthTypeDisabled,
 			}: {
@@ -186,8 +186,8 @@ func Test_authMapCache_DeleteIf(t *testing.T) {
 				storedAt: time.Now().Add(-10 * time.Minute),
 			},
 			{
-				localIdentity:  3,
-				remoteIdentity: 2,
+				localIdentity:  3000,
+				remoteIdentity: 2000,
 				remoteNodeID:   10,
 				authType:       policy.AuthTypeDisabled,
 			}: {
@@ -195,8 +195,8 @@ func Test_authMapCache_DeleteIf(t *testing.T) {
 				storedAt: time.Now().Add(-10 * time.Minute),
 			},
 			{
-				localIdentity:  4,
-				remoteIdentity: 2,
+				localIdentity:  4000,
+				remoteIdentity: 2000,
 				remoteNodeID:   10,
 				authType:       policy.AuthTypeDisabled,
 			}: {
@@ -209,14 +209,14 @@ func Test_authMapCache_DeleteIf(t *testing.T) {
 	assert.Len(t, am.cacheEntries, 3)
 
 	err := am.DeleteIf(func(key authKey, info authInfo) bool {
-		return key.localIdentity == 1 || key.localIdentity == 3
+		return key.localIdentity == 1000 || key.localIdentity == 3000
 	})
 	assert.NoError(t, err)
 	assert.Len(t, am.cacheEntries, 1)
 
 	fakeMap.failDelete = true
 	err = am.DeleteIf(func(key authKey, info authInfo) bool {
-		return key.localIdentity == 4
+		return key.localIdentity == 4000
 	})
 	assert.ErrorContains(t, err, "failed to delete auth entry from map: failed to delete entry")
 	assert.Len(t, am.cacheEntries, 1)

--- a/pkg/auth/manager.go
+++ b/pkg/auth/manager.go
@@ -95,6 +95,13 @@ func (a *AuthManager) handleAuthRequest(_ context.Context, key signalAuthKey) er
 		authType:       policy.AuthType(key.AuthType),
 	}
 
+	if k.localIdentity.IsReservedIdentity() || k.remoteIdentity.IsReservedIdentity() {
+		a.logger.
+			WithField("key", k).
+			Info("Reserved identity, skipping authentication as reserved identities are not compatible with authentication")
+		return nil
+	}
+
 	a.logger.
 		WithField("key", k).
 		Debug("Handle authentication request")

--- a/pkg/auth/manager_test.go
+++ b/pkg/auth/manager_test.go
@@ -56,8 +56,8 @@ func Test_authManager_authenticate(t *testing.T) {
 		{
 			name: "missing handler for auth type",
 			args: authKey{
-				localIdentity:  1,
-				remoteIdentity: 2,
+				localIdentity:  1000,
+				remoteIdentity: 2000,
 				remoteNodeID:   2,
 				authType:       1,
 			},
@@ -67,8 +67,8 @@ func Test_authManager_authenticate(t *testing.T) {
 		{
 			name: "missing node IP for node ID",
 			args: authKey{
-				localIdentity:  1,
-				remoteIdentity: 2,
+				localIdentity:  1000,
+				remoteIdentity: 2000,
 				remoteNodeID:   1,
 				authType:       2,
 			},
@@ -78,8 +78,8 @@ func Test_authManager_authenticate(t *testing.T) {
 		{
 			name: "successful auth",
 			args: authKey{
-				localIdentity:  1,
-				remoteIdentity: 2,
+				localIdentity:  1000,
+				remoteIdentity: 2000,
 				remoteNodeID:   2,
 				authType:       100,
 			},
@@ -124,12 +124,46 @@ func Test_authManager_handleAuthRequest(t *testing.T) {
 	am.handleAuthenticationFunc = func(_ *AuthManager, k authKey, reAuth bool) {
 		handleAuthCalled = true
 		assert.False(t, reAuth)
-		assert.Equal(t, authKey{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 0, authType: 100}, k)
+		assert.Equal(t, authKey{localIdentity: 1000, remoteIdentity: 2000, remoteNodeID: 0, authType: 100}, k)
 	}
 
-	err = am.handleAuthRequest(context.Background(), signalAuthKey{LocalIdentity: 1, RemoteIdentity: 2, RemoteNodeID: 0, AuthType: 100, Pad: 0})
+	err = am.handleAuthRequest(context.Background(), signalAuthKey{LocalIdentity: 1000, RemoteIdentity: 2000, RemoteNodeID: 0, AuthType: 100, Pad: 0})
 	assert.NoError(t, err)
 	assert.True(t, handleAuthCalled)
+}
+
+func Test_authManager_handleAuthRequest_reservedRemoteIdentity(t *testing.T) {
+	authHandlers := []authHandler{newAlwaysPassAuthHandler(logrus.New())}
+
+	am, err := newAuthManager(logrus.New(), authHandlers, nil, nil, time.Second)
+	assert.NoError(t, err)
+	assert.NotNil(t, am)
+
+	handleAuthCalled := false
+	am.handleAuthenticationFunc = func(_ *AuthManager, k authKey, reAuth bool) {
+		handleAuthCalled = true
+	}
+
+	err = am.handleAuthRequest(context.Background(), signalAuthKey{LocalIdentity: 100, RemoteIdentity: identity.ReservedIdentityWorld.Uint32(), RemoteNodeID: 0, AuthType: 100, Pad: 0})
+	assert.NoError(t, err)
+	assert.False(t, handleAuthCalled)
+}
+
+func Test_authManager_handleAuthRequest_reservedLocalIdentity(t *testing.T) {
+	authHandlers := []authHandler{newAlwaysPassAuthHandler(logrus.New())}
+
+	am, err := newAuthManager(logrus.New(), authHandlers, nil, nil, time.Second)
+	assert.NoError(t, err)
+	assert.NotNil(t, am)
+
+	handleAuthCalled := false
+	am.handleAuthenticationFunc = func(_ *AuthManager, k authKey, reAuth bool) {
+		handleAuthCalled = true
+	}
+
+	err = am.handleAuthRequest(context.Background(), signalAuthKey{LocalIdentity: identity.ReservedIdentityWorld.Uint32(), RemoteIdentity: 100, RemoteNodeID: 0, AuthType: 100, Pad: 0})
+	assert.NoError(t, err)
+	assert.False(t, handleAuthCalled)
 }
 
 func Test_authManager_handleCertificateRotationEvent_Error(t *testing.T) {
@@ -150,9 +184,9 @@ func Test_authManager_handleCertificateRotationEvent(t *testing.T) {
 	authHandlers := []authHandler{newAlwaysPassAuthHandler(logrus.New())}
 	aMap := &fakeAuthMap{
 		entries: map[authKey]authInfo{
-			{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 1, authType: 100}: {expiration: time.Now()},
-			{localIdentity: 2, remoteIdentity: 3, remoteNodeID: 1, authType: 100}: {expiration: time.Now()},
-			{localIdentity: 3, remoteIdentity: 4, remoteNodeID: 1, authType: 100}: {expiration: time.Now()},
+			{localIdentity: 1000, remoteIdentity: 2000, remoteNodeID: 1, authType: 100}: {expiration: time.Now()},
+			{localIdentity: 2000, remoteIdentity: 3000, remoteNodeID: 1, authType: 100}: {expiration: time.Now()},
+			{localIdentity: 3000, remoteIdentity: 4000, remoteNodeID: 1, authType: 100}: {expiration: time.Now()},
 		},
 	}
 
@@ -164,10 +198,10 @@ func Test_authManager_handleCertificateRotationEvent(t *testing.T) {
 	am.handleAuthenticationFunc = func(_ *AuthManager, k authKey, reAuth bool) {
 		handleAuthCalled = true
 		assert.True(t, reAuth)
-		assert.True(t, k.localIdentity == 2 || k.remoteIdentity == 2)
+		assert.True(t, k.localIdentity == 2000 || k.remoteIdentity == 2000)
 	}
 
-	err = am.handleCertificateRotationEvent(context.Background(), certs.CertificateRotationEvent{Identity: identity.NumericIdentity(2)})
+	err = am.handleCertificateRotationEvent(context.Background(), certs.CertificateRotationEvent{Identity: identity.NumericIdentity(2000)})
 	assert.NoError(t, err)
 	assert.True(t, handleAuthCalled)
 }


### PR DESCRIPTION
 * [x] #29400 (@meyskens)
   - :warning: Conflicts in `manager_test.go`:
     - Changed `ReservedIdentityWorldIPv6` to `ReservedIdentityWorld` for v1.14
     - Skipped changes to `Test_authManager_handleCertificateDeletionEvent` as that test function does not exist in v1.14
 * [x] #30194 (@julianwiedmann)
 * [x] #28698 (@meyskens)
 * [ ] #28974 (@vipul-21)
   * :warning: Trivial conflicts because cilium-dbg/ is cilium/ in v1.14
 * [x] #30209 (@squeed)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 29400 30194 28698 28974 30209
```
