### PR TITLE
linux/node: don't run validation functions if not yet initialized

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1334,6 +1334,10 @@ func (n *linuxNodeHandler) NodeValidateImplementation(nodeToValidate nodeTypes.N
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
+	if !n.isInitialized {
+		return nil
+	}
+
 	return n.nodeUpdate(nil, &nodeToValidate, false)
 }
 
@@ -1342,6 +1346,10 @@ func (n *linuxNodeHandler) NodeValidateImplementation(nodeToValidate nodeTypes.N
 func (n *linuxNodeHandler) AllNodeValidateImplementation() {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
+
+	if !n.isInitialized {
+		return
+	}
 
 	var errs error
 	for _, updateNode := range n.nodes {


### PR DESCRIPTION
The Node{Add,Update,Delete} functions of the linux node handler are already guarded in order not to execute the underlying logic if the node subsystem is not yet fully initialized. Once initialized, all updates are then automatically replayed.

Yet, this does not apply to the NodeValidateImplementation and AllNodeValidateImplementation functions, which can also be invoked asynchronously, leading to a panic if not fully initialized (even without panicing, we would be enforcing an incorrect configuration, possibly disrupting existing connections):

```
github.com/cilium/cilium/pkg/datapath/linux.(*linuxNodeHandler).nodeUpdate(0xc0022be1a0, 0x0, 0xc001936480, 0x0)
	/go/src/github.com/cilium/cilium/pkg/datapath/linux/node.go:1030 +0x142d
github.com/cilium/cilium/pkg/datapath/linux.(*linuxNodeHandler).NodeValidateImplementation(_, {{0xc000f10720, 0x1b}, {0xc00068b2d8, 0x13}, {0xc000d6a3c0, 0x4, 0x4}, 0xc0005fc0e8, {0x0, ...}, ...})
	/go/src/github.com/cilium/cilium/pkg/datapath/linux/node.go:1337 +0xc8
github.com/cilium/cilium/pkg/node/manager.(*manager).backgroundSync.func1({0x4019e80, 0xc0022be1a0})
	/go/src/github.com/cilium/cilium/pkg/node/manager/manager.go:342 +0x9a
github.com/cilium/cilium/pkg/node/manager.(*manager).Iter(0x3251f40?, 0xc001f0bdb8)
	/go/src/github.com/cilium/cilium/pkg/node/manager/manager.go:174 +0xdb
github.com/cilium/cilium/pkg/node/manager.(*manager).backgroundSync(0xc00083c460, {0x400c390, 0xc00135b630})
	/go/src/github.com/cilium/cilium/pkg/node/manager/manager.go:341 +0x4ab
github.com/cilium/workerpool.(*WorkerPool).run.func1()
```

Let's fix this by also checking the initialization status there.

<!-- Description of change -->

```release-note
Fix rare bug possibly causing connection disruption and/or agent panic due to node events processing before full initialization.
```
