### PR TITLE
.github: Fix LVH image bump for main branch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -431,7 +431,6 @@
       ],
       "allowedVersions": "!/bpf-next-.*/",
       "matchBaseBranches": [
-        "main",
         "v1.15",
         "v1.14",
         "v1.13",
@@ -439,12 +438,11 @@
       ],
     },
     {
-      "groupName": "bpf-next lvh-images main",
-      "groupSlug": "bpf-next-lvh-images-main",
+      "groupName": "all lvh-images main",
+      "groupSlug": "all-lvh-images-main",
       "matchPackageNames": [
         "quay.io/lvh-images/kind"
       ],
-      "allowedVersions": "/bpf-next-.*/",
       "matchBaseBranches": [
         "main"
       ],


### PR DESCRIPTION
André reports that the main branch isn't receiving stable image updates,
likely because the second rule here is overwriting the first rule for
the quay.io/lvh-images/kind package name. Fix it by removing main from
the special "stable" branch rule and ensuring that the main branch rule
applies for not only bpf-next images, but all lvh-images.

Fixes: 4e93d90fc71b (".github: Don't update LVH images on stable branches")
Reported-by: André Martins <andre@cilium.io>

Tested-At: https://github.com/joestringer/cilium/pull/10
Fixes: https://github.com/cilium/cilium/pull/29835