### PR TITLE
service: NodePort frontend reconcilation

### DIFF
--- a/daemon/cmd/device-reloader.go
+++ b/daemon/cmd/device-reloader.go
@@ -129,7 +129,6 @@ func (d *deviceReloader) reload(ctx context.Context) error {
 
 	if d.params.Config.EnableNodePort {
 		// Synchronize services and endpoints to reflect new addresses onto lbmap.
-		daemon.svc.SyncServicesOnDeviceChange(daemon.Datapath().LocalNodeAddressing())
 		daemon.controllers.TriggerController(syncHostIPsController)
 	}
 

--- a/pkg/service/cell.go
+++ b/pkg/service/cell.go
@@ -15,6 +15,9 @@ var Cell = cell.Module(
 	"Service Manager",
 
 	cell.Provide(newServiceManager),
+
+	cell.ProvidePrivate(func(sm ServiceManager) syncNodePort { return sm }),
+	cell.Invoke(registerServiceReconciler),
 )
 
 type serviceManagerParams struct {

--- a/pkg/service/reconciler.go
+++ b/pkg/service/reconciler.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/backoff"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/inctimer"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// registerServiceReconciler registers a background job to synchronize NodePort frontends
+// with the new set of node addresses assigned for NodePort use.
+func registerServiceReconciler(p serviceReconcilerParams) {
+	sr := serviceReconciler(p)
+	g := p.Jobs.NewGroup(p.Scope)
+	g.Add(job.OneShot("ServiceReconciler", sr.reconcileLoop))
+	p.Lifecycle.Append(g)
+}
+
+type syncNodePort interface {
+	SyncNodePortFrontends(sets.Set[netip.Addr]) error
+}
+
+type serviceReconcilerParams struct {
+	cell.In
+
+	Lifecycle      hive.Lifecycle
+	Jobs           job.Registry
+	Scope          cell.Scope
+	DB             *statedb.DB
+	NodeAddresses  statedb.Table[tables.NodeAddress]
+	ServiceManager syncNodePort
+}
+
+type serviceReconciler serviceReconcilerParams
+
+func (sr serviceReconciler) reconcileLoop(ctx context.Context, health cell.HealthReporter) error {
+	var (
+		retry        <-chan time.Time
+		retryAttempt int
+		addrs        sets.Set[netip.Addr]
+	)
+
+	retryTimer, retryTimerStop := inctimer.New()
+	defer retryTimerStop()
+
+	// Use exponential backoff for retries. Keep small minimum time for fast tests,
+	// but backoff with aggressive factor.
+	backoff := backoff.Exponential{
+		Min:    10 * time.Millisecond,
+		Max:    30 * time.Second,
+		Factor: 8,
+	}
+
+	// Perform a sync periodically. This resolves the rare races where k8s.ParseService uses old
+	// set of frontend addresses. This will eventually be fixed by moving the NodePort frontend
+	// expansion further down the stack, ideally to datapath.
+	const periodicSyncInterval = 15 * time.Minute
+	periodicSyncTicker := time.NewTicker(periodicSyncInterval)
+	defer periodicSyncTicker.Stop()
+
+	for {
+		iter, watch := sr.NodeAddresses.All(sr.DB.ReadTxn())
+
+		// Collect all NodePort addresses
+		newAddrs := statedb.CollectSet(
+			statedb.Map(
+				statedb.Filter(
+					iter,
+					func(addr tables.NodeAddress) bool { return addr.NodePort },
+				),
+				func(addr tables.NodeAddress) netip.Addr { return addr.Addr },
+			),
+		)
+
+		// Refresh the frontends if the set of NodePort addresses changed
+		if !addrs.Equal(newAddrs) {
+			err := sr.ServiceManager.SyncNodePortFrontends(newAddrs)
+			if err != nil {
+				duration := backoff.Duration(retryAttempt)
+				retry = retryTimer.After(duration)
+				retryAttempt++
+				log.WithError(err).Warnf("Could not synchronize new frontend addresses, retrying in %s", duration)
+				health.Degraded("Failed to sync NodePort frontends", err)
+			} else {
+				addrs = newAddrs
+				retryAttempt = 0
+				retry = nil
+				health.OK(fmt.Sprintf("%d NodePort frontend addresses", len(addrs)))
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-watch:
+		case <-retry:
+		case <-periodicSyncTicker.C:
+		}
+	}
+
+}

--- a/pkg/service/reconciler_test.go
+++ b/pkg/service/reconciler_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package service
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/statedb"
+)
+
+type mockSyncNodePort struct {
+	lock.Mutex
+	errToReturn error
+	addrs       sets.Set[netip.Addr]
+	success     bool
+}
+
+// SyncNodePortFrontends implements syncNodePort.
+func (m *mockSyncNodePort) SyncNodePortFrontends(addrs sets.Set[netip.Addr]) error {
+	m.Lock()
+	defer m.Unlock()
+	m.addrs = addrs
+	m.success = m.errToReturn == nil
+	return m.errToReturn
+}
+
+var _ syncNodePort = &mockSyncNodePort{}
+
+func TestServiceReconciler(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	mock := &mockSyncNodePort{
+		errToReturn: nil,
+		addrs:       nil,
+	}
+	var (
+		db        *statedb.DB
+		nodeAddrs statedb.RWTable[tables.NodeAddress]
+	)
+
+	h := hive.New(
+		job.Cell,
+		statedb.Cell,
+		cell.Module("test", "test",
+			cell.Provide(
+				tables.NewNodeAddressTable,
+				statedb.RWTable[tables.NodeAddress].ToTable,
+			),
+			cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
+			cell.Provide(func() syncNodePort { return mock }),
+			cell.Invoke(registerServiceReconciler),
+			cell.Invoke(func(d *statedb.DB, na statedb.RWTable[tables.NodeAddress]) {
+				db = d
+				nodeAddrs = na
+			}),
+		),
+	)
+
+	require.NoError(t, h.Start(context.TODO()), "Start")
+
+	mock.Lock()
+	mock.errToReturn = errors.New("fail")
+	mock.Unlock()
+
+	wtxn := db.WriteTxn(nodeAddrs)
+	nodeAddrs.Insert(
+		wtxn,
+		tables.NodeAddress{
+			Addr:       netip.MustParseAddr("1.2.3.4"),
+			NodePort:   true,
+			Primary:    true,
+			DeviceName: "test",
+		},
+	)
+	wtxn.Commit()
+
+	require.Eventually(t,
+		func() bool {
+			mock.Lock()
+			defer mock.Unlock()
+			return len(mock.addrs) == 1 && !mock.success
+		}, time.Second, 10*time.Millisecond)
+
+	mock.Lock()
+	mock.errToReturn = nil
+	mock.Unlock()
+
+	require.Eventually(t,
+		func() bool {
+			mock.Lock()
+			defer mock.Unlock()
+			return mock.success
+		}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, h.Stop(context.TODO()), "Stop")
+
+}

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -4,9 +4,10 @@
 package service
 
 import (
+	"net/netip"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/time"
@@ -59,8 +60,9 @@ type ServiceManager interface {
 	// RestoreServices restores services from BPF maps.
 	RestoreServices() error
 
-	// SyncServicesOnDeviceChange finds and adds missing load-balancing entries for new devices.
-	SyncServicesOnDeviceChange(nodeAddressing types.NodeAddressing)
+	// SyncNodePortFrontends updates all NodePort service frontends with a new set of frontend
+	// IP addresses.
+	SyncNodePortFrontends(sets.Set[netip.Addr]) error
 
 	// SyncWithK8sFinished removes services which we haven't heard about during
 	// a sync period of cilium-agent's k8s service cache.

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -66,7 +66,7 @@ WORKER_MAC=$(nsenter -t $NGINX_PID -n ip -o l show dev eth0 | grep -oP '(?<=link
 LB_VIP="10.0.0.4"
 
 ${CILIUM_EXEC} \
-    cilium-dbg service update --id 1 --frontend "${LB_VIP}:80" --backends "[${WORKER_IP6}]:80" --k8s-node-port
+    cilium-dbg service update --id 1 --frontend "${LB_VIP}:80" --backends "[${WORKER_IP6}]:80" --k8s-load-balancer
 
 SVC_BEFORE=$(${CILIUM_EXEC} cilium-dbg service list)
 
@@ -138,7 +138,7 @@ done
 LB_ALT="fd00:dead:beef:15:bad::1"
 
 ${CILIUM_EXEC} \
-    cilium-dbg service update --id 2 --frontend "[${LB_ALT}]:80" --backends "[${WORKER_IP6}]:80" --k8s-node-port
+    cilium-dbg service update --id 2 --frontend "[${LB_ALT}]:80" --backends "[${WORKER_IP6}]:80" --k8s-load-balancer
 
 ${CILIUM_EXEC} cilium-dbg service list
 ${CILIUM_EXEC} cilium-dbg bpf lb list
@@ -195,7 +195,7 @@ nsenter -t $CONTROL_PLANE_PID -n ip neigh del ${WORKER_IP6} dev eth0
 LB_VIP="fd00:cafe::1"
 
 ${CILIUM_EXEC} \
-    cilium-dbg service update --id 1 --frontend "[${LB_VIP}]:80" --backends "${WORKER_IP4}:80" --k8s-node-port
+    cilium-dbg service update --id 1 --frontend "[${LB_VIP}]:80" --backends "${WORKER_IP4}:80" --k8s-load-balancer
 
 SVC_BEFORE=$(${CILIUM_EXEC} cilium-dbg service list)
 
@@ -267,7 +267,7 @@ done
 LB_ALT="10.0.0.8"
 
 ${CILIUM_EXEC} \
-    cilium-dbg service update --id 2 --frontend "${LB_ALT}:80" --backends "${WORKER_IP4}:80" --k8s-node-port
+    cilium-dbg service update --id 2 --frontend "${LB_ALT}:80" --backends "${WORKER_IP4}:80" --k8s-load-balancer
 
 ${CILIUM_EXEC} cilium-dbg service list
 ${CILIUM_EXEC} cilium-dbg bpf lb list


### PR DESCRIPTION
The runtime device detection feature requires refreshing the NodePort services if the frontend addresses change (e.g. the IP addresses assigned to the node). This was implemented under `daemon/cmd` by watching device changes (`DeviceManager.Listen`), but now the node addresses are available as `Table[NodeAddress]` and can be directly watched from pkg/service.

This PR implements a reconciliation loop in pkg/service that watches the NodeAddress table and refreshes the services when addresses change. It also mitigates the race condition where ParseService might use stale addresses by periodically checking all services for missing NodePort frontends.

The changes this PR makes are also tested by the ginko test `Checks device reconfiguration` in `test/k8s/services.go` which creates a new vxlan device connected to a non-cilium node and tests that a NodePort service can be accessed via the new IP assigned to it.

Side note: the race condition with ParseService should really be addressed by moving the handling of the actual NodePort frontend IPs way down the stack, either to the datapath layer ("lbmap") or potentially even to BPF code. That's a larger refactoring though that also has implications to the `/service` REST API, so not feasible to tackle it currently.

Side note 2: this new code does not check for `--runtime-device-detection`. We're going to make that a no-op and eventually remove the flag.