### PR TITLE
statedb:  Reconciler utility

### DIFF
--- a/pkg/hive/cell/structured.go
+++ b/pkg/hive/cell/structured.go
@@ -50,6 +50,9 @@ type Scope interface {
 	// Thus it is preferable for all reporters to be Stopped first, before calling Close.
 	Close()
 
+	// Realize schedules an immediate realization of the status.
+	Realize()
+
 	scope() *subReporter
 }
 
@@ -215,6 +218,12 @@ func (s *scope) Close() {
 	s.base.removeTreeLocked(s.id)
 	s.base.Unlock()
 	s.scheduleRealize()
+}
+
+func (s *scope) Realize() {
+	s.base.Lock()
+	s.realizeSync()
+	s.base.Unlock()
 }
 
 // A scope can be removed if it has no references and all child scopes can be removed.

--- a/pkg/statedb/reconciler/benchmark/.gitignore
+++ b/pkg/statedb/reconciler/benchmark/.gitignore
@@ -1,0 +1,1 @@
+benchmark

--- a/pkg/statedb/reconciler/benchmark/main.go
+++ b/pkg/statedb/reconciler/benchmark/main.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"runtime"
+	"runtime/pprof"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/index"
+	"github.com/cilium/cilium/pkg/statedb/reconciler"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+var cpuprofile = flag.String("cpuprofile", "", "write cpu profile to `file`")
+var memprofile = flag.String("memprofile", "", "write memory profile to `file`")
+var numObjects = flag.Int("objects", 100000, "number of objects to create")
+var batchSize = flag.Int("batchsize", 1000, "batch size for writes")
+var incrBatchSize = flag.Int("incrbatchsize", 1000, "maximum batch size for incremental reconciliation")
+
+type testObject struct {
+	id     uint64
+	status reconciler.Status
+}
+
+func (t *testObject) GetStatus() reconciler.Status {
+	return t.status
+}
+
+func (t *testObject) WithStatus(status reconciler.Status) *testObject {
+	return &testObject{id: t.id, status: status}
+}
+
+type mockOps struct {
+}
+
+// Delete implements reconciler.Operations.
+func (mt *mockOps) Delete(ctx context.Context, txn statedb.ReadTxn, obj *testObject) error {
+	return nil
+}
+
+// Prune implements reconciler.Operations.
+func (mt *mockOps) Prune(ctx context.Context, txn statedb.ReadTxn, iter statedb.Iterator[*testObject]) error {
+	return nil
+}
+
+// Update implements reconciler.Operations.
+func (mt *mockOps) Update(ctx context.Context, txn statedb.ReadTxn, obj *testObject, changed *bool) error {
+	if changed != nil {
+		*changed = true
+	}
+	return nil
+}
+
+var _ reconciler.Operations[*testObject] = &mockOps{}
+
+var idIndex = statedb.Index[*testObject, uint64]{
+	Name: "id",
+	FromObject: func(t *testObject) index.KeySet {
+		return index.NewKeySet(index.Uint64(t.id))
+	},
+	FromKey: index.Uint64,
+	Unique:  true,
+}
+
+func main() {
+	flag.Parse()
+	if *cpuprofile != "" {
+		f, err := os.Create(*cpuprofile)
+		if err != nil {
+			log.Fatal("could not create CPU profile: ", err)
+		}
+		defer f.Close() // error handling omitted for example
+		if err := pprof.StartCPUProfile(f); err != nil {
+			log.Fatal("could not start CPU profile: ", err)
+		}
+		defer pprof.StopCPUProfile()
+	}
+
+	var (
+		mt = &mockOps{}
+		db *statedb.DB
+	)
+
+	testObjects, err := statedb.NewTable[*testObject]("test-objects", idIndex)
+	if err != nil {
+		panic(err)
+	}
+
+	logging.SetLogLevel(logrus.WarnLevel)
+
+	hive := hive.New(
+		statedb.Cell,
+		job.Cell,
+		reconciler.Cell,
+
+		cell.Module(
+			"test",
+			"Test",
+
+			cell.Provide(func(db_ *statedb.DB) (statedb.RWTable[*testObject], error) {
+				db = db_
+				return testObjects, db.RegisterTable(testObjects)
+			}),
+			cell.Provide(
+				func() (*mockOps, reconciler.Operations[*testObject]) {
+					return mt, mt
+				},
+			),
+			cell.Provide(func() reconciler.Config[*testObject] {
+				return reconciler.Config[*testObject]{
+					// Don't run the full reconciliation via timer, but rather explicitly so that the full
+					// reconciliation operations don't mix with incremental when not expected.
+					FullReconcilationInterval: time.Hour,
+
+					RetryBackoffMinDuration: time.Millisecond,
+					RetryBackoffMaxDuration: 10 * time.Millisecond,
+					IncrementalRoundSize:    *incrBatchSize,
+					GetObjectStatus:         (*testObject).GetStatus,
+					WithObjectStatus:        (*testObject).WithStatus,
+					Operations:              mt,
+				}
+			}),
+			cell.Invoke(reconciler.Register[*testObject]),
+		),
+	)
+
+	err = hive.Start(context.TODO())
+	if err != nil {
+		panic(err)
+	}
+
+	start := time.Now()
+
+	// Create objects in batches to allow the reconciler to start working
+	// on them while they're added.
+	id := uint64(0)
+	batches := int(*numObjects / *batchSize)
+	for b := 0; b < batches; b++ {
+		fmt.Printf("\rInserting batch %d/%d ...", b+1, batches)
+		wtxn := db.WriteTxn(testObjects)
+		for j := 0; j < *batchSize; j++ {
+			testObjects.Insert(wtxn, &testObject{
+				id:     id,
+				status: reconciler.StatusPending(),
+			})
+			id++
+		}
+		wtxn.Commit()
+	}
+
+	fmt.Printf("\nWaiting for reconciliation to finish ...\n")
+
+	// Wait for all to be reconciled by waiting for the last added objects to be marked
+	// reconciled. This only works here since none of the operations fail.
+	for {
+		obj, _, watch, ok := testObjects.FirstWatch(db.ReadTxn(), idIndex.Query(id-1))
+		if ok && obj.status.Kind == reconciler.StatusKindDone {
+			break
+		}
+		<-watch
+	}
+
+	end := time.Now()
+	duration := end.Sub(start)
+
+	timePerObject := float64(duration) / float64(*numObjects)
+	objsPerSecond := float64(time.Second) / timePerObject
+
+	if *memprofile != "" {
+		f, err := os.Create(*memprofile)
+		if err != nil {
+			log.Fatal("could not create memory profile: ", err)
+		}
+		defer f.Close() // error handling omitted for example
+		runtime.GC()    // get up-to-date statistics
+		if err := pprof.WriteHeapProfile(f); err != nil {
+			log.Fatal("could not write memory profile: ", err)
+		}
+	}
+
+	err = hive.Stop(context.TODO())
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("\n%d objects reconciled in %.2f seconds (batch size %d)\n",
+		*numObjects, float64(duration)/float64(time.Second), *batchSize)
+	fmt.Printf("Throughput %.2f objects per second\n", objsPerSecond)
+
+}

--- a/pkg/statedb/reconciler/cell.go
+++ b/pkg/statedb/reconciler/cell.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import "github.com/cilium/cilium/pkg/hive/cell"
+
+// Cell provides shared objects used by all reconciler instances.
+// Currently it provides only the Metrics object.
+var Cell = cell.Module(
+	"reconciler",
+	"Shared metrics for the reconcilers",
+
+	cell.Metric(newMetrics),
+)

--- a/pkg/statedb/reconciler/example/.gitignore
+++ b/pkg/statedb/reconciler/example/.gitignore
@@ -1,0 +1,1 @@
+example

--- a/pkg/statedb/reconciler/example/main.go
+++ b/pkg/statedb/reconciler/example/main.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/safeio"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/reconciler"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// This is a simple example of the statedb reconciler. It implements an
+// HTTP API for creating and deleting "memos" that are stored on the
+// disk.
+//
+// To run the application:
+//
+//   $ go run .
+//   (ctrl-c to stop)
+//
+// To create a memo:
+//
+//   $ curl -d 'hello world' http://localhost:8080/memos/greeting
+//   $ cat memos/greeting
+//
+// To delete a memo:
+//
+//   $ curl -XDELETE http://localhost:8080/memos/greeting
+//
+// The application builds on top of the reconciler which retries any failed
+// operations and also does periodic "full reconciliation" to prune unknown
+// memos and check that the stored memos are up-to-date. To test the resilence
+// you can try out the following:
+//
+//   # Create 'memos/greeting'
+//   $ curl -d 'hello world' http://localhost:8080/memos/greeting
+//
+//   # Make the file read-only and try changing it:
+//   $ chmod a-w memos/greeting
+//   $ curl -d 'hei maailma' http://localhost:8080/memos/greeting
+//   # (You should now see the update operation hitting permission denied)
+//
+//   # The reconciliation state can be observed in the Table[*Memo]:
+//   $ curl -q http://localhost:8080/statedb | jq .
+//
+//   # Let's give write permissions back:
+//   $ chmod u+w memos/greeting
+//   # (The update operation should now succeed)
+//   $ cat memos/greeting
+//   $ curl -s http://localhost:8080/statedb | jq .
+//
+//   # The full reconciliation runs every 10 seconds. We can see it in
+//   # action by modifying the contents of our greeting or by creating
+//   # a file directly:
+//   $ echo bogus > memos/bogus
+//   $ echo mangled > memos/greeting
+//   # (wait up to 10 seconds)
+//   $ cat memos/bogus
+//   $ cat memos/greeting
+//
+
+func main() {
+	cmd := cobra.Command{
+		Use: "example",
+		Run: func(_ *cobra.Command, args []string) {
+			if err := Hive.Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "Run: %s\n", err)
+			}
+		},
+	}
+
+	// Register command-line flags. Currently only
+	// has --directory for specifying where to store
+	// the memos.
+	Hive.RegisterFlags(cmd.Flags())
+
+	// Add the "hive" command for inspecting the object graph:
+	//
+	//  $ go run . hive
+	//
+	cmd.AddCommand(Hive.Command())
+
+	cmd.Execute()
+}
+
+var Hive = hive.New(
+	statedb.Cell,
+	job.Cell,
+	reconciler.Cell,
+
+	cell.Module(
+		"example",
+		"Reconciler example",
+
+		cell.Config(Config{}),
+
+		cell.Provide(
+			// Create and register the RWTable[*Memo]
+			NewMemoTable,
+
+			// Provide the Operations[*Memo] for reconciling Memos.
+			NewMemoOps,
+
+			// Construct the configuration for the memo reconciler.
+			NewReconcilerConfig,
+		),
+
+		// Create and register the reconciler for memos. This takes
+		// in Operations[*Memo] and Config[*Memo] and constructs a
+		// reconciler that will watch Table[*Memo] for changes and
+		// using Operations[*Memo] updates the memo files on disk.
+		cell.Invoke(reconciler.Register[*Memo]),
+
+		cell.Invoke(registerHTTPServer),
+	),
+)
+
+func NewReconcilerConfig(ops reconciler.Operations[*Memo]) reconciler.Config[*Memo] {
+	return reconciler.Config[*Memo]{
+		FullReconcilationInterval: 10 * time.Second,
+		RetryBackoffMinDuration:   100 * time.Millisecond,
+		RetryBackoffMaxDuration:   5 * time.Second,
+		IncrementalRoundSize:      100,
+		GetObjectStatus:           (*Memo).GetStatus,
+		WithObjectStatus:          (*Memo).WithStatus,
+		Operations:                ops,
+	}
+}
+
+// maxMemoSize defines the maximum size for a memo.
+const maxMemoSize = 1024
+
+func registerHTTPServer(
+	lc hive.Lifecycle,
+	log logrus.FieldLogger,
+	db *statedb.DB,
+	memos statedb.RWTable[*Memo]) {
+
+	mux := http.NewServeMux()
+
+	// For dumping the database:
+	// curl -s http://localhost:8080/statedb | jq .
+	mux.HandleFunc("/statedb", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		db.ReadTxn().WriteJSON(w)
+	})
+
+	// For creating and deleting memos:
+	// curl -d 'foo' http://localhost:8080/memos/bar
+	// curl -XDELETE http://localhost:8080/memos/bar
+	mux.HandleFunc("/memos/", func(w http.ResponseWriter, r *http.Request) {
+		name, ok := strings.CutPrefix(r.URL.Path, "/memos/")
+		if !ok {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		txn := db.WriteTxn(memos)
+		defer txn.Commit()
+
+		switch r.Method {
+		case "POST":
+			content, err := safeio.ReadAllLimit(r.Body, maxMemoSize)
+			if err != nil {
+				return
+			}
+			memos.Insert(
+				txn,
+				&Memo{
+					Name:    name,
+					Content: string(content),
+					Status:  reconciler.StatusPending(),
+				})
+			log.Infof("Inserted memo '%s'", name)
+			w.WriteHeader(http.StatusOK)
+
+		case "DELETE":
+			memo, _, ok := memos.First(txn, MemoNameIndex.Query(name))
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			memos.Insert(
+				txn,
+				memo.WithStatus(reconciler.StatusPendingDelete()))
+			log.Infof("Deleted memo '%s'", name)
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	server := http.Server{
+		Addr:    "127.0.0.1:8080",
+		Handler: mux,
+	}
+
+	lc.Append(hive.Hook{
+		OnStart: func(hive.HookContext) error {
+			log.Infof("Serving API at %s", server.Addr)
+			go server.ListenAndServe()
+			return nil
+		},
+		OnStop: func(ctx hive.HookContext) error {
+			return server.Shutdown(ctx)
+		},
+	})
+
+}

--- a/pkg/statedb/reconciler/example/ops.go
+++ b/pkg/statedb/reconciler/example/ops.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/reconciler"
+)
+
+// MemoOps writes [Memo]s to disk.
+// Implements the Reconciler.Operations[*Memo] API.
+type MemoOps struct {
+	log       logrus.FieldLogger
+	directory string
+}
+
+// NewMemoOps creates the memo operations.
+func NewMemoOps(lc hive.Lifecycle, log logrus.FieldLogger, cfg Config) reconciler.Operations[*Memo] {
+	ops := &MemoOps{directory: cfg.Directory, log: log}
+
+	// Register the Start and Stop methods to be called when the application
+	// starts and stops respectively. The start hook will create the
+	// memo directory.
+	lc.Append(ops)
+	return ops
+}
+
+// Delete a memo.
+func (ops *MemoOps) Delete(ctx context.Context, txn statedb.ReadTxn, memo *Memo) error {
+	filename := path.Join(ops.directory, memo.Name)
+	err := os.Remove(filename)
+	ops.log.Infof("Delete(%s): %s", filename, err)
+	return err
+}
+
+// Prune unexpected memos.
+func (ops *MemoOps) Prune(ctx context.Context, txn statedb.ReadTxn, iter statedb.Iterator[*Memo]) error {
+	expected := sets.New[string]()
+	for memo, _, ok := iter.Next(); ok; memo, _, ok = iter.Next() {
+		expected.Insert(memo.Name)
+	}
+
+	// Find unexpected files
+	unexpected := sets.New[string]()
+	if entries, err := os.ReadDir(ops.directory); err != nil {
+		return err
+	} else {
+		for _, entry := range entries {
+			if !expected.Has(entry.Name()) {
+				unexpected.Insert(entry.Name())
+			}
+		}
+	}
+
+	// ... and remove them.
+	var errs []error
+	for name := range unexpected {
+		filename := path.Join(ops.directory, name)
+		err := os.Remove(filename)
+		ops.log.Infof("Prune(%s): %v", filename, err)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// Update a memo.
+func (ops *MemoOps) Update(ctx context.Context, txn statedb.ReadTxn, memo *Memo, changed *bool) error {
+	filename := path.Join(ops.directory, memo.Name)
+
+	// Read the old file to figure out if it had changed.
+	// The 'changed' boolean is used by full reconciliation to keep track of when the target
+	// has gone out-of-sync (e.g. there has been some outside influence to it).
+	old, err := os.ReadFile(filename)
+	if err == nil && bytes.Equal(old, []byte(memo.Content)) {
+
+		// Nothing to do.
+		return nil
+	}
+	if changed != nil {
+		*changed = true
+	}
+	err = os.WriteFile(filename, []byte(memo.Content), 0644)
+	ops.log.Infof("Update(%s): %v", filename, err)
+	return err
+}
+
+var _ reconciler.Operations[*Memo] = &MemoOps{}
+
+func (ops *MemoOps) Start(hive.HookContext) error {
+	return os.MkdirAll(ops.directory, 0755)
+}
+
+func (*MemoOps) Stop(hive.HookContext) error {
+	return nil
+}
+
+var _ hive.HookInterface = &MemoOps{}

--- a/pkg/statedb/reconciler/example/types.go
+++ b/pkg/statedb/reconciler/example/types.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/index"
+	"github.com/cilium/cilium/pkg/statedb/reconciler"
+)
+
+// Config defines the command-line configuration for the memos
+// example application.
+type Config struct {
+	Directory string // the directory in which memos are stored.
+}
+
+func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.String("directory", "memos", "Memo directory")
+}
+
+// Memo is a brief note stored in the memos directory. A memo
+// can be created with the /memos API.
+type Memo struct {
+	Name    string            // filename of the memo. Stored in <directory>/<name>.
+	Content string            // contents of the memo.
+	Status  reconciler.Status // reconciliation status
+}
+
+// GetStatus returns the reconciliation status. Used to provide the
+// reconciler access to it.
+func (memo *Memo) GetStatus() reconciler.Status {
+	return memo.Status
+}
+
+// WithStatus returns a copy of the memo with a new reconciliation status.
+// Used by the reconciler to update the reconciliation status of the memo.
+func (memo *Memo) WithStatus(newStatus reconciler.Status) *Memo {
+	return &Memo{
+		Name:    memo.Name,
+		Content: memo.Content,
+		Status:  newStatus,
+	}
+}
+
+// MemoNameIndex allows looking up the memo by its name, e.g.
+// memos.First(txn, MemoNameIndex.Query("my-memo"))
+var MemoNameIndex = statedb.Index[*Memo, string]{
+	Name: "name",
+	FromObject: func(memo *Memo) index.KeySet {
+		return index.NewKeySet(index.String(memo.Name))
+	},
+	FromKey: index.String,
+	Unique:  true,
+}
+
+// MemoStatusIndex indexes memos by their reconciliation status.
+// This is mainly used by the reconciler to implement WaitForReconciliation.
+var MemoStatusIndex = reconciler.NewStatusIndex[*Memo]((*Memo).GetStatus)
+
+// NewMemoTable creates and registers the memos table.
+func NewMemoTable(db *statedb.DB) (statedb.RWTable[*Memo], statedb.Index[*Memo, reconciler.StatusKind], error) {
+	tbl, err := statedb.NewTable[*Memo](
+		"memos",
+		MemoNameIndex,
+		MemoStatusIndex,
+	)
+	if err == nil {
+		err = db.RegisterTable(tbl)
+	}
+	return tbl, MemoStatusIndex, err
+}

--- a/pkg/statedb/reconciler/full.go
+++ b/pkg/statedb/reconciler/full.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/exp/maps"
+
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// full performs full reconciliation of all objects. First the Prune() operations is performed to clean up and then
+// Update() is called for each object. Full reconciliation is used to recover from unexpected outside modifications.
+func (r *reconciler[Obj]) full(ctx context.Context, txn statedb.ReadTxn, lastRev statedb.Revision) (statedb.Revision, error) {
+	defer r.Metrics.FullReconciliationCount.With(r.labels).Add(1)
+
+	var errs []error
+	outOfSync := false
+	ops := r.Config.Operations
+
+	// First perform pruning to make room in the target.
+	iter, _ := r.Table.All(txn)
+	start := time.Now()
+	if err := ops.Prune(ctx, txn, iter); err != nil {
+		outOfSync = true
+		errs = append(errs, fmt.Errorf("pruning failed: %w", err))
+	}
+	labels := maps.Clone(r.labels)
+	labels[LabelOperation] = OpPrune
+	r.Metrics.FullReconciliationDuration.With(labels).Observe(
+		float64(time.Since(start)) / float64(time.Second),
+	)
+
+	// Call Update() for each desired object to validate that it is up-to-date.
+	updateResults := make(map[Obj]opResult)
+	iter, _ = r.Table.All(txn) // Grab a new iterator as Prune() may have consumed it.
+	for obj, rev, ok := iter.Next(); ok; obj, rev, ok = iter.Next() {
+		start := time.Now()
+		var changed bool
+		err := ops.Update(ctx, txn, obj, &changed)
+
+		labels := maps.Clone(r.labels)
+		labels[LabelOperation] = OpUpdate
+		r.Metrics.FullReconciliationDuration.With(labels).Observe(
+			float64(time.Since(start)) / float64(time.Second),
+		)
+
+		outOfSync = outOfSync || changed
+		if err == nil {
+			updateResults[obj] = opResult{rev: rev, status: StatusDone()}
+			r.retries.Clear(obj)
+		} else {
+			updateResults[obj] = opResult{rev: rev, status: StatusError(false, err)}
+			errs = append(errs, err)
+		}
+	}
+
+	// Increment the out-of-sync counter if full reconciliation catched any out-of-sync
+	// objects.
+	if outOfSync {
+		r.Metrics.FullReconciliationOutOfSyncCount.With(r.labels).Add(1)
+	}
+
+	// Commit the new desired object status. This is performed separately in order
+	// to not lock the table when performing long-running target operations.
+	// If the desired object has been updated in the meanwhile the status update is dropped.
+	if len(updateResults) > 0 {
+		wtxn := r.DB.WriteTxn(r.Table)
+		for obj, result := range updateResults {
+			obj = r.Config.WithObjectStatus(obj, result.status)
+			_, _, err := r.Table.CompareAndSwap(wtxn, result.rev, obj)
+			if err == nil && result.status.Kind != StatusKindDone {
+				// Object had not changed in the meantime, queue the retry.
+				r.retries.Add(obj)
+			}
+		}
+		wtxn.Commit()
+	}
+
+	if len(errs) > 0 {
+		r.Metrics.FullReconciliationTotalErrors.With(r.labels).Add(1)
+		return r.Table.Revision(txn), fmt.Errorf("full: %w", joinErrors(errs))
+	}
+
+	// Sync succeeded up to latest revision. Continue incremental reconciliation from
+	// this revision.
+	return r.Table.Revision(txn), nil
+}

--- a/pkg/statedb/reconciler/helpers.go
+++ b/pkg/statedb/reconciler/helpers.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/exp/slices"
+)
+
+var closedWatchChannel = func() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}()
+
+const (
+	// maxJoinedErrors limits the number of errors to join and return from
+	// failed reconciliation. This avoids constructing a massive error for
+	// health status when many operations fail at once.
+	maxJoinedErrors = 10
+)
+
+func omittedError(n int) error {
+	return fmt.Errorf("%d further errors omitted", n)
+}
+
+func joinErrors(errs []error) error {
+	if len(errs) > maxJoinedErrors {
+		errs = append(slices.Clone(errs)[:maxJoinedErrors], omittedError(len(errs)))
+	}
+	return errors.Join(errs...)
+}

--- a/pkg/statedb/reconciler/incremental.go
+++ b/pkg/statedb/reconciler/incremental.go
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/exp/maps"
+
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// incrementalRound is the shared context for incremental reconciliation and retries.
+type incrementalRound[Obj comparable] struct {
+	metrics        *Metrics
+	config         *Config[Obj]
+	retries        *retries
+	primaryIndexer statedb.Indexer[Obj]
+	db             *statedb.DB
+	ctx            context.Context
+	txn            statedb.ReadTxn
+	table          statedb.RWTable[Obj]
+	oldRevision    statedb.Revision
+
+	// numReconciled counts the number of objects that have been reconciled in this
+	// round, both for new & changed objects and for retried objects. If
+	// Config.IncrementalBatchSize is reached the round is stopped.
+	// This allows for timely reporting of status when lot of objects have changed and
+	// reconciliation per object is slow.
+	numReconciled int
+
+	// results collects the results of update and delete operations.
+	// The results are committed in a separate write transaction in order to
+	// not lock the table while reconciling. If an object has changed in the meanwhile
+	// the stale reconciliation result for that object is dropped.
+	results map[Obj]opResult
+
+	errs []error
+}
+
+func (r *reconciler[Obj]) incremental(ctx context.Context, txn statedb.ReadTxn, rev statedb.Revision) (statedb.Revision, <-chan struct{}, error) {
+	round := incrementalRound[Obj]{
+		metrics:        r.Metrics,
+		config:         &r.Config,
+		retries:        r.retries,
+		primaryIndexer: r.primaryIndexer,
+		db:             r.DB,
+		oldRevision:    rev,
+		ctx:            ctx,
+		txn:            txn,
+		table:          r.Table,
+		results:        make(map[Obj]opResult),
+	}
+
+	// Reconcile new and changed objects using either Operations
+	// or BatchOperations.
+	var newRevision statedb.Revision
+	if r.Config.BatchOperations != nil {
+		newRevision = round.batch(maps.Clone(r.labels))
+	} else {
+		newRevision = round.single(maps.Clone(r.labels))
+	}
+
+	// Process objects that need to be retried that were not cleared.
+	round.processRetries(maps.Clone(r.labels))
+
+	// Finally commit the status updates.
+	watch := round.commitStatus()
+
+	if round.numReconciled >= r.Config.IncrementalRoundSize {
+		// Round size limit was hit, use a closed watch channel to retrigger
+		// incremental reconciliation immediately.
+		watch = closedWatchChannel
+	}
+
+	r.Metrics.IncrementalReconciliationTotalErrors.With(r.labels).Add(float64(len(round.errs)))
+	r.Metrics.IncrementalReconciliationCurrentErrors.With(r.labels).Set(float64(len(round.errs)))
+	r.Metrics.IncrementalReconciliationCount.With(r.labels).Add(1)
+
+	if len(round.errs) > 0 {
+		return newRevision, watch, fmt.Errorf("incremental: %w", joinErrors(round.errs))
+	}
+	return newRevision, watch, nil
+}
+
+func (round *incrementalRound[Obj]) single(labels prometheus.Labels) statedb.Revision {
+	// Iterate in revision order through new and changed objects.
+	newRevision := round.oldRevision
+	iter, _ := round.table.LowerBound(round.txn, statedb.ByRevision[Obj](round.oldRevision+1))
+	for obj, rev, ok := iter.Next(); ok; obj, rev, ok = iter.Next() {
+		newRevision = rev
+
+		status := round.config.GetObjectStatus(obj)
+		if status.Kind != StatusKindPending {
+			// Only process objects that are pending reconciliation, e.g.
+			// changed from outside.
+			// Failures (e.g. StatusKindError) are processed via the retry queue.
+			continue
+		}
+
+		// Clear retries as the object has changed.
+		round.retries.Clear(obj)
+
+		err := round.processSingle(obj, rev, status, labels)
+		if err != nil {
+			round.errs = append(round.errs, err)
+		}
+
+		round.numReconciled++
+		if round.numReconciled >= round.config.IncrementalRoundSize {
+			break
+		}
+	}
+	return newRevision
+}
+
+func (round *incrementalRound[Obj]) batch(labels prometheus.Labels) statedb.Revision {
+	ops := round.config.BatchOperations
+	updateBatch := []BatchEntry[Obj]{}
+	deleteBatch := []BatchEntry[Obj]{}
+
+	// Iterate in revision order through new and changed objects.
+	newRevision := round.oldRevision
+	iter, _ := round.table.LowerBound(round.txn, statedb.ByRevision[Obj](round.oldRevision+1))
+	for obj, rev, ok := iter.Next(); ok; obj, rev, ok = iter.Next() {
+		newRevision = rev
+
+		status := round.config.GetObjectStatus(obj)
+		if status.Kind != StatusKindPending {
+			// Only process objects that are pending reconciliation, e.g.
+			// changed from outside.
+			// Failures (e.g. StatusKindError) are processed via the retry queue.
+			continue
+		}
+
+		// Clear an existing retry as the object has changed.
+		round.retries.Clear(obj)
+
+		if status.Delete {
+			deleteBatch = append(deleteBatch, BatchEntry[Obj]{Object: obj, Revision: rev})
+		} else {
+			updateBatch = append(updateBatch, BatchEntry[Obj]{Object: obj, Revision: rev})
+		}
+
+		round.numReconciled++
+		if round.numReconciled >= round.config.IncrementalRoundSize {
+			break
+		}
+	}
+
+	// Process the delete batch first to make room.
+	if len(deleteBatch) > 0 {
+		start := time.Now()
+		ops.DeleteBatch(round.ctx, round.txn, deleteBatch)
+		labels[LabelOperation] = OpDelete
+		round.metrics.IncrementalReconciliationDuration.With(labels).Observe(
+			float64(time.Since(start)) / float64(time.Second),
+		)
+		for _, entry := range deleteBatch {
+			if entry.Result == nil {
+				// Reconciling succeeded, so clear the retries.
+				round.retries.Clear(entry.Object)
+				round.results[entry.Object] = opResult{rev: entry.Revision, delete: true}
+			} else {
+				round.errs = append(round.errs, entry.Result)
+				round.results[entry.Object] = opResult{rev: entry.Revision, status: StatusError(true, entry.Result)}
+			}
+		}
+	}
+
+	// And then the update batch.
+	if len(updateBatch) > 0 {
+		start := time.Now()
+		ops.UpdateBatch(round.ctx, round.txn, updateBatch)
+		labels[LabelOperation] = OpUpdate
+		round.metrics.IncrementalReconciliationDuration.With(labels).Observe(
+			float64(time.Since(start)) / float64(time.Second),
+		)
+
+		for _, entry := range updateBatch {
+			if entry.Result == nil {
+				// Reconciling succeeded, so clear the retries.
+				round.retries.Clear(entry.Object)
+				round.results[entry.Object] = opResult{rev: entry.Revision, status: StatusDone()}
+			} else {
+				round.errs = append(round.errs, entry.Result)
+				round.results[entry.Object] = opResult{rev: entry.Revision, status: StatusError(false, entry.Result)}
+			}
+		}
+	}
+	return newRevision
+}
+
+func (round *incrementalRound[Obj]) processRetries(labels prometheus.Labels) {
+	now := time.Now()
+	for round.numReconciled < round.config.IncrementalRoundSize {
+		robj, retryAt, ok := round.retries.Top()
+		if !ok || retryAt.After(now) {
+			break
+		}
+		round.retries.Pop()
+
+		obj, rev, ok := round.table.First(round.txn, round.primaryIndexer.QueryFromObject(robj.(Obj)))
+		if !ok {
+			// Object has been deleted unexpectedly (e.g. from outside
+			// the reconciler). Assume that it can be forgotten about.
+			round.retries.Clear(robj)
+			continue
+		}
+
+		status := round.config.GetObjectStatus(obj)
+		if status.Kind != StatusKindError {
+			continue
+		}
+
+		err := round.processSingle(obj, rev, status, labels)
+		if err != nil {
+			round.errs = append(round.errs, err)
+		}
+
+		round.numReconciled++
+	}
+}
+
+func (round *incrementalRound[Obj]) processSingle(obj Obj, rev statedb.Revision, status Status, labels prometheus.Labels) error {
+	start := time.Now()
+
+	var err error
+	if status.Delete {
+		labels[LabelOperation] = OpDelete
+		err = round.config.Operations.Delete(round.ctx, round.txn, obj)
+		if err == nil {
+			round.results[obj] = opResult{rev: rev, delete: true}
+		} else {
+			round.results[obj] = opResult{rev: rev, status: StatusError(true, err)}
+		}
+	} else {
+		labels[LabelOperation] = OpUpdate
+		err = round.config.Operations.Update(round.ctx, round.txn, obj, nil /* changed */)
+		if err == nil {
+			round.results[obj] = opResult{rev: rev, status: StatusDone()}
+		} else {
+			round.results[obj] = opResult{rev: rev, status: StatusError(false, err)}
+		}
+	}
+	round.metrics.IncrementalReconciliationDuration.With(labels).Observe(
+		float64(time.Since(start)) / float64(time.Second),
+	)
+
+	if err == nil {
+		// Reconciling succeeded, so clear the object.
+		round.retries.Clear(obj)
+	}
+
+	return err
+
+}
+
+func (round *incrementalRound[Obj]) commitStatus() <-chan struct{} {
+	wtxn := round.db.WriteTxn(round.table)
+	defer wtxn.Commit()
+
+	// The revision before committing the status updates.
+	revBeforeWrite := round.table.Revision(wtxn)
+
+	// Commit status for updated objects.
+	for obj, result := range round.results {
+		if result.delete {
+			round.table.CompareAndDelete(wtxn, result.rev, obj)
+			continue
+		}
+
+		// Update the object if it is unchanged. It may happen that the object has
+		// been updated in the meanwhile, in which case we ignore the status as the
+		// update will be picked up by next reconciliation round.
+		round.table.CompareAndSwap(wtxn, result.rev, round.config.WithObjectStatus(obj, result.status))
+
+		if result.status.Kind == StatusKindError {
+			// Reconciling the object failed, so add it to be retried now that it's
+			// status is updated.
+			round.retries.Add(obj)
+		}
+	}
+
+	watch := closedWatchChannel
+	if round.oldRevision == revBeforeWrite {
+		// No changes happened between the ReadTxn and this WriteTxn. Grab a new
+		// watch channel of the root to only watch for new changes after
+		// this write.
+		//
+		// If changes did happen, we'll return a closed watch channel and
+		// immediately reconcile again.
+		_, watch = round.table.All(wtxn)
+	}
+	return watch
+}

--- a/pkg/statedb/reconciler/index.go
+++ b/pkg/statedb/reconciler/index.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/index"
+)
+
+// NewStatusIndex creates a status index for a table of reconcilable objects.
+func NewStatusIndex[Obj any](getObjectStatus func(Obj) Status) statedb.Index[Obj, StatusKind] {
+	return statedb.Index[Obj, StatusKind]{
+		Name: "status",
+		FromObject: func(obj Obj) index.KeySet {
+			return index.NewKeySet(getObjectStatus(obj).Kind.Key())
+		},
+		FromKey: StatusKind.Key,
+		Unique:  false,
+	}
+}

--- a/pkg/statedb/reconciler/metrics.go
+++ b/pkg/statedb/reconciler/metrics.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+type Metrics struct {
+	IncrementalReconciliationCount         metric.Vec[metric.Counter]
+	IncrementalReconciliationDuration      metric.Vec[metric.Observer]
+	IncrementalReconciliationTotalErrors   metric.Vec[metric.Counter]
+	IncrementalReconciliationCurrentErrors metric.Vec[metric.Gauge]
+
+	FullReconciliationCount          metric.Vec[metric.Counter]
+	FullReconciliationOutOfSyncCount metric.Vec[metric.Counter]
+	FullReconciliationTotalErrors    metric.Vec[metric.Counter]
+	FullReconciliationDuration       metric.Vec[metric.Observer]
+}
+
+const (
+	LabelModuleId  = "module_id"
+	LabelOperation = "op"
+
+	OpUpdate = "update"
+	OpDelete = "delete"
+	OpPrune  = "prune"
+)
+
+func newMetrics() *Metrics {
+	return &Metrics{
+		IncrementalReconciliationCount: metric.NewCounterVec(metric.CounterOpts{
+			ConfigName: metrics.Namespace + "_reconciler_incremental_total",
+			Disabled:   true,
+			Namespace:  metrics.Namespace,
+			Subsystem:  "reconciler",
+			Name:       "incremental_total",
+			Help:       "Number of incremental reconciliations performed",
+		}, []string{LabelModuleId}),
+
+		IncrementalReconciliationDuration: metric.NewHistogramVec(metric.HistogramOpts{
+			ConfigName: metrics.Namespace + "_reconciler_incremental_duration_seconds",
+			Disabled:   true,
+			Namespace:  metrics.Namespace,
+			Subsystem:  "reconciler",
+			Name:       "incremental_duration_seconds",
+			Help:       "Histogram of per-operation duration during incremental reconciliation",
+		}, []string{LabelModuleId, LabelOperation}),
+
+		IncrementalReconciliationTotalErrors: metric.NewCounterVec(metric.CounterOpts{
+			ConfigName: metrics.Namespace + "_reconciler_incremental_errors_total",
+			Disabled:   true,
+			Namespace:  metrics.Namespace,
+			Subsystem:  "reconciler",
+			Name:       "incremental_errors_total",
+			Help:       "Total number of errors encountered during incremental reconciliation",
+		}, []string{LabelModuleId}),
+
+		IncrementalReconciliationCurrentErrors: metric.NewGaugeVec(metric.GaugeOpts{
+			ConfigName: metrics.Namespace + "_reconciler_incremental_errors_current",
+			Disabled:   true,
+			Namespace:  metrics.Namespace,
+			Subsystem:  "reconciler",
+			Name:       "incremental_errors_current",
+			Help:       "The number of objects currently failing to be reconciled",
+		}, []string{LabelModuleId}),
+
+		FullReconciliationCount: metric.NewCounterVec(metric.CounterOpts{
+			ConfigName: metrics.Namespace + "_reconciler_full_total",
+			Disabled:   true,
+			Namespace:  metrics.Namespace,
+			Subsystem:  "reconciler",
+			Name:       "full_total",
+			Help:       "Number of full reconciliations performed",
+		}, []string{LabelModuleId}),
+
+		FullReconciliationOutOfSyncCount: metric.NewCounterVec(metric.CounterOpts{
+			ConfigName: metrics.Namespace + "_reconciler_full_out_of_sync_total",
+			Disabled:   true,
+			Namespace:  metrics.Namespace,
+			Subsystem:  "reconciler",
+			Name:       "full_out_of_sync_total",
+			Help:       "Number of times full reconciliation found objects to reconcile",
+		}, []string{LabelModuleId}),
+
+		FullReconciliationTotalErrors: metric.NewCounterVec(metric.CounterOpts{
+			ConfigName: metrics.Namespace + "_reconciler_full_errors_total",
+			Disabled:   true,
+			Namespace:  metrics.Namespace,
+			Subsystem:  "reconciler",
+			Name:       "full_errors_total",
+			Help:       "Total number of errors encountered during full reconciliation",
+		}, []string{LabelModuleId}),
+
+		FullReconciliationDuration: metric.NewHistogramVec(metric.HistogramOpts{
+			ConfigName: metrics.Namespace + "_reconciler_full_duration_seconds",
+			Disabled:   true,
+			Namespace:  metrics.Namespace,
+			Subsystem:  "reconciler",
+			Name:       "full_duration_seconds",
+			Help:       "Histogram of per-operation duration during full reconciliation",
+		}, []string{LabelModuleId, LabelOperation}),
+	}
+}

--- a/pkg/statedb/reconciler/reconciler.go
+++ b/pkg/statedb/reconciler/reconciler.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/index"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// Register creates a new reconciler and registers to the application
+// lifecycle. To be used with cell.Invoke when the API of the reconciler
+// is not needed.
+func Register[Obj comparable](p Params[Obj]) error {
+	_, err := New(p)
+	return err
+}
+
+// New creates and registers a new reconciler.
+func New[Obj comparable](p Params[Obj]) (Reconciler[Obj], error) {
+	if err := p.Config.validate(); err != nil {
+		return nil, err
+	}
+
+	idx := p.Table.PrimaryIndexer()
+	objectToKey := func(o any) index.Key {
+		return idx.ObjectToKey(o.(Obj))
+	}
+	r := &reconciler[Obj]{
+		Params:              p,
+		retries:             newRetries(p.Config.RetryBackoffMinDuration, p.Config.RetryBackoffMaxDuration, objectToKey),
+		externalFullTrigger: make(chan struct{}, 1),
+		labels: prometheus.Labels{
+			LabelModuleId: string(p.ModuleId),
+		},
+		primaryIndexer: idx,
+	}
+
+	g := p.Jobs.NewGroup(p.Scope)
+
+	g.Add(job.OneShot("reconciler-loop", r.loop))
+	p.Lifecycle.Append(g)
+
+	return r, nil
+}
+
+type Params[Obj comparable] struct {
+	cell.In
+
+	Config    Config[Obj]
+	Lifecycle hive.Lifecycle
+	Log       logrus.FieldLogger
+	DB        *statedb.DB
+	Table     statedb.RWTable[Obj]
+	Jobs      job.Registry
+	Metrics   *Metrics
+	ModuleId  cell.ModuleID
+	Scope     cell.Scope
+}
+
+type reconciler[Obj comparable] struct {
+	Params[Obj]
+	retries             *retries
+	externalFullTrigger chan struct{}
+	primaryIndexer      statedb.Indexer[Obj]
+	labels              prometheus.Labels
+}
+
+func (r *reconciler[Obj]) TriggerFullReconciliation() {
+	select {
+	case r.externalFullTrigger <- struct{}{}:
+	default:
+	}
+}
+
+// WaitForReconciliation blocks until all objects have been reconciled or the context
+// has cancelled.
+func WaitForReconciliation[Obj any](ctx context.Context, db *statedb.DB, table statedb.Table[Obj], statusIndex statedb.Index[Obj, StatusKind]) error {
+	for {
+		txn := db.ReadTxn()
+
+		// See if there are any pending or error'd objects.
+		_, _, watchPending, okPending := table.FirstWatch(txn, statusIndex.Query(StatusKindPending))
+		_, _, watchError, okError := table.FirstWatch(txn, statusIndex.Query(StatusKindError))
+		if !okPending && !okError {
+			return nil
+		}
+
+		// Wait for updates before checking again.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-watchPending:
+		case <-watchError:
+		}
+	}
+}
+
+func (r *reconciler[Obj]) loop(ctx context.Context, health cell.HealthReporter) error {
+	var fullReconTickerChan <-chan time.Time
+	if r.Config.FullReconcilationInterval > 0 {
+		fullReconTicker := time.NewTicker(r.Config.FullReconcilationInterval)
+		defer fullReconTicker.Stop()
+		fullReconTickerChan = fullReconTicker.C
+	}
+
+	tableWatchChan := closedWatchChannel
+	revision := statedb.Revision(0)
+	fullReconciliation := false
+
+	for {
+		if r.Config.RateLimiter != nil {
+			r.Config.RateLimiter.Wait(ctx)
+		}
+
+		// Wait for trigger
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case <-fullReconTickerChan:
+			fullReconciliation = true
+		case <-r.externalFullTrigger:
+			fullReconciliation = true
+
+		case <-r.retries.Wait():
+			// Object(s) are ready to be retried
+
+		case <-tableWatchChan:
+			// Table has changed
+		}
+
+		var (
+			err  error
+			errs []error
+			txn  = r.DB.ReadTxn()
+		)
+
+		// Perform incremental reconciliation and retries of previously failed
+		// objects.
+		revision, tableWatchChan, err = r.incremental(ctx, txn, revision)
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		if fullReconciliation {
+			// Time to perform a full reconciliation. An incremental reconciliation
+			// has been performed prior to this, so the assumption is that everything
+			// is up to date (provided incremental reconciliation did not fail). We
+			// report full reconciliation disparencies as they're indicative of something
+			// interfering with Cilium operations.
+
+			// Clear full reconciliation even if there's errors. Individual objects
+			// will be retried via the retry queue.
+			fullReconciliation = false
+
+			var err error
+			revision, err = r.full(ctx, txn, revision)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+
+		if len(errs) == 0 {
+			health.OK(fmt.Sprintf("OK, %d objects", r.Table.NumObjects(txn)))
+		} else {
+			health.Degraded("Reconciliation failed", errors.Join(errs...))
+		}
+	}
+}

--- a/pkg/statedb/reconciler/reconciler_test.go
+++ b/pkg/statedb/reconciler/reconciler_test.go
@@ -1,0 +1,608 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"golang.org/x/exp/slices"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/lock"
+	metricsPkg "github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/index"
+	"github.com/cilium/cilium/pkg/statedb/reconciler"
+)
+
+// Some constants so we don't use mysterious numbers in the test steps.
+const (
+	ID_1 = uint64(1)
+	ID_2 = uint64(2)
+	ID_3 = uint64(3)
+)
+
+func TestReconciler(t *testing.T) {
+	testReconciler(t, false)
+}
+
+func TestReconciler_Batch(t *testing.T) {
+	testReconciler(t, true)
+}
+
+func testReconciler(t *testing.T, batchOps bool) {
+	defer goleak.VerifyNone(t,
+		goleak.IgnoreCurrent(),
+		// metrics.statusCollector uses cilium client, so we see some http connections.
+		goleak.IgnoreAnyFunction("net/http.(*persistConn).readLoop"),
+		goleak.IgnoreAnyFunction("net/http.(*persistConn).writeLoop"),
+	)
+
+	var (
+		mt       = &mockOps{}
+		db       *statedb.DB
+		registry *metricsPkg.Registry
+		r        reconciler.Reconciler[*testObject]
+		health   cell.Health
+		scope    cell.Scope
+	)
+
+	testObjects, err := statedb.NewTable[*testObject]("test-objects", idIndex, statusIndex)
+	require.NoError(t, err, "NewTable")
+
+	hive := hive.New(
+		statedb.Cell,
+		job.Cell,
+		reconciler.Cell,
+
+		cell.Group(
+			cell.Provide(func() *option.DaemonConfig { return option.Config }),
+			cell.Provide(func() metricsPkg.RegistryConfig { return metricsPkg.RegistryConfig{} }),
+			cell.Provide(metricsPkg.NewRegistry),
+		),
+
+		cell.Invoke(func(r *metricsPkg.Registry) {
+			registry = r
+		}),
+
+		cell.Module(
+			"test",
+			"Test",
+
+			cell.Provide(func(db_ *statedb.DB) (statedb.RWTable[*testObject], error) {
+				db = db_
+				return testObjects, db.RegisterTable(testObjects)
+			}),
+			cell.Provide(func() reconciler.Config[*testObject] {
+				cfg := reconciler.Config[*testObject]{
+					// Don't run the full reconciliation via timer, but rather explicitly so that the full
+					// reconciliation operations don't mix with incremental when not expected.
+					FullReconcilationInterval: time.Hour,
+
+					RetryBackoffMinDuration: time.Millisecond,
+					RetryBackoffMaxDuration: 10 * time.Millisecond,
+					IncrementalRoundSize:    1000,
+					GetObjectStatus:         (*testObject).GetStatus,
+					WithObjectStatus:        (*testObject).WithStatus,
+					Operations:              mt,
+				}
+				if batchOps {
+					cfg.BatchOperations = mt
+				}
+				return cfg
+			}),
+			cell.Provide(reconciler.New[*testObject]),
+
+			cell.Invoke(func(r_ reconciler.Reconciler[*testObject], m *reconciler.Metrics, h cell.Health, s cell.Scope) {
+				r = r_
+				health = h
+				scope = s
+
+				// Enable all metrics for the test
+				m.IncrementalReconciliationCount.SetEnabled(true)
+				m.IncrementalReconciliationDuration.SetEnabled(true)
+				m.IncrementalReconciliationTotalErrors.SetEnabled(true)
+				m.IncrementalReconciliationCurrentErrors.SetEnabled(true)
+				m.FullReconciliationCount.SetEnabled(true)
+				m.FullReconciliationOutOfSyncCount.SetEnabled(true)
+				m.FullReconciliationTotalErrors.SetEnabled(true)
+				m.FullReconciliationDuration.SetEnabled(true)
+			}),
+		),
+	)
+
+	require.NoError(t, hive.Start(context.TODO()), "Start")
+
+	h := testHelper{
+		t:      t,
+		db:     db,
+		tbl:    testObjects,
+		ops:    mt,
+		r:      r,
+		health: health,
+		scope:  scope,
+	}
+
+	numIterations := 3
+
+	t.Run("incremental", func(t *testing.T) {
+		h.t = t
+
+		for i := 0; i < numIterations; i++ {
+			t.Logf("Iteration %d", i)
+
+			// Insert some test objects and check that they're reconciled
+			t.Logf("Inserting test objects 1, 2 & 3")
+			h.insert(ID_1, NonFaulty, reconciler.StatusPending())
+			h.expectOp(opUpdate(ID_1))
+			h.expectStatus(ID_1, reconciler.StatusKindDone, "")
+
+			h.insert(ID_2, NonFaulty, reconciler.StatusPending())
+			h.expectOp(opUpdate(ID_2))
+			h.expectStatus(ID_2, reconciler.StatusKindDone, "")
+
+			h.insert(ID_3, NonFaulty, reconciler.StatusPending())
+			h.expectOp(opUpdate(ID_3))
+			h.expectStatus(ID_3, reconciler.StatusKindDone, "")
+
+			h.expectHealthLevel(cell.StatusOK)
+			h.waitForReconciliation()
+
+			// Set one to be faulty => object will error
+			t.Log("Setting '1' faulty")
+			h.insert(ID_1, Faulty, reconciler.StatusPending())
+			h.expectOp(opFail(opUpdate(ID_1)))
+			h.expectStatus(ID_1, reconciler.StatusKindError, "update fail")
+			h.expectRetried(ID_1)
+			h.expectHealthLevel(cell.StatusDegraded)
+
+			// Fix the object => object will reconcile again.
+			t.Log("Setting '1' non-faulty")
+			h.insert(ID_1, NonFaulty, reconciler.StatusPending())
+			h.expectOp(opUpdate(ID_1))
+			h.expectStatus(ID_1, reconciler.StatusKindDone, "")
+			h.expectHealthLevel(cell.StatusOK)
+
+			t.Log("Delete 1 & 2")
+			h.markForDelete(ID_1)
+			h.expectOp(opDelete(1))
+			h.expectNotFound(ID_1)
+
+			h.markForDelete(ID_2)
+			h.expectOp(opDelete(2))
+			h.expectNotFound(ID_2)
+
+			t.Log("Try to delete '3' with faulty ops")
+			h.setTargetFaulty(true)
+			h.markForDelete(ID_3)
+			h.expectOp(opFail(opDelete(3)))
+			h.expectStatus(ID_3, reconciler.StatusKindError, "delete fail")
+			h.expectHealthLevel(cell.StatusDegraded)
+
+			t.Log("Delete 3")
+			h.setTargetFaulty(false)
+			h.expectOp(opDelete(3))
+			h.expectNotFound(ID_3)
+			h.expectHealthLevel(cell.StatusOK)
+
+			h.waitForReconciliation()
+
+		}
+	})
+
+	t.Run("full", func(t *testing.T) {
+		h.t = t
+
+		for i := 0; i < numIterations; i++ {
+			t.Logf("Iteration %d", i)
+
+			// Without any objects, we should only see prune.
+			t.Log("Full reconciliation without objects")
+			h.triggerFullReconciliation()
+			h.expectOp(opPrune(0))
+			h.expectHealthLevel(cell.StatusOK)
+
+			// Add few objects and wait until incremental reconciliation is done.
+			t.Log("Insert test objects")
+			h.insert(ID_1, NonFaulty, reconciler.StatusPending())
+			h.insert(ID_2, NonFaulty, reconciler.StatusPending())
+			h.insert(ID_3, NonFaulty, reconciler.StatusPending())
+			h.expectStatus(ID_1, reconciler.StatusKindDone, "")
+			h.expectStatus(ID_2, reconciler.StatusKindDone, "")
+			h.expectStatus(ID_3, reconciler.StatusKindDone, "")
+			h.expectHealthLevel(cell.StatusOK)
+
+			// Full reconciliation with functioning ops.
+			t.Log("Full reconciliation with non-faulty ops")
+			h.triggerFullReconciliation()
+			h.expectOps(opPrune(3), opUpdate(ID_1), opUpdate(ID_2), opUpdate(ID_3))
+			h.expectStatus(ID_1, reconciler.StatusKindDone, "")
+			h.expectStatus(ID_2, reconciler.StatusKindDone, "")
+			h.expectStatus(ID_3, reconciler.StatusKindDone, "")
+			h.expectHealthLevel(cell.StatusOK)
+
+			// Make the ops faulty and trigger the full reconciliation.
+			t.Log("Full reconciliation with faulty ops")
+			h.setTargetFaulty(true)
+			h.triggerFullReconciliation()
+			h.expectOps(
+				opFail(opUpdate(ID_1)),
+				opFail(opUpdate(ID_2)),
+				opFail(opUpdate(ID_3)),
+			)
+			h.expectHealthLevel(cell.StatusDegraded)
+
+			// Expect the objects to be retried also after the full reconciliation.
+			h.expectRetried(ID_1)
+			h.expectRetried(ID_2)
+			h.expectRetried(ID_3)
+
+			// All should be marked as errored.
+			h.expectStatus(ID_1, reconciler.StatusKindError, "update fail")
+			h.expectStatus(ID_2, reconciler.StatusKindError, "update fail")
+			h.expectStatus(ID_3, reconciler.StatusKindError, "update fail")
+
+			// Make the ops healthy again and check that the objects recover.
+			t.Log("Retries succeed after ops is non-faulty")
+			h.setTargetFaulty(false)
+			h.expectOps(opUpdate(ID_1), opUpdate(ID_2), opUpdate(ID_3))
+			h.expectStatus(ID_1, reconciler.StatusKindDone, "")
+			h.expectStatus(ID_2, reconciler.StatusKindDone, "")
+			h.expectStatus(ID_3, reconciler.StatusKindDone, "")
+			h.expectHealthLevel(cell.StatusOK)
+
+			// Cleanup.
+			h.markForDelete(ID_1)
+			h.markForDelete(ID_2)
+			h.markForDelete(ID_3)
+			h.expectNotFound(ID_1)
+			h.expectNotFound(ID_2)
+			h.expectNotFound(ID_3)
+			h.triggerFullReconciliation()
+			h.expectOps(opDelete(1), opDelete(2), opDelete(3), opPrune(0))
+			h.waitForReconciliation()
+
+		}
+	})
+
+	// ---
+	// Validate that the metrics are populated and make some sense.
+	m := dumpMetrics(registry)
+	assertSensibleMetricDuration(t, m, "cilium_reconciler_full_duration_seconds/module_id=test,op=prune")
+	assertSensibleMetricDuration(t, m, "cilium_reconciler_full_duration_seconds/module_id=test,op=update")
+	assert.Greater(t, m["cilium_reconciler_full_out_of_sync_total/module_id=test"], 0.0)
+	assert.Greater(t, m["cilium_reconciler_full_total/module_id=test"], 0.0)
+
+	assertSensibleMetricDuration(t, m, "cilium_reconciler_incremental_duration_seconds/module_id=test,op=update")
+	assertSensibleMetricDuration(t, m, "cilium_reconciler_incremental_duration_seconds/module_id=test,op=delete")
+	assert.Equal(t, m["cilium_reconciler_incremental_errors_current/module_id=test"], 0.0)
+	assert.Greater(t, m["cilium_reconciler_incremental_errors_total/module_id=test"], 0.0)
+	assert.Greater(t, m["cilium_reconciler_incremental_total/module_id=test"], 0.0)
+
+	assert.NoError(t, hive.Stop(context.TODO()), "Stop")
+}
+
+type testObject struct {
+	id     uint64
+	faulty bool
+	status reconciler.Status
+}
+
+var idIndex = statedb.Index[*testObject, uint64]{
+	Name: "id",
+	FromObject: func(t *testObject) index.KeySet {
+		return index.NewKeySet(index.Uint64(t.id))
+	},
+	FromKey: index.Uint64,
+	Unique:  true,
+}
+
+var statusIndex = reconciler.NewStatusIndex[*testObject]((*testObject).GetStatus)
+
+// GetStatus implements reconciler.Reconcilable.
+func (t *testObject) GetStatus() reconciler.Status {
+	return t.status
+}
+
+// WithStatus implements reconciler.Reconcilable.
+func (t *testObject) WithStatus(status reconciler.Status) *testObject {
+	t2 := *t
+	t2.status = status
+	return &t2
+}
+
+type opHistory struct {
+	mu      lock.Mutex
+	history []opHistoryItem
+}
+
+type opHistoryItem = string
+
+func opUpdate(id uint64) opHistoryItem {
+	return opHistoryItem(fmt.Sprintf("update(%d)", id))
+}
+func opDelete(id uint64) opHistoryItem {
+	return opHistoryItem(fmt.Sprintf("delete(%d)", id))
+}
+func opPrune(numDesiredObjects int) opHistoryItem {
+	return opHistoryItem(fmt.Sprintf("prune(n=%d)", numDesiredObjects))
+}
+func opFail(item opHistoryItem) opHistoryItem {
+	return item + " fail"
+}
+
+func (o *opHistory) add(item opHistoryItem) {
+	o.mu.Lock()
+	o.history = append(o.history, item)
+	o.mu.Unlock()
+}
+
+func (o *opHistory) latest() opHistoryItem {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if len(o.history) > 0 {
+		return o.history[len(o.history)-1]
+	}
+	return "<empty history>"
+}
+
+func (o *opHistory) take(n int) []opHistoryItem {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	out := []opHistoryItem{}
+	for n > 0 {
+		idx := len(o.history) - n
+		if idx >= 0 {
+			out = append(out, o.history[idx])
+		}
+		n--
+	}
+	return out
+}
+
+type intMap struct {
+	lock.Map[uint64, int]
+}
+
+func (m *intMap) incr(key uint64) {
+	if n, ok := m.Load(key); ok {
+		m.Store(key, n+1)
+	} else {
+		m.Store(key, 1)
+	}
+}
+
+func (m *intMap) get(key uint64) int {
+	if n, ok := m.Load(key); ok {
+		return n
+	}
+	return 0
+}
+
+type mockOps struct {
+	history opHistory
+	faulty  atomic.Bool
+	updates intMap
+}
+
+// DeleteBatch implements recogciler.BatchOperations.
+func (mt *mockOps) DeleteBatch(ctx context.Context, txn statedb.ReadTxn, batch []reconciler.BatchEntry[*testObject]) {
+	for i := range batch {
+		batch[i].Result = mt.Delete(ctx, txn, batch[i].Object)
+	}
+}
+
+// UpdateBatch implements reconciler.BatchOperations.
+func (mt *mockOps) UpdateBatch(ctx context.Context, txn statedb.ReadTxn, batch []reconciler.BatchEntry[*testObject]) {
+	for i := range batch {
+		batch[i].Result = mt.Update(ctx, txn, batch[i].Object, nil)
+	}
+}
+
+// Delete implements reconciler.Operations.
+func (mt *mockOps) Delete(ctx context.Context, txn statedb.ReadTxn, obj *testObject) error {
+	if mt.faulty.Load() || obj.faulty {
+		mt.history.add(opFail(opDelete(obj.id)))
+		return errors.New("delete fail")
+	}
+	mt.history.add(opDelete(obj.id))
+
+	return nil
+}
+
+// Prune implements reconciler.Operations.
+func (mt *mockOps) Prune(ctx context.Context, txn statedb.ReadTxn, iter statedb.Iterator[*testObject]) error {
+	objs := statedb.Collect(iter)
+	mt.history.add(opPrune(len(objs)))
+	return nil
+}
+
+// Update implements reconciler.Operations.
+func (mt *mockOps) Update(ctx context.Context, txn statedb.ReadTxn, obj *testObject, changed *bool) error {
+	if changed != nil {
+		*changed = true
+	}
+	mt.updates.incr(obj.id)
+	if mt.faulty.Load() || obj.faulty {
+		mt.history.add(opFail(opUpdate(obj.id)))
+		return errors.New("update fail")
+	}
+	mt.history.add(opUpdate(obj.id))
+	return nil
+}
+
+var _ reconciler.Operations[*testObject] = &mockOps{}
+var _ reconciler.BatchOperations[*testObject] = &mockOps{}
+
+// testHelper defines a sort of mini-language for writing the test steps.
+type testHelper struct {
+	t      testing.TB
+	db     *statedb.DB
+	tbl    statedb.RWTable[*testObject]
+	ops    *mockOps
+	r      reconciler.Reconciler[*testObject]
+	health cell.Health
+	scope  cell.Scope
+}
+
+const (
+	Faulty    = true
+	NonFaulty = false
+)
+
+func (h testHelper) insert(id uint64, faulty bool, status reconciler.Status) {
+	wtxn := h.db.WriteTxn(h.tbl)
+	_, _, err := h.tbl.Insert(wtxn, &testObject{
+		id:     id,
+		faulty: faulty,
+		status: status,
+	})
+	require.NoError(h.t, err, "insert failed")
+	wtxn.Commit()
+}
+
+func (h testHelper) markForDelete(id uint64) {
+	wtxn := h.db.WriteTxn(h.tbl)
+	_, _, err := h.tbl.Insert(wtxn, &testObject{
+		id:     id,
+		faulty: false,
+		status: reconciler.StatusPendingDelete(),
+	})
+	require.NoError(h.t, err, "delete failed")
+	wtxn.Commit()
+}
+
+func (h testHelper) expectStatus(id uint64, kind reconciler.StatusKind, err string) {
+	cond := func() bool {
+		obj, _, ok := h.tbl.First(h.db.ReadTxn(), idIndex.Query(id))
+		return ok && obj.status.Kind == kind && obj.status.Error == err
+	}
+	if !assert.Eventually(h.t, cond, time.Second, time.Millisecond) {
+		actual := "<not found>"
+		obj, _, ok := h.tbl.First(h.db.ReadTxn(), idIndex.Query(id))
+		if ok {
+			actual = string(obj.status.Kind)
+		}
+		require.Failf(h.t, "status mismatch", "expected object %d to be marked with status %q, but it was %q",
+			id, kind, actual)
+
+	}
+}
+
+func (h testHelper) expectNotFound(id uint64) {
+	cond := func() bool {
+		_, _, ok := h.tbl.First(h.db.ReadTxn(), idIndex.Query(id))
+		return !ok
+	}
+	require.Eventually(h.t, cond, time.Second, time.Millisecond, "expected object %d to not be found", id)
+}
+
+func (h testHelper) expectOp(op opHistoryItem) {
+	cond := func() bool {
+		return h.ops.history.latest() == op
+	}
+	if !assert.Eventually(h.t, cond, time.Second, time.Millisecond) {
+		require.Failf(h.t, "operation mismatch", "expected last operation to be %q, it was %q", op, h.ops.history.latest())
+	}
+}
+
+func (h testHelper) expectOps(ops ...opHistoryItem) {
+	sort.Strings(ops)
+	cond := func() bool {
+		actual := h.ops.history.take(len(ops))
+		sort.Strings(actual)
+		return slices.Equal(ops, actual)
+	}
+	if !assert.Eventually(h.t, cond, time.Second, time.Millisecond) {
+		actual := h.ops.history.take(len(ops))
+		sort.Strings(actual)
+		require.Failf(h.t, "operations mismatch", "expected operations to be %v, but they were %v", ops, actual)
+	}
+}
+
+func (h testHelper) expectRetried(id uint64) {
+	old := h.ops.updates.get(id)
+	cond := func() bool {
+		new := h.ops.updates.get(id)
+		return new > old
+	}
+	require.Eventually(h.t, cond, time.Second, time.Millisecond, "expected %d to be retried", id)
+}
+
+func (h testHelper) expectHealthLevel(level cell.Level) {
+	cond := func() bool {
+		h.scope.Realize()
+		status, err := h.health.Get([]string{"test"})
+		return err == nil && level == status.Level()
+	}
+	if !assert.Eventually(h.t, cond, time.Second, time.Millisecond) {
+		status, _ := h.health.Get([]string{"test"})
+		// Since the current health provider API doesn't provide access to the sub-reporter
+		// status, just dump the full JSON out. Please refactor this to validate the actual
+		// contents (e.g. degraded error and so on) once it is possible.
+		bs, _ := status.JSON()
+		os.Stdout.Write(bs)
+		require.Failf(h.t, "health mismatch", "expected health level %q, got: %q (%s)", level, status.Level(), status.String())
+	}
+}
+
+func (h testHelper) setTargetFaulty(faulty bool) {
+	h.ops.faulty.Store(faulty)
+}
+
+func (h testHelper) triggerFullReconciliation() {
+	h.r.TriggerFullReconciliation()
+}
+
+func (h testHelper) waitForReconciliation() {
+	err := reconciler.WaitForReconciliation[*testObject](context.TODO(), h.db, h.tbl, statusIndex)
+	require.NoError(h.t, err, "expected WaitForReconciliation to succeed")
+}
+func assertSensibleMetricDuration(t *testing.T, metrics map[string]float64, metric string) {
+	assert.Less(t, metrics[metric], 1.0, "expected metric %q to be above zero", metric)
+
+	// TODO: Sometimes the histogram metric is 0.0 even though samples have been added. Figure
+	// out why and what's a better way to validate it. For now just log that it was 0.
+	//assert.Greater(t, metrics[metric], 0.0, "expected metric %q to be above zero", metric)
+	if metrics[metric] == 0.0 {
+		t.Logf("!!! metric %q unexpectedly zero", metric)
+	}
+}
+
+func dumpMetrics(r *metricsPkg.Registry) map[string]float64 {
+	out := map[string]float64{}
+	metrics, err := r.DumpMetrics()
+	if err != nil {
+		return nil
+	}
+	for _, m := range metrics {
+		if strings.HasPrefix(m.Name, "cilium_reconciler") {
+			out[m.Name+"/"+concatLabels(m.Labels)] = m.Value
+		}
+	}
+	return out
+}
+
+func concatLabels(m map[string]string) string {
+	labels := []string{}
+	for k, v := range m {
+		labels = append(labels, k+"="+v)
+	}
+	return strings.Join(labels, ",")
+}

--- a/pkg/statedb/reconciler/retries.go
+++ b/pkg/statedb/reconciler/retries.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"container/heap"
+
+	"github.com/cilium/cilium/pkg/backoff"
+	"github.com/cilium/cilium/pkg/statedb/index"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func newRetries(minDuration, maxDuration time.Duration, objectToKey func(any) index.Key) *retries {
+	return &retries{
+		backoff: backoff.Exponential{
+			Min: minDuration,
+			Max: maxDuration,
+		},
+		queue:       nil,
+		items:       make(map[string]*retryItem),
+		objectToKey: objectToKey,
+	}
+}
+
+// retries holds the items that failed to be reconciled in
+// a priority queue ordered by retry time. Methods of 'retries'
+// are not safe to access concurrently.
+type retries struct {
+	backoff     backoff.Exponential
+	queue       retryPrioQueue
+	items       map[string]*retryItem
+	objectToKey func(any) index.Key
+}
+
+type retryItem struct {
+	object     any       // the object that is being retried. 'any' to avoid specializing this internal code.
+	index      int       // item's index in the priority queue
+	retryAt    time.Time // time at which to retry
+	numRetries int       // number of retries attempted (for calculating backoff)
+}
+
+// Wait returns a channel that is closed when there is an item to retry.
+// Returns nil channel if no items are queued.
+func (rq *retries) Wait() <-chan struct{} {
+	if _, retryAt, ok := rq.Top(); ok {
+		now := time.Now()
+		ch := make(chan struct{}, 1)
+		if now.After(retryAt) {
+			// Already expired.
+			close(ch)
+		} else {
+			time.AfterFunc(retryAt.Sub(now), func() { close(ch) })
+		}
+		return ch
+	}
+	return nil
+}
+
+func (rq *retries) Top() (object any, retryAt time.Time, ok bool) {
+	if rq.queue.Len() == 0 {
+		return
+	}
+	item := rq.queue[0]
+	return item.object, item.retryAt, true
+}
+
+func (rq *retries) Pop() {
+	// Pop the object from the queue, but leave it into the map until
+	// the object is cleared or re-added.
+	heap.Pop(&rq.queue)
+}
+
+func (rq *retries) Add(obj any) {
+	var (
+		item *retryItem
+		ok   bool
+	)
+	key := rq.objectToKey(obj)
+	if item, ok = rq.items[string(key)]; !ok {
+		item = &retryItem{
+			numRetries: 0,
+		}
+		rq.items[string(key)] = item
+	}
+	item.object = obj
+	item.numRetries += 1
+	item.retryAt = time.Now().Add(rq.backoff.Duration(item.numRetries))
+	heap.Push(&rq.queue, item)
+}
+
+func (rq *retries) Clear(obj any) {
+	key := rq.objectToKey(obj)
+	if item, ok := rq.items[string(key)]; ok {
+		// Remove the object from the queue if it is still there.
+		if item.index >= 0 && item.index < len(rq.queue) &&
+			key.Equal(rq.objectToKey(rq.queue[item.index].object)) {
+			heap.Remove(&rq.queue, item.index)
+		}
+		// Completely forget the object and its retry count.
+		delete(rq.items, string(key))
+	}
+}
+
+// retryPrioQueue is a slice-backed priority heap with the next
+// expiring 'retryItem' at top. Implementation is adapted from the
+// 'container/heap' PriorityQueue example.
+type retryPrioQueue []*retryItem
+
+func (pq retryPrioQueue) Len() int { return len(pq) }
+
+func (pq retryPrioQueue) Less(i, j int) bool {
+	return pq[i].retryAt.Before(pq[j].retryAt)
+}
+
+func (pq retryPrioQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *retryPrioQueue) Push(x any) {
+	retryObj := x.(*retryItem)
+	retryObj.index = len(*pq)
+	*pq = append(*pq, retryObj)
+}
+
+func (pq *retryPrioQueue) Pop() any {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil  // avoid memory leak
+	item.index = -1 // for safety
+	*pq = old[0 : n-1]
+	return item
+}

--- a/pkg/statedb/reconciler/retries_test.go
+++ b/pkg/statedb/reconciler/retries_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/statedb/index"
+)
+
+func TestRetries(t *testing.T) {
+	objectToKey := func(o any) index.Key {
+		return index.Uint64(o.(uint64))
+	}
+	rq := newRetries(time.Millisecond, 100*time.Millisecond, objectToKey)
+
+	obj1, obj2, obj3 := uint64(1), uint64(2), uint64(3)
+
+	// Add objects to be retried in order. We assume here that 'time.Time' has
+	// enough granularity for these to be added with rising retryAt times.
+	rq.Add(obj1)
+	rq.Add(obj2)
+	rq.Add(obj3)
+
+	<-rq.Wait()
+	obj, retryAt, ok := rq.Top()
+	if assert.True(t, ok) {
+		rq.Pop()
+		rq.Clear(obj)
+		assert.True(t, retryAt.Before(time.Now()), "expected item to be expired")
+		assert.Equal(t, obj, obj1)
+	}
+
+	<-rq.Wait()
+	obj, retryAt, ok = rq.Top()
+	if assert.True(t, ok) {
+		rq.Pop()
+		rq.Clear(obj)
+		assert.True(t, retryAt.Before(time.Now()), "expected item to be expired")
+		assert.Equal(t, obj, obj2)
+	}
+
+	<-rq.Wait()
+	obj, retryAt, ok = rq.Top()
+	if assert.True(t, ok) {
+		rq.Pop()
+		assert.True(t, retryAt.Before(time.Now()), "expected item to be expired")
+		assert.Equal(t, obj, obj3)
+	}
+
+	// Retry 'obj3' and since it was added back without clearing it'll be retried
+	// later. Add obj1 and check that 'obj3' has later retry time.
+	rq.Add(obj3)
+	rq.Add(obj1)
+
+	<-rq.Wait()
+	obj, retryAt1, ok := rq.Top()
+	if assert.True(t, ok) {
+		rq.Pop()
+		rq.Clear(obj)
+		assert.True(t, retryAt.Before(time.Now()), "expected item to be expired")
+		assert.Equal(t, obj, obj1)
+	}
+
+	<-rq.Wait()
+	obj, retryAt, ok = rq.Top()
+	if assert.True(t, ok) {
+		rq.Pop()
+		rq.Clear(obj)
+		assert.True(t, retryAt1.Before(retryAt), "expected obj1 before obj3")
+		assert.True(t, retryAt.Before(time.Now()), "expected item to be expired")
+		assert.Equal(t, obj, obj3)
+	}
+
+	_, _, ok = rq.Top()
+	assert.False(t, ok)
+
+	// Test that object can be cleared from the queue without popping it.
+	rq.Add(obj1)
+	rq.Add(obj2)
+	rq.Add(obj3)
+	rq.Clear(obj1) // Remove obj1, testing that it'll fix the queue correctly.
+	rq.Pop()       // Pop and remove obj2 and clear it to test that Clear doesn't mess with queue
+	rq.Clear(obj2)
+	obj, _, ok = rq.Top()
+	if assert.True(t, ok) {
+		rq.Pop()
+		rq.Clear(obj)
+		assert.Equal(t, obj, obj3)
+	}
+	_, _, ok = rq.Top()
+	assert.False(t, ok)
+
+}

--- a/pkg/statedb/reconciler/types.go
+++ b/pkg/statedb/reconciler/types.go
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/index"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type Reconciler[Obj any] interface {
+	// TriggerFullReconciliation triggers an immediate full reconciliation,
+	// e.g. Prune() of unknown objects and Update() of all objects.
+	// Implemented as a select+send to a channel of size 1, so N concurrent
+	// calls of this method may result in less than N full reconciliations.
+	//
+	// Primarily useful in tests, but may be of use when there's knowledge
+	// that something has gone wrong in the reconciliation target and full
+	// reconciliation is needed to recover.
+	TriggerFullReconciliation()
+}
+
+type Config[Obj any] struct {
+	// FullReconcilationInterval is the amount of time to wait between full
+	// reconciliation rounds. A full reconciliation is Prune() of unexpected
+	// objects and Update() of all objects. With full reconciliation we're
+	// resilient towards outside changes. If FullReconcilationInterval is
+	// 0 then full reconciliation is disabled.
+	FullReconcilationInterval time.Duration
+
+	// RetryBackoffMinDuration is the minimum amount of time to wait before
+	// retrying a failed Update() or Delete() operation on an object.
+	// The retry wait time for an object will increase exponentially on
+	// subsequent failures until RetryBackoffMaxDuration is reached.
+	RetryBackoffMinDuration time.Duration
+
+	// RetryBackoffMaxDuration is the maximum amount of time to wait before
+	// retrying.
+	RetryBackoffMaxDuration time.Duration
+
+	// IncrementalRoundSize is the maximum number objects to reconcile during
+	// incremental reconciliation before updating status and refreshing the
+	// statedb snapshot. This should be tuned based on the cost of each operation
+	// and the rate of expected changes so that health and per-object status
+	// updates are not delayed too much. If in doubt, use a value between 100-1000.
+	IncrementalRoundSize int
+
+	// GetObjectStatus returns the reconciliation status for the object.
+	GetObjectStatus func(Obj) Status
+
+	// WithObjectStatus returns a COPY of the object with the status set to
+	// the given value.
+	WithObjectStatus func(Obj, Status) Obj
+
+	// RateLimiter is optional and if set will use the limiter to wait between
+	// reconciliation rounds. This allows trading latency with throughput by
+	// waiting longer to collect a batch of objects to reconcile.
+	RateLimiter *rate.Limiter
+
+	// Operations defines how an object is reconciled.
+	Operations Operations[Obj]
+
+	// BatchOperations is optional and if provided these are used instead of normal operations.
+	BatchOperations BatchOperations[Obj]
+}
+
+func (cfg Config[Obj]) validate() error {
+	if cfg.GetObjectStatus == nil {
+		return fmt.Errorf("%T.GetObjectStatus cannot be nil", cfg)
+	}
+	if cfg.WithObjectStatus == nil {
+		return fmt.Errorf("%T.WithObjectStatus cannot be nil", cfg)
+	}
+	if cfg.IncrementalRoundSize <= 0 {
+		return fmt.Errorf("%T.IncrementalBatchSize needs to be >0", cfg)
+	}
+	if cfg.FullReconcilationInterval < 0 {
+		return fmt.Errorf("%T.FullReconcilationInterval must be >=0", cfg)
+	}
+	if cfg.RetryBackoffMaxDuration <= 0 {
+		return fmt.Errorf("%T.RetryBackoffMaxDuration must be >0", cfg)
+	}
+	if cfg.RetryBackoffMinDuration <= 0 {
+		return fmt.Errorf("%T.RetryBackoffMinDuration must be >0", cfg)
+	}
+	if cfg.Operations == nil {
+		return fmt.Errorf("%T.Operations must be defined", cfg)
+	}
+	return nil
+}
+
+// Operations defines how to reconcile an object.
+//
+// Each operation is given a context that limits the lifetime of the operation
+// and a ReadTxn to allow for the option of looking up realized state from another
+// statedb table as an optimization (main use-case is reconciling routes against
+// Table[Route] to avoid a syscall per route).
+type Operations[Obj any] interface {
+	// Update the object in the target. If the operation is long-running it should
+	// abort if context is cancelled. Should return an error if the operation fails.
+	// The reconciler will retry the operation again at a later time, potentially
+	// with a new version of the object. The operation should thus be idempotent.
+	//
+	// Update is used both for incremental and full reconciliation. Incremental
+	// reconciliation is performed when the desired state is updated. A full
+	// reconciliation is done periodically by calling 'Update' on all objects.
+	//
+	// If 'changed' is non-nil then the Update must compare the realized state
+	// with the desired state and set it to true if they differ, e.g. whether
+	// the operation resulted in a change to the realized state. This is used
+	// during full reconciliation to catch cases where the realized state has
+	// gone out of sync due to outside influence. This is tracked in the
+	// "full_out_of_sync_total" metric.
+	Update(ctx context.Context, txn statedb.ReadTxn, obj Obj, changed *bool) error
+
+	// Delete the object in the target. Same semantics as with Update.
+	// Deleting a non-existing object is not an error and returns nil.
+	Delete(context.Context, statedb.ReadTxn, Obj) error
+
+	// Prune undesired state. It is given an iterator for the full set of
+	// desired objects. The implementation should diff the desired state against
+	// the realized state to find things to prune.
+	// Invoked during full reconciliation before the individual objects are Update()'d.
+	//
+	// Unlike failed Update()'s a failed Prune() operation is not retried until
+	// the next full reconciliation round.
+	Prune(context.Context, statedb.ReadTxn, statedb.Iterator[Obj]) error
+}
+
+type BatchEntry[Obj any] struct {
+	Object   Obj
+	Revision statedb.Revision
+	Result   error
+}
+
+type BatchOperations[Obj any] interface {
+	UpdateBatch(ctx context.Context, txn statedb.ReadTxn, batch []BatchEntry[Obj])
+	DeleteBatch(context.Context, statedb.ReadTxn, []BatchEntry[Obj])
+}
+
+type StatusKind string
+
+const (
+	StatusKindPending StatusKind = "pending"
+	StatusKindDone    StatusKind = "done"
+	StatusKindError   StatusKind = "error"
+)
+
+// Key implements an optimized construction of index.Key for StatusKind
+// to avoid copying and allocation.
+func (s StatusKind) Key() index.Key {
+	switch s {
+	case StatusKindPending:
+		return index.Key("P")
+	case StatusKindDone:
+		return index.Key("D")
+	case StatusKindError:
+		return index.Key("E")
+	}
+	panic("BUG: unmatched StatusKind")
+}
+
+// Status is embedded into the reconcilable object. It allows
+// inspecting per-object reconciliation status and waiting for
+// the reconciler.
+type Status struct {
+	Kind StatusKind
+
+	// Delete is true if the object should be deleted by the reconciler.
+	// If an object is deleted outside the reconciler it will not be
+	// processed by the incremental reconciliation.
+	// We use soft deletes in order to observe and wait for deletions.
+	Delete bool
+
+	UpdatedAt time.Time
+	Error     string
+}
+
+func (s Status) String() string {
+	if s.Kind == StatusKindError {
+		return fmt.Sprintf("%s (delete: %v, updated: %s ago, error: %s)", s.Kind, s.Delete, time.Now().Sub(s.UpdatedAt), s.Error)
+	}
+	return fmt.Sprintf("%s (delete: %v, updated: %s ago)", s.Kind, s.Delete, time.Now().Sub(s.UpdatedAt))
+}
+
+// StatusPending constructs the status for marking the object as
+// requiring reconciliation. The reconciler will perform the
+// Update operation and on success transition to Done status, or
+// on failure to Error status.
+func StatusPending() Status {
+	return Status{
+		Kind:      StatusKindPending,
+		UpdatedAt: time.Now(),
+		Delete:    false,
+		Error:     "",
+	}
+}
+
+// StatusPendingDelete constructs the status for marking the
+// object to be deleted.
+//
+// The reconciler uses soft-deletes in order to be able to
+// retry and to report failed deletions of objects.
+// When the delete operation is successfully performed
+// the reconciler will delete the object from the table.
+func StatusPendingDelete() Status {
+	return Status{
+		Kind:      StatusKindPending,
+		UpdatedAt: time.Now(),
+		Delete:    true,
+		Error:     "",
+	}
+}
+
+// StatusDone constructs the status that marks the object as
+// reconciled.
+func StatusDone() Status {
+	return Status{
+		Kind:      StatusKindDone,
+		UpdatedAt: time.Now(),
+		Error:     "",
+	}
+}
+
+// StatusError constructs the status that marks the object
+// as failed to be reconciled.
+func StatusError(delete bool, err error) Status {
+	return Status{
+		Kind:      StatusKindError,
+		UpdatedAt: time.Now(),
+		Delete:    delete,
+		Error:     err.Error(),
+	}
+}
+
+// opResult is the outcome from reconciling a single object
+type opResult struct {
+	rev    statedb.Revision // revision of the object
+	status Status           // the status to commit
+	delete bool             // if true delete object from the table
+}


### PR DESCRIPTION
This adds the statedb reconciler, a utility for reconciling a StateDB table with a target system defined by the operations Update/Delete/Prune.

The reconciler performs incremental reconciliation as objects change as well periodic full reconciliation to catch cases where the target may have diverged. Metrics are gathered for errors and the durations of the operations. Module health is reported and marked degraded if operations fail.