### PR TITLE
[WIP] Health V2

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -353,6 +353,7 @@ jobs:
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
             --junit-property github_job_step="Run tests (${{ matrix.name }})" \
+            --request-timeout 30s
 
       - name: Fetch artifacts
         if: ${{ !success() && steps.run-tests.outcome != 'skipped' }}

--- a/cilium-dbg/cmd/status.go
+++ b/cilium-dbg/cmd/status.go
@@ -105,7 +105,7 @@ func statusDaemon() {
 		}
 		if healthEnabled {
 			healthPkg.GetAndFormatHealthStatus(w, true, allHealth, healthLines)
-			healthPkg.GetAndFormatModulesHealth(w, client.Daemon, allHealth)
+			//healthPkg.GetAndFormatModulesHealth(w, client.Daemon, allHealth)
 		} else {
 			fmt.Fprint(w, "Cluster health:\t\tProbe disabled\n")
 		}

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/signal"
 	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/vitals"
 )
 
 var (
@@ -108,6 +109,8 @@ var (
 		// Store cell provides factory for creating watchStore/syncStore/storeManager
 		// useful for synchronizing data from/to kvstore.
 		store.Cell,
+
+		vitals.Cell,
 	)
 
 	// ControlPlane implement the per-node control functions. These are pure

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -49,7 +49,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/fqdn"
-	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hubble/observer"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
@@ -91,6 +90,7 @@ import (
 	"github.com/cilium/cilium/pkg/status"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
+	vitalsHealth "github.com/cilium/cilium/pkg/vitals/health"
 )
 
 const (
@@ -216,7 +216,7 @@ type Daemon struct {
 	settings cellSettings
 
 	// enable modules health support
-	healthProvider cell.Health
+	healthProvider vitalsHealth.Health
 
 	// Tunnel-related configuration
 	tunnelConfig tunnel.Config

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -98,6 +98,7 @@ import (
 	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/version"
+	"github.com/cilium/cilium/pkg/vitals/health"
 	wireguard "github.com/cilium/cilium/pkg/wireguard/agent"
 )
 
@@ -1600,6 +1601,7 @@ var daemonCell = cell.Module(
 	"daemon",
 	"Legacy Daemon",
 
+	health.ProvideHealthScope(),
 	cell.Provide(newDaemonPromise),
 	cell.Provide(newRestorerPromise),
 	cell.Provide(func() k8s.CacheStatus { return make(k8s.CacheStatus) }),
@@ -1645,8 +1647,8 @@ type daemonParams struct {
 	APILimiterSet        *rate.APILimiterSet
 	AuthManager          *auth.AuthManager
 	Settings             cellSettings
-	HealthProvider       cell.Health
-	HealthScope          cell.Scope
+	HealthProvider       health.Health
+	HealthScope          health.Scope
 	DeviceManager        *linuxdatapath.DeviceManager `optional:"true"`
 	Devices              statedb.Table[*datapathTables.Device]
 	// Grab the GC object so that we can start the CT/NAT map garbage collection.

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/types"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 type DaemonSuite struct {
@@ -99,7 +100,7 @@ func TestMain(m *testing.M) {
 
 type dummyEpSyncher struct{}
 
-func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration, hr cell.HealthReporter) {
+func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration, hr health.HealthReporter) {
 }
 
 func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {

--- a/daemon/cmd/device-reloader.go
+++ b/daemon/cmd/device-reloader.go
@@ -16,13 +16,14 @@ import (
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 type deviceReloaderParams struct {
 	cell.In
 
 	Jobs          job.Registry
-	Scope         cell.Scope
+	Scope         health.Scope
 	DB            *statedb.DB
 	Daemon        promise.Promise[*Daemon]
 	Config        *option.DaemonConfig

--- a/daemon/cmd/vitals.go
+++ b/daemon/cmd/vitals.go
@@ -57,7 +57,7 @@ func toModuleHealth(m health.Status) (*models.ModuleHealth, error) {
 		ModuleID: m.FullModuleID.String(),
 		Message:  string(d),
 		Level:    string(m.Level()),
-		//LastOk:      client.ToAgeHuman(m.LastOK),
+		//LastOk:   client.ToAgeHuman(m.LastOK),
 		//LastUpdated: client.ToAgeHuman(m.LastUpdated),
 	}, nil
 }

--- a/daemon/cmd/vitals.go
+++ b/daemon/cmd/vitals.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/health/client"
-	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 type getHealth struct {
@@ -49,7 +49,7 @@ func (d *Daemon) getHealthReport() (models.ModulesHealth, error) {
 
 // Helpers...
 
-func toModuleHealth(m cell.Status) (*models.ModuleHealth, error) {
+func toModuleHealth(m health.Status) (*models.ModuleHealth, error) {
 	d, err := m.JSON()
 	if err != nil {
 		return nil, err

--- a/daemon/cmd/vitals.go
+++ b/daemon/cmd/vitals.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/api"
-	"github.com/cilium/cilium/pkg/health/client"
 	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
@@ -55,10 +54,10 @@ func toModuleHealth(m health.Status) (*models.ModuleHealth, error) {
 		return nil, err
 	}
 	return &models.ModuleHealth{
-		ModuleID:    m.FullModuleID.String(),
-		Message:     string(d),
-		Level:       string(m.Level()),
-		LastOk:      client.ToAgeHuman(m.LastOK),
-		LastUpdated: client.ToAgeHuman(m.LastUpdated),
+		ModuleID: m.FullModuleID.String(),
+		Message:  string(d),
+		Level:    string(m.Level()),
+		//LastOk:      client.ToAgeHuman(m.LastOK),
+		//LastUpdated: client.ToAgeHuman(m.LastUpdated),
 	}, nil
 }

--- a/daemon/cmd/vitals_test.go
+++ b/daemon/cmd/vitals_test.go
@@ -12,11 +12,12 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/health/client"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 func TestVitalsToModuleHealth(t *testing.T) {
 	uu := map[string]struct {
-		s cell.Status
+		s health.Status
 		e *models.ModuleHealth
 	}{
 		"empty": {
@@ -25,12 +26,12 @@ func TestVitalsToModuleHealth(t *testing.T) {
 				LastUpdated: "n/a",
 				Level:       "Unknown",
 			},
-			s: cell.Status{},
+			s: health.Status{},
 		},
 		"happy": {
-			s: cell.Status{
+			s: health.Status{
 				FullModuleID: cell.FullModuleID{"fred"},
-				Update:       mockUpdate{"blee", cell.StatusOK},
+				Update:       mockUpdate{"blee", health.StatusOK},
 				Stopped:      true,
 			},
 			e: &models.ModuleHealth{

--- a/daemon/cmd/watchdogs.go
+++ b/daemon/cmd/watchdogs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 const epBPFProgWatchdog = "ep-bpf-prog-watchdog"
@@ -37,7 +38,7 @@ type epBPFProgWatchdogParams struct {
 	Logger        logrus.FieldLogger
 	Lifecycle     hive.Lifecycle
 	DaemonPromise promise.Promise[*Daemon]
-	Scope         cell.Scope
+	Scope         health.Scope
 }
 
 var (
@@ -70,7 +71,7 @@ func registerEndpointBPFProgWatchdog(p epBPFProgWatchdogParams) {
 				epBPFProgWatchdog,
 				controller.ControllerParams{
 					Group:          controller.NewGroup(epBPFProgWatchdog),
-					HealthReporter: cell.GetHealthReporter(p.Scope, epBPFProgWatchdog),
+					HealthReporter: health.GetHealthReporter(p.Scope, epBPFProgWatchdog),
 					DoFunc: func(ctx context.Context) error {
 						d, err := p.DaemonPromise.Await(ctx)
 						if err != nil {

--- a/gopsout
+++ b/gopsout
@@ -1,0 +1,2391 @@
+goroutine 226 [running]:
+runtime/pprof.writeGoroutineStacks({0x3f00760, 0xc0006dc008})
+	/usr/local/bin/go/src/runtime/pprof/pprof.go:703 +0x6a
+runtime/pprof.writeGoroutine({0x3f00760?, 0xc0006dc008?}, 0x0?)
+	/usr/local/bin/go/src/runtime/pprof/pprof.go:692 +0x25
+runtime/pprof.(*Profile).WriteTo(0x3942619?, {0x3f00760?, 0xc0006dc008?}, 0x0?)
+	/usr/local/bin/go/src/runtime/pprof/pprof.go:329 +0x146
+github.com/google/gops/agent.handle({0x7fe24b821ea0?, 0xc0006dc008}, {0xc000b82000?, 0x1?, 0x1?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/google/gops/agent/agent.go:200 +0xd2
+github.com/google/gops/agent.listen({0x3f3d120, 0xc00093b0e0})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/google/gops/agent/agent.go:144 +0x1a5
+created by github.com/google/gops/agent.Listen in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/google/gops/agent/agent.go:122 +0x379
+
+goroutine 1 [chan send, 2 minutes]:
+github.com/cilium/cilium/pkg/vitals/health.(*healthProvider).forModule.func1({{0xc001403440, 0x3, 0x4}, {0xc000f11ed0, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, {0xc000f11ed0, ...}}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:390 +0x2cc
+github.com/cilium/cilium/pkg/vitals/health.(*reporter).upsertStatus(0x2fbc900?, {{0xc001403440, 0x3, 0x4}, {0xc000f11ed0, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:477 +0xa5
+github.com/cilium/cilium/pkg/vitals/health.(*subReporter).OK(0x3f3dbe0?, {0x3970a37?, 0x39425e3?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/structured.go:201 +0x127
+github.com/cilium/cilium/pkg/node/manager.(*manager).NodeUpdated(_, {{0xc00017e580, 0xb}, {0xc0014a2bd0, 0x9}, {0xc0001bcd20, 0x4, 0x6}, 0xc000b790b0, {0x0, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/node/manager/manager.go:636 +0x1cc6
+github.com/cilium/cilium/pkg/nodediscovery.(*NodeDiscovery).StartDiscovery(0xc001d81110)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/nodediscovery/nodediscovery.go:226 +0x275
+github.com/cilium/cilium/daemon/cmd.newDaemon({0x3f52368, 0xc0004d9860}, 0xc000931130, 0xc000005800)
+	/home/tom/go/src/github.com/cilium/cilium/daemon/cmd/daemon.go:919 +0x50ef
+github.com/cilium/cilium/daemon/cmd.newDaemonPromise.func1({0x356bea0, 0x496b00})
+	/home/tom/go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:1686 +0x66
+github.com/cilium/cilium/pkg/hive.Hook.Start(...)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/lifecycle.go:35
+github.com/cilium/cilium/pkg/hive.(*DefaultLifecycle).Start(0xc000d0f800, {0x3f523d8?, 0xc001560310?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/lifecycle.go:104 +0x2f4
+github.com/cilium/cilium/pkg/hive.(*Hive).Start(0xc0009a9900, {0x3f523d8, 0xc001560310})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/hive.go:303 +0xf4
+github.com/cilium/cilium/pkg/hive.(*Hive).Run(0xc0009a9900)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/hive.go:203 +0x73
+github.com/cilium/cilium/daemon/cmd.NewAgentCmd.func1(0xc00089a300?, {0x3934f09?, 0x4?, 0x3934d75?})
+	/home/tom/go/src/github.com/cilium/cilium/daemon/cmd/root.go:39 +0x17b
+github.com/spf13/cobra.(*Command).execute(0xc000960600, {0xc000072050, 0x1, 0x1})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:987 +0xaa3
+github.com/spf13/cobra.(*Command).ExecuteC(0xc000960600)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:1115 +0x3ff
+github.com/spf13/cobra.(*Command).Execute(...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:1039
+github.com/cilium/cilium/daemon/cmd.Execute(0xc0009a9900?)
+	/home/tom/go/src/github.com/cilium/cilium/daemon/cmd/root.go:79 +0x13
+main.main()
+	/home/tom/go/src/github.com/cilium/cilium/daemon/main.go:14 +0x57
+
+goroutine 16 [select]:
+k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop(0xc0007c2a80)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:276 +0x305
+created by k8s.io/client-go/util/workqueue.newDelayingQueue in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:113 +0x21f
+
+goroutine 94 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/identity/cache.(*identityWatcher).watch.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/identity/cache/cache.go:151 +0x71
+created by github.com/cilium/cilium/pkg/identity/cache.(*identityWatcher).watch in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/identity/cache/cache.go:145 +0x67
+
+goroutine 84 [select, 2 minutes]:
+io.(*pipe).read(0xc00066f920, {0xc0019be000, 0x10000, 0x425adc?})
+	/usr/local/bin/go/src/io/pipe.go:57 +0xa5
+io.(*PipeReader).Read(0x7fe24ba22568?, {0xc0019be000?, 0x410985?, 0x0?})
+	/usr/local/bin/go/src/io/pipe.go:136 +0x1b
+bufio.(*Scanner).Scan(0xc000029f28)
+	/usr/local/bin/go/src/bufio/scan.go:214 +0x81b
+github.com/sirupsen/logrus.(*Entry).writerScanner(0x0?, 0xc0011ae8f8, 0xc0011b79e0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/sirupsen/logrus/writer.go:86 +0x125
+created by github.com/sirupsen/logrus.(*Entry).WriterLevel in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/sirupsen/logrus/writer.go:57 +0x385
+
+goroutine 85 [select, 2 minutes]:
+io.(*pipe).read(0xc00066f980, {0xc0018b0000, 0x10000, 0x425adc?})
+	/usr/local/bin/go/src/io/pipe.go:57 +0xa5
+io.(*PipeReader).Read(0x7fe24b9baac0?, {0xc0018b0000?, 0x410985?, 0x0?})
+	/usr/local/bin/go/src/io/pipe.go:136 +0x1b
+bufio.(*Scanner).Scan(0xc0018e5f28)
+	/usr/local/bin/go/src/bufio/scan.go:214 +0x81b
+github.com/sirupsen/logrus.(*Entry).writerScanner(0xc00011d7d0?, 0xc0011ae908, 0xc0011b7a00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/sirupsen/logrus/writer.go:86 +0x125
+created by github.com/sirupsen/logrus.(*Entry).WriterLevel in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/sirupsen/logrus/writer.go:57 +0x385
+
+goroutine 86 [select, 2 minutes]:
+io.(*pipe).read(0xc00066f9e0, {0xc0019ce000, 0x10000, 0x425adc?})
+	/usr/local/bin/go/src/io/pipe.go:57 +0xa5
+io.(*PipeReader).Read(0x6117e20?, {0xc0019ce000?, 0x410985?, 0x100000000000000?})
+	/usr/local/bin/go/src/io/pipe.go:136 +0x1b
+bufio.(*Scanner).Scan(0xc00002bf28)
+	/usr/local/bin/go/src/bufio/scan.go:214 +0x81b
+github.com/sirupsen/logrus.(*Entry).writerScanner(0x0?, 0xc0011ae918, 0xc0011b7a20)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/sirupsen/logrus/writer.go:86 +0x125
+created by github.com/sirupsen/logrus.(*Entry).WriterLevel in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/sirupsen/logrus/writer.go:57 +0x385
+
+goroutine 87 [select, 2 minutes]:
+io.(*pipe).read(0xc00066fa40, {0xc00123e000, 0x10000, 0x425adc?})
+	/usr/local/bin/go/src/io/pipe.go:57 +0xa5
+io.(*PipeReader).Read(0x7fe24ba2a5e0?, {0xc00123e000?, 0x410985?, 0x0?})
+	/usr/local/bin/go/src/io/pipe.go:136 +0x1b
+bufio.(*Scanner).Scan(0xc0000a1f28)
+	/usr/local/bin/go/src/bufio/scan.go:214 +0x81b
+github.com/sirupsen/logrus.(*Entry).writerScanner(0x0?, 0xc0011ae928, 0xc0011b7a40)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/sirupsen/logrus/writer.go:86 +0x125
+created by github.com/sirupsen/logrus.(*Entry).WriterLevel in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/sirupsen/logrus/writer.go:57 +0x385
+
+goroutine 91 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/cleanup.DeferTerminationCleanupFunction.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/cleanup/cleanup.go:19 +0x58
+created by github.com/cilium/cilium/pkg/cleanup.DeferTerminationCleanupFunction in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/cleanup/cleanup.go:17 +0x90
+
+goroutine 98 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded(0x3f8d620)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:346 +0xdf
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).start in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:326 +0xa7
+
+goroutine 92 [select]:
+github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter(0xc001157cc0)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:209 +0x2e5
+created by github.com/cilium/cilium/pkg/trigger.NewTrigger in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:122 +0x1d8
+
+goroutine 460 [chan receive, 2 minutes]:
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:132 +0x25
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 455
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:131 +0xab
+
+goroutine 95 [select]:
+github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter(0xc001157d60)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:209 +0x2e5
+created by github.com/cilium/cilium/pkg/trigger.NewTrigger in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:122 +0x1d8
+
+goroutine 96 [select]:
+github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter(0xc001157e00)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:209 +0x2e5
+created by github.com/cilium/cilium/pkg/trigger.NewTrigger in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:122 +0x1d8
+
+goroutine 225 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/hive.(*Hive).fatalOnTimeout.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/hive.go:318 +0x6a
+created by github.com/cilium/cilium/pkg/hive.(*Hive).fatalOnTimeout in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/hive.go:317 +0xa5
+
+goroutine 227 [IO wait, 2 minutes]:
+internal/poll.runtime_pollWait(0x7fe24bca0db8, 0x72)
+	/usr/local/bin/go/src/runtime/netpoll.go:343 +0x85
+internal/poll.(*pollDesc).wait(0xc00062c280?, 0xc000028d00?, 0x0)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Accept(0xc00062c280)
+	/usr/local/bin/go/src/internal/poll/fd_unix.go:611 +0x2ac
+net.(*netFD).accept(0xc00062c280)
+	/usr/local/bin/go/src/net/fd_unix.go:172 +0x29
+net.(*TCPListener).accept(0xc00096e000)
+	/usr/local/bin/go/src/net/tcpsock_posix.go:152 +0x1e
+net.(*TCPListener).Accept(0xc00096e000)
+	/usr/local/bin/go/src/net/tcpsock.go:315 +0x30
+net/http.(*Server).Serve(0xc0001bc3c0, {0x3f3d120, 0xc00096e000})
+	/usr/local/bin/go/src/net/http/server.go:3056 +0x364
+net/http.(*Server).ListenAndServe(0xc0001bc3c0)
+	/usr/local/bin/go/src/net/http/server.go:2985 +0x71
+github.com/cilium/cilium/pkg/metrics.NewRegistry.func1.1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/metrics/registry.go:89 +0xa8
+created by github.com/cilium/cilium/pkg/metrics.NewRegistry.func1 in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/metrics/registry.go:87 +0xc5
+
+goroutine 237 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:510 +0x135
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 273
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:508 +0x64a
+
+goroutine 239 [select]:
+github.com/cilium/cilium/pkg/rate.NewLimiter.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/rate/limiter.go:47 +0x93
+created by github.com/cilium/cilium/pkg/rate.NewLimiter in goroutine 274
+	/home/tom/go/src/github.com/cilium/cilium/pkg/rate/limiter.go:45 +0x147
+
+goroutine 232 [IO wait]:
+internal/poll.runtime_pollWait(0x7fe24bca0cc0, 0x72)
+	/usr/local/bin/go/src/runtime/netpoll.go:343 +0x85
+internal/poll.(*pollDesc).wait(0xc000847580?, 0xc00220e000?, 0x0)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Read(0xc000847580, {0xc00220e000, 0xa000, 0xa000})
+	/usr/local/bin/go/src/internal/poll/fd_unix.go:164 +0x27a
+net.(*netFD).Read(0xc000847580, {0xc00220e000?, 0x9ffb?, 0xc00093b3c0?})
+	/usr/local/bin/go/src/net/fd_posix.go:55 +0x25
+net.(*conn).Read(0xc0015f9dd8, {0xc00220e000?, 0xc00220e000?, 0x5?})
+	/usr/local/bin/go/src/net/net.go:179 +0x45
+crypto/tls.(*atLeastReader).Read(0xc001266768, {0xc00220e000?, 0xc001266768?, 0x0?})
+	/usr/local/bin/go/src/crypto/tls/conn.go:805 +0x3b
+bytes.(*Buffer).ReadFrom(0xc000df1428, {0x3f05bc0, 0xc001266768})
+	/usr/local/bin/go/src/bytes/buffer.go:211 +0x98
+crypto/tls.(*Conn).readFromUntil(0xc000df1180, {0x7fe24b856508?, 0xc000c71110}, 0xa000?)
+	/usr/local/bin/go/src/crypto/tls/conn.go:827 +0xde
+crypto/tls.(*Conn).readRecordOrCCS(0xc000df1180, 0x0)
+	/usr/local/bin/go/src/crypto/tls/conn.go:625 +0x250
+crypto/tls.(*Conn).readRecord(...)
+	/usr/local/bin/go/src/crypto/tls/conn.go:587
+crypto/tls.(*Conn).Read(0xc000df1180, {0xc0019b6000, 0x1000, 0xfc8b89?})
+	/usr/local/bin/go/src/crypto/tls/conn.go:1369 +0x158
+bufio.(*Reader).Read(0xc000b05d40, {0xc0001b6d60, 0x9, 0x31d4a80?})
+	/usr/local/bin/go/src/bufio/bufio.go:244 +0x197
+io.ReadAtLeast({0x3f00980, 0xc000b05d40}, {0xc0001b6d60, 0x9, 0x9}, 0x9)
+	/usr/local/bin/go/src/io/io.go:335 +0x90
+io.ReadFull(...)
+	/usr/local/bin/go/src/io/io.go:354
+golang.org/x/net/http2.readFrameHeader({0xc0001b6d60, 0x9, 0x800000?}, {0x3f00980?, 0xc000b05d40?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/frame.go:237 +0x65
+golang.org/x/net/http2.(*Framer).ReadFrame(0xc0001b6d20)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/frame.go:498 +0x85
+golang.org/x/net/http2.(*clientConnReadLoop).run(0xc00070ff98)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:2275 +0x11f
+golang.org/x/net/http2.(*ClientConn).readLoop(0xc000da6d80)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:2170 +0x65
+created by golang.org/x/net/http2.(*Transport).newClientConn in goroutine 231
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:821 +0xcbe
+
+goroutine 25 [select]:
+github.com/cilium/cilium/pkg/controller.(*controller).runController(0xc0003bc000, {{{0x39530f7, 0xd}}, {0x0, 0x0}, 0xc000328060, 0x0, 0x3b5e8e0, 0x6fc23ac00, 0x0, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/controller.go:322 +0x9d9
+created by github.com/cilium/cilium/pkg/controller.(*Manager).createControllerLocked in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/manager.go:111 +0x458
+
+goroutine 27 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 245
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 234 [chan receive]:
+k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop(0xc000b05ec0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:281 +0x9c
+created by k8s.io/client-go/util/workqueue.newQueue in goroutine 273
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:106 +0x1ba
+
+goroutine 235 [select]:
+k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop(0xc001442000)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:276 +0x305
+created by k8s.io/client-go/util/workqueue.newDelayingQueue in goroutine 273
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:113 +0x21f
+
+goroutine 236 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc0012869d0, 0x3)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0x34aca40?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/util/workqueue.(*Type).Get(0xc000b05ec0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:200 +0x99
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).getWorkItem(...)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:685
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).processLoop(0x3f702a0, {0x3f52368, 0xc0007242d0}, 0xc0014cf4a0, {0x3f63828, 0xc001f810e0})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:609 +0x144
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:498 +0x33a
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 273
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:464 +0x586
+
+goroutine 245 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc001ea22e8, 0x1)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0xc000328620?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc001ea22c0, 0xc00134d200)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:575 +0x236
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc001eae140)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:188 +0x30
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4470a0?, {0x3f06e40, 0xc0015866f0}, 0x1, 0xc0016e2de0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00017e180?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0xc001eae140, 0xc0016e2de0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:159 +0x393
+github.com/cilium/cilium/pkg/k8s/resource.(*wrapperController).Run(0xc00096e9e0, 0xc0016e2de0)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:808 +0x9e
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:366 +0xbb
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded in goroutine 224
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:364 +0x2a6
+
+goroutine 246 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 224
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 368 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).ciliumNodeInit(0xc001dc8300, {0x3f92228, 0xc0015b2160}, 0xc000404560)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/cilium_node.go:112 +0x585
+created by github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).enableK8sWatchers in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/watcher.go:578 +0x509
+
+goroutine 532 [chan receive]:
+k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop(0xc001f51620)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:281 +0x9c
+created by k8s.io/client-go/util/workqueue.newQueue in goroutine 364
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:106 +0x1ba
+
+goroutine 250 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 106
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 29 [chan receive, 2 minutes]:
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:132 +0x25
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 245
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:131 +0xab
+
+goroutine 30 [select]:
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x60c3340?}, {0x3f35d90, 0xc0012ea940}, {0x7fe24bc21918, 0xc001ea22c0}, {0x3f866f8?, 0x38f1c60}, 0x0, ...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:724 +0x17b
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc000df4000, {0x0?, 0x0?}, 0xc0016e2de0, 0x1?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:437 +0x545
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0xc000df4000, 0xc0016e2de0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:357 +0x4c5
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:291 +0x25
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x10?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0004d03c0?, {0x3f06e60, 0xc0006fa280}, 0x1, 0xc0016e2de0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/client-go/tools/cache.(*Reflector).Run(0xc000df4000, 0xc0016e2de0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:290 +0x1cd
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:55 +0x1e
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x4f
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 245
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 257 [select, 2 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc000df4000, 0xc0016e2de0, 0xc0016e38c0, 0xc00011bf10?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:369 +0x10f
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 30
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:356 +0x49d
+
+goroutine 258 [select, 2 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc00094cf00, 0xc001b60800)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1464 +0xac7
+golang.org/x/net/http2.(*clientStream).doRequest(0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1326 +0x18
+created by golang.org/x/net/http2.(*ClientConn).RoundTrip in goroutine 30
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1232 +0x308
+
+goroutine 273 [chan receive, 2 minutes]:
+github.com/cilium/cilium/daemon/cmd.(*localNodeSynchronizer).SyncLocalNode(0xc00175c580, {0x3f52368?, 0xc000772d70?}, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/daemon/cmd/local_node_sync.go:63 +0xae
+github.com/cilium/cilium/pkg/node.NewLocalNodeStore.func1.1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/node/local_node_store.go:107 +0x31
+created by github.com/cilium/cilium/pkg/node.NewLocalNodeStore.func1 in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/node/local_node_store.go:106 +0x2c5
+
+goroutine 274 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/statedb.graveyardWorker(0xc0015a21c0, {0x3f52368, 0xc00072f360}, 0x3b9aca00?)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/statedb/graveyard.go:27 +0xf1
+created by github.com/cilium/cilium/pkg/statedb.(*DB).Start in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/statedb/db.go:231 +0x152
+
+goroutine 259 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc00094cf48, 0x2)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0xc0018e1d40?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+golang.org/x/net/http2.(*pipe).Read(0xc00094cf30, {0xc0007fc200, 0x4, 0x4})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/pipe.go:76 +0xdf
+golang.org/x/net/http2.transportResponseBody.Read({0xc0007fc200?}, {0xc0007fc200?, 0xc0018e1ce0?, 0x40e50c?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:2558 +0x65
+io.ReadAtLeast({0x7fe24bc21840, 0xc00094cf00}, {0xc0007fc200, 0x4, 0x4}, 0x4)
+	/usr/local/bin/go/src/io/io.go:335 +0x90
+k8s.io/apimachinery/pkg/util/framer.(*lengthDelimitedFrameReader).Read(0xc000d6a5a0, {0xc001b63400, 0x400, 0x400})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/framer/framer.go:76 +0x85
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc0006fa410, 0xc0016e3da0?, {0x3f34360, 0xc000ab0300})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc000328840)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc0012ea940)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:105 +0xdb
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 30
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:76 +0x125
+
+goroutine 275 [select]:
+github.com/cilium/cilium/pkg/datapath/linux.(*devicesController).processUpdates(0xc001157720, 0xc002030360, 0xc002030420, 0xc002030480)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/datapath/linux/devices_controller.go:336 +0x286
+github.com/cilium/cilium/pkg/datapath/linux.(*devicesController).subscribeAndProcess(0xc001157720, {0x3f52368?, 0xc00072f720?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/datapath/linux/devices_controller.go:228 +0x305
+github.com/cilium/cilium/pkg/datapath/linux.(*devicesController).run(0xc001157720, {0x3f52368, 0xc00072f720})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/datapath/linux/devices_controller.go:170 +0x97
+created by github.com/cilium/cilium/pkg/datapath/linux.(*devicesController).Start in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/datapath/linux/devices_controller.go:150 +0x156
+
+goroutine 276 [chan receive, 2 minutes]:
+github.com/vishvananda/netlink.addrSubscribeAt.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/vishvananda/netlink/addr_linux.go:350 +0x25
+created by github.com/vishvananda/netlink.addrSubscribeAt in goroutine 275
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/vishvananda/netlink/addr_linux.go:349 +0x14f
+
+goroutine 277 [syscall, 2 minutes]:
+syscall.Syscall6(0x10010c0100caff?, 0x9010103d9ff4100?, 0x65736e6f70736552?, 0x1020100daff0173?, 0x45726f646e655610?, 0xc001b8fca0?, 0x410685?)
+	/usr/local/bin/go/src/syscall/syscall_linux.go:91 +0x30
+golang.org/x/sys/unix.recvfrom(0x6e65747845726f64?, {0xc001b8fd70?, 0x103dfff52000000?, 0x6e6f707365520d01?}, 0x173706f72506573?, 0x440b01040100e0ff?, 0x6974706972637365?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/sys/unix/zsyscall_linux_amd64.go:527 +0x6f
+golang.org/x/sys/unix.Recvfrom(0x70616d16010104e5?, {0xc001b8fd70, 0x10000, 0x10000}, 0xff5c0000e2ff010c?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/sys/unix/syscall_unix.go:332 +0x70
+github.com/vishvananda/netlink/nl.(*NetlinkSocket).Receive(0xc000f66450?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/vishvananda/netlink/nl/nl_linux.go:781 +0x59
+github.com/vishvananda/netlink.addrSubscribeAt.func2()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/vishvananda/netlink/addr_linux.go:366 +0x94
+created by github.com/vishvananda/netlink.addrSubscribeAt in goroutine 275
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/vishvananda/netlink/addr_linux.go:363 +0x35f
+
+goroutine 278 [chan receive, 2 minutes]:
+github.com/vishvananda/netlink.routeSubscribeAt.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/vishvananda/netlink/route_linux.go:1512 +0x25
+created by github.com/vishvananda/netlink.routeSubscribeAt in goroutine 275
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/vishvananda/netlink/route_linux.go:1511 +0x14f
+
+goroutine 279 [syscall, 2 minutes]:
+syscall.Syscall6(0x80100b4ff016570?, 0x656c62616c6c754e?, 0x726f460601000201?, 0x501000c0174616d?, 0xc01656c746954?, 0xc001baf878?, 0x410685?)
+	/usr/local/bin/go/src/syscall/syscall_linux.go:91 +0x30
+golang.org/x/sys/unix.recvfrom(0x7069746c754d0a01?, {0xc001baf948?, 0xa8ff016d756e4504?, 0x725078614d0d0100?}, 0x736569747265706f?, 0x6e694d0d01000401?, 0x69747265706f7250?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/sys/unix/zsyscall_linux_amd64.go:527 +0x6f
+golang.org/x/sys/unix.Recvfrom(0x6e41050100b8ff01?, {0xc001baf948, 0x10000, 0x10000}, 0xbaff0173656974?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/sys/unix/syscall_unix.go:332 +0x70
+github.com/vishvananda/netlink/nl.(*NetlinkSocket).Receive(0xc000f66480?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/vishvananda/netlink/nl/nl_linux.go:781 +0x59
+github.com/vishvananda/netlink.routeSubscribeAt.func2()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/vishvananda/netlink/route_linux.go:1528 +0x9a
+created by github.com/vishvananda/netlink.routeSubscribeAt in goroutine 275
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/vishvananda/netlink/route_linux.go:1525 +0x35f
+
+goroutine 280 [chan receive, 2 minutes]:
+github.com/vishvananda/netlink.linkSubscribeAt.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/vishvananda/netlink/link_linux.go:2338 +0x25
+created by github.com/vishvananda/netlink.linkSubscribeAt in goroutine 275
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/vishvananda/netlink/link_linux.go:2337 +0x13e
+
+goroutine 281 [syscall, 2 minutes]:
+syscall.Syscall6(0x643a73386b2b0a0a?, 0x2d79706f63706565?, 0x657572743d6e6567?, 0x7961727261050101?, 0x601050100010114?, 0xc001bcfdc8?, 0x410685?)
+	/usr/local/bin/go/src/syscall/syscall_linux.go:91 +0x30
+golang.org/x/sys/unix.recvfrom(0x6f06010165757274?, {0xc001bcfe98?, 0x69747365676e6f63?, 0x6f72746e6f436e6f?}, 0x730601050100016c?, 0x60210676e697274?, 0x70c676e69727473?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/sys/unix/zsyscall_linux_amd64.go:527 +0x6f
+golang.org/x/sys/unix.Recvfrom(0x6972747306010501?, {0xc001bcfe98, 0x10000, 0x10000}, 0x77646e6162207349?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/sys/unix/syscall_unix.go:332 +0x70
+github.com/vishvananda/netlink/nl.(*NetlinkSocket).Receive(0xc000f664b0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/vishvananda/netlink/nl/nl_linux.go:781 +0x59
+github.com/vishvananda/netlink.linkSubscribeAt.func2()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/vishvananda/netlink/link_linux.go:2354 +0x7f
+created by github.com/vishvananda/netlink.linkSubscribeAt in goroutine 275
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/vishvananda/netlink/link_linux.go:2351 +0x34f
+
+goroutine 282 [chan send, 2 minutes]:
+github.com/cilium/cilium/pkg/vitals/health.(*healthProvider).forModule.func1({{0xc001403440, 0x3, 0x4}, {0xc000c50030, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, {0xc000c50030, ...}}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:390 +0x2cc
+github.com/cilium/cilium/pkg/vitals/health.(*reporter).upsertStatus(0xc00136a060?, {{0xc001403440, 0x3, 0x4}, {0xc000c50030, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:477 +0xa5
+github.com/cilium/cilium/pkg/vitals/health.(*subReporter).OK(0xc00049e000?, {0x393b518?, 0xc001c0cc20?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/structured.go:201 +0x127
+github.com/cilium/cilium/pkg/hive/job.(*jobOneShot).start(0xc001982b40, {0x3f52330, 0xc001322a80}, 0x736e6f6974616469?, {0x3f3dbe0, 0xc0008a2120}, {{{0x0, 0x0, 0x0}}, {0x3f84a70, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/job/job.go:347 +0x67f
+created by github.com/cilium/cilium/pkg/hive/job.(*group).Start.func1 in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/job/job.go:163 +0x196
+
+goroutine 287 [chan send, 2 minutes]:
+github.com/cilium/cilium/pkg/vitals/health.(*healthProvider).forModule.func1({{0xc001403440, 0x3, 0x4}, {0xc000be7180, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, {0xc000be7180, ...}}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:390 +0x2cc
+github.com/cilium/cilium/pkg/vitals/health.(*reporter).upsertStatus(0xc0013d6000?, {{0xc001403440, 0x3, 0x4}, {0xc000be7180, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:477 +0xa5
+github.com/cilium/cilium/pkg/vitals/health.(*subReporter).OK(0xc001c235b0?, {0x394a48b?, 0x73d8c8?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/structured.go:201 +0x127
+github.com/cilium/cilium/pkg/controller.(*controller).recordSuccess(0xc0001c8640, {0x3f3cec0?, 0xc0007a5860?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/controller.go:392 +0x3a
+github.com/cilium/cilium/pkg/controller.(*controller).runController(0xc0001c8640, {{{0x394a48b, 0xb}}, {0x3f3cec0, 0xc0007a5860}, 0xc000be7190, 0x0, 0x3b5e8e0, 0x45d964b800, 0x0, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/controller.go:304 +0x859
+created by github.com/cilium/cilium/pkg/controller.(*Manager).createControllerLocked in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/manager.go:111 +0x458
+
+goroutine 288 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:234 +0x73
+sync.(*Once).doSlow(0x0?, 0x0?)
+	/usr/local/bin/go/src/sync/once.go:74 +0xbf
+sync.(*Once).Do(...)
+	/usr/local/bin/go/src/sync/once.go:65
+github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).run(0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:232 +0x3c
+created by github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).Run in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:228 +0x69
+
+goroutine 289 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:234 +0x73
+sync.(*Once).doSlow(0x0?, 0x0?)
+	/usr/local/bin/go/src/sync/once.go:74 +0xbf
+sync.(*Once).Do(...)
+	/usr/local/bin/go/src/sync/once.go:65
+github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).run(0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:232 +0x3c
+created by github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).Run in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:228 +0x69
+
+goroutine 290 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded(0x3f8c5e0)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:346 +0xdf
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).start in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:326 +0xa7
+
+goroutine 99 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded(0x3f8c920)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:346 +0xdf
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).start in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:326 +0xa7
+
+goroutine 101 [chan send, 2 minutes]:
+github.com/cilium/cilium/pkg/vitals/health.(*healthProvider).forModule.func1({{0xc001403440, 0x3, 0x4}, {0xc000c50350, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, {0xc000c50350, ...}}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:390 +0x2cc
+github.com/cilium/cilium/pkg/vitals/health.(*reporter).upsertStatus(0xc00136a1e0?, {{0xc001403440, 0x3, 0x4}, {0xc000c50350, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:477 +0xa5
+github.com/cilium/cilium/pkg/vitals/health.(*subReporter).OK(0xc00049e310?, {0x393b518?, 0xc001c0dc20?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/structured.go:201 +0x127
+github.com/cilium/cilium/pkg/hive/job.(*jobOneShot).start(0xc0019834a0, {0x3f52330, 0xc0014265d0}, 0x1000001fe020103?, {0x3f3dbe0, 0xc0008a2120}, {{{0xc001530f00, 0x1, 0x1}}, {0x3f84a70, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/job/job.go:347 +0x67f
+created by github.com/cilium/cilium/pkg/hive/job.(*group).Start.func1 in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/job/job.go:163 +0x196
+
+goroutine 103 [chan send, 2 minutes]:
+github.com/cilium/cilium/pkg/vitals/health.(*healthProvider).forModule.func1({{0xc001403440, 0x3, 0x4}, {0xc000c503c0, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, {0xc000c503c0, ...}}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:390 +0x2cc
+github.com/cilium/cilium/pkg/vitals/health.(*reporter).upsertStatus(0xc00136a270?, {{0xc001403440, 0x3, 0x4}, {0xc000c503c0, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:477 +0xa5
+github.com/cilium/cilium/pkg/vitals/health.(*subReporter).OK(0xc00049e3f0?, {0x393b518?, 0xc001c0ec20?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/structured.go:201 +0x127
+github.com/cilium/cilium/pkg/hive/job.(*jobOneShot).start(0xc001983560, {0x3f52330, 0xc001426840}, 0x1736d6574496575?, {0x3f3dbe0, 0xc0008a2120}, {{{0xc0015314e0, 0x1, 0x1}}, {0x3f84a70, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/job/job.go:347 +0x67f
+created by github.com/cilium/cilium/pkg/hive/job.(*group).Start.func1 in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/job/job.go:163 +0x196
+
+goroutine 104 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded(0x3f8d620)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:346 +0xdf
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).start in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:326 +0xa7
+
+goroutine 500 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/endpoint.(*Endpoint).UpdateNoTrackRules(0xc000e13880, 0xc001599920)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:932 +0x290
+github.com/cilium/cilium/pkg/endpoint.(*Endpoint).metadataResolver(0xc000e13880, {0x3f52368, 0xc00089d220}, 0x1, 0x0, 0x0, {0x3f3ebc0, 0xc000613d10}, 0xc000f11040)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1694 +0x6b6
+github.com/cilium/cilium/pkg/endpoint.(*Endpoint).RunMetadataResolver.func1({0x3f52368?, 0xc00089d220?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1774 +0x6b
+github.com/cilium/cilium/pkg/controller.(*controller).runController(0xc000370500, {{{0x3957c43, 0xe}}, {0x0, 0x0}, 0xc00089d1d0, 0x0, 0x3b5e8e0, 0x0, 0x0, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/controller.go:254 +0x122
+created by github.com/cilium/cilium/pkg/controller.(*Manager).createControllerLocked in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/manager.go:111 +0x458
+
+goroutine 533 [select]:
+k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop(0xc001f517a0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:276 +0x305
+created by k8s.io/client-go/util/workqueue.newDelayingQueue in goroutine 364
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:113 +0x21f
+
+goroutine 480 [chan receive]:
+k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop(0xc001f513e0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:281 +0x9c
+created by k8s.io/client-go/util/workqueue.newQueue in goroutine 364
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:106 +0x1ba
+
+goroutine 55 [chan receive, 2 minutes]:
+github.com/cilium/workerpool.(*WorkerPool).run(0xc00089c460, {0x3f52368?, 0xc00089c4b0})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/workerpool/workerpool.go:173 +0x5e
+created by github.com/cilium/workerpool.NewWithContext in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/workerpool/workerpool.go:68 +0x14a
+
+goroutine 56 [chan send, 2 minutes]:
+github.com/cilium/cilium/pkg/vitals/health.(*healthProvider).forModule.func1({{0xc001403440, 0x3, 0x4}, {0xc000c50ce0, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, {0xc000c50ce0, ...}}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:390 +0x2cc
+github.com/cilium/cilium/pkg/vitals/health.(*reporter).upsertStatus(0x2fbc900?, {{0xc001403440, 0x3, 0x4}, {0xc000c50ce0, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:477 +0xa5
+github.com/cilium/cilium/pkg/vitals/health.(*subReporter).OK(0x3f3dbe0?, {0x39894d7?, 0x395ce54?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/structured.go:201 +0x127
+github.com/cilium/cilium/pkg/node/manager.(*manager).backgroundSync(0xc000af8460, {0x3f52368, 0xc00089c4b0})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/node/manager/manager.go:359 +0x2ac
+github.com/cilium/workerpool.(*WorkerPool).run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/workerpool/workerpool.go:181 +0x75
+created by github.com/cilium/workerpool.(*WorkerPool).run in goroutine 55
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/workerpool/workerpool.go:178 +0x4c
+
+goroutine 57 [IO wait, 2 minutes]:
+internal/poll.runtime_pollWait(0x7fe24bca0bc8, 0x72)
+	/usr/local/bin/go/src/runtime/netpoll.go:343 +0x85
+internal/poll.(*pollDesc).wait(0xc0013a4b40?, 0xc001e0feb0?, 0x1)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Read(0xc0013a4b40, {0xc001e0feb0, 0x10000, 0x10000})
+	/usr/local/bin/go/src/internal/poll/fd_unix.go:164 +0x27a
+os.(*File).read(...)
+	/usr/local/bin/go/src/os/file_posix.go:29
+os.(*File).Read(0xc001880030, {0xc001e0feb0?, 0x2016574756269?, 0x6570706172570701?})
+	/usr/local/bin/go/src/os/file.go:118 +0x52
+github.com/fsnotify/fsnotify.(*Watcher).readEvents(0xc000e320c0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/fsnotify/fsnotify/backend_inotify.go:483 +0xd2
+created by github.com/fsnotify/fsnotify.NewBufferedWatcher in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/fsnotify/fsnotify/backend_inotify.go:270 +0x1c5
+
+goroutine 58 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/controller.(*controller).runController(0xc000370140, {{{0x3957b55, 0xe}}, {0x0, 0x0}, 0xc000c50fc0, 0x0, 0x3b5e8e0, 0x0, 0x0, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/controller.go:322 +0x9d9
+created by github.com/cilium/cilium/pkg/controller.(*Manager).createControllerLocked in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/manager.go:111 +0x458
+
+goroutine 59 [select, 2 minutes]:
+github.com/cilium/cilium/daemon/cmd/cni.(*cniConfigManager).watchForDirectoryChanges(0xc0015e4480)
+	/home/tom/go/src/github.com/cilium/cilium/daemon/cmd/cni/config.go:242 +0x105
+created by github.com/cilium/cilium/daemon/cmd/cni.(*cniConfigManager).Start in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/daemon/cmd/cni/config.go:216 +0x3ee
+
+goroutine 60 [IO wait, 2 minutes]:
+internal/poll.runtime_pollWait(0x7fe24bca0ad0, 0x72)
+	/usr/local/bin/go/src/runtime/netpoll.go:343 +0x85
+internal/poll.(*pollDesc).wait(0xc001c3c080?, 0x6974696e69666564?, 0x0)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Accept(0xc001c3c080)
+	/usr/local/bin/go/src/internal/poll/fd_unix.go:611 +0x2ac
+net.(*netFD).accept(0xc001c3c080)
+	/usr/local/bin/go/src/net/fd_unix.go:172 +0x29
+net.(*UnixListener).accept(0x409f7e?)
+	/usr/local/bin/go/src/net/unixsock_posix.go:172 +0x16
+net.(*UnixListener).Accept(0xc00136ad50)
+	/usr/local/bin/go/src/net/unixsock.go:260 +0x30
+github.com/cilium/cilium/pkg/monitor/agent.(*server).connectionHandler1_2(0xc00079a220, {0x3f52368?, 0xc0009b4870}, 0x1001656c706d?)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/monitor/agent/server.go:83 +0xe2
+created by github.com/cilium/cilium/pkg/monitor/agent.ServeMonitorAPI in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/monitor/agent/server.go:69 +0x192
+
+goroutine 61 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded(0x3f8db00)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:346 +0xdf
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).start in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:326 +0xa7
+
+goroutine 62 [chan send, 2 minutes]:
+github.com/cilium/cilium/pkg/vitals/health.(*healthProvider).forModule.func1({{0xc001403440, 0x3, 0x4}, {0xc000be7b60, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, {0xc000be7b60, ...}}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:390 +0x2cc
+github.com/cilium/cilium/pkg/vitals/health.(*reporter).upsertStatus(0xc001323c80?, {{0xc001403440, 0x3, 0x4}, {0xc000be7b60, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:477 +0xa5
+github.com/cilium/cilium/pkg/vitals/health.(*subReporter).OK(0xc00039ed20?, {0x393b518?, 0xc001eb9c20?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/structured.go:201 +0x127
+github.com/cilium/cilium/pkg/hive/job.(*jobOneShot).start(0xc0019004e0, {0x3f52330, 0xc00136b080}, 0x6863530601000201?, {0x3f3dbe0, 0xc0008a2120}, {{{0xc000073e20, 0x1, 0x1}}, {0x3f84a70, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/job/job.go:347 +0x67f
+created by github.com/cilium/cilium/pkg/hive/job.(*group).Start.func1 in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/job/job.go:163 +0x196
+
+goroutine 291 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/monitor/agent.(*server).connectionHandler1_2.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/monitor/agent/server.go:78 +0x2c
+created by github.com/cilium/cilium/pkg/monitor/agent.(*server).connectionHandler1_2 in goroutine 60
+	/home/tom/go/src/github.com/cilium/cilium/pkg/monitor/agent/server.go:77 +0xa5
+
+goroutine 63 [IO wait, 2 minutes]:
+internal/poll.runtime_pollWait(0x7fe24bca09d8, 0x72)
+	/usr/local/bin/go/src/runtime/netpoll.go:343 +0x85
+internal/poll.(*pollDesc).wait(0xc001c3c300?, 0x3874ec0?, 0x0)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Accept(0xc001c3c300)
+	/usr/local/bin/go/src/internal/poll/fd_unix.go:611 +0x2ac
+net.(*netFD).accept(0xc001c3c300)
+	/usr/local/bin/go/src/net/fd_unix.go:172 +0x29
+net.(*UnixListener).accept(0x1?)
+	/usr/local/bin/go/src/net/unixsock_posix.go:172 +0x16
+net.(*UnixListener).AcceptUnix(0xc00136b1a0)
+	/usr/local/bin/go/src/net/unixsock.go:247 +0x30
+github.com/cilium/cilium/pkg/envoy.(*AccessLogServer).start.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/envoy/accesslog_server.go:58 +0xaf
+created by github.com/cilium/cilium/pkg/envoy.(*AccessLogServer).start in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/envoy/accesslog_server.go:53 +0x136
+
+goroutine 64 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/envoy.(*AccessLogServer).start.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/envoy/accesslog_server.go:76 +0x2f
+created by github.com/cilium/cilium/pkg/envoy.(*AccessLogServer).start in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/envoy/accesslog_server.go:75 +0x199
+
+goroutine 292 [IO wait, 2 minutes]:
+internal/poll.runtime_pollWait(0x7fe24bca08e0, 0x72)
+	/usr/local/bin/go/src/runtime/netpoll.go:343 +0x85
+internal/poll.(*pollDesc).wait(0xc00171f500?, 0xc0006ee160?, 0x0)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Accept(0xc00171f500)
+	/usr/local/bin/go/src/internal/poll/fd_unix.go:611 +0x2ac
+net.(*netFD).accept(0xc00171f500)
+	/usr/local/bin/go/src/net/fd_unix.go:172 +0x29
+net.(*UnixListener).accept(0xc000b44b28?)
+	/usr/local/bin/go/src/net/unixsock_posix.go:172 +0x16
+net.(*UnixListener).Accept(0xc001323f80)
+	/usr/local/bin/go/src/net/unixsock.go:260 +0x30
+google.golang.org/grpc.(*Server).Serve(0xc002041800, {0x3f3d150?, 0xc001323f80})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/google.golang.org/grpc/server.go:871 +0x462
+github.com/cilium/cilium/pkg/envoy.startXDSGRPCServer.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/envoy/grpc.go:55 +0xa5
+created by github.com/cilium/cilium/pkg/envoy.startXDSGRPCServer in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/envoy/grpc.go:53 +0x191
+
+goroutine 107 [syscall, 2 minutes]:
+syscall.Syscall6(0xc001c4f960?, 0xc001c4f948?, 0x4e4d7c?, 0xc00136a090?, 0x80000000000?, 0xc001c4f960?, 0x4e8605?)
+	/usr/local/bin/go/src/syscall/syscall_linux.go:91 +0x30
+golang.org/x/sys/unix.EpollWait(0xc0004e20b4?, {0xc001d865a0?, 0xc001c4fa10?, 0x46e573?}, 0x4e85e0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/sys/unix/zsyscall_linux_amd64.go:55 +0x4f
+github.com/cilium/ebpf/internal/unix.EpollWait(...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/ebpf/internal/unix/types_linux.go:127
+github.com/cilium/ebpf/internal/epoll.(*Poller).Wait(0xc0006ee1a0, {0xc001d865a0?, 0x8, 0x8}, {0xc001c4fae8?, 0x73d3d8?, 0x0?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/ebpf/internal/epoll/poller.go:145 +0x2a5
+github.com/cilium/ebpf/perf.(*Reader).ReadInto(0xc001db0000, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/ebpf/perf/reader.go:354 +0x2c5
+github.com/cilium/ebpf/perf.(*Reader).Read(0xc000423180?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/ebpf/perf/reader.go:328 +0x45
+github.com/cilium/cilium/pkg/signal.(*signalManager).start.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/signal/signal.go:266 +0x82
+created by github.com/cilium/cilium/pkg/signal.(*signalManager).start in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/signal/signal.go:263 +0x118
+
+goroutine 108 [chan send, 2 minutes]:
+github.com/cilium/cilium/pkg/vitals/health.(*healthProvider).forModule.func1({{0xc001403440, 0x3, 0x4}, {0xc000e8e300, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, {0xc000e8e300, ...}}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:390 +0x2cc
+github.com/cilium/cilium/pkg/vitals/health.(*reporter).upsertStatus(0xc00147ae10?, {{0xc001403440, 0x3, 0x4}, {0xc000e8e300, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:477 +0xa5
+github.com/cilium/cilium/pkg/vitals/health.(*subReporter).OK(0xc00039f810?, {0x39386b5?, 0xc001eb9c08?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/structured.go:201 +0x127
+github.com/cilium/cilium/pkg/hive/job.(*jobObserver[...]).start(0x3f3d580, {0x3f52330, 0xc0014270b0?}, 0x6e694d0701000201, {0x3f3dbe0?, 0xc0008a2120}, {{{0xc0004df9e0, 0x1, 0x1}}, {0x3f84a70, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/job/job.go:569 +0x374
+created by github.com/cilium/cilium/pkg/hive/job.(*group).Start.func1 in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/job/job.go:163 +0x196
+
+goroutine 109 [chan send, 2 minutes]:
+github.com/cilium/cilium/pkg/vitals/health.(*healthProvider).forModule.func1({{0xc001403440, 0x3, 0x4}, {0xc000e54120, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, {0xc000e54120, ...}}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:390 +0x2cc
+github.com/cilium/cilium/pkg/vitals/health.(*reporter).upsertStatus(0xc0013d6270?, {{0xc001403440, 0x3, 0x4}, {0xc000e54120, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:477 +0xa5
+github.com/cilium/cilium/pkg/vitals/health.(*subReporter).OK(0xc00037e5b0?, {0x39386b5?, 0xc001c08c08?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/structured.go:201 +0x127
+github.com/cilium/cilium/pkg/hive/job.(*jobObserver[...]).start(0x3f3d540, {0x3f52330, 0xc001427110?}, 0x1009cff01656c62, {0x3f3dbe0?, 0xc0008a2120}, {{{0xc0004df9e0, 0x1, 0x1}}, {0x3f84a70, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/job/job.go:569 +0x374
+created by github.com/cilium/cilium/pkg/hive/job.(*group).Start.func1 in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/job/job.go:163 +0x196
+
+goroutine 110 [chan send, 2 minutes]:
+github.com/cilium/cilium/pkg/vitals/health.(*healthProvider).forModule.func1({{0xc001403440, 0x3, 0x4}, {0xc000ec8010, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, {0xc000ec8010, ...}}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:390 +0x2cc
+github.com/cilium/cilium/pkg/vitals/health.(*reporter).upsertStatus(0xc001486060?, {{0xc001403440, 0x3, 0x4}, {0xc000ec8010, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:477 +0xa5
+github.com/cilium/cilium/pkg/vitals/health.(*subReporter).OK(0xc0002d8000?, {0x39386b5?, 0xc001da8d90?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/structured.go:201 +0x127
+github.com/cilium/cilium/pkg/hive/job.(*jobTimer).start(0xc0019009c0, {0x3f52330, 0xc001427170}, 0x7265646165480701?, {0x3f3dbe0, 0xc0008a2120}, {{{0xc0004df9e0, 0x1, 0x1}}, {0x3f84a70, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/job/job.go:471 +0x391
+created by github.com/cilium/cilium/pkg/hive/job.(*group).Start.func1 in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/hive/job/job.go:163 +0x196
+
+goroutine 305 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:234 +0x73
+sync.(*Once).doSlow(0xc001c46fd0?, 0x445ebc?)
+	/usr/local/bin/go/src/sync/once.go:74 +0xbf
+sync.(*Once).Do(...)
+	/usr/local/bin/go/src/sync/once.go:65
+github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).run(0xc001d86f00?)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:232 +0x3c
+created by github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).Run in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:228 +0x69
+
+goroutine 306 [select]:
+github.com/cilium/cilium/pkg/controller.(*controller).runController(0xc000493a40, {{{0x3975204, 0x15}}, {0x0, 0x0}, 0xc000e8ba70, 0x0, 0x3b5e8e0, 0x0, 0xdf8475800, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/controller.go:322 +0x9d9
+created by github.com/cilium/cilium/pkg/controller.(*Manager).createControllerLocked in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/manager.go:111 +0x458
+
+goroutine 307 [select]:
+github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter(0xc001da2e60)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:209 +0x2e5
+created by github.com/cilium/cilium/pkg/trigger.NewTrigger in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:122 +0x1d8
+
+goroutine 308 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/cgroups/manager.(*CgroupManager).processPodEvents(0xc0009a3ae0)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/cgroups/manager/manager.go:237 +0x89
+created by github.com/cilium/cilium/pkg/cgroups/manager.initManager in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/cgroups/manager/manager.go:207 +0x1b6
+
+goroutine 293 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).k8sServiceHandler(0xc001dc8300)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/watcher.go:697 +0xe5
+created by github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).RunK8sServiceHandler in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/watcher.go:710 +0x4f
+
+goroutine 294 [select]:
+github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter(0xc00203caa0)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:209 +0x2e5
+created by github.com/cilium/cilium/pkg/trigger.NewTrigger in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:122 +0x1d8
+
+goroutine 295 [select]:
+github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter(0xc00203cb40)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:209 +0x2e5
+created by github.com/cilium/cilium/pkg/trigger.NewTrigger in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:122 +0x1d8
+
+goroutine 296 [select]:
+github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter(0xc00203cbe0)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:209 +0x2e5
+created by github.com/cilium/cilium/pkg/trigger.NewTrigger in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:122 +0x1d8
+
+goroutine 297 [select]:
+github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter(0xc00203cc80)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:209 +0x2e5
+created by github.com/cilium/cilium/pkg/trigger.NewTrigger in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:122 +0x1d8
+
+goroutine 298 [select]:
+github.com/cilium/cilium/pkg/controller.(*controller).runController(0xc0001c9540, {{{0x398479a, 0x19}}, {0x0, 0x0}, 0xc000eccf70, 0x0, 0x3b5e8e0, 0xdf8475800, 0x0, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/controller.go:322 +0x9d9
+created by github.com/cilium/cilium/pkg/controller.(*Manager).createControllerLocked in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/manager.go:111 +0x458
+
+goroutine 388 [chan receive]:
+k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop(0xc0013a5440)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:281 +0x9c
+created by k8s.io/client-go/util/workqueue.newQueue in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:106 +0x1ba
+
+goroutine 249 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc001ea2398, 0x1)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0xc0006effe0?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc001ea2370, 0xc00134d280)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:575 +0x236
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc001eae1e0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:188 +0x30
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4470a0?, {0x3f06e40, 0xc001598060}, 0x1, 0xc002096000)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0007fc030?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0xc001eae1e0, 0xc002096000)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:159 +0x393
+github.com/cilium/cilium/pkg/k8s/resource.(*wrapperController).Run(0xc00096ea40, 0xc002096000)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:808 +0x9e
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:366 +0xbb
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded in goroutine 106
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:364 +0x2a6
+
+goroutine 302 [IO wait, 2 minutes]:
+internal/poll.runtime_pollWait(0x7fe24bca0500, 0x72)
+	/usr/local/bin/go/src/runtime/netpoll.go:343 +0x85
+internal/poll.(*pollDesc).wait(0xc001cbea80?, 0xc00060f680?, 0x0)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Accept(0xc001cbea80)
+	/usr/local/bin/go/src/internal/poll/fd_unix.go:611 +0x2ac
+net.(*netFD).accept(0xc001cbea80)
+	/usr/local/bin/go/src/net/fd_unix.go:172 +0x29
+net.(*TCPListener).accept(0xc0006097e0)
+	/usr/local/bin/go/src/net/tcpsock_posix.go:152 +0x1e
+net.(*TCPListener).Accept(0xc0006097e0)
+	/usr/local/bin/go/src/net/tcpsock.go:315 +0x30
+github.com/cilium/dns.(*Server).serveTCP(0xc00205ba00, {0x3f3d120?, 0xc0006097e0})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/dns/server.go:454 +0x142
+github.com/cilium/dns.(*Server).ActivateAndServe(0xc00205ba00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/dns/server.go:372 +0x26c
+github.com/cilium/cilium/pkg/fqdn/dnsproxy.StartDNSProxy.func1(0xc00205ba00)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/proxy.go:675 +0x22a
+created by github.com/cilium/cilium/pkg/fqdn/dnsproxy.StartDNSProxy in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/proxy.go:667 +0x8f9
+
+goroutine 303 [IO wait]:
+internal/poll.runtime_pollWait(0x7fe24bca06f0, 0x72)
+	/usr/local/bin/go/src/runtime/netpoll.go:343 +0x85
+internal/poll.(*pollDesc).wait(0xc001cbeb00?, 0xc0019fc000?, 0x0)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).ReadMsgInet4(0xc001cbeb00, {0xc0019fc000, 0x200, 0x200}, {0xc00153c3f0, 0x2c, 0x2c}, 0x0?, 0x0?)
+	/usr/local/bin/go/src/internal/poll/fd_unix.go:328 +0x339
+net.(*netFD).readMsgInet4(0xc001cbeb00, {0xc0019fc000?, 0x4259a5?, 0x7fe24ba02c38?}, {0xc00153c3f0?, 0xc0019f9820?, 0x45bebe?}, 0xc00011f000?, 0x9?)
+	/usr/local/bin/go/src/net/fd_posix.go:84 +0x31
+net.(*UDPConn).readMsg(0x3b5f090?, {0xc0019fc000?, 0x418e68?, 0x47?}, {0xc00153c3f0?, 0x0?, 0xffffffffffffffff?})
+	/usr/local/bin/go/src/net/udpsock_posix.go:101 +0x15c
+net.(*UDPConn).ReadMsgUDPAddrPort(0xc000b79030, {0xc0019fc000?, 0x7fe24bca06f0?, 0x47e278?}, {0xc00153c3f0?, 0xc0019f9980?, 0x47e065?})
+	/usr/local/bin/go/src/net/udpsock.go:203 +0x3e
+net.(*UDPConn).ReadMsgUDP(0xc001535320?, {0xc0019fc000?, 0xc000800000?, 0xc000e1e0d0?}, {0xc00153c3f0?, 0xc0019f99e0?, 0x410a05?})
+	/usr/local/bin/go/src/net/udpsock.go:191 +0x25
+github.com/cilium/cilium/pkg/fqdn/dnsproxy.(*sessionUDPFactory).ReadRequest(0xc000b79030?, 0xc000b79030)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/udp.go:158 +0x58
+github.com/cilium/dns.(*Server).readUDP(0xc00205bb00, 0xc000b79030, 0xc000772c30?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/dns/server.go:688 +0xeb
+github.com/cilium/dns.defaultReader.ReadUDP({0x73ba45?}, 0x3f005e0?, 0xc000772c30?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/dns/server.go:174 +0x13
+github.com/cilium/dns.(*Server).serveUDP(0xc00205bb00, {0x3f5f628?, 0xc000b79030?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/dns/server.go:510 +0x29c
+github.com/cilium/dns.(*Server).ActivateAndServe(0xc00205bb00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/dns/server.go:367 +0x1c7
+github.com/cilium/cilium/pkg/fqdn/dnsproxy.StartDNSProxy.func1(0xc00205bb00)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/proxy.go:675 +0x22a
+created by github.com/cilium/cilium/pkg/fqdn/dnsproxy.StartDNSProxy in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/proxy.go:667 +0x8f9
+
+goroutine 304 [IO wait, 2 minutes]:
+internal/poll.runtime_pollWait(0x7fe24bca05f8, 0x72)
+	/usr/local/bin/go/src/runtime/netpoll.go:343 +0x85
+internal/poll.(*pollDesc).wait(0xc001cbec00?, 0xc0015861b0?, 0x0)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Accept(0xc001cbec00)
+	/usr/local/bin/go/src/internal/poll/fd_unix.go:611 +0x2ac
+net.(*netFD).accept(0xc001cbec00)
+	/usr/local/bin/go/src/net/fd_unix.go:172 +0x29
+net.(*TCPListener).accept(0xc000609800)
+	/usr/local/bin/go/src/net/tcpsock_posix.go:152 +0x1e
+net.(*TCPListener).Accept(0xc000609800)
+	/usr/local/bin/go/src/net/tcpsock.go:315 +0x30
+github.com/cilium/dns.(*Server).serveTCP(0xc00205bc00, {0x3f3d120?, 0xc000609800})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/dns/server.go:454 +0x142
+github.com/cilium/dns.(*Server).ActivateAndServe(0xc00205bc00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/dns/server.go:372 +0x26c
+github.com/cilium/cilium/pkg/fqdn/dnsproxy.StartDNSProxy.func1(0xc00205bc00)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/proxy.go:675 +0x22a
+created by github.com/cilium/cilium/pkg/fqdn/dnsproxy.StartDNSProxy in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/proxy.go:667 +0x8f9
+
+goroutine 321 [IO wait]:
+internal/poll.runtime_pollWait(0x7fe24bca0310, 0x72)
+	/usr/local/bin/go/src/runtime/netpoll.go:343 +0x85
+internal/poll.(*pollDesc).wait(0xc001cbec80?, 0xc0019fc200?, 0x0)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/bin/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).ReadMsgInet6(0xc001cbec80, {0xc0019fc200, 0x200, 0x200}, {0xc00153c450, 0x2c, 0x2c}, 0x7fe24b81daf8?, 0x0?)
+	/usr/local/bin/go/src/internal/poll/fd_unix.go:355 +0x339
+net.(*netFD).readMsgInet6(0xc001cbec80, {0xc0019fc200?, 0xc000010030?, 0x0?}, {0xc00153c450?, 0xc0019f5820?, 0x45bebe?}, 0xc00062d580?, 0xc?)
+	/usr/local/bin/go/src/net/fd_posix.go:90 +0x31
+net.(*UDPConn).readMsg(0x3b5f090?, {0xc0019fc200?, 0x418e68?, 0x3f?}, {0xc00153c450?, 0x0?, 0xffffffffffffffff?})
+	/usr/local/bin/go/src/net/udpsock_posix.go:106 +0x9c
+net.(*UDPConn).ReadMsgUDPAddrPort(0xc000b79060, {0xc0019fc200?, 0x7fe24bca0310?, 0x47e278?}, {0xc00153c450?, 0xc0019f5980?, 0x47e065?})
+	/usr/local/bin/go/src/net/udpsock.go:203 +0x3e
+net.(*UDPConn).ReadMsgUDP(0xc001535500?, {0xc0019fc200?, 0xc0019e8000?, 0xc000d7e170?}, {0xc00153c450?, 0xc0019f59e0?, 0x410a05?})
+	/usr/local/bin/go/src/net/udpsock.go:191 +0x25
+github.com/cilium/cilium/pkg/fqdn/dnsproxy.(*sessionUDPFactory).ReadRequest(0xc000b79060?, 0xc000b79060)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/udp.go:158 +0x58
+github.com/cilium/dns.(*Server).readUDP(0xc00205bd00, 0xc000b79060, 0xc0007bebe0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/dns/server.go:688 +0xeb
+github.com/cilium/dns.defaultReader.ReadUDP({0x73ba45?}, 0x3f005e0?, 0xc0007bebe0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/dns/server.go:174 +0x13
+github.com/cilium/dns.(*Server).serveUDP(0xc00205bd00, {0x3f5f628?, 0xc000b79060?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/dns/server.go:510 +0x29c
+github.com/cilium/dns.(*Server).ActivateAndServe(0xc00205bd00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/github.com/cilium/dns/server.go:367 +0x1c7
+github.com/cilium/cilium/pkg/fqdn/dnsproxy.StartDNSProxy.func1(0xc00205bd00)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/proxy.go:675 +0x22a
+created by github.com/cilium/cilium/pkg/fqdn/dnsproxy.StartDNSProxy in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/proxy.go:667 +0x8f9
+
+goroutine 309 [select, 2 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc0001b6ee0, 0xc002096000, 0xc001d87800, 0x2016d756d696e69?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:369 +0x10f
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 346
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:356 +0x49d
+
+goroutine 476 [chan receive]:
+k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop(0xc001f511a0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:281 +0x9c
+created by k8s.io/client-go/util/workqueue.newQueue in goroutine 364
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:106 +0x1ba
+
+goroutine 456 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 53
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 477 [select]:
+k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop(0xc001f51320)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:276 +0x305
+created by k8s.io/client-go/util/workqueue.newDelayingQueue in goroutine 364
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:113 +0x21f
+
+goroutine 485 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/kvstore.Client(...)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/kvstore/client.go:53
+github.com/cilium/cilium/pkg/kvstore.Connected.func1(0xc000404560?)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/kvstore/client.go:96 +0x48
+created by github.com/cilium/cilium/pkg/kvstore.Connected in goroutine 481
+	/home/tom/go/src/github.com/cilium/cilium/pkg/kvstore/client.go:94 +0x68
+
+goroutine 487 [chan receive, 2 minutes]:
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:132 +0x25
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 484
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:131 +0xab
+
+goroutine 488 [select]:
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x60c3340?}, {0x3f35d90, 0xc00140eec0}, {0x7fe24bc21918, 0xc001e269a0}, {0x3f866f8?, 0x38b7800}, 0x0, ...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:724 +0x17b
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc000fae460, {0x0?, 0x0?}, 0xc001e22a20, 0xc001f305a0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:437 +0x545
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0xc000fae460, 0xc001e22a20)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:357 +0x4c5
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:291 +0x25
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x10?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0014dd440?, {0x3f06e60, 0xc000b069b0}, 0x1, 0xc001e22a20)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/client-go/tools/cache.(*Reflector).Run(0xc000fae460, 0xc001e22a20)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:290 +0x1cd
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:55 +0x1e
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x4f
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 484
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 358 [select]:
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x60c3340?}, {0x3f35d90, 0xc001526a00}, {0x7fe24bc21918, 0xc001c164d0}, {0x3f866f8?, 0x38f3a60}, 0x0, ...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:724 +0x17b
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc000fae000, {0x0?, 0x0?}, 0xc001e22420, 0x1?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:437 +0x545
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0xc000fae000, 0xc001e22420)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:357 +0x4c5
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:291 +0x25
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x10?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0014dcc40?, {0x3f06e60, 0xc000b06230}, 0x1, 0xc001e22420)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/client-go/tools/cache.(*Reflector).Run(0xc000fae000, 0xc001e22420)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:290 +0x1cd
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:55 +0x1e
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x4f
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 395
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 343 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 249
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 386 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).serviceEventLoop(0xc001dc8300, 0xc00040457c, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/service.go:40 +0x11d
+created by github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).servicesInit in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/service.go:28 +0x168
+
+goroutine 536 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc002015418, 0x0)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0x1e418e8?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc0020153f0, 0xc0015484c0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:575 +0x236
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc00203d720)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:188 +0x30
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4470a0?, {0x3f06e40, 0xc00164b440}, 0x1, 0xc001f52f00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0007d7140?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0xc00203d720, 0xc001f52f00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:159 +0x393
+github.com/cilium/cilium/pkg/k8s/resource.(*wrapperController).Run(0xc000de8160, 0xc001f52f00)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:808 +0x9e
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:366 +0xbb
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded in goroutine 54
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:364 +0x2a6
+
+goroutine 455 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc0021002e8, 0x0)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0xc001ef4c80?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc0021002c0, 0xc0012eba80)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:575 +0x236
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc001b6c460)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:188 +0x30
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4470a0?, {0x3f06e40, 0xc0015ef4a0}, 0x1, 0xc001b7afc0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00017f300?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0xc001b6c460, 0xc001b7afc0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:159 +0x393
+github.com/cilium/cilium/pkg/k8s/resource.(*wrapperController).Run(0xc0003293e0, 0xc001b7afc0)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:808 +0x9e
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:366 +0xbb
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded in goroutine 53
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:364 +0x2a6
+
+goroutine 345 [chan receive, 2 minutes]:
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:132 +0x25
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 249
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:131 +0xab
+
+goroutine 375 [chan receive]:
+k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop(0xc001cc93e0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:281 +0x9c
+created by k8s.io/client-go/util/workqueue.newQueue in goroutine 386
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:106 +0x1ba
+
+goroutine 349 [select, 2 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc000fae000, 0xc001e22420, 0xc0020964e0, 0xc000116778?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:369 +0x10f
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 358
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:356 +0x49d
+
+goroutine 481 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).ciliumEndpointsInit(0xc001dc8300, {0x3f92228, 0xc0015b2160}, 0xc000404560)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/cilium_endpoint.go:101 +0x71
+created by github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).initCiliumEndpointOrSlices in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/watcher.go:1061 +0x145
+
+goroutine 484 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc001e269c8, 0x1)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0xc000bb05e0?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc001e269a0, 0xc001219600)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:575 +0x236
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc001e38140)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:188 +0x30
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4470a0?, {0x3f06e40, 0xc00163e480}, 0x1, 0xc001e22a20)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0006f1010?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0xc001e38140, 0xc001e22a20)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:159 +0x393
+github.com/cilium/cilium/pkg/k8s/informer.(*privateRunner).Run(0xc000beab60, 0xc001e22a20)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/informer/informer.go:46 +0x9e
+created by github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).ciliumEndpointsInit in goroutine 481
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/cilium_endpoint.go:99 +0x65
+
+goroutine 346 [select]:
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x60c3340?}, {0x3f35d90, 0xc001526800}, {0x7fe24bc21918, 0xc001ea2370}, {0x3f866f8?, 0x38f2020}, 0x0, ...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:724 +0x17b
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc0001b6ee0, {0x0?, 0x0?}, 0xc002096000, 0x418e01?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:437 +0x545
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0xc0001b6ee0, 0xc002096000)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:357 +0x4c5
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:291 +0x25
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x10?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0009ab9c0?, {0x3f06e60, 0xc000725c20}, 0x1, 0xc002096000)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/client-go/tools/cache.(*Reflector).Run(0xc0001b6ee0, 0xc002096000)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:290 +0x1cd
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:55 +0x1e
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x4f
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 249
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 265 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 105
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 357 [chan receive, 2 minutes]:
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:132 +0x25
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 395
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:131 +0xab
+
+goroutine 355 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 395
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 264 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc002100028, 0x8)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0xc000ecb9a0?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc002100000, 0xc0012eaa00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:575 +0x236
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc001b6c280)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:188 +0x30
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4470a0?, {0x3f06e40, 0xc001587fb0}, 0x1, 0xc001b7a420)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00017e940?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0xc001b6c280, 0xc001b7a420)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:159 +0x393
+github.com/cilium/cilium/pkg/k8s/resource.(*wrapperController).Run(0xc0003288e0, 0xc001b7a420)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:808 +0x9e
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:366 +0xbb
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded in goroutine 105
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:364 +0x2a6
+
+goroutine 370 [chan receive]:
+k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop(0xc001cc90e0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:281 +0x9c
+created by k8s.io/client-go/util/workqueue.newQueue in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:106 +0x1ba
+
+goroutine 371 [select]:
+k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop(0xc001cc9200)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:276 +0x305
+created by k8s.io/client-go/util/workqueue.newDelayingQueue in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:113 +0x21f
+
+goroutine 372 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).processLoop(0x3f702a0, {0x3f52368, 0xc001e90690}, 0xc001cb1b00, {0x3f63828, 0xc001f810e0})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:664 +0x5a6
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:498 +0x33a
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:464 +0x586
+
+goroutine 373 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:510 +0x135
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:508 +0x64a
+
+goroutine 389 [select]:
+k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop(0xc0013a55c0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:276 +0x305
+created by k8s.io/client-go/util/workqueue.newDelayingQueue in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:113 +0x21f
+
+goroutine 390 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc000e32490, 0x4)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0x34aca40?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/util/workqueue.(*Type).Get(0xc0013a5440)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:200 +0x99
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).getWorkItem(...)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:685
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).processLoop(0x3f70120, {0x3f52368, 0xc00089c8c0}, 0xc001c12b40, {0x3f63720, 0xc001f811e8})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:609 +0x144
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:498 +0x33a
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:464 +0x586
+
+goroutine 391 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:510 +0x135
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:508 +0x64a
+
+goroutine 392 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).namespacesInit.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/namespace.go:47 +0xc5
+created by github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).namespacesInit in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/namespace.go:45 +0x1ed
+
+goroutine 479 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:510 +0x135
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 364
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:508 +0x64a
+
+goroutine 458 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 455
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 395 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc001c164f8, 0x1)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0xc00093bc20?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc001c164d0, 0xc000e32740)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:575 +0x236
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc001c68000)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:188 +0x30
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4470a0?, {0x3f06e40, 0xc001487140}, 0x1, 0xc001e22420)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0006f0ba0?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0xc001c68000, 0xc001e22420)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:159 +0x393
+github.com/cilium/cilium/pkg/k8s/resource.(*wrapperController).Run(0xc00079a400, 0xc001e22420)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:808 +0x9e
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:366 +0xbb
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded in goroutine 102
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:364 +0x2a6
+
+goroutine 396 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 102
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 531 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:510 +0x135
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 364
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:508 +0x64a
+
+goroutine 398 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).podsInit.func1.1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/pod.go:125 +0x116
+created by github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).podsInit.func1 in goroutine 393
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/pod.go:123 +0xe5
+
+goroutine 376 [select]:
+k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop(0xc001cc9560)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:276 +0x305
+created by k8s.io/client-go/util/workqueue.newDelayingQueue in goroutine 386
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:113 +0x21f
+
+goroutine 377 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc00130a150, 0x4)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0x34aca40?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/util/workqueue.(*Type).Get(0xc001cc93e0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:200 +0x99
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).getWorkItem(...)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:685
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).processLoop(0x3f70320, {0x3f52368, 0xc001e90870}, 0xc001cb1c80, {0x3f63880, 0xc000e087f8})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:609 +0x144
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:498 +0x33a
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 386
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:464 +0x586
+
+goroutine 378 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:510 +0x135
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 386
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:508 +0x64a
+
+goroutine 478 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc00130b990, 0x2)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0x34aca40?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/util/workqueue.(*Type).Get(0xc001f511a0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:200 +0x99
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).getWorkItem(...)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:685
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).processLoop(0x3f70020, {0x3f52368, 0xc001e91590}, 0xc001f52a20, {0x3f63670, 0xc000c71b90})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:609 +0x144
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:498 +0x33a
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 364
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:464 +0x586
+
+goroutine 409 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 406
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 253 [chan receive]:
+k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop(0xc001fadb00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:281 +0x9c
+created by k8s.io/client-go/util/workqueue.newQueue in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:106 +0x1ba
+
+goroutine 401 [chan receive]:
+k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop(0xc001c72180)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:281 +0x9c
+created by k8s.io/client-go/util/workqueue.newQueue in goroutine 398
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:106 +0x1ba
+
+goroutine 402 [select]:
+k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop(0xc001c72300)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:276 +0x305
+created by k8s.io/client-go/util/workqueue.newDelayingQueue in goroutine 398
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:113 +0x21f
+
+goroutine 403 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc000e32a50, 0x12)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0x0?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/util/workqueue.(*Type).Get(0xc001c72180)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:200 +0x99
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).getWorkItem(...)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:685
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).processLoop(0x3f701a0, {0x3f52368, 0xc00089cc80}, 0xc001c13140, {0x3f63778, 0xc000d6a780})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:609 +0x144
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:498 +0x33a
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 398
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:464 +0x586
+
+goroutine 404 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:510 +0x135
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 398
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:508 +0x64a
+
+goroutine 254 [select]:
+k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop(0xc001fadc80)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:276 +0x305
+created by k8s.io/client-go/util/workqueue.newDelayingQueue in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:113 +0x21f
+
+goroutine 267 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 264
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 255 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc00134d450, 0x4)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0x34aca40?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/util/workqueue.(*Type).Get(0xc001fadb00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:200 +0x99
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).getWorkItem(...)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:685
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).processLoop(0x3f6fea0, {0x3f52368, 0xc00089ca00}, 0xc001c12d80, {0x3f63568, 0xc000e08648})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:609 +0x144
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:498 +0x33a
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:464 +0x586
+
+goroutine 256 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:510 +0x135
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:508 +0x64a
+
+goroutine 417 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).endpointsInit.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/endpoints.go:42 +0xec
+created by github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).endpointsInit in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/endpoints.go:40 +0x236
+
+goroutine 364 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).ciliumNetworkPoliciesInit.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/cilium_network_policy.go:93 +0x352
+created by github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).ciliumNetworkPoliciesInit in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/cilium_network_policy.go:74 +0x13a
+
+goroutine 419 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).networkPolicyEventLoop(0xc001dc8300, 0xc0001785c8)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/network_policy.go:41 +0x129
+created by github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).NetworkPoliciesInit.func1 in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/network_policy.go:28 +0x157
+
+goroutine 406 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc001c16708, 0x1)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0xc00079a8c0?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc001c166e0, 0xc000e32c00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:575 +0x236
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc001c680a0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:188 +0x30
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4470a0?, {0x3f06e40, 0xc0015d0000}, 0x1, 0xc001c13500)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000404630?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0xc001c680a0, 0xc001c13500)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:159 +0x393
+github.com/cilium/cilium/pkg/k8s/resource.(*wrapperController).Run(0xc00079a4c0, 0xc001c13500)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:808 +0x9e
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:366 +0xbb
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded in goroutine 100
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:364 +0x2a6
+
+goroutine 407 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 100
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 530 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc00130be90, 0x1)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0x1?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/util/workqueue.(*Type).Get(0xc001f513e0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:200 +0x99
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).getWorkItem(...)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:685
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).processLoop(0x3f6ffa0, {0x3f52368, 0xc001e91680}, 0xc001f52ae0, {0x3f63618, 0xc000d6aeb8})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:609 +0x144
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:498 +0x33a
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 364
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:464 +0x586
+
+goroutine 535 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:510 +0x135
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 364
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:508 +0x64a
+
+goroutine 411 [chan receive, 2 minutes]:
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:132 +0x25
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 406
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:131 +0xab
+
+goroutine 412 [select]:
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x60c3340?}, {0x3f35d90, 0xc001526680}, {0x7fe24bc21918, 0xc001c166e0}, {0x3f866f8?, 0x38f14e0}, 0x0, ...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:724 +0x17b
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc000f422a0, {0x0?, 0x0?}, 0xc001c13500, 0x1?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:437 +0x545
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0xc000f422a0, 0xc001c13500)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:357 +0x4c5
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:291 +0x25
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x10?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000898d80?, {0x3f06e60, 0xc00089ce60}, 0x1, 0xc001c13500)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/client-go/tools/cache.(*Reflector).Run(0xc000f422a0, 0xc001c13500)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:290 +0x1cd
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:55 +0x1e
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x4f
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 406
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 310 [select, 2 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc001dc3e00, 0xc001dd7500)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1464 +0xac7
+golang.org/x/net/http2.(*clientStream).doRequest(0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1326 +0x18
+created by golang.org/x/net/http2.(*ClientConn).RoundTrip in goroutine 346
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1232 +0x308
+
+goroutine 534 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc001548350, 0x2)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0x34aca40?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/util/workqueue.(*Type).Get(0xc001f51620)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:200 +0x99
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).getWorkItem(...)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:685
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).processLoop(0x3f6ff20, {0x3f52368, 0xc001e91770}, 0xc001f52ba0, {0x3f635c0, 0xc001159530})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:609 +0x144
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:498 +0x33a
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 364
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:464 +0x586
+
+goroutine 269 [chan receive, 2 minutes]:
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:132 +0x25
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 264
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:131 +0xab
+
+goroutine 415 [select, 2 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc000f422a0, 0xc001c13500, 0xc001c13d40, 0xc001da1f10?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:369 +0x10f
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 412
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:356 +0x49d
+
+goroutine 420 [chan receive]:
+k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop(0xc001fadd40)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:281 +0x9c
+created by k8s.io/client-go/util/workqueue.newQueue in goroutine 419
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:106 +0x1ba
+
+goroutine 270 [select]:
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x60c3340?}, {0x3f35d90, 0xc001526880}, {0x7fe24bc21918, 0xc002100000}, {0x3f866f8?, 0x38f1120}, 0x0, ...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:724 +0x17b
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc000df4380, {0x0?, 0x0?}, 0xc001b7a420, 0x1?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:437 +0x545
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0xc000df4380, 0xc001b7a420)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:357 +0x4c5
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:291 +0x25
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x10?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0004d0d00?, {0x3f06e60, 0xc0006faf00}, 0x1, 0xc001b7a420)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/client-go/tools/cache.(*Reflector).Run(0xc000df4380, 0xc001b7a420)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:290 +0x1cd
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:55 +0x1e
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x4f
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 264
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 421 [select]:
+k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop(0xc001fadec0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:276 +0x305
+created by k8s.io/client-go/util/workqueue.newDelayingQueue in goroutine 419
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:113 +0x21f
+
+goroutine 422 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc00134d8d0, 0x2)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0x34aca40?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/util/workqueue.(*Type).Get(0xc001fadd40)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/queue.go:200 +0x99
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).getWorkItem(...)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:685
+github.com/cilium/cilium/pkg/k8s/resource.(*subscriber[...]).processLoop(0x3f700a0, {0x3f52368, 0xc0000d0c80}, 0xc001e9a840, {0x3f636c8, 0xc001f81410})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:609 +0x144
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:498 +0x33a
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 419
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:464 +0x586
+
+goroutine 423 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:510 +0x135
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).Events in goroutine 419
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:508 +0x64a
+
+goroutine 434 [select, 2 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc000df4380, 0xc001b7a420, 0xc001e9b020, 0xc001c01710?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:369 +0x10f
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 270
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:356 +0x49d
+
+goroutine 424 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc001ea2708, 0x0)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0xc001c7ac80?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc001ea26e0, 0xc00134da40)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:575 +0x236
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc001eae280)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:188 +0x30
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4470a0?, {0x3f06e40, 0xc0007afe30}, 0x1, 0xc001e9ac00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000178610?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0xc001eae280, 0xc001e9ac00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:159 +0x393
+github.com/cilium/cilium/pkg/k8s/resource.(*wrapperController).Run(0xc00096eb00, 0xc001e9ac00)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:808 +0x9e
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:366 +0xbb
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded in goroutine 51
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:364 +0x2a6
+
+goroutine 425 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 51
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 529 [select]:
+k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop(0xc001f51560)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:276 +0x305
+created by k8s.io/client-go/util/workqueue.newDelayingQueue in goroutine 364
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:113 +0x21f
+
+goroutine 428 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 424
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 579 [select, 2 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc00211a000, 0xc001b61700)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1464 +0xac7
+golang.org/x/net/http2.(*clientStream).doRequest(0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1326 +0x18
+created by golang.org/x/net/http2.(*ClientConn).RoundTrip in goroutine 543
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1232 +0x308
+
+goroutine 430 [chan receive, 2 minutes]:
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:132 +0x25
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 424
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:131 +0xab
+
+goroutine 431 [select]:
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x60c3340?}, {0x3f35d90, 0xc001526b00}, {0x7fe24bc21918, 0xc001ea26e0}, {0x3f866f8?, 0x38f2f20}, 0x0, ...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:724 +0x17b
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc000d9e1c0, {0x0?, 0x0?}, 0xc001e9ac00, 0x1?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:437 +0x545
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0xc000d9e1c0, 0xc001e9ac00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:357 +0x4c5
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:291 +0x25
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x10?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000b88480?, {0x3f06e60, 0xc0000d0eb0}, 0x1, 0xc001e9ac00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/client-go/tools/cache.(*Reflector).Run(0xc000d9e1c0, 0xc001e9ac00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:290 +0x1cd
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:55 +0x1e
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x4f
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 424
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 449 [select, 2 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc000d9e1c0, 0xc001e9ac00, 0xc001b7a900, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:369 +0x10f
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 431
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:356 +0x49d
+
+goroutine 439 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc000da7248, 0x2)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0xc0022f6d40?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+golang.org/x/net/http2.(*pipe).Read(0xc000da7230, {0xc0007fc600, 0x4, 0x4})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/pipe.go:76 +0xdf
+golang.org/x/net/http2.transportResponseBody.Read({0xc0007fc600?}, {0xc0007fc600?, 0xc0022f6ce0?, 0x40e50c?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:2558 +0x65
+io.ReadAtLeast({0x7fe24bc21840, 0xc000da7200}, {0xc0007fc600, 0x4, 0x4}, 0x4)
+	/usr/local/bin/go/src/io/io.go:335 +0x90
+k8s.io/apimachinery/pkg/util/framer.(*lengthDelimitedFrameReader).Read(0xc001f81ae8, {0xc001efd800, 0x400, 0x400})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/framer/framer.go:76 +0x85
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc0000d1810, 0xc001e9b740?, {0x3f34360, 0xc000ab08c0})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc00096f600)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc001526a00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:105 +0xdb
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 358
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:76 +0x125
+
+goroutine 350 [select, 2 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc000da7200, 0xc000245f00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1464 +0xac7
+golang.org/x/net/http2.(*clientStream).doRequest(0x0?, 0xc001b66f10?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1326 +0x18
+created by golang.org/x/net/http2.(*ClientConn).RoundTrip in goroutine 358
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1232 +0x308
+
+goroutine 450 [select, 2 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc00094d800, 0xc001b60e00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1464 +0xac7
+golang.org/x/net/http2.(*clientStream).doRequest(0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1326 +0x18
+created by golang.org/x/net/http2.(*ClientConn).RoundTrip in goroutine 431
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1232 +0x308
+
+goroutine 416 [select, 2 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc00218e180, 0xc001c5e600)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1464 +0xac7
+golang.org/x/net/http2.(*clientStream).doRequest(0x6e654c6e694d0901?, 0x701000401687467?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1326 +0x18
+created by golang.org/x/net/http2.(*ClientConn).RoundTrip in goroutine 412
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1232 +0x308
+
+goroutine 435 [select, 2 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc000b58780, 0xc001eb0900)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1464 +0xac7
+golang.org/x/net/http2.(*clientStream).doRequest(0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1326 +0x18
+created by golang.org/x/net/http2.(*ClientConn).RoundTrip in goroutine 270
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1232 +0x308
+
+goroutine 436 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc00218e1c8, 0x2)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0xc001ef5d40?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+golang.org/x/net/http2.(*pipe).Read(0xc00218e1b0, {0xc0007fc4f0, 0x4, 0x4})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/pipe.go:76 +0xdf
+golang.org/x/net/http2.transportResponseBody.Read({0xc0007fc4f0?}, {0xc0007fc4f0?, 0xc001ef5ce0?, 0x40e50c?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:2558 +0x65
+io.ReadAtLeast({0x7fe24bc21840, 0xc00218e180}, {0xc0007fc4f0, 0x4, 0x4}, 0x4)
+	/usr/local/bin/go/src/io/io.go:335 +0x90
+k8s.io/apimachinery/pkg/util/framer.(*lengthDelimitedFrameReader).Read(0xc001f81a10, {0xc001efcc00, 0x400, 0x400})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/framer/framer.go:76 +0x85
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc0000d14f0, 0xc001e9b3e0?, {0x3f34360, 0xc000ab0700})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc00096f5a0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc001526680)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:105 +0xdb
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 412
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:76 +0x125
+
+goroutine 437 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc001dc3e48, 0x2)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0xc001ef6d40?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+golang.org/x/net/http2.(*pipe).Read(0xc001dc3e30, {0xc0007fc120, 0x4, 0x4})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/pipe.go:76 +0xdf
+golang.org/x/net/http2.transportResponseBody.Read({0xc0007fc120?}, {0xc0007fc120?, 0xc001ef6ce0?, 0x40e50c?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:2558 +0x65
+io.ReadAtLeast({0x7fe24bc21840, 0xc001dc3e00}, {0xc0007fc120, 0x4, 0x4}, 0x4)
+	/usr/local/bin/go/src/io/io.go:335 +0x90
+k8s.io/apimachinery/pkg/util/framer.(*lengthDelimitedFrameReader).Read(0xc001f81a70, {0xc001efd000, 0x400, 0x400})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/framer/framer.go:76 +0x85
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc0000d16d0, 0xc001e9b500?, {0x3f34360, 0xc000ab01c0})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc00096f5c0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc001526800)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:105 +0xdb
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 346
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:76 +0x125
+
+goroutine 438 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc000b587c8, 0xa)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0xc001ef7d40?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+golang.org/x/net/http2.(*pipe).Read(0xc000b587b0, {0xc0013d02fc, 0x4, 0x4})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/pipe.go:76 +0xdf
+golang.org/x/net/http2.transportResponseBody.Read({0xc0013d02f2?}, {0xc0013d02fc?, 0xc001ef7ce0?, 0x40e50c?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:2558 +0x65
+io.ReadAtLeast({0x7fe24bc21840, 0xc000b58780}, {0xc0013d02fc, 0x4, 0x4}, 0x4)
+	/usr/local/bin/go/src/io/io.go:335 +0x90
+k8s.io/apimachinery/pkg/util/framer.(*lengthDelimitedFrameReader).Read(0xc001f81aa0, {0xc002374000, 0x4000, 0x5000})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/framer/framer.go:76 +0x85
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc0000d1720, 0xc001e9b680?, {0x3f34360, 0xc0012860c0})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc00096f5e0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc001526880)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:105 +0xdb
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 270
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:76 +0x125
+
+goroutine 440 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc00094d848, 0x2)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0xc0022f7d40?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+golang.org/x/net/http2.(*pipe).Read(0xc00094d830, {0xc0007fc518, 0x4, 0x4})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/pipe.go:76 +0xdf
+golang.org/x/net/http2.transportResponseBody.Read({0xc0007fc500?}, {0xc0007fc518?, 0xc0022f7ce0?, 0x40e50c?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:2558 +0x65
+io.ReadAtLeast({0x7fe24bc21840, 0xc00094d800}, {0xc0007fc518, 0x4, 0x4}, 0x4)
+	/usr/local/bin/go/src/io/io.go:335 +0x90
+k8s.io/apimachinery/pkg/util/framer.(*lengthDelimitedFrameReader).Read(0xc001f81b30, {0xc001efdc00, 0x400, 0x400})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/framer/framer.go:76 +0x85
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc0000d1950, 0xc001e9b8c0?, {0x3f34360, 0xc000ab07c0})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc00096f620)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc001526b00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:105 +0xdb
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 431
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:76 +0x125
+
+goroutine 441 [sync.Mutex.Lock, 2 minutes]:
+sync.runtime_SemacquireMutex(0x0?, 0x1?, 0x2?)
+	/usr/local/bin/go/src/runtime/sema.go:77 +0x25
+sync.(*Mutex).lockSlow(0xc001ea2790)
+	/usr/local/bin/go/src/sync/mutex.go:171 +0x15d
+sync.(*Mutex).Lock(...)
+	/usr/local/bin/go/src/sync/mutex.go:90
+sync.(*RWMutex).Lock(0xc002301b98?)
+	/usr/local/bin/go/src/sync/rwmutex.go:147 +0x31
+k8s.io/client-go/tools/cache.(*DeltaFIFO).HasSynced(0xc001ea2790)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:301 +0x2f
+k8s.io/client-go/tools/cache.(*controller).HasSynced(0x1?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:165 +0x1b
+k8s.io/client-go/tools/cache.WaitForCacheSync.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/shared_informer.go:329 +0x47
+k8s.io/apimachinery/pkg/util/wait.PollImmediateUntil.ConditionFunc.WithContext.func1({0xc0000d1b30, 0x0})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:109 +0x13
+k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtectionWithContext({0x3f53670?, 0xc001e9b9e0?}, 0xc002301c60?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:154 +0x4c
+k8s.io/apimachinery/pkg/util/wait.waitForWithContext({0x3f53670, 0xc001e9b9e0}, 0xc002301d28, 0x2fbc900?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:207 +0x107
+k8s.io/apimachinery/pkg/util/wait.poll({0x3f53670, 0xc001e9b9e0}, 0x10?, 0xc0007ae090?, 0x3f2f4e8?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/poll.go:260 +0x89
+k8s.io/apimachinery/pkg/util/wait.PollImmediateUntilWithContext({0x3f53670?, 0xc001e9b9e0?}, 0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/poll.go:200 +0x53
+k8s.io/apimachinery/pkg/util/wait.PollImmediateUntil(0xc002301d08?, 0xc002301dc8?, 0x73d8c8?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/poll.go:187 +0x3c
+k8s.io/client-go/tools/cache.WaitForCacheSync(0xc0002bf7a0?, {0xc002301e58?, 0xc001b68e80?, 0x12?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/shared_informer.go:326 +0x4c
+github.com/cilium/cilium/pkg/k8s/synced.(*Resources).BlockWaitGroupToSyncResources.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/synced/resources.go:82 +0x1ad
+created by github.com/cilium/cilium/pkg/k8s/synced.(*Resources).BlockWaitGroupToSyncResources in goroutine 368
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/synced/resources.go:79 +0x1e9
+
+goroutine 442 [chan send, 2 minutes]:
+github.com/cilium/cilium/pkg/vitals/health.(*healthProvider).forModule.func1({{0xc001403440, 0x3, 0x4}, {0xc000f52580, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, {0xc000f52580, ...}}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:390 +0x2cc
+github.com/cilium/cilium/pkg/vitals/health.(*reporter).upsertStatus(0x2fbc900?, {{0xc001403440, 0x3, 0x4}, {0xc000f52580, 0x1, 0x1}}, {{{0xc001403440, 0x3, 0x4}, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/health.go:477 +0xa5
+github.com/cilium/cilium/pkg/vitals/health.(*subReporter).OK(0x3f3dbe0?, {0x3970a37?, 0x39425e3?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/vitals/health/structured.go:201 +0x127
+github.com/cilium/cilium/pkg/node/manager.(*manager).NodeUpdated(_, {{0xc001579b60, 0x12}, {0xc0014a2bd0, 0x9}, {0xc001da2f00, 0x4, 0x4}, 0xc0018c4138, {0x0, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/node/manager/manager.go:636 +0x1cc6
+github.com/cilium/cilium/pkg/nodediscovery.(*NodeDiscovery).NodeUpdated(_, {{0xc001579b60, 0x12}, {0xc0014a2bd0, 0x9}, {0xc001da2f00, 0x4, 0x4}, 0xc0018c4138, {0x0, ...}, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/nodediscovery/nodediscovery.go:251 +0x55
+github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).ciliumNodeInit.func1({0x38c0420?, 0xc002309800?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/cilium_node.go:48 +0x1d5
+k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd(...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:239
+github.com/cilium/cilium/pkg/k8s/informer.NewInformerWithStore.func1({0x3253460?, 0xc000fc1230?}, 0x1?)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/informer/informer.go:132 +0x2ad
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc001ea2790, 0xc001526b80)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:603 +0x55e
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc001eae6e0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:188 +0x30
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4470a0?, {0x3f06e40, 0xc001598db0}, 0x1, 0xc001e9b9e0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0007fc560?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0xc001eae6e0, 0xc001e9b9e0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:159 +0x393
+github.com/cilium/cilium/pkg/k8s/informer.(*privateRunner).Run(0xc00096f6a0, 0xc001e9b9e0)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/informer/informer.go:46 +0x9e
+created by github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).ciliumNodeInit in goroutine 368
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/cilium_node.go:110 +0x579
+
+goroutine 443 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/kvstore.Client(...)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/kvstore/client.go:53
+github.com/cilium/cilium/pkg/kvstore.Connected.func1(0xc001526880?)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/kvstore/client.go:96 +0x48
+created by github.com/cilium/cilium/pkg/kvstore.Connected in goroutine 368
+	/home/tom/go/src/github.com/cilium/cilium/pkg/kvstore/client.go:94 +0x68
+
+goroutine 67 [select, 2 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc000fae460, 0xc001e22a20, 0xc001d0a240, 0xc00140e440?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:369 +0x10f
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 488
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:356 +0x49d
+
+goroutine 497 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/nodediscovery.(*NodeDiscovery).WaitForLocalNodeInit(0xc000423650?)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/nodediscovery/nodediscovery.go:243 +0x1c
+github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).InitK8sSubsystem.func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/watcher.go:535 +0xe8
+created by github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).InitK8sSubsystem in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/watchers/watcher.go:533 +0x368
+
+goroutine 70 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc0023404c8, 0x2)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0x3f30640?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+golang.org/x/net/http2.(*pipe).Read(0xc0023404b0, {0xc001dbf801, 0x5ff, 0x5ff})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/pipe.go:76 +0xdf
+golang.org/x/net/http2.transportResponseBody.Read({0x3933c88?}, {0xc001dbf801?, 0x3946b61?, 0xa?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:2558 +0x65
+encoding/json.(*Decoder).refill(0xc001d36c80)
+	/usr/local/bin/go/src/encoding/json/stream.go:165 +0x188
+encoding/json.(*Decoder).readValue(0xc001d36c80)
+	/usr/local/bin/go/src/encoding/json/stream.go:140 +0xa9
+encoding/json.(*Decoder).Decode(0xc001d36c80, {0x3254a60, 0xc0012666d8})
+	/usr/local/bin/go/src/encoding/json/stream.go:63 +0x75
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0xc0020d0210, {0xc001d03800, 0x400, 0x400})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/framer/framer.go:152 +0x19c
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc000940690, 0xc001d0a720?, {0x3f34360, 0xc000ab0880})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc000bb0860)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc00140eec0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:105 +0xdb
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 488
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:76 +0x125
+
+goroutine 352 [chan receive, 2 minutes]:
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:132 +0x25
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 442
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:131 +0xab
+
+goroutine 513 [select]:
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x60c3340?}, {0x3f35d90, 0xc000ab0480}, {0x7fe24bc21918, 0xc001ea2790}, {0x3f866f8?, 0x38c0420}, 0x0, ...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:724 +0x17b
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc0001b7260, {0x0?, 0x0?}, 0xc001e9b9e0, 0xc001f30da0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:437 +0x545
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0xc0001b7260, 0xc001e9b9e0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:357 +0x4c5
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:291 +0x25
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x10?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0009abb00?, {0x3f06e60, 0xc002222140}, 0x1, 0xc001e9b9e0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/client-go/tools/cache.(*Reflector).Run(0xc0001b7260, 0xc001e9b9e0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:290 +0x1cd
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:55 +0x1e
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x4f
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 442
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 553 [select, 2 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc0001b7260, 0xc001e9b9e0, 0xc0022ff260, 0x1796c6e4f746e65?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:369 +0x10f
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 513
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:356 +0x49d
+
+goroutine 68 [select, 2 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc002340480, 0xc0020ce200)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1464 +0xac7
+golang.org/x/net/http2.(*clientStream).doRequest(0x2123dc5?, 0xc001da2e60?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1326 +0x18
+created by golang.org/x/net/http2.(*ClientConn).RoundTrip in goroutine 488
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1232 +0x308
+
+goroutine 554 [select, 2 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc000b59b00, 0xc001eb1d00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1464 +0xac7
+golang.org/x/net/http2.(*clientStream).doRequest(0x74735b70616d1601?, 0x6570735d676e6972?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1326 +0x18
+created by golang.org/x/net/http2.(*ClientConn).RoundTrip in goroutine 513
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1232 +0x308
+
+goroutine 516 [sync.Cond.Wait, 2 minutes]:
+sync.runtime_notifyListWait(0xc000e86a78, 0x0)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0xc0022f2c80?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc000e86a50, 0xc001287580)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:575 +0x236
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc0018db2c0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:188 +0x30
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4470a0?, {0x3f06e40, 0xc001599260}, 0x1, 0xc002096c60)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0007fc6c0?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0xc0018db2c0, 0xc002096c60)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:159 +0x393
+github.com/cilium/cilium/pkg/k8s/resource.(*wrapperController).Run(0xc000e8c200, 0xc002096c60)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:808 +0x9e
+github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded.func2()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:366 +0xbb
+created by github.com/cilium/cilium/pkg/k8s/resource.(*resource[...]).startWhenNeeded in goroutine 52
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:364 +0x2a6
+
+goroutine 517 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 52
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 519 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 516
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 567 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc0020a44c8, 0x2)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0x3f30ac8?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+golang.org/x/net/http2.(*pipe).Read(0xc0020a44b0, {0xc001dbec01, 0x5ff, 0x5ff})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/pipe.go:76 +0xdf
+golang.org/x/net/http2.transportResponseBody.Read({0x3933c88?}, {0xc001dbec01?, 0x3946b61?, 0xa?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:2558 +0x65
+encoding/json.(*Decoder).refill(0xc000966500)
+	/usr/local/bin/go/src/encoding/json/stream.go:165 +0x188
+encoding/json.(*Decoder).readValue(0xc000966500)
+	/usr/local/bin/go/src/encoding/json/stream.go:140 +0xa9
+encoding/json.(*Decoder).Decode(0xc000966500, {0x3254a60, 0xc001266588})
+	/usr/local/bin/go/src/encoding/json/stream.go:63 +0x75
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0xc0016a6c90, {0xc00222c400, 0x400, 0x400})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/framer/framer.go:152 +0x19c
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc0022230e0, 0xc002097920?, {0x3f34360, 0xc000ab02c0})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc000e8c960)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc001287d00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:105 +0xdb
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 522
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:76 +0x125
+
+goroutine 521 [chan receive, 2 minutes]:
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:132 +0x25
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 516
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:131 +0xab
+
+goroutine 446 [select]:
+k8s.io/apimachinery/pkg/util/wait.PollImmediateUntilWithContext.poller.func1.1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/poll.go:297 +0x1c5
+created by k8s.io/apimachinery/pkg/util/wait.PollImmediateUntilWithContext.poller.func1 in goroutine 441
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/poll.go:280 +0xc5
+
+goroutine 522 [select]:
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x60c3340?}, {0x3f35d90, 0xc001287d00}, {0x7fe24bc21918, 0xc000e86a50}, {0x3f866f8?, 0x38d6460}, 0x0, ...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:724 +0x17b
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc0001b75e0, {0x0?, 0x0?}, 0xc002096c60, 0x1?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:437 +0x545
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0xc0001b75e0, 0xc002096c60)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:357 +0x4c5
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:291 +0x25
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x10?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0009abbc0?, {0x3f06e60, 0xc002222320}, 0x1, 0xc002096c60)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/client-go/tools/cache.(*Reflector).Run(0xc0001b75e0, 0xc002096c60)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:290 +0x1cd
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:55 +0x1e
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x4f
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 516
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 491 [select, 2 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc0001b75e0, 0xc002096c60, 0xc001e22ea0, 0xc001f30710?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:369 +0x10f
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 522
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:356 +0x49d
+
+goroutine 508 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/stream.Multicast[...].func3.1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/stream/sources.go:246 +0x156
+created by github.com/cilium/cilium/pkg/stream.Multicast[...].func3 in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/stream/sources.go:239 +0x36f
+
+goroutine 537 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 54
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 461 [select]:
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x60c3340?}, {0x3f35d90, 0xc00140ed40}, {0x7fe24bc21918, 0xc0021002c0}, {0x3f866f8?, 0x38ca800}, 0x0, ...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:724 +0x17b
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc000df48c0, {0x0?, 0x0?}, 0xc001b7afc0, 0x1?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:437 +0x545
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0xc000df48c0, 0xc001b7afc0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:357 +0x4c5
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:291 +0x25
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x10?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0004d1340?, {0x3f06e60, 0xc0006fb720}, 0x1, 0xc001b7afc0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/client-go/tools/cache.(*Reflector).Run(0xc000df48c0, 0xc001b7afc0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:290 +0x1cd
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:55 +0x1e
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x4f
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 455
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 540 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/k8s/resource.merge[...].func1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:905 +0x53
+created by github.com/cilium/cilium/pkg/k8s/resource.merge[...] in goroutine 536
+	/home/tom/go/src/github.com/cilium/cilium/pkg/k8s/resource/resource.go:904 +0xab
+
+goroutine 464 [select, 2 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc000df48c0, 0xc001b7afc0, 0xc001b7b380, 0xc0009b3180?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:369 +0x10f
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 461
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:356 +0x49d
+
+goroutine 593 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc000b59b48, 0x2)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0x3f30f00?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+golang.org/x/net/http2.(*pipe).Read(0xc000b59b30, {0xc002128001, 0x5ff, 0x5ff})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/pipe.go:76 +0xdf
+golang.org/x/net/http2.transportResponseBody.Read({0x3933c88?}, {0xc002128001?, 0x3946b61?, 0xa?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:2558 +0x65
+encoding/json.(*Decoder).refill(0xc0009b3b80)
+	/usr/local/bin/go/src/encoding/json/stream.go:165 +0x188
+encoding/json.(*Decoder).readValue(0xc0009b3b80)
+	/usr/local/bin/go/src/encoding/json/stream.go:140 +0xa9
+encoding/json.(*Decoder).Decode(0xc0009b3b80, {0x3254a60, 0xc001266540})
+	/usr/local/bin/go/src/encoding/json/stream.go:63 +0x75
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0xc00174a4b0, {0xc002335800, 0x400, 0x400})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/framer/framer.go:152 +0x19c
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc002316fa0, 0xc0022ffaa0?, {0x3f34360, 0xc000ab0080})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc000ecb2a0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc000ab0480)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:105 +0xdb
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 513
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:76 +0x125
+
+goroutine 542 [chan receive, 2 minutes]:
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:132 +0x25
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 536
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:131 +0xab
+
+goroutine 543 [select]:
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x60c3340?}, {0x3f35d90, 0xc000ab0840}, {0x7fe24bc21918, 0xc0020153f0}, {0x3f866f8?, 0x38b45e0}, 0x0, ...)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:724 +0x17b
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc000e9ac40, {0x0?, 0x0?}, 0xc001f52f00, 0x1?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:437 +0x545
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0xc000e9ac40, 0xc001f52f00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:357 +0x4c5
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:291 +0x25
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x10?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0006de000?, {0x3f06e60, 0xc001e91950}, 0x1, 0xc001f52f00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
+k8s.io/client-go/tools/cache.(*Reflector).Run(0xc000e9ac40, 0xc001f52f00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:290 +0x1cd
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:55 +0x1e
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x4f
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 536
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 578 [select, 2 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc000e9ac40, 0xc001f52f00, 0xc001b7b740, 0xc001c47710?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:369 +0x10f
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 543
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/reflector.go:356 +0x49d
+
+goroutine 69 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc00094de48, 0x2)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0x3f309d8?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+golang.org/x/net/http2.(*pipe).Read(0xc00094de30, {0xc00231b801, 0x5ff, 0x5ff})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/pipe.go:76 +0xdf
+golang.org/x/net/http2.transportResponseBody.Read({0x3933c88?}, {0xc00231b801?, 0x3946b61?, 0xa?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:2558 +0x65
+encoding/json.(*Decoder).refill(0xc001d368c0)
+	/usr/local/bin/go/src/encoding/json/stream.go:165 +0x188
+encoding/json.(*Decoder).readValue(0xc001d368c0)
+	/usr/local/bin/go/src/encoding/json/stream.go:140 +0xa9
+encoding/json.(*Decoder).Decode(0xc001d368c0, {0x3254a60, 0xc00173c030})
+	/usr/local/bin/go/src/encoding/json/stream.go:63 +0x75
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0xc0013d7fb0, {0xc001d03400, 0x400, 0x400})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/framer/framer.go:152 +0x19c
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc000940550, 0xc001d0a5a0?, {0x3f34360, 0xc001286000})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc000bb0820)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc00140ed40)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:105 +0xdb
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 461
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:76 +0x125
+
+goroutine 551 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/endpoint.(*Endpoint).UpdateNoTrackRules(0xc000e13180, 0xc00163f860)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:932 +0x290
+github.com/cilium/cilium/pkg/endpoint.(*Endpoint).metadataResolver(0xc000e13180, {0x3f52368, 0xc002316640}, 0x1, 0x0, 0x0, {0x3f3ebc0, 0xc000613d10}, 0xc000fda750)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1694 +0x6b6
+github.com/cilium/cilium/pkg/endpoint.(*Endpoint).RunMetadataResolver.func1({0x3f52368?, 0xc002316640?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1774 +0x6b
+github.com/cilium/cilium/pkg/controller.(*controller).runController(0xc0009b3180, {{{0x3957c43, 0xe}}, {0x0, 0x0}, 0xc0023165f0, 0x0, 0x3b5e8e0, 0x0, 0x0, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/controller.go:254 +0x122
+created by github.com/cilium/cilium/pkg/controller.(*Manager).createControllerLocked in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/manager.go:111 +0x458
+
+goroutine 552 [chan receive, 2 minutes]:
+github.com/cilium/cilium/pkg/endpoint.(*Endpoint).UpdateNoTrackRules(0xc000e13500, 0xc0015d0f30)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:932 +0x290
+github.com/cilium/cilium/pkg/endpoint.(*Endpoint).metadataResolver(0xc000e13500, {0x3f52368, 0xc002316820}, 0x1, 0x0, 0x0, {0x3f3ebc0, 0xc000613d10}, 0xc000fdabf0)
+	/home/tom/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1694 +0x6b6
+github.com/cilium/cilium/pkg/endpoint.(*Endpoint).RunMetadataResolver.func1({0x3f52368?, 0xc002316820?})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1774 +0x6b
+github.com/cilium/cilium/pkg/controller.(*controller).runController(0xc0009b3400, {{{0x3957c43, 0xe}}, {0x0, 0x0}, 0xc0023167d0, 0x0, 0x3b5e8e0, 0x0, 0x0, ...})
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/controller.go:254 +0x122
+created by github.com/cilium/cilium/pkg/controller.(*Manager).createControllerLocked in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/controller/manager.go:111 +0x458
+
+goroutine 492 [select, 2 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc0020a4480, 0xc00209ec00)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1464 +0xac7
+golang.org/x/net/http2.(*clientStream).doRequest(0xc0006f0ba0?, 0xc001c00fb8?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1326 +0x18
+created by golang.org/x/net/http2.(*ClientConn).RoundTrip in goroutine 522
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1232 +0x308
+
+goroutine 577 [select, 2 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc00094de00, 0xc001b61400)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1464 +0xac7
+golang.org/x/net/http2.(*clientStream).doRequest(0x0?, 0xc001c47710?)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1326 +0x18
+created by golang.org/x/net/http2.(*ClientConn).RoundTrip in goroutine 461
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:1232 +0x308
+
+goroutine 509 [select, 2 minutes]:
+github.com/cilium/cilium/pkg/nodediscovery.(*NodeDiscovery).StartDiscovery.Debounce[...].func4.1()
+	/home/tom/go/src/github.com/cilium/cilium/pkg/stream/operators.go:214 +0x1d5
+created by github.com/cilium/cilium/pkg/nodediscovery.(*NodeDiscovery).StartDiscovery.Debounce[...].func4 in goroutine 1
+	/home/tom/go/src/github.com/cilium/cilium/pkg/stream/operators.go:204 +0x199
+
+goroutine 594 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc00211a048, 0x2)
+	/usr/local/bin/go/src/runtime/sema.go:527 +0x159
+sync.(*Cond).Wait(0x3f308e8?)
+	/usr/local/bin/go/src/sync/cond.go:70 +0x85
+golang.org/x/net/http2.(*pipe).Read(0xc00211a030, {0xc001dbf201, 0x5ff, 0x5ff})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/pipe.go:76 +0xdf
+golang.org/x/net/http2.transportResponseBody.Read({0x3933c88?}, {0xc001dbf201?, 0x3946b61?, 0xa?})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/golang.org/x/net/http2/transport.go:2558 +0x65
+encoding/json.(*Decoder).refill(0xc0009b3e00)
+	/usr/local/bin/go/src/encoding/json/stream.go:165 +0x188
+encoding/json.(*Decoder).readValue(0xc0009b3e00)
+	/usr/local/bin/go/src/encoding/json/stream.go:140 +0xa9
+encoding/json.(*Decoder).Decode(0xc0009b3e00, {0x3254a60, 0xc00173c060})
+	/usr/local/bin/go/src/encoding/json/stream.go:63 +0x75
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0xc00174a630, {0xc002335c00, 0x400, 0x400})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/framer/framer.go:152 +0x19c
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc002317090, 0xc0022ffbc0?, {0x3f34360, 0xc001286040})
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc000ecb2e0)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc000ab0840)
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:105 +0xdb
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 543
+	/home/tom/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:76 +0x125

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -61,6 +61,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pprof"
+	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/version"
 	"github.com/cilium/cilium/pkg/vitals"
 )
@@ -113,6 +114,7 @@ var (
 			}
 		}),
 
+		statedb.Cell,
 		vitals.Cell,
 	)
 

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -62,6 +62,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pprof"
 	"github.com/cilium/cilium/pkg/version"
+	"github.com/cilium/cilium/pkg/vitals"
 )
 
 var (
@@ -111,6 +112,8 @@ var (
 				EnableGatewayAPI: operatorCfg.EnableGatewayAPI,
 			}
 		}),
+
+		vitals.Cell,
 	)
 
 	// ControlPlane implements the control functions.

--- a/operator/pkg/controller-runtime/cell.go
+++ b/operator/pkg/controller-runtime/cell.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/job"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 // Cell integrates the components of the controller-runtime library into Hive.
@@ -55,7 +56,7 @@ type managerParams struct {
 	Logger      logrus.FieldLogger
 	Lifecycle   hive.Lifecycle
 	JobRegistry job.Registry
-	Scope       cell.Scope
+	Scope       health.Scope
 
 	K8sClient client.Clientset
 	Scheme    *runtime.Scheme
@@ -92,7 +93,7 @@ func newManager(params managerParams) (ctrlRuntime.Manager, error) {
 		job.WithPprofLabels(pprof.Labels("cell", "controller-runtime")),
 	)
 
-	jobGroup.Add(job.OneShot("manager", func(ctx context.Context, health cell.HealthReporter) error {
+	jobGroup.Add(job.OneShot("manager", func(ctx context.Context, health health.HealthReporter) error {
 		return mgr.Start(ctx)
 	}))
 

--- a/operator/pkg/lbipam/cell.go
+++ b/operator/pkg/lbipam/cell.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 var Cell = cell.Module(
@@ -37,7 +38,7 @@ type lbipamCellParams struct {
 
 	LC          hive.Lifecycle
 	JobRegistry job.Registry
-	Scope       cell.Scope
+	Scope       health.Scope
 
 	Clientset    k8sClient.Clientset
 	PoolResource resource.Resource[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool]
@@ -82,7 +83,7 @@ func newLBIPAMCell(params lbipamCellParams) *LBIPAM {
 	})
 
 	jobGroup.Add(
-		job.OneShot("lbipam main", func(ctx context.Context, health cell.HealthReporter) error {
+		job.OneShot("lbipam main", func(ctx context.Context, health health.HealthReporter) error {
 			lbIPAM.Run(ctx, health)
 			return nil
 		}),

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 
-	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/ipalloc"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -34,6 +33,7 @@ import (
 	slim_meta "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/api/meta"
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	client_typed_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/typed/core/v1"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 const (
@@ -120,14 +120,14 @@ func (ipam *LBIPAM) restart() {
 
 	// Re-start the main goroutine
 	ipam.jobGroup.Add(
-		job.OneShot("lbipam main", func(ctx context.Context, health cell.HealthReporter) error {
+		job.OneShot("lbipam main", func(ctx context.Context, health health.HealthReporter) error {
 			ipam.Run(ctx, health)
 			return nil
 		}),
 	)
 }
 
-func (ipam *LBIPAM) Run(ctx context.Context, health cell.HealthReporter) {
+func (ipam *LBIPAM) Run(ctx context.Context, health health.HealthReporter) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/signal"
 	"github.com/cilium/cilium/pkg/stream"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 // Cell provides AuthManager which is responsible for request authentication.
@@ -75,7 +76,7 @@ type authManagerParams struct {
 	Logger      logrus.FieldLogger
 	Lifecycle   hive.Lifecycle
 	JobRegistry job.Registry
-	Scope       cell.Scope
+	Scope       health.Scope
 
 	Config       config
 	AuthMap      authmap.Map

--- a/pkg/bgpv1/agent/controller.go
+++ b/pkg/bgpv1/agent/controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 var (
@@ -79,7 +80,7 @@ type ControllerParams struct {
 	cell.In
 
 	Lifecycle               hive.Lifecycle
-	Scope                   cell.Scope
+	Scope                   health.Scope
 	JobRegistry             job.Registry
 	Shutdowner              hive.Shutdowner
 	Sig                     *signaler.BGPCPSignaler
@@ -118,7 +119,7 @@ func NewController(params ControllerParams) (*Controller, error) {
 	)
 
 	jobGroup.Add(
-		job.OneShot("bgp-policy-observer", func(ctx context.Context, health cell.HealthReporter) (err error) {
+		job.OneShot("bgp-policy-observer", func(ctx context.Context, health health.HealthReporter) (err error) {
 			for ev := range c.PolicyResource.Events(ctx) {
 				switch ev.Kind {
 				case resource.Upsert, resource.Delete:
@@ -130,7 +131,7 @@ func NewController(params ControllerParams) (*Controller, error) {
 			return nil
 		}),
 
-		job.OneShot("cilium-node-observer", func(ctx context.Context, health cell.HealthReporter) (err error) {
+		job.OneShot("cilium-node-observer", func(ctx context.Context, health health.HealthReporter) (err error) {
 			for ev := range c.CiliumNodeResource.Events(ctx) {
 				switch ev.Kind {
 				case resource.Upsert:
@@ -144,7 +145,7 @@ func NewController(params ControllerParams) (*Controller, error) {
 			return nil
 		}),
 
-		job.OneShot("bgp-controller", func(ctx context.Context, health cell.HealthReporter) (err error) {
+		job.OneShot("bgp-controller", func(ctx context.Context, health health.HealthReporter) (err error) {
 			// initialize PolicyLister used in the controller
 			policyStore, err := c.PolicyResource.Store(ctx)
 			if err != nil {

--- a/pkg/bgpv1/manager/store/diffstore.go
+++ b/pkg/bgpv1/manager/store/diffstore.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/vitals/health"
 
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/workqueue"
@@ -42,7 +43,7 @@ type diffStoreParams[T k8sRuntime.Object] struct {
 	cell.In
 
 	Lifecycle   hive.Lifecycle
-	Scope       cell.Scope
+	Scope       health.Scope
 	JobRegistry job.Registry
 	Resource    resource.Resource[T]
 	Signaler    *signaler.BGPCPSignaler
@@ -81,7 +82,7 @@ func NewDiffStore[T k8sRuntime.Object](params diffStoreParams[T]) DiffStore[T] {
 	)
 
 	jobGroup.Add(
-		job.OneShot("diffstore-events", func(ctx context.Context, health cell.HealthReporter) (err error) {
+		job.OneShot("diffstore-events", func(ctx context.Context, health health.HealthReporter) (err error) {
 			ds.store, err = ds.resource.Store(ctx)
 			if err != nil {
 				return fmt.Errorf("error creating resource store: %w", err)

--- a/pkg/bgpv1/manager/store/diffstore_test.go
+++ b/pkg/bgpv1/manager/store/diffstore_test.go
@@ -18,6 +18,7 @@ import (
 	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	slim_fake "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/fake"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 type DiffStoreFixture struct {
@@ -63,7 +64,7 @@ func newDiffStoreFixture() *DiffStoreFixture {
 		cell.Provide(NewDiffStore[*slimv1.Service]),
 
 		job.Cell,
-		cell.Provide(func() cell.Scope {
+		cell.Provide(func() health.Scope {
 			return cell.TestScope()
 		}),
 	)

--- a/pkg/bgpv1/manager/store/resource_store.go
+++ b/pkg/bgpv1/manager/store/resource_store.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/vitals/health"
 
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/workqueue"
@@ -35,7 +36,7 @@ type bgpCPResourceStoreParams[T k8sRuntime.Object] struct {
 	cell.In
 
 	Lifecycle   hive.Lifecycle
-	Scope       cell.Scope
+	Scope       health.Scope
 	JobRegistry job.Registry
 	Resource    resource.Resource[T]
 	Signaler    *signaler.BGPCPSignaler
@@ -68,7 +69,7 @@ func NewBGPCPResourceStore[T k8sRuntime.Object](params bgpCPResourceStoreParams[
 	)
 
 	jobGroup.Add(
-		job.OneShot("bgpcp-resource-store-events", func(ctx context.Context, health cell.HealthReporter) (err error) {
+		job.OneShot("bgpcp-resource-store-events", func(ctx context.Context, health health.HealthReporter) (err error) {
 			s.store, err = s.resource.Store(ctx)
 			if err != nil {
 				return fmt.Errorf("error creating resource store: %w", err)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 const (
@@ -66,7 +66,7 @@ type ControllerParams struct {
 	// resource identifier in order to limit metrics cardinality.
 	Group Group
 
-	HealthReporter cell.HealthReporter
+	HealthReporter health.HealthReporter
 
 	// DoFunc is the function that will be run until it succeeds and/or
 	// using the interval RunInterval if not 0.
@@ -369,7 +369,7 @@ func (c *controller) getLogger() *logrus.Entry {
 
 // recordError updates all statistic collection variables on error
 // c.mutex must be held.
-func (c *controller) recordError(err error, hr cell.HealthReporter) {
+func (c *controller) recordError(err error, hr health.HealthReporter) {
 	if hr != nil {
 		hr.Degraded(c.name, err)
 	}
@@ -387,7 +387,7 @@ func (c *controller) recordError(err error, hr cell.HealthReporter) {
 
 // recordSuccess updates all statistic collection variables on success
 // c.mutex must be held.
-func (c *controller) recordSuccess(hr cell.HealthReporter) {
+func (c *controller) recordSuccess(hr health.HealthReporter) {
 	if hr != nil {
 		hr.OK(c.name)
 	}

--- a/pkg/datapath/agentliveness/agent_liveness.go
+++ b/pkg/datapath/agentliveness/agent_liveness.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/maps/configmap"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -45,7 +46,7 @@ func newAgentLivenessUpdater(
 	logger logrus.FieldLogger,
 	lifecycle hive.Lifecycle,
 	jobRegistry job.Registry,
-	scope cell.Scope,
+	scope health.Scope,
 	configMap configmap.Map,
 	agentLivenessConfig agentLivenessConfig,
 ) {

--- a/pkg/datapath/l2responder/l2responder.go
+++ b/pkg/datapath/l2responder/l2responder.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/types"
+	"github.com/cilium/cilium/pkg/vitals/health"
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -55,7 +56,7 @@ type params struct {
 	L2ResponderMap      l2respondermap.Map
 	NetLink             linkByNamer
 	JobRegistry         job.Registry
-	Scope               cell.Scope
+	Scope               health.Scope
 }
 
 type linkByNamer interface {
@@ -86,7 +87,7 @@ func NewL2ResponderReconciler(params params) *l2ResponderReconciler {
 	return &reconciler
 }
 
-func (p *l2ResponderReconciler) run(ctx context.Context, health cell.HealthReporter) error {
+func (p *l2ResponderReconciler) run(ctx context.Context, health health.HealthReporter) error {
 	log := p.params.Logger
 
 	// This timer triggers full reconciliation once in a while, in case partial reconciliation

--- a/pkg/datapath/linux/ipsec/cell.go
+++ b/pkg/datapath/linux/ipsec/cell.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 // The IPsec key custodian handles key-related initialisation tasks for the
@@ -32,7 +33,7 @@ type custodianParameters struct {
 	cell.In
 
 	Logger         logrus.FieldLogger
-	Scope          cell.Scope
+	Scope          health.Scope
 	JobRegistry    job.Registry
 	LocalNodeStore *node.LocalNodeStore
 }

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/fswatcher"
-	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -36,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/resiliency"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 type IPSecDir string
@@ -962,7 +962,7 @@ func DeleteIPsecEncryptRoute() {
 	}
 }
 
-func keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, keyfilePath string, nodeHandler datapath.NodeHandler, health cell.HealthReporter) error {
+func keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, keyfilePath string, nodeHandler datapath.NodeHandler, health health.HealthReporter) error {
 	for {
 		select {
 		case event := <-watcher.Events:
@@ -1019,7 +1019,7 @@ func StartKeyfileWatcher(group job.Group, keyfilePath string, nodeHandler datapa
 		return err
 	}
 
-	group.Add(job.OneShot("keyfile-watcher", func(ctx context.Context, health cell.HealthReporter) error {
+	group.Add(job.OneShot("keyfile-watcher", func(ctx context.Context, health health.HealthReporter) error {
 		return keyfileWatcher(ctx, watcher, keyfilePath, nodeHandler, health)
 	}))
 

--- a/pkg/datapath/tables/node_address.go
+++ b/pkg/datapath/tables/node_address.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/statedb/index"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 // NodeAddress is an IP address assigned to a network interface on a Cilium node
@@ -170,7 +171,7 @@ func (NodeAddressConfig) Flags(flags *pflag.FlagSet) {
 type nodeAddressControllerParams struct {
 	cell.In
 
-	HealthScope     cell.Scope
+	HealthScope     health.Scope
 	Log             logrus.FieldLogger
 	Config          NodeAddressConfig
 	Lifecycle       hive.Lifecycle
@@ -235,7 +236,7 @@ func (n *nodeAddressController) register() {
 
 }
 
-func (n *nodeAddressController) run(ctx context.Context, reporter cell.HealthReporter) error {
+func (n *nodeAddressController) run(ctx context.Context, reporter health.HealthReporter) error {
 	defer n.tracker.Close()
 
 	limiter := rate.NewLimiter(nodeAddressControllerMinInterval, 1)
@@ -270,7 +271,7 @@ func (n *nodeAddressController) run(ctx context.Context, reporter cell.HealthRep
 }
 
 // updates the node addresses of a single device.
-func (n *nodeAddressController) update(txn statedb.WriteTxn, existing, new sets.Set[NodeAddress], reporter cell.HealthReporter, device string) {
+func (n *nodeAddressController) update(txn statedb.WriteTxn, existing, new sets.Set[NodeAddress], reporter health.HealthReporter, device string) {
 	updated := false
 	prefixLen := len(device)
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
-	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
@@ -58,6 +57,7 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 	"github.com/cilium/cilium/pkg/types"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 const (
@@ -386,16 +386,16 @@ type Endpoint struct {
 	ciliumEndpointUID k8sTypes.UID
 
 	// Root scope for all of this endpoints reporters.
-	reporterScope       cell.Scope
+	reporterScope       health.Scope
 	closeHealthReporter func()
 }
 
-func (e *Endpoint) GetReporter(name string) cell.HealthReporter {
-	return cell.GetHealthReporter(e.reporterScope, name)
+func (e *Endpoint) GetReporter(name string) health.HealthReporter {
+	return health.GetHealthReporter(e.reporterScope, name)
 }
 
-func (e *Endpoint) InitEndpointScope(parent cell.Scope) {
-	s := cell.GetSubScope(parent, fmt.Sprintf("cilium-endpoint-%d (%s)", e.ID, e.GetK8sNamespaceAndPodName()))
+func (e *Endpoint) InitEndpointScope(parent health.Scope) {
+	s := health.GetSubScope(parent, fmt.Sprintf("cilium-endpoint-%d (%s)", e.ID, e.GetK8sNamespaceAndPodName()))
 	if s != nil {
 		e.closeHealthReporter = s.Close
 		e.reporterScope = s

--- a/pkg/endpointcleanup/cleanup.go
+++ b/pkg/endpointcleanup/cleanup.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/resiliency"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 type localEndpointCache interface {
@@ -43,7 +44,7 @@ type params struct {
 	Logger              logrus.FieldLogger
 	Lifecycle           hive.Lifecycle
 	JobRegistry         job.Registry
-	Scope               cell.Scope
+	Scope               health.Scope
 	CiliumEndpoint      resource.Resource[*types.CiliumEndpoint]
 	CiliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
 	Clientset           k8sClient.Clientset
@@ -86,7 +87,7 @@ func registerCleanup(p params) {
 	)
 
 	jobGroup.Add(
-		job.OneShot("endpoint-cleanup", func(ctx context.Context, health cell.HealthReporter) error {
+		job.OneShot("endpoint-cleanup", func(ctx context.Context, health health.HealthReporter) error {
 			return cleanup.run(ctx)
 		}),
 	)

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 // Cell provides the EndpointManager which maintains the collection of locally
@@ -177,7 +178,7 @@ type EndpointManager interface {
 // EndpointResourceSynchronizer is an interface which synchronizes CiliumEndpoint
 // resources with Kubernetes.
 type EndpointResourceSynchronizer interface {
-	RunK8sCiliumEndpointSync(ep *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration, hr cell.HealthReporter)
+	RunK8sCiliumEndpointSync(ep *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration, hr health.HealthReporter)
 	DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint)
 }
 
@@ -194,7 +195,7 @@ type endpointManagerParams struct {
 	Config          EndpointManagerConfig
 	Clientset       client.Clientset
 	MetricsRegistry *metrics.Registry
-	Scope           cell.Scope
+	Scope           health.Scope
 	EPSynchronizer  EndpointResourceSynchronizer
 	LocalNodeStore  *node.LocalNodeStore
 }

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -34,6 +34,7 @@ var Cell = cell.Module(
 	cell.Config(defaultEndpointManagerConfig),
 	cell.Provide(newDefaultEndpointManager),
 	cell.ProvidePrivate(newEndpointSynchronizer),
+	health.DecorateModuleScope(),
 )
 
 type EndpointsLookup interface {

--- a/pkg/endpointmanager/endpointsynchronizer.go
+++ b/pkg/endpointmanager/endpointsynchronizer.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
-	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -29,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 const (
@@ -49,7 +49,7 @@ type EndpointSynchronizer struct {
 // has 1 controller that updates it, and a local copy is retained and only
 // updates are pushed up.
 // CiliumEndpoint objects have the same name as the pod they represent.
-func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration, hr cell.HealthReporter) {
+func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration, hr health.HealthReporter) {
 	var (
 		endpointID     = e.ID
 		controllerName = endpoint.EndpointSyncControllerName(endpointID)

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -18,7 +18,6 @@ import (
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager/idallocator"
-	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/lock"
@@ -31,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 var (
@@ -44,7 +44,7 @@ var (
 // endpointManager is a structure designed for containing state about the
 // collection of locally running endpoints.
 type endpointManager struct {
-	reporterScope cell.Scope
+	reporterScope health.Scope
 
 	// mutex protects endpoints and endpointsAux
 	mutex lock.RWMutex
@@ -95,7 +95,7 @@ type endpointManager struct {
 type endpointDeleteFunc func(*endpoint.Endpoint, endpoint.DeleteConfig) []error
 
 // New creates a new endpointManager.
-func New(epSynchronizer EndpointResourceSynchronizer, lns *node.LocalNodeStore, reporterScope cell.Scope) *endpointManager {
+func New(epSynchronizer EndpointResourceSynchronizer, lns *node.LocalNodeStore, reporterScope health.Scope) *endpointManager {
 	mgr := endpointManager{
 		reporterScope:                reporterScope,
 		endpoints:                    make(map[uint16]*endpoint.Endpoint),
@@ -121,7 +121,7 @@ func (mgr *endpointManager) WithPeriodicEndpointGC(ctx context.Context, checkHea
 			DoFunc:         mgr.markAndSweep,
 			RunInterval:    interval,
 			Context:        ctx,
-			HealthReporter: cell.GetHealthReporter(mgr.reporterScope, "endpoint-gc"),
+			HealthReporter: health.GetHealthReporter(mgr.reporterScope, "endpoint-gc"),
 		})
 	return mgr
 }

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager/idallocator"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
-	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
@@ -29,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/revert"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -112,7 +112,7 @@ func (d *DummyRuleCacheOwner) ClearPolicyConsumers(id uint16) *sync.WaitGroup {
 
 type dummyEpSyncher struct{}
 
-func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration, hr cell.HealthReporter) {
+func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration, hr health.HealthReporter) {
 }
 
 func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 // Cell initializes and manages the Envoy proxy and its control-plane components like xDS- and accesslog server.
@@ -126,7 +127,7 @@ type versionCheckParams struct {
 	Lifecycle        hive.Lifecycle
 	Logger           logrus.FieldLogger
 	JobRegistry      job.Registry
-	Scope            cell.Scope
+	Scope            health.Scope
 	EnvoyAdminClient *EnvoyAdminClient
 }
 

--- a/pkg/health/client/modules_test.go
+++ b/pkg/health/client/modules_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cilium/cilium/api/v1/client/daemon"
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/health/client"
-	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 func TestGetAndFormatModulesHealth(t *testing.T) {
@@ -83,14 +83,14 @@ func (m *testMHappy) GetHealth(params *daemon.GetHealthParams, opts ...daemon.Cl
 			Modules: []*models.ModuleHealth{
 				{
 					ModuleID:    "m1",
-					Level:       string(cell.StatusOK),
+					Level:       string(health.StatusOK),
 					Message:     makeSimpleMsg(t1),
 					LastOk:      "3s",
 					LastUpdated: "2s",
 				},
 				{
 					ModuleID:    "a.b.c",
-					Level:       string(cell.StatusDegraded),
+					Level:       string(health.StatusDegraded),
 					Message:     makeComplexMsg(t2),
 					LastOk:      "5m30s",
 					LastUpdated: "20s",
@@ -101,9 +101,9 @@ func (m *testMHappy) GetHealth(params *daemon.GetHealthParams, opts ...daemon.Cl
 }
 
 func makeSimpleMsg(t time.Time) string {
-	s := cell.StatusNode{
+	s := health.StatusNode{
 		Name:            "m1",
-		LastLevel:       cell.StatusOK,
+		LastLevel:       health.StatusOK,
 		UpdateTimestamp: t,
 		Message:         "status nominal",
 	}
@@ -113,26 +113,26 @@ func makeSimpleMsg(t time.Time) string {
 }
 
 func makeComplexMsg(t time.Time) string {
-	s := cell.StatusNode{
+	s := health.StatusNode{
 		Name:      "a.b.c",
-		LastLevel: cell.StatusOK,
+		LastLevel: health.StatusOK,
 		Count:     1,
-		SubStatuses: []*cell.StatusNode{
+		SubStatuses: []*health.StatusNode{
 			{
 				Name:      "fred",
-				LastLevel: cell.StatusOK,
+				LastLevel: health.StatusOK,
 				Count:     1,
-				SubStatuses: []*cell.StatusNode{
+				SubStatuses: []*health.StatusNode{
 					{
 						Name:            "blee",
-						LastLevel:       cell.StatusOK,
+						LastLevel:       health.StatusOK,
 						Message:         "doh",
 						UpdateTimestamp: t,
 						Count:           1,
 					},
 					{
 						Name:            "fred",
-						LastLevel:       cell.StatusOK,
+						LastLevel:       health.StatusOK,
 						Message:         "yo",
 						UpdateTimestamp: t,
 						Count:           1,
@@ -141,7 +141,7 @@ func makeComplexMsg(t time.Time) string {
 			},
 			{
 				Name:            "dork",
-				LastLevel:       cell.StatusDegraded,
+				LastLevel:       health.StatusDegraded,
 				Message:         "bozo",
 				Count:           1,
 				Error:           fmt.Errorf("BOOM!").Error(),

--- a/pkg/health/client/tree.go
+++ b/pkg/health/client/tree.go
@@ -3,209 +3,209 @@
 
 package client
 
-import (
-	"bytes"
-	"fmt"
-	"io"
-	"strconv"
-	"strings"
-)
+// import (
+// 	"bytes"
+// 	"fmt"
+// 	"io"
+// 	"strconv"
+// 	"strings"
+// )
 
-const (
-	indentSize              = 3
-	leafMaxWidth            = 40
-	link         decoration = "│"
-	mid          decoration = "├──"
-	end          decoration = "└──"
-)
+// const (
+// 	indentSize              = 3
+// 	leafMaxWidth            = 40
+// 	link         decoration = "│"
+// 	mid          decoration = "├──"
+// 	end          decoration = "└──"
+// )
 
-type decoration string
+// type decoration string
 
-func newRoot(r string) *node {
-	return &node{val: r}
-}
+// func newRoot(r string) *node {
+// 	return &node{val: r}
+// }
 
-type node struct {
-	val, meta string
-	parent    *node
-	nodes     []*node
-}
+// type node struct {
+// 	val, meta string
+// 	parent    *node
+// 	nodes     []*node
+// }
 
-func (n *node) addNode(v string) *node {
-	return n.addNodeWithMeta(v, "")
-}
+// func (n *node) addNode(v string) *node {
+// 	return n.addNodeWithMeta(v, "")
+// }
 
-func (n *node) addNodeWithMeta(v, m string) *node {
-	node := node{
-		parent: n,
-		val:    v,
-		meta:   m,
-	}
-	n.nodes = append(n.nodes, &node)
+// func (n *node) addNodeWithMeta(v, m string) *node {
+// 	node := node{
+// 		parent: n,
+// 		val:    v,
+// 		meta:   m,
+// 	}
+// 	n.nodes = append(n.nodes, &node)
 
-	return &node
-}
+// 	return &node
+// }
 
-func (n *node) addBranch(v string) *node {
-	return n.addBranchWithMeta(v, "")
-}
+// func (n *node) addBranch(v string) *node {
+// 	return n.addBranchWithMeta(v, "")
+// }
 
-func (n *node) addBranchWithMeta(v, m string) *node {
-	b := node{
-		parent: n,
-		meta:   m,
-		val:    v,
-	}
-	n.nodes = append(n.nodes, &b)
+// func (n *node) addBranchWithMeta(v, m string) *node {
+// 	b := node{
+// 		parent: n,
+// 		meta:   m,
+// 		val:    v,
+// 	}
+// 	n.nodes = append(n.nodes, &b)
 
-	return &b
-}
+// 	return &b
+// }
 
-func (n *node) find(val string) *node {
-	if n.val == val {
-		return n
-	}
-	for _, node := range n.nodes {
-		if node.val == val {
-			return node
-		}
-		if v := node.find(val); v != nil {
-			return v
-		}
-	}
+// func (n *node) find(val string) *node {
+// 	if n.val == val {
+// 		return n
+// 	}
+// 	for _, node := range n.nodes {
+// 		if node.val == val {
+// 			return node
+// 		}
+// 		if v := node.find(val); v != nil {
+// 			return v
+// 		}
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
-func (n *node) asBytes() []byte {
-	var (
-		w           = new(bytes.Buffer)
-		levelsEnded []int
-		max         = computeMaxLevel(0, n)
-	)
-	if n.parent == nil {
-		w.WriteString(n.val)
-		if n.meta != "" {
-			w.WriteString(" " + n.meta)
-		}
-		fmt.Fprintln(w)
-	} else {
-		edge := mid
-		if len(n.nodes) == 0 {
-			edge = end
-			levelsEnded = append(levelsEnded, 0)
-		}
-		dumpVals(w, 0, max, levelsEnded, edge, n)
-	}
-	if len(n.nodes) > 0 {
-		dumpNodes(w, 0, max, levelsEnded, n.nodes)
-	}
+// func (n *node) asBytes() []byte {
+// 	var (
+// 		w           = new(bytes.Buffer)
+// 		levelsEnded []int
+// 		max         = computeMaxLevel(0, n)
+// 	)
+// 	if n.parent == nil {
+// 		w.WriteString(n.val)
+// 		if n.meta != "" {
+// 			w.WriteString(" " + n.meta)
+// 		}
+// 		fmt.Fprintln(w)
+// 	} else {
+// 		edge := mid
+// 		if len(n.nodes) == 0 {
+// 			edge = end
+// 			levelsEnded = append(levelsEnded, 0)
+// 		}
+// 		dumpVals(w, 0, max, levelsEnded, edge, n)
+// 	}
+// 	if len(n.nodes) > 0 {
+// 		dumpNodes(w, 0, max, levelsEnded, n.nodes)
+// 	}
 
-	return w.Bytes()
-}
+// 	return w.Bytes()
+// }
 
-func (n *node) String() string {
-	return string(n.asBytes())
-}
+// func (n *node) String() string {
+// 	return string(n.asBytes())
+// }
 
-func (n *node) lastNode() *node {
-	c := len(n.nodes)
-	if c == 0 {
-		return nil
-	}
+// func (n *node) lastNode() *node {
+// 	c := len(n.nodes)
+// 	if c == 0 {
+// 		return nil
+// 	}
 
-	return n.nodes[c-1]
-}
+// 	return n.nodes[c-1]
+// }
 
-func computeMaxLevel(level int, n *node) int {
-	if n == nil || len(n.nodes) == 0 {
-		return level
-	}
-	var max int
-	for _, n := range n.nodes {
-		m := computeMaxLevel(level+1, n)
-		if m > max {
-			max = m
-		}
-	}
+// func computeMaxLevel(level int, n *node) int {
+// 	if n == nil || len(n.nodes) == 0 {
+// 		return level
+// 	}
+// 	var max int
+// 	for _, n := range n.nodes {
+// 		m := computeMaxLevel(level+1, n)
+// 		if m > max {
+// 			max = m
+// 		}
+// 	}
 
-	return max
-}
+// 	return max
+// }
 
-func dumpNodes(w io.Writer, level, maxLevel int, levelsEnded []int, nodes []*node) {
-	for i, node := range nodes {
-		edge := mid
-		if i == len(nodes)-1 {
-			levelsEnded = append(levelsEnded, level)
-			edge = end
-		}
-		dumpVals(w, level, maxLevel, levelsEnded, edge, node)
-		if len(node.nodes) > 0 {
-			dumpNodes(w, level+1, maxLevel, levelsEnded, node.nodes)
-		}
-	}
-}
+// func dumpNodes(w io.Writer, level, maxLevel int, levelsEnded []int, nodes []*node) {
+// 	for i, node := range nodes {
+// 		edge := mid
+// 		if i == len(nodes)-1 {
+// 			levelsEnded = append(levelsEnded, level)
+// 			edge = end
+// 		}
+// 		dumpVals(w, level, maxLevel, levelsEnded, edge, node)
+// 		if len(node.nodes) > 0 {
+// 			dumpNodes(w, level+1, maxLevel, levelsEnded, node.nodes)
+// 		}
+// 	}
+// }
 
-func dumpVals(w io.Writer, level, maxLevel int, levelsEnded []int, edge decoration, node *node) {
-	for i := 0; i < level; i++ {
-		if isEnded(levelsEnded, i) {
-			fmt.Fprint(w, strings.Repeat(" ", indentSize+1))
-			continue
-		}
-		fmt.Fprintf(w, "%s%s", link, strings.Repeat(" ", indentSize))
-	}
+// func dumpVals(w io.Writer, level, maxLevel int, levelsEnded []int, edge decoration, node *node) {
+// 	for i := 0; i < level; i++ {
+// 		if isEnded(levelsEnded, i) {
+// 			fmt.Fprint(w, strings.Repeat(" ", indentSize+1))
+// 			continue
+// 		}
+// 		fmt.Fprintf(w, "%s%s", link, strings.Repeat(" ", indentSize))
+// 	}
 
-	val := dumpVal(level, node)
-	if node.meta != "" {
-		c := maxLevel - level
-		if c < 0 {
-			c = 0
-		}
-		fmt.Fprintf(w, "%s %-"+strconv.Itoa(leafMaxWidth+c*2)+"s%s%s\n", edge, val, strings.Repeat("  ", c), node.meta)
-		return
-	}
-	fmt.Fprintf(w, "%s %s\n", edge, val)
-}
+// 	val := dumpVal(level, node)
+// 	if node.meta != "" {
+// 		c := maxLevel - level
+// 		if c < 0 {
+// 			c = 0
+// 		}
+// 		fmt.Fprintf(w, "%s %-"+strconv.Itoa(leafMaxWidth+c*2)+"s%s%s\n", edge, val, strings.Repeat("  ", c), node.meta)
+// 		return
+// 	}
+// 	fmt.Fprintf(w, "%s %s\n", edge, val)
+// }
 
-func isEnded(levelsEnded []int, level int) bool {
-	for _, l := range levelsEnded {
-		if l == level {
-			return true
-		}
-	}
+// func isEnded(levelsEnded []int, level int) bool {
+// 	for _, l := range levelsEnded {
+// 		if l == level {
+// 			return true
+// 		}
+// 	}
 
-	return false
-}
+// 	return false
+// }
 
-func dumpVal(level int, node *node) string {
-	lines := strings.Split(node.val, "\n")
-	if len(lines) < 2 {
-		return node.val
-	}
+// func dumpVal(level int, node *node) string {
+// 	lines := strings.Split(node.val, "\n")
+// 	if len(lines) < 2 {
+// 		return node.val
+// 	}
 
-	pad := indent(level, node)
-	for i := 1; i < len(lines); i++ {
-		lines[i] = fmt.Sprintf("%s%s", pad, lines[i])
-	}
+// 	pad := indent(level, node)
+// 	for i := 1; i < len(lines); i++ {
+// 		lines[i] = fmt.Sprintf("%s%s", pad, lines[i])
+// 	}
 
-	return strings.Join(lines, "\n")
-}
+// 	return strings.Join(lines, "\n")
+// }
 
-func indent(level int, node *node) string {
-	links := make([]string, level+1)
-	for node.parent != nil {
-		if isLast(node) {
-			links[level] = strings.Repeat(" ", indentSize+1)
-		} else {
-			links[level] = fmt.Sprintf("%s%s", link, strings.Repeat(" ", indentSize))
-		}
-		level--
-		node = node.parent
-	}
+// func indent(level int, node *node) string {
+// 	links := make([]string, level+1)
+// 	for node.parent != nil {
+// 		if isLast(node) {
+// 			links[level] = strings.Repeat(" ", indentSize+1)
+// 		} else {
+// 			links[level] = fmt.Sprintf("%s%s", link, strings.Repeat(" ", indentSize))
+// 		}
+// 		level--
+// 		node = node.parent
+// 	}
 
-	return strings.Join(links, "")
-}
+// 	return strings.Join(links, "")
+// }
 
-func isLast(n *node) bool {
-	return n == n.parent.lastNode()
-}
+// func isLast(n *node) bool {
+// 	return n == n.parent.lastNode()
+// }

--- a/pkg/hive/cell/module.go
+++ b/pkg/hive/cell/module.go
@@ -10,9 +10,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"go.uber.org/dig"
 
-	"github.com/cilium/cilium/pkg/hive/cell/lifecycle"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -83,26 +81,6 @@ func (m *module) fullModuleID(parent FullModuleID) FullModuleID {
 	return parent.append(m.moduleID())
 }
 
-type reporterHooks struct {
-	rootScope *scope
-}
-
-func (r *reporterHooks) Start(ctx lifecycle.HookContext) error {
-	r.rootScope.start()
-	return nil
-}
-
-func (r *reporterHooks) Stop(ctx lifecycle.HookContext) error {
-	flushAndClose(r.rootScope, "Hive shutting down")
-	return nil
-}
-
-func createStructedScope(id FullModuleID, p Health, lc lifecycle.Lifecycle) Scope {
-	rs := rootScope(id, p.forModule(id))
-	lc.Append(&reporterHooks{rootScope: rs})
-	return rs
-}
-
 func (m *module) Apply(c container) error {
 	scope := c.Scope(m.id)
 
@@ -111,12 +89,6 @@ func (m *module) Apply(c container) error {
 		return err
 	}
 	if err := scope.Decorate(m.fullModuleID); err != nil {
-		return err
-	}
-
-	// Provide module scoped status reporter, used for reporting module level
-	// health status.
-	if err := scope.Provide(createStructedScope, dig.Export(false)); err != nil {
 		return err
 	}
 

--- a/pkg/hive/example/jobs.go
+++ b/pkg/hive/example/jobs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/stream"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 // This example shows a number of use cases in one cell. The cell starts by requesting the job.Registry
@@ -51,7 +52,7 @@ func newExampleCell(
 	lifecycle hive.Lifecycle,
 	logger logrus.FieldLogger,
 	registry job.Registry,
-	scope cell.Scope,
+	scope health.Scope,
 ) *exampleCell {
 	ex := exampleCell{
 		jobGroup: registry.NewGroup(
@@ -81,7 +82,7 @@ func newExampleCell(
 	return &ex
 }
 
-func (ex *exampleCell) sync(ctx context.Context, health cell.HealthReporter) error {
+func (ex *exampleCell) sync(ctx context.Context, health health.HealthReporter) error {
 	for i := 0; i < 3; i++ {
 		if err := ex.doSomeWork(); err != nil {
 			return fmt.Errorf("doSomeWork: %w", err)
@@ -91,7 +92,7 @@ func (ex *exampleCell) sync(ctx context.Context, health cell.HealthReporter) err
 	return nil
 }
 
-func (ex *exampleCell) daemon(ctx context.Context, health cell.HealthReporter) error {
+func (ex *exampleCell) daemon(ctx context.Context, health health.HealthReporter) error {
 	for {
 		randomTimeout := time.NewTimer(time.Duration(rand.Intn(3000)) * time.Millisecond)
 		select {
@@ -122,7 +123,7 @@ func (ex *exampleCell) observer(ctx context.Context, event struct{}) error {
 }
 
 func (ex *exampleCell) HeavyLifting() {
-	ex.jobGroup.Add(job.OneShot("long-running-job", func(ctx context.Context, health cell.HealthReporter) error {
+	ex.jobGroup.Add(job.OneShot("long-running-job", func(ctx context.Context, health health.HealthReporter) error {
 		for i := 0; i < 1_000_000; i++ {
 			// Do some heavy lifting
 		}

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -93,32 +93,6 @@ func New(cells ...cell.Cell) *Hive {
 		log.WithError(err).Fatal("Failed to apply Hive metrics cell")
 	}
 
-	// Use a single health provider for all cells, which is used to create
-	// module scoped health reporters.
-	if err := h.container.Provide(func(healthMetrics *metrics.HealthMetrics, lc Lifecycle) cell.Health {
-		hp := cell.NewHealthProvider()
-		updateStats := func() {
-			for l, c := range hp.Stats() {
-				healthMetrics.HealthStatusGauge.WithLabelValues(strings.ToLower(string(l))).Set(float64(c))
-			}
-		}
-		lc.Append(Hook{
-			OnStart: func(ctx HookContext) error {
-				updateStats()
-				hp.Subscribe(ctx, func(u cell.Update) {
-					updateStats()
-				}, func(err error) {})
-				return nil
-			},
-			OnStop: func(ctx HookContext) error {
-				return hp.Stop(ctx)
-			},
-		})
-		return hp
-	}); err != nil {
-		log.WithError(err).Fatal("Failed to provide health provider")
-	}
-
 	// Apply all cells to the container. This registers all constructors
 	// and adds all config flags. Invokes are delayed until Start() is
 	// called.

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -24,6 +24,7 @@ import (
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/vitals/health"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -49,14 +50,14 @@ func newFixture() *fixture {
 		tbl statedb.RWTable[*tables.L2AnnounceEntry]
 		db  *statedb.DB
 		jr  job.Registry
-		sk  cell.Scope
+		sk  health.Scope
 	)
 
 	hive.New(
 		statedb.Cell,
 		job.Cell,
 		cell.Provide(tables.NewL2AnnounceTable),
-		cell.Module("test", "test", cell.Invoke(func(d *statedb.DB, t statedb.RWTable[*tables.L2AnnounceEntry], s cell.Scope, j job.Registry) {
+		cell.Module("test", "test", cell.Invoke(func(d *statedb.DB, t statedb.RWTable[*tables.L2AnnounceEntry], s health.Scope, j job.Registry) {
 			d.RegisterTable(t)
 			db = d
 			tbl = t

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 // Cell provides the NodeManager, which manages information about Cilium nodes
@@ -80,7 +81,7 @@ func newAllNodeManager(
 	ipCache *ipcache.IPCache,
 	ipsetMgr ipsetManager,
 	nodeMetrics *nodeMetrics,
-	healthScope cell.Scope,
+	healthScope health.Scope,
 ) (NodeManager, error) {
 	mngr, err := New(option.Config, ipCache, ipsetMgr, nodeMetrics, healthScope)
 	if err != nil {

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -30,6 +30,7 @@ import (
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/source"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 func Test(t *testing.T) {
@@ -893,11 +894,11 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 	go func() {
 		<-nh1.NodeValidateImplementationEvent
 		u := <-update
-		assert.Equal(u.Level(), cell.StatusDegraded)
+		assert.Equal(u.Level(), health.StatusDegraded)
 		nh1.NodeValidateImplementationEventError = nil
 		<-nh1.NodeValidateImplementationEvent
 		u = <-update
-		assert.Equal(u.Level(), cell.StatusOK)
+		assert.Equal(u.Level(), health.StatusOK)
 		close(done)
 	}()
 	// Start the manager

--- a/pkg/statedb/example/control.go
+++ b/pkg/statedb/example/control.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 var controlCell = cell.Module(
@@ -33,7 +34,7 @@ type controlParams struct {
 	Lifecycle hive.Lifecycle
 	Log       logrus.FieldLogger
 	Registry  job.Registry
-	Scope     cell.Scope
+	Scope     health.Scope
 }
 
 func registerControl(p controlParams) {
@@ -47,7 +48,7 @@ type control struct {
 	controlParams
 }
 
-func (c *control) controlLoop(ctx context.Context, health cell.HealthReporter) error {
+func (c *control) controlLoop(ctx context.Context, health health.HealthReporter) error {
 	tick := time.NewTicker(100 * time.Millisecond)
 	defer tick.Stop()
 	for {

--- a/pkg/statedb/example/main.go
+++ b/pkg/statedb/example/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 var Hive = hive.New(
@@ -43,7 +44,7 @@ func main() {
 	}
 }
 
-func reportHealth(health cell.Health, log logrus.FieldLogger, scope cell.Scope, jobs job.Registry, lc hive.Lifecycle) {
+func reportHealth(health health.Health, log logrus.FieldLogger, scope health.Scope, jobs job.Registry, lc hive.Lifecycle) {
 	g := jobs.NewGroup(scope)
 	reportHealth := func(ctx context.Context) error {
 		for _, status := range health.All() {

--- a/pkg/statedb/example/reconcile.go
+++ b/pkg/statedb/example/reconcile.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/vitals/health"
 )
 
 var reconcilerCell = cell.Module(
@@ -34,8 +35,8 @@ type reconcilerParams struct {
 	Lifecycle hive.Lifecycle
 	Log       logrus.FieldLogger
 	Registry  job.Registry
-	Scope     cell.Scope
-	Reporter  cell.HealthReporter
+	Scope     health.Scope
+	Reporter  health.HealthReporter
 }
 
 func registerReconciler(p reconcilerParams) {
@@ -54,7 +55,7 @@ type reconciler struct {
 	handle *backendsHandle
 }
 
-func (r *reconciler) reconcileLoop(ctx context.Context, health cell.HealthReporter) error {
+func (r *reconciler) reconcileLoop(ctx context.Context, health health.HealthReporter) error {
 	defer r.Reporter.Stopped("Stopped")
 
 	wtxn := r.DB.WriteTxn(r.Backends)

--- a/pkg/statedb/table.go
+++ b/pkg/statedb/table.go
@@ -121,6 +121,13 @@ func (t *genTable[Obj]) First(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint
 	return
 }
 
+func (t *genTable[Obj]) Prefix(txn ReadTxn, q Query[Obj]) Iterator[Obj] {
+	indexTxn := txn.getTxn().mustIndexReadTxn(t.table, q.index)
+	iter := indexTxn.txn.Root().Iterator()
+	iter.SeekPrefix(q.key)
+	return &iterator[Obj]{iter}
+}
+
 func (t *genTable[Obj]) FirstWatch(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, watch <-chan struct{}, ok bool) {
 	indexTxn := txn.getTxn().mustIndexReadTxn(t.table, q.index)
 	iter := indexTxn.txn.Root().Iterator()

--- a/pkg/statedb/types.go
+++ b/pkg/statedb/types.go
@@ -96,6 +96,8 @@ type RWTable[Obj any] interface {
 	// revision.
 	Insert(WriteTxn, Obj) (oldObj Obj, hadOld bool, err error)
 
+	Prefix(txn ReadTxn, q Query[Obj]) Iterator[Obj]
+
 	// CompareAndSwap compares the existing object's revision against the
 	// given revision and if equal it replaces the object.
 	//

--- a/pkg/vitals/cell.go
+++ b/pkg/vitals/cell.go
@@ -1,7 +1,7 @@
 package vitals
 
 import (
-	"strings"
+	"context"
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
@@ -14,21 +14,11 @@ var Cell = cell.Module(
 	"Cilium Vitals Health",
 	cell.Provide(health.NewHealthProvider),
 	cell.Invoke(func(healthMetrics *metrics.HealthMetrics, lc hive.Lifecycle, hp health.Health) {
-		updateStats := func() {
-			for l, c := range hp.Stats() {
-				healthMetrics.HealthStatusGauge.WithLabelValues(strings.ToLower(string(l))).Set(float64(c))
-			}
-		}
+		hp.Start(context.Background())
 		lc.Append(hive.Hook{
-			OnStart: func(ctx hive.HookContext) error {
-				updateStats()
-				hp.Subscribe(ctx, func(u health.Update) {
-					updateStats()
-				}, func(err error) {})
-				return nil
-			},
 			OnStop: func(ctx hive.HookContext) error {
-				return hp.Stop(ctx)
+				hp.Stop(ctx)
+				return nil
 			},
 		})
 	}),

--- a/pkg/vitals/cell.go
+++ b/pkg/vitals/cell.go
@@ -1,0 +1,39 @@
+package vitals
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/metrics"
+	"github.com/cilium/cilium/pkg/vitals/health"
+)
+
+var Cell = cell.Module(
+	"vitals",
+	"Cilium Vitals Health",
+	cell.Provide(func(healthMetrics *metrics.HealthMetrics, lc hive.Lifecycle) health.Health {
+		fmt.Println("[tom-debug] creating vitals")
+		hp := health.NewHealthProvider()
+		updateStats := func() {
+			for l, c := range hp.Stats() {
+				healthMetrics.HealthStatusGauge.WithLabelValues(strings.ToLower(string(l))).Set(float64(c))
+			}
+		}
+		lc.Append(hive.Hook{
+			OnStart: func(ctx hive.HookContext) error {
+				updateStats()
+				hp.Subscribe(ctx, func(u health.Update) {
+					updateStats()
+				}, func(err error) {})
+				return nil
+			},
+			OnStop: func(ctx hive.HookContext) error {
+				return hp.Stop(ctx)
+			},
+		})
+		return hp
+	}),
+	health.Cell,
+)

--- a/pkg/vitals/cell.go
+++ b/pkg/vitals/cell.go
@@ -1,7 +1,6 @@
 package vitals
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/hive"
@@ -13,9 +12,8 @@ import (
 var Cell = cell.Module(
 	"vitals",
 	"Cilium Vitals Health",
-	cell.Provide(func(healthMetrics *metrics.HealthMetrics, lc hive.Lifecycle) health.Health {
-		fmt.Println("[tom-debug] creating vitals")
-		hp := health.NewHealthProvider()
+	cell.Provide(health.NewHealthProvider),
+	cell.Invoke(func(healthMetrics *metrics.HealthMetrics, lc hive.Lifecycle, hp health.Health) {
 		updateStats := func() {
 			for l, c := range hp.Stats() {
 				healthMetrics.HealthStatusGauge.WithLabelValues(strings.ToLower(string(l))).Set(float64(c))
@@ -33,7 +31,6 @@ var Cell = cell.Module(
 				return hp.Stop(ctx)
 			},
 		})
-		return hp
 	}),
 	health.Cell,
 )

--- a/pkg/vitals/health/cell.go
+++ b/pkg/vitals/health/cell.go
@@ -17,10 +17,14 @@ func (r *reporterHooks) Stop(ctx hive.HookContext) error {
 	return nil
 }
 
-func createStructedScope(id cell.FullModuleID, p Health, lc hive.Lifecycle) Scope {
-	rs := rootScope(id, p.forModule(id))
+func createStructedScope(id cell.FullModuleID, p Health, lc hive.Lifecycle) (Scope, error) {
+	s, err := p.forModule(id)
+	if err != nil {
+		return nil, err
+	}
+	rs := rootScope(id, s)
 	lc.Append(&reporterHooks{rootScope: rs})
-	return rs
+	return rs, nil
 }
 
 type healthScopeParams struct {
@@ -42,7 +46,7 @@ type initRootParams struct {
 	Lifecycle    hive.Lifecycle
 }
 
-var Cell = cell.Provide(func(p initRootParams) Scope {
+var Cell = cell.Provide(func(p initRootParams) (Scope, error) {
 	return createStructedScope(p.FullModuleID, p.Health, p.Lifecycle)
 })
 

--- a/pkg/vitals/health/cell.go
+++ b/pkg/vitals/health/cell.go
@@ -1,0 +1,77 @@
+package health
+
+import (
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+type reporterHooks struct {
+	rootScope *scope
+}
+
+func (r *reporterHooks) Start(ctx hive.HookContext) error {
+	r.rootScope.start()
+	return nil
+}
+
+func (r *reporterHooks) Stop(ctx hive.HookContext) error {
+	flushAndClose(r.rootScope, "Hive shutting down")
+	return nil
+}
+
+func createStructedScope(id cell.FullModuleID, p Health, lc hive.Lifecycle) Scope {
+	rs := rootScope(id, p.forModule(id))
+	lc.Append(&reporterHooks{rootScope: rs})
+	return rs
+}
+
+type healthScopeParams struct {
+	cell.In
+
+	FullModuleID cell.FullModuleID
+	Health       Health
+	Lifecycle    hive.Lifecycle
+
+	Scope Scope `optional:"true"` // injected as optional, if one already exists then we derive
+	// from that one, otherwise we create a new one.
+}
+
+type initRootParams struct {
+	cell.In
+
+	FullModuleID cell.FullModuleID
+	Health       Health
+	Lifecycle    hive.Lifecycle
+}
+
+var Cell = cell.Provide(func(p initRootParams) Scope {
+	return createStructedScope(p.FullModuleID, p.Health, p.Lifecycle)
+})
+
+func ProvideHealthScope() cell.Cell {
+	// So what's happening here, is that we actually have a health reporter bring provided globally.
+	//
+	// This is a bit scary, since the structure reporter is now a global singleton, but the next step
+	// is to use a immutable, radix-based, data structure to store the health information so that would
+	// actually be fine.
+	//
+	// Maybe, as a proof-of-concept, lets just use StateDB to store the health information and I can
+	// work with Jussi to figure out any circular dependency type issues that might arise later.
+	//
+	// We provide private, so that we can only access down the tree.
+	// This will likely crash if add more of these, so we should probably use a decorator pattern.
+	// return cell.ProvidePrivate(func(id cell.FullModuleID, p Health, lc hive.Lifecycle) Scope {
+	// 	return createStructedScope(id, p, lc)
+	// })
+
+	// TODO: Decorate private?
+	return cell.Decorate(func(p healthScopeParams) Scope {
+		// if p.Scope == nil {
+		// 	return createStructedScope(p.FullModuleID, p.Health, p.Lifecycle)
+		// } else {
+		// 	return GetSubScope(p.Scope, p.FullModuleID.String())
+		// }
+		return GetSubScope(p.Scope, p.FullModuleID.String())
+	})
+	// Idea: we could try a an "optional" decorator pattern:
+}

--- a/pkg/vitals/health/cell.go
+++ b/pkg/vitals/health/cell.go
@@ -10,12 +10,10 @@ type reporterHooks struct {
 }
 
 func (r *reporterHooks) Start(ctx hive.HookContext) error {
-	r.rootScope.start()
 	return nil
 }
 
 func (r *reporterHooks) Stop(ctx hive.HookContext) error {
-	flushAndClose(r.rootScope, "Hive shutting down")
 	return nil
 }
 

--- a/pkg/vitals/health/health.go
+++ b/pkg/vitals/health/health.go
@@ -6,17 +6,16 @@ package health
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync/atomic"
 	"time"
 
 	"github.com/cilium/cilium/pkg/hive/cell"
-	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/statedb/index"
 	"github.com/cilium/cilium/pkg/stream"
 	"github.com/sirupsen/logrus"
-
-	"golang.org/x/exp/maps"
 )
 
 // Level denotes what kind an update is.
@@ -86,6 +85,8 @@ type statusNodeReporter interface {
 type Health interface {
 	// All returns a copy of all module statuses.
 	// This includes unknown status for modules that have not reported a status yet.
+	AllV2() []StatusV2
+
 	All() []Status
 
 	// Get returns a copy of a modules status, by module ID.
@@ -95,17 +96,15 @@ type Health interface {
 	// Stats returns a map of the number of module statuses reported by level.
 	Stats() map[Level]uint64
 
-	// Stop stops the health provider from processing updates.
-	Stop(context.Context) error
-
 	// Subscribe to health status updates.
 	Subscribe(context.Context, func(Update), func(error))
 
+	Start(context.Context)
+
+	Stop(context.Context)
+
 	// forModule creates a moduleID scoped reporter handle.
 	forModule(cell.FullModuleID) (statusNodeReporter, error)
-
-	// processed returns the number of updates processed.
-	processed() uint64
 }
 
 type StatusResult struct {
@@ -133,7 +132,7 @@ type Status struct {
 }
 
 type StatusV2 struct {
-	ID      Identifier
+	ID      Identifier // stable!
 	Level   Level
 	Message string
 	Feature Feature
@@ -178,17 +177,31 @@ func NewHealthProvider(pp healthProviderParams) (Health, error) {
 	p := &healthProvider{
 		moduleStatuses: make(map[string]Status),
 		byLevel:        make(map[Level]uint64),
-		running:        true,
 		db:             pp.DB,
+
+		stop:    make(chan struct{}),
+		updates: make(chan update),
 	}
 
 	// Example for how we might start to index by different types of data.
 	featureIndex := statedb.Index[StatusV2, Feature]{
-		Name: "id",
+		Name: "feature",
 		FromObject: func(s StatusV2) index.KeySet {
 			return index.NewKeySet([]byte(s.Feature))
 		},
 		FromKey: func(k Feature) index.Key {
+			return index.Key([]byte(k))
+		},
+		Unique: false,
+	}
+
+	// Index by level, so we can efficiently query for all modules of a given level.
+	levelIndex := statedb.Index[StatusV2, Level]{
+		Name: "level",
+		FromObject: func(s StatusV2) index.KeySet {
+			return index.NewKeySet([]byte(s.Level))
+		},
+		FromKey: func(k Level) index.Key {
 			return index.Key([]byte(k))
 		},
 		Unique: false,
@@ -205,9 +218,11 @@ func NewHealthProvider(pp healthProviderParams) (Health, error) {
 		Unique: true,
 	}
 	var err error
-	p.statusTable, err = statedb.NewTable("health-status", idIndex)
+	p.statusTable, err = statedb.NewTable("health-status", idIndex,
+		featureIndex, levelIndex)
 	p.pathIndex = idIndex
 	p.featureIndex = featureIndex
+	p.levelIndex = levelIndex
 	if err != nil {
 		return nil, err
 	}
@@ -224,19 +239,6 @@ func (p *healthProvider) Subscribe(ctx context.Context, cb func(Update), complet
 	p.obs.Observe(ctx, cb, complete)
 }
 
-func (p *healthProvider) processed() uint64 {
-	return p.numProcessed.Load()
-}
-
-func (p *healthProvider) updateMetricsLocked(prev Update, curr Level) {
-	// If an update is processed that transitions the level state of a module
-	// then update the level counters.
-	if prev.Level() != curr {
-		p.byLevel[curr]++
-		p.byLevel[prev.Level()]--
-	}
-}
-
 func (p *healthProvider) removePrefix(prefix Identifier) error {
 	tx := p.db.WriteTxn(p.statusTable)
 	q := p.pathIndex.Query(prefix)
@@ -246,7 +248,6 @@ func (p *healthProvider) removePrefix(prefix Identifier) error {
 		if !ok {
 			break
 		}
-		fmt.Println("[tom-debug7] iter prefix:", o)
 		_, _, err := p.statusTable.Delete(tx, o)
 		if err != nil {
 			return fmt.Errorf("failed to delete status %s: %w", prefix.String(), err)
@@ -256,108 +257,169 @@ func (p *healthProvider) removePrefix(prefix Identifier) error {
 	return nil
 }
 
-// func (p *healthProvider) getPrefix() {
-// 	tx := p.db.ReadTxn()
-// 	q := p.pathIndex.Query(Identifier{"agent", "infra", "vitals", "cilium-endpoint-8"})
-// 	iter := p.statusTable.Prefix(tx, q)
-// 	for {
-// 		o, _, ok := iter.Next()
-// 		if !ok {
-// 			break
-// 		}
-// 		fmt.Println("[tom-debug7] iter prefix:", o)
-// 	}
-// }
+func (p *healthProvider) Start(ctx context.Context) {
+	go p.runLoop(ctx)
+}
 
-func (p *healthProvider) upsertStatus(id Identifier, s StatusV2) {
-	tx := p.db.WriteTxn(p.statusTable)
-	if _, _, err := p.statusTable.Insert(tx, s); err != nil {
-		panic(err)
+const updateMaxBatchSize = 16
+
+func (p *healthProvider) runLoop(ctx context.Context) {
+	batch := make([]update, 0, updateMaxBatchSize)
+	p.running.Store(true)
+	for {
+		select {
+		case <-p.stop:
+			log.Info("stopping health provider")
+			return
+		case <-ctx.Done():
+			// TODO: cleanup
+			log.Info("context cancelled, stopping health provider")
+			return
+		case u := <-p.updates:
+			switch u.updateType {
+			case "upsert", "delete":
+				batch = append(batch, u)
+			default:
+				log.WithFields(
+					logrus.Fields{
+						"updateType": u.updateType,
+						"id":         u.id,
+						"status":     u.s,
+					}).Error("BUG: unknown update type")
+			}
+			if len(batch) >= updateMaxBatchSize {
+				p.handleBatch(batch)
+				batch = batch[:0]
+			}
+		case <-inctimer.After(time.Second):
+			if len(batch) == 0 {
+				continue
+			}
+
+			p.handleBatch(batch)
+
+			batch = batch[:0]
+		}
 	}
-	tx.Commit()
+}
+
+func (p *healthProvider) handleBatch(batch []update) {
+	tx := p.db.WriteTxn(p.statusTable)
+	defer tx.Commit()
+	for _, u := range batch {
+		switch u.updateType {
+		case "upsert":
+			if _, _, err := p.statusTable.Insert(tx, u.s); err != nil {
+				log.WithField("status", u.s).WithError(err).Error("BUG: failed to insert status")
+				tx.Abort()
+				return
+			}
+		case "delete":
+			q := p.pathIndex.Query(u.id)
+			iter := p.statusTable.Prefix(tx, q)
+			for {
+				o, _, ok := iter.Next()
+				if !ok {
+					break
+				}
+				_, _, err := p.statusTable.Delete(tx, o)
+				if err != nil {
+					log.WithField("status", u.s).WithError(err).Error("BUG: failed to delete status")
+					tx.Abort()
+					return
+				}
+			}
+		}
+	}
+}
+
+type update struct {
+	updateType string
+	id         Identifier
+	s          StatusV2
 }
 
 var log = logrus.New().WithField("subsys", "health-vitals")
 
 // Finish stops the status provider, and waits for all updates to be processed or
 // returns an error if the context is cancelled first.
-func (p *healthProvider) Stop(ctx context.Context) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.running = false // following this, no new reporters will send.
-	p.complete(nil)   // complete the observable, no new subscribers will receive further updates.
-	return nil
+func (p *healthProvider) Stop(ctx context.Context) {
+	close(p.stop)
 }
 
 // forModule returns a module scoped status reporter handle for emitting status updates.
 // This is used to automatically provide declared modules with a status reported.
 func (p *healthProvider) forModule(moduleID cell.FullModuleID) (statusNodeReporter, error) {
-	tx := p.db.WriteTxn(p.statusTable)
-	_, _, err := p.statusTable.Insert(tx, StatusV2{
-		ID:      NewIdentifier(moduleID),
-		Level:   StatusUnknown,
-		Message: "no status reported yet",
-	})
-	if err != nil {
-		tx.Abort()
-		return nil, err
-	}
-	tx.Commit()
-
 	return &reporter{
-		ident:  NewIdentifier(moduleID),
-		upsert: p.upsertStatus,
+		ident: NewIdentifier(moduleID),
+		upsert: func(path Identifier, s StatusV2) {
+			if !p.running.Load() {
+				log.Warn("health provider not running yet, dropping update")
+			}
+			p.updates <- update{
+				updateType: "upsert",
+				id:         path,
+				s:          s,
+			}
+		},
 		delete: func(path Identifier) {
-			if err := p.removePrefix(path); err != nil {
-				log.WithError(err).Error("failed to remove status tree")
+			if !p.running.Load() {
+				log.Warn("health provider not running yet, dropping update")
+			}
+			p.updates <- update{
+				updateType: "delete",
+				id:         path,
 			}
 		},
 	}, nil
 }
 
-// All returns a copy of all the latest statuses.
 func (p *healthProvider) All() []Status {
-	// tx := p.db.ReadTxn()
-	// iter, := p.statusTable.All(tx)
-	// ss := make([]Status, 0, iter.Count())
-	// for {
-	// 	o, _, ok := iter.Next()
-	// 	if !ok {
-	// 		break
-	// 	}
-	// 	ss = append(ss, Status{
-	// 		FullModuleID: s.ID,
-	// 	})
-	// }
-	// sort.Slice(all, func(i, j int) bool {
-	// 	return all[i].FullModuleID.String() < all[j].FullModuleID.String()
-	// })
 	return []Status{}
+}
+
+func (p *healthProvider) AllV2() []StatusV2 {
+	tx := p.db.ReadTxn()
+	iter, _ := p.statusTable.All(tx)
+	all := make([]StatusV2, 0)
+	for {
+		o, _, ok := iter.Next()
+		if !ok {
+			break
+		}
+		all = append(all, o)
+	}
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].ID.String() < all[j].ID.String()
+	})
+	return all
 }
 
 // Get returns the latest status for a module, by module ID.
 func (p *healthProvider) Get(moduleID Identifier) (Status, error) {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	s, ok := p.moduleStatuses[moduleID.String()]
-	if ok {
-		return s, nil
-	}
-	return Status{}, fmt.Errorf("module %q not found", moduleID)
+	return Status{}, nil
 }
 
 func (p *healthProvider) Stats() map[Level]uint64 {
-	n := make(map[Level]uint64, len(p.byLevel))
-	p.mu.Lock()
-	maps.Copy(n, p.byLevel)
-	p.mu.Unlock()
-	return n
+	freqs := map[Level]uint64{}
+	tx := p.db.ReadTxn()
+	for _, l := range []Level{StatusOK, StatusDegraded, StatusStopped} {
+		q := p.levelIndex.Query(l)
+		iter, _ := p.statusTable.Get(tx, q)
+		var count uint64
+		for {
+			_, _, ok := iter.Next()
+			if !ok {
+				break
+			}
+			count++
+		}
+		freqs[l] = count
+	}
+	return freqs
 }
 
 type healthProvider struct {
-	mu lock.RWMutex
-
-	running      bool
 	numProcessed atomic.Uint64
 
 	byLevel        map[Level]uint64
@@ -366,6 +428,10 @@ type healthProvider struct {
 	statusTable    statedb.RWTable[StatusV2]
 	pathIndex      statedb.Index[StatusV2, Identifier]
 	featureIndex   statedb.Index[StatusV2, Feature]
+	levelIndex     statedb.Index[StatusV2, Level]
+	updates        chan update
+	stop           chan struct{}
+	running        atomic.Bool
 
 	obs      stream.Observable[Update]
 	emit     func(Update)

--- a/pkg/vitals/health/health_test.go
+++ b/pkg/vitals/health/health_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package cell
+package health
 
 import (
 	"context"

--- a/pkg/vitals/health/health_test.go
+++ b/pkg/vitals/health/health_test.go
@@ -6,79 +6,128 @@ package health
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestStatusProvider(t *testing.T) {
-	assert := assert.New(t)
-	sp := NewHealthProvider()
-	mid := FullModuleID{"module000"}
-	reporter := GetHealthReporter(TestScopeFromProvider(mid, sp), "foo")
+// Goals:
+// * Simplicity
+// * Data schema
+// * Testing store
+// * Hubble integration
 
-	reporter.OK("OK")
-	var err error
-	var s Status
-	assertStatus := func(l Level) {
-		assert.Eventually(func() bool {
-			s, err = sp.Get(mid)
-			return err == nil && s.Level() == l
-		}, time.Second, time.Millisecond*50)
-	}
-	assertStatus(StatusOK)
-	reporter.Degraded("degraded", nil)
-	assertStatus(StatusDegraded)
-	reporter.OK("-")
-	assertStatus(StatusOK)
-	reporter.Stopped("done")
-	assertStatus(StatusOK)
-}
-
-func TestHealthReporter(t *testing.T) {
-	m := 200
-	u := 200
-
-	assert := assert.New(t)
-	s := NewHealthProvider()
-	wg := &sync.WaitGroup{}
-	for i := 0; i < m; i++ {
-		reporter := s.forModule([]string{fmt.Sprintf("module-%d", i)})
-		wg.Add(1)
-		go func(hr statusNodeReporter) {
-			for j := 1; j <= u; j++ {
-				if j%2 == 0 {
-					hr.setStatus(&StatusNode{LastLevel: StatusOK})
-				} else {
-					hr.setStatus(&StatusNode{LastLevel: StatusDegraded})
-				}
+func TestLoop(t *testing.T) {
+	h := hive.New(
+		statedb.Cell,
+		cell.Invoke(func(pp healthProviderParams, sh hive.Shutdowner) error {
+			defer sh.Shutdown()
+			hp, err := NewHealthProvider(pp)
+			if err != nil {
+				return err
 			}
-			wg.Done()
-		}(reporter)
-	}
-	wg.Wait()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Hour)
-	defer cancel()
-	assert.NoError(s.Stop(ctx))
-	assert.Equal(m*u, int(s.processed()))
-
-	for _, s := range s.(*healthProvider).moduleStatuses {
-		assert.Equal(StatusOK, s.Update.Level())
-	}
+			hp.Start(context.Background())
+			mid := cell.FullModuleID([]string{"foo", "bar"})
+			m, err := hp.forModule(mid)
+			assert.NoError(t, err)
+			r := rootScope(mid, m)
+			go func() {
+				for {
+					GetHealthReporter(r, "comp0").OK("all good")
+					GetHealthReporter(r, "comp02").OK("all good")
+					s := GetSubScope(r, "comp1")
+					GetHealthReporter(s, "leaf").OK("all good")
+					time.Sleep(1 * time.Second)
+				}
+			}()
+			time.Sleep(3 * time.Second)
+			hp.Stop(context.Background())
+			fmt.Println(hp.All())
+			tx := hp.(*healthProvider).db.ReadTxn()
+			iter, _ := hp.(*healthProvider).statusTable.All(tx)
+			for {
+				o, _, ok := iter.Next()
+				if !ok {
+					break
+				}
+				fmt.Println("s:", o)
+			}
+			return nil
+		}),
+	)
+	assert.NoError(t, h.Run())
 }
 
-func TestStatusString(t *testing.T) {
-	assert := assert.New(t)
-	un := &StatusNode{
-		LastLevel: StatusOK,
-		Message:   "something happened",
-	}
-	s := Status{
-		Update:       un,
-		FullModuleID: FullModuleID{"m-000"},
-	}
-	assert.Equal("Status{ModuleID: m-000, Level: OK, Since: never, Message: something happened}",
-		s.String())
-}
+// func TestStatusProvider(t *testing.T) {
+// 	assert := assert.New(t)
+// 	sp := NewHealthProvider()
+// 	mid := FullModuleID{"module000"}
+// 	reporter := GetHealthReporter(TestScopeFromProvider(mid, sp), "foo")
+
+// 	reporter.OK("OK")
+// 	var err error
+// 	var s Status
+// 	assertStatus := func(l Level) {
+// 		assert.Eventually(func() bool {
+// 			s, err = sp.Get(mid)
+// 			return err == nil && s.Level() == l
+// 		}, time.Second, time.Millisecond*50)
+// 	}
+// 	assertStatus(StatusOK)
+// 	reporter.Degraded("degraded", nil)
+// 	assertStatus(StatusDegraded)
+// 	reporter.OK("-")
+// 	assertStatus(StatusOK)
+// 	reporter.Stopped("done")
+// 	assertStatus(StatusOK)
+// }
+
+// func TestHealthReporter(t *testing.T) {
+// 	m := 200
+// 	u := 200
+
+// 	assert := assert.New(t)
+// 	s := NewHealthProvider()
+// 	wg := &sync.WaitGroup{}
+// 	for i := 0; i < m; i++ {
+// 		reporter := s.forModule([]string{fmt.Sprintf("module-%d", i)})
+// 		wg.Add(1)
+// 		go func(hr statusNodeReporter) {
+// 			for j := 1; j <= u; j++ {
+// 				if j%2 == 0 {
+// 					hr.setStatus(&StatusNode{LastLevel: StatusOK})
+// 				} else {
+// 					hr.setStatus(&StatusNode{LastLevel: StatusDegraded})
+// 				}
+// 			}
+// 			wg.Done()
+// 		}(reporter)
+// 	}
+// 	wg.Wait()
+// 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Hour)
+// 	defer cancel()
+// 	assert.NoError(s.Stop(ctx))
+// 	assert.Equal(m*u, int(s.processed()))
+
+// 	for _, s := range s.(*healthProvider).moduleStatuses {
+// 		assert.Equal(StatusOK, s.Update.Level())
+// 	}
+// }
+
+// func TestStatusString(t *testing.T) {
+// 	assert := assert.New(t)
+// 	un := &StatusNode{
+// 		LastLevel: StatusOK,
+// 		Message:   "something happened",
+// 	}
+// 	s := Status{
+// 		Update:       un,
+// 		FullModuleID: FullModuleID{"m-000"},
+// 	}
+// 	assert.Equal("Status{ModuleID: m-000, Level: OK, Since: never, Message: something happened}",
+// 		s.String())
+// }

--- a/pkg/vitals/health/identifier.go
+++ b/pkg/vitals/health/identifier.go
@@ -1,0 +1,21 @@
+package health
+
+import (
+	"strings"
+
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/statedb/index"
+)
+
+type Identifier struct {
+	ModuleID    cell.FullModuleID
+	ComponentID []string
+}
+
+func (i Identifier) String() string {
+	return i.ModuleID.String() + "." + strings.Join(i.ComponentID, ".")
+}
+
+func (i Identifier) Key() index.Key {
+	return []byte(i.String())
+}

--- a/pkg/vitals/health/identifier.go
+++ b/pkg/vitals/health/identifier.go
@@ -28,8 +28,16 @@ func (i Identifier) withSubComponent(componentID string) Identifier {
 	}
 }
 
+func (i Identifier) component() string {
+	return strings.Join(i.ComponentID, ".")
+}
+
+func (i Identifier) module() string {
+	return string(i.ModuleID.String())
+}
+
 func (i Identifier) String() string {
-	return i.ModuleID.String() + "." + strings.Join(i.ComponentID, ".")
+	return i.module() + "." + i.component()
 }
 
 func (i Identifier) Key() index.Key {

--- a/pkg/vitals/health/identifier.go
+++ b/pkg/vitals/health/identifier.go
@@ -7,9 +7,25 @@ import (
 	"github.com/cilium/cilium/pkg/statedb/index"
 )
 
+// Identifier is a unique identifier for a health reporter, it is a composition of
+// two parts: the module ID, and the component ID.
 type Identifier struct {
 	ModuleID    cell.FullModuleID
 	ComponentID []string
+}
+
+func NewIdentifier(id cell.FullModuleID, componentID ...string) Identifier {
+	return Identifier{
+		ModuleID:    id,
+		ComponentID: componentID,
+	}
+}
+
+func (i Identifier) withSubComponent(componentID string) Identifier {
+	return Identifier{
+		ModuleID:    i.ModuleID,
+		ComponentID: append(i.ComponentID, componentID),
+	}
 }
 
 func (i Identifier) String() string {

--- a/pkg/vitals/health/structured.go
+++ b/pkg/vitals/health/structured.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package cell
+package health
 
 import (
 	"bytes"
@@ -17,6 +17,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/lock"
 
@@ -106,17 +107,17 @@ func GetHealthReporter(parent Scope, name string) HealthReporter {
 
 // TestScope exposes creating a root scope for testing purposes only.
 func TestScope() Scope {
-	return TestScopeFromProvider(FullModuleID{"test"}, NewHealthProvider())
+	return TestScopeFromProvider(cell.FullModuleID{"test"}, NewHealthProvider())
 }
 
 // TestScope exposes creating a root scope from a health provider for testing purposes only.
-func TestScopeFromProvider(moduleID FullModuleID, hp Health) Scope {
+func TestScopeFromProvider(moduleID cell.FullModuleID, hp Health) Scope {
 	s := rootScope(moduleID, hp.forModule(moduleID))
 	s.start()
 	return s
 }
 
-func rootScope(id FullModuleID, hr statusNodeReporter) *scope {
+func rootScope(id cell.FullModuleID, hr statusNodeReporter) *scope {
 	r := &subReporter{
 		base: &subreporterBase{
 			hr:           hr,

--- a/pkg/vitals/health/structured.go
+++ b/pkg/vitals/health/structured.go
@@ -5,23 +5,17 @@ package health
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"runtime"
-	"sort"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"text/tabwriter"
 	"time"
 
 	"github.com/cilium/cilium/pkg/hive/cell"
-	"github.com/cilium/cilium/pkg/inctimer"
-	"github.com/cilium/cilium/pkg/lock"
 
-	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -97,6 +91,12 @@ func GetSubScope(parent Scope, name string) Scope {
 	return createSubScope(parent, name)
 }
 
+func DecorateModuleScope() cell.Cell {
+	return cell.Decorate(func(parent Scope, id cell.ModuleID) Scope {
+		return createSubScope(parent, string(id))
+	})
+}
+
 // GetHealthReporter creates a new reporter under the given parent scope.
 func GetHealthReporter(parent Scope, name string) HealthReporter {
 	if parent == nil {
@@ -113,101 +113,17 @@ func GetHealthReporter(parent Scope, name string) HealthReporter {
 // TestScope exposes creating a root scope from a health provider for testing purposes only.
 func TestScopeFromProvider(moduleID cell.FullModuleID, hp Health) Scope {
 	s := rootScope(moduleID, hp.forModule(moduleID))
-	s.start()
 	return s
 }
 
 func rootScope(id cell.FullModuleID, hr statusNodeReporter) *scope {
-	fmt.Println("[tom-debug7] creating root scope:", id)
 	r := &subReporter{
-		base: &subreporterBase{
-			hr:           hr,
-			idToChildren: map[string]children{},
-			nodes:        map[string]*node{},
-			wakeup:       make(chan struct{}, 16),
-		},
-
+		base: &subreporterBase{},
 		path: id,
 	}
+	r.base.hr.Store(&hr)
 	// create root node, required in case reporters are created without any subscopes.
-	r.id = r.base.addChild("", id.String(), false)
-	r.base.rootID = r.id
-
-	// Realize walks the tree and creates a updated status for the reporter.
-	// Because this is blocking and can be expensive, we have a reconcile loop
-	// that only performs this if the revision has changed.
-	realize := func() {
-		if r.base.stopped {
-			return
-		}
-		statusTree := r.base.getStatusTreeLocked(r.base.rootID)
-		if r.base.stopped {
-			r.base.hr.setStatus(statusTree)
-			return
-		}
-		if r.base.revision.Load() == 0 {
-			return
-		}
-		fmt.Println("[tom-debug7] realize:", statusTree.String())
-		r.base.hr.setStatus(statusTree)
-	}
-
-	r.scheduleRealize = func() {
-		r.base.revision.Add(1)
-		r.base.wakeup <- struct{}{}
-	}
-	r.realizeSync = realize
-
 	return &scope{subReporter: r}
-}
-
-func (r *scope) start() {
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		var rev uint64
-		var lastUpdate time.Time
-		for {
-			select {
-			case <-inctimer.After(reporterMinTimeout):
-			case <-r.base.wakeup:
-			case <-ctx.Done():
-			}
-			if rev < r.base.revision.Load() && time.Since(lastUpdate) > reporterMinTimeout {
-				rev = r.base.revision.Load()
-				r.base.Lock()
-				r.realizeSync()
-				r.base.Unlock()
-				lastUpdate = time.Now()
-			}
-			if ctx.Err() != nil {
-				return
-			}
-		}
-	}()
-	r.closeReconciler = cancel
-}
-
-// Flushes out any remaining unprocessed updates and closes the reporter tree.
-// Used to finalize any remaining status updates before the module is stopped.
-// This will allow for collecting of health status during shutdown.
-func flushAndClose(rs Scope, reason string) {
-	rs.scope().base.Lock()
-	defer rs.scope().base.Unlock()
-
-	// Stop reconciler loop, flush any pending updates synchronously.
-	rs.scope().closeReconciler()
-
-	// Realize and flush the final status.
-	rs.scope().realizeSync()
-
-	// Mark the module as stopped, and emit a stopped status.
-	rs.scope().base.stopped = true
-	rs.scope().base.hr.setStatus(&StatusNode{
-		ID:        rs.scope().base.rootID,
-		LastLevel: StatusStopped,
-		Message:   reason,
-	})
-	rs.scope().base.removeTreeLocked(rs.scope().id)
 }
 
 type scope struct {
@@ -215,32 +131,7 @@ type scope struct {
 }
 
 func (s *scope) Close() {
-	s.base.Lock()
-	s.base.removeRefLocked(s.id)
-	if s.base.canRemoveTreeLocked(s.id) {
-		s.base.removeTreeLocked(s.id)
-	}
-	s.base.Unlock()
-	s.scheduleRealize()
-}
-
-// A scope can be removed if it has no references and all child scopes can be removed.
-// Reporter leaf nodes are always immediately removed when Stopped. Thus if the condition
-// holds that all subtrees of the scope can be removed, then the scope can be removed.
-func (s *subreporterBase) canRemoveTreeLocked(id string) bool {
-	if _, ok := s.nodes[id]; ok {
-		node := s.nodes[id]
-		if (node.isReporter) || s.nodes[id].refs > 0 {
-			return false
-		}
-		for child := range s.idToChildren[id] {
-			if !s.canRemoveTreeLocked(child) {
-				return false
-			}
-		}
-	}
-	// If it does not exist, we assume it's ok to remove (noop).
-	return true
+	// TODO
 }
 
 func (s *scope) scope() *subReporter {
@@ -271,13 +162,7 @@ func createSubScope(parent Scope, name string) *scope {
 		subReporter: getSubReporter(parent, name, false),
 	}
 	runtime.SetFinalizer(s, func(s *scope) {
-		s.base.Lock()
-		s.base.removeRefLocked(s.id)
-		if s.base.canRemoveTreeLocked(s.id) {
-			s.base.removeTreeLocked(s.id)
-		}
-		s.base.Unlock()
-		runtime.SetFinalizer(s, nil)
+		// TODO: Remove updates that are not a prefix to any other updates.
 	})
 	return s
 }
@@ -287,32 +172,10 @@ func getSubReporter(parent Scope, name string, isReporter bool) *subReporter {
 }
 
 func scopeFromParent(parent Scope, name string, isReporter bool) *subReporter {
-	r := parent.scope()
-	r.base.Lock()
-	defer r.base.Unlock()
-
-	// If such a reporter already exists at this scope, we just return the same reporter
-	// by recreating the subreporter.
-	for cid := range r.base.idToChildren[r.id] {
-		child := r.base.nodes[cid]
-		if child.name == name {
-			r.base.addRefLocked(cid)
-			return &subReporter{
-				base:            r.base,
-				id:              cid,
-				scheduleRealize: r.scheduleRealize,
-				name:            name,
-			}
-		}
-	}
-
-	id := r.base.addChild(r.id, name, isReporter)
-
+	fmt.Println("[tom-debug] parent:", parent.scope().name, "new:", name)
 	return &subReporter{
-		base:            r.base,
-		id:              id,
-		scheduleRealize: r.scheduleRealize,
-		name:            name,
+		base: parent.scope().base,
+		name: name,
 
 		path: append(parent.scope().path, name),
 	}
@@ -324,90 +187,12 @@ func scopeFromParent(parent Scope, name string, isReporter bool) *subReporter {
 // subreporterBase maintains the tree structure, as well as is responsible for
 // realizing the status tree, and emitting the status to the module HealthReporter.
 type subreporterBase struct {
-	lock.Mutex
-
 	// Module level health reporter, all realized status is emitted to this reporter.
-	hr statusNodeReporter
-
-	// idToChildren is the adjacency map of parentID to children IDs.
-	idToChildren map[string]children
-	nodes        map[string]*node
-
-	// rootID is the root node of the tree, it should always exist in idToChildren and nodes.
-	rootID string
-
-	stopped bool
-
-	// Variables used for realization loop, because realization involves traversing the tree
-	// we only perform this when the revision has changed.
-	revision atomic.Uint64
-	counter  atomic.Int32
-	wakeup   chan struct{}
-}
-
-func (s *subreporterBase) addNode(n *node) {
-	if _, ok := s.idToChildren[n.parentID]; !ok {
-		s.idToChildren[n.parentID] = children{}
-	}
-	s.idToChildren[n.parentID][n.id] = struct{}{}
-	s.idToChildren[n.id] = children{}
-	s.nodes[n.id] = n
-}
-
-func (s *subreporterBase) addChild(pid string, name string, isReporter bool) string {
-	id := strconv.Itoa(int(s.counter.Add(1))) + "-" + name
-	s.addNode(&node{
-		id:       id,
-		parentID: pid,
-		count:    1,
-		nodeUpdate: nodeUpdate{
-			Level:     StatusUnknown,
-			Timestamp: time.Now(),
-		},
-		name:       name,
-		isReporter: isReporter,
-		refs:       1,
-	})
-	return id
+	hr atomic.Pointer[statusNodeReporter]
 }
 
 func (s *subreporterBase) setStatus(id string, level Level, message string, err error) error {
-	s.Lock()
-	defer s.Unlock()
-
-	if s.stopped {
-		return fmt.Errorf("reporter tree %s has been stopped", id)
-	}
-
-	if _, ok := s.nodes[id]; !ok {
-		return fmt.Errorf("reporter %s has been stopped", id)
-	}
-
-	n := s.nodes[id]
-
-	if n.Level == level && n.Message == message {
-		n.count++
-	} else {
-		n.count = 1
-	}
-
-	n.Level = level
-	n.Message = message
-	n.Error = err
 	return nil
-}
-
-func (s *subreporterBase) removeTreeLocked(rid string) {
-	for child := range s.idToChildren[rid] {
-		s.removeTreeLocked(child)
-	}
-	// Safely remove parents reference to this node.
-	if _, ok := s.nodes[rid]; ok {
-		pid := s.nodes[rid].parentID
-		delete(s.idToChildren[pid], rid)
-	}
-	delete(s.idToChildren, rid)
-	delete(s.nodes, rid)
 }
 
 // StatusNode is a model struct for a status tree realization result.
@@ -474,51 +259,6 @@ func (s *StatusNode) String() string {
 	return s.Message
 }
 
-func (s *subreporterBase) getStatusTreeLocked(nid string) *StatusNode {
-	if children, ok := s.idToChildren[nid]; ok {
-		rn := s.nodes[nid]
-		n := &StatusNode{
-			ID:              nid,
-			Message:         rn.Message,
-			Name:            rn.name,
-			UpdateTimestamp: rn.Timestamp,
-			Count:           rn.count,
-		}
-		if err := rn.Error; err != nil {
-			n.Error = err.Error()
-		}
-		allok := true
-		childIDs := maps.Keys(children)
-		sort.Strings(childIDs)
-		for _, child := range childIDs {
-			cn := s.getStatusTreeLocked(child)
-			if cn == nil {
-				log.Errorf("failed to get status for node %s", child)
-				continue
-			}
-			n.SubStatuses = append(n.SubStatuses, cn)
-			if !cn.allOk() {
-				allok = false
-			}
-		}
-		// If this is not a leaf and all children are ok then report ok.
-		// case 1: Non-reporter, has no children, should be ok?
-		// case 2: Non-reporter, has children, defer down to children.
-		if rn.isReporter {
-			n.LastLevel = rn.Level
-		} else {
-			if allok {
-				n.LastLevel = StatusOK
-			} else {
-				n.LastLevel = StatusDegraded
-			}
-		}
-
-		return n
-	}
-	return nil
-}
-
 type node struct {
 	id         string
 	name       string
@@ -535,47 +275,29 @@ type nodeUpdate struct {
 	Timestamp time.Time
 }
 
-func (b *subreporterBase) removeRefLocked(id string) {
-	if _, ok := b.nodes[id]; ok {
-		if b.nodes[id].refs > 0 {
-			b.nodes[id].refs--
-		}
-	}
-}
-
-func (b *subreporterBase) addRefLocked(id string) {
-	if _, ok := b.nodes[id]; ok {
-		b.nodes[id].refs++
-	}
-}
-
 // subReporter represents both reporter "leaf" nodes and intermediate
 // "scope" nodes.
 // subReporter only has a pointer to the base, thus copying a subReporter
 // by value yields the same "reporter".
+//
+// Note: For the V2 implementation of this, we will still pass around a reporter
+// scope which will allow modules to derive subreporters or subscopes.
+// However, this will now be lock free, variables in the reporter scope must
+// be immutable or use atomics after creation to ensure thread safety.
 type subReporter struct {
 	base *subreporterBase
-	// Triggers realization asynchronously, should not hold lock when calling.
-	scheduleRealize func()
-	// Triggers realization synchronously, base lock must be held when calling.
-	// Use for final status flushes.
-	realizeSync func()
-
-	closeReconciler func()
-	id              string
-	name            string
+	id   string
+	name string
 
 	path cell.FullModuleID
 }
 
 func (s *subReporter) OK(message string) {
-	fmt.Println("[tom-debug] subreporter:", s.id, "OK:", message, "=>", s.path)
-	if err := s.base.setStatus(s.id, StatusOK, message, nil); err != nil {
-		log.WithError(err).Warnf("could not set OK status on subreporter %q", s.id)
+	hr := s.base.hr.Load()
+	if hr == nil {
 		return
 	}
-	s.scheduleRealize()
-	s.base.hr.setStatusV2(s.path, StatusV2{
+	(*hr).setStatusV2(s.path, StatusV2{
 		ID:      s.path,
 		Level:   StatusOK,
 		Message: message,
@@ -583,12 +305,11 @@ func (s *subReporter) OK(message string) {
 }
 
 func (s *subReporter) Degraded(message string, err error) {
-	if err := s.base.setStatus(s.id, StatusDegraded, message, err); err != nil {
-		log.WithError(err).Warnf("could not set degraded status on subreporter %q", s.id)
+	hr := s.base.hr.Load()
+	if hr == nil {
 		return
 	}
-	s.scheduleRealize()
-	s.base.hr.setStatusV2(s.path, StatusV2{
+	(*hr).setStatusV2(s.path, StatusV2{
 		ID:      s.path,
 		Level:   StatusDegraded,
 		Message: message,
@@ -599,10 +320,10 @@ func (s *subReporter) Degraded(message string, err error) {
 // Stopped reporters can immediately be removed from the tree, since they do
 // not have any children.
 func (s *subReporter) Stopped(message string) {
-	s.base.Lock()
-	s.base.removeTreeLocked(s.id)
-	s.base.Unlock()
-	s.scheduleRealize()
+	// s.base.Lock()
+	// s.base.removeTreeLocked(s.id)
+	// s.base.Unlock()
+	// s.scheduleRealize()
 
 	// TODO: V2 -> remove from tree.
 }

--- a/pkg/vitals/health/structured.go
+++ b/pkg/vitals/health/structured.go
@@ -4,7 +4,6 @@
 package health
 
 import (
-	"fmt"
 	"runtime"
 	"sync/atomic"
 
@@ -84,21 +83,6 @@ func GetHealthReporter(parent Scope, name string) HealthReporter {
 	return getSubReporter(parent, name, true)
 }
 
-// TestScope exposes creating a root scope for testing purposes only.
-// func TestScope() Scope {
-// 	return TestScopeFromProvider(cell.FullModuleID{"test"}, NewHealthProvider())
-// }
-
-// TestScope exposes creating a root scope from a health provider for testing purposes only.
-// func TestScopeFromProvider(moduleID cell.FullModuleID, hp Health) Scope {
-// 	r, err := hp.forModule(moduleID)
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	s := rootScope(moduleID, r)
-// 	return s
-// }
-
 // rootScope always
 func rootScope(id cell.FullModuleID, hr statusNodeReporter) *scope {
 	r := &subReporter{
@@ -123,7 +107,7 @@ func (s *scope) scope() *subReporter {
 }
 
 func (s *scope) Name() string {
-	return s.id
+	return s.path.component()
 }
 
 // When a scope is orphaned and garbage collected, we want to remove it from the tree if
@@ -157,11 +141,8 @@ func getSubReporter(parent Scope, name string, isReporter bool) *subReporter {
 }
 
 func scopeFromParent(parent Scope, name string, isReporter bool) *subReporter {
-	fmt.Println("[tom-debug] parent:", parent.scope().id, "new:", name)
 	return &subReporter{
 		base: parent.scope().base,
-		id:   name,
-
 		path: parent.scope().path.withSubComponent(name),
 	}
 }
@@ -187,9 +168,6 @@ type subreporterBase struct {
 // be immutable or use atomics after creation to ensure thread safety.
 type subReporter struct {
 	base *subreporterBase
-	id   string
-
-	//path cell.FullModuleID
 	path Identifier
 }
 

--- a/pkg/vitals/health/structured_test.go
+++ b/pkg/vitals/health/structured_test.go
@@ -3,307 +3,292 @@
 
 package health
 
-import (
-	"context"
-	"fmt"
-	"runtime"
-	"sync"
-	"sync/atomic"
-	"testing"
-	"time"
+// func init() {
+// 	reporterMinTimeout = time.Millisecond * 10
+// }
 
-	"github.com/stretchr/testify/assert"
+// func createRoot(hr statusNodeReporter) (Scope, func()) {
+// 	s := rootScope(cell.FullModuleID{"root.foo"}, hr)
+// 	s.start()
+// 	return s, func() {
+// 		flushAndClose(s, "test is done")
+// 	}
+// }
 
-	"github.com/cilium/cilium/pkg/hive/cell"
-	"github.com/cilium/cilium/pkg/lock"
-)
+// func createMockReporter(assert *assert.Assertions) (*mockReporter, func(), func(), func()) {
 
-func init() {
-	reporterMinTimeout = time.Millisecond * 10
-}
+// 	l := new(lock.Mutex)
+// 	last := new(Level)
+// 	*last = StatusUnknown
+// 	hr := &mockReporter{
+// 		ok: func(s string) {
+// 			l.Lock()
+// 			defer l.Unlock()
+// 			*last = StatusOK
+// 		},
+// 		degraded: func(s string) {
+// 			l.Lock()
+// 			defer l.Unlock()
+// 			*last = StatusDegraded
+// 		},
+// 		stopped: func(s string) {
+// 			l.Lock()
+// 			defer l.Unlock()
+// 			*last = StatusStopped
+// 		},
+// 	}
 
-func createRoot(hr statusNodeReporter) (Scope, func()) {
-	s := rootScope(cell.FullModuleID{"root.foo"}, hr)
-	s.start()
-	return s, func() {
-		flushAndClose(s, "test is done")
-	}
-}
+// 	assertOK := func() {
+// 		assert.Eventually(func() bool {
+// 			l.Lock()
+// 			defer l.Unlock()
+// 			return *last == StatusOK
+// 		}, time.Second*5, time.Millisecond*10)
+// 	}
+// 	assertDegraded := func() {
+// 		assert.Eventually(func() bool {
+// 			l.Lock()
+// 			defer l.Unlock()
+// 			return *last == StatusDegraded
+// 		}, time.Second*5, time.Millisecond*10)
+// 	}
+// 	assertUnknown := func() {
+// 		assert.Eventually(func() bool {
+// 			l.Lock()
+// 			defer l.Unlock()
+// 			return *last == StatusUnknown
+// 		}, time.Second*5, time.Millisecond*10)
+// 	}
+// 	return hr, assertOK, assertDegraded, assertUnknown
+// }
 
-func createMockReporter(assert *assert.Assertions) (*mockReporter, func(), func(), func()) {
+// func TestCloseEmpty(t *testing.T) {
+// 	hr, _, _, assertUnknown := createMockReporter(assert.New(t))
+// 	_, done := createRoot(hr)
+// 	defer done()
+// 	assertUnknown()
+// }
 
-	l := new(lock.Mutex)
-	last := new(Level)
-	*last = StatusUnknown
-	hr := &mockReporter{
-		ok: func(s string) {
-			l.Lock()
-			defer l.Unlock()
-			*last = StatusOK
-		},
-		degraded: func(s string) {
-			l.Lock()
-			defer l.Unlock()
-			*last = StatusDegraded
-		},
-		stopped: func(s string) {
-			l.Lock()
-			defer l.Unlock()
-			*last = StatusStopped
-		},
-	}
+// func TestReporterV2(t *testing.T) {
+// 	hr, assertOk, assertDegraded, _ := createMockReporter(assert.New(t))
+// 	s, done := createRoot(hr)
+// 	defer done()
 
-	assertOK := func() {
-		assert.Eventually(func() bool {
-			l.Lock()
-			defer l.Unlock()
-			return *last == StatusOK
-		}, time.Second*5, time.Millisecond*10)
-	}
-	assertDegraded := func() {
-		assert.Eventually(func() bool {
-			l.Lock()
-			defer l.Unlock()
-			return *last == StatusDegraded
-		}, time.Second*5, time.Millisecond*10)
-	}
-	assertUnknown := func() {
-		assert.Eventually(func() bool {
-			l.Lock()
-			defer l.Unlock()
-			return *last == StatusUnknown
-		}, time.Second*5, time.Millisecond*10)
-	}
-	return hr, assertOK, assertDegraded, assertUnknown
-}
+// 	hs := GetSubScope(s, "test_scope")
+// 	hs2 := GetSubScope(s, "test_scope2")
+// 	GetHealthReporter(hs2, "foo").OK("ok")
+// 	GetHealthReporter(hs, "test").OK("ok")
+// 	GetHealthReporter(hs, "test").OK("ok")
+// 	assertOk()
+// 	GetHealthReporter(hs, "test").Degraded("oops", nil)
+// 	assertDegraded()
+// }
 
-func TestCloseEmpty(t *testing.T) {
-	hr, _, _, assertUnknown := createMockReporter(assert.New(t))
-	_, done := createRoot(hr)
-	defer done()
-	assertUnknown()
-}
+// func TestSubreporter(t *testing.T) {
+// 	hr, assertOK, assertDegraded, _ := createMockReporter(assert.New(t))
+// 	s, done := createRoot(hr)
+// 	defer done()
 
-func TestReporterV2(t *testing.T) {
-	hr, assertOk, assertDegraded, _ := createMockReporter(assert.New(t))
-	s, done := createRoot(hr)
-	defer done()
+// 	fooScope := GetSubScope(s, "foo")
+// 	GetHealthReporter(fooScope, "1").OK("ok")
+// 	GetHealthReporter(fooScope, "2").OK("ok")
+// 	GetHealthReporter(fooScope, "3").OK("ok")
+// 	assertOK()
+// 	GetHealthReporter(fooScope, "1").Degraded("oops", nil)
+// 	assertDegraded()
+// 	GetHealthReporter(fooScope, "1").Stopped("")
+// 	assertOK()
 
-	hs := GetSubScope(s, "test_scope")
-	hs2 := GetSubScope(s, "test_scope2")
-	GetHealthReporter(hs2, "foo").OK("ok")
-	GetHealthReporter(hs, "test").OK("ok")
-	GetHealthReporter(hs, "test").OK("ok")
-	assertOk()
-	GetHealthReporter(hs, "test").Degraded("oops", nil)
-	assertDegraded()
-}
+// 	foo2Scope := GetSubScope(s, "foo2")
+// 	GetHealthReporter(foo2Scope, "1").OK("ok")
+// 	assertOK()
+// 	barScope := GetSubScope(s, "bar")
+// 	GetHealthReporter(barScope, "1").Degraded("boom", nil)
+// 	assertDegraded()
+// 	GetHealthReporter(barScope, "1").Stopped("")
+// 	assertOK()
+// }
 
-func TestSubreporter(t *testing.T) {
-	hr, assertOK, assertDegraded, _ := createMockReporter(assert.New(t))
-	s, done := createRoot(hr)
-	defer done()
+// func TestStructuredReporterCancel(t *testing.T) {
+// 	hr, assertOK, assertDegraded, _ := createMockReporter(assert.New(t))
+// 	s, done := createRoot(hr)
+// 	defer done()
 
-	fooScope := GetSubScope(s, "foo")
-	GetHealthReporter(fooScope, "1").OK("ok")
-	GetHealthReporter(fooScope, "2").OK("ok")
-	GetHealthReporter(fooScope, "3").OK("ok")
-	assertOK()
-	GetHealthReporter(fooScope, "1").Degraded("oops", nil)
-	assertDegraded()
-	GetHealthReporter(fooScope, "1").Stopped("")
-	assertOK()
+// 	epmScope := GetSubScope(s, "endpoint-manager")
+// 	ep000Scope := GetSubScope(epmScope, "endpoint-000")
+// 	GetHealthReporter(ep000Scope, "k8s-sync").Degraded("nooo", nil)
+// 	GetHealthReporter(ep000Scope, "k8s-sync2").OK("nooo")
+// 	assertDegraded()
+// 	GetHealthReporter(ep000Scope, "k8s-sync").Stopped("no more")
+// 	assertOK()
+// }
 
-	foo2Scope := GetSubScope(s, "foo2")
-	GetHealthReporter(foo2Scope, "1").OK("ok")
-	assertOK()
-	barScope := GetSubScope(s, "bar")
-	GetHealthReporter(barScope, "1").Degraded("boom", nil)
-	assertDegraded()
-	GetHealthReporter(barScope, "1").Stopped("")
-	assertOK()
-}
+// func TestWithBaseReporter(t *testing.T) {
+// 	hr, assertOK, assertDegraded, _ := createMockReporter(assert.New(t))
+// 	s, done := createRoot(hr)
+// 	defer done()
+// 	GetHealthReporter(s, "test").OK("")
+// 	assertOK()
+// 	GetHealthReporter(s, "test").Degraded("", nil)
+// 	assertDegraded()
+// }
 
-func TestStructuredReporterCancel(t *testing.T) {
-	hr, assertOK, assertDegraded, _ := createMockReporter(assert.New(t))
-	s, done := createRoot(hr)
-	defer done()
+// func TestStopped(t *testing.T) {
+// 	hr, assertOK, assertDegraded, _ := createMockReporter(assert.New(t))
+// 	var s Scope
+// 	s, done := createRoot(hr)
+// 	defer done()
+// 	s = GetSubScope(s, "foo")
+// 	GetHealthReporter(s, "test").Degraded("", nil)
+// 	assertDegraded()
+// 	GetHealthReporter(s, "test").Stopped("")
+// 	assertOK()
+// }
 
-	epmScope := GetSubScope(s, "endpoint-manager")
-	ep000Scope := GetSubScope(epmScope, "endpoint-000")
-	GetHealthReporter(ep000Scope, "k8s-sync").Degraded("nooo", nil)
-	GetHealthReporter(ep000Scope, "k8s-sync2").OK("nooo")
-	assertDegraded()
-	GetHealthReporter(ep000Scope, "k8s-sync").Stopped("no more")
-	assertOK()
-}
+// // This test validates that:
+// //  1. A scope that is orphaned and then garbage collected, that satisifies the
+// //     constraint that it or none of its children are referenced, is removed.
+// func TestUnreferencedScope(t *testing.T) {
+// 	assert := assert.New(t)
+// 	hr, assertOK, _, assertUnknown := createMockReporter(assert)
+// 	r, done := createRoot(hr)
+// 	defer done()
 
-func TestWithBaseReporter(t *testing.T) {
-	hr, assertOK, assertDegraded, _ := createMockReporter(assert.New(t))
-	s, done := createRoot(hr)
-	defer done()
-	GetHealthReporter(s, "test").OK("")
-	assertOK()
-	GetHealthReporter(s, "test").Degraded("", nil)
-	assertDegraded()
-}
+// 	// Create two orphaned scopes, one is a child of the other.
+// 	func() {
+// 		type closureScope struct {
+// 			s Scope
+// 		}
+// 		c := &closureScope{s: GetSubScope(GetSubScope(r, "orphan0"), "orphan1")}
+// 		// This temporarily prevents the scope from being garbage collected so
+// 		// we can validate the base reporter graph.
+// 		runtime.SetFinalizer(c, func(s *closureScope) {})
+// 		defer runtime.SetFinalizer(c, nil)
+// 		assertUnknown()
+// 		r.scope().base.Lock()
+// 		assert.Equal(1, r.scope().base.nodes["2-orphan0"].refs, "should have one ref")
+// 		assert.Equal(1, r.scope().base.nodes["3-orphan1"].refs, "should have one ref")
+// 		r.scope().base.Unlock()
+// 	}()
 
-func TestStopped(t *testing.T) {
-	hr, assertOK, assertDegraded, _ := createMockReporter(assert.New(t))
-	var s Scope
-	s, done := createRoot(hr)
-	defer done()
-	s = GetSubScope(s, "foo")
-	GetHealthReporter(s, "test").Degraded("", nil)
-	assertDegraded()
-	GetHealthReporter(s, "test").Stopped("")
-	assertOK()
-}
+// 	// Create referenced scope.
+// 	s2 := GetSubScope(r, "foo2")
+// 	assertUnknown()
+// 	r.scope().base.Lock()
+// 	assert.Equal(1, r.scope().base.nodes["4-foo2"].refs, "should have one ref")
+// 	r.scope().base.Unlock()
 
-// This test validates that:
-//  1. A scope that is orphaned and then garbage collected, that satisifies the
-//     constraint that it or none of its children are referenced, is removed.
-func TestUnreferencedScope(t *testing.T) {
-	assert := assert.New(t)
-	hr, assertOK, _, assertUnknown := createMockReporter(assert)
-	r, done := createRoot(hr)
-	defer done()
+// 	// Create unreferenced scope, with unreferenced child, but with a reporter
+// 	// leaf.
+// 	GetHealthReporter(GetSubScope(GetSubScope(r, "orphan2"), "orphan3"), "bar").OK("")
+// 	r.scope().base.Lock()
+// 	assert.Contains(r.scope().base.nodes, "5-orphan2")
+// 	assert.Contains(r.scope().base.nodes, "6-orphan3")
+// 	r.scope().base.Unlock()
 
-	// Create two orphaned scopes, one is a child of the other.
-	func() {
-		type closureScope struct {
-			s Scope
-		}
-		c := &closureScope{s: GetSubScope(GetSubScope(r, "orphan0"), "orphan1")}
-		// This temporarily prevents the scope from being garbage collected so
-		// we can validate the base reporter graph.
-		runtime.SetFinalizer(c, func(s *closureScope) {})
-		defer runtime.SetFinalizer(c, nil)
-		assertUnknown()
-		r.scope().base.Lock()
-		assert.Equal(1, r.scope().base.nodes["2-orphan0"].refs, "should have one ref")
-		assert.Equal(1, r.scope().base.nodes["3-orphan1"].refs, "should have one ref")
-		r.scope().base.Unlock()
-	}()
+// 	// Force GC.
+// 	runtime.GC()
 
-	// Create referenced scope.
-	s2 := GetSubScope(r, "foo2")
-	assertUnknown()
-	r.scope().base.Lock()
-	assert.Equal(1, r.scope().base.nodes["4-foo2"].refs, "should have one ref")
-	r.scope().base.Unlock()
+// 	r.scope().base.Lock()
+// 	assert.NotContains(r.scope().base.nodes, "2-this-one-should-be-gone", "should have been removed")
+// 	assert.Contains(r.scope().base.nodes, "4-foo2", "")
 
-	// Create unreferenced scope, with unreferenced child, but with a reporter
-	// leaf.
-	GetHealthReporter(GetSubScope(GetSubScope(r, "orphan2"), "orphan3"), "bar").OK("")
-	r.scope().base.Lock()
-	assert.Contains(r.scope().base.nodes, "5-orphan2")
-	assert.Contains(r.scope().base.nodes, "6-orphan3")
-	r.scope().base.Unlock()
+// 	assert.Contains(r.scope().base.nodes, "5-orphan2")
+// 	assert.Contains(r.scope().base.nodes, "6-orphan3")
+// 	r.scope().base.Unlock()
 
-	// Force GC.
-	runtime.GC()
+// 	GetHealthReporter(s2, "bar").OK("")
+// 	assertOK()
+// }
 
-	r.scope().base.Lock()
-	assert.NotContains(r.scope().base.nodes, "2-this-one-should-be-gone", "should have been removed")
-	assert.Contains(r.scope().base.nodes, "4-foo2", "")
+// func TestDuplicateReporters(t *testing.T) {
+// 	assert := assert.New(t)
+// 	hr, assertOK, _, _ := createMockReporter(assert)
+// 	s, done := createRoot(hr)
+// 	defer done()
 
-	assert.Contains(r.scope().base.nodes, "5-orphan2")
-	assert.Contains(r.scope().base.nodes, "6-orphan3")
-	r.scope().base.Unlock()
+// 	fooScope := GetSubScope(s, "foo")
+// 	for i := 0; i < 10; i++ {
+// 		GetHealthReporter(fooScope, "test").OK("")
+// 	}
+// 	assertOK()
+// 	base := fooScope.(*scope).base
+// 	assert.Len(base.nodes, 3, "should have root, foo and just one test")
+// 	assert.Len(base.idToChildren[base.rootID], 1, "root should have only one (foo)")
+// 	GetHealthReporter(fooScope, "test2").OK("")
+// 	assert.Len(base.nodes, 4, "should have root, foo, test, test2")
+// }
 
-	GetHealthReporter(s2, "bar").OK("")
-	assertOK()
-}
+// func BenchmarkStructuredReporter(b *testing.B) {
+// 	wg := &sync.WaitGroup{}
+// 	hr, _, _, _ := createMockReporter(nil)
+// 	s, done := createRoot(hr)
+// 	defer done()
+// 	ctx, cancel := context.WithCancel(context.Background())
+// 	// 10^6 reporters
+// 	recurse(ctx, 4, 10, s, wg)
+// 	wg.Wait()
+// 	cancel()
+// }
 
-func TestDuplicateReporters(t *testing.T) {
-	assert := assert.New(t)
-	hr, assertOK, _, _ := createMockReporter(assert)
-	s, done := createRoot(hr)
-	defer done()
+// var count atomic.Uint32
 
-	fooScope := GetSubScope(s, "foo")
-	for i := 0; i < 10; i++ {
-		GetHealthReporter(fooScope, "test").OK("")
-	}
-	assertOK()
-	base := fooScope.(*scope).base
-	assert.Len(base.nodes, 3, "should have root, foo and just one test")
-	assert.Len(base.idToChildren[base.rootID], 1, "root should have only one (foo)")
-	GetHealthReporter(fooScope, "test2").OK("")
-	assert.Len(base.nodes, 4, "should have root, foo, test, test2")
-}
+// func recurse(ctx context.Context, d, factor int, s Scope, wg *sync.WaitGroup) {
+// 	type frame struct {
+// 		d, factor int
+// 		s         Scope
+// 	}
+// 	stack := []frame{
+// 		{
+// 			d:      d,
+// 			factor: factor,
+// 			s:      s,
+// 		},
+// 	}
+// 	for len(stack) != 0 {
+// 		s := stack[len(stack)-1]
+// 		stack = stack[:len(stack)-1]
+// 		if s.d == 0 {
+// 			wg.Add(1)
+// 			go func() {
+// 				defer func() {
+// 					wg.Done()
+// 				}()
+// 				hr := GetHealthReporter(s.s, "foo")
+// 				fmt.Println("Starting:", count.Add(1))
+// 				for i := 0; i < 100; i++ {
+// 					select {
+// 					case <-ctx.Done():
+// 						return
+// 					default:
+// 						hr.OK("yay")
+// 					}
+// 				}
+// 			}()
+// 			continue
+// 		} else {
+// 			for i := 0; i < s.factor; i++ {
+// 				stack = append(stack, frame{
+// 					d:      s.d - 1,
+// 					factor: s.factor,
+// 					s:      s.s,
+// 				})
+// 			}
+// 		}
+// 	}
+// }
 
-func BenchmarkStructuredReporter(b *testing.B) {
-	wg := &sync.WaitGroup{}
-	hr, _, _, _ := createMockReporter(nil)
-	s, done := createRoot(hr)
-	defer done()
-	ctx, cancel := context.WithCancel(context.Background())
-	// 10^6 reporters
-	recurse(ctx, 4, 10, s, wg)
-	wg.Wait()
-	cancel()
-}
+// type mockReporter struct {
+// 	ok, degraded, stopped func(string)
+// }
 
-var count atomic.Uint32
-
-func recurse(ctx context.Context, d, factor int, s Scope, wg *sync.WaitGroup) {
-	type frame struct {
-		d, factor int
-		s         Scope
-	}
-	stack := []frame{
-		{
-			d:      d,
-			factor: factor,
-			s:      s,
-		},
-	}
-	for len(stack) != 0 {
-		s := stack[len(stack)-1]
-		stack = stack[:len(stack)-1]
-		if s.d == 0 {
-			wg.Add(1)
-			go func() {
-				defer func() {
-					wg.Done()
-				}()
-				hr := GetHealthReporter(s.s, "foo")
-				fmt.Println("Starting:", count.Add(1))
-				for i := 0; i < 100; i++ {
-					select {
-					case <-ctx.Done():
-						return
-					default:
-						hr.OK("yay")
-					}
-				}
-			}()
-			continue
-		} else {
-			for i := 0; i < s.factor; i++ {
-				stack = append(stack, frame{
-					d:      s.d - 1,
-					factor: s.factor,
-					s:      s.s,
-				})
-			}
-		}
-	}
-}
-
-type mockReporter struct {
-	ok, degraded, stopped func(string)
-}
-
-func (s *mockReporter) setStatus(n Update) {
-	switch n.Level() {
-	case StatusOK:
-		s.ok(n.String())
-	case StatusDegraded:
-		s.degraded(n.String())
-	case StatusStopped:
-		s.stopped(n.String())
-	}
-}
+// func (s *mockReporter) setStatus(n Update) {
+// 	switch n.Level() {
+// 	case StatusOK:
+// 		s.ok(n.String())
+// 	case StatusDegraded:
+// 		s.degraded(n.String())
+// 	case StatusStopped:
+// 		s.stopped(n.String())
+// 	}
+// }

--- a/pkg/vitals/health/structured_test.go
+++ b/pkg/vitals/health/structured_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package cell
+package health
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/lock"
 )
 
@@ -22,7 +23,7 @@ func init() {
 }
 
 func createRoot(hr statusNodeReporter) (Scope, func()) {
-	s := rootScope(FullModuleID{"root.foo"}, hr)
+	s := rootScope(cell.FullModuleID{"root.foo"}, hr)
 	s.start()
 	return s, func() {
 		flushAndClose(s, "test is done")


### PR DESCRIPTION
Building on the current implementation, this re-implements the modular health reporting using statedb, as well as re-imagining the data model for storing health data:
* Global Statedb means we can safely manage health state at the "Provider" level, this massively simplifies the implementation of the reporter instrumentation implementation and makes health much more flexible in terms of querying and iterating on health status data models.
    * Statedb also means we can leverage existing statedb APIs for working with data (i.e `cilium statedb dump health-status`).
    * Paths from root to Health Reporters encode unique identifiers for reporters/reportingScopes, which work well with how StateDB uses radix trees for storing/querying data.  Adds Prefix querying functionality to Statedb to allow us to manage modules/reporters/scopes. 
* Seeks to move Provider implementation out of `pkg/hive/cell` and reduce dependencies on health component implementations.
* Add "Functionality" based grouping, with the goal being to make ~modular~ Health be more targetted towards reporting on Cilium functionality status, rather than internal Hive modules (which on their own, are just implementation details).

Example output:

```
ModuleID                                                              ComponentID                                                                                             Level   Message                             Feature
agent.datapath.node-address.node-address                              job-node-address-update                                                                                 OK      Running
agent.controlplane.bgp-cp.bgp-cp                                      job-diffstore-events                                                                                    OK      Running
agent.controlplane.auth.auth                                          observer-job-auth request-authentication                                                                OK      Primed
agent.controlplane.node-manager.node-manager                          nodes-add                                                                                               OK      Node adds successful
agent.datapath.l2-responder.l2-responder                              job-l2-responder-reconciler                                                                             OK      Running
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-768 (cilium-test/client2-88575dbb7-pdbqw).policymap-sync                                OK      sync-policymap-768
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-1562 (cilium-test/client-75bff5f5b9-gq8zs).policymap-sync                               OK      sync-policymap-1562
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-1151 (cilium-test/echo-same-node-769767965f-tw67c).policymap-sync                       OK      sync-policymap-1151
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-1151 (cilium-test/echo-same-node-769767965f-tw67c).datapath-regenerate                  OK      Endpoint regeneration successful
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-768 (cilium-test/client2-88575dbb7-pdbqw).datapath-regenerate                           OK      Endpoint regeneration successful
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-1562 (cilium-test/client-75bff5f5b9-gq8zs).datapath-regenerate                          OK      Endpoint regeneration successful
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-1562 (cilium-test/client-75bff5f5b9-gq8zs).cep-k8s-sync                                 OK      sync-to-k8s-ciliumendpoint (1562)
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-768 (cilium-test/client2-88575dbb7-pdbqw).cep-k8s-sync                                  OK      sync-to-k8s-ciliumendpoint (768)
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-1151 (cilium-test/echo-same-node-769767965f-tw67c).cep-k8s-sync                         OK      sync-to-k8s-ciliumendpoint (1151)
agent.controlplane.auth.auth                                          observer-job-auth gc-identity-events                                                                    OK      OK (547.256µs) [9]
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-1980 (local-path-storage/local-path-provisioner-6bc4bddd6b-z9mh8).datapath-regenerate   OK      Endpoint regeneration successful
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-521 (kube-system/coredns-5d78c9869d-j4gvm).datapath-regenerate                          OK      Endpoint regeneration successful
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-3112 (kube-system/coredns-5d78c9869d-xjqgz).datapath-regenerate                         OK      Endpoint regeneration successful
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-1539 (/).datapath-regenerate                                                            OK      Endpoint regeneration successful
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-337 (/).datapath-regenerate                                                             OK      Endpoint regeneration successful
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-337 (/).policymap-sync                                                                  OK      sync-policymap-337
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-1980 (local-path-storage/local-path-provisioner-6bc4bddd6b-z9mh8).policymap-sync        OK      sync-policymap-1980
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-1539 (/).policymap-sync                                                                 OK      sync-policymap-1539
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-521 (kube-system/coredns-5d78c9869d-j4gvm).policymap-sync                               OK      sync-policymap-521
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-3112 (kube-system/coredns-5d78c9869d-xjqgz).policymap-sync                              OK      sync-policymap-3112
agent.controlplane.auth.auth                                          timer-job-auth gc-cleanup                                                                               OK      OK (42.741µs)
agent.controlplane.endpoint-manager.endpoint-manager                  endpoint-gc                                                                                             OK      endpoint-gc
agent.controlplane.envoy-proxy.envoy-proxy                            timer-job-version-check                                                                                 OK      OK (20.092757ms)
agent.controlplane.node-manager.node-manager                          background-sync                                                                                         OK      Node validation successful
agent.controlplane.daemon.ep-bpf-prog-watchdog.ep-bpf-prog-watchdog   ep-bpf-prog-watchdog                                                                                    OK      ep-bpf-prog-watchdog
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-521 (kube-system/coredns-5d78c9869d-j4gvm).cep-k8s-sync                                 OK      sync-to-k8s-ciliumendpoint (521)
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-3112 (kube-system/coredns-5d78c9869d-xjqgz).cep-k8s-sync                                OK      sync-to-k8s-ciliumendpoint (3112)
agent.controlplane.endpoint-manager.endpoint-manager                  cilium-endpoint-1980 (local-path-storage/local-path-provisioner-6bc4bddd6b-z9mh8).cep-k8s-sync          OK      sync-to-k8s-ciliumendpoint (1980)
agent.datapath.agent-liveness-updater.agent-liveness-updater          timer-job-agent-liveness-updater                                                                        OK      OK (35.191µs)
```