### PR TITLE
Periodically sync ENI limits using EC2 API to update newly launched AWS instance info.

### DIFF
--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -8,8 +8,11 @@ package eni
 import (
 	"context"
 
+	ec2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/sirupsen/logrus"
 
+	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/pkg/aws/eni/limits"
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/aws/types"
 	"github.com/cilium/cilium/pkg/ipam"
@@ -35,6 +38,7 @@ type EC2API interface {
 	UnassignPrivateIpAddresses(ctx context.Context, eniID string, addresses []string) error
 	AssignENIPrefixes(ctx context.Context, eniID string, prefixes int32) error
 	UnassignENIPrefixes(ctx context.Context, eniID string, prefixes []string) error
+	GetInstanceTypes(context.Context) ([]ec2_types.InstanceTypeInfo, error)
 }
 
 // InstancesManager maintains the list of instances. It must be kept up to date
@@ -241,6 +245,13 @@ func (m *InstancesManager) resync(ctx context.Context, instanceID string) time.T
 	m.subnets = subnets
 	m.vpcs = vpcs
 	m.securityGroups = securityGroups
+
+	if operatorOption.Config.UpdateEC2AdapterLimitViaAPI {
+		if err := limits.UpdateFromEC2API(ctx, m.api); err != nil {
+			log.WithError(err).Warning("Unable to update instance type to adapter limits from EC2 API")
+			return time.Time{}
+		}
+	}
 
 	return resyncStart
 }

--- a/pkg/aws/eni/limits/limits.go
+++ b/pkg/aws/eni/limits/limits.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
-	ec2shim "github.com/cilium/cilium/pkg/aws/ec2"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/lock"
 )
@@ -832,10 +832,14 @@ func UpdateFromUserDefinedMappings(m map[string]string) (err error) {
 	return nil
 }
 
+type ec2API interface {
+	GetInstanceTypes(context.Context) ([]ec2_types.InstanceTypeInfo, error)
+}
+
 // UpdateFromEC2API updates limits from the EC2 API via calling
 // https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypes.html.
-func UpdateFromEC2API(ctx context.Context, ec2Client *ec2shim.Client) error {
-	instanceTypeInfos, err := ec2Client.GetInstanceTypes(ctx)
+func UpdateFromEC2API(ctx context.Context, api ec2API) error {
+	instanceTypeInfos, err := api.GetInstanceTypes(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

I'm periodically calling `GetInstanceTypes` EC2 API call to keep updating ENI limits. I think this is overkill (since AWS might be launched only a few new instances per year). But I think it is ok as there are only hundreds of AWS instances and shouldn't impact memory/network perf.

Another alternative is to lazy fetch new instance type only when we don't find the instance type. I tried implementing this approach but it required a lot of refactoring. 

Fixes: #28424 

```release-note
Fix an issue where cilium is unable to allocate IP addresses when it is running on newly launched AWS instances
```
