### PR TITLE
[v1.13] bpf: l3: fix-up kube-proxy workaround in l3_local_delivery() to bpf_overlay

### DIFF
--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -175,7 +175,7 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 	ctx->mark |= MARK_MAGIC_IDENTITY;
 	set_identity_mark(ctx, seclabel);
 
-# if defined(TUNNEL_MODE) && !defined(ENABLE_NODEPORT)
+# if defined(IS_BPF_OVERLAY) && !defined(ENABLE_NODEPORT)
 	/* In tunneling mode, we execute this code to send the packet from
 	 * cilium_vxlan to lxc*. If we're using kube-proxy, we don't want to use
 	 * redirect() because that would bypass conntrack and the reverse DNAT.
@@ -187,7 +187,7 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 	return CTX_ACT_OK;
 # else
 	return redirect_ep(ctx, ep->ifindex, from_host);
-# endif /* !ENABLE_ROUTING && TUNNEL_MODE && !ENABLE_NODEPORT */
+# endif /* IS_BPF_OVERLAY && !ENABLE_NODEPORT */
 #else
 	/* Jumps to destination pod's BPF program to enforce ingress policies. */
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);


### PR DESCRIPTION
When backporting
334f7f0456b5 ("bpf: l3: limit kube-proxy workaround in l3_local_delivery() to bpf_overlay"), I missed that v1.13 still has separate paths for IPv4 and IPv6.

The backport only changed ipv6_local_delivery(), so we still need to fix up ipv4_local_delivery().

Fixes: f67260a842eb ("bpf: l3: limit kube-proxy workaround in l3_local_delivery() to bpf_overlay")