### PR TITLE
Reconcile iptables rules in case of runtime device updates

### DIFF
--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -6,6 +6,7 @@ package fake
 import (
 	"context"
 	"io"
+	"net/netip"
 
 	"github.com/vishvananda/netlink"
 
@@ -84,28 +85,21 @@ func (f *FakeDatapath) WriteEndpointConfig(io.Writer, datapath.EndpointConfigura
 	return nil
 }
 
-func (f *FakeDatapath) InstallProxyRules(context.Context, uint16, bool, bool, string) error {
-	return nil
+func (f *FakeDatapath) InstallProxyRules(uint16, bool, bool, string) {
 }
 
 func (f *FakeDatapath) SupportsOriginalSourceAddr() bool {
 	return false
 }
 
-func (f *FakeDatapath) InstallRules(ctx context.Context, ifName string, quiet, install bool) error {
-	return nil
-}
-
 func (m *FakeDatapath) GetProxyPort(name string) uint16 {
 	return 0
 }
 
-func (m *FakeDatapath) InstallNoTrackRules(IP string, port uint16, ipv6 bool) error {
-	return nil
+func (m *FakeDatapath) InstallNoTrackRules(ip netip.Addr, port uint16) {
 }
 
-func (m *FakeDatapath) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error {
-	return nil
+func (m *FakeDatapath) RemoveNoTrackRules(ip netip.Addr, port uint16) {
 }
 
 func (f *FakeDatapath) Loader() datapath.Loader {

--- a/pkg/datapath/iptables/cell.go
+++ b/pkg/datapath/iptables/cell.go
@@ -26,6 +26,7 @@ var Cell = cell.Module(
 			IptablesMasqueradingIPv4Enabled: cfg.IptablesMasqueradingIPv4Enabled(),
 			IptablesMasqueradingIPv6Enabled: cfg.IptablesMasqueradingIPv6Enabled(),
 			IPv4NativeRoutingCIDR:           cfg.GetIPv4NativeRoutingCIDR(),
+			IPv6NativeRoutingCIDR:           cfg.GetIPv6NativeRoutingCIDR(),
 
 			EnableIPv4:                  cfg.EnableIPv4,
 			EnableIPv6:                  cfg.EnableIPv6,
@@ -38,6 +39,7 @@ var Cell = cell.Module(
 			MasqueradeInterfaces:        cfg.MasqueradeInterfaces,
 			EnableMasqueradeRouteSource: cfg.EnableMasqueradeRouteSource,
 			EnableL7Proxy:               cfg.EnableL7Proxy,
+			InstallIptRules:             cfg.InstallIptRules,
 		}
 	}),
 	cell.Provide(newIptablesManager),
@@ -78,6 +80,7 @@ type SharedConfig struct {
 	IptablesMasqueradingIPv4Enabled bool
 	IptablesMasqueradingIPv6Enabled bool
 	IPv4NativeRoutingCIDR           *cidr.CIDR
+	IPv6NativeRoutingCIDR           *cidr.CIDR
 
 	EnableIPv4                  bool
 	EnableIPv6                  bool
@@ -90,4 +93,5 @@ type SharedConfig struct {
 	MasqueradeInterfaces        []string
 	EnableMasqueradeRouteSource bool
 	EnableL7Proxy               bool
+	InstallIptRules             bool
 }

--- a/pkg/datapath/iptables/custom_chain.go
+++ b/pkg/datapath/iptables/custom_chain.go
@@ -94,7 +94,7 @@ var ciliumChains = []customChain{
 	},
 }
 
-func (c *customChain) exists(prog iptablesInterface) (bool, error) {
+func (c *customChain) exists(prog runnable) (bool, error) {
 	args := []string{"-t", c.table, "-S", c.name}
 
 	output, err := prog.runProgOutput(args)
@@ -121,7 +121,7 @@ func (c *customChain) exists(prog iptablesInterface) (bool, error) {
 	return true, nil
 }
 
-func (c *customChain) doAdd(prog iptablesInterface) error {
+func (c *customChain) doAdd(prog runnable) error {
 	args := []string{"-t", c.table, "-N", c.name}
 
 	output, err := prog.runProgOutput(args)
@@ -147,7 +147,7 @@ func (c *customChain) add(ipv4, ipv6 bool) error {
 	return nil
 }
 
-func (c *customChain) doRename(prog iptablesInterface, newName string) error {
+func (c *customChain) doRename(prog runnable, newName string) error {
 	if exists, err := c.exists(prog); err != nil {
 		return err
 	} else if !exists {

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1242,7 +1242,7 @@ func (m *Manager) installMasqueradeRules(
 		} else {
 			family = "inet6"
 		}
-		if err := createIpset(prog.getIpset(), family); err != nil {
+		if err := createIpset(ipset, prog.getIpset(), family); err != nil {
 			return err
 		}
 
@@ -1496,26 +1496,26 @@ func (m *Manager) installMasqueradeRules(
 	return nil
 }
 
-func createIpset(name string, family string) error {
+func createIpset(ipset runnable, name string, family string) error {
 	progArgs := []string{"create", name, "iphash", "family", family, "-exist"}
 	return ipset.runProg(progArgs)
 }
 
-func removeIpset(name string) error {
-	if !ipsetExists(name) {
+func removeIpset(ipset runnable, name string) error {
+	if !ipsetExists(ipset, name) {
 		return nil
 	}
 	progArgs := []string{"destroy", name}
 	return ipset.runProg(progArgs)
 }
 
-func ipsetExists(name string) bool {
+func ipsetExists(ipset runnable, name string) bool {
 	progArgs := []string{"list", name}
 	err := ipset.runProg(progArgs)
 	return err == nil
 }
 
-func ipsetList(name string) (sets.Set[netip.Addr], error) {
+func ipsetList(ipset runnable, name string) (sets.Set[netip.Addr], error) {
 	args := []string{"list", name}
 	out, err := ipset.runProgOutput(args)
 	if err != nil {
@@ -1660,10 +1660,10 @@ func (m *Manager) reconcileIPSets(ipv4Set, ipv6Set sets.Set[netip.Addr]) error {
 			}
 		}
 	} else {
-		if err := removeIpset(CiliumNodeIpsetV4); err != nil {
+		if err := removeIpset(ipset, CiliumNodeIpsetV4); err != nil {
 			return err
 		}
-		if err := removeIpset(CiliumNodeIpsetV6); err != nil {
+		if err := removeIpset(ipset, CiliumNodeIpsetV6); err != nil {
 			return err
 		}
 	}
@@ -1671,11 +1671,11 @@ func (m *Manager) reconcileIPSets(ipv4Set, ipv6Set sets.Set[netip.Addr]) error {
 }
 
 func reconcileIPSet(name, family string, set sets.Set[netip.Addr]) error {
-	if err := createIpset(name, family); err != nil {
+	if err := createIpset(ipset, name, family); err != nil {
 		return fmt.Errorf("failed to create ipset %s: %w", name, err)
 	}
 
-	curSet, err := ipsetList(name)
+	curSet, err := ipsetList(ipset, name)
 	if err != nil {
 		return fmt.Errorf("failed to list ips in ipset %s: %w", name, err)
 	}

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-
-	"github.com/blang/semver/v4"
 )
 
 type expectation struct {
@@ -31,10 +29,6 @@ func (ipt *mockIptables) getProg() string {
 
 func (ipt *mockIptables) getIpset() string {
 	return ipt.ipset
-}
-
-func (ipt *mockIptables) getVersion() (semver.Version, error) {
-	return semver.Version{}, nil
 }
 
 func (ipt *mockIptables) runProgOutput(args []string) (out string, err error) {

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -9,16 +9,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
-	check "github.com/cilium/checkmate"
 )
-
-func Test(t *testing.T) {
-	check.TestingT(t)
-}
-
-type iptablesTestSuite struct{}
-
-var _ = check.Suite(&iptablesTestSuite{})
 
 type expectation struct {
 	args string
@@ -27,7 +18,7 @@ type expectation struct {
 }
 
 type mockIptables struct {
-	c            *check.C
+	t            *testing.T
 	prog         string
 	ipset        string
 	expectations []expectation
@@ -52,11 +43,11 @@ func (ipt *mockIptables) runProgOutput(args []string) (out string, err error) {
 	ipt.index++
 
 	if len(ipt.expectations) < ipt.index {
-		ipt.c.Errorf("%d: Unexpected %s %s", i, ipt.prog, a)
+		ipt.t.Errorf("%d: Unexpected %s %s", i, ipt.prog, a)
 		return "", fmt.Errorf("Unexpected %s %s", ipt.prog, a)
 	}
 	if a != ipt.expectations[i].args {
-		ipt.c.Errorf("%d: Unexpected %s (%q != %q)", i, ipt.prog, a, ipt.expectations[i].args)
+		ipt.t.Errorf("%d: Unexpected %s (%q != %q)", i, ipt.prog, a, ipt.expectations[i].args)
 		return "", fmt.Errorf("Unexpected %s %s", ipt.prog, a)
 	}
 	out = string(ipt.expectations[i].out)
@@ -68,7 +59,7 @@ func (ipt *mockIptables) runProgOutput(args []string) (out string, err error) {
 func (ipt *mockIptables) runProg(args []string) error {
 	out, err := ipt.runProgOutput(args)
 	if len(out) > 0 {
-		ipt.c.Errorf("%d: Unexpected output for %s %s", ipt.index-1, ipt.prog, strings.Join(args, " "))
+		ipt.t.Errorf("%d: Unexpected output for %s %s", ipt.index-1, ipt.prog, strings.Join(args, " "))
 	}
 	return err
 }
@@ -95,8 +86,8 @@ var mockManager = &Manager{
 	},
 }
 
-func (s *iptablesTestSuite) TestRenameCustomChain(c *check.C) {
-	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+func TestRenameCustomChain(t *testing.T) {
+	mockIp4tables := &mockIptables{t: t, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
 		{
 			args: "-t mangle -S CILIUM_PRE_mangle",
@@ -111,17 +102,21 @@ func (s *iptablesTestSuite) TestRenameCustomChain(c *check.C) {
 	}
 	chain.doRename(mockIp4tables, "OLD_CILIUM_PRE_mangle")
 	err := mockIp4tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+	mockIp6tables := &mockIptables{t: t, prog: "ip6tables"}
 	mockIp6tables.expectations = mockIp4tables.expectations
 	chain.doRename(mockIp6tables, "OLD_CILIUM_PRE_mangle")
 	err = mockIp6tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
-func (s *iptablesTestSuite) TestCopyProxyRulesv4(c *check.C) {
-	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+func TestCopyProxyRulesv4(t *testing.T) {
+	mockIp4tables := &mockIptables{t: t, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
 		{
 			args: "-t mangle -S",
@@ -152,11 +147,13 @@ func (s *iptablesTestSuite) TestCopyProxyRulesv4(c *check.C) {
 	// Copies DNS proxy rules from OLD_CILIUM_PRE_mangle to CILIUM_PRE_mangle
 	mockManager.doCopyProxyRules(mockIp4tables, "mangle", tproxyMatch, "cilium-dns-egress", "OLD_"+ciliumPreMangleChain, ciliumPreMangleChain)
 	err := mockIp4tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
-func (s *iptablesTestSuite) TestCopyProxyRulesv6(c *check.C) {
-	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+func TestCopyProxyRulesv6(t *testing.T) {
+	mockIp6tables := &mockIptables{t: t, prog: "ip6tables"}
 	mockIp6tables.expectations = []expectation{
 		{
 			args: "-t mangle -S",
@@ -187,11 +184,13 @@ func (s *iptablesTestSuite) TestCopyProxyRulesv6(c *check.C) {
 	// Copies DNS proxy rules from OLD_CILIUM_PRE_mangle to CILIUM_PRE_mangle
 	mockManager.doCopyProxyRules(mockIp6tables, "mangle", tproxyMatch, "cilium-dns-egress", "OLD_"+ciliumPreMangleChain, ciliumPreMangleChain)
 	err := mockIp6tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
-func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
-	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+func TestAddProxyRulesv4(t *testing.T) {
+	mockIp4tables := &mockIptables{t: t, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
 		{
 			args: "-t mangle -S",
@@ -225,7 +224,9 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 	// Adds new proxy rules
 	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37379, false, "cilium-dns-egress")
 	err := mockIp4tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	mockIp4tables.expectations = []expectation{
 		{
@@ -258,7 +259,9 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 	// Nothing to add
 	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37379, false, "cilium-dns-egress")
 	err = mockIp4tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	mockIp4tables.expectations = []expectation{
 		{
@@ -293,7 +296,9 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
 	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37379, false, "cilium-dns-egress")
 	err = mockIp4tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	mockIp4tables.expectations = []expectation{
 		{
@@ -334,11 +339,13 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 	// Same port number, new IP, adds new ones, deletes stale rules. Does not touch OLD_ chains
 	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37379, false, "cilium-dns-egress")
 	err = mockIp4tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
-func (s *iptablesTestSuite) TestGetProxyPort(c *check.C) {
-	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+func TestGetProxyPort(t *testing.T) {
+	mockIp4tables := &mockIptables{t: t, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
 		{
 			args: "-t mangle -n -L CILIUM_PRE_mangle",
@@ -356,8 +363,12 @@ TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd7a90
 
 	// Finds the latest port number if multiple rules for the same proxy name
 	port := mockManager.doGetProxyPort(mockIp4tables, "cilium-dns-egress")
-	c.Assert(port, check.Equals, uint16(43479))
-	c.Assert(mockIp4tables.checkExpectations(), check.IsNil)
+	if port != uint16(43479) {
+		t.Fatalf("expected port number %d, got %d", uint16(43479), port)
+	}
+	if err := mockIp4tables.checkExpectations(); err != nil {
+		t.Fatal(err)
+	}
 
 	// Now test the proxy port fetch when the proxy is not DNS. It should
 	// fallback to 0.0.0.0 instead of localhost.
@@ -377,12 +388,16 @@ TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd7a90
 	}
 
 	port = mockManager.doGetProxyPort(mockIp4tables, "cilium-random-proxy")
-	c.Assert(port, check.Equals, uint16(43479))
-	c.Assert(mockIp4tables.checkExpectations(), check.IsNil)
+	if port != uint16(43479) {
+		t.Fatalf("expected port number %d, got %d", uint16(43479), port)
+	}
+	if err := mockIp4tables.checkExpectations(); err != nil {
+		t.Fatal(err)
+	}
 }
 
-func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
-	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+func TestAddProxyRulesv6(t *testing.T) {
+	mockIp6tables := &mockIptables{t: t, prog: "ip6tables"}
 	mockIp6tables.expectations = []expectation{
 		{
 			args: "-t mangle -S",
@@ -416,7 +431,9 @@ func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
 	// Adds new proxy rules
 	mockManager.addProxyRules(mockIp6tables, "::1", 43477, false, "cilium-dns-egress")
 	err := mockIp6tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	mockIp6tables.expectations = []expectation{
 		{
@@ -449,7 +466,9 @@ func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
 	// Nothing to add
 	mockManager.addProxyRules(mockIp6tables, "::1", 43477, false, "cilium-dns-egress")
 	err = mockIp6tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	mockIp6tables.expectations = []expectation{
 		{
@@ -484,11 +503,13 @@ func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
 	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
 	mockManager.addProxyRules(mockIp6tables, "::1", 43479, false, "cilium-dns-egress")
 	err = mockIp6tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
-func (s *iptablesTestSuite) TestRemoveCiliumRulesv4(c *check.C) {
-	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+func TestRemoveCiliumRulesv4(t *testing.T) {
+	mockIp4tables := &mockIptables{t: t, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
 		{
 			args: "-t mangle -S",
@@ -531,11 +552,13 @@ func (s *iptablesTestSuite) TestRemoveCiliumRulesv4(c *check.C) {
 	// Only removes Cilium chains with the OLD_ prefix
 	mockManager.removeCiliumRules("mangle", mockIp4tables, oldCiliumPrefix+"CILIUM_")
 	err := mockIp4tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
-func (s *iptablesTestSuite) TestRemoveCiliumRulesv6(c *check.C) {
-	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+func TestRemoveCiliumRulesv6(t *testing.T) {
+	mockIp6tables := &mockIptables{t: t, prog: "ip6tables"}
 	mockIp6tables.expectations = []expectation{
 		{
 			args: "-t mangle -S",
@@ -578,5 +601,7 @@ func (s *iptablesTestSuite) TestRemoveCiliumRulesv6(c *check.C) {
 	// Only removes Cilium chains with the OLD_ prefix
 	mockManager.removeCiliumRules("mangle", mockIp6tables, oldCiliumPrefix+"CILIUM_")
 	err := mockIp6tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -285,16 +285,22 @@ func TestAddProxyRulesv4(t *testing.T) {
 -A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
 -A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 127.0.0.1 --tproxy-mark 0x200/0xffffffff
 -A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 127.0.0.1 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 127.0.0.1 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 127.0.0.1 --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-ip 127.0.0.1 --on-port 37379",
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0x4920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-ip 127.0.0.1 --on-port 37380",
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-ip 127.0.0.1 --on-port 37379",
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0x4920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-ip 127.0.0.1 --on-port 37380",
+		}, {
+			args: "-t mangle -D CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 37379 --on-ip 127.0.0.1 --tproxy-mark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -D CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 37379 --on-ip 127.0.0.1 --tproxy-mark 0x200/0xffffffff",
 		},
 	}
 
 	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
-	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37379, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37380, false, "cilium-dns-egress")
 	err = mockIp4tables.checkExpectations()
 	if err != nil {
 		t.Fatal(err)
@@ -492,11 +498,17 @@ func TestAddProxyRulesv6(t *testing.T) {
 -A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
 -A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip ::1 --tproxy-mark 0x200/0xffffffff
 -A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip ::1 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip ::1 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip ::1 --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
 			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-ip ::1 --on-port 43479",
 		}, {
 			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-ip ::1 --on-port 43479",
+		}, {
+			args: "-t mangle -D CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip ::1 --tproxy-mark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -D CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip ::1 --tproxy-mark 0x200/0xffffffff",
 		},
 	}
 

--- a/pkg/datapath/iptables/reconciler.go
+++ b/pkg/datapath/iptables/reconciler.go
@@ -98,6 +98,8 @@ func reconciliationLoop(
 	devices, devicesWatch := tables.SelectedDevices(dependents.devices, dependents.db.ReadTxn())
 	state.devices = sets.New(tables.DeviceNames(devices)...)
 
+	log.WithField("state", state).Info("updating rules to reconcile state")
+
 	if err := updateRules(ctx, state, true); err != nil {
 		health.Degraded("iptables rules installation failed", err)
 	} else {
@@ -176,6 +178,9 @@ func reconciliationLoop(
 			}
 			delete(state.noTrackPods, noTrackPod)
 		}
+
+		log.WithField("state", state).Info("updating rules to reconcile state")
+
 		if err := updateRules(ctx, state, false); err != nil {
 			health.Degraded("iptables rules update failed", err)
 		} else {

--- a/pkg/datapath/iptables/reconciler.go
+++ b/pkg/datapath/iptables/reconciler.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package iptables
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/stream"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type desiredState struct {
+	installRules bool
+
+	devices       sets.Set[string]
+	localNodeInfo localNodeInfo
+	proxies       sets.Set[proxyInfo]
+	ipv4Set       sets.Set[netip.Addr]
+	ipv6Set       sets.Set[netip.Addr]
+	noTrackPods   sets.Set[noTrackPodInfo]
+}
+
+type localNodeInfo struct {
+	internalIPv4  net.IP
+	internalIPv6  net.IP
+	ipv4AllocCIDR string
+	ipv6AllocCIDR string
+}
+
+func (lni localNodeInfo) equal(other localNodeInfo) bool {
+	if !lni.internalIPv4.Equal(other.internalIPv4) ||
+		!lni.internalIPv6.Equal(other.internalIPv6) ||
+		lni.ipv4AllocCIDR != other.ipv4AllocCIDR ||
+		lni.ipv6AllocCIDR != other.ipv6AllocCIDR {
+		return false
+	}
+	return true
+}
+
+func toLocalNodeInfo(n node.LocalNode) localNodeInfo {
+	var v4AllocCIDR, v6AllocCIDR string
+
+	if n.IPv4AllocCIDR != nil {
+		v4AllocCIDR = n.IPv4AllocCIDR.String()
+	}
+	if n.IPv6AllocCIDR != nil {
+		v6AllocCIDR = n.IPv6AllocCIDR.String()
+	}
+
+	return localNodeInfo{
+		internalIPv4:  n.GetCiliumInternalIP(false),
+		internalIPv6:  n.GetCiliumInternalIP(true),
+		ipv4AllocCIDR: v4AllocCIDR,
+		ipv6AllocCIDR: v6AllocCIDR,
+	}
+}
+
+type proxyInfo struct {
+	name        string
+	port        uint16
+	isIngress   bool
+	isLocalOnly bool
+}
+
+type noTrackPodInfo struct {
+	ip   netip.Addr
+	port uint16
+}
+
+func reconciliationLoop(
+	ctx context.Context,
+	health cell.HealthReporter,
+	installIptRules bool,
+	dependents *dependents,
+	updateRules func(ctx context.Context, state desiredState, firstInit bool) error,
+) error {
+	state := desiredState{
+		installRules: installIptRules,
+		proxies:      sets.New[proxyInfo](),
+		ipv4Set:      sets.New[netip.Addr](),
+		ipv6Set:      sets.New[netip.Addr](),
+		noTrackPods:  sets.New[noTrackPodInfo](),
+	}
+
+	localNodeEvents := stream.ToChannel(ctx, dependents.localNodeStore)
+	state.localNodeInfo = toLocalNodeInfo(<-localNodeEvents)
+
+	devices, devicesWatch := tables.SelectedDevices(dependents.devices, dependents.db.ReadTxn())
+	state.devices = sets.New(tables.DeviceNames(devices)...)
+
+	if err := updateRules(ctx, state, true); err != nil {
+		health.Degraded("iptables rules installation failed", err)
+	} else {
+		health.OK("iptables rules installation completed")
+	}
+
+	limiter := rate.NewLimiter(time.Second, 1)
+	defer limiter.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-devicesWatch:
+			devices, devicesWatch = tables.SelectedDevices(dependents.devices, dependents.db.ReadTxn())
+			newDevices := sets.New(tables.DeviceNames(devices)...)
+			if newDevices.Equal(state.devices) {
+				continue
+			}
+			state.devices = newDevices
+		case localNode, ok := <-localNodeEvents:
+			if !ok {
+				return nil
+			}
+			localNodeInfo := toLocalNodeInfo(localNode)
+			if localNodeInfo.equal(state.localNodeInfo) {
+				continue
+			}
+			state.localNodeInfo = localNodeInfo
+		case proxyInfo, ok := <-dependents.proxies:
+			if !ok {
+				return nil
+			}
+			if state.proxies.Has(proxyInfo) {
+				continue
+			}
+			state.proxies.Insert(proxyInfo)
+		case ip, ok := <-dependents.addIPInSet:
+			if !ok {
+				return nil
+			}
+			if state.ipv6Set.Has(ip) || state.ipv4Set.Has(ip) {
+				continue
+			}
+			if ip.Is6() {
+				state.ipv6Set[ip] = sets.Empty{}
+			} else {
+				state.ipv4Set[ip] = sets.Empty{}
+			}
+		case ip, ok := <-dependents.delIPFromSet:
+			if !ok {
+				return nil
+			}
+			if !state.ipv6Set.Has(ip) && !state.ipv4Set.Has(ip) {
+				continue
+			}
+			if ip.Is6() {
+				delete(state.ipv6Set, ip)
+			} else {
+				delete(state.ipv4Set, ip)
+			}
+		case noTrackPod, ok := <-dependents.addNoTrackPod:
+			if !ok {
+				return nil
+			}
+			if state.noTrackPods.Has(noTrackPod) {
+				continue
+			}
+			state.noTrackPods[noTrackPod] = sets.Empty{}
+		case noTrackPod, ok := <-dependents.delNoTrackPod:
+			if !ok {
+				return nil
+			}
+			if !state.noTrackPods.Has(noTrackPod) {
+				continue
+			}
+			delete(state.noTrackPods, noTrackPod)
+		}
+		if err := updateRules(ctx, state, false); err != nil {
+			health.Degraded("iptables rules update failed", err)
+		} else {
+			health.OK("iptables rules update completed")
+		}
+
+		if err := limiter.Wait(ctx); err != nil {
+			if errors.Is(err, context.Canceled) {
+				return nil
+			}
+			return err
+		}
+	}
+}

--- a/pkg/datapath/iptables/reconciler_test.go
+++ b/pkg/datapath/iptables/reconciler_test.go
@@ -1,0 +1,530 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package iptables
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	"github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func TestReconciliationLoop(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var (
+		db      *statedb.DB
+		devices statedb.RWTable[*tables.Device]
+		store   *node.LocalNodeStore
+		health  cell.HealthReporter
+		deps    *dependents
+	)
+	h := hive.New(
+		cell.Module(
+			"iptables-reconciler-test",
+			"iptables-reconciler-test",
+
+			statedb.Cell,
+			cell.Provide(
+				tables.NewDeviceTable,
+				statedb.RWTable[*tables.Device].ToTable,
+				func() *node.LocalNodeStore { return node.NewTestLocalNodeStore(node.LocalNode{}) },
+			),
+			cell.Invoke(func(
+				db_ *statedb.DB,
+				devices_ statedb.RWTable[*tables.Device],
+				store_ *node.LocalNodeStore,
+				scope cell.Scope,
+			) {
+				db = db_
+				devices = devices_
+				store = store_
+				db.RegisterTable(devices_)
+				health = cell.GetHealthReporter(scope, "test")
+				deps = &dependents{
+					localNodeStore: store_,
+					db:             db_,
+					devices:        devices_,
+					proxies:        make(chan proxyInfo),
+					addIPInSet:     make(chan netip.Addr),
+					delIPFromSet:   make(chan netip.Addr),
+					addNoTrackPod:  make(chan noTrackPodInfo),
+					delNoTrackPod:  make(chan noTrackPodInfo),
+				}
+			}),
+		),
+	)
+
+	var (
+		lastState atomic.Pointer[desiredState]
+		lastErr   error
+	)
+
+	updateFunc := func(ctx context.Context, state desiredState, firstInit bool) error {
+		lastState.Store(&state)
+		return nil
+	}
+
+	testCases := []struct {
+		name     string
+		action   func()
+		expected desiredState
+	}{
+		{
+			name: "initial state",
+			action: func() {
+				store.Update(func(n *node.LocalNode) {
+					n.IPAddresses = []types.Address{
+						{
+							IP:   netip.MustParseAddr("1.1.1.1").AsSlice(),
+							Type: addressing.NodeCiliumInternalIP,
+						},
+					}
+					n.IPv4AllocCIDR = cidr.MustParseCIDR("5.5.5.0/24")
+					n.IPv6AllocCIDR = cidr.MustParseCIDR("2001:aaaa::/96")
+				})
+
+				txn := db.WriteTxn(devices)
+				if _, _, err := devices.Insert(txn, &tables.Device{
+					Index:    1,
+					Name:     "test-1",
+					Selected: true,
+				}); err != nil {
+					t.Fatal(err)
+				}
+				txn.Commit()
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("1.1.1.1"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("5.5.5.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("2001:aaaa::/96").String(),
+				},
+			},
+		},
+		{
+			name: "devices update",
+			action: func() {
+				txn := db.WriteTxn(devices)
+				devices.Insert(txn, &tables.Device{
+					Index:    2,
+					Name:     "test-2",
+					Selected: true,
+				})
+				txn.Commit()
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1", "test-2"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("1.1.1.1"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("5.5.5.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("2001:aaaa::/96").String(),
+				},
+			},
+		},
+		{
+			name: "local node update",
+			action: func() {
+				store.Update(func(n *node.LocalNode) {
+					n.IPAddresses = []types.Address{
+						{
+							IP:   netip.MustParseAddr("2.2.2.2").AsSlice(),
+							Type: addressing.NodeCiliumInternalIP,
+						},
+					}
+					n.IPv4AllocCIDR = cidr.MustParseCIDR("6.6.6.0/24")
+					n.IPv6AllocCIDR = cidr.MustParseCIDR("3002:bbbb::/96")
+				})
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1", "test-2"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("2.2.2.2"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("6.6.6.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("3002:bbbb::/96").String(),
+				},
+			},
+		},
+		{
+			name: "add first proxy",
+			action: func() {
+				deps.proxies <- proxyInfo{
+					name:        "proxy-test-1",
+					port:        9090,
+					isIngress:   false,
+					isLocalOnly: true,
+				}
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1", "test-2"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("2.2.2.2"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("6.6.6.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("3002:bbbb::/96").String(),
+				},
+				proxies: sets.New(proxyInfo{
+					name:        "proxy-test-1",
+					port:        9090,
+					isIngress:   false,
+					isLocalOnly: true,
+				}),
+			},
+		},
+		{
+			name: "add second proxy",
+			action: func() {
+				deps.proxies <- proxyInfo{
+					name:        "proxy-test-2",
+					port:        9091,
+					isIngress:   true,
+					isLocalOnly: false,
+				}
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1", "test-2"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("2.2.2.2"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("6.6.6.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("3002:bbbb::/96").String(),
+				},
+				proxies: sets.New(
+					proxyInfo{
+						name:        "proxy-test-1",
+						port:        9090,
+						isIngress:   false,
+						isLocalOnly: true,
+					},
+					proxyInfo{
+						name:        "proxy-test-2",
+						port:        9091,
+						isIngress:   true,
+						isLocalOnly: false,
+					},
+				),
+			},
+		},
+		{
+			name: "add ips to ipv4 set",
+			action: func() {
+				deps.addIPInSet <- netip.MustParseAddr("10.10.10.10")
+				deps.addIPInSet <- netip.MustParseAddr("11.11.11.11")
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1", "test-2"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("2.2.2.2"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("6.6.6.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("3002:bbbb::/96").String(),
+				},
+				proxies: sets.New(
+					proxyInfo{
+						name:        "proxy-test-1",
+						port:        9090,
+						isIngress:   false,
+						isLocalOnly: true,
+					},
+					proxyInfo{
+						name:        "proxy-test-2",
+						port:        9091,
+						isIngress:   true,
+						isLocalOnly: false,
+					},
+				),
+				ipv4Set: sets.New(
+					netip.MustParseAddr("10.10.10.10"),
+					netip.MustParseAddr("11.11.11.11"),
+				),
+			},
+		},
+		{
+			name: "remove ip from ipv4 set",
+			action: func() {
+				deps.delIPFromSet <- netip.MustParseAddr("10.10.10.10")
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1", "test-2"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("2.2.2.2"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("6.6.6.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("3002:bbbb::/96").String(),
+				},
+				proxies: sets.New(
+					proxyInfo{
+						name:        "proxy-test-1",
+						port:        9090,
+						isIngress:   false,
+						isLocalOnly: true,
+					},
+					proxyInfo{
+						name:        "proxy-test-2",
+						port:        9091,
+						isIngress:   true,
+						isLocalOnly: false,
+					},
+				),
+				ipv4Set: sets.New(
+					netip.MustParseAddr("11.11.11.11"),
+				),
+			},
+		},
+		{
+			name: "add ips to ipv6 set",
+			action: func() {
+				deps.addIPInSet <- netip.MustParseAddr("5000:aaaa::")
+				deps.addIPInSet <- netip.MustParseAddr("5000:bbbb::")
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1", "test-2"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("2.2.2.2"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("6.6.6.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("3002:bbbb::/96").String(),
+				},
+				proxies: sets.New(
+					proxyInfo{
+						name:        "proxy-test-1",
+						port:        9090,
+						isIngress:   false,
+						isLocalOnly: true,
+					},
+					proxyInfo{
+						name:        "proxy-test-2",
+						port:        9091,
+						isIngress:   true,
+						isLocalOnly: false,
+					},
+				),
+				ipv4Set: sets.New(
+					netip.MustParseAddr("11.11.11.11"),
+				),
+				ipv6Set: sets.New(
+					netip.MustParseAddr("5000:aaaa::"),
+					netip.MustParseAddr("5000:bbbb::"),
+				),
+			},
+		},
+		{
+			name: "remove ip from ipv6 set",
+			action: func() {
+				deps.delIPFromSet <- netip.MustParseAddr("5000:aaaa::")
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1", "test-2"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("2.2.2.2"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("6.6.6.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("3002:bbbb::/96").String(),
+				},
+				proxies: sets.New(
+					proxyInfo{
+						name:        "proxy-test-1",
+						port:        9090,
+						isIngress:   false,
+						isLocalOnly: true,
+					},
+					proxyInfo{
+						name:        "proxy-test-2",
+						port:        9091,
+						isIngress:   true,
+						isLocalOnly: false,
+					},
+				),
+				ipv4Set: sets.New(
+					netip.MustParseAddr("11.11.11.11"),
+				),
+				ipv6Set: sets.New(
+					netip.MustParseAddr("5000:bbbb::"),
+				),
+			},
+		},
+		{
+			name: "add no track pods",
+			action: func() {
+				deps.addNoTrackPod <- noTrackPodInfo{netip.MustParseAddr("1.2.3.4"), 10001}
+				deps.addNoTrackPod <- noTrackPodInfo{netip.MustParseAddr("11.22.33.44"), 10002}
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1", "test-2"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("2.2.2.2"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("6.6.6.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("3002:bbbb::/96").String(),
+				},
+				proxies: sets.New(
+					proxyInfo{
+						name:        "proxy-test-1",
+						port:        9090,
+						isIngress:   false,
+						isLocalOnly: true,
+					},
+					proxyInfo{
+						name:        "proxy-test-2",
+						port:        9091,
+						isIngress:   true,
+						isLocalOnly: false,
+					},
+				),
+				ipv4Set: sets.New(
+					netip.MustParseAddr("11.11.11.11"),
+				),
+				ipv6Set: sets.New(
+					netip.MustParseAddr("5000:bbbb::"),
+				),
+				noTrackPods: sets.New(
+					noTrackPodInfo{netip.MustParseAddr("1.2.3.4"), 10001},
+					noTrackPodInfo{netip.MustParseAddr("11.22.33.44"), 10002},
+				),
+			},
+		},
+		{
+			name: "remove no track pod",
+			action: func() {
+				deps.delNoTrackPod <- noTrackPodInfo{netip.MustParseAddr("1.2.3.4"), 10001}
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1", "test-2"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("2.2.2.2"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("6.6.6.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("3002:bbbb::/96").String(),
+				},
+				proxies: sets.New(
+					proxyInfo{
+						name:        "proxy-test-1",
+						port:        9090,
+						isIngress:   false,
+						isLocalOnly: true,
+					},
+					proxyInfo{
+						name:        "proxy-test-2",
+						port:        9091,
+						isIngress:   true,
+						isLocalOnly: false,
+					},
+				),
+				ipv4Set: sets.New(
+					netip.MustParseAddr("11.11.11.11"),
+				),
+				ipv6Set: sets.New(
+					netip.MustParseAddr("5000:bbbb::"),
+				),
+				noTrackPods: sets.New(
+					noTrackPodInfo{netip.MustParseAddr("11.22.33.44"), 10002},
+				),
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	assert.NoError(t, h.Start(ctx))
+
+	// apply initial state
+	testCases[0].action()
+
+	// start the reconciliation loop
+	errs := make(chan error)
+	go func() {
+		defer close(errs)
+		errs <- reconciliationLoop(ctx, health, true, deps, updateFunc)
+	}()
+
+	// wait for reconciler to react to the initial state
+	assert.Eventually(t, func() bool {
+		curState := lastState.Load()
+		if curState == nil {
+			// not yet loaded
+			return false
+		}
+		if err := assertState(*curState, testCases[0].expected); err != nil {
+			lastErr = err
+			return false
+		}
+		return true
+	}, 10*time.Second, 10*time.Millisecond, "assertion failed: %s", lastErr)
+
+	// test all the remaining steps
+	for _, tc := range testCases[1:] {
+		t.Run(tc.name, func(t *testing.T) {
+			// apply the action to update the state
+			tc.action()
+
+			// wait for reconciler to react to the update
+			assert.Eventuallyf(t, func() bool {
+				curState := lastState.Load()
+				if err := assertState(*curState, tc.expected); err != nil {
+					lastErr = err
+					return false
+				}
+				return true
+			}, 10*time.Second, 10*time.Millisecond, "assertion failed: %s", lastErr)
+		})
+	}
+
+	assert.NoError(t, h.Stop(ctx))
+
+	cancel()
+	assert.NoError(t, <-errs)
+}
+
+func assertState(current, expected desiredState) error {
+	if current.installRules != expected.installRules {
+		return fmt.Errorf("expected installRules to be %t, found %t",
+			expected.installRules, current.installRules)
+	}
+	if !current.devices.Equal(expected.devices) {
+		return fmt.Errorf("expected devices names to be %v, found %v",
+			current.devices.UnsortedList(), expected.devices.UnsortedList())
+	}
+	if !current.localNodeInfo.equal(expected.localNodeInfo) {
+		return fmt.Errorf("expected local node info to be %v, found %v",
+			current.localNodeInfo, expected.localNodeInfo)
+	}
+	if !current.proxies.Equal(expected.proxies) {
+		return fmt.Errorf("expected proxies info to be %v, found %v",
+			current.proxies.UnsortedList(), expected.proxies.UnsortedList())
+	}
+	if !current.ipv4Set.Equal(expected.ipv4Set) {
+		return fmt.Errorf("expected ipv4 set to be %v, found %v",
+			current.ipv4Set.UnsortedList(), expected.ipv4Set.UnsortedList())
+	}
+	if !current.ipv6Set.Equal(expected.ipv6Set) {
+		return fmt.Errorf("expected ipv6 set to be %v, found %v",
+			current.ipv6Set.UnsortedList(), expected.ipv6Set.UnsortedList())
+	}
+	if !current.noTrackPods.Equal(expected.noTrackPods) {
+		return fmt.Errorf("expected no tracking pods info to be %v, found %v",
+			current.noTrackPods.UnsortedList(), expected.noTrackPods.UnsortedList())
+	}
+	return nil
+}

--- a/pkg/datapath/iptables/reconciler_test.go
+++ b/pkg/datapath/iptables/reconciler_test.go
@@ -74,10 +74,9 @@ func TestReconciliationLoop(t *testing.T) {
 
 	var (
 		lastState atomic.Pointer[desiredState]
-		lastErr   error
 	)
 
-	updateFunc := func(ctx context.Context, state desiredState, firstInit bool) error {
+	updateFunc := func(state desiredState, firstInit bool) error {
 		lastState.Store(&state)
 		return nil
 	}
@@ -456,7 +455,7 @@ func TestReconciliationLoop(t *testing.T) {
 	errs := make(chan error)
 	go func() {
 		defer close(errs)
-		errs <- reconciliationLoop(ctx, health, true, deps, updateFunc)
+		errs <- reconciliationLoop(ctx, log, health, true, deps, updateFunc)
 	}()
 
 	// wait for reconciler to react to the initial state
@@ -467,11 +466,11 @@ func TestReconciliationLoop(t *testing.T) {
 			return false
 		}
 		if err := assertState(*curState, testCases[0].expected); err != nil {
-			lastErr = err
+			t.Logf("assertState: %s", err)
 			return false
 		}
 		return true
-	}, 10*time.Second, 10*time.Millisecond, "assertion failed: %s", lastErr)
+	}, 10*time.Second, 10*time.Millisecond, "initial state not reconciled. %v", testCases[0].expected)
 
 	// test all the remaining steps
 	for _, tc := range testCases[1:] {
@@ -483,11 +482,11 @@ func TestReconciliationLoop(t *testing.T) {
 			assert.Eventuallyf(t, func() bool {
 				curState := lastState.Load()
 				if err := assertState(*curState, tc.expected); err != nil {
-					lastErr = err
+					t.Logf("assertState: %s", err)
 					return false
 				}
 				return true
-			}, 10*time.Second, 10*time.Millisecond, "assertion failed: %s", lastErr)
+			}, 10*time.Second, 10*time.Millisecond, "expected state not reached. %v", tc.expected)
 		})
 	}
 

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -458,17 +458,9 @@ func (l *loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		return err
 	}
 
-	if err := iptMgr.InstallRules(ctx, defaults.HostDevice, l.firstInitialization, option.Config.InstallIptRules); err != nil {
-		return err
-	}
-
 	// Reinstall proxy rules for any running proxies if needed
 	if option.Config.EnableL7Proxy {
 		if err := p.ReinstallRoutingRules(); err != nil {
-			return err
-		}
-
-		if err := p.ReinstallIPTablesRules(ctx); err != nil {
 			return err
 		}
 	}

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"net/netip"
 
 	"github.com/vishvananda/netlink"
 
@@ -54,20 +55,18 @@ type PreFilter interface {
 // a proxy.
 type Proxy interface {
 	ReinstallRoutingRules() error
-	ReinstallIPTablesRules(ctx context.Context) error
 }
 
 // IptablesManager manages iptables rules.
 type IptablesManager interface {
 	// InstallProxyRules creates the necessary datapath config (e.g., iptables
 	// rules for redirecting host proxy traffic on a specific ProxyPort)
-	InstallProxyRules(ctx context.Context, proxyPort uint16, ingress, localOnly bool, name string) error
+	InstallProxyRules(proxyPort uint16, ingress, localOnly bool, name string)
 
 	// SupportsOriginalSourceAddr tells if the datapath supports
 	// use of original source addresses in proxy upstream
 	// connections.
 	SupportsOriginalSourceAddr() bool
-	InstallRules(ctx context.Context, ifName string, quiet, install bool) error
 
 	// GetProxyPort fetches the existing proxy port configured for the
 	// specified listener. Used early in bootstrap to reopen proxy ports.
@@ -82,8 +81,8 @@ type IptablesManager interface {
 	// will be executed to install NOTRACK rules.  The rules installed by
 	// this function is very specific, for now, the only user is
 	// node-local-dns pods.
-	InstallNoTrackRules(IP string, port uint16, ipv6 bool) error
+	InstallNoTrackRules(ip netip.Addr, port uint16)
 
 	// See comments for InstallNoTrackRules.
-	RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error
+	RemoveNoTrackRules(ip netip.Addr, port uint16)
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2431,14 +2431,10 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 		}).Debug("Deleting endpoint NOTRACK rules")
 
 		if e.IPv4.IsValid() {
-			if err := e.owner.Datapath().RemoveNoTrackRules(e.IPv4.String(), e.noTrackPort, false); err != nil {
-				errs = append(errs, fmt.Errorf("unable to delete endpoint NOTRACK ipv4 rules: %s", err))
-			}
+			e.owner.Datapath().RemoveNoTrackRules(e.IPv4, e.noTrackPort)
 		}
 		if e.IPv6.IsValid() {
-			if err := e.owner.Datapath().RemoveNoTrackRules(e.IPv6.String(), e.noTrackPort, true); err != nil {
-				errs = append(errs, fmt.Errorf("unable to delete endpoint NOTRACK ipv6 rules: %s", err))
-			}
+			e.owner.Datapath().RemoveNoTrackRules(e.IPv6, e.noTrackPort)
 		}
 	}
 

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -158,22 +158,18 @@ func (ev *EndpointNoTrackEvent) Handle(res chan interface{}) {
 		log.Debug("Updating NOTRACK rules")
 		if e.IPv4.IsValid() {
 			if port > 0 {
-				err = e.owner.Datapath().InstallNoTrackRules(e.IPv4.String(), port, false)
-				log.WithError(err).Warn("Error installing iptable NOTRACK rules")
+				e.owner.Datapath().InstallNoTrackRules(e.IPv4, port)
 			}
 			if e.noTrackPort > 0 {
-				err = e.owner.Datapath().RemoveNoTrackRules(e.IPv4.String(), e.noTrackPort, false)
-				log.WithError(err).Warn("Error removing iptable NOTRACK rules")
+				e.owner.Datapath().RemoveNoTrackRules(e.IPv4, e.noTrackPort)
 			}
 		}
 		if e.IPv6.IsValid() {
 			if port > 0 {
-				e.owner.Datapath().InstallNoTrackRules(e.IPv6.String(), port, true)
-				log.WithError(err).Warn("Error installing iptable NOTRACK rules")
+				e.owner.Datapath().InstallNoTrackRules(e.IPv6, port)
 			}
 			if e.noTrackPort > 0 {
-				err = e.owner.Datapath().RemoveNoTrackRules(e.IPv6.String(), e.noTrackPort, true)
-				log.WithError(err).Warn("Error removing iptable NOTRACK rules")
+				e.owner.Datapath().RemoveNoTrackRules(e.IPv6, e.noTrackPort)
 			}
 		}
 		e.noTrackPort = port

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -470,7 +470,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 	for _, address := range n.IPAddresses {
 		prefix := ip.IPToNetPrefix(address.IP)
 
-		if m.conf.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
+		if address.Type == addressing.NodeInternalIP {
 			m.ipsetMgr.AddToNodeIpset(address.IP)
 			ipsetEntries = append(ipsetEntries, prefix)
 		}
@@ -655,8 +655,7 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 			continue
 		}
 
-		if m.conf.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP &&
-			!slices.Contains(ipsetEntries, oldPrefix) {
+		if address.Type == addressing.NodeInternalIP && !slices.Contains(ipsetEntries, oldPrefix) {
 			m.ipsetMgr.RemoveFromNodeIpset(address.IP)
 		}
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -46,7 +46,7 @@ const (
 )
 
 type DatapathUpdater interface {
-	InstallProxyRules(ctx context.Context, proxyPort uint16, ingress, localOnly bool, name string) error
+	InstallProxyRules(proxyPort uint16, ingress, localOnly bool, name string)
 	SupportsOriginalSourceAddr() bool
 }
 
@@ -237,9 +237,7 @@ func (p *Proxy) ackProxyPort(ctx context.Context, name string, pp *ProxyPort) er
 		// Add rules for the new port
 		// This should always succeed if we have managed to start-up properly
 		scopedLog.Infof("Adding new proxy port rules for %s:%d", name, pp.proxyPort)
-		if err := p.datapathUpdater.InstallProxyRules(ctx, pp.proxyPort, pp.ingress, pp.localOnly, name); err != nil {
-			return fmt.Errorf("cannot install proxy rules for %s: %w", name, err)
-		}
+		p.datapathUpdater.InstallProxyRules(pp.proxyPort, pp.ingress, pp.localOnly, name)
 		pp.rulesPort = pp.proxyPort
 	}
 	pp.nRedirects++
@@ -473,23 +471,6 @@ func getCiliumNetIPv6() (net.IP, error) {
 	}
 
 	return nil, fmt.Errorf("failed to find valid IPv6 address for cilium_net")
-}
-
-// ReinstallIPTablesRules is called by daemon reconfiguration to reinstall
-// proxy ports rules that were removed during the removal of all Cilium rules.
-func (p *Proxy) ReinstallIPTablesRules(ctx context.Context) error {
-	p.mutex.RLock()
-	defer p.mutex.RUnlock()
-	for name, pp := range p.proxyPorts {
-		if pp.rulesPort > 0 {
-			// This should always succeed if we have managed to start-up properly
-			if err := p.datapathUpdater.InstallProxyRules(ctx, pp.rulesPort, pp.ingress, pp.localOnly, name); err != nil {
-				return fmt.Errorf("cannot install proxy rules for %s: %w", name, err)
-			}
-		}
-	}
-
-	return nil
 }
 
 // CreateOrUpdateRedirect creates or updates a L4 redirect with corresponding

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -26,8 +26,7 @@ var _ = Suite(&ProxySuite{})
 
 type MockDatapathUpdater struct{}
 
-func (m *MockDatapathUpdater) InstallProxyRules(ctx context.Context, proxyPort uint16, ingress, localOnly bool, name string) error {
-	return nil
+func (m *MockDatapathUpdater) InstallProxyRules(proxyPort uint16, ingress, localOnly bool, name string) {
 }
 
 func (m *MockDatapathUpdater) SupportsOriginalSourceAddr() bool {


### PR DESCRIPTION
iptables rules manager currently exposes some methods to reinstall rules after a datapath reconfiguration (`loader.Reinitialize`).

This PR changes the manager so that it dynamically reconcile the iptables rules every time:

- there is an update regarding a device
- there is an update for the local node
- a new proxy redirection is installed
- an ipset is changed (addition/removal of an ip in the set)
- a pod with "policy.cilium.io/no-track-port" annotation is added or removed

The exposed methods are changed so that each request is processed asynchronously by the manager internal reconciler.