### PR TITLE
wireguard: also account for tunnel overhead

### DIFF
--- a/pkg/mtu/mtu.go
+++ b/pkg/mtu/mtu.go
@@ -169,6 +169,9 @@ func (c *Configuration) GetRoutePostEncryptMTU() int {
 // encryption overhead accounted for.
 func (c *Configuration) GetRouteMTU() int {
 	if c.wireguardEnabled {
+		if c.encapEnabled {
+			return c.GetDeviceMTU() - (WireguardOverhead + TunnelOverhead)
+		}
 		return c.GetDeviceMTU() - WireguardOverhead
 	}
 

--- a/pkg/mtu/mtu_test.go
+++ b/pkg/mtu/mtu_test.go
@@ -75,7 +75,7 @@ func (m *MTUSuite) TestNewConfiguration(c *C) {
 
 	conf = NewConfiguration(32, false, true, true, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
-	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-WireguardOverhead)
+	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(WireguardOverhead+TunnelOverhead))
 
 	testIP1 := net.IPv4(0, 0, 0, 0)
 	testIP2 := net.IPv4(127, 0, 0, 1)


### PR DESCRIPTION
<!-- Description of change -->
Since #29000 packets are always encapsulated before they are encrypted with WireGuard. Therefore, we also need to take the tunnel overhead for the route MTU into account.

This fixes a performance regression. Before this commit WireGuard encrypted pod-to-pod traffic the iperf3 bandwidth was ~102 Mbits/sec. With this patch the bandwidth increases to 656 Mbits/sec. Without encryption the bandwidth is ~2 Gbits/sec.

This is related to https://github.com/cilium/cilium/issues/28413. But this does not fix all issues, see: https://github.com/cilium/cilium/issues/28413#issuecomment-1898943563.

Fixes: b67291f039266418a9050dd47c4d01ff857865b8
```release-note
Fix performance regression for pod-to-pod traffic WireGuard and tunneling.
```
