### PR TITLE
[Kind] ipfamily should be set by platform configuration.

### DIFF
--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -9,7 +9,11 @@ default_workers=1
 default_cluster_name=""
 default_image=""
 default_kubeproxy_mode="iptables"
-default_ipfamily="dual"
+if [ "$(uname 2>/dev/null)" == "Linux" ] && [ $(sysctl -n net.ipv6.conf.all.disable_ipv6) == 1 ] ; then
+  default_ipfamily="ipv4"
+else
+  default_ipfamily="dual"
+fi
 default_pod_subnet=""
 default_service_subnet=""
 default_agent_port_prefix="234"


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

just a cosmetic minor fix for `devcontainer` with `KIND` environment.

if we start `devcontainer` with `vscode`, `sysctl net.ipv6.conf.all.disable_ipv6` can be `1` unless explicitly IPv6 is enabled.
at least, in default `sysctl net.ipv6.conf.all.disable_ipv6` will return `1`, this leads to the following `kube-proxy` error.

```bash
root@3db4a4d3b3b7:/go/src/github.com/cilium/cilium# kubectl logs -n kube-system kube-proxy-qg4qx
I0119 01:08:50.979992       1 node.go:141] Successfully retrieved node IP: 172.23.0.2
I0119 01:08:50.980028       1 server_others.go:110] "Detected node IP" address="172.23.0.2"
I0119 01:08:50.988007       1 server_others.go:176] "kube-proxy running in single-stack mode: secondary ipFamily is not supported" ipFamily=IPv6
I0119 01:08:50.988015       1 server_others.go:190] "Using iptables Proxier"
E0119 01:08:50.988025       1 server.go:494] "Error running ProxyServer" err="unable to create proxier: invalid CIDR address: 10.244.0.0/16,fd00:10:244::/56"
E0119 01:08:50.988031       1 run.go:74] "command failed" err="unable to create proxier: invalid CIDR address: 10.244.0.0/16,fd00:10:244::/56"
```

eventually [kind-based-setup-preferred](https://docs.cilium.io/en/stable/contributing/development/dev_setup/#kind-based-setup-preferred) does not work out of the box.
instead, we can check the system configuration to see what needs to be set `default_ipfamily`.
