### PR TITLE
bpf: xdp: don't include nodeport.h's egress sections

### DIFF
--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -11,12 +11,12 @@
 #define SKIP_POLICY_MAP 1
 
 /* Controls the inclusion of the CILIUM_CALL_HANDLE_ICMP6_NS section in the
- * bpf_lxc object file.
+ * object file.
  */
 #define SKIP_ICMPV6_NS_HANDLING
 
 /* Controls the inclusion of the CILIUM_CALL_SEND_ICMP6_TIME_EXCEEDED section
- * in the bpf_lxc object file. This is needed for all callers of
+ * in the object file. This is needed for all callers of
  * ipv6_local_delivery, which calls into the IPv6 L3 handling.
  */
 #define SKIP_ICMPV6_HOPLIMIT_HANDLING
@@ -24,6 +24,11 @@
 /* Controls the inclusion of the CILIUM_CALL_SRV6 section in the object file.
  */
 #define SKIP_SRV6_HANDLING
+
+/* Controls the inclusion of egress-related nodeport sections in the object file.
+ * As XDP doesn't have an egress hook, they are not needed.
+ */
+#define SKIP_NODEPORT_EGRESS_HANDLING		1
 
 /* The XDP datapath does not take care of health probes from the local node,
  * thus do not compile it in.

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1520,7 +1520,8 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	return CTX_ACT_OK;
 }
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_SNAT_FWD)
+declare_tailcall_if(__not(is_defined(SKIP_NODEPORT_EGRESS_HANDLING)),
+		    CILIUM_CALL_IPV6_NODEPORT_SNAT_FWD)
 int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 {
 	struct trace_ctx trace = {
@@ -1584,10 +1585,11 @@ handle_nat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	return __handle_nat_fwd_ipv6(ctx, trace, ext_err);
 }
 
-declare_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
-			       is_defined(ENABLE_IPV6)),
-			 __and(is_defined(ENABLE_HOST_FIREWALL),
-			       is_defined(IS_BPF_HOST))),
+declare_tailcall_if(__and(__not(is_defined(SKIP_NODEPORT_EGRESS_HANDLING)),
+			  __or(__and(is_defined(ENABLE_IPV4),
+				     is_defined(ENABLE_IPV6)),
+			       __and(is_defined(ENABLE_HOST_FIREWALL),
+				     is_defined(IS_BPF_HOST)))),
 		    CILIUM_CALL_IPV6_NODEPORT_NAT_FWD)
 int tail_handle_nat_fwd_ipv6(struct __ctx_buff *ctx)
 {
@@ -3066,7 +3068,8 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	return CTX_ACT_OK;
 }
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_SNAT_FWD)
+declare_tailcall_if(__not(is_defined(SKIP_NODEPORT_EGRESS_HANDLING)),
+		    CILIUM_CALL_IPV4_NODEPORT_SNAT_FWD)
 int tail_handle_snat_fwd_ipv4(struct __ctx_buff *ctx)
 {
 	__u32 cluster_id = ctx_load_and_clear_meta(ctx, CB_CLUSTER_ID_EGRESS);
@@ -3133,14 +3136,15 @@ handle_nat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	return __handle_nat_fwd_ipv4(ctx, cluster_id, trace, ext_err);
 }
 
-declare_tailcall_if(__or4(__and(is_defined(ENABLE_IPV4),
-				is_defined(ENABLE_IPV6)),
-			  __and(is_defined(ENABLE_HOST_FIREWALL),
-				is_defined(IS_BPF_HOST)),
-			  __and(is_defined(ENABLE_CLUSTER_AWARE_ADDRESSING),
-				is_defined(ENABLE_INTER_CLUSTER_SNAT)),
-			  __and(is_defined(ENABLE_EGRESS_GATEWAY_COMMON),
-				is_defined(IS_BPF_HOST))),
+declare_tailcall_if(__and(__not(is_defined(SKIP_NODEPORT_EGRESS_HANDLING)),
+			  __or4(__and(is_defined(ENABLE_IPV4),
+				      is_defined(ENABLE_IPV6)),
+				__and(is_defined(ENABLE_HOST_FIREWALL),
+				      is_defined(IS_BPF_HOST)),
+				__and(is_defined(ENABLE_CLUSTER_AWARE_ADDRESSING),
+				      is_defined(ENABLE_INTER_CLUSTER_SNAT)),
+				__and(is_defined(ENABLE_EGRESS_GATEWAY_COMMON),
+				      is_defined(IS_BPF_HOST)))),
 		    CILIUM_CALL_IPV4_NODEPORT_NAT_FWD)
 int tail_handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
 {


### PR DESCRIPTION
As XDP doesn't provide an egress hook, we don't need to include the tail-calls that are relevant for SNAT / RevDNAT. The relevant functionality is provided by bpf_host's to-netdev.

This reduces verification time and allows us to ignore any verifier trouble in this code that would only affect XDP (eg. increased program size due to helpers that are implemented in assembly on older kernels).

As follow-on work we can also use SKIP_NODEPORT_EGRESS_HANDLING to detect that the ingress path needs to do additional work that would normally happen in the egress path (eg. emitting trace events).