### PR TITLE
gha: explicilty specify beefier runner type for clustermesh workflows

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -80,7 +80,7 @@ jobs:
 
   installation-and-connectivity:
     name: Installation and Connectivity Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4cores-16gb
     timeout-minutes: 60
     env:
       job_name: "Installation and Connectivity Test"

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -79,7 +79,7 @@ jobs:
 
   upgrade-and-downgrade:
     name: "Upgrade and Downgrade Test"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4cores-16gb
     timeout-minutes: 60
     env:
       job_name: "Installation and Connectivity Test"


### PR DESCRIPTION
Clustermesh workflows need to setup two multi-node kind clusters, which don't fit well in the default GH runners (2 vCPU and 7GiB or RAM). Although GitHub recently upgraded \[1\] the default runners for OSS projects to 4 vCPU and 16GiB of RAM, let's still make it explicit that these workflow actually need that amount of power to run seamlessly.

\[1\]: https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/
