### PR TITLE
l2announcer: Retry getting lease after losing it

### DIFF
--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -1099,32 +1099,37 @@ func (ss *selectedService) serviceLeaderElection(ctx context.Context, health cel
 
 	ss.ctx, ss.cancel = context.WithCancel(ctx)
 
-	leaderelection.RunOrDie(ss.ctx, leaderelection.LeaderElectionConfig{
-		Name:            ss.lock.LeaseMeta.Name,
-		Lock:            ss.lock,
-		ReleaseOnCancel: true,
+	for {
+		select {
+		case <-ss.ctx.Done():
+			return nil
+		default:
+			leaderelection.RunOrDie(ss.ctx, leaderelection.LeaderElectionConfig{
+				Name:            ss.lock.LeaseMeta.Name,
+				Lock:            ss.lock,
+				ReleaseOnCancel: true,
 
-		LeaseDuration: ss.leaseDuration,
-		RenewDeadline: ss.renewDeadline,
-		RetryPeriod:   ss.retryPeriod,
+				LeaseDuration: ss.leaseDuration,
+				RenewDeadline: ss.renewDeadline,
+				RetryPeriod:   ss.retryPeriod,
 
-		Callbacks: leaderelection.LeaderCallbacks{
-			OnStartedLeading: func(ctx context.Context) {
-				ss.leaderChannel <- leaderElectionEvent{
-					typ:             leaderElectionLeading,
-					selectedService: ss,
-				}
-			},
-			OnStoppedLeading: func() {
-				ss.leaderChannel <- leaderElectionEvent{
-					typ:             leaderElectionStoppedLeading,
-					selectedService: ss,
-				}
-			},
-		},
-	})
-
-	return nil
+				Callbacks: leaderelection.LeaderCallbacks{
+					OnStartedLeading: func(ctx context.Context) {
+						ss.leaderChannel <- leaderElectionEvent{
+							typ:             leaderElectionLeading,
+							selectedService: ss,
+						}
+					},
+					OnStoppedLeading: func() {
+						ss.leaderChannel <- leaderElectionEvent{
+							typ:             leaderElectionStoppedLeading,
+							selectedService: ss,
+						}
+					},
+				},
+			})
+		}
+	}
 }
 
 func (ss *selectedService) stop() {


### PR DESCRIPTION
Once a service gets selected we start leader election. However, if we lose the lease for some reason, we don't retry getting it until the service is deselected and reselect, recreated or the agent restarts. This commit surrounds the lease leader election logic with a loop that ends when the context is cancelled.

Possibly fixes: #26586

```release-note
L2 announcements retry getting lease after losing it
```
