### PR TITLE
bpf: overlay: restore bpf_clear_meta() in from-overlay

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -549,6 +549,10 @@ int cil_from_overlay(struct __ctx_buff *ctx)
 	__u16 proto;
 	int ret;
 
+#ifndef ENABLE_HIGH_SCALE_IPCACHE
+	/* preserve skb->cb for hs-ipcache, from-netdev is passing info */
+	bpf_clear_meta(ctx);
+#endif
 	ctx_skip_nodeport_clear(ctx);
 
 	if (!validate_ethertype(ctx, &proto)) {


### PR DESCRIPTION
Prior to 8ea31e07de2f ("bpf: Decapsulate traffic encapsulated with pod IPs") we were clearing the skb->cb on entry of from-overlay.

For hs-ipcache this wasn't possible anymore, as from-netdev manually strips the tunnel encap and transfers its content via skb->cb. But we should still clear the skb->cb when hs-ipcache is disabled, and thus avoid handling stale data.

Reported-by: Gray Lian <gray.liang@isovalent.com>