### PR TITLE
bpf: ct: allow CT entry creation / lookup without detailed information

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -895,9 +895,7 @@ static __always_inline int ct_lookup4(const void *map,
 static __always_inline int ct_create6(const void *map_main, const void *map_related,
 				      struct ipv6_ct_tuple *tuple,
 				      struct __ctx_buff *ctx, const enum ct_dir dir,
-				      const struct ct_state *ct_state,
-				      bool proxy_redirect, bool from_l7lb,
-				      __s8 *ext_err)
+				      const struct ct_state *ct_state, __s8 *ext_err)
 {
 	/* Create entry in original direction */
 	struct ct_entry entry = { };
@@ -916,8 +914,8 @@ static __always_inline int ct_create6(const void *map_main, const void *map_rela
 		/* Note if this is a proxy connection so that replies can be redirected
 		 * back to the proxy.
 		 */
-		entry.proxy_redirect = proxy_redirect;
-		entry.from_l7lb = from_l7lb;
+		entry.proxy_redirect = ct_state->proxy_redirect;
+		entry.from_l7lb = ct_state->from_l7lb;
 	}
 
 	entry.rev_nat_index = ct_state->rev_nat_index;
@@ -971,7 +969,6 @@ static __always_inline int ct_create4(const void *map_main,
 				      struct ipv4_ct_tuple *tuple,
 				      struct __ctx_buff *ctx, const enum ct_dir dir,
 				      const struct ct_state *ct_state,
-				      bool proxy_redirect, bool from_l7lb,
 				      __s8 *ext_err)
 {
 	/* Create entry in original direction */
@@ -995,8 +992,8 @@ static __always_inline int ct_create4(const void *map_main,
 		/* Note if this is a proxy connection so that replies can be redirected
 		 * back to the proxy.
 		 */
-		entry.proxy_redirect = proxy_redirect;
-		entry.from_l7lb = from_l7lb;
+		entry.proxy_redirect = ct_state->proxy_redirect;
+		entry.from_l7lb = ct_state->from_l7lb;
 	}
 
 	entry.rev_nat_index = ct_state->rev_nat_index;

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -70,7 +70,7 @@ ipv6_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 	}
 	ct_buffer->l4_off = l3_off + hdrlen;
 	ct_buffer->ret = ct_lookup6(get_ct_map6(tuple), tuple, ctx, ct_buffer->l4_off,
-				    CT_EGRESS, &ct_buffer->ct_state, &ct_buffer->monitor);
+				    CT_EGRESS, NULL, &ct_buffer->monitor);
 	return true;
 }
 
@@ -197,7 +197,7 @@ ipv6_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 	}
 	ct_buffer->l4_off = ETH_HLEN + hdrlen;
 	ct_buffer->ret = ct_lookup6(get_ct_map6(tuple), tuple, ctx, ct_buffer->l4_off,
-				    CT_INGRESS, &ct_buffer->ct_state, &ct_buffer->monitor);
+				    CT_INGRESS, NULL, &ct_buffer->monitor);
 
 	return true;
 }
@@ -345,7 +345,7 @@ ipv4_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 	tuple->saddr = ip4->saddr;
 	ct_buffer->l4_off = l3_off + ipv4_hdrlen(ip4);
 	ct_buffer->ret = ct_lookup4(get_ct_map4(tuple), tuple, ctx, ip4, ct_buffer->l4_off,
-				    CT_EGRESS, &ct_buffer->ct_state, &ct_buffer->monitor);
+				    CT_EGRESS, NULL, &ct_buffer->monitor);
 	return true;
 }
 
@@ -466,7 +466,7 @@ ipv4_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct iphdr *ip4,
 	tuple->saddr = ip4->saddr;
 	ct_buffer->l4_off = l3_off + ipv4_hdrlen(ip4);
 	ct_buffer->ret = ct_lookup4(get_ct_map4(tuple), tuple, ctx, ip4, ct_buffer->l4_off,
-				    CT_INGRESS, &ct_buffer->ct_state, &ct_buffer->monitor);
+				    CT_INGRESS, NULL, &ct_buffer->monitor);
 
 	return true;
 }

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -20,8 +20,6 @@ static __always_inline int
 ipv6_whitelist_snated_egress_connections(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 					 enum ct_status ct_ret, __s8 *ext_err)
 {
-	struct ct_state ct_state_new = {};
-
 	/* If kube-proxy is in use (no BPF-based masquerading), packets from
 	 * pods may be SNATed. The response packet will therefore have a host
 	 * IP as the destination IP.
@@ -34,8 +32,7 @@ ipv6_whitelist_snated_egress_connections(struct __ctx_buff *ctx, struct ipv6_ct_
 	 */
 	if (ct_ret == CT_NEW) {
 		int ret = ct_create6(get_ct_map6(tuple), &CT_MAP_ANY6,
-				     tuple, ctx, CT_EGRESS, &ct_state_new,
-				     ext_err);
+				     tuple, ctx, CT_EGRESS, NULL, ext_err);
 		if (unlikely(ret < 0))
 			return ret;
 	}
@@ -304,8 +301,6 @@ static __always_inline int
 ipv4_whitelist_snated_egress_connections(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 					 enum ct_status ct_ret, __s8 *ext_err)
 {
-	struct ct_state ct_state_new = {};
-
 	/* If kube-proxy is in use (no BPF-based masquerading), packets from
 	 * pods may be SNATed. The response packet will therefore have a host
 	 * IP as the destination IP.
@@ -318,8 +313,7 @@ ipv4_whitelist_snated_egress_connections(struct __ctx_buff *ctx, struct ipv4_ct_
 	 */
 	if (ct_ret == CT_NEW) {
 		int ret = ct_create4(get_ct_map4(tuple), &CT_MAP_ANY4,
-				     tuple, ctx, CT_EGRESS, &ct_state_new,
-				     ext_err);
+				     tuple, ctx, CT_EGRESS, NULL, ext_err);
 		if (unlikely(ret < 0))
 			return ret;
 	}

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -35,7 +35,7 @@ ipv6_whitelist_snated_egress_connections(struct __ctx_buff *ctx, struct ipv6_ct_
 	if (ct_ret == CT_NEW) {
 		int ret = ct_create6(get_ct_map6(tuple), &CT_MAP_ANY6,
 				     tuple, ctx, CT_EGRESS, &ct_state_new,
-				     false, false, ext_err);
+				     ext_err);
 		if (unlikely(ret < 0))
 			return ret;
 	}
@@ -129,6 +129,9 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 	/* Only create CT entry for accepted connections */
 	if (ret == CT_NEW && verdict == CTX_ACT_OK) {
 		ct_state_new.src_sec_id = HOST_ID;
+		ct_state_new.proxy_redirect = proxy_port > 0;
+		ct_state_new.from_l7lb = false;
+
 		/* ext_err may contain a value from __policy_can_access, and
 		 * ct_create6 overwrites it only if it returns an error itself.
 		 * As the error from __policy_can_access is dropped in that
@@ -136,8 +139,7 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 		 * its error code.
 		 */
 		ret = ct_create6(get_ct_map6(tuple), &CT_MAP_ANY6, tuple,
-				 ctx, CT_EGRESS, &ct_state_new, proxy_port > 0, false,
-				 ext_err);
+				 ctx, CT_EGRESS, &ct_state_new, ext_err);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -247,6 +249,9 @@ __ipv6_host_policy_ingress(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 	if (ret == CT_NEW && verdict == CTX_ACT_OK) {
 		/* Create new entry for connection in conntrack map. */
 		ct_state_new.src_sec_id = *src_sec_identity;
+		ct_state_new.proxy_redirect = proxy_port > 0;
+		ct_state_new.from_l7lb = false;
+
 		/* ext_err may contain a value from __policy_can_access, and
 		 * ct_create6 overwrites it only if it returns an error itself.
 		 * As the error from __policy_can_access is dropped in that
@@ -254,8 +259,7 @@ __ipv6_host_policy_ingress(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 		 * its error code.
 		 */
 		ret = ct_create6(get_ct_map6(tuple), &CT_MAP_ANY6, tuple,
-				 ctx, CT_INGRESS, &ct_state_new, proxy_port > 0, false,
-				 ext_err);
+				 ctx, CT_INGRESS, &ct_state_new, ext_err);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -315,7 +319,7 @@ ipv4_whitelist_snated_egress_connections(struct __ctx_buff *ctx, struct ipv4_ct_
 	if (ct_ret == CT_NEW) {
 		int ret = ct_create4(get_ct_map4(tuple), &CT_MAP_ANY4,
 				     tuple, ctx, CT_EGRESS, &ct_state_new,
-				     false, false, ext_err);
+				     ext_err);
 		if (unlikely(ret < 0))
 			return ret;
 	}
@@ -403,6 +407,9 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 	/* Only create CT entry for accepted connections */
 	if (ret == CT_NEW && verdict == CTX_ACT_OK) {
 		ct_state_new.src_sec_id = HOST_ID;
+		ct_state_new.proxy_redirect = proxy_port > 0;
+		ct_state_new.from_l7lb = false;
+
 		/* ext_err may contain a value from __policy_can_access, and
 		 * ct_create4 overwrites it only if it returns an error itself.
 		 * As the error from __policy_can_access is dropped in that
@@ -410,8 +417,7 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 		 * its error code.
 		 */
 		ret = ct_create4(get_ct_map4(tuple), &CT_MAP_ANY4, tuple,
-				 ctx, CT_EGRESS, &ct_state_new, proxy_port > 0, false,
-				 ext_err);
+				 ctx, CT_EGRESS, &ct_state_new, ext_err);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -524,6 +530,9 @@ __ipv4_host_policy_ingress(struct __ctx_buff *ctx, struct iphdr *ip4,
 	if (ret == CT_NEW && verdict == CTX_ACT_OK) {
 		/* Create new entry for connection in conntrack map. */
 		ct_state_new.src_sec_id = *src_sec_identity;
+		ct_state_new.proxy_redirect = proxy_port > 0;
+		ct_state_new.from_l7lb = false;
+
 		/* ext_err may contain a value from __policy_can_access, and
 		 * ct_create4 overwrites it only if it returns an error itself.
 		 * As the error from __policy_can_access is dropped in that
@@ -531,8 +540,7 @@ __ipv4_host_policy_ingress(struct __ctx_buff *ctx, struct iphdr *ip4,
 		 * its error code.
 		 */
 		ret = ct_create4(get_ct_map4(tuple), &CT_MAP_ANY4, tuple,
-				 ctx, CT_INGRESS, &ct_state_new, proxy_port > 0, false,
-				 ext_err);
+				 ctx, CT_INGRESS, &ct_state_new, ext_err);
 		if (IS_ERR(ret))
 			return ret;
 	}

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -896,8 +896,10 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 
 		state->backend_id = backend_id;
 		state->rev_nat_index = svc->rev_nat_index;
+		state->proxy_redirect = false;
+		state->from_l7lb = false;
 
-		ret = ct_create6(map, NULL, tuple, ctx, CT_SERVICE, state, false, false, ext_err);
+		ret = ct_create6(map, NULL, tuple, ctx, CT_SERVICE, state, ext_err);
 		/* Fail closed, if the conntrack entry create fails drop
 		 * service lookup.
 		 */
@@ -1572,8 +1574,10 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 
 		state->backend_id = backend_id;
 		state->rev_nat_index = svc->rev_nat_index;
+		state->proxy_redirect = false;
+		state->from_l7lb = false;
 
-		ret = ct_create4(map, NULL, tuple, ctx, CT_SERVICE, state, false, false, ext_err);
+		ret = ct_create4(map, NULL, tuple, ctx, CT_SERVICE, state, ext_err);
 		/* Fail closed, if the conntrack entry create fails drop
 		 * service lookup.
 		 */

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -292,7 +292,7 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 		if (ret == CT_NEW) {
 			ret = ct_create4(get_ct_map4(&tuple_snat), NULL,
 					 &tuple_snat, ctx, CT_EGRESS,
-					 &ct_state, ext_err);
+					 NULL, ext_err);
 			if (IS_ERR(ret))
 				return ret;
 		}
@@ -1148,7 +1148,7 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 		if (ret == CT_NEW) {
 			ret = ct_create6(get_ct_map6(&tuple_snat), NULL,
 					 &tuple_snat, ctx, CT_EGRESS,
-					 &ct_state, ext_err);
+					 NULL, ext_err);
 			if (IS_ERR(ret))
 				return ret;
 		}

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -274,7 +274,6 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 
 	if (needs_ct) {
 		struct ipv4_ct_tuple tuple_snat;
-		struct ct_state ct_state = {};
 		int ret;
 
 		memcpy(&tuple_snat, tuple, sizeof(tuple_snat));
@@ -284,7 +283,7 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple_snat), &tuple_snat,
 				      ctx, ipv4_is_fragment(ip4), off, has_l4_header,
 				      CT_EGRESS, SCOPE_FORWARD, CT_ENTRY_ANY,
-				      &ct_state, &trace->monitor);
+				      NULL, &trace->monitor);
 		if (ret < 0)
 			return ret;
 
@@ -326,7 +325,6 @@ snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 
 	if (*state && (*state)->common.needs_ct) {
 		struct ipv4_ct_tuple tuple_revsnat;
-		struct ct_state ct_state = {};
 		int ret;
 
 		memcpy(&tuple_revsnat, tuple, sizeof(tuple_revsnat));
@@ -341,7 +339,7 @@ snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple_revsnat), &tuple_revsnat,
 				      ctx, ipv4_is_fragment(ip4), off, has_l4_header,
 				      CT_INGRESS, SCOPE_REVERSE, CT_ENTRY_ANY,
-				      &ct_state, &trace->monitor);
+				      NULL, &trace->monitor);
 		if (ret < 0)
 			return ret;
 
@@ -1131,7 +1129,6 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 
 	if (needs_ct) {
 		struct ipv6_ct_tuple tuple_snat;
-		struct ct_state ct_state = {};
 		int ret;
 
 		memcpy(&tuple_snat, tuple, sizeof(tuple_snat));
@@ -1140,7 +1137,7 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 
 		ret = ct_lazy_lookup6(get_ct_map6(&tuple_snat), &tuple_snat,
 				      ctx, off, CT_EGRESS, SCOPE_FORWARD,
-				      CT_ENTRY_ANY, &ct_state, &trace->monitor);
+				      CT_ENTRY_ANY, NULL, &trace->monitor);
 		if (ret < 0)
 			return ret;
 
@@ -1174,7 +1171,6 @@ snat_v6_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 
 	if (*state && (*state)->common.needs_ct) {
 		struct ipv6_ct_tuple tuple_revsnat;
-		struct ct_state ct_state = {};
 		int ret;
 
 		memcpy(&tuple_revsnat, tuple, sizeof(tuple_revsnat));
@@ -1188,7 +1184,7 @@ snat_v6_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 
 		ret = ct_lazy_lookup6(get_ct_map6(&tuple_revsnat), &tuple_revsnat,
 				      ctx, off, CT_INGRESS, SCOPE_REVERSE,
-				      CT_ENTRY_ANY, &ct_state, &trace->monitor);
+				      CT_ENTRY_ANY, NULL, &trace->monitor);
 		if (ret < 0)
 			return ret;
 

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -292,7 +292,7 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 		if (ret == CT_NEW) {
 			ret = ct_create4(get_ct_map4(&tuple_snat), NULL,
 					 &tuple_snat, ctx, CT_EGRESS,
-					 &ct_state, false, false, ext_err);
+					 &ct_state, ext_err);
 			if (IS_ERR(ret))
 				return ret;
 		}
@@ -1148,7 +1148,7 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 		if (ret == CT_NEW) {
 			ret = ct_create6(get_ct_map6(&tuple_snat), NULL,
 					 &tuple_snat, ctx, CT_EGRESS,
-					 &ct_state, false, false, ext_err);
+					 &ct_state, ext_err);
 			if (IS_ERR(ret))
 				return ret;
 		}

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -778,7 +778,6 @@ nodeport_dsr_ingress_ipv6(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 			  __s8 *ext_err)
 {
 	struct ct_state ct_state_new = {};
-	struct ct_state ct_state = {};
 	__u32 monitor = 0;
 	int ret;
 
@@ -787,7 +786,7 @@ nodeport_dsr_ingress_ipv6(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 
 	ret = ct_lazy_lookup6(get_ct_map6(tuple), tuple, ctx, l4_off,
 			      CT_EGRESS, SCOPE_FORWARD, CT_ENTRY_DSR,
-			      &ct_state, &monitor);
+			      NULL, &monitor);
 	switch (ret) {
 	case CT_NEW:
 	case CT_REOPENED:
@@ -1477,7 +1476,6 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	struct bpf_fib_lookup_padded fib_params __maybe_unused = {};
 	struct lb6_reverse_nat *nat_info;
 	struct ipv6_ct_tuple tuple = {};
-	struct ct_state ct_state = {};
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	int ret, l4_off;
@@ -1511,7 +1509,7 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS,
 			      SCOPE_REVERSE, CT_ENTRY_NODEPORT | CT_ENTRY_DSR,
-			      &ct_state, &trace->monitor);
+			      NULL, &trace->monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 
@@ -2298,7 +2296,6 @@ nodeport_dsr_ingress_ipv4(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 			  __be32 addr, __be16 port, __s8 *ext_err)
 {
 	struct ct_state ct_state_new = {};
-	struct ct_state ct_state = {};
 	__u32 monitor = 0;
 	int ret;
 
@@ -2307,7 +2304,7 @@ nodeport_dsr_ingress_ipv4(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 
 	ret = ct_lazy_lookup4(get_ct_map4(tuple), tuple, ctx, ipv4_is_fragment(ip4),
 			      l4_off, has_l4_header, CT_EGRESS, SCOPE_FORWARD,
-			      CT_ENTRY_DSR, &ct_state, &monitor);
+			      CT_ENTRY_DSR, NULL, &monitor);
 	switch (ret) {
 	case CT_NEW:
 	/* Maybe we can be a bit more selective about CT_REOPENED?

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -797,8 +797,11 @@ create_ct:
 
 		ct_state_new.src_sec_id = WORLD_IPV6_ID;
 		ct_state_new.dsr = 1;
+		ct_state_new.proxy_redirect = false;
+		ct_state_new.from_l7lb = false;
+
 		ret = ct_create6(get_ct_map6(tuple), NULL, tuple, ctx,
-				 CT_EGRESS, &ct_state_new, false, false, ext_err);
+				 CT_EGRESS, &ct_state_new, ext_err);
 		if (!IS_ERR(ret))
 			ret = snat_v6_create_dsr(tuple, addr, port, ext_err);
 
@@ -1405,8 +1408,11 @@ redo:
 #ifndef HAVE_FIB_IFINDEX
 			ct_state_new.ifindex = (__u16)NATIVE_DEV_IFINDEX;
 #endif
+			ct_state_new.proxy_redirect = false;
+			ct_state_new.from_l7lb = false;
+
 			ret = ct_create6(get_ct_map6(&tuple), NULL, &tuple, ctx,
-					 CT_EGRESS, &ct_state_new, false, false, ext_err);
+					 CT_EGRESS, &ct_state_new, ext_err);
 			if (IS_ERR(ret))
 				return ret;
 			break;
@@ -2318,8 +2324,11 @@ create_ct:
 
 		ct_state_new.src_sec_id = WORLD_IPV4_ID;
 		ct_state_new.dsr = 1;
+		ct_state_new.proxy_redirect = 0;
+		ct_state_new.from_l7lb = 0;
+
 		ret = ct_create4(get_ct_map4(tuple), NULL, tuple, ctx,
-				 CT_EGRESS, &ct_state_new, false, false, ext_err);
+				 CT_EGRESS, &ct_state_new, ext_err);
 		if (!IS_ERR(ret))
 			ret = snat_v4_create_dsr(tuple, addr, port, ext_err);
 
@@ -2927,8 +2936,11 @@ redo:
 #ifndef HAVE_FIB_IFINDEX
 			ct_state_new.ifindex = (__u16)NATIVE_DEV_IFINDEX;
 #endif
+			ct_state_new.proxy_redirect = false;
+			ct_state_new.from_l7lb = false;
+
 			ret = ct_create4(get_ct_map4(&tuple), NULL, &tuple, ctx,
-					 CT_EGRESS, &ct_state_new, false, false, ext_err);
+					 CT_EGRESS, &ct_state_new, ext_err);
 			if (IS_ERR(ret))
 				return ret;
 			break;

--- a/bpf/tests/bpf_ct_tests.c
+++ b/bpf/tests/bpf_ct_tests.c
@@ -133,7 +133,7 @@ int test_ct4_rst1_check(__maybe_unused struct __ctx_buff *ctx)
 			ct_state_new.node_port = ct_state.node_port;
 			ct_state_new.ifindex = ct_state.ifindex;
 			ret = ct_create4(get_ct_map4(&tuple), &CT_MAP_ANY4, &tuple, ctx,
-					 CT_EGRESS, &ct_state_new, false, false, NULL);
+					 CT_EGRESS, &ct_state_new, NULL);
 			break;
 
 		default:

--- a/bpf/tests/bpf_ct_tests.c
+++ b/bpf/tests/bpf_ct_tests.c
@@ -173,7 +173,6 @@ int test_ct4_rst1_check(__maybe_unused struct __ctx_buff *ctx)
 		struct iphdr *ip4;
 		int l3_off = ETH_HLEN;
 		int l4_off;
-		struct ct_state ct_state = {};
 		__u16 proto;
 		__u32 monitor = 0;
 
@@ -187,7 +186,7 @@ int test_ct4_rst1_check(__maybe_unused struct __ctx_buff *ctx)
 		l4_off = l3_off + ipv4_hdrlen(ip4);
 
 		ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, ip4, l4_off,
-			   CT_INGRESS, &ct_state, &monitor);
+			   CT_INGRESS, NULL, &monitor);
 
 		if (data + pkt_size > data_end)
 			test_fatal("packet shrank");

--- a/bpf/tests/conntrack_test.c
+++ b/bpf/tests/conntrack_test.c
@@ -112,7 +112,6 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		if (!entry)
 			test_fatal("ct entry lookup failed");
 
-		struct ct_state ct_state;
 		union tcp_flags seen_flags = {0};
 		__u32 monitor;
 
@@ -121,7 +120,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		/* First packet is monitored */
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_INGRESS,
-				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, NULL, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == TRACE_PAYLOAD_LEN);
 		assert(timeout_in(entry, CT_SYN_TIMEOUT));
@@ -132,7 +131,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		advance_time();
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_INGRESS,
-				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, NULL, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == 0);
 		assert(timeout_in(entry, CT_SYN_TIMEOUT));
@@ -142,7 +141,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value &= ~TCP_FLAG_SYN;
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_INGRESS,
-				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, NULL, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == 0);
 		assert(timeout_in(entry, CT_CONNECTION_LIFETIME_TCP));
@@ -152,7 +151,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value |= TCP_FLAG_FIN;
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_INGRESS,
-				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, NULL, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == TRACE_PAYLOAD_LEN);
 		assert(timeout_in(entry, CT_CONNECTION_LIFETIME_TCP));
@@ -162,7 +161,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value &= ~TCP_FLAG_FIN;
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_INGRESS,
-				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, NULL, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == 0);
 		assert(timeout_in(entry, CT_CONNECTION_LIFETIME_TCP));
@@ -175,7 +174,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value |= TCP_FLAG_FIN;
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_EGRESS,
-				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, NULL, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == TRACE_PAYLOAD_LEN);
 		assert(timeout_in(entry, CT_CLOSE_TIMEOUT));
@@ -186,7 +185,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value &= ~TCP_FLAG_FIN;
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_EGRESS,
-				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, NULL, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == 0);
 		assert(timeout_in(entry, CT_CLOSE_TIMEOUT - 1));
@@ -197,7 +196,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value = TCP_FLAG_SYN;
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_EGRESS,
-				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, NULL, true, seen_flags, &monitor);
 		assert(res == CT_REOPENED);
 		assert(monitor == TRACE_PAYLOAD_LEN);
 		assert(timeout_in(entry, CT_CONNECTION_LIFETIME_TCP));
@@ -207,7 +206,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value = TCP_FLAG_SYN;
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_INGRESS,
-				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, NULL, true, seen_flags, &monitor);
 		assert(res == CT_NEW);
 		assert(monitor == TRACE_PAYLOAD_LEN);
 	});


### PR DESCRIPTION
Clean up a few bits in the CT entry creation / lookup code, where the caller currently needs to provide a placeholder `ct_state` parameter.