### PR TITLE
iptables: early skip proxy rules install if BPF tproxy enabled

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -800,29 +800,6 @@ func (m *Manager) addProxyRules(prog iptablesInterface, ip string, proxyPort uin
 	return nil
 }
 
-// install or remove rules for a single proxy port
-func (m *Manager) iptProxyRules(proxyPort uint16, ingress, localOnly bool, name string) error {
-	ipv4 := "0.0.0.0"
-	ipv6 := "::"
-
-	if localOnly {
-		ipv4 = "127.0.0.1"
-		ipv6 = "::1"
-	}
-	if m.sharedCfg.EnableIPv4 {
-		if err := m.addProxyRules(ip4tables, ipv4, proxyPort, ingress, name); err != nil {
-			return err
-		}
-	}
-	if m.sharedCfg.EnableIPv6 {
-		if err := m.addProxyRules(ip6tables, ipv6, proxyPort, ingress, name); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (m *Manager) endpointNoTrackRules(prog iptablesInterface, cmd string, IP string, port *lb.L4Addr) error {
 	var err error
 
@@ -1009,6 +986,12 @@ func (m *Manager) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error {
 }
 
 func (m *Manager) InstallProxyRules(ctx context.Context, proxyPort uint16, ingress, localOnly bool, name string) error {
+	if m.haveBPFSocketAssign {
+		log.WithField("port", proxyPort).
+			Debug("Skipping proxy rule install due to BPF support")
+		return nil
+	}
+
 	backoff := backoff.Exponential{
 		Min:  20 * time.Second,
 		Max:  3 * time.Minute,
@@ -1039,12 +1022,25 @@ func (m *Manager) doInstallProxyRules(proxyPort uint16, ingress, localOnly bool,
 	m.Lock()
 	defer m.Unlock()
 
-	if m.haveBPFSocketAssign {
-		log.WithField("port", proxyPort).
-			Debug("Skipping proxy rule install due to BPF support")
-		return nil
+	ipv4 := "0.0.0.0"
+	ipv6 := "::"
+
+	if localOnly {
+		ipv4 = "127.0.0.1"
+		ipv6 = "::1"
 	}
-	return m.iptProxyRules(proxyPort, ingress, localOnly, name)
+	if m.sharedCfg.EnableIPv4 {
+		if err := m.addProxyRules(ip4tables, ipv4, proxyPort, ingress, name); err != nil {
+			return err
+		}
+	}
+	if m.sharedCfg.EnableIPv6 {
+		if err := m.addProxyRules(ip6tables, ipv6, proxyPort, ingress, name); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // GetProxyPort finds a proxy port used for redirect 'name' installed earlier with InstallProxyRules.


### PR DESCRIPTION
Currently, the iptables manager skips installing iptables proxy rules if BPF tproxy support is configured. But it doesn't happen right after entering the method - which potentially leads to the following confusing log output.

```
level=debug msg="Skipping proxy rule install due to BPF support" port=40223 subsys=iptables
level=info msg="Iptables proxy rules installed" subsys=iptables
```

`Iptables proxy rules installed` is misleading and should not be logged if we skip the iptables. (Especially in case log level `info` is configured - and the "skipping" message (level `debug`) isn't logged.)

Therefore, this commit moves the check at the beginning of the method `InstallProxyRules`. This way, only `Skipping proxy rule install due to BPF support` gets logged.