### PR TITLE
[1.12] ci-ipsec-upgrade: run no-unexpected-packet-drops for patch downgrades

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -175,6 +175,9 @@ jobs:
           if [ "${{ matrix.mode }}" = "minor" ]; then
             CILIUM_DOWNGRADE_VERSION=$(contrib/scripts/print-downgrade-version.sh)
             IMAGE_TAG=${CILIUM_DOWNGRADE_VERSION}
+            # Disable no-unexpected-packet-drops (formerly no-missed-tail-calls) 
+            # because the API to retrieve those is different in v1.11.
+            EXTRA_CONN_TEST_FLAGS='--test "!no-unexpected-packet-drops"'
           else
             # Upgrade from / downgrade to patch release.
             # In some cases we expect to fail to get the version number, do not
@@ -189,9 +192,14 @@ jobs:
             # default release image, without crafting an image path with the
             # "-ci" suffix
             IMAGE_TAG=''
+            # On patch downgrades we allowlist missed tail calls and ct buffer drops, see :
+            # https://github.com/cilium/cilium/issues/26739
+            # https://github.com/cilium/cilium/pull/30202
+            EXTRA_CONN_TEST_FLAGS='--expected-drop-reasons "+Missed tail call,+Failed to update or lookup TC buffer"'
           fi
           echo downgrade_version=${CILIUM_DOWNGRADE_VERSION} >> $GITHUB_OUTPUT
           echo image_tag=${IMAGE_TAG} >> $GITHUB_OUTPUT
+          echo extra_conn_test_flags=${EXTRA_CONN_TEST_FLAGS} >> $GITHUB_OUTPUT
 
       - name: Derive stable Cilium installation config
         id: cilium-stable-config
@@ -352,10 +360,7 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test
         with:
           job-name: ipsec-downgrade-${{ matrix.name }}
-          # Disable no-missed-tail-calls due to https://github.com/cilium/cilium/issues/26739
-          # Disable no-unexpected-packet-drops because the API to retrieve
-          # those is different in v1.11.
-          extra-connectivity-test-flags: --test '!no-missed-tail-calls,!no-unexpected-packet-drops'
+          extra-connectivity-test-flags: '${{ steps.vars.outputs.extra_conn_test_flags }}'
           operation-cmd: |
             cd /host/
 


### PR DESCRIPTION
Currently we disable the no-unexpected-packet-drops test because for 1.11 the necessary APIs are missing to execute that test. Because the flag is unconditionally set, this applies to downgrades between patch AND minor versions. However, it should only apply to minor (1.12 -> 1.11) downgrades. On downgrades between patch versions (1.12.x -> 1.12.y) we should run this test and allowlist certain reasons that are known to fail.
