### PR TITLE
Revert "bpf: ct: avoid header revalidation in ct_lookup4()"

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -285,7 +285,7 @@ int NAME(struct __ctx_buff *ctx)						\
 		return drop_for_direction(ctx, DIR, DROP_CT_NO_MAP_FOUND,	\
 					  ext_err);				\
 										\
-	ct_buffer.ret = ct_lookup4(map, tuple, ctx, ip4, ct_buffer.l4_off,	\
+	ct_buffer.ret = ct_lookup4(map, tuple, ctx, ct_buffer.l4_off,		\
 				   DIR, ct_state, &ct_buffer.monitor);		\
 	if (ct_buffer.ret < 0)							\
 		return drop_for_direction(ctx, DIR, ct_buffer.ret, ext_err);	\

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -884,15 +884,25 @@ ct_lazy_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff 
 /* Offset must point to IPv4 header */
 static __always_inline int ct_lookup4(const void *map,
 				      struct ipv4_ct_tuple *tuple,
-				      struct __ctx_buff *ctx, struct iphdr *ip4,
-				      int off, enum ct_dir dir,
+				      struct __ctx_buff *ctx, int off, enum ct_dir dir,
 				      struct ct_state *ct_state, __u32 *monitor)
 {
-	bool is_fragment = ipv4_is_fragment(ip4);
 	bool has_l4_header = true;
+	bool is_fragment = false;
+	struct iphdr *ip4 = NULL;
+#ifdef ENABLE_IPV4_FRAGMENTS
+	void *data, *data_end;
+#endif
 	int ret;
 
 	tuple->flags = ct_lookup_select_tuple_type(dir, SCOPE_BIDIR);
+
+#ifdef ENABLE_IPV4_FRAGMENTS
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+		return DROP_CT_INVALID_HDR;
+
+	is_fragment = ipv4_is_fragment(ip4);
+#endif
 
 	ret = ct_extract_ports4(ctx, ip4, off, dir, tuple, &has_l4_header);
 	if (ret < 0)

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -344,7 +344,7 @@ ipv4_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 	tuple->daddr = ip4->daddr;
 	tuple->saddr = ip4->saddr;
 	ct_buffer->l4_off = l3_off + ipv4_hdrlen(ip4);
-	ct_buffer->ret = ct_lookup4(get_ct_map4(tuple), tuple, ctx, ip4, ct_buffer->l4_off,
+	ct_buffer->ret = ct_lookup4(get_ct_map4(tuple), tuple, ctx, ct_buffer->l4_off,
 				    CT_EGRESS, NULL, &ct_buffer->monitor);
 	return true;
 }
@@ -465,7 +465,7 @@ ipv4_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct iphdr *ip4,
 	tuple->daddr = ip4->daddr;
 	tuple->saddr = ip4->saddr;
 	ct_buffer->l4_off = l3_off + ipv4_hdrlen(ip4);
-	ct_buffer->ret = ct_lookup4(get_ct_map4(tuple), tuple, ctx, ip4, ct_buffer->l4_off,
+	ct_buffer->ret = ct_lookup4(get_ct_map4(tuple), tuple, ctx, ct_buffer->l4_off,
 				    CT_INGRESS, NULL, &ct_buffer->monitor);
 
 	return true;

--- a/bpf/tests/bpf_ct_tests.c
+++ b/bpf/tests/bpf_ct_tests.c
@@ -126,8 +126,8 @@ int test_ct4_rst1_check(__maybe_unused struct __ctx_buff *ctx)
 		tuple.saddr = ip4->saddr;
 		l4_off = l3_off + ipv4_hdrlen(ip4);
 
-		ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, ip4, l4_off,
-				 CT_EGRESS, &ct_state, &monitor);
+		ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_EGRESS,
+				 &ct_state, &monitor);
 		switch (ret) {
 		case CT_NEW:
 			ct_state_new.node_port = ct_state.node_port;
@@ -185,7 +185,7 @@ int test_ct4_rst1_check(__maybe_unused struct __ctx_buff *ctx)
 		tuple.saddr = ip4->saddr;
 		l4_off = l3_off + ipv4_hdrlen(ip4);
 
-		ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, ip4, l4_off,
+		ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
 			   CT_INGRESS, NULL, &monitor);
 
 		if (data + pkt_size > data_end)


### PR DESCRIPTION
This reverts commit 3951a179711fed9519414d7f95eff73563180d56.

Per - https://github.com/cilium/cilium/issues/30093#issuecomment-1879181788

Related - https://github.com/cilium/cilium/issues/30266

