### PR TITLE
go.mod: Bump controller-tools fork version to v0.8.0-2 to allow `XValidation` kubebuilder markers 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -270,5 +270,5 @@ replace (
 
 	// Using private fork of controller-tools. See commit msg for more context
 	// as to why we are using a private fork.
-	sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.8.0-1
+	sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.8.0-2
 )

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cilium/checkmate v1.0.3 h1:CQC5eOmlAZeEjPrVZY3ZwEBH64lHlx9mXYdUehEwI5w=
 github.com/cilium/checkmate v1.0.3/go.mod h1:KiBTasf39/F2hf2yAmHw21YFl3hcEyP4Yk6filxc12A=
-github.com/cilium/controller-tools v0.8.0-1 h1:D5xhwSUZZceaKAacHOyfcpUMgLbs2TGeJEijNHlAQlc=
-github.com/cilium/controller-tools v0.8.0-1/go.mod h1:qE2DXhVOiEq5ijmINcFbqi9GZrrUjzB1TuJU0xa6eoY=
+github.com/cilium/controller-tools v0.8.0-2 h1:QkYiSOyZz4Aww7JrvoH/8DjuEZ/Hlq2VREWe2Sb2NTQ=
+github.com/cilium/controller-tools v0.8.0-2/go.mod h1:qE2DXhVOiEq5ijmINcFbqi9GZrrUjzB1TuJU0xa6eoY=
 github.com/cilium/coverbee v0.3.2 h1:RaJN5OaHf/M8tmeLemHmdO0H5bFUhvtTAoYbStDIX14=
 github.com/cilium/coverbee v0.3.2/go.mod h1:p9Q2SRC/sPA0qATNfY19GXBUPdcQP6UVV2LKgOHRIzQ=
 github.com/cilium/deepequal-gen v0.0.0-20231116094812-0d6c075c335f h1:t1A8nGkbZcjLACtNGIkfhfnKgG7V83+Tzr1pMeoPuA8=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2066,7 +2066,7 @@ sigs.k8s.io/controller-runtime/pkg/webhook
 sigs.k8s.io/controller-runtime/pkg/webhook/admission
 sigs.k8s.io/controller-runtime/pkg/webhook/conversion
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
-# sigs.k8s.io/controller-tools v0.13.0 => github.com/cilium/controller-tools v0.8.0-1
+# sigs.k8s.io/controller-tools v0.13.0 => github.com/cilium/controller-tools v0.8.0-2
 ## explicit; go 1.17
 sigs.k8s.io/controller-tools/cmd/controller-gen
 sigs.k8s.io/controller-tools/pkg/crd
@@ -2118,4 +2118,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 # go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7
-# sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.8.0-1
+# sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.8.0-2

--- a/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/validation.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/validation.go
@@ -67,6 +67,7 @@ var ValidationMarkers = mustMakeAllWithPrefix("kubebuilder:validation", markers.
 	XPreserveUnknownFields{},
 	XEmbeddedResource{},
 	XIntOrString{},
+	XValidation{},
 )
 
 // FieldOnlyMarkers list field-specific validation markers (i.e. those markers that don't make
@@ -256,6 +257,17 @@ type XIntOrString struct{}
 // to be used only as a last resort.
 type Schemaless struct{}
 
+// +controllertools:marker:generateHelp:category="CRD validation"
+// XValidation marks a field as requiring a value for which a given
+// expression evaluates to true.
+//
+// This marker may be repeated to specify multiple expressions, all of
+// which must evaluate to true.
+type XValidation struct {
+	Rule    string
+	Message string `marker:",optional"`
+}
+
 func (m Maximum) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	if schema.Type != "integer" {
 		return fmt.Errorf("must apply maximum to an integer")
@@ -433,3 +445,11 @@ func (m XIntOrString) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 }
 
 func (m XIntOrString) ApplyFirst() {}
+
+func (m XValidation) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
+	schema.XValidations = append(schema.XValidations, apiext.ValidationRule{
+		Rule:    m.Rule,
+		Message: m.Message,
+	})
+	return nil
+}

--- a/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/zz_generated.markerhelp.go
@@ -467,3 +467,23 @@ func (XPreserveUnknownFields) Help() *markers.DefinitionHelp {
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
 }
+
+func (XValidation) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD validation",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "marks a field as requiring a value for which a given expression evaluates to true. ",
+			Details: "This marker may be repeated to specify multiple expressions, all of which must evaluate to true.",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{
+			"Rule": {
+				Summary: "",
+				Details: "",
+			},
+			"Message": {
+				Summary: "",
+				Details: "",
+			},
+		},
+	}
+}


### PR DESCRIPTION
Bumps `controller-tools` fork to the newly released version [v0.8.0-2](https://github.com/cilium/controller-tools/releases/tag/v0.8.0-2) which adds support for kubebuilder `XValidation` markers (https://github.com/cilium/controller-tools/pull/5). This allows using [Common Expression Language (CEL)](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules) to validate custom resource values in cilium CRDs.

Example marker in CRD types:
```
  // +kubebuilder:validation:XValidation:rule="self.keepAliveTimeSeconds <= self.holdTimeSeconds",message="keepAliveTimeSeconds should be smaller than or equal to holdTimeSeconds"
```

Generated API:
```
   x-kubernetes-validations:
   - message: keepAliveTimeSeconds should be smaller than or equal to
       holdTimeSeconds
     rule: self.keepAliveTimeSeconds <= self.holdTimeSeconds
```
