### PR TITLE
Docs: Adds IPv6 Tunneling Caveat to Networking Concepts

### DIFF
--- a/Documentation/network/concepts/routing.rst
+++ b/Documentation/network/concepts/routing.rst
@@ -31,6 +31,9 @@ Requirements on the network
   Cilium nodes can already reach each other, all routing requirements are
   already met.
 
+* The underlying network must support IPv4. See :gh-issue:`17240`
+  for the status of IPv6-based tunneling.
+
 * The underlying network and firewalls must allow encapsulated packets:
 
   ================== =====================


### PR DESCRIPTION
Previously, the network concepts doc did not state an IPv4 networking requirement. Therefore, users are safe to assume that tunnel mode is supported for IPv6-only networks.

This PR adds the IPv4 network support to the list of tunnel mode requirements.

Fixes #30360