### PR TITLE
pkg/endpoint: fix endpoint health update always being ok.

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -711,8 +711,9 @@ func (e *Endpoint) Regenerate(regenMetadata *regeneration.ExternalRegenerationMe
 			if regenError != nil && !errors.Is(regenError, context.Canceled) {
 				e.getLogger().WithError(regenError).Error("endpoint regeneration failed")
 				hr.Degraded("Endpoint regeneration failed", regenError)
+			} else {
+				hr.OK("Endpoint regeneration successful")
 			}
-			hr.OK("Endpoint regeneration successful")
 		} else {
 			// This may be unnecessary(?) since 'closing' of the results
 			// channel means that event has been cancelled?


### PR DESCRIPTION
In cases where the endpoint regen fails, such as in a complexity issue, the endpoints reporter should be put into a degraded state.

However, currently it will degrade the endpoint hr, and the immediately clear the degraded state with hr.Ok(...).

This fixes that to only clear if there is no error while regenerating.

