### PR TITLE
gitignore: add files related to direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,7 @@ bpf/.cache
 
 # Include dummy bpf object necessary for XDP_TX
 !test/l4lb/bpf_xdp_veth_host.o
+
+# Files used for direnv
+.direnv
+.envrc


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

This commit modifies gitignore to ignore files related to direnv, which is a developer tool whose files shouldn't be committed into the repository.

```release-note
Modify gitignore to ignore direnv-related files
```
