### PR TITLE
v1.14 Backports 2024-01-23

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -114,7 +114,7 @@ jobs:
             uname -a
             # The LVH image might ship with an arbitrary Go toolchain version,
             # install the same Go toolchain version as current HEAD.
-            CGO_ENABLED=0 go install golang.org/dl/go${{ env.go-version }}@latest
+            CGO_ENABLED=0 GOPROXY=direct GOSUMDB= go install golang.org/dl/go${{ env.go-version }}@latest
             go${{ env.go-version }} download
 
       - name: Run verifier tests

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -110,6 +110,8 @@ jobs:
           cpu: 4
           install-dependencies: 'true'
           cmd: |
+            for i in {1..5}; do curl "https://golang.org" > /dev/null 2>&1 && break || sleep 5; echo "Waiting for systemd-resolved to be ready..."; done
+
             git config --global --add safe.directory /host
             uname -a
             # The LVH image might ship with an arbitrary Go toolchain version,

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -114,7 +114,7 @@ jobs:
             uname -a
             # The LVH image might ship with an arbitrary Go toolchain version,
             # install the same Go toolchain version as current HEAD.
-            go install golang.org/dl/go${{ env.go-version }}@latest
+            CGO_ENABLED=0 go install golang.org/dl/go${{ env.go-version }}@latest
             go${{ env.go-version }} download
 
       - name: Run verifier tests

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -52,6 +52,8 @@ concurrency:
 
 env:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  # renovate: datasource=golang-version depName=go
+  go-version: 1.21.0
 
 jobs:
   commit-status-start:
@@ -110,6 +112,10 @@ jobs:
           cmd: |
             git config --global --add safe.directory /host
             uname -a
+            # The LVH image might ship with an arbitrary Go toolchain version,
+            # install the same Go toolchain version as current HEAD.
+            go install golang.org/dl/go${{ env.go-version }}@latest
+            go${{ env.go-version }} download
 
       - name: Run verifier tests
         uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
@@ -118,7 +124,7 @@ jobs:
           cmd: |
             cd /host/
             # Run with cgo disabled, LVH images don't ship with gcc.
-            CGO_ENABLED=0 go test -v -parallel=1 ./test/verifier -cilium-base-path /host -ci-kernel-version ${{ matrix.ci-kernel }}
+            CGO_ENABLED=0 go${{ env.go-version }} test -v -parallel=1 ./test/verifier -cilium-base-path /host -ci-kernel-version ${{ matrix.ci-kernel }}
 
       - name: Fetch artifacts
         if: ${{ !success() }}


### PR DESCRIPTION
Backporting ci-verifier fixes to address the failure observed in https://github.com/cilium/cilium/pull/30355:

```
go: errors parsing go.mod:
/host/go.mod:4: invalid go version '1.21.0': must match format 1.23
```

 * [x] #27857 (@tklauser)
 * [x] #27869 (@tklauser)
 * [x] #29549 (@tklauser)
 * [x] #29633 (@mhofstetter)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 27857 27869 29549 29633
```
