### PR TITLE
[v1.14] bpf: fib: fix issues with L2 resolution

### DIFF
--- a/bpf/lib/egress_policies.h
+++ b/bpf/lib/egress_policies.h
@@ -615,7 +615,7 @@ srv6_refib(struct __ctx_buff *ctx, int *ext_err)
 		 * rewrite the layer 2 and continue processing.
 		 */
 		if (old_oif != params.l.ifindex)
-			return fib_do_redirect(ctx, true, &params,
+			return fib_do_redirect(ctx, true, &params, false,
 					      (__s8 *)ext_err, (int *)&old_oif);
 
 		if (eth_store_daddr(ctx, params.l.dmac, 0) < 0)
@@ -630,7 +630,7 @@ srv6_refib(struct __ctx_buff *ctx, int *ext_err)
 		 * or redirect.
 		 */
 		if (old_oif != params.l.ifindex)
-			return fib_do_redirect(ctx, true, &params,
+			return fib_do_redirect(ctx, true, &params, false,
 					      (__s8 *)ext_err, (int *)&old_oif);
 		break;
 	default:

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -80,11 +80,6 @@ fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 		const struct bpf_fib_lookup_padded *fib_params,
 		bool allow_neigh_map, __s8 *fib_ret, int *oif)
 {
-	struct bpf_redir_neigh nh_params;
-	struct bpf_redir_neigh *nh = NULL;
-	union macaddr *dmac = 0;
-	int ret;
-
 	/* sanity check, we only enter this function with these two fib lookup
 	 * return codes.
 	 */
@@ -111,6 +106,7 @@ fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 	/* determine if we need to append layer 2 header */
 	if (needs_l2_check) {
 		bool l2_hdr_required = true;
+		int ret;
 
 		ret = maybe_add_l2_hdr(ctx, *oif, &l2_hdr_required);
 		if (ret != 0)
@@ -128,43 +124,37 @@ fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 			return DROP_WRITE_ERROR;
 		break;
 	case BPF_FIB_LKUP_RET_NO_NEIGH:
-		/* previous fib lookup was performed, we can fillout both
-		 * a bpf_redir_neigh and a dmac.
-		 *
-		 * the former is used if we have access to redirect_neigh
-		 * the latter is used if we don't and have to use the eBPF
-		 * neighbor map.
-		 */
-		if (fib_params) {
-			nh_params.nh_family = fib_params->l.family;
-			__bpf_memcpy_builtin(&nh_params.ipv6_nh,
-					     &fib_params->l.ipv6_dst,
-					     sizeof(nh_params.ipv6_nh));
-			nh = &nh_params;
-
-			if (!neigh_resolver_available() && allow_neigh_map) {
-				/* The neigh_record_ip{4,6} locations are mainly from
-				 * inbound client traffic on the load-balancer where we
-				 * know that replies need to go back to them.
-				 */
-				dmac = fib_params->l.family == AF_INET ?
-				neigh_lookup_ip4(&fib_params->l.ipv4_dst) :
-				neigh_lookup_ip6((void *)&fib_params->l.ipv6_dst);
-			}
-		}
-
 		/* If we are able to resolve neighbors on demand, always
 		 * prefer that over the BPF neighbor map since the latter
 		 * might be less accurate in some asymmetric corner cases.
 		 */
 		if (neigh_resolver_available()) {
-			if (nh)
+			if (fib_params) {
+				struct bpf_redir_neigh nh_params;
+
+				nh_params.nh_family = fib_params->l.family;
+				__bpf_memcpy_builtin(&nh_params.ipv6_nh,
+						     &fib_params->l.ipv6_dst,
+						     sizeof(nh_params.ipv6_nh));
+
 				return redirect_neigh(*oif, &nh_params,
 						sizeof(nh_params), 0);
-			else
-				return redirect_neigh(*oif, NULL, 0, 0);
+			}
+
+			return redirect_neigh(*oif, NULL, 0, 0);
 		} else {
 			union macaddr smac = NATIVE_DEV_MAC_BY_IFINDEX(*oif);
+			union macaddr *dmac = NULL;
+
+			if (allow_neigh_map) {
+				/* The neigh_record_ip{4,6} locations are mainly from
+				 * inbound client traffic on the load-balancer where we
+				 * know that replies need to go back to them.
+				 */
+				dmac = fib_params->l.family == AF_INET ?
+					neigh_lookup_ip4(&fib_params->l.ipv4_dst) :
+					neigh_lookup_ip6((void *)&fib_params->l.ipv6_dst);
+			}
 
 			if (!dmac) {
 				*fib_ret = BPF_FIB_MAP_NO_NEIGH;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -141,7 +141,7 @@ nodeport_fib_lookup_and_redirect(struct __ctx_buff *ctx,
 		if ((__u32)oif == fib_params->l.ifindex)
 			return CTX_ACT_OK;
 
-		return fib_do_redirect(ctx, true, fib_params, ext_err, &oif);
+		return fib_do_redirect(ctx, true, fib_params, true, ext_err, &oif);
 	default:
 		return DROP_NO_FIB;
 	}

--- a/bpf/tests/fib_tests.c
+++ b/bpf/tests/fib_tests.c
@@ -90,7 +90,7 @@ int test1_check(struct __ctx_buff *ctx)
 
 		params.l.ifindex = ifindex_good;
 
-		ret = fib_do_redirect(ctx, false, &params, &flags,
+		ret = fib_do_redirect(ctx, false, &params, true, &flags,
 				      (int *)&ifindex_bad);
 		if (ret != CTX_REDIRECT_ENTERED)
 			test_fatal("did not enter ctx_redirect");
@@ -124,7 +124,7 @@ int test1_check(struct __ctx_buff *ctx)
 		if (!neigh_resolver_available())
 			test_fatal("expected neigh_resolver_available true");
 
-		ret = fib_do_redirect(ctx, false, &params, &flags, (int *)&ifindex_bad);
+		ret = fib_do_redirect(ctx, false, &params, true, &flags, (int *)&ifindex_bad);
 		if (ret != REDIR_NEIGH_ENTERED)
 			test_fatal("did not enter redirect_neigh");
 
@@ -158,7 +158,7 @@ int test1_check(struct __ctx_buff *ctx)
 		if (!neigh_resolver_available())
 			test_fatal("expected neigh_resolver_available true");
 
-		ret = fib_do_redirect(ctx, false, NULL, &flags, (int *)&ifindex_good);
+		ret = fib_do_redirect(ctx, false, NULL, true, &flags, (int *)&ifindex_good);
 		if (ret != REDIR_NEIGH_ENTERED)
 			test_fatal("did not enter redirect_neigh");
 
@@ -193,7 +193,7 @@ int test2_check(__maybe_unused struct __ctx_buff *ctx)
 			if (flag == BPF_FIB_LKUP_RET_NO_NEIGH)
 				continue;
 
-			if (fib_do_redirect(NULL, false, NULL, &flag, NULL) != DROP_NO_FIB)
+			if (fib_do_redirect(NULL, false, NULL, true, &flag, NULL) != DROP_NO_FIB)
 				test_fatal("expected DROP_NO_FIB with flag %d", flag);
 		}
 	});


### PR DESCRIPTION
Manual & minimal backport of
* [ ] #30128

I opted to add the `allow_neigh_map` parameter only for `fib_do_redirect()`, while ignoring the legacy `fib_redirect()`.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 30128
```
