### PR TITLE
daemon: Refactor syncHostIPs

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -989,6 +989,20 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 			Context:     d.ctx,
 		})
 
+	if option.Config.EnableVTEP {
+		// Start controller to setup and periodically verify VTEP
+		// endpoints and routes.
+		syncVTEPControllerGroup := controller.NewGroup("sync-vtep")
+		d.controllers.UpdateController(
+			syncVTEPControllerGroup.Name,
+			controller.ControllerParams{
+				Group:       syncVTEPControllerGroup,
+				DoFunc:      syncVTEP,
+				RunInterval: time.Minute,
+				Context:     d.ctx,
+			})
+	}
+
 	// Wait for the initial sync and check that it succeeded.
 	if err := <-syncErrs; err != nil {
 		return nil, nil, err

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1688,7 +1688,10 @@ func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
 			daemon = d
 
 			if !option.Config.DryMode {
-				startDaemon(daemon, restoredEndpoints, cleaner, params)
+				if err := startDaemon(daemon, restoredEndpoints, cleaner, params); err != nil {
+					daemonResolver.Reject(err)
+					return err
+				}
 			}
 			daemonResolver.Resolve(daemon)
 
@@ -1708,14 +1711,14 @@ func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
 }
 
 // startDaemon starts the old unmodular part of the cilium-agent.
-func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daemonCleanup, params daemonParams) {
+func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daemonCleanup, params daemonParams) error {
 	log.Info("Initializing daemon")
 
 	// This validation needs to be done outside of the agent until
 	// datapath.NodeAddressing is used consistently across the code base.
 	log.Info("Validating configured node address ranges")
 	if err := node.ValidatePostInit(); err != nil {
-		log.Fatalf("postinit failed: %s", err)
+		return fmt.Errorf("postinit failed: %w", err)
 	}
 
 	bootstrapStats.enableConntrack.Start()
@@ -1744,11 +1747,11 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 		d.endpointManager.InitHostEndpointLabels(d.ctx)
 	} else {
 		log.Info("Creating host endpoint")
-		if err := d.endpointManager.AddHostEndpoint(
+		err := d.endpointManager.AddHostEndpoint(
 			d.ctx, d, d, d.ipcache, d.l7Proxy, d.identityAllocator,
-			"Create host endpoint", nodeTypes.GetName(),
-		); err != nil {
-			log.Fatalf("unable to create host endpoint: %s", err)
+			"Create host endpoint", nodeTypes.GetName())
+		if err != nil {
+			return fmt.Errorf("unable to create host endpoint: %w", err)
 		}
 	}
 
@@ -1761,11 +1764,11 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 				log.Warn("Ingress IPs are not available, skipping creation of the Ingress Endpoint: Policy enforcement on Cilium Ingress will not work as expected.")
 			} else {
 				log.Info("Creating ingress endpoint")
-				if err := d.endpointManager.AddIngressEndpoint(
+				err := d.endpointManager.AddIngressEndpoint(
 					d.ctx, d, d, d.ipcache, d.l7Proxy, d.identityAllocator,
-					"Create ingress endpoint",
-				); err != nil {
-					log.Fatalf("unable to create ingress endpoint: %s", err)
+					"Create ingress endpoint")
+				if err != nil {
+					return fmt.Errorf("unable to create ingress endpoint: %w", err)
 				}
 			}
 		}
@@ -1774,7 +1777,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 	if option.Config.EnableIPMasqAgent {
 		ipmasqAgent, err := ipmasq.NewIPMasqAgent(option.Config.IPMasqAgentConfigPath)
 		if err != nil {
-			log.Fatalf("failed to create ipmasq agent: %s", err)
+			return fmt.Errorf("failed to create ipmasq agent: %w", err)
 		}
 		ipmasqAgent.Start()
 	}
@@ -1876,6 +1879,8 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 	if err != nil {
 		log.WithError(err).Error("Unable to store Viper's configuration")
 	}
+
+	return nil
 }
 
 func newRestorerPromise(lc cell.Lifecycle, daemonPromise promise.Promise[*Daemon]) promise.Promise[endpointstate.Restorer] {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1597,9 +1597,12 @@ var daemonCell = cell.Module(
 	"daemon",
 	"Legacy Daemon",
 
-	cell.Provide(newDaemonPromise),
-	cell.Provide(newRestorerPromise),
-	cell.Provide(func() k8s.CacheStatus { return make(k8s.CacheStatus) }),
+	cell.Provide(
+		newDaemonPromise,
+		newRestorerPromise,
+		func() k8s.CacheStatus { return make(k8s.CacheStatus) },
+		newSyncHostIPs,
+	),
 	// Provide a read-only copy of the current daemon settings to be consumed
 	// by the debuginfo API
 	cell.ProvidePrivate(daemonSettings),
@@ -1661,6 +1664,7 @@ type daemonParams struct {
 	IPsecKeyCustodian   datapath.IPsecKeyCustodian
 	MTU                 mtu.MTU
 	Sysctl              sysctl.Sysctl
+	SyncHostIPs         *syncHostIPs
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
@@ -1694,7 +1698,6 @@ func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
 				}
 			}
 			daemonResolver.Resolve(daemon)
-
 			return nil
 		},
 		OnStop: func(cell.HookContext) error {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/netip"
@@ -289,17 +290,6 @@ func (d *Daemon) syncHostIPs() error {
 	}
 	metrics.EndpointMaxIfindex.Set(float64(maxIfindex))
 
-	if option.Config.EnableVTEP {
-		err := setupVTEPMapping()
-		if err != nil {
-			return err
-		}
-		err = setupRouteToVtepCidr()
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -469,6 +459,20 @@ func (d *Daemon) initMaps() error {
 	return nil
 }
 
+func syncVTEP(context.Context) error {
+	if option.Config.EnableVTEP {
+		err := setupVTEPMapping()
+		if err != nil {
+			return err
+		}
+		err = setupRouteToVtepCidr()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func setupVTEPMapping() error {
 	for i, ep := range option.Config.VtepEndpoints {
 		log.WithFields(logrus.Fields{
@@ -479,10 +483,8 @@ func setupVTEPMapping() error {
 		if err != nil {
 			return fmt.Errorf("Unable to set up VTEP ipcache mappings: %w", err)
 		}
-
 	}
 	return nil
-
 }
 
 func setupRouteToVtepCidr() error {

--- a/daemon/cmd/device-reloader.go
+++ b/daemon/cmd/device-reloader.go
@@ -126,11 +126,6 @@ func (d *deviceReloader) reload(ctx context.Context) error {
 		daemon.l2announcer.DevicesChanged(devices)
 	}
 
-	if d.params.Config.EnableNodePort {
-		// Synchronize services and endpoints to reflect new addresses onto lbmap.
-		daemon.controllers.TriggerController(syncHostIPsController)
-	}
-
 	// Reload the datapath.
 	wg, err := daemon.TriggerReloadWithoutCompile("devices changed")
 	if err != nil {

--- a/daemon/cmd/hostips-sync.go
+++ b/daemon/cmd/hostips-sync.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/identity"
+	ippkg "github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/lxcmap"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+const syncHostIPsInterval = time.Minute
+
+type syncHostIPsParams struct {
+	cell.In
+
+	Jobs          job.Registry
+	Scope         cell.Scope
+	DB            *statedb.DB
+	Config        *option.DaemonConfig
+	NodeAddresses statedb.Table[tables.NodeAddress]
+	IPCache       *ipcache.IPCache
+}
+
+type syncHostIPs struct {
+	params     syncHostIPsParams
+	start      chan struct{}
+	firstError chan error
+}
+
+func (s *syncHostIPs) StartAndWaitFirst(ctx context.Context) error {
+	close(s.start)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-s.firstError:
+		return err
+	}
+}
+
+func newSyncHostIPs(lc cell.Lifecycle, p syncHostIPsParams) *syncHostIPs {
+	s := &syncHostIPs{
+		params:     p,
+		start:      make(chan struct{}),
+		firstError: make(chan error, 1),
+	}
+
+	if option.Config.DryMode {
+		s.firstError <- nil
+		return s
+	}
+
+	g := p.Jobs.NewGroup(p.Scope)
+	g.Add(job.OneShot("sync-hostips", s.loop))
+	lc.Append(g)
+
+	return s
+}
+
+func (s *syncHostIPs) loop(ctx context.Context, health cell.HealthReporter) error {
+	// Wait for start signal. This is needed for now to synchronize with initialization
+	// (e.g. IPcache restoration, map init) that still happens in newDaemon.
+	select {
+	case <-s.start:
+	case <-ctx.Done():
+		s.firstError <- ctx.Err()
+		return nil
+	}
+
+	first := true
+	ticker := time.NewTicker(syncHostIPsInterval)
+	defer ticker.Stop()
+
+	for {
+		txn := s.params.DB.ReadTxn()
+		addrs, watch := s.params.NodeAddresses.All(txn)
+
+		err := s.sync(addrs)
+		if err != nil {
+			log.WithError(err).Errorf("Failed to sync host IPs, retrying later")
+			health.Degraded("Failed to sync host IPs", err)
+		} else {
+			health.OK("Synchronized")
+		}
+
+		if first {
+			first = false
+			s.firstError <- err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-watch:
+		case <-ticker.C:
+		}
+	}
+}
+
+// sync adds local host entries to bpf lxcmap, as well as ipcache, if
+// needed, and also notifies the daemon and network policy hosts cache if
+// changes were made.
+func (s *syncHostIPs) sync(addrs statedb.Iterator[tables.NodeAddress]) error {
+	type ipIDLabel struct {
+		identity.IPIdentityPair
+		labels.Labels
+	}
+	specialIdentities := make([]ipIDLabel, 0, 2)
+
+	addIdentity := func(ip net.IP, mask net.IPMask, id identity.NumericIdentity, labels labels.Labels) {
+		specialIdentities = append(specialIdentities, ipIDLabel{
+			identity.IPIdentityPair{
+				IP:   ip,
+				Mask: mask,
+				ID:   id,
+			},
+			labels,
+		})
+	}
+
+	for addr, _, ok := addrs.Next(); ok; addr, _, ok = addrs.Next() {
+		ip := addr.Addr.AsSlice()
+		if (!option.Config.EnableIPv4 && addr.Addr.Is4()) || (!option.Config.EnableIPv6 && addr.Addr.Is6()) {
+			continue
+		}
+		if option.Config.IsExcludedLocalAddress(ip) {
+			continue
+		}
+		addIdentity(ip, nil, identity.ReservedIdentityHost, labels.LabelHost)
+	}
+
+	if option.Config.EnableIPv6 {
+		ipv6Ident := identity.ReservedIdentityWorldIPv6
+		ipv6Label := labels.LabelWorldIPv6
+		if !option.Config.EnableIPv4 {
+			ipv6Ident = identity.ReservedIdentityWorld
+			ipv6Label = labels.LabelWorld
+		}
+		addIdentity(net.IPv6zero, net.CIDRMask(0, net.IPv6len*8), ipv6Ident, ipv6Label)
+	}
+
+	if option.Config.EnableIPv4 {
+		ipv4Ident := identity.ReservedIdentityWorldIPv4
+		ipv4Label := labels.LabelWorldIPv4
+		if !option.Config.EnableIPv6 {
+			ipv4Ident = identity.ReservedIdentityWorld
+			ipv4Label = labels.LabelWorld
+		}
+		addIdentity(net.IPv4zero, net.CIDRMask(0, net.IPv4len*8), ipv4Ident, ipv4Label)
+	}
+
+	existingEndpoints, err := lxcmap.DumpToMap()
+	if err != nil {
+		return fmt.Errorf("dump lxcmap: %w", err)
+	}
+
+	daemonResourceID := ipcachetypes.NewResourceID(ipcachetypes.ResourceKindDaemon, "", "reserved")
+	for _, ipIDLblsPair := range specialIdentities {
+		isHost := ipIDLblsPair.ID == identity.ReservedIdentityHost
+		if isHost {
+			added, err := lxcmap.SyncHostEntry(ipIDLblsPair.IP)
+			if err != nil {
+				return fmt.Errorf("Unable to add host entry to endpoint map: %s", err)
+			}
+			if added {
+				log.WithField(logfields.IPAddr, ipIDLblsPair.IP).Debugf("Added local ip to endpoint map")
+			}
+		}
+
+		delete(existingEndpoints, ipIDLblsPair.IP.String())
+
+		lbls := ipIDLblsPair.Labels
+		if ipIDLblsPair.ID.IsWorld() {
+			p := netip.PrefixFrom(ippkg.MustAddrFromIP(ipIDLblsPair.IP), 0)
+			s.params.IPCache.OverrideIdentity(p, lbls, source.Local, daemonResourceID)
+		} else {
+			s.params.IPCache.UpsertLabels(ippkg.IPToNetPrefix(ipIDLblsPair.IP),
+				lbls,
+				source.Local, daemonResourceID,
+			)
+		}
+	}
+
+	// existingEndpoints is a map from endpoint IP to endpoint info. Referring
+	// to the key as host IP here because we only care about the host endpoint.
+	for hostIP, info := range existingEndpoints {
+		if ip := net.ParseIP(hostIP); info.IsHost() && ip != nil {
+			if err := lxcmap.DeleteEntry(ip); err != nil {
+				return fmt.Errorf("unable to delete obsolete host IP: %w", err)
+			} else {
+				log.Debugf("Removed outdated host IP %s from endpoint map", hostIP)
+			}
+			s.params.IPCache.RemoveLabels(ippkg.IPToNetPrefix(ip), labels.LabelHost, daemonResourceID)
+		}
+	}
+
+	// we have a reference to all ifindex values, so we update the related metric
+	maxIfindex := uint32(0)
+	for _, endpoint := range existingEndpoints {
+		if endpoint.IfIndex > maxIfindex {
+			maxIfindex = endpoint.IfIndex
+		}
+	}
+	metrics.EndpointMaxIfindex.Set(float64(maxIfindex))
+
+	return nil
+}


### PR DESCRIPTION
syncHostIPs depends on the set of node addresses. This is now a changing set and thus hostIPs need to be reconciled if it changes.

In order to get rid of the "deviceReloader" and eventually end up in a situation where components directly watch device & addresses tables, move the syncHostIPs from a controller into a reconciliation loop that watches the addresses.

For now the periodic sync is still kept as-is, though it likely could be removed and replaced with a retry mechanism (the EndpointMaxIfIndex metric seems like the only issue to solve).

The VTEP setup is moved to 'startDaemon' as it is not related to the host IP sync and needs to be performed only once at startup as it depends solely on configuration.