### PR TITLE
docs: Gateway API HTTP Route example

### DIFF
--- a/examples/kubernetes/gateway/basic-https.yaml
+++ b/examples/kubernetes/gateway/basic-https.yaml
@@ -55,5 +55,5 @@ spec:
         type: PathPrefix
         value: /
     backendRefs:
-    - name: productpage
-      port: 9080
+    - name: frontend
+      port: 80


### PR DESCRIPTION
The documentation where this example is used (https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/https/) states that "For simplicity, the second route to productpage is omitted." However, it looks this route is still included in the example although with an incorrect hostname. 

If the route in this example should refer to the hipstershop.cilium.rocks values should be:  
spec.rules.backendRefs.name = frontend
spec.rules.backendRefs.port = 80