### PR TITLE
Revert "pkg/policy: index policies by k8s UID"

### DIFF
--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -111,9 +111,6 @@ type Repository struct {
 	Mutex lock.RWMutex
 	rules ruleSlice
 
-	// rulesIndexByK8sUID indexes the rules by k8s UID.
-	rulesIndexByK8sUID map[string]*rule
-
 	// revision is the revision of the policy repository. It will be
 	// incremented whenever the policy repository is changed.
 	// Always positive (>0).
@@ -193,10 +190,9 @@ func NewStoppedPolicyRepository(
 ) *Repository {
 	selectorCache := NewSelectorCache(idAllocator, idCache)
 	repo := &Repository{
-		rulesIndexByK8sUID: map[string]*rule{},
-		selectorCache:      selectorCache,
-		certManager:        certManager,
-		secretManager:      secretManager,
+		selectorCache: selectorCache,
+		certManager:   certManager,
+		secretManager: secretManager,
 	}
 	repo.revision.Store(1)
 	repo.policyCache = NewPolicyCache(repo, true)
@@ -371,13 +367,6 @@ func (p *Repository) AllowsEgressRLocked(ctx *SearchContext) api.Decision {
 func (p *Repository) SearchRLocked(lbls labels.LabelArray) api.Rules {
 	result := api.Rules{}
 
-	if uid := lbls.Get(labels.LabelSourceK8sKeyPrefix + k8sConst.PolicyLabelUID); uid != "" {
-		r, ok := p.rulesIndexByK8sUID[uid]
-		if ok {
-			result = append(result, &r.Rule)
-		}
-		return result
-	}
 	for _, r := range p.rules {
 		if r.Labels.Contains(lbls) {
 			result = append(result, &r.Rule)
@@ -417,9 +406,6 @@ func (p *Repository) AddListLocked(rules api.Rules) (ruleSlice, uint64) {
 			metadata: newRuleMetadata(),
 		}
 		newList[i] = newRule
-		if uid := rules[i].Labels.Get(labels.LabelSourceK8sKeyPrefix + k8sConst.PolicyLabelUID); uid != "" {
-			p.rulesIndexByK8sUID[uid] = newRule
-		}
 	}
 
 	p.rules = append(p.rules, newList...)
@@ -530,9 +516,6 @@ func (p *Repository) DeleteByLabelsLocked(lbls labels.LabelArray) (ruleSlice, ui
 	if deleted > 0 {
 		p.BumpRevision()
 		p.rules = new
-		if uid := lbls.Get(labels.LabelSourceK8sKeyPrefix + k8sConst.PolicyLabelUID); uid != "" {
-			delete(p.rulesIndexByK8sUID, uid)
-		}
 		metrics.Policy.Sub(float64(deleted))
 	}
 


### PR DESCRIPTION
Reverts cilium/cilium#28173

Seems like fixing the issues in https://github.com/cilium/cilium/pull/30338 are non-trivial, so lets check if the revert is clean and figure out what the best path is.