### PR TITLE
CI: Change cloud regions

### DIFF
--- a/.github/actions/aws/k8s-versions.yaml
+++ b/.github/actions/aws/k8s-versions.yaml
@@ -2,15 +2,15 @@
 ---
 include:
   - version: "1.23"
-    region: eu-central-1
+    region: ca-west-1
   - version: "1.24"
-    region: eu-west-1
+    region: us-west-2
   - version: "1.25"
-    region: ap-northeast-1
+    region: us-west-1
   - version: "1.26"
     region: us-east-2
   - version: "1.27"
     region: ca-central-1
   - version: "1.28"
-    region: eu-north-1
+    region: us-east-1
     default: true

--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -2,13 +2,13 @@
 ---
 include:
   - version: "1.25"
-    location: westeurope
+    location: westus3
     index: 1
   - version: "1.26"
-    location: westus
+    location: westus2
     index: 2
   - version: "1.27"
-    location: eastasia
+    location: eastus2
     index: 3
   - version: "1.28"
     location: eastus

--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -2,18 +2,18 @@
 ---
 k8s:
   - version: "1.24"
-    zone: europe-west6-b
+    zone: us-west1-b
     vmIndex: 1
   - version: "1.25"
-    zone: us-west2-a
+    zone: us-west2-c
     vmIndex: 2
   - version: "1.26"
-    zone: asia-northeast1-c
+    zone: us-west3-a
     vmIndex: 3
   - version: "1.27"
-    zone: europe-north1-b
+    zone: us-east4-b
     vmIndex: 4
   - version: "1.28"
-    zone: us-east5-a
+    zone: us-east1-c
     vmIndex: 5
     default: true


### PR DESCRIPTION
Scheduled workflows run all the supported k8s versions on different regions. During some flake investigation, I have realized that regions in or close to the US take less time than others. Due to long-running tests, some workflows fail.
This PR changes regions to ones in the US or Canada.  Run times before and after are down below. 

Scheduled tests are simulated and links to the successful runs are below.
[aks](https://github.com/cilium/cilium/actions/runs/7681599023)
[aws-cni](https://github.com/cilium/cilium/actions/runs/7681599031)
[eks](https://github.com/cilium/cilium/actions/runs/7681599043)
[external-workloads](https://github.com/cilium/cilium/actions/runs/7681599045)
[gke](https://github.com/cilium/cilium/actions/runs/7681599061)

Note: GKE runs 4 tests per k8s version, they all have similar run times, for simplicity only one of them was included.

As a side effect, Fixes: #30312

Average run times before the change
```
Workflow: Conformance AKS (ci-aks)
Job: Installation and Connectivity Test (1.25, westeurope, 1),  AvgRunTime: 47m9.875s
Job: Installation and Connectivity Test (1.26, westus, 2),  AvgRunTime: 42m3.5s
Job: Installation and Connectivity Test (1.27, eastasia, 3),  AvgRunTime: 59m46s
Job: Installation and Connectivity Test (1.28, eastus, 4, true),  AvgRunTime: 37m5.25s

Workflow: Conformance AWS-CNI (ci-awscni)
Job: Installation and Connectivity Test (1.23, eu-central-1),  AvgRunTime: 33m46.125s
Job: Installation and Connectivity Test (1.24, eu-west-1),  AvgRunTime: 56.3125s
Job: Installation and Connectivity Test (1.25, ap-northeast-1),  AvgRunTime: 33m45.5s
Job: Installation and Connectivity Test (1.26, us-east-2),  AvgRunTime: 25m59.0625s
Job: Installation and Connectivity Test (1.27, ca-central-1),  AvgRunTime: 25m24.125s
Job: Installation and Connectivity Test (1.28, eu-north-1, true),  AvgRunTime: 33m30.4375s

Workflow: Conformance External Workloads (ci-external-workloads)
Job: Installation and Connectivity Test (1.24, europe-west6-b, 1),  AvgRunTime: 30m22s
Job: Installation and Connectivity Test (1.25, us-west2-a, 2),  AvgRunTime: 25m57.6s
Job: Installation and Connectivity Test (1.26, asia-northeast1-c, 3),  AvgRunTime: 38m2.066666666s
Job: Installation and Connectivity Test (1.27, europe-north1-b, 4),  AvgRunTime: 34m17.933333333s
Job: Installation and Connectivity Test (1.28, us-east5-a, 5, true),  AvgRunTime: 24m27.933333333s

Workflow: Conformance EKS (ci-eks)
Job: Installation and Connectivity Test (1.23, eu-central-1),  AvgRunTime: 1h2m58.125s
Job: Installation and Connectivity Test (1.24, eu-west-1),  AvgRunTime: 55m31.375s
Job: Installation and Connectivity Test (1.25, ap-northeast-1),  AvgRunTime: 1h4m43.25s
Job: Installation and Connectivity Test (1.26, us-east-2),  AvgRunTime: 47m37.4375s
Job: Installation and Connectivity Test (1.27, ca-central-1),  AvgRunTime: 45m27.375s
Job: Installation and Connectivity Test (1.28, eu-north-1, true),  AvgRunTime: 57m59.25s

Workflow: Conformance GKE (ci-gke)
Job: Installation and Connectivity Test (1.24, europe-west6-b, 1, no-tunnel, 1),  AvgRunTime: 29m
Job: Installation and Connectivity Test (1.25, us-west2-a, 2, no-tunnel, 1),  AvgRunTime: 24m
Job: Installation and Connectivity Test (1.26, asia-northeast1-c, 3, no-tunnel, 1),  AvgRunTime: 36m
Job: Installation and Connectivity Test (1.27, europe-north1-b, 4, no-tunnel, 1),  AvgRunTime: 32m35.0625s
Job: Installation and Connectivity Test (1.28, us-east5-a, 5, true, no-tunnel, 1),  AvgRunTime: 23m30.3125s
```
Average run times after the change
```
Workflow: Conformance AKS (ci-aks)
Job: Installation and Connectivity Test (1.25, westus3, 1),  AvgRunTime: 41m22s
Job: Installation and Connectivity Test (1.26, westus2, 2),  AvgRunTime: 45m29s
Job: Installation and Connectivity Test (1.27, eastus2, 3),  AvgRunTime: 34m17s
Job: Installation and Connectivity Test (1.28, eastus, 4, true),  AvgRunTime: 38m33s

Workflow: Conformance AWS-CNI (ci-awscni)
Job: Installation and Connectivity Test (1.23, ca-west-1),  AvgRunTime: 27m37s
Job: Installation and Connectivity Test (1.24, us-west-2),  AvgRunTime: 24m34s
Job: Installation and Connectivity Test (1.25, us-west-1),  AvgRunTime: 27m28s
Job: Installation and Connectivity Test (1.26, us-east-2),  AvgRunTime: 25m46s
Job: Installation and Connectivity Test (1.27, ca-central-1),  AvgRunTime: 25m6s
Job: Installation and Connectivity Test (1.28, us-east-1, true),  AvgRunTime: 24m56s

Workflow: Conformance External Workloads (ci-external-workloads)
Job: Installation and Connectivity Test (1.24, us-west1-b, 1),  AvgRunTime: 27m23s
Job: Installation and Connectivity Test (1.25, us-west2-c, 2),  AvgRunTime: 27m45s
Job: Installation and Connectivity Test (1.26, us-west3-a, 3),  AvgRunTime: 29m2s
Job: Installation and Connectivity Test (1.27, us-east4-b, 4),  AvgRunTime: 23m3s
Job: Installation and Connectivity Test (1.28, us-east1-c, 5, true),  AvgRunTime: 25m7s

Workflow: Conformance EKS (ci-eks)
Job: Installation and Connectivity Test (1.23, ca-west-1),  AvgRunTime: 58m15s
Job: Installation and Connectivity Test (1.24, us-west-2),  AvgRunTime: 56m45s
Job: Installation and Connectivity Test (1.25, us-west-1),  AvgRunTime: 45m0s
Job: Installation and Connectivity Test (1.26, us-east-2),  AvgRunTime: 43m21s
Job: Installation and Connectivity Test (1.27, ca-central-1),  AvgRunTime: 43m42s
Job: Installation and Connectivity Test (1.28, us-east-1, true),  AvgRunTime: 51m28s

Workflow: Conformance GKE (ci-gke)
Job: Installation and Connectivity Test (1.24, us-west1-b, 1, no-tunnel, 1),  AvgRunTime: 23m34s
Job: Installation and Connectivity Test (1.25, us-west2-c, 2, no-tunnel, 1),  AvgRunTime: 22m2s
Job: Installation and Connectivity Test (1.26, us-west3-a, 3, no-tunnel, 1),  AvgRunTime: 24m47s
Job: Installation and Connectivity Test (1.27, us-east4-b, 4, no-tunnel, 1),  AvgRunTime: 25m32s
Job: Installation and Connectivity Test (1.28, us-east1-c, 5, true, no-tunnel, 1),  AvgRunTime: 24m19s
```
