### PR TITLE
CODEOWNERS: pull in sig-wireguard for wireguard-related files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -268,6 +268,7 @@ Makefile* @cilium/build
 /bpf/custom/Makefile* @cilium/build @cilium/loader
 /bpf/lib/auth.h @cilium/sig-datapath @cilium/sig-servicemesh
 /bpf/lib/encrypt.h @cilium/ipsec
+/bpf/lib/wireguard.h @cilium/wireguard @cilium/sig-datapath
 /bugtool/ @cilium/tophat
 /bugtool/cmd/ @cilium/cli
 /cilium-dbg/ @cilium/cli
@@ -356,6 +357,7 @@ Makefile* @cilium/build
 /Documentation/security/http.rst @cilium/sig-policy @cilium/docs-structure
 /Documentation/security/images/cilium_threat_model* @cilium/security @cilium/docs-structure
 /Documentation/security/network/encryption-ipsec.rst @cilium/ipsec @cilium/docs-structure
+/Documentation/security/network/encryption-wireguard.rst @cilium/wireguard @cilium/docs-structure
 /Documentation/security/network/proxy/ @cilium/proxy @cilium/docs-structure
 /Documentation/security/policy-creation.rst @cilium/sig-policy @cilium/docs-structure
 /Documentation/security/policy/ @cilium/sig-policy @cilium/docs-structure


### PR DESCRIPTION
CODEOWNERS: pull in sig-wireguard for wireguard-related files