### PR TITLE
bgpv1: Remove disruptive error handling from BGPRouterManager

### DIFF
--- a/pkg/bgpv1/manager/manager.go
+++ b/pkg/bgpv1/manager/manager.go
@@ -224,20 +224,6 @@ func (m *BGPRouterManager) registerBGPServer(ctx context.Context,
 
 	l.Infof("Registering BGP servers for policy with local ASN %v", c.LocalASN)
 
-	// ATTENTION: this defer handles cleaning up of a server if an error in
-	// registration occurs. for this to work the below err variable must be
-	// overwritten for the length of this method.
-	var err error
-	var s *instance.ServerWithConfig
-	defer func() {
-		if err != nil {
-			if s != nil {
-				s.Server.Stop()
-			}
-			delete(m.Servers, c.LocalASN) // optimistic delete
-		}
-	}()
-
 	annoMap, err := agent.NewAnnotationMap(ciliumNode.Annotations)
 	if err != nil {
 		return fmt.Errorf("unable to parse local node's annotations: %v", err)
@@ -272,16 +258,21 @@ func (m *BGPRouterManager) registerBGPServer(ctx context.Context,
 		},
 	}
 
-	if s, err = instance.NewServerWithConfig(ctx, log, globalConfig); err != nil {
+	s, err := instance.NewServerWithConfig(ctx, log, globalConfig)
+	if err != nil {
 		return fmt.Errorf("failed to start BGP server for config with local ASN %v: %w", c.LocalASN, err)
 	}
+
+	// We can commit the register the server here. Even if the following
+	// reconciliation fails, we can return error and it triggers retry. The
+	// next retry will be handled by reconcile(). We don't need to retry
+	// the server creation which already succeeded.
+	m.Servers[c.LocalASN] = s
 
 	if err = m.reconcileBGPConfig(ctx, s, c, ciliumNode); err != nil {
 		return fmt.Errorf("failed initial reconciliation for peer config with local ASN %v: %w", c.LocalASN, err)
 	}
 
-	// register with manager
-	m.Servers[c.LocalASN] = s
 	l.Infof("Successfully registered GoBGP servers for policy with local ASN %v", c.LocalASN)
 
 	return err
@@ -346,11 +337,8 @@ func (m *BGPRouterManager) reconcile(ctx context.Context, rd *reconcileDiff) err
 			l.Errorf("Virtual router with local ASN %v marked for reconciliation but missing from incoming configurations", sc.Config.LocalASN) // also really shouldn't happen
 			continue
 		}
-
 		if err := m.reconcileBGPConfig(ctx, sc, newc, rd.ciliumNode); err != nil {
-			l.WithError(err).Errorf("Encountered error reconciling virtual router with local ASN %v, shutting down this server", newc.LocalASN)
-			sc.Server.Stop()
-			delete(m.Servers, asn)
+			l.WithError(err).Errorf("Encountered error reconciling virtual router with local ASN %v", newc.LocalASN)
 		}
 	}
 	return nil

--- a/pkg/bgpv1/manager/reconciler/lb_service_test.go
+++ b/pkg/bgpv1/manager/reconciler/lb_service_test.go
@@ -633,17 +633,23 @@ func TestLBServiceReconciler(t *testing.T) {
 				ServiceSelector: tt.newServiceSelector,
 			}
 
-			err = reconciler.Reconcile(context.Background(), ReconcileParams{
-				CurrentServer: testSC,
-				DesiredConfig: newc,
-				CiliumNode: &v2api.CiliumNode{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name: "node1",
-					},
-				},
-			})
-			if err != nil {
-				t.Fatalf("failed to reconcile new lb svc advertisements: %v", err)
+			// Run the reconciler twice to ensure idempotency. This
+			// simulates the retrying behavior of the controller.
+			for i := 0; i < 2; i++ {
+				t.Run(tt.name, func(t *testing.T) {
+					err = reconciler.Reconcile(context.Background(), ReconcileParams{
+						CurrentServer: testSC,
+						DesiredConfig: newc,
+						CiliumNode: &v2api.CiliumNode{
+							ObjectMeta: meta_v1.ObjectMeta{
+								Name: "node1",
+							},
+						},
+					})
+					if err != nil {
+						t.Fatalf("failed to reconcile new lb svc advertisements: %v", err)
+					}
+				})
 			}
 
 			// if we disable exports of pod cidr ensure no advertisements are

--- a/pkg/bgpv1/manager/reconciler/neighbor.go
+++ b/pkg/bgpv1/manager/reconciler/neighbor.go
@@ -69,14 +69,17 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 		toCreate []*v2alpha1api.CiliumBGPNeighbor
 		toRemove []*v2alpha1api.CiliumBGPNeighbor
 		toUpdate []*v2alpha1api.CiliumBGPNeighbor
-		curNeigh []v2alpha1api.CiliumBGPNeighbor = nil
+		curNeigh []*v2alpha1api.CiliumBGPNeighbor = nil
 	)
 	newNeigh := p.DesiredConfig.Neighbors
 	l.Debugf("Begin reconciling peers for virtual router with local ASN %v", p.DesiredConfig.LocalASN)
 
-	// sc.Config can be nil if there is no previous configuration.
-	if p.CurrentServer.Config != nil {
-		curNeigh = p.CurrentServer.Config.Neighbors
+	metaMap := r.getMetadata(p.CurrentServer)
+	if len(metaMap) > 0 {
+		curNeigh = []*v2alpha1api.CiliumBGPNeighbor{}
+		for _, meta := range metaMap {
+			curNeigh = append(curNeigh, meta.currentConfig)
+		}
 	}
 
 	// an nset member which book keeps which universe it exists in.
@@ -104,19 +107,19 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 	}
 
 	// populate set from universe of current neighbors
-	for i, n := range curNeigh {
+	for _, n := range curNeigh {
 		var (
-			key = r.neighborID(&n)
+			key = r.neighborID(n)
 			h   *member
 			ok  bool
 		)
 		if h, ok = nset[key]; !ok {
 			nset[key] = &member{
-				cur: &curNeigh[i],
+				cur: n,
 			}
 			continue
 		}
-		h.cur = &curNeigh[i]
+		h.cur = n
 	}
 
 	for _, m := range nset {
@@ -161,7 +164,7 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 		if err := p.CurrentServer.Server.AddNeighbor(ctx, types.NeighborRequest{Neighbor: n, Password: tcpPassword}); err != nil {
 			return fmt.Errorf("failed while reconciling neighbor %v %v: %w", n.PeerAddress, n.PeerASN, err)
 		}
-		r.updatePeerPassword(p.CurrentServer, n, tcpPassword)
+		r.updateMetadata(p.CurrentServer, n, tcpPassword)
 	}
 
 	// update neighbors
@@ -174,9 +177,7 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 		if err := p.CurrentServer.Server.UpdateNeighbor(ctx, types.NeighborRequest{Neighbor: n, Password: tcpPassword}); err != nil {
 			return fmt.Errorf("failed while reconciling neighbor %v %v: %w", n.PeerAddress, n.PeerASN, err)
 		}
-		if r.changedPeerPassword(p.CurrentServer, n, tcpPassword) {
-			r.updatePeerPassword(p.CurrentServer, n, tcpPassword)
-		}
+		r.updateMetadata(p.CurrentServer, n, tcpPassword)
 	}
 
 	// remove neighbors
@@ -185,6 +186,7 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 		if err := p.CurrentServer.Server.RemoveNeighbor(ctx, types.NeighborRequest{Neighbor: n}); err != nil {
 			return fmt.Errorf("failed while reconciling neighbor %v %v: %w", n.PeerAddress, n.PeerASN, err)
 		}
+		r.deleteMetadata(p.CurrentServer, n)
 	}
 
 	l.Infof("Done reconciling peers for virtual router with local ASN %v", p.DesiredConfig.LocalASN)
@@ -193,7 +195,12 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 
 // NeighborReconcilerMetadata keeps a map of peers to passwords, fetched from
 // secrets. Key is PeerAddress+PeerASN.
-type NeighborReconcilerMetadata map[string]string
+type NeighborReconcilerMetadata map[string]neighborReconcilerMetadata
+
+type neighborReconcilerMetadata struct {
+	currentPassword string
+	currentConfig   *v2alpha1api.CiliumBGPNeighbor
+}
 
 func (r *NeighborReconciler) getMetadata(sc *instance.ServerWithConfig) NeighborReconcilerMetadata {
 	if _, found := sc.ReconcilerMetadata[r.Name()]; !found {
@@ -203,8 +210,6 @@ func (r *NeighborReconciler) getMetadata(sc *instance.ServerWithConfig) Neighbor
 }
 
 func (r *NeighborReconciler) fetchPeerPassword(sc *instance.ServerWithConfig, n *v2alpha1api.CiliumBGPNeighbor) (string, error) {
-	peerPasswords := r.getMetadata(sc)
-
 	l := log.WithFields(
 		logrus.Fields{
 			"component": "NeighborReconciler.fetchPeerPassword",
@@ -212,7 +217,7 @@ func (r *NeighborReconciler) fetchPeerPassword(sc *instance.ServerWithConfig, n 
 	)
 	if n.AuthSecretRef != nil {
 		secretRef := *n.AuthSecretRef
-		old := peerPasswords[r.neighborID(n)]
+		old := r.getMetadata(sc)[r.neighborID(n)].currentPassword
 
 		secret, ok, err := r.fetchSecret(secretRef)
 		if err != nil {
@@ -252,14 +257,18 @@ func (r *NeighborReconciler) fetchSecret(name string) (map[string][]byte, bool, 
 }
 
 func (r *NeighborReconciler) changedPeerPassword(sc *instance.ServerWithConfig, n *v2alpha1api.CiliumBGPNeighbor, tcpPassword string) bool {
-	peerPasswords := r.getMetadata(sc)
-	old := peerPasswords[r.neighborID(n)]
-	return old != tcpPassword
+	return r.getMetadata(sc)[r.neighborID(n)].currentPassword != tcpPassword
 }
 
-func (r *NeighborReconciler) updatePeerPassword(sc *instance.ServerWithConfig, n *v2alpha1api.CiliumBGPNeighbor, tcpPassword string) {
-	peerPasswords := r.getMetadata(sc)
-	peerPasswords[r.neighborID(n)] = tcpPassword
+func (r *NeighborReconciler) updateMetadata(sc *instance.ServerWithConfig, n *v2alpha1api.CiliumBGPNeighbor, tcpPassword string) {
+	r.getMetadata(sc)[r.neighborID(n)] = neighborReconcilerMetadata{
+		currentPassword: tcpPassword,
+		currentConfig:   n.DeepCopy(),
+	}
+}
+
+func (r *NeighborReconciler) deleteMetadata(sc *instance.ServerWithConfig, n *v2alpha1api.CiliumBGPNeighbor) {
+	delete(r.getMetadata(sc), r.neighborID(n))
 }
 
 func (r *NeighborReconciler) neighborID(n *v2alpha1api.CiliumBGPNeighbor) string {

--- a/pkg/bgpv1/manager/reconciler/pod_cidr_test.go
+++ b/pkg/bgpv1/manager/reconciler/pod_cidr_test.go
@@ -135,10 +135,15 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 				},
 			}
 
-			// run the reconciler
-			err = exportPodCIDRReconciler.Reconcile(context.Background(), params)
-			if err != nil {
-				t.Fatalf("failed to reconcile new pod cidr advertisements: %v", err)
+			// Run the reconciler twice to ensure idempotency. This
+			// simulates the retrying behavior of the controller.
+			for i := 0; i < 2; i++ {
+				t.Run(tt.name, func(t *testing.T) {
+					err = exportPodCIDRReconciler.Reconcile(context.Background(), params)
+					if err != nil {
+						t.Fatalf("failed to reconcile new pod cidr advertisements: %v", err)
+					}
+				})
 			}
 			podCIDRAnnouncements = reconciler.getMetadata(testSC)
 

--- a/pkg/bgpv1/manager/reconciler/preflight_test.go
+++ b/pkg/bgpv1/manager/reconciler/preflight_test.go
@@ -139,9 +139,15 @@ func TestPreflightReconciler(t *testing.T) {
 				},
 			}
 
-			err = preflightReconciler.Reconcile(context.Background(), params)
-			if (tt.err == nil) != (err == nil) {
-				t.Fatalf("wanted error: %v", (tt.err == nil))
+			// Run the reconciler twice to ensure idempotency. This
+			// simulates the retrying behavior of the controller.
+			for i := 0; i < 2; i++ {
+				t.Run(tt.name, func(t *testing.T) {
+					err = preflightReconciler.Reconcile(context.Background(), params)
+					if (tt.err == nil) != (err == nil) {
+						t.Fatalf("wanted error: %v", (tt.err == nil))
+					}
+				})
 			}
 			if tt.shouldRecreate && testSC.Server == originalServer {
 				t.Fatalf("preflightReconciler did not recreate server")


### PR DESCRIPTION
Currently, we have some disruptive error handling in the `BGPRouterManager`. First in `register()` and the second in `reconcile()` method. Both of them stop the GoBGP instance when it encounters an error in any of the reconcilers in the chain. 

This PR removes the disruptive error-handling from `BGPRouterManager`.

```release-note
bgpv1: Remove disruptive error handling from BGPRouterManager
```
