### PR TITLE
daemon: Restore health IPs from local ciliumnode resource

### DIFF
--- a/daemon/cmd/local_node_sync.go
+++ b/daemon/cmd/local_node_sync.go
@@ -184,8 +184,18 @@ func (ini *localNodeSynchronizer) initFromK8s(ctx context.Context, node *node.Lo
 				node.SetCiliumInternalIP(net.ParseIP(addr.IP))
 			}
 		}
+
+		if ini.Config.EnableHealthChecking && ini.Config.EnableEndpointHealthChecking {
+			if ini.Config.EnableIPv4 {
+				node.IPv4HealthIP = net.ParseIP(k8sCiliumNode.Spec.HealthAddressing.IPv4)
+			}
+
+			if ini.Config.EnableIPv6 {
+				node.IPv6HealthIP = net.ParseIP(k8sCiliumNode.Spec.HealthAddressing.IPv6)
+			}
+		}
 	} else {
-		log.Info("no local ciliumnode found, will not restore cilium internal ips from k8s")
+		log.Info("no local ciliumnode found, will not restore cilium internal and health ips from k8s")
 	}
 	if ini.Config.NodeEncryptionOptOutLabels.Matches(k8sLabels.Set(node.Labels)) {
 		log.WithField(logfields.Selector, ini.Config.NodeEncryptionOptOutLabels).

--- a/daemon/cmd/local_node_sync_test.go
+++ b/daemon/cmd/local_node_sync_test.go
@@ -134,9 +134,14 @@ func TestInitLocalNode_initFromK8s(t *testing.T) {
 	lni := &localNodeSynchronizer{
 		localNodeSynchronizerParams: localNodeSynchronizerParams{
 			Config: &option.DaemonConfig{
-				IPv4NodeAddr:               "auto",
-				IPv6NodeAddr:               "auto",
-				NodeEncryptionOptOutLabels: k8sLabels.NewSelector(),
+				IPv4NodeAddr:                 "auto",
+				IPv6NodeAddr:                 "auto",
+				IPv6ClusterAllocCIDRBase:     "fd00::",
+				EnableIPv4:                   true,
+				EnableIPv6:                   true,
+				EnableHealthChecking:         true,
+				EnableEndpointHealthChecking: true,
+				NodeEncryptionOptOutLabels:   k8sLabels.NewSelector(),
 			},
 			K8sLocalNode: &mockResource[*slim_corev1.Node]{
 				items: []resource.Event[*slim_corev1.Node]{
@@ -178,6 +183,10 @@ func TestInitLocalNode_initFromK8s(t *testing.T) {
 										IP:   "fd00:10:244:1::aaa6",
 									},
 								},
+								HealthAddressing: v2.HealthAddressingSpec{
+									IPv4: "10.0.0.2",
+									IPv6: "fd00:10:244:1::aaa7",
+								},
 							},
 						},
 						Done: func(err error) {},
@@ -195,6 +204,8 @@ func TestInitLocalNode_initFromK8s(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "10.0.0.1", n.GetCiliumInternalIP(false).String())
 	assert.Equal(t, "fd00:10:244:1::aaa6", n.GetCiliumInternalIP(true).String())
+	assert.Equal(t, "10.0.0.2", n.IPv4HealthIP.String())
+	assert.Equal(t, "fd00:10:244:1::aaa7", n.IPv6HealthIP.String())
 	assert.Equal(t, n.Name, "test-node")
 }
 


### PR DESCRIPTION
Currently, although health IPs are recorded in the ciliumnode resource, cilium will allocate a new health IP when the cilium agent restarts. In addition, it will cause unnecessary node update events.

This patch obtains health IPs from ciliumnode and restores them. If the restoration fails, a new health IP is allocated.

```release-note
Restore health IPs from local ciliumnode resource
```
