### PR TITLE
Pr/tp/revert fix complexity issue

### DIFF
--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -160,7 +160,7 @@ ipv4_handle_fragmentation(struct __ctx_buff *ctx,
 	/* load sport + dport into tuple */
 	ret = l4_load_ports(ctx, l4_off, (__be16 *)ports);
 	if (ret < 0)
-		return DROP_CT_INVALID_HDR;
+		return ret;
 
 	if (unlikely(is_fragment)) {
 		/* First logical fragment for this datagram (not necessarily the first


### PR DESCRIPTION
Issues:
* https://github.com/cilium/cilium/issues/30266
* https://github.com/cilium/cilium/issues/30093

Both seem related to these two commits.  I was able to consistently reproduce this on a Talos cluster, where I bisected out first 4994d58d6bd320488e4b2eb88e6fb8956cf3a1e3 as causing the issue, and later the issue seemingly cropping up again following 5c768a4eddbb71662dc8573c0e63f910a64477df.

For more context, to mirror internal discussions, I've also noticed a large increase in the complexity in several changes in the past few months in this code path, namely [here](https://github.com/cilium/cilium/commit/229b44644e630b88810e6354be1e9e1157b9f078#diff-304969c111195cf4253b336fc67c9891f17b91d49738a0cc334333ac11e84b9eR2531) where my testing using verifier_test goes from ~80k -> ~500k.   An increase in complexity makes sense given the nature of the changes (i.e. seemingly moving more host-fw logic into the nodeport nat ingress code).

So this revert fixes some recent sources of added complexity, specifically in my local test environment. To see if this fixes the similar CI issues, we'll run this through conformance-e2e multiple times.

Luckily, both of these changes seem to be either minor, or not have any impact on behaviour, so we may consider this as a way to unblock the v1.15 pipeline issues.

CC: @julianwiedmann @gentoo-root 

```release-note
Fix issue where cilium_host endpoint program failed to compile in some configurations, due to complexity/instruction-limits.
```
