### PR TITLE
 Fix quoting in nodeinit temporary cilium config

### DIFF
--- a/install/kubernetes/cilium/files/nodeinit/startup.bash
+++ b/install/kubernetes/cilium/files/nodeinit/startup.bash
@@ -100,7 +100,7 @@ then
     # Since that version containerd no longer allows missing configuration for the CNI,
     # not even for pods with hostNetwork set to true. Thus, we add a temporary one.
     # This will be replaced with the real config by the agent pod.
-    echo -e "{\n\t"cniVersion": "0.3.1",\n\t"name": "cilium",\n\t"type": "cilium-cni"\n}" > /etc/cni/net.d/05-cilium.conf
+    echo -e '{\n\t"cniVersion": "0.3.1",\n\t"name": "cilium",\n\t"type": "cilium-cni"\n}' > /etc/cni/net.d/05-cilium.conf
   fi
 
   # Start containerd. It won't create it's CNI configuration file anymore.


### PR DESCRIPTION
The Cilium nodeinit startup script lays down a temporary CNI config in order to be able to restart a version of containerd that doesn't allow a missing CNI config.

This commit fixes an issue with missing double quotes in the creation of the temporary config that causes an error in containerd which in turn causes Kubernetes nodes to become NotReady

I also considered heredoc or escaping the quote characters but settled on single quoting as I think its the most readable one line solution without needing to deal with the indentation issue with heredoc

```release-note
Fix nodeinit issue causing NotReady state in Kubernetes nodes when laying down an incorrect CNI config
```
