### PR TITLE
[v1.14] ci/ipsec: Re-enable node-to-node-encryption check

### DIFF
--- a/.github/actions/conn-disrupt-test/action.yaml
+++ b/.github/actions/conn-disrupt-test/action.yaml
@@ -31,11 +31,9 @@ runs:
 
     - name: Perform Conn Disrupt Test
       shell: bash
-      # Skip test node-to-node-encryption until we've solved https://github.com/cilium/cilium/issues/29351
       run: |
         ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
           --include-conn-disrupt-test \
-          --test '!node-to-node-encryption' \
           --flush-ct \
           --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
           --sysdump-output-filename "cilium-sysdump-${{ inputs.job-name }}-<ts>" \


### PR DESCRIPTION
We disabled the check in commit 6896a4f7591f ("ci: In conn-disrupt-test action, disable node-to-node-encryption check") because we used to observe flakes. As far as we understand, these flakes were due to an issue in branch v1.13, to which we downgrade as part as the IPsec upgrade/downgrade workflow.

The issue has been fixed in v1.13 with commit 3a4deb3f14c5 ("node: Fix IP removal from ipset on node updates"). With the recent patch release v1.13.11 that contains the fix, we can now re-enable the check.

Link: https://github.com/cilium/cilium/issues/29351
Link: https://github.com/cilium/cilium/pull/29898
