### PR TITLE
doc: clarify supported upgrade and rollback scenarios

### DIFF
--- a/Documentation/operations/upgrade-warning.rst
+++ b/Documentation/operations/upgrade-warning.rst
@@ -9,6 +9,14 @@
    Read the full upgrade guide to understand all the necessary steps before
    performing them.
 
-   Do not upgrade to \ |NEXT_RELEASE|.0 before reading the section
+   Do not upgrade to \ |NEXT_RELEASE| before reading the section
    :ref:`current_release_required_changes` and completing the required steps.
    Skipping this step may lead to an non-functional upgrade.
+
+   The only tested rollback and upgrade path is between consecutive minor releases.
+   Always perform rollbacks and upgrades between one minor release at a time.
+   This means that going from (a hypothetical) 1.1 to 1.2 and back is supported
+   while going from 1.1 to 1.3 and back is not.
+
+   Always update to the latest patch release of your current version before
+   attempting an upgrade.

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -140,9 +140,8 @@ Step 1: Upgrade to latest patch version
 ---------------------------------------
 
 When upgrading from one minor release to another minor release, for example
-1.x to 1.y, it is recommended to upgrade to the latest patch release for a
-Cilium release series first. The latest patch releases for each supported
-version of Cilium are `here <https://github.com/cilium/cilium#stable-releases>`_.
+1.x to 1.y, it is recommended to upgrade to the `latest patch release
+<https://github.com/cilium/cilium#stable-releases>`__ for a Cilium release series first.
 Upgrading to the latest patch release ensures the most seamless experience if a
 rollback is required following the minor release upgrade. The upgrade guides
 for previous versions can be found for each minor version at the bottom left


### PR DESCRIPTION
Make it explicit in the upgrade documentation that the only upgrade and rollback combination we test are the latest patches of consecutive minor releases.

```release-note
Document supported upgrade and rollback paths
```
