### PR TITLE
bpf: lb: return drop reasons from __lb4_rev_nat()

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1066,9 +1066,8 @@ static __always_inline int __lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int
 		old_sip = tuple->saddr;
 		tuple->saddr = nat->address;
 	} else {
-		ret = ctx_load_bytes(ctx, l3_off + offsetof(struct iphdr, saddr), &old_sip, 4);
-		if (IS_ERR(ret))
-			return ret;
+		if (ctx_load_bytes(ctx, l3_off + offsetof(struct iphdr, saddr), &old_sip, 4) < 0)
+			return DROP_INVALID;
 	}
 
 #ifndef DISABLE_LOOPBACK_LB
@@ -1081,9 +1080,8 @@ static __always_inline int __lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int
 		 */
 		__be32 old_dip;
 
-		ret = ctx_load_bytes(ctx, l3_off + offsetof(struct iphdr, daddr), &old_dip, 4);
-		if (IS_ERR(ret))
-			return ret;
+		if (ctx_load_bytes(ctx, l3_off + offsetof(struct iphdr, daddr), &old_dip, 4) < 0)
+			return DROP_INVALID;
 
 		cilium_dbg_lb(ctx, DBG_LB4_LOOPBACK_SNAT_REV, old_dip, old_sip);
 


### PR DESCRIPTION
Fix up some ctx_load_bytes() usage to return a drop reason, and not the raw kernel errno.
