### PR TITLE
Fix Hubble label selector parsing for labels with dots

### DIFF
--- a/pkg/hubble/filters/labelparser.go
+++ b/pkg/hubble/filters/labelparser.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package filters
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"unicode"
+)
+
+// translateSelector takes a label selector with colon-based source prefixes
+// and translates it to a valid k8s label selector with dot-based prefixes,
+// i.e. "k8s:foo in (bar, baz)" becomes "k8s.foo in (bar, baz)".
+// It also makes sure that bare keys without an explicit source will get an
+// `any` source prefix.
+func translateSelector(selector string) (string, error) {
+	out := &strings.Builder{}
+	in := strings.NewReader(selector)
+
+	for in.Len() > 0 {
+		err := advanceToNextKey(in, out)
+		if err != nil {
+			return "", err
+		}
+		err = translateKey(in, out)
+		if err != nil {
+			return "", err
+		}
+		err = advanceToNextSelector(in, out)
+		if err != nil {
+			return "", err
+		}
+	}
+	return out.String(), nil
+}
+
+// advanceToNextKey scans from the beginning of a selector to the next
+// key and writes everything before the start of the key from in to out.
+func advanceToNextKey(in *strings.Reader, out *strings.Builder) error {
+	for {
+		r, _, err := in.ReadRune()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if !unicode.IsSpace(r) && r != '!' {
+			return in.UnreadRune()
+		}
+		out.WriteRune(r)
+	}
+}
+
+// translateKey takes a reader that point to the start of a key. It reads
+// until the end of the key and writes the translated key (with dot prefixes
+// instead of colon-based source prefixes) to out
+func translateKey(in *strings.Reader, out *strings.Builder) error {
+	key := &strings.Builder{}
+	defer func() {
+		ckey := key.String()
+		if !strings.Contains(ckey, ":") {
+			ckey = fmt.Sprintf("any:%s", ckey)
+		}
+		ckey = strings.Replace(ckey, ":", ".", 1)
+		out.WriteString(ckey)
+	}()
+	for {
+		r, _, err := in.ReadRune()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if unicode.IsSpace(r) || r == '=' || r == '!' || r == ',' {
+			return in.UnreadRune()
+		}
+		key.WriteRune(r)
+	}
+}
+
+// advanceToNextSelector takes a read that points to the end of a key and will
+// advance the reader to the beginning of the next selector and writes everything
+// it scans to out.
+func advanceToNextSelector(in *strings.Reader, out *strings.Builder) error {
+	nesting := 0
+	for {
+		r, _, err := in.ReadRune()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		switch r {
+		case '(':
+			nesting++
+		case ')':
+			nesting--
+		}
+		out.WriteRune(r)
+		if r == ',' && nesting == 0 {
+			return nil
+		}
+	}
+}

--- a/pkg/hubble/filters/labelparser_test.go
+++ b/pkg/hubble/filters/labelparser_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package filters
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_translateSelector(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "simple",
+			in:   "foo",
+			want: "any.foo",
+		},
+		{
+			name: "multiple",
+			in:   "foo, bar",
+			want: "any.foo, any.bar",
+		},
+		{
+			name: "with prefix",
+			in:   "k8s:foo, bar",
+			want: "k8s.foo, any.bar",
+		},
+		{
+			name: "with negation",
+			in:   "k8s:foo, !bar",
+			want: "k8s.foo, !any.bar",
+		},
+		{
+			name: "with negation",
+			in:   "k8s:foo, !bar",
+			want: "k8s.foo, !any.bar",
+		},
+		{
+			name: "match value",
+			in:   "foo, bar=buzz",
+			want: "any.foo, any.bar=buzz",
+		},
+		{
+			name: "don't match value",
+			in:   "foo, bar!= buzz",
+			want: "any.foo, any.bar!= buzz",
+		},
+		{
+			name: "in values",
+			in:   "foo in (a,b,c)",
+			want: "any.foo in (a,b,c)",
+		},
+		{
+			name: "notin values",
+			in:   "foo notin   (a,b,c)",
+			want: "any.foo notin   (a,b,c)",
+		},
+		{
+			name: "with dots",
+			in:   "foo.example.com, bar.example.com=buzz",
+			want: "any.foo.example.com, any.bar.example.com=buzz",
+		},
+		{
+			name: "dots and colons in value",
+			in:   "foo.example.com=some:other.thing, bar.example.com=buzz:any:thing.example.org",
+			want: "any.foo.example.com=some:other.thing, any.bar.example.com=buzz:any:thing.example.org",
+		},
+		{
+			name: "edgecase missing values",
+			in:   "x in (foo,,baz),y,z notin ()",
+			want: "any.x in (foo,,baz),any.y,any.z notin ()",
+		},
+		{
+			name: "multi value edgecase",
+			in:   "foo.example.com in (foo, any.bar, k8s:buzz, some.other,, end), k8s:bar in (a,b,c,  ,d,  e,),!any:test",
+			want: "any.foo.example.com in (foo, any.bar, k8s:buzz, some.other,, end), k8s.bar in (a,b,c,  ,d,  e,),!any.test",
+		},
+		{
+			name: "complex edgecase",
+			in:   "a=b, foo:bar, !k8s:b, foo in  (a, ,   c, d), !any:buzz, c!= d.e, foo:bar.example.com=any.value, !any.other, k8s.example.com in (foo.bar, bar.buzz,  a)",
+			want: "any.a=b, foo.bar, !k8s.b, any.foo in  (a, ,   c, d), !any.buzz, any.c!= d.e, foo.bar.example.com=any.value, !any.any.other, any.k8s.example.com in (foo.bar, bar.buzz,  a)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := translateSelector(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseSelector() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseSelector() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/hubble/filters/labels.go
+++ b/pkg/hubble/filters/labels.go
@@ -6,7 +6,6 @@ package filters
 import (
 	"context"
 	"fmt"
-	"regexp"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
@@ -24,10 +23,6 @@ func destinationLabels(ev *v1.Event) k8sLabels.Labels {
 	return ciliumLabels.ParseLabelArrayFromArray(labels)
 }
 
-var (
-	labelSelectorWithColon = regexp.MustCompile(`([^,]\s*[a-z0-9-]+):([a-z0-9-]+)`)
-)
-
 func parseSelector(selector string) (k8sLabels.Selector, error) {
 	// ciliumLabels.LabelArray extends the k8sLabels.Selector logic with
 	// support for Cilium source prefixes such as "k8s:foo" or "any:bar".
@@ -39,8 +34,13 @@ func parseSelector(selector string) (k8sLabels.Selector, error) {
 	// therefore we translate any user-specified source prefixes by
 	// replacing colon-based source prefixes in labels with dot-based prefixes,
 	// i.e. "k8s:foo in (bar, baz)" becomes "k8s.foo in (bar, baz)".
-
-	translated := labelSelectorWithColon.ReplaceAllString(selector, "${1}.${2}")
+	//
+	// We also prefix any key that doesn ot specify with "any."
+	// i.e. "example.com in (bar, buzz)" becomes "any.example.com in (bar, buzz)"
+	translated, err := translateSelector(selector)
+	if err != nil {
+		return nil, err
+	}
 	return k8sLabels.Parse(translated)
 }
 

--- a/pkg/hubble/filters/labels_test.go
+++ b/pkg/hubble/filters/labels_test.go
@@ -338,6 +338,52 @@ func TestLabelSelectorFilter(t *testing.T) {
 			},
 		},
 		{
+			name: "cilium fixed prefix not filter",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						SourceLabel: []string{"!k8s:app"},
+					},
+				},
+				ev: []*v1.Event{
+					{
+						Event: &flowpb.Flow{
+							Source: &flowpb.Endpoint{
+								Labels: []string{"k8s:app=bar"},
+							},
+						},
+					},
+					{
+						Event: &flowpb.Flow{
+							Source: &flowpb.Endpoint{
+								Labels: []string{"k8s:app=baz"},
+							},
+						},
+					},
+					{
+						Event: &flowpb.Flow{
+							Source: &flowpb.Endpoint{
+								Labels: []string{"k8s.app=bar"},
+							},
+						},
+					},
+					{
+						Event: &flowpb.Flow{
+							Source: &flowpb.Endpoint{
+								Labels: []string{"container:foo=bar", "reserved:host"},
+							},
+						},
+					},
+				},
+			},
+			want: []bool{
+				false,
+				false,
+				true,
+				true,
+			},
+		},
+		{
 			name: "cilium any prefix filters",
 			args: args{
 				f: []*flowpb.FlowFilter{
@@ -372,6 +418,90 @@ func TestLabelSelectorFilter(t *testing.T) {
 			want: []bool{
 				true,
 				true,
+				false,
+			},
+		},
+		{
+			name: "cilium no prefix filters",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						SourceLabel: []string{"key"},
+					},
+				},
+				ev: []*v1.Event{
+					{
+						Event: &flowpb.Flow{
+							Source: &flowpb.Endpoint{
+								Labels: []string{"key"},
+							},
+						},
+					},
+					{
+						Event: &flowpb.Flow{
+							Source: &flowpb.Endpoint{
+								Labels: []string{"reserved:key"},
+							},
+						},
+					},
+					{
+						Event: &flowpb.Flow{
+							Source: &flowpb.Endpoint{
+								Labels: []string{"any.key"},
+							},
+						},
+					},
+				},
+			},
+			want: []bool{
+				true,
+				true,
+				false,
+			},
+		},
+		{
+			name: "cilium k8s label with dot",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						SourceLabel: []string{"key.with.dot"},
+					},
+				},
+				ev: []*v1.Event{
+					{
+						Event: &flowpb.Flow{
+							Source: &flowpb.Endpoint{
+								Labels: []string{"k8s:key.with.dot"},
+							},
+						},
+					},
+					{
+						Event: &flowpb.Flow{
+							Source: &flowpb.Endpoint{
+								Labels: []string{"reserved:key.with.dot"},
+							},
+						},
+					},
+					{
+						Event: &flowpb.Flow{
+							Source: &flowpb.Endpoint{
+								Labels: []string{"any.key.with.dot"},
+							},
+						},
+					},
+					{
+						Event: &flowpb.Flow{
+							Source: &flowpb.Endpoint{
+								Labels: []string{"key:with.dot"},
+							},
+						},
+					},
+				},
+			},
+			want: []bool{
+				true,
+				true,
+				false,
 				false,
 			},
 		},
@@ -432,7 +562,14 @@ func Test_parseSelector(t *testing.T) {
 			args: args{
 				selector: "bar=baz,k8s:app=hubble,reserved:world",
 			},
-			want: "bar=baz,k8s.app=hubble,reserved.world",
+			want: "any.bar=baz,k8s.app=hubble,reserved.world",
+		},
+		{
+			name: "not label",
+			args: args{
+				selector: "!k8s:app",
+			},
+			want: "!k8s.app",
 		},
 		{
 			name: "complex labels",
@@ -440,6 +577,14 @@ func Test_parseSelector(t *testing.T) {
 				selector: "any:dash-label.com,k8s:io.cilium in (is-awesome,rocks)",
 			},
 			want: "any.dash-label.com,k8s.io.cilium in (is-awesome,rocks)",
+		},
+		{
+			name: "more complex labels",
+			args: args{
+				selector: "any:dash-label.com,k8s:io.cilium in (is-awesome, andsoon, rocks), !foobar, io.cilium notin (), test:label.com/foobar",
+			},
+			// NOTE: re-ordering and whitespace trimming is due to k8sLabels.Parse()
+			want: "any.dash-label.com,!any.foobar,any.io.cilium notin (),k8s.io.cilium in (andsoon,is-awesome,rocks),test.label.com/foobar",
 		},
 		{
 			name: "too many colons",
@@ -457,7 +602,7 @@ func Test_parseSelector(t *testing.T) {
 				return
 			}
 			if !tt.wantErr && !reflect.DeepEqual(got.String(), tt.want) {
-				t.Errorf("parseSelector() = %v, want %v", got, tt.want)
+				t.Errorf("parseSelector() = %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.


## The bug

Hubble label filters do not properly parse labels with dots `.` and no explicit source prefix. The label `foo.bar/buzz` is interpreted as the cilium label `foo:bar/buzz`.

This was caused by the fact that the ciliumLabels.LabelArray extends the k8sLabels.Selector logic with support for Cilium source prefixes such as "k8s:foo" or "any:bar", by treating the string before the first dot as the source prefix, i.e. `k8s.foo` is treated like `k8s:foo`. This is needed because k8sLabels.Selector does not support colons in labels.

So a hubble label filter `k8s:foo=bar` becomes `k8s.foo=bar`. This works fine for label filters with explicit prefixes. It also works fine for label filters without a prefix. If a label does not contain a dot it will be treated as having `any` source.

This does not work for labels without a prefix that contain a dot. So the label selector `foo.bar/buzz=test` will match the label `foo:bar/buzz` instead of matching `any:foo.bar/buzz`.

So that means `hubble observe --label k8s-app=hubble-relay`  works as expected but `hubble observe --label io.kubernetes.pod.namespace=kube-system` doesn't. The second one only matches a `io:kubernetes.pod.namespace` label


## Implementation Ideas

I already opened a PR(#29110) once to address this issue, but I did not come up with a clean solution and the PR got stale. I took another look at it and came up with the following options:

### Parsing with Regex

The obvious first approach, and what was suggested in the original PR, is to solve this with another regex. However, I encountered a few issues that make me very hesitant to use regex.

My first attempt was the following. We try to match the keys by looking for either the beginning of the string or a comma and the end of the key marked by a space, equal, comma, or end of string.
If the key then does not contain a colon, we add an `any:`.


    bareLabelSelector := regexp.MustCompile(`((?:^\s*|,\s*)!?)([a-z0-9A-Z-_./]+)(\s|=|,|$)`)
	selector = bareLabelSelector.ReplaceAllString(selector, "${1}any:${2}${3}")

The first case where this doesn't work is for the following `foo, bar=buzz`, because the matches overlap. I suspect this can't actually be matched in one go by RE2, because it doesn't support positive-lookaheads. But we can match it in a loop:

    bareLabelSelector := regexp.MustCompile(`((?:^\s*|,\s*)!?)([a-z0-9A-Z-_./]+)(\s|=|,|$)`)
	for {
		nsel := bareLabelSelector.ReplaceAllString(selector, "${1}any:$2$3")
		if nsel == selector {
			break
		}
		selector = nsel
	}


However, this still doesn't work for selectors with three or more values in parentheses. It will add `any:` to the middle values.

So `k8s:io.cilium in (is-awesome, best, rocks)` will result in `k8s:io.cilium in (is-awesome, any:best, rocks)`.

I could make this work with the following:

	bareLabelSelector := regexp.MustCompile(`((?:^\s*|,\s*)!?)([a-z0-9A-Z-_./]+)((?:\s|=|,|$))((?:[^\)]|\([^\)]*\))*$)`)
	for {
		nsel := bareLabelSelector.ReplaceAllString(selector, "${1}any:$2$3$4")
		if nsel == selector {
			break
		}
		selector = nsel
	}

What this regex does is: It looks for the key the same as the previous regex. It then only matches if there is either no closing parentheses in the rest of the string, or there is an equal number of opening and closing parentheses in the rest of the string.

This will only match one key at a time, so we need to call it in a loop.

So that works and passed all test cases I could come up with, but I'm really not happy with this.

1. It's very not obvious. Even with a long comment explaining how this works, this is hard to understand and maintain.
2. I'm not 100% convinced this works for every case. I couldn't come up with test case that doesn't, but I'm just not sure.


### Custom Parser

The other option I saw is to write some custom Go code to parse the label selector, identify keys without a specific source, and prepend an `any:`.

I added a custom parser (or rather translator) in this PR. It's more or less what I suggested in the original PR, but a bit cleaner and hopefully more readable. It's still not a particularly pretty solution. But instead of one very dense, and very hard to understand line of regex, it's ~100 lines of more or less readable Go code.

### Extend K8s label selector and add support for source prefixes

I also tried to see if we could extend the k8s label selector to actually understand source prefixes instead of adding the hack with a dot. However, I wasn't able to extend the selector code without having to rewrite larger parts of it. I don't think that's something we'd want to do.

Given these options, I'd argue for the handwritten parser. It's not an elegant solution, but it's the best I could come up with.