### PR TITLE
contrib/scripts: Remove special handling for patch release number 90

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -173,12 +173,8 @@ jobs:
           else
             # Upgrade from / downgrade to patch release.
             # In some cases we expect to fail to get the version number, do not
-            # fail the workflow in such case. This includes:
-            # - on main branch where we don't have preceeding patch releases
-            # - on stable branches on top of release preparation commits, where
-            #   we bump the patch version number to 90 and we can't easily
-            #   derive the number of the previous patch release version from
-            #   that.
+            # fail the workflow in such case. This is typically the case on
+            # main branch where we don't have preceeding patch releases.
             CILIUM_DOWNGRADE_VERSION=$(contrib/scripts/print-downgrade-version.sh patch || true)
             # Pass an empty tag to the cilium-config action to fall back to the
             # default release image, without crafting an image path with the

--- a/contrib/scripts/print-downgrade-version.sh
+++ b/contrib/scripts/print-downgrade-version.sh
@@ -20,8 +20,7 @@ fi
 if [[ ${1-} == "patch" ]] ; then
     # If user passed "patch" as first argument, print the latest patch version
     case ${patch} in
-        0|90)
-            # Patch release number 90 is used for preparing releases.
+        0)
             >&2 echo "ERROR: failed to deduce patch release previous to version '$VERSION'"
             exit 1
             ;;


### PR DESCRIPTION
In commit 56dfec2f1ac5 ("contrib/scripts: Support patch releases in print-downgrade-version.sh"), we added support to disaply the previous patch release for a given version number to the print-downgrade-version.sh script. We treated to patch release values as special cases: 0, because this means that we don't have a previous patch release on the branch, and 90, because it used to be a temporary value used during release processes.

But as Joe commented, we no longer use this "90" convention, but we use something like vX.Y.Z-dev instead. Let's remove the reverence to 90 from the script (and the workflow calling it).

Comparing with the commit introducing the special cases in the script, the output remains nearly the same as when it was introduced, only the previous patch release for "1.13.90" naturally turns to "1.13.89" instead of providing an error.

        VERSION         Previous minor  Previous patch release

        1.14.3          v1.13           v1.14.2
        1.14.1          v1.13           v1.14.0
        1.14.0          v1.13           <error>
        1.14.1-dev      v1.13           v1.14.0
        1.15.0-dev      v1.14           <error>
        1.13.90         v1.12           v1.13.89
