### PR TITLE
endpoint: move locking into getProxyStatistics

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -271,10 +271,7 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 				// Update the endpoint API model to report that Cilium manages a
 				// redirect for that port.
 				statsKey := policy.ProxyStatsKey(l4.Ingress, string(l4.Protocol), dstPort, redirectPort)
-				e.proxyStatisticsMutex.Lock()
-				proxyStats := e.getProxyStatisticsLocked(statsKey, string(l4.L7Parser), dstPort, l4.Ingress)
-				proxyStats.AllocatedProxyPort = int64(redirectPort)
-				e.proxyStatisticsMutex.Unlock()
+				proxyStats := e.getProxyStatistics(statsKey, string(l4.L7Parser), dstPort, l4.Ingress, redirectPort)
 
 				updatedStats = append(updatedStats, proxyStats)
 			}
@@ -359,10 +356,7 @@ func (e *Endpoint) addVisibilityRedirects(ingress bool, desiredRedirects map[str
 		// Update the endpoint API model to report that Cilium manages a
 		// redirect for that port.
 		statsKey := policy.ProxyStatsKey(visMeta.Ingress, visMeta.Proto.String(), visMeta.Port, redirectPort)
-		e.proxyStatisticsMutex.Lock()
-		proxyStats := e.getProxyStatisticsLocked(statsKey, string(visMeta.Parser), visMeta.Port, visMeta.Ingress)
-		proxyStats.AllocatedProxyPort = int64(redirectPort)
-		e.proxyStatisticsMutex.Unlock()
+		proxyStats := e.getProxyStatistics(statsKey, string(visMeta.Parser), visMeta.Port, visMeta.Ingress, redirectPort)
 
 		updatedStats = append(updatedStats, proxyStats)
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1551,10 +1551,12 @@ func (e *Endpoint) OnDNSPolicyUpdateLocked(rules restore.DNSRules) {
 	e.DNSRules = rules
 }
 
-// getProxyStatisticsLocked gets the ProxyStatistics for the flows with the
+// getProxyStatistics gets the ProxyStatistics for the flows with the
 // given characteristics, or adds a new one and returns it.
-// Must be called with e.proxyStatisticsMutex held.
-func (e *Endpoint) getProxyStatisticsLocked(key string, l7Protocol string, port uint16, ingress bool) *models.ProxyStatistics {
+func (e *Endpoint) getProxyStatistics(key string, l7Protocol string, port uint16, ingress bool, redirectPort uint16) *models.ProxyStatistics {
+	e.proxyStatisticsMutex.Lock()
+	defer e.proxyStatisticsMutex.Unlock()
+
 	if e.proxyStatistics == nil {
 		e.proxyStatistics = make(map[string]*models.ProxyStatistics)
 	}
@@ -1579,6 +1581,8 @@ func (e *Endpoint) getProxyStatisticsLocked(key string, l7Protocol string, port 
 
 		e.proxyStatistics[key] = proxyStats
 	}
+
+	proxyStats.AllocatedProxyPort = int64(redirectPort)
 
 	return proxyStats
 }


### PR DESCRIPTION
The only two callers of (*Endpoint).getProxyStatisticsLocked take the lock right before the call and release it right after. Move locking into the method to avoid some boilerplate and rename the method accordingly.