### PR TITLE
Envoy: Extract Secret Sync from global k8swatcher

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -106,6 +106,7 @@ cilium-agent [flags]
       --enable-endpoint-routes                                    Use per endpoint routes instead of routing via cilium_host
       --enable-envoy-config                                       Enable Envoy Config CRDs
       --enable-external-ips                                       Enable k8s service externalIPs feature (requires enabling enable-node-port)
+      --enable-gateway-api                                        Enables Envoy secret sync for Gateway API related TLS secrets
       --enable-health-check-loadbalancer-ip                       Enable access of the healthcheck nodePort on the LoadBalancerIP. Needs --enable-health-check-nodeport to be enabled
       --enable-health-check-nodeport                              Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
       --enable-health-checking                                    Enable connectivity health checking (default true)
@@ -116,6 +117,7 @@ cilium-agent [flags]
       --enable-hubble                                             Enable hubble server
       --enable-hubble-recorder-api                                Enable the Hubble recorder API (default true)
       --enable-identity-mark                                      Enable setting identity mark for local traffic (default true)
+      --enable-ingress-controller                                 Enables Envoy secret sync for Ingress controller related TLS secrets
       --enable-ip-masq-agent                                      Enable BPF ip-masq-agent
       --enable-ipsec                                              Enable IPSec support
       --enable-ipsec-key-watcher                                  Enable watcher for IPsec key. If disabled, a restart of the agent will be necessary on key rotations. (default true)
@@ -167,9 +169,11 @@ cilium-agent [flags]
       --endpoint-status strings                                   Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
       --envoy-config-timeout duration                             Timeout duration for Envoy Config acknowledgements (default 2m0s)
       --envoy-log string                                          Path to a separate Envoy log file, if any
+      --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC
       --exclude-local-address strings                             Exclude CIDR from being recognized as local address
       --external-envoy-proxy                                      whether the Envoy is deployed externally in form of a DaemonSet or not
       --fixed-identity-mapping map                                Key-value for the fixed identity mapping which allows to use reserved label for fixed identities, e.g. 128=kv-store,129=kube-dns
+      --gateway-api-secrets-namespace string                      GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API
       --gops-port uint16                                          Port for gops server to listen on (default 9890)
   -h, --help                                                      help for cilium-agent
       --http-idle-timeout uint                                    Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
@@ -210,6 +214,7 @@ cilium-agent [flags]
       --identity-allocation-mode string                           Method to use for identity allocation (default "kvstore")
       --identity-change-grace-period duration                     Time to wait before using new identity on endpoint identity change (default 5s)
       --identity-restore-grace-period duration                    Time to wait before releasing unused restored CIDR identities during agent restart (default 10m0s)
+      --ingress-secrets-namespace string                          IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller
       --install-no-conntrack-iptables-rules                       Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.
       --ip-allocation-timeout duration                            Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
       --ip-masq-agent-config-path string                          ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -31,6 +31,8 @@ cilium-agent hive [flags]
       --enable-bbr                                                Enable BBR for the bandwidth manager
       --enable-cilium-api-server-access strings                   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cilium-health-api-server-access strings            List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api                                        Enables Envoy secret sync for Gateway API related TLS secrets
+      --enable-ingress-controller                                 Enables Envoy secret sync for Ingress controller related TLS secrets
       --enable-ipv4-big-tcp                                       Enable IPv4 BIG TCP option which increases device's maximum GRO/GSO limits for IPv4
       --enable-ipv6-big-tcp                                       Enable IPv6 BIG TCP option which increases device's maximum GRO/GSO limits for IPv6
       --enable-k8s                                                Enable the k8s clientset (default true)
@@ -40,8 +42,11 @@ cilium-agent hive [flags]
       --enable-monitor                                            Enable the monitor unix domain socket server (default true)
       --enable-service-topology                                   Enable support for service topology aware hints
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
+      --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC
+      --gateway-api-secrets-namespace string                      GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API
       --gops-port uint16                                          Port for gops server to listen on (default 9890)
   -h, --help                                                      help for hive
+      --ingress-secrets-namespace string                          IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --iptables-random-fully                                     Set iptables flag random-fully on masquerading rules
       --k8s-api-server string                                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -37,6 +37,8 @@ cilium-agent hive dot-graph [flags]
       --enable-bbr                                                Enable BBR for the bandwidth manager
       --enable-cilium-api-server-access strings                   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cilium-health-api-server-access strings            List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api                                        Enables Envoy secret sync for Gateway API related TLS secrets
+      --enable-ingress-controller                                 Enables Envoy secret sync for Ingress controller related TLS secrets
       --enable-ipv4-big-tcp                                       Enable IPv4 BIG TCP option which increases device's maximum GRO/GSO limits for IPv4
       --enable-ipv6-big-tcp                                       Enable IPv6 BIG TCP option which increases device's maximum GRO/GSO limits for IPv6
       --enable-k8s                                                Enable the k8s clientset (default true)
@@ -46,7 +48,10 @@ cilium-agent hive dot-graph [flags]
       --enable-monitor                                            Enable the monitor unix domain socket server (default true)
       --enable-service-topology                                   Enable support for service topology aware hints
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
+      --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC
+      --gateway-api-secrets-namespace string                      GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API
       --gops-port uint16                                          Port for gops server to listen on (default 9890)
+      --ingress-secrets-namespace string                          IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --iptables-random-fully                                     Set iptables flag random-fully on masquerading rules
       --k8s-api-server string                                     Kubernetes API server URL

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -510,7 +510,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		d.datapath,
 		d.redirectPolicyManager,
 		d.bgpSpeaker,
-		d.envoyXdsServer,
 		option.Config,
 		d.ipcache,
 		d.cgroupManager,

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -10,11 +10,16 @@ import (
 	"runtime/pprof"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/time"
@@ -26,6 +31,7 @@ var Cell = cell.Module(
 	"envoy-proxy",
 	"Envoy proxy and control-plane",
 
+	cell.Config(secretSyncConfig{}),
 	cell.Provide(newEnvoyXDSServer),
 	cell.Provide(newEnvoyAdminClient),
 	cell.Provide(newEnvoyServiceBackendSyncer),
@@ -33,7 +39,26 @@ var Cell = cell.Module(
 	cell.ProvidePrivate(newLocalEndpointStore),
 	cell.ProvidePrivate(newArtifactCopier),
 	cell.Invoke(registerEnvoyVersionCheck),
+	cell.Invoke(registerSecretSyncer),
 )
+
+type secretSyncConfig struct {
+	EnvoySecretsNamespace string
+
+	EnableIngressController bool
+	IngressSecretsNamespace string
+
+	EnableGatewayAPI           bool
+	GatewayAPISecretsNamespace string
+}
+
+func (r secretSyncConfig) Flags(flags *pflag.FlagSet) {
+	flags.String("envoy-secrets-namespace", r.EnvoySecretsNamespace, "EnvoySecretsNamespace is the namespace having secrets used by CEC")
+	flags.Bool("enable-ingress-controller", false, "Enables Envoy secret sync for Ingress controller related TLS secrets")
+	flags.String("ingress-secrets-namespace", r.IngressSecretsNamespace, "IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller")
+	flags.Bool("enable-gateway-api", false, "Enables Envoy secret sync for Gateway API related TLS secrets")
+	flags.String("gateway-api-secrets-namespace", r.GatewayAPISecretsNamespace, "GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API")
+}
 
 type xdsServerParams struct {
 	cell.In
@@ -186,4 +211,74 @@ func newArtifactCopier(lifecycle hive.Lifecycle) *ArtifactCopier {
 	})
 
 	return artifactCopier
+}
+
+type syncerParams struct {
+	cell.In
+
+	Logger      logrus.FieldLogger
+	Lifecycle   hive.Lifecycle
+	JobRegistry job.Registry
+	Scope       cell.Scope
+
+	K8sClientset client.Clientset
+
+	Config    secretSyncConfig
+	XdsServer XDSServer
+}
+
+func registerSecretSyncer(params syncerParams) error {
+	if !params.Config.EnableIngressController && !params.Config.EnableGatewayAPI {
+		return nil
+	}
+
+	secretSyncer := newSecretSyncer(params.Logger, params.XdsServer)
+
+	// Create a Secret Resource for each namespace.
+	// The Cilium Agent only has permissions on the specific namespaces.
+	// Note that the different features can use the same namespace for
+	// their TLS.
+	namespaces := map[string]struct{}{}
+
+	for namespace, cond := range map[string]func() bool{
+		params.Config.EnvoySecretsNamespace:      func() bool { return option.Config.EnableEnvoyConfig },
+		params.Config.IngressSecretsNamespace:    func() bool { return params.Config.EnableIngressController },
+		params.Config.GatewayAPISecretsNamespace: func() bool { return params.Config.EnableGatewayAPI },
+	} {
+		if len(namespace) > 0 && cond() {
+			namespaces[namespace] = struct{}{}
+		}
+	}
+
+	if len(namespaces) == 0 {
+		return nil
+	}
+
+	jobGroup := params.JobRegistry.NewGroup(
+		params.Scope,
+		job.WithLogger(params.Logger),
+		job.WithPprofLabels(pprof.Labels("cell", "envoy-secretsyncer")),
+	)
+
+	params.Lifecycle.Append(jobGroup)
+	for ns := range namespaces {
+		jobGroup.Add(job.Observer(
+			fmt.Sprintf("k8s-secrets-resource-events-%s", ns),
+			secretSyncer.handleSecretEvent,
+			newK8sSecretResource(params.Lifecycle, params.K8sClientset, ns),
+		))
+	}
+
+	return nil
+}
+
+func newK8sSecretResource(lc hive.Lifecycle, cs client.Clientset, namespace string) resource.Resource[*slim_corev1.Secret] {
+	if !cs.IsEnabled() {
+		return nil
+	}
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped[*slim_corev1.SecretList](cs.Slim().CoreV1().Secrets(namespace)),
+	)
+
+	return resource.New[*slim_corev1.Secret](lc, lw, resource.WithMetric("Secret"))
 }

--- a/pkg/envoy/secretsync_test.go
+++ b/pkg/envoy/secretsync_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package watchers
+package envoy
 
 import (
 	"testing"

--- a/pkg/envoy/secretsync_test.go
+++ b/pkg/envoy/secretsync_test.go
@@ -4,12 +4,23 @@
 package envoy
 
 import (
+	"context"
+	"errors"
+	"io"
 	"testing"
 
+	cilium "github.com/cilium/proxy/go/cilium/api"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/envoy/xds"
+	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/proxy/endpoint"
 )
 
 func Test_k8sToEnvoySecret(t *testing.T) {
@@ -28,4 +39,202 @@ func Test_k8sToEnvoySecret(t *testing.T) {
 	require.Equal(t, "dummy-namespace/dummy-secret", envoySecret.Name)
 	require.Equal(t, []byte{1, 2, 3}, envoySecret.GetTlsCertificate().GetCertificateChain().GetInlineBytes())
 	require.Equal(t, []byte{4, 5, 6}, envoySecret.GetTlsCertificate().GetPrivateKey().GetInlineBytes())
+}
+
+func TestHandleSecretEvent(t *testing.T) {
+	tests := []struct {
+		name                 string
+		secret               *slim_corev1.Secret
+		kind                 resource.EventKind
+		currentNodeLabels    map[string]string
+		newNodeLabels        map[string]string
+		xdsShouldReturnError bool
+		expectedError        bool
+		expectedUpserts      int
+		expectedDeletions    int
+	}{
+		{
+			name:              "upserted secret should be upserted in xDS",
+			secret:            testSecret(),
+			kind:              resource.Upsert,
+			expectedError:     false,
+			expectedUpserts:   1,
+			expectedDeletions: 0,
+		},
+		{
+			name:              "deleted secret should be deleted in xDS",
+			secret:            testSecret(),
+			kind:              resource.Delete,
+			expectedError:     false,
+			expectedUpserts:   0,
+			expectedDeletions: 1,
+		},
+		{
+			name:              "sync event should not be handled",
+			secret:            testSecret(),
+			kind:              resource.Sync,
+			expectedError:     false,
+			expectedUpserts:   0,
+			expectedDeletions: 0,
+		},
+		{
+			name:              "upserting a nil secret should result in an error",
+			secret:            nil,
+			kind:              resource.Upsert,
+			expectedError:     true,
+			expectedUpserts:   0,
+			expectedDeletions: 0,
+		},
+		{
+			name:              "delete event with empty key namespace and/or name should result in an error",
+			secret:            nil,
+			kind:              resource.Delete,
+			expectedError:     true,
+			expectedUpserts:   0,
+			expectedDeletions: 0,
+		},
+		{
+			name:                 "upsert errors of xDS server should be returned",
+			secret:               testSecret(),
+			kind:                 resource.Upsert,
+			xdsShouldReturnError: true,
+			expectedError:        true,
+			expectedUpserts:      0,
+			expectedDeletions:    0,
+		},
+		{
+			name:                 "delete errors of xDS server should be returned",
+			secret:               testSecret(),
+			kind:                 resource.Delete,
+			xdsShouldReturnError: true,
+			expectedError:        true,
+			expectedUpserts:      0,
+			expectedDeletions:    0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := logrus.New()
+			logger.SetOutput(io.Discard)
+
+			xdsServer := &fakeXdsServer{
+				returnError: tc.xdsShouldReturnError,
+			}
+
+			syncer := newSecretSyncer(logger, xdsServer)
+
+			doneCalled := false
+			var doneError error
+
+			doneFunc := func(err error) {
+				doneCalled = true
+				doneError = err
+			}
+
+			err := syncer.handleSecretEvent(context.Background(), testEvent(tc.secret, tc.kind, doneFunc))
+			assert.Equal(t, tc.expectedError, err != nil, "Expected returned error should match")
+
+			assert.True(t, doneCalled, "Done must be called on the event in all cases")
+			assert.Equal(t, tc.expectedError, doneError != nil, "Expected done error should match")
+
+			assert.Equal(t, tc.expectedUpserts, xdsServer.nrOfUpserts)
+			assert.Equal(t, tc.expectedDeletions, xdsServer.nrOfDeletions)
+			assert.Equal(t, 0, xdsServer.nrOfUpdates, "Secret sync should never use update functionality")
+		})
+	}
+}
+
+func testEvent(secret *slim_corev1.Secret, eventKind resource.EventKind, eventDone func(err error)) resource.Event[*slim_corev1.Secret] {
+	event := resource.Event[*slim_corev1.Secret]{}
+	if secret != nil {
+		event.Key = resource.NewKey(secret)
+	}
+	event.Object = secret
+	event.Kind = eventKind
+	event.Done = eventDone
+
+	return event
+}
+
+func testSecret() *slim_corev1.Secret {
+	return &slim_corev1.Secret{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "test",
+		},
+		Data: map[string]slim_corev1.Bytes{
+			"tls.crt": []byte("content"),
+		},
+		Type: "kubernetes.io/tls",
+	}
+}
+
+type fakeXdsServer struct {
+	nrOfDeletions int
+	returnError   bool
+	nrOfUpdates   int
+	nrOfUpserts   int
+}
+
+var _ XDSServer = &fakeXdsServer{}
+
+func (r *fakeXdsServer) Reset() {
+	r.nrOfUpdates = 0
+	r.nrOfUpserts = 0
+	r.nrOfDeletions = 0
+}
+
+func (r *fakeXdsServer) UpdateEnvoyResources(ctx context.Context, old Resources, new Resources) error {
+	if r.returnError {
+		return errors.New("failed to update envoy resources")
+	}
+
+	r.nrOfUpdates++
+	return nil
+}
+
+func (r *fakeXdsServer) DeleteEnvoyResources(ctx context.Context, resources Resources) error {
+	if r.returnError {
+		return errors.New("failed to delete envoy resources")
+	}
+
+	r.nrOfDeletions++
+	return nil
+}
+
+func (r *fakeXdsServer) UpsertEnvoyResources(ctx context.Context, resources Resources) error {
+	if r.returnError {
+		return errors.New("failed to upsert envoy resources")
+	}
+
+	r.nrOfUpserts++
+	return nil
+}
+
+func (*fakeXdsServer) AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup) {
+	panic("unimplemented")
+}
+
+func (*fakeXdsServer) AddMetricsListener(port uint16, wg *completion.WaitGroup) {
+	panic("unimplemented")
+}
+
+func (*fakeXdsServer) GetNetworkPolicies(resourceNames []string) (map[string]*cilium.NetworkPolicy, error) {
+	panic("unimplemented")
+}
+
+func (*fakeXdsServer) RemoveAllNetworkPolicies() {
+	panic("unimplemented")
+}
+
+func (*fakeXdsServer) RemoveListener(name string, wg *completion.WaitGroup) xds.AckingResourceMutatorRevertFunc {
+	panic("unimplemented")
+}
+
+func (*fakeXdsServer) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
+	panic("unimplemented")
+}
+
+func (*fakeXdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, vis *policy.VisibilityPolicy, policy *policy.L4Policy, ingressPolicyEnforced bool, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
+	panic("unimplemented")
 }

--- a/pkg/k8s/utils/utils.go
+++ b/pkg/k8s/utils/utils.go
@@ -62,18 +62,6 @@ func GetObjNamespaceName(obj NamespaceNameGetter) string {
 	return ns + "/" + obj.GetName()
 }
 
-// IngressConfiguration is the required configuration for GetServiceAndEndpointListOptionsModifier
-type IngressConfiguration interface {
-	// K8sIngressControllerEnabled returns true if ingress controller feature is enabled in Cilium
-	K8sIngressControllerEnabled() bool
-}
-
-// GatewayAPIConfiguration is the required configuration for GetServiceAndEndpointListOptionsModifier
-type GatewayAPIConfiguration interface {
-	// K8sGatewayAPIEnabled returns true if gateway API is enabled in Cilium
-	K8sGatewayAPIEnabled() bool
-}
-
 // PolicyConfiguration is the required configuration for K8s NetworkPolicy
 type PolicyConfiguration interface {
 	// K8sNetworkPolicyEnabled returns true if cilium agent needs to support K8s NetworkPolicy

--- a/pkg/k8s/watchers/resources/resources.go
+++ b/pkg/k8s/watchers/resources/resources.go
@@ -10,8 +10,6 @@ const (
 	K8sAPIGroupServiceV1Core = "core/v1::Service"
 	// K8sAPIGroupPodV1Core is the identifier for K8s resources of type core/v1/Pod.
 	K8sAPIGroupPodV1Core = "core/v1::Pods"
-	// K8sAPIGroupSecretV1Cores is the identifier for K8s resources of type core/v1/Secret.
-	K8sAPIGroupSecretV1Core = "core/v1::Secrets"
 	// K8sAPIGroupEndpointSliceOrEndpoint is the combined identifier for K8s EndpointSlice and
 	// Endpoint resources.
 	K8sAPIGroupEndpointSliceOrEndpoint = "EndpointSliceOrEndpoint"

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -75,7 +75,6 @@ const (
 
 	metricKNP            = "NetworkPolicy"
 	metricNS             = "Namespace"
-	metricSecret         = "Secret"
 	metricCiliumNode     = "CiliumNode"
 	metricCiliumEndpoint = "CiliumEndpoint"
 	metricCLRP           = "CiliumLocalRedirectPolicy"
@@ -558,10 +557,6 @@ func (k *K8sWatcher) enableK8sWatchers(ctx context.Context, resourceNames []stri
 			k.servicesInit()
 		case resources.K8sAPIGroupEndpointSliceOrEndpoint:
 			k.endpointsInit()
-		case resources.K8sAPIGroupSecretV1Core:
-			swgSecret := lock.NewStoppableWaitGroup()
-			// only watch secrets in specific namespaces
-			k.tlsSecretInit(k.clientset.Slim(), option.Config.EnvoySecretNamespaces, swgSecret)
 		// Custom resource definitions
 		case k8sAPIGroupCiliumNetworkPolicyV2, k8sAPIGroupCiliumClusterwideNetworkPolicyV2, k8sAPIGroupCiliumCIDRGroupV2Alpha1:
 			cnpOnce.Do(func() { k.ciliumNetworkPoliciesInit(ctx, k.clientset) })

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/bandwidth"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpoint"
-	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -70,8 +69,6 @@ const (
 	k8sAPIGroupCiliumEndpointV2                 = "cilium/v2::CiliumEndpoint"
 	k8sAPIGroupCiliumLocalRedirectPolicyV2      = "cilium/v2::CiliumLocalRedirectPolicy"
 	k8sAPIGroupCiliumEndpointSliceV2Alpha1      = "cilium/v2alpha1::CiliumEndpointSlice"
-	k8sAPIGroupCiliumClusterwideEnvoyConfigV2   = "cilium/v2::CiliumClusterwideEnvoyConfig"
-	k8sAPIGroupCiliumEnvoyConfigV2              = "cilium/v2::CiliumEnvoyConfig"
 
 	metricKNP            = "NetworkPolicy"
 	metricNS             = "Namespace"
@@ -79,8 +76,6 @@ const (
 	metricCiliumEndpoint = "CiliumEndpoint"
 	metricCLRP           = "CiliumLocalRedirectPolicy"
 	metricCEGP           = "CiliumEgressGatewayPolicy"
-	metricCCEC           = "CiliumClusterwideEnvoyConfig"
-	metricCEC            = "CiliumEnvoyConfig"
 	metricPod            = "Pod"
 	metricNode           = "Node"
 )
@@ -159,10 +154,6 @@ type svcManager interface {
 	DeleteService(frontend loadbalancer.L3n4Addr) (bool, error)
 	GetDeepCopyServiceByFrontend(frontend loadbalancer.L3n4Addr) (*loadbalancer.SVC, bool)
 	UpsertService(*loadbalancer.SVC) (bool, loadbalancer.ID, error)
-	RegisterL7LBServiceRedirect(serviceName loadbalancer.ServiceName, resourceName service.L7LBResourceName, proxyPort uint16) error
-	DeregisterL7LBServiceRedirect(serviceName loadbalancer.ServiceName, resourceName service.L7LBResourceName) error
-	RegisterL7LBServiceBackendSync(serviceName loadbalancer.ServiceName, backendSyncRegistration service.BackendSyncer) error
-	DeregisterL7LBServiceBackendSync(serviceName loadbalancer.ServiceName, backendSyncRegistration service.BackendSyncer) error
 }
 
 type redirectPolicyManager interface {
@@ -226,7 +217,6 @@ type K8sWatcher struct {
 	redirectPolicyManager redirectPolicyManager
 	bgpSpeakerManager     bgpSpeakerManager
 	ipcache               ipcacheManager
-	envoyXdsServer        envoy.XDSServer
 	cgroupManager         cgroupManager
 
 	bandwidthManager bandwidth.Manager
@@ -270,7 +260,6 @@ func NewK8sWatcher(
 	datapath datapath.Datapath,
 	redirectPolicyManager redirectPolicyManager,
 	bgpSpeakerManager bgpSpeakerManager,
-	envoyXdsServer envoy.XDSServer,
 	cfg WatcherConfiguration,
 	ipcache ipcacheManager,
 	cgroupManager cgroupManager,
@@ -296,7 +285,6 @@ func NewK8sWatcher(
 		bgpSpeakerManager:       bgpSpeakerManager,
 		cgroupManager:           cgroupManager,
 		bandwidthManager:        bandwidthManager,
-		envoyXdsServer:          envoyXdsServer,
 		cfg:                     cfg,
 		resources:               resources,
 	}
@@ -473,12 +461,6 @@ func (k *K8sWatcher) resourceGroups() []string {
 		k8sGroups = append(k8sGroups, k8sAPIGroupNetworkingV1Core)
 	}
 
-	if k.cfg.K8sIngressControllerEnabled() || k.cfg.K8sGatewayAPIEnabled() {
-		// While Ingress controller is part of operator, we need to watch
-		// TLS secrets in pre-defined namespace for populating Envoy xDS SDS cache.
-		k8sGroups = append(k8sGroups, resources.K8sAPIGroupSecretV1Core)
-	}
-
 	ciliumResources := synced.AgentCRDResourceNames()
 	ciliumGroups := make([]string, 0, len(ciliumResources))
 	for _, r := range ciliumResources {
@@ -524,8 +506,6 @@ func (k *K8sWatcher) InitK8sSubsystem(ctx context.Context, cachesSynced chan str
 
 // WatcherConfiguration is the required configuration for enableK8sWatchers
 type WatcherConfiguration interface {
-	utils.IngressConfiguration
-	utils.GatewayAPIConfiguration
 	utils.PolicyConfiguration
 }
 

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/service"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
 
@@ -38,14 +37,6 @@ var _ = Suite(&K8sWatcherSuite{})
 var emptyResources = agentK8s.Resources{}
 
 type fakeWatcherConfiguration struct{}
-
-func (f *fakeWatcherConfiguration) K8sIngressControllerEnabled() bool {
-	return false
-}
-
-func (f *fakeWatcherConfiguration) K8sGatewayAPIEnabled() bool {
-	return false
-}
 
 func (f *fakeWatcherConfiguration) K8sNetworkPolicyEnabled() bool {
 	return true
@@ -121,22 +112,6 @@ func (f *fakeSvcManager) UpsertService(p *loadbalancer.SVC) (bool, loadbalancer.
 	panic("OnUpsertService() was called and is not set!")
 }
 
-func (f *fakeSvcManager) RegisterL7LBServiceRedirect(serviceName loadbalancer.ServiceName, resourceName service.L7LBResourceName, proxyPort uint16) error {
-	return nil
-}
-
-func (f *fakeSvcManager) DeregisterL7LBServiceRedirect(serviceName loadbalancer.ServiceName, resourceName service.L7LBResourceName) error {
-	return nil
-}
-
-func (f *fakeSvcManager) RegisterL7LBServiceBackendSync(serviceName loadbalancer.ServiceName, backendSyncRegistration service.BackendSyncer) error {
-	return nil
-}
-
-func (f *fakeSvcManager) DeregisterL7LBServiceBackendSync(serviceName loadbalancer.ServiceName, backendSyncRegistration service.BackendSyncer) error {
-	return nil
-}
-
 func (s *K8sWatcherSuite) TestUpdateToServiceEndpointsGH9525(c *C) {
 	ep1stApply := &slim_corev1.Endpoints{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -198,7 +173,6 @@ func (s *K8sWatcherSuite) TestUpdateToServiceEndpointsGH9525(c *C) {
 		policyRepository,
 		nil,
 		dp,
-		nil,
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
@@ -525,7 +499,6 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		dp,
 		nil,
 		nil,
-		nil,
 		&fakeWatcherConfiguration{},
 		testipcache.NewMockIPCache(),
 		nil,
@@ -677,7 +650,6 @@ func (s *K8sWatcherSuite) TestChangeSVCPort(c *C) {
 		policyRepository,
 		svcManager,
 		dp,
-		nil,
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
@@ -1162,7 +1134,6 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		dp,
 		nil,
 		nil,
-		nil,
 		&fakeWatcherConfiguration{},
 		testipcache.NewMockIPCache(),
 		nil,
@@ -1479,7 +1450,6 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		dp,
 		nil,
 		nil,
-		nil,
 		&fakeWatcherConfiguration{},
 		testipcache.NewMockIPCache(),
 		nil,
@@ -1787,7 +1757,6 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		policyRepository,
 		svcManager,
 		dp,
-		nil,
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
@@ -2711,7 +2680,6 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		policyRepository,
 		svcManager,
 		dp,
-		nil,
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1167,15 +1167,6 @@ const (
 	// Flag to enable BGP control plane features
 	EnableBGPControlPlane = "enable-bgp-control-plane"
 
-	// EnvoySecretsNamespace is the namespace having secrets used by CEC.
-	EnvoySecretsNamespace = "envoy-secrets-namespace"
-
-	// IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller.
-	IngressSecretsNamespace = "ingress-secrets-namespace"
-
-	// GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API.
-	GatewayAPISecretsNamespace = "gateway-api-secrets-namespace"
-
 	// EnableRuntimeDeviceDetection is the name of the option to enable detection
 	// of new and removed datapath devices during the agent runtime.
 	EnableRuntimeDeviceDetection = "enable-runtime-device-detection"
@@ -3537,17 +3528,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 
 	// Enable BGP control plane features
 	c.EnableBGPControlPlane = vp.GetBool(EnableBGPControlPlane)
-
-	// Envoy secrets namespaces to watch
-	params := []string{EnvoySecretsNamespace, IngressSecretsNamespace, GatewayAPISecretsNamespace}
-	var nsList = make([]string, 0, len(params))
-	for _, param := range params {
-		ns := vp.GetString(param)
-		if ns != "" {
-			nsList = append(nsList, ns)
-		}
-	}
-	c.EnvoySecretNamespaces = nsList
 
 	// To support K8s NetworkPolicy
 	c.EnableK8sNetworkPolicy = vp.GetBool(EnableK8sNetworkPolicy)


### PR DESCRIPTION
This commit extracts the Envoy Secret Syncer (K8s Secrets -> Envoy sDS) from the global `k8swatcher` (`pkg/k8s`) into the Envoy package and hive cell (`pkg/envoy`).

Please review the individual commits.