### PR TITLE
node/wireguard: Fix node-to-node encryption inconsistencies in kvstore mode

### DIFF
--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/nodemap"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/mtu"
-	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	wg "github.com/cilium/cilium/pkg/wireguard/agent"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
@@ -127,7 +126,7 @@ var Cell = cell.Module(
 	loader.Cell,
 )
 
-func newWireguardAgent(lc cell.Lifecycle, localNodeStore *node.LocalNodeStore) *wg.Agent {
+func newWireguardAgent(lc cell.Lifecycle) *wg.Agent {
 	var wgAgent *wg.Agent
 	if option.Config.EnableWireguard {
 		if option.Config.EnableIPSec {
@@ -137,7 +136,7 @@ func newWireguardAgent(lc cell.Lifecycle, localNodeStore *node.LocalNodeStore) *
 
 		var err error
 		privateKeyPath := filepath.Join(option.Config.StateDir, wgTypes.PrivKeyFilename)
-		wgAgent, err = wg.NewAgent(privateKeyPath, localNodeStore)
+		wgAgent, err = wg.NewAgent(privateKeyPath)
 		if err != nil {
 			log.Fatalf("failed to initialize WireGuard: %s", err)
 		}

--- a/pkg/endpoint/endpoint_status.go
+++ b/pkg/endpoint/endpoint_status.go
@@ -355,7 +355,7 @@ func (e *Endpoint) GetCiliumEndpointStatus(conf EndpointStatusConfiguration) *ci
 		Identity:            getEndpointIdentity(identitymodel.CreateModel(e.SecurityIdentity)),
 		Networking:          getEndpointNetworking(e.getModelNetworkingRLocked()),
 		State:               compressEndpointState(e.getModelCurrentStateRLocked()),
-		Encryption:          cilium_v2.EncryptionSpec{Key: int(node.GetEncryptKeyIndex())},
+		Encryption:          cilium_v2.EncryptionSpec{Key: int(node.GetEndpointEncryptKeyIndex())},
 		NamedPorts:          e.getNamedPortsModel(),
 	}
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -839,7 +839,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 				if !ok {
 					return controller.NewExitReason("Failed to convert node IPv4 address")
 				}
-				key := node.GetIPsecKeyIdentity()
+				key := node.GetEndpointEncryptKeyIndex()
 				metadata := e.FormatGlobalEndpointID()
 				k8sNamespace := e.K8sNamespace
 				k8sPodName := e.K8sPodName

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -132,7 +132,7 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 	}
 
 	// default to the standard key
-	encryptionKey := node.GetIPsecKeyIdentity()
+	encryptionKey := node.GetEndpointEncryptKeyIndex()
 
 	id := identity.ReservedIdentityUnmanaged
 	if endpoint.Identity != nil {

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -880,7 +880,7 @@ func (k *K8sWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPodIP
 		return fmt.Errorf("no/invalid HostIP: %s", newPod.Status.HostIP)
 	}
 
-	hostKey := node.GetIPsecKeyIdentity()
+	hostKey := node.GetEndpointEncryptKeyIndex()
 
 	k8sMeta := &ipcache.K8sMetadata{
 		Namespace: newPod.Namespace,

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -507,11 +507,6 @@ func SetIPsecKeyIdentity(id uint8) {
 	})
 }
 
-// GetIPsecKeyIdentity returns the IPsec key identity of the node
-func GetIPsecKeyIdentity() uint8 {
-	return getLocalNode().EncryptionKey
-}
-
 // GetK8sNodeIPs returns k8s Node IP addr.
 func GetK8sNodeIP() net.IP {
 	n := getLocalNode()
@@ -574,14 +569,17 @@ func GetIngressIPv6() net.IP {
 	return getLocalNode().IPv6IngressIP
 }
 
-// GetEncryptKeyIndex returns the encryption key value for the local node.
-// With IPSec encryption, this is equivalent to GetIPsecKeyIdentity().
-// With WireGuard encryption, this function returns a non-zero static value
-// if the local node has WireGuard enabled.
-func GetEncryptKeyIndex() uint8 {
+// GetEndpointEncryptKeyIndex returns the encryption key value for an endpoint
+// owned by the local node.
+// With IPSec encryption, this is the ID of the currently loaded key.
+// With WireGuard, this returns a non-zero static value.
+// Note that the key index returned by this function is only valid for _endpoints_
+// of the local node. If you want to obtain the key index of the local node itself,
+// access the `EncryptionKey` field via the LocalNodeStore.
+func GetEndpointEncryptKeyIndex() uint8 {
 	switch {
 	case option.Config.EnableIPSec:
-		return GetIPsecKeyIdentity()
+		return getLocalNode().EncryptionKey
 	case option.Config.EnableWireguard:
 		if len(GetWireguardPubKey()) > 0 {
 			return wgTypes.StaticEncryptKey

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -526,12 +526,6 @@ func GetOptOutNodeEncryption() bool {
 	return getLocalNode().OptOutNodeEncryption
 }
 
-func SetOptOutNodeEncryption(b bool) {
-	localNode.Update(func(node *LocalNode) {
-		node.OptOutNodeEncryption = b
-	})
-}
-
 // SetEndpointHealthIPv4 sets the IPv4 cilium-health endpoint address.
 func SetEndpointHealthIPv4(ip net.IP) {
 	localNode.Update(func(n *LocalNode) {

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -581,9 +581,8 @@ func GetEndpointEncryptKeyIndex() uint8 {
 	case option.Config.EnableIPSec:
 		return getLocalNode().EncryptionKey
 	case option.Config.EnableWireguard:
-		if len(GetWireguardPubKey()) > 0 {
-			return wgTypes.StaticEncryptKey
-		}
+		return wgTypes.StaticEncryptKey
+
 	}
 	return 0
 }

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 var (
@@ -386,7 +387,7 @@ func (m *manager) nodeAddressHasTunnelIP(address nodeTypes.Address) bool {
 		m.conf.EnableHostFirewall || m.conf.JoinCluster
 }
 
-func (m *manager) nodeAddressHasEncryptKey(address nodeTypes.Address) bool {
+func (m *manager) nodeAddressHasEncryptKey() bool {
 	// If we are doing encryption, but not node based encryption, then do not
 	// add a key to the nodeIPs so that we avoid a trip through stack and attempting
 	// to encrypt something we know does not have an encryption policy installed
@@ -396,6 +397,22 @@ func (m *manager) nodeAddressHasEncryptKey(address nodeTypes.Address) bool {
 		// Also ignore any remote node's key if the local node opted to not perform
 		// node-to-node encryption
 		!node.GetOptOutNodeEncryption()
+}
+
+// endpointEncryptionKey returns the encryption key index to use for the health
+// and ingress endpoints of a node. This is needed for WireGuard where the
+// node's EncryptionKey and the endpoint's EncryptionKey are not the same if
+// a node has opted out of node-to-node encryption by zeroing n.EncryptionKey.
+// With WireGuard, we always want to encrypt pod-to-pod traffic, thus we return
+// a static non-zero encrypt key here.
+// With IPSec (or no encryption), the node's encryption key index and the
+// encryption key of the endpoint on that node are the same.
+func (m *manager) endpointEncryptionKey(n *nodeTypes.Node) ipcacheTypes.EncryptKey {
+	if m.conf.EnableWireguard {
+		return ipcacheTypes.EncryptKey(types.StaticEncryptKey)
+	}
+
+	return ipcacheTypes.EncryptKey(n.EncryptionKey)
 }
 
 func (m *manager) nodeAddressSkipsIPCache(address nodeTypes.Address) bool {
@@ -484,7 +501,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		}
 
 		var key uint8
-		if m.nodeAddressHasEncryptKey(address) {
+		if m.nodeAddressHasEncryptKey() {
 			key = n.EncryptionKey
 		}
 
@@ -538,7 +555,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		m.ipcache.UpsertMetadata(healthIP, n.Source, resource,
 			labels.LabelHealth,
 			ipcacheTypes.TunnelPeer{Addr: nodeIP},
-			ipcacheTypes.EncryptKey(n.EncryptionKey))
+			m.endpointEncryptionKey(&n))
 		healthIPsAdded = append(healthIPsAdded, healthIP)
 	}
 
@@ -554,7 +571,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		m.ipcache.UpsertMetadata(ingressIP, n.Source, resource,
 			labels.LabelIngress,
 			ipcacheTypes.TunnelPeer{Addr: nodeIP},
-			ipcacheTypes.EncryptKey(n.EncryptionKey))
+			m.endpointEncryptionKey(&n))
 		ingressIPsAdded = append(ingressIPsAdded, ingressIP)
 	}
 
@@ -669,7 +686,7 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 		}
 
 		var oldKey uint8
-		if m.nodeAddressHasEncryptKey(address) {
+		if m.nodeAddressHasEncryptKey() {
 			oldKey = oldNode.EncryptionKey
 		}
 
@@ -692,7 +709,7 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 		m.ipcache.RemoveMetadata(healthIP, resource,
 			labels.LabelHealth,
 			ipcacheTypes.TunnelPeer{Addr: oldNodeIP},
-			ipcacheTypes.EncryptKey(oldNode.EncryptionKey))
+			m.endpointEncryptionKey(&oldNode))
 	}
 
 	// Delete the old ingress IP addresses if they have changed in this node.
@@ -705,7 +722,7 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 		m.ipcache.RemoveMetadata(ingressIP, resource,
 			labels.LabelIngress,
 			ipcacheTypes.TunnelPeer{Addr: oldNodeIP},
-			ipcacheTypes.EncryptKey(oldNode.EncryptionKey))
+			m.endpointEncryptionKey(&oldNode))
 	}
 }
 

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -428,11 +428,7 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode, ln
 		}
 	}
 
-	if option.Config.EnableIPSec || (option.Config.EnableWireguard && option.Config.EncryptNode && !ln.OptOutNodeEncryption) {
-		nodeResource.Spec.Encryption.Key = int(ln.EncryptionKey)
-	} else {
-		nodeResource.Spec.Encryption.Key = 0
-	}
+	nodeResource.Spec.Encryption.Key = int(ln.EncryptionKey)
 
 	nodeResource.Spec.HealthAddressing.IPv4 = ""
 	if ip := ln.IPv4HealthIP; ip != nil {

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -66,11 +66,11 @@ type wireguardClient interface {
 // the public key of peer discovered via the node manager.
 type Agent struct {
 	lock.RWMutex
-	localNodeStore *node.LocalNodeStore
-	wgClient       wireguardClient
-	ipCache        *ipcache.IPCache
-	listenPort     int
-	privKey        wgtypes.Key
+
+	wgClient   wireguardClient
+	ipCache    *ipcache.IPCache
+	listenPort int
+	privKey    wgtypes.Key
 
 	peerByNodeName   map[string]*peerConfig
 	nodeNameByNodeIP map[string]string
@@ -108,10 +108,9 @@ func NewAgent(privKeyPath string, localNodeStore *node.LocalNodeStore) (*Agent, 
 	})
 
 	return &Agent{
-		localNodeStore: localNodeStore,
-		wgClient:       wgClient,
-		privKey:        key,
-		listenPort:     listenPort,
+		wgClient:   wgClient,
+		privKey:    key,
+		listenPort: listenPort,
 
 		peerByNodeName:   map[string]*peerConfig{},
 		nodeNameByNodeIP: map[string]string{},

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"maps"
 	"net"
 	"os"
 	"strconv"
@@ -26,6 +25,7 @@ import (
 	"golang.zx2c4.com/wireguard/tun"
 	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	k8sLabels "k8s.io/apimachinery/pkg/labels"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/annotation"
@@ -79,12 +79,13 @@ type Agent struct {
 
 	cleanup []func()
 
+	// initialized in InitLocalNodeFromWireGuard
 	optOut                 bool
 	requireNodesInPeerList bool
 }
 
 // NewAgent creates a new WireGuard Agent
-func NewAgent(privKeyPath string, localNodeStore *node.LocalNodeStore) (*Agent, error) {
+func NewAgent(privKeyPath string) (*Agent, error) {
 	key, err := loadOrGeneratePrivKey(privKeyPath)
 	if err != nil {
 		return nil, err
@@ -94,18 +95,6 @@ func NewAgent(privKeyPath string, localNodeStore *node.LocalNodeStore) (*Agent, 
 	if err != nil {
 		return nil, err
 	}
-
-	optOut := false
-	localNodeStore.Update(func(localNode *node.LocalNode) {
-		optOut = localNode.OptOutNodeEncryption
-		localNode.EncryptionKey = types.StaticEncryptKey
-		localNode.WireguardPubKey = key.PublicKey().String()
-
-		// Create a clone, so that we don't mutate the current annotations,
-		// as LocalNodeStore.Update emits a shallow copy of the whole object.
-		localNode.Annotations = maps.Clone(localNode.Annotations)
-		localNode.Annotations[annotation.WireguardPubKey] = localNode.WireguardPubKey
-	})
 
 	return &Agent{
 		wgClient:   wgClient,
@@ -118,12 +107,6 @@ func NewAgent(privKeyPath string, localNodeStore *node.LocalNodeStore) (*Agent, 
 		restoredPubKeys:  map[wgtypes.Key]struct{}{},
 
 		cleanup: []func(){},
-
-		optOut: optOut,
-		requireNodesInPeerList: (option.Config.EncryptNode && !optOut) ||
-			// Enapsulated pkt is encrypted in tunneling mode. So, outer
-			// src/dst IP (= nodes IP) needs to be in the WG peer list.
-			option.Config.TunnelingEnabled(),
 	}, nil
 }
 
@@ -141,6 +124,42 @@ func (a *Agent) Close() error {
 	}
 
 	return a.wgClient.Close()
+}
+
+// InitLocalNodeFromWireGuard configures the fields on the local node. Called from
+// the LocalNodeSynchronizer _before_ the local node is published in the K8s
+// CiliumNode CRD or the kvstore.
+//
+// This method does the following:
+//   - It sets the local WireGuard public key (to be read by other nodes).
+//   - It reads the local node's labels to determine if the local node wants to
+//     opt-out of node-to-node encryption.
+//   - If the local node opts out of node-to-node encryption, we set the
+//     localNode.EncryptKey to zero. This indicates to other nodes that they
+//     should not encrypt node-to-node traffic with us.
+func (a *Agent) InitLocalNodeFromWireGuard(localNode *node.LocalNode) {
+	a.Lock()
+	defer a.Unlock()
+
+	log.Debug("Initializing local node store with WireGuard public key and settings")
+
+	localNode.EncryptionKey = types.StaticEncryptKey
+	localNode.WireguardPubKey = a.privKey.PublicKey().String()
+	localNode.Annotations[annotation.WireguardPubKey] = localNode.WireguardPubKey
+
+	if option.Config.EncryptNode && option.Config.NodeEncryptionOptOutLabels.Matches(k8sLabels.Set(localNode.Labels)) {
+		log.WithField(logfields.Selector, option.Config.NodeEncryptionOptOutLabels).
+			Infof("Opting out from node-to-node encryption on this node as per '%s' label selector",
+				option.NodeEncryptionOptOutLabels)
+		localNode.OptOutNodeEncryption = true
+		localNode.EncryptionKey = 0
+	}
+
+	a.optOut = localNode.OptOutNodeEncryption
+	a.requireNodesInPeerList = (option.Config.EncryptNode && !localNode.OptOutNodeEncryption) ||
+		// Enapsulated pkt is encrypted in tunneling mode. So, outer
+		// src/dst IP (= nodes IP) needs to be in the WG peer list.
+		option.Config.TunnelingEnabled()
 }
 
 func (a *Agent) initUserspaceDevice(linkMTU int) (netlink.Link, error) {


### PR DESCRIPTION
WireGuard-based encryption uses different values when it comes to the encryptKey field in the IPCache:

 - For endpoints, the encryptKey should always be non-zero if pod-to-pod encryption is enabled.
 - For nodes, the encryptKey should only be non-zero if node-to-node encryption is enabled and the node has not opted out of node-to-node encryption via label selector.

Before this PR, we would derive the endpoint encryptKey from the local node store  encryptKey. This however led to inconsistencies, in particular in combination with kvstore-mode. This PR changes that approach slightly and changes the local node store encryptKey to always match the encryptKey of the published CiliumNode or kvstore node resource. 

This fixes three issues:

 - Fixes a bug where opt-out from node-to-node encryption was not working in kvstore mode
 - Fixes a bug where the encryptKey for the node object in the kvstore was flapping if node-to-node encryption was turned off. This did not affect encryption of workloads, as the node encryptKey is only relevant for node-to-node encryption. It did affect health and ingress IPs however (see next item).
 - Fixes a bug where traffic to a node's health and ingress IP were not encrypted in all cases.