### PR TITLE
bpf: nodeport: remove TC_INDEX_F_SKIP_RECIRCULATION logic

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -551,7 +551,6 @@ ct_recreate6:
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV6,
 					  *dst_sec_identity, 0, 0,
 					  trace.reason, trace.monitor);
-			ctx->tc_index |= TC_INDEX_F_SKIP_RECIRCULATION;
 			ep_tail_call(ctx, CILIUM_CALL_IPV6_NODEPORT_REVNAT);
 			return DROP_MISSED_TAIL_CALL;
 		}
@@ -1002,7 +1001,6 @@ ct_recreate4:
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV4,
 					  *dst_sec_identity, 0, 0,
 					  trace.reason, trace.monitor);
-			ctx->tc_index |= TC_INDEX_F_SKIP_RECIRCULATION;
 			ep_tail_call(ctx, CILIUM_CALL_IPV4_NODEPORT_REVNAT);
 			return DROP_MISSED_TAIL_CALL;
 		}

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -786,7 +786,7 @@ static __always_inline __u32 or_encrypt_key(__u8 key)
 #define TC_INDEX_F_FROM_INGRESS_PROXY	1
 #define TC_INDEX_F_FROM_EGRESS_PROXY	2
 #define TC_INDEX_F_SKIP_NODEPORT	4
-#define TC_INDEX_F_SKIP_RECIRCULATION	8
+#define TC_INDEX_F_UNUSED		8
 #define TC_INDEX_F_SKIP_HOST_FIREWALL	16
 
 /*

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -59,19 +59,6 @@ static __always_inline bool nodeport_uses_dsr(__u8 nexthdr __maybe_unused)
 # endif
 }
 
-static __always_inline bool
-bpf_skip_recirculation(const struct __ctx_buff *ctx __maybe_unused)
-{
-	/* From XDP layer, we do not go through an egress hook from
-	 * here, hence nothing to be skipped.
-	 */
-#if __ctx_is == __ctx_skb
-	return ctx->tc_index & TC_INDEX_F_SKIP_RECIRCULATION;
-#else
-	return false;
-#endif
-}
-
 #ifdef HAVE_ENCAP
 static __always_inline int
 nodeport_add_tunnel_encap(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
@@ -1049,7 +1036,7 @@ int tail_nodeport_rev_dnat_ingress_ipv6(struct __ctx_buff *ctx)
 		goto drop;
 
 	if (ret == CTX_ACT_OK) {
-		if (bpf_skip_recirculation(ctx)) {
+		if (is_defined(IS_BPF_LXC)) {
 			ret = DROP_NAT_NO_MAPPING;
 			goto drop;
 		}
@@ -2520,7 +2507,10 @@ int tail_nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx)
 		goto drop_err;
 
 	if (ret == CTX_ACT_OK) {
-		if (bpf_skip_recirculation(ctx)) {
+		/* When called by bpf_lxc to handle a reply by local backend,
+		 * the packet *must* be redirected.
+		 */
+		if (is_defined(IS_BPF_LXC)) {
 			ret = DROP_NAT_NO_MAPPING;
 			goto drop_err;
 		}


### PR DESCRIPTION
For local backends, we still handle RevDNAT for replies by tail-calling into the RevDNAT code from bpf_lxc. In which case the packet gets marked with TC_INDEX_F_SKIP_RECIRCULATION, to indicate that it *must* be RevDNAT-processed and get redirected to an egress interface.

But the CILIUM_CALL_IPV*_NODEPORT_REVNAT tail-call can also be used by eg bpf_host, when tail_nodeport_nat_ingress_ipv*() is unable to inline the call to nodeport_rev_dnat_ingress_ipv*(). In which case it's totally fine to *not* match any CT entry for RevDNAT, and just continue in the packet path.

As we don't sanitize the tc_index, this leaves the possibility for false-positives where packets handled by bpf_host accidentally have TC_INDEX_F_SKIP_RECIRCULATION set and get dropped.

Switch the logic to a hard-coded model, and only apply the "must redirect" check when included from bpf_lxc.