### PR TITLE
Drop broken and superseded CiliumInternalIP restoration logic

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -128,10 +128,6 @@ func (s *DaemonSuite) setupConfigOptions() {
 	option.Config.Opts.SetBool(option.TraceNotify, true)
 	option.Config.Opts.SetBool(option.PolicyVerdictNotify, true)
 
-	// Disable restore of host IPs for unit tests. There can be arbitrary
-	// state left on disk.
-	option.Config.EnableHostIPRestore = false
-
 	// Disable the replacement, as its initialization function execs bpftool
 	// which requires root privileges. This would require marking the test suite
 	// as privileged.

--- a/daemon/k8s/init.go
+++ b/daemon/k8s/init.go
@@ -129,7 +129,6 @@ func WaitForNodeInformation(ctx context.Context, log logrus.FieldLogger, localNo
 		}).Info("Received own node information from API server")
 
 		useNodeCIDR(n)
-		restoreRouterHostIPs(n, log)
 	} else {
 		// if node resource could not be received, fail if
 		// PodCIDR requirement has been requested
@@ -141,30 +140,4 @@ func WaitForNodeInformation(ctx context.Context, log logrus.FieldLogger, localNo
 	// Annotate addresses will occur later since the user might
 	// want to specify them manually
 	return nil
-}
-
-// restoreRouterHostIPs restores (sets) the router IPs found from the
-// Kubernetes resource.
-//
-// Note that it does not validate the correctness of the IPs, as that is done
-// later in the daemon initialization when node.AutoComplete() is called.
-func restoreRouterHostIPs(n *nodeTypes.Node, log logrus.FieldLogger) {
-	if !option.Config.EnableHostIPRestore {
-		return
-	}
-
-	router4 := n.GetCiliumInternalIP(false)
-	router6 := n.GetCiliumInternalIP(true)
-	if router4 != nil {
-		node.SetInternalIPv4Router(router4)
-	}
-	if router6 != nil {
-		node.SetIPv6Router(router6)
-	}
-	if router4 != nil || router6 != nil {
-		log.WithFields(logrus.Fields{
-			logfields.IPv4: router4,
-			logfields.IPv6: router6,
-		}).Info("Restored router IPs from node information")
-	}
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -114,10 +114,6 @@ const (
 	// the agent and the CNI plugin processes
 	DeleteQueueLockfile = DeleteQueueDir + "/lockfile"
 
-	// EnableHostIPRestore controls whether the host IP should be restored
-	// from previous state automatically
-	EnableHostIPRestore = true
-
 	// BPFFSRoot is the default path where BPFFS should be mounted
 	BPFFSRoot = "/sys/fs/bpf"
 

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -482,10 +482,6 @@ func getCiliumHostIPsFromFile(nodeConfig string) (ipv4GW, ipv6Router net.IP) {
 // the node_config.h file if is present; or by deriving it from
 // defaults.HostDevice interface, on which only the IPv4 is possible to derive.
 func ExtractCiliumHostIPFromFS() (ipv4GW, ipv6Router net.IP) {
-	if !option.Config.EnableHostIPRestore {
-		return nil, nil
-	}
-
 	nodeConfig := option.Config.GetNodeConfigPath()
 	ipv4GW, ipv6Router = getCiliumHostIPsFromFile(nodeConfig)
 	if ipv4GW != nil || ipv6Router != nil {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1439,10 +1439,6 @@ type DaemonConfig struct {
 	// RestoreState enables restoring the state from previous running daemons.
 	RestoreState bool
 
-	// EnableHostIPRestore enables restoring the host IPs based on state
-	// left behind by previous Cilium runs.
-	EnableHostIPRestore bool
-
 	KeepConfig bool // Keep configuration of existing endpoints when starting up.
 
 	// AllowLocalhost defines when to allows the local stack to local endpoints
@@ -2443,7 +2439,6 @@ var (
 		IPv6ClusterAllocCIDR:            defaults.IPv6ClusterAllocCIDR,
 		IPv6ClusterAllocCIDRBase:        defaults.IPv6ClusterAllocCIDRBase,
 		IPAMDefaultIPPool:               defaults.IPAMDefaultIPPool,
-		EnableHostIPRestore:             defaults.EnableHostIPRestore,
 		EnableHealthChecking:            defaults.EnableHealthChecking,
 		EnableEndpointHealthChecking:    defaults.EnableEndpointHealthChecking,
 		EnableHealthCheckLoadBalancerIP: defaults.EnableHealthCheckLoadBalancerIP,

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -100,7 +100,6 @@ func (h *agentHandle) populateCiliumAgentOptions(testDir string, modConfig func(
 	option.Config.EnableIPSec = false
 	option.Config.EnableIPv6 = false
 	option.Config.KubeProxyReplacement = option.KubeProxyReplacementTrue
-	option.Config.EnableHostIPRestore = false
 	option.Config.K8sRequireIPv6PodCIDR = false
 	option.Config.EnableL7Proxy = false
 	option.Config.EnableHealthCheckNodePort = false


### PR DESCRIPTION
This old logic does work only when the IPAM is configured in clusterpool mode, as in all other cases we attempt the restoration from a plain k8s node resource, which does not contain the CiliumInternalIP information.

Hence, let's drop this obsolete logic, which is now superseded by the one introduced in c67d4eeea73c.

Moreover, the EnableHostIPRestore config option was introduced more than five years ago in a627e898067e65518a00306d795be34ce6272616 to allow disabling the CiliumInternalIP restoration logic in unit tests and prevent flakes caused by possible preexisting state.

Yet, this is no longer necessary, given that the relevant tests are already configured to use a temporary state directory, and in any case they are not expected to be run on a machine where another Cilium instance is running. Additionally, the k8s restoration logic recently introduced in c67d4eeea73c9d192776afab6ebc4f6107a21dc3 also didn't account for this flag.

To keep things simple, let's just drop this option and the remaining usages (affecting tests only).

Related: https://github.com/cilium/cilium/issues/29019, https://github.com/cilium/cilium/pull/29460

/cc @tommyp1ckles, @gandro 