### PR TITLE
ci: increase conformance-aks timeout

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -111,7 +111,7 @@ jobs:
     name: Installation and Connectivity Test
     needs: generate-matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       job_name: "Installation and Connectivity Test"
     strategy:


### PR DESCRIPTION
Scheduled conformance-aks tests have been failing
often with timeouts. This commit increases the timeout for the installation-and-connectivity job.

Successful job that normally failing, https://github.com/cilium/cilium/actions/runs/7653271853/job/20854788360

Fixes: #30310
