### PR TITLE
bgpv1: Allow specifying well-known BGP standard communities using their names

### DIFF
--- a/Documentation/network/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane.rst
@@ -674,10 +674,32 @@ There are three possible values of the ``SelectorType`` which define the object 
 There are two types of additional Path Attributes that can be advertised with the routes: ``Communities`` and ``LocalPreference``.
 
 ``Communities`` defines a set of community values advertised in the supported BGP Communities Path Attributes.
-The values can be of two types:
+The values can be of three types:
 
  - ``Standard``: represents a value of the "standard" 32-bit BGP Communities Attribute (`RFC-1997`_)
    as a 4-byte decimal number or two 2-byte decimal numbers separated by a colon (e.g. ``64512:100``).
+ - ``WellKnown``: represents a value of the "standard" 32-bit BGP Communities Attribute (`RFC-1997`_)
+   as a well-known string alias to its numeric value. Allowed values and their mapping to the numeric values:
+
+    =============================== ================= =================
+    Well-Known Value                Hexadecimal Value 16-bit Pair Value
+    ------------------------------- ----------------- -----------------
+    ``internet``                    ``0x00000000``    ``0:0``
+    ``planned-shut``                ``0xffff0000``    ``65535:0``
+    ``accept-own``                  ``0xffff0001``    ``65535:1``
+    ``route-filter-translated-v4``  ``0xffff0002``    ``65535:2``
+    ``route-filter-v4``             ``0xffff0003``    ``65535:3``
+    ``route-filter-translated-v6``  ``0xffff0004``    ``65535:4``
+    ``route-filter-v6``             ``0xffff0005``    ``65535:5``
+    ``llgr-stale``                  ``0xffff0006``    ``65535:6``
+    ``no-llgr``                     ``0xffff0007``    ``65535:7``
+    ``blackhole``                   ``0xffff029a``    ``65535:666``
+    ``no-export``                   ``0xffffff01``    ``65535:65281``
+    ``no-advertise``                ``0xffffff02``    ``65535:65282``
+    ``no-export-subconfed``         ``0xffffff03``    ``65535:65283``
+    ``no-peer``                     ``0xffffff04``    ``65535:65284``
+    =============================== ================= =================
+
  - ``Large``: represents a value of the BGP Large Communities Attribute (`RFC-8092`_),
    as three 4-byte decimal numbers separated by colons (e.g. ``64512:100:50``).
 

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpadvertisements.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpadvertisements.yaml
@@ -80,13 +80,56 @@ spec:
                               type: array
                             standard:
                               description: Standard holds a list of "standard" 32-bit
-                                BGP Communities Attribute (RFC 1997) values.
+                                BGP Communities Attribute (RFC 1997) values defined
+                                as numeric values.
                               items:
                                 description: BGPStandardCommunity type represents
                                   a value of the "standard" 32-bit BGP Communities
                                   Attribute (RFC 1997) as a 4-byte decimal number
-                                  or two 2-byte decimal numbers separated by a colon.
+                                  or two 2-byte decimal numbers separated by a colon
+                                  (<0-65535>:<0-65535>). For example, no-export community
+                                  value is 65553:65281.
                                 pattern: ^([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[01][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[01][0-9]{2}|42949672[0-8][0-9]|429496729[0-5])$|^([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                                type: string
+                              type: array
+                            wellKnown:
+                              description: WellKnown holds a list "standard" 32-bit
+                                BGP Communities Attribute (RFC 1997) values defined
+                                as well-known string aliases to their numeric values.
+                              items:
+                                description: "BGPWellKnownCommunity type represents
+                                  a value of the \"standard\" 32-bit BGP Communities
+                                  Attribute (RFC 1997) as a well-known string alias
+                                  to its numeric value. Allowed values and their mapping
+                                  to the numeric values: \n internet                   =
+                                  0x00000000 (0:0) planned-shut               = 0xffff0000
+                                  (65535:0) accept-own                 = 0xffff0001
+                                  (65535:1) route-filter-translated-v4 = 0xffff0002
+                                  (65535:2) route-filter-v4            = 0xffff0003
+                                  (65535:3) route-filter-translated-v6 = 0xffff0004
+                                  (65535:4) route-filter-v6            = 0xffff0005
+                                  (65535:5) llgr-stale                 = 0xffff0006
+                                  (65535:6) no-llgr                    = 0xffff0007
+                                  (65535:7) blackhole                  = 0xffff029a
+                                  (65535:666) no-export                  = 0xffffff01\t(65535:65281)
+                                  no-advertise               = 0xffffff02 (65535:65282)
+                                  no-export-subconfed        = 0xffffff03 (65535:65283)
+                                  no-peer                    = 0xffffff04 (65535:65284)"
+                                enum:
+                                - internet
+                                - planned-shut
+                                - accept-own
+                                - route-filter-translated-v4
+                                - route-filter-v4
+                                - route-filter-translated-v6
+                                - route-filter-v6
+                                - llgr-stale
+                                - no-llgr
+                                - blackhole
+                                - no-export
+                                - no-advertise
+                                - no-export-subconfed
+                                - no-peer
                                 type: string
                               type: array
                           type: object

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
@@ -156,14 +156,58 @@ spec:
                                     standard:
                                       description: Standard holds a list of "standard"
                                         32-bit BGP Communities Attribute (RFC 1997)
-                                        values.
+                                        values defined as numeric values.
                                       items:
                                         description: BGPStandardCommunity type represents
                                           a value of the "standard" 32-bit BGP Communities
                                           Attribute (RFC 1997) as a 4-byte decimal
                                           number or two 2-byte decimal numbers separated
-                                          by a colon.
+                                          by a colon (<0-65535>:<0-65535>). For example,
+                                          no-export community value is 65553:65281.
                                         pattern: ^([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[01][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[01][0-9]{2}|42949672[0-8][0-9]|429496729[0-5])$|^([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                                        type: string
+                                      type: array
+                                    wellKnown:
+                                      description: WellKnown holds a list "standard"
+                                        32-bit BGP Communities Attribute (RFC 1997)
+                                        values defined as well-known string aliases
+                                        to their numeric values.
+                                      items:
+                                        description: "BGPWellKnownCommunity type represents
+                                          a value of the \"standard\" 32-bit BGP Communities
+                                          Attribute (RFC 1997) as a well-known string
+                                          alias to its numeric value. Allowed values
+                                          and their mapping to the numeric values:
+                                          \n internet                   = 0x00000000
+                                          (0:0) planned-shut               = 0xffff0000
+                                          (65535:0) accept-own                 = 0xffff0001
+                                          (65535:1) route-filter-translated-v4 = 0xffff0002
+                                          (65535:2) route-filter-v4            = 0xffff0003
+                                          (65535:3) route-filter-translated-v6 = 0xffff0004
+                                          (65535:4) route-filter-v6            = 0xffff0005
+                                          (65535:5) llgr-stale                 = 0xffff0006
+                                          (65535:6) no-llgr                    = 0xffff0007
+                                          (65535:7) blackhole                  = 0xffff029a
+                                          (65535:666) no-export                  =
+                                          0xffffff01\t(65535:65281) no-advertise               =
+                                          0xffffff02 (65535:65282) no-export-subconfed
+                                          \       = 0xffffff03 (65535:65283) no-peer
+                                          \                   = 0xffffff04 (65535:65284)"
+                                        enum:
+                                        - internet
+                                        - planned-shut
+                                        - accept-own
+                                        - route-filter-translated-v4
+                                        - route-filter-v4
+                                        - route-filter-translated-v6
+                                        - route-filter-v6
+                                        - llgr-stale
+                                        - no-llgr
+                                        - blackhole
+                                        - no-export
+                                        - no-advertise
+                                        - no-export-subconfed
+                                        - no-peer
                                         type: string
                                       type: array
                                   type: object

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
@@ -118,9 +118,31 @@ func (gr *CiliumBGPNeighborGracefulRestart) SetDefaults() {
 }
 
 // BGPStandardCommunity type represents a value of the "standard" 32-bit BGP Communities Attribute (RFC 1997)
-// as a 4-byte decimal number or two 2-byte decimal numbers separated by a colon.
+// as a 4-byte decimal number or two 2-byte decimal numbers separated by a colon (<0-65535>:<0-65535>).
+// For example, no-export community value is 65553:65281.
 // +kubebuilder:validation:Pattern=`^([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[01][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[01][0-9]{2}|42949672[0-8][0-9]|429496729[0-5])$|^([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$`
 type BGPStandardCommunity string
+
+// BGPWellKnownCommunity type represents a value of the "standard" 32-bit BGP Communities Attribute (RFC 1997)
+// as a well-known string alias to its numeric value. Allowed values and their mapping to the numeric values:
+//
+//	internet                   = 0x00000000 (0:0)
+//	planned-shut               = 0xffff0000 (65535:0)
+//	accept-own                 = 0xffff0001 (65535:1)
+//	route-filter-translated-v4 = 0xffff0002 (65535:2)
+//	route-filter-v4            = 0xffff0003 (65535:3)
+//	route-filter-translated-v6 = 0xffff0004 (65535:4)
+//	route-filter-v6            = 0xffff0005 (65535:5)
+//	llgr-stale                 = 0xffff0006 (65535:6)
+//	no-llgr                    = 0xffff0007 (65535:7)
+//	blackhole                  = 0xffff029a (65535:666)
+//	no-export                  = 0xffffff01	(65535:65281)
+//	no-advertise               = 0xffffff02 (65535:65282)
+//	no-export-subconfed        = 0xffffff03 (65535:65283)
+//	no-peer                    = 0xffffff04 (65535:65284)
+//
+// +kubebuilder:validation:Enum=internet;planned-shut;accept-own;route-filter-translated-v4;route-filter-v4;route-filter-translated-v6;route-filter-v6;llgr-stale;no-llgr;blackhole;no-export;no-advertise;no-export-subconfed;no-peer
+type BGPWellKnownCommunity string
 
 // BGPLargeCommunity type represents a value of the BGP Large Communities Attribute (RFC 8092),
 // as three 4-byte decimal numbers separated by colons.
@@ -129,10 +151,16 @@ type BGPLargeCommunity string
 
 // BGPCommunities holds community values of the supported BGP community path attributes.
 type BGPCommunities struct {
-	// Standard holds a list of "standard" 32-bit BGP Communities Attribute (RFC 1997) values.
+	// Standard holds a list of "standard" 32-bit BGP Communities Attribute (RFC 1997) values defined as numeric values.
 	//
 	// +kubebuilder:validation:Optional
 	Standard []BGPStandardCommunity `json:"standard,omitempty"`
+
+	// WellKnown holds a list "standard" 32-bit BGP Communities Attribute (RFC 1997) values defined as
+	// well-known string aliases to their numeric values.
+	//
+	// +kubebuilder:validation:Optional
+	WellKnown []BGPWellKnownCommunity `json:"wellKnown,omitempty"`
 
 	// Large holds a list of the BGP Large Communities Attribute (RFC 8092) values.
 	//

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
@@ -51,6 +51,11 @@ func (in *BGPCommunities) DeepCopyInto(out *BGPCommunities) {
 		*out = make([]BGPStandardCommunity, len(*in))
 		copy(*out, *in)
 	}
+	if in.WellKnown != nil {
+		in, out := &in.WellKnown, &out.WellKnown
+		*out = make([]BGPWellKnownCommunity, len(*in))
+		copy(*out, *in)
+	}
 	if in.Large != nil {
 		in, out := &in.Large, &out.Large
 		*out = make([]BGPLargeCommunity, len(*in))

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
@@ -61,6 +61,23 @@ func (in *BGPCommunities) DeepEqual(other *BGPCommunities) bool {
 		}
 	}
 
+	if ((in.WellKnown != nil) && (other.WellKnown != nil)) || ((in.WellKnown == nil) != (other.WellKnown == nil)) {
+		in, other := &in.WellKnown, &other.WellKnown
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if inElement != (*other)[i] {
+					return false
+				}
+			}
+		}
+	}
+
 	if ((in.Large != nil) && (other.Large != nil)) || ((in.Large == nil) != (other.Large == nil)) {
 		in, other := &in.Large, &other.Large
 		if other == nil {


### PR DESCRIPTION
This change allows specifying well-known BGP communities using their name alias instead of their numeric values, e.g. `no-export` instead of `65535:65281`.

 The `BGPCommunities` CRD struct is extended with a new field `WellKnown` for this purpose. From functionality perspective, configuring the `WellKnown` value is equivalent to using the `Standard` numeric value.

Example usage in a `CiliumBGPPeeringPolicy`:

```yaml
apiVersion: v1
items:
- apiVersion: cilium.io/v2alpha1
  kind: CiliumBGPPeeringPolicy
  spec:
    virtualRouters:
    - exportPodCIDR: true
      localASN: 65001
      neighbors:
      - peerAddress: 172.0.0.1/32
        peerPort: 179
        advertisedPathAttributes:
        - selectorType: PodCIDR
          communities:
            wellKnown:
            - no-export
```