### PR TITLE
Fix where ls was an alias for flush in bpf auth

### DIFF
--- a/cilium-dbg/cmd/bpf_auth_flush.go
+++ b/cilium-dbg/cmd/bpf_auth_flush.go
@@ -20,7 +20,7 @@ var bpfAuthFlushCmd = &cobra.Command{
 	Use:     "flush",
 	Short:   "Deletes all entries for authenticated connections between identities",
 	Long:    "Deletes all entries for authenticated connections between identities",
-	Aliases: []string{"ls"},
+	Aliases: []string{},
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf auth flush")
 


### PR DESCRIPTION
Remove a misplaces ls alias that caused cilium-dbg bpf auth ls to flush the map when issued. Discovered that the hard way when debugging :sweat_smile: 

```release-note
Remove a misplaces ls alias that caused `cilium-dbg bpf auth ls` to flush the map.
```
