### PR TITLE
doc,bgpv1: Add documentation about the address family option

### DIFF
--- a/Documentation/network/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane.rst
@@ -691,3 +691,38 @@ Once configured, the additional Path Attributes advertised with the routes for a
    VRouter   Prefix               NextHop     Age     Attrs
    64512     10.1.0.0/24          10.0.0.2    3m31s   [{Origin: i} {LocalPref: 150} {Nexthop: 10.0.0.2}]
    64512     192.168.100.190/32   10.0.0.2    3m32s   [{Origin: i} {LocalPref: 100} {Communities: 64512:100} {Nexthop: 10.0.0.2}]
+
+Address Families
+^^^^^^^^^^^^^^^^
+
+By default, the BGP Control Plane advertises IPv4 Unicast and IPv6 Unicast
+Multiprotocol Extensions Capability (`RFC-4760`_) as well as Graceful Restart
+address families (`RFC-4724`_) if enabled. If you wish to change the default
+behavior and advertise only specific address families, you can use the
+``families`` field. The ``families`` field is a list of AFI (Address Family
+Identifier) and SAFI (Subsequent Address Family Identifier) pairs. The only
+options currently supported are ``{afi: ipv4, safi: unicast}`` and ``{afi:
+ipv6, safi: unicast}``.
+
+Following example shows how to advertise only IPv4 Unicast address family:
+
+.. _RFC-4760 : https://www.rfc-editor.org/rfc/rfc4760.html
+
+.. code-block:: yaml
+
+   apiVersion: "cilium.io/v2alpha1"
+   kind: CiliumBGPPeeringPolicy
+   metadata:
+     name: rack0
+   spec:
+     nodeSelector:
+       matchLabels:
+         rack: rack0
+     virtualRouters:
+     - localASN: 64512
+       neighbors:
+       - peerAddress: '10.0.0.1/32'
+         peerASN: 64512
+         families:
+         - afi: ipv4
+           safi: unicast

--- a/Documentation/network/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane.rst
@@ -585,9 +585,16 @@ Configure graceful restart on per-neighbor basis, as follows:
            enabled: true           # <-- enable graceful restart
            restartTimeSeconds: 120 # <-- set RestartTime
 
-.. note::
+.. warning::
 
-   When enabled, graceful restart capability is advertised for IPv4 and IPv6 address families.
+   When enabled, graceful restart capability is advertised for IPv4 and IPv6
+   address families by default. From v1.15, we have a known issue where Cilium
+   takes long time (approximately 300s) to restart route advertisement after
+   graceful restart when Cilium advertises both IPv4 and IPv6 address families,
+   but a remote peer advertises only one of them. You can work around this
+   issue by aligning the address families advertised by Cilium and remote with
+   the `families field <bgp-control-plane-address-families_>`_. You can track
+   `#30367 <https://github.com/cilium/cilium/issues/30367/>`_ for updates.
 
 Optionally, you can use the ``RestartTime`` parameter. ``RestartTime`` is the time
 advertised to the peer within which Cilium BGP control plane is expected to re-establish
@@ -691,6 +698,8 @@ Once configured, the additional Path Attributes advertised with the routes for a
    VRouter   Prefix               NextHop     Age     Attrs
    64512     10.1.0.0/24          10.0.0.2    3m31s   [{Origin: i} {LocalPref: 150} {Nexthop: 10.0.0.2}]
    64512     192.168.100.190/32   10.0.0.2    3m32s   [{Origin: i} {LocalPref: 100} {Communities: 64512:100} {Nexthop: 10.0.0.2}]
+
+.. _bgp-control-plane-address-families:
 
 Address Families
 ^^^^^^^^^^^^^^^^

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -77,6 +77,7 @@ Menlo
 MiB
 Monnet
 Multihop
+Multiprotocol
 Mythbusters
 NDP
 Neovim


### PR DESCRIPTION
Add documentation about the address family option and caveats about the graceful restart address family mentioned in https://github.com/cilium/cilium/issues/30367/.

```release-note
doc,bgpv1: Add documentation about the address family option
```
