### PR TITLE
Update Example: kafka-sw-gen-traffic.sh

### DIFF
--- a/examples/kubernetes-kafka/kafka-sw-gen-traffic.sh
+++ b/examples/kubernetes-kafka/kafka-sw-gen-traffic.sh
@@ -1,20 +1,18 @@
 #!/usr/bin/env bash
 
-
 HQ_POD=$(kubectl get pods -l app=empire-hq -o jsonpath='{.items[0].metadata.name}')
 OUTPOST_8888_POD=$(kubectl get pods -l outpostid=8888 -o jsonpath='{.items[0].metadata.name}')
 OUTPOST_9999_POD=$(kubectl get pods -l outpostid=9999 -o jsonpath='{.items[0].metadata.name}')
 BACKUP_POD=$(kubectl get pods -l app=empire-backup -o jsonpath='{.items[0].metadata.name}')
 
-#generate traffic
+# generate traffic
 
 echo "producing messages"
-kubectl exec $HQ_POD sh -- -c "echo “Happy 40th Birthday to General Tagge” | ./kafka-produce.sh --topic empire-announce"
-kubectl exec $HQ_POD sh -- -c "echo “deathstar plans v3” | ./kafka-produce.sh --topic deathstar-plans"
+kubectl exec "$HQ_POD" -- sh -c 'echo "Happy 40th Birthday to General Tagge" | ./kafka-produce.sh --topic empire-announce'
+kubectl exec "$HQ_POD" -- sh -c 'echo "deathstar plans v3" | ./kafka-produce.sh --topic deathstar-plans'
 
 echo "consuming messages"
 
-kubectl exec $OUTPOST_9999_POD sh -- -c "./kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1"
-kubectl exec $OUTPOST_8888_POD sh -- -c "./kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1"
-kubectl exec $BACKUP_POD sh -- -c "./kafka-consume.sh --topic deathstar-plans --from-beginning --max-messages 1"
-
+kubectl exec "$OUTPOST_9999_POD" -- sh -c './kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1'
+kubectl exec "$OUTPOST_8888_POD" -- sh -c './kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1'
+kubectl exec "$BACKUP_POD" -- sh -c './kafka-consume.sh --topic deathstar-plans --from-beginning --max-messages 1'


### PR DESCRIPTION
Fixed `kubectl exec` syntax

Error's recieved when running this in lab environment before changes :
```sh
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
Error from server (BadRequest): container ./kafka-consume.sh --topic deathstar-plans --from-beginning --max-messages 1 is not valid for pod empire-backup-74b865868c-wv5r4
```

After changes

```sh
root@server:~# #!/usr/bin/env bash

HQ_POD=$(kubectl get pods -l app=empire-hq -o jsonpath='{.items[0].metadata.name}')
OUTPOST_8888_POD=$(kubectl get pods -l outpostid=8888 -o jsonpath='{.items[0].metadata.name}')
OUTPOST_9999_POD=$(kubectl get pods -l outpostid=9999 -o jsonpath='{.items[0].metadata.name}')
BACKUP_POD=$(kubectl get pods -l app=empire-backup -o jsonpath='{.items[0].metadata.name}')

# generate traffic

echo "producing messages"
kubectl exec "$HQ_POD" -- sh -c 'echo "Happy 40th Birthday to General Tagge" | ./kafka-produce.sh --topic empire-announce'
kubectl exec "$HQ_POD" -- sh -c 'echo "deathstar plans v3" | ./kafka-produce.sh --topic deathstar-plans'

echo "consuming messages"

kubectl exec "$OUTPOST_9999_POD" -- sh -c './kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1'
kubectl exec "$OUTPOST_8888_POD" -- sh -c './kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1'
kubectl exec "$BACKUP_POD" -- sh -c './kafka-consume.sh --topic deathstar-plans --from-beginning --max-messages 1'
producing messages
>>>>consuming messages
Happy 40th Birthday to General Tagge
Processed a total of 1 messages
Happy 40th Birthday to General Tagge
Processed a total of 1 messages
deathstar plans v3
Processed a total of 1 messages
root@server:~# 
```

```release-note
docs: Fix 'kubectl exec' invocations (quotes, double dash separator) in example script kafka-sw-gen-traffic.sh
```