### PR TITLE
images: support release branches when updating envoy image

### DIFF
--- a/images/scripts/update-cilium-envoy-image.sh
+++ b/images/scripts/update-cilium-envoy-image.sh
@@ -21,7 +21,7 @@ envoy_version="$(curl -s https://raw.githubusercontent.com/"${github_repo}"/"${l
 
 image="quay.io/cilium/cilium-envoy"
 image_tag="${envoy_version//envoy-/v}-${latest_commit_sha}"
-if [ "${github_branch}" != "main" ]; then
+if [ "${github_branch}" != "main" ] && ! [[ "${github_branch}" =~ ^v1\.[0-9]+$ ]]; then
     image="quay.io/cilium/cilium-envoy-dev"
     image_tag="${latest_commit_sha}"
 fi


### PR DESCRIPTION
Currently, the script `update-cilium-envoy-image.sh` uses the docker image `quay.io/cilium/cilium-envoy-dev` when defining a `github_branch` other than `main`. With the intention to support feature branches.

But this breaks support for updating an envoy image from a stable release branch from `cilium/proxy` - e.g. `v1.27`.

Therefore, this commit changes the condition to switch only if the
`github_branch` doesn't match `main` AND doesn't match the pattern `^v1\.[0-9]+$`.