### PR TITLE
helm: Allow configuration of Envoy --base-id for Envoy DaemonSet

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1096,6 +1096,10 @@
      - Annotations to be added to all top-level cilium-envoy objects (resources under templates/cilium-envoy)
      - object
      - ``{}``
+   * - :spelling:ignore:`envoy.baseID`
+     - Set Envoy'--base-id' to use when allocating shared memory regions. Only needs to be changed if multiple Envoy instances will run on the same node and may have conflicts. Supported values: 0 - 4294967295. Defaults to '0'
+     - int
+     - ``0``
    * - :spelling:ignore:`envoy.connectTimeoutSeconds`
      - Time in seconds after which a TCP connection attempt times out
      - int

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -324,6 +324,7 @@ contributors across the globe, there is almost always someone available to help.
 | eni.updateEC2AdapterLimitViaAPI | bool | `true` | Update ENI Adapter limits from the EC2 API |
 | envoy.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium-envoy"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-envoy. |
 | envoy.annotations | object | `{}` | Annotations to be added to all top-level cilium-envoy objects (resources under templates/cilium-envoy) |
+| envoy.baseID | int | `0` |  Set Envoy'--base-id' to use when allocating shared memory regions. Only needs to be changed if multiple Envoy instances will run on the same node and may have conflicts. Supported values: 0 - 4294967295. Defaults to '0' |
 | envoy.connectTimeoutSeconds | int | `2` | Time in seconds after which a TCP connection attempt times out |
 | envoy.dnsPolicy | string | `nil` | DNS policy for Cilium envoy pods. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
 | envoy.enabled | bool | `false` | Enable Envoy Proxy in standalone DaemonSet. |

--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -68,7 +68,7 @@ spec:
         - /usr/bin/cilium-envoy-starter
         args:
         - '-c /var/run/cilium/envoy/bootstrap-config.json'
-        - '--base-id 0'
+        - '--base-id {{ int .Values.envoy.baseID }}'
         {{- if and (.Values.debug.enabled) (hasKey .Values.debug "verbose") (.Values.debug.verbose) (has "envoy" ( splitList " " .Values.debug.verbose )) }}
         - '--log-level trace'
         {{- else if and (.Values.debug.enabled) (hasKey .Values.debug "verbose") (.Values.debug.verbose) (has "flow" ( splitList " " .Values.debug.verbose )) }}

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -101,3 +101,8 @@
 {{- if and (ne (int .Values.clustermesh.maxConnectedClusters) 255) (ne (int .Values.clustermesh.maxConnectedClusters) 511) }}
   {{- fail "max-connected-clusters must be set to 255 or 511" }}
 {{- end }}
+
+{{/*validate Envoy baseID */}}
+{{- if not (and (ge (int .Values.envoy.baseID) 0) (le (int .Values.envoy.baseID) 4294967295)) }}
+  {{- fail "envoy.baseID must be an int. Supported values 0 - 4294967295" }}
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1786,6 +1786,10 @@ proxy:
 envoy:
   # -- Enable Envoy Proxy in standalone DaemonSet.
   enabled: false
+  # -- (int)
+  # Set Envoy'--base-id' to use when allocating shared memory regions.
+  # Only needs to be changed if multiple Envoy instances will run on the same node and may have conflicts. Supported values: 0 - 4294967295. Defaults to '0'
+  baseID: 0
   log:
     # -- The format string to use for laying out the log message metadata of Envoy.
     format: "[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1783,6 +1783,10 @@ proxy:
 envoy:
   # -- Enable Envoy Proxy in standalone DaemonSet.
   enabled: false
+  # -- (int)
+  # Set Envoy'--base-id' to use when allocating shared memory regions.
+  # Only needs to be changed if multiple Envoy instances will run on the same node and may have conflicts. Supported values: 0 - 4294967295. Defaults to '0'
+  baseID: 0
   log:
     # -- The format string to use for laying out the log message metadata of Envoy.
     format: "[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"


### PR DESCRIPTION
This PR allows manual configuration of Envoy `--base-id` via Helm for the Cilium Envoy DaemonSet.

Currently, Envoy `--base-id` is hard coded to use `0` for the Cilium Envoy DaemonSet which can lead to Envoy startup issues if another Envoy based solution on the same node uses the same `--base-id`.

Having the `--base-id` user configurable allows to solve such issues easily.

This fixes e.g. kubermatic/kubermatic#12922
