### PR TITLE
policy: Wraps SelectorCache to reduce lock contention

### DIFF
--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -133,12 +133,10 @@ func (p *selectorPolicy) DistillPolicy(policyOwner PolicyOwner, isHost bool) *En
 	// Must come after the 'insertUser()' above to guarantee
 	// PolicyMapChanges will contain all changes that are applied
 	// after the computation of PolicyMapState has started.
-	p.SelectorCache.mutex.RLock()
 	calculatedPolicy.toMapState()
 	if !isHost {
 		calculatedPolicy.policyMapState.determineAllowLocalhostIngress()
 	}
-	p.SelectorCache.mutex.RUnlock()
 
 	return calculatedPolicy
 }
@@ -207,10 +205,6 @@ func (p *EndpointPolicy) UpdateRedirects(ingress bool, createRedirects createRed
 }
 
 func (l4policy L4DirectionPolicy) updateRedirects(p *EndpointPolicy, createRedirects createRedirectsFunc, changes ChangeState) {
-	// Selectorcache needs to be locked for toMapState (GetLabels()) call
-	p.SelectorCache.mutex.RLock()
-	defer p.SelectorCache.mutex.RUnlock()
-
 	for _, l4 := range l4policy.PortRules {
 		if l4.IsRedirect() {
 			// Check if we are denying this specific L4 first regardless the L3, if there are any deny policies


### PR DESCRIPTION
In `L4Filter.ToMapState` a reference to the SelectorCache is passed down to `denyPreferredInsertWithChanges`, in order to get the most specific CIDR for a given identity with `GetNetsLocked`. `GetNetsLocked` requires the SelectorCache to be read-locked.

`denyPreferredInsertWithChanges` is also called from `EndpointPolicy.ConsumeMapChanges`, where the SelectorCache is already locked to avoid concurrent identity updates.

Instead, in `L4Filter.ToMapState`, it is possible to lock the SelectorCache just before its usage in `GetNetsLocked`. Narrowing the critical section reduces the contention on the lock, hopefully improving concurrency.

A SelectorCacheWrapper wraps a reference to a SelectorCache and overloads the `GetNetsLocked` in order to lock the cache for the execution of the method. The new type satisfies the `policy.Identities` interface and can be used interchangeably with the wrapped SelectorCache.

This allows to remove the locking of the SelectorCache for the entire duration of `selectorPolicy.DistillPolicy` and
`L4DirectionPolicy.updateRedirects`.

Related: #24322
Related: #22966
