### PR TITLE
Included documentation and verified platform compatibility unmanaged pods

### DIFF
--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -8,6 +8,7 @@ case `uname -m` in
     CLANG_DIR="clang+llvm-$CLANG_VERSION-x86_64-linux-gnu-ubuntu-18.04"
     ;;
   'aarch64' )
+  
     CLANG_DIR="clang+llvm-$CLANG_VERSION-aarch64-linux-gnu"
     ;;
 esac

--- a/Documentation/installation/k8s-install-restart-pods.rst
+++ b/Documentation/installation/k8s-install-restart-pods.rst
@@ -11,7 +11,11 @@ to them:
 
 .. code-block:: shell-session
 
-    $ kubectl get pods --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{print "-n "$1" "$2}' | xargs -L 1 -r kubectl delete pod
+    $ git grep xargs Documentation/
+    Documentation/gettingstarted/k8s-install-restart-pods.rst:    kubectl get pods --all-namespaces -o custom-       columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{print "-n "$1" "$2}' | xargs -L 1 -r kubectl delete pod
+    Documentation/gettingstarted/k8s-install-restart-pods.rst:    ``xargs``. In this case you can safely run this command without ``-r``
+    Documentation/policy/troubleshooting.rst:    $ cilium endpoint get 568 -o jsonpath='{range ..status.policy.realized.l4.ingress[*].derived-from-rules}{@}{"\n"}{end}'|tr -d '][' | xargs -I{} bash -c 'echo "Labels: {}"; cilium policy get {}'
+    Documentation/policy/troubleshooting.rst:    $ cilium endpoint get 568 -o jsonpath='{range ..status.policy.realized.l4.egress[*].derived-from-rules}{@}{"\n"}{end}' | tr -d '][' | xargs -I{} bash -c 'echo "Labels: {}"; cilium policy get {}'
     pod "event-exporter-v0.2.3-f9c896d75-cbvcz" deleted
     pod "fluentd-gcp-scaler-69d79984cb-nfwwk" deleted
     pod "heapster-v1.6.0-beta.1-56d5d5d87f-qw8pv" deleted
@@ -21,6 +25,11 @@ to them:
     pod "kube-state-metrics-7d9774bbd5-n6m5k" deleted
     pod "l7-default-backend-6f8697844f-d2rq2" deleted
     pod "metrics-server-v0.3.1-54699c9cc8-7l5w2" deleted
+
+    $ git grep k8s-install-restart
+    Documentation/gettingstarted/k3s.rst:.. include:: k8s-install-restart-pods.rst
+    Documentation/gettingstarted/k8s-install-azure.rst:.. include:: k8s-install-restart-pods.rst
+    Documentation/gettingstarted/k8s-install-gke.rst:.. include:: k8s-install-restart-pods.rst
 
 .. note::
 


### PR DESCRIPTION
The current command for restarting pods is complex and potentially incompatible with non-Linux platforms.
This PR:
-  Removes the existing complex command section from the guides.
- Documents how to use restartPods instead.
- Verifies compatibility of restartPods in k3s, azure, and gke environments before removal.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes:#14177` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x]  Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #14177

```release-note
Document how to use restartPods instead and Verified compatibility of restartPods in k3s, azure, and gke environments before removal.
```

