### PR TITLE
Add the initialDelaySeconds of preflight to the helm chart

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2788,6 +2788,14 @@
      - The priority class to use for the preflight pod.
      - string
      - ``""``
+   * - :spelling:ignore:`preflight.readinessProbe.initialDelaySeconds`
+     - For how long kubelet should wait before performing the first probe
+     - int
+     - ``5``
+   * - :spelling:ignore:`preflight.readinessProbe.periodSeconds`
+     - interval between checks of the readiness probe
+     - int
+     - ``5``
    * - :spelling:ignore:`preflight.resources`
      - preflight resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -382,6 +382,7 @@ impactful
 ingressing
 init
 initContainer
+initialDelaySeconds
 inlined
 inlines
 inlining

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -747,6 +747,8 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.podLabels | object | `{}` | Labels to be added to the preflight pod. |
 | preflight.podSecurityContext | object | `{}` | Security context to be added to preflight pods. |
 | preflight.priorityClassName | string | `""` | The priority class to use for the preflight pod. |
+| preflight.readinessProbe.initialDelaySeconds | int | `5` | For how long kubelet should wait before performing the first probe |
+| preflight.readinessProbe.periodSeconds | int | `5` | interval between checks of the readiness probe |
 | preflight.resources | object | `{}` | preflight resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | preflight.securityContext | object | `{}` | Security context to be added to preflight pods |
 | preflight.terminationGracePeriodSeconds | int | `1` | Configure termination grace period for preflight Deployment and DaemonSet. |

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -46,20 +46,13 @@ spec:
             cilium-dbg preflight validate-cnp;
             touch /tmp/ready-validate-cnp;
             sleep 1h;
-          livenessProbe:
-            exec:
-              command:
-              - cat
-              - /tmp/ready-validate-cnp
-            initialDelaySeconds: 5
-            periodSeconds: 5
           readinessProbe:
             exec:
               command:
               - cat
               - /tmp/ready-validate-cnp
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.preflight.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.preflight.readinessProbe.periodSeconds }}
           {{- with .Values.preflight.extraVolumeMounts }}
           volumeMounts:
           {{- toYaml . | nindent 10 }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4412,6 +4412,17 @@
         "priorityClassName": {
           "type": "string"
         },
+        "readinessProbe": {
+          "properties": {
+            "initialDelaySeconds": {
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
         "resources": {
           "type": "object"
         },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2779,6 +2779,11 @@ preflight:
   #     cpu: 100m
   #     memory: 512Mi
 
+  readinessProbe:
+    # -- For how long kubelet should wait before performing the first probe
+    initialDelaySeconds: 5
+    # -- interval between checks of the readiness probe
+    periodSeconds: 5
   # -- Security context to be added to preflight pods
   securityContext: {}
   #   runAsUser: 0

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2782,6 +2782,11 @@ preflight:
   #     cpu: 100m
   #     memory: 512Mi
 
+  readinessProbe:
+    # -- For how long kubelet should wait before performing the first probe
+    initialDelaySeconds: 5
+    # -- interval between checks of the readiness probe
+    periodSeconds: 5
   # -- Security context to be added to preflight pods
   securityContext: {}
   #   runAsUser: 0


### PR DESCRIPTION
Fixes: #30379


<!-- Description of change -->

```release-note
This allows the initialDelaySeconds option to be configured. This allows users running larger clusters to extend the time it takes for preflight to become ready.
```
