### PR TITLE
gha: make runner type for clustermesh workflows configurable

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -80,7 +80,7 @@ jobs:
 
   installation-and-connectivity:
     name: Installation and Connectivity Test
-    runs-on: ubuntu-latest-4cores-16gb
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER }}
     timeout-minutes: 60
     env:
       job_name: "Installation and Connectivity Test"

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -79,7 +79,7 @@ jobs:
 
   upgrade-and-downgrade:
     name: "Upgrade and Downgrade Test"
-    runs-on: ubuntu-latest-4cores-16gb
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER }}
     timeout-minutes: 60
     env:
       job_name: "Installation and Connectivity Test"


### PR DESCRIPTION
b20038e242d7 ("gha: explicilty specify beefier runner type for clustermesh workflows") explicitly configured beefier runners for clustermesh workflows, as they require more power to host two multi-node kind clusters. However, this change turned out to have unexpected billing consequences, even though GitHub recently upgraded \[1\] the default runners for OSS projects to 4 vCPU and 16GiB of RAM (the same specs of the runner which had been configured). Hence, let's revert this change, and instead make the runner type configurable through an environment variable. This will also make it easier to change the runner type in the future, if needed.

\[1\]: https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/

Fixes: b20038e242d7 ("gha: explicilty specify beefier runner type for clustermesh workflows")
Suggested-by: André Martins <andre@cilium.io>