### PR TITLE
fix aws specific PostStart is appended to daemonset

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -214,7 +214,7 @@ spec:
         {{- end }}
         {{- if .Values.cni.install }}
         lifecycle:
-          {{- if ne .Values.cni.chainingMode "aws-cni" }}
+          {{- if eq .Values.cni.chainingMode "aws-cni" }}
           postStart:
             exec:
               command:


### PR DESCRIPTION


Fixes: #30223

```release-note
fix aws specific PostStart is appended to daemonset when not chainingMode=aws-cni
```
