### PR TITLE
gh: ci-verifier: use lvh-images/complexity-test as renovate dependency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -75,6 +75,7 @@
         ".github/workflows/**"
       ],
       excludeDepNames: [
+        "quay.io/lvh-images/complexity-test",
         "quay.io/lvh-images/kind",
         "quay.io/cilium/kindest-node"
       ],
@@ -419,6 +420,7 @@
     },
     {
       "matchDepNames": [
+        "quay.io/lvh-images/complexity-test",
         "quay.io/lvh-images/kind"
       ],
       "versioning": "regex:^((?<compatibility>[a-z-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
@@ -427,6 +429,7 @@
       "groupName": "stable lvh-images",
       "groupSlug": "stable-lvh-images",
       "matchPackageNames": [
+        "quay.io/lvh-images/complexity-test",
         "quay.io/lvh-images/kind"
       ],
       "allowedVersions": "!/bpf-next-.*/",
@@ -441,6 +444,7 @@
       "groupName": "all lvh-images main",
       "groupSlug": "all-lvh-images-main",
       "matchPackageNames": [
+        "quay.io/lvh-images/complexity-test",
         "quay.io/lvh-images/kind"
       ],
       "matchBaseBranches": [
@@ -465,6 +469,7 @@
       // Do not allow any updates for major.minor, they will be done by maintainers
       "enabled": false,
       "matchPackageNames": [
+        "quay.io/lvh-images/complexity-test",
         "quay.io/lvh-images/kind",
         "kindest/node",
         "quay.io/cilium/kindest-node"

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -72,22 +72,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # renovate: datasource=docker depName=quay.io/lvh-images/kind
+          # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: '4.19-20240110.080621'
             ci-kernel: '419'
-          # renovate: datasource=docker depName=quay.io/lvh-images/kind
+          # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: '5.4-20240110.080621'
             ci-kernel: '54'
-          # renovate: datasource=docker depName=quay.io/lvh-images/kind
+          # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: '5.10-20240110.080621'
             ci-kernel: '510'
-          # renovate: datasource=docker depName=quay.io/lvh-images/kind
+          # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: '5.15-20240110.080621'
             ci-kernel: '510'
-          # renovate: datasource=docker depName=quay.io/lvh-images/kind
+          # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: '6.1-20240110.080621'
             ci-kernel: '61'
-          # renovate: datasource=docker depName=quay.io/lvh-images/kind
+          # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: 'bpf-next-20240122.013132'
             ci-kernel: 'netnext'
     timeout-minutes: 60


### PR DESCRIPTION
ci-verifier uses the lvh complexity-test image, not the kind image. Adjust the dependency accordingly.