### PR TITLE
statedb: Add ServeHTTP and Iterate method 

### DIFF
--- a/pkg/datapath/l2responder/l2responder.go
+++ b/pkg/datapath/l2responder/l2responder.go
@@ -105,13 +105,13 @@ func (p *l2ResponderReconciler) run(ctx context.Context, health cell.HealthRepor
 	defer tracker.Close()
 
 	// At startup, do an initial full reconciliation
-	maxRev, err := p.fullReconciliation()
+	_, err = p.fullReconciliation()
 	if err != nil {
 		log.WithError(err).Error("Error(s) while reconciling l2 responder map")
 	}
 
 	for ctx.Err() == nil {
-		maxRev = p.cycle(ctx, tracker, maxRev, ticker.C)
+		p.cycle(ctx, tracker, ticker.C)
 	}
 
 	return nil
@@ -120,9 +120,8 @@ func (p *l2ResponderReconciler) run(ctx context.Context, health cell.HealthRepor
 func (p *l2ResponderReconciler) cycle(
 	ctx context.Context,
 	tracker *statedb.DeleteTracker[*tables.L2AnnounceEntry],
-	maxRevIn statedb.Revision,
 	fullReconciliation <-chan time.Time,
-) (maxRev statedb.Revision) {
+) {
 	arMap := p.params.L2ResponderMap
 	rtx := p.params.StateDB.ReadTxn()
 	log := p.params.Logger
@@ -130,7 +129,7 @@ func (p *l2ResponderReconciler) cycle(
 	lr := cachingLinkResolver{nl: p.params.NetLink}
 
 	// Partial reconciliation
-	maxRev, invalid, err := tracker.Process(rtx, maxRevIn, func(e *tables.L2AnnounceEntry, deleted bool, rev uint64) error {
+	invalid, err := tracker.IterateWithError(rtx, func(e *tables.L2AnnounceEntry, deleted bool, rev uint64) error {
 		// Ignore IPv6 addresses, L2 is IPv4 only
 		if e.IP.Is6() {
 			return nil
@@ -169,23 +168,22 @@ func (p *l2ResponderReconciler) cycle(
 	select {
 	case <-ctx.Done():
 		// Shutdown
-		return 0
+		return
 
 	case <-invalid:
 		// There are pending changes in the table, return from the cycle
-		return maxRev
 
 	case <-fullReconciliation:
 		// Full reconciliation timer fired, perform full reconciliation
 
 		// The existing `iter` is the result of a `All` query, so this will return all
 		// entries in the table for full reconciliation.
-		maxRev, err = p.fullReconciliation()
+		newRev, err := p.fullReconciliation()
 		if err != nil {
 			log.WithError(err).Error("Error(s) while full reconciling l2 responder map")
 		}
+		tracker.Mark(newRev)
 
-		return maxRev
 	}
 }
 

--- a/pkg/datapath/l2responder/l2responder_test.go
+++ b/pkg/datapath/l2responder/l2responder_test.go
@@ -92,7 +92,6 @@ func TestEmptyMapAddPartialSync(t *testing.T) {
 	fix := newFixture()
 
 	txn := fix.stateDB.WriteTxn(fix.proxyNeighborTable)
-	rev := fix.proxyNeighborTable.Revision(txn)
 	tracker, err := fix.proxyNeighborTable.DeleteTracker(txn, "l2-responder-reconciler")
 	assert.NoError(t, err)
 	txn.Commit()
@@ -120,7 +119,7 @@ func TestEmptyMapAddPartialSync(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	fix.reconciler.cycle(ctx, tracker, rev, nil)
+	fix.reconciler.cycle(ctx, tracker, nil)
 
 	stats, err := fix.respondermap.Lookup(ip1, ifidx1)
 	assert.NoError(t, err)
@@ -134,7 +133,6 @@ func TestEmptyMapAddDelPartialSync(t *testing.T) {
 	fix := newFixture()
 
 	txn := fix.stateDB.WriteTxn(fix.proxyNeighborTable)
-	rev := fix.proxyNeighborTable.Revision(txn)
 	tracker, err := fix.proxyNeighborTable.DeleteTracker(txn, "l2-responder-reconciler")
 	assert.NoError(t, err)
 	txn.Commit()
@@ -179,7 +177,7 @@ func TestEmptyMapAddDelPartialSync(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	fix.reconciler.cycle(ctx, tracker, rev, nil)
+	fix.reconciler.cycle(ctx, tracker, nil)
 
 	// Added entry should be present
 	stats, err := fix.respondermap.Lookup(ip1, ifidx1)
@@ -282,7 +280,6 @@ func Test1RougeAddPartialSync(t *testing.T) {
 	fix := newFixture()
 
 	txn := fix.stateDB.WriteTxn(fix.proxyNeighborTable)
-	rev := fix.proxyNeighborTable.Revision(txn)
 	tracker, err := fix.proxyNeighborTable.DeleteTracker(txn, "l2-responder-reconciler")
 	assert.NoError(t, err)
 	txn.Commit()
@@ -313,7 +310,7 @@ func Test1RougeAddPartialSync(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	fix.reconciler.cycle(ctx, tracker, rev, nil)
+	fix.reconciler.cycle(ctx, tracker, nil)
 
 	// Added entry should be present
 	stats, err := fix.respondermap.Lookup(ip1, ifidx1)

--- a/pkg/statedb/benchmarks_test.go
+++ b/pkg/statedb/benchmarks_test.go
@@ -160,12 +160,10 @@ func BenchmarkDB_DeleteTracker(b *testing.B) {
 	txn.Commit()
 
 	nDeleted := 0
-	dt.Process(
+	dt.Iterate(
 		db.ReadTxn(),
-		0,
-		func(obj testObject, deleted bool, _ Revision) error {
+		func(obj testObject, deleted bool, _ Revision) {
 			nDeleted++
-			return nil
 		})
 	require.EqualValues(b, nDeleted, b.N)
 	b.StopTimer()
@@ -267,12 +265,6 @@ var (
 	}
 )
 
-func closedWatchChannel() <-chan struct{} {
-	ch := make(chan struct{})
-	close(ch)
-	return ch
-}
-
 // BenchmarkDB_PropagationDelay tests the propagation delay when changes from one
 // table are propagated to another.
 func BenchmarkDB_PropagationDelay(b *testing.B) {
@@ -304,7 +296,7 @@ func BenchmarkDB_PropagationDelay(b *testing.B) {
 
 	var (
 		revision = Revision(0)
-		watch1   = closedWatchChannel()
+		watch1   = closedWatchChannel
 	)
 
 	samples := []time.Duration{}

--- a/pkg/statedb/db.go
+++ b/pkg/statedb/db.go
@@ -6,6 +6,7 @@ package statedb
 import (
 	"context"
 	"errors"
+	"net/http"
 	"reflect"
 	"runtime"
 	"strings"
@@ -241,6 +242,20 @@ func (db *DB) Stop(stopCtx hive.HookContext) error {
 	case <-db.gcExited:
 	}
 	return nil
+}
+
+// ServeHTTP is an HTTP handler for dumping StateDB as JSON.
+//
+// Example usage:
+//
+//	var db *statedb.DB
+//
+//	http.Handle("/db", db)
+//	http.ListenAndServe(":8080", nil)
+func (db *DB) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	db.ReadTxn().WriteJSON(w)
 }
 
 // setGCRateLimitInterval can set the graveyard GC interval before DB is started.

--- a/pkg/statedb/derive.go
+++ b/pkg/statedb/derive.go
@@ -79,14 +79,12 @@ func (d derive[In, Out]) loop(ctx context.Context, health cell.HealthReporter) e
 	}
 	wtxn.Commit()
 	defer tracker.Close()
-	revision := Revision(0)
 	for {
 		wtxn := d.DB.WriteTxn(out)
 
 		var watch <-chan struct{}
-		revision, watch, err = tracker.Process(
+		watch, err = tracker.IterateWithError(
 			wtxn,
-			revision,
 			func(obj In, deleted bool, rev Revision) (err error) {
 				outObj, result := d.transform(obj, deleted)
 				switch result {

--- a/pkg/statedb/example/reconcile.go
+++ b/pkg/statedb/example/reconcile.go
@@ -66,7 +66,6 @@ func (r *reconciler) reconcileLoop(ctx context.Context, health cell.HealthReport
 	defer deleteTracker.Close()
 
 	txn := r.DB.ReadTxn()
-	minRevision := statedb.Revision(0)
 
 	// Limit processing rate to 10 op/s.
 	burst := int64(10)
@@ -79,14 +78,12 @@ func (r *reconciler) reconcileLoop(ctx context.Context, health cell.HealthReport
 	}
 
 	for {
-		tableRevision := r.Backends.Revision(txn)
-		r.Log.WithField("minRevision", minRevision).Info("Reconciling backends")
+		r.Log.Info("Reconciling backends")
 
 		// Process upserts and deletions between minRevision..maxRevision.
 		// Returns the new revision to run the next query from.
-		newRevision, watch, processErr := deleteTracker.Process(
+		watch, processErr := deleteTracker.IterateWithError(
 			txn,
-			minRevision,
 			func(be Backend, deleted bool, rev statedb.Revision) error {
 				if err := limiter.Wait(ctx); err != nil {
 					return err
@@ -107,18 +104,15 @@ func (r *reconciler) reconcileLoop(ctx context.Context, health cell.HealthReport
 			},
 		)
 
-		minRevision = newRevision
-
 		if processErr != nil {
-			r.Reporter.Degraded(fmt.Sprintf("Failure at revision %d, latest is %d", minRevision, tableRevision), processErr)
+			r.Reporter.Degraded("Failure to process", processErr)
 			if err := backoff.Wait(ctx); err != nil {
 				return err
 			}
 		} else {
 			backoff.Reset()
-			r.Reporter.OK(fmt.Sprintf("All processed up to %d", minRevision))
+			r.Reporter.OK("OK")
 
-			fmt.Printf(">>> validate revision %d\n", newRevision)
 			r.validate(txn)
 		}
 

--- a/pkg/statedb/graveyard.go
+++ b/pkg/statedb/graveyard.go
@@ -47,7 +47,10 @@ func graveyardWorker(db *DB, ctx context.Context, gcRateLimitInterval time.Durat
 			dtIter := table.deleteTrackers.Root().Iterator()
 			for _, dt, ok := dtIter.Next(); ok; _, dt, ok = dtIter.Next() {
 				rev := dt.getRevision()
-				if rev < lowWatermark {
+				// If the revision is higher than zero than the tracker has been observed
+				// at least once. If it is zero, then no objects have been seen and thus
+				// we don't need to hold onto deleted objects for it.
+				if rev > 0 && rev < lowWatermark {
 					lowWatermark = rev
 				}
 			}

--- a/pkg/statedb/txn.go
+++ b/pkg/statedb/txn.go
@@ -272,7 +272,6 @@ func (txn *txn) addDeleteTracker(meta TableMeta, trackerName string, dt deleteTr
 	if !ok {
 		return tableError(meta.Name(), ErrTableNotLockedForWriting)
 	}
-	dt.setRevision(table.revision)
 	table.deleteTrackers, _, _ = table.deleteTrackers.Insert([]byte(trackerName), dt)
 	txn.db.metrics.TableDeleteTrackerCount.With(prometheus.Labels{
 		"table": meta.Name(),


### PR DESCRIPTION
Couple small improvements to statedb:

* Add ServeHTTP method to `*statedb.DB` for use in simple applications to dump the contents of the DB.
* Rename `Process` to `IterateWithError` and simplify it by using the low watermark revision instead of having to pass the revision in. In cases where the revision needs to be manipulated one can use `DeleteTracker.Mark`.
* Add `DeleteTracker.Iterate` which is like `Process` but without the error return and short-circuiting.
