### PR TITLE
enable Prometheus metrics for Hubble Relay

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -31,6 +31,10 @@ spec:
         {{- with .Values.hubble.relay.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if and .Values.hubble.relay.prometheus.enabled (not .Values.hubble.relay.prometheus.serviceMonitor.enabled) }}
+        prometheus.io/port: { { .Values.hubble.relay.prometheus.port | quote } }
+        prometheus.io/scrape: "true"
+        {{- end }}
       labels:
         k8s-app: hubble-relay
         app.kubernetes.io/name: hubble-relay

--- a/install/kubernetes/cilium/templates/hubble-relay/service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/service.yaml
@@ -4,10 +4,14 @@ apiVersion: v1
 metadata:
   name: hubble-relay
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.hubble.relay.annotations }}
   annotations:
+    {{- with .Values.hubble.relay.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    {{- if and .Values.hubble.relay.prometheus.enabled (not .Values.hubble.relay.prometheus.serviceMonitor.enabled) }}
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ .Values.hubble.relay.prometheus.port | quote }}
+    {{- end }}
   labels:
     k8s-app: hubble-relay
     app.kubernetes.io/name: hubble-relay


### PR DESCRIPTION
Fixes: #30475


```release-note
helm: Fix Prometheus metrics annotations for Hubble Relay
```
