### PR TITLE
l7lb: log service ns and name when upserting endpoints

### DIFF
--- a/pkg/ciliumenvoyconfig/envoy_l7lb_backend_syncer.go
+++ b/pkg/ciliumenvoyconfig/envoy_l7lb_backend_syncer.go
@@ -62,6 +62,8 @@ func (r *envoyServiceBackendSyncer) Sync(svc *loadbalancer.SVC) error {
 	r.logger.
 		WithField("filteredBackends", be).
 		WithField(logfields.L7LBFrontendPorts, l7lbInfo.GetAllFrontendPorts()).
+		WithField(logfields.ServiceNamespace, svc.Name.Namespace).
+		WithField(logfields.ServiceName, svc.Name.Name).
 		Debug("Upsert envoy endpoints")
 	if err := r.upsertEnvoyEndpoints(svc.Name, be); err != nil {
 		return fmt.Errorf("failed to update backends in Envoy: %w", err)


### PR DESCRIPTION
Currently, when upserting a k8s service into Envoy for L7LB backend synchronization, only the filtered backends and frontend ports are logged. Information about the actual service are missing.

Therefore, this commit adds the service namespace and name as logfields to the log message.