### PR TITLE
ci/ipsec: Fix version retrieval for downgrades to closest patch release

### DIFF
--- a/contrib/scripts/print-downgrade-version.sh
+++ b/contrib/scripts/print-downgrade-version.sh
@@ -25,11 +25,14 @@ if [[ ${1-} == "patch" ]] ; then
             exit 1
             ;;
         *)
-            ((patch--))
             echo "v${major}.${minor}.${patch}${TAG_SUFFIX:-}"
             ;;
     esac
 else
+    if [[ "${minor}" == "0" ]] ; then
+        >&2 echo "ERROR: failed to deduce release previous to version '$VERSION'"
+        exit 1
+    fi
     # Else print the previous stable version by decrementing the minor version
     # and trimming the patch version.
     ((minor--))


### PR DESCRIPTION
[Julian reports](https://github.com/cilium/cilium/pull/30402#issuecomment-1911890955) that the IPsec upgrade/downgrade workflow still has a flake that we expected to be gone, now that the fix is released patch version 1.13.11. As it turns out, the workflow does _not_ pick and downgrade to the latest patch release, but to _the one before that_, because the script would decrement the value found in file `VERSION`. We don't need this, `VERSION` already contains the last patch release that was published, not the one to come.

Fixes: 56dfec2f1ac5 ("contrib/scripts: Support patch releases in print-downgrade-version.sh")
Fixes: https://github.com/cilium/cilium/pull/28815

Cc @pchaigno just FYI