### PR TITLE
Fix various health-server probing bugs.

### DIFF
--- a/pkg/health/server/prober.go
+++ b/pkg/health/server/prober.go
@@ -137,7 +137,7 @@ func skipAddress(elem *ciliumModels.NodeAddressingElement) bool {
 // resolveIP attempts to sanitize 'node' and 'ip', and if successful, returns
 // the name of the node and the IP address specified in the addressing element.
 // If validation fails or this IP should not be pinged, 'ip' is returned as nil.
-func resolveIP(n *healthNode, addr *ciliumModels.NodeAddressingElement, proto string, primary bool) (string, *net.IPAddr) {
+func resolveIP(n *healthNode, addr *ciliumModels.NodeAddressingElement, primary bool) (string, *net.IPAddr) {
 	node := n.NodeElement
 	network := "ip6:icmp"
 	if isIPv4(addr.IP) {
@@ -152,7 +152,6 @@ func resolveIP(n *healthNode, addr *ciliumModels.NodeAddressingElement, proto st
 			logfields.NodeName: node.Name,
 			logfields.IPAddr:   addr.IP,
 			"primary":          primary,
-			"protocol":         proto,
 		})
 	}
 
@@ -201,7 +200,7 @@ func (p *prober) setNodes(added nodeMap, removed nodeMap) {
 
 	for _, n := range added {
 		for elem, primary := range n.Addresses() {
-			_, addr := resolveIP(&n, elem, "icmp", primary)
+			_, addr := resolveIP(&n, elem, primary)
 			if addr == nil {
 				continue
 			}
@@ -279,7 +278,7 @@ func (p *prober) getIPsByNode() map[string][]*net.IPAddr {
 		}
 		nodes[node.Name] = []*net.IPAddr{}
 		for elem, primary := range node.Addresses() {
-			if _, addr := resolveIP(&node, elem, "http", primary); addr != nil {
+			if _, addr := resolveIP(&node, elem, primary); addr != nil {
 				nodes[node.Name] = append(nodes[node.Name], addr)
 			}
 		}

--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -338,8 +338,13 @@ func (s *Server) runActiveServices() error {
 	prober := newProber(s, nodesAdded)
 	prober.MaxRTT = s.ProbeInterval
 	prober.OnIdle = func() {
-		// Update set of nodes to probe every ProbeInterval and then fetch
-		// results
+		// OnIdle is called every ProbeInterval after sending out all icmp pings.
+		// There are a few important consideration here:
+		// (1) ICMP prober doesn't report failed probes
+		// (2) We can receive the same nodes multiple times in nodesAdded in case of updates
+		// (3) We need to clean icmp status to not retain stale probe results
+		// (4) We don't want to report stale nodes in metrics
+
 		if nodesAdded, nodesRemoved, err := s.getNodes(); err != nil {
 			// reset the cache by setting clientID to 0 and removing all current nodes
 			s.clientID = 0
@@ -347,8 +352,15 @@ func (s *Server) runActiveServices() error {
 			log.WithError(err).Error("unable to get cluster nodes")
 			return
 		} else {
+			// (1) Mark ips that did not receive ICMP as unreachable.
+			prober.updateIcmpStatus()
+			// (2) setNodes implementation doesn't override results for existing nodes.
+			// (4) Remove stale nodes so we don't report them in metrics before updating results
 			prober.setNodes(nodesAdded, nodesRemoved)
+			// (4) Update results without stale nodes
 			s.updateCluster(prober.getResults())
+			// (3) Cleanup icmp results for next iteration of probing
+			prober.clearIcmpStatus()
 		}
 	}
 	prober.RunLoop()


### PR DESCRIPTION
Fixes https://github.com/cilium/cilium/pull/29566 - The first issue mentioned in commit message was triggered by this change, all other issues existed before.

Commit message for convenience:

```
There were three issues with health-reporting/probing:
- Whenever node was updated, it was received in nodesAdded
and was overriding icmp result reporting node as unreachable
- If Icmp probe stopped working and there were no node updates,
it was reporting node as healthy even though probe was failing.
- Http prober was not triggered at the start and only after
  probeInterval.
```

## How to test it

- Triggering node update resets ICMP result: `kubectl label node kind-worker somelabel=label`
- ICMP results are not updated after first successful probe: 
```
docker exec -it KIND_WORKER_CONTAINER_ID /bin/sh
echo "1" >  /proc/sys/net/ipv4/icmp_echo_ignore_all
```

```release-note
Fixed health probing where ICMP probe was incorrectly reporting node as unreachable or reporting unreachable node as reachable in some cases.
```
