### PR TITLE
ci: Fix PR labels parsing in update label workflow

### DIFF
--- a/.github/workflows/call-backport-label-updater.yaml
+++ b/.github/workflows/call-backport-label-updater.yaml
@@ -23,10 +23,15 @@
       steps:
         - name: Get Branch
           id: get-branch
+          env:
+            LABELS: ${{ toJson(github.event.pull_request.labels) }}
           run: |
-            if echo ",${{ github.event.pull_request.labels.*.name }}," | grep -q ",backport/${{ matrix.branch }},"; then
-              echo "version=${{ matrix.branch }}" >> "$GITHUB_OUTPUT"
-            fi
+            echo "${LABELS}" | jq -c -r '.[].name' | while read -r label; do
+              if [ "${label}" = "backport/${{ matrix.branch }}" ]; then
+                echo "version=${{ matrix.branch }}" >> "$GITHUB_OUTPUT"
+                break
+              fi
+            done
 
     call-backport-label-updater:
       name: Update backport labels for upstream PR


### PR DESCRIPTION
`github.event.pull_request.labels` contains an array of objects that describe various attributes of each label attached to the PR.

An example is the following from the GitHub docs:

```json
"labels": [
  {
    "id": 208045946,
    "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
    "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
    "name": "bug",
    "description": "Something isn't working",
    "color": "f29513",
    "default": true
  }
]
```

(see
https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request)

Being a JSON object, we cannot collect all the names of the labels in a list with a '*' wildcard. Instead, the commit fixes the workflow first copying the labels JSON array in an env variable and then using `jq` to get all the labels names.

Fixes: 7fc78e9d5f ("ci: Add a call to the update label backport action")

Once backported to v1.15, this should fix errors in the workflow like this one: https://github.com/cilium/cilium/actions/runs/7637627812