### PR TITLE
Remove skip-cnp-status-startup-clean

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -100,7 +100,6 @@ cilium-operator-alibabacloud [flags]
       --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
-      --skip-cnp-status-startup-clean                        If set to true, the operator will not clean up CNP node status updates at startup
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                            Subnets IDs (separated by commas)
       --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -108,7 +108,6 @@ cilium-operator-aws [flags]
       --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
-      --skip-cnp-status-startup-clean                        If set to true, the operator will not clean up CNP node status updates at startup
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                            Subnets IDs (separated by commas)
       --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -103,7 +103,6 @@ cilium-operator-azure [flags]
       --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
-      --skip-cnp-status-startup-clean                        If set to true, the operator will not clean up CNP node status updates at startup
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                            Subnets IDs (separated by commas)
       --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -99,7 +99,6 @@ cilium-operator-generic [flags]
       --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
-      --skip-cnp-status-startup-clean                        If set to true, the operator will not clean up CNP node status updates at startup
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                            Subnets IDs (separated by commas)
       --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -113,7 +113,6 @@ cilium-operator [flags]
       --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
-      --skip-cnp-status-startup-clean                        If set to true, the operator will not clean up CNP node status updates at startup
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                            Subnets IDs (separated by commas)
       --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2596,10 +2596,6 @@
      - Taint nodes where Cilium is scheduled but not running. This prevents pods from being scheduled to nodes where Cilium is not the default CNI provider.
      - string
      - same as removeNodeTaints
-   * - :spelling:ignore:`operator.skipCNPStatusStartupClean`
-     - Skip CNP node status clean up at operator startup.
-     - bool
-     - ``false``
    * - :spelling:ignore:`operator.skipCRDCreation`
      - Skip CRDs creation for cilium-operator
      - bool

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -477,10 +477,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(option.IPv6ServiceRange, AutoCIDR, "Kubernetes IPv6 services CIDR if not inside cluster prefix")
 	option.BindEnv(vp, option.IPv6ServiceRange)
 
-	flags.Bool(option.LegacyTurnOffK8sEventHandover, defaults.LegacyTurnOffK8sEventHandover, "Turn off K8sEventsHandover - this is legacy behaviour")
-	option.BindEnv(vp, option.LegacyTurnOffK8sEventHandover)
-	flags.MarkHidden(option.LegacyTurnOffK8sEventHandover)
-
 	flags.String(option.K8sNamespaceName, "", "Name of the Kubernetes namespace in which Cilium is deployed in")
 	option.BindEnv(vp, option.K8sNamespaceName)
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -699,7 +699,6 @@ contributors across the globe, there is almost always someone available to help.
 | operator.securityContext | object | `{}` | Security context to be added to cilium-operator pods |
 | operator.setNodeNetworkStatus | bool | `true` | Set Node condition NetworkUnavailable to 'false' with the reason 'CiliumIsUp' for nodes that have a healthy Cilium pod. |
 | operator.setNodeTaints | string | same as removeNodeTaints | Taint nodes where Cilium is scheduled but not running. This prevents pods from being scheduled to nodes where Cilium is not the default CNI provider. |
-| operator.skipCNPStatusStartupClean | bool | `false` | Skip CNP node status clean up at operator startup. |
 | operator.skipCRDCreation | bool | `false` | Skip CRDs creation for cilium-operator |
 | operator.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for cilium-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | operator.topologySpreadConstraints | list | `[]` | Pod topology spread constraints for cilium-operator |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -148,10 +148,6 @@ data:
   cilium-endpoint-gc-interval: {{ include "validateDuration" .Values.operator.endpointGCInterval | quote }}
   nodes-gc-interval: {{ include "validateDuration" .Values.operator.nodeGCInterval | quote }}
 
-{{- if hasKey .Values.operator "skipCNPStatusStartupClean" }}
-  skip-cnp-status-startup-clean: "{{ .Values.operator.skipCNPStatusStartupClean }}"
-{{- end }}
-
 {{- if eq .Values.disableEndpointCRD true }}
   # Disable the usage of CiliumEndpoint CRD
   disable-endpoint-crd: "true"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2256,8 +2256,6 @@ operator:
   endpointGCInterval: "5m0s"
   # -- Interval for cilium node garbage collection.
   nodeGCInterval: "5m0s"
-  # -- Skip CNP node status clean up at operator startup.
-  skipCNPStatusStartupClean: false
   # -- Interval for identity garbage collection.
   identityGCInterval: "15m0s"
   # -- Timeout for identity heartbeats.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2253,8 +2253,6 @@ operator:
   endpointGCInterval: "5m0s"
   # -- Interval for cilium node garbage collection.
   nodeGCInterval: "5m0s"
-  # -- Skip CNP node status clean up at operator startup.
-  skipCNPStatusStartupClean: false
   # -- Interval for identity garbage collection.
   identityGCInterval: "15m0s"
   # -- Timeout for identity heartbeats.

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -54,9 +54,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(option.ConfigDir, "", `Configuration directory that contains a file for each option`)
 	option.BindEnv(vp, option.ConfigDir)
 
-	flags.Bool(operatorOption.SkipCNPStatusStartupClean, false, `If set to true, the operator will not clean up CNP node status updates at startup`)
-	option.BindEnv(vp, operatorOption.SkipCNPStatusStartupClean)
-
 	flags.Float64(operatorOption.CNPStatusCleanupQPS, operatorOption.CNPStatusCleanupQPSDefault,
 		"Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps")
 	option.BindEnv(vp, operatorOption.CNPStatusCleanupQPS)

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -666,22 +666,16 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 			log.WithError(err).Fatal("Unable to setup cilium node synchronizer")
 		}
 
-		if operatorOption.Config.SkipCNPStatusStartupClean {
-			log.Info("Skipping clean up of CNP and CCNP node status updates")
-		} else {
-			// If CNP status updates are disabled, we clean up all the
-			// possible updates written when the option was enabled.
-			// This is done to avoid accumulating stale updates and thus
-			// hindering scalability for large clusters.
-			RunCNPStatusNodesCleaner(
-				legacy.ctx,
-				legacy.clientset,
-				xrate.NewLimiter(
-					xrate.Limit(operatorOption.Config.CNPStatusCleanupQPS),
-					operatorOption.Config.CNPStatusCleanupBurst,
-				),
-			)
-		}
+		// This is done to avoid accumulating stale updates and thus
+		// hindering scalability for large clusters.
+		RunCNPStatusNodesCleaner(
+			legacy.ctx,
+			legacy.clientset,
+			xrate.NewLimiter(
+				xrate.Limit(operatorOption.Config.CNPStatusCleanupQPS),
+				operatorOption.Config.CNPStatusCleanupBurst,
+			),
+		)
 
 		if operatorOption.Config.NodesGCInterval != 0 {
 			operatorWatchers.RunCiliumNodeGC(legacy.ctx, &legacy.wg, legacy.clientset, ciliumNodeSynchronizer.ciliumNodeStore, operatorOption.Config.NodesGCInterval)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -67,10 +67,6 @@ const (
 	// compatible with MetalLB's configuration.
 	BGPConfigPath = "bgp-config-path"
 
-	// SkipCNPStatusStartupClean specifies if the cleanup of all the CNP
-	// NodeStatus updates at startup must be skipped.
-	SkipCNPStatusStartupClean = "skip-cnp-status-startup-clean"
-
 	// CNPStatusCleanupQPS is the rate at which the cleanup operation of the status
 	// nodes updates in CNPs is carried out. It is expressed as queries per second,
 	// and for each query a single CNP status update will be deleted.
@@ -265,10 +261,6 @@ type OperatorConfig struct {
 
 	// NodesGCInterval is the GC interval for CiliumNodes
 	NodesGCInterval time.Duration
-
-	// SkipCNPStatusStartupClean disables the cleanup of all the CNP
-	// NodeStatus updates at startup.
-	SkipCNPStatusStartupClean bool
 
 	// CNPStatusCleanupQPS is the rate at which the cleanup operation of the status
 	// nodes updates in CNPs is carried out. It is expressed as queries per second,
@@ -467,7 +459,6 @@ type OperatorConfig struct {
 // Populate sets all options with the values from viper.
 func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.NodesGCInterval = vp.GetDuration(NodesGCInterval)
-	c.SkipCNPStatusStartupClean = vp.GetBool(SkipCNPStatusStartupClean)
 	c.CNPStatusCleanupQPS = vp.GetFloat64(CNPStatusCleanupQPS)
 	c.CNPStatusCleanupBurst = vp.GetInt(CNPStatusCleanupBurst)
 	c.EnableMetrics = vp.GetBool(EnableMetrics)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -341,8 +341,6 @@ const (
 	// connection tracking garbage collection
 	ConntrackGCStartingInterval = 5 * time.Minute
 
-	LegacyTurnOffK8sEventHandover = false
-
 	// LoopbackIPv4 is the default address for service loopback
 	LoopbackIPv4 = "169.254.42.1"
 

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -204,10 +204,6 @@ func (k *K8sWatcher) podsInit(slimClient slimclientset.Interface, asyncControlle
 			close(k.podStoreSet)
 		})
 
-		if option.Config.LegacyTurnOffK8sEventHandover {
-			return
-		}
-
 		// Replace pod controller by only receiving events from our own
 		// node once we are connected to the kvstore.
 		<-kvstore.Connected()

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -818,14 +818,6 @@ const (
 	// endpoints that are no longer alive and healthy.
 	EndpointGCInterval = "endpoint-gc-interval"
 
-	// This option turns off switching from full pods informer to node's local pods informer
-	// when CEP CRD is disabled and kvstore is used.
-	// Switching from full pods informer to node's local pods informer is considered default behaviour
-	// and this option allows us to change it back to having full pods informer all the time.
-	// It's meant to be mitigation only in case if endpoint synchronization from kvstore has some bugs
-	// and we actually need to watch all pods all the time.
-	LegacyTurnOffK8sEventHandover = "legacy-turn-off-k8s-event-handover"
-
 	// LoopbackIPv4 is the address to use for service loopback SNAT
 	LoopbackIPv4 = "ipv4-service-loopback-address"
 
@@ -1766,7 +1758,6 @@ type DaemonConfig struct {
 	KVStoreOpt                    map[string]string
 	LabelPrefixFile               string
 	Labels                        []string
-	LegacyTurnOffK8sEventHandover bool
 	LogDriver                     []string
 	LogOpt                        map[string]string
 	Logstash                      bool
@@ -3084,7 +3075,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.K8sRequireIPv4PodCIDR = vp.GetBool(K8sRequireIPv4PodCIDRName)
 	c.K8sRequireIPv6PodCIDR = vp.GetBool(K8sRequireIPv6PodCIDRName)
 	c.K8sServiceCacheSize = uint(vp.GetInt(K8sServiceCacheSize))
-	c.LegacyTurnOffK8sEventHandover = vp.GetBool(LegacyTurnOffK8sEventHandover)
 	c.K8sSyncTimeout = vp.GetDuration(K8sSyncTimeoutName)
 	c.AllocatorListTimeout = vp.GetDuration(AllocatorListTimeoutName)
 	c.K8sWatcherEndpointSelector = vp.GetString(K8sWatcherEndpointSelector)

--- a/test/controlplane/ciliumnetworkpolicies/status_updates_gc.go
+++ b/test/controlplane/ciliumnetworkpolicies/status_updates_gc.go
@@ -252,7 +252,6 @@ func init() {
 			StartAgent(func(_ *option.DaemonConfig) {}).
 			StartOperator(
 				func(operatorCfg *operatorOption.OperatorConfig) {
-					operatorCfg.SkipCNPStatusStartupClean = true
 				},
 				func(vp *viper.Viper) {
 					vp.Set(operatorApi.OperatorAPIServeAddr, "localhost:0")
@@ -273,7 +272,6 @@ func init() {
 			StartAgent(func(_ *option.DaemonConfig) {}).
 			StartOperator(
 				func(operatorCfg *operatorOption.OperatorConfig) {
-					operatorCfg.SkipCNPStatusStartupClean = false
 				},
 				func(vp *viper.Viper) {
 					vp.Set(operatorApi.OperatorAPIServeAddr, "localhost:0")


### PR DESCRIPTION
Remove `skip-cnp-status-startup-clean`

Fixes: #29590

```release-note
Remove `skip-cnp-status-startup-clean`
```
