### PR TITLE
v1.12 Backports 2024-01-29

### DIFF
--- a/Documentation/gettingstarted/encryption-ipsec.rst
+++ b/Documentation/gettingstarted/encryption-ipsec.rst
@@ -297,6 +297,9 @@ Limitations
     * Transparent encryption is not currently supported when chaining Cilium on
       top of other CNI plugins. For more information, see :gh-issue:`15596`.
     * :ref:`HostPolicies` are not currently supported with IPsec encryption.
+    * IPsec encryption does not work when using :ref:`kube-proxy replacement
+      <kubeproxy-free>`. Be aware that other features may require a kube-proxy
+      free environment in which case they are mutual exclusive.
     * IPsec encryption is not supported on clusters or clustermeshes with more
       than 65535 nodes.
     * Decryption with Cilium IPsec is limited to a single CPU core per IPsec


### PR DESCRIPTION
 * [x] #30403 (@f1ko)

PRs skipped due to conflicts:

 * #30052 (@yingnanzhang666)
 * #30410 (@julianwiedmann) (complexity check says no, v1.12 backport dropped)


Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 30403 30410
```
