### PR TITLE
add doc for logOptions configuration

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1567,9 +1567,20 @@ localRedirectPolicy: false
 # To include or exclude matched resources from cilium identity evaluation
 # labels: ""
 
-# logOptions allows you to define logging options. eg:
-# logOptions:
-#   format: json
+# -- (string) Allows you to define logging options.
+# LogOpt sets log driver options for cilium
+# "log-opt", "Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent"
+# level, network (syslog.LOG_KERN(3)), address, severity(loglevel), facility
+# eg: "level=warn,format=(text|json|json-ts),syslog.facility=local4,syslog.severity=info,syslog.tag=cilium"
+logOptions:
+  level: "info"
+  format: "text"
+  syslog:
+    facility: "kernel"
+    # mirrors "level" setting if none specified
+    severity: "info"
+    address: ""
+    tag: ""
 
 # -- Enables periodic logging of system load
 logSystemLoad: false


### PR DESCRIPTION
Cilium supports overriding default log options, but the default and allowed values for this configuration are undocumented. This PR attempts to provide a structure and specify the defaults for logging options. I have included the json structure only; cilium also supports key/value pairs, but I don't see how it's possible to have both options in the docs effectively -- potentially one reason they were not included to begin with.

Comments/suggestions welcome. I tried to detail the breadth of options as best I could without getting too granular.

Fixes: #5578

```release-note
Document Cilium's logOptions and overrides
```
