### PR TITLE
docs: document logOptions in cilium install

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2368,6 +2368,10 @@
      - Enable Local Redirect Policy.
      - bool
      - ``false``
+   * - :spelling:ignore:`logOptions`
+     - Define logging options. These options can also be set as json key value pairs, for example "level=warn,format=(text
+     - string
+     - ``{"format":"text","level":"info"}``
    * - :spelling:ignore:`logSystemLoad`
      - Enables periodic logging of system load
      - bool

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -473,6 +473,7 @@ loadinfo
 localhost
 lockless
 logfile
+loglevel
 lookups
 loopback
 lrp
@@ -487,6 +488,7 @@ mainboard
 makefile
 mana
 masq
+matchExpressions
 matchLabels
 matchPattern
 maxUnavailable
@@ -684,6 +686,7 @@ syscall
 sysctl
 sysctls
 sysdump
+syslog
 systemd
 systemtap
 targetPort
@@ -782,4 +785,3 @@ xt
 xwing
 yaml
 zsh
-matchExpressions

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -642,6 +642,7 @@ contributors across the globe, there is almost always someone available to help.
 | loadBalancer.l7.backend | string | `"disabled"` | Enable L7 service load balancing via envoy proxy. The request to a k8s service, which has specific annotation e.g. service.cilium.io/lb-l7, will be forwarded to the local backend proxy to be load balanced to the service endpoints. Please refer to docs for supported annotations for more configuration.  Applicable values:   - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well.   - disabled: Disable L7 load balancing by way of service annotation. |
 | loadBalancer.l7.ports | list | `[]` | List of ports from service to be automatically redirected to above backend. Any service exposing one of these ports will be automatically redirected. Fine-grained control can be achieved by using the service annotation. |
 | localRedirectPolicy | bool | `false` | Enable Local Redirect Policy. |
+| logOptions | string | `{"format":"text","level":"info"}` | Define logging options. These options can also be set as json key value pairs, for example "level=warn,format=(text|json|json-ts),syslog.facility=local4,syslog.severity=info,syslog.tag=cilium" |
 | logSystemLoad | bool | `false` | Enables periodic logging of system load |
 | maglev | object | `{}` | Configure maglev consistent hashing |
 | monitor | object | `{"enabled":false}` | cilium-monitor sidecar. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1602,10 +1602,18 @@ localRedirectPolicy: false
 # To include or exclude matched resources from cilium identity evaluation
 # labels: ""
 
-# logOptions allows you to define logging options. eg:
-# logOptions:
-#   format: json
-
+# -- (string) Define logging options.
+# These options can also be set as json key value pairs, for example "level=warn,format=(text|json|json-ts),syslog.facility=local4,syslog.severity=info,syslog.tag=cilium"
+logOptions:
+  level: "info"
+  format: "text"
+  # -- specify syslog options to enable syslog logging
+  # syslog:
+  # facility: "kernel"
+  # -- "severity" mirrors logOptions.level by default
+  # severity: "info"
+  # address: ""
+  # tag: ""
 # -- Enables periodic logging of system load
 logSystemLoad: false
 # -- Configure maglev consistent hashing

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1602,9 +1602,18 @@ localRedirectPolicy: false
 # To include or exclude matched resources from cilium identity evaluation
 # labels: ""
 
-# logOptions allows you to define logging options. eg:
-# logOptions:
-#   format: json
+# -- (string) Define logging options.
+# These options can also be set as json key value pairs, for example "level=warn,format=(text|json|json-ts),syslog.facility=local4,syslog.severity=info,syslog.tag=cilium"
+logOptions:
+  level: "info"
+  format: "text"
+  # -- specify syslog options to enable syslog logging
+  # syslog:
+    # facility: "kernel"
+    # -- "severity" mirrors logOptions.level by default
+    # severity: "info"
+    # address: ""
+    # tag: ""
 
 # -- Enables periodic logging of system load
 logSystemLoad: false


### PR DESCRIPTION
Cilium supports overriding default log options, but the default and allowed values for this configuration are undocumented. This PR attempts to provide a structure and specify the defaults for logging options. I have included the json structure only; cilium also supports key/value pairs, but I don't see how it's possible to have both options in the docs effectively -- potentially one reason they were not included to begin with.

Comments/suggestions welcome. I tried to detail the breadth of options as best I could without getting too granular.

Fixes: https://github.com/cilium/cilium/issues/5578

```release-note
Document Cilium's logOptions and overrides
```
