### PR TITLE
datapath/fake: Move commonly imported types to fake/types package

### DIFF
--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
-	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/hive/hivetest"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -73,7 +73,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	clusterName2 := s.randomName + "2"
 
 	kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName)
-	s.svcCache = k8s.NewServiceCache(fakeDatapath.NewNodeAddressing())
+	s.svcCache = k8s.NewServiceCache(fakeTypes.NewNodeAddressing())
 
 	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -9,6 +9,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -47,7 +48,7 @@ var Cell = cell.Module(
 		func() *iptables.Manager { return &iptables.Manager{} },
 		func() types.BandwidthManager { return &BandwidthManager{} },
 		func() types.IPsecKeyCustodian { return &ipsecKeyCustodian{} },
-		func() mtu.MTU { return &MTU{} },
+		func() mtu.MTU { return &fakeTypes.MTU{} },
 
 		tables.NewDeviceTable,
 		tables.NewL2AnnounceTable, statedb.RWTable[*tables.L2AnnounceEntry].ToTable,

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -79,8 +79,8 @@ func fakeDevices(db *statedb.DB, devices statedb.RWTable[*tables.Device]) stated
 		HardwareAddr: []byte{1, 2, 3, 4, 5, 6},
 		Flags:        net.FlagUp,
 		Addrs: []tables.DeviceAddress{
-			{Addr: ip.MustAddrFromIP(IPv4NodePortAddress), Scope: unix.RT_SCOPE_UNIVERSE},
-			{Addr: ip.MustAddrFromIP(IPv6NodePortAddress), Scope: unix.RT_SCOPE_UNIVERSE},
+			{Addr: ip.MustAddrFromIP(fakeTypes.IPv4NodePortAddress), Scope: unix.RT_SCOPE_UNIVERSE},
+			{Addr: ip.MustAddrFromIP(fakeTypes.IPv6NodePortAddress), Scope: unix.RT_SCOPE_UNIVERSE},
 		},
 		Type:     "test",
 		Selected: true,
@@ -93,8 +93,8 @@ func fakeDevices(db *statedb.DB, devices statedb.RWTable[*tables.Device]) stated
 		HardwareAddr: []byte{2, 3, 4, 5, 6, 7},
 		Flags:        net.FlagUp,
 		Addrs: []tables.DeviceAddress{
-			{Addr: ip.MustAddrFromIP(IPv4InternalAddress), Scope: unix.RT_SCOPE_UNIVERSE},
-			{Addr: ip.MustAddrFromIP(IPv6InternalAddress), Scope: unix.RT_SCOPE_UNIVERSE},
+			{Addr: ip.MustAddrFromIP(fakeTypes.IPv4InternalAddress), Scope: unix.RT_SCOPE_UNIVERSE},
+			{Addr: ip.MustAddrFromIP(fakeTypes.IPv6InternalAddress), Scope: unix.RT_SCOPE_UNIVERSE},
 
 			{Addr: netip.MustParseAddr("10.0.0.4"), Scope: unix.RT_SCOPE_UNIVERSE, Secondary: true},
 			{Addr: netip.MustParseAddr("f00d::3"), Scope: unix.RT_SCOPE_UNIVERSE, Secondary: true},

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -36,8 +36,8 @@ var Cell = cell.Module(
 	"Fake Datapath",
 
 	cell.Provide(
-		func(na types.NodeAddressing) (*FakeDatapath, types.Datapath, types.NodeIDHandler) {
-			dp := newDatapath(na)
+		func(na types.NodeAddressing) (*fakeTypes.FakeDatapath, types.Datapath, types.NodeIDHandler) {
+			dp := fakeTypes.NewDatapathWithNodeAddressing(na)
 			return dp, dp, dp.NodeIDs()
 		},
 

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -46,7 +46,7 @@ var Cell = cell.Module(
 		func() egressmap.PolicyMap { return nil },
 		func() *bigtcp.Configuration { return &bigtcp.Configuration{} },
 		func() *iptables.Manager { return &iptables.Manager{} },
-		func() types.BandwidthManager { return &BandwidthManager{} },
+		func() types.BandwidthManager { return &fakeTypes.BandwidthManager{} },
 		func() types.IPsecKeyCustodian { return &ipsecKeyCustodian{} },
 		func() mtu.MTU { return &fakeTypes.MTU{} },
 

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -16,7 +17,7 @@ import (
 var _ datapath.Datapath = (*FakeDatapath)(nil)
 
 type FakeDatapath struct {
-	node           *FakeNodeHandler
+	node           *types.FakeNodeHandler
 	nodeAddressing datapath.NodeAddressing
 	loader         datapath.Loader
 	lbmap          *mockmaps.LBMockMap
@@ -29,7 +30,7 @@ func NewDatapath() *FakeDatapath {
 
 func newDatapath(na datapath.NodeAddressing) *FakeDatapath {
 	return &FakeDatapath{
-		node:           NewNodeHandler(),
+		node:           types.NewNodeHandler(),
 		nodeAddressing: na,
 		loader:         &fakeLoader{},
 		lbmap:          mockmaps.NewLBMockMap(),
@@ -49,7 +50,7 @@ func (f *FakeDatapath) NodeNeighbors() datapath.NodeNeighbors {
 	return f.node
 }
 
-func (f *FakeDatapath) FakeNode() *FakeNodeHandler {
+func (f *FakeDatapath) FakeNode() *types.FakeNodeHandler {
 	return f.node
 }
 

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -125,7 +125,7 @@ func (f *FakeDatapath) LBMockMap() *mockmaps.LBMockMap {
 }
 
 func (f *FakeDatapath) BandwidthManager() datapath.BandwidthManager {
-	return &BandwidthManager{}
+	return &fakeTypes.BandwidthManager{}
 }
 
 // Loader is an interface to abstract out loading of datapath programs.

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/cilium/cilium/pkg/datapath/fake/types"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -17,7 +17,7 @@ import (
 var _ datapath.Datapath = (*FakeDatapath)(nil)
 
 type FakeDatapath struct {
-	node           *types.FakeNodeHandler
+	node           *fakeTypes.FakeNodeHandler
 	nodeAddressing datapath.NodeAddressing
 	loader         datapath.Loader
 	lbmap          *mockmaps.LBMockMap
@@ -25,12 +25,12 @@ type FakeDatapath struct {
 
 // NewDatapath returns a new fake datapath
 func NewDatapath() *FakeDatapath {
-	return newDatapath(NewNodeAddressing())
+	return newDatapath(fakeTypes.NewNodeAddressing())
 }
 
 func newDatapath(na datapath.NodeAddressing) *FakeDatapath {
 	return &FakeDatapath{
-		node:           types.NewNodeHandler(),
+		node:           fakeTypes.NewNodeHandler(),
 		nodeAddressing: na,
 		loader:         &fakeLoader{},
 		lbmap:          mockmaps.NewLBMockMap(),
@@ -50,7 +50,7 @@ func (f *FakeDatapath) NodeNeighbors() datapath.NodeNeighbors {
 	return f.node
 }
 
-func (f *FakeDatapath) FakeNode() *types.FakeNodeHandler {
+func (f *FakeDatapath) FakeNode() *fakeTypes.FakeNodeHandler {
 	return f.node
 }
 

--- a/pkg/datapath/fake/types/bandwidth.go
+++ b/pkg/datapath/fake/types/bandwidth.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package fake
+package types
 
 import "github.com/cilium/cilium/pkg/datapath/types"
 

--- a/pkg/datapath/fake/types/datapath.go
+++ b/pkg/datapath/fake/types/datapath.go
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package fake
+package types
 
 import (
 	"context"
 	"io"
 
-	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -17,7 +16,7 @@ import (
 var _ datapath.Datapath = (*FakeDatapath)(nil)
 
 type FakeDatapath struct {
-	node           *fakeTypes.FakeNodeHandler
+	node           *FakeNodeHandler
 	nodeAddressing datapath.NodeAddressing
 	loader         datapath.Loader
 	lbmap          *mockmaps.LBMockMap
@@ -25,12 +24,12 @@ type FakeDatapath struct {
 
 // NewDatapath returns a new fake datapath
 func NewDatapath() *FakeDatapath {
-	return newDatapath(fakeTypes.NewNodeAddressing())
+	return NewDatapathWithNodeAddressing(NewNodeAddressing())
 }
 
-func newDatapath(na datapath.NodeAddressing) *FakeDatapath {
+func NewDatapathWithNodeAddressing(na datapath.NodeAddressing) *FakeDatapath {
 	return &FakeDatapath{
-		node:           fakeTypes.NewNodeHandler(),
+		node:           NewNodeHandler(),
 		nodeAddressing: na,
 		loader:         &fakeLoader{},
 		lbmap:          mockmaps.NewLBMockMap(),
@@ -50,7 +49,7 @@ func (f *FakeDatapath) NodeNeighbors() datapath.NodeNeighbors {
 	return f.node
 }
 
-func (f *FakeDatapath) FakeNode() *fakeTypes.FakeNodeHandler {
+func (f *FakeDatapath) FakeNode() *FakeNodeHandler {
 	return f.node
 }
 
@@ -125,7 +124,7 @@ func (f *FakeDatapath) LBMockMap() *mockmaps.LBMockMap {
 }
 
 func (f *FakeDatapath) BandwidthManager() datapath.BandwidthManager {
-	return &fakeTypes.BandwidthManager{}
+	return &BandwidthManager{}
 }
 
 // Loader is an interface to abstract out loading of datapath programs.

--- a/pkg/datapath/fake/types/datapath_test.go
+++ b/pkg/datapath/fake/types/datapath_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package fake
+package types
 
 import (
 	"testing"

--- a/pkg/datapath/fake/types/mtu.go
+++ b/pkg/datapath/fake/types/mtu.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package fake
+package types
 
 import "github.com/cilium/cilium/pkg/mtu"
 

--- a/pkg/datapath/fake/types/node.go
+++ b/pkg/datapath/fake/types/node.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package fake
+package types
 
 import (
 	"context"

--- a/pkg/datapath/fake/types/node_addressing.go
+++ b/pkg/datapath/fake/types/node_addressing.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package fake
+package types
 
 import (
 	"net"

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/cilium/ebpf/rlimit"
 
-	"github.com/cilium/cilium/pkg/datapath/fake"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	dpdef "github.com/cilium/cilium/pkg/datapath/linux/config/defines"
 	"github.com/cilium/cilium/pkg/datapath/loader"
@@ -102,7 +101,7 @@ func writeConfig(c *C, header string, write writeFn) {
 		h := hive.New(
 			cell.Provide(
 				fakeTypes.NewNodeAddressing,
-				func() datapath.BandwidthManager { return &fake.BandwidthManager{} },
+				func() datapath.BandwidthManager { return &fakeTypes.BandwidthManager{} },
 				NewHeaderfileWriter,
 			),
 			cell.Invoke(func(writer_ datapath.ConfigWriter) {
@@ -384,7 +383,7 @@ func TestWriteNodeConfigExtraDefines(t *testing.T) {
 		NodeExtraDefineFns: []dpdef.Fn{
 			func() (dpdef.Map, error) { return nil, errors.New("failing on purpose") },
 		},
-		BandwidthManager: &fake.BandwidthManager{},
+		BandwidthManager: &fakeTypes.BandwidthManager{},
 	})
 	require.NoError(t, err)
 
@@ -399,7 +398,7 @@ func TestWriteNodeConfigExtraDefines(t *testing.T) {
 			func() (dpdef.Map, error) { return dpdef.Map{"FOO": "0x1", "BAR": "0x2"}, nil },
 			func() (dpdef.Map, error) { return dpdef.Map{"FOO": "0x3"}, nil },
 		},
-		BandwidthManager: &fake.BandwidthManager{},
+		BandwidthManager: &fakeTypes.BandwidthManager{},
 	})
 	require.NoError(t, err)
 
@@ -418,7 +417,7 @@ func TestNewHeaderfileWriter(t *testing.T) {
 		NodeAddressing:     fakeTypes.NewNodeAddressing(),
 		NodeExtraDefines:   []dpdef.Map{a, a},
 		NodeExtraDefineFns: nil,
-		BandwidthManager:   &fake.BandwidthManager{},
+		BandwidthManager:   &fakeTypes.BandwidthManager{},
 	})
 
 	require.Error(t, err, "duplicate keys should be rejected")
@@ -427,7 +426,7 @@ func TestNewHeaderfileWriter(t *testing.T) {
 		NodeAddressing:     fakeTypes.NewNodeAddressing(),
 		NodeExtraDefines:   []dpdef.Map{a},
 		NodeExtraDefineFns: nil,
-		BandwidthManager:   &fake.BandwidthManager{},
+		BandwidthManager:   &fakeTypes.BandwidthManager{},
 	})
 	require.NoError(t, err)
 	require.NoError(t, cfg.WriteNodeConfig(&buffer, &dummyNodeCfg))

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -101,7 +101,7 @@ func writeConfig(c *C, header string, write writeFn) {
 		c.Logf("  Testing %s configuration: %s", header, test.description)
 		h := hive.New(
 			cell.Provide(
-				fake.NewNodeAddressing,
+				fakeTypes.NewNodeAddressing,
 				func() datapath.BandwidthManager { return &fake.BandwidthManager{} },
 				NewHeaderfileWriter,
 			),
@@ -361,7 +361,7 @@ func TestWriteNodeConfigExtraDefines(t *testing.T) {
 
 	// Assert that configurations are propagated when all generated extra defines are valid
 	cfg, err := NewHeaderfileWriter(WriterParams{
-		NodeAddressing:   fake.NewNodeAddressing(),
+		NodeAddressing:   fakeTypes.NewNodeAddressing(),
 		NodeExtraDefines: nil,
 		NodeExtraDefineFns: []dpdef.Fn{
 			func() (dpdef.Map, error) { return dpdef.Map{"FOO": "0x1", "BAR": "0x2"}, nil },
@@ -379,7 +379,7 @@ func TestWriteNodeConfigExtraDefines(t *testing.T) {
 
 	// Assert that an error is returned when one extra define function returns an error
 	cfg, err = NewHeaderfileWriter(WriterParams{
-		NodeAddressing:   fake.NewNodeAddressing(),
+		NodeAddressing:   fakeTypes.NewNodeAddressing(),
 		NodeExtraDefines: nil,
 		NodeExtraDefineFns: []dpdef.Fn{
 			func() (dpdef.Map, error) { return nil, errors.New("failing on purpose") },
@@ -393,7 +393,7 @@ func TestWriteNodeConfigExtraDefines(t *testing.T) {
 
 	// Assert that an error is returned when one extra define would overwrite an already existing entry
 	cfg, err = NewHeaderfileWriter(WriterParams{
-		NodeAddressing:   fake.NewNodeAddressing(),
+		NodeAddressing:   fakeTypes.NewNodeAddressing(),
 		NodeExtraDefines: nil,
 		NodeExtraDefineFns: []dpdef.Fn{
 			func() (dpdef.Map, error) { return dpdef.Map{"FOO": "0x1", "BAR": "0x2"}, nil },
@@ -415,7 +415,7 @@ func TestNewHeaderfileWriter(t *testing.T) {
 	var buffer bytes.Buffer
 
 	_, err := NewHeaderfileWriter(WriterParams{
-		NodeAddressing:     fake.NewNodeAddressing(),
+		NodeAddressing:     fakeTypes.NewNodeAddressing(),
 		NodeExtraDefines:   []dpdef.Map{a, a},
 		NodeExtraDefineFns: nil,
 		BandwidthManager:   &fake.BandwidthManager{},
@@ -424,7 +424,7 @@ func TestNewHeaderfileWriter(t *testing.T) {
 	require.Error(t, err, "duplicate keys should be rejected")
 
 	cfg, err := NewHeaderfileWriter(WriterParams{
-		NodeAddressing:     fake.NewNodeAddressing(),
+		NodeAddressing:     fakeTypes.NewNodeAddressing(),
 		NodeExtraDefines:   []dpdef.Map{a},
 		NodeExtraDefineFns: nil,
 		BandwidthManager:   &fake.BandwidthManager{},

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 
 	"github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	dpdef "github.com/cilium/cilium/pkg/datapath/linux/config/defines"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -40,7 +41,7 @@ var (
 	_ = Suite(&ConfigSuite{})
 
 	dummyNodeCfg = datapath.LocalNodeConfiguration{
-		MtuConfig: &fake.MTU{},
+		MtuConfig: &fakeTypes.MTU{},
 	}
 	dummyDevCfg   = testutils.NewTestEndpoint()
 	dummyEPCfg    = testutils.NewTestEndpoint()

--- a/pkg/datapath/linux/fuzz_test.go
+++ b/pkg/datapath/linux/fuzz_test.go
@@ -9,7 +9,6 @@ import (
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 
-	"github.com/cilium/cilium/pkg/datapath/fake"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
@@ -23,7 +22,7 @@ func FuzzNodeHandler(f *testing.F) {
 			t.Skip()
 		}
 		dpConfig := DatapathConfiguration{HostDevice: "veth0"}
-		fakeNodeAddressing := fake.NewNodeAddressing()
+		fakeNodeAddressing := fakeTypes.NewNodeAddressing()
 		linuxNodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil, &fakeTypes.MTU{})
 		if linuxNodeHandler == nil {
 			panic("Should not be nil")

--- a/pkg/datapath/linux/fuzz_test.go
+++ b/pkg/datapath/linux/fuzz_test.go
@@ -10,6 +10,7 @@ import (
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 
 	"github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
 
@@ -23,7 +24,7 @@ func FuzzNodeHandler(f *testing.F) {
 		}
 		dpConfig := DatapathConfiguration{HostDevice: "veth0"}
 		fakeNodeAddressing := fake.NewNodeAddressing()
-		linuxNodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil, &fake.MTU{})
+		linuxNodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil, &fakeTypes.MTU{})
 		if linuxNodeHandler == nil {
 			panic("Should not be nil")
 		}

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/cidr"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -123,17 +123,17 @@ func (s *linuxPrivilegedBaseTestSuite) SetUpTest(c *check.C, addressing datapath
 }
 
 func (s *linuxPrivilegedIPv6OnlyTestSuite) SetUpTest(c *check.C) {
-	addressing := fake.NewIPv6OnlyNodeAddressing()
+	addressing := fakeTypes.NewIPv6OnlyNodeAddressing()
 	s.linuxPrivilegedBaseTestSuite.SetUpTest(c, addressing, true, false)
 }
 
 func (s *linuxPrivilegedIPv4OnlyTestSuite) SetUpTest(c *check.C) {
-	addressing := fake.NewIPv4OnlyNodeAddressing()
+	addressing := fakeTypes.NewIPv4OnlyNodeAddressing()
 	s.linuxPrivilegedBaseTestSuite.SetUpTest(c, addressing, false, true)
 }
 
 func (s *linuxPrivilegedIPv4AndIPv6TestSuite) SetUpTest(c *check.C) {
-	addressing := fake.NewNodeAddressing()
+	addressing := fakeTypes.NewNodeAddressing()
 	s.linuxPrivilegedBaseTestSuite.SetUpTest(c, addressing, true, true)
 }
 

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/cidr"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -32,7 +32,7 @@ var (
 		nodeConfig: datapath.LocalNodeConfiguration{
 			MtuConfig: &mtuConfig,
 		},
-		nodeAddressing: fake.NewNodeAddressing(),
+		nodeAddressing: fakeTypes.NewNodeAddressing(),
 		datapathConfig: DatapathConfiguration{
 			HostDevice: "host_device",
 		},
@@ -76,7 +76,7 @@ func (s *linuxTestSuite) TestCreateNodeRoute(c *check.C) {
 		HostDevice: "host_device",
 	}
 
-	fakeNodeAddressing := fake.NewNodeAddressing()
+	fakeNodeAddressing := fakeTypes.NewNodeAddressing()
 
 	nodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil, &mtuConfig)
 

--- a/pkg/datapath/loader/hash_test.go
+++ b/pkg/datapath/loader/hash_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/datapath/fake"
+	"github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/hive"
@@ -19,7 +20,7 @@ import (
 
 var (
 	dummyNodeCfg = datapath.LocalNodeConfiguration{
-		MtuConfig: &fake.MTU{},
+		MtuConfig: &types.MTU{},
 	}
 	dummyDevCfg = testutils.NewTestEndpoint()
 	dummyEPCfg  = testutils.NewTestEndpoint()

--- a/pkg/datapath/loader/hash_test.go
+++ b/pkg/datapath/loader/hash_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/datapath/fake"
-	"github.com/cilium/cilium/pkg/datapath/fake/types"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/hive"
@@ -20,7 +20,7 @@ import (
 
 var (
 	dummyNodeCfg = datapath.LocalNodeConfiguration{
-		MtuConfig: &types.MTU{},
+		MtuConfig: &fakeTypes.MTU{},
 	}
 	dummyDevCfg = testutils.NewTestEndpoint()
 	dummyEPCfg  = testutils.NewTestEndpoint()
@@ -32,7 +32,7 @@ func (s *LoaderTestSuite) TesthashDatapath(c *C) {
 	var cfg datapath.ConfigWriter
 	hv := hive.New(
 		cell.Provide(
-			fake.NewNodeAddressing,
+			fakeTypes.NewNodeAddressing,
 			func() datapath.BandwidthManager { return &fake.BandwidthManager{} },
 			config.NewHeaderfileWriter,
 		),

--- a/pkg/datapath/loader/hash_test.go
+++ b/pkg/datapath/loader/hash_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/cilium/checkmate"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/datapath/fake"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -33,7 +32,7 @@ func (s *LoaderTestSuite) TesthashDatapath(c *C) {
 	hv := hive.New(
 		cell.Provide(
 			fakeTypes.NewNodeAddressing,
-			func() datapath.BandwidthManager { return &fake.BandwidthManager{} },
+			func() datapath.BandwidthManager { return &fakeTypes.BandwidthManager{} },
 			config.NewHeaderfileWriter,
 		),
 		cell.Invoke(func(writer_ datapath.ConfigWriter) {

--- a/pkg/datapath/maps/map_test.go
+++ b/pkg/datapath/maps/map_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/cilium/checkmate"
 
 	"github.com/cilium/cilium/pkg/checker"
-	"github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/types"
 )
 
@@ -60,7 +60,7 @@ func newTestEPManager() *testEPManager {
 }
 
 func newTestBWManager() types.BandwidthManager {
-	return &fake.BandwidthManager{}
+	return &fakeTypes.BandwidthManager{}
 }
 
 func (s *MapTestSuite) TestCollectStaleMapGarbage(c *C) {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/cilium/checkmate"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/eventqueue"
@@ -662,7 +662,7 @@ func (s *EndpointSuite) TestEndpointEventQueueDeadlockUponStop(c *C) {
 
 	oldDatapath := s.datapath
 
-	s.datapath = fake.NewDatapath()
+	s.datapath = fakeTypes.NewDatapath()
 
 	defer func() {
 		s.datapath = oldDatapath

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -11,7 +11,7 @@ import (
 
 	. "github.com/cilium/checkmate"
 
-	"github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/mtu"
@@ -41,7 +41,7 @@ func (rm *resourceMock) Store(context.Context) (resource.Store[*ciliumv2.CiliumN
 var mtuMock = mtu.NewConfiguration(0, false, false, false, false, 1500, nil)
 
 func (s *IPAMSuite) TestAllocatedIPDump(c *C) {
-	fakeAddressing := fake.NewNodeAddressing()
+	fakeAddressing := fakeTypes.NewNodeAddressing()
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
 	allocv4, allocv6, status := ipam.Dump()
@@ -60,7 +60,7 @@ func (s *IPAMSuite) TestExpirationTimer(c *C) {
 	ip := net.ParseIP("1.1.1.1")
 	timeout := 50 * time.Millisecond
 
-	fakeAddressing := fake.NewNodeAddressing()
+	fakeAddressing := fakeTypes.NewNodeAddressing()
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
 	err := ipam.AllocateIP(ip, "foo", PoolDefault())
@@ -125,7 +125,7 @@ func (s *IPAMSuite) TestExpirationTimer(c *C) {
 func (s *IPAMSuite) TestAllocateNextWithExpiration(c *C) {
 	timeout := 50 * time.Millisecond
 
-	fakeAddressing := fake.NewNodeAddressing()
+	fakeAddressing := fakeTypes.NewNodeAddressing()
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
 	// Allocate IPs and test expiration timer. 'pool' is empty in order to test

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/pkg/checker"
-	"github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/option"
@@ -91,7 +91,7 @@ func (s *IPAMSuite) TestMarkForReleaseNoAllocate(c *C) {
 		cn.Spec.IPAM.Pool[fmt.Sprintf("1.1.1.%d", i)] = dummyResource
 	}
 
-	fakeAddressing := fake.NewNodeAddressing()
+	fakeAddressing := fakeTypes.NewNodeAddressing()
 	conf := testConfigurationCRD
 	initNodeStore.Do(func() {
 		sharedNodeStore = newFakeNodeStore(conf, c)

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/cilium/checkmate"
 
 	"github.com/cilium/cilium/pkg/checker"
-	"github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/option"
@@ -128,7 +128,7 @@ func (f fakePoolAllocator) Capacity() uint64 {
 func (f fakePoolAllocator) RestoreFinished() {}
 
 func (s *IPAMSuite) TestLock(c *C) {
-	fakeAddressing := fake.NewNodeAddressing()
+	fakeAddressing := fakeTypes.NewNodeAddressing()
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
 	// Since the IPs we have allocated to the endpoints might or might not
@@ -150,7 +150,7 @@ func (s *IPAMSuite) TestLock(c *C) {
 }
 
 func (s *IPAMSuite) TestExcludeIP(c *C) {
-	fakeAddressing := fake.NewNodeAddressing()
+	fakeAddressing := fakeTypes.NewNodeAddressing()
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
@@ -181,7 +181,7 @@ func (s *IPAMSuite) TestDeriveFamily(c *C) {
 }
 
 func (s *IPAMSuite) TestIPAMMetadata(c *C) {
-	fakeAddressing := fake.NewNodeAddressing()
+	fakeAddressing := fakeTypes.NewNodeAddressing()
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 	ipam.IPv4Allocator = newFakePoolAllocator(map[string]string{
 		"default": "10.10.0.0/16",
@@ -258,7 +258,7 @@ func (s *IPAMSuite) TestLegacyAllocatorIPAMMetadata(c *C) {
 	// IPAM pools. We assert that in this scenario, the pool returned in the
 	// AllocationResult is always set to PoolDefault(), regardless of the requested
 	// pool
-	fakeAddressing := fake.NewNodeAddressing()
+	fakeAddressing := fakeTypes.NewNodeAddressing()
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 	ipam.WithMetadata(fakeMetadataFunc(func(owner string, family Family) (pool string, err error) {
 		return "some-pool", nil

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/checker"
-	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -901,7 +901,7 @@ func (s *K8sSuite) Test_EqualV1Service(c *C) {
 		},
 	}
 	for _, tt := range tests {
-		got := EqualV1Services(tt.args.o1, tt.args.o2, fakeDatapath.NewNodeAddressing())
+		got := EqualV1Services(tt.args.o1, tt.args.o2, fakeTypes.NewNodeAddressing())
 		c.Assert(got, Equals, tt.want, Commentf("Test Name: %s", tt.name))
 	}
 }

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/policy"
@@ -489,7 +489,7 @@ func (s *K8sSuite) TestPreprocessRules(c *C) {
 
 	epAddrCluster := cmtypes.MustParseAddrCluster("10.1.1.1")
 
-	cache := NewServiceCache(fakeDatapath.NewNodeAddressing())
+	cache := NewServiceCache(fakeTypes.NewNodeAddressing())
 
 	endpointInfo := Endpoints{
 		Backends: map[cmtypes.AddrCluster]*Backend{

--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/hive/hivetest"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_discovery_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
@@ -44,7 +44,7 @@ func (s *K8sSuite) TestGetUniqueServiceFrontends(c *check.C) {
 		},
 	}
 
-	cache := NewServiceCache(fakeDatapath.NewNodeAddressing())
+	cache := NewServiceCache(fakeTypes.NewNodeAddressing())
 	cache.services = map[ServiceID]*Service{
 		svcID1: {
 			FrontendIPs: []net.IP{net.ParseIP("1.1.1.1")},
@@ -188,7 +188,7 @@ func (s *K8sSuite) TestServiceCacheEndpointSlice(c *check.C) {
 func testServiceCache(c *check.C,
 	updateEndpointsCB, deleteEndpointsCB func(svcCache *ServiceCache, swgEps *lock.StoppableWaitGroup)) {
 
-	svcCache := NewServiceCache(fakeDatapath.NewNodeAddressing())
+	svcCache := NewServiceCache(fakeTypes.NewNodeAddressing())
 
 	k8sSvc := &slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -333,7 +333,7 @@ func (s *K8sSuite) TestCacheActionString(c *check.C) {
 func (s *K8sSuite) TestServiceMutators(c *check.C) {
 	var m1, m2 int
 
-	svcCache := NewServiceCache(fakeDatapath.NewNodeAddressing())
+	svcCache := NewServiceCache(fakeTypes.NewNodeAddressing())
 	svcCache.ServiceMutators = append(svcCache.ServiceMutators,
 		func(svc *slim_corev1.Service, svcInfo *Service) { m1++ },
 		func(svc *slim_corev1.Service, svcInfo *Service) { m2++ },
@@ -354,7 +354,7 @@ func (s *K8sSuite) TestServiceMutators(c *check.C) {
 }
 
 func (s *K8sSuite) TestExternalServiceMerging(c *check.C) {
-	svcCache := NewServiceCache(fakeDatapath.NewNodeAddressing())
+	svcCache := NewServiceCache(fakeTypes.NewNodeAddressing())
 
 	k8sSvc := &slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -716,7 +716,7 @@ func (s *K8sSuite) TestExternalServiceDeletion(c *check.C) {
 	id2 := ServiceID{Cluster: cluster, Namespace: "bar", Name: "foo"}
 
 	swg := lock.NewStoppableWaitGroup()
-	svcCache := NewServiceCache(fakeDatapath.NewNodeAddressing())
+	svcCache := NewServiceCache(fakeTypes.NewNodeAddressing())
 
 	// Store the service with the non-cluster-aware ID
 	svcCache.services[id1] = &svc
@@ -776,7 +776,7 @@ func (s *K8sSuite) TestExternalServiceDeletion(c *check.C) {
 }
 
 func (s *K8sSuite) TestClusterServiceMerging(c *check.C) {
-	svcCache := NewServiceCache(fakeDatapath.NewNodeAddressing())
+	svcCache := NewServiceCache(fakeTypes.NewNodeAddressing())
 	swgSvcs := lock.NewStoppableWaitGroup()
 	swgEps := lock.NewStoppableWaitGroup()
 
@@ -844,7 +844,7 @@ func (s *K8sSuite) TestClusterServiceMerging(c *check.C) {
 }
 
 func (s *K8sSuite) TestNonSharedService(c *check.C) {
-	svcCache := NewServiceCache(fakeDatapath.NewNodeAddressing())
+	svcCache := NewServiceCache(fakeTypes.NewNodeAddressing())
 
 	k8sSvc := &slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -968,7 +968,7 @@ func (s *K8sSuite) TestServiceCacheWith2EndpointSlice(c *check.C) {
 		},
 	})
 
-	svcCache := NewServiceCache(fakeDatapath.NewNodeAddressing())
+	svcCache := NewServiceCache(fakeTypes.NewNodeAddressing())
 
 	k8sSvc := &slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -1186,7 +1186,7 @@ func (s *K8sSuite) TestServiceCacheWith2EndpointSliceSameAddress(c *check.C) {
 		},
 	})
 
-	svcCache := NewServiceCache(fakeDatapath.NewNodeAddressing())
+	svcCache := NewServiceCache(fakeTypes.NewNodeAddressing())
 
 	k8sSvc := &slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -1399,7 +1399,7 @@ func (s *K8sSuite) TestServiceEndpointFiltering(c *check.C) {
 	store := node.NewTestLocalNodeStore(node.LocalNode{Node: types.Node{
 		Labels: map[string]string{v1.LabelTopologyZone: "test-zone-2"},
 	}})
-	svcCache := newServiceCache(hivetest.Lifecycle(c), fakeDatapath.NewNodeAddressing(),
+	svcCache := newServiceCache(hivetest.Lifecycle(c), fakeTypes.NewNodeAddressing(),
 		ServiceCacheConfig{EnableServiceTopology: true}, store)
 
 	swg := lock.NewStoppableWaitGroup()

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/cidr"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/loadbalancer"
@@ -191,7 +191,7 @@ func (s *K8sSuite) TestParseService(c *check.C) {
 		},
 	}
 
-	id, svc := ParseService(k8sSvc, fakeDatapath.NewNodeAddressing())
+	id, svc := ParseService(k8sSvc, fakeTypes.NewNodeAddressing())
 	c.Assert(id, checker.DeepEquals, ServiceID{Namespace: "bar", Name: "foo"})
 	c.Assert(svc, checker.DeepEquals, &Service{
 		ExtTrafficPolicy:         loadbalancer.SVCTrafficPolicyCluster,
@@ -213,7 +213,7 @@ func (s *K8sSuite) TestParseService(c *check.C) {
 		},
 	}
 
-	id, svc = ParseService(k8sSvc, fakeDatapath.NewNodeAddressing())
+	id, svc = ParseService(k8sSvc, fakeTypes.NewNodeAddressing())
 	c.Assert(id, checker.DeepEquals, ServiceID{Namespace: "bar", Name: "foo"})
 	c.Assert(svc, checker.DeepEquals, &Service{
 		IsHeadless:               true,
@@ -237,7 +237,7 @@ func (s *K8sSuite) TestParseService(c *check.C) {
 		},
 	}
 
-	id, svc = ParseService(k8sSvc, fakeDatapath.NewNodeAddressing())
+	id, svc = ParseService(k8sSvc, fakeTypes.NewNodeAddressing())
 	c.Assert(id, checker.DeepEquals, ServiceID{Namespace: "bar", Name: "foo"})
 	c.Assert(svc, checker.DeepEquals, &Service{
 		FrontendIPs:              []net.IP{net.ParseIP("127.0.0.1")},
@@ -282,8 +282,8 @@ func (s *K8sSuite) TestParseService(c *check.C) {
 	}
 
 	ipv4ZeroAddrCluster := cmtypes.MustParseAddrCluster("0.0.0.0")
-	ipv4InternalAddrCluster := cmtypes.MustAddrClusterFromIP(fakeDatapath.IPv4InternalAddress)
-	ipv4NodePortAddrCluster := cmtypes.MustAddrClusterFromIP(fakeDatapath.IPv4NodePortAddress)
+	ipv4InternalAddrCluster := cmtypes.MustAddrClusterFromIP(fakeTypes.IPv4InternalAddress)
+	ipv4NodePortAddrCluster := cmtypes.MustAddrClusterFromIP(fakeTypes.IPv4NodePortAddress)
 
 	lbID := loadbalancer.ID(0)
 	tcpProto := loadbalancer.L4Type(slim_corev1.ProtocolTCP)
@@ -294,7 +294,7 @@ func (s *K8sSuite) TestParseService(c *check.C) {
 	nodePortFE := loadbalancer.NewL3n4AddrID(tcpProto, ipv4NodePortAddrCluster, 31111,
 		loadbalancer.ScopeExternal, lbID)
 
-	id, svc = ParseService(k8sSvc, fakeDatapath.NewIPv4OnlyNodeAddressing())
+	id, svc = ParseService(k8sSvc, fakeTypes.NewIPv4OnlyNodeAddressing())
 	c.Assert(id, checker.DeepEquals, ServiceID{Namespace: "bar", Name: "foo"})
 	c.Assert(svc, checker.DeepEquals, &Service{
 		FrontendIPs: []net.IP{net.ParseIP("127.0.0.1")},
@@ -968,7 +968,7 @@ func (s *K8sSuite) TestServiceString(c *check.C) {
 		},
 	}
 
-	nodeAddressing := fakeDatapath.NewNodeAddressing()
+	nodeAddressing := fakeTypes.NewNodeAddressing()
 	for _, tt := range tests {
 		_, svc := ParseService(tt.service, nodeAddressing)
 		c.Assert(svc.String(), check.Equals, tt.svcString)
@@ -992,7 +992,7 @@ func (s *K8sSuite) TestNewClusterService(c *check.C) {
 				},
 				Type: slim_corev1.ServiceTypeClusterIP,
 			},
-		}, fakeDatapath.NewNodeAddressing())
+		}, fakeTypes.NewNodeAddressing())
 
 	endpoints := ParseEndpoints(&slim_corev1.Endpoints{
 		ObjectMeta: slim_metav1.ObjectMeta{

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -814,8 +815,8 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		},
 	}
 
-	ipv4NodePortAddrCluster := cmtypes.MustAddrClusterFromIP(fakeDatapath.IPv4NodePortAddress)
-	ipv4InternalAddrCluster := cmtypes.MustAddrClusterFromIP(fakeDatapath.IPv4InternalAddress)
+	ipv4NodePortAddrCluster := cmtypes.MustAddrClusterFromIP(fakeTypes.IPv4NodePortAddress)
+	ipv4InternalAddrCluster := cmtypes.MustAddrClusterFromIP(fakeTypes.IPv4InternalAddress)
 
 	nodePortIPs1 := []*loadbalancer.L3n4AddrID{
 		loadbalancer.NewL3n4AddrID(loadbalancer.UDP, cmtypes.MustParseAddrCluster("0.0.0.0"), 18080, loadbalancer.ScopeExternal, 0),
@@ -1255,8 +1256,8 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 
 	clusterIP1 := loadbalancer.NewL3n4AddrID(loadbalancer.UDP, cmtypes.MustParseAddrCluster("172.0.20.1"), 80, loadbalancer.ScopeExternal, 0)
 	clusterIP2 := loadbalancer.NewL3n4AddrID(loadbalancer.TCP, cmtypes.MustParseAddrCluster("172.0.20.1"), 81, loadbalancer.ScopeExternal, 0)
-	ipv4NodePortAddrCluster := cmtypes.MustAddrClusterFromIP(fakeDatapath.IPv4NodePortAddress)
-	ipv4InternalAddrCluster := cmtypes.MustAddrClusterFromIP(fakeDatapath.IPv4InternalAddress)
+	ipv4NodePortAddrCluster := cmtypes.MustAddrClusterFromIP(fakeTypes.IPv4NodePortAddress)
+	ipv4InternalAddrCluster := cmtypes.MustAddrClusterFromIP(fakeTypes.IPv4InternalAddress)
 
 	nodePortIPs1 := []*loadbalancer.L3n4AddrID{
 		loadbalancer.NewL3n4AddrID(loadbalancer.UDP, cmtypes.MustParseAddrCluster("0.0.0.0"), 18080, loadbalancer.ScopeExternal, 0),
@@ -1560,8 +1561,8 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 
 	clusterIP1 := loadbalancer.NewL3n4AddrID(loadbalancer.UDP, cmtypes.MustParseAddrCluster("172.0.20.1"), 80, loadbalancer.ScopeExternal, 0)
 	clusterIP2 := loadbalancer.NewL3n4AddrID(loadbalancer.TCP, cmtypes.MustParseAddrCluster("172.0.20.1"), 81, loadbalancer.ScopeExternal, 0)
-	ipv4NodePortAddrCluster := cmtypes.MustAddrClusterFromIP(fakeDatapath.IPv4NodePortAddress)
-	ipv4InternalAddrCluster := cmtypes.MustAddrClusterFromIP(fakeDatapath.IPv4InternalAddress)
+	ipv4NodePortAddrCluster := cmtypes.MustAddrClusterFromIP(fakeTypes.IPv4NodePortAddress)
+	ipv4InternalAddrCluster := cmtypes.MustAddrClusterFromIP(fakeTypes.IPv4InternalAddress)
 
 	nodePortIPs1 := []*loadbalancer.L3n4AddrID{
 		loadbalancer.NewL3n4AddrID(loadbalancer.UDP, cmtypes.MustParseAddrCluster("0.0.0.0"), 18080, loadbalancer.ScopeExternal, 0),
@@ -1997,8 +1998,8 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		}
 	}
 
-	ipv4NodePortAddrCluster := cmtypes.MustAddrClusterFromIP(fakeDatapath.IPv4NodePortAddress)
-	ipv4InternalAddrCluster := cmtypes.MustAddrClusterFromIP(fakeDatapath.IPv4InternalAddress)
+	ipv4NodePortAddrCluster := cmtypes.MustAddrClusterFromIP(fakeTypes.IPv4NodePortAddress)
+	ipv4InternalAddrCluster := cmtypes.MustAddrClusterFromIP(fakeTypes.IPv4InternalAddress)
 
 	nodePortIPs1 := []*loadbalancer.L3n4AddrID{
 		loadbalancer.NewL3n4AddrID(loadbalancer.UDP, cmtypes.MustParseAddrCluster("0.0.0.0"), 18080, loadbalancer.ScopeExternal, 0),

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -12,7 +12,6 @@ import (
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/checker"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -165,7 +164,7 @@ func (s *K8sWatcherSuite) TestUpdateToServiceEndpointsGH9525(c *C) {
 		},
 	}
 
-	dp := fakeDatapath.NewDatapath()
+	dp := fakeTypes.NewDatapath()
 	w := NewK8sWatcher(
 		nil,
 		nil,
@@ -489,7 +488,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		},
 	}
 
-	dp := fakeDatapath.NewDatapath()
+	dp := fakeTypes.NewDatapath()
 	w := NewK8sWatcher(
 		nil,
 		nil,
@@ -642,7 +641,7 @@ func (s *K8sWatcherSuite) TestChangeSVCPort(c *C) {
 		},
 	}
 
-	dp := fakeDatapath.NewDatapath()
+	dp := fakeTypes.NewDatapath()
 	w := NewK8sWatcher(
 		nil,
 		nil,
@@ -1124,7 +1123,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		},
 	}
 
-	dp := fakeDatapath.NewDatapath()
+	dp := fakeTypes.NewDatapath()
 	w := NewK8sWatcher(
 		nil,
 		nil,
@@ -1440,7 +1439,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		},
 	}
 
-	dp := fakeDatapath.NewDatapath()
+	dp := fakeTypes.NewDatapath()
 	w := NewK8sWatcher(
 		nil,
 		nil,
@@ -1749,7 +1748,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		},
 	}
 
-	dp := fakeDatapath.NewDatapath()
+	dp := fakeTypes.NewDatapath()
 	w := NewK8sWatcher(
 		nil,
 		nil,
@@ -2672,7 +2671,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		},
 	}
 
-	dp := fakeDatapath.NewDatapath()
+	dp := fakeTypes.NewDatapath()
 	w := NewK8sWatcher(
 		nil,
 		nil,

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/pkg/checker"
-	"github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/hive/cell"
@@ -393,7 +393,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 
 func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 	ipcacheMock := newIPcacheMock()
-	dp := fake.NewNodeHandler()
+	dp := fakeTypes.NewNodeHandler()
 	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), NewNodeMetrics(), cell.TestScope())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
@@ -414,7 +414,7 @@ func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 
 func (s *managerTestSuite) TestClusterSizeDependantInterval(c *check.C) {
 	ipcacheMock := newIPcacheMock()
-	dp := fake.NewNodeHandler()
+	dp := fakeTypes.NewNodeHandler()
 	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), NewNodeMetrics(), cell.TestScope())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)

--- a/test/controlplane/node/nodehandler.go
+++ b/test/controlplane/node/nodehandler.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/pkg/cidr"
-	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/test/controlplane"
 	"github.com/cilium/cilium/test/controlplane/suite"
@@ -37,7 +37,7 @@ var (
 	}
 )
 
-func validateNodes(dp *fakeDatapath.FakeDatapath) error {
+func validateNodes(dp *fakeTypes.FakeDatapath) error {
 	nodes := dp.FakeNode().Nodes
 
 	if len(nodes) != 1 {

--- a/test/controlplane/services/helpers/lbmap_validation.go
+++ b/test/controlplane/services/helpers/lbmap_validation.go
@@ -17,13 +17,13 @@ import (
 	"golang.org/x/exp/constraints"
 	"golang.org/x/exp/maps"
 
-	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/testutils/mockmaps"
 	"github.com/cilium/cilium/test/controlplane/suite"
 )
 
-func ValidateLBMapGoldenFile(file string, datapath *fakeDatapath.FakeDatapath) error {
+func ValidateLBMapGoldenFile(file string, datapath *fakeTypes.FakeDatapath) error {
 	lbmap := datapath.LBMockMap()
 	writeLBMap := func() error {
 		f, err := os.OpenFile(file, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)

--- a/test/controlplane/services/nodeport/nodeport.go
+++ b/test/controlplane/services/nodeport/nodeport.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
 	agentOption "github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/test/controlplane"
@@ -61,7 +61,7 @@ func validate(test *suite.ControlPlaneTest, goldenFile string) error {
 	return nil
 }
 
-func validateExternalTrafficPolicyLocal(dp *fake.FakeDatapath) error {
+func validateExternalTrafficPolicyLocal(dp *fakeTypes.FakeDatapath) error {
 	lbmap := dp.LBMockMap()
 	lbmap.Lock()
 	defer lbmap.Unlock()

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -13,6 +13,7 @@ import (
 	cnicell "github.com/cilium/cilium/daemon/cmd/cni"
 	fakecni "github.com/cilium/cilium/daemon/cmd/cni/fake"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	fqdnproxy "github.com/cilium/cilium/pkg/fqdn/proxy"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
@@ -33,7 +34,7 @@ type agentHandle struct {
 	t  *testing.T
 	d  *cmd.Daemon
 	p  promise.Promise[*cmd.Daemon]
-	dp *fakeDatapath.FakeDatapath
+	dp *fakeTypes.FakeDatapath
 
 	hive *hive.Hive
 }
@@ -75,7 +76,7 @@ func (h *agentHandle) setupCiliumAgentHive(clientset k8sClient.Clientset, extraC
 		metrics.Cell,
 		store.Cell,
 		cmd.ControlPlane,
-		cell.Invoke(func(p promise.Promise[*cmd.Daemon], dp *fakeDatapath.FakeDatapath) {
+		cell.Invoke(func(p promise.Promise[*cmd.Daemon], dp *fakeTypes.FakeDatapath) {
 			h.p = p
 			h.dp = dp
 		}),

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -29,7 +29,7 @@ import (
 	agentCmd "github.com/cilium/cilium/daemon/cmd"
 	operatorCmd "github.com/cilium/cilium/operator/cmd"
 	operatorOption "github.com/cilium/cilium/operator/option"
-	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/k8s/apis"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -56,7 +56,7 @@ type ControlPlaneTest struct {
 	trackers       []trackerAndDecoder
 	agentHandle    *agentHandle
 	operatorHandle *operatorHandle
-	Datapath       *fakeDatapath.FakeDatapath
+	Datapath       *fakeTypes.FakeDatapath
 }
 
 func NewControlPlaneTest(t *testing.T, nodeName string, k8sVersion string) *ControlPlaneTest {


### PR DESCRIPTION
This is a series of commits which moves various mock types from `pkg/datapath/fake` to `pkg/datapath/fake/types`. The motivation behind this change lies in the fact that `pkg/datapath/fake` serves two purposes:

1. It contains a "fake-datapath" hive cell providing various (mock) dependencies needed to run the `test/controlplane` tests. As such, the `cells.go` file defining the "fake-datapath" cell imports a lot of other Go packages.
2. It contains a few mock implementation of various datapath-related bookkeeping structures, such as `NodeHandler`, `MTU` or  `NodeAddressing`. Those are used by the "fake-datapath" cell, but also commonly used by unit tests in various packages.

This means that any package referenced by the "fake-datapath" cell (and any transitively reachable packages) cannot use any of the mock types in unit testing, as we would otherwise introduce a circular dependency. This means blocks the "fake-datapath" cell from providing certain types provided by the real datapath cell (found in `pkg/datapath/cells.go`). An example of this can be found here: https://github.com/cilium/cilium/pull/30423#issuecomment-1914659406. 

Therefore, this series of commits attempts to separate the two use-cases by splitting the `pkg/datapath/fake` package into two.

The existing package will continue to provide the "fake-datapath" cell (in `pkg/datapath/fake/cells.go`), mirroring the real
`datapath/cells.go`, where as a new `pkg/datapath/fake/types` package will provide mock types referenced in unit tests by various other packages, in some sense mirroring the real `pkg/datapath/types`.