### PR TITLE
ci: add trigger phrase to Gateway API conformance test workflow name

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -1,4 +1,4 @@
-name: Conformance Gateway API
+name: Conformance Gateway API (ci-gateway-api)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:


### PR DESCRIPTION
Like in other GitHub actions workflows triggered by Ariane, mention the trigger phrase in the workflow name.