### PR TITLE
statedb/reflector: Add Kubernetes to StateDB reflector

### DIFF
--- a/pkg/statedb/reflector/common.go
+++ b/pkg/statedb/reflector/common.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reflector
+
+import (
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+// Reflector reflects external data into a statedb table
+type Reflector[Obj any] interface {
+	cell.HookInterface // Can be started and stopped.
+}

--- a/pkg/statedb/reflector/doc.go
+++ b/pkg/statedb/reflector/doc.go
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// The reflector package provides a set of utilities to reflect external data into a statedb table.
+package reflector

--- a/pkg/statedb/reflector/k8s.go
+++ b/pkg/statedb/reflector/k8s.go
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reflector
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/stream"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type KubernetesConfig[Obj any] struct {
+	BufferSize     int                  // Maximum number of objects to commit in one transaction. Uses default if left zero.
+	BufferWaitTime time.Duration        // The amount of time to wait for the buffer to fill. Uses default if left zero.
+	ListerWatcher  cache.ListerWatcher  // The ListerWatcher to use to retrieve the objects
+	Transform      TransformFunc[Obj]   // Optional function to transform the objects given by the ListerWatcher
+	QueryAll       QueryAllFunc[Obj]    // Optional function to query all objects
+	Table          statedb.RWTable[Obj] // The table to populate
+}
+
+// TransformFunc is an optional function to give to the Kubernetes reflector
+// to transform the object returned by the ListerWatcher to the desired
+// target object. If the function returns false the object is silently
+// skipped.
+type TransformFunc[Obj any] func(any) (obj Obj, ok bool)
+
+// QueryAllFunc is an optional function to give to the Kubernetes reflector
+// to query all objects in the table that are managed by the reflector.
+// It is used to delete all objects when the underlying cache.Reflector needs
+// to Replace() all items for a resync.
+type QueryAllFunc[Obj any] func(statedb.ReadTxn, statedb.Table[Obj]) statedb.Iterator[Obj]
+
+const (
+	// DefaultBufferSize is the maximum number of objects to commit to the table in one write transaction.
+	DefaultBufferSize = 64
+
+	// DefaultBufferWaitTime is the amount of time to wait to fill the buffer before committing objects.
+	DefaultBufferWaitTime = 50 * time.Millisecond
+)
+
+func (cfg KubernetesConfig[Obj]) getBufferSize() int {
+	if cfg.BufferSize == 0 {
+		return DefaultBufferSize
+	}
+	return cfg.BufferSize
+}
+
+func (cfg KubernetesConfig[Obj]) getWaitTime() time.Duration {
+	if cfg.BufferWaitTime == 0 {
+		return DefaultBufferWaitTime
+	}
+	return cfg.BufferWaitTime
+}
+
+type KubernetesParams[Obj any] struct {
+	cell.In
+
+	Config KubernetesConfig[Obj]
+	Jobs   job.Registry
+	Scope  cell.Scope
+	DB     *statedb.DB
+}
+
+// Kubernetes synchronizes statedb table with an external Kubernetes resource.
+// Returns a 'Reflector' for starting and stopping it. If the source can be started
+// unconditionally, consider using [KubernetesCell] instead.
+func Kubernetes[Obj any](p KubernetesParams[Obj]) Reflector[Obj] {
+	tr := &k8sReflector[Obj]{
+		KubernetesConfig: p.Config,
+		db:               p.DB,
+	}
+	g := p.Jobs.NewGroup(p.Scope)
+	g.Add(job.OneShot(
+		fmt.Sprintf("k8s-reflector-[%T]", *new(Obj)),
+		tr.run))
+	return g
+}
+
+// KubernetesCell constructs a cell that constructs a Kubernetes source and
+// adds it to the the application lifecycle. If you need dynamic control
+// over if and when to start or stop the reflection, use [Kubernetes] and
+// call Reflector.Start and Reflector.Stop manually.
+//
+// For dependencies needed by this cell see [KubernetesParams].
+func KubernetesCell[Obj any]() cell.Cell {
+	return cell.Group(
+		cell.ProvidePrivate(Kubernetes[Obj]),
+		cell.Invoke(func(s Reflector[Obj], lc cell.Lifecycle) {
+			lc.Append(s)
+		}),
+	)
+}
+
+type k8sReflector[Obj any] struct {
+	KubernetesConfig[Obj]
+
+	db *statedb.DB
+}
+
+func (s *k8sReflector[Obj]) run(ctx context.Context, health cell.HealthReporter) error {
+	type entry struct {
+		deleted   bool
+		name      string
+		namespace string
+		obj       Obj
+	}
+	type buffer struct {
+		replaceItems []any
+		entries      map[string]entry
+	}
+	bufferSize := s.getBufferSize()
+	waitTime := s.getWaitTime()
+	table := s.Table
+
+	transform := s.Transform
+	if transform == nil {
+		// No provided transform function, use the identity function instead.
+		transform = TransformFunc[Obj](func(obj any) (Obj, bool) { return obj.(Obj), true })
+	}
+
+	queryAll := s.QueryAll
+	if queryAll == nil {
+		// No query function provided, use All()
+		queryAll = QueryAllFunc[Obj](func(txn statedb.ReadTxn, tbl statedb.Table[Obj]) statedb.Iterator[Obj] {
+			iter, _ := tbl.All(txn)
+			return iter
+		})
+	}
+
+	// Construct a stream of K8s objects, buffered into chunks every [waitTime] period
+	// and then committed.
+	// This reduces the number of write transactions required and thus the number of times
+	// readers get woken up, which results in much better overall throughput.
+	src := stream.Buffer(
+		k8sEventObservable(s.ListerWatcher),
+		bufferSize,
+		waitTime,
+
+		// Buffer the events into a map, coalescing them by key.
+		func(buf *buffer, ev cacheStoreEvent) *buffer {
+			switch {
+			case ev.Type == cacheStoreReplace:
+				return &buffer{
+					replaceItems: ev.Obj.([]any),
+					entries:      make(map[string]entry, bufferSize), // Forget prior entries
+				}
+			case buf == nil:
+				buf = &buffer{
+					replaceItems: nil,
+					entries:      make(map[string]entry, bufferSize),
+				}
+			}
+
+			var entry entry
+			entry.deleted = ev.Type == cacheStoreDelete
+
+			var key string
+			if d, ok := ev.Obj.(cache.DeletedFinalStateUnknown); ok {
+				key = d.Key
+				var err error
+				entry.namespace, entry.name, err = cache.SplitMetaNamespaceKey(d.Key)
+				if err != nil {
+					panic(fmt.Sprintf("%T internal error: cache.SplitMetaNamespaceKey(%q) failed: %s", s, d.Key, err))
+				}
+				entry.obj, ok = transform(d.Obj)
+				if !ok {
+					return buf
+				}
+			} else {
+				meta, err := meta.Accessor(ev.Obj)
+				if err != nil {
+					panic(fmt.Sprintf("%T internal error: meta.Accessor failed: %s", s, err))
+				}
+				entry.name = meta.GetName()
+				if ns := meta.GetNamespace(); ns != "" {
+					key = ns + "/" + meta.GetName()
+					entry.namespace = ns
+				} else {
+					key = meta.GetName()
+				}
+
+				var ok bool
+				entry.obj, ok = transform(ev.Obj)
+				if !ok {
+					return buf
+				}
+			}
+			buf.entries[key] = entry
+			return buf
+		},
+	)
+
+	commitBuffer := func(buf *buffer) {
+		txn := s.db.WriteTxn(s.Table)
+		defer txn.Commit()
+
+		if buf.replaceItems != nil {
+			iter := queryAll(txn, table)
+			for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+				table.Delete(txn, obj)
+			}
+			for _, item := range buf.replaceItems {
+				table.Insert(txn, item.(Obj))
+			}
+		}
+
+		for _, entry := range buf.entries {
+			if !entry.deleted {
+				table.Insert(txn, entry.obj)
+			} else {
+				table.Delete(txn, entry.obj)
+			}
+		}
+	}
+
+	errs := make(chan error)
+	src.Observe(
+		ctx,
+		commitBuffer,
+		func(err error) {
+			errs <- err
+			close(errs)
+		},
+	)
+	return <-errs
+}
+
+// k8sEventObservable turns a ListerWatcher into an observable using the client-go's Reflector.
+func k8sEventObservable(lw cache.ListerWatcher) stream.Observable[cacheStoreEvent] {
+	return stream.FuncObservable[cacheStoreEvent](
+		func(ctx context.Context, next func(cacheStoreEvent), complete func(err error)) {
+			store := &cacheStoreListener{
+				onAdd: func(obj any) {
+					next(cacheStoreEvent{cacheStoreAdd, obj})
+				},
+				onUpdate:  func(obj any) { next(cacheStoreEvent{cacheStoreUpdate, obj}) },
+				onDelete:  func(obj any) { next(cacheStoreEvent{cacheStoreDelete, obj}) },
+				onReplace: func(objs []any) { next(cacheStoreEvent{cacheStoreReplace, objs}) },
+			}
+			reflector := cache.NewReflector(lw, nil, store, 0)
+			go func() {
+				reflector.Run(ctx.Done())
+				complete(nil)
+			}()
+		})
+}
+
+const (
+	cacheStoreAdd = iota
+	cacheStoreUpdate
+	cacheStoreDelete
+	cacheStoreReplace
+)
+
+type cacheStoreEvent struct {
+	Type int
+	Obj  any
+}
+
+// cacheStoreListener implements the methods used by the cache reflector and
+// calls the given handlers for added, updated and deleted objects.
+type cacheStoreListener struct {
+	onAdd, onUpdate, onDelete func(any)
+	onReplace                 func([]any)
+}
+
+func (s *cacheStoreListener) Add(obj interface{}) error {
+	s.onAdd(obj)
+	return nil
+}
+
+func (s *cacheStoreListener) Update(obj interface{}) error {
+	s.onUpdate(obj)
+	return nil
+}
+
+func (s *cacheStoreListener) Delete(obj interface{}) error {
+	s.onDelete(obj)
+	return nil
+}
+
+func (s *cacheStoreListener) Replace(items []interface{}, resourceVersion string) error {
+	if items == nil {
+		// Always emit a non-nil slice for replace.
+		items = []interface{}{}
+	}
+	s.onReplace(items)
+	return nil
+}
+
+// These methods are never called by cache.Reflector:
+
+func (*cacheStoreListener) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	panic("unimplemented")
+}
+func (*cacheStoreListener) GetByKey(key string) (item interface{}, exists bool, err error) {
+	panic("unimplemented")
+}
+func (*cacheStoreListener) List() []interface{} { panic("unimplemented") }
+func (*cacheStoreListener) ListKeys() []string  { panic("unimplemented") }
+func (*cacheStoreListener) Resync() error       { panic("unimplemented") }
+
+var _ cache.Store = &cacheStoreListener{}

--- a/pkg/statedb/reflector/k8s_test.go
+++ b/pkg/statedb/reflector/k8s_test.go
@@ -1,0 +1,475 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reflector_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/index"
+	"github.com/cilium/cilium/pkg/statedb/reflector"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func TestKubernetes(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	podNameIndex := statedb.Index[*v1.Pod, string]{
+		Name: "name",
+		FromObject: func(p *v1.Pod) index.KeySet {
+			return index.NewKeySet(index.String(p.Namespace + "/" + p.Name))
+		},
+		FromKey: index.String,
+		Unique:  true,
+	}
+
+	table, err := statedb.NewTable[*v1.Pod]("pods", podNameIndex)
+	require.NoError(t, err, "NewTable")
+
+	var (
+		db *statedb.DB
+		lw = &fakePodListerWatcher{
+			watchChan: make(chan watch.Event, 100),
+		}
+	)
+
+	sourceConfig := func() reflector.KubernetesConfig[*v1.Pod] {
+		return reflector.KubernetesConfig[*v1.Pod]{
+			ListerWatcher: lw,
+			Table:         table,
+		}
+	}
+
+	h := hive.New(
+		statedb.Cell,
+		job.Cell,
+		cell.Module("test", "Test",
+			cell.ProvidePrivate(sourceConfig),
+			reflector.KubernetesCell[*v1.Pod](),
+		),
+		cell.Invoke(func(db_ *statedb.DB) {
+			db_.RegisterTable(table)
+			db = db_
+		}),
+	)
+
+	require.NoError(t, h.Start(context.TODO()))
+
+	// Table is empty when starting.
+	txn := db.ReadTxn()
+	iter, watchAll := table.All(txn)
+	objs := statedb.Collect[*v1.Pod](iter)
+	assert.Len(t, objs, 0)
+
+	// Send a new pod and wait for table to update.
+	expectedPod := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod1", Namespace: "test1",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+	lw.watchChan <- watch.Event{
+		Type:   watch.Added,
+		Object: expectedPod.DeepCopy(),
+	}
+
+	<-watchAll
+
+	// Table should now contain the new pod
+	txn = db.ReadTxn()
+	iter, _ = table.All(txn)
+	objs = statedb.Collect[*v1.Pod](iter)
+	assert.Len(t, objs, 1)
+
+	// Pod can be retrieved by name
+	pod, _, ok := table.First(txn, podNameIndex.Query(expectedPod.Namespace+"/"+expectedPod.Name))
+	if assert.True(t, ok) && assert.NotNil(t, pod) {
+		assert.Equal(t, expectedPod.Name, pod.Name)
+	}
+
+	// Modify the pod and observe the update
+	_, watchAll = table.All(db.ReadTxn())
+
+	expectedPod.Labels["bar"] = "baz"
+	lw.watchChan <- watch.Event{
+		Type:   watch.Added,
+		Object: expectedPod.DeepCopy(),
+	}
+
+	<-watchAll
+
+	pod, _, ok = table.First(txn, podNameIndex.Query(expectedPod.Namespace+"/"+expectedPod.Name))
+	if assert.True(t, ok) && assert.NotNil(t, pod) {
+		assert.Equal(t, expectedPod.Name, pod.Name)
+		assert.Equal(t, expectedPod.Labels["bar"], "baz")
+	}
+
+	// Pod deletion can be observed
+	_, watchAll = table.All(db.ReadTxn())
+
+	lw.watchChan <- watch.Event{
+		Type:   watch.Deleted,
+		Object: expectedPod.DeepCopy(),
+	}
+
+	<-watchAll
+
+	iter, _ = table.All(db.ReadTxn())
+	objs = statedb.Collect[*v1.Pod](iter)
+	assert.Len(t, objs, 0)
+
+	assert.NoError(t, h.Stop(context.TODO()))
+}
+
+type slimPod struct {
+	Name, Namespace string
+	Source          string
+}
+
+// TestKubernetesWithTransformAndQueryAll checks that the Transform and QueryAll options
+// are properly handled. The Transform allows transforming the object received from the
+// ListerWatcher to another one before it is stored. The QueryAll allows using a single
+// table with multiple reflectors or other writers by namespacing them.
+func TestKubernetesWithTransformAndQueryAll(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	podNameIndex := statedb.Index[*slimPod, string]{
+		Name: "name",
+		FromObject: func(p *slimPod) index.KeySet {
+			return index.NewKeySet(index.String(p.Namespace + "/" + p.Name))
+		},
+		FromKey: index.String,
+		Unique:  true,
+	}
+
+	podSourceIndex := statedb.Index[*slimPod, string]{
+		Name: "source",
+		FromObject: func(p *slimPod) index.KeySet {
+			return index.NewKeySet(index.String(p.Source))
+		},
+		FromKey: index.String,
+		Unique:  false,
+	}
+
+	table, err := statedb.NewTable[*slimPod]("pods", podNameIndex, podSourceIndex)
+	require.NoError(t, err, "NewTable")
+
+	var (
+		db *statedb.DB
+		lw = &fakePodListerWatcher{
+			watchChan: make(chan watch.Event, 100),
+		}
+	)
+
+	sourceConfig := func() reflector.KubernetesConfig[*slimPod] {
+		return reflector.KubernetesConfig[*slimPod]{
+			ListerWatcher: lw,
+			Table:         table,
+			Transform: func(obj any) (*slimPod, bool) {
+				pod := obj.(*v1.Pod)
+				return &slimPod{
+					Name:      pod.Name,
+					Namespace: pod.Namespace,
+					Source:    "k8s",
+				}, true
+			},
+			QueryAll: func(txn statedb.ReadTxn, tbl statedb.Table[*slimPod]) statedb.Iterator[*slimPod] {
+				iter, _ := tbl.Get(txn, podSourceIndex.Query("k8s"))
+				return iter
+			},
+		}
+	}
+
+	h := hive.New(
+		statedb.Cell,
+		job.Cell,
+		cell.Module("test", "Test",
+			cell.ProvidePrivate(sourceConfig),
+			reflector.KubernetesCell[*slimPod](),
+		),
+		cell.Invoke(func(db_ *statedb.DB) {
+			db_.RegisterTable(table)
+			db = db_
+		}),
+	)
+
+	require.NoError(t, h.Start(context.TODO()))
+
+	{
+		txn := db.WriteTxn(table)
+		// Insert some objects that are not managed by the reflector. These should be left alone.
+		table.Insert(txn, &slimPod{Name: "foo", Namespace: "bar", Source: "test"})
+		table.Insert(txn, &slimPod{Name: "baz", Namespace: "quux", Source: "test"})
+
+		// Insert a "leftover" object that is managed by the reflector. This should be removed.
+		table.Insert(txn, &slimPod{Name: "leftover", Namespace: "test1", Source: "k8s"})
+
+		txn.Commit()
+	}
+
+	_, watchAll := table.Get(db.ReadTxn(), podSourceIndex.Query("k8s"))
+
+	// Send a new pod and wait for table to update.
+	expectedPod := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod1", Namespace: "test1",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+	lw.watchChan <- watch.Event{
+		Type:   watch.Added,
+		Object: expectedPod.DeepCopy(),
+	}
+
+	<-watchAll
+
+	// Table should now contain the new pod. The leftover should be gone.
+	txn := db.ReadTxn()
+	iter, watchAll := table.Get(db.ReadTxn(), podSourceIndex.Query("k8s"))
+	objs := statedb.Collect[*slimPod](iter)
+	assert.Len(t, objs, 1)
+
+	// Pod can be retrieved by name
+	pod, _, ok := table.First(txn, podNameIndex.Query(expectedPod.Namespace+"/"+expectedPod.Name))
+	if assert.True(t, ok) && assert.NotNil(t, pod) {
+		assert.Equal(t, expectedPod.Name, pod.Name)
+	}
+
+	// Pod deletion can be observed
+	lw.watchChan <- watch.Event{
+		Type:   watch.Deleted,
+		Object: expectedPod.DeepCopy(),
+	}
+
+	<-watchAll
+
+	iter, _ = table.Get(db.ReadTxn(), podSourceIndex.Query("k8s"))
+	objs = statedb.Collect[*slimPod](iter)
+	assert.Len(t, objs, 0)
+
+	// The objects from the other source should not have been touched.
+	iter, _ = table.Get(db.ReadTxn(), podSourceIndex.Query("test"))
+	objs = statedb.Collect[*slimPod](iter)
+	assert.Len(t, objs, 2)
+
+	assert.NoError(t, h.Stop(context.TODO()))
+}
+
+// BenchmarkKubernetes uses the fake client to benchmark how many objects per second
+// we can insert into a StateDB table.
+func BenchmarkKubernetes(b *testing.B) {
+	logging.SetLogLevel(logrus.WarnLevel)
+
+	podNameIndex := statedb.Index[*v1.Pod, string]{
+		Name: "name",
+		FromObject: func(p *v1.Pod) index.KeySet {
+			return index.NewKeySet(index.String(p.Namespace + "/" + p.Name))
+		},
+		FromKey: index.String,
+		Unique:  true,
+	}
+
+	// To make this slightly more realistic, also index the labels. This
+	// is a secondary index with 3 entries (labels) per object.
+	// This does have a significant impact on throughput, on my machine I get
+	// ~365k/s without this index and ~150k/s with the index. So we do need
+	// to be careful in how eagerly we index things and may often want to do
+	// filtering on iteration instead (e.g. a control-plane controller should
+	// likely watch all changes by revision and skip uninteresting things rather
+	// than have an indexing on the interesting fields).
+	podLabelsIndex := statedb.Index[*v1.Pod, string]{
+		Name: "labels",
+		FromObject: func(p *v1.Pod) index.KeySet {
+			keys := make([]index.Key, 0, len(p.Labels))
+			for k, v := range p.Labels {
+				keys = append(keys, index.String(k+"="+v))
+			}
+			return index.NewKeySet(keys...)
+		},
+		FromKey: index.String,
+		Unique:  false,
+	}
+
+	table, err := statedb.NewTable[*v1.Pod]("pods", podNameIndex, podLabelsIndex)
+	require.NoError(b, err, "NewTable")
+
+	// batchSize is the number of objects that we update and the number that are committed
+	// in one write transaction.
+	batchSize := 100
+
+	lw := &fakePodListerWatcher{
+		watchChan: make(chan watch.Event, batchSize),
+	}
+
+	sourceConfig := func() reflector.KubernetesConfig[*v1.Pod] {
+		return reflector.KubernetesConfig[*v1.Pod]{
+			BufferSize:     batchSize,
+			BufferWaitTime: 100 * time.Millisecond,
+			ListerWatcher:  lw,
+			Table:          table,
+		}
+	}
+
+	var db *statedb.DB
+
+	h := hive.New(
+		statedb.Cell,
+		job.Cell,
+		cell.Module("test", "Test",
+			cell.ProvidePrivate(sourceConfig),
+			reflector.KubernetesCell[*v1.Pod](),
+		),
+		cell.Invoke(func(db_ *statedb.DB) {
+			db_.RegisterTable(table)
+			db = db_
+		}),
+	)
+
+	generation := int64(1)
+
+	pod := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod1", Namespace: "test1",
+			Labels: map[string]string{
+				"foo": "bar",
+				"baz": "quux",
+			},
+		},
+	}
+
+	// Create the initial pods (e.g. what List() returns)
+	for j := 0; j < batchSize; j++ {
+		pod.Name = fmt.Sprintf("pod%d", j)
+		pod.Namespace = "test1"
+		pod.ResourceVersion = fmt.Sprintf("%d", generation)
+		pod.Generation = generation
+		generation++
+		pod.UID = types.UID(pod.Name)
+		lw.initial = append(lw.initial, *pod.DeepCopy())
+	}
+
+	require.NoError(b, h.Start(context.TODO()))
+
+	// Wait for the initial pods to be created
+	iter, watchAll := table.All(db.ReadTxn())
+	for {
+		objs := statedb.Collect[*v1.Pod](iter)
+		if len(objs) == batchSize {
+			break
+		}
+		<-watchAll
+		iter, watchAll = table.All(db.ReadTxn())
+	}
+
+	// Benchmark updating a batch of objects b.N times.
+	b.ResetTimer()
+	lastLabelI := ""
+	for i := 0; i < b.N; i++ {
+		lastLabelI = fmt.Sprintf("%d", i)
+		pod.Labels["i"] = lastLabelI
+		for j := 0; j < batchSize; j++ {
+			pod.Name = fmt.Sprintf("pod%d", j)
+			pod.Namespace = "test1"
+			pod.UID = types.UID(pod.Name)
+			pod.ResourceVersion = fmt.Sprintf("%d", generation)
+			pod.Generation = generation
+			generation++
+
+			lw.watchChan <- watch.Event{
+				Type:   watch.Modified,
+				Object: pod.DeepCopy(),
+			}
+		}
+
+		// Wait until the whole batch has been processed. If we would not wait here,
+		// then updates would get coalesced by stream.Buffer. This of course does
+		// slightly decrease the measured throughput.
+	waitLoop:
+		for {
+			<-watchAll
+			iter, watchAll = table.All(db.ReadTxn())
+
+			objs := statedb.Collect[*v1.Pod](iter)
+			if len(objs) != batchSize {
+				continue
+			}
+			// Check that all objects have the final state.
+			for _, obj := range objs {
+				if obj.Labels["i"] != lastLabelI {
+					continue waitLoop
+				}
+			}
+			break
+		}
+
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(batchSize)*float64(b.N)/b.Elapsed().Seconds(), "objects/sec")
+}
+
+// A fake lister watcher to have full control over what List and Watch returns.
+// The k8s-client's fake client has a fixed buffer size and we'd have to be careful
+// with timing as it holds no state, so instead we're faking it at this level. This
+// also provides a better baseline number for the benchmarking.
+type fakePodListerWatcher struct {
+	initial   []v1.Pod
+	watchChan chan watch.Event
+}
+
+// List implements cache.ListerWatcher.
+func (lw *fakePodListerWatcher) List(options metav1.ListOptions) (runtime.Object, error) {
+	return &v1.PodList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PodList",
+			APIVersion: "v1",
+		},
+		ListMeta: metav1.ListMeta{
+			ResourceVersion:    "1",
+			Continue:           "",
+			RemainingItemCount: new(int64),
+		},
+		Items: lw.initial,
+	}, nil
+}
+
+// Watch implements cache.ListerWatcher.
+func (lw *fakePodListerWatcher) Watch(options metav1.ListOptions) (watch.Interface, error) {
+	return lw, nil
+}
+
+// ResultChan implements watch.Interface.
+func (lw *fakePodListerWatcher) ResultChan() <-chan watch.Event {
+	return lw.watchChan
+}
+
+// Stop implements watch.Interface.
+func (lw *fakePodListerWatcher) Stop() {
+}
+
+var _ cache.ListerWatcher = &fakePodListerWatcher{}
+var _ watch.Interface = &fakePodListerWatcher{}


### PR DESCRIPTION
Utility for populating and keeping in sync a StateDB table with a Kubernetes resource.

Example usage:
```
    cell.Module("example", "Example",
      cell.ProvidePrivate(podTable), // RWTable[*v1.Pod]
      cell.Provide(statedb.RWTable[*v1.Pod].ToTable), // Table[*v1.Pod]
      cell.ProvidePrivate(podConfig),
      reflector.KubernetesCell[*v1.Pod](),
    )

    func podConfig(
      cs client.Clientset,
      tbl statedb.RWTable[*v1.Pod]) reflector.KubernetesConfig[*v1.Pod] {
        return reflector.KubernetesConfig[*v1.Pod]{
          ListerWatcher: utils.ListerWatcherFromTyped[*v1.PodList(cs.CoreV1().Pods("")),
          Table: tbl,
        }
    }
```
