### PR TITLE
bgpv2: use different ports in unit tests

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/preflight_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/preflight_test.go
@@ -26,10 +26,11 @@ import (
 // the ephemeral (source) ports. As this range is configurable, ideally, we should
 // use the IANA-assigned ports below 1024 (e.g. 179) or mock GoBGP in these tests.
 // See https://github.com/cilium/cilium/issues/26209 for more info.
+// Note these ports should be different from the ports used in the pkg/bgpv1/manager/reconciler
 const (
-	localListenPort  = 1793
-	localListenPort2 = 1794
-	localListenPort3 = 1795
+	localListenPort  = 1780
+	localListenPort2 = 1781
+	localListenPort3 = 1782
 )
 
 // TestPreflightReconciler ensures if a BgpServer must be recreated, due to


### PR DESCRIPTION
BGP reconciler and reconcilerV2 should not use same local port for testing. As package tests may run concurrently, having same local port will cause sporadic failures due to port already in use error.