### PR TITLE
ci/ipsec: Fix downgrade version for release preparation commits

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -153,6 +153,12 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ inputs.context-ref || github.sha }}
+          # We need to be able to check the existence of the tag we want to
+          # downgrade to, in case we're on a release preparation commit and the
+          # value in VERSION does not correspond to an existing tag yet. In
+          # that case, print-downgrade-version.sh needs to adjust the patch
+          # release number to downgrade to.
+          fetch-tags: true
           persist-credentials: false
 
       - name: Set Environment Variables

--- a/contrib/scripts/print-downgrade-version.sh
+++ b/contrib/scripts/print-downgrade-version.sh
@@ -19,15 +19,30 @@ fi
 
 if [[ ${1-} == "patch" ]] ; then
     # If user passed "patch" as first argument, print the latest patch version
-    case ${patch} in
-        0)
-            >&2 echo "ERROR: failed to deduce patch release previous to version '$VERSION'"
-            exit 1
-            ;;
-        *)
-            echo "v${major}.${minor}.${patch}${TAG_SUFFIX:-}"
-            ;;
-    esac
+
+    if [[ "${patch}" -le "0" ]] ; then
+        >&2 echo "ERROR: failed to deduce patch release previous to version '$VERSION'"
+        exit 1
+    fi
+
+    tag="v${major}.${minor}.${patch}${TAG_SUFFIX:-}"
+
+    # Hack: When working on a patch release preparation commit, file VERSION
+    # contains the new value for the release that is yet to be tagged and
+    # published. So if the tag does not exist, we want to downgrade to the
+    # previous patch release.
+    #
+    # Only run this step if we're in a Git repository, and we have tag v1.0.0
+    # in the repo (otherwise, we're likely on a shallow clone, with no tags
+    # fetched).
+    if git rev-parse --is-inside-work-tree &> /dev/null && \
+        git rev-parse --verify --end-of-options v1.0.0 &> /dev/null && \
+        ! git rev-parse --verify --end-of-options "${tag}" &> /dev/null; then
+        >&2 echo "INFO: tag ${tag} not found, decrementing patch release number"
+        patch=$((patch - 1))
+        tag="v${major}.${minor}.${patch}${TAG_SUFFIX:-}"
+    fi
+    echo "${tag}"
 else
     if [[ "${minor}" == "0" ]] ; then
         >&2 echo "ERROR: failed to deduce release previous to version '$VERSION'"


### PR DESCRIPTION
For the IPsec upgrade/downgrade CI test, for the jobs where we upgrade/downgrade to the closest patch release, the script print-downgrade-version.sh determines the patch release by picking up the value in file VERSION. This works most of the time.

For release preparation commits, however, this approach fails because the reference in VERSION points to a release that has not been tagged or published yet. We need to pick the previous patch release in that case.

However, it's non-trivial to figure out whether we're on a release preparation commit, in particular because the CI workflow does a shallow Git clone and we don't have access to the Git history. I couldn't find an ideal solution, so this commit changes the shallow-clone into a clone with 2 commits (one for the last commit, which is the one we're interested in, and another one squashing all the rest of the history). And we add a hack in the script to account for this last commit and check whether it modifies the VERSION file. If it does, we decrement the version found in VERSION before computing the patch release to downgrade to.

Fixes: 5581963cbf94 ("ci/ipsec: Fix version retrieval for downgrades to closest patch release")
