### PR TITLE
Improve efficiency of applying policy map changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -417,6 +417,7 @@ Makefile* @cilium/build
 /pkg/bpf/ @cilium/loader
 /pkg/byteorder/ @cilium/sig-datapath @cilium/api
 /pkg/cgroups/ @cilium/sig-datapath
+/pkg/channels/ @cilium/sig-foundations
 /pkg/checker/ @cilium/ci-structure
 /pkg/ciliumenvoyconfig/ @cilium/envoy @cilium/sig-servicemesh
 /pkg/cleanup/ @cilium/sig-agent

--- a/pkg/channels/channels.go
+++ b/pkg/channels/channels.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package channels
+
+type DoneChan <-chan struct{}
+
+var ClosedDoneChan DoneChan
+
+func init() {
+	ch := make(chan struct{})
+	close(ch)
+	ClosedDoneChan = ch
+}
+
+// Merge merges a slice of channels and returns a channel that is
+// closed when all the merged channels are closed.
+// Each merged channel is expected to be used to notify the receiver
+// exactly once, by closing it, and never to be used again thereafter.
+// In other words, Merge does not support multiple notifications sent
+// through the same channel. This is done to avoid spawning N+1
+// goroutines to receive independently from each channel.
+func Merge(cs ...<-chan struct{}) <-chan struct{} {
+	out := make(chan struct{})
+	go func() {
+		for _, c := range cs {
+			<-c
+		}
+		close(out)
+	}()
+	return out
+}

--- a/pkg/channels/channels_test.go
+++ b/pkg/channels/channels_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package channels
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+)
+
+func TestMergeNilSlice(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var chs []<-chan struct{}
+	_, ok := <-Merge(chs...)
+	assert.False(t, ok)
+}
+
+func TestMergeSingleChannel(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	ch := make(chan struct{})
+	chs := []<-chan struct{}{ch}
+	merged := Merge(chs...)
+
+	var (
+		wg sync.WaitGroup
+		ok bool
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, ok = <-merged
+	}()
+
+	close(ch)
+
+	wg.Wait()
+	assert.False(t, ok)
+}
+
+func TestMergeMultipleChannels(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	ch1, ch2, ch3 := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	chs := []<-chan struct{}{ch1, ch2, ch3}
+	merged := Merge(chs...)
+
+	oks := make([]bool, len(chs))
+	var wg sync.WaitGroup
+	wg.Add(len(chs))
+	for i := 0; i < len(chs); i++ {
+		go func(ok *bool) {
+			defer wg.Done()
+			_, *ok = <-merged
+		}(&oks[i])
+	}
+
+	close(ch1)
+	close(ch2)
+	close(ch3)
+
+	wg.Wait()
+	for i := 0; i < len(chs); i++ {
+		assert.False(t, oks[i])
+	}
+}

--- a/pkg/channels/doc.go
+++ b/pkg/channels/doc.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+/*
+Package channels provides common utilities related to channels.
+*/
+package channels

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"sync"
 
+	"github.com/cilium/cilium/pkg/channels"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/hive/cell"
@@ -138,7 +139,7 @@ type EndpointManager interface {
 	// have had their PolicyMaps updated against the Endpoint's desired policy state.
 	//
 	// Endpoints will wait on the 'notifyWg' parameter before updating policy maps.
-	UpdatePolicyMaps(ctx context.Context, notifyWg *sync.WaitGroup) *sync.WaitGroup
+	UpdatePolicyMaps(ctx context.Context, notifyWg *sync.WaitGroup) channels.DoneChan
 
 	// RegenerateAllEndpoints calls a setState for each endpoint and
 	// regenerates if state transaction is valid. During this process, the endpoint

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/channels"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
@@ -126,62 +126,34 @@ func (mgr *endpointManager) WithPeriodicEndpointGC(ctx context.Context, checkHea
 	return mgr
 }
 
-// waitForProxyCompletions blocks until all proxy changes have been completed.
-func waitForProxyCompletions(proxyWaitGroup *completion.WaitGroup) error {
-	err := proxyWaitGroup.Context().Err()
-	if err != nil {
-		return fmt.Errorf("context cancelled before waiting for proxy updates: %w", err)
-	}
-
-	start := time.Now()
-	log.Debug("Waiting for proxy updates to complete...")
-	err = proxyWaitGroup.Wait()
-	if err != nil {
-		return fmt.Errorf("proxy updates failed: %s", err)
-	}
-	log.Debug("Wait time for proxy updates: ", time.Since(start))
-
-	return nil
-}
-
 // UpdatePolicyMaps returns a WaitGroup which is signaled upon once all endpoints
 // have had their PolicyMaps updated against the Endpoint's desired policy state.
 //
 // Endpoints will wait on the 'notifyWg' parameter before updating policy maps.
-func (mgr *endpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync.WaitGroup) *sync.WaitGroup {
-	var epWG sync.WaitGroup
-	var wg sync.WaitGroup
+func (mgr *endpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync.WaitGroup) channels.DoneChan {
+	done := make(chan struct{})
 
-	proxyWaitGroup := completion.NewWaitGroup(ctx)
-
-	eps := mgr.GetEndpoints()
-	epWG.Add(len(eps))
-	wg.Add(1)
-
-	// This is in a goroutine to allow the caller to proceed with other tasks before waiting for the ACKs to complete
 	go func() {
-		// Wait for all the eps to have applied policy map
-		// changes before waiting for the changes to be ACKed
-		epWG.Wait()
-		if err := waitForProxyCompletions(proxyWaitGroup); err != nil {
-			log.WithError(err).Warning("Failed to apply L7 proxy policy changes. These will be re-applied in future updates.")
+		defer close(done)
+
+		// Wait until caller has updated the desired policy state.
+		notifyWg.Wait()
+
+		eps := mgr.GetEndpoints()
+		doneChs := make([]<-chan struct{}, len(eps))
+		// Trigger applying of the policy map changes.
+		for i, ep := range eps {
+			doneChs[i] = ep.ApplyPolicyMapChanges()
 		}
-		wg.Done()
+		// Wait for completion.
+		select {
+		case <-ctx.Done():
+			return
+		case <-channels.Merge(doneChs...):
+		}
 	}()
 
-	// TODO: bound by number of CPUs?
-	for _, ep := range eps {
-		go func(ep *endpoint.Endpoint) {
-			// Proceed only after all notifications have been delivered to endpoints
-			notifyWg.Wait()
-			if err := ep.ApplyPolicyMapChanges(proxyWaitGroup); err != nil {
-				ep.Logger("endpointmanager").WithError(err).Warning("Failed to apply policy map changes. These will be re-applied in future updates.")
-			}
-			epWG.Done()
-		}(ep)
-	}
-
-	return &wg
+	return done
 }
 
 // InitMetrics hooks the endpointManager into the metrics subsystem. This can

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -6,8 +6,8 @@ package fqdn
 import (
 	"context"
 	"net/netip"
-	"sync"
 
+	"github.com/cilium/cilium/pkg/channels"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/source"
@@ -25,7 +25,7 @@ type Config struct {
 
 	// UpdateSelectors is a callback to update the mapping of FQDNSelector to
 	// sets of IPs.
-	UpdateSelectors func(ctx context.Context, selectorsToIPs map[api.FQDNSelector][]netip.Addr, ipcacheRevision uint64) *sync.WaitGroup
+	UpdateSelectors func(ctx context.Context, selectorsToIPs map[api.FQDNSelector][]netip.Addr, ipcacheRevision uint64) channels.DoneChan
 
 	// GetEndpointsDNSInfo is a function that returns a list of fqdn-relevant fields from all Endpoints known to the agent.
 	// The endpoint's DNSHistory and DNSZombies are used as part of the garbage collection and restoration processes.

--- a/pkg/fqdn/name_manager_test.go
+++ b/pkg/fqdn/name_manager_test.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"net"
 	"net/netip"
-	"sync"
 	"time"
 
 	. "github.com/cilium/checkmate"
 
+	"github.com/cilium/cilium/pkg/channels"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/ip"
@@ -33,11 +33,11 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 			Cache:   NewDNSCache(0),
 			IPCache: testipcache.NewMockIPCache(),
 
-			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]netip.Addr, _ uint64) *sync.WaitGroup {
+			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]netip.Addr, _ uint64) channels.DoneChan {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
-				return &sync.WaitGroup{}
+				return channels.ClosedDoneChan
 			},
 		})
 	)
@@ -79,11 +79,11 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 			Cache:   NewDNSCache(0),
 			IPCache: testipcache.NewMockIPCache(),
 
-			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]netip.Addr, _ uint64) *sync.WaitGroup {
+			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]netip.Addr, _ uint64) channels.DoneChan {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
-				return &sync.WaitGroup{}
+				return channels.ClosedDoneChan
 			},
 		})
 	)

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -475,8 +475,7 @@ func (ipc *IPCache) UpdatePolicyMaps(ctx context.Context, addedIdentities, delet
 	if addedIdentities != nil {
 		ipc.PolicyHandler.UpdateIdentities(addedIdentities, nil, &wg)
 	}
-	policyImplementedWG := ipc.DatapathHandler.UpdatePolicyMaps(ctx, &wg)
-	policyImplementedWG.Wait()
+	<-ipc.DatapathHandler.UpdatePolicyMaps(ctx, &wg)
 }
 
 // resolveIdentity will either return a previously-allocated identity for the

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/cilium/cilium/pkg/channels"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache/types"
@@ -755,6 +756,6 @@ func (m *mockUpdater) UpdateIdentities(added, deleted cache.IdentityCache, _ *sy
 
 type mockTriggerer struct{}
 
-func (m *mockTriggerer) UpdatePolicyMaps(ctx context.Context, wg *sync.WaitGroup) *sync.WaitGroup {
-	return wg
+func (m *mockTriggerer) UpdatePolicyMaps(ctx context.Context, wg *sync.WaitGroup) channels.DoneChan {
+	return channels.ClosedDoneChan
 }

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/cilium/cilium/pkg/channels"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 )
@@ -29,7 +30,7 @@ type PolicyHandler interface {
 // Wait on the returned sync.WaitGroup to ensure that the operation is complete
 // before updating the datapath's IPCache maps.
 type DatapathHandler interface {
-	UpdatePolicyMaps(context.Context, *sync.WaitGroup) *sync.WaitGroup
+	UpdatePolicyMaps(context.Context, *sync.WaitGroup) channels.DoneChan
 }
 
 // ResourceID identifies a unique copy of a resource that provides a source for

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/channels"
 	"github.com/cilium/cilium/pkg/cidr"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -112,7 +113,7 @@ type endpointManager interface {
 	GetHostEndpoint() *endpoint.Endpoint
 	GetEndpointsByPodName(string) []*endpoint.Endpoint
 	WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error
-	UpdatePolicyMaps(context.Context, *sync.WaitGroup) *sync.WaitGroup
+	UpdatePolicyMaps(context.Context, *sync.WaitGroup) channels.DoneChan
 }
 
 type nodeDiscoverManager interface {

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -17,6 +17,7 @@ import (
 	check "github.com/cilium/checkmate"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/cilium/cilium/pkg/channels"
 	"github.com/cilium/cilium/pkg/checker"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
@@ -926,8 +927,8 @@ func (m *mockUpdater) UpdateIdentities(_, _ cache.IdentityCache, _ *sync.WaitGro
 
 type mockTriggerer struct{}
 
-func (m *mockTriggerer) UpdatePolicyMaps(ctx context.Context, wg *sync.WaitGroup) *sync.WaitGroup {
-	return wg
+func (m *mockTriggerer) UpdatePolicyMaps(ctx context.Context, wg *sync.WaitGroup) channels.DoneChan {
+	return channels.ClosedDoneChan
 }
 
 func (s *managerTestSuite) TestNodeWithSameInternalIP(c *check.C) {


### PR DESCRIPTION
Revamp of #28472 

Original PR description:

---

This moves the incremental policy map change applying into the "sync-policy-map" controller instead of performing the applying of the changes directly. EndpointManager.UpdatePolicyMaps is refactored to trigger the controller of each endpoint and then to wait for reconciliation to finish. Semantics with regards to when e.g. UpdatePolicyMaps returns are unchanged, e.g. a failed reconciliation attempt does not block. Compared to prior a failed incremental policy map update is now retried by the controller.

This will reduce the amount of overhead in processing of ToFQDN policies in relation to a DNS request/response. Prior to this each DNS response would have triggered call to EndpointManager.UpdatePolicyMaps which in turn spawned a goroutine per endpoint to apply the changes. With high rate of DNS requests this may lead to lots of endpoint lock contention and context switching overhead due to queueing of calls to ApplyPolicyMaps that are unnecessary since a prior call likely had already applied the pending changes.

---

Apart from rebasing, the main difference with the original PR is the introduction of the `channels.Merge` helper to wait on multiple channels, as needed in `Daemon.updateSelectors` to wait for both the policy map changes and the ipcache.