### PR TITLE
bpf,chore: declare wireguard includes properly

### DIFF
--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -12,6 +12,7 @@
 #include "tailcall.h"
 #include "common.h"
 #include "overloadable.h"
+#include "identity.h"
 
 static __always_inline int
 wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)


### PR DESCRIPTION
Ran into a compilation failure due to this.

wireguard.h compiles today only because identity.h is included prior to its usage.

If code wants to use encap.h, which also includes wireguard.h, which does not include identity.h first the data-path will fail to compile.

Fix this by simply declaring wireguard.h's dependencies correctly.

```release-note
Ensure wireguard.h includes the correct headers 
```
