### PR TITLE
daemon/hive: No longer make WireGuard an optional dependency

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1619,7 +1619,7 @@ type daemonParams struct {
 	Lifecycle            cell.Lifecycle
 	Clientset            k8sClient.Clientset
 	Datapath             datapath.Datapath
-	WGAgent              *wireguard.Agent `optional:"true"`
+	WGAgent              *wireguard.Agent
 	LocalNodeStore       *node.LocalNodeStore
 	BGPController        *bgpv1.Controller
 	Shutdowner           hive.Shutdowner

--- a/daemon/cmd/local_node_sync.go
+++ b/daemon/cmd/local_node_sync.go
@@ -32,7 +32,7 @@ type localNodeSynchronizerParams struct {
 	K8sLocalNode       agentK8s.LocalNodeResource
 	K8sCiliumLocalNode agentK8s.LocalCiliumNodeResource
 
-	WireGuard *wg.Agent `optional:"true"`
+	WireGuard *wg.Agent // nil if WireGuard is disabled
 }
 
 // localNodeSynchronizer performs the bootstrapping of the LocalNodeStore,

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/time"
+	wg "github.com/cilium/cilium/pkg/wireguard/agent"
 
 	fakeauthmap "github.com/cilium/cilium/pkg/maps/authmap/fake"
 	fakesignalmap "github.com/cilium/cilium/pkg/maps/signalmap/fake"
@@ -49,6 +50,7 @@ var Cell = cell.Module(
 		func() types.BandwidthManager { return &fakeTypes.BandwidthManager{} },
 		func() types.IPsecKeyCustodian { return &ipsecKeyCustodian{} },
 		func() mtu.MTU { return &fakeTypes.MTU{} },
+		func() *wg.Agent { return nil },
 
 		tables.NewDeviceTable,
 		tables.NewL2AnnounceTable, statedb.RWTable[*tables.L2AnnounceEntry].ToTable,


### PR DESCRIPTION
This commit removes the `optional` tag from the WireGuard dependency in the daemon and local node initializer. This is possible now because a previous PR (cilium/cilium#30523) broke a cyclic dependency which prevented the "fake-datapath" cell from providing a dummy WireGuard dependency. It should be noted that in the Hive framework, a required dependency can still be `nil` - which is the case for WireGuard if the feature is disabled.

The motivation for removing the `optional` tag is that optional dependencies are prone to be accidentally skipped: A change in the dependency graph of an optional dependency can cause the constructor of the optional dependency to no longer be satisfied, thereby causing the optional dependency to be silently skipped even in scenarios where it should have been provided. By ensuring that dependencies are always required (even if they can be nil) we instruct the Hive framework to complain loudly if there is a breaking change in the dependency graph.

An example of this (involving WireGuard) can be found here: https://github.com/cilium/cilium/pull/30423#issuecomment-1912385968