### PR TITLE
pkg: don't cache Host identity rule matches

### DIFF
--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -2642,10 +2642,23 @@ func (ds *PolicyTestSuite) TestMatches(c *C) {
 	c.Assert(hostRule.matches(selectedIdentity), Equals, false)
 	c.Assert(hostRule.metadata.IdentitySelected, checker.DeepEquals, map[identity.NumericIdentity]bool{selectedIdentity.ID: false})
 
-	// host endpoint is selected by rule, so we it should be added to EndpointsSelected.
+	// host endpoint is selected by rule, but host labels are mutable, so don't cache them
 	c.Assert(hostRule.matches(hostIdentity), Equals, true)
 	c.Assert(hostRule.metadata.IdentitySelected, checker.DeepEquals,
-		map[identity.NumericIdentity]bool{selectedIdentity.ID: false, hostIdentity.ID: true})
+		map[identity.NumericIdentity]bool{selectedIdentity.ID: false})
+
+	// Assert that mutable host identities are handled
+	// First, add an additional label, ensure that match succeeds
+	hostLabels.MergeLabels(labels.NewLabelsFromModel([]string{"foo=bar"}))
+	hostIdentity = identity.NewIdentity(identity.ReservedIdentityHost, hostLabels)
+	c.Assert(hostRule.matches(hostIdentity), Equals, true)
+
+	// Then, change host to id=c, which is not selected, and ensure match is correct
+	hostIdentity = identity.NewIdentity(identity.ReservedIdentityHost, labels.NewLabelsFromModel([]string{"id=c"}))
+	c.Assert(hostRule.matches(hostIdentity), Equals, false)
+	c.Assert(hostRule.metadata.IdentitySelected, checker.DeepEquals,
+		map[identity.NumericIdentity]bool{selectedIdentity.ID: false})
+
 }
 
 func BenchmarkRuleString(b *testing.B) {


### PR DESCRIPTION
I was poking around the codebase and noticed this issue.

Unlike every other identity, the set of labels for the reserved:host identity is mutable. That means that rules should not cache matches for this identity.

So, clean up the code around determining matches.

```release-note
Fixes an (unlikely) bug where HostFirewall policies may miss updates to a node's labels.
```
