### PR TITLE
[v1.15] fix: Error using multiple allowRoutes namespaces in gateway

### DIFF
--- a/operator/pkg/gateway-api/httproute_reconcile_test.go
+++ b/operator/pkg/gateway-api/httproute_reconcile_test.go
@@ -76,7 +76,37 @@ var (
 			},
 			Status: gatewayv1.GatewayStatus{},
 		},
-
+		// Gateway in default namespace
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dummy-gateway-two-listeners",
+				Namespace: "default",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "cilium",
+				Listeners: []gatewayv1.Listener{
+					{
+						Name: "http",
+						Port: 80,
+						AllowedRoutes: &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: model.AddressOf(gatewayv1.NamespacesFromSame),
+							},
+						},
+					},
+					{
+						Name: "https",
+						Port: 443,
+						AllowedRoutes: &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: model.AddressOf(gatewayv1.NamespacesFromAll),
+							},
+						},
+					},
+				},
+			},
+			Status: gatewayv1.GatewayStatus{},
+		},
 		// Service for valid HTTPRoute
 		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -204,7 +234,38 @@ var (
 				},
 			},
 		},
-
+		// HTTPRoute with cross namespace listener
+		&gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "http-route-with-cross-namespace-listener",
+				Namespace: "another-namespace",
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Name:      "dummy-gateway-two-listeners",
+							Namespace: model.AddressOf[gatewayv1.Namespace]("default"),
+						},
+					},
+				},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name:      "dummy-backend",
+										Namespace: model.AddressOf[gatewayv1.Namespace]("another-namespace"),
+										Port:      model.AddressOf(gatewayv1.PortNumber(8080)),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		// HTTPRoute with cross namespace backend
 		&gatewayv1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
@@ -478,7 +539,6 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 
 		require.Equal(t, "ResolvedRefs", route.Status.RouteStatus.Parents[0].Conditions[1].Type)
 		require.Equal(t, metav1.ConditionStatus("True"), route.Status.RouteStatus.Parents[0].Conditions[1].Status)
-
 	})
 
 	t.Run("http route with nonexistent backend", func(t *testing.T) {
@@ -505,7 +565,6 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 
 		require.Equal(t, "ResolvedRefs", route.Status.RouteStatus.Parents[0].Conditions[1].Type)
 		require.Equal(t, "BackendNotFound", route.Status.RouteStatus.Parents[0].Conditions[1].Reason)
-
 	})
 
 	t.Run("http route with nonexistent gateway", func(t *testing.T) {
@@ -617,6 +676,32 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, metav1.ConditionStatus("False"), route.Status.RouteStatus.Parents[0].Conditions[1].Status)
 		require.Equal(t, "RefNotPermitted", route.Status.RouteStatus.Parents[0].Conditions[1].Reason)
 		require.Equal(t, "Cross namespace references are not allowed", route.Status.RouteStatus.Parents[0].Conditions[1].Message)
+	})
+
+	t.Run("http route with cross namespace listener", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "http-route-with-cross-namespace-listener",
+			Namespace: "another-namespace",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err, "Error reconciling httpRoute")
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		route := &gatewayv1.HTTPRoute{}
+		err = c.Get(context.Background(), key, route)
+
+		require.NoError(t, err)
+		require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
+		require.Len(t, route.Status.RouteStatus.Parents[0].Conditions, 2)
+
+		require.Equal(t, "Accepted", route.Status.RouteStatus.Parents[0].Conditions[0].Type)
+		require.Equal(t, metav1.ConditionStatus("True"), route.Status.RouteStatus.Parents[0].Conditions[0].Status)
+
+		require.Equal(t, "ResolvedRefs", route.Status.RouteStatus.Parents[0].Conditions[1].Type)
+		require.Equal(t, metav1.ConditionStatus("True"), route.Status.RouteStatus.Parents[0].Conditions[1].Status)
 	})
 
 	t.Run("http route with cross namespace backend with reference grant", func(t *testing.T) {

--- a/operator/pkg/gateway-api/routechecks/gateway_checks.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks.go
@@ -24,7 +24,7 @@ func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentRefe
 
 		return false, nil
 	}
-
+	hasNamespaceRestriction := false
 	for _, listener := range gw.Spec.Listeners {
 
 		if listener.AllowedRoutes == nil {
@@ -34,10 +34,12 @@ func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentRefe
 		if listener.AllowedRoutes.Namespaces == nil {
 			continue
 		}
-
+		if parentRef.SectionName != nil && listener.Name != *parentRef.SectionName {
+			continue
+		}
 		// if gateway allows all namespaces, we do not need to check anything here
 		if *listener.AllowedRoutes.Namespaces.From == gatewayv1.NamespacesFromAll {
-			continue
+			return true, nil
 		}
 
 		if *listener.AllowedRoutes.Namespaces.From == gatewayv1.NamespacesFromSelector {
@@ -63,22 +65,25 @@ func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentRefe
 
 				return false, nil
 			}
+			return true, nil
 		}
 
 		// check if the gateway allows the same namespace as the route
 		if *listener.AllowedRoutes.Namespaces.From == gatewayv1.NamespacesFromSame &&
-			input.GetNamespace() != gw.GetNamespace() {
-			input.SetParentCondition(parentRef, metav1.Condition{
-				Type:    "Accepted",
-				Status:  metav1.ConditionFalse,
-				Reason:  string(gatewayv1.RouteReasonNotAllowedByListeners),
-				Message: input.GetGVK().Kind + " is not allowed to attach to this Gateway due to namespace restrictions",
-			})
-
-			return false, nil
+			input.GetNamespace() == gw.GetNamespace() {
+			return true, nil
 		}
+		hasNamespaceRestriction = true
 	}
-
+	if hasNamespaceRestriction {
+		input.SetParentCondition(parentRef, metav1.Condition{
+			Type:    "Accepted",
+			Status:  metav1.ConditionFalse,
+			Reason:  string(gatewayv1.RouteReasonNotAllowedByListeners),
+			Message: input.GetGVK().Kind + " is not allowed to attach to this Gateway due to namespace restrictions",
+		})
+		return false, nil
+	}
 	return true, nil
 }
 


### PR DESCRIPTION
Manual backport of https://github.com/cilium/cilium/pull/30100 (merge conflicts with [MCS API support for Gateway API](https://github.com/cilium/cilium/pull/28769))

Fixes: #30085

```release-note
Fix error when using multiple allowRoutes namespaces in gateway
```
