### PR TITLE
Fix bpf_sock compilation for ipv6-only

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -1090,9 +1090,12 @@ __sock6_health_fwd(struct bpf_sock_addr *ctx __maybe_unused)
 	union v6addr addr6;
 
 	ctx_get_v6_address(ctx, &addr6);
+#ifdef ENABLE_IPV4
 	if (is_v4_in_v6(&addr6)) {
 		return __sock4_health_fwd(ctx);
-	} else {
+	} else
+#endif /* ENABLE_IPV4 */
+    {
 #ifdef ENABLE_IPV6
 		__sock_cookie key = get_socket_cookie(ctx);
 		struct lb6_health *val = NULL;


### PR DESCRIPTION
Otherwise,  when started with `--enable-ipv4=false --enable-ipv6=true` I got
```
level=error msg="Failed to compile bpf_sock.o: exit status 1" compiler-pid=2393 subsys=datapath-loader
level=warning msg="/var/lib/cilium/bpf/bpf_sock.c:1094:10: error: implicit declaration of function '__sock4_health_fwd' [-Werror,-Wimplicit-function-declaration]" subsys=datapath-loader
level=warning msg="                return __sock4_health_fwd(ctx);" subsys=datapath-loader
level=warning msg="                       ^" subsys=datapath-loader
level=warning msg="/var/lib/cilium/bpf/bpf_sock.c:1094:10: note: did you mean '__sock6_health_fwd'?" subsys=datapath-loader
level=warning msg="/var/lib/cilium/bpf/bpf_sock.c:1086:1: note: '__sock6_health_fwd' declared here" subsys=datapath-loader
level=warning msg="__sock6_health_fwd(struct bpf_sock_addr *ctx __maybe_unused)" subsys=datapath-loader
level=warning msg=^ subsys=datapath-loader
level=warning msg="1 error generated." subsys=datapath-loader

```