### PR TITLE
docs: Add command hints in make kind output

### DIFF
--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -263,3 +263,7 @@ fi
 echo "Kind is up! Time to install cilium:"
 echo "  make kind-image"
 echo "  make kind-install-cilium"
+echo ""
+echo "On Linux, the below can be used for faster feedback:"
+echo "  make kind-image-fast"
+echo "  make kind-install-cilium-fast"


### PR DESCRIPTION
This is to print out command hints for Linux host, so that new Cilium contributors didn't need to check docs.

Relates: #27931

