### PR TITLE
[operator] Refactor - export CiliumEndpointSlice test utils

### DIFF
--- a/operator/identitygc/crd_gc_test.go
+++ b/operator/identitygc/crd_gc_test.go
@@ -12,6 +12,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/operator/k8s"
+	tu "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -45,7 +46,7 @@ func TestUsedIdentitiesInCESs(t *testing.T) {
 	assertEqualIDs(t, wantIdentities, gotIdentities)
 
 	// 5 IDs in the store.
-	cesA := createCESWithIDs("cesA", []int64{1, 2, 3, 4, 5})
+	cesA := tu.CreateCESWithIDs("cesA", []int64{1, 2, 3, 4, 5})
 	fakeClient.CiliumV2alpha1().CiliumEndpointSlices().Create(context.Background(), cesA, meta_v1.CreateOptions{})
 	err = testutils.WaitUntil(isCESPresent("cesA", cesStore), time.Second)
 	if err != nil {
@@ -60,7 +61,7 @@ func TestUsedIdentitiesInCESs(t *testing.T) {
 	assertEqualIDs(t, wantIdentities, gotIdentities)
 
 	// 10 IDs in the store.
-	cesB := createCESWithIDs("cesB", []int64{10, 20, 30, 40, 50})
+	cesB := tu.CreateCESWithIDs("cesB", []int64{10, 20, 30, 40, 50})
 	fakeClient.CiliumV2alpha1().CiliumEndpointSlices().Create(context.Background(), cesB, meta_v1.CreateOptions{})
 	err = testutils.WaitUntil(isCESPresent("cesB", cesStore), time.Second)
 	if err != nil {
@@ -85,15 +86,6 @@ func isCESPresent(cesName string, cesStore resource.Store[*cilium_v2a1.CiliumEnd
 		_, exists, _ := cesStore.GetByKey(resource.Key{Name: cesName})
 		return exists
 	}
-}
-
-func createCESWithIDs(cesName string, ids []int64) *cilium_v2a1.CiliumEndpointSlice {
-	ces := &cilium_v2a1.CiliumEndpointSlice{ObjectMeta: meta_v1.ObjectMeta{Name: cesName}}
-	for _, id := range ids {
-		cep := cilium_v2a1.CoreCiliumEndpoint{IdentityID: id}
-		ces.Endpoints = append(ces.Endpoints, cep)
-	}
-	return ces
 }
 
 func assertEqualIDs(t *testing.T, wantIdentities, gotIdentities map[string]bool) {

--- a/operator/pkg/ciliumendpointslice/controller_test.go
+++ b/operator/pkg/ciliumendpointslice/controller_test.go
@@ -14,6 +14,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/operator/k8s"
+	tu "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -120,7 +121,7 @@ func TestNotRegisterControllerWithCESDisabled(t *testing.T) {
 }
 
 func createCEPandVerifyCESCreated(fakeClient k8sClient.FakeClientset, ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint], ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) (bool, error) {
-	cep := createStoreEndpoint("cep1", "ns", 1)
+	cep := tu.CreateStoreEndpoint("cep1", "ns", 1)
 	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(context.Background(), cep, meta_v1.CreateOptions{})
 	cepStore, _ := ciliumEndpoint.Store(context.Background())
 	if err := testutils.WaitUntil(func() bool {

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/operator/k8s"
+	tu "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -19,38 +19,6 @@ import (
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 )
-
-func createManagerEndpoint(name string, identity int64) cilium_v2a1.CoreCiliumEndpoint {
-	return cilium_v2a1.CoreCiliumEndpoint{
-		Name:       name,
-		IdentityID: identity,
-	}
-}
-
-func createStoreEndpoint(name string, namespace string, identity int64) *cilium_v2.CiliumEndpoint {
-	return &cilium_v2.CiliumEndpoint{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Status: cilium_v2.EndpointStatus{
-			Identity: &cilium_v2.EndpointIdentity{
-				ID: identity,
-			},
-			Networking: &cilium_v2.EndpointNetworking{},
-		},
-	}
-}
-
-func createStoreEndpointSlice(name string, namespace string, endpoints []cilium_v2a1.CoreCiliumEndpoint) *cilium_v2a1.CiliumEndpointSlice {
-	return &cilium_v2a1.CiliumEndpointSlice{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name: name,
-		},
-		Namespace: namespace,
-		Endpoints: endpoints,
-	}
-}
 
 func TestSyncCESsInLocalCache(t *testing.T) {
 	var r *reconciler
@@ -91,16 +59,16 @@ func TestSyncCESsInLocalCache(t *testing.T) {
 	}
 	cesController.initializeQueue()
 
-	cep1 := createManagerEndpoint("cep1", 1)
-	cep2 := createManagerEndpoint("cep2", 1)
-	cep3 := createManagerEndpoint("cep3", 2)
-	cep4 := createManagerEndpoint("cep4", 2)
-	ces1 := createStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep1, cep2, cep3, cep4})
+	cep1 := tu.CreateManagerEndpoint("cep1", 1)
+	cep2 := tu.CreateManagerEndpoint("cep2", 1)
+	cep3 := tu.CreateManagerEndpoint("cep3", 2)
+	cep4 := tu.CreateManagerEndpoint("cep4", 2)
+	ces1 := tu.CreateStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep1, cep2, cep3, cep4})
 	cesStore.CacheStore().Add(ces1)
-	cep5 := createManagerEndpoint("cep5", 1)
-	cep6 := createManagerEndpoint("cep6", 1)
-	cep7 := createManagerEndpoint("cep7", 2)
-	ces2 := createStoreEndpointSlice("ces2", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep5, cep6, cep7})
+	cep5 := tu.CreateManagerEndpoint("cep5", 1)
+	cep6 := tu.CreateManagerEndpoint("cep6", 1)
+	cep7 := tu.CreateManagerEndpoint("cep7", 2)
+	ces2 := tu.CreateStoreEndpointSlice("ces2", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep5, cep6, cep7})
 	cesStore.CacheStore().Add(ces2)
 
 	cesController.syncCESsInLocalCache(context.Background())

--- a/operator/pkg/ciliumendpointslice/reconciler_test.go
+++ b/operator/pkg/ciliumendpointslice/reconciler_test.go
@@ -12,6 +12,7 @@ import (
 	k8sTesting "k8s.io/client-go/testing"
 
 	"github.com/cilium/cilium/operator/k8s"
+	tu "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -59,11 +60,11 @@ func TestReconcileCreate(t *testing.T) {
 		return true, nil, nil
 	})
 
-	cep1 := createStoreEndpoint("cep1", "ns", 1)
+	cep1 := tu.CreateStoreEndpoint("cep1", "ns", 1)
 	cepStore.CacheStore().Add(cep1)
-	cep2 := createStoreEndpoint("cep2", "ns", 2)
+	cep2 := tu.CreateStoreEndpoint("cep2", "ns", 2)
 	cepStore.CacheStore().Add(cep2)
-	cep3 := createStoreEndpoint("cep3", "ns", 2)
+	cep3 := tu.CreateStoreEndpoint("cep3", "ns", 2)
 	cepStore.CacheStore().Add(cep3)
 	m.mapping.insertCES(NewCESName("ces1"), "ns")
 	m.mapping.insertCES(NewCESName("ces2"), "ns")
@@ -118,13 +119,13 @@ func TestReconcileUpdate(t *testing.T) {
 		return true, nil, nil
 	})
 
-	cep1 := createStoreEndpoint("cep1", "ns", 1)
+	cep1 := tu.CreateStoreEndpoint("cep1", "ns", 1)
 	cepStore.CacheStore().Add(cep1)
-	cep2 := createStoreEndpoint("cep2", "ns", 2)
+	cep2 := tu.CreateStoreEndpoint("cep2", "ns", 2)
 	cepStore.CacheStore().Add(cep2)
-	cep3 := createStoreEndpoint("cep3", "ns", 2)
+	cep3 := tu.CreateStoreEndpoint("cep3", "ns", 2)
 	cepStore.CacheStore().Add(cep3)
-	ces1 := createStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{createManagerEndpoint("cep1", 1), createManagerEndpoint("cep3", 2)})
+	ces1 := tu.CreateStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{tu.CreateManagerEndpoint("cep1", 1), tu.CreateManagerEndpoint("cep3", 2)})
 	cesStore.CacheStore().Add(ces1)
 	m.mapping.insertCES(NewCESName("ces1"), "ns")
 	m.mapping.insertCES(NewCESName("ces2"), "ns")
@@ -181,13 +182,13 @@ func TestReconcileDelete(t *testing.T) {
 		return true, nil, nil
 	})
 
-	cep1 := createStoreEndpoint("cep1", "ns", 1)
+	cep1 := tu.CreateStoreEndpoint("cep1", "ns", 1)
 	cepStore.CacheStore().Add(cep1)
-	cep2 := createStoreEndpoint("cep2", "ns", 2)
+	cep2 := tu.CreateStoreEndpoint("cep2", "ns", 2)
 	cepStore.CacheStore().Add(cep2)
-	cep3 := createStoreEndpoint("cep3", "ns", 2)
+	cep3 := tu.CreateStoreEndpoint("cep3", "ns", 2)
 	cepStore.CacheStore().Add(cep3)
-	ces1 := createStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{createManagerEndpoint("cep1", 1), createManagerEndpoint("cep3", 2)})
+	ces1 := tu.CreateStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{tu.CreateManagerEndpoint("cep1", 1), tu.CreateManagerEndpoint("cep3", 2)})
 	cesStore.CacheStore().Add(ces1)
 	m.mapping.insertCES(NewCESName("ces1"), "ns")
 	m.mapping.insertCES(NewCESName("ces2"), "ns")
@@ -236,11 +237,11 @@ func TestReconcileNoop(t *testing.T) {
 		return true, nil, nil
 	})
 
-	cep1 := createStoreEndpoint("cep1", "ns", 1)
+	cep1 := tu.CreateStoreEndpoint("cep1", "ns", 1)
 	cepStore.CacheStore().Add(cep1)
-	cep2 := createStoreEndpoint("cep2", "ns", 2)
+	cep2 := tu.CreateStoreEndpoint("cep2", "ns", 2)
 	cepStore.CacheStore().Add(cep2)
-	cep3 := createStoreEndpoint("cep3", "ns", 2)
+	cep3 := tu.CreateStoreEndpoint("cep3", "ns", 2)
 	cepStore.CacheStore().Add(cep3)
 	m.mapping.insertCES(NewCESName("ces1"), "ns")
 	m.mapping.insertCES(NewCESName("ces2"), "ns")

--- a/operator/pkg/ciliumendpointslice/testutils/test_utils.go
+++ b/operator/pkg/ciliumendpointslice/testutils/test_utils.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+package testutils
+
+import (
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+)
+
+func CreateManagerEndpoint(name string, identity int64) capi_v2a1.CoreCiliumEndpoint {
+	return capi_v2a1.CoreCiliumEndpoint{
+		Name:       name,
+		IdentityID: identity,
+	}
+}
+
+func CreateStoreEndpoint(name string, namespace string, identity int64) *v2.CiliumEndpoint {
+	return &v2.CiliumEndpoint{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: v2.EndpointStatus{
+			Identity: &v2.EndpointIdentity{
+				ID: identity,
+			},
+			Networking: &v2.EndpointNetworking{},
+		},
+	}
+}
+
+func CreateStoreEndpointSlice(name string, namespace string, endpoints []capi_v2a1.CoreCiliumEndpoint) *capi_v2a1.CiliumEndpointSlice {
+	return &capi_v2a1.CiliumEndpointSlice{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: name,
+		},
+		Namespace: namespace,
+		Endpoints: endpoints,
+	}
+}
+
+func CreateCESWithIDs(cesName string, ids []int64) *capi_v2a1.CiliumEndpointSlice {
+	ces := &capi_v2a1.CiliumEndpointSlice{ObjectMeta: meta_v1.ObjectMeta{Name: cesName}}
+	for _, id := range ids {
+		cep := capi_v2a1.CoreCiliumEndpoint{IdentityID: id}
+		ces.Endpoints = append(ces.Endpoints, cep)
+	}
+	return ces
+}


### PR DESCRIPTION
Extract test utility functions to a new package that exports them.
It's required for testing features that interact with CiliumEndpointSlices - e.g. https://github.com/cilium/cilium/pull/30356

No user facing changes.

area/operator
kind/cleanup

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>