### PR TITLE
Replace `option.Config.{Get,Set,Append}Devices` by table lookups

### DIFF
--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -25,6 +25,7 @@ cilium-agent hive [flags]
       --cni-external-routing                                      Whether the chained CNI plugin handles routing on the node
       --cni-log-file string                                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
       --controller-group-metrics strings                          List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --devices strings                                           List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'
       --disable-envoy-version-check                               Do not perform Envoy version check
       --disable-iptables-feeder-rules strings                     Chains to ignore when installing feeder rules.
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -31,6 +31,7 @@ cilium-agent hive dot-graph [flags]
       --cni-external-routing                                      Whether the chained CNI plugin handles routing on the node
       --cni-log-file string                                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
       --controller-group-metrics strings                          List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --devices strings                                           List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'
       --disable-envoy-version-check                               Do not perform Envoy version check
       --disable-iptables-feeder-rules strings                     Chains to ignore when installing feeder rules.
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)

--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/api"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
@@ -153,7 +154,8 @@ func getConfigHandler(d *Daemon, params GetConfigParams) middleware.Responder {
 	option.Config.ConfigPatchMutex.RUnlock()
 
 	// Manually add fields that are behind accessors.
-	m["Devices"] = option.Config.GetDevices()
+	devs, _ := tables.SelectedDevices(d.devices, d.db.ReadTxn())
+	m["Devices"] = tables.DeviceNames(devs)
 
 	spec := &models.DaemonConfigurationSpec{
 		Options:           *option.Config.Opts.GetMutableModel(),

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -747,7 +747,8 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		d.l2announcer.DevicesChanged(devices)
 	}
 
-	if err := finishKubeProxyReplacementInit(params.Sysctl); err != nil {
+	nativeDevices, _ := datapathTables.SelectedDevices(d.devices, d.db.ReadTxn())
+	if err := finishKubeProxyReplacementInit(params.Sysctl, nativeDevices); err != nil {
 		log.WithError(err).Error("failed to finalise LB initialization")
 		return nil, nil, fmt.Errorf("failed to finalise LB initialization: %w", err)
 	}
@@ -787,7 +788,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		log.Error("IPv4 and IPv6 masquerading are both disabled, BPF masquerading requires at least one to be enabled")
 		return nil, nil, fmt.Errorf("BPF masquerade requires (--%s=\"true\" or --%s=\"true\")", option.EnableIPv4Masquerade, option.EnableIPv6Masquerade)
 	}
-	if len(option.Config.GetDevices()) == 0 {
+	if len(devices) == 0 {
 		if option.Config.EnableHostFirewall {
 			msg := "Host firewall's external facing device could not be determined. Use --%s to specify."
 			log.WithError(err).Errorf(msg, option.Devices)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1359,7 +1359,10 @@ func initEnv(vp *viper.Viper) {
 	if option.Config.EnableIPSec &&
 		!option.Config.TunnelingEnabled() &&
 		len(option.Config.EncryptInterface) == 0 &&
-		len(option.Config.GetDevices()) == 0 &&
+		// If devices are required, we don't look at the EncryptInterface, as we
+		// don't load bpf_network in loader.reinitializeIPSec. Instead, we load
+		// bpf_host onto physical devices as chosen by configuration.
+		!option.Config.AreDevicesRequired() &&
 		option.Config.IPAM != ipamOption.IPAMENI {
 		link, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
 		if err != nil {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -225,9 +225,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.StringSlice(option.DebugVerbose, []string{}, "List of enabled verbose debug groups")
 	option.BindEnv(vp, option.DebugVerbose)
 
-	flags.StringSlice(option.Devices, []string{}, "List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'")
-	option.BindEnv(vp, option.Devices)
-
 	flags.String(option.DirectRoutingDevice, "", "Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)")
 	option.BindEnv(vp, option.DirectRoutingDevice)
 

--- a/daemon/cmd/device-reloader.go
+++ b/daemon/cmd/device-reloader.go
@@ -109,8 +109,6 @@ func (d *deviceReloader) reload(ctx context.Context) error {
 		return nil
 	}
 
-	d.params.Config.SetDevices(devices)
-
 	daemon, err := d.params.Daemon.Await(ctx)
 	if err != nil {
 		return err

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cilium/cilium/pkg/mountinfo"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/safeio"
-	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 // initKubeProxyReplacementOptions will grok the global config and determine
@@ -373,17 +372,6 @@ func finishKubeProxyReplacementInit(sysctl sysctl.Sysctl, devices []*tables.Devi
 	// +-------------------------------------------------------+
 	// | After this point, BPF NodePort should not be disabled |
 	// +-------------------------------------------------------+
-
-	// When WG & encrypt-node are on, a NodePort BPF to-be forwarded request
-	// to a remote node running a selected service endpoint must be encrypted.
-	// To make the NodePort's rev-{S,D}NAT translations to happen for a reply
-	// from the remote node, we need to attach bpf_host to the Cilium's WG
-	// netdev (otherwise, the WG netdev after decrypting the reply will pass
-	// it to the stack which drops the packet).
-	if option.Config.EnableNodePort &&
-		option.Config.EnableWireguard && option.Config.EncryptNode {
-		option.Config.AppendDevice(wgTypes.IfaceName)
-	}
 
 	// For MKE, we only need to change/extend the socket LB behavior in case
 	// of kube-proxy replacement. Otherwise, nothing else is needed.

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -185,7 +185,8 @@ func (d *Daemon) getBandwidthManagerStatus() *models.BandwidthManager {
 		s.CongestionControl = models.BandwidthManagerCongestionControlBbr
 	}
 
-	s.Devices = option.Config.GetDevices()
+	devs, _ := datapathTables.SelectedDevices(d.devices, d.db.ReadTxn())
+	s.Devices = datapathTables.DeviceNames(devs)
 	return s
 }
 
@@ -202,9 +203,10 @@ func (d *Daemon) getHostFirewallStatus() *models.HostFirewall {
 	if option.Config.EnableHostFirewall {
 		mode = models.HostFirewallModeEnabled
 	}
+	devs, _ := datapathTables.SelectedDevices(d.devices, d.db.ReadTxn())
 	return &models.HostFirewall{
 		Mode:    mode,
-		Devices: option.Config.GetDevices(),
+		Devices: datapathTables.DeviceNames(devs),
 	}
 }
 

--- a/daemon/k8s/init.go
+++ b/daemon/k8s/init.go
@@ -90,9 +90,7 @@ func WaitForNodeInformation(ctx context.Context, log logrus.FieldLogger, localNo
 		if option.Config.K8sRequireIPv4PodCIDR || option.Config.K8sRequireIPv6PodCIDR {
 			return fmt.Errorf("node name must be specified via environment variable '%s' to retrieve Kubernetes PodCIDR range", k8sConst.EnvNodeNameSpec)
 		}
-		if option.MightAutoDetectDevices() {
-			log.Info("K8s node name is empty. BPF NodePort might not be able to auto detect all devices")
-		}
+		log.Info("K8s node name is empty. BPF NodePort might not be able to auto detect all devices")
 		return nil
 	}
 
@@ -104,7 +102,7 @@ func WaitForNodeInformation(ctx context.Context, log logrus.FieldLogger, localNo
 	// happen, as initKubeProxyReplacementOptions() might disable BPF NodePort.
 	// Anyway, to be on the safe side, don't give up waiting for a (Cilium)Node
 	// self object.
-	isNodeInformationOptional := (!requireIPv4CIDR && !requireIPv6CIDR && !option.MightAutoDetectDevices())
+	isNodeInformationOptional := (!requireIPv4CIDR && !requireIPv6CIDR)
 	// If node information is optional, let's wait 10 seconds only.
 	// It node information is required, wait indefinitely.
 	if isNodeInformationOptional {

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/mtu"
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/statedb"
 	wg "github.com/cilium/cilium/pkg/wireguard/agent"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
@@ -175,6 +176,8 @@ func newDatapath(params datapathParams) types.Datapath {
 		BWManager:      params.BandwidthManager,
 		Loader:         params.Loader,
 		NodeManager:    params.NodeManager,
+		DB:             params.DB,
+		Devices:        params.Devices,
 	}, datapathConfig)
 
 	params.LC.Append(cell.Hook{
@@ -205,6 +208,8 @@ type datapathParams struct {
 	// This is required until option.Config.GetDevices() has been removed and
 	// uses of it converted to Table[Device].
 	DeviceManager *linuxdatapath.DeviceManager
+	DB            *statedb.DB
+	Devices       statedb.Table[*tables.Device]
 
 	BandwidthManager types.BandwidthManager
 

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -117,14 +117,6 @@ var Cell = cell.Module(
 
 	// DevicesController manages the devices and routes tables
 	linuxdatapath.DevicesControllerCell,
-	cell.Provide(func(cfg *option.DaemonConfig) linuxdatapath.DevicesConfig {
-		// Provide the configured devices to the devices controller.
-		// This is temporary until DevicesController takes ownership of the
-		// device-related configuration options.
-		return linuxdatapath.DevicesConfig{
-			Devices: cfg.GetDevices(),
-		}
-	}),
 
 	// Synchronizes the userspace ipcache with the corresponding BPF map.
 	ipcache.Cell,

--- a/pkg/datapath/iptables/cell.go
+++ b/pkg/datapath/iptables/cell.go
@@ -29,7 +29,6 @@ var Cell = cell.Module(
 		return SharedConfig{
 			TunnelingEnabled:                cfg.TunnelingEnabled(),
 			NodeIpsetNeeded:                 cfg.NodeIpsetNeeded(),
-			Devices:                         cfg.GetDevices(),
 			IptablesMasqueradingIPv4Enabled: cfg.IptablesMasqueradingIPv4Enabled(),
 			IptablesMasqueradingIPv6Enabled: cfg.IptablesMasqueradingIPv6Enabled(),
 			IPv4NativeRoutingCIDR:           cfg.GetIPv4NativeRoutingCIDR(),
@@ -82,7 +81,6 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 type SharedConfig struct {
 	TunnelingEnabled                bool
 	NodeIpsetNeeded                 bool
-	Devices                         []string
 	IptablesMasqueradingIPv4Enabled bool
 	IptablesMasqueradingIPv6Enabled bool
 	IPv4NativeRoutingCIDR           *cidr.CIDR

--- a/pkg/datapath/linux/config/cell.go
+++ b/pkg/datapath/linux/config/cell.go
@@ -23,7 +23,6 @@ type WriterParams struct {
 	NodeAddressing     datapath.NodeAddressing
 	NodeExtraDefines   []dpdef.Map `group:"header-node-defines"`
 	NodeExtraDefineFns []dpdef.Fn  `group:"header-node-define-fns"`
-	BandwidthManager   datapath.BandwidthManager
 	Sysctl             sysctl.Sysctl
 	DB                 *statedb.DB
 	Devices            statedb.Table[*tables.Device]

--- a/pkg/datapath/linux/config/cell.go
+++ b/pkg/datapath/linux/config/cell.go
@@ -8,9 +8,11 @@ import (
 
 	dpdef "github.com/cilium/cilium/pkg/datapath/linux/config/defines"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
+	"github.com/cilium/cilium/pkg/statedb"
 )
 
 type WriterParams struct {
@@ -23,6 +25,8 @@ type WriterParams struct {
 	NodeExtraDefineFns []dpdef.Fn  `group:"header-node-define-fns"`
 	BandwidthManager   datapath.BandwidthManager
 	Sysctl             sysctl.Sysctl
+	DB                 *statedb.DB
+	Devices            statedb.Table[*tables.Device]
 }
 
 var Cell = cell.Module(

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/link"
 	dpdef "github.com/cilium/cilium/pkg/datapath/linux/config/defines"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
@@ -59,12 +60,15 @@ import (
 	"github.com/cilium/cilium/pkg/netns"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/statedb"
 	wgtypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 // HeaderfileWriter is a wrapper type which implements datapath.ConfigWriter.
 // It manages writing of configuration of datapath program headerfiles.
 type HeaderfileWriter struct {
+	db                 *statedb.DB
+	devices            statedb.Table[*tables.Device]
 	log                logrus.FieldLogger
 	nodeMap            nodemap.MapV2
 	nodeAddressing     datapath.NodeAddressing
@@ -82,6 +86,8 @@ func NewHeaderfileWriter(p WriterParams) (datapath.ConfigWriter, error) {
 	}
 	return &HeaderfileWriter{
 		nodeMap:            p.NodeMap,
+		db:                 p.DB,
+		devices:            p.Devices,
 		nodeAddressing:     p.NodeAddressing,
 		nodeExtraDefines:   merged,
 		nodeExtraDefineFns: p.NodeExtraDefineFns,
@@ -98,6 +104,12 @@ func writeIncludes(w io.Writer) (int, error) {
 func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeConfiguration) error {
 	extraMacrosMap := make(dpdef.Map)
 	cDefinesMap := make(dpdef.Map)
+
+	var nativeDevices []*tables.Device
+	if h.db != nil && h.devices != nil {
+		txn := h.db.ReadTxn()
+		nativeDevices, _ = tables.SelectedDevices(h.devices, txn)
+	}
 
 	fw := bufio.NewWriter(w)
 
@@ -525,7 +537,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["NODEPORT_PORT_MAX_NAT"] = "65535"
 	}
 
-	macByIfIndexMacro, isL3DevMacro, err := devMacros()
+	macByIfIndexMacro, isL3DevMacro, err := devMacros(nativeDevices)
 	if err != nil {
 		return err
 	}
@@ -685,7 +697,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 
 	}
 
-	vlanFilter, err := vlanFilterMacros()
+	vlanFilter, err := vlanFilterMacros(nativeDevices)
 	if err != nil {
 		return err
 	}
@@ -814,14 +826,10 @@ func getEphemeralPortRangeMin(sysctl sysctl.Sysctl) (int, error) {
 
 // vlanFilterMacros generates VLAN_FILTER macros which
 // are written to node_config.h
-func vlanFilterMacros() (string, error) {
+func vlanFilterMacros(nativeDevices []*tables.Device) (string, error) {
 	devices := make(map[int]bool)
-	for _, device := range option.Config.GetDevices() {
-		ifindex, err := link.GetIfIndex(device)
-		if err != nil {
-			return "", err
-		}
-		devices[int(ifindex)] = true
+	for _, device := range nativeDevices {
+		devices[device.Index] = true
 	}
 
 	allowedVlans := make(map[int]bool)
@@ -883,7 +891,7 @@ return false;`))
 
 // devMacros generates NATIVE_DEV_MAC_BY_IFINDEX and IS_L3_DEV macros which
 // are written to node_config.h.
-func devMacros() (string, string, error) {
+func devMacros(devs []*tables.Device) (string, string, error) {
 	var (
 		macByIfIndexMacro, isL3DevMacroBuf bytes.Buffer
 		isL3DevMacro                       string
@@ -891,17 +899,11 @@ func devMacros() (string, string, error) {
 	macByIfIndex := make(map[int]string)
 	l3DevIfIndices := make([]int, 0)
 
-	for _, iface := range option.Config.GetDevices() {
-		link, err := netlink.LinkByName(iface)
-		if err != nil {
-			return "", "", fmt.Errorf("failed to retrieve link %s by name: %w", iface, err)
+	for _, dev := range devs {
+		if len(dev.HardwareAddr) != 6 {
+			l3DevIfIndices = append(l3DevIfIndices, dev.Index)
 		}
-		idx := link.Attrs().Index
-		m := link.Attrs().HardwareAddr
-		if m == nil || len(m) != 6 {
-			l3DevIfIndices = append(l3DevIfIndices, idx)
-		}
-		macByIfIndex[idx] = mac.CArrayString(m)
+		macByIfIndex[dev.Index] = mac.CArrayString(net.HardwareAddr(dev.HardwareAddr))
 	}
 
 	macByIfindexTmpl := template.Must(template.New("macByIfIndex").Parse(
@@ -952,7 +954,7 @@ func (h *HeaderfileWriter) WriteNetdevConfig(w io.Writer, cfg datapath.DeviceCon
 
 // writeStaticData writes the endpoint-specific static data defines to the
 // specified writer. This must be kept in sync with loader.ELFSubstitutions().
-func (h *HeaderfileWriter) writeStaticData(fw io.Writer, e datapath.EndpointConfiguration) {
+func (h *HeaderfileWriter) writeStaticData(devices []string, fw io.Writer, e datapath.EndpointConfiguration) {
 	if e.IsHost() {
 		if option.Config.EnableNodePort {
 			// Values defined here are for the host datapath attached to the
@@ -983,7 +985,7 @@ func (h *HeaderfileWriter) writeStaticData(fw io.Writer, e datapath.EndpointConf
 		fmt.Fprint(fw, defineUint32("SECCTX_FROM_IPCACHE", 1))
 
 		// Use templating for ETH_HLEN only if there is any L2-less device
-		if !mac.HaveMACAddrs(option.Config.GetDevices()) {
+		if !mac.HaveMACAddrs(devices) {
 			// L2 hdr len (for L2-less devices it will be replaced with "0")
 			fmt.Fprint(fw, defineUint16("ETH_HLEN", mac.EthHdrLen))
 		}
@@ -1036,13 +1038,22 @@ func (h *HeaderfileWriter) writeStaticData(fw io.Writer, e datapath.EndpointConf
 func (h *HeaderfileWriter) WriteEndpointConfig(w io.Writer, e datapath.EndpointConfiguration) error {
 	fw := bufio.NewWriter(w)
 
-	writeIncludes(w)
-	h.writeStaticData(fw, e)
+	var (
+		nativeDevices []*tables.Device
+		deviceNames   []string
+	)
+	if h.db != nil && h.devices != nil {
+		nativeDevices, _ = tables.SelectedDevices(h.devices, h.db.ReadTxn())
+		deviceNames = tables.DeviceNames(nativeDevices)
+	}
 
-	return h.writeTemplateConfig(fw, e)
+	writeIncludes(w)
+	h.writeStaticData(deviceNames, fw, e)
+
+	return h.writeTemplateConfig(fw, nativeDevices, e)
 }
 
-func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.EndpointConfiguration) error {
+func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, devices []*tables.Device, e datapath.EndpointConfiguration) error {
 	if e.RequireEgressProg() {
 		fmt.Fprintf(fw, "#define USE_BPF_PROG_FOR_INGRESS_POLICY 1\n")
 	}
@@ -1058,7 +1069,7 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 			return err
 		}
 		fmt.Fprintf(fw, "#define DIRECT_ROUTING_DEV_IFINDEX %d\n", directRoutingIfIndex)
-		if len(option.Config.GetDevices()) == 1 {
+		if len(devices) == 1 {
 			if e.IsHost() || !option.Config.EnforceLXCFibLookup() {
 				fmt.Fprintf(fw, "#define ENABLE_SKIP_FIB 1\n")
 			}
@@ -1098,5 +1109,9 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 // WriteTemplateConfig writes the BPF configuration for the template to a writer.
 func (h *HeaderfileWriter) WriteTemplateConfig(w io.Writer, e datapath.EndpointConfiguration) error {
 	fw := bufio.NewWriter(w)
-	return h.writeTemplateConfig(fw, e)
+	var nativeDevices []*tables.Device
+	if h.db != nil && h.devices != nil {
+		nativeDevices, _ = tables.SelectedDevices(h.devices, h.db.ReadTxn())
+	}
+	return h.writeTemplateConfig(fw, nativeDevices, e)
 }

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -1047,6 +1047,11 @@ func (h *HeaderfileWriter) WriteEndpointConfig(w io.Writer, e datapath.EndpointC
 		deviceNames = tables.DeviceNames(nativeDevices)
 	}
 
+	// Add cilium_wg0 if necessary.
+	if option.Config.NeedBPFHostOnWireGuardDevice() {
+		deviceNames = append(deviceNames, wgtypes.IfaceName)
+	}
+
 	writeIncludes(w)
 	h.writeStaticData(deviceNames, fw, e)
 

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -109,7 +109,6 @@ func writeConfig(c *C, header string, write writeFn) {
 			statedb.Cell,
 			cell.Provide(
 				fakeTypes.NewNodeAddressing,
-				func() datapath.BandwidthManager { return &fakeTypes.BandwidthManager{} },
 				func() sysctl.Sysctl { return sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc") },
 				tables.NewDeviceTable,
 				func(_ *statedb.DB, devices statedb.RWTable[*tables.Device]) statedb.Table[*tables.Device] {
@@ -444,9 +443,8 @@ func TestWriteNodeConfigExtraDefines(t *testing.T) {
 		NodeExtraDefineFns: []dpdef.Fn{
 			func() (dpdef.Map, error) { return nil, errors.New("failing on purpose") },
 		},
-		BandwidthManager: &fakeTypes.BandwidthManager{},
-		Sysctl:           sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
-		NodeMap:          fake.NewFakeNodeMapV2(),
+		Sysctl:  sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
+		NodeMap: fake.NewFakeNodeMapV2(),
 	})
 	require.NoError(t, err)
 
@@ -463,9 +461,8 @@ func TestWriteNodeConfigExtraDefines(t *testing.T) {
 			func() (dpdef.Map, error) { return dpdef.Map{"FOO": "0x1", "BAR": "0x2"}, nil },
 			func() (dpdef.Map, error) { return dpdef.Map{"FOO": "0x3"}, nil },
 		},
-		BandwidthManager: &fakeTypes.BandwidthManager{},
-		Sysctl:           sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
-		NodeMap:          fake.NewFakeNodeMapV2(),
+		Sysctl:  sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
+		NodeMap: fake.NewFakeNodeMapV2(),
 	})
 	require.NoError(t, err)
 
@@ -491,7 +488,6 @@ func TestNewHeaderfileWriter(t *testing.T) {
 		NodeAddressing:     fakeTypes.NewNodeAddressing(),
 		NodeExtraDefines:   []dpdef.Map{a, a},
 		NodeExtraDefineFns: nil,
-		BandwidthManager:   &fakeTypes.BandwidthManager{},
 		Sysctl:             sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
 		NodeMap:            fake.NewFakeNodeMapV2(),
 	})
@@ -504,7 +500,6 @@ func TestNewHeaderfileWriter(t *testing.T) {
 		NodeAddressing:     fakeTypes.NewNodeAddressing(),
 		NodeExtraDefines:   []dpdef.Map{a},
 		NodeExtraDefineFns: nil,
-		BandwidthManager:   &fakeTypes.BandwidthManager{},
 		Sysctl:             sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
 		NodeMap:            fake.NewFakeNodeMapV2(),
 	})

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -5,10 +5,12 @@ package linux
 
 import (
 	loader "github.com/cilium/cilium/pkg/datapath/loader/types"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
 	"github.com/cilium/cilium/pkg/node/manager"
+	"github.com/cilium/cilium/pkg/statedb"
 )
 
 // DatapathConfiguration is the static configuration of the datapath. The
@@ -43,6 +45,8 @@ type DatapathParams struct {
 	MTU            datapath.MTUConfiguration
 	Loader         loader.Loader
 	NodeManager    manager.NodeManager
+	DB             *statedb.DB
+	Devices        statedb.Table[*tables.Device]
 }
 
 // NewDatapath creates a new Linux datapath
@@ -58,7 +62,7 @@ func NewDatapath(p DatapathParams, cfg DatapathConfiguration) datapath.Datapath 
 		bwmgr:           p.BWManager,
 	}
 
-	dp.node = NewNodeHandler(cfg, dp.nodeAddressing, p.NodeMap, p.MTU, p.NodeManager)
+	dp.node = NewNodeHandler(cfg, dp.nodeAddressing, p.NodeMap, p.MTU, p.NodeManager, p.DB, p.Devices)
 	return dp
 }
 

--- a/pkg/datapath/linux/devices.go
+++ b/pkg/datapath/linux/devices.go
@@ -29,26 +29,9 @@ type DeviceManager struct {
 }
 
 func (dm *DeviceManager) Detect(k8sEnabled bool) ([]string, error) {
-	hasWildcard := false
-	userDevices := option.Config.GetDevices()
-	for _, name := range userDevices {
-		hasWildcard = hasWildcard || strings.HasSuffix(name, "+")
-	}
-
-	if len(userDevices) == 0 && !option.Config.AreDevicesRequired() {
-		return nil, nil
-	}
-
 	rxn := dm.params.DB.ReadTxn()
 	devs, _ := tables.SelectedDevices(dm.params.DeviceTable, rxn)
 	names := tables.DeviceNames(devs)
-
-	if len(names) == 0 && hasWildcard {
-		// Fail if user provided a device wildcard which didn't match anything.
-		return nil, fmt.Errorf("No device found matching %v", userDevices)
-	}
-
-	option.Config.SetDevices(names)
 	dm.initialDevices = names
 
 	// Look up the device that holds the node IP. Used as fallback for direct-routing

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
 	vns "github.com/vishvananda/netns"
@@ -32,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/netns"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -56,6 +58,7 @@ var DevicesControllerCell = cell.Module(
 		newDevicesController,
 		newDeviceManager,
 	),
+	cell.Config(DevicesConfig{}),
 
 	// Always construct the devices controller. We provide the
 	// *devicesController for DeviceManager, but once it has been removed,
@@ -63,6 +66,10 @@ var DevicesControllerCell = cell.Module(
 	// controller jobs.
 	cell.Invoke(func(*devicesController) {}),
 )
+
+func (c DevicesConfig) Flags(flags *pflag.FlagSet) {
+	flags.StringSlice(option.Devices, []string{}, "List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'")
+}
 
 var (
 	// batchingDuration is the amount of time to wait for more

--- a/pkg/datapath/linux/devices_controller_test.go
+++ b/pkg/datapath/linux/devices_controller_test.go
@@ -303,12 +303,6 @@ func TestDevicesController(t *testing.T) {
 				return makeNetlinkFuncs()
 			}),
 
-			cell.Provide(func() DevicesConfig {
-				return DevicesConfig{
-					Devices: []string{},
-				}
-			}),
-
 			cell.Invoke(func(db_ *statedb.DB, devicesTable_ statedb.Table[*tables.Device], routesTable_ statedb.Table[*tables.Route]) {
 				db = db_
 				devicesTable = devicesTable_
@@ -379,16 +373,14 @@ func TestDevicesController_Wildcards(t *testing.T) {
 		h := hive.New(
 			statedb.Cell,
 			DevicesControllerCell,
-			cell.Provide(func() DevicesConfig {
-				return DevicesConfig{
-					Devices: []string{"dummy+"},
-				}
-			}),
 			cell.Provide(func() (*netlinkFuncs, error) { return makeNetlinkFuncs() }),
 			cell.Invoke(func(db_ *statedb.DB, devicesTable_ statedb.Table[*tables.Device]) {
 				db = db_
 				devicesTable = devicesTable_
 			}))
+		hive.AddConfigOverride(h, func(c *DevicesConfig) {
+			c.Devices = []string{"dummy+"}
+		})
 
 		err := h.Start(ctx)
 		require.NoError(t, err)
@@ -530,7 +522,6 @@ func TestDevicesController_Restarts(t *testing.T) {
 	h := hive.New(
 		statedb.Cell,
 		DevicesControllerCell,
-		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
 		cell.Provide(func() *netlinkFuncs { return &funcs }),
 		cell.Invoke(func(db_ *statedb.DB, devicesTable_ statedb.Table[*tables.Device]) {
 			db = db_

--- a/pkg/datapath/linux/fuzz_test.go
+++ b/pkg/datapath/linux/fuzz_test.go
@@ -23,7 +23,7 @@ func FuzzNodeHandler(f *testing.F) {
 		}
 		dpConfig := DatapathConfiguration{HostDevice: "veth0"}
 		fakeNodeAddressing := fakeTypes.NewNodeAddressing()
-		linuxNodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil, &fakeTypes.MTU{}, new(mockEnqueuer))
+		linuxNodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil, &fakeTypes.MTU{}, new(mockEnqueuer), nil, nil)
 		if linuxNodeHandler == nil {
 			panic("Should not be nil")
 		}

--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -31,9 +32,9 @@ func (n *linuxNodeHandler) getDefaultEncryptionInterface() string {
 	if option.Config.TunnelingEnabled() {
 		return n.datapathConfig.TunnelDevice
 	}
-	devices := option.Config.GetDevices()
+	devices, _ := tables.SelectedDevices(n.devices, n.db.ReadTxn())
 	if len(devices) > 0 {
-		return devices[0]
+		return devices[0].Name
 	}
 	if len(option.Config.EncryptInterface) > 0 {
 		return option.Config.EncryptInterface[0]

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -668,6 +668,7 @@ func (n *linuxNodeHandler) insertNeighborCommon(ctx context.Context, nextHop Nex
 			HardwareAddr: nil,
 		}
 		if err := netlink.NeighSet(&neighInit); err != nil {
+			// EINVAL is expected (see above)
 			errs = errors.Join(errs, fmt.Errorf("next hop insert failed for %+v: %w", neighInit, err))
 		}
 	}

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -221,7 +221,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestUpdateNodeRoute(c *check.C) {
 		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer))
+			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 	c.Assert(h.Start(context.TODO()), check.IsNil)
@@ -283,7 +283,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestAuxiliaryPrefixes(c *check.C) {
 		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer))
+			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 	c.Assert(h.Start(context.TODO()), check.IsNil)
@@ -379,7 +379,7 @@ func (s *linuxPrivilegedBaseTestSuite) commonNodeUpdateEncapsulation(c *check.C,
 		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer))
+			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 	c.Assert(h.Start(context.TODO()), check.IsNil)
@@ -660,7 +660,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateIDs(c *check.C) {
 		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodeMap, &s.mtuConfig, new(mockEnqueuer))
+			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodeMap, &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 	c.Assert(h.Start(context.TODO()), check.IsNil)
@@ -820,7 +820,7 @@ func (s *linuxPrivilegedBaseTestSuite) testNodeChurnXFRMLeaksWithConfig(c *check
 		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer))
+			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 	c.Assert(h.Start(context.TODO()), check.IsNil)
@@ -921,7 +921,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateDirectRouting(c *check.C) {
 		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer))
+			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 	c.Assert(h.Start(context.TODO()), check.IsNil)
@@ -1148,7 +1148,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestAgentRestartOptionChanges(c *check.C)
 		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer))
+			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 	c.Assert(h.Start(context.TODO()), check.IsNil)
@@ -1270,7 +1270,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeValidationDirectRouting(c *check.
 		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer))
+			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 	c.Assert(h.Start(context.TODO()), check.IsNil)
@@ -1445,7 +1445,7 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		}),
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: "veth0"}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, mq)
+			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, mq, db, devices)
 			mq.nh = linuxNodeHandler
 		}),
 	)
@@ -2210,7 +2210,7 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 		}),
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: "veth0"}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, mq)
+			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, mq, db, devices)
 			mq.nh = linuxNodeHandler
 		}),
 	)
@@ -2493,7 +2493,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: "veth0"}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, mq)
+			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, mq, db, devices)
 			mq.nh = linuxNodeHandler
 		}),
 	)
@@ -3254,7 +3254,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: "veth0"}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, mq)
+			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, mq, db, devices)
 			mq.nh = linuxNodeHandler
 		}),
 	)
@@ -3451,7 +3451,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdate(c *check.C, config da
 		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer))
+			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 	c.Assert(h.Start(context.TODO()), check.IsNil)
@@ -3558,7 +3558,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdateNOP(c *check.C, config
 		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer))
+			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 	c.Assert(h.Start(context.TODO()), check.IsNil)
@@ -3637,7 +3637,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeValidateImplementation(c *ch
 		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer))
+			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 	c.Assert(h.Start(context.TODO()), check.IsNil)

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -387,7 +387,6 @@ func (s *linuxPrivilegedBaseTestSuite) commonNodeUpdateEncapsulation(c *check.C,
 
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	linuxNodeHandler.OverrideEnableEncapsulation(override)
-	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4:          s.enableIPv4,
 		EnableIPv6:          s.enableIPv6,
@@ -1263,6 +1262,7 @@ func lookupFakeRoute(c *check.C, n *linuxNodeHandler, prefix *cidr.CIDR) bool {
 func (s *linuxPrivilegedBaseTestSuite) TestNodeValidationDirectRouting(c *check.C) {
 	ip4Alloc1 := cidr.MustParseCIDR("5.5.5.0/24")
 	ip6Alloc1 := cidr.MustParseCIDR("2001:aaaa::/96")
+
 	var linuxNodeHandler *linuxNodeHandler
 	h := hive.New(
 		statedb.Cell,
@@ -1329,26 +1329,15 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeValidationDirectRouting(c *check.
 	}
 }
 
-func neighStateOk(n netlink.Neigh) (bool, bool) {
-	retry := false
-	good := false
+func neighStateOk(n netlink.Neigh) bool {
 	switch {
 	case (n.State & netlink.NUD_REACHABLE) > 0:
 		fallthrough
 	case (n.State & netlink.NUD_STALE) > 0:
 		// Current final state
-		good = true
-	case (n.State & netlink.NUD_DELAY) > 0:
-		fallthrough
-	case (n.State & netlink.NUD_PROBE) > 0:
-		fallthrough
-	case (n.State & netlink.NUD_FAILED) > 0:
-		fallthrough
-	case (n.State & netlink.NUD_INCOMPLETE) > 0:
-		// Still potential ongoing resolution
-		retry = true
+		return true
 	}
-	return good, retry
+	return false
 }
 
 func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandling(c *check.C) {
@@ -1395,7 +1384,7 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	}
 	err = netlink.LinkAdd(veth)
 	c.Assert(err, check.IsNil)
-	defer netlink.LinkDel(veth)
+	c.Cleanup(func() { netlink.LinkDel(veth) })
 	veth0, err := netlink.LinkByName("veth0")
 	c.Assert(err, check.IsNil)
 	veth1, err := netlink.LinkByName("veth1")
@@ -1474,6 +1463,7 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandling(c *check.C) {
 
 	// wait waits for neigh entry update or waits for removal if waitForDelete=true
 	wait := func(nodeID nodeTypes.Identity, link string, before *time.Time, waitForDelete bool) {
+		c.T.Helper()
 		err := testutils.WaitUntil(func() bool {
 			linuxNodeHandler.neighLock.Lock()
 			defer linuxNodeHandler.neighLock.Unlock()
@@ -1497,6 +1487,38 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		c.Assert(err, check.IsNil)
 	}
 
+	assertNeigh := func(ip net.IP, checkNeigh func(neigh netlink.Neigh) bool) {
+		c.T.Helper()
+		err := testutils.WaitUntil(func() bool {
+			neighs, err := netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
+			c.Assert(err, check.IsNil)
+			for _, n := range neighs {
+				if n.IP.Equal(ip) && checkNeigh(n) {
+					return true
+				}
+			}
+			return false
+		}, 5*time.Second)
+		c.Assert(err, check.IsNil, check.Commentf("expected neighbor %s", ip))
+	}
+
+	assertNoNeigh := func(msg string, ips ...net.IP) {
+		c.T.Helper()
+		err := testutils.WaitUntil(func() bool {
+			neighs, err := netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
+			c.Assert(err, check.IsNil)
+			for _, n := range neighs {
+				for _, ip := range ips {
+					if n.IP.Equal(ip) {
+						return false
+					}
+				}
+			}
+			return true
+		}, 5*time.Second)
+		c.Assert(err, check.IsNil, check.Commentf(msg))
+	}
+
 	nodev1 := nodeTypes.Node{
 		Name: "node1",
 		IPAddresses: []nodeTypes.Address{{
@@ -1515,24 +1537,9 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	c.Assert(err, check.IsNil)
 	// insertNeighbor is invoked async, so thus this wait based on last ping
 	wait(nodev1.Identity(), "veth0", &now, false)
-refetch1:
+
 	// Check whether an arp entry for nodev1 IP addr (=veth1) was added
-	neighs, err := netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found := false
-	for _, n := range neighs {
-		if n.IP.Equal(ip1) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch1
-			}
-		}
-	}
-	c.Assert(found, check.Equals, true)
+	assertNeigh(ip1, neighStateOk)
 
 	// Swap MAC addresses of veth0 and veth1 to ensure the MAC address of veth1 changed.
 	// Trigger neighbor refresh on veth0 and check whether the arp entry was updated.
@@ -1553,24 +1560,14 @@ refetch1:
 
 	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1, true)
 	wait(nodev1.Identity(), "veth0", &now, false)
-refetch2:
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(ip1) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				updatedHwAddrFromArpEntry = n.HardwareAddr
-				break
-			}
-			if retry {
-				goto refetch2
-			}
+
+	assertNeigh(ip1, func(neigh netlink.Neigh) bool {
+		if neighStateOk(neigh) {
+			updatedHwAddrFromArpEntry = neigh.HardwareAddr
+			return true
 		}
-	}
-	c.Assert(found, check.Equals, true)
+		return false
+	})
 	c.Assert(updatedHwAddrFromArpEntry.String(), check.Equals, veth0HwAddr.String())
 
 	// Remove nodev1, and check whether the arp entry was removed
@@ -1579,16 +1576,7 @@ refetch2:
 	// deleteNeighbor is invoked async too
 	wait(nodev1.Identity(), "veth0", nil, true)
 
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(ip1) {
-			found = true
-			break
-		}
-	}
-	c.Assert(found, check.Equals, false)
+	assertNoNeigh("expected removed neigh "+ip1.String(), ip1)
 
 	// Create multiple goroutines which call insertNeighbor and check whether
 	// MAC changes of veth1 are properly handled. This is a basic randomized
@@ -1629,7 +1617,7 @@ refetch2:
 			}
 		}()
 	}
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 3; i++ {
 		mac := rndHWAddr()
 		// Change MAC
 		ns.Do(func() error {
@@ -1643,7 +1631,7 @@ refetch2:
 		// Check that MAC has been changed in the neigh table
 		var found bool
 		err := testutils.WaitUntilWithSleep(func() bool {
-			neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
+			neighs, err := netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
 			c.Assert(err, check.IsNil)
 			found = false
 			for _, n := range neighs {
@@ -1825,102 +1813,35 @@ refetch2:
 	wait(nodev3.Identity(), "veth0", &now, false)
 
 	nextHop := net.ParseIP("f00d::250")
-refetch3:
 	// Check that both node{2,3} are via nextHop (gw)
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch3
-			}
-		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
-			c.ExpectFailure("node{2,3} should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, true)
+	assertNeigh(nextHop, neighStateOk)
+	assertNoNeigh("node{2,3} should not be in the same L2", node2IP, node3IP)
 
 	// Check that removing node2 will not remove nextHop, as it is still used by node3
 	c.Assert(linuxNodeHandler.NodeDelete(nodev2), check.IsNil)
 	wait(nodev2.Identity(), "veth0", nil, true)
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			found = true
-			break
-		}
-	}
-	c.Assert(found, check.Equals, true)
+
+	assertNeigh(nextHop, func(n netlink.Neigh) bool { return true })
 
 	// However, removing node3 should remove the neigh entry for nextHop
 	c.Assert(linuxNodeHandler.NodeDelete(nodev3), check.IsNil)
 	wait(nodev3.Identity(), "veth0", nil, true)
 
-	found = false
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			found = true
-			break
-		}
-	}
-	c.Assert(found, check.Equals, false)
+	assertNoNeigh("expected removed neigh "+nextHop.String(), nextHop)
 
 	now = time.Now()
 	c.Assert(linuxNodeHandler.NodeAdd(nodev3), check.IsNil)
 	wait(nodev3.Identity(), "veth0", &now, false)
 
 	nextHop = net.ParseIP("f00d::250")
-refetch4:
-	// Check that both node{2,3} are via nextHop (gw)
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch4
-			}
-		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
-			c.ExpectFailure("node{2,3} should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, true)
+	assertNeigh(nextHop, neighStateOk)
+	assertNoNeigh("node{2,3} should not be in the same L2", node2IP, node3IP)
 
 	// We have stored the devices in NodeConfigurationChanged
 	linuxNodeHandler.NodeCleanNeighbors(false)
-refetch5:
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch5
-			}
-		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
-			c.ExpectFailure("node{2,3} should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, false)
+
+	assertNoNeigh("expected removed neigh "+nextHop.String(), nextHop)
+	assertNoNeigh("node{2,3} should not be in the same L2", node2IP, node3IP)
 
 	// Setup routine for the 3. test
 	setupNewGateway := func(vethCIDR, gwIP string) (errRet error) {
@@ -1951,26 +1872,9 @@ refetch5:
 	wait(nodev3.Identity(), "veth0", &now, false)
 
 	nextHop = net.ParseIP("f00d::250")
-refetch6:
-	// Check that both node{2,3} are via nextHop (gw)
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch6
-			}
-		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
-			c.ExpectFailure("node{2,3} should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, true)
+
+	assertNeigh(nextHop, neighStateOk)
+	assertNoNeigh("node{2,3} should not be in the same L2", node2IP, node3IP)
 
 	// Switch to new nextHop address for node2
 	err = setupNewGateway("f00a::/96", "f00d::251")
@@ -1978,6 +1882,7 @@ refetch6:
 
 	// waitGw waits for the nextHop to appear in the agent's nextHop table
 	waitGw := func(nextHopNew string, nodeID nodeTypes.Identity, link string, before *time.Time) {
+		c.T.Helper()
 		err := testutils.WaitUntil(func() bool {
 			linuxNodeHandler.neighLock.Lock()
 			defer linuxNodeHandler.neighLock.Unlock()
@@ -2010,46 +1915,10 @@ refetch6:
 
 	// Both nextHops now need to be present
 	nextHop = net.ParseIP("f00d::250")
-refetch7:
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch7
-			}
-		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
-			c.ExpectFailure("node{2,3} should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, true)
-
+	assertNeigh(nextHop, neighStateOk)
 	nextHop = net.ParseIP("f00d::251")
-refetch8:
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch8
-			}
-		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
-			c.ExpectFailure("node{2,3} should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, true)
+	assertNeigh(nextHop, neighStateOk)
+	assertNoNeigh("node{2,3} should not be in the same L2", node2IP, node3IP)
 
 	// Now also switch over the other node.
 	err = setupNewGateway("f00b::/96", "f00d::251")
@@ -2063,48 +1932,13 @@ refetch8:
 	waitGw("f00d::251", nodev3.Identity(), "veth0", &now)
 
 	nextHop = net.ParseIP("f00d::250")
-refetch9:
+
 	// Check that old nextHop address got removed
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch9
-			}
-		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
-			c.ExpectFailure("node{2,3} should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, false)
+	assertNoNeigh("expected removed neigh "+nextHop.String(), nextHop)
+	assertNoNeigh("node{2,3} should not be in the same L2", node2IP, node3IP)
 
 	nextHop = net.ParseIP("f00d::251")
-refetch10:
-	// Check that new nextHop address got added
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch10
-			}
-		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
-			c.ExpectFailure("node{2,3} should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, true)
+	assertNeigh(nextHop, neighStateOk)
 
 	c.Assert(linuxNodeHandler.NodeDelete(nodev3), check.IsNil)
 	wait(nodev3.Identity(), "veth0", nil, true)
@@ -2126,54 +1960,18 @@ refetch10:
 	c.Assert(err, check.IsNil)
 
 	// Check that new nextHop address got added, we don't care about its NUD_* state
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			found = true
-			break
-		}
-	}
-	c.Assert(found, check.Equals, true)
+	assertNeigh(nextHop, func(neigh netlink.Neigh) bool { return true })
 
 	// Clean unrelated externally learned entries
 	linuxNodeHandler.NodeCleanNeighborsLink(veth0, true)
 
 	// Check that new nextHop address got removed
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			found = true
-			break
-		}
-	}
-	c.Assert(found, check.Equals, false)
+	assertNoNeigh("expected removed neigh "+nextHop.String(), nextHop)
 
 	// Check that node2 nextHop address is still there
 	nextHop = net.ParseIP("f00d::251")
-refetch11:
-	// Check that new nextHop address got added
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch11
-			}
-		} else if n.IP.Equal(node2IP) {
-			c.ExpectFailure("node2 should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, true)
+	assertNeigh(nextHop, neighStateOk)
+	assertNoNeigh("node2 should not be in the same L2", node2IP)
 
 	c.Assert(linuxNodeHandler.NodeDelete(nodev2), check.IsNil)
 	wait(nodev2.Identity(), "veth0", nil, true)
@@ -2243,7 +2041,7 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 	}
 	err = netlink.LinkAdd(vethPair01)
 	c.Assert(err, check.IsNil)
-	defer netlink.LinkDel(vethPair01)
+	c.Cleanup(func() { netlink.LinkDel(vethPair01) })
 	veth0, err := netlink.LinkByName("veth0")
 	c.Assert(err, check.IsNil)
 	veth1, err := netlink.LinkByName("veth1")
@@ -2293,7 +2091,7 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 	}
 	err = netlink.LinkAdd(vethPair23)
 	c.Assert(err, check.IsNil)
-	defer netlink.LinkDel(vethPair23)
+	c.Cleanup(func() { netlink.LinkDel(vethPair23) })
 	veth2, err := netlink.LinkByName("veth2")
 	c.Assert(err, check.IsNil)
 	veth3, err := netlink.LinkByName("veth3")
@@ -2352,7 +2150,7 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 	}
 	err = netlink.LinkAdd(vethPair45)
 	c.Assert(err, check.IsNil)
-	defer netlink.LinkDel(vethPair45)
+	c.Cleanup(func() { netlink.LinkDel(vethPair45) })
 	veth4, err := netlink.LinkByName("veth4")
 	c.Assert(err, check.IsNil)
 	veth5, err := netlink.LinkByName("veth5")
@@ -2430,6 +2228,7 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 
 	// wait waits for neigh entry update or waits for removal if waitForDelete=true
 	wait := func(nodeID nodeTypes.Identity, link string, before *time.Time, waitForDelete bool) {
+		c.T.Helper()
 		err := testutils.WaitUntil(func() bool {
 			linuxNodeHandler.neighLock.Lock()
 			defer linuxNodeHandler.neighLock.Unlock()
@@ -2453,6 +2252,38 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 		c.Assert(err, check.IsNil)
 	}
 
+	assertNeigh := func(ip net.IP, link netlink.Link, checkNeigh func(neigh netlink.Neigh) bool) {
+		c.T.Helper()
+		err := testutils.WaitUntil(func() bool {
+			neighs, err := netlink.NeighList(link.Attrs().Index, netlink.FAMILY_V6)
+			c.Assert(err, check.IsNil)
+			for _, n := range neighs {
+				if n.IP.Equal(ip) && checkNeigh(n) {
+					return true
+				}
+			}
+			return false
+		}, 5*time.Second)
+		c.Assert(err, check.IsNil, check.Commentf("expected neighbor %s", ip))
+	}
+
+	assertNoNeigh := func(link netlink.Link, ips ...net.IP) {
+		c.T.Helper()
+		err := testutils.WaitUntil(func() bool {
+			neighs, err := netlink.NeighList(link.Attrs().Index, netlink.FAMILY_V6)
+			c.Assert(err, check.IsNil)
+			for _, n := range neighs {
+				for _, ip := range ips {
+					if n.IP.Equal(ip) {
+						return false
+					}
+				}
+			}
+			return true
+		}, 5*time.Second)
+		c.Assert(err, check.IsNil, check.Commentf("expected no neighbors: %v", ips))
+	}
+
 	nodev1 := nodeTypes.Node{
 		Name: "node1",
 		IPAddresses: []nodeTypes.Address{{
@@ -2472,43 +2303,9 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 	// insertNeighbor is invoked async, so thus this wait based on last ping
 	wait(nodev1.Identity(), "veth0", &now, false)
 	wait(nodev1.Identity(), "veth2", &now, false)
-refetch1:
-	// Check whether an arp entry for nodev1 IP addr (=veth1) was added
-	neighs, err := netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found := false
-	for _, n := range neighs {
-		if n.IP.Equal(v1IP1) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch1
-			}
-		}
-	}
-	c.Assert(found, check.Equals, true)
 
-refetch2:
-	// Check whether an arp entry for nodev1 IP addr (=veth3) was added
-	neighs, err = netlink.NeighList(veth2.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(v2IP1) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch2
-			}
-		}
-	}
-	c.Assert(found, check.Equals, true)
+	assertNeigh(v1IP1, veth0, neighStateOk)
+	assertNeigh(v2IP1, veth2, neighStateOk)
 
 	// Check whether we don't install the neighbor entries to nodes on the device where the actual route isn't.
 	// "Consistently(<check>, 5sec, 1sec)"
@@ -2518,9 +2315,9 @@ refetch2:
 			break
 		}
 
-		neighs, err = netlink.NeighList(veth4.Attrs().Index, netlink.FAMILY_V6)
+		neighs, err := netlink.NeighList(veth4.Attrs().Index, netlink.FAMILY_V6)
 		c.Assert(err, check.IsNil)
-		found = false
+		found := false
 		for _, n := range neighs {
 			if n.IP.Equal(v3IP1) || n.IP.Equal(node1Addr.IP) {
 				found = true
@@ -2561,44 +2358,27 @@ refetch2:
 	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1, true)
 	wait(nodev1.Identity(), "veth0", &now, false)
 	wait(nodev1.Identity(), "veth2", &now, false)
-refetch3:
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(v1IP1) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				updatedHwAddrFromArpEntry = n.HardwareAddr
-				break
+
+	assertNeigh(v1IP1, veth0,
+		func(neigh netlink.Neigh) bool {
+			if neighStateOk(neigh) {
+				updatedHwAddrFromArpEntry = neigh.HardwareAddr
+				return true
 			}
-			if retry {
-				goto refetch3
-			}
-		}
-	}
-	c.Assert(found, check.Equals, true)
+			return false
+		})
+
 	c.Assert(updatedHwAddrFromArpEntry.String(), check.Equals, veth0HwAddr.String())
 
-refetch4:
-	neighs, err = netlink.NeighList(veth2.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(v2IP1) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				updatedHwAddrFromArpEntry = n.HardwareAddr
-				break
+	assertNeigh(v2IP1, veth2,
+		func(neigh netlink.Neigh) bool {
+			if neighStateOk(neigh) {
+				updatedHwAddrFromArpEntry = neigh.HardwareAddr
+				return true
 			}
-			if retry {
-				goto refetch4
-			}
-		}
-	}
-	c.Assert(found, check.Equals, true)
+			return false
+		})
+
 	c.Assert(updatedHwAddrFromArpEntry.String(), check.Equals, veth2HwAddr.String())
 
 	// Remove nodev1, and check whether the arp entry was removed
@@ -2608,27 +2388,8 @@ refetch4:
 	wait(nodev1.Identity(), "veth0", nil, true)
 	wait(nodev1.Identity(), "veth2", nil, true)
 
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(v1IP1) {
-			found = true
-			break
-		}
-	}
-	c.Assert(found, check.Equals, false)
-
-	neighs, err = netlink.NeighList(veth2.Attrs().Index, netlink.FAMILY_V6)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(v2IP1) {
-			found = true
-			break
-		}
-	}
-	c.Assert(found, check.Equals, false)
+	assertNoNeigh(veth0, v1IP1)
+	assertNoNeigh(veth2, v2IP1)
 }
 
 func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
@@ -2675,7 +2436,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	}
 	err = netlink.LinkAdd(veth)
 	c.Assert(err, check.IsNil)
-	defer netlink.LinkDel(veth)
+	c.Cleanup(func() { netlink.LinkDel(veth) })
 	veth0, err := netlink.LinkByName("veth0")
 	c.Assert(err, check.IsNil)
 	veth1, err := netlink.LinkByName("veth1")
@@ -2749,6 +2510,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 
 	// wait waits for neigh entry update or waits for removal if waitForDelete=true
 	wait := func(nodeID nodeTypes.Identity, link string, before *time.Time, waitForDelete bool) {
+		c.T.Helper()
 		err := testutils.WaitUntil(func() bool {
 			linuxNodeHandler.neighLock.Lock()
 			defer linuxNodeHandler.neighLock.Unlock()
@@ -2772,6 +2534,38 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		c.Assert(err, check.IsNil)
 	}
 
+	assertNeigh := func(ip net.IP, checkNeigh func(neigh netlink.Neigh) bool) {
+		c.T.Helper()
+		err := testutils.WaitUntil(func() bool {
+			neighs, err := netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+			c.Assert(err, check.IsNil)
+			for _, n := range neighs {
+				if n.IP.Equal(ip) && checkNeigh(n) {
+					return true
+				}
+			}
+			return false
+		}, 5*time.Second)
+		c.Assert(err, check.IsNil, check.Commentf("expected neighbor %s", ip))
+	}
+
+	assertNoNeigh := func(msg string, ips ...net.IP) {
+		c.T.Helper()
+		err := testutils.WaitUntil(func() bool {
+			neighs, err := netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+			c.Assert(err, check.IsNil)
+			for _, n := range neighs {
+				for _, ip := range ips {
+					if n.IP.Equal(ip) {
+						return false
+					}
+				}
+			}
+			return true
+		}, 5*time.Second)
+		c.Assert(err, check.IsNil, check.Commentf(msg))
+	}
+
 	nodev1 := nodeTypes.Node{
 		Name: "node1",
 		IPAddresses: []nodeTypes.Address{{
@@ -2790,24 +2584,8 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	c.Assert(err, check.IsNil)
 	// insertNeighbor is invoked async, so thus this wait based on last ping
 	wait(nodev1.Identity(), "veth0", &now, false)
-refetch1:
-	// Check whether an arp entry for nodev1 IP addr (=veth1) was added
-	neighs, err := netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found := false
-	for _, n := range neighs {
-		if n.IP.Equal(ip1) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch1
-			}
-		}
-	}
-	c.Assert(found, check.Equals, true)
+
+	assertNeigh(ip1, neighStateOk)
 
 	// Swap MAC addresses of veth0 and veth1 to ensure the MAC address of veth1 changed.
 	// Trigger neighbor refresh on veth0 and check whether the arp entry was updated.
@@ -2828,24 +2606,16 @@ refetch1:
 
 	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1, true)
 	wait(nodev1.Identity(), "veth0", &now, false)
-refetch2:
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(ip1) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				updatedHwAddrFromArpEntry = n.HardwareAddr
-				break
+
+	assertNeigh(ip1,
+		func(neigh netlink.Neigh) bool {
+			if neighStateOk(neigh) {
+				updatedHwAddrFromArpEntry = neigh.HardwareAddr
+				return true
 			}
-			if retry {
-				goto refetch2
-			}
-		}
-	}
-	c.Assert(found, check.Equals, true)
+			return false
+		})
+
 	c.Assert(updatedHwAddrFromArpEntry.String(), check.Equals, veth0HwAddr.String())
 
 	// Remove nodev1, and check whether the arp entry was removed
@@ -2854,16 +2624,7 @@ refetch2:
 	// deleteNeighbor is invoked async too
 	wait(nodev1.Identity(), "veth0", nil, true)
 
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(ip1) {
-			found = true
-			break
-		}
-	}
-	c.Assert(found, check.Equals, false)
+	assertNoNeigh("expected removed neigh "+ip1.String(), ip1)
 
 	// Create multiple goroutines which call insertNeighbor and check whether
 	// MAC changes of veth1 are properly handled. This is a basic randomized
@@ -2904,7 +2665,7 @@ refetch2:
 			}
 		}()
 	}
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 3; i++ {
 		mac := rndHWAddr()
 		// Change MAC
 		ns.Do(func() error {
@@ -2918,7 +2679,7 @@ refetch2:
 		// Check that MAC has been changed in the neigh table
 		var found bool
 		err := testutils.WaitUntilWithSleep(func() bool {
-			neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+			neighs, err := netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
 			c.Assert(err, check.IsNil)
 			found = false
 			for _, n := range neighs {
@@ -3101,102 +2862,34 @@ refetch2:
 	wait(nodev3.Identity(), "veth0", &now, false)
 
 	nextHop := net.ParseIP("9.9.9.250")
-refetch3:
-	// Check that both node{2,3} are via nextHop (gw)
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch3
-			}
-		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
-			c.ExpectFailure("node{2,3} should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, true)
+	assertNeigh(nextHop, neighStateOk)
+	assertNoNeigh("node{2,3} should not be in the same L2", node2IP, node3IP)
 
 	// Check that removing node2 will not remove nextHop, as it is still used by node3
 	c.Assert(linuxNodeHandler.NodeDelete(nodev2), check.IsNil)
 	wait(nodev2.Identity(), "veth0", nil, true)
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			found = true
-			break
-		}
-	}
-	c.Assert(found, check.Equals, true)
+
+	assertNeigh(nextHop, func(n netlink.Neigh) bool { return true })
 
 	// However, removing node3 should remove the neigh entry for nextHop
 	c.Assert(linuxNodeHandler.NodeDelete(nodev3), check.IsNil)
 	wait(nodev3.Identity(), "veth0", nil, true)
 
-	found = false
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			found = true
-			break
-		}
-	}
-	c.Assert(found, check.Equals, false)
+	assertNoNeigh("expected removed neigh "+nextHop.String(), nextHop)
 
 	now = time.Now()
 	c.Assert(linuxNodeHandler.NodeAdd(nodev3), check.IsNil)
 	wait(nodev3.Identity(), "veth0", &now, false)
 
 	nextHop = net.ParseIP("9.9.9.250")
-refetch4:
-	// Check that both node{2,3} are via nextHop (gw)
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch4
-			}
-		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
-			c.ExpectFailure("node{2,3} should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, true)
+	assertNeigh(nextHop, neighStateOk)
+	assertNoNeigh("node{2,3} should not be in the same L2", node2IP, node3IP)
 
 	// We have stored the devices in NodeConfigurationChanged
 	linuxNodeHandler.NodeCleanNeighbors(false)
-refetch5:
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch5
-			}
-		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
-			c.ExpectFailure("node{2,3} should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, false)
+
+	assertNoNeigh("expected removed neigh "+nextHop.String(), nextHop)
+	assertNoNeigh("node{2,3} should not be in the same L2", node2IP, node3IP)
 
 	// Setup routine for the 3. test
 	setupNewGateway := func(vethCIDR, gwIP string) (errRet error) {
@@ -3227,26 +2920,9 @@ refetch5:
 	wait(nodev3.Identity(), "veth0", &now, false)
 
 	nextHop = net.ParseIP("9.9.9.250")
-refetch6:
-	// Check that both node{2,3} are via nextHop (gw)
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch6
-			}
-		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
-			c.ExpectFailure("node{2,3} should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, true)
+
+	assertNeigh(nextHop, neighStateOk)
+	assertNoNeigh("node{2,3} should not be in the same L2", node2IP, node3IP)
 
 	// Switch to new nextHop address for node2
 	err = setupNewGateway("8.8.8.248/29", "9.9.9.251")
@@ -3254,6 +2930,7 @@ refetch6:
 
 	// waitGw waits for the nextHop to appear in the agent's nextHop table
 	waitGw := func(nextHopNew string, nodeID nodeTypes.Identity, link string, before *time.Time) {
+		c.T.Helper()
 		err := testutils.WaitUntil(func() bool {
 			linuxNodeHandler.neighLock.Lock()
 			defer linuxNodeHandler.neighLock.Unlock()
@@ -3286,46 +2963,10 @@ refetch6:
 
 	// Both nextHops now need to be present
 	nextHop = net.ParseIP("9.9.9.250")
-refetch7:
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch7
-			}
-		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
-			c.ExpectFailure("node{2,3} should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, true)
-
+	assertNeigh(nextHop, neighStateOk)
 	nextHop = net.ParseIP("9.9.9.251")
-refetch8:
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch8
-			}
-		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
-			c.ExpectFailure("node{2,3} should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, true)
+	assertNeigh(nextHop, neighStateOk)
+	assertNoNeigh("node{2,3} should not be in the same L2", node2IP, node3IP)
 
 	// Now also switch over the other node.
 	err = setupNewGateway("7.7.7.248/29", "9.9.9.251")
@@ -3339,48 +2980,12 @@ refetch8:
 	waitGw("9.9.9.251", nodev3.Identity(), "veth0", &now)
 
 	nextHop = net.ParseIP("9.9.9.250")
-refetch9:
-	// Check that old nextHop address got removed
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch9
-			}
-		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
-			c.ExpectFailure("node{2,3} should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, false)
+
+	assertNoNeigh("expected removed neigh "+nextHop.String(), nextHop)
+	assertNoNeigh("node{2,3} should not be in the same L2", node2IP, node3IP)
 
 	nextHop = net.ParseIP("9.9.9.251")
-refetch10:
-	// Check that new nextHop address got added
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch10
-			}
-		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
-			c.ExpectFailure("node{2,3} should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, true)
+	assertNeigh(nextHop, neighStateOk)
 
 	c.Assert(linuxNodeHandler.NodeDelete(nodev3), check.IsNil)
 	wait(nodev3.Identity(), "veth0", nil, true)
@@ -3402,54 +3007,18 @@ refetch10:
 	c.Assert(err, check.IsNil)
 
 	// Check that new nextHop address got added, we don't care about its NUD_* state
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			found = true
-			break
-		}
-	}
-	c.Assert(found, check.Equals, true)
+	assertNeigh(nextHop, func(n netlink.Neigh) bool { return true })
 
 	// Clean unrelated externally learned entries
 	linuxNodeHandler.NodeCleanNeighborsLink(veth0, true)
 
 	// Check that new nextHop address got removed
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			found = true
-			break
-		}
-	}
-	c.Assert(found, check.Equals, false)
+	assertNoNeigh("expected removed neigh "+nextHop.String(), nextHop)
 
 	// Check that node2 nextHop address is still there
 	nextHop = net.ParseIP("9.9.9.251")
-refetch11:
-	// Check that new nextHop address got added
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(nextHop) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch11
-			}
-		} else if n.IP.Equal(node2IP) {
-			c.ExpectFailure("node2 should not be in the same L2")
-		}
-	}
-	c.Assert(found, check.Equals, true)
+	assertNeigh(nextHop, neighStateOk)
+	assertNoNeigh("node2 should not be in the same L2", node2IP)
 
 	c.Assert(linuxNodeHandler.NodeDelete(nodev2), check.IsNil)
 	wait(nodev2.Identity(), "veth0", nil, true)
@@ -3519,7 +3088,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 	}
 	err = netlink.LinkAdd(vethPair01)
 	c.Assert(err, check.IsNil)
-	defer netlink.LinkDel(vethPair01)
+	c.Cleanup(func() { netlink.LinkDel(vethPair01) })
 	veth0, err := netlink.LinkByName("veth0")
 	c.Assert(err, check.IsNil)
 	veth1, err := netlink.LinkByName("veth1")
@@ -3571,7 +3140,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 	}
 	err = netlink.LinkAdd(vethPair23)
 	c.Assert(err, check.IsNil)
-	defer netlink.LinkDel(vethPair23)
+	c.Cleanup(func() { netlink.LinkDel(vethPair23) })
 	veth2, err := netlink.LinkByName("veth2")
 	c.Assert(err, check.IsNil)
 	veth3, err := netlink.LinkByName("veth3")
@@ -3629,7 +3198,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 	}
 	err = netlink.LinkAdd(vethPair45)
 	c.Assert(err, check.IsNil)
-	defer netlink.LinkDel(vethPair45)
+	c.Cleanup(func() { netlink.LinkDel(vethPair45) })
 	veth4, err := netlink.LinkByName("veth4")
 	c.Assert(err, check.IsNil)
 	veth5, err := netlink.LinkByName("veth5")
@@ -3702,6 +3271,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 
 	// wait waits for neigh entry update or waits for removal if waitForDelete=true
 	wait := func(nodeID nodeTypes.Identity, link string, before *time.Time, waitForDelete bool) {
+		c.T.Helper()
 		err := testutils.WaitUntil(func() bool {
 			linuxNodeHandler.neighLock.Lock()
 			defer linuxNodeHandler.neighLock.Unlock()
@@ -3725,6 +3295,38 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 		c.Assert(err, check.IsNil)
 	}
 
+	assertNeigh := func(ip net.IP, link netlink.Link, checkNeigh func(neigh netlink.Neigh) bool) {
+		c.T.Helper()
+		err := testutils.WaitUntil(func() bool {
+			neighs, err := netlink.NeighList(link.Attrs().Index, netlink.FAMILY_V4)
+			c.Assert(err, check.IsNil)
+			for _, n := range neighs {
+				if n.IP.Equal(ip) && checkNeigh(n) {
+					return true
+				}
+			}
+			return false
+		}, 5*time.Second)
+		c.Assert(err, check.IsNil, check.Commentf("expected neighbor %s", ip))
+	}
+
+	assertNoNeigh := func(link netlink.Link, ips ...net.IP) {
+		c.T.Helper()
+		err := testutils.WaitUntil(func() bool {
+			neighs, err := netlink.NeighList(link.Attrs().Index, netlink.FAMILY_V4)
+			c.Assert(err, check.IsNil)
+			for _, n := range neighs {
+				for _, ip := range ips {
+					if n.IP.Equal(ip) {
+						return false
+					}
+				}
+			}
+			return true
+		}, 5*time.Second)
+		c.Assert(err, check.IsNil, check.Commentf("expected no neighbors: %v", ips))
+	}
+
 	nodev1 := nodeTypes.Node{
 		Name: "node1",
 		IPAddresses: []nodeTypes.Address{{
@@ -3744,43 +3346,12 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 	// insertNeighbor is invoked async, so thus this wait based on last ping
 	wait(nodev1.Identity(), "veth0", &now, false)
 	wait(nodev1.Identity(), "veth2", &now, false)
-refetch1:
-	// Check whether an arp entry for nodev1 IP addr (=veth1) was added
-	neighs, err := netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found := false
-	for _, n := range neighs {
-		if n.IP.Equal(v1IP1) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch1
-			}
-		}
-	}
-	c.Assert(found, check.Equals, true)
 
-refetch2:
-	// Check whether an arp entry for nodev1 IP addr (=veth3) was added
-	neighs, err = netlink.NeighList(veth2.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(v2IP1) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				break
-			}
-			if retry {
-				goto refetch2
-			}
-		}
-	}
-	c.Assert(found, check.Equals, true)
+	// Check whether an arp entry for nodev1 IP addr (=veth1) was added
+	assertNeigh(v1IP1, veth0, neighStateOk)
+
+	// Check whether an arp entry for nodev2 IP addr (=veth3) was added
+	assertNeigh(v2IP1, veth2, neighStateOk)
 
 	// Check whether we don't install the neighbor entries to nodes on the device where the actual route isn't.
 	// "Consistently(<check>, 5sec, 1sec)"
@@ -3790,9 +3361,9 @@ refetch2:
 			break
 		}
 
-		neighs, err = netlink.NeighList(veth4.Attrs().Index, netlink.FAMILY_V4)
+		neighs, err := netlink.NeighList(veth4.Attrs().Index, netlink.FAMILY_V4)
 		c.Assert(err, check.IsNil)
-		found = false
+		found := false
 		for _, n := range neighs {
 			if n.IP.Equal(v3IP1) || n.IP.Equal(node1Addr.IP) {
 				found = true
@@ -3833,44 +3404,27 @@ refetch2:
 	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1, true)
 	wait(nodev1.Identity(), "veth0", &now, false)
 	wait(nodev1.Identity(), "veth2", &now, false)
-refetch3:
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(v1IP1) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				updatedHwAddrFromArpEntry = n.HardwareAddr
-				break
+
+	assertNeigh(v1IP1, veth0,
+		func(neigh netlink.Neigh) bool {
+			if neighStateOk(neigh) {
+				updatedHwAddrFromArpEntry = neigh.HardwareAddr
+				return true
 			}
-			if retry {
-				goto refetch3
-			}
-		}
-	}
-	c.Assert(found, check.Equals, true)
+			return false
+		})
+
 	c.Assert(updatedHwAddrFromArpEntry.String(), check.Equals, veth0HwAddr.String())
 
-refetch4:
-	neighs, err = netlink.NeighList(veth2.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(v2IP1) {
-			good, retry := neighStateOk(n)
-			if good {
-				found = true
-				updatedHwAddrFromArpEntry = n.HardwareAddr
-				break
+	assertNeigh(v2IP1, veth2,
+		func(neigh netlink.Neigh) bool {
+			if neighStateOk(neigh) {
+				updatedHwAddrFromArpEntry = neigh.HardwareAddr
+				return true
 			}
-			if retry {
-				goto refetch4
-			}
-		}
-	}
-	c.Assert(found, check.Equals, true)
+			return false
+		})
+
 	c.Assert(updatedHwAddrFromArpEntry.String(), check.Equals, veth2HwAddr.String())
 
 	// Remove nodev1, and check whether the arp entry was removed
@@ -3880,27 +3434,8 @@ refetch4:
 	wait(nodev1.Identity(), "veth0", nil, true)
 	wait(nodev1.Identity(), "veth2", nil, true)
 
-	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(v1IP1) {
-			found = true
-			break
-		}
-	}
-	c.Assert(found, check.Equals, false)
-
-	neighs, err = netlink.NeighList(veth2.Attrs().Index, netlink.FAMILY_V4)
-	c.Assert(err, check.IsNil)
-	found = false
-	for _, n := range neighs {
-		if n.IP.Equal(v2IP1) {
-			found = true
-			break
-		}
-	}
-	c.Assert(found, check.Equals, false)
+	assertNoNeigh(veth0, v1IP1)
+	assertNoNeigh(veth2, v2IP1)
 }
 
 func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdate(c *check.C, config datapath.LocalNodeConfiguration) {

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -77,7 +77,7 @@ func (s *linuxTestSuite) TestCreateNodeRoute(c *check.C) {
 
 	fakeNodeAddressing := fakeTypes.NewNodeAddressing()
 
-	nodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil, &mtuConfig, new(mockEnqueuer))
+	nodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil, &mtuConfig, new(mockEnqueuer), nil, nil)
 
 	c1 := cidr.MustParseCIDR("10.10.0.0/16")
 	generatedRoute, err := nodeHandler.createNodeRouteSpec(c1, false)

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -170,9 +170,12 @@ func cleanIngressQdisc(devices []string) error {
 
 // reinitializeIPSec is used to recompile and load encryption network programs.
 func (l *loader) reinitializeIPSec(ctx context.Context) error {
-	// If devices are specified, then we are relying on autodetection and don't
-	// need the code below, specific to EncryptInterface.
-	if !option.Config.EnableIPSec || len(option.Config.GetDevices()) > 0 {
+	// We need to take care not to load bpf_network and bpf_host onto the same
+	// device. If devices are required, we load bpf_host and hence don't need
+	// the code below, specific to EncryptInterface. Specifically, we will load
+	// bpf_host code in reloadHostDatapath onto the physical devices as selected
+	// by configuration.
+	if !option.Config.EnableIPSec || option.Config.AreDevicesRequired() {
 		return nil
 	}
 

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -79,7 +79,7 @@ func (l *loader) writeNodeConfigHeader(o datapath.BaseProgramOwner) error {
 }
 
 // Must be called with option.Config.EnablePolicyMU locked.
-func writePreFilterHeader(preFilter *prefilter.PreFilter, dir string) error {
+func writePreFilterHeader(preFilter *prefilter.PreFilter, dir string, devices []string) error {
 	headerPath := filepath.Join(dir, preFilterHeaderFileName)
 	log.WithField(logfields.Path, headerPath).Debug("writing configuration")
 
@@ -91,7 +91,7 @@ func writePreFilterHeader(preFilter *prefilter.PreFilter, dir string) error {
 
 	fw := bufio.NewWriter(f)
 	fmt.Fprint(fw, "/*\n")
-	fmt.Fprintf(fw, " * XDP devices: %s\n", strings.Join(option.Config.GetDevices(), " "))
+	fmt.Fprintf(fw, " * XDP devices: %s\n", strings.Join(devices, " "))
 	fmt.Fprintf(fw, " * XDP mode: %s\n", option.Config.NodePortAcceleration)
 	fmt.Fprint(fw, " */\n\n")
 	preFilter.WriteConfig(fw)
@@ -143,8 +143,8 @@ func addENIRules(sysSettings []tables.Sysctl) ([]tables.Sysctl, error) {
 	return retSettings, nil
 }
 
-func cleanIngressQdisc() error {
-	for _, iface := range option.Config.GetDevices() {
+func cleanIngressQdisc(devices []string) error {
+	for _, iface := range devices {
 		link, err := netlink.LinkByName(iface)
 		if err != nil {
 			return fmt.Errorf("failed to retrieve link %s by name: %w", iface, err)
@@ -278,12 +278,12 @@ func (l *loader) reinitializeOverlay(ctx context.Context, tunnelConfig tunnel.Co
 	return nil
 }
 
-func (l *loader) reinitializeXDPLocked(ctx context.Context, extraCArgs []string) error {
-	l.maybeUnloadObsoleteXDPPrograms(option.Config.GetDevices(), option.Config.XDPMode, bpf.CiliumPath())
+func (l *loader) reinitializeXDPLocked(ctx context.Context, extraCArgs []string, devices []string) error {
+	l.maybeUnloadObsoleteXDPPrograms(devices, option.Config.XDPMode, bpf.CiliumPath())
 	if option.Config.XDPMode == option.XDPModeDisabled {
 		return nil
 	}
-	for _, dev := range option.Config.GetDevices() {
+	for _, dev := range devices {
 		// When WG & encrypt-node are on, the devices include cilium_wg0 to attach bpf_host
 		// so that NodePort's rev-{S,D}NAT translations happens for a reply from the remote node.
 		// So We need to exclude cilium_wg0 not to attach the XDP program when XDP acceleration
@@ -307,9 +307,13 @@ func (l *loader) reinitializeXDPLocked(ctx context.Context, extraCArgs []string)
 // and reinsertion of the object into the kernel as well as an atomic program replacement
 // at the XDP hook. extraCArgs can be passed-in in order to alter BPF code defines.
 func (l *loader) ReinitializeXDP(ctx context.Context, o datapath.BaseProgramOwner, extraCArgs []string) error {
+	// TODO: react to changes (using the currently ignored watch channel)
+	nativeDevices, _ := tables.SelectedDevices(l.devices, l.db.ReadTxn())
+	devices := tables.DeviceNames(nativeDevices)
+
 	o.GetCompilationLock().Lock()
 	defer o.GetCompilationLock().Unlock()
-	return l.reinitializeXDPLocked(ctx, extraCArgs)
+	return l.reinitializeXDPLocked(ctx, extraCArgs, devices)
 }
 
 // Reinitialize (re-)configures the base datapath configuration including global
@@ -384,7 +388,10 @@ func (l *loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		return fmt.Errorf("failed to add internal IP address to %s: %w", hostDev1.Attrs().Name, err)
 	}
 
-	if err := cleanIngressQdisc(); err != nil {
+	// TODO: react to changes (using the currently ignored watch channel)
+	nativeDevices, _ := tables.SelectedDevices(l.devices, l.db.ReadTxn())
+	devices := tables.DeviceNames(nativeDevices)
+	if err := cleanIngressQdisc(devices); err != nil {
 		log.WithError(err).Warn("Unable to clean up ingress qdiscs")
 		return err
 	}
@@ -400,7 +407,7 @@ func (l *loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 
 	if option.Config.EnableXDPPrefilter {
-		scopedLog := log.WithField(logfields.Devices, option.Config.GetDevices())
+		scopedLog := log.WithField(logfields.Devices, devices)
 
 		preFilter, err := prefilter.NewPreFilter()
 		if err != nil {
@@ -408,7 +415,7 @@ func (l *loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 			return err
 		}
 
-		if err := writePreFilterHeader(preFilter, "./"); err != nil {
+		if err := writePreFilterHeader(preFilter, "./", devices); err != nil {
 			scopedLog.WithError(err).Warn("Unable to write prefilter header")
 			return err
 		}
@@ -434,7 +441,7 @@ func (l *loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 
 	extraArgs := []string{"-Dcapture_enabled=0"}
-	if err := l.reinitializeXDPLocked(ctx, extraArgs); err != nil {
+	if err := l.reinitializeXDPLocked(ctx, extraArgs, devices); err != nil {
 		log.WithError(err).Fatal("Failed to compile XDP program")
 	}
 

--- a/pkg/datapath/loader/hash_test.go
+++ b/pkg/datapath/loader/hash_test.go
@@ -39,7 +39,6 @@ func TestHashDatapath(t *testing.T) {
 		provideNodemap,
 		cell.Provide(
 			fakeTypes.NewNodeAddressing,
-			func() datapath.BandwidthManager { return &fakeTypes.BandwidthManager{} },
 			func() sysctl.Sysctl { return sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc") },
 			config.NewHeaderfileWriter,
 		),

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -536,6 +536,10 @@ func (l *loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 		nativeDevices, _ := tables.SelectedDevices(l.devices, l.db.ReadTxn())
 		devices := tables.DeviceNames(nativeDevices)
 
+		if option.Config.NeedBPFHostOnWireGuardDevice() {
+			devices = append(devices, wgTypes.IfaceName)
+		}
+
 		objPath = path.Join(dirs.Output, hostEndpointObj)
 		if err := l.reloadHostDatapath(ctx, ep, objPath, devices); err != nil {
 			return err

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -87,6 +87,7 @@ type loader struct {
 	sysctl    sysctl.Sysctl
 	db        *statedb.DB
 	nodeAddrs statedb.Table[tables.NodeAddress]
+	devices   statedb.Table[*tables.Device]
 }
 
 type Params struct {
@@ -96,6 +97,7 @@ type Params struct {
 	DB        *statedb.DB
 	NodeAddrs statedb.Table[tables.NodeAddress]
 	Sysctl    sysctl.Sysctl
+	Devices   statedb.Table[*tables.Device]
 }
 
 // newLoader returns a new loader.
@@ -105,6 +107,7 @@ func newLoader(p Params) *loader {
 		db:                p.DB,
 		nodeAddrs:         p.NodeAddrs,
 		sysctl:            p.Sysctl,
+		devices:           p.Devices,
 		hostDpInitialized: make(chan struct{}),
 	}
 }
@@ -112,13 +115,16 @@ func newLoader(p Params) *loader {
 func NewLoaderForTest(tb testing.TB) *loader {
 	nodeAddrs, err := tables.NewNodeAddressTable()
 	require.NoError(tb, err, "NewNodeAddressTable")
-	db, err := statedb.NewDB([]statedb.TableMeta{nodeAddrs}, statedb.NewMetrics())
+	devices, err := tables.NewDeviceTable()
+	require.NoError(tb, err, "NewDeviceTable")
+	db, err := statedb.NewDB([]statedb.TableMeta{nodeAddrs, devices}, statedb.NewMetrics())
 	require.NoError(tb, err, "NewDB")
 	return newLoader(Params{
 		Config:    DefaultConfig,
 		DB:        db,
 		NodeAddrs: nodeAddrs,
 		Sysctl:    sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
+		Devices:   devices,
 	})
 }
 
@@ -283,7 +289,7 @@ func (l *loader) patchHostNetdevDatapath(ep datapath.Endpoint, objPath, dstPath,
 	return hostObj.Write(dstPath, opts, strings)
 }
 
-func isObsoleteDev(dev string) bool {
+func isObsoleteDev(dev string, devices []string) bool {
 	// exclude devices we never attach to/from_netdev to.
 	for _, prefix := range defaults.ExcludedDevicePrefixes {
 		if strings.HasPrefix(dev, prefix) {
@@ -292,7 +298,7 @@ func isObsoleteDev(dev string) bool {
 	}
 
 	// exclude devices that will still be managed going forward.
-	for _, d := range option.Config.GetDevices() {
+	for _, d := range devices {
 		if dev == d {
 			return false
 		}
@@ -303,7 +309,7 @@ func isObsoleteDev(dev string) bool {
 
 // removeObsoleteNetdevPrograms removes cil_to_netdev and cil_from_netdev from devices
 // that cilium potentially doesn't manage anymore after a restart, e.g. if the set of
-// devices in option.Config.GetDevices() changes between restarts.
+// devices changes between restarts.
 //
 // This code assumes that the agent was upgraded from a prior version while maintaining
 // the same list of managed physical devices. This ensures that all tc bpf filters get
@@ -311,7 +317,7 @@ func isObsoleteDev(dev string) bool {
 // before 1.13, most filters were named e.g. bpf_host.o:[to-host], to be changed to
 // cilium-<device> in 1.13, then to cil_to_host-<device> in 1.14. As a result, this
 // function only cleans up filters following the current naming scheme.
-func removeObsoleteNetdevPrograms() error {
+func removeObsoleteNetdevPrograms(devices []string) error {
 	links, err := netlink.LinkList()
 	if err != nil {
 		return fmt.Errorf("retrieving all netlink devices: %w", err)
@@ -321,7 +327,7 @@ func removeObsoleteNetdevPrograms() error {
 	ingressDevs := []netlink.Link{}
 	egressDevs := []netlink.Link{}
 	for _, l := range links {
-		if !isObsoleteDev(l.Attrs().Name) {
+		if !isObsoleteDev(l.Attrs().Name, devices) {
 			continue
 		}
 
@@ -371,7 +377,7 @@ func removeObsoleteNetdevPrograms() error {
 // - cilium_host: ingress and egress
 // - cilium_net: ingress
 // - native devices: ingress and (optionally) egress if certain features require it
-func (l *loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, objPath string) error {
+func (l *loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, objPath string, devices []string) error {
 	// Warning: here be dragons. There used to be a single loop over
 	// interfaces+objs+progs here from the iproute2 days, but this was never
 	// correct to begin with. Tail call maps were always reused when possible,
@@ -454,7 +460,7 @@ func (l *loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 	defer finalize()
 
 	// Replace programs on physical devices.
-	for _, device := range option.Config.GetDevices() {
+	for _, device := range devices {
 		iface, err := netlink.LinkByName(device)
 		if err != nil {
 			log.WithError(err).WithField("device", device).Warn("Link does not exist")
@@ -509,7 +515,7 @@ func (l *loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 
 	// call at the end of the function so that we can easily detect if this removes necessary
 	// programs that have just been attached.
-	if err := removeObsoleteNetdevPrograms(); err != nil {
+	if err := removeObsoleteNetdevPrograms(devices); err != nil {
 		log.WithError(err).Error("Failed to remove obsolete netdev programs")
 	}
 
@@ -526,8 +532,12 @@ func (l *loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 	objPath := path.Join(dirs.Output, endpointObj)
 
 	if ep.IsHost() {
+		// TODO: react to changes (using the currently ignored watch channel)
+		nativeDevices, _ := tables.SelectedDevices(l.devices, l.db.ReadTxn())
+		devices := tables.DeviceNames(nativeDevices)
+
 		objPath = path.Join(dirs.Output, hostEndpointObj)
-		if err := l.reloadHostDatapath(ctx, ep, objPath); err != nil {
+		if err := l.reloadHostDatapath(ctx, ep, objPath, devices); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/datapath/loader/template_test.go
+++ b/pkg/datapath/loader/template_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -21,7 +20,7 @@ func TestWrap(t *testing.T) {
 
 	realEP := testutils.NewTestEndpoint()
 	template := wrap(&realEP, nil)
-	cfg := &config.HeaderfileWriter{}
+	cfg := configWriterForTest(t)
 
 	// Write the configuration that should be the same, and verify it is.
 	err := cfg.WriteTemplateConfig(&realEPBuffer, &realEP)

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -15,8 +15,7 @@ import (
 	. "github.com/cilium/checkmate"
 
 	"github.com/cilium/cilium/pkg/checker"
-	linuxDatapath "github.com/cilium/cilium/pkg/datapath/linux"
-	"github.com/cilium/cilium/pkg/datapath/linux/config"
+	fake "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/mac"
@@ -76,22 +75,12 @@ func (ds *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdenti
 }
 
 func (ds *EndpointSuite) TestReadEPsFromDirNames(c *C) {
-	// For this test, the real linux datapath is necessary to properly
-	// serialize config files to disk and test the restore.
 	oldDatapath := ds.datapath
 	defer func() {
 		ds.datapath = oldDatapath
 	}()
-	ds.datapath = linuxDatapath.NewDatapath(
-		linuxDatapath.DatapathParams{
-			RuleManager:    nil,
-			NodeAddressing: nil,
-			NodeMap:        nil,
-			ConfigWriter:   &config.HeaderfileWriter{},
-		},
-		linuxDatapath.DatapathConfiguration{},
-	)
 
+	ds.datapath = fake.NewDatapath()
 	epsWanted, _ := ds.createEndpoints()
 	tmpDir, err := os.MkdirTemp("", "cilium-tests")
 	defer func() {
@@ -154,22 +143,12 @@ func (ds *EndpointSuite) TestReadEPsFromDirNames(c *C) {
 }
 
 func (ds *EndpointSuite) TestReadEPsFromDirNamesWithRestoreFailure(c *C) {
-	// For this test, the real linux datapath is necessary to properly
-	// serialize config files to disk and test the restore.
 	oldDatapath := ds.datapath
 	defer func() {
 		ds.datapath = oldDatapath
 	}()
 
-	ds.datapath = linuxDatapath.NewDatapath(
-		linuxDatapath.DatapathParams{
-			RuleManager:    nil,
-			NodeAddressing: nil,
-			NodeMap:        nil,
-			ConfigWriter:   &config.HeaderfileWriter{},
-		},
-		linuxDatapath.DatapathConfiguration{},
-	)
+	ds.datapath = fake.NewDatapath()
 
 	eps, _ := ds.createEndpoints()
 	ep := eps[0]
@@ -235,15 +214,8 @@ func (ds *EndpointSuite) BenchmarkReadEPsFromDirNames(c *C) {
 	defer func() {
 		ds.datapath = oldDatapath
 	}()
-	ds.datapath = linuxDatapath.NewDatapath(
-		linuxDatapath.DatapathParams{
-			RuleManager:    nil,
-			NodeAddressing: nil,
-			NodeMap:        nil,
-			ConfigWriter:   &config.HeaderfileWriter{},
-		},
-		linuxDatapath.DatapathConfiguration{},
-	)
+
+	ds.datapath = fake.NewDatapath()
 
 	epsWanted, _ := ds.createEndpoints()
 	tmpDir, err := os.MkdirTemp("", "cilium-tests")

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2486,6 +2486,16 @@ func (c *DaemonConfig) AreDevicesRequired() bool {
 		c.EnableHighScaleIPcache || c.EnableL2Announcements || c.ForceDeviceRequired
 }
 
+// When WG & encrypt-node are on, a NodePort BPF to-be forwarded request
+// to a remote node running a selected service endpoint must be encrypted.
+// To make the NodePort's rev-{S,D}NAT translations to happen for a reply
+// from the remote node, we need to attach bpf_host to the Cilium's WG
+// netdev (otherwise, the WG netdev after decrypting the reply will pass
+// it to the stack which drops the packet).
+func (c *DaemonConfig) NeedBPFHostOnWireGuardDevice() bool {
+	return c.EnableNodePort && c.EnableWireguard && c.EncryptNode
+}
+
 // MasqueradingEnabled returns true if either IPv4 or IPv6 masquerading is enabled.
 func (c *DaemonConfig) MasqueradingEnabled() bool {
 	return c.EnableIPv4Masquerade || c.EnableIPv6Masquerade

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3054,7 +3054,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	}
 
 	c.populateLoadBalancerSettings(vp)
-	c.populateDevices(vp)
 	c.EnableRuntimeDeviceDetection = vp.GetBool(EnableRuntimeDeviceDetection)
 	c.EgressMultiHomeIPRuleCompat = vp.GetBool(EgressMultiHomeIPRuleCompat)
 
@@ -3419,23 +3418,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 			continue
 		}
 		c.ExcludeNodeLabelPatterns = append(c.ExcludeNodeLabelPatterns, r)
-	}
-}
-
-func (c *DaemonConfig) populateDevices(vp *viper.Viper) {
-	c.devices = vp.GetStringSlice(Devices)
-
-	// Make sure that devices are unique
-	if len(c.devices) <= 1 {
-		return
-	}
-	devSet := map[string]struct{}{}
-	for _, dev := range c.devices {
-		devSet[dev] = struct{}{}
-	}
-	c.devices = make([]string, 0, len(devSet))
-	for dev := range devSet {
-		c.devices = append(c.devices, dev)
 	}
 }
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2406,12 +2406,14 @@ func (c *DaemonConfig) SetIPv6NativeRoutingCIDR(cidr *cidr.CIDR) {
 	c.ConfigPatchMutex.Unlock()
 }
 
+// Deprecated: Use the devices table instead, which allows reacting to changes.
 func (c *DaemonConfig) SetDevices(devices []string) {
 	c.devicesMu.Lock()
 	c.devices = devices
 	c.devicesMu.Unlock()
 }
 
+// Deprecated: Use the devices table instead, which allows reacting to changes.
 func (c *DaemonConfig) GetDevices() []string {
 	c.devicesMu.RLock()
 	defer c.devicesMu.RUnlock()


### PR DESCRIPTION
This replaces usages of the Get/SetDevices APIs by lookups to the device table, and includes the necessary plumbing of that everywhere.

Scary stuff includes the wireguard interface thing in daemon/loader, not sure my transformation is functionally equivalent. CI will hopefully tell.