### PR TITLE
Fix datasource for Hubble DNS and Network dashboards

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -470,6 +470,13 @@ Users (Alphabetically)
       L: https://www.parseable.io/blog/ebpf-log-analytics
       Q: @nitisht
 
+    * N: Pionative
+      D: Pionative supplies all its clients across cloud providers with
+      Kubernetes running Cilium to deliver the best performance out there.
+      U: CNI, Networking, Security, eBPF
+      L: https://www.pionative.com
+      Q: @Pionerd
+
     * N: Plaid Inc
       D: Plaid is using Cilium as their CNI plugin in self-hosted Kubernetes on AWS.
       U: CNI, network policies

--- a/install/kubernetes/cilium/files/hubble/dashboards/hubble-dashboard.json
+++ b/install/kubernetes/cilium/files/hubble/dashboards/hubble-dashboard.json
@@ -3303,7 +3303,23 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/install/kubernetes/cilium/files/hubble/dashboards/hubble-dns-namespace.json
+++ b/install/kubernetes/cilium/files/hubble/dashboards/hubble-dns-namespace.json
@@ -484,7 +484,7 @@
           "includeAll": false,
           "label": "Data Source",
           "multi": false,
-          "name": "prometheus_datasource",
+          "name": "DS_PROMETHEUS",
           "options": [],
           "query": "prometheus",
           "queryValue": "",

--- a/install/kubernetes/cilium/files/hubble/dashboards/hubble-network-overview-namespace.json
+++ b/install/kubernetes/cilium/files/hubble/dashboards/hubble-network-overview-namespace.json
@@ -883,7 +883,7 @@
           "includeAll": false,
           "label": "Data Source",
           "multi": false,
-          "name": "prometheus_datasource",
+          "name": "DS_PROMETHEUS",
           "options": [],
           "query": "prometheus",
           "queryValue": "",


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

The new Hubble dashboards for DNS and Network (https://github.com/cilium/cilium/pull/27751, coming with Cilium v1.15.0) do not work out of the box due to an error in Grafana: `Templating: Failed to upgrade legacy queries Datasource ${DS_PROMETHEUS} was not found`.
Also, the main Hubble dashboard (`Hubble Metrics and Monitoring`) was not included in https://github.com/cilium/cilium/pull/30161, this is now fixed.

```release-note
Datasource error fixed for Hubble DNS and Network dashboards
```
