### PR TITLE
Docs: restructure Cluster Mesh scaling section

### DIFF
--- a/Documentation/internals/security-identities.rst
+++ b/Documentation/internals/security-identities.rst
@@ -4,6 +4,8 @@
     Please use the official rendered version released here:
     https://docs.cilium.io
 
+.. _security_identities:
+
 *******************
 Security Identities
 *******************

--- a/Documentation/network/clustermesh/clustermesh.rst
+++ b/Documentation/network/clustermesh/clustermesh.rst
@@ -70,18 +70,8 @@ Scaling Limitations
 
 * By default, the maximum number of clusters that can be connected together using Cluster Mesh is
   255. By using the option ``maxConnectedClusters`` this limit can be set to 511, at the expense of
-  lowering the maximum number of cluster-local identities. Valid configurations for this option are
-  255 and 511.
-
-* All clusters across a Cluster Mesh must be configured with the same ``maxConnectedClusters``
-  value.
-
- * ConfigMap option ``max-connected-clusters=511``
- * Helm option ``--set clustermesh.maxConnectedClusters=511``
- * ``cilium install`` option ``--set clustermesh.maxConnectedClusters=511``
-
-* This option controls the bit allocation of numeric identities and will affect the number of
-  identities that can be allocated per cluster:
+  lowering the maximum number of cluster-local identities. Reference the following table for valid
+  configurations and their corresponding cluster-local identity limits:
 
 +------------------------+------------+----------+----------+
 | MaxConnectedClusters   | Maximum cluster-local identities |
@@ -90,6 +80,20 @@ Scaling Limitations
 +------------------------+------------+----------+----------+
 | 511                    | 32767                            |
 +------------------------+------------+----------+----------+
+
+* All clusters across a Cluster Mesh must be configured with the same ``maxConnectedClusters``
+  value.
+
+ * ConfigMap option ``max-connected-clusters=511``
+ * Helm option ``--set clustermesh.maxConnectedClusters=511``
+ * ``cilium install`` option ``--set clustermesh.maxConnectedClusters=511``
+
+.. note::
+
+   This option controls the bit allocation of numeric identities and will affect the maximum number
+   of cluster-local identities that can be allocated. By default, cluster-local
+   :ref:`security_identities` are limited to 65535, regardless of whether Cluster Mesh is used or
+   not.
 
 .. warning::
   ``MaxConnectedClusters`` can only be set once during Cilium installation and should not be


### PR DESCRIPTION
A user in the community mentioned some confusion around cluster-local identity limit in the Scaling Limitations section of the Cluster Mesh guide. A note was added to call out that this is a Cilium limitation, and not one specific to Cluster Mesh.

Additionally, the section was reorganized to reduce repetition.