### PR TITLE
fix: prometheus can't scrape serviceMonitor job

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Values.prometheus.serviceMonitor.namespace | default .Release.Namespace }}
   labels:
     app.kubernetes.io/part-of: cilium
+    release: prometheus
     {{- with .Values.prometheus.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/servicemonitor.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-envoy
+    release: prometheus
     {{- with .Values.envoy.prometheus.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-operator
+    release: prometheus
     {{- with .Values.operator.prometheus.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: {{ .Values.clustermesh.apiserver.metrics.serviceMonitor.namespace | default .Release.Namespace }}
   labels:
     app.kubernetes.io/part-of: cilium
+    release: prometheus
     {{- with .Values.clustermesh.apiserver.metrics.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/servicemonitor.yaml
@@ -5,6 +5,7 @@ metadata:
   name: hubble-relay
   namespace: {{ .Values.hubble.relay.prometheus.serviceMonitor.namespace | default .Release.Namespace }}
   labels:
+    release: prometheus
     {{- with .Values.hubble.relay.prometheus.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
Fixes: #30594 
Prometheus can't scrape serviceMonitor job, plz see PR commit