### PR TITLE
check-sources.sh: move file lists to env variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyAddres
 
 TEST_UNITTEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/datapath.datapathSHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
+BPF_SOURCE_NAMES_TO_IDS ?= bpf/source_names_to_ids.h
+GO_SOURCE_NAMES_TO_IDS ?= pkg/monitor/datapath_drop.go
+
 build: check-sources $(SUBDIRS) ## Builds all the components for Cilium by executing make in the respective sub directories.
 
 build-container: check-sources ## Builds components required for cilium-agent container.
@@ -495,7 +498,7 @@ endif
 
 check-sources:
 	@$(ECHO_CHECK) pkg/datapath/loader/check-sources.sh
-	$(QUIET) pkg/datapath/loader/check-sources.sh
+	$(QUIET) BPF_SOURCE_NAMES_TO_IDS=$(BPF_SOURCE_NAMES_TO_IDS) GO_SOURCE_NAMES_TO_IDS=$(GO_SOURCE_NAMES_TO_IDS) pkg/datapath/loader/check-sources.sh
 
 pprof-heap: ## Get Go pprof heap profile.
 	$(QUIET)$(GO) tool pprof http://localhost:6060/debug/pprof/heap

--- a/bpf/source_names_to_ids.h
+++ b/bpf/source_names_to_ids.h
@@ -19,6 +19,8 @@
 static __always_inline int
 __source_file_name_to_id(const char *const header_name)
 {
+	/* @@ source files list begin */
+
 	/* source files from bpf/ */
 	_strcase_(1, "bpf_host.c");
 	_strcase_(2, "bpf_lxc.c");
@@ -33,6 +35,8 @@ __source_file_name_to_id(const char *const header_name)
 	_strcase_(105, "nodeport.h");
 	_strcase_(106, "lb.h");
 	_strcase_(107, "mcast.h");
+
+	/* @@ source files list end */
 
 	return 0;
 }

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -48,6 +48,8 @@ func (n *DropNotify) dumpIdentity(buf *bufio.Writer, numeric DisplayFormat) {
 }
 
 var sourceFileNames = map[int]string{
+	// @@ source files list begin
+
 	// source files from bpf/
 	1: "bpf_host.c",
 	2: "bpf_lxc.c",
@@ -62,7 +64,8 @@ var sourceFileNames = map[int]string{
 	105: "nodeport.h",
 	106: "lb.h",
 	107: "mcast.h",
-	//end
+
+	// @@ source files list end
 }
 
 // DecodeDropNotify will decode 'data' into the provided DropNotify structure


### PR DESCRIPTION
to allow alternative implementations to expand them.

With that in mind, make the awk logic used to match filenames a bit more
generic.