### PR TITLE
gha: Avoid the warning for kind-action

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -317,7 +317,7 @@ jobs:
             envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster2.yaml
 
       - name: Create Kind cluster 1
-        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
+        uses: helm/kind-action@4be822c96b3a80076fb61a4e54a4e89d8d79c9c6 # v1.8.0
         with:
           cluster_name: ${{ env.clusterName1 }}
           version: ${{ env.kind_version }}
@@ -326,7 +326,7 @@ jobs:
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Create Kind cluster 2
-        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
+        uses: helm/kind-action@4be822c96b3a80076fb61a4e54a4e89d8d79c9c6 # v1.8.0
         with:
           cluster_name: ${{ env.clusterName2 }}
           version: ${{ env.kind_version }}

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -147,7 +147,7 @@ jobs:
             examples
 
       - name: Create kind cluster
-        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
+        uses: helm/kind-action@4be822c96b3a80076fb61a4e54a4e89d8d79c9c6 # v1.8.0
         with:
           version: ${{ env.kind_version }}
           config: ${{ env.kind_config }}

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -167,7 +167,7 @@ jobs:
             examples
 
       - name: Create kind cluster
-        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
+        uses: helm/kind-action@4be822c96b3a80076fb61a4e54a4e89d8d79c9c6 # v1.8.0
         with:
           version: ${{ env.kind_version }}
           config: ${{ env.kind_config }}

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -81,7 +81,7 @@ jobs:
           until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator-generic-ci:${{ steps.vars.outputs.tag }} &> /dev/null; do sleep 45s; done
 
       - name: Create kind cluster
-        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
+        uses: helm/kind-action@4be822c96b3a80076fb61a4e54a4e89d8d79c9c6 # v1.8.0
         with:
           version: ${{ env.KIND_VERSION }}
           config: ${{ env.KIND_CONFIG }}

--- a/.github/workflows/conformance-kind-proxy-daemonset.yaml
+++ b/.github/workflows/conformance-kind-proxy-daemonset.yaml
@@ -81,7 +81,7 @@ jobs:
           persist-credentials: false
 
       - name: Create kind cluster
-        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
+        uses: helm/kind-action@4be822c96b3a80076fb61a4e54a4e89d8d79c9c6 # v1.8.0
         with:
           version: ${{ env.kind_version }}
           config: ${{ env.kind_config }}

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -169,7 +169,7 @@ jobs:
             install/kubernetes/cilium
 
       - name: Create kind cluster
-        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
+        uses: helm/kind-action@4be822c96b3a80076fb61a4e54a4e89d8d79c9c6 # v1.8.0
         with:
           version: ${{ env.kind_version }}
           config: ${{ env.kind_config }}

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -211,7 +211,7 @@ jobs:
             envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster2.yaml
 
       - name: Create Kind cluster 1
-        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
+        uses: helm/kind-action@4be822c96b3a80076fb61a4e54a4e89d8d79c9c6 # v1.8.0
         with:
           cluster_name: ${{ env.clusterName1 }}
           version: ${{ env.kind_version }}
@@ -220,7 +220,7 @@ jobs:
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Create Kind cluster 2
-        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
+        uses: helm/kind-action@4be822c96b3a80076fb61a4e54a4e89d8d79c9c6 # v1.8.0
         with:
           cluster_name: ${{ env.clusterName2 }}
           version: ${{ env.kind_version }}

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -96,7 +96,7 @@ jobs:
           sudo systemctl restart docker
 
       - name: Create kind cluster
-        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
+        uses: helm/kind-action@4be822c96b3a80076fb61a4e54a4e89d8d79c9c6 # v1.8.0
         with:
           version: ${{ env.KIND_VERSION }}
           config: ${{ env.KIND_CONFIG }}

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -113,7 +113,7 @@ jobs:
           test -z "$(git status --porcelain)" || (echo "please run 'make -C examples/kubernetes/connectivity-check fmt all' and submit your changes"; exit 1)
 
       - name: Create kind cluster
-        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
+        uses: helm/kind-action@4be822c96b3a80076fb61a4e54a4e89d8d79c9c6 # v1.8.0
         with:
           version: ${{ env.KIND_VERSION }}
           config: ${{ env.KIND_CONFIG }}


### PR DESCRIPTION
Only the commit hash is updated, so that once v1.9.0 is released, rennovate will be able to pick it up.

Related PR: https://github.com/helm/kind-action/pull/102

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

