### PR TITLE
Implement Basic Identity Allocator

### DIFF
--- a/pkg/identity/basicallocator/basic_allocator.go
+++ b/pkg/identity/basicallocator/basic_allocator.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package basicallocator
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/cilium/cilium/pkg/idpool"
+)
+
+// BasicIDAllocator is used for managing a range of identities (unsigned
+// integers) in a very simple way, by allocating specified or random identities,
+// and returning them to the available pool.
+// Concurrency control (mutex locks) is built into IDPool.
+type BasicIDAllocator struct {
+	idPool     idpool.IDPool
+	minIDValue idpool.ID
+	maxIDValue idpool.ID
+}
+
+// NewBasicIDAllocator creates a new BasicIDAllocator for ID values between
+// the provided minIDValue and maxIDValue.
+func NewBasicIDAllocator(minIDValue, maxIDValue idpool.ID) *BasicIDAllocator {
+	return &BasicIDAllocator{
+		idPool:     idpool.NewIDPool(minIDValue, maxIDValue),
+		minIDValue: minIDValue,
+		maxIDValue: maxIDValue,
+	}
+}
+
+func (b *BasicIDAllocator) AllocateRandom() (idpool.ID, error) {
+	id := b.idPool.AllocateID()
+	if id == idpool.NoID {
+		return id, fmt.Errorf("failed to allocate random ID")
+	}
+
+	return id, nil
+}
+
+func (b *BasicIDAllocator) Allocate(id idpool.ID) error {
+	if !b.IsInPoolRange(id) {
+		return fmt.Errorf("cannot allocate %d because it's out of the pool range [%d, %d]", id, b.minIDValue, b.maxIDValue)
+	}
+
+	idRemovedFromPool := b.idPool.Remove(id)
+	if !idRemovedFromPool {
+		return fmt.Errorf("failed to allocate ID=%d", id)
+	}
+
+	return nil
+}
+
+func (b *BasicIDAllocator) ReturnToAvailablePool(id idpool.ID) error {
+	if !b.IsInPoolRange(id) {
+		return fmt.Errorf("cannot return %d to the available pool because it's out of the pool range [%d, %d]", id, b.minIDValue, b.maxIDValue)
+	}
+
+	returnedToPool := b.idPool.Insert(id)
+	if !returnedToPool {
+		return fmt.Errorf("failed to return ID %d to available pool", id)
+	}
+
+	return nil
+}
+
+func (b *BasicIDAllocator) IsInPoolRange(id idpool.ID) bool {
+	return id >= b.minIDValue && id <= b.maxIDValue
+}
+
+func (b *BasicIDAllocator) ValidateIDString(idStr string) (int64, error) {
+	idInt, err := strconv.Atoi(idStr)
+	if err != nil {
+		return 0, fmt.Errorf("failed to validate id(%d): %v", idInt, err)
+	}
+
+	if idInt < 0 {
+		return 0, fmt.Errorf("failed to validate id(%d), id cannot be negative", idInt)
+	}
+
+	idInt64 := int64(idInt)
+
+	if !b.IsInPoolRange(idpool.ID(idInt64)) {
+		return 0, fmt.Errorf("failed to validate id(%d), out of the pool range [%d, %d]", idInt, b.minIDValue, b.maxIDValue)
+	}
+
+	return idInt64, nil
+}

--- a/pkg/identity/basicallocator/basic_allocator_test.go
+++ b/pkg/identity/basicallocator/basic_allocator_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package basicallocator
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/idpool"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasicAllocator(t *testing.T) {
+	midID, maxID := 10, 20
+	a := NewBasicIDAllocator(idpool.ID(midID), idpool.ID(maxID))
+	assert.NoError(t, a.Allocate(idpool.ID(15)), "ID 15 inserted")
+	assert.Error(t, a.Allocate(idpool.ID(15)), "ID 15 insert conflict")
+	assert.NoError(t, a.ReturnToAvailablePool(idpool.ID(15)), "ID 15 returned to the pool")
+	assert.NoError(t, a.Allocate(idpool.ID(15)), "ID 15 inserted again")
+	assert.Error(t, a.ReturnToAvailablePool(idpool.ID(10)), "ID 10 cannot be returned to the pool because it isn't used")
+
+	for i := 0; i < 10; i++ {
+		_, err := a.AllocateRandom()
+		assert.NoError(t, err, "Fill out all available spaces")
+	}
+
+	_, err := a.AllocateRandom()
+	assert.Error(t, err, "Unable to allocate when there aren't any available")
+
+	assert.NoError(t, a.ReturnToAvailablePool(idpool.ID(15)), "ID 15 returned to the pool")
+	id, err := a.AllocateRandom()
+	assert.NoError(t, err, "ID 15 allocated")
+	assert.Equal(t, idpool.ID(15), id, "ID 15 allocated")
+
+	assert.Error(t, a.Allocate(idpool.ID(30)), "ID 30 cannot be inserted because it's outside the pool's range")
+	assert.Error(t, a.ReturnToAvailablePool(idpool.ID(30)), "ID 30 cannot be returned to the pool because it's outside the pool's range")
+}
+
+func TestValidateIDString(t *testing.T) {
+	midID, maxID := 10, 20
+	a := NewBasicIDAllocator(idpool.ID(midID), idpool.ID(maxID))
+
+	type tc struct {
+		description string
+		cidName     string
+		expectedID  int64
+		expectErr   bool
+	}
+
+	testCases := []tc{
+		{
+			description: "The ID must be convertable to an integer",
+			cidName:     "cid-name-1",
+			expectedID:  0,
+			expectErr:   true,
+		},
+		{
+			description: "The ID cannot be negative",
+			cidName:     "-1",
+			expectedID:  0,
+			expectErr:   true,
+		},
+		{
+			description: "The ID cannot be outside the ID pool",
+			cidName:     "9",
+			expectedID:  0,
+			expectErr:   true,
+		},
+		{
+			description: "The ID cannot be outside the ID pool",
+			cidName:     "21",
+			expectedID:  0,
+			expectErr:   true,
+		},
+		{
+			description: "The ID is inside the ID pool",
+			cidName:     "10",
+			expectedID:  10,
+			expectErr:   false,
+		},
+		{
+			description: "The ID is inside the ID pool",
+			cidName:     "15",
+			expectedID:  15,
+			expectErr:   false,
+		},
+		{
+			description: "The ID is inside the ID pool",
+			cidName:     "20",
+			expectedID:  20,
+			expectErr:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		id, err := a.ValidateIDString(tc.cidName)
+		hasErr := err != nil
+
+		assert.Equal(t, tc.expectedID, id, tc.description)
+		assert.Equal(t, tc.expectErr, hasErr, tc.description)
+	}
+}


### PR DESCRIPTION
Basic identity allocator will be used both by operator to manage global identities (Cilium Identities) and agent to manage locally created identities that don’t require complex features and behavior like in `pkg/allocator/allocator.go`.

Related: https://github.com/cilium/cilium/pull/30356

No user facing changes.

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>