### PR TITLE
add users doc to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -74,6 +74,13 @@ body:
     validations:
       required: false
   - type: checkboxes
+    id: users
+    attributes:
+      label: Cilium Users Document
+      options:
+        - label: Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
+          required: false
+  - type: checkboxes
     id: terms
     attributes:
       label: Code of Conduct


### PR DESCRIPTION
adds a link to the users doc in the issue template to make it more visible to community members who are probably using Cilium already
