### PR TITLE
[agent] Implement Temporary Security Identity Allocation

### DIFF
--- a/pkg/identity/basicallocator/basic_allocator.go
+++ b/pkg/identity/basicallocator/basic_allocator.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package basicallocator
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/cilium/cilium/pkg/idpool"
+)
+
+type BasicIDAllocator struct {
+	idPool     idpool.IDPool
+	minIDValue idpool.ID
+	maxIDValue idpool.ID
+}
+
+// NewBasicIDAllocator creates a new BasicIDAllocator for ID values between
+// the provided minIDValue and maxIDValue.
+func NewBasicIDAllocator(minIDValue, maxIDValue idpool.ID) *BasicIDAllocator {
+	return &BasicIDAllocator{
+		idPool:     idpool.NewIDPool(minIDValue, maxIDValue),
+		minIDValue: minIDValue,
+		maxIDValue: maxIDValue,
+	}
+}
+
+func (b *BasicIDAllocator) AllocateRandom() (idpool.ID, error) {
+	id := b.idPool.AllocateID()
+	if id == idpool.NoID {
+		return id, fmt.Errorf("failed to allocate random ID")
+	}
+
+	return id, nil
+}
+
+func (b *BasicIDAllocator) Allocate(id idpool.ID) error {
+	if !b.IsInPoolRange(id) {
+		return fmt.Errorf("cannot allocate %d because it's out of the pool range [%d, %d]", id, b.minIDValue, b.maxIDValue)
+	}
+
+	idRemovedFromPool := b.idPool.Remove(id)
+	if !idRemovedFromPool {
+		return fmt.Errorf("failed to allocate ID=%d", id)
+	}
+
+	return nil
+}
+
+func (b *BasicIDAllocator) ReturnToAvailablePool(id idpool.ID) error {
+	if !b.IsInPoolRange(id) {
+		return fmt.Errorf("cannot return %d to the available pool because it's out of the pool range [%d, %d]", id, b.minIDValue, b.maxIDValue)
+	}
+
+	returnedToPool := b.idPool.Insert(id)
+	if !returnedToPool {
+		return fmt.Errorf("failed to return ID %d to available pool", id)
+	}
+
+	return nil
+}
+
+func (b *BasicIDAllocator) IsInPoolRange(id idpool.ID) bool {
+	return id >= b.minIDValue && id <= b.maxIDValue
+}
+
+func (b *BasicIDAllocator) ValidateIDString(idStr string) (int64, error) {
+	idInt, err := strconv.Atoi(idStr)
+	if err != nil {
+		return 0, fmt.Errorf("failed to validate id(%d): %v", idInt, err)
+	}
+
+	if idInt < 0 {
+		return 0, fmt.Errorf("failed to validate id(%d), id cannot be negative", idInt)
+	}
+
+	idInt64 := int64(idInt)
+
+	if !b.IsInPoolRange(idpool.ID(idInt64)) {
+		return 0, fmt.Errorf("failed to validate id(%d), out of the pool range [%d, %d]", idInt, b.minIDValue, b.maxIDValue)
+	}
+
+	return idInt64, nil
+}

--- a/pkg/identity/basicallocator/basic_allocator_test.go
+++ b/pkg/identity/basicallocator/basic_allocator_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package basicallocator
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/idpool"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasicAllocator(t *testing.T) {
+	midID, maxID := 10, 20
+	a := NewBasicIDAllocator(idpool.ID(midID), idpool.ID(maxID))
+	assert.NoError(t, a.Allocate(idpool.ID(15)), "ID 15 inserted")
+	assert.Error(t, a.Allocate(idpool.ID(15)), "ID 15 insert conflict")
+	assert.NoError(t, a.ReturnToAvailablePool(idpool.ID(15)), "ID 15 returned to the pool")
+	assert.NoError(t, a.Allocate(idpool.ID(15)), "ID 15 inserted again")
+	assert.Error(t, a.ReturnToAvailablePool(idpool.ID(10)), "ID 10 cannot be returned to the pool because it isn't used")
+
+	for i := 0; i < 10; i++ {
+		_, err := a.AllocateRandom()
+		assert.NoError(t, err, "Fill out all available spaces")
+	}
+
+	_, err := a.AllocateRandom()
+	assert.Error(t, err, "Unable to allocate when there aren't any available")
+
+	assert.NoError(t, a.ReturnToAvailablePool(idpool.ID(15)), "ID 15 returned to the pool")
+	id, err := a.AllocateRandom()
+	assert.NoError(t, err, "ID 15 allocated")
+	assert.Equal(t, idpool.ID(15), id, "ID 15 allocated")
+
+	assert.Error(t, a.Allocate(idpool.ID(30)), "ID 30 cannot be inserted because it's outside the pool's range")
+	assert.Error(t, a.ReturnToAvailablePool(idpool.ID(30)), "ID 30 cannot be returned to the pool because it's outside the pool's range")
+}
+
+func TestValidateIDString(t *testing.T) {
+	midID, maxID := 10, 20
+	a := NewBasicIDAllocator(idpool.ID(midID), idpool.ID(maxID))
+
+	type tc struct {
+		description string
+		cidName     string
+		expectedID  int64
+		expectErr   bool
+	}
+
+	testCases := []tc{
+		{
+			description: "The ID must be convertable to an integer",
+			cidName:     "cid-name-1",
+			expectedID:  0,
+			expectErr:   true,
+		},
+		{
+			description: "The ID cannot be negative",
+			cidName:     "-1",
+			expectedID:  0,
+			expectErr:   true,
+		},
+		{
+			description: "The ID cannot be outside the ID pool",
+			cidName:     "9",
+			expectedID:  0,
+			expectErr:   true,
+		},
+		{
+			description: "The ID cannot be outside the ID pool",
+			cidName:     "21",
+			expectedID:  0,
+			expectErr:   true,
+		},
+		{
+			description: "The ID is inside the ID pool",
+			cidName:     "10",
+			expectedID:  10,
+			expectErr:   false,
+		},
+		{
+			description: "The ID is inside the ID pool",
+			cidName:     "15",
+			expectedID:  15,
+			expectErr:   false,
+		},
+		{
+			description: "The ID is inside the ID pool",
+			cidName:     "20",
+			expectedID:  20,
+			expectErr:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		id, err := a.ValidateIDString(tc.cidName)
+		hasErr := err != nil
+
+		assert.Equal(t, tc.expectedID, id, tc.description)
+		assert.Equal(t, tc.expectErr, hasErr, tc.description)
+	}
+}

--- a/pkg/identity/nonglobal/temp_id.go
+++ b/pkg/identity/nonglobal/temp_id.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nonglobal
+
+import (
+	"time"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/basicallocator"
+	"github.com/cilium/cilium/pkg/identity/key"
+	"github.com/cilium/cilium/pkg/idpool"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	TempIDGCInterval = 2 * time.Minute
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "non-global-identity")
+)
+
+// TempSecIDAllocator is responsible for allocating temporary security
+// identities. Temporary security identities are used by new pods before a
+// global security identity is allocated by cilium-operator.
+type TempSecIDAllocator struct {
+	allocator          *basicallocator.BasicIDAllocator
+	tempIDCache        *TempIDCache
+	endpointListerFunc func() []*endpoint.Endpoint
+}
+
+// NewTempSecIDAllocator creates a new TempSecIDAllocator for ID values
+// between the provided minIDValue and maxIDValue.
+func NewTempSecIDAllocator(endpointListerFunc func() []*endpoint.Endpoint) *TempSecIDAllocator {
+	return &TempSecIDAllocator{
+		allocator:          basicallocator.NewBasicIDAllocator(identity.DefaultMinTempID, identity.DefaultMaxTempID),
+		tempIDCache:        NewTempIDCache(),
+		endpointListerFunc: endpointListerFunc,
+	}
+}
+
+type TempIDCache struct {
+	mu                lock.RWMutex
+	idToIdentity      map[identity.NumericIdentity]*identity.Identity
+	keyToIdentity     map[string]*identity.Identity
+	markedForDeletion map[identity.NumericIdentity]bool
+}
+
+func NewTempIDCache() *TempIDCache {
+	return &TempIDCache{
+		mu:                lock.RWMutex{},
+		idToIdentity:      make(map[identity.NumericIdentity]*identity.Identity),
+		keyToIdentity:     make(map[string]*identity.Identity),
+		markedForDeletion: make(map[identity.NumericIdentity]bool),
+	}
+}
+
+// FindOrCreateTempID gets ans existing or creates a temporary security identity
+// for the specified labels, to be used before operator creates a global
+// security identity.
+func (a *TempSecIDAllocator) FindOrCreateTempID(lbls labels.Labels) (*identity.Identity, error) {
+	if id, exists := a.LookupByIDKey(&key.GlobalIdentity{LabelArray: lbls.LabelArray()}); exists {
+		return id, nil
+	}
+
+	a.tempIDCache.mu.Lock()
+	defer a.tempIDCache.mu.Unlock()
+
+	allocatedID, err := a.allocator.AllocateRandom()
+	if err != nil {
+		return nil, err
+	}
+
+	numID := identity.NumericIdentity(int64(allocatedID))
+	id := identity.NewIdentity(numID, lbls)
+	a.insertToCache(id)
+
+	return id, nil
+}
+
+func (a *TempSecIDAllocator) LookupByID(numID identity.NumericIdentity) (*identity.Identity, bool) {
+	cache := a.tempIDCache
+	cache.mu.RLock()
+	defer cache.mu.RUnlock()
+
+	id, exists := cache.idToIdentity[numID]
+	return id, exists
+}
+
+func (a *TempSecIDAllocator) LookupByIDKey(idKey *key.GlobalIdentity) (*identity.Identity, bool) {
+	cache := a.tempIDCache
+	cache.mu.RLock()
+	defer cache.mu.RUnlock()
+
+	id, exists := cache.keyToIdentity[idKey.GetKey()]
+	return id, exists
+}
+
+func (a *TempSecIDAllocator) insertToCache(id *identity.Identity) {
+	numID := id.ID
+	if !a.allocator.IsInPoolRange(idpool.ID(numID)) {
+		return
+	}
+
+	cache := a.tempIDCache
+	idKey := &key.GlobalIdentity{LabelArray: id.LabelArray}
+	cache.idToIdentity[numID] = id
+	cache.keyToIdentity[idKey.GetKey()] = id
+}
+
+func (a *TempSecIDAllocator) StartPeriodicGC(stopChan chan struct{}) {
+	log.Info("Starting Temp ID periodic garbage collection")
+
+	wait.Until(a.runGC, TempIDGCInterval, stopChan)
+
+	log.Info("Stopping Temp ID periodic garbage collection")
+}
+
+// runGC cleans up temp IDs that aren't used by any local endpoints for two
+// consecutive GC cycles.
+// It finds all temp IDs that aren't used by any local endpoints. It marks
+// them for deletion if they aren't already marked. It deletes them if they are
+// already marked for deletion in the previous GC run.
+func (a *TempSecIDAllocator) runGC() {
+	cache := a.tempIDCache
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	gcStartTime := time.Now()
+	log.Debug("Running Temp ID garbage collection")
+	deletedCount := 0
+	defer func() {
+		gcDuration := time.Since(gcStartTime)
+		log.Debugf("Completed Temp ID periodic garbage collection after %v. Deleted Temp IDs: %d", gcDuration, deletedCount)
+	}()
+
+	eps := a.endpointListerFunc()
+	if len(eps) == 0 {
+		return
+	}
+
+	usedTempIDs := make(map[identity.NumericIdentity]bool)
+	for _, ep := range eps {
+		if ep == nil || ep.SecurityIdentity == nil {
+			continue
+		}
+
+		if identity.IsTempID(ep.SecurityIdentity.ID) {
+			usedTempIDs[ep.SecurityIdentity.ID] = true
+		}
+	}
+
+	for numID, id := range cache.idToIdentity {
+		if _, isUsed := usedTempIDs[numID]; isUsed {
+			delete(cache.markedForDeletion, numID)
+			continue
+		}
+
+		if markedforDeletion := cache.markedForDeletion[numID]; !markedforDeletion {
+			cache.markedForDeletion[numID] = true
+			continue
+		}
+
+		idKey := &key.GlobalIdentity{LabelArray: id.Labels.LabelArray()}
+		a.allocator.ReturnToAvailablePool(idpool.ID(numID))
+
+		delete(cache.idToIdentity, numID)
+		delete(cache.keyToIdentity, idKey.GetKey())
+		delete(cache.markedForDeletion, numID)
+
+		deletedCount++
+	}
+}

--- a/pkg/identity/nonglobal/temp_id_test.go
+++ b/pkg/identity/nonglobal/temp_id_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nonglobal
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/key"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testLblsA    = labels.Map2Labels(map[string]string{"key-a": "val-1"}, labels.LabelSourceK8s)
+	testLblsB    = labels.Map2Labels(map[string]string{"key-b": "val-2"}, labels.LabelSourceK8s)
+	testNumOfEps = 10
+
+	nilID   *identity.Identity
+	testEps []*endpoint.Endpoint
+)
+
+func testGCEndpointListerFunc() []*endpoint.Endpoint {
+	return testEps
+}
+
+func testGenerateGCEndpointList() {
+	testEps = []*endpoint.Endpoint{}
+	for i := 0; i < testNumOfEps; i++ {
+		testEps = append(testEps, &endpoint.Endpoint{})
+	}
+}
+
+func TestTempSecIDAllocator(t *testing.T) {
+	tempAllocator := NewTempSecIDAllocator(nil)
+	id1, err := tempAllocator.FindOrCreateTempID(testLblsA)
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, int(id1.ID), identity.DefaultMinTempID)
+	assert.LessOrEqual(t, int(id1.ID), identity.DefaultMaxTempID)
+
+	id2, err := tempAllocator.FindOrCreateTempID(testLblsA)
+	assert.NoError(t, err)
+	assert.Equal(t, id1, id2)
+
+	id3, exists := tempAllocator.LookupByID(identity.NumericIdentity(id1.ID))
+	assert.Equal(t, true, exists)
+	assert.Equal(t, id3, id2)
+
+	id4, exists := tempAllocator.LookupByIDKey(&key.GlobalIdentity{LabelArray: testLblsA.LabelArray()})
+	assert.Equal(t, true, exists)
+	assert.Equal(t, id4, id3)
+
+	outOfBoundID := identity.NumericIdentity(1000)
+	id5, exists := tempAllocator.LookupByID(outOfBoundID)
+	assert.Equal(t, false, exists)
+	assert.Equal(t, id5, nilID)
+
+	id6, exists := tempAllocator.LookupByIDKey(&key.GlobalIdentity{LabelArray: testLblsB.LabelArray()})
+	assert.Equal(t, false, exists)
+	assert.Equal(t, id6, nilID)
+}
+
+func TestTempSecIDGC(t *testing.T) {
+	tempAllocator := NewTempSecIDAllocator(testGCEndpointListerFunc)
+	defer func() {
+		testEps = []*endpoint.Endpoint{}
+	}()
+
+	min := identity.DefaultMinTempID
+	max := identity.DefaultMaxTempID
+	for i := 0; i < testNumOfEps; i++ {
+		if i%2 == 0 {
+			tempAllocator.insertToCache(&identity.Identity{ID: identity.NumericIdentity(min + i)})
+		} else {
+			tempAllocator.insertToCache(&identity.Identity{ID: identity.NumericIdentity(max - i)})
+		}
+	}
+
+	assert.Equal(t, 10, len(tempAllocator.tempIDCache.idToIdentity))
+
+	tempAllocator.runGC()
+	tempAllocator.runGC()
+	assert.Equal(t, 10, len(tempAllocator.tempIDCache.idToIdentity))
+
+	testGenerateGCEndpointList()
+	eps := testGCEndpointListerFunc()
+	for i, ep := range eps {
+		ep.SecurityIdentity = &identity.Identity{ID: identity.NumericIdentity(min + i)}
+	}
+	tempAllocator.runGC()
+	assert.Equal(t, 10, len(tempAllocator.tempIDCache.idToIdentity))
+
+	tempAllocator.runGC()
+	assert.Equal(t, 5, len(tempAllocator.tempIDCache.idToIdentity))
+
+	expectedID := &identity.Identity{ID: identity.NumericIdentity(min)}
+	id1, exists := tempAllocator.LookupByID(identity.NumericIdentity(min))
+	assert.Equal(t, true, exists)
+	assert.Equal(t, expectedID, id1)
+
+	testEps = testEps[1:]
+	tempAllocator.runGC()
+	id1, exists = tempAllocator.LookupByID(identity.NumericIdentity(min))
+	assert.Equal(t, true, exists)
+	assert.Equal(t, expectedID, id1)
+
+	tempAllocator.runGC()
+	id1, exists = tempAllocator.LookupByID(identity.NumericIdentity(min))
+	assert.Equal(t, false, exists)
+	assert.Equal(t, nilID, id1)
+}

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -81,6 +81,10 @@ const (
 	// InvalidIdentity is the identity assigned if the identity is invalid
 	// or not determined yet
 	InvalidIdentity = NumericIdentity(0)
+
+	// 4096 (2^12) temp IDs to be available.
+	DefaultMinTempID = 1<<24 + 1<<16         // 2^24 + 2^16
+	DefaultMaxTempID = 1<<24 + 1<<16 + 1<<12 // 2^24 + 2^16 + 2^12
 )
 
 var (
@@ -636,6 +640,10 @@ func iterateReservedIdentityLabels(f func(_ NumericIdentity, _ labels.Labels)) {
 
 // HasLocalScope returns true if the identity is in the Local (CIDR) scope
 func (id NumericIdentity) HasLocalScope() bool {
+	if IsTempID(id) {
+		return false
+	}
+
 	return id.Scope() == IdentityScopeLocal
 }
 
@@ -665,4 +673,8 @@ func (id NumericIdentity) IsCluster() bool {
 		return false
 	}
 	return true
+}
+
+func IsTempID(numID NumericIdentity) bool {
+	return numID >= DefaultMinTempID && numID <= DefaultMaxTempID
 }


### PR DESCRIPTION
Temporary security identities are required when global identity (Cilium Identity) management is moved to cilium-operator.
This will be integrated with the Local Only Identity Allocator.
(reference: https://github.com/cilium/cilium/pull/30356)

No user facing changes.

**Reviewer note**

This change depends on https://github.com/cilium/cilium/pull/30602, so the basic allocator code is included here. It doesn't need to be reviewed here, because this PR will be rebased when https://github.com/cilium/cilium/pull/30602 is merged.

**More context**

Cilium-operator is creating Cilium Identities on Pod object creation, which is before the pod is scheduled.
In most cases global identities (Cilium Identities) will be present in the agent’s watcher store at the moment when that identity is required for endpoint regeneration.

In rare case of delayed Cilium Identity creation, like Cilium Identity creation is throttled by kube-apiserver or cilium-operator is not running, cilium-agents will still be able to regenerate endpoints and run pods, by assigning temporary identities to them based on the same labels that are relevant to security identity.

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>