### PR TITLE
daemon: check incompatibility EnableAutoDirectRouting and IPAM type

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1386,8 +1386,13 @@ func initEnv(vp *viper.Viper) {
 		option.Config.EncryptInterface = append(option.Config.EncryptInterface, link)
 	}
 
-	if option.Config.TunnelingEnabled() && option.Config.EnableAutoDirectRouting {
-		log.Fatalf("%s cannot be used with tunneling. Packets must be routed through the tunnel device.", option.EnableAutoDirectRoutingName)
+	if option.Config.EnableAutoDirectRouting {
+		if option.Config.TunnelingEnabled() {
+			log.Fatalf("%s cannot be used with tunneling. Packets must be routed through the tunnel device.", option.EnableAutoDirectRoutingName)
+		}
+		if option.Config.IPAM != ipamOption.IPAMKubernetes {
+			log.Fatalf("%s can only be used with Kubernetes IPAM.", option.EnableAutoDirectRoutingName)
+		}
 	}
 
 	initClockSourceOption()


### PR DESCRIPTION


As a result of https://github.com/cilium/cilium/pull/26663  (https://github.com/cilium/cilium/commit/2ca717e34477), `autoDirectNodeRoutes` is not compatible with non-Kubernetes IPAM.
Here we add a check for this in `initEnv` and `log.Fatal` when this is attempted.

```release-note
`autoDirectNodeRoutes` can be enabled only with Kubernetes IPAM
```
