### PR TITLE
helm: Remove deprecated values encryption.*

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -956,10 +956,6 @@
      - Enable transparent network encryption.
      - bool
      - ``false``
-   * - :spelling:ignore:`encryption.interface`
-     - Deprecated in favor of encryption.ipsec.interface. To be removed in 1.15. The interface to use for encrypted traffic. This option is only effective when encryption.type is set to ipsec.
-     - string
-     - ``""``
    * - :spelling:ignore:`encryption.ipsec.interface`
      - The interface to use for encrypted traffic.
      - string
@@ -967,7 +963,7 @@
    * - :spelling:ignore:`encryption.ipsec.keyFile`
      - Name of the key file inside the Kubernetes secret configured via secretName.
      - string
-     - ``""``
+     - ``"keys"``
    * - :spelling:ignore:`encryption.ipsec.keyRotationDuration`
      - Maximum duration of the IPsec key rotation. The previous key will be removed after that delay.
      - string
@@ -979,27 +975,15 @@
    * - :spelling:ignore:`encryption.ipsec.mountPath`
      - Path to mount the secret inside the Cilium pod.
      - string
-     - ``""``
+     - ``"/etc/ipsec"``
    * - :spelling:ignore:`encryption.ipsec.secretName`
      - Name of the Kubernetes secret containing the encryption keys.
      - string
-     - ``""``
-   * - :spelling:ignore:`encryption.keyFile`
-     - Deprecated in favor of encryption.ipsec.keyFile. To be removed in 1.15. Name of the key file inside the Kubernetes secret configured via secretName. This option is only effective when encryption.type is set to ipsec.
-     - string
-     - ``"keys"``
-   * - :spelling:ignore:`encryption.mountPath`
-     - Deprecated in favor of encryption.ipsec.mountPath. To be removed in 1.15. Path to mount the secret inside the Cilium pod. This option is only effective when encryption.type is set to ipsec.
-     - string
-     - ``"/etc/ipsec"``
+     - ``"cilium-ipsec-keys"``
    * - :spelling:ignore:`encryption.nodeEncryption`
      - Enable encryption for pure node to node traffic. This option is only effective when encryption.type is set to "wireguard".
      - bool
      - ``false``
-   * - :spelling:ignore:`encryption.secretName`
-     - Deprecated in favor of encryption.ipsec.secretName. To be removed in 1.15. Name of the Kubernetes secret containing the encryption keys. This option is only effective when encryption.type is set to ipsec.
-     - string
-     - ``"cilium-ipsec-keys"``
    * - :spelling:ignore:`encryption.strictMode`
      - Configure the WireGuard Pod2Pod strict mode.
      - object

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -316,7 +316,8 @@ Removed Options
 Helm Options
 ~~~~~~~~~~~~
 
-* TBD
+* Deprecated helm option encryption.{keyFile,mountPath,secretName,interface} are removed
+  in favor of encryption.ipsec.*.
 
 Added Metrics
 ~~~~~~~~~~~~~

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -289,17 +289,13 @@ contributors across the globe, there is almost always someone available to help.
 | enableRuntimeDeviceDetection | bool | `false` | Enables experimental support for the detection of new and removed datapath devices. When devices change the eBPF datapath is reloaded and services updated. If "devices" is set then only those devices, or devices matching a wildcard will be considered. |
 | enableXTSocketFallback | bool | `true` | Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: https://docs.cilium.io/en/stable/operations/system_requirements/#linux-kernel. |
 | encryption.enabled | bool | `false` | Enable transparent network encryption. |
-| encryption.interface | string | `""` | Deprecated in favor of encryption.ipsec.interface. To be removed in 1.15. The interface to use for encrypted traffic. This option is only effective when encryption.type is set to ipsec. |
 | encryption.ipsec.interface | string | `""` | The interface to use for encrypted traffic. |
-| encryption.ipsec.keyFile | string | `""` | Name of the key file inside the Kubernetes secret configured via secretName. |
+| encryption.ipsec.keyFile | string | `"keys"` | Name of the key file inside the Kubernetes secret configured via secretName. |
 | encryption.ipsec.keyRotationDuration | string | `"5m"` | Maximum duration of the IPsec key rotation. The previous key will be removed after that delay. |
 | encryption.ipsec.keyWatcher | bool | `true` | Enable the key watcher. If disabled, a restart of the agent will be necessary on key rotations. |
-| encryption.ipsec.mountPath | string | `""` | Path to mount the secret inside the Cilium pod. |
-| encryption.ipsec.secretName | string | `""` | Name of the Kubernetes secret containing the encryption keys. |
-| encryption.keyFile | string | `"keys"` | Deprecated in favor of encryption.ipsec.keyFile. To be removed in 1.15. Name of the key file inside the Kubernetes secret configured via secretName. This option is only effective when encryption.type is set to ipsec. |
-| encryption.mountPath | string | `"/etc/ipsec"` | Deprecated in favor of encryption.ipsec.mountPath. To be removed in 1.15. Path to mount the secret inside the Cilium pod. This option is only effective when encryption.type is set to ipsec. |
+| encryption.ipsec.mountPath | string | `"/etc/ipsec"` | Path to mount the secret inside the Cilium pod. |
+| encryption.ipsec.secretName | string | `"cilium-ipsec-keys"` | Name of the Kubernetes secret containing the encryption keys. |
 | encryption.nodeEncryption | bool | `false` | Enable encryption for pure node to node traffic. This option is only effective when encryption.type is set to "wireguard". |
-| encryption.secretName | string | `"cilium-ipsec-keys"` | Deprecated in favor of encryption.ipsec.secretName. To be removed in 1.15. Name of the Kubernetes secret containing the encryption keys. This option is only effective when encryption.type is set to ipsec. |
 | encryption.strictMode | object | `{"allowRemoteNodeIdentities":false,"cidr":"","enabled":false}` | Configure the WireGuard Pod2Pod strict mode. |
 | encryption.strictMode.allowRemoteNodeIdentities | bool | `false` | Allow dynamic lookup of remote node identities. This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap. |
 | encryption.strictMode.cidr | string | `""` | CIDR for the WireGuard Pod2Pod strict mode. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -349,7 +349,7 @@ spec:
           mountPath: /run/xtables.lock
         {{- if and .Values.encryption.enabled (eq .Values.encryption.type "ipsec") }}
         - name: cilium-ipsec-secrets
-          mountPath: {{ .Values.encryption.ipsec.mountPath | default .Values.encryption.mountPath }}
+          mountPath: {{ .Values.encryption.ipsec.mountPath }}
         {{- end }}
         {{- if .Values.kubeConfigPath }}
         - name: kube-config
@@ -912,7 +912,7 @@ spec:
       {{- if and .Values.encryption.enabled (eq .Values.encryption.type "ipsec") }}
       - name: cilium-ipsec-secrets
         secret:
-          secretName: {{ .Values.encryption.ipsec.secretName | default .Values.encryption.secretName }}
+          secretName: {{ .Values.encryption.ipsec.secretName }}
       {{- end }}
       {{- if .Values.cni.configMap }}
       - name: cni-configuration

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -579,13 +579,9 @@ data:
 
     {{- if and .Values.encryption.ipsec.mountPath .Values.encryption.ipsec.keyFile }}
   ipsec-key-file: {{ .Values.encryption.ipsec.mountPath }}/{{ .Values.encryption.ipsec.keyFile }}
-    {{- else }}
-  ipsec-key-file: {{ .Values.encryption.mountPath }}/{{ .Values.encryption.keyFile }}
     {{- end }}
     {{- if .Values.encryption.ipsec.interface }}
   encrypt-interface: {{ .Values.encryption.ipsec.interface }}
-    {{- else if .Values.encryption.interface }}
-  encrypt-interface: {{ .Values.encryption.interface }}
     {{- end }}
     {{- if hasKey .Values.encryption.ipsec "keyWatcher" }}
   enable-ipsec-key-watcher: {{ .Values.encryption.ipsec.keyWatcher | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -707,11 +707,11 @@ encryption:
     allowRemoteNodeIdentities: false
   ipsec:
     # -- Name of the key file inside the Kubernetes secret configured via secretName.
-    keyFile: ""
+    keyFile: keys
     # -- Path to mount the secret inside the Cilium pod.
-    mountPath: ""
+    mountPath: /etc/ipsec
     # -- Name of the Kubernetes secret containing the encryption keys.
-    secretName: ""
+    secretName: cilium-ipsec-keys
     # -- The interface to use for encrypted traffic.
     interface: ""
     # -- Enable the key watcher. If disabled, a restart of the agent will be
@@ -725,22 +725,6 @@ encryption:
     userspaceFallback: false
     # -- Controls Wireguard PersistentKeepalive option. Set 0s to disable.
     persistentKeepalive: 0s
-  # -- Deprecated in favor of encryption.ipsec.keyFile. To be removed in 1.15.
-  # Name of the key file inside the Kubernetes secret configured via secretName.
-  # This option is only effective when encryption.type is set to ipsec.
-  keyFile: keys
-  # -- Deprecated in favor of encryption.ipsec.mountPath. To be removed in 1.15.
-  # Path to mount the secret inside the Cilium pod.
-  # This option is only effective when encryption.type is set to ipsec.
-  mountPath: /etc/ipsec
-  # -- Deprecated in favor of encryption.ipsec.secretName. To be removed in 1.15.
-  # Name of the Kubernetes secret containing the encryption keys.
-  # This option is only effective when encryption.type is set to ipsec.
-  secretName: cilium-ipsec-keys
-  # -- Deprecated in favor of encryption.ipsec.interface. To be removed in 1.15.
-  # The interface to use for encrypted traffic.
-  # This option is only effective when encryption.type is set to ipsec.
-  interface: ""
 endpointHealthChecking:
   # -- Enable connectivity health checking between virtual endpoints.
   enabled: true

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -704,11 +704,11 @@ encryption:
     allowRemoteNodeIdentities: false
   ipsec:
     # -- Name of the key file inside the Kubernetes secret configured via secretName.
-    keyFile: ""
+    keyFile: keys
     # -- Path to mount the secret inside the Cilium pod.
-    mountPath: ""
+    mountPath: /etc/ipsec
     # -- Name of the Kubernetes secret containing the encryption keys.
-    secretName: ""
+    secretName: cilium-ipsec-keys
     # -- The interface to use for encrypted traffic.
     interface: ""
     # -- Enable the key watcher. If disabled, a restart of the agent will be
@@ -722,22 +722,6 @@ encryption:
     userspaceFallback: false
     # -- Controls Wireguard PersistentKeepalive option. Set 0s to disable.
     persistentKeepalive: 0s
-  # -- Deprecated in favor of encryption.ipsec.keyFile. To be removed in 1.15.
-  # Name of the key file inside the Kubernetes secret configured via secretName.
-  # This option is only effective when encryption.type is set to ipsec.
-  keyFile: keys
-  # -- Deprecated in favor of encryption.ipsec.mountPath. To be removed in 1.15.
-  # Path to mount the secret inside the Cilium pod.
-  # This option is only effective when encryption.type is set to ipsec.
-  mountPath: /etc/ipsec
-  # -- Deprecated in favor of encryption.ipsec.secretName. To be removed in 1.15.
-  # Name of the Kubernetes secret containing the encryption keys.
-  # This option is only effective when encryption.type is set to ipsec.
-  secretName: cilium-ipsec-keys
-  # -- Deprecated in favor of encryption.ipsec.interface. To be removed in 1.15.
-  # The interface to use for encrypted traffic.
-  # This option is only effective when encryption.type is set to ipsec.
-  interface: ""
 endpointHealthChecking:
   # -- Enable connectivity health checking between virtual endpoints.
   enabled: true


### PR DESCRIPTION
This commit is to remove deprecated helm values encryption.{keyFile, mountPath,secretName,interface} in favour of encryption.ipsec.*.

Relates: #24214
