### PR TITLE
golangci-lint(daemon): enable testifylint linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -82,6 +82,21 @@ linters-settings:
 
   stylecheck:
     checks: ["ST1019"]
+  testifylint:
+    disable:
+      - float-compare
+      - go-require
+    enable:
+      - bool-compare
+      - compares
+      - empty
+      - error-is-as
+      - error-nil
+      - expected-actual
+      - len
+      - require-error
+      - suite-dont-use-pkg
+      - suite-extra-assert-call
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source
@@ -102,23 +117,32 @@ issues:
     - path: "pkg/ipam/(cidrset|service)/.+\\.go"
       linters:
         - goheader
+    - linters: [testifylint]
+      path: operator
+    - linters: [testifylint]
+      path: pkg
+    - linters: [testifylint]
+      path: test
+  max-issues-per-linter: 0
+  max-same-issues: 0
 
 linters:
   disable-all: true
   enable:
     - goerr113
     - gofmt
+    - goheader
     - goimports
+    - gomodguard
+    - gosec
+    - gosimple
     - govet
     - ineffassign
     - misspell
     - staticcheck
     - stylecheck
+    - testifylint
     - unused
-    - goheader
-    - gosec
-    - gomodguard
-    - gosimple
 
 # To enable later if makes sense
 #    - deadcode

--- a/daemon/cmd/cells_test.go
+++ b/daemon/cmd/cells_test.go
@@ -6,7 +6,7 @@ package cmd
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/pkg/hive"
@@ -33,5 +33,5 @@ func TestAgentCell(t *testing.T) {
 
 	logging.SetLogLevelToDebug()
 	err := hive.New(Agent).Populate()
-	assert.NoError(t, err, "Populate()")
+	require.NoError(t, err, "Populate()")
 }

--- a/daemon/cmd/cni/cni_test.go
+++ b/daemon/cmd/cni/cni_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
 
@@ -29,7 +30,7 @@ func TestInstallCNIConfFile(t *testing.T) {
 	touch(t, workdir, "05-cilium.conf") // older config file we no longer create
 
 	err := c.setupCNIConfFile()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	filenames := ls(t, workdir)
 
@@ -40,7 +41,7 @@ func TestInstallCNIConfFile(t *testing.T) {
 	})
 
 	data, err := os.ReadFile(path.Join(workdir, "05-cilium.conflist"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	val := gjson.GetBytes(data, "plugins.0.type")
 	assert.Equal(t, "cilium-cni", val.String())
 
@@ -55,7 +56,7 @@ func TestRenderCNIConfUnchained(t *testing.T) {
 	for mode := range cniConfigs {
 		c.config.CNIChainingMode = mode
 		conf, err := c.renderCNIConf()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		res := gjson.GetBytes(conf, `plugins.#(type=="cilium-cni").log-file`)
 		assert.True(t, res.Exists(), mode)
 		assert.Equal(t, `/opt"/cni.log`, res.String(), mode)
@@ -216,15 +217,15 @@ func TestRenderCNIConfChained(t *testing.T) {
 
 			if tc.cniConf != "" {
 				err := os.WriteFile(filepath.Join(workDir, tc.cniConfFilename), []byte(tc.cniConf), 0o644)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			result, err := c.renderCNIConf()
 			if tc.expected == "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.JSONEq(t, tc.expected, string(result))
 		})
 	}
@@ -248,7 +249,7 @@ func TestCleanupOtherCNI(t *testing.T) {
 	}
 
 	err := c.cleanupOtherCNI()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	filenames := ls(t, workdir)
 	assert.ElementsMatch(t, filenames, []string{
@@ -261,13 +262,13 @@ func TestCleanupOtherCNI(t *testing.T) {
 
 func touch(t *testing.T, dir, name string) {
 	f, err := os.Create(path.Join(dir, name))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	f.Close()
 }
 
 func ls(t *testing.T, dir string) []string {
 	files, err := os.ReadDir(dir)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	filenames := []string{}
 	for _, f := range files {

--- a/daemon/cmd/local_node_sync_test.go
+++ b/daemon/cmd/local_node_sync_test.go
@@ -200,12 +200,12 @@ func TestInitLocalNode_initFromK8s(t *testing.T) {
 		},
 	}
 	err := lni.InitLocalNode(context.Background(), n)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "10.0.0.1", n.GetCiliumInternalIP(false).String())
 	assert.Equal(t, "fd00:10:244:1::aaa6", n.GetCiliumInternalIP(true).String())
 	assert.Equal(t, "10.0.0.2", n.IPv4HealthIP.String())
 	assert.Equal(t, "fd00:10:244:1::aaa7", n.IPv6HealthIP.String())
-	assert.Equal(t, n.Name, "test-node")
+	assert.Equal(t, "test-node", n.Name)
 }
 
 type mockResource[T k8sRuntime.Object] struct {

--- a/daemon/cmd/map_test.go
+++ b/daemon/cmd/map_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/bpf"
@@ -55,13 +56,12 @@ func (f *fakeProducer) Produce(w io.Writer, i any) error {
 }
 
 func Test_getMapNameEvents(t *testing.T) {
-	assert := assert.New(t)
 	eh := NewGetMapNameEventsHandler(&Daemon{}, &fakeMapGetter{
 		name: "test_map_name",
 		m:    &fakeMap{},
 	})
 	req, err := http.NewRequest(http.MethodGet, "https://localhost/v1/map/test_map_name/events", nil)
-	assert.NoError(err)
+	require.NoError(t, err)
 	restreq := restapi.GetMapNameEventsParams{
 		HTTPRequest: req,
 		Name:        "test_map_name",
@@ -74,18 +74,17 @@ func Test_getMapNameEvents(t *testing.T) {
 	fp := &fakeProducer{}
 	resp.WriteResponse(mw, fp)
 	d, err := safeio.ReadAllLimit(w.Body, safeio.MB)
-	assert.NoError(err)
-	assert.Equal(`{"action":"update","desired-action":"sync","key":"\u003cnil\u003e","last-error":"\u003cnil\u003e","timestamp":"2006-01-02T15:04:05.000Z","value":"\u003cnil\u003e"}`+"\n", string(d))
+	require.NoError(t, err)
+	assert.Equal(t, `{"action":"update","desired-action":"sync","key":"\u003cnil\u003e","last-error":"\u003cnil\u003e","timestamp":"2006-01-02T15:04:05.000Z","value":"\u003cnil\u003e"}`+"\n", string(d))
 }
 
 func Test_getMapNameEventsMapErrors(t *testing.T) {
-	assert := assert.New(t)
 	m := &fakeMap{err: fmt.Errorf("test0")}
 	eh := NewGetMapNameEventsHandler(&Daemon{}, &fakeMapGetter{
 		m: m,
 	})
 	req, err := http.NewRequest(http.MethodGet, "https://localhost/v1/map/test_map_name_fake/events", nil)
-	assert.NoError(err)
+	require.NoError(t, err)
 	restreq := restapi.GetMapNameEventsParams{
 		HTTPRequest: req,
 		Name:        "test_map_name_fake",
@@ -94,5 +93,5 @@ func Test_getMapNameEventsMapErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	fp := &fakeProducer{}
 	resp.WriteResponse(w, fp)
-	assert.Equal(http.StatusNotFound, w.Code)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }

--- a/daemon/cmd/vitals_test.go
+++ b/daemon/cmd/vitals_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/health/client"
@@ -46,7 +47,7 @@ func TestVitalsToModuleHealth(t *testing.T) {
 	for k := range uu {
 		u := uu[k]
 		mh, err := toModuleHealth(u.s)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, u.e, mh)
 	}
 }

--- a/daemon/restapi/api_limits_test.go
+++ b/daemon/restapi/api_limits_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	timeRate "golang.org/x/time/rate"
 
 	"github.com/cilium/cilium/pkg/hive"
@@ -27,7 +28,7 @@ func testRateLimiterConfig(t *testing.T, setConfig func(h *hive.Hive, limiter st
 	h := hive.New(rateLimiterCell, take)
 
 	setConfig(h, APIRequestEndpointCreate, "rate-limit:42/m,rate-burst:1234")
-	assert.Nil(t, h.Start(context.TODO()))
+	require.NoError(t, h.Start(context.TODO()))
 
 	l := limiterSet.Limiter(APIRequestEndpointCreate)
 	assert.NotNil(t, l)
@@ -35,7 +36,7 @@ func testRateLimiterConfig(t *testing.T, setConfig func(h *hive.Hive, limiter st
 	p := l.Parameters()
 	assert.Equal(t, timeRate.Limit(42.0/60.0), p.RateLimit)
 	assert.Equal(t, 1234, p.RateBurst)
-	assert.Nil(t, h.Stop(context.TODO()))
+	require.NoError(t, h.Stop(context.TODO()))
 }
 
 // TestRateLimiterConfigFlag checks that rateLimiterConfig is properly parsed from
@@ -46,7 +47,7 @@ func TestRateLimiterConfigFlag(t *testing.T) {
 			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 			h.RegisterFlags(flags)
 			err := flags.Parse([]string{"--api-rate-limit", limiter + "=" + limits})
-			assert.Nil(t, err, "failed to parse flags")
+			require.NoError(t, err, "failed to parse flags")
 		})
 }
 
@@ -58,6 +59,6 @@ func TestRateLimiterConfigFile(t *testing.T) {
 			cfg := fmt.Sprintf("api-rate-limit:\n  %s:%s\n", limiter, limits)
 			buf := bytes.NewReader([]byte(cfg))
 			err := h.Viper().ReadConfig(buf)
-			assert.Nil(t, err, "failed to ReadConfig with Viper")
+			require.NoError(t, err, "failed to ReadConfig with Viper")
 		})
 }


### PR DESCRIPTION
Testifylint is a linter that helps follow testify's best practices.
As it would make a big PR to apply it everywhere I applied it first on daemon package.


Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
golangci-lint(daemon): enable testifylint linter
```
