### PR TITLE
ingress: Add force-https annotation support

### DIFF
--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -127,6 +127,19 @@ Supported Ingress Annotations
        | the ``ssl-passthrough`` on other Ingress
        | controllers.
      - ``disabled``
+   * - ``ingress.cilium.io/force-https``
+     - | Enable enforced HTTPS redirects for this Ingress.
+       | Applicable values are ``enabled`` and ``disabled``,
+       | although boolean-style values will also be
+       | accepted.
+       |
+       | Note that if the annotation is not present, this
+       | behavior will be controlled by the ``enforce-ingress-https`` configuration
+       | file setting (or ``ingressController.enforceHttps`` in Helm).
+       | 
+       | Any host with TLS config will have redirects to HTTPS
+       | configured for each match specified in the Ingress.
+     - unspecified
 
 Additionally, cloud-provider specific annotations for the LoadBalancer service
 are supported.

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -92,7 +92,7 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		return err
 	}
 
-	cecTranslator := translation.NewCECTranslator(params.Config.GatewayAPISecretsNamespace, false, params.Config.EnableGatewayAPIProxyProtocol, true, operatorOption.Config.ProxyIdleTimeoutSeconds)
+	cecTranslator := translation.NewCECTranslator(params.Config.GatewayAPISecretsNamespace, params.Config.EnableGatewayAPIProxyProtocol, true, operatorOption.Config.ProxyIdleTimeoutSeconds)
 	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator)
 
 	if err := registerReconcilers(

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -235,7 +235,7 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 		WithStatusSubresource(&gatewayv1.Gateway{}).
 		Build()
 
-	cecTranslator := translation.NewCECTranslator("", false, false, true, 60)
+	cecTranslator := translation.NewCECTranslator("", false, true, 60)
 	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator)
 
 	r := &gatewayReconciler{

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -78,7 +78,7 @@ func registerReconciler(params ingressParams) error {
 		return nil
 	}
 
-	cecTranslator := translation.NewCECTranslator(params.Config.IngressSecretsNamespace, params.Config.EnforceIngressHTTPS, params.Config.EnableIngressProxyProtocol, false, operatorOption.Config.ProxyIdleTimeoutSeconds)
+	cecTranslator := translation.NewCECTranslator(params.Config.IngressSecretsNamespace, params.Config.EnableIngressProxyProtocol, false, operatorOption.Config.ProxyIdleTimeoutSeconds)
 	dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
 
 	reconciler := newIngressReconciler(

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -38,6 +38,7 @@ type ingressReconciler struct {
 	defaultLoadbalancerMode string
 	defaultSecretNamespace  string
 	defaultSecretName       string
+	enforcedHTTPS           bool
 
 	cecTranslator       translation.CECTranslator
 	dedicatedTranslator translation.Translator

--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -207,7 +207,7 @@ func (r *ingressReconciler) buildSharedResources(ctx context.Context) (*ciliumv2
 		if annotations.GetAnnotationTLSPassthroughEnabled(&item) {
 			m.TLS = append(m.TLS, ingestion.IngressPassthrough(item, r.defaultSecretNamespace, r.defaultSecretName)...)
 		} else {
-			m.HTTP = append(m.HTTP, ingestion.Ingress(item, r.defaultSecretNamespace, r.defaultSecretName)...)
+			m.HTTP = append(m.HTTP, ingestion.Ingress(item, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS)...)
 		}
 	}
 
@@ -220,7 +220,7 @@ func (r *ingressReconciler) buildDedicatedResources(ctx context.Context, ingress
 	if annotations.GetAnnotationTLSPassthroughEnabled(ingress) {
 		m.TLS = append(m.TLS, ingestion.IngressPassthrough(*ingress, r.defaultSecretNamespace, r.defaultSecretName)...)
 	} else {
-		m.HTTP = append(m.HTTP, ingestion.Ingress(*ingress, r.defaultSecretNamespace, r.defaultSecretName)...)
+		m.HTTP = append(m.HTTP, ingestion.Ingress(*ingress, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS)...)
 	}
 
 	cec, svc, ep, err := r.dedicatedTranslator.Translate(m)

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -28,7 +28,6 @@ import (
 
 const (
 	testCiliumNamespace                 = "cilium"
-	testEnforceHTTPS                    = true
 	testUseProxyProtocol                = true
 	testCiliumSecretsNamespace          = "cilium-secrets"
 	testDefaultLoadbalancingServiceName = "cilium-ingress"
@@ -58,7 +57,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testEnforceHTTPS, testUseProxyProtocol, false, testDefaultTimeout)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName)
@@ -114,7 +113,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testEnforceHTTPS, testUseProxyProtocol, false, testDefaultTimeout)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName)
@@ -170,7 +169,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testEnforceHTTPS, testUseProxyProtocol, false, testDefaultTimeout)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName)
@@ -214,7 +213,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testEnforceHTTPS, testUseProxyProtocol, false, testDefaultTimeout)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName)
@@ -284,7 +283,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testEnforceHTTPS, testUseProxyProtocol, false, testDefaultTimeout)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName)
@@ -351,7 +350,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testEnforceHTTPS, testUseProxyProtocol, false, testDefaultTimeout)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName)
@@ -405,7 +404,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testEnforceHTTPS, testUseProxyProtocol, false, testDefaultTimeout)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName)
@@ -487,7 +486,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testEnforceHTTPS, testUseProxyProtocol, false, testDefaultTimeout)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName)
@@ -559,7 +558,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testEnforceHTTPS, testUseProxyProtocol, false, testDefaultTimeout)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName)
@@ -615,7 +614,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testEnforceHTTPS, testUseProxyProtocol, false, testDefaultTimeout)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName)
@@ -655,7 +654,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testEnforceHTTPS, testUseProxyProtocol, false, testDefaultTimeout)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName)
@@ -696,7 +695,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testEnforceHTTPS, testUseProxyProtocol, false, testDefaultTimeout)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{"test.acme.io/"}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName)
@@ -781,7 +780,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testEnforceHTTPS, testUseProxyProtocol, false, testDefaultTimeout)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName)
@@ -846,7 +845,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testEnforceHTTPS, testUseProxyProtocol, false, testDefaultTimeout)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName)
@@ -888,7 +887,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testEnforceHTTPS, testUseProxyProtocol, false, testDefaultTimeout)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName)

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -69,6 +69,13 @@ type HTTPListener struct {
 	Service *Service `json:"service,omitempty"`
 	// Infrastructure configuration
 	Infrastructure *Infrastructure `json:"infrastructure,omitempty"`
+	// ForceHTTPtoHTTPSRedirect enforces that, for HTTPListeners that have a
+	// TLS field set and create a HTTPS listener, an equivalent plaintext HTTP
+	// listener will be created that redirects requests from HTTP to HTTPS.
+	//
+	// This plaintext listener will override any other plaintext HTTP config in
+	// the final rendered Envoy Config.
+	ForceHTTPtoHTTPSRedirect bool
 }
 
 func (l *HTTPListener) GetSources() []FullyQualifiedResource {

--- a/operator/pkg/model/translation/fixture_test.go
+++ b/operator/pkg/model/translation/fixture_test.go
@@ -211,6 +211,105 @@ var hostRulesExpectedConfig = []*envoy_config_route_v3.RouteConfiguration{
 	},
 }
 
+var hostRulesModelEnforcedHTTPS = &model.Model{
+	HTTP: []model.HTTPListener{
+		{
+			Name: "ing-host-rules-random-namespace-*.foo.com",
+			Sources: []model.FullyQualifiedResource{
+				{
+					Name:      "host-rules",
+					Namespace: "random-namespace",
+					Version:   "v1",
+					Kind:      "Ingress",
+				},
+			},
+			Port:     80,
+			Hostname: "*.foo.com",
+			Routes: []model.HTTPRoute{
+				{
+					PathMatch: model.StringMatch{
+						Prefix: "/",
+					},
+					Backends: []model.Backend{
+						{
+							Name:      "wildcard-foo-com",
+							Namespace: "random-namespace",
+							Port: &model.BackendPort{
+								Port: 8080,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "ing-host-rules-random-namespace-foo.bar.com",
+			Sources: []model.FullyQualifiedResource{
+				{
+					Name:      "host-rules",
+					Namespace: "random-namespace",
+					Version:   "v1",
+					Kind:      "Ingress",
+				},
+			},
+			Port:     80,
+			Hostname: "foo.bar.com",
+			Routes: []model.HTTPRoute{
+				{
+					PathMatch: model.StringMatch{
+						Prefix: "/",
+					},
+					Backends: []model.Backend{
+						{
+							Name:      "foo-bar-com",
+							Namespace: "random-namespace",
+							Port: &model.BackendPort{
+								Name: "http",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "ing-host-rules-random-namespace-foo.bar.com",
+			Sources: []model.FullyQualifiedResource{
+				{
+					Name:      "host-rules",
+					Namespace: "random-namespace",
+					Version:   "v1",
+					Kind:      "Ingress",
+				},
+			},
+			Port:     443,
+			Hostname: "foo.bar.com",
+			TLS: []model.TLSSecret{
+				{
+					Name:      "conformance-tls",
+					Namespace: "random-namespace",
+				},
+			},
+			ForceHTTPtoHTTPSRedirect: true,
+			Routes: []model.HTTPRoute{
+				{
+					PathMatch: model.StringMatch{
+						Prefix: "/",
+					},
+					Backends: []model.Backend{
+						{
+							Name:      "foo-bar-com",
+							Namespace: "random-namespace",
+							Port: &model.BackendPort{
+								Name: "http",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
 var hostRulesExpectedConfigEnforceHTTPS = []*envoy_config_route_v3.RouteConfiguration{
 	{
 		Name: "listener-insecure",
@@ -625,6 +724,184 @@ var complexIngressModel = &model.Model{
 					Namespace: "dummy-namespace",
 				},
 			},
+			Routes: []model.HTTPRoute{
+				{
+					Backends: []model.Backend{
+						{
+							Name:      "default-backend",
+							Namespace: "dummy-namespace",
+							Port: &model.BackendPort{
+								Port: 8080,
+							},
+						},
+					},
+				},
+				{
+					PathMatch: model.StringMatch{
+						Exact: "/dummy-path",
+					},
+					Backends: []model.Backend{
+						{
+							Name:      "dummy-backend",
+							Namespace: "dummy-namespace",
+							Port: &model.BackendPort{
+								Port: 8080,
+							},
+						},
+					},
+				},
+				{
+					PathMatch: model.StringMatch{
+						Prefix: "/another-dummy-path",
+					},
+					Backends: []model.Backend{
+						{
+							Name:      "another-dummy-backend",
+							Namespace: "dummy-namespace",
+							Port: &model.BackendPort{
+								Port: 8081,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var complexIngressModelwithRedirects = &model.Model{
+	HTTP: []model.HTTPListener{
+		{
+			Sources: []model.FullyQualifiedResource{
+				{
+					Name:      "dummy-ingress",
+					Namespace: "dummy-namespace",
+					Version:   "v1",
+					Kind:      "Ingress",
+				},
+			},
+			Port:     80,
+			Hostname: "*",
+			Routes: []model.HTTPRoute{
+				{
+					Backends: []model.Backend{
+						{
+							Name:      "default-backend",
+							Namespace: "dummy-namespace",
+							Port: &model.BackendPort{
+								Port: 8080,
+							},
+						},
+					},
+				},
+				{
+					PathMatch: model.StringMatch{
+						Exact: "/dummy-path",
+					},
+					Backends: []model.Backend{
+						{
+							Name:      "dummy-backend",
+							Namespace: "dummy-namespace",
+							Port: &model.BackendPort{
+								Port: 8080,
+							},
+						},
+					},
+				},
+				{
+					PathMatch: model.StringMatch{
+						Prefix: "/another-dummy-path",
+					},
+					Backends: []model.Backend{
+						{
+							Name:      "another-dummy-backend",
+							Namespace: "dummy-namespace",
+							Port: &model.BackendPort{
+								Port: 8081,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Sources: []model.FullyQualifiedResource{
+				{
+					Name:      "dummy-ingress",
+					Namespace: "dummy-namespace",
+					Version:   "v1",
+					Kind:      "Ingress",
+				},
+			},
+			Port:     443,
+			Hostname: "another-very-secure.server.com",
+			TLS: []model.TLSSecret{
+				{
+					Name:      "tls-another-very-secure-server-com",
+					Namespace: "dummy-namespace",
+				},
+			},
+			ForceHTTPtoHTTPSRedirect: true,
+			Routes: []model.HTTPRoute{
+				{
+					Backends: []model.Backend{
+						{
+							Name:      "default-backend",
+							Namespace: "dummy-namespace",
+							Port: &model.BackendPort{
+								Port: 8080,
+							},
+						},
+					},
+				},
+				{
+					PathMatch: model.StringMatch{
+						Exact: "/dummy-path",
+					},
+					Backends: []model.Backend{
+						{
+							Name:      "dummy-backend",
+							Namespace: "dummy-namespace",
+							Port: &model.BackendPort{
+								Port: 8080,
+							},
+						},
+					},
+				},
+				{
+					PathMatch: model.StringMatch{
+						Prefix: "/another-dummy-path",
+					},
+					Backends: []model.Backend{
+						{
+							Name:      "another-dummy-backend",
+							Namespace: "dummy-namespace",
+							Port: &model.BackendPort{
+								Port: 8081,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Sources: []model.FullyQualifiedResource{
+				{
+					Name:      "dummy-ingress",
+					Namespace: "dummy-namespace",
+					Version:   "v1",
+					Kind:      "Ingress",
+				},
+			},
+			Port:     443,
+			Hostname: "very-secure.server.com",
+			TLS: []model.TLSSecret{
+				{
+					Name:      "tls-very-secure-server-com",
+					Namespace: "dummy-namespace",
+				},
+			},
+			ForceHTTPtoHTTPSRedirect: true,
 			Routes: []model.HTTPRoute{
 				{
 					Backends: []model.Backend{

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -209,7 +209,7 @@ func Test_translator_Translate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			trans := &gatewayAPITranslator{
-				cecTranslator: translation.NewCECTranslator("cilium-secrets", false, false, true, 60),
+				cecTranslator: translation.NewCECTranslator("cilium-secrets", false, true, 60),
 			}
 			cec, _, _, err := trans.Translate(tt.args.m)
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
@@ -310,7 +310,7 @@ func Test_translator_TranslateResource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			trans := &gatewayAPITranslator{
-				cecTranslator: translation.NewCECTranslator("cilium-secrets", false, false, true, 60),
+				cecTranslator: translation.NewCECTranslator("cilium-secrets", false, true, 60),
 			}
 			cec, _, _, err := trans.Translate(tt.args.m)
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")


### PR DESCRIPTION
This change adds support for the new `ingress.cilium.io/force-https` annotation. This annotation changes generated model.Listeners such that, if a TLS Listener is present, any config for that secure listener is copied to an insecure listener, with redirects to the secure listener for routing instead of direct routing.

The annotation itself can be set to `enabled`, `disabled`, or any truthy or false-y value (as understood by Go's `strconv.ParseBool()` function).

The annotation _overrides_ the exsiting "enforce-https" config, which does the same thing.

That is, if both `ingress.cilium.io/force-https` and `enforce-https` are set, the annotation's value will override the value of `enforce-https`.

When the annotation is unset, `enforce-https` produces similar functionality.

Tests for all cases have been added.

Implementation details:
- `model.Listener` now has a `ForceHTTPtoHTTPSRedirect` field that controls if the redirect behavior will be used.
- The value of `enforceHTTPS` is no longer passed into Translators. Ingress ingestion now handles folding the possible values of `enforceHTTPS` into the `model.Listener`, so the Translators now don't need to know.

Updates: #22887

```release-note
Support `ingress.cilium.io/force-https` annotation (functionally equivalent to `nginx.ingress.kubernetes.io/force-ssl-redirect`)
```
