### PR TITLE
[agent] Export and refactor parts of identity cache allocator

### DIFF
--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/stream"
 )
@@ -36,6 +35,8 @@ var (
 // CachingIdentityAllocator manages the allocation of identities for both
 // global and local identities.
 type CachingIdentityAllocator struct {
+	*LocalCacheAllocator
+
 	// IdentityAllocator is an allocator for security identities from the
 	// kvstore.
 	IdentityAllocator *allocator.Allocator
@@ -44,22 +45,16 @@ type CachingIdentityAllocator struct {
 	// allocator is initialized.
 	globalIdentityAllocatorInitialized chan struct{}
 
-	localIdentities *localIdentityCache
-
-	localNodeIdentities *localIdentityCache
-
 	identitiesPath string
 
 	// This field exists is to hand out references that are either for sending
 	// and receiving. It should not be used directly without converting it first
 	// to a AllocatorEventSendChan or AllocatorEventRecvChan.
 	events  allocator.AllocatorEventChan
-	watcher identityWatcher
+	watcher IdentityWatcher
 
 	// setupMutex synchronizes InitIdentityAllocator() and Close()
 	setupMutex lock.Mutex
-
-	owner IdentityAllocatorOwner
 }
 
 // IdentityAllocatorOwner is the interface the owner of an identity allocator
@@ -159,7 +154,7 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 	// and start a new watch.
 	if m.events == nil {
 		m.events = make(allocator.AllocatorEventChan, eventsQueueSize)
-		m.watcher.watch(m.events)
+		m.watcher.Watch(m.events)
 	}
 
 	// Asynchronously set up the global identity allocator since it connects
@@ -207,7 +202,7 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 
 		m.IdentityAllocator = a
 		close(m.globalIdentityAllocatorInitialized)
-	}(m.owner, m.events, minID, maxID)
+	}(m.Owner, m.events, minID, maxID)
 
 	return m.globalIdentityAllocatorInitialized
 }
@@ -229,23 +224,24 @@ const eventsQueueSize = 1024
 // NewCachingIdentityAllocator creates a new instance of an
 // CachingIdentityAllocator.
 func NewCachingIdentityAllocator(owner IdentityAllocatorOwner) *CachingIdentityAllocator {
-	watcher := identityWatcher{
-		owner: owner,
+	watcher := IdentityWatcher{
+		Owner: owner,
 	}
 
 	m := &CachingIdentityAllocator{
+		LocalCacheAllocator:                &LocalCacheAllocator{},
 		globalIdentityAllocatorInitialized: make(chan struct{}),
-		owner:                              owner,
 		identitiesPath:                     IdentitiesPath,
 		watcher:                            watcher,
 		events:                             make(allocator.AllocatorEventChan, eventsQueueSize),
 	}
-	m.watcher.watch(m.events)
+	m.Owner = owner
+	m.watcher.Watch(m.events)
 
 	// Local identity cache can be created synchronously since it doesn't
 	// rely upon any external resources (e.g., external kvstore).
-	m.localIdentities = newLocalIdentityCache(identity.IdentityScopeLocal, identity.MinAllocatorLocalIdentity, identity.MaxAllocatorLocalIdentity, m.events)
-	m.localNodeIdentities = newLocalIdentityCache(identity.IdentityScopeRemoteNode, identity.MinAllocatorLocalIdentity, identity.MaxAllocatorLocalIdentity, m.events)
+	m.LocalIdentities = NewLocalIdentityCache(identity.IdentityScopeLocal, identity.MinAllocatorLocalIdentity, identity.MaxAllocatorLocalIdentity, m.events)
+	m.LocalNodeIdentities = NewLocalIdentityCache(identity.IdentityScopeRemoteNode, identity.MinAllocatorLocalIdentity, identity.MaxAllocatorLocalIdentity, m.events)
 
 	return m
 }
@@ -267,8 +263,8 @@ func (m *CachingIdentityAllocator) Close() {
 
 	m.IdentityAllocator.Delete()
 	if m.events != nil {
-		m.localIdentities.close()
-		m.localNodeIdentities.close()
+		m.LocalIdentities.close()
+		m.LocalNodeIdentities.close()
 		close(m.events)
 		m.events = nil
 	}
@@ -298,58 +294,11 @@ func (m *CachingIdentityAllocator) WaitForInitialGlobalIdentities(ctx context.Co
 // previous numeric identity exists.
 func (m *CachingIdentityAllocator) AllocateIdentity(ctx context.Context, lbls labels.Labels, notifyOwner bool, oldNID identity.NumericIdentity) (id *identity.Identity, allocated bool, err error) {
 	isNewLocally := false
+	defer m.RecordCompletedAllocation(id, allocated, isNewLocally, notifyOwner)
 
-	// Notify the owner of the newly added identities so that the
-	// cached identities can be updated ASAP, rather than just
-	// relying on the kv-store update events.
-	defer func() {
-		if err == nil {
-			if allocated || isNewLocally {
-				if id.ID.HasLocalScope() {
-					metrics.Identity.WithLabelValues(identity.NodeLocalIdentityType).Inc()
-				} else if id.ID.HasRemoteNodeScope() {
-					metrics.Identity.WithLabelValues(identity.RemoteNodeIdentityType).Inc()
-				} else if id.ID.IsReservedIdentity() {
-					metrics.Identity.WithLabelValues(identity.ReservedIdentityType).Inc()
-				} else {
-					metrics.Identity.WithLabelValues(identity.ClusterLocalIdentityType).Inc()
-				}
-			}
-
-			if allocated && notifyOwner {
-				added := IdentityCache{
-					id.ID: id.LabelArray,
-				}
-				m.owner.UpdateIdentities(added, nil)
-			}
-		}
-	}()
-	if option.Config.Debug {
-		log.WithFields(logrus.Fields{
-			logfields.IdentityLabels: lbls.String(),
-		}).Debug("Resolving identity")
-	}
-
-	// If there is only one label with the "reserved" source and a well-known
-	// key, use the well-known identity for that key.
-	if reservedIdentity := identity.LookupReservedIdentityByLabels(lbls); reservedIdentity != nil {
-		if option.Config.Debug {
-			log.WithFields(logrus.Fields{
-				logfields.Identity:       reservedIdentity.ID,
-				logfields.IdentityLabels: lbls.String(),
-				"isNew":                  false,
-			}).Debug("Resolved reserved identity")
-		}
-		return reservedIdentity, false, nil
-	}
-
-	// If the set of labels uses non-global scope,
-	// then allocate with the appropriate local allocator and return.
-	switch identity.ScopeForLabels(lbls) {
-	case identity.IdentityScopeLocal:
-		return m.localIdentities.lookupOrCreate(lbls, oldNID, notifyOwner)
-	case identity.IdentityScopeRemoteNode:
-		return m.localNodeIdentities.lookupOrCreate(lbls, oldNID, notifyOwner)
+	id, allocated, completed, err := m.AllocateLocalIdentity(ctx, lbls, notifyOwner, oldNID)
+	if err != nil || completed {
+		return id, allocated, err
 	}
 
 	// This will block until the kvstore can be accessed and all identities
@@ -380,62 +329,27 @@ func (m *CachingIdentityAllocator) AllocateIdentity(ctx context.Context, lbls la
 		}).Debug("Resolved identity")
 	}
 
-	return identity.NewIdentity(identity.NumericIdentity(idp), lbls), isNew, nil
+	id = identity.NewIdentity(identity.NumericIdentity(idp), lbls)
+	return id, isNew, nil
 }
 
 func (m *CachingIdentityAllocator) WithholdLocalIdentities(nids []identity.NumericIdentity) {
-	log.WithField(logfields.Identity, nids).Debug("Withholding numeric identities for later restoration")
-
-	// The allocators will return any identities that are not in-scope.
-	nids = m.localIdentities.withhold(nids)
-	nids = m.localNodeIdentities.withhold(nids)
-	if len(nids) > 0 {
-		log.WithField(logfields.Identity, nids).Error("Attempt to restore invalid numeric identities.")
-	}
+	m.WithholdLocalIDs(nids)
 }
 
 func (m *CachingIdentityAllocator) UnwithholdLocalIdentities(nids []identity.NumericIdentity) {
-	log.WithField(logfields.Identity, nids).Debug("Unwithholding numeric identities")
-
-	// The allocators will ignore any identities that are not in-scope.
-	m.localIdentities.unwithhold(nids)
-	m.localNodeIdentities.unwithhold(nids)
+	m.UnwithholdLocalIDs(nids)
 }
 
 // Release is the reverse operation of AllocateIdentity() and releases the
 // identity again. This function may result in kvstore operations.
 // After the last user has released the ID, the returned lastUse value is true.
 func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Identity, notifyOwner bool) (released bool, err error) {
-	defer func() {
-		if released {
-			if id.ID.HasLocalScope() {
-				metrics.Identity.WithLabelValues(identity.NodeLocalIdentityType).Dec()
-			} else if id.ID.HasRemoteNodeScope() {
-				metrics.Identity.WithLabelValues(identity.RemoteNodeIdentityType).Dec()
-			} else if id.ID.IsReservedIdentity() {
-				metrics.Identity.WithLabelValues(identity.ReservedIdentityType).Dec()
-			} else {
-				metrics.Identity.WithLabelValues(identity.ClusterLocalIdentityType).Dec()
-			}
-		}
-		if m.owner != nil && released && notifyOwner {
-			deleted := IdentityCache{
-				id.ID: id.LabelArray,
-			}
-			m.owner.UpdateIdentities(nil, deleted)
-		}
-	}()
+	defer m.RecordCompletedRelease(id, released, notifyOwner)
 
-	// Ignore reserved identities.
-	if id.IsReserved() {
-		return false, nil
-	}
-
-	switch identity.ScopeForLabels(id.Labels) {
-	case identity.IdentityScopeLocal:
-		return m.localIdentities.release(id, notifyOwner), nil
-	case identity.IdentityScopeRemoteNode:
-		return m.localNodeIdentities.release(id, notifyOwner), nil
+	released, completed, err := m.ReleaseLocalIdentity(ctx, id, notifyOwner)
+	if completed {
+		return released, err
 	}
 
 	// This will block until the kvstore can be accessed and all identities
@@ -491,7 +405,7 @@ func (m *CachingIdentityAllocator) WatchRemoteIdentities(remoteName string, back
 		prefix = path.Join(kvstore.StateToCachePrefix(prefix), remoteName)
 	}
 
-	remoteAllocatorBackend, err := kvstoreallocator.NewKVStoreBackend(prefix, m.owner.GetNodeSuffix(), &key.GlobalIdentity{}, backend)
+	remoteAllocatorBackend, err := kvstoreallocator.NewKVStoreBackend(prefix, m.Owner.GetNodeSuffix(), &key.GlobalIdentity{}, backend)
 	if err != nil {
 		return nil, fmt.Errorf("error setting up remote allocator backend: %s", err)
 	}
@@ -553,14 +467,14 @@ func (m *CachingIdentityAllocator) Observe(ctx context.Context, next func(Identi
 				return IdentityChange{
 					Kind:   IdentityChangeKind(change.Kind),
 					ID:     identity.NumericIdentity(change.ID),
-					Labels: mapLabels(change.Key),
+					Labels: MapLabels(change.Key),
 				}
 			},
 		).Observe(ctx, next, complete)
 	}()
 }
 
-func mapLabels(allocatorKey allocator.AllocatorKey) labels.Labels {
+func MapLabels(allocatorKey allocator.AllocatorKey) labels.Labels {
 	var idLabels labels.Labels = nil
 
 	if allocatorKey != nil {

--- a/pkg/identity/cache/cache_test.go
+++ b/pkg/identity/cache/cache_test.go
@@ -40,7 +40,7 @@ func (s *IdentityCacheTestSuite) SetUpSuite(c *C) {
 }
 
 func (s *IdentityCacheTestSuite) TestLookupReservedIdentity(c *C) {
-	mgr := NewCachingIdentityAllocator(newDummyOwner())
+	mgr := NewCachingIdentityAllocator(NewDummyOwner())
 	<-mgr.InitIdentityAllocator(nil)
 
 	hostID := identity.GetReservedID("host")

--- a/pkg/identity/cache/local_allocator.go
+++ b/pkg/identity/cache/local_allocator.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cache
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/identity"
+	identitymodel "github.com/cilium/cilium/pkg/identity/model"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// LocalCacheAllocator is used to share common code for allocating local and
+// reserved identities between different implementations of identity allocators.
+type LocalCacheAllocator struct {
+	Owner               IdentityAllocatorOwner
+	LocalIdentities     *LocalIdentityCache
+	LocalNodeIdentities *LocalIdentityCache
+}
+
+func (l *LocalCacheAllocator) AllocateLocalIdentity(ctx context.Context, lbls labels.Labels, notifyOwner bool, oldNID identity.NumericIdentity) (id *identity.Identity, allocated, completed bool, err error) {
+	if option.Config.Debug {
+		log.WithFields(logrus.Fields{
+			logfields.IdentityLabels: lbls.String(),
+		}).Debug("Resolving identity")
+	}
+
+	// If there is only one label with the "reserved" source and a well-known
+	// key, use the well-known identity for that key.
+	if reservedIdentity := identity.LookupReservedIdentityByLabels(lbls); reservedIdentity != nil {
+		if option.Config.Debug {
+			log.WithFields(logrus.Fields{
+				logfields.Identity:       reservedIdentity.ID,
+				logfields.IdentityLabels: lbls.String(),
+				"isNew":                  false,
+			}).Debug("Resolved reserved identity")
+		}
+		return reservedIdentity, false, true, nil
+	}
+
+	// If the set of labels uses non-global scope,
+	// then allocate with the appropriate local allocator and return.
+	switch identity.ScopeForLabels(lbls) {
+	case identity.IdentityScopeLocal:
+		id, allocated, err = l.LocalIdentities.LookupOrCreate(lbls, oldNID, notifyOwner)
+		return id, allocated, true, err
+	case identity.IdentityScopeRemoteNode:
+		id, allocated, err = l.LocalNodeIdentities.LookupOrCreate(lbls, oldNID, notifyOwner)
+		return id, allocated, true, err
+	}
+
+	return nil, false, false, nil
+}
+
+// Release is the reverse operation of AllocateIdentity() and releases the
+// identity again. This function may result in kvstore operations.
+// After the last user has released the ID, the returned lastUse value is true.
+func (l *LocalCacheAllocator) ReleaseLocalIdentity(ctx context.Context, id *identity.Identity, notifyOwner bool) (released, completed bool, err error) {
+	// Ignore reserved identities.
+	if id.IsReserved() {
+		return false, true, nil
+	}
+
+	switch identity.ScopeForLabels(id.Labels) {
+	case identity.IdentityScopeLocal:
+		return l.LocalIdentities.Release(id, notifyOwner), true, nil
+	case identity.IdentityScopeRemoteNode:
+		return l.LocalNodeIdentities.Release(id, notifyOwner), true, nil
+	}
+
+	return false, false, nil
+}
+
+func (l *LocalCacheAllocator) WithholdLocalIDs(nids []identity.NumericIdentity) {
+	log.WithField(logfields.Identity, nids).Debug("Withholding numeric identities for later restoration")
+
+	// The allocators will return any identities that are not in-scope.
+	nids = l.LocalIdentities.withhold(nids)
+	nids = append(nids, l.LocalNodeIdentities.withhold(nids)...)
+	if len(nids) > 0 {
+		log.WithField(logfields.Identity, nids).Error("Attempt to restore invalid numeric identities.")
+	}
+}
+
+func (l *LocalCacheAllocator) UnwithholdLocalIDs(nids []identity.NumericIdentity) {
+	log.WithField(logfields.Identity, nids).Debug("Unwithholding numeric identities")
+
+	// The allocators will ignore any identities that are not in-scope.
+	l.LocalIdentities.unwithhold(nids)
+	l.LocalNodeIdentities.unwithhold(nids)
+}
+
+// GetIdentityCache returns a cache of all known identities
+func (l *LocalCacheAllocator) GetLocalIdentityCache() IdentityCache {
+	log.Debug("getting identity cache for identity allocator manager")
+	cache := IdentityCache{}
+
+	identity.IterateReservedIdentities(func(ni identity.NumericIdentity, id *identity.Identity) {
+		cache[ni] = id.Labels.LabelArray()
+	})
+
+	for _, identity := range l.LocalIdentities.GetIdentities() {
+		cache[identity.ID] = identity.Labels.LabelArray()
+	}
+	for _, identity := range l.LocalNodeIdentities.GetIdentities() {
+		cache[identity.ID] = identity.Labels.LabelArray()
+	}
+
+	return cache
+}
+
+// GetIdentities returns all known identities
+func (l *LocalCacheAllocator) GetLocalIdentities() IdentitiesModel {
+	identities := IdentitiesModel{}
+	identity.IterateReservedIdentities(func(ni identity.NumericIdentity, id *identity.Identity) {
+		identities = append(identities, identitymodel.CreateModel(id))
+	})
+
+	for _, v := range l.LocalIdentities.GetIdentities() {
+		identities = append(identities, identitymodel.CreateModel(v))
+	}
+	for _, v := range l.LocalNodeIdentities.GetIdentities() {
+		identities = append(identities, identitymodel.CreateModel(v))
+	}
+
+	return identities
+}
+
+func (l *LocalCacheAllocator) LookupLocalIdentity(ctx context.Context, lbls labels.Labels) (*identity.Identity, bool) {
+	if reservedIdentity := identity.LookupReservedIdentityByLabels(lbls); reservedIdentity != nil {
+		return reservedIdentity, true
+	}
+
+	switch identity.ScopeForLabels(lbls) {
+	case identity.IdentityScopeLocal:
+		return l.LocalIdentities.Lookup(lbls), true
+	case identity.IdentityScopeRemoteNode:
+		return l.LocalNodeIdentities.Lookup(lbls), true
+	}
+
+	return nil, false
+}
+
+func (l *LocalCacheAllocator) LookupLocalIdentityByID(ctx context.Context, id identity.NumericIdentity) (*identity.Identity, bool) {
+	if id == identity.IdentityUnknown {
+		return identity.UnknownIdentity, true
+	}
+
+	if identity := identity.LookupReservedIdentity(id); identity != nil {
+		return identity, true
+	}
+
+	switch id.Scope() {
+	case identity.IdentityScopeLocal:
+		return l.LocalIdentities.LookupByID(id), true
+	case identity.IdentityScopeRemoteNode:
+		return l.LocalNodeIdentities.LookupByID(id), true
+	}
+
+	return nil, false
+}
+
+func (l *LocalCacheAllocator) RecordCompletedAllocation(id *identity.Identity, allocated, isNewLocally, notifyOwner bool) {
+	// Notify the owner of the newly added identities so that the
+	// cached identities can be updated ASAP, rather than just
+	// relying on the kv-store update events.
+	if allocated || isNewLocally {
+		if id.ID.HasLocalScope() {
+			metrics.Identity.WithLabelValues(identity.NodeLocalIdentityType).Inc()
+		} else if id.ID.HasRemoteNodeScope() {
+			metrics.Identity.WithLabelValues(identity.RemoteNodeIdentityType).Inc()
+		} else if id.ID.IsReservedIdentity() {
+			metrics.Identity.WithLabelValues(identity.ReservedIdentityType).Inc()
+		} else {
+			metrics.Identity.WithLabelValues(identity.ClusterLocalIdentityType).Inc()
+		}
+	}
+
+	if allocated && notifyOwner {
+		added := IdentityCache{
+			id.ID: id.LabelArray,
+		}
+		l.Owner.UpdateIdentities(added, nil)
+	}
+}
+
+func (l *LocalCacheAllocator) RecordCompletedRelease(id *identity.Identity, released, notifyOwner bool) {
+	if released {
+		if id.ID.HasLocalScope() {
+			metrics.Identity.WithLabelValues(identity.NodeLocalIdentityType).Dec()
+		} else if id.ID.HasRemoteNodeScope() {
+			metrics.Identity.WithLabelValues(identity.RemoteNodeIdentityType).Dec()
+		} else if id.ID.IsReservedIdentity() {
+			metrics.Identity.WithLabelValues(identity.ReservedIdentityType).Dec()
+		} else {
+			metrics.Identity.WithLabelValues(identity.ClusterLocalIdentityType).Dec()
+		}
+	}
+	if l.Owner != nil && released && notifyOwner {
+		deleted := IdentityCache{
+			id.ID: id.LabelArray,
+		}
+		l.Owner.UpdateIdentities(nil, deleted)
+	}
+}

--- a/pkg/identity/cache/local_test.go
+++ b/pkg/identity/cache/local_test.go
@@ -19,7 +19,7 @@ import (
 func (s *IdentityCacheTestSuite) TestBumpNextNumericIdentity(c *C) {
 	minID, maxID := identity.NumericIdentity(1), identity.NumericIdentity(5)
 	scope := identity.NumericIdentity(0x42_00_00_00)
-	cache := newLocalIdentityCache(scope, minID, maxID, nil)
+	cache := NewLocalIdentityCache(scope, minID, maxID, nil)
 
 	for i := minID; i <= maxID; i++ {
 		c.Assert(cache.nextNumericIdentity, Equals, i)
@@ -33,14 +33,14 @@ func (s *IdentityCacheTestSuite) TestBumpNextNumericIdentity(c *C) {
 func (s *IdentityCacheTestSuite) TestLocalIdentityCache(c *C) {
 	minID, maxID := identity.NumericIdentity(1), identity.NumericIdentity(5)
 	scope := identity.NumericIdentity(0x42_00_00_00)
-	cache := newLocalIdentityCache(scope, minID, maxID, nil)
+	cache := NewLocalIdentityCache(scope, minID, maxID, nil)
 
 	identities := map[identity.NumericIdentity]*identity.Identity{}
 
 	// allocate identities for all available numeric identities with a
 	// unique label
 	for i := minID; i <= maxID; i++ {
-		id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}), identity.InvalidIdentity, false)
+		id, isNew, err := cache.LookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}), identity.InvalidIdentity, false)
 		c.Assert(err, IsNil)
 		c.Assert(isNew, Equals, true)
 		c.Assert(id.ID, Equals, scope+i)
@@ -50,7 +50,7 @@ func (s *IdentityCacheTestSuite) TestLocalIdentityCache(c *C) {
 	// allocate the same labels again. This must be successful and the same
 	// identities must be returned.
 	for i := minID; i <= maxID; i++ {
-		id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}), identity.InvalidIdentity, false)
+		id, isNew, err := cache.LookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}), identity.InvalidIdentity, false)
 		c.Assert(isNew, Equals, false)
 		c.Assert(err, IsNil)
 
@@ -59,29 +59,29 @@ func (s *IdentityCacheTestSuite) TestLocalIdentityCache(c *C) {
 	}
 
 	// Allocation must fail as we are out of IDs
-	_, _, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{"foo"}), identity.InvalidIdentity, false)
+	_, _, err := cache.LookupOrCreate(labels.NewLabelsFromModel([]string{"foo"}), identity.InvalidIdentity, false)
 	c.Assert(err, Not(IsNil))
 
 	// release all identities, this must decrement the reference count but not release the identities yet
 	for _, id := range identities {
-		c.Assert(cache.release(id, false), Equals, false)
+		c.Assert(cache.Release(id, false), Equals, false)
 	}
 
 	// lookup must still be successful
 	for i := minID; i <= maxID; i++ {
-		c.Assert(cache.lookup(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)})), Not(IsNil))
-		c.Assert(cache.lookupByID(i|scope), Not(IsNil))
+		c.Assert(cache.Lookup(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)})), Not(IsNil))
+		c.Assert(cache.LookupByID(i|scope), Not(IsNil))
 	}
 
 	// release the identities a second time, this must cause the identity
 	// to be forgotten
 	for _, id := range identities {
-		c.Assert(cache.release(id, false), Equals, true)
+		c.Assert(cache.Release(id, false), Equals, true)
 	}
 
 	// allocate all identities again
 	for i := minID; i <= maxID; i++ {
-		id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}), identity.InvalidIdentity, false)
+		id, isNew, err := cache.LookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}), identity.InvalidIdentity, false)
 		c.Assert(err, IsNil)
 		c.Assert(isNew, Equals, true)
 		identities[id.ID] = id
@@ -89,9 +89,9 @@ func (s *IdentityCacheTestSuite) TestLocalIdentityCache(c *C) {
 
 	// release a random identity in the middle
 	randomID := identity.NumericIdentity(3) | scope
-	c.Assert(cache.release(identities[randomID], false), Equals, true)
+	c.Assert(cache.Release(identities[randomID], false), Equals, true)
 
-	id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{"foo"}), identity.InvalidIdentity, false)
+	id, isNew, err := cache.LookupOrCreate(labels.NewLabelsFromModel([]string{"foo"}), identity.InvalidIdentity, false)
 	c.Assert(err, IsNil)
 	c.Assert(isNew, Equals, true)
 	// the selected numeric identity must be the one released before
@@ -101,17 +101,17 @@ func (s *IdentityCacheTestSuite) TestLocalIdentityCache(c *C) {
 func TestOldNID(t *testing.T) {
 	minID, maxID := identity.NumericIdentity(1), identity.NumericIdentity(10)
 	scope := identity.NumericIdentity(0x42_00_00_00)
-	c := newLocalIdentityCache(scope, minID, maxID, nil)
+	c := NewLocalIdentityCache(scope, minID, maxID, nil)
 
 	// Request identity, it should work
 	l := labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.1/32"))
-	id, _, _ := c.lookupOrCreate(l, scope, false)
+	id, _, _ := c.LookupOrCreate(l, scope, false)
 	assert.NotNil(t, id)
 	assert.EqualValues(t, scope, id.ID)
 
 	// Re-request identity, it should not
 	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.2/32"))
-	id, _, _ = c.lookupOrCreate(l, scope, false)
+	id, _, _ = c.LookupOrCreate(l, scope, false)
 	assert.NotNil(t, id)
 	assert.EqualValues(t, scope+1, id.ID)
 
@@ -119,33 +119,33 @@ func TestOldNID(t *testing.T) {
 	c.withhold([]identity.NumericIdentity{scope + 2})
 
 	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.3/32"))
-	id, _, _ = c.lookupOrCreate(l, 0, false)
+	id, _, _ = c.LookupOrCreate(l, 0, false)
 	assert.NotNil(t, id)
 	assert.EqualValues(t, scope+3, id.ID)
 
 	// Request a withheld identity, it should succeed
 	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.4/32"))
-	id2, _, _ := c.lookupOrCreate(l, scope+2, false)
+	id2, _, _ := c.LookupOrCreate(l, scope+2, false)
 	assert.NotNil(t, id2)
 	assert.EqualValues(t, scope+2, id2.ID)
 
 	// Request a withheld and allocated identity, it should be ignored
 	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.5/32"))
-	id, _, _ = c.lookupOrCreate(l, scope+2, false)
+	id, _, _ = c.LookupOrCreate(l, scope+2, false)
 	assert.NotNil(t, id)
 	assert.EqualValues(t, scope+4, id.ID)
 
 	// Unwithhold and release an identity, requesting should now succeed
 	c.unwithhold([]identity.NumericIdentity{scope + 2})
-	c.release(id2, false)
+	c.Release(id2, false)
 	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.6/32"))
-	id, _, _ = c.lookupOrCreate(l, scope+2, false)
+	id, _, _ = c.LookupOrCreate(l, scope+2, false)
 	assert.NotNil(t, id)
 	assert.EqualValues(t, scope+2, id.ID)
 
 	// Request an identity out of scope, it should not be honored
 	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.7/32"))
-	id, _, _ = c.lookupOrCreate(l, scope-2, false)
+	id, _, _ = c.LookupOrCreate(l, scope-2, false)
 	assert.NotNil(t, id)
 	assert.EqualValues(t, scope+5, id.ID)
 
@@ -153,7 +153,7 @@ func TestOldNID(t *testing.T) {
 	c.withhold([]identity.NumericIdentity{scope + 6, scope + 7, scope + 8, scope + 9, scope + 10})
 
 	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.8/32"))
-	id, _, _ = c.lookupOrCreate(l, scope-2, false)
+	id, _, _ = c.LookupOrCreate(l, scope-2, false)
 	assert.NotNil(t, id)
 	// actual value is random, just need it to succeed
 	assert.True(t, id.ID >= scope+6 && id.ID <= scope+10, "%d <= %d <= %d", scope+6, id.ID, scope+10)

--- a/pkg/identity/cache/test_utils.go
+++ b/pkg/identity/cache/test_utils.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cache
+
+import (
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/inctimer"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type DummyOwner struct {
+	updated chan identity.NumericIdentity
+	mutex   lock.Mutex
+	cache   IdentityCache
+}
+
+func NewDummyOwner() *DummyOwner {
+	return &DummyOwner{
+		cache:   IdentityCache{},
+		updated: make(chan identity.NumericIdentity, 1024),
+	}
+}
+
+func (d *DummyOwner) UpdateIdentities(added, deleted IdentityCache) {
+	d.mutex.Lock()
+	log.Debugf("Dummy UpdateIdentities(added: %v, deleted: %v)", added, deleted)
+	for id, lbls := range added {
+		d.cache[id] = lbls
+		d.updated <- id
+	}
+	for id := range deleted {
+		delete(d.cache, id)
+		d.updated <- id
+	}
+	d.mutex.Unlock()
+}
+
+func (d *DummyOwner) GetIdentity(id identity.NumericIdentity) labels.LabelArray {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	return d.cache[id]
+}
+
+func (d *DummyOwner) GetNodeSuffix() string {
+	return "foo"
+}
+
+// WaitUntilID waits until an update event is received for the
+// 'target' identity and returns the number of events processed to get
+// there. Returns 0 in case of 'd.updated' channel is closed or
+// nothing is received from that channel in 60 seconds.
+func (d *DummyOwner) WaitUntilID(target identity.NumericIdentity) int {
+	rounds := 0
+	timer, timerDone := inctimer.New()
+	defer timerDone()
+	for {
+		select {
+		case nid, ok := <-d.updated:
+			if !ok {
+				// updates channel closed
+				return 0
+			}
+			rounds++
+			if nid == target {
+				return rounds
+			}
+		case <-timer.After(60 * time.Second):
+			// Timed out waiting for KV-store events
+			return 0
+		}
+	}
+}

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -185,6 +185,8 @@ var localNodeIdentity = struct {
 	identity: ReservedIdentityRemoteNode,
 }
 
+var UnknownIdentity = NewIdentity(IdentityUnknown, labels.Labels{labels.IDNameUnknown: labels.NewLabel(labels.IDNameUnknown, "", labels.LabelSourceReserved)})
+
 type wellKnownIdentities map[NumericIdentity]wellKnownIdentity
 
 // wellKnownIdentitity is an identity for well-known security labels for which


### PR DESCRIPTION
The common code for local identity allocation is extracted into a new struct `LocalCacheAllocator`, which is used by the `CachingIdentityAllocator` to allocate reserved and local identities, before executing it's logic for allocating global identities.

It's required for implementing different modes of identity allocation.
`LocalOnlyCachingIDAllocator` will use the exported code to implement agent's behavior that won't manage global security identities (Cilium Identities), because operator will do so -- https://github.com/cilium/cilium/pull/30356

No user facing changes.

area/agent
kind/cleanup

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>