### PR TITLE
dep: Bump grpc_health_probe to v0.4.24

### DIFF
--- a/images/hubble-relay/download-grpc-health-probe.sh
+++ b/images/hubble-relay/download-grpc-health-probe.sh
@@ -9,13 +9,13 @@ set -o pipefail
 set -o nounset
 
 # renovate: datasource=github-release-attachments depName=grpc-ecosystem/grpc-health-probe
-grpc_health_probe_version="v0.4.21"
+grpc_health_probe_version="v0.4.24"
 
 declare -A grpc_health_probe_sha256
-# renovate: datasource=github-release-attachments depName=grpc-ecosystem/grpc-health-probe digestVersion=v0.4.21
-grpc_health_probe_sha256[amd64]="dbf3d1ea952ffe6dac5405b6d4cc0e630476272ef17ece02e020c55430f471ce"
-# renovate: datasource=github-release-attachments depName=grpc-ecosystem/grpc-health-probe digestVersion=v0.4.21
-grpc_health_probe_sha256[arm64]="815247e7038e92e82194bba2cd1588f7704754d1a9ea982121e734f358e37c99"
+# renovate: datasource=github-release-attachments depName=grpc-ecosystem/grpc-health-probe digestVersion=v0.4.24
+grpc_health_probe_sha256[amd64]="7e564681110ee4563637457b91e42f62f96b79618a835bb05ae2305acdcc3db0"
+# renovate: datasource=github-release-attachments depName=grpc-ecosystem/grpc-health-probe digestVersion=v0.4.24
+grpc_health_probe_sha256[arm64]="3759148e22a494149a4abae269adee0d20c428b966683426e2319f9047da521d"
 
 for arch in amd64 arm64 ; do
   curl --fail --show-error --silent --location "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${grpc_health_probe_version}/grpc_health_probe-linux-${arch}" --output "/tmp/grpc_health_probe-${arch}"


### PR DESCRIPTION
Contains updated deps that clear up some CVEs.