### PR TITLE
operator: Implement cache to be used for Cilium Identity management

### DIFF
--- a/operator/pkg/ciliumidentity/cache.go
+++ b/operator/pkg/ciliumidentity/cache.go
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/cilium/cilium/pkg/identity/key"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// SecIDs is used to handle duplicate CIDs. Operator itself will not generate
+// duplicate CIDs. This is required when migrating to Operator managing CIDs.
+// Operator is compatible with Agents simultaneously managing CIDs.
+type SecIDs struct {
+	selectedID string
+	ids        map[string]struct{}
+}
+
+type CIDState struct {
+	// Maps CID name to a GlobalIdentity which holds labels.
+	idToLabels map[string]*key.GlobalIdentity
+	// Maps label string generated from GlobalIdentity.GetKey() to CID name.
+	labelsToID map[string]*SecIDs
+	mu         lock.RWMutex
+}
+
+func NewCIDState() *CIDState {
+	cidState := &CIDState{
+		idToLabels: make(map[string]*key.GlobalIdentity),
+		labelsToID: make(map[string]*SecIDs),
+	}
+
+	return cidState
+}
+
+func (c *CIDState) Upsert(id string, k *key.GlobalIdentity) {
+	if len(id) == 0 || k == nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, exists := c.idToLabels[id]; exists {
+		return
+	}
+
+	c.idToLabels[id] = k
+
+	keyStr := k.GetKey()
+	secIDs, exists := c.labelsToID[keyStr]
+	if !exists {
+		c.labelsToID[keyStr] = &SecIDs{
+			selectedID: id,
+			ids:        map[string]struct{}{id: {}},
+		}
+		return
+	}
+
+	secIDs.ids[id] = struct{}{}
+}
+
+func (c *CIDState) Remove(id string) {
+	if len(id) == 0 {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	k, exists := c.idToLabels[id]
+	if !exists {
+		return
+	}
+
+	delete(c.idToLabels, id)
+
+	keyStr := k.GetKey()
+	secIDs := c.labelsToID[keyStr]
+
+	delete(secIDs.ids, id)
+	if len(secIDs.ids) == 0 {
+		delete(c.labelsToID, keyStr)
+		return
+	}
+
+	// After removing id, we need to set another one in selectedID by taking it
+	// from the duplicates.
+	if secIDs.selectedID == id {
+		for nextID := range secIDs.ids {
+			secIDs.selectedID = nextID
+			break
+		}
+	}
+}
+
+func (c *CIDState) LookupByID(id string) (*key.GlobalIdentity, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	k, exists := c.idToLabels[id]
+	return k, exists
+}
+
+func (c *CIDState) LookupByKey(k *key.GlobalIdentity) (string, bool) {
+	if k == nil {
+		return "", false
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	secIDs, exists := c.labelsToID[k.GetKey()]
+	if !exists {
+		return "", false
+	}
+
+	return secIDs.selectedID, true
+}
+
+type CIDUsageInPods struct {
+	podToCID      map[string]string
+	cidUsageCount map[string]int
+
+	mu lock.RWMutex
+}
+
+func NewCIDUsageInPods() *CIDUsageInPods {
+	return &CIDUsageInPods{
+		podToCID:      make(map[string]string),
+		cidUsageCount: make(map[string]int),
+	}
+}
+
+// AssignCIDToPod updates the pod to CID map and increments the CID usage.
+// It also decrements the previous CID usage and returns the CID name of
+// previously set CID and its usage count after decrementing the CID usage.
+// The return values are used to track when old CIDs are no longer used.
+func (c *CIDUsageInPods) AssignCIDToPod(podName, cidName string) (string, int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var prevCIDUsageCount int
+	prevCIDName, exists := c.podToCID[podName]
+	if exists {
+		if cidName == prevCIDName {
+			return cidName, c.cidUsageCount[cidName]
+		}
+
+		prevCIDUsageCount = c.decrementUsage(prevCIDName)
+	}
+
+	c.podToCID[podName] = cidName
+	c.cidUsageCount[cidName]++
+
+	return prevCIDName, prevCIDUsageCount
+}
+
+// RemovePod removes the pod from the pod to CID map, decrements the CID usage
+// and returns the CID name and its usage count after decrementing the usage.
+// The return values are used to track when old CIDs are no longer used.
+func (c *CIDUsageInPods) RemovePod(podName string) (string, int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	cidName, exists := c.podToCID[podName]
+	if !exists {
+		return "", 0, errors.New("cilium identity not found in pods usage cache")
+	}
+	count := c.decrementUsage(cidName)
+	delete(c.podToCID, podName)
+
+	return cidName, count, nil
+}
+
+func (c *CIDUsageInPods) CIDUsedByPod(podName string) (string, bool) {
+	if len(podName) == 0 {
+		return "", false
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	cidName, exists := c.podToCID[podName]
+	return cidName, exists
+}
+
+func (c *CIDUsageInPods) CIDUsageCount(cidName string) int {
+	if len(cidName) == 0 {
+		return 0
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.cidUsageCount[cidName]
+}
+
+// decrementUsage reduces the usage count for a CID and removes it from the map
+// if the count is 0. Must be used only after acquiring the write lock.
+func (c *CIDUsageInPods) decrementUsage(cidName string) int {
+	c.cidUsageCount[cidName]--
+
+	count := c.cidUsageCount[cidName]
+	if count == 0 {
+		delete(c.cidUsageCount, cidName)
+	}
+
+	return count
+}
+
+type CIDUsageInCES struct {
+	cidUsageCount     map[int64]int
+	prevCIDsUsedInCES map[string][]int64
+
+	mu lock.RWMutex
+}
+
+func NewCIDUsageInCES() *CIDUsageInCES {
+	return &CIDUsageInCES{
+		cidUsageCount:     make(map[int64]int),
+		prevCIDsUsedInCES: make(map[string][]int64),
+	}
+}
+
+// ProcessCESUpsert updates the CID usage in CES based on the provided CES.
+// When the CES is new, it will just add all used CIDs. When CES is updated, it
+// uses previous CID usage for the same CES, that it tracks, to accordingly
+// reduce CID usage in CES.
+func (c *CIDUsageInCES) ProcessCESUpsert(cesName string, endpoints []v2alpha1.CoreCiliumEndpoint) []int64 {
+	if cesName == "" {
+		return nil
+	}
+
+	var cidsWithNoCESUsage []int64
+	newUsedCIDs := make([]int64, len(endpoints))
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for i, cep := range endpoints {
+		c.cidUsageCount[cep.IdentityID]++
+		newUsedCIDs[i] = cep.IdentityID
+	}
+
+	for _, cid := range c.prevCIDsUsedInCES[cesName] {
+		count := c.decrementUsage(cid)
+		if count == 0 {
+			cidsWithNoCESUsage = append(cidsWithNoCESUsage, cid)
+		}
+	}
+
+	c.prevCIDsUsedInCES[cesName] = newUsedCIDs
+
+	return cidsWithNoCESUsage
+}
+
+// ProcessCESDelete reduces the CID usage in CES, based on the provided CES.
+func (c *CIDUsageInCES) ProcessCESDelete(cesName string, endpoints []v2alpha1.CoreCiliumEndpoint) []int64 {
+	if cesName == "" {
+		return nil
+	}
+
+	var cidsWithNoCESUsage []int64
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, cep := range endpoints {
+		count := c.decrementUsage(cep.IdentityID)
+		if count == 0 {
+			cidsWithNoCESUsage = append(cidsWithNoCESUsage, cep.IdentityID)
+		}
+	}
+
+	delete(c.prevCIDsUsedInCES, cesName)
+
+	return cidsWithNoCESUsage
+}
+
+func (c *CIDUsageInCES) CIDUsageCount(cidName string) int {
+	if len(cidName) == 0 {
+		return 0
+	}
+
+	cidNum, err := strconv.Atoi(cidName)
+	if err != nil {
+		return 0
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.cidUsageCount[int64(cidNum)]
+}
+
+// decrementUsage reduces the usage count for a CID and removes it from the map
+// if the count is 0. Must be used only after acquiring the write lock.
+func (c *CIDUsageInCES) decrementUsage(cidName int64) int {
+	c.cidUsageCount[cidName]--
+	count := c.cidUsageCount[cidName]
+
+	if count == 0 {
+		delete(c.cidUsageCount, cidName)
+	}
+
+	return count
+}

--- a/operator/pkg/ciliumidentity/cache_test.go
+++ b/operator/pkg/ciliumidentity/cache_test.go
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	cestest "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
+	"github.com/cilium/cilium/pkg/identity/key"
+	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/labelsfilter"
+)
+
+var (
+	k8sLables_A           = map[string]string{"a1": "1", "a2": "2"}
+	k8sLables_B           = map[string]string{"b1": "1", "b2": "2"}
+	k8sLables_B_duplicate = map[string]string{"b1": "1", "b2": "2"}
+	k8sLables_C           = map[string]string{"c1": "1", "c2": "2"}
+)
+
+func TestMain(m *testing.M) {
+	labelsfilter.ParseLabelPrefixCfg(nil, nil, "")
+
+	os.Exit(m.Run())
+}
+
+func TestCIDState(t *testing.T) {
+	// The subtests below share the same state to serially test insert, lookup and
+	// remove operations of CIDState.
+	state := NewCIDState()
+	k1 := GetCIDKeyFromK8sLabels(k8sLables_A)
+	k2 := GetCIDKeyFromK8sLabels(k8sLables_B)
+	k3 := GetCIDKeyFromK8sLabels(k8sLables_B_duplicate)
+
+	t.Run("Insert into CID state", func(t *testing.T) {
+		state.Upsert("1", k1)
+		expectedState := &CIDState{
+			idToLabels: map[string]*key.GlobalIdentity{"1": k1},
+			labelsToID: map[string]*SecIDs{
+				k1.GetKey(): {
+					selectedID: "1",
+					ids:        map[string]struct{}{"1": {}},
+				},
+			},
+		}
+
+		assert.NoError(t, validateCIDState(state, expectedState), "cid 1 added")
+
+		state.Upsert("2", k2)
+		expectedState = &CIDState{
+			idToLabels: map[string]*key.GlobalIdentity{"1": k1, "2": k2},
+			labelsToID: map[string]*SecIDs{
+				k1.GetKey(): {
+					selectedID: "1",
+					ids:        map[string]struct{}{"1": {}},
+				},
+				k2.GetKey(): {
+					selectedID: "2",
+					ids:        map[string]struct{}{"2": {}},
+				},
+			},
+		}
+
+		assert.NoError(t, validateCIDState(state, expectedState), "cid 2 added")
+
+		state.Upsert("3", k3)
+		expectedState = &CIDState{
+			idToLabels: map[string]*key.GlobalIdentity{"1": k1, "2": k2, "3": k3},
+			labelsToID: map[string]*SecIDs{
+				k1.GetKey(): {
+					selectedID: "1",
+					ids:        map[string]struct{}{"1": {}},
+				},
+				k2.GetKey(): {
+					selectedID: "2",
+					ids:        map[string]struct{}{"2": {}, "3": {}},
+				},
+			},
+		}
+
+		assert.NoError(t, validateCIDState(state, expectedState), "cid 3 added - duplicate")
+	})
+
+	t.Run("Lookup CID state", func(t *testing.T) {
+		_, exists := state.LookupByID("0")
+		assert.Equal(t, false, exists, "cid 0 LookupByID - not found")
+
+		cidKey, exists := state.LookupByID("1")
+		assert.Equal(t, true, exists, "cid 1 LookupByID - found")
+		assert.Equal(t, GetCIDKeyFromK8sLabels(k8sLables_A), cidKey, "cid 1 LookupByID - correct key")
+
+		_, exists = state.LookupByKey(GetCIDKeyFromK8sLabels(k8sLables_C))
+		assert.Equal(t, false, exists, "labels C LookupByKey - not found")
+
+		cidName, exists := state.LookupByKey(GetCIDKeyFromK8sLabels(k8sLables_A))
+		assert.Equal(t, true, exists, "labels C LookupByKey - not found")
+		assert.Equal(t, "1", cidName, "labels C LookupByKey - correct CID")
+	})
+
+	t.Run("Remove from CID state", func(t *testing.T) {
+		state.Remove("2")
+		expectedState := &CIDState{
+			idToLabels: map[string]*key.GlobalIdentity{"1": k1, "3": k3},
+			labelsToID: map[string]*SecIDs{
+				k1.GetKey(): {
+					selectedID: "1",
+					ids:        map[string]struct{}{"1": {}},
+				},
+				k2.GetKey(): {
+					selectedID: "3",
+					ids:        map[string]struct{}{"3": {}},
+				},
+			},
+		}
+
+		assert.NoError(t, validateCIDState(state, expectedState), "cid 2 removed")
+
+		_, exists := state.LookupByID("2")
+		assert.Equal(t, false, exists, "cid 2 LookupByID - not found")
+
+		state.Remove("3")
+		expectedState = &CIDState{
+			idToLabels: map[string]*key.GlobalIdentity{"1": k1},
+			labelsToID: map[string]*SecIDs{
+				k1.GetKey(): {
+					selectedID: "1",
+					ids:        map[string]struct{}{"1": {}},
+				},
+			},
+		}
+		assert.NoError(t, validateCIDState(state, expectedState), "cid 3 removed")
+	})
+}
+
+func TestCIDStateThreadSafety(t *testing.T) {
+	// This test ensures that no changes to the CID state break its thread safety.
+	// Multiple go routines in parallel continuously keep using CIDState.
+	state := NewCIDState()
+
+	k := GetCIDKeyFromK8sLabels(k8sLables_A)
+	k2 := GetCIDKeyFromK8sLabels(k8sLables_B)
+
+	wg := sync.WaitGroup{}
+	queryStateFunc := func() {
+		for i := 0; i < 500; i++ {
+			state.LookupByID("1000")
+			state.Upsert("1000", k)
+			state.LookupByKey(k)
+			state.Upsert("2000", k2)
+			state.Remove("1000")
+			state.LookupByID("2000")
+		}
+
+		wg.Done()
+	}
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go queryStateFunc()
+	}
+
+	wg.Wait()
+}
+
+func validateCIDState(state, expectedState *CIDState) error {
+	if !reflect.DeepEqual(state.idToLabels, expectedState.idToLabels) {
+		return fmt.Errorf("failed to validate the state, expected idToLabels %v, got %v", expectedState.idToLabels, state.idToLabels)
+	}
+
+	if !reflect.DeepEqual(state.labelsToID, expectedState.labelsToID) {
+		return fmt.Errorf("failed to validate the state, expected labelsToID %v, got %v", expectedState.labelsToID, state.labelsToID)
+	}
+
+	return nil
+}
+
+func TestCIDUsageInPods(t *testing.T) {
+	state := NewCIDUsageInPods()
+
+	assertTxt := "Empty state"
+	cidName1 := "1000"
+	podName1 := "pod1"
+	assert.Equal(t, 0, state.CIDUsageCount(cidName1), assertTxt)
+
+	usedCID, exists := state.CIDUsedByPod(podName1)
+	assert.Equal(t, false, exists, assertTxt)
+	assert.Equal(t, "", usedCID, assertTxt)
+
+	prevCID, count, err := state.RemovePod(podName1)
+	assert.Error(t, err)
+	assert.Equal(t, "", prevCID, assertTxt)
+	assert.Equal(t, 0, count, assertTxt)
+
+	assertTxt = "Assign CID to Pod 1"
+	prevCID, count = state.AssignCIDToPod(podName1, cidName1)
+	assert.Equal(t, "", prevCID, assertTxt)
+	assert.Equal(t, 0, count, assertTxt)
+	assert.Equal(t, 1, state.CIDUsageCount(cidName1), assertTxt)
+
+	usedCID, exists = state.CIDUsedByPod(podName1)
+	assert.Equal(t, true, exists, assertTxt)
+	assert.Equal(t, cidName1, usedCID, assertTxt)
+
+	assertTxt = "Assign CID to Pod 2"
+	podName2 := "pod2"
+	prevCID, count = state.AssignCIDToPod(podName2, cidName1)
+	assert.Equal(t, "", prevCID, assertTxt)
+	assert.Equal(t, 0, count, assertTxt)
+	assert.Equal(t, 2, state.CIDUsageCount(cidName1), assertTxt)
+
+	usedCID, exists = state.CIDUsedByPod(podName2)
+	assert.Equal(t, true, exists, assertTxt)
+	assert.Equal(t, cidName1, usedCID, assertTxt)
+
+	assertTxt = "Assign CID 2 to Pod 2"
+	cidName2 := "2000"
+	prevCID, count = state.AssignCIDToPod(podName2, cidName2)
+	assert.Equal(t, cidName1, prevCID, assertTxt)
+	assert.Equal(t, 1, count, assertTxt)
+	assert.Equal(t, 1, state.CIDUsageCount(cidName2), assertTxt)
+
+	usedCID, exists = state.CIDUsedByPod(podName2)
+	assert.Equal(t, true, exists, assertTxt)
+	assert.Equal(t, cidName2, usedCID, assertTxt)
+
+	assertTxt = "Assign CID 2 to Pod 1"
+	prevCID, count = state.AssignCIDToPod(podName1, cidName2)
+	assert.Equal(t, cidName1, prevCID, assertTxt)
+	assert.Equal(t, 0, count, assertTxt)
+	assert.Equal(t, 2, state.CIDUsageCount(cidName2), assertTxt)
+	assert.Equal(t, 0, state.CIDUsageCount(cidName1), assertTxt)
+
+	usedCID, exists = state.CIDUsedByPod(podName1)
+	assert.Equal(t, true, exists, assertTxt)
+	assert.Equal(t, cidName2, usedCID, assertTxt)
+
+	assertTxt = "Again assign CID 2 to Pod 1"
+	prevCID, count = state.AssignCIDToPod(podName1, cidName2)
+	assert.Equal(t, cidName2, prevCID, assertTxt)
+	assert.Equal(t, 2, count, assertTxt)
+	assert.Equal(t, 2, state.CIDUsageCount(cidName2), assertTxt)
+	assert.Equal(t, 0, state.CIDUsageCount(cidName1), assertTxt)
+
+	assertTxt = "Remove Pod 1"
+	prevCID, count, err = state.RemovePod(podName1)
+	assert.NoError(t, err)
+	assert.Equal(t, cidName2, prevCID, assertTxt)
+	assert.Equal(t, 1, count, assertTxt)
+	assert.Equal(t, 1, state.CIDUsageCount(cidName2), assertTxt)
+
+	usedCID, exists = state.CIDUsedByPod(podName1)
+	assert.Equal(t, false, exists, assertTxt)
+	assert.Equal(t, "", usedCID, assertTxt)
+
+	assertTxt = "Remove Pod 2"
+	prevCID, count, err = state.RemovePod(podName2)
+	assert.NoError(t, err)
+	assert.Equal(t, cidName2, prevCID, assertTxt)
+	assert.Equal(t, 0, count, assertTxt)
+	assert.Equal(t, 0, state.CIDUsageCount(cidName2), assertTxt)
+
+	usedCID, exists = state.CIDUsedByPod(podName2)
+	assert.Equal(t, false, exists, assertTxt)
+	assert.Equal(t, "", usedCID, assertTxt)
+}
+
+func TestCIDUsageInCES(t *testing.T) {
+	cep1 := cestest.CreateManagerEndpoint("cep1", 1000)
+	cep2 := cestest.CreateManagerEndpoint("cep2", 1000)
+	cep3 := cestest.CreateManagerEndpoint("cep3", 2000)
+	cep4 := cestest.CreateManagerEndpoint("cep4", 3000)
+	ces1 := cestest.CreateStoreEndpointSlice("ces1", "ns", []capi_v2a1.CoreCiliumEndpoint{cep1, cep2, cep3, cep4})
+
+	cep5 := cestest.CreateManagerEndpoint("cep5", 1000)
+	cep6 := cestest.CreateManagerEndpoint("cep6", 1000)
+	cep7 := cestest.CreateManagerEndpoint("cep7", 2000)
+	ces2 := cestest.CreateStoreEndpointSlice("ces2", "ns", []capi_v2a1.CoreCiliumEndpoint{cep5, cep6, cep7})
+
+	assertTxt := "CES 1 is added"
+	state := NewCIDUsageInCES()
+	unusedCIDs := state.ProcessCESUpsert(ces1.Name, ces1.Endpoints)
+	assert.Equal(t, 0, len(unusedCIDs), assertTxt)
+	assert.Equal(t, 2, state.CIDUsageCount("1000"), assertTxt)
+	assert.Equal(t, 1, state.CIDUsageCount("2000"), assertTxt)
+	assert.Equal(t, 1, state.CIDUsageCount("3000"), assertTxt)
+
+	assertTxt = "CES 2 is added"
+	unusedCIDs = state.ProcessCESUpsert(ces2.Name, ces2.Endpoints)
+	assert.Equal(t, 0, len(unusedCIDs), assertTxt)
+	assert.Equal(t, 4, state.CIDUsageCount("1000"), assertTxt)
+	assert.Equal(t, 2, state.CIDUsageCount("2000"), assertTxt)
+	assert.Equal(t, 1, state.CIDUsageCount("3000"), assertTxt)
+
+	assertTxt = "Endpoint with CID 3000 is removed from CES 1"
+	ces1 = cestest.CreateStoreEndpointSlice("ces1", "ns", []capi_v2a1.CoreCiliumEndpoint{cep1, cep2, cep3})
+	unusedCIDs = state.ProcessCESUpsert(ces1.Name, ces1.Endpoints)
+	assert.Equal(t, 1, len(unusedCIDs), assertTxt)
+	if len(unusedCIDs) > 0 {
+		assert.Equal(t, int64(3000), unusedCIDs[0], assertTxt)
+	}
+	assert.Equal(t, 4, state.CIDUsageCount("1000"), assertTxt)
+	assert.Equal(t, 2, state.CIDUsageCount("2000"), assertTxt)
+	assert.Equal(t, 0, state.CIDUsageCount("3000"), assertTxt)
+
+	assertTxt = "CES 1 is removed"
+	unusedCIDs = state.ProcessCESDelete(ces1.Name, ces1.Endpoints)
+	assert.Equal(t, 0, len(unusedCIDs), assertTxt)
+	assert.Equal(t, 2, state.CIDUsageCount("1000"), assertTxt)
+	assert.Equal(t, 1, state.CIDUsageCount("2000"), assertTxt)
+
+	assertTxt = "CES 2 is removed"
+	unusedCIDs = state.ProcessCESDelete(ces1.Name, ces1.Endpoints)
+	assert.Equal(t, 2, len(unusedCIDs), assertTxt)
+	assert.Equal(t, 0, state.CIDUsageCount("1000"), assertTxt)
+	assert.Equal(t, 0, state.CIDUsageCount("2000"), assertTxt)
+}

--- a/operator/pkg/ciliumidentity/identity.go
+++ b/operator/pkg/ciliumidentity/identity.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import (
+	"github.com/cilium/cilium/pkg/identity/key"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/labelsfilter"
+)
+
+func GetCIDKeyFromK8sLabels(k8sLabels map[string]string) *key.GlobalIdentity {
+	lbls := labels.Map2Labels(k8sLabels, labels.LabelSourceK8s)
+	idLabels, _ := labelsfilter.Filter(lbls)
+	return &key.GlobalIdentity{LabelArray: idLabels.LabelArray()}
+}


### PR DESCRIPTION
A part of the "Operator manages global identities" implementation -- https://github.com/cilium/cilium/pull/30356

No user facing changes.

The cache is to be used by the Cilium Identity controller in cilium-operator to track:
- Desired Cilium Identity state
- Cilium Identity usage for Pods
- Cilium Identity usage for Cilium Endpoint Slices

**Reviewer note**: The PR includes CES test utils (operator/pkg/ciliumendpointslice/testutils/test_utils.go) that don't need to be reviewed here, because they are expected to be merged in https://github.com/cilium/cilium/pull/30577

area/operator
kind/feature

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>