### PR TITLE
CiliumNetworkPolicy: match endpoint by namespace label is overwritten with match by namespace name

### DIFF
--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -34,9 +34,12 @@ const (
 	// kubernetes namespace's labels.
 	PodNamespaceMetaLabels = LabelPrefix + ".namespace.labels"
 
+	// PodNamespaceMetaLabelsPrefix is the prefix used for kubernetes namespace's labels
+	PodNamespaceMetaLabelsPrefix = PodNamespaceMetaLabels + "."
+
 	// PodNamespaceMetaNameLabel is the label that Kubernetes automatically adds
 	// to namespaces.
-	PodNamespaceMetaNameLabel = PodNamespaceMetaLabels + "." + LabelMetadataName
+	PodNamespaceMetaNameLabel = PodNamespaceMetaLabelsPrefix + LabelMetadataName
 
 	// LabelMetadataName is the label name which, in-tree, is used to
 	// automatically label namespaces, so they can be selected easily by tools

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -26,6 +26,12 @@ const (
 	// represent pods in the default namespace for any source type.
 	podAnyPrefixLbl = labels.LabelSourceAnyKeyPrefix + k8sConst.PodNamespaceLabel
 
+	// podK8SNamespaceLabelsPrefix is the prefix use in the label selector for namespace labels.
+	podK8SNamespaceLabelsPrefix = labels.LabelSourceK8sKeyPrefix + k8sConst.PodNamespaceMetaLabelsPrefix
+	// podAnyNamespaceLabelsPrefix is the prefix use in the label selector for namespace labels
+	// for any source type.
+	podAnyNamespaceLabelsPrefix = labels.LabelSourceAnyKeyPrefix + k8sConst.PodNamespaceMetaLabelsPrefix
+
 	// podInitLbl is the label used in a label selector to match on
 	// initializing pods.
 	podInitLbl = labels.LabelSourceReservedKeyPrefix + labels.IDNameInit
@@ -92,7 +98,7 @@ func getEndpointSelector(namespace string, labelSelector *slim_metav1.LabelSelec
 			if !matchesInit {
 				es.AddMatchExpression(podPrefixLbl, slim_metav1.LabelSelectorOpExists, []string{})
 			}
-		} else {
+		} else if !es.HasKeyPrefix(podK8SNamespaceLabelsPrefix) && !es.HasKeyPrefix(podAnyNamespaceLabelsPrefix) {
 			es.AddMatch(podPrefixLbl, namespace)
 		}
 	}


### PR DESCRIPTION
It was not possible to match endpoints by namespace labels even though web policy editor suggested it.
Label matching namespace by name was added implicitly to the policy which makes selector by labels invalid.
After fix label matching namespace by name is not added in case user specified matching by namespace labels.

Fixes: #30149

```release-note
Fix selecting of endpoints by namespace labels in network policies
```
