### PR TITLE
envoy: Add support for exposing Envoy Admin API

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1084,6 +1084,14 @@
      - Time in seconds after which a TCP connection attempt times out
      - int
      - ``2``
+   * - :spelling:ignore:`envoy.debug.admin.enabled`
+     - Enable admin interface for cilium-envoy. This is useful for debugging and should not be enabled in production.
+     - bool
+     - ``false``
+   * - :spelling:ignore:`envoy.debug.admin.port`
+     - Port number (bound to loopback interface). kubectl port-forward can be used to access the admin interface.
+     - int
+     - ``9901``
    * - :spelling:ignore:`envoy.dnsPolicy`
      - DNS policy for Cilium envoy pods. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
      - string

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -417,6 +417,7 @@ Port Range / Protocol    Description
 9890/tcp                 cilium-agent gops server (listening on 127.0.0.1)
 9891/tcp                 operator gops server (listening on 127.0.0.1)
 9893/tcp                 Hubble Relay gops server (listening on 127.0.0.1)
+9901/tcp                 cilium-envoy Admin API (listening on 127.0.0.1)
 9962/tcp                 cilium-agent Prometheus metrics
 9963/tcp                 cilium-operator Prometheus metrics
 9964/tcp                 cilium-envoy Prometheus metrics

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -321,6 +321,8 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.annotations | object | `{}` | Annotations to be added to all top-level cilium-envoy objects (resources under templates/cilium-envoy) |
 | envoy.baseID | int | `0` |  Set Envoy'--base-id' to use when allocating shared memory regions. Only needs to be changed if multiple Envoy instances will run on the same node and may have conflicts. Supported values: 0 - 4294967295. Defaults to '0' |
 | envoy.connectTimeoutSeconds | int | `2` | Time in seconds after which a TCP connection attempt times out |
+| envoy.debug.admin.enabled | bool | `false` | Enable admin interface for cilium-envoy. This is useful for debugging and should not be enabled in production. |
+| envoy.debug.admin.port | int | `9901` | Port number (bound to loopback interface). kubectl port-forward can be used to access the admin interface. |
 | envoy.dnsPolicy | string | `nil` | DNS policy for Cilium envoy pods. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
 | envoy.enabled | bool | `true` | Enable Envoy Proxy in standalone DaemonSet. |
 | envoy.extraArgs | list | `[]` | Additional envoy container arguments. |

--- a/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.json
+++ b/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.json
@@ -60,6 +60,73 @@
         ]
       },
       {{- end }}
+      {{- if and .Values.envoy.debug.admin.enabled }}
+      {
+        "name": "envoy-admin-listener",
+        "address": {
+          "socket_address": {
+            "address": {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }},
+            "port_value": {{ .Values.envoy.debug.admin.port }}
+          }
+        },
+        {{- if and .Values.ipv4.enabled .Values.ipv6.enabled }}
+        "additional_addresses": [
+          {
+            "address": {
+              "socket_address": {
+                "address": "::1",
+                "port_value": {{ .Values.envoy.debug.admin.port }}
+              }
+            }
+          }
+        ],
+        {{- end }}
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "stat_prefix": "envoy-admin-listener",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "admin_route",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "name": "admin_route",
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "route": {
+                              "cluster": "/envoy-admin",
+                              "prefix_rewrite": "/"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typed_config": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "stream_idle_timeout": "0s"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {{- end }}
       {
         "name": "envoy-health-listener",
         "address": {

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -250,6 +250,12 @@ spec:
           hostPort: {{ .Values.envoy.prometheus.port }}
           protocol: TCP
         {{- end }}
+        {{- if and .Values.envoy.debug.admin.port (not .Values.envoy.enabled) }}
+        - name: envoy-admin
+          containerPort: {{ .Values.envoy.debug.admin.port }}
+          hostPort: {{ .Values.envoy.debug.admin.port }}
+          protocol: TCP
+        {{- end }}
         {{- end }}
         {{- if .Values.hubble.metrics.enabled }}
         - name: hubble-metrics

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -228,6 +228,10 @@ data:
   {{- if .Values.envoy.prometheus.enabled }}
   proxy-prometheus-port: "{{ .Values.envoy.prometheus.port }}"
   {{- end }}
+
+  {{- if and .Values.envoy.debug.admin.enabled .Values.envoy.debug.admin.port }}
+  proxy-admin-port: "{{ .Values.envoy.debug.admin.port }}"
+  {{- end }}
 {{- end }}
 
 {{- if .Values.operator.prometheus.enabled }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -158,6 +158,12 @@ spec:
           containerPort: {{ .Values.envoy.prometheus.port }}
           hostPort: {{ .Values.envoy.prometheus.port }}
           protocol: TCP
+        {{- if and .Values.envoy.debug.admin.enabled .Values.envoy.debug.admin.port }}
+        - name: envoy-admin
+          containerPort: {{ .Values.envoy.debug.admin.port }}
+          hostPort: {{ .Values.envoy.debug.admin.port }}
+          protocol: TCP
+        {{- end }}
         {{- end }}
         securityContext:
           {{- if .Values.envoy.securityContext.privileged }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1941,6 +1941,14 @@ envoy:
   # -- DNS policy for Cilium envoy pods.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ~
+  debug:
+    admin:
+      # -- Enable admin interface for cilium-envoy.
+      # This is useful for debugging and should not be enabled in production.
+      enabled: false
+      # -- Port number (bound to loopback interface).
+      # kubectl port-forward can be used to access the admin interface.
+      port: 9901
   # -- Configure Cilium Envoy Prometheus options.
   # Note that some of these apply to either cilium-agent or cilium-envoy.
   prometheus:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1941,6 +1941,14 @@ envoy:
   # -- DNS policy for Cilium envoy pods.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ~
+  debug:
+    admin:
+      # -- Enable admin interface for cilium-envoy.
+      # This is useful for debugging and should not be enabled in production.
+      enabled: false
+      # -- Port number (bound to loopback interface).
+      # kubectl port-forward can be used to access the admin interface.
+      port: 9901
   # -- Configure Cilium Envoy Prometheus options.
   # Note that some of these apply to either cilium-agent or cilium-envoy.
   prometheus:

--- a/pkg/envoy/secretsync_test.go
+++ b/pkg/envoy/secretsync_test.go
@@ -215,6 +215,10 @@ func (*fakeXdsServer) AddListener(name string, kind policy.L7ParserType, port ui
 	panic("unimplemented")
 }
 
+func (*fakeXdsServer) AddAdminListener(port uint16, wg *completion.WaitGroup) {
+	panic("unimplemented")
+}
+
 func (*fakeXdsServer) AddMetricsListener(port uint16, wg *completion.WaitGroup) {
 	panic("unimplemented")
 }

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -73,6 +73,7 @@ const (
 	ingressClusterName    = "ingress-cluster"
 	ingressTLSClusterName = "ingress-cluster-tls"
 	metricsListenerName   = "envoy-prometheus-metrics-listener"
+	adminListenerName     = "envoy-admin-listener"
 )
 
 type Listener struct {
@@ -91,6 +92,8 @@ type Listener struct {
 type XDSServer interface {
 	// AddListener adds a listener to a running Envoy proxy.
 	AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup)
+	// AddAdminListener adds an Admin API listener to Envoy.
+	AddAdminListener(port uint16, wg *completion.WaitGroup)
 	// AddMetricsListener adds a prometheus metrics listener to Envoy.
 	AddMetricsListener(port uint16, wg *completion.WaitGroup)
 	// RemoveListener removes an existing Envoy Listener.
@@ -583,6 +586,73 @@ func GetLocalListenerAddresses(port uint16, ipv4, ipv6 bool) (*envoy_config_core
 	return &envoy_config_core.Address{
 		Address: addresses[0],
 	}, additionalAddress
+}
+
+func (s *xdsServer) AddAdminListener(port uint16, wg *completion.WaitGroup) {
+	if port == 0 {
+		return // 0 == disabled
+	}
+	log.WithField(logfields.Port, port).Debug("Envoy: AddAdminListener")
+
+	s.addListener(adminListenerName, func() *envoy_config_listener.Listener {
+		hcmConfig := &envoy_config_http.HttpConnectionManager{
+			StatPrefix:       adminListenerName,
+			UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
+			SkipXffAppend:    true,
+			HttpFilters: []*envoy_config_http.HttpFilter{{
+				Name: "envoy.filters.http.router",
+				ConfigType: &envoy_config_http.HttpFilter_TypedConfig{
+					TypedConfig: toAny(&envoy_extensions_filters_http_router_v3.Router{}),
+				},
+			}},
+			StreamIdleTimeout: &durationpb.Duration{}, // 0 == disabled
+			RouteSpecifier: &envoy_config_http.HttpConnectionManager_RouteConfig{
+				RouteConfig: &envoy_config_route.RouteConfiguration{
+					VirtualHosts: []*envoy_config_route.VirtualHost{{
+						Name:    "admin_listener_route",
+						Domains: []string{"*"},
+						Routes: []*envoy_config_route.Route{{
+							Match: &envoy_config_route.RouteMatch{
+								PathSpecifier: &envoy_config_route.RouteMatch_Prefix{Prefix: "/"},
+							},
+							Action: &envoy_config_route.Route_Route{
+								Route: &envoy_config_route.RouteAction{
+									ClusterSpecifier: &envoy_config_route.RouteAction_Cluster{
+										Cluster: adminClusterName,
+									},
+								},
+							},
+						}},
+					}},
+				},
+			},
+		}
+
+		addr, additionalAddr := GetLocalListenerAddresses(port, option.Config.IPv4Enabled(), option.Config.IPv6Enabled())
+		listenerConf := &envoy_config_listener.Listener{
+			Name:                adminListenerName,
+			Address:             addr,
+			AdditionalAddresses: additionalAddr,
+			FilterChains: []*envoy_config_listener.FilterChain{{
+				Filters: []*envoy_config_listener.Filter{{
+					Name: "envoy.filters.network.http_connection_manager",
+					ConfigType: &envoy_config_listener.Filter_TypedConfig{
+						TypedConfig: toAny(hcmConfig),
+					},
+				}},
+			}},
+		}
+
+		return listenerConf
+	}, wg, func(err error) {
+		if err != nil {
+			log.WithField(logfields.Port, port).WithError(err).Debug("Envoy: Adding admin listener failed")
+			// Remove the added listener in case of a failure
+			s.removeListener(adminListenerName, nil, false)
+		} else {
+			log.WithField(logfields.Port, port).Info("Envoy: Listening for Admin API")
+		}
+	}, false)
 }
 
 func (s *xdsServer) AddMetricsListener(port uint16, wg *completion.WaitGroup) {

--- a/pkg/envoy/xds_server_ondemand.go
+++ b/pkg/envoy/xds_server_ondemand.go
@@ -61,6 +61,13 @@ func (o *onDemandXdsStarter) startEmbeddedEnvoy(wg *completion.WaitGroup) error 
 			// but then a failure to bind to the configured port would fail starting Envoy.
 			o.XDSServer.AddMetricsListener(uint16(option.Config.ProxyPrometheusPort), wg)
 		}
+
+		// Add Admin listener if the port is (properly) configured
+		if option.Config.ProxyAdminPort < 0 || option.Config.ProxyAdminPort > 65535 {
+			log.WithField(logfields.Port, option.Config.ProxyAdminPort).Error("Envoy: Invalid configured proxy-admin-port")
+		} else if option.Config.ProxyAdminPort != 0 {
+			o.XDSServer.AddAdminListener(uint16(option.Config.ProxyAdminPort), wg)
+		}
 	})
 
 	return startErr

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -157,6 +157,9 @@ const (
 	// GopsPort is the TCP port for the gops server.
 	GopsPort = "gops-port"
 
+	// ProxyAdminPort specifies the port to serve Cilium Envoy Admin API on.
+	ProxyAdminPort = "proxy-admin-port"
+
 	// ProxyPrometheusPort specifies the port to serve Cilium host proxy metrics on.
 	ProxyPrometheusPort = "proxy-prometheus-port"
 
@@ -1596,6 +1599,9 @@ type DaemonConfig struct {
 	// ProxyGID specifies the group ID that has access to unix domain sockets opened by Cilium
 	// agent for proxy configuration and access logging.
 	ProxyGID int
+
+	// ProxyAdminPort specifies the port to serve Envoy admin on.
+	ProxyAdminPort int
 
 	// ProxyPrometheusPort specifies the port to serve Envoy metrics on.
 	ProxyPrometheusPort int
@@ -3105,6 +3111,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.ProcFs = vp.GetString(ProcFs)
 	c.ProxyConnectTimeout = vp.GetInt(ProxyConnectTimeout)
 	c.ProxyGID = vp.GetInt(ProxyGID)
+	c.ProxyAdminPort = vp.GetInt(ProxyAdminPort)
 	c.ProxyPrometheusPort = vp.GetInt(ProxyPrometheusPort)
 	c.ProxyMaxRequestsPerConnection = vp.GetInt(ProxyMaxRequestsPerConnection)
 	c.ProxyMaxConnectionDuration = time.Duration(vp.GetInt64(ProxyMaxConnectionDuration))


### PR DESCRIPTION
This is to support the capability to expose Envoy Admin API via new helm flags envoy.debug.admin.{enabled,port} for both embeded and daemonset modes.

Fixes: #30647
