### PR TITLE
ci-e2e: Enable Ingress Controller test for more setup

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -233,7 +233,7 @@ jobs:
             lb-mode: 'snat'
             egress-gateway: 'true'
             lb-acceleration: 'testing-only'
-
+            ingress-controller: 'true'
 
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Ideally, we should be able to enable for all the cases having KPR, this work is in progress.

