### PR TITLE
.github: switch kind images back to kind

### DIFF
--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -4,7 +4,7 @@ include:
   - k8s-version: "1.29"
     ip-family: "dual"
     # renovate: datasource=docker
-    kube-image: "quay.io/cilium/kindest-node:v1.29.0-rc.1@sha256:6631d58da3569930cf21697c2113feb9c76bc044c1c13d98808a3695dd91d8b0"
+    kube-image: "kindest/node:v1.29.1@sha256:a0cc28af37cf39b019e2b448c54d1a3f789de32536cb5a5db61a49623e527144"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
     kernel: "bpf-next-20240204.012837@sha256:5ea765f57df9ef4c8f67662617290c5574f0774f43025f57284ae1cc3b6f140e"
 

--- a/.github/actions/lvh-kind/action.yaml
+++ b/.github/actions/lvh-kind/action.yaml
@@ -37,7 +37,7 @@ runs:
         cmd: |
           cd /host
           if [ "${{ inputs.kind-image-vsn }}" != "" ]; then
-            export IMAGE=quay.io/cilium/kindest-node:${{ inputs.kind-image-vsn }}
+            export IMAGE=kindest/node:${{ inputs.kind-image-vsn }}
           fi
           ./contrib/scripts/kind.sh ${{ inputs.kind-params }} 0.0.0.0 6443
 

--- a/.github/kind-config-ipv6.yaml
+++ b/.github/kind-config-ipv6.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: quay.io/cilium/kindest-node:v1.29.0-rc.1
+    image: kindest/node:v1.29.1@sha256:a0cc28af37cf39b019e2b448c54d1a3f789de32536cb5a5db61a49623e527144
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -12,7 +12,7 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: quay.io/cilium/kindest-node:v1.29.0-rc.1
+    image: kindest/node:v1.29.1@sha256:a0cc28af37cf39b019e2b448c54d1a3f789de32536cb5a5db61a49623e527144
 networking:
   ipFamily: ipv6
   disableDefaultCNI: true

--- a/.github/kind-config.yaml
+++ b/.github/kind-config.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: quay.io/cilium/kindest-node:v1.29.0-rc.1
+    image: kindest/node:v1.29.1@sha256:a0cc28af37cf39b019e2b448c54d1a3f789de32536cb5a5db61a49623e527144
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -12,7 +12,7 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: quay.io/cilium/kindest-node:v1.29.0-rc.1
+    image: kindest/node:v1.29.1@sha256:a0cc28af37cf39b019e2b448c54d1a3f789de32536cb5a5db61a49623e527144
 networking:
   disableDefaultCNI: true
   podSubnet: "10.244.0.0/16"

--- a/.github/kind-config.yaml.tmpl
+++ b/.github/kind-config.yaml.tmpl
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: quay.io/cilium/kindest-node:${K8S_VERSION}
+    image: kindest/node:${K8S_VERSION}
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -12,9 +12,9 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: quay.io/cilium/kindest-node:${K8S_VERSION}
+    image: kindest/node:${K8S_VERSION}
   - role: worker
-    image: quay.io/cilium/kindest-node:${K8S_VERSION}
+    image: kindest/node:${K8S_VERSION}
 networking:
   disableDefaultCNI: true
   ipFamily: ${IPFAMILY}

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -57,8 +57,8 @@ concurrency:
 env:
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   kind_version: v0.20.0
-  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
-  k8s_version: v1.29.0-rc.1
+  # renovate: datasource=docker depName=kindest/node
+  k8s_version: v1.29.1
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
   clusterName1: cluster1-${{ github.run_id }}

--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -26,8 +26,8 @@ env:
   cluster_name: cilium-testing
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
-  k8s_version: v1.29.0-rc.1
+  # renovate: datasource=docker depName=kindest/node
+  k8s_version: v1.29.1
 
 jobs:
   kubernetes-e2e-net-conformance:
@@ -80,7 +80,7 @@ jobs:
         run: |
           cat <<EOF | /usr/local/bin/kind create cluster \
             --name ${{ env.cluster_name}}           \
-            --image quay.io/cilium/kindest-node:${{ env.k8s_version }}  \
+            --image kindest/node:${{ env.k8s_version }}  \
             -v7 --wait 1m --retain --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -26,8 +26,8 @@ env:
   cluster_name: cilium-testing
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
-  k8s_version: v1.29.0-rc.1
+  # renovate: datasource=docker depName=kindest/node
+  k8s_version: v1.29.1
 
 jobs:
   kubernetes-e2e:
@@ -80,7 +80,7 @@ jobs:
         run: |
           cat <<EOF | /usr/local/bin/kind create cluster \
             --name ${{ env.cluster_name}}           \
-            --image quay.io/cilium/kindest-node:${{ env.k8s_version }}  \
+            --image kindest/node:${{ env.k8s_version }}  \
             -v7 --wait 1m --retain --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -57,8 +57,8 @@ concurrency:
 env:
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   kind_version: v0.20.0
-  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
-  k8s_version: v1.29.0-rc.1
+  # renovate: datasource=docker depName=kindest/node
+  k8s_version: v1.29.1
   cilium_cli_ci_version:
 
   clusterName1: cluster1

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -53,8 +53,8 @@ concurrency:
 env:
   cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
-  k8s_version: v1.29.0-rc.1
+  # renovate: datasource=docker depName=kindest/node
+  k8s_version: v1.29.1
 
 jobs:
   commit-status-start:


### PR DESCRIPTION
Kind has released stable versions for k8s 1.29 so we can use this image instead of the cilium kindest.
