### PR TITLE
gateway-api: Supports the number of trusted loadbalancer hops

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -58,6 +58,7 @@ cilium-operator-alibabacloud [flags]
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-xff-num-trusted-hops uint32                 The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for cilium-operator-alibabacloud
       --identity-allocation-mode string                         Method to use for identity allocation (default "kvstore")

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -38,6 +38,7 @@ cilium-operator-alibabacloud hive [flags]
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-xff-num-trusted-hops uint32                 The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for hive
       --identity-gc-interval duration                           GC interval for security identities (default 15m0s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -44,6 +44,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-xff-num-trusted-hops uint32                 The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -66,6 +66,7 @@ cilium-operator-aws [flags]
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-xff-num-trusted-hops uint32                 The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for cilium-operator-aws
       --identity-allocation-mode string                         Method to use for identity allocation (default "kvstore")

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -38,6 +38,7 @@ cilium-operator-aws hive [flags]
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-xff-num-trusted-hops uint32                 The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for hive
       --identity-gc-interval duration                           GC interval for security identities (default 15m0s)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -44,6 +44,7 @@ cilium-operator-aws hive dot-graph [flags]
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-xff-num-trusted-hops uint32                 The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -61,6 +61,7 @@ cilium-operator-azure [flags]
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-xff-num-trusted-hops uint32                 The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for cilium-operator-azure
       --identity-allocation-mode string                         Method to use for identity allocation (default "kvstore")

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -38,6 +38,7 @@ cilium-operator-azure hive [flags]
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-xff-num-trusted-hops uint32                 The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for hive
       --identity-gc-interval duration                           GC interval for security identities (default 15m0s)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -44,6 +44,7 @@ cilium-operator-azure hive dot-graph [flags]
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-xff-num-trusted-hops uint32                 The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -57,6 +57,7 @@ cilium-operator-generic [flags]
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-xff-num-trusted-hops uint32                 The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for cilium-operator-generic
       --identity-allocation-mode string                         Method to use for identity allocation (default "kvstore")

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -38,6 +38,7 @@ cilium-operator-generic hive [flags]
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-xff-num-trusted-hops uint32                 The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for hive
       --identity-gc-interval duration                           GC interval for security identities (default 15m0s)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -44,6 +44,7 @@ cilium-operator-generic hive dot-graph [flags]
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-xff-num-trusted-hops uint32                 The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -71,6 +71,7 @@ cilium-operator [flags]
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-xff-num-trusted-hops uint32                 The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for cilium-operator
       --identity-allocation-mode string                         Method to use for identity allocation (default "kvstore")

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -38,6 +38,7 @@ cilium-operator hive [flags]
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-xff-num-trusted-hops uint32                 The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for hive
       --identity-gc-interval duration                           GC interval for security identities (default 15m0s)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -44,6 +44,7 @@ cilium-operator hive dot-graph [flags]
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-xff-num-trusted-hops uint32                 The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1440,6 +1440,10 @@
      - Enable secret sync, which will make sure all TLS secrets used by Ingress are synced to secretsNamespace.name. If disabled, TLS secrets must be maintained externally.
      - bool
      - ``true``
+   * - :spelling:ignore:`gatewayAPI.xffNumTrustedHops`
+     - The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+     - int
+     - ``0``
    * - :spelling:ignore:`gke.enabled`
      - Enable Google Kubernetes Engine integration
      - bool

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -410,6 +410,7 @@ contributors across the globe, there is almost always someone available to help.
 | gatewayAPI.secretsNamespace.create | bool | `true` | Create secrets namespace for Gateway API. |
 | gatewayAPI.secretsNamespace.name | string | `"cilium-secrets"` | Name of Gateway API secret namespace. |
 | gatewayAPI.secretsNamespace.sync | bool | `true` | Enable secret sync, which will make sure all TLS secrets used by Ingress are synced to secretsNamespace.name. If disabled, TLS secrets must be maintained externally. |
+| gatewayAPI.xffNumTrustedHops | int | `0` | The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address. |
 | gke.enabled | bool | `false` | Enable Google Kubernetes Engine integration |
 | healthChecking | bool | `true` | Enable connectivity health checking. |
 | healthPort | int | `9879` | TCP port for the agent health API. This is not the port for cilium-health. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -274,6 +274,7 @@ data:
   enable-gateway-api: "true"
   enable-gateway-api-secrets-sync: {{ .Values.gatewayAPI.secretsNamespace.sync | quote }}
   enable-gateway-api-proxy-protocol: {{ .Values.gatewayAPI.enableProxyProtocol | quote }}
+  gateway-api-xff-num-trusted-hops: {{ .Values.gatewayAPI.xffNumTrustedHops | quote }}
   gateway-api-secrets-namespace: {{ .Values.gatewayAPI.secretsNamespace.name | quote }}
   gateway-api-hostnetwork-enabled: {{ .Values.gatewayAPI.hostNetwork.enabled | quote }}
   gateway-api-hostnetwork-nodelabelselector: {{ include "mapToString" .Values.gatewayAPI.hostNetwork.nodes.matchLabels | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -695,6 +695,8 @@ gatewayAPI:
   enabled: false
   # -- Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
   enableProxyProtocol: false
+  # -- The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+  xffNumTrustedHops: 0
   # -- SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
   secretsNamespace:
     # -- Create secrets namespace for Gateway API.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -692,6 +692,8 @@ gatewayAPI:
   enabled: false
   # -- Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
   enableProxyProtocol: false
+  # -- The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+  xffNumTrustedHops: 0
   # -- SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
   secretsNamespace:
     # -- Create secrets namespace for Gateway API.

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -37,6 +37,7 @@ var Cell = cell.Module(
 		EnableGatewayAPISecretsSync:   true,
 		EnableGatewayAPIProxyProtocol: false,
 		GatewayAPISecretsNamespace:    "cilium-secrets",
+		GatewayAPIXffNumTrustedHops:   0,
 
 		GatewayAPIHostnetworkEnabled:           false,
 		GatewayAPIHostnetworkNodelabelselector: "",
@@ -61,6 +62,7 @@ type gatewayApiConfig struct {
 	EnableGatewayAPISecretsSync   bool
 	EnableGatewayAPIProxyProtocol bool
 	GatewayAPISecretsNamespace    string
+	GatewayAPIXffNumTrustedHops   uint32
 
 	GatewayAPIHostnetworkEnabled           bool
 	GatewayAPIHostnetworkNodelabelselector string
@@ -72,6 +74,7 @@ func (r gatewayApiConfig) Flags(flags *pflag.FlagSet) {
 
 	flags.Bool("enable-gateway-api-secrets-sync", r.EnableGatewayAPISecretsSync, "Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag)")
 	flags.Bool("enable-gateway-api-proxy-protocol", r.EnableGatewayAPIProxyProtocol, "Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.")
+	flags.Uint32("gateway-api-xff-num-trusted-hops", r.GatewayAPIXffNumTrustedHops, "The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.")
 	flags.String("gateway-api-secrets-namespace", r.GatewayAPISecretsNamespace, "Namespace having tls secrets used by CEC for Gateway API")
 	flags.Bool("gateway-api-hostnetwork-enabled", r.GatewayAPIHostnetworkEnabled, "Exposes Gateway listeners on the host network.")
 	flags.String("gateway-api-hostnetwork-nodelabelselector", r.GatewayAPIHostnetworkNodelabelselector, "Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'")
@@ -123,6 +126,7 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		translation.ParseNodeLabelSelector(params.GatewayApiConfig.GatewayAPIHostnetworkNodelabelselector),
 		params.AgentConfig.EnableIPv4,
 		params.AgentConfig.EnableIPv6,
+		params.GatewayApiConfig.GatewayAPIXffNumTrustedHops,
 	)
 
 	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, params.GatewayApiConfig.GatewayAPIHostnetworkEnabled)

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -235,7 +235,7 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 		WithStatusSubresource(&gatewayv1.Gateway{}).
 		Build()
 
-	cecTranslator := translation.NewCECTranslator("", false, true, 60, false, nil, false, false)
+	cecTranslator := translation.NewCECTranslator("", false, true, 60, false, nil, false, false, 0)
 	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, false)
 
 	r := &gatewayReconciler{

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -112,6 +112,7 @@ func registerReconciler(params ingressParams) error {
 		translation.ParseNodeLabelSelector(params.IngressConfig.IngressHostnetworkNodelabelselector),
 		params.AgentConfig.EnableIPv4,
 		params.AgentConfig.EnableIPv6,
+		operatorOption.Config.IngressProxyXffNumTrustedHops,
 	)
 
 	dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, params.IngressConfig.IngressHostnetworkEnabled)

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -60,7 +60,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -116,7 +116,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -172,7 +172,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -216,7 +216,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -286,7 +286,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -353,7 +353,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -407,7 +407,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -489,7 +489,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -561,7 +561,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -617,7 +617,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -657,7 +657,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -698,7 +698,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{"test.acme.io/"}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -783,7 +783,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -848,7 +848,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -890,7 +890,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -948,7 +948,7 @@ func TestReconcile(t *testing.T) {
 			}).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)

--- a/operator/pkg/model/translation/cec_translator.go
+++ b/operator/pkg/model/translation/cec_translator.go
@@ -47,18 +47,21 @@ type cecTranslator struct {
 	hostNameSuffixMatch bool
 
 	idleTimeoutSeconds int
+
+	xffNumTrustedHops uint32
 }
 
 // NewCECTranslator returns a new translator
 func NewCECTranslator(secretsNamespace string, useProxyProtocol bool, hostNameSuffixMatch bool, idleTimeoutSeconds int,
 	hostNetworkEnabled bool, hostNetworkNodeLabelSelector *slim_metav1.LabelSelector, ipv4Enabled bool, ipv6Enabled bool,
+	xffNumTrustedHops uint32,
 ) CECTranslator {
 	return &cecTranslator{
-		secretsNamespace:    secretsNamespace,
-		useProxyProtocol:    useProxyProtocol,
-		hostNameSuffixMatch: hostNameSuffixMatch,
-		idleTimeoutSeconds:  idleTimeoutSeconds,
-
+		secretsNamespace:             secretsNamespace,
+		useProxyProtocol:             useProxyProtocol,
+		hostNameSuffixMatch:          hostNameSuffixMatch,
+		idleTimeoutSeconds:           idleTimeoutSeconds,
+		xffNumTrustedHops:            xffNumTrustedHops,
 		hostNetworkEnabled:           hostNetworkEnabled,
 		hostNetworkNodeLabelSelector: hostNetworkNodeLabelSelector,
 		ipv4Enabled:                  ipv4Enabled,
@@ -156,6 +159,10 @@ func (i *cecTranslator) getHTTPRouteListener(m *model.Model) []ciliumv2.XDSResou
 
 	if i.hostNetworkEnabled {
 		mutatorFuncs = append(mutatorFuncs, WithHostNetworkPort(m.HTTP, i.ipv4Enabled, i.ipv6Enabled))
+	}
+
+	if i.xffNumTrustedHops > 0 {
+		mutatorFuncs = append(mutatorFuncs, WithXffNumTrustedHops(i.xffNumTrustedHops))
 	}
 
 	l, _ := NewHTTPListenerWithDefaults("listener", i.secretsNamespace, tlsMap, mutatorFuncs...)

--- a/operator/pkg/model/translation/envoy_http_connection_manager.go
+++ b/operator/pkg/model/translation/envoy_http_connection_manager.go
@@ -14,7 +14,6 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/envoy"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
@@ -80,11 +79,4 @@ func NewHTTPConnectionManager(name, routeName string, mutationFunc ...HttpConnec
 			Value:   connectionManagerBytes,
 		},
 	}, nil
-}
-
-func WithXffNumTrustedHops() func(*httpConnectionManagerv3.HttpConnectionManager) *httpConnectionManagerv3.HttpConnectionManager {
-	return func(connectionManager *httpConnectionManagerv3.HttpConnectionManager) *httpConnectionManagerv3.HttpConnectionManager {
-		connectionManager.XffNumTrustedHops = operatorOption.Config.IngressProxyXffNumTrustedHops
-		return connectionManager
-	}
 }

--- a/operator/pkg/model/translation/envoy_http_connection_manager_test.go
+++ b/operator/pkg/model/translation/envoy_http_connection_manager_test.go
@@ -9,8 +9,6 @@ import (
 	httpConnectionManagerv3 "github.com/cilium/proxy/go/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
-
-	operatorOption "github.com/cilium/cilium/operator/option"
 )
 
 func TestNewHTTPConnectionManager(t *testing.T) {
@@ -34,33 +32,4 @@ func TestNewHTTPConnectionManager(t *testing.T) {
 
 	require.Len(t, httpConnectionManager.GetUpgradeConfigs(), 1)
 	require.Equal(t, "websocket", httpConnectionManager.GetUpgradeConfigs()[0].UpgradeType)
-}
-
-func TestNewHTTPConnectionManagerWithXffNumTrustedHops(t *testing.T) {
-	res, err := NewHTTPConnectionManager("dummy-name", "dummy-route-name", WithXffNumTrustedHops())
-	require.Nil(t, err)
-
-	httpConnectionManager := &httpConnectionManagerv3.HttpConnectionManager{}
-	err = proto.Unmarshal(res.Value, httpConnectionManager)
-	require.Nil(t, err)
-
-	// Default value is 0
-	require.Equal(t, uint32(0), httpConnectionManager.XffNumTrustedHops)
-
-	var xffNumTrustedHops = uint32(1)
-
-	operatorOption.Config.IngressProxyXffNumTrustedHops = xffNumTrustedHops
-
-	defer func() {
-		// Restore the value after the test
-		operatorOption.Config.IngressProxyXffNumTrustedHops = uint32(0)
-	}()
-	res, err = NewHTTPConnectionManager("dummy-name", "dummy-route-name", WithXffNumTrustedHops())
-	require.Nil(t, err)
-
-	httpConnectionManager = &httpConnectionManagerv3.HttpConnectionManager{}
-	err = proto.Unmarshal(res.Value, httpConnectionManager)
-	require.Nil(t, err)
-	// Now it should be 1
-	require.Equal(t, xffNumTrustedHops, httpConnectionManager.XffNumTrustedHops)
 }

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
@@ -265,7 +265,7 @@ func Test_translator_Translate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			trans := &dedicatedIngressTranslator{
-				cecTranslator:      translation.NewCECTranslator("cilium-secrets", tt.args.useProxyProtocol, false, 60, tt.args.hostNetworkEnabled, tt.args.hostNetworkNodeLabelSelector, tt.args.ipv4Enabled, tt.args.ipv6Enabled),
+				cecTranslator:      translation.NewCECTranslator("cilium-secrets", tt.args.useProxyProtocol, false, 60, tt.args.hostNetworkEnabled, tt.args.hostNetworkNodeLabelSelector, tt.args.ipv4Enabled, tt.args.ipv6Enabled, 0),
 				hostNetworkEnabled: tt.args.hostNetworkEnabled,
 			}
 


### PR DESCRIPTION
Currently, cilium supports setting `xff_num_trusted_hops`, but it only supports [ingress](https://github.com/cilium/cilium/issues/24292).
This PR is to allow GatewayAPI to also set `xff_num_trusted_hops`.

In this way, we can set different values for the `xff_num_trusted_hops` of ingress and GatewayAPI.

Additionally, it seems that Istio already supports this feature.

https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/

```release-note
GatewayAPI supports to setting the number of trusted loadbalancer hops
```
