### PR TITLE
Fix renovate config for grpc_health_probe

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -499,7 +499,8 @@
     {
       "fileMatch": [
         "images/cilium/download-hubble\\.sh",
-        "images/runtime/build-gops.sh"
+        "images/runtime/build-gops.sh",
+        "images/hubble-relay/download-grpc-health-probe.sh"
       ],
       // These regexes manage version and digest strings in shell scripts,
       // similar to the examples shown here:


### PR DESCRIPTION
In #30643 we noticed that we forgot to add a file match so renovate did not update the dependency. This PR should fix that and renovate should start updating the dependency automatically.

Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)


