### PR TITLE
gke: Bump gke minimum versions

### DIFF
--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,10 +1,10 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.23"
+  - version: "1.25"
     zone: europe-west6-b
     vmIndex: 1
-  - version: "1.24"
+  - version: "1.26"
     zone: us-west2-a
     vmIndex: 2
     default: true


### PR DESCRIPTION
This is to avoid the below issue

```
ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=No valid versions with the prefix "1.24" found.
```