### PR TITLE
slices: don't modify input slices in test

### DIFF
--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -63,10 +64,11 @@ func TestUnique(t *testing.T) {
 func TestUniqueFunc(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			input := slices.Clone(tc.input)
 			got := UniqueFunc(
-				tc.input,
+				input,
 				func(i int) int {
-					return tc.input[i]
+					return input[i]
 				},
 			)
 			assert.ElementsMatch(t, tc.expected, got)
@@ -77,7 +79,8 @@ func TestUniqueFunc(t *testing.T) {
 func TestSortedUnique(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := SortedUnique(tc.input)
+			input := slices.Clone(tc.input)
+			got := SortedUnique(input)
 			assert.ElementsMatch(t, tc.expected, got)
 		})
 	}
@@ -86,10 +89,11 @@ func TestSortedUnique(t *testing.T) {
 func TestSortedUniqueFunc(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			input := slices.Clone(tc.input)
 			got := SortedUniqueFunc(
-				tc.input,
+				input,
 				func(i, j int) bool {
-					return tc.input[i] < tc.input[j]
+					return input[i] < input[j]
 				},
 				func(a, b int) bool {
 					return a == b


### PR DESCRIPTION
In Go 1.22, slices.CompactFunc will clear the slice elements that got discarded. This makes TestSortedUniqueFunc fail if it is run in succession to other tests modifying the input slice.

Avoid this case by not modifying the input slice in the test case but make a copy for the sake of the test.