### PR TITLE
IPAM: Refactors Node API Types to Support Separate IP Families

### DIFF
--- a/pkg/alibabacloud/eni/node.go
+++ b/pkg/alibabacloud/eni/node.go
@@ -104,7 +104,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 	n.mutex.RUnlock()
 
 	// Must allocate secondary ENI IPs as needed, up to ENI instance limit
-	toAllocate := math.IntMin(allocation.MaxIPsToAllocate, l.IPv4)
+	toAllocate := math.IntMin(allocation.IPv4.MaxIPsToAllocate, l.IPv4)
 	toAllocate = math.IntMin(maxENIIPCreate, toAllocate) // in first alloc no more than 10
 	// Validate whether request has already been fulfilled in the meantime
 	if toAllocate == 0 {
@@ -273,7 +273,7 @@ func (n *Node) PrepareIPAllocation(scopedLog *logrus.Entry) (*ipam.AllocationAct
 		if availableOnENI <= 0 {
 			continue
 		} else {
-			a.InterfaceCandidates++
+			a.IPv4.InterfaceCandidates++
 		}
 
 		scopedLog.WithFields(logrus.Fields{
@@ -290,7 +290,7 @@ func (n *Node) PrepareIPAllocation(scopedLog *logrus.Entry) (*ipam.AllocationAct
 
 				a.InterfaceID = key
 				a.PoolID = ipamTypes.PoolID(subnet.ID)
-				a.AvailableForAllocation = math.IntMin(subnet.AvailableAddresses, availableOnENI)
+				a.IPv4.AvailableForAllocation = math.IntMin(subnet.AvailableAddresses, availableOnENI)
 			}
 		}
 	}
@@ -300,7 +300,7 @@ func (n *Node) PrepareIPAllocation(scopedLog *logrus.Entry) (*ipam.AllocationAct
 
 // AllocateIPs performs the ENI allocation operation
 func (n *Node) AllocateIPs(ctx context.Context, a *ipam.AllocationAction) error {
-	_, err := n.manager.api.AssignPrivateIPAddresses(ctx, a.InterfaceID, a.AvailableForAllocation)
+	_, err := n.manager.api.AssignPrivateIPAddresses(ctx, a.InterfaceID, a.IPv4.AvailableForAllocation)
 	return err
 }
 

--- a/pkg/alibabacloud/eni/node_test.go
+++ b/pkg/alibabacloud/eni/node_test.go
@@ -89,14 +89,18 @@ func (e *ENISuite) TestCreateInterface(c *check.C) {
 	})
 
 	toAlloc, _, err := mngr.Get("node1").Ops().CreateInterface(context.Background(), &ipam.AllocationAction{
-		MaxIPsToAllocate:    10,
+		IPv4: ipam.IPAllocationAction{
+			MaxIPsToAllocate: 10,
+		},
 		EmptyInterfaceSlots: 2,
 	}, log)
 	c.Assert(err, check.IsNil)
 	c.Assert(toAlloc, check.Equals, 10)
 
 	toAlloc, _, err = mngr.Get("node1").Ops().CreateInterface(context.Background(), &ipam.AllocationAction{
-		MaxIPsToAllocate:    11,
+		IPv4: ipam.IPAllocationAction{
+			MaxIPsToAllocate: 11,
+		},
 		EmptyInterfaceSlots: 1,
 	}, log)
 	c.Assert(err, check.IsNil)
@@ -127,9 +131,9 @@ func (e *ENISuite) TestCandidateAndEmtpyInterfaces(c *check.C) {
 	a, err := node3.Ops().PrepareIPAllocation(log)
 	c.Assert(err, check.IsNil)
 	// 1 ENI attached, 1/3 IPs allocated, 0 empty slots left
-	c.Assert(a.InterfaceCandidates, check.Equals, 1)
+	c.Assert(a.IPv4.InterfaceCandidates, check.Equals, 1)
 	c.Assert(a.EmptyInterfaceSlots, check.Equals, 0)
-	c.Assert(node3.Stats().AvailableIPs, check.Equals, 1)
+	c.Assert(node3.Stats().IPv4.AvailableIPs, check.Equals, 1)
 }
 
 func (e *ENISuite) TestPrepareIPAllocation(c *check.C) {
@@ -143,11 +147,13 @@ func (e *ENISuite) TestPrepareIPAllocation(c *check.C) {
 	mngr.Upsert(newCiliumNode("node1", "i-1", "ecs.g7ne.large", "cn-hangzhou-i", "vpc-1"))
 	a, err := mngr.Get("node1").Ops().PrepareIPAllocation(log)
 	c.Assert(err, check.IsNil)
-	c.Assert(a.EmptyInterfaceSlots+a.InterfaceCandidates, check.Equals, 2)
+	c.Assert(a.EmptyInterfaceSlots+a.IPv4.InterfaceCandidates, check.Equals, 2)
 
 	// create one eni
 	toAlloc, _, err := mngr.Get("node1").Ops().CreateInterface(context.Background(), &ipam.AllocationAction{
-		MaxIPsToAllocate:    10,
+		IPv4: ipam.IPAllocationAction{
+			MaxIPsToAllocate: 10,
+		},
 		EmptyInterfaceSlots: 2,
 	}, log)
 	c.Assert(err, check.IsNil)
@@ -156,7 +162,7 @@ func (e *ENISuite) TestPrepareIPAllocation(c *check.C) {
 	// one eni left
 	a, err = mngr.Get("node1").Ops().PrepareIPAllocation(log)
 	c.Assert(err, check.IsNil)
-	c.Assert(a.EmptyInterfaceSlots+a.InterfaceCandidates, check.Equals, 1)
+	c.Assert(a.EmptyInterfaceSlots+a.IPv4.InterfaceCandidates, check.Equals, 1)
 }
 
 func (e *ENISuite) TestNode_allocENIIndex(c *check.C) {

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -137,8 +137,8 @@ func (e *ENISuite) TestNodeManagerDefaultAllocation(c *check.C) {
 
 	node := mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 8)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 8)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
 
 	// Use 7 out of 8 IPs
 	mngr.Upsert(updateCiliumNode(cn, 8, 7))
@@ -146,8 +146,8 @@ func (e *ENISuite) TestNodeManagerDefaultAllocation(c *check.C) {
 
 	node = mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 15)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 7)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 15)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 7)
 }
 
 // TestNodeManagerPrefixDelegation tests allocation with default parameters
@@ -180,8 +180,8 @@ func (e *ENISuite) TestNodeManagerPrefixDelegation(c *check.C) {
 
 	node := mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 16)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 16)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
 
 	// Use 12 out of 16 IPs
 	mngr.Upsert(updateCiliumNode(cn, 16, 12))
@@ -189,8 +189,8 @@ func (e *ENISuite) TestNodeManagerPrefixDelegation(c *check.C) {
 
 	node = mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 32)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 12)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 32)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 12)
 
 	node.Ops().PopulateStatusFields(cn)
 
@@ -214,8 +214,8 @@ func (e *ENISuite) TestNodeManagerPrefixDelegation(c *check.C) {
 	node = mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
 	// Should allocate only 1 additional IP after fallback, not an entire /28 prefix
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 33)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 25)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 33)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 25)
 }
 
 // TestNodeManagerENIWithSGTags tests ENI allocation + association with a SG based on tags
@@ -251,8 +251,8 @@ func (e *ENISuite) TestNodeManagerENIWithSGTags(c *check.C) {
 
 	node := mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 8)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 8)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
 
 	// Use 7 out of 8 IPs
 	mngr.Upsert(updateCiliumNode(cn, 8, 7))
@@ -260,8 +260,8 @@ func (e *ENISuite) TestNodeManagerENIWithSGTags(c *check.C) {
 
 	node = mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 15)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 7)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 15)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 7)
 
 	// At this point we have 2 enis, make a local copy
 	// and remove eth0 from the map
@@ -305,16 +305,16 @@ func (e *ENISuite) TestNodeManagerMinAllocate20(c *check.C) {
 
 	node := mngr.Get("node2")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 10)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 10)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
 
 	mngr.Upsert(updateCiliumNode(cn, 10, 8))
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
 
 	node = mngr.Get("node2")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 10)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 8)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 10)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 8)
 
 	// Change MinAllocate to 20
 	withIPAMPreAllocate(0)(cn)
@@ -326,8 +326,8 @@ func (e *ENISuite) TestNodeManagerMinAllocate20(c *check.C) {
 
 	node = mngr.Get("node2")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 20)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 8)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 20)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 8)
 }
 
 // TestNodeManagerMinAllocateAndPreallocate tests MinAllocate in combination with PreAllocate
@@ -360,16 +360,16 @@ func (e *ENISuite) TestNodeManagerMinAllocateAndPreallocate(c *check.C) {
 
 	node := mngr.Get("node2")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 10)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 10)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
 
 	// Use 9 out of 10 IPs, no additional IPs should be allocated
 	mngr.Upsert(updateCiliumNode(cn, 10, 9))
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
 	node = mngr.Get("node2")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 10)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 9)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 10)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 9)
 
 	// Use 10 out of 10 IPs, PreAllocate 1 must kick in and allocate an additional IP
 	mngr.Upsert(updateCiliumNode(cn, 10, 10))
@@ -378,16 +378,16 @@ func (e *ENISuite) TestNodeManagerMinAllocateAndPreallocate(c *check.C) {
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
 	node = mngr.Get("node2")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 11)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 10)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 11)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 10)
 
 	// Release some IPs, no additional IPs should be allocated
 	mngr.Upsert(updateCiliumNode(cn, 10, 8))
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
 	node = mngr.Get("node2")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 11)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 8)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 11)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 8)
 }
 
 // TestNodeManagerReleaseAddress tests PreAllocate, MinAllocate and MaxAboveWatermark
@@ -425,16 +425,16 @@ func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 	// available as 13 < 14 (interface limit)
 	node := mngr.Get("node3")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 13)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 13)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
 
 	// Use 11 out of 13 IPs, no additional IPs should be allocated
 	mngr.Upsert(updateCiliumNode(cn, 13, 11))
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node3", 0) }, 5*time.Second), check.IsNil)
 	node = mngr.Get("node3")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 13)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 11)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 13)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 11)
 
 	// Use 13 out of 13 IPs, PreAllocate 2 + MaxAboveWatermark 3 must kick in
 	// and allocate 5 additional IPs
@@ -442,8 +442,8 @@ func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node3", 0) }, 5*time.Second), check.IsNil)
 	node = mngr.Get("node3")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 18)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 13)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 18)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 13)
 
 	// Reduce used IPs to 10, this leads to 8 excess IPs but release
 	// occurs at interval based resync, so expect timeout at first
@@ -451,8 +451,8 @@ func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node3", 0) }, 2*time.Second), check.Not(check.IsNil))
 	node = mngr.Get("node3")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 18)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 10)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 18)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 10)
 
 	// Trigger resync manually, excess IPs should be released
 	// 10 used + 2 pre-allocate + 3 max-above-watermark => 15
@@ -488,8 +488,8 @@ func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node3", 0) }, 5*time.Second), check.IsNil)
 	node = mngr.Get("node3")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 13)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 10)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 13)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 10)
 }
 
 // TestNodeManagerENIExcludeInterfaceTags tests ENI allocation with interface exclusion
@@ -528,8 +528,8 @@ func (e *ENISuite) TestNodeManagerENIExcludeInterfaceTags(c *check.C) {
 
 	node := mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 8)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 8)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
 
 	// Checks that we have created a new interface, and not allocated any IPs
 	// to the existing one
@@ -548,8 +548,8 @@ func (e *ENISuite) TestNodeManagerENIExcludeInterfaceTags(c *check.C) {
 
 	node = mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 15)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 7)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 15)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 7)
 
 	// Unmanaged ENI remains unmanaged
 	eniNode.mutex.RLock()
@@ -589,8 +589,8 @@ func (e *ENISuite) TestNodeManagerExceedENICapacity(c *check.C) {
 
 	node := mngr.Get("node2")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 20)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 20)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
 
 	// Use 40 out of 42 available IPs, we should reach 0 address needed once we
 	// assigned the remaining 3 that the t2.xlarge instance type supports
@@ -602,8 +602,8 @@ func (e *ENISuite) TestNodeManagerExceedENICapacity(c *check.C) {
 
 	node = mngr.Get("node2")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 42)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 40)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 42)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 40)
 }
 
 // TestInterfaceCreatedInInitialSubnet tests that additional ENIs are allocated in the same subnet
@@ -645,8 +645,8 @@ func (e *ENISuite) TestInterfaceCreatedInInitialSubnet(c *check.C) {
 
 	node := mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 16)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 16)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
 
 	// Checks that we have created a new interface and that we did so in the same subnet.
 	eniNode, castOK := node.Ops().(*Node)
@@ -713,11 +713,11 @@ func (e *ENISuite) TestNodeManagerManyNodes(c *check.C) {
 
 		node := mngr.Get(s.name)
 		c.Assert(node, check.Not(check.IsNil))
-		if node.Stats().AvailableIPs < minAllocate {
-			c.Errorf("Node %s allocation shortage. expected at least: %d, allocated: %d", s.name, minAllocate, node.Stats().AvailableIPs)
+		if node.Stats().IPv4.AvailableIPs < minAllocate {
+			c.Errorf("Node %s allocation shortage. expected at least: %d, allocated: %d", s.name, minAllocate, node.Stats().IPv4.AvailableIPs)
 			c.Fail()
 		}
-		c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+		c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
 	}
 
 	// The above check returns as soon as the address requirements are met.
@@ -785,8 +785,8 @@ func (e *ENISuite) TestNodeManagerInstanceNotRunning(c *check.C) {
 
 	node := mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 0)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
 }
 
 // TestInstanceBeenDeleted verifies that instance deletion is correctly detected
@@ -819,8 +819,8 @@ func (e *ENISuite) TestInstanceBeenDeleted(c *check.C) {
 
 	node := mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 8)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 8)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
 
 	// Delete all enis attached to instance, this mocks the operation of
 	// deleting the instance. The deletion should be detected.
@@ -838,10 +838,10 @@ func (e *ENISuite) TestInstanceBeenDeleted(c *check.C) {
 	mngr.Upsert(updateCiliumNode(cn, 9, 2))
 
 	// Instance deletion detected, no allocation happened despite of the IP deficit.
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 8)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
-	c.Assert(node.Stats().NeededIPs, check.Equals, 0)
-	c.Assert(node.Stats().ExcessIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, 8)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.NeededIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.ExcessIPs, check.Equals, 0)
 }
 
 func benchmarkAllocWorker(c *check.C, workers int64, delay time.Duration, rateLimit float64, burst int) {

--- a/pkg/azure/ipam/ipam_test.go
+++ b/pkg/azure/ipam/ipam_test.go
@@ -193,8 +193,8 @@ func (e *IPAMSuite) TestIpamPreAllocate8(c *check.C) {
 
 	node := mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, preAllocate)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, preAllocate)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
 
 	// Use 7 out of 8 IPs
 	mngr.Upsert(updateCiliumNode(k8sapi.getLatestNode("node1"), toUse))
@@ -204,8 +204,8 @@ func (e *IPAMSuite) TestIpamPreAllocate8(c *check.C) {
 
 	node = mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, toUse+preAllocate)
-	c.Assert(node.Stats().UsedIPs, check.Equals, toUse)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, toUse+preAllocate)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, toUse)
 }
 
 // TestIpamMinAllocate10 tests IPAM with pre-allocation=8, min-allocate=10
@@ -255,8 +255,8 @@ func (e *IPAMSuite) TestIpamMinAllocate10(c *check.C) {
 
 	node := mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, minAllocate)
-	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, minAllocate)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
 
 	// Use 7 out of 10 IPs
 	mngr.Upsert(updateCiliumNode(k8sapi.getLatestNode("node1"), toUse))
@@ -266,8 +266,8 @@ func (e *IPAMSuite) TestIpamMinAllocate10(c *check.C) {
 
 	node = mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, toUse+preAllocate)
-	c.Assert(node.Stats().UsedIPs, check.Equals, toUse)
+	c.Assert(node.Stats().IPv4.AvailableIPs, check.Equals, toUse+preAllocate)
+	c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, toUse)
 
 	quota := instances.GetPoolQuota()
 	c.Assert(len(quota), check.Equals, 1)
@@ -327,11 +327,11 @@ func (e *IPAMSuite) TestIpamManyNodes(c *check.C) {
 
 		node := mngr.Get(s.name)
 		c.Assert(node, check.Not(check.IsNil))
-		if node.Stats().AvailableIPs != minAllocate {
-			c.Errorf("Node %s allocation mismatch. expected: %d allocated: %d", s.name, minAllocate, node.Stats().AvailableIPs)
+		if node.Stats().IPv4.AvailableIPs != minAllocate {
+			c.Errorf("Node %s allocation mismatch. expected: %d allocated: %d", s.name, minAllocate, node.Stats().IPv4.AvailableIPs)
 			c.Fail()
 		}
-		c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+		c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
 	}
 
 	// The above check returns as soon as the address requirements are met.

--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -82,7 +82,7 @@ func (n *Node) PrepareIPAllocation(scopedLog *logrus.Entry) (a *ipam.AllocationA
 			return nil
 		}
 
-		a.InterfaceCandidates++
+		a.IPv4.InterfaceCandidates++
 
 		if a.InterfaceID == "" {
 			scopedLog.WithFields(logrus.Fields{
@@ -107,7 +107,7 @@ func (n *Node) PrepareIPAllocation(scopedLog *logrus.Entry) (a *ipam.AllocationA
 				a.InterfaceID = iface.ID
 				a.Interface = interfaceObj
 				a.PoolID = poolID
-				a.AvailableForAllocation = math.IntMin(available, availableOnInterface)
+				a.IPv4.AvailableForAllocation = math.IntMin(available, availableOnInterface)
 			}
 		}
 		return nil
@@ -124,9 +124,9 @@ func (n *Node) AllocateIPs(ctx context.Context, a *ipam.AllocationAction) error 
 	}
 
 	if iface.GetVMScaleSetName() == "" {
-		return n.manager.api.AssignPrivateIpAddressesVM(ctx, string(a.PoolID), iface.Name, a.AvailableForAllocation)
+		return n.manager.api.AssignPrivateIpAddressesVM(ctx, string(a.PoolID), iface.Name, a.IPv4.AvailableForAllocation)
 	} else {
-		return n.manager.api.AssignPrivateIpAddressesVMSS(ctx, iface.GetVMID(), iface.GetVMScaleSetName(), string(a.PoolID), iface.Name, a.AvailableForAllocation)
+		return n.manager.api.AssignPrivateIpAddressesVMSS(ctx, iface.GetVMID(), iface.GetVMScaleSetName(), string(a.PoolID), iface.Name, a.IPv4.AvailableForAllocation)
 	}
 }
 

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -83,10 +83,10 @@ type Node struct {
 	// instanceStoppedRunning records when an instance was most recently set to not running
 	instanceStoppedRunning time.Time
 
-	// waitingForPoolMaintenance is true when the node is subject to an
-	// IP allocation or release which must be performed before another
-	// allocation or release can be attempted
-	waitingForPoolMaintenance bool
+	// ipv4Alloc represents IPv4-specific allocation attributes for this node
+	ipv4Alloc ipAllocAttrs
+
+	// TODO: Add support for IPv6 allocation: https://github.com/cilium/cilium/issues/19251
 
 	// resyncNeeded is set to the current time when a resync with the EC2
 	// API is required. The timestamp is required to ensure that this is
@@ -94,9 +94,6 @@ type Node struct {
 	// resyncNeeded. This is needed because resyncs and allocations happen
 	// in parallel.
 	resyncNeeded time.Time
-
-	// available is the map of IPs available to this node
-	available ipamTypes.AllocationMap
 
 	// manager is the NodeManager responsible for this node
 	manager *NodeManager
@@ -124,23 +121,45 @@ type Node struct {
 	// instances API is unstable
 	retry *trigger.Trigger
 
-	// Excess IPs from a cilium node would be marked for release only after a delay configured by excess-ip-release-delay
-	// flag. ipsMarkedForRelease tracks the IP and the timestamp at which it was marked for release.
+	// logLimiter rate limits potentially repeating warning logs
+	logLimiter logging.Limiter
+}
+
+// ipAllocAttrs represents IP-specific allocation attributes.
+type ipAllocAttrs struct {
+	// waitingForPoolMaintenance is true when the node is subject to an
+	// IP address allocation or release which must be performed before
+	// another allocation or release can be attempted
+	waitingForPoolMaintenance bool
+
+	// available is the map of IP addresses available to this node
+	available ipamTypes.AllocationMap
+
+	// Excess IP address from a cilium node would be marked for release only after a delay
+	// configured by excess-ip-release-delay flag. ipsMarkedForRelease tracks the IP and the
+	// timestamp at which it was marked for release.
 	ipsMarkedForRelease map[string]time.Time
 
-	// ipReleaseStatus tracks the state for every IP considered for release.
+	// ipReleaseStatus tracks the state for every IP address considered for release.
 	// IPAMMarkForRelease  : Marked for Release
 	// IPAMReadyForRelease : Acknowledged as safe to release by agent
 	// IPAMDoNotRelease    : Release request denied by agent
 	// IPAMReleased        : IP released by the operator
 	ipReleaseStatus map[string]string
-
-	// logLimiter rate limits potentially repeating warning logs
-	logLimiter logging.Limiter
 }
 
 // Statistics represent the IP allocation statistics of a node
 type Statistics struct {
+	// IPv4 represents IPv4-specific statistics.
+	IPv4 IPStatistics
+
+	// EmptyInterfaceSlots is the number of empty interface slots available
+	// for interfaces to be attached.
+	EmptyInterfaceSlots int
+}
+
+// IPStatistics represents IP-specific allocation statistics.
+type IPStatistics struct {
 	// UsedIPs is the number of IPs currently in use
 	UsedIPs int
 
@@ -167,10 +186,6 @@ type Statistics struct {
 	// InterfaceCandidates is the number of attached interfaces with IPs
 	// available for allocation.
 	InterfaceCandidates int
-
-	// EmptyInterfaceSlots is the number of empty interface slots available
-	// for interfaces to be attached
-	EmptyInterfaceSlots int
 }
 
 // IsRunning returns true if the node is considered to be running
@@ -273,13 +288,13 @@ func (n *Node) getMaxAllocate() int {
 // A negative number is returned to indicate release of addresses.
 func (n *Node) GetNeededAddresses() int {
 	stats := n.Stats()
-	if stats.NeededIPs > 0 {
-		return stats.NeededIPs
+	if stats.IPv4.NeededIPs > 0 {
+		return stats.IPv4.NeededIPs
 	}
-	if n.manager.releaseExcessIPs && stats.ExcessIPs > 0 {
+	if n.manager.releaseExcessIPs && stats.IPv4.ExcessIPs > 0 {
 		// Nodes are sorted by needed addresses, return negative values of excessIPs
 		// so that nodes with IP deficit are resolved first
-		return stats.ExcessIPs * -1
+		return stats.IPv4.ExcessIPs * -1
 	}
 	return 0
 }
@@ -359,13 +374,13 @@ func calculateExcessIPs(availableIPs, usedIPs, preAllocate, minAllocate, maxAbov
 
 func (n *Node) requirePoolMaintenance() {
 	n.mutex.Lock()
-	n.waitingForPoolMaintenance = true
+	n.ipv4Alloc.waitingForPoolMaintenance = true
 	n.mutex.Unlock()
 }
 
 func (n *Node) poolMaintenanceComplete() {
 	n.mutex.Lock()
-	n.waitingForPoolMaintenance = false
+	n.ipv4Alloc.waitingForPoolMaintenance = false
 	n.mutex.Unlock()
 }
 
@@ -441,33 +456,33 @@ func (n *Node) recalculate() {
 	if err != nil {
 		scopedLog.Warning("Instance not found! Please delete corresponding ciliumnode if instance has already been deleted.")
 		// Avoid any further action
-		n.stats.NeededIPs = 0
-		n.stats.ExcessIPs = 0
+		n.stats.IPv4.NeededIPs = 0
+		n.stats.IPv4.ExcessIPs = 0
 		return
 	}
 
-	n.available = a
-	n.stats.UsedIPs = len(n.resource.Status.IPAM.Used)
+	n.ipv4Alloc.available = a
+	n.stats.IPv4.UsedIPs = len(n.resource.Status.IPAM.Used)
 
 	// Get used IP count with prefixes included
-	usedIPForExcessCalc := n.stats.UsedIPs
+	usedIPForExcessCalc := n.stats.IPv4.UsedIPs
 	if n.ops.IsPrefixDelegated() {
 		usedIPForExcessCalc = n.ops.GetUsedIPWithPrefixes()
 	}
 
-	n.stats.AvailableIPs = len(n.available)
-	n.stats.NeededIPs = calculateNeededIPs(n.stats.AvailableIPs, n.stats.UsedIPs, n.getPreAllocate(), n.getMinAllocate(), n.getMaxAllocate())
-	n.stats.ExcessIPs = calculateExcessIPs(n.stats.AvailableIPs, usedIPForExcessCalc, n.getPreAllocate(), n.getMinAllocate(), n.getMaxAboveWatermark())
-	n.stats.RemainingInterfaces = stats.RemainingAvailableInterfaceCount
-	n.stats.Capacity = stats.NodeCapacity
+	n.stats.IPv4.AvailableIPs = len(n.ipv4Alloc.available)
+	n.stats.IPv4.NeededIPs = calculateNeededIPs(n.stats.IPv4.AvailableIPs, n.stats.IPv4.UsedIPs, n.getPreAllocate(), n.getMinAllocate(), n.getMaxAllocate())
+	n.stats.IPv4.ExcessIPs = calculateExcessIPs(n.stats.IPv4.AvailableIPs, usedIPForExcessCalc, n.getPreAllocate(), n.getMinAllocate(), n.getMaxAboveWatermark())
+	n.stats.IPv4.RemainingInterfaces = stats.RemainingAvailableInterfaceCount
+	n.stats.IPv4.Capacity = stats.NodeCapacity
 
 	scopedLog.WithFields(logrus.Fields{
-		"available":                 n.stats.AvailableIPs,
-		"capacity":                  n.stats.Capacity,
-		"used":                      n.stats.UsedIPs,
-		"toAlloc":                   n.stats.NeededIPs,
-		"toRelease":                 n.stats.ExcessIPs,
-		"waitingForPoolMaintenance": n.waitingForPoolMaintenance,
+		"available":                 n.stats.IPv4.AvailableIPs,
+		"capacity":                  n.stats.IPv4.Capacity,
+		"used":                      n.stats.IPv4.UsedIPs,
+		"toAlloc":                   n.stats.IPv4.NeededIPs,
+		"toRelease":                 n.stats.IPv4.ExcessIPs,
+		"waitingForPoolMaintenance": n.ipv4Alloc.waitingForPoolMaintenance,
 		"resyncNeeded":              n.resyncNeeded,
 		"remainingInterfaces":       stats.RemainingAvailableInterfaceCount,
 	}).Debug("Recalculated needed addresses")
@@ -476,7 +491,7 @@ func (n *Node) recalculate() {
 // allocationNeeded returns true if this node requires IPs to be allocated
 func (n *Node) allocationNeeded() (needed bool) {
 	n.mutex.RLock()
-	needed = !n.waitingForPoolMaintenance && n.resyncNeeded.IsZero() && n.stats.NeededIPs > 0
+	needed = !n.ipv4Alloc.waitingForPoolMaintenance && n.resyncNeeded.IsZero() && n.stats.IPv4.NeededIPs > 0
 	n.mutex.RUnlock()
 	return
 }
@@ -484,7 +499,7 @@ func (n *Node) allocationNeeded() (needed bool) {
 // releaseNeeded returns true if this node requires IPs to be released
 func (n *Node) releaseNeeded() (needed bool) {
 	n.mutex.RLock()
-	needed = n.manager.releaseExcessIPs && !n.waitingForPoolMaintenance && n.resyncNeeded.IsZero() && n.stats.ExcessIPs > 0
+	needed = n.manager.releaseExcessIPs && !n.ipv4Alloc.waitingForPoolMaintenance && n.resyncNeeded.IsZero() && n.stats.IPv4.ExcessIPs > 0
 	if n.resource != nil {
 		releaseInProgress := len(n.resource.Status.IPAM.ReleaseIPs) > 0
 		needed = needed || releaseInProgress
@@ -497,7 +512,7 @@ func (n *Node) releaseNeeded() (needed bool) {
 func (n *Node) Pool() (pool ipamTypes.AllocationMap) {
 	pool = ipamTypes.AllocationMap{}
 	n.mutex.RLock()
-	for k, allocationIP := range n.available {
+	for k, allocationIP := range n.ipv4Alloc.available {
 		pool[k] = allocationIP
 	}
 	n.mutex.RUnlock()
@@ -565,6 +580,17 @@ type AllocationAction struct {
 	// value such as "global" to indicate a single address pool.
 	PoolID ipamTypes.PoolID
 
+	// EmptyInterfaceSlots is the number of empty interface slots available
+	// for interfaces to be attached.
+	EmptyInterfaceSlots int
+
+	// IPv4 represents IPv4-specific allocation actions.
+	IPv4 IPAllocationAction
+}
+
+// IPAllocationAction is the IP-specific action to be taken to resolve allocation deficits
+// for a particular node.
+type IPAllocationAction struct {
 	// AvailableForAllocation is the number IPs available for allocation.
 	// If InterfaceID is set, then this number corresponds to the number of
 	// IPs available for allocation on that interface. This number may be
@@ -581,10 +607,6 @@ type AllocationAction struct {
 	// InterfaceCandidates is the number of attached interfaces with IPs
 	// available for allocation.
 	InterfaceCandidates int
-
-	// EmptyInterfaceSlots is the number of empty interface slots available
-	// for interfaces to be attached
-	EmptyInterfaceSlots int
 }
 
 // ReleaseAction is the action to be taken to resolve allocation excess for a
@@ -625,14 +647,14 @@ func (n *Node) determineMaintenanceAction() (*maintenanceAction, error) {
 
 	// Validate that the node still requires addresses to be released, the
 	// request may have been resolved in the meantime.
-	if n.manager.releaseExcessIPs && stats.ExcessIPs > 0 {
-		a.release = n.ops.PrepareIPRelease(stats.ExcessIPs, scopedLog)
+	if n.manager.releaseExcessIPs && stats.IPv4.ExcessIPs > 0 {
+		a.release = n.ops.PrepareIPRelease(stats.IPv4.ExcessIPs, scopedLog)
 		return a, nil
 	}
 
 	// Validate that the node still requires addresses to be allocated, the
 	// request may have been resolved in the meantime.
-	if stats.NeededIPs == 0 {
+	if stats.IPv4.NeededIPs == 0 {
 		return nil, nil
 	}
 
@@ -647,35 +669,35 @@ func (n *Node) determineMaintenanceAction() (*maintenanceAction, error) {
 		if n.logLimiter.Allow() {
 			scopedLog.WithError(err).Warningf("Unable to compute pending pods, will not surge-allocate")
 		}
-	} else if numPendingPods > stats.NeededIPs {
-		surgeAllocate = numPendingPods - stats.NeededIPs
+	} else if numPendingPods > stats.IPv4.NeededIPs {
+		surgeAllocate = numPendingPods - stats.IPv4.NeededIPs
 	}
 
 	n.mutex.RLock()
 	// handleIPAllocation() takes a min of MaxIPsToAllocate and IPs available for allocation on the interface.
 	// This makes sure we don't try to allocate more than what's available.
-	a.allocation.MaxIPsToAllocate = stats.NeededIPs + n.getMaxAboveWatermark() + surgeAllocate
+	a.allocation.IPv4.MaxIPsToAllocate = stats.IPv4.NeededIPs + n.getMaxAboveWatermark() + surgeAllocate
 	n.mutex.RUnlock()
 
 	if a.allocation != nil {
 		n.mutex.Lock()
-		n.stats.RemainingInterfaces = a.allocation.InterfaceCandidates + a.allocation.EmptyInterfaceSlots
+		n.stats.IPv4.RemainingInterfaces = a.allocation.IPv4.InterfaceCandidates + a.allocation.EmptyInterfaceSlots
 		stats = n.stats
 		n.mutex.Unlock()
 		scopedLog = scopedLog.WithFields(logrus.Fields{
 			"selectedInterface":      a.allocation.InterfaceID,
 			"selectedPoolID":         a.allocation.PoolID,
-			"maxIPsToAllocate":       a.allocation.MaxIPsToAllocate,
-			"availableForAllocation": a.allocation.AvailableForAllocation,
+			"maxIPsToAllocate":       a.allocation.IPv4.MaxIPsToAllocate,
+			"availableForAllocation": a.allocation.IPv4.AvailableForAllocation,
 			"emptyInterfaceSlots":    a.allocation.EmptyInterfaceSlots,
 		})
 	}
 
 	scopedLog.WithFields(logrus.Fields{
-		"available":           stats.AvailableIPs,
-		"used":                stats.UsedIPs,
-		"neededIPs":           stats.NeededIPs,
-		"remainingInterfaces": stats.RemainingInterfaces,
+		"available":           stats.IPv4.AvailableIPs,
+		"used":                stats.IPv4.UsedIPs,
+		"neededIPs":           stats.IPv4.NeededIPs,
+		"remainingInterfaces": stats.IPv4.RemainingInterfaces,
 	}).Info("Resolving IP deficit of node")
 
 	return a, nil
@@ -687,12 +709,12 @@ func (n *Node) determineMaintenanceAction() (*maintenanceAction, error) {
 func (n *Node) removeStaleReleaseIPs() {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
-	for ip, status := range n.ipReleaseStatus {
+	for ip, status := range n.ipv4Alloc.ipReleaseStatus {
 		if status != ipamOption.IPAMReleased {
 			continue
 		}
 		if _, ok := n.resource.Status.IPAM.ReleaseIPs[ip]; !ok {
-			delete(n.ipReleaseStatus, ip)
+			delete(n.ipv4Alloc.ipReleaseStatus, ip)
 		}
 	}
 }
@@ -714,9 +736,9 @@ func (n *Node) abortNoLongerExcessIPs(excessMap map[string]bool) {
 		if status == ipamOption.IPAMReleased {
 			continue
 		}
-		if status, ok := n.ipReleaseStatus[ip]; ok && status != ipamOption.IPAMReleased {
-			delete(n.ipsMarkedForRelease, ip)
-			delete(n.ipReleaseStatus, ip)
+		if status, ok := n.ipv4Alloc.ipReleaseStatus[ip]; ok && status != ipamOption.IPAMReleased {
+			delete(n.ipv4Alloc.ipsMarkedForRelease, ip)
+			delete(n.ipv4Alloc.ipReleaseStatus, ip)
 		}
 	}
 }
@@ -731,8 +753,8 @@ func (n *Node) handleIPReleaseResponse(markedIP string, ipsToRelease *[]string) 
 			case ipamOption.IPAMReadyForRelease:
 				*ipsToRelease = append(*ipsToRelease, markedIP)
 			case ipamOption.IPAMDoNotRelease:
-				delete(n.ipsMarkedForRelease, markedIP)
-				delete(n.ipReleaseStatus, markedIP)
+				delete(n.ipv4Alloc.ipsMarkedForRelease, markedIP)
+				delete(n.ipv4Alloc.ipReleaseStatus, markedIP)
 			}
 			// 'released' state is already handled in removeStaleReleaseIPs()
 			// Other states don't need additional handling.
@@ -745,7 +767,7 @@ func (n *Node) handleIPReleaseResponse(markedIP string, ipsToRelease *[]string) 
 func (n *Node) deleteLocalReleaseStatus(ip string) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
-	delete(n.ipReleaseStatus, ip)
+	delete(n.ipv4Alloc.ipReleaseStatus, ip)
 }
 
 // handleIPRelease implements IP release handshake needed for releasing excess IPs on the node.
@@ -770,18 +792,18 @@ func (n *Node) handleIPRelease(ctx context.Context, a *maintenanceAction) (insta
 	releaseTS := time.Now()
 	if a.release != nil && a.release.IPsToRelease != nil {
 		for _, ip := range a.release.IPsToRelease {
-			if _, ok := n.ipsMarkedForRelease[ip]; !ok {
-				n.ipsMarkedForRelease[ip] = releaseTS
+			if _, ok := n.ipv4Alloc.ipsMarkedForRelease[ip]; !ok {
+				n.ipv4Alloc.ipsMarkedForRelease[ip] = releaseTS
 			}
 		}
 	}
 
-	if n.ipsMarkedForRelease == nil || a.release == nil || len(a.release.IPsToRelease) == 0 {
+	if n.ipv4Alloc.ipsMarkedForRelease == nil || a.release == nil || len(a.release.IPsToRelease) == 0 {
 		// Resetting ipsMarkedForRelease if there are no IPs to release in this iteration
-		n.ipsMarkedForRelease = make(map[string]time.Time)
+		n.ipv4Alloc.ipsMarkedForRelease = make(map[string]time.Time)
 	}
 
-	for markedIP, ts := range n.ipsMarkedForRelease {
+	for markedIP, ts := range n.ipv4Alloc.ipsMarkedForRelease {
 		// Determine which IPs are still marked for release.
 		stillMarkedForRelease := false
 		for _, ip := range a.release.IPsToRelease {
@@ -794,7 +816,7 @@ func (n *Node) handleIPRelease(ctx context.Context, a *maintenanceAction) (insta
 			// n.determineMaintenanceAction() only returns the IPs on the interface with maximum number of IPs that
 			// can be freed up. If the selected interface changes or if this IP is not excess anymore, remove entry
 			// from local maps.
-			delete(n.ipsMarkedForRelease, markedIP)
+			delete(n.ipv4Alloc.ipsMarkedForRelease, markedIP)
 			n.deleteLocalReleaseStatus(markedIP)
 			continue
 		}
@@ -813,7 +835,7 @@ func (n *Node) handleIPRelease(ctx context.Context, a *maintenanceAction) (insta
 	n.mutex.Lock()
 	for _, ip := range ipsToMark {
 		scopedLog.WithFields(logrus.Fields{logfields.IPAddr: ip}).Debug("Marking IP for release")
-		n.ipReleaseStatus[ip] = ipamOption.IPAMMarkForRelease
+		n.ipv4Alloc.ipReleaseStatus[ip] = ipamOption.IPAMMarkForRelease
 	}
 	n.mutex.Unlock()
 
@@ -830,9 +852,9 @@ func (n *Node) handleIPRelease(ctx context.Context, a *maintenanceAction) (insta
 	if len(ipsToRelease) > 0 {
 		a.release.IPsToRelease = ipsToRelease
 		scopedLog = scopedLog.WithFields(logrus.Fields{
-			"available":         n.stats.AvailableIPs,
-			"used":              n.stats.UsedIPs,
-			"excess":            n.stats.ExcessIPs,
+			"available":         n.stats.IPv4.AvailableIPs,
+			"used":              n.stats.IPv4.UsedIPs,
+			"excess":            n.stats.IPv4.ExcessIPs,
 			"excessIps":         a.release.IPsToRelease,
 			"releasing":         ipsToRelease,
 			"selectedInterface": a.release.InterfaceID,
@@ -848,8 +870,8 @@ func (n *Node) handleIPRelease(ctx context.Context, a *maintenanceAction) (insta
 			// Remove the IPs from ipsMarkedForRelease
 			n.mutex.Lock()
 			for _, ip := range ipsToRelease {
-				delete(n.ipsMarkedForRelease, ip)
-				n.ipReleaseStatus[ip] = ipamOption.IPAMReleased
+				delete(n.ipv4Alloc.ipsMarkedForRelease, ip)
+				n.ipv4Alloc.ipReleaseStatus[ip] = ipamOption.IPAMReleased
 			}
 			n.mutex.Unlock()
 			return true, nil
@@ -874,21 +896,21 @@ func (n *Node) handleIPAllocation(ctx context.Context, a *maintenanceAction) (in
 	}
 
 	// Assign needed addresses
-	if a.allocation.AvailableForAllocation > 0 {
-		a.allocation.AvailableForAllocation = math.IntMin(a.allocation.AvailableForAllocation, a.allocation.MaxIPsToAllocate)
+	if a.allocation.IPv4.AvailableForAllocation > 0 {
+		a.allocation.IPv4.AvailableForAllocation = math.IntMin(a.allocation.IPv4.AvailableForAllocation, a.allocation.IPv4.MaxIPsToAllocate)
 
 		start := time.Now()
 		err := n.ops.AllocateIPs(ctx, a.allocation)
 		if err == nil {
 			n.manager.metricsAPI.AllocationAttempt(allocateIP, success, string(a.allocation.PoolID), metrics.SinceInSeconds(start))
-			n.manager.metricsAPI.AddIPAllocation(string(a.allocation.PoolID), int64(a.allocation.AvailableForAllocation))
+			n.manager.metricsAPI.AddIPAllocation(string(a.allocation.PoolID), int64(a.allocation.IPv4.AvailableForAllocation))
 			return true, nil
 		}
 
 		n.manager.metricsAPI.AllocationAttempt(allocateIP, failed, string(a.allocation.PoolID), metrics.SinceInSeconds(start))
 		scopedLog.WithFields(logrus.Fields{
 			"selectedInterface": a.allocation.InterfaceID,
-			"ipsToAllocate":     a.allocation.AvailableForAllocation,
+			"ipsToAllocate":     a.allocation.IPv4.AvailableForAllocation,
 		}).WithError(err).Warning("Unable to assign additional IPs to interface, will create new interface")
 	}
 
@@ -984,7 +1006,7 @@ func (n *Node) PopulateIPReleaseStatus(node *v2.CiliumNode) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 	releaseStatus := make(map[string]ipamTypes.IPReleaseStatus)
-	for ip, status := range n.ipReleaseStatus {
+	for ip, status := range n.ipv4Alloc.ipReleaseStatus {
 		if existingStatus, ok := node.Status.IPAM.ReleaseIPs[ip]; ok && status == ipamOption.IPAMMarkForRelease {
 			// retain status if agent already responded to this IP
 			if existingStatus == ipamOption.IPAMReadyForRelease || existingStatus == ipamOption.IPAMDoNotRelease {


### PR DESCRIPTION
Previously, the IPAM Node type represented IP information such as pools, allocations, etc. that are specific to IPv4. This PR introduces the following changes:

- Adds the IPAllocAttrs type to represent IP-specific allocation attributes.
- Updates the Node type to expose separate attributes for IPv4 and IPv6.
- Updates Node instantiation, methods, etc. for the Node type changes introduced in this PR.
- Updates the internal resyncStats API to expose separate attributes for IPv4
  and IPv6 node statistics.
- Updates the AllocationAction API to expose separate IP allocation attributes for IPv4
  and IPv6.
- Updates cloud provider IPAM pkgs for API changes.

__Note:__ This PR does not implement IPv6 Node attributes.

Supports: #19251