### PR TITLE
gateway-api: Ensure hostname check  when set on both the HTTPRoute and the Gateway Listener

### DIFF
--- a/operator/pkg/gateway-api/routechecks/gateway_checks.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks.go
@@ -24,6 +24,7 @@ func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentRefe
 
 		return false, nil
 	}
+
 	hasNamespaceRestriction := false
 	for _, listener := range gw.Spec.Listeners {
 
@@ -34,9 +35,15 @@ func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentRefe
 		if listener.AllowedRoutes.Namespaces == nil {
 			continue
 		}
+
 		if parentRef.SectionName != nil && listener.Name != *parentRef.SectionName {
 			continue
 		}
+
+		if listener.Hostname != nil && (len(computeHostsForListener(&listener, input.GetHostnames())) > 0) {
+			continue
+		}
+
 		// if gateway allows all namespaces, we do not need to check anything here
 		if *listener.AllowedRoutes.Namespaces.From == gatewayv1.NamespacesFromAll {
 			return true, nil


### PR DESCRIPTION
# Description

This PR ensures that the `gateway_checks` code for the operator respects the `hostname` field, when it is set on both the `HTTPRoute` and the `Gateway` listener. Per the text of `kubectl explain gateway.spec.listeners.hostname`:

```
     For HTTPRoute and TLSRoute resources, there is an interaction with the
    `spec.hostnames` array. When both listener and route specify hostnames,
    there MUST be an intersection between the values for a Route to be accepted.
```

# Contribution Text

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #30685

```release-note
gateway-api: Ensure hostname check when set on both the HTTPRoute and the Gateway Listener
```
