### PR TITLE
Fix indexing of routes

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -130,6 +130,7 @@ jobs:
             kernel: '6.1-20240201.165956'
             kube-proxy: 'none'
             kpr: 'true'
+            devices: '{eth0,eth1}'
             tunnel: 'vxlan'
             lb-mode: 'snat'
             egress-gateway: 'true'

--- a/pkg/datapath/linux/devices_test.go
+++ b/pkg/datapath/linux/devices_test.go
@@ -488,6 +488,44 @@ func addRoute(p addRouteParams) error {
 	return nil
 }
 
+func delRoute(p addRouteParams) error {
+	link, err := netlink.LinkByName(p.iface)
+	if err != nil {
+		return err
+	}
+
+	var dst *net.IPNet
+	if p.dst != "" {
+		_, dst, err = net.ParseCIDR(p.dst)
+		if err != nil {
+			return err
+		}
+	}
+
+	var src net.IP
+	if p.src != "" {
+		src = net.ParseIP(p.src)
+	}
+
+	if p.table == 0 {
+		p.table = unix.RT_TABLE_MAIN
+	}
+
+	route := &netlink.Route{
+		LinkIndex: link.Attrs().Index,
+		Dst:       dst,
+		Src:       src,
+		Gw:        net.ParseIP(p.gw),
+		Table:     p.table,
+		Scope:     p.scope,
+	}
+	if err := netlink.RouteDel(route); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func delRoutes(iface string) error {
 	link, err := netlink.LinkByName(iface)
 	if err != nil {


### PR DESCRIPTION
The RouteID.Key() was supposed to make a composite key from 'table + index + destination', but due to a copy-paste brainfart the composite index was 'table + table + destination'.

Fix Key() to correctly build the key. While at it, make it more efficient by pre-allocating the correct fixed-size byte slice.
  
Fixes: #30563
Fixes: 8abf620c714f ("devices_controller: Switched devices and routes from StateDB to StateDB2")

```release-note
Fix bug in indexing of routes that lead to veth devices being considered native devices, which caused the wrong BPF program to be loaded onto them.
```
