### PR TITLE
envoy: Bump envoy version to v1.26.7

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1051,7 +1051,7 @@
    * - :spelling:ignore:`envoy.image`
      - Envoy container image.
      - object
-     - ``{"digest":"sha256:b62a70c2229d3404ff959f9f642211ef34bb47dd910f3fa63caaacc3ed9b5ccf","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.26.6-79d0a5128aa4b19abf7784cec499022391c77d6a","useDigest":true}``
+     - ``{"digest":"sha256:e77adfe8a263fe4b8c56dcb9bd0f4d68bb36067602e7be1388528c02fb8765c5","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.26.7-39dc41f86c465d2a2d16386339dc0bf4d425babc","useDigest":true}``
    * - :spelling:ignore:`envoy.livenessProbe.failureThreshold`
      - failure threshold of liveness probe
      - int

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:92994197c02e130a551323090
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.26.6-79d0a5128aa4b19abf7784cec499022391c77d6a@sha256:b62a70c2229d3404ff959f9f642211ef34bb47dd910f3fa63caaacc3ed9b5ccf as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.26.7-39dc41f86c465d2a2d16386339dc0bf4d425babc@sha256:e77adfe8a263fe4b8c56dcb9bd0f4d68bb36067602e7be1388528c02fb8765c5 as cilium-envoy
 
 #
 # Hubble CLI

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -312,7 +312,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:b62a70c2229d3404ff959f9f642211ef34bb47dd910f3fa63caaacc3ed9b5ccf","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.26.6-79d0a5128aa4b19abf7784cec499022391c77d6a","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:e77adfe8a263fe4b8c56dcb9bd0f4d68bb36067602e7be1388528c02fb8765c5","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.26.7-39dc41f86c465d2a2d16386339dc0bf4d425babc","useDigest":true}` | Envoy container image. |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | envoy.log.format | string | `"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"` | The format string to use for laying out the log message metadata of Envoy. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1857,9 +1857,9 @@ envoy:
   image:
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.26.6-79d0a5128aa4b19abf7784cec499022391c77d6a"
+    tag: "v1.26.7-39dc41f86c465d2a2d16386339dc0bf4d425babc"
     pullPolicy: "IfNotPresent"
-    digest: "sha256:b62a70c2229d3404ff959f9f642211ef34bb47dd910f3fa63caaacc3ed9b5ccf"
+    digest: "sha256:e77adfe8a263fe4b8c56dcb9bd0f4d68bb36067602e7be1388528c02fb8765c5"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1854,9 +1854,9 @@ envoy:
   image:
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.26.6-79d0a5128aa4b19abf7784cec499022391c77d6a"
+    tag: "v1.26.7-39dc41f86c465d2a2d16386339dc0bf4d425babc"
     pullPolicy: "${PULL_POLICY}"
-    digest: "sha256:b62a70c2229d3404ff959f9f642211ef34bb47dd910f3fa63caaacc3ed9b5ccf"
+    digest: "sha256:e77adfe8a263fe4b8c56dcb9bd0f4d68bb36067602e7be1388528c02fb8765c5"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.


### PR DESCRIPTION
This is mainly for below security fixes

- [CVE-2024-23324](https://github.com/envoyproxy/envoy/security/advisories/GHSA-gq3v-vvhj-96j6)
- [CVE-2024-23325](https://github.com/envoyproxy/envoy/security/advisories/GHSA-5m7c-mrwr-pm26)
- [CVE-2024-23322](https://github.com/envoyproxy/envoy/security/advisories/GHSA-6p83-mfmh-qv38)
- [CVE-2024-23323](https://github.com/envoyproxy/envoy/security/advisories/GHSA-x278-4w4x-r7ch)
- [CVE-2024-23327](https://github.com/envoyproxy/envoy/security/advisories/GHSA-4h5x-x9vh-m29j)

Related build: https://github.com/cilium/proxy/actions/runs/7849677399/job/21423527703
Upstream release: https://github.com/envoyproxy/envoy/releases/tag/v1.26.7

