### PR TITLE
envoy: Bump envoy version to v1.26.7

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -7,7 +7,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:112ec8fbb1e6a29932ae50ec9
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.26-79d0a5128aa4b19abf7784cec499022391c77d6a@sha256:b62a70c2229d3404ff959f9f642211ef34bb47dd910f3fa63caaacc3ed9b5ccf as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.26-39dc41f86c465d2a2d16386339dc0bf4d425babc@sha256:e77adfe8a263fe4b8c56dcb9bd0f4d68bb36067602e7be1388528c02fb8765c5 as cilium-envoy
 
 #
 # Hubble CLI


### PR DESCRIPTION
This is mainly for below security fixes

- [CVE-2024-23324](https://github.com/envoyproxy/envoy/security/advisories/GHSA-gq3v-vvhj-96j6)
- [CVE-2024-23325](https://github.com/envoyproxy/envoy/security/advisories/GHSA-5m7c-mrwr-pm26)
- [CVE-2024-23322](https://github.com/envoyproxy/envoy/security/advisories/GHSA-6p83-mfmh-qv38)
- [CVE-2024-23323](https://github.com/envoyproxy/envoy/security/advisories/GHSA-x278-4w4x-r7ch)
- [CVE-2024-23327](https://github.com/envoyproxy/envoy/security/advisories/GHSA-4h5x-x9vh-m29j)

Related build: https://github.com/cilium/proxy/actions/runs/7849677399/job/21423527703
Upstream release: https://github.com/envoyproxy/envoy/releases/tag/v1.26.7
