### PR TITLE
bug_fix: updating the parseKernelVersion() function

### DIFF
--- a/pkg/version/version_unix.go
+++ b/pkg/version/version_unix.go
@@ -18,23 +18,33 @@ import (
 
 func parseKernelVersion(ver string) (semver.Version, error) {
 	verStrs := strings.Split(ver, ".")
-	switch {
-	case len(verStrs) < 2:
+
+	// We are assuming the kernel version will be one of the following:
+	// 4.9.17-040917-generic or 4.9-040917-generic or 4-generic
+	// So as observed, the kernel value is N.N.N-m or N.N-m or N-m
+	// This implies the len(verStrs) should be between 1 and 3
+
+	if len(verStrs) < 1 || len(verStrs) > 3 {
 		return semver.Version{}, fmt.Errorf("unable to get kernel version from %q", ver)
-	case len(verStrs) < 3:
+	}
+
+	// Given the observations, we use regular expression to extract
+	// the patch number from the last element of the verStrs array and
+	// append "0" to the verStrs array in case the until its length is
+	// 3 as in all cases we want to return from this function :
+	// Major.Minor.PatchNumber
+
+	patch := regexp.MustCompilePOSIX(`^[0-9]+`).FindString(verStrs[len(verStrs)-1])
+	if patch == "" {
+		verStrs[len(verStrs)-1] = "0"
+	} else {
+		verStrs[len(verStrs)-1] = patch
+	}
+
+	for len(verStrs) < 3 {
 		verStrs = append(verStrs, "0")
 	}
-	// We are assuming the kernel version will be something as:
-	// 4.9.17-040917-generic
 
-	// If verStrs is []string{ "4", "9", "17-040917-generic" }
-	// then we need to retrieve patch number.
-	patch := regexp.MustCompilePOSIX(`^[0-9]+`).FindString(verStrs[2])
-	if patch == "" {
-		verStrs[2] = "0"
-	} else {
-		verStrs[2] = patch
-	}
 	return versioncheck.Version(strings.Join(verStrs[:3], "."))
 }
 

--- a/pkg/version/version_unix_test.go
+++ b/pkg/version/version_unix_test.go
@@ -30,6 +30,11 @@ func (vs *VersionSuite) TestParseKernelVersion(c *C) {
 		{"4.14.0-rc7+", mustHaveVersion("4.14.0")},
 		{"4.9.17-040917-generic", mustHaveVersion("4.9.17")},
 		{"4.9.generic", mustHaveVersion("4.9.0")},
+		{"6.5.0-15-generic", mustHaveVersion("6.5.0")},
+		{"6.7-amd64", mustHaveVersion("6.7.0")},
+		{"6.5-15-generic", mustHaveVersion("6.5.0")},
+		{"6.5.2-rc8+", mustHaveVersion("6.5.2")},
+		{"6-generic", mustHaveVersion("6.0.0")},
 	}
 	for _, tt := range flagtests {
 		s, err := parseKernelVersion(tt.in)


### PR DESCRIPTION
Previously, Cilium expects the kernel version to always have 3 digits.
However, the kernel is perfectly allowed to have only 2 or even only 1 digit
for the version number.
https://github.com/torvalds/linux/blob/35a4474b5c3dd4315f72bd53e87b97f128d9bb3d/Makefile#L367

This patch makes changes to the following :
- cilium/pkg/version/version_unix.go - updated the parseKernelVersion() to
handle single as well double digit kernel versions along with the standard
kernel versioning.
- cilium/pkg/version/version_unix_test.go - added additional test cases

Fixes: https://github.com/cilium/cilium/issues/30630

Signed-off-by: MeherRushi <meherrushi2@gmail.com>

### Description of change
The issue #30630 address that kernel versions of single and double digit are not being parsed by cilium. I have updated the parseKernelVersion() to handle this case.

Previously the assumption was that kernel version will be something as:
	4.9.17-040917-generic

I have updated it based on the following:

	We are assuming the kernel version will be one of the following:
	4.9.17-040917-generic or 4.9-040917-generic or 4-generic

	So as observered the kernel value is N.N.N-m or N.N-m or N-m
	There for we use regular expresions to extract the patch number
	from the last element of the verStrs array and append "0" to 
	the verStrs array in case the until its lenght is 3 as in all
	cases we want to return from this function : Major.Minor.PatchNumber
	
@lmb @tklauser Please do review the change in code. If it is correct, I also plan on adding test cases for the same

Fixes: #30630 

```release-note
Updated Kernel parsing to handle single and double digit kernel version as well
```