### PR TITLE
bpf: lb: clean up REV_NAT_F_TUPLE_SADDR parts in RevDNAT logic

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1529,7 +1529,8 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, int ifindex, __u32 src_
 			int ret2;
 
 			ret2 = lb6_rev_nat(ctx, l4_off,
-					   ct_state->rev_nat_index, tuple, 0);
+					   ct_state->rev_nat_index, tuple,
+					   REV_NAT_F_TUPLE_SADDR);
 			if (IS_ERR(ret2))
 				return ret2;
 		}

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1011,7 +1011,8 @@ ct_recreate4:
 		if (ct_state->rev_nat_index && ct_state->loopback) {
 			ret = lb4_rev_nat(ctx, ETH_HLEN, l4_off,
 					  ct_state->rev_nat_index,
-					  true, tuple, 0, has_l4_header);
+					  true, tuple, REV_NAT_F_TUPLE_SADDR,
+					  has_l4_header);
 			if (IS_ERR(ret))
 				return ret;
 		}

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1008,11 +1008,10 @@ ct_recreate4:
 #endif /* ENABLE_NODEPORT */
 
 		/* RevNAT for replies on a loopback connection: */
-		if (ct_state->rev_nat_index) {
+		if (ct_state->rev_nat_index && ct_state->loopback) {
 			ret = lb4_rev_nat(ctx, ETH_HLEN, l4_off,
 					  ct_state->rev_nat_index,
-					  ct_state->loopback,
-					  tuple, 0, has_l4_header);
+					  true, tuple, 0, has_l4_header);
 			if (IS_ERR(ret))
 				return ret;
 		}

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1011,8 +1011,7 @@ ct_recreate4:
 		if (ct_state->rev_nat_index && ct_state->loopback) {
 			ret = lb4_rev_nat(ctx, ETH_HLEN, l4_off,
 					  ct_state->rev_nat_index,
-					  true, tuple, REV_NAT_F_TUPLE_SADDR,
-					  has_l4_header);
+					  true, tuple, has_l4_header);
 			if (IS_ERR(ret))
 				return ret;
 		}
@@ -1529,8 +1528,7 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, int ifindex, __u32 src_
 			int ret2;
 
 			ret2 = lb6_rev_nat(ctx, l4_off,
-					   ct_state->rev_nat_index, tuple,
-					   REV_NAT_F_TUPLE_SADDR);
+					   ct_state->rev_nat_index, tuple);
 			if (IS_ERR(ret2))
 				return ret2;
 		}
@@ -1865,8 +1863,7 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, int ifindex, __u32 src_la
 
 			ret2 = lb4_rev_nat(ctx, ETH_HLEN, l4_off,
 					   ct_state->rev_nat_index, false,
-					   tuple, REV_NAT_F_TUPLE_SADDR,
-					   has_l4_header);
+					   tuple, has_l4_header);
 			if (IS_ERR(ret2))
 				return ret2;
 		}

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1065,10 +1065,7 @@ static __always_inline int __lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int
 		 * current packet. We therefore need to make the current source
 		 * address the new destination address.
 		 */
-		__be32 old_dip;
-
-		if (ctx_load_bytes(ctx, l3_off + offsetof(struct iphdr, daddr), &old_dip, 4) < 0)
-			return DROP_INVALID;
+		__be32 old_dip = tuple->daddr;
 
 		cilium_dbg_lb(ctx, DBG_LB4_LOOPBACK_SNAT_REV, old_dip, old_sip);
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -949,7 +949,7 @@ nodeport_rev_dnat_ingress_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 			return ret;
 
 		ret = lb6_rev_nat(ctx, l4_off, ct_state.rev_nat_index,
-				  &tuple, REV_NAT_F_TUPLE_SADDR);
+				  &tuple);
 		if (IS_ERR(ret))
 			return ret;
 		if (!revalidate_data(ctx, &data, &data_end, &ip6))
@@ -1502,8 +1502,7 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 
-		ret = __lb6_rev_nat(ctx, l4_off, &tuple, REV_NAT_F_TUPLE_SADDR,
-				    nat_info);
+		ret = __lb6_rev_nat(ctx, l4_off, &tuple, nat_info);
 		if (IS_ERR(ret))
 			return ret;
 
@@ -2438,7 +2437,7 @@ nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 		ret = lb4_rev_nat(ctx, l3_off, l4_off, ct_state.rev_nat_index, false,
-				  &tuple, REV_NAT_F_TUPLE_SADDR, has_l4_header);
+				  &tuple, has_l4_header);
 		if (IS_ERR(ret))
 			return ret;
 		if (!revalidate_data(ctx, &data, &data_end, &ip4))
@@ -3062,8 +3061,7 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 		trace->reason = TRACE_REASON_CT_REPLY;
 
 		ret = __lb4_rev_nat(ctx, l3_off, l4_off, &tuple,
-				    REV_NAT_F_TUPLE_SADDR, nat_info,
-				    false, has_l4_header);
+				    nat_info, false, has_l4_header);
 		if (IS_ERR(ret))
 			return ret;
 


### PR DESCRIPTION
Harmonize the various RevDNAT parts to use the provided CT tuple, and not peek at the packet headers.

As side-effect, the CT tuple now always gets updated with the post-RevNAT address (ie stays consistent with the rewritten packet headers).