### PR TITLE
bpf: egressgw: avoid false-positive EDT match on gateway node

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -417,6 +417,9 @@ not_esp:
 			/* to-netdev@bpf_host handles SNAT, so no need to do it here. */
 			ret = egress_gw_fib_lookup_and_redirect(ctx, snat_addr,
 								daddr, ext_err);
+			if (ret == CTX_ACT_REDIRECT)
+				edt_set_aggregate(ctx, 0);
+
 			if (ret != CTX_ACT_OK)
 				return ret;
 


### PR DESCRIPTION
For EgressGW forward traffic that gets handled on a gateway node, the sequence is typically as follows:
1. VXLAN-encapsulated traffic arrives on the gateway node's eth0,
2. proceeds to cilium_vxlan, where from-overlay does a BPF-redirect to the corresponding egress interface eth1,
3. to-netdev@eth1 handles the SNAT

But when a RX `queue_mapping` is stored into the skb, this would propagate all the way into the Bandwidth Manager logic in to-netdev and potentially clash with a local endpoint.

Avoid such aliasing by clearing the `queue_mapping` before redirecting.