### PR TITLE
cilium, tests: Temporary disable agent restart test in l4lb

### DIFF
--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -152,7 +152,11 @@ docker exec -t lb-node docker exec -t cilium-lb \
 curl -o /dev/null "${LB_VIP}:80" -m1 || (echo "Failed"; exit -1)
 
 # Restart cilium-agent and issue 50 requests to LB
-docker exec -d lb-node docker restart cilium-lb
+#
+# FIXME:
+#   The restart test has been flaky recently, disable for now until
+#   we figure out why.
+#docker exec -d lb-node docker restart cilium-lb
 
 # Requests should not timeout when agent is starting up
 for i in $(seq 1 50); do


### PR DESCRIPTION
The test is currently causing a lot of flakes, so it looks like we need to revisit #30163 to figure out why it is still not addressed. For now comment out the agent restart to stop the flakes. Cc @oblazek for visibility.

Related: #30114
Closes: #30707
Closes: #24728
