### PR TITLE
hive: Fix start hook log output

### DIFF
--- a/pkg/hive/cell/lifecycle.go
+++ b/pkg/hive/cell/lifecycle.go
@@ -199,6 +199,9 @@ func getHookFuncName(hook HookInterface, start bool) (name string, hasHook bool)
 	// and the type params would be missing, so instead we'll just use the
 	// type name + method name.
 	switch hook := hook.(type) {
+	case augmentedHook:
+		name, hasHook = getHookFuncName(hook.HookInterface, start)
+		return
 	case Hook:
 		if start {
 			if hook.OnStart == nil {


### PR DESCRIPTION
Commit 07595dae12fc added module ID to the start/stop hook output by carrying the module ID in the hook. Unfortunately I forgot to fix the getHooKFuncName to actually handle this wrapped handle which caused the log output to always show "augmentedHook.Start" as the function name. Fix this by looking through the wrapper.

Fixes: 07595dae12fc ("hive: Add module ID to hive start/stop hook output")

Before:
```
pkg/hive/example % go run .    
...                                                                                                                                                             
level=info msg="Start hook executed" duration="28.273µs" function=cell.augmentedHook.Start subsys=hive
```

After:
```
pkg/hive/example % go run . 
...
level=info msg="Start hook executed" duration="18.316µs" function="*main.exampleEventSource.Start" subsys=hive
```

