### PR TITLE
ingress: remove unused annotations

### DIFF
--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -90,23 +90,6 @@ Supported Ingress Annotations
        | Applicable only if ``ingress.cilium.io/service-type`` is ``NodePort``. If unspecified, a random
        | NodePort will be allocated by kubernetes.
      - unspecified
-   * - ``ingress.cilium.io/tcp-keep-alive``
-     - | Enable TCP keep-alive. Applicable values
-       | are ``enabled`` and ``disabled``.
-     - ``enabled``
-   * - ``ingress.cilium.io/tcp-keep-alive-idle``
-     - TCP keep-alive idle time (in seconds)
-     - ``10``
-   * - ``ingress.cilium.io/tcp-keep-alive-probe-interval``
-     - TCP keep-alive probe intervals (in seconds)
-     - ``5``
-   * - ``ingress.cilium.io/tcp-keep-alive-probe-max-failures``
-     - TCP keep-alive probe max failures
-     - ``10``
-   * - ``ingress.cilium.io/websocket``
-     - | Enable websocket passthrough support.
-       | Applicable values are ``enabled`` and ``disabled``.
-     - ``disabled``
    * - ``ingress.cilium.io/tls-passthrough``
      - | Enable TLS Passthrough mode for this Ingress.
        | Applicable values are ``enabled`` and ``disabled``,

--- a/operator/pkg/ingress/annotations/annotations.go
+++ b/operator/pkg/ingress/annotations/annotations.go
@@ -21,23 +21,11 @@ const (
 	TLSPassthroughAnnotation   = annotation.IngressPrefix + "/tls-passthrough"
 	ForceHTTPSAnnotation       = annotation.IngressPrefix + "/force-https"
 
-	TCPKeepAliveEnabledAnnotation          = annotation.IngressPrefix + "/tcp-keep-alive"
-	TCPKeepAliveIdleAnnotation             = annotation.IngressPrefix + "/tcp-keep-alive-idle"
-	TCPKeepAliveProbeIntervalAnnotation    = annotation.IngressPrefix + "/tcp-keep-alive-probe-interval"
-	TCPKeepAliveProbeMaxFailuresAnnotation = annotation.IngressPrefix + "/tcp-keep-alive-probe-max-failures"
-	WebsocketEnabledAnnotation             = annotation.IngressPrefix + "/websocket"
-
 	LBModeAnnotationAlias           = annotation.Prefix + ".ingress" + "/loadbalancer-mode"
 	ServiceTypeAnnotationAlias      = annotation.Prefix + ".ingress" + "/service-type"
 	InsecureNodePortAnnotationAlias = annotation.Prefix + ".ingress" + "/insecure-node-port"
 	SecureNodePortAnnotationAlias   = annotation.Prefix + ".ingress" + "/secure-node-port"
 	TLSPassthroughAnnotationAlias   = annotation.Prefix + ".ingress" + "/tls-passthrough"
-
-	TCPKeepAliveEnabledAnnotationAlias          = annotation.Prefix + "/tcp-keep-alive"
-	TCPKeepAliveIdleAnnotationAlias             = annotation.Prefix + "/tcp-keep-alive-idle"
-	TCPKeepAliveProbeIntervalAnnotationAlias    = annotation.Prefix + "/tcp-keep-alive-probe-interval"
-	TCPKeepAliveProbeMaxFailuresAnnotationAlias = annotation.Prefix + "/tcp-keep-alive-probe-max-failures"
-	WebsocketEnabledAnnotationAlias             = annotation.Prefix + "/websocket"
 )
 
 const (
@@ -97,78 +85,6 @@ func GetAnnotationInsecureNodePort(ingress *networkingv1.Ingress) (*uint32, erro
 	}
 	res := uint32(intVal)
 	return &res, nil
-}
-
-// GetAnnotationTCPKeepAliveEnabled returns 1 if enabled (default), 0 if disabled
-func GetAnnotationTCPKeepAliveEnabled(ingress *networkingv1.Ingress) int64 {
-	val, exists := annotation.Get(ingress, TCPKeepAliveEnabledAnnotation, TCPKeepAliveEnabledAnnotationAlias)
-	if !exists {
-		return defaultTCPKeepAliveEnabled
-	}
-	if val == enabled {
-		return 1
-	}
-	return 0
-}
-
-// GetAnnotationTCPKeepAliveIdle returns the time (in seconds) the connection needs to
-// remain idle before TCP starts sending keepalive probes. Defaults to 10s.
-// Related references:
-//   - https://man7.org/linux/man-pages/man7/tcp.7.html
-func GetAnnotationTCPKeepAliveIdle(ingress *networkingv1.Ingress) int64 {
-	val, exists := annotation.Get(ingress, TCPKeepAliveIdleAnnotation, TCPKeepAliveIdleAnnotationAlias)
-	if !exists {
-		return defaultTCPKeepAliveInitialIdle
-	}
-	intVal, err := strconv.ParseInt(val, 10, 64)
-	if err != nil {
-		return defaultTCPKeepAliveInitialIdle
-	}
-	return intVal
-}
-
-// GetAnnotationTCPKeepAliveProbeInterval returns the time (in seconds) between individual
-// keepalive probes. Defaults to 5s.
-// Related references:
-//   - https://man7.org/linux/man-pages/man7/tcp.7.html
-func GetAnnotationTCPKeepAliveProbeInterval(ingress *networkingv1.Ingress) int64 {
-	val, exists := annotation.Get(ingress, TCPKeepAliveProbeIntervalAnnotation, TCPKeepAliveProbeIntervalAnnotationAlias)
-	if !exists {
-		return defaultTCPKeepAliveProbeInterval
-	}
-	intVal, err := strconv.ParseInt(val, 10, 64)
-	if err != nil {
-		return defaultTCPKeepAliveProbeInterval
-	}
-	return intVal
-}
-
-// GetAnnotationTCPKeepAliveProbeMaxFailures returns the maximum number of keepalive probes TCP
-// should send before dropping the connection. Defaults to 10.
-// Related references:
-//   - https://man7.org/linux/man-pages/man7/tcp.7.html
-func GetAnnotationTCPKeepAliveProbeMaxFailures(ingress *networkingv1.Ingress) int64 {
-	val, exists := annotation.Get(ingress, TCPKeepAliveProbeMaxFailuresAnnotation, TCPKeepAliveProbeMaxFailuresAnnotationAlias)
-	if !exists {
-		return defaultTCPKeepAliveMaxProbeCount
-	}
-	intVal, err := strconv.ParseInt(val, 10, 64)
-	if err != nil {
-		return defaultTCPKeepAliveMaxProbeCount
-	}
-	return intVal
-}
-
-// GetAnnotationWebsocketEnabled returns 1 if enabled (default), 0 if disabled
-func GetAnnotationWebsocketEnabled(ingress *networkingv1.Ingress) int64 {
-	val, exists := annotation.Get(ingress, WebsocketEnabledAnnotation, WebsocketEnabledAnnotationAlias)
-	if !exists {
-		return defaultWebsocketEnabled
-	}
-	if val == enabled {
-		return 1
-	}
-	return 0
 }
 
 func GetAnnotationTLSPassthroughEnabled(ingress *networkingv1.Ingress) bool {


### PR DESCRIPTION
The following Ingress annotations aren't actually used by any Ingress related logic.

- `ingress.cilium.io/tcp-keep-alive`
- `ingress.cilium.io/tcp-keep-alive-idle`
- `ingress.cilium.io/tcp-keep-probe-interval`
- `ingress.cilium.io/tcp-keep-probe-max-failures`
- `ingress.cilium.io/websocket`

Support has been removed with https://github.com/cilium/cilium/pull/21386, while introducing the shared loadbalancer support.

It looks like the current logic only uses hard-coded defaults for these values: https://github.com/cilium/cilium/blob/main/operator/pkg/model/translation/envoy_listener.go#L103-L112

IMO we should remove the unused annotations and their functionality or add back the support for these annotations.
