### PR TITLE
Trim clustermesh-apiserver ClusterRole permissions when external workloads support is disabled

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
@@ -10,6 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 rules:
+{{- if .Values.externalWorkloads.enabled }}
 - apiGroups:
   - cilium.io
   resources:
@@ -33,11 +34,14 @@ rules:
   - ciliumendpoints/status
   verbs:
   - patch
+{{- end }}
 - apiGroups:
   - cilium.io
   resources:
   - ciliumidentities
+{{- if .Values.externalWorkloads.enabled }}
   - ciliumexternalworkloads
+{{- end }}
   - ciliumendpoints
   - ciliumnodes
   verbs:


### PR DESCRIPTION
The clustermesh-apiserver only requires read-only access to a limited set of Kubernetes resources and Cilium CRDs, except when external workflows are enabled, as in that case it needs to additionally be able to create and update CiliumNodes, CiliumIdentities and CiliumEndpoints on behalf of the external workloads themselves.

As an effort to harden the clustermesh security posture, let's make sure that we grant these additional write permissions only when external workflows support is effectively enabled, so that in all other cases we stick with the reduced set of read-only permissions.

<!-- Description of change -->

```release-note
Trim clustermesh-apiserver ClusterRole permissions when external workloads support is disabled
```
