### PR TITLE
policy: Calculate Portnames at the Selection Layer

### DIFF
--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -547,11 +547,6 @@ func (s *EndpointSuite) TestProxyID(c *C) {
 	c.Assert(port, Equals, uint16(8080))
 	c.Assert(listener, Equals, "test-listener")
 	c.Assert(err, IsNil)
-
-	// Undefined named port
-	id, port = e.proxyID(&policy.L4Filter{PortName: "foobar", Protocol: api.ProtoTCP, Ingress: true}, "")
-	c.Assert(id, Equals, "")
-	c.Assert(port, Equals, uint16(0))
 }
 
 func TestEndpoint_GetK8sPodLabels(t *testing.T) {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -93,13 +93,6 @@ func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string
 // Must be called with e.mutex held.
 func (e *Endpoint) proxyID(l4 *policy.L4Filter, listener string) (string, uint16) {
 	port := uint16(l4.Port)
-	if port == 0 && l4.PortName != "" {
-		port = e.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
-		if port == 0 {
-			return "", 0
-		}
-	}
-
 	return policy.ProxyID(e.ID, l4.Ingress, string(l4.Protocol), port, listener), port
 }
 
@@ -280,7 +273,7 @@ func (e *Endpoint) regeneratePolicy() (*policyGenerateResult, error) {
 	// TODO: GH-7515: Consider ways to compute policy outside of the
 	// endpoint regeneration process, ideally as part of the policy change
 	// handler.
-	err = repo.GetPolicyCache().UpdatePolicy(securityIdentity)
+	err = repo.GetPolicyCache().UpdatePolicy(securityIdentity, e)
 	if err != nil {
 		e.getLogger().WithError(err).Warning("Failed to update policy")
 		repo.Mutex.RUnlock()

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1467,13 +1467,6 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 		}
 
 		port := uint16(l4.Port)
-		if port == 0 && l4.PortName != "" {
-			port = ep.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
-			if port == 0 {
-				continue
-			}
-		}
-
 		rules := make([]*cilium.PortNetworkPolicyRule, 0, len(l4.PerSelectorPolicies))
 		allowAll := false
 

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -92,7 +92,7 @@ func (cache *PolicyCache) delete(identity *identityPkg.Identity) bool {
 // Returns whether the cache was updated, or an error.
 //
 // Must be called with repo.Mutex held for reading.
-func (cache *PolicyCache) updateSelectorPolicy(identity *identityPkg.Identity) (bool, error) {
+func (cache *PolicyCache) updateSelectorPolicy(identity *identityPkg.Identity, owner PolicyOwner) (bool, error) {
 	cache.Lock()
 	cip, ok := cache.policies[identity.ID]
 	cache.Unlock()
@@ -118,7 +118,7 @@ func (cache *PolicyCache) updateSelectorPolicy(identity *identityPkg.Identity) (
 	}
 
 	// Resolve the policies, which could fail
-	selPolicy, err := cache.repo.resolvePolicyLocked(identity)
+	selPolicy, err := cache.repo.resolvePolicyLocked(identity, owner)
 	if err != nil {
 		return false, err
 	}
@@ -151,8 +151,8 @@ func (cache *PolicyCache) Lookup(identity *identityPkg.Identity) SelectorPolicy 
 //
 // The caller must provide threadsafety for iteration over the policy
 // repository.
-func (cache *PolicyCache) UpdatePolicy(identity *identityPkg.Identity) error {
-	_, err := cache.updateSelectorPolicy(identity)
+func (cache *PolicyCache) UpdatePolicy(identity *identityPkg.Identity, owner PolicyOwner) error {
+	_, err := cache.updateSelectorPolicy(identity, owner)
 	return err
 }
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -90,10 +90,10 @@ func (s *DistilleryTestSuite) TestCachePopulation(c *C) {
 	policy1 := cache.insert(identity1)
 
 	// Calculate the policy and observe that it's cached
-	updated, err := cache.updateSelectorPolicy(identity1)
+	updated, err := cache.updateSelectorPolicy(identity1, DummyOwner{})
 	c.Assert(err, IsNil)
 	c.Assert(updated, Equals, true)
-	updated, err = cache.updateSelectorPolicy(identity1)
+	updated, err = cache.updateSelectorPolicy(identity1, DummyOwner{})
 	c.Assert(err, IsNil)
 	c.Assert(updated, Equals, false)
 	policy2 := cache.insert(identity1)
@@ -104,13 +104,13 @@ func (s *DistilleryTestSuite) TestCachePopulation(c *C) {
 	// Remove the identity and observe that it is no longer available
 	cacheCleared := cache.delete(identity1)
 	c.Assert(cacheCleared, Equals, true)
-	updated, err = cache.updateSelectorPolicy(identity1)
+	updated, err = cache.updateSelectorPolicy(identity1, DummyOwner{})
 	c.Assert(err, NotNil)
 
 	// Attempt to update policy for non-cached endpoint and observe failure
 	ep3 := testutils.NewTestEndpoint()
 	ep3.SetIdentity(1234, true)
-	_, err = cache.updateSelectorPolicy(ep3.GetSecurityIdentity())
+	_, err = cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), DummyOwner{})
 	c.Assert(err, NotNil)
 	c.Assert(updated, Equals, false)
 
@@ -122,7 +122,7 @@ func (s *DistilleryTestSuite) TestCachePopulation(c *C) {
 	identity3 := ep3.GetSecurityIdentity()
 	policy3 := cache.insert(identity3)
 	c.Assert(policy3, Not(Equals), policy1)
-	updated, err = cache.updateSelectorPolicy(identity3)
+	updated, err = cache.updateSelectorPolicy(identity3, DummyOwner{})
 	c.Assert(err, IsNil)
 	c.Assert(updated, Equals, true)
 	idp3 := policy3.(*cachedSelectorPolicy).getPolicy()
@@ -420,7 +420,7 @@ func (d *policyDistillery) WithLogBuffer(w io.Writer) *policyDistillery {
 // entries for an endpoint with the specified labels.
 func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.LabelArray, identity *identity.Identity) (MapState, error) {
 	sp := d.Repository.GetPolicyCache().insert(identity)
-	d.Repository.GetPolicyCache().UpdatePolicy(identity)
+	d.Repository.GetPolicyCache().UpdatePolicy(identity, DummyOwner{})
 	epp := sp.Consume(DummyOwner{})
 	if epp == nil {
 		return nil, errors.New("policy distillation failure")

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -52,6 +52,7 @@ var (
 
 type testPolicyContextType struct {
 	isDeny bool
+	owner  PolicyOwner
 	ns     string
 }
 
@@ -85,6 +86,13 @@ func (p *testPolicyContextType) SetDeny(isDeny bool) bool {
 
 func (p *testPolicyContextType) IsDeny() bool {
 	return p.isDeny
+}
+
+func (p *testPolicyContextType) GetOwner() PolicyOwner {
+	if p.owner != nil {
+		return p.owner
+	}
+	return DummyOwner{}
 }
 
 var (

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -1350,14 +1350,6 @@ func (ms *mapState) deniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
 	port := uint16(l4.Port)
 	proto := uint8(l4.U8Proto)
 
-	// resolve named port
-	if port == 0 && l4.PortName != "" {
-		port = policyOwner.GetNamedPort(l4.Ingress, l4.PortName, proto)
-		if port == 0 {
-			return true
-		}
-	}
-
 	var dir uint8
 	if l4.Ingress {
 		dir = trafficdirection.Ingress.Uint8()

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -60,6 +60,7 @@ type SearchContext struct {
 	From    labels.LabelArray
 	To      labels.LabelArray
 	DPorts  []*models.Port
+	Owner   PolicyOwner
 	// rulesSelect specifies whether or not to check whether a rule which is
 	// being analyzed using this SearchContext matches either From or To.
 	// This is used to avoid using EndpointSelector.Matches() if possible,

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -135,7 +135,7 @@ func (ds *PolicyTestSuite) TestL3WithIngressDenyWildcard(c *C) {
 
 	repo.Mutex.RLock()
 	defer repo.Mutex.RUnlock()
-	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
+	selPolicy, err := repo.resolvePolicyLocked(fooIdentity, DummyOwner{})
 	c.Assert(err, IsNil)
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
 
@@ -217,7 +217,7 @@ func (ds *PolicyTestSuite) TestL3WithLocalHostWildcardd(c *C) {
 	repo.Mutex.RLock()
 	defer repo.Mutex.RUnlock()
 
-	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
+	selPolicy, err := repo.resolvePolicyLocked(fooIdentity, DummyOwner{})
 	c.Assert(err, IsNil)
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
 
@@ -301,7 +301,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDenyWildcard(c *C) {
 
 	repo.Mutex.RLock()
 	defer repo.Mutex.RUnlock()
-	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
+	selPolicy, err := repo.resolvePolicyLocked(fooIdentity, DummyOwner{})
 	c.Assert(err, IsNil)
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
 
@@ -414,7 +414,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 
 	repo.Mutex.RLock()
 	defer repo.Mutex.RUnlock()
-	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
+	selPolicy, err := repo.resolvePolicyLocked(fooIdentity, DummyOwner{})
 	c.Assert(err, IsNil)
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
 

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -194,10 +194,6 @@ func (d DummyOwner) GetNamedPort(ingress bool, name string, proto uint8) uint16 
 	return 80
 }
 
-func (d DummyOwner) GetNamedPortLocked(ingress bool, name string, proto uint8) uint16 {
-	return 80
-}
-
 func (d DummyOwner) GetID() uint64 {
 	return 1234
 }
@@ -242,7 +238,7 @@ func BenchmarkRegenerateCIDRPolicyRules(b *testing.B) {
 	testRepo := bootstrapRepo(GenerateCIDRRules, 1000, b)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ip, _ := testRepo.resolvePolicyLocked(fooIdentity)
+		ip, _ := testRepo.resolvePolicyLocked(fooIdentity, DummyOwner{})
 		_ = ip.DistillPolicy(DummyOwner{}, false)
 		ip.Detach()
 	}
@@ -252,7 +248,7 @@ func BenchmarkRegenerateL3IngressPolicyRules(b *testing.B) {
 	testRepo := bootstrapRepo(GenerateL3IngressRules, 1000, b)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ip, _ := testRepo.resolvePolicyLocked(fooIdentity)
+		ip, _ := testRepo.resolvePolicyLocked(fooIdentity, DummyOwner{})
 		_ = ip.DistillPolicy(DummyOwner{}, false)
 		ip.Detach()
 	}
@@ -262,7 +258,7 @@ func BenchmarkRegenerateL3EgressPolicyRules(b *testing.B) {
 	testRepo := bootstrapRepo(GenerateL3EgressRules, 1000, b)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ip, _ := testRepo.resolvePolicyLocked(fooIdentity)
+		ip, _ := testRepo.resolvePolicyLocked(fooIdentity, DummyOwner{})
 		_ = ip.DistillPolicy(DummyOwner{}, false)
 		ip.Detach()
 	}
@@ -303,7 +299,7 @@ func (ds *PolicyTestSuite) TestL7WithIngressWildcard(c *C) {
 
 	repo.Mutex.RLock()
 	defer repo.Mutex.RUnlock()
-	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
+	selPolicy, err := repo.resolvePolicyLocked(fooIdentity, DummyOwner{})
 	c.Assert(err, IsNil)
 	c.Assert(selPolicy.L4Policy.redirectTypes, Equals, redirectTypeEnvoy)
 
@@ -398,7 +394,7 @@ func (ds *PolicyTestSuite) TestL7WithLocalHostWildcardd(c *C) {
 	repo.Mutex.RLock()
 	defer repo.Mutex.RUnlock()
 
-	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
+	selPolicy, err := repo.resolvePolicyLocked(fooIdentity, DummyOwner{})
 	c.Assert(err, IsNil)
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
 
@@ -490,7 +486,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressWildcard(c *C) {
 
 	repo.Mutex.RLock()
 	defer repo.Mutex.RUnlock()
-	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
+	selPolicy, err := repo.resolvePolicyLocked(fooIdentity, DummyOwner{})
 	c.Assert(err, IsNil)
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
 
@@ -605,7 +601,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 
 	repo.Mutex.RLock()
 	defer repo.Mutex.RUnlock()
-	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
+	selPolicy, err := repo.resolvePolicyLocked(fooIdentity, DummyOwner{})
 	c.Assert(err, IsNil)
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
 

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -335,7 +335,7 @@ func mergeIngressPortProto(policyCtx PolicyContext, ctx *SearchContext, endpoint
 		return 0, err
 	}
 
-	err = addL4Filter(policyCtx, ctx, resMap, p, proto, filterToMerge, ruleLabels)
+	err = addL4Filter(policyCtx, ctx, resMap, filterToMerge, ruleLabels)
 	if err != nil {
 		return 0, err
 	}
@@ -771,7 +771,7 @@ func mergeEgressPortProto(policyCtx PolicyContext, ctx *SearchContext, endpoints
 		return 0, err
 	}
 
-	err = addL4Filter(policyCtx, ctx, resMap, p, proto, filterToMerge, ruleLabels)
+	err = addL4Filter(policyCtx, ctx, resMap, filterToMerge, ruleLabels)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1614,14 +1614,15 @@ var (
 
 	endpointSelectorC = api.NewESFromLabels(labels.ParseSelectLabel("id=c"))
 
-	ctxAToB = SearchContext{From: labelsA, To: labelsB, Trace: TRACE_VERBOSE}
-	ctxAToC = SearchContext{From: labelsA, To: labelsC, Trace: TRACE_VERBOSE}
+	ctxAToB = SearchContext{From: labelsA, To: labelsB, Owner: DummyOwner{}, Trace: TRACE_VERBOSE}
+	ctxAToC = SearchContext{From: labelsA, To: labelsC, Owner: DummyOwner{}, Trace: TRACE_VERBOSE}
 )
 
 func expectResult(c *C, expected, obtained api.Decision, buffer *bytes.Buffer) {
 	if obtained != expected {
 		c.Errorf("Unexpected result: obtained=%v, expected=%v", obtained, expected)
 		c.Log(buffer)
+		c.FailNow()
 	}
 }
 
@@ -1828,10 +1829,9 @@ func (ds *PolicyTestSuite) TestIngressL4AllowAllNamedPort(c *C) {
 	l4IngressPolicy, err := repo.ResolveL4IngressPolicy(&ctxAToCNamed80)
 	c.Assert(err, IsNil)
 
-	filter, ok := l4IngressPolicy["port-80/TCP"]
+	filter, ok := l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 0)
-	c.Assert(filter.PortName, Equals, "port-80")
+	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
 	c.Assert(len(filter.PerSelectorPolicies), Equals, 1)


### PR DESCRIPTION
The policy cache is created for endpoint objects
without calculating port names. This creates non-determinative behavior when the policy map is calculated *after* selection, because port-protocol logic is used in the higher level selection calculation to keep port names tracked, but uncalculated, until map update/create (this can lead to accidental collisions between named ports and unnamed ports).

This commit moves port name calculation to the earlier policy calculation stage of selection so that all L4Filters are guaranteed to have an integer port. All search and policy contexts require an owner, and widespread calculation of named ports is consolidated in the policy package.

All named-port logic has been moved to `createL4Filter` and `containsAllL3L4` (this method takes arbitrary ports as arguments, not `L4Filter`s, so it needs to repeat the same logic). 
