### PR TITLE
ci: Remove unsupported versions from GKE and AKS

### DIFF
--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -1,16 +1,13 @@
 # List of k8s version for AKS tests
 ---
 include:
-  - version: "1.25"
-    location: westus3
-    index: 1
   - version: "1.26"
     location: westus2
-    index: 2
+    index: 0
   - version: "1.27"
     location: eastus2
-    index: 3
+    index: 1
   - version: "1.28"
     location: eastus
-    index: 4
+    index: 2
     default: true

--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,19 +1,16 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.24"
-    zone: us-west1-b
-    vmIndex: 1
   - version: "1.25"
     zone: us-west2-c
-    vmIndex: 2
+    vmIndex: 1
   - version: "1.26"
     zone: us-west3-a
-    vmIndex: 3
+    vmIndex: 2
   - version: "1.27"
     zone: us-east4-b
-    vmIndex: 4
+    vmIndex: 3
   - version: "1.28"
     zone: us-east1-c
-    vmIndex: 5
+    dmIndex: 4
     default: true


### PR DESCRIPTION
This commit updates the list of tested kubernetes versions on GKE and AKS, removing versions that are no longer supported. AKS version 1.25 hit EOL on Jan 14, 2024; GKE version 1.24 hit EOL on Oct 31, 2023.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
