### PR TITLE
node_addressing: fix edge case where `getDirectRouting` returns nil

### DIFF
--- a/pkg/datapath/tables/node_addressing.go
+++ b/pkg/datapath/tables/node_addressing.go
@@ -106,10 +106,12 @@ func (a addressFamily) getDirectRouting(flags getFlags) (int, net.IP, bool) {
 	if option.Config.DirectRoutingDevice == "" {
 		return 0, nil, false
 	}
+
 	dev, _, ok := a.devices.First(a.db.ReadTxn(), DeviceNameIndex.Query(option.Config.DirectRoutingDevice))
 	if !ok {
 		return 0, nil, false
 	}
+
 	var addr net.IP
 	for _, a := range dev.Addrs {
 		if flags&ipv6 != 0 && a.Addr.Is6() {
@@ -120,6 +122,10 @@ func (a addressFamily) getDirectRouting(flags getFlags) (int, net.IP, bool) {
 			break
 		}
 	}
+	if addr == nil {
+		return 0, nil, false
+	}
+
 	return dev.Index, addr, true
 }
 


### PR DESCRIPTION
If we construct a `nodeAddressing` object with the IPv4 flag, and then call `getDirectRouting` while the directRoutingDevice doesn't contain an IPv4 address, it would return a nil address instead of the error condition. This can cause a panic in the caller who assumes that the IP is never nil.

Fixes: #30746

```release-note
fix edge case in node addressing logic which could result in a panic
```
