### PR TITLE
workflows: Clean IPsec test output

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -230,7 +230,7 @@ jobs:
 
           ./cilium-cli status --wait
           kubectl get pods --all-namespaces -o wide
-          kubectl -n kube-system exec daemonset/cilium -- cilium-dbg status
+          kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 
           mkdir -p cilium-junits
 
@@ -261,7 +261,7 @@ jobs:
 
             # Wait until key rotation starts
             while true; do
-              keys_in_use=$(kubectl -n kube-system exec daemonset/cilium -- cilium-dbg encrypt status | awk '/Keys in use/ {print $NF}')
+              keys_in_use=$(kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg encrypt status | awk '/Keys in use/ {print $NF}')
               if [[ $keys_in_use == 2 ]]; then
                 break
               fi
@@ -273,7 +273,7 @@ jobs:
             # By default the key rotation cleanup delay is 5min, let's sleep 4min before actively polling
             sleep $((4*60))
             while true; do
-              keys_in_use=$(kubectl -n kube-system exec daemonset/cilium -- cilium-dbg encrypt status | awk '/Keys in use/ {print $NF}')
+              keys_in_use=$(kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg encrypt status | awk '/Keys in use/ {print $NF}')
               if [[ $keys_in_use == 1 ]]; then
                 break
               fi

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -307,7 +307,7 @@ jobs:
           ./cilium-cli status --wait
           kubectl get pods --all-namespaces -o wide
           # TODO: After Cilium 1.15 release, update to cilium-dbg
-          kubectl -n kube-system exec daemonset/cilium -- cilium status
+          kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium status
 
       - name: Start conn-disrupt-test
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
@@ -330,7 +330,7 @@ jobs:
 
             ./cilium-cli status --wait
             kubectl get pods --all-namespaces -o wide
-            kubectl -n kube-system exec daemonset/cilium -- cilium-dbg status
+            kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 
       - name: Downgrade Cilium to ${{ steps.vars.outputs.downgrade_version }} & Test (${{ matrix.name }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
@@ -344,7 +344,7 @@ jobs:
             ./cilium-cli status --wait
             kubectl get pods --all-namespaces -o wide
             # TODO: After Cilium 1.15 release, update to cilium-dbg
-            kubectl -n kube-system exec daemonset/cilium -- cilium status
+            kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium status
 
       - name: Fetch artifacts
         if: ${{ steps.vars.outputs.downgrade_version != '' && !success() }}


### PR DESCRIPTION
The test output are riddled with logs such as:

    Defaulted container "cilium-agent" out of: cilium-agent, config (init), mount-cgroup (init), apply-sysctl-overwrites (init), mount-bpf-fs (init), clean-cilium-state (init), install-cni-binaries (init)

This gets particularly noisy when waiting for the key rotation to complete, during which time we run kubectl exec repeatedly. This pull request fixes it.