### PR TITLE
[v1.14] bgpv1: Remove disruptive error handling from BGPRouterManager

### DIFF
--- a/pkg/bgpv1/manager/instance.go
+++ b/pkg/bgpv1/manager/instance.go
@@ -36,6 +36,9 @@ type ServerWithConfig struct {
 
 	// Holds any announced Service routes.
 	ServiceAnnouncements map[resource.Key][]types.Advertisement
+
+	// Holds neighbor metadata
+	NeighborReconcilerMetadata NeighborReconcilerMetadata
 }
 
 // NewServerWithConfig will start an underlying BgpServer utilizing types.ServerParameters
@@ -53,9 +56,10 @@ func NewServerWithConfig(ctx context.Context, params types.ServerParameters, cst
 	}
 
 	return &ServerWithConfig{
-		Server:               s,
-		Config:               nil,
-		PodCIDRAnnouncements: []types.Advertisement{},
-		ServiceAnnouncements: make(map[resource.Key][]types.Advertisement),
+		Server:                     s,
+		Config:                     nil,
+		PodCIDRAnnouncements:       []types.Advertisement{},
+		ServiceAnnouncements:       make(map[resource.Key][]types.Advertisement),
+		NeighborReconcilerMetadata: NeighborReconcilerMetadata{},
 	}, nil
 }

--- a/pkg/bgpv1/manager/manager.go
+++ b/pkg/bgpv1/manager/manager.go
@@ -197,20 +197,6 @@ func (m *BGPRouterManager) registerBGPServer(ctx context.Context, c *v2alpha1api
 
 	l.Infof("Registering BGP servers for policy with local ASN %v", c.LocalASN)
 
-	// ATTENTION: this defer handles cleaning up of a server if an error in
-	// registration occurs. for this to work the below err variable must be
-	// overwritten for the length of this method.
-	var err error
-	var s *ServerWithConfig
-	defer func() {
-		if err != nil {
-			if s != nil {
-				s.Server.Stop()
-			}
-			delete(m.Servers, c.LocalASN) // optimistic delete
-		}
-	}()
-
 	// resolve local port from kubernetes annotations
 	var localPort int32
 	localPort = -1
@@ -236,16 +222,21 @@ func (m *BGPRouterManager) registerBGPServer(ctx context.Context, c *v2alpha1api
 		},
 	}
 
-	if s, err = NewServerWithConfig(ctx, globalConfig, cstate); err != nil {
+	s, err := NewServerWithConfig(ctx, globalConfig, cstate)
+	if err != nil {
 		return fmt.Errorf("failed to start BGP server for config with local ASN %v: %w", c.LocalASN, err)
 	}
+
+	// We can commit the register the server here. Even if the following
+	// reconciliation fails, we can return error and it triggers retry. The
+	// next retry will be handled by reconcile(). We don't need to retry
+	// the server creation which already succeeded.
+	m.Servers[c.LocalASN] = s
 
 	if err = m.reconcileBGPConfig(ctx, s, c, cstate); err != nil {
 		return fmt.Errorf("failed initial reconciliation for peer config with local ASN %v: %w", c.LocalASN, err)
 	}
 
-	// register with manager
-	m.Servers[c.LocalASN] = s
 	l.Infof("Successfully registered GoBGP servers for policy with local ASN %v", c.LocalASN)
 
 	return err
@@ -310,11 +301,8 @@ func (m *BGPRouterManager) reconcile(ctx context.Context, rd *reconcileDiff) err
 			l.Errorf("Virtual router with local ASN %v marked for reconciliation but missing from incoming configurations", sc.Config.LocalASN) // also really shouldn't happen
 			continue
 		}
-
 		if err := m.reconcileBGPConfig(ctx, sc, newc, rd.state); err != nil {
-			l.WithError(err).Errorf("Encountered error reconciling virtual router with local ASN %v, shutting down this server", newc.LocalASN)
-			sc.Server.Stop()
-			delete(m.Servers, asn)
+			l.WithError(err).Errorf("Encountered error reconciling virtual router with local ASN %v", newc.LocalASN)
 		}
 	}
 	return nil

--- a/pkg/bgpv1/manager/reconcile_test.go
+++ b/pkg/bgpv1/manager/reconcile_test.go
@@ -132,9 +132,13 @@ func TestPreflightReconciler(t *testing.T) {
 				},
 			}
 
-			err = preflightReconciler(context.Background(), testSC, newc, cstate)
-			if (tt.err == nil) != (err == nil) {
-				t.Fatalf("wanted error: %v", (tt.err == nil))
+			for i := 0; i < 2; i++ {
+				t.Run(tt.name, func(t *testing.T) {
+					err = preflightReconciler(context.Background(), testSC, newc, cstate)
+					if (tt.err == nil) != (err == nil) {
+						t.Fatalf("wanted error: %v", (tt.err == nil))
+					}
+				})
 			}
 			if tt.shouldRecreate && testSC.Server == originalServer {
 				t.Fatalf("preflightReconciler did not recreate server")
@@ -496,9 +500,13 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 				IPv4:     netip.MustParseAddr("127.0.0.1"),
 			}
 
-			err = exportPodCIDRReconciler(context.Background(), testSC, newc, &newcstate)
-			if err != nil {
-				t.Fatalf("failed to reconcile new pod cidr advertisements: %v", err)
+			for i := 0; i < 2; i++ {
+				t.Run(tt.name, func(t *testing.T) {
+					err = exportPodCIDRReconciler(context.Background(), testSC, newc, &newcstate)
+					if err != nil {
+						t.Fatalf("failed to reconcile new pod cidr advertisements: %v", err)
+					}
+				})
 			}
 
 			// if we disable exports of pod cidr ensure no advertisements are
@@ -1101,13 +1109,17 @@ func TestLBServiceReconciler(t *testing.T) {
 			}
 
 			reconciler := NewLBServiceReconciler(diffstore, epDiffStore)
-			err = reconciler.Reconciler.Reconcile(context.Background(), ReconcileParams{
-				Server: testSC,
-				NewC:   newc,
-				CState: &newcstate,
-			})
-			if err != nil {
-				t.Fatalf("failed to reconcile new lb svc advertisements: %v", err)
+			for i := 0; i < 2; i++ {
+				t.Run(tt.name, func(t *testing.T) {
+					err = reconciler.Reconciler.Reconcile(context.Background(), ReconcileParams{
+						Server: testSC,
+						NewC:   newc,
+						CState: &newcstate,
+					})
+					if err != nil {
+						t.Fatalf("failed to reconcile new lb svc advertisements: %v", err)
+					}
+				})
 			}
 
 			// if we disable exports of pod cidr ensure no advertisements are
@@ -1230,12 +1242,16 @@ func TestReconcileAfterServerReinit(t *testing.T) {
 
 	diffstore.Upsert(obj)
 	reconciler := NewLBServiceReconciler(diffstore, epDiffStore)
-	err = reconciler.Reconciler.Reconcile(context.Background(), ReconcileParams{
-		Server: testSC,
-		NewC:   newc,
-		CState: cstate,
-	})
-	require.NoError(t, err)
+	for i := 0; i < 2; i++ {
+		t.Run(t.Name(), func(t *testing.T) {
+			err = reconciler.Reconciler.Reconcile(context.Background(), ReconcileParams{
+				Server: testSC,
+				NewC:   newc,
+				CState: cstate,
+			})
+			require.NoError(t, err)
+		})
+	}
 
 	// update server config, this is done outside of reconcilers
 	testSC.Config = newc
@@ -1260,12 +1276,16 @@ func TestReconcileAfterServerReinit(t *testing.T) {
 
 	// Update LB service
 	reconciler = NewLBServiceReconciler(diffstore, epDiffStore)
-	err = reconciler.Reconciler.Reconcile(context.Background(), ReconcileParams{
-		Server: testSC,
-		NewC:   newc,
-		CState: cstate,
-	})
-	require.NoError(t, err)
+	for i := 0; i < 2; i++ {
+		t.Run(t.Name(), func(t *testing.T) {
+			err = reconciler.Reconciler.Reconcile(context.Background(), ReconcileParams{
+				Server: testSC,
+				NewC:   newc,
+				CState: cstate,
+			})
+			require.NoError(t, err)
+		})
+	}
 }
 
 // hostPrefixLen returns addr/32 for ipv4 address and addr/128 for ipv6 address

--- a/pkg/bgpv1/manager/reconcile_test.go
+++ b/pkg/bgpv1/manager/reconcile_test.go
@@ -347,7 +347,15 @@ func TestNeighborReconciler(t *testing.T) {
 			newc.Neighbors = append(newc.Neighbors, tt.newNeighbors...)
 			newc.SetDefaults()
 
-			err = neighborReconciler(context.Background(), testSC, newc, nil)
+			r := NeighborReconciler{}
+
+			err = r.Reconcile(
+				context.Background(),
+				ReconcileParams{
+					Server: testSC,
+					NewC:   newc,
+				},
+			)
 			if (tt.err == nil) != (err == nil) {
 				t.Fatalf("want error: %v, got: %v", (tt.err == nil), err)
 			}


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/30382. Many conflicts were observed.

```release-note
bgpv1: Remove disruptive error handling from BGPRouterManager
```
