### PR TITLE
ginkgo: Gather logs of containers in cilium-agent pods after failure

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3302,6 +3302,12 @@ func (kub *Kubectl) CiliumReport(commands ...string) {
 	res := kub.ExecContextShort(ctx, fmt.Sprintf("%s get pods -o wide --all-namespaces", KubectlCmd))
 	ginkgoext.GinkgoPrint(res.GetDebugMessage())
 
+	ginkgoext.GinkgoPrint("Fetching log output from all containers in pods %s", pods)
+	for _, pod := range pods {
+		res := kub.ExecContextShort(ctx, fmt.Sprintf("%s logs %s --all-containers=true", KubectlCmd, pod))
+		ginkgoext.GinkgoPrint(res.GetDebugMessage())
+	}
+
 	results := make([]*CmdRes, 0, len(pods)*len(commands))
 	ginkgoext.GinkgoPrint("Fetching command output from pods %s", pods)
 	for _, pod := range pods {


### PR DESCRIPTION
This commit adds another step to
test/helpers/kubectl.go#Kubectl.CiliumReport which gathers and prints the logs from all containers in cilium-agent pods. This will ease debugging of CI failures, as it allows for these logs to be displayed in the test output, rather than being hidden inside the generated sysdump. By having these logs accessible outside of the sysdump, it is easier for developers to use the output when creating CI flake issues on GH.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
