### PR TITLE
Hubble: add no-metrics label suport for namespace or pod 

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -155,6 +155,20 @@ have it scrape all Hubble metrics from the endpoints automatically:
 
 .. _hubble_open_metrics:
 
+Excluding Namespaces/Pods from Hubble Metrics
+--------------------------------------------
+
+By default, Hubble metrics are collected for all pods in the cluster. If you
+want to exclude certain namespaces or pods from Hubble metrics, you can use the 
+label ``hubble.cilium.io/no-metrics: "true"`` on the namespace or pod. This label
+will prevent Hubble from collecting metrics for all pods in the namespace or the 
+specific pod.
+
+.. parsed-literal::
+
+   kubectl label namespace <namespace> hubble.cilium.io/no-metrics=true
+   kubectl label pod <pod> hubble.cilium.io/no-metrics=true
+
 OpenMetrics
 -----------
 

--- a/pkg/hubble/metrics/flow/handler_test.go
+++ b/pkg/hubble/metrics/flow/handler_test.go
@@ -127,6 +127,46 @@ func TestFlowHandler(t *testing.T) {
 
 		assert.Equal(t, "verdict", *metric.Label[5].Name)
 		assert.Equal(t, "DROPPED", *metric.Label[5].Value)
+
+		flow4 := &pb.Flow{
+			EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog},
+			L7: &pb.Layer7{
+				Record: &pb.Layer7_Http{Http: &pb.HTTP{}},
+			},
+			Source: &pb.Endpoint{
+				Namespace: "foo",
+				Labels:    []string{"k8s:hubble.cilium.io/no-metrics=true"},
+			},
+			Destination: &pb.Endpoint{Namespace: "bar"},
+			Verdict:     pb.Verdict_FORWARDED,
+		}
+		h.ProcessFlow(context.TODO(), flow4)
+
+		metricFamilies, err = registry.Gather()
+		require.NoError(t, err)
+		require.Len(t, metricFamilies, 1)
+
+		assert.Equal(t, "hubble_flows_processed_total", *metricFamilies[0].Name)
+		require.Len(t, metricFamilies[0].Metric, 4)
+		metric = metricFamilies[0].Metric[2]
+
+		assert.Equal(t, "destination", *metric.Label[0].Name)
+		assert.Equal(t, "bar", *metric.Label[0].Value)
+
+		assert.Equal(t, "protocol", *metric.Label[1].Name)
+		assert.Equal(t, "HTTP", *metric.Label[1].Value)
+
+		assert.Equal(t, "source", *metric.Label[2].Name)
+		assert.Equal(t, "", *metric.Label[2].Value)
+
+		assert.Equal(t, "subtype", *metric.Label[3].Name)
+		assert.Equal(t, "HTTP", *metric.Label[3].Value)
+
+		assert.Equal(t, "type", *metric.Label[4].Name)
+		assert.Equal(t, "L7", *metric.Label[4].Value)
+
+		assert.Equal(t, "verdict", *metric.Label[5].Name)
+		assert.Equal(t, "FORWARDED", *metric.Label[5].Value)
 	})
 
 }


### PR DESCRIPTION
<!-- Description of change -->

This change will introduce a new hubble label which can be applied on namespace or pod. Hubble while generating context labels for a given metrics, will check for the given src/dst endpoint inside the flow for this label, if the label is present, then hubble will ignore generating labels for this endpoints and will return empty label.

``hubble.cilium.io/no-metrics: "true"``

Applying this label on:

- Namespace: Since this label gets applied on each endpoint inside this namespace, we can ignore all the endpoints to be included in hubble context label generation
- Pods: we can ignore context label generation for this endpoint alone.

Fixes: #30788 , #23162
