### PR TITLE
ci: Enhance test execution security by restricting permissions to the 'organization-members' team

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -1,3 +1,6 @@
+allowed-teams:
+  - organization-members
+
 triggers:
   /test:
     workflows:


### PR DESCRIPTION
This PR updates the Ariane configuration to include the GitHub organization team 'organization-members' in the list of allowed teams. Consequently, only members of this specific team will have the authorization to initiate test runs via issue comments.