### PR TITLE
CI: Update tested K8S versions across all cloud providers

### DIFF
--- a/.github/actions/aws/k8s-versions.yaml
+++ b/.github/actions/aws/k8s-versions.yaml
@@ -1,16 +1,16 @@
 # List of k8s version for EKS tests
 ---
 include:
-  - version: "1.23"
-    region: ca-west-1
   - version: "1.24"
-    region: us-west-2
+    region: ca-west-1
   - version: "1.25"
-    region: us-west-1
+    region: us-west-2
   - version: "1.26"
-    region: us-east-2
+    region: us-west-1
   - version: "1.27"
-    region: ca-central-1
-  - version: "1.28"
-    region: us-east-1
+    region: us-east-2
     default: true
+  - version: "1.28"
+    region: ca-central-1
+  - version: "1.29"
+    region: us-east-1

--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -11,7 +11,7 @@ include:
   - version: "1.27"
     location: eastus2
     index: 3
+    default: true
   - version: "1.28"
     location: eastus
     index: 4
-    default: true

--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -4,6 +4,7 @@ include:
   - version: "1.25"
     location: westus3
     index: 1
+    disabled: true
   - version: "1.26"
     location: westus2
     index: 2

--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,19 +1,19 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.24"
+  - version: "1.25"
     zone: us-west1-b
     vmIndex: 1
-  - version: "1.25"
+  - version: "1.26"
     zone: us-west2-c
     vmIndex: 2
-  - version: "1.26"
+  - version: "1.27"
     zone: us-west3-a
     vmIndex: 3
-  - version: "1.27"
+    default: true
+  - version: "1.28"
     zone: us-east4-b
     vmIndex: 4
-  - version: "1.28"
+  - version: "1.29"
     zone: us-east1-c
     vmIndex: 5
-    default: true

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -98,7 +98,7 @@ jobs:
           # main -> event_name = schedule
           # other stable branches -> PR-number starting with v (e.g. v1.14)
           if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
-            cp azure.json /tmp/matrix.json
+            jq '{ "include": [ .include[] | select(.disabled==null) ] }' azure.json > /tmp/matrix.json
           else
             jq '{ "include": [ .include[] | select(.default) ] }' azure.json > /tmp/matrix.json
           fi


### PR DESCRIPTION
This PR revises the Kubernetes versions tested for compatibility across all supported cloud providers.
Additionally, it adjusts the default Kubernetes version to match the default version provided by each cloud provider

In the AKS release cycle, a gap exists between the introduction of newly supported Kubernetes versions
and the removal of older versions, leading to failures in scheduled tests.
This PR introduces the capability to disable older Kubernetes versions, mitigating test failures.

Successful tests are below.
AKS: https://github.com/cilium/cilium/actions/runs/7915596604
AWS-CNI: https://github.com/cilium/cilium/actions/runs/7915596619
EKS: https://github.com/cilium/cilium/actions/runs/7915596795
External-Workloads: https://github.com/cilium/cilium/actions/runs/7915596806
GKE: https://github.com/cilium/cilium/actions/runs/7915596959


Fixes: #30769