### PR TITLE
Change ariane config CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -233,6 +233,7 @@
 /.devcontainer @cilium/contributing
 /.gitattributes @cilium/tophat
 /.github/ @cilium/contributing
+/.github/ariane-config.yaml @cilium/github-sec @cilium/ci-structure
 /.github/renovate.json5 @cilium/github-sec @cilium/ci-structure
 /.github/actions/ @cilium/github-sec @cilium/ci-structure
 /.github/actions/kvstore/ @cilium/sig-clustermesh @cilium/kvstore @cilium/github-sec @cilium/ci-structure


### PR DESCRIPTION
The current process delegates the review of ariane-config.yaml changes to the contributing group. With this PR reviewing responsibilities be transferred to the github-sec and ci-structure groups.

