### PR TITLE
Require dead code elimination support

### DIFF
--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -550,6 +550,44 @@ func HaveSKBAdjustRoomL2RoomMACSupport() (err error) {
 	return nil
 }
 
+// HaveDeadCodeElim tests whether the kernel supports dead code elimination.
+func HaveDeadCodeElim() error {
+	spec := ebpf.ProgramSpec{
+		Name: "test",
+		Type: ebpf.XDP,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R1, 0),
+			asm.JEq.Imm(asm.R1, 1, "else"),
+			asm.Mov.Imm(asm.R0, 2),
+			asm.Ja.Label("end"),
+			asm.Mov.Imm(asm.R0, 3).WithSymbol("else"),
+			asm.Return().WithSymbol("end"),
+		},
+	}
+
+	prog, err := ebpf.NewProgram(&spec)
+	if err != nil {
+		return fmt.Errorf("loading program: %w", err)
+	}
+
+	info, err := prog.Info()
+	if err != nil {
+		return fmt.Errorf("get prog info: %w", err)
+	}
+	infoInst, err := info.Instructions()
+	if err != nil {
+		return fmt.Errorf("get instructions: %w", err)
+	}
+
+	for _, inst := range infoInst {
+		if inst.OpCode.Class().IsJump() && inst.OpCode.JumpOp() != asm.Exit {
+			return fmt.Errorf("Jump instruction found in the final program, no dead code elimination performed")
+		}
+	}
+
+	return nil
+}
+
 // HaveIPv6Support tests whether kernel can open an IPv6 socket. This will
 // also implicitly auto-load IPv6 kernel module if available and not yet
 // loaded.

--- a/pkg/datapath/linux/probes/probes_test.go
+++ b/pkg/datapath/linux/probes/probes_test.go
@@ -327,3 +327,11 @@ func TestIPv6Support(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestHaveDeadCodeElimSupport(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	if err := HaveDeadCodeElim(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -33,6 +33,10 @@ func CheckRequirements() {
 	if !option.Config.DryMode {
 		probeManager := probes.NewProbeManager()
 
+		if probes.HaveDeadCodeElim() != nil {
+			log.Fatalf("Require support for dead code elimination (Linux 5.1 or newer)")
+		}
+
 		if probes.HaveLargeInstructionLimit() != nil {
 			log.Fatalf("Require support for large programs (Linux 5.2.0 or newer)")
 		}


### PR DESCRIPTION
This PR adds a test to check for dead code elimination support in
the kernel. Support was added in v5.1, our new minimum supported version
is v5.4. This feature will be crucial for the datapath to properly
function in the future. So assert this kernel feature works on startup.

```release-note
Require dead code elimination support
```
