### PR TITLE
statedb: Fix race between Observable and DB stopping

### DIFF
--- a/pkg/statedb/db.go
+++ b/pkg/statedb/db.go
@@ -234,7 +234,6 @@ func (db *DB) Start(cell.HookContext) error {
 }
 
 func (db *DB) Stop(stopCtx cell.HookContext) error {
-	close(db.gcTrigger)
 	db.cancel()
 	select {
 	case <-stopCtx.Done():

--- a/pkg/statedb/graveyard.go
+++ b/pkg/statedb/graveyard.go
@@ -24,7 +24,13 @@ func graveyardWorker(db *DB, ctx context.Context, gcRateLimitInterval time.Durat
 	defer limiter.Stop()
 	defer close(db.gcExited)
 
-	for range db.gcTrigger {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-db.gcTrigger:
+		}
+
 		// Throttle garbage collection.
 		if err := limiter.Wait(ctx); err != nil {
 			return


### PR DESCRIPTION
Since "Observable" forks a goroutine that is not tied to the lifecycle of the application what may occur is that the "observe" goroutine calls DeleteTracker.Close after DB.Stop, leading to:

```
    panic: send on closed channel

    goroutine 106 [running]:
    github.com/cilium/cilium/pkg/statedb.(*DeleteTracker[...]).Close(0x0)
        /host/pkg/statedb/deletetracker.go:76 +0x21e
```

While it would be ideal that goroutines created by statedb would be tied to its lifecycle and thus Stop() could wait for e.g. all observable goroutines to be finished, it's not enough as DeleteTracker's may be created outside and stopped after DB. Thus this commit changes the logic to make it safe to call DeleteTracker.Close() even after the DB has stopped.

The fix was validated by adding a "defer time.Sleep(100*time.Millisecond)" to observable.go before the "dt.Close()" to force it to run after DB.Stop, with it failing with "send on closed channel" before fix and passing after.

As a future follow-up it would make sense to use a Hive job group tied to DB's lifecycle to make sure all goroutines are cleaned up (this follow-up will be done against the cilium/statedb repo as it's being moved there). The fix in this commit is already part of cilium/statedb repo and does not need to be ported.

Fixes: #30806
Fixes: 23b0492f30c8 ("statedb2: StateDB v2.0 with per-table locks and deletion tracking")