### PR TITLE
[v1.14] bpf: improve trace events in SNAT path

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -968,7 +968,7 @@ __snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 
 static __always_inline __maybe_unused int
 snat_v4_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
-	    struct trace_ctx *trace, __s8 *ext_err)
+	    __be32 *saddr, struct trace_ctx *trace, __s8 *ext_err)
 {
 	struct icmphdr icmphdr __align_stack_8;
 	struct ipv4_ct_tuple tuple = {};
@@ -988,6 +988,7 @@ snat_v4_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 		return DROP_INVALID;
 
 	snat_v4_init_tuple(ip4, NAT_DIR_EGRESS, &tuple);
+	*saddr = tuple.saddr;
 	has_l4_header = ipv4_has_l4_header(ip4);
 
 	off = ((void *)ip4 - data) + ipv4_hdrlen(ip4);
@@ -1825,7 +1826,7 @@ __snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 
 static __always_inline __maybe_unused int
 snat_v6_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
-	    struct trace_ctx *trace, __s8 *ext_err)
+	    union v6addr *saddr, struct trace_ctx *trace, __s8 *ext_err)
 {
 	struct icmp6hdr icmp6hdr __align_stack_8;
 	struct ipv6_ct_tuple tuple = {};
@@ -1850,6 +1851,7 @@ snat_v6_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 		return hdrlen;
 
 	snat_v6_init_tuple(ip6, NAT_DIR_EGRESS, &tuple);
+	ipv6_addr_copy(saddr, &tuple.saddr);
 
 	off = ((void *)ip6 - data) + hdrlen;
 	switch (tuple.nexthdr) {

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1450,7 +1450,7 @@ int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 		return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
 						  CTX_ACT_DROP, METRIC_EGRESS);
 
-	send_trace_notify6(ctx, obs_point, 0, 0, &saddr, 0, 0,
+	send_trace_notify6(ctx, obs_point, 0, 0, &saddr, 0, NATIVE_DEV_IFINDEX,
 			   trace.reason, trace.monitor);
 
 	return ret;
@@ -2894,7 +2894,7 @@ int tail_handle_snat_fwd_ipv4(struct __ctx_buff *ctx)
 		return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
 						  CTX_ACT_DROP, METRIC_EGRESS);
 
-	send_trace_notify4(ctx, obs_point, 0, 0, saddr, 0, 0,
+	send_trace_notify4(ctx, obs_point, 0, 0, saddr, 0, NATIVE_DEV_IFINDEX,
 			   trace.reason, trace.monitor);
 
 	return ret;

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -563,6 +563,7 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 	};
 	struct ipv4_nat_entry state;
 	struct trace_ctx trace;
+	__be32 saddr = 0;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
 				  false, NULL);
@@ -571,7 +572,7 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &target, &trace, NULL);
+	ret = snat_v4_nat(ctx, &target, &saddr, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -673,6 +674,7 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 	};
 	struct ipv4_nat_entry state;
 	struct trace_ctx trace;
+	__be32 saddr = 0;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
 				  false, NULL);
@@ -681,7 +683,7 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &target, &trace, NULL);
+	ret = snat_v4_nat(ctx, &target, &saddr, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -782,6 +784,7 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 	};
 	struct ipv4_nat_entry state;
 	struct trace_ctx trace;
+	__be32 saddr = 0;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
 				  false, NULL);
@@ -790,7 +793,7 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &target, &trace, NULL);
+	ret = snat_v4_nat(ctx, &target, &saddr, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -880,6 +883,7 @@ int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 	};
 	struct ipv4_nat_entry state;
 	struct trace_ctx trace;
+	__be32 saddr = 0;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
 				  false, NULL);
@@ -888,7 +892,7 @@ int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &target, &trace, NULL);
+	ret = snat_v4_nat(ctx, &target, &saddr, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;


### PR DESCRIPTION
Manual backport of https://github.com/cilium/cilium/pull/28723, as the SNAT code looks slightly different in `v1.14`.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 28723
```