### PR TITLE
bpf: Re-introduce ICMPv6 NS responder on from-netdev

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -144,31 +144,28 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 #ifdef ENABLE_HOST_FIREWALL
 	struct ct_buffer6 ct_buffer = {};
 	bool need_hostfw = false;
-	__u8 nexthdr;
-	int hdrlen;
 	bool is_host_id = false;
 #endif /* ENABLE_HOST_FIREWALL */
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
-	int __maybe_unused ret;
+	int ret, hdrlen;
+	__u8 nexthdr;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-#ifdef ENABLE_HOST_FIREWALL
 	nexthdr = ip6->nexthdr;
 	hdrlen = ipv6_hdrlen(ctx, &nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 
 	if (likely(nexthdr == IPPROTO_ICMPV6)) {
-		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen);
+		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen, ext_err, !from_host);
 		if (ret == SKIP_HOST_FIREWALL)
 			goto skip_host_firewall;
 		if (IS_ERR(ret))
 			return ret;
 	}
-#endif /* ENABLE_HOST_FIREWALL */
 
 #ifdef ENABLE_NODEPORT
 	if (!from_host) {
@@ -213,8 +210,10 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 		if (map_update_elem(&CT_TAIL_CALL_BUFFER6, &zero, &ct_buffer, 0) < 0)
 			return DROP_INVALID_TC_BUFFER;
 	}
+#endif /* ENABLE_HOST_FIREWALL */
 
 skip_host_firewall:
+#ifdef ENABLE_HOST_FIREWALL
 	ctx_store_meta(ctx, CB_FROM_HOST,
 		       (need_hostfw ? FROM_HOST_FLAG_NEED_HOSTFW : 0) |
 		       (is_host_id ? FROM_HOST_FLAG_HOST_ID : 0));
@@ -497,7 +496,7 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext
 		return hdrlen;
 
 	if (likely(nexthdr == IPPROTO_ICMPV6)) {
-		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen);
+		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen, ext_err, false);
 		if (ret == SKIP_HOST_FIREWALL)
 			return CTX_ACT_OK;
 		if (IS_ERR(ret))

--- a/bpf/tests/ipv6_ndp_from_netdev_test.c
+++ b/bpf/tests/ipv6_ndp_from_netdev_test.c
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+#define ROUTER_IP
+#define HOST_IP
+#include "config_replacement.h"
+#undef ROUTER_IP
+#undef HOST_IP
+
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define SECCTX_FROM_IPCACHE 1
+
+#include "bpf_host.c"
+
+#include "lib/ipcache.h"
+#include "lib/endpoint.h"
+
+#define FROM_NETDEV 0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_from_netdev,
+	},
+};
+
+PKTGEN("tc", "01_ipv6_from_netdev_ns_for_pod")
+int ipv6_from_netdev_ns_for_pod_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmp6hdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_icmp6_packet(&builder,
+					    (__u8 *)mac_one, (__u8 *)mac_two,
+					    (__u8 *)v6_pod_one, (__u8 *)v6_pod_two,
+					    ICMP6_NS_MSG_TYPE);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, (__u8 *)v6_pod_three, 16);
+	if (!data)
+		return TEST_ERROR;
+
+	__u8 options[] = {0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1};
+
+	data = pktgen__push_data(&builder, (__u8 *)options, 8);
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "01_ipv6_from_netdev_ns_for_pod")
+int ipv6_from_netdev_ns_for_pod_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v6_add_entry((union v6addr *)v6_pod_three, 0, 0, 0,
+			      (__u8 *)mac_three, (__u8 *)mac_two);
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "01_ipv6_from_netdev_ns_for_pod")
+int ipv6_from_netdev_ns_for_pod_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct icmp6hdr *l4;
+	void *payload;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	printk("status_code: %d\n", *status_code);
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(*status_code);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IPV6))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	union macaddr node_mac = NODE_MAC;
+
+	if (memcmp(l2->h_source, (__u8 *)&node_mac.addr, ETH_ALEN) != 0)
+		test_fatal("src mac hasn't been set to node mac");
+
+	if (memcmp(l2->h_dest, (__u8 *)mac_one, ETH_ALEN) != 0)
+		test_fatal("dest mac hasn't been set to source mac");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	union v6addr router_ip;
+
+	BPF_V6(router_ip, ROUTER_IP);
+	if (memcmp((__u8 *)&l3->saddr, (__u8 *)&router_ip, 16) != 0)
+		test_fatal("src IP hasn't been set to router IP");
+
+	if (memcmp((__u8 *)&l3->daddr, (__u8 *)v6_pod_one, 16) != 0)
+		test_fatal("dest IP hasn't been set to source IP");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+
+	if ((void *)l4 + sizeof(struct icmp6hdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->icmp6_type != ICMP6_NA_MSG_TYPE)
+		test_fatal("icmp6 type hasn't been set to ICMP6_NA_MSG_TYPE");
+
+	payload = (void *)l4 + sizeof(struct icmp6hdr);
+	if ((void *)payload + 24 > data_end)
+		test_fatal("payload out of bounds");
+
+	void *target = payload;
+
+	if (memcmp(target, (__u8 *)v6_pod_three, 16) != 0)
+		test_fatal("icmp6 payload target hasn't been set properly");
+
+	void *target_lladdr = payload + 16 + 2;
+
+	if (memcmp(target_lladdr, (__u8 *)&node_mac.addr, ETH_ALEN) != 0)
+		test_fatal("icmp6 payload target_lladdr hasn't been set properly");
+
+	test_finish();
+}
+
+PKTGEN("tc", "02_ipv6_from_netdev_ns_for_node_ip")
+int ipv6_from_netdev_ns_for_node_ip_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmp6hdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_icmp6_packet(&builder,
+					    (__u8 *)mac_one, (__u8 *)mac_two,
+					    (__u8 *)v6_pod_one, (__u8 *)v6_pod_two,
+					    ICMP6_NS_MSG_TYPE);
+	if (!l4)
+		return TEST_ERROR;
+
+	union v6addr node_ip;
+
+	BPF_V6(node_ip, HOST_IP);
+	data = pktgen__push_data(&builder, (__u8 *)&node_ip, 16);
+	if (!data)
+		return TEST_ERROR;
+
+	__u8 options[] = {0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1};
+
+	data = pktgen__push_data(&builder, (__u8 *)options, 8);
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "02_ipv6_from_netdev_ns_for_node_ip")
+int ipv6_from_netdev_ns_for_node_ip_setup(struct __ctx_buff *ctx)
+{
+	union v6addr node_ip;
+
+	BPF_V6(node_ip, HOST_IP);
+	endpoint_v6_add_entry((union v6addr *)&node_ip, 0, 0, ENDPOINT_F_HOST,
+			      (__u8 *)mac_three, (__u8 *)mac_two);
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "02_ipv6_from_netdev_ns_for_node_ip")
+int ipv6_from_netdev_ns_for_node_ip_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct icmp6hdr *l4;
+	void *payload;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	printk("status_code: %d\n", *status_code);
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(*status_code);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IPV6))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	if (memcmp(l2->h_source, (__u8 *)mac_one, ETH_ALEN) != 0)
+		test_fatal("src mac hasn't been set to source ep's mac");
+
+	if (memcmp(l2->h_dest, (__u8 *)mac_two, ETH_ALEN) != 0)
+		test_fatal("dest mac hasn't been set to dest ep's mac");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (memcmp((__u8 *)&l3->saddr, (__u8 *)v6_pod_one, 16) != 0)
+		test_fatal("src IP was changed");
+
+	if (memcmp((__u8 *)&l3->daddr, (__u8 *)v6_pod_two, 16) != 0)
+		test_fatal("dest IP was changed");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+
+	if ((void *)l4 + sizeof(struct icmp6hdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->icmp6_type != ICMP6_NS_MSG_TYPE)
+		test_fatal("icmp6 type was changed");
+
+	payload = (void *)l4 + sizeof(struct icmp6hdr);
+	if ((void *)payload + 24 > data_end)
+		test_fatal("payload out of bounds");
+
+	union v6addr node_ip;
+
+	BPF_V6(node_ip, HOST_IP);
+	if (memcmp(payload, (__u8 *)&node_ip, 16) != 0)
+		test_fatal("icmp6 payload target was changed");
+
+	test_finish();
+}

--- a/bpf/tests/tc_nodeport_l3_dev.c
+++ b/bpf/tests/tc_nodeport_l3_dev.c
@@ -12,7 +12,6 @@
 #define ENABLE_HOST_ROUTING
 #define ENABLE_IPV4
 #define ENABLE_IPV6
-#define SKIP_ICMPV6_NS_HANDLING
 
 #define TEST_IP_LOCAL		v4_pod_one
 #define TEST_IP_REMOTE		v4_pod_two


### PR DESCRIPTION
This reverts commit 658071414ca4606e537bc4bbb37dcae5e18cd7dc, to fix the breakage of "IPv6 NS responder for pod" introduced by https://github.com/cilium/cilium/pull/12086 (bpf: Reply NA when recv ND for local IPv6 endpoints).

658071414ca4606e537bc4bbb37dcae5e18cd7dc was merged to solve https://github.com/cilium/cilium/issues/14509. To not revive #14509, this commit also passes through ICMPv6 NS if the target is native node IP (eth0's addr). By letting stack take care of those NS-for-node-IP packets, we managed to:

1. Solve #14509 again, but in a way keeping NS responder. The cause of #14509 was NS responder always generates ND whose source IP is "router_ip" (cilium_internal_ip) rather than "node_ip". Once we pass those NS-for-node-IP packets to stack, the ND response would naturally have "node_ip" as source.

2. Avoid the fib_lookup failure mentioned at https://github.com/cilium/cilium/pull/30837#issuecomment-1960897445.

This PR also adds bpf unit test to cover IPv6 NS responder feature.

Fixes: #30926 

```release-note
Fixes an IPv6 issue that cilium doesn't respond to Neighbor Solicitation targeting the pods on same node.
```
