### PR TITLE
ingress/gateway-api: expose listeners on host network

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -11,110 +11,114 @@ cilium-operator-alibabacloud [flags]
 ### Options
 
 ```
-      --alibaba-cloud-vpc-id string                          Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
-      --auto-create-cilium-pod-ip-pools map                  Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
-      --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
-      --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
-      --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
-      --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
-      --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
-      --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
-      --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
-      --cluster-pool-ipv6-mask-size int                      Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
-      --cnp-status-cleanup-burst int                         Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
-      --cnp-status-cleanup-qps float                         Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
-      --config string                                        Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                                    Configuration directory that contains a file for each option
-      --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-  -D, --debug                                                Enable debugging mode
-      --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipv4                                          Enable IPv4 support (default true)
-      --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-metrics                                       Enable Prometheus metrics
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for cilium-operator-alibabacloud
-      --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --ipam string                                          Backend to use for IPAM (default "alibabacloud")
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-client-burst int                                 Burst value allowed for the K8s client
-      --k8s-client-qps float32                               Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                                 Name of the Kubernetes namespace in which Cilium Operator is deployed in
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --kvstore string                                       Key-value store type
-      --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
-      --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
-      --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
-      --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                             Upper burst limit when accessing external APIs (default 20)
-      --limit-ipam-api-qps float                             Queries per second limit when accessing external IPAM APIs (default 4)
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --log-driver strings                                   Logging endpoints to use for example syslog
-      --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
-      --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
-      --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
-      --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --subnet-ids-filter strings                            Subnets IDs (separated by commas)
-      --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
-      --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
-      --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --version                                              Print version information
+      --alibaba-cloud-vpc-id string                             Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
+      --auto-create-cilium-pod-ip-pools map                     Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
+      --bgp-announce-lb-ip                                      Announces service IPs of type LoadBalancer via BGP
+      --bgp-config-path string                                  Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
+      --bgp-v2-api-enabled                                      Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                    List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings                List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings                List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                           Flag to enable dynamic rate limit specified in separate fields instead of the static one
+      --ces-max-ciliumendpoints-per-ces int                     Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                   Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                                 CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                               CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
+      --cilium-endpoint-gc-interval duration                    GC interval for cilium endpoints (default 5m0s)
+      --cilium-pod-labels string                                Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
+      --cilium-pod-namespace string                             Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
+      --cluster-id uint32                                       Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --cluster-pool-ipv4-cidr strings                          IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
+      --cluster-pool-ipv4-mask-size int                         Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
+      --cluster-pool-ipv6-cidr strings                          IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
+      --cluster-pool-ipv6-mask-size int                         Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --cnp-status-cleanup-burst int                            Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
+      --cnp-status-cleanup-qps float                            Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
+      --config string                                           Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                                       Configuration directory that contains a file for each option
+      --controller-group-metrics strings                        List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+  -D, --debug                                                   Enable debugging mode
+      --enable-cilium-endpoint-slice                            If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
+      --enable-cilium-operator-server-access strings            List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-proxy-protocol                       Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                         Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                               Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                           Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                             Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipv4                                             Enable IPv4 support (default true)
+      --enable-ipv6                                             Enable IPv6 support (default true)
+      --enable-k8s                                              Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-metrics                                          Enable Prometheus metrics
+      --enable-node-ipam                                        Enable Node IPAM
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gops-port uint16                                        Port for gops server to listen on (default 9891)
+  -h, --help                                                    help for cilium-operator-alibabacloud
+      --identity-allocation-mode string                         Method to use for identity allocation (default "kvstore")
+      --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                     Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                          Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                      Default secret name for Ingress.
+      --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32             The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
+      --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                        Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                   Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --instance-tags-filter map                                EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --ipam string                                             Backend to use for IPAM (default "alibabacloud")
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-client-burst int                                    Burst value allowed for the K8s client
+      --k8s-client-qps float32                                  Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                                    Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kube-proxy-replacement string                           Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --kvstore string                                          Key-value store type
+      --kvstore-opt map                                         Key-value store options e.g. etcd.address=127.0.0.1:4001
+      --leader-election-lease-duration duration                 Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
+      --leader-election-renew-deadline duration                 Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-retry-period duration                   Duration that LeaderElector clients should wait between retries of the actions (default 2s)
+      --limit-ipam-api-burst int                                Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                Queries per second limit when accessing external IPAM APIs (default 4)
+      --loadbalancer-l7-algorithm string                        Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                           List of service ports that will be automatically redirected to backend.
+      --log-driver strings                                      Logging endpoints to use for example syslog
+      --log-opt map                                             Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
+      --max-connected-clusters uint32                           Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-mutual-enabled                                The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                     The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                   SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration      SPIRE server connection timeout. (default 10s)
+      --nodes-gc-interval duration                              GC interval for CiliumNodes (default 5m0s)
+      --operator-api-serve-addr string                          Address to serve API requests (default "localhost:9234")
+      --operator-pprof                                          Enable serving pprof debugging API
+      --operator-pprof-address string                           Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                              Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                   Address to serve Prometheus metrics (default ":9963")
+      --parallel-alloc-workers int                              Maximum number of parallel IPAM workers (default 50)
+      --pod-restart-selector string                             cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --remove-cilium-node-taints                               Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                              Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                  Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
+      --skip-crd-creation                                       When true, Kubernetes Custom Resource Definitions will not be created
+      --subnet-ids-filter strings                               Subnets IDs (separated by commas)
+      --subnet-tags-filter map                                  Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --synchronize-k8s-nodes                                   Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
+      --synchronize-k8s-services                                Synchronize Kubernetes services to kvstore (default true)
+      --unmanaged-pod-watcher-interval int                      Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
+      --version                                                 Print version information
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -56,6 +56,7 @@ cilium-operator-alibabacloud [flags]
       --enable-node-port                                        Enable NodePort type services by Cilium
       --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for cilium-operator-alibabacloud
@@ -69,6 +70,7 @@ cilium-operator-alibabacloud [flags]
       --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32             The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-nodelabelselector string            Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
       --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
       --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -11,64 +11,68 @@ cilium-operator-alibabacloud hive [flags]
 ### Options
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for hive
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-client-burst int                                 Burst value allowed for the K8s client
-      --k8s-client-qps float32                               Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --bgp-v2-api-enabled                                      Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                    List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings                List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings                List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                           Flag to enable dynamic rate limit specified in separate fields instead of the static one
+      --ces-max-ciliumendpoints-per-ces int                     Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                   Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                                 CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                               CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
+      --cluster-id uint32                                       Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --controller-group-metrics strings                        List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --enable-cilium-operator-server-access strings            List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-proxy-protocol                       Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                         Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                               Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                           Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                             Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-k8s                                              Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-node-ipam                                        Enable Node IPAM
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gops-port uint16                                        Port for gops server to listen on (default 9891)
+  -h, --help                                                    help for hive
+      --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                     Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                          Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                      Default secret name for Ingress.
+      --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
+      --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
+      --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                        Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                   Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-client-burst int                                    Burst value allowed for the K8s client
+      --k8s-client-qps float32                                  Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kube-proxy-replacement string                           Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --loadbalancer-l7-algorithm string                        Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                           List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                           Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-mutual-enabled                                The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                     The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                   SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration      SPIRE server connection timeout. (default 10s)
+      --operator-api-serve-addr string                          Address to serve API requests (default "localhost:9234")
+      --operator-pprof                                          Enable serving pprof debugging API
+      --operator-pprof-address string                           Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                              Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                   Address to serve Prometheus metrics (default ":9963")
+      --skip-crd-creation                                       When true, Kubernetes Custom Resource Definitions will not be created
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -36,6 +36,7 @@ cilium-operator-alibabacloud hive [flags]
       --enable-node-port                                        Enable NodePort type services by Cilium
       --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for hive
@@ -47,6 +48,7 @@ cilium-operator-alibabacloud hive [flags]
       --ingress-default-secret-name string                      Default secret name for Ingress.
       --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
       --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-nodelabelselector string            Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
       --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
       --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -17,63 +17,67 @@ cilium-operator-alibabacloud hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-client-burst int                                 Burst value allowed for the K8s client
-      --k8s-client-qps float32                               Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --bgp-v2-api-enabled                                      Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                    List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings                List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings                List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                           Flag to enable dynamic rate limit specified in separate fields instead of the static one
+      --ces-max-ciliumendpoints-per-ces int                     Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                   Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                                 CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                               CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
+      --cluster-id uint32                                       Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --controller-group-metrics strings                        List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --enable-cilium-operator-server-access strings            List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-proxy-protocol                       Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                         Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                               Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                           Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                             Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-k8s                                              Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-node-ipam                                        Enable Node IPAM
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gops-port uint16                                        Port for gops server to listen on (default 9891)
+      --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                     Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                          Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                      Default secret name for Ingress.
+      --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
+      --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
+      --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                        Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                   Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-client-burst int                                    Burst value allowed for the K8s client
+      --k8s-client-qps float32                                  Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kube-proxy-replacement string                           Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --loadbalancer-l7-algorithm string                        Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                           List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                           Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-mutual-enabled                                The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                     The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                   SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration      SPIRE server connection timeout. (default 10s)
+      --operator-api-serve-addr string                          Address to serve API requests (default "localhost:9234")
+      --operator-pprof                                          Enable serving pprof debugging API
+      --operator-pprof-address string                           Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                              Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                   Address to serve Prometheus metrics (default ":9963")
+      --skip-crd-creation                                       When true, Kubernetes Custom Resource Definitions will not be created
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -42,6 +42,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --enable-node-port                                        Enable NodePort type services by Cilium
       --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
@@ -52,6 +53,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --ingress-default-secret-name string                      Default secret name for Ingress.
       --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
       --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-nodelabelselector string            Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
       --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
       --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -64,6 +64,7 @@ cilium-operator-aws [flags]
       --eni-tags map                                            ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)
       --excess-ip-release-delay int                             Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for cilium-operator-aws
@@ -77,6 +78,7 @@ cilium-operator-aws [flags]
       --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32             The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-nodelabelselector string            Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
       --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
       --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -11,119 +11,123 @@ cilium-operator-aws [flags]
 ### Options
 
 ```
-      --auto-create-cilium-pod-ip-pools map                  Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
-      --aws-enable-prefix-delegation                         Allows operator to allocate prefixes to ENIs instead of individual IP addresses
-      --aws-instance-limit-mapping map                       Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"}
-      --aws-release-excess-ips                               Enable releasing excess free IP addresses from AWS ENI.
-      --aws-use-primary-address                              Allows for using primary address of the ENI for allocations on the node
-      --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
-      --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
-      --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
-      --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
-      --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
-      --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
-      --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
-      --cluster-pool-ipv6-mask-size int                      Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
-      --cnp-status-cleanup-burst int                         Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
-      --cnp-status-cleanup-qps float                         Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
-      --config string                                        Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                                    Configuration directory that contains a file for each option
-      --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-  -D, --debug                                                Enable debugging mode
-      --ec2-api-endpoint string                              AWS API endpoint for the EC2 service
-      --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipv4                                          Enable IPv4 support (default true)
-      --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-metrics                                       Enable Prometheus metrics
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --eni-gc-interval duration                             Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
-      --eni-gc-tags map                                      Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected
-      --eni-tags map                                         ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)
-      --excess-ip-release-delay int                          Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for cilium-operator-aws
-      --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --ipam string                                          Backend to use for IPAM (default "eni")
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-client-burst int                                 Burst value allowed for the K8s client
-      --k8s-client-qps float32                               Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                                 Name of the Kubernetes namespace in which Cilium Operator is deployed in
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --kvstore string                                       Key-value store type
-      --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
-      --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
-      --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
-      --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                             Upper burst limit when accessing external APIs (default 20)
-      --limit-ipam-api-qps float                             Queries per second limit when accessing external IPAM APIs (default 4)
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --log-driver strings                                   Logging endpoints to use for example syslog
-      --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
-      --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
-      --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
-      --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --subnet-ids-filter strings                            Subnets IDs (separated by commas)
-      --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
-      --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
-      --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --update-ec2-adapter-limit-via-api                     Use the EC2 API to update the instance type to adapter limits (default true)
-      --version                                              Print version information
+      --auto-create-cilium-pod-ip-pools map                     Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
+      --aws-enable-prefix-delegation                            Allows operator to allocate prefixes to ENIs instead of individual IP addresses
+      --aws-instance-limit-mapping map                          Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"}
+      --aws-release-excess-ips                                  Enable releasing excess free IP addresses from AWS ENI.
+      --aws-use-primary-address                                 Allows for using primary address of the ENI for allocations on the node
+      --bgp-announce-lb-ip                                      Announces service IPs of type LoadBalancer via BGP
+      --bgp-config-path string                                  Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
+      --bgp-v2-api-enabled                                      Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                    List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings                List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings                List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                           Flag to enable dynamic rate limit specified in separate fields instead of the static one
+      --ces-max-ciliumendpoints-per-ces int                     Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                   Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                                 CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                               CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
+      --cilium-endpoint-gc-interval duration                    GC interval for cilium endpoints (default 5m0s)
+      --cilium-pod-labels string                                Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
+      --cilium-pod-namespace string                             Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
+      --cluster-id uint32                                       Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --cluster-pool-ipv4-cidr strings                          IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
+      --cluster-pool-ipv4-mask-size int                         Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
+      --cluster-pool-ipv6-cidr strings                          IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
+      --cluster-pool-ipv6-mask-size int                         Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --cnp-status-cleanup-burst int                            Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
+      --cnp-status-cleanup-qps float                            Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
+      --config string                                           Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                                       Configuration directory that contains a file for each option
+      --controller-group-metrics strings                        List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+  -D, --debug                                                   Enable debugging mode
+      --ec2-api-endpoint string                                 AWS API endpoint for the EC2 service
+      --enable-cilium-endpoint-slice                            If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
+      --enable-cilium-operator-server-access strings            List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-proxy-protocol                       Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                         Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                               Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                           Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                             Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipv4                                             Enable IPv4 support (default true)
+      --enable-ipv6                                             Enable IPv6 support (default true)
+      --enable-k8s                                              Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-metrics                                          Enable Prometheus metrics
+      --enable-node-ipam                                        Enable Node IPAM
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --eni-gc-interval duration                                Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
+      --eni-gc-tags map                                         Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected
+      --eni-tags map                                            ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)
+      --excess-ip-release-delay int                             Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
+      --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gops-port uint16                                        Port for gops server to listen on (default 9891)
+  -h, --help                                                    help for cilium-operator-aws
+      --identity-allocation-mode string                         Method to use for identity allocation (default "kvstore")
+      --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                     Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                          Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                      Default secret name for Ingress.
+      --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32             The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
+      --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                        Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                   Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --instance-tags-filter map                                EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --ipam string                                             Backend to use for IPAM (default "eni")
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-client-burst int                                    Burst value allowed for the K8s client
+      --k8s-client-qps float32                                  Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                                    Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kube-proxy-replacement string                           Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --kvstore string                                          Key-value store type
+      --kvstore-opt map                                         Key-value store options e.g. etcd.address=127.0.0.1:4001
+      --leader-election-lease-duration duration                 Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
+      --leader-election-renew-deadline duration                 Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-retry-period duration                   Duration that LeaderElector clients should wait between retries of the actions (default 2s)
+      --limit-ipam-api-burst int                                Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                Queries per second limit when accessing external IPAM APIs (default 4)
+      --loadbalancer-l7-algorithm string                        Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                           List of service ports that will be automatically redirected to backend.
+      --log-driver strings                                      Logging endpoints to use for example syslog
+      --log-opt map                                             Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
+      --max-connected-clusters uint32                           Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-mutual-enabled                                The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                     The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                   SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration      SPIRE server connection timeout. (default 10s)
+      --nodes-gc-interval duration                              GC interval for CiliumNodes (default 5m0s)
+      --operator-api-serve-addr string                          Address to serve API requests (default "localhost:9234")
+      --operator-pprof                                          Enable serving pprof debugging API
+      --operator-pprof-address string                           Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                              Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                   Address to serve Prometheus metrics (default ":9963")
+      --parallel-alloc-workers int                              Maximum number of parallel IPAM workers (default 50)
+      --pod-restart-selector string                             cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --remove-cilium-node-taints                               Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                              Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                  Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
+      --skip-crd-creation                                       When true, Kubernetes Custom Resource Definitions will not be created
+      --subnet-ids-filter strings                               Subnets IDs (separated by commas)
+      --subnet-tags-filter map                                  Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --synchronize-k8s-nodes                                   Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
+      --synchronize-k8s-services                                Synchronize Kubernetes services to kvstore (default true)
+      --unmanaged-pod-watcher-interval int                      Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
+      --update-ec2-adapter-limit-via-api                        Use the EC2 API to update the instance type to adapter limits (default true)
+      --version                                                 Print version information
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -11,64 +11,68 @@ cilium-operator-aws hive [flags]
 ### Options
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for hive
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-client-burst int                                 Burst value allowed for the K8s client
-      --k8s-client-qps float32                               Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --bgp-v2-api-enabled                                      Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                    List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings                List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings                List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                           Flag to enable dynamic rate limit specified in separate fields instead of the static one
+      --ces-max-ciliumendpoints-per-ces int                     Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                   Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                                 CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                               CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
+      --cluster-id uint32                                       Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --controller-group-metrics strings                        List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --enable-cilium-operator-server-access strings            List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-proxy-protocol                       Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                         Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                               Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                           Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                             Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-k8s                                              Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-node-ipam                                        Enable Node IPAM
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gops-port uint16                                        Port for gops server to listen on (default 9891)
+  -h, --help                                                    help for hive
+      --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                     Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                          Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                      Default secret name for Ingress.
+      --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
+      --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
+      --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                        Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                   Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-client-burst int                                    Burst value allowed for the K8s client
+      --k8s-client-qps float32                                  Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kube-proxy-replacement string                           Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --loadbalancer-l7-algorithm string                        Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                           List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                           Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-mutual-enabled                                The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                     The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                   SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration      SPIRE server connection timeout. (default 10s)
+      --operator-api-serve-addr string                          Address to serve API requests (default "localhost:9234")
+      --operator-pprof                                          Enable serving pprof debugging API
+      --operator-pprof-address string                           Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                              Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                   Address to serve Prometheus metrics (default ":9963")
+      --skip-crd-creation                                       When true, Kubernetes Custom Resource Definitions will not be created
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -36,6 +36,7 @@ cilium-operator-aws hive [flags]
       --enable-node-port                                        Enable NodePort type services by Cilium
       --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for hive
@@ -47,6 +48,7 @@ cilium-operator-aws hive [flags]
       --ingress-default-secret-name string                      Default secret name for Ingress.
       --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
       --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-nodelabelselector string            Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
       --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
       --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -42,6 +42,7 @@ cilium-operator-aws hive dot-graph [flags]
       --enable-node-port                                        Enable NodePort type services by Cilium
       --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
@@ -52,6 +53,7 @@ cilium-operator-aws hive dot-graph [flags]
       --ingress-default-secret-name string                      Default secret name for Ingress.
       --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
       --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-nodelabelselector string            Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
       --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
       --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -17,63 +17,67 @@ cilium-operator-aws hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-client-burst int                                 Burst value allowed for the K8s client
-      --k8s-client-qps float32                               Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --bgp-v2-api-enabled                                      Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                    List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings                List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings                List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                           Flag to enable dynamic rate limit specified in separate fields instead of the static one
+      --ces-max-ciliumendpoints-per-ces int                     Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                   Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                                 CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                               CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
+      --cluster-id uint32                                       Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --controller-group-metrics strings                        List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --enable-cilium-operator-server-access strings            List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-proxy-protocol                       Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                         Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                               Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                           Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                             Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-k8s                                              Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-node-ipam                                        Enable Node IPAM
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gops-port uint16                                        Port for gops server to listen on (default 9891)
+      --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                     Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                          Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                      Default secret name for Ingress.
+      --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
+      --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
+      --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                        Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                   Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-client-burst int                                    Burst value allowed for the K8s client
+      --k8s-client-qps float32                                  Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kube-proxy-replacement string                           Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --loadbalancer-l7-algorithm string                        Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                           List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                           Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-mutual-enabled                                The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                     The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                   SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration      SPIRE server connection timeout. (default 10s)
+      --operator-api-serve-addr string                          Address to serve API requests (default "localhost:9234")
+      --operator-pprof                                          Enable serving pprof debugging API
+      --operator-pprof-address string                           Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                              Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                   Address to serve Prometheus metrics (default ":9963")
+      --skip-crd-creation                                       When true, Kubernetes Custom Resource Definitions will not be created
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -59,6 +59,7 @@ cilium-operator-azure [flags]
       --enable-node-port                                        Enable NodePort type services by Cilium
       --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for cilium-operator-azure
@@ -72,6 +73,7 @@ cilium-operator-azure [flags]
       --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32             The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-nodelabelselector string            Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
       --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
       --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -11,113 +11,117 @@ cilium-operator-azure [flags]
 ### Options
 
 ```
-      --auto-create-cilium-pod-ip-pools map                  Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
-      --azure-resource-group string                          Resource group to use for Azure IPAM
-      --azure-subscription-id string                         Subscription ID to access Azure API
-      --azure-use-primary-address                            Use Azure IP address from interface's primary IPConfigurations
-      --azure-user-assigned-identity-id string               ID of the user assigned identity used to auth with the Azure API
-      --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
-      --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
-      --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
-      --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
-      --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
-      --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
-      --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
-      --cluster-pool-ipv6-mask-size int                      Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
-      --cnp-status-cleanup-burst int                         Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
-      --cnp-status-cleanup-qps float                         Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
-      --config string                                        Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                                    Configuration directory that contains a file for each option
-      --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-  -D, --debug                                                Enable debugging mode
-      --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipv4                                          Enable IPv4 support (default true)
-      --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-metrics                                       Enable Prometheus metrics
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for cilium-operator-azure
-      --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --ipam string                                          Backend to use for IPAM (default "azure")
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-client-burst int                                 Burst value allowed for the K8s client
-      --k8s-client-qps float32                               Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                                 Name of the Kubernetes namespace in which Cilium Operator is deployed in
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --kvstore string                                       Key-value store type
-      --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
-      --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
-      --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
-      --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                             Upper burst limit when accessing external APIs (default 20)
-      --limit-ipam-api-qps float                             Queries per second limit when accessing external IPAM APIs (default 4)
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --log-driver strings                                   Logging endpoints to use for example syslog
-      --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
-      --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
-      --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
-      --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --subnet-ids-filter strings                            Subnets IDs (separated by commas)
-      --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
-      --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
-      --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --version                                              Print version information
+      --auto-create-cilium-pod-ip-pools map                     Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
+      --azure-resource-group string                             Resource group to use for Azure IPAM
+      --azure-subscription-id string                            Subscription ID to access Azure API
+      --azure-use-primary-address                               Use Azure IP address from interface's primary IPConfigurations
+      --azure-user-assigned-identity-id string                  ID of the user assigned identity used to auth with the Azure API
+      --bgp-announce-lb-ip                                      Announces service IPs of type LoadBalancer via BGP
+      --bgp-config-path string                                  Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
+      --bgp-v2-api-enabled                                      Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                    List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings                List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings                List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                           Flag to enable dynamic rate limit specified in separate fields instead of the static one
+      --ces-max-ciliumendpoints-per-ces int                     Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                   Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                                 CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                               CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
+      --cilium-endpoint-gc-interval duration                    GC interval for cilium endpoints (default 5m0s)
+      --cilium-pod-labels string                                Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
+      --cilium-pod-namespace string                             Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
+      --cluster-id uint32                                       Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --cluster-pool-ipv4-cidr strings                          IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
+      --cluster-pool-ipv4-mask-size int                         Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
+      --cluster-pool-ipv6-cidr strings                          IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
+      --cluster-pool-ipv6-mask-size int                         Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --cnp-status-cleanup-burst int                            Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
+      --cnp-status-cleanup-qps float                            Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
+      --config string                                           Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                                       Configuration directory that contains a file for each option
+      --controller-group-metrics strings                        List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+  -D, --debug                                                   Enable debugging mode
+      --enable-cilium-endpoint-slice                            If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
+      --enable-cilium-operator-server-access strings            List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-proxy-protocol                       Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                         Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                               Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                           Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                             Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipv4                                             Enable IPv4 support (default true)
+      --enable-ipv6                                             Enable IPv6 support (default true)
+      --enable-k8s                                              Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-metrics                                          Enable Prometheus metrics
+      --enable-node-ipam                                        Enable Node IPAM
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gops-port uint16                                        Port for gops server to listen on (default 9891)
+  -h, --help                                                    help for cilium-operator-azure
+      --identity-allocation-mode string                         Method to use for identity allocation (default "kvstore")
+      --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                     Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                          Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                      Default secret name for Ingress.
+      --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32             The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
+      --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                        Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                   Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --instance-tags-filter map                                EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --ipam string                                             Backend to use for IPAM (default "azure")
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-client-burst int                                    Burst value allowed for the K8s client
+      --k8s-client-qps float32                                  Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                                    Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kube-proxy-replacement string                           Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --kvstore string                                          Key-value store type
+      --kvstore-opt map                                         Key-value store options e.g. etcd.address=127.0.0.1:4001
+      --leader-election-lease-duration duration                 Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
+      --leader-election-renew-deadline duration                 Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-retry-period duration                   Duration that LeaderElector clients should wait between retries of the actions (default 2s)
+      --limit-ipam-api-burst int                                Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                Queries per second limit when accessing external IPAM APIs (default 4)
+      --loadbalancer-l7-algorithm string                        Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                           List of service ports that will be automatically redirected to backend.
+      --log-driver strings                                      Logging endpoints to use for example syslog
+      --log-opt map                                             Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
+      --max-connected-clusters uint32                           Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-mutual-enabled                                The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                     The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                   SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration      SPIRE server connection timeout. (default 10s)
+      --nodes-gc-interval duration                              GC interval for CiliumNodes (default 5m0s)
+      --operator-api-serve-addr string                          Address to serve API requests (default "localhost:9234")
+      --operator-pprof                                          Enable serving pprof debugging API
+      --operator-pprof-address string                           Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                              Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                   Address to serve Prometheus metrics (default ":9963")
+      --parallel-alloc-workers int                              Maximum number of parallel IPAM workers (default 50)
+      --pod-restart-selector string                             cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --remove-cilium-node-taints                               Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                              Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                  Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
+      --skip-crd-creation                                       When true, Kubernetes Custom Resource Definitions will not be created
+      --subnet-ids-filter strings                               Subnets IDs (separated by commas)
+      --subnet-tags-filter map                                  Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --synchronize-k8s-nodes                                   Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
+      --synchronize-k8s-services                                Synchronize Kubernetes services to kvstore (default true)
+      --unmanaged-pod-watcher-interval int                      Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
+      --version                                                 Print version information
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -36,6 +36,7 @@ cilium-operator-azure hive [flags]
       --enable-node-port                                        Enable NodePort type services by Cilium
       --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for hive
@@ -47,6 +48,7 @@ cilium-operator-azure hive [flags]
       --ingress-default-secret-name string                      Default secret name for Ingress.
       --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
       --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-nodelabelselector string            Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
       --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
       --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -11,64 +11,68 @@ cilium-operator-azure hive [flags]
 ### Options
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for hive
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-client-burst int                                 Burst value allowed for the K8s client
-      --k8s-client-qps float32                               Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --bgp-v2-api-enabled                                      Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                    List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings                List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings                List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                           Flag to enable dynamic rate limit specified in separate fields instead of the static one
+      --ces-max-ciliumendpoints-per-ces int                     Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                   Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                                 CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                               CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
+      --cluster-id uint32                                       Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --controller-group-metrics strings                        List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --enable-cilium-operator-server-access strings            List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-proxy-protocol                       Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                         Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                               Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                           Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                             Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-k8s                                              Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-node-ipam                                        Enable Node IPAM
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gops-port uint16                                        Port for gops server to listen on (default 9891)
+  -h, --help                                                    help for hive
+      --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                     Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                          Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                      Default secret name for Ingress.
+      --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
+      --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
+      --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                        Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                   Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-client-burst int                                    Burst value allowed for the K8s client
+      --k8s-client-qps float32                                  Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kube-proxy-replacement string                           Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --loadbalancer-l7-algorithm string                        Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                           List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                           Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-mutual-enabled                                The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                     The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                   SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration      SPIRE server connection timeout. (default 10s)
+      --operator-api-serve-addr string                          Address to serve API requests (default "localhost:9234")
+      --operator-pprof                                          Enable serving pprof debugging API
+      --operator-pprof-address string                           Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                              Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                   Address to serve Prometheus metrics (default ":9963")
+      --skip-crd-creation                                       When true, Kubernetes Custom Resource Definitions will not be created
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -42,6 +42,7 @@ cilium-operator-azure hive dot-graph [flags]
       --enable-node-port                                        Enable NodePort type services by Cilium
       --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
@@ -52,6 +53,7 @@ cilium-operator-azure hive dot-graph [flags]
       --ingress-default-secret-name string                      Default secret name for Ingress.
       --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
       --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-nodelabelselector string            Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
       --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
       --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -17,63 +17,67 @@ cilium-operator-azure hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-client-burst int                                 Burst value allowed for the K8s client
-      --k8s-client-qps float32                               Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --bgp-v2-api-enabled                                      Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                    List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings                List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings                List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                           Flag to enable dynamic rate limit specified in separate fields instead of the static one
+      --ces-max-ciliumendpoints-per-ces int                     Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                   Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                                 CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                               CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
+      --cluster-id uint32                                       Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --controller-group-metrics strings                        List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --enable-cilium-operator-server-access strings            List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-proxy-protocol                       Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                         Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                               Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                           Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                             Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-k8s                                              Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-node-ipam                                        Enable Node IPAM
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gops-port uint16                                        Port for gops server to listen on (default 9891)
+      --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                     Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                          Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                      Default secret name for Ingress.
+      --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
+      --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
+      --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                        Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                   Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-client-burst int                                    Burst value allowed for the K8s client
+      --k8s-client-qps float32                                  Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kube-proxy-replacement string                           Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --loadbalancer-l7-algorithm string                        Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                           List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                           Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-mutual-enabled                                The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                     The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                   SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration      SPIRE server connection timeout. (default 10s)
+      --operator-api-serve-addr string                          Address to serve API requests (default "localhost:9234")
+      --operator-pprof                                          Enable serving pprof debugging API
+      --operator-pprof-address string                           Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                              Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                   Address to serve Prometheus metrics (default ":9963")
+      --skip-crd-creation                                       When true, Kubernetes Custom Resource Definitions will not be created
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -55,6 +55,7 @@ cilium-operator-generic [flags]
       --enable-node-port                                        Enable NodePort type services by Cilium
       --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for cilium-operator-generic
@@ -68,6 +69,7 @@ cilium-operator-generic [flags]
       --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32             The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-nodelabelselector string            Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
       --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
       --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -11,109 +11,113 @@ cilium-operator-generic [flags]
 ### Options
 
 ```
-      --auto-create-cilium-pod-ip-pools map                  Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
-      --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
-      --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
-      --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
-      --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
-      --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
-      --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
-      --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
-      --cluster-pool-ipv6-mask-size int                      Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
-      --cnp-status-cleanup-burst int                         Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
-      --cnp-status-cleanup-qps float                         Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
-      --config string                                        Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                                    Configuration directory that contains a file for each option
-      --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-  -D, --debug                                                Enable debugging mode
-      --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipv4                                          Enable IPv4 support (default true)
-      --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-metrics                                       Enable Prometheus metrics
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for cilium-operator-generic
-      --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --ipam string                                          Backend to use for IPAM (default "cluster-pool")
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-client-burst int                                 Burst value allowed for the K8s client
-      --k8s-client-qps float32                               Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                                 Name of the Kubernetes namespace in which Cilium Operator is deployed in
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --kvstore string                                       Key-value store type
-      --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
-      --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
-      --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
-      --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                             Upper burst limit when accessing external APIs (default 20)
-      --limit-ipam-api-qps float                             Queries per second limit when accessing external IPAM APIs (default 4)
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --log-driver strings                                   Logging endpoints to use for example syslog
-      --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
-      --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
-      --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
-      --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --subnet-ids-filter strings                            Subnets IDs (separated by commas)
-      --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
-      --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
-      --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --version                                              Print version information
+      --auto-create-cilium-pod-ip-pools map                     Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
+      --bgp-announce-lb-ip                                      Announces service IPs of type LoadBalancer via BGP
+      --bgp-config-path string                                  Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
+      --bgp-v2-api-enabled                                      Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                    List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings                List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings                List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                           Flag to enable dynamic rate limit specified in separate fields instead of the static one
+      --ces-max-ciliumendpoints-per-ces int                     Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                   Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                                 CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                               CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
+      --cilium-endpoint-gc-interval duration                    GC interval for cilium endpoints (default 5m0s)
+      --cilium-pod-labels string                                Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
+      --cilium-pod-namespace string                             Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
+      --cluster-id uint32                                       Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --cluster-pool-ipv4-cidr strings                          IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
+      --cluster-pool-ipv4-mask-size int                         Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
+      --cluster-pool-ipv6-cidr strings                          IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
+      --cluster-pool-ipv6-mask-size int                         Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --cnp-status-cleanup-burst int                            Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
+      --cnp-status-cleanup-qps float                            Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
+      --config string                                           Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                                       Configuration directory that contains a file for each option
+      --controller-group-metrics strings                        List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+  -D, --debug                                                   Enable debugging mode
+      --enable-cilium-endpoint-slice                            If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
+      --enable-cilium-operator-server-access strings            List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-proxy-protocol                       Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                         Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                               Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                           Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                             Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipv4                                             Enable IPv4 support (default true)
+      --enable-ipv6                                             Enable IPv6 support (default true)
+      --enable-k8s                                              Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-metrics                                          Enable Prometheus metrics
+      --enable-node-ipam                                        Enable Node IPAM
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gops-port uint16                                        Port for gops server to listen on (default 9891)
+  -h, --help                                                    help for cilium-operator-generic
+      --identity-allocation-mode string                         Method to use for identity allocation (default "kvstore")
+      --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                     Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                          Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                      Default secret name for Ingress.
+      --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32             The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
+      --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                        Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                   Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --instance-tags-filter map                                EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --ipam string                                             Backend to use for IPAM (default "cluster-pool")
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-client-burst int                                    Burst value allowed for the K8s client
+      --k8s-client-qps float32                                  Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                                    Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kube-proxy-replacement string                           Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --kvstore string                                          Key-value store type
+      --kvstore-opt map                                         Key-value store options e.g. etcd.address=127.0.0.1:4001
+      --leader-election-lease-duration duration                 Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
+      --leader-election-renew-deadline duration                 Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-retry-period duration                   Duration that LeaderElector clients should wait between retries of the actions (default 2s)
+      --limit-ipam-api-burst int                                Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                Queries per second limit when accessing external IPAM APIs (default 4)
+      --loadbalancer-l7-algorithm string                        Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                           List of service ports that will be automatically redirected to backend.
+      --log-driver strings                                      Logging endpoints to use for example syslog
+      --log-opt map                                             Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
+      --max-connected-clusters uint32                           Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-mutual-enabled                                The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                     The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                   SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration      SPIRE server connection timeout. (default 10s)
+      --nodes-gc-interval duration                              GC interval for CiliumNodes (default 5m0s)
+      --operator-api-serve-addr string                          Address to serve API requests (default "localhost:9234")
+      --operator-pprof                                          Enable serving pprof debugging API
+      --operator-pprof-address string                           Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                              Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                   Address to serve Prometheus metrics (default ":9963")
+      --parallel-alloc-workers int                              Maximum number of parallel IPAM workers (default 50)
+      --pod-restart-selector string                             cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --remove-cilium-node-taints                               Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                              Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                  Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
+      --skip-crd-creation                                       When true, Kubernetes Custom Resource Definitions will not be created
+      --subnet-ids-filter strings                               Subnets IDs (separated by commas)
+      --subnet-tags-filter map                                  Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --synchronize-k8s-nodes                                   Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
+      --synchronize-k8s-services                                Synchronize Kubernetes services to kvstore (default true)
+      --unmanaged-pod-watcher-interval int                      Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
+      --version                                                 Print version information
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -11,64 +11,68 @@ cilium-operator-generic hive [flags]
 ### Options
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for hive
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-client-burst int                                 Burst value allowed for the K8s client
-      --k8s-client-qps float32                               Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --bgp-v2-api-enabled                                      Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                    List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings                List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings                List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                           Flag to enable dynamic rate limit specified in separate fields instead of the static one
+      --ces-max-ciliumendpoints-per-ces int                     Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                   Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                                 CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                               CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
+      --cluster-id uint32                                       Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --controller-group-metrics strings                        List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --enable-cilium-operator-server-access strings            List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-proxy-protocol                       Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                         Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                               Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                           Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                             Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-k8s                                              Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-node-ipam                                        Enable Node IPAM
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gops-port uint16                                        Port for gops server to listen on (default 9891)
+  -h, --help                                                    help for hive
+      --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                     Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                          Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                      Default secret name for Ingress.
+      --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
+      --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
+      --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                        Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                   Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-client-burst int                                    Burst value allowed for the K8s client
+      --k8s-client-qps float32                                  Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kube-proxy-replacement string                           Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --loadbalancer-l7-algorithm string                        Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                           List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                           Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-mutual-enabled                                The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                     The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                   SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration      SPIRE server connection timeout. (default 10s)
+      --operator-api-serve-addr string                          Address to serve API requests (default "localhost:9234")
+      --operator-pprof                                          Enable serving pprof debugging API
+      --operator-pprof-address string                           Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                              Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                   Address to serve Prometheus metrics (default ":9963")
+      --skip-crd-creation                                       When true, Kubernetes Custom Resource Definitions will not be created
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -36,6 +36,7 @@ cilium-operator-generic hive [flags]
       --enable-node-port                                        Enable NodePort type services by Cilium
       --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for hive
@@ -47,6 +48,7 @@ cilium-operator-generic hive [flags]
       --ingress-default-secret-name string                      Default secret name for Ingress.
       --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
       --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-nodelabelselector string            Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
       --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
       --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -42,6 +42,7 @@ cilium-operator-generic hive dot-graph [flags]
       --enable-node-port                                        Enable NodePort type services by Cilium
       --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
@@ -52,6 +53,7 @@ cilium-operator-generic hive dot-graph [flags]
       --ingress-default-secret-name string                      Default secret name for Ingress.
       --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
       --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-nodelabelselector string            Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
       --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
       --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -17,63 +17,67 @@ cilium-operator-generic hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-client-burst int                                 Burst value allowed for the K8s client
-      --k8s-client-qps float32                               Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --bgp-v2-api-enabled                                      Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                    List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings                List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings                List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                           Flag to enable dynamic rate limit specified in separate fields instead of the static one
+      --ces-max-ciliumendpoints-per-ces int                     Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                   Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                                 CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                               CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
+      --cluster-id uint32                                       Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --controller-group-metrics strings                        List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --enable-cilium-operator-server-access strings            List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-proxy-protocol                       Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                         Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                               Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                           Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                             Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-k8s                                              Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-node-ipam                                        Enable Node IPAM
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gops-port uint16                                        Port for gops server to listen on (default 9891)
+      --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                     Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                          Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                      Default secret name for Ingress.
+      --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
+      --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
+      --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                        Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                   Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-client-burst int                                    Burst value allowed for the K8s client
+      --k8s-client-qps float32                                  Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kube-proxy-replacement string                           Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --loadbalancer-l7-algorithm string                        Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                           List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                           Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-mutual-enabled                                The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                     The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                   SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration      SPIRE server connection timeout. (default 10s)
+      --operator-api-serve-addr string                          Address to serve API requests (default "localhost:9234")
+      --operator-pprof                                          Enable serving pprof debugging API
+      --operator-pprof-address string                           Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                              Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                   Address to serve Prometheus metrics (default ":9963")
+      --skip-crd-creation                                       When true, Kubernetes Custom Resource Definitions will not be created
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -69,6 +69,7 @@ cilium-operator [flags]
       --eni-tags map                                            ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)
       --excess-ip-release-delay int                             Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for cilium-operator
@@ -82,6 +83,7 @@ cilium-operator [flags]
       --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32             The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-nodelabelselector string            Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
       --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
       --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -11,124 +11,128 @@ cilium-operator [flags]
 ### Options
 
 ```
-      --alibaba-cloud-vpc-id string                          Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
-      --auto-create-cilium-pod-ip-pools map                  Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
-      --aws-enable-prefix-delegation                         Allows operator to allocate prefixes to ENIs instead of individual IP addresses
-      --aws-instance-limit-mapping map                       Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"}
-      --aws-release-excess-ips                               Enable releasing excess free IP addresses from AWS ENI.
-      --aws-use-primary-address                              Allows for using primary address of the ENI for allocations on the node
-      --azure-resource-group string                          Resource group to use for Azure IPAM
-      --azure-subscription-id string                         Subscription ID to access Azure API
-      --azure-use-primary-address                            Use Azure IP address from interface's primary IPConfigurations
-      --azure-user-assigned-identity-id string               ID of the user assigned identity used to auth with the Azure API
-      --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
-      --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
-      --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
-      --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
-      --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
-      --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
-      --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
-      --cluster-pool-ipv6-mask-size int                      Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
-      --cnp-status-cleanup-burst int                         Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
-      --cnp-status-cleanup-qps float                         Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
-      --config string                                        Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                                    Configuration directory that contains a file for each option
-      --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-  -D, --debug                                                Enable debugging mode
-      --ec2-api-endpoint string                              AWS API endpoint for the EC2 service
-      --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipv4                                          Enable IPv4 support (default true)
-      --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-metrics                                       Enable Prometheus metrics
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --eni-gc-interval duration                             Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
-      --eni-gc-tags map                                      Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected
-      --eni-tags map                                         ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)
-      --excess-ip-release-delay int                          Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for cilium-operator
-      --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --ipam string                                          Backend to use for IPAM (default "cluster-pool")
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-client-burst int                                 Burst value allowed for the K8s client
-      --k8s-client-qps float32                               Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                                 Name of the Kubernetes namespace in which Cilium Operator is deployed in
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --kvstore string                                       Key-value store type
-      --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
-      --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
-      --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
-      --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                             Upper burst limit when accessing external APIs (default 20)
-      --limit-ipam-api-qps float                             Queries per second limit when accessing external IPAM APIs (default 4)
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --log-driver strings                                   Logging endpoints to use for example syslog
-      --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
-      --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
-      --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
-      --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --subnet-ids-filter strings                            Subnets IDs (separated by commas)
-      --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
-      --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
-      --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --update-ec2-adapter-limit-via-api                     Use the EC2 API to update the instance type to adapter limits (default true)
-      --version                                              Print version information
+      --alibaba-cloud-vpc-id string                             Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
+      --auto-create-cilium-pod-ip-pools map                     Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
+      --aws-enable-prefix-delegation                            Allows operator to allocate prefixes to ENIs instead of individual IP addresses
+      --aws-instance-limit-mapping map                          Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"}
+      --aws-release-excess-ips                                  Enable releasing excess free IP addresses from AWS ENI.
+      --aws-use-primary-address                                 Allows for using primary address of the ENI for allocations on the node
+      --azure-resource-group string                             Resource group to use for Azure IPAM
+      --azure-subscription-id string                            Subscription ID to access Azure API
+      --azure-use-primary-address                               Use Azure IP address from interface's primary IPConfigurations
+      --azure-user-assigned-identity-id string                  ID of the user assigned identity used to auth with the Azure API
+      --bgp-announce-lb-ip                                      Announces service IPs of type LoadBalancer via BGP
+      --bgp-config-path string                                  Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
+      --bgp-v2-api-enabled                                      Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                    List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings                List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings                List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                           Flag to enable dynamic rate limit specified in separate fields instead of the static one
+      --ces-max-ciliumendpoints-per-ces int                     Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                   Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                                 CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                               CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
+      --cilium-endpoint-gc-interval duration                    GC interval for cilium endpoints (default 5m0s)
+      --cilium-pod-labels string                                Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
+      --cilium-pod-namespace string                             Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
+      --cluster-id uint32                                       Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --cluster-pool-ipv4-cidr strings                          IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
+      --cluster-pool-ipv4-mask-size int                         Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
+      --cluster-pool-ipv6-cidr strings                          IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
+      --cluster-pool-ipv6-mask-size int                         Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --cnp-status-cleanup-burst int                            Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
+      --cnp-status-cleanup-qps float                            Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
+      --config string                                           Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                                       Configuration directory that contains a file for each option
+      --controller-group-metrics strings                        List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+  -D, --debug                                                   Enable debugging mode
+      --ec2-api-endpoint string                                 AWS API endpoint for the EC2 service
+      --enable-cilium-endpoint-slice                            If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
+      --enable-cilium-operator-server-access strings            List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-proxy-protocol                       Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                         Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                               Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                           Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                             Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipv4                                             Enable IPv4 support (default true)
+      --enable-ipv6                                             Enable IPv6 support (default true)
+      --enable-k8s                                              Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-metrics                                          Enable Prometheus metrics
+      --enable-node-ipam                                        Enable Node IPAM
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --eni-gc-interval duration                                Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
+      --eni-gc-tags map                                         Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected
+      --eni-tags map                                            ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)
+      --excess-ip-release-delay int                             Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
+      --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gops-port uint16                                        Port for gops server to listen on (default 9891)
+  -h, --help                                                    help for cilium-operator
+      --identity-allocation-mode string                         Method to use for identity allocation (default "kvstore")
+      --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                     Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                          Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                      Default secret name for Ingress.
+      --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32             The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
+      --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                        Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                   Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --instance-tags-filter map                                EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --ipam string                                             Backend to use for IPAM (default "cluster-pool")
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-client-burst int                                    Burst value allowed for the K8s client
+      --k8s-client-qps float32                                  Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                                    Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kube-proxy-replacement string                           Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --kvstore string                                          Key-value store type
+      --kvstore-opt map                                         Key-value store options e.g. etcd.address=127.0.0.1:4001
+      --leader-election-lease-duration duration                 Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
+      --leader-election-renew-deadline duration                 Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-retry-period duration                   Duration that LeaderElector clients should wait between retries of the actions (default 2s)
+      --limit-ipam-api-burst int                                Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                Queries per second limit when accessing external IPAM APIs (default 4)
+      --loadbalancer-l7-algorithm string                        Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                           List of service ports that will be automatically redirected to backend.
+      --log-driver strings                                      Logging endpoints to use for example syslog
+      --log-opt map                                             Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
+      --max-connected-clusters uint32                           Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-mutual-enabled                                The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                     The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                   SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration      SPIRE server connection timeout. (default 10s)
+      --nodes-gc-interval duration                              GC interval for CiliumNodes (default 5m0s)
+      --operator-api-serve-addr string                          Address to serve API requests (default "localhost:9234")
+      --operator-pprof                                          Enable serving pprof debugging API
+      --operator-pprof-address string                           Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                              Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                   Address to serve Prometheus metrics (default ":9963")
+      --parallel-alloc-workers int                              Maximum number of parallel IPAM workers (default 50)
+      --pod-restart-selector string                             cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --remove-cilium-node-taints                               Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                              Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                  Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
+      --skip-crd-creation                                       When true, Kubernetes Custom Resource Definitions will not be created
+      --subnet-ids-filter strings                               Subnets IDs (separated by commas)
+      --subnet-tags-filter map                                  Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --synchronize-k8s-nodes                                   Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
+      --synchronize-k8s-services                                Synchronize Kubernetes services to kvstore (default true)
+      --unmanaged-pod-watcher-interval int                      Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
+      --update-ec2-adapter-limit-via-api                        Use the EC2 API to update the instance type to adapter limits (default true)
+      --version                                                 Print version information
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -11,64 +11,68 @@ cilium-operator hive [flags]
 ### Options
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for hive
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-client-burst int                                 Burst value allowed for the K8s client
-      --k8s-client-qps float32                               Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --bgp-v2-api-enabled                                      Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                    List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings                List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings                List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                           Flag to enable dynamic rate limit specified in separate fields instead of the static one
+      --ces-max-ciliumendpoints-per-ces int                     Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                   Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                                 CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                               CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
+      --cluster-id uint32                                       Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --controller-group-metrics strings                        List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --enable-cilium-operator-server-access strings            List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-proxy-protocol                       Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                         Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                               Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                           Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                             Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-k8s                                              Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-node-ipam                                        Enable Node IPAM
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gops-port uint16                                        Port for gops server to listen on (default 9891)
+  -h, --help                                                    help for hive
+      --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                     Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                          Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                      Default secret name for Ingress.
+      --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
+      --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
+      --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                        Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                   Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-client-burst int                                    Burst value allowed for the K8s client
+      --k8s-client-qps float32                                  Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kube-proxy-replacement string                           Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --loadbalancer-l7-algorithm string                        Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                           List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                           Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-mutual-enabled                                The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                     The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                   SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration      SPIRE server connection timeout. (default 10s)
+      --operator-api-serve-addr string                          Address to serve API requests (default "localhost:9234")
+      --operator-pprof                                          Enable serving pprof debugging API
+      --operator-pprof-address string                           Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                              Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                   Address to serve Prometheus metrics (default ":9963")
+      --skip-crd-creation                                       When true, Kubernetes Custom Resource Definitions will not be created
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -36,6 +36,7 @@ cilium-operator hive [flags]
       --enable-node-port                                        Enable NodePort type services by Cilium
       --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
   -h, --help                                                    help for hive
@@ -47,6 +48,7 @@ cilium-operator hive [flags]
       --ingress-default-secret-name string                      Default secret name for Ingress.
       --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
       --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-nodelabelselector string            Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
       --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
       --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -17,63 +17,67 @@ cilium-operator hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-client-burst int                                 Burst value allowed for the K8s client
-      --k8s-client-qps float32                               Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --bgp-v2-api-enabled                                      Enables BGPv2 APIs in Cilium
+      --ces-dynamic-rate-limit-nodes strings                    List of nodes used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-burst strings                List of qps burst used for the dynamic rate limit steps
+      --ces-dynamic-rate-limit-qps-limit strings                List of qps limits used for the dynamic rate limit steps
+      --ces-enable-dynamic-rate-limit                           Flag to enable dynamic rate limit specified in separate fields instead of the static one
+      --ces-max-ciliumendpoints-per-ces int                     Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                   Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                                 CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
+      --ces-write-qps-limit float                               CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
+      --cluster-id uint32                                       Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --controller-group-metrics strings                        List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --enable-cilium-operator-server-access strings            List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-proxy-protocol                       Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                         Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                               Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                           Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                             Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-k8s                                              Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-node-ipam                                        Enable Node IPAM
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gops-port uint16                                        Port for gops server to listen on (default 9891)
+      --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                     Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                          Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                      Default secret name for Ingress.
+      --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
+      --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
+      --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                        Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                   Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-client-burst int                                    Burst value allowed for the K8s client
+      --k8s-client-qps float32                                  Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kube-proxy-replacement string                           Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --loadbalancer-l7-algorithm string                        Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                           List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                           Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-mutual-enabled                                The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                     The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                   SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration      SPIRE server connection timeout. (default 10s)
+      --operator-api-serve-addr string                          Address to serve API requests (default "localhost:9234")
+      --operator-pprof                                          Enable serving pprof debugging API
+      --operator-pprof-address string                           Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                              Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                   Address to serve Prometheus metrics (default ":9963")
+      --skip-crd-creation                                       When true, Kubernetes Custom Resource Definitions will not be created
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -42,6 +42,7 @@ cilium-operator hive dot-graph [flags]
       --enable-node-port                                        Enable NodePort type services by Cilium
       --enforce-ingress-https                                   Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                         Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string        Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                    Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                        Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                           GC interval for security identities (default 15m0s)
@@ -52,6 +53,7 @@ cilium-operator hive dot-graph [flags]
       --ingress-default-secret-name string                      Default secret name for Ingress.
       --ingress-default-secret-namespace string                 Default secret namespace for Ingress.
       --ingress-hostnetwork-enabled                             Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-nodelabelselector string            Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-http-port uint32             Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)
       --ingress-hostnetwork-shared-tlspassthrough-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
       --ingress-lb-annotation-prefixes strings                  Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1412,6 +1412,10 @@
      - Enable support for Gateway API in cilium This will automatically set enable-envoy-config as well.
      - bool
      - ``false``
+   * - :spelling:ignore:`gatewayAPI.hostNetwork.enabled`
+     - Configure whether the Envoy listeners should be exposed on the host network.
+     - bool
+     - ``false``
    * - :spelling:ignore:`gatewayAPI.secretsNamespace`
      - SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
      - object
@@ -2052,6 +2056,18 @@
      - Enforce https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header.
      - bool
      - ``true``
+   * - :spelling:ignore:`ingressController.hostNetwork.enabled`
+     - Configure whether the Envoy listeners should be exposed on the host network.
+     - bool
+     - ``false``
+   * - :spelling:ignore:`ingressController.hostNetwork.sharedHTTPPort`
+     - Configure a specific port on the host network that gets used for the shared HTTP listener. This is used for HTTP and HTTPS.
+     - int
+     - ``0``
+   * - :spelling:ignore:`ingressController.hostNetwork.sharedTLSPassthroughPort`
+     - Configure a specific port on the host network that gets used for the shared TLS passthrough listener
+     - int
+     - ``0``
    * - :spelling:ignore:`ingressController.ingressLBAnnotationPrefixes`
      - IngressLBAnnotations are the annotation and label prefixes, which are used to filter annotations and/or labels to propagate from Ingress to the Load Balancer service
      - list

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1416,6 +1416,10 @@
      - Configure whether the Envoy listeners should be exposed on the host network.
      - bool
      - ``false``
+   * - :spelling:ignore:`gatewayAPI.hostNetwork.nodes.matchLabels`
+     - Specify the labels of the nodes where the Ingress listeners should be exposed  matchLabels:   kubernetes.io/os: linux   kubernetes.io/hostname: kind-worker
+     - object
+     - ``{}``
    * - :spelling:ignore:`gatewayAPI.secretsNamespace`
      - SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
      - object
@@ -2060,6 +2064,10 @@
      - Configure whether the Envoy listeners should be exposed on the host network.
      - bool
      - ``false``
+   * - :spelling:ignore:`ingressController.hostNetwork.nodes.matchLabels`
+     - Specify the labels of the nodes where the Ingress listeners should be exposed  matchLabels:   kubernetes.io/os: linux   kubernetes.io/hostname: kind-worker
+     - object
+     - ``{}``
    * - :spelling:ignore:`ingressController.hostNetwork.sharedHTTPPort`
      - Configure a specific port on the host network that gets used for the shared HTTP listener. This is used for HTTP and HTTPS.
      - int

--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -90,6 +90,16 @@ Supported Ingress Annotations
        | Applicable only if ``ingress.cilium.io/service-type`` is ``NodePort``. If unspecified, a random
        | NodePort will be allocated by kubernetes.
      - unspecified
+   * - ``ingress.cilium.io/http-host-port``
+     - | The port to use for the HTTP listener (HTTP and HTTPS) on the host network.
+       | Applicable only for dedicated Ingress and if hostnetwork mode is enabled for IngressController.
+       | If unspecified, the default ports (80/443) are used.
+     - unspecified
+   * - ``ingress.cilium.io/tls-passthrough-host-port``
+     - | The port to use for the TLS passthrough listener on the host network.
+       | Applicable only for dedicated Ingress and if hostnetwork mode is enabled for IngressController.
+       | If unspecified, the default port (443) are used.
+     - unspecified
    * - ``ingress.cilium.io/tls-passthrough``
      - | Enable TLS Passthrough mode for this Ingress.
        | Applicable values are ``enabled`` and ``disabled``,

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -552,6 +552,7 @@ openapi
 openssl
 originatingTLS
 otx
+os
 pahole
 parsable
 parserfactory

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -487,6 +487,7 @@ mainboard
 makefile
 mana
 masq
+matchLabels
 matchPattern
 maxUnavailable
 mc
@@ -551,8 +552,8 @@ openSUSE
 openapi
 openssl
 originatingTLS
-otx
 os
+otx
 pahole
 parsable
 parserfactory

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -404,6 +404,7 @@ contributors across the globe, there is almost always someone available to help.
 | gatewayAPI.enableProxyProtocol | bool | `false` | Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled. |
 | gatewayAPI.enabled | bool | `false` | Enable support for Gateway API in cilium This will automatically set enable-envoy-config as well. |
 | gatewayAPI.hostNetwork.enabled | bool | `false` | Configure whether the Envoy listeners should be exposed on the host network. |
+| gatewayAPI.hostNetwork.nodes.matchLabels | object | `{}` | Specify the labels of the nodes where the Ingress listeners should be exposed  matchLabels:   kubernetes.io/os: linux   kubernetes.io/hostname: kind-worker |
 | gatewayAPI.secretsNamespace | object | `{"create":true,"name":"cilium-secrets","sync":true}` | SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from. |
 | gatewayAPI.secretsNamespace.create | bool | `true` | Create secrets namespace for Gateway API. |
 | gatewayAPI.secretsNamespace.name | string | `"cilium-secrets"` | Name of Gateway API secret namespace. |
@@ -565,6 +566,7 @@ contributors across the globe, there is almost always someone available to help.
 | ingressController.enabled | bool | `false` | Enable cilium ingress controller This will automatically set enable-envoy-config as well. |
 | ingressController.enforceHttps | bool | `true` | Enforce https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. |
 | ingressController.hostNetwork.enabled | bool | `false` | Configure whether the Envoy listeners should be exposed on the host network. |
+| ingressController.hostNetwork.nodes.matchLabels | object | `{}` | Specify the labels of the nodes where the Ingress listeners should be exposed  matchLabels:   kubernetes.io/os: linux   kubernetes.io/hostname: kind-worker |
 | ingressController.hostNetwork.sharedHTTPPort | int | `0` | Configure a specific port on the host network that gets used for the shared HTTP listener. This is used for HTTP and HTTPS. |
 | ingressController.hostNetwork.sharedTLSPassthroughPort | int | `0` | Configure a specific port on the host network that gets used for the shared TLS passthrough listener |
 | ingressController.ingressLBAnnotationPrefixes | list | `["lbipam.cilium.io","service.beta.kubernetes.io","service.kubernetes.io","cloud.google.com"]` | IngressLBAnnotations are the annotation and label prefixes, which are used to filter annotations and/or labels to propagate from Ingress to the Load Balancer service |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -403,6 +403,7 @@ contributors across the globe, there is almost always someone available to help.
 | extraVolumes | list | `[]` | Additional agent volumes. |
 | gatewayAPI.enableProxyProtocol | bool | `false` | Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled. |
 | gatewayAPI.enabled | bool | `false` | Enable support for Gateway API in cilium This will automatically set enable-envoy-config as well. |
+| gatewayAPI.hostNetwork.enabled | bool | `false` | Configure whether the Envoy listeners should be exposed on the host network. |
 | gatewayAPI.secretsNamespace | object | `{"create":true,"name":"cilium-secrets","sync":true}` | SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from. |
 | gatewayAPI.secretsNamespace.create | bool | `true` | Create secrets namespace for Gateway API. |
 | gatewayAPI.secretsNamespace.name | string | `"cilium-secrets"` | Name of Gateway API secret namespace. |
@@ -563,6 +564,9 @@ contributors across the globe, there is almost always someone available to help.
 | ingressController.enableProxyProtocol | bool | `false` | Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled. |
 | ingressController.enabled | bool | `false` | Enable cilium ingress controller This will automatically set enable-envoy-config as well. |
 | ingressController.enforceHttps | bool | `true` | Enforce https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. |
+| ingressController.hostNetwork.enabled | bool | `false` | Configure whether the Envoy listeners should be exposed on the host network. |
+| ingressController.hostNetwork.sharedHTTPPort | int | `0` | Configure a specific port on the host network that gets used for the shared HTTP listener. This is used for HTTP and HTTPS. |
+| ingressController.hostNetwork.sharedTLSPassthroughPort | int | `0` | Configure a specific port on the host network that gets used for the shared TLS passthrough listener |
 | ingressController.ingressLBAnnotationPrefixes | list | `["lbipam.cilium.io","service.beta.kubernetes.io","service.kubernetes.io","cloud.google.com"]` | IngressLBAnnotations are the annotation and label prefixes, which are used to filter annotations and/or labels to propagate from Ingress to the Load Balancer service |
 | ingressController.loadbalancerMode | string | `"dedicated"` | Default ingress load balancer mode Supported values: shared, dedicated For granular control, use the following annotations on the ingress resource ingress.cilium.io/loadbalancer-mode: shared|dedicated, |
 | ingressController.secretsNamespace | object | `{"create":true,"name":"cilium-secrets","sync":true}` | SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from. |

--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -154,3 +154,14 @@ Validate duration field, return validated duration, 0s when provided duration is
 0s
 {{- end }}
 {{- end }}
+
+{{/*
+Convert a map to a comma-separated string: key1=value1,key2=value2
+*/}}
+{{- define "mapToString" -}}
+{{- $list := list -}}
+{{- range $k, $v := . -}}
+{{- $list = append $list (printf "%s=%s" $k $v) -}}
+{{- end -}}
+{{ join "," $list }}
+{{- end -}}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -263,6 +263,9 @@ data:
   ingress-default-secret-namespace: {{ .Values.ingressController.defaultSecretNamespace | quote }}
   ingress-default-secret-name: {{ .Values.ingressController.defaultSecretName | quote }}
   {{- end }}
+  ingress-hostnetwork-enabled: {{ .Values.ingressController.hostNetwork.enabled | quote }}
+  ingress-hostnetwork-shared-http-port: {{ .Values.ingressController.hostNetwork.sharedHTTPPort | quote }}
+  ingress-hostnetwork-shared-tlspassthrough-port: {{ .Values.ingressController.hostNetwork.sharedTLSPassthroughPort | quote }}
 {{- end }}
 
 {{- if .Values.gatewayAPI.enabled }}
@@ -270,6 +273,7 @@ data:
   enable-gateway-api-secrets-sync: {{ .Values.gatewayAPI.secretsNamespace.sync | quote }}
   enable-gateway-api-proxy-protocol: {{ .Values.gatewayAPI.enableProxyProtocol | quote }}
   gateway-api-secrets-namespace: {{ .Values.gatewayAPI.secretsNamespace.name | quote }}
+  gateway-api-hostnetwork-enabled: {{ .Values.gatewayAPI.hostNetwork.enabled | quote }}
 {{- end }}
 
 {{- if hasKey .Values "loadBalancer" }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -266,6 +266,7 @@ data:
   ingress-hostnetwork-enabled: {{ .Values.ingressController.hostNetwork.enabled | quote }}
   ingress-hostnetwork-shared-http-port: {{ .Values.ingressController.hostNetwork.sharedHTTPPort | quote }}
   ingress-hostnetwork-shared-tlspassthrough-port: {{ .Values.ingressController.hostNetwork.sharedTLSPassthroughPort | quote }}
+  ingress-hostnetwork-nodelabelselector: {{ include "mapToString" .Values.ingressController.hostNetwork.nodes.matchLabels | quote }}
 {{- end }}
 
 {{- if .Values.gatewayAPI.enabled }}
@@ -274,6 +275,7 @@ data:
   enable-gateway-api-proxy-protocol: {{ .Values.gatewayAPI.enableProxyProtocol | quote }}
   gateway-api-secrets-namespace: {{ .Values.gatewayAPI.secretsNamespace.name | quote }}
   gateway-api-hostnetwork-enabled: {{ .Values.gatewayAPI.hostNetwork.enabled | quote }}
+  gateway-api-hostnetwork-nodelabelselector: {{ include "mapToString" .Values.gatewayAPI.hostNetwork.nodes.matchLabels | quote }}
 {{- end }}
 
 {{- if hasKey .Values "loadBalancer" }}

--- a/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
@@ -23,7 +23,11 @@ spec:
     port: 443
     protocol: TCP
     nodePort: {{ .Values.ingressController.service.secureNodePort }}
+  {{- if .Values.ingressController.hostNetwork.enabled }}
+  type: ClusterIP
+  {{- else }}
   type: {{ .Values.ingressController.service.type }}
+  {{- end }}
   {{- if semverCompare ">=1.24-0" .Capabilities.KubeVersion.Version -}}
   {{- if .Values.ingressController.service.loadBalancerClass }}
   loadBalancerClass: {{ .Values.ingressController.service.loadBalancerClass }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -670,6 +670,15 @@ ingressController:
     # -- Configure if node port allocation is required for LB service
     # ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
     allocateLoadBalancerNodePorts: ~
+  # Host Network related configuration
+  hostNetwork:
+    # -- Configure whether the Envoy listeners should be exposed on the host network.
+    enabled: false
+    # -- Configure a specific port on the host network that gets used for the shared HTTP listener.
+    # This is used for HTTP and HTTPS.
+    sharedHTTPPort: 0
+    # -- Configure a specific port on the host network that gets used for the shared TLS passthrough listener
+    sharedTLSPassthroughPort: 0
 gatewayAPI:
   # -- Enable support for Gateway API in cilium
   # This will automatically set enable-envoy-config as well.
@@ -685,6 +694,10 @@ gatewayAPI:
     # -- Enable secret sync, which will make sure all TLS secrets used by Ingress are synced to secretsNamespace.name.
     # If disabled, TLS secrets must be maintained externally.
     sync: true
+  # Host Network related configuration
+  hostNetwork:
+    # -- Configure whether the Envoy listeners should be exposed on the host network.
+    enabled: false
 # -- Enables the fallback compatibility solution for when the xt_socket kernel
 # module is missing and it is needed for the datapath L7 redirection to work
 # properly. See documentation for details on when this can be disabled:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -679,6 +679,14 @@ ingressController:
     sharedHTTPPort: 0
     # -- Configure a specific port on the host network that gets used for the shared TLS passthrough listener
     sharedTLSPassthroughPort: 0
+    # Specify the nodes where the Ingress listeners should be exposed
+    nodes:
+      # -- Specify the labels of the nodes where the Ingress listeners should be exposed
+      #
+      # matchLabels:
+      #   kubernetes.io/os: linux
+      #   kubernetes.io/hostname: kind-worker
+      matchLabels: {}
 gatewayAPI:
   # -- Enable support for Gateway API in cilium
   # This will automatically set enable-envoy-config as well.
@@ -698,6 +706,14 @@ gatewayAPI:
   hostNetwork:
     # -- Configure whether the Envoy listeners should be exposed on the host network.
     enabled: false
+    # Specify the nodes where the Ingress listeners should be exposed
+    nodes:
+      # -- Specify the labels of the nodes where the Ingress listeners should be exposed
+      #
+      # matchLabels:
+      #   kubernetes.io/os: linux
+      #   kubernetes.io/hostname: kind-worker
+      matchLabels: {}
 # -- Enables the fallback compatibility solution for when the xt_socket kernel
 # module is missing and it is needed for the datapath L7 redirection to work
 # properly. See documentation for details on when this can be disabled:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -676,6 +676,14 @@ ingressController:
     sharedHTTPPort: 0
     # -- Configure a specific port on the host network that gets used for the shared TLS passthrough listener
     sharedTLSPassthroughPort: 0
+    # Specify the nodes where the Ingress listeners should be exposed
+    nodes:
+      # -- Specify the labels of the nodes where the Ingress listeners should be exposed
+      #
+      # matchLabels:
+      #   kubernetes.io/os: linux
+      #   kubernetes.io/hostname: kind-worker
+      matchLabels: {}
 gatewayAPI:
   # -- Enable support for Gateway API in cilium
   # This will automatically set enable-envoy-config as well.
@@ -695,6 +703,14 @@ gatewayAPI:
   hostNetwork:
     # -- Configure whether the Envoy listeners should be exposed on the host network.
     enabled: false
+    # Specify the nodes where the Ingress listeners should be exposed
+    nodes:
+      # -- Specify the labels of the nodes where the Ingress listeners should be exposed
+      #
+      # matchLabels:
+      #   kubernetes.io/os: linux
+      #   kubernetes.io/hostname: kind-worker
+      matchLabels: {}
 
 # -- Enables the fallback compatibility solution for when the xt_socket kernel
 # module is missing and it is needed for the datapath L7 redirection to work

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -667,6 +667,15 @@ ingressController:
     # -- Configure if node port allocation is required for LB service
     # ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
     allocateLoadBalancerNodePorts: ~
+  # Host Network related configuration
+  hostNetwork:
+    # -- Configure whether the Envoy listeners should be exposed on the host network.
+    enabled: false
+    # -- Configure a specific port on the host network that gets used for the shared HTTP listener.
+    # This is used for HTTP and HTTPS.
+    sharedHTTPPort: 0
+    # -- Configure a specific port on the host network that gets used for the shared TLS passthrough listener
+    sharedTLSPassthroughPort: 0
 gatewayAPI:
   # -- Enable support for Gateway API in cilium
   # This will automatically set enable-envoy-config as well.
@@ -682,6 +691,11 @@ gatewayAPI:
     # -- Enable secret sync, which will make sure all TLS secrets used by Ingress are synced to secretsNamespace.name.
     # If disabled, TLS secrets must be maintained externally.
     sync: true
+  # Host Network related configuration
+  hostNetwork:
+    # -- Configure whether the Envoy listeners should be exposed on the host network.
+    enabled: false
+
 # -- Enables the fallback compatibility solution for when the xt_socket kernel
 # module is missing and it is needed for the datapath L7 redirection to work
 # properly. See documentation for details on when this can be disabled:

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -37,6 +37,8 @@ var Cell = cell.Module(
 		EnableGatewayAPISecretsSync:   true,
 		EnableGatewayAPIProxyProtocol: false,
 		GatewayAPISecretsNamespace:    "cilium-secrets",
+
+		GatewayAPIHostnetworkEnabled: false,
 	}),
 	cell.Invoke(initGatewayAPIController),
 	cell.Provide(registerSecretSync),
@@ -58,6 +60,8 @@ type gatewayApiConfig struct {
 	EnableGatewayAPISecretsSync   bool
 	EnableGatewayAPIProxyProtocol bool
 	GatewayAPISecretsNamespace    string
+
+	GatewayAPIHostnetworkEnabled bool
 }
 
 func (r gatewayApiConfig) Flags(flags *pflag.FlagSet) {
@@ -67,6 +71,7 @@ func (r gatewayApiConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool("enable-gateway-api-secrets-sync", r.EnableGatewayAPISecretsSync, "Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag)")
 	flags.Bool("enable-gateway-api-proxy-protocol", r.EnableGatewayAPIProxyProtocol, "Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.")
 	flags.String("gateway-api-secrets-namespace", r.GatewayAPISecretsNamespace, "Namespace having tls secrets used by CEC for Gateway API")
+	flags.Bool("gateway-api-hostnetwork-enabled", r.GatewayAPIHostnetworkEnabled, "Exposes Gateway listeners on the host network.")
 }
 
 type gatewayAPIParams struct {
@@ -77,7 +82,9 @@ type gatewayAPIParams struct {
 	CtrlRuntimeManager ctrlRuntime.Manager
 	Scheme             *runtime.Scheme
 
-	Config gatewayApiConfig
+	AgentConfig      *option.DaemonConfig
+	OperatorConfig   *operatorOption.OperatorConfig
+	GatewayApiConfig gatewayApiConfig
 }
 
 func initGatewayAPIController(params gatewayAPIParams) error {
@@ -85,7 +92,7 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		return nil
 	}
 
-	if params.Config.KubeProxyReplacement != option.KubeProxyReplacementTrue && !params.Config.EnableNodePort {
+	if params.GatewayApiConfig.KubeProxyReplacement != option.KubeProxyReplacementTrue && !params.GatewayApiConfig.EnableNodePort {
 		params.Logger.Warn("Gateway API support requires either kube-proxy-replacement or enable-node-port enabled")
 		return nil
 	}
@@ -104,8 +111,17 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		return err
 	}
 
-	cecTranslator := translation.NewCECTranslator(params.Config.GatewayAPISecretsNamespace, params.Config.EnableGatewayAPIProxyProtocol, true, operatorOption.Config.ProxyIdleTimeoutSeconds)
-	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator)
+	cecTranslator := translation.NewCECTranslator(
+		params.GatewayApiConfig.GatewayAPISecretsNamespace,
+		params.GatewayApiConfig.EnableGatewayAPIProxyProtocol,
+		true, // hostNameSuffixMatch
+		params.OperatorConfig.ProxyIdleTimeoutSeconds,
+		params.GatewayApiConfig.GatewayAPIHostnetworkEnabled,
+		params.AgentConfig.EnableIPv4,
+		params.AgentConfig.EnableIPv6,
+	)
+
+	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, params.GatewayApiConfig.GatewayAPIHostnetworkEnabled)
 
 	if err := registerReconcilers(
 		params.CtrlRuntimeManager,
@@ -124,7 +140,7 @@ func registerSecretSync(params gatewayAPIParams) secretsync.SecretSyncRegistrati
 		return secretsync.SecretSyncRegistrationOut{}
 	}
 
-	if !operatorOption.Config.EnableGatewayAPI || !params.Config.EnableGatewayAPISecretsSync {
+	if !operatorOption.Config.EnableGatewayAPI || !params.GatewayApiConfig.EnableGatewayAPISecretsSync {
 		return secretsync.SecretSyncRegistrationOut{}
 	}
 
@@ -133,7 +149,7 @@ func registerSecretSync(params gatewayAPIParams) secretsync.SecretSyncRegistrati
 			RefObject:            &gatewayv1.Gateway{},
 			RefObjectEnqueueFunc: EnqueueTLSSecrets(params.CtrlRuntimeManager.GetClient(), params.Logger),
 			RefObjectCheckFunc:   IsReferencedByCiliumGateway,
-			SecretsNamespace:     params.Config.GatewayAPISecretsNamespace,
+			SecretsNamespace:     params.GatewayApiConfig.GatewayAPISecretsNamespace,
 		},
 	}
 }

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -38,7 +38,8 @@ var Cell = cell.Module(
 		EnableGatewayAPIProxyProtocol: false,
 		GatewayAPISecretsNamespace:    "cilium-secrets",
 
-		GatewayAPIHostnetworkEnabled: false,
+		GatewayAPIHostnetworkEnabled:           false,
+		GatewayAPIHostnetworkNodelabelselector: "",
 	}),
 	cell.Invoke(initGatewayAPIController),
 	cell.Provide(registerSecretSync),
@@ -61,7 +62,8 @@ type gatewayApiConfig struct {
 	EnableGatewayAPIProxyProtocol bool
 	GatewayAPISecretsNamespace    string
 
-	GatewayAPIHostnetworkEnabled bool
+	GatewayAPIHostnetworkEnabled           bool
+	GatewayAPIHostnetworkNodelabelselector string
 }
 
 func (r gatewayApiConfig) Flags(flags *pflag.FlagSet) {
@@ -72,6 +74,7 @@ func (r gatewayApiConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool("enable-gateway-api-proxy-protocol", r.EnableGatewayAPIProxyProtocol, "Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.")
 	flags.String("gateway-api-secrets-namespace", r.GatewayAPISecretsNamespace, "Namespace having tls secrets used by CEC for Gateway API")
 	flags.Bool("gateway-api-hostnetwork-enabled", r.GatewayAPIHostnetworkEnabled, "Exposes Gateway listeners on the host network.")
+	flags.String("gateway-api-hostnetwork-nodelabelselector", r.GatewayAPIHostnetworkNodelabelselector, "Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'")
 }
 
 type gatewayAPIParams struct {
@@ -117,6 +120,7 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		true, // hostNameSuffixMatch
 		params.OperatorConfig.ProxyIdleTimeoutSeconds,
 		params.GatewayApiConfig.GatewayAPIHostnetworkEnabled,
+		translation.ParseNodeLabelSelector(params.GatewayApiConfig.GatewayAPIHostnetworkNodelabelselector),
 		params.AgentConfig.EnableIPv4,
 		params.AgentConfig.EnableIPv6,
 	)

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -329,7 +329,9 @@ func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.
 
 	svc := svcList.Items[0]
 	if len(svc.Status.LoadBalancer.Ingress) == 0 {
-		return fmt.Errorf("load balancer status is not ready")
+		// Potential loadbalancer service isn't ready yet. No need to report as an error, because
+		// reconciliation should be triggered when the loadbalancer services gets updated.
+		return nil
 	}
 
 	var addresses []gatewayv1.GatewayStatusAddress

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -235,7 +235,7 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 		WithStatusSubresource(&gatewayv1.Gateway{}).
 		Build()
 
-	cecTranslator := translation.NewCECTranslator("", false, true, 60, false, false, false)
+	cecTranslator := translation.NewCECTranslator("", false, true, 60, false, nil, false, false)
 	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, false)
 
 	r := &gatewayReconciler{

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -235,8 +235,8 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 		WithStatusSubresource(&gatewayv1.Gateway{}).
 		Build()
 
-	cecTranslator := translation.NewCECTranslator("", false, true, 60)
-	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator)
+	cecTranslator := translation.NewCECTranslator("", false, true, 60, false, false, false)
+	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, false)
 
 	r := &gatewayReconciler{
 		Client:     c,

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -285,10 +285,14 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 		}
 		result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 
-		// First reconcile should wait for LB status
-		require.Error(t, err)
-		require.Equal(t, "load balancer status is not ready", err.Error())
+		// First reconcile should wait for LB status before writing addresses into Ingress status
+		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
+
+		gw := &gatewayv1.Gateway{}
+		err = c.Get(context.Background(), key, gw)
+		require.NoError(t, err)
+		require.Empty(t, gw.Status.Addresses)
 
 		// Simulate LB service update
 		lb := &corev1.Service{}
@@ -319,7 +323,6 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result)
 
 		// Check that the gateway status has been updated
-		gw := &gatewayv1.Gateway{}
 		err = c.Get(context.Background(), key, gw)
 		require.NoError(t, err)
 
@@ -355,10 +358,14 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 		}
 		result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 
-		// First reconcile should wait for LB status
-		require.Error(t, err)
-		require.Equal(t, "load balancer status is not ready", err.Error())
+		// First reconcile should wait for LB status before writing addresses into Ingress status
+		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
+
+		gw := &gatewayv1.Gateway{}
+		err = c.Get(context.Background(), key, gw)
+		require.NoError(t, err)
+		require.Empty(t, gw.Status.Addresses)
 
 		// Simulate LB service update
 		lb := &corev1.Service{}
@@ -388,7 +395,6 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result)
 
 		// Check that the gateway status has been updated
-		gw := &gatewayv1.Gateway{}
 		err = c.Get(context.Background(), key, gw)
 		require.NoError(t, err)
 

--- a/operator/pkg/ingress/annotations/annotations.go
+++ b/operator/pkg/ingress/annotations/annotations.go
@@ -18,6 +18,8 @@ const (
 	ServiceTypeAnnotation      = annotation.IngressPrefix + "/service-type"
 	InsecureNodePortAnnotation = annotation.IngressPrefix + "/insecure-node-port"
 	SecureNodePortAnnotation   = annotation.IngressPrefix + "/secure-node-port"
+	TLSPtHostPortAnnotation    = annotation.IngressPrefix + "/tls-passthrough-host-port"
+	HTTPHostPortAnnotation     = annotation.IngressPrefix + "/http-host-port"
 	TLSPassthroughAnnotation   = annotation.IngressPrefix + "/tls-passthrough"
 	ForceHTTPSAnnotation       = annotation.IngressPrefix + "/force-https"
 
@@ -87,6 +89,34 @@ func GetAnnotationInsecureNodePort(ingress *networkingv1.Ingress) (*uint32, erro
 	return &res, nil
 }
 
+// GetAnnotationHTTPHostPort returns the HTTP host port for the ingress if possible.
+func GetAnnotationHTTPHostPort(ingress *networkingv1.Ingress) (*uint32, error) {
+	val, exists := annotation.Get(ingress, HTTPHostPortAnnotation)
+	if !exists {
+		return nil, nil
+	}
+	intVal, err := strconv.ParseInt(val, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	res := uint32(intVal)
+	return &res, nil
+}
+
+// GetAnnotationTLSHostPort returns the TLS host port for the ingress if possible.
+func GetAnnotationTLSHostPort(ingress *networkingv1.Ingress) (*uint32, error) {
+	val, exists := annotation.Get(ingress, TLSPtHostPortAnnotation)
+	if !exists {
+		return nil, nil
+	}
+	intVal, err := strconv.ParseInt(val, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	res := uint32(intVal)
+	return &res, nil
+}
+
 func GetAnnotationTLSPassthroughEnabled(ingress *networkingv1.Ingress) bool {
 	val, exists := annotation.Get(ingress, TLSPassthroughAnnotation, TLSPassthroughAnnotationAlias)
 	if !exists {
@@ -124,7 +154,6 @@ func GetAnnotationTLSPassthroughEnabled(ingress *networkingv1.Ingress) bool {
 // - &false - the annovation is present and set to a false value
 // - nil - the annotatation is not present
 func GetAnnotationForceHTTPSEnabled(ingress *networkingv1.Ingress) *bool {
-
 	val, exists := annotation.Get(ingress, ForceHTTPSAnnotation)
 	if !exists {
 		return nil

--- a/operator/pkg/ingress/annotations/annotations_test.go
+++ b/operator/pkg/ingress/annotations/annotations_test.go
@@ -184,6 +184,126 @@ func TestGetAnnotationInsecureNodePort(t *testing.T) {
 	}
 }
 
+func TestGetAnnotationTLSHostPort(t *testing.T) {
+	type args struct {
+		ingress *networkingv1.Ingress
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *uint32
+		wantErr bool
+	}{
+		{
+			name: "no TLS host port annotation",
+			args: args{
+				ingress: &networkingv1.Ingress{},
+			},
+			want: nil,
+		},
+		{
+			name: "TLS host port annotation with valid value",
+			args: args{
+				ingress: &networkingv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"ingress.cilium.io/tls-passthrough-host-port": "1000",
+						},
+					},
+				},
+			},
+			want: uint32p(1000),
+		},
+		{
+			name: "TLS host port annotation with invalid non-numeric value",
+			args: args{
+				ingress: &networkingv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"ingress.cilium.io/tls-passthrough-host-port": "invalid-numeric-value",
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetAnnotationTLSHostPort(tt.args.ingress)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAnnotationTLSHostPort() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetAnnotationTLSHostPort() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAnnotationHTTPHostPort(t *testing.T) {
+	type args struct {
+		ingress *networkingv1.Ingress
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *uint32
+		wantErr bool
+	}{
+		{
+			name: "no HTTP host port annotation",
+			args: args{
+				ingress: &networkingv1.Ingress{},
+			},
+			want: nil,
+		},
+		{
+			name: "HTTP host port annotation with valid value",
+			args: args{
+				ingress: &networkingv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"ingress.cilium.io/http-host-port": "1000",
+						},
+					},
+				},
+			},
+			want: uint32p(1000),
+		},
+		{
+			name: "HTTP host port annotation with invalid non-numeric value",
+			args: args{
+				ingress: &networkingv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"ingress.cilium.io/http-host-port": "invalid-numeric-value",
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetAnnotationHTTPHostPort(tt.args.ingress)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAnnotationHTTPHostPort() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetAnnotationHTTPHostPort() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetAnnotationSSLPassthrough(t *testing.T) {
 	type args struct {
 		ingress *networkingv1.Ingress

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -39,6 +39,7 @@ var Cell = cell.Module(
 		IngressHostnetworkEnabled:                  false,
 		IngressHostnetworkSharedHTTPPort:           0,
 		IngressHostnetworkSharedTLSPassthroughPort: 0,
+		IngressHostnetworkNodelabelselector:        "",
 	}),
 	cell.Invoke(registerReconciler),
 	cell.Provide(registerSecretSync),
@@ -60,6 +61,7 @@ type ingressConfig struct {
 	IngressHostnetworkEnabled                  bool
 	IngressHostnetworkSharedHTTPPort           uint32
 	IngressHostnetworkSharedTLSPassthroughPort uint32
+	IngressHostnetworkNodelabelselector        string
 }
 
 func (r ingressConfig) Flags(flags *pflag.FlagSet) {
@@ -78,6 +80,7 @@ func (r ingressConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool("ingress-hostnetwork-enabled", r.IngressHostnetworkEnabled, "Exposes ingress listeners on the host network.")
 	flags.Uint32("ingress-hostnetwork-shared-http-port", r.IngressHostnetworkSharedHTTPPort, "Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)")
 	flags.Uint32("ingress-hostnetwork-shared-tlspassthrough-port", r.IngressHostnetworkSharedTLSPassthroughPort, "Port on the host network that gets used for the shared TLS passthrough listener")
+	flags.String("ingress-hostnetwork-nodelabelselector", r.IngressHostnetworkNodelabelselector, "Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'")
 }
 
 type ingressParams struct {
@@ -106,6 +109,7 @@ func registerReconciler(params ingressParams) error {
 		false, // hostNameSuffixMatch
 		params.OperatorConfig.ProxyIdleTimeoutSeconds,
 		params.IngressConfig.IngressHostnetworkEnabled,
+		translation.ParseNodeLabelSelector(params.IngressConfig.IngressHostnetworkNodelabelselector),
 		params.AgentConfig.EnableIPv4,
 		params.AgentConfig.EnableIPv6,
 	)

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -35,24 +35,31 @@ var Cell = cell.Module(
 		IngressLBAnnotationPrefixes: []string{"lbipam.cilium.io", "service.beta.kubernetes.io", "service.kubernetes.io", "cloud.google.com"},
 		IngressSharedLBServiceName:  "cilium-ingress",
 		IngressDefaultLBMode:        "dedicated",
+
+		IngressHostnetworkEnabled:                  false,
+		IngressHostnetworkSharedHTTPPort:           0,
+		IngressHostnetworkSharedTLSPassthroughPort: 0,
 	}),
 	cell.Invoke(registerReconciler),
 	cell.Provide(registerSecretSync),
 )
 
 type ingressConfig struct {
-	KubeProxyReplacement          string
-	EnableNodePort                bool
-	EnableIngressController       bool
-	EnforceIngressHTTPS           bool
-	EnableIngressProxyProtocol    bool
-	EnableIngressSecretsSync      bool
-	IngressSecretsNamespace       string
-	IngressLBAnnotationPrefixes   []string
-	IngressSharedLBServiceName    string
-	IngressDefaultLBMode          string
-	IngressDefaultSecretNamespace string
-	IngressDefaultSecretName      string
+	KubeProxyReplacement                       string
+	EnableNodePort                             bool
+	EnableIngressController                    bool
+	EnforceIngressHTTPS                        bool
+	EnableIngressProxyProtocol                 bool
+	EnableIngressSecretsSync                   bool
+	IngressSecretsNamespace                    string
+	IngressLBAnnotationPrefixes                []string
+	IngressSharedLBServiceName                 string
+	IngressDefaultLBMode                       string
+	IngressDefaultSecretNamespace              string
+	IngressDefaultSecretName                   string
+	IngressHostnetworkEnabled                  bool
+	IngressHostnetworkSharedHTTPPort           uint32
+	IngressHostnetworkSharedTLSPassthroughPort uint32
 }
 
 func (r ingressConfig) Flags(flags *pflag.FlagSet) {
@@ -68,6 +75,9 @@ func (r ingressConfig) Flags(flags *pflag.FlagSet) {
 	flags.String("ingress-default-lb-mode", r.IngressDefaultLBMode, "Default loadbalancer mode for Ingress. Applicable values: dedicated, shared")
 	flags.String("ingress-default-secret-namespace", r.IngressDefaultSecretNamespace, "Default secret namespace for Ingress.")
 	flags.String("ingress-default-secret-name", r.IngressDefaultSecretName, "Default secret name for Ingress.")
+	flags.Bool("ingress-hostnetwork-enabled", r.IngressHostnetworkEnabled, "Exposes ingress listeners on the host network.")
+	flags.Uint32("ingress-hostnetwork-shared-http-port", r.IngressHostnetworkSharedHTTPPort, "Port on the host network that gets used for the shared HTTP listener (HTTP & HTTPS)")
+	flags.Uint32("ingress-hostnetwork-shared-tlspassthrough-port", r.IngressHostnetworkSharedTLSPassthroughPort, "Port on the host network that gets used for the shared TLS passthrough listener")
 }
 
 type ingressParams struct {
@@ -75,21 +85,32 @@ type ingressParams struct {
 
 	Logger             logrus.FieldLogger
 	CtrlRuntimeManager ctrlRuntime.Manager
-	Config             ingressConfig
+	AgentConfig        *option.DaemonConfig
+	OperatorConfig     *operatorOption.OperatorConfig
+	IngressConfig      ingressConfig
 }
 
 func registerReconciler(params ingressParams) error {
-	if !params.Config.EnableIngressController {
+	if !params.IngressConfig.EnableIngressController {
 		return nil
 	}
 
-	if params.Config.KubeProxyReplacement != option.KubeProxyReplacementTrue && !params.Config.EnableNodePort {
+	if params.IngressConfig.KubeProxyReplacement != option.KubeProxyReplacementTrue && !params.IngressConfig.EnableNodePort {
 		params.Logger.Warn("Ingress Controller support requires either kube-proxy-replacement or enable-node-port enabled")
 		return nil
 	}
 
-	cecTranslator := translation.NewCECTranslator(params.Config.IngressSecretsNamespace, params.Config.EnableIngressProxyProtocol, false, operatorOption.Config.ProxyIdleTimeoutSeconds)
-	dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+	cecTranslator := translation.NewCECTranslator(
+		params.IngressConfig.IngressSecretsNamespace,
+		params.IngressConfig.EnableIngressProxyProtocol,
+		false, // hostNameSuffixMatch
+		params.OperatorConfig.ProxyIdleTimeoutSeconds,
+		params.IngressConfig.IngressHostnetworkEnabled,
+		params.AgentConfig.EnableIPv4,
+		params.AgentConfig.EnableIPv6,
+	)
+
+	dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, params.IngressConfig.IngressHostnetworkEnabled)
 
 	reconciler := newIngressReconciler(
 		params.Logger,
@@ -99,12 +120,16 @@ func registerReconciler(params ingressParams) error {
 		dedicatedIngressTranslator,
 
 		operatorOption.Config.CiliumK8sNamespace,
-		params.Config.IngressLBAnnotationPrefixes,
-		params.Config.IngressSharedLBServiceName,
-		params.Config.IngressDefaultLBMode,
-		params.Config.IngressDefaultSecretNamespace,
-		params.Config.IngressDefaultSecretName,
-		params.Config.EnforceIngressHTTPS,
+		params.IngressConfig.IngressLBAnnotationPrefixes,
+		params.IngressConfig.IngressSharedLBServiceName,
+		params.IngressConfig.IngressDefaultLBMode,
+		params.IngressConfig.IngressDefaultSecretNamespace,
+		params.IngressConfig.IngressDefaultSecretName,
+		params.IngressConfig.EnforceIngressHTTPS,
+
+		params.IngressConfig.IngressHostnetworkEnabled,
+		params.IngressConfig.IngressHostnetworkSharedHTTPPort,
+		params.IngressConfig.IngressHostnetworkSharedTLSPassthroughPort,
 	)
 
 	if err := reconciler.SetupWithManager(params.CtrlRuntimeManager); err != nil {
@@ -117,7 +142,7 @@ func registerReconciler(params ingressParams) error {
 // registerSecretSync registers the Ingress Controller for secret synchronization based on TLS secrets referenced
 // by a Cilium Ingress resource.
 func registerSecretSync(params ingressParams) secretsync.SecretSyncRegistrationOut {
-	if !params.Config.EnableIngressController || !params.Config.EnableIngressSecretsSync {
+	if !params.IngressConfig.EnableIngressController || !params.IngressConfig.EnableIngressSecretsSync {
 		return secretsync.SecretSyncRegistrationOut{}
 	}
 
@@ -126,7 +151,7 @@ func registerSecretSync(params ingressParams) secretsync.SecretSyncRegistrationO
 			RefObject:            &networkingv1.Ingress{},
 			RefObjectEnqueueFunc: EnqueueReferencedTLSSecrets(params.CtrlRuntimeManager.GetClient(), params.Logger),
 			RefObjectCheckFunc:   IsReferencedByCiliumIngress,
-			SecretsNamespace:     params.Config.IngressSecretsNamespace,
+			SecretsNamespace:     params.IngressConfig.IngressSecretsNamespace,
 			// In addition to changed Ingresses an additional watch on IngressClass gets added.
 			// Its purpose is to detect any changes regarding the default IngressClass
 			// (that is marked via annotation).
@@ -142,10 +167,10 @@ func registerSecretSync(params ingressParams) secretsync.SecretSyncRegistrationO
 		},
 	}
 
-	if params.Config.IngressDefaultSecretName != "" && params.Config.IngressDefaultSecretNamespace != "" {
+	if params.IngressConfig.IngressDefaultSecretName != "" && params.IngressConfig.IngressDefaultSecretNamespace != "" {
 		registration.SecretSyncRegistration.DefaultSecret = &secretsync.DefaultSecret{
-			Namespace: params.Config.IngressDefaultSecretNamespace,
-			Name:      params.Config.IngressDefaultSecretName,
+			Namespace: params.IngressConfig.IngressDefaultSecretNamespace,
+			Name:      params.IngressConfig.IngressDefaultSecretName,
 		}
 	}
 

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -40,6 +40,10 @@ type ingressReconciler struct {
 	defaultSecretName       string
 	enforcedHTTPS           bool
 
+	hostNetworkEnabled                  bool
+	hostNetworkSharedHTTPPort           uint32
+	hostNetworkSharedTLSPassthroughPort uint32
+
 	cecTranslator       translation.CECTranslator
 	dedicatedTranslator translation.Translator
 }
@@ -56,6 +60,9 @@ func newIngressReconciler(
 	defaultSecretNamespace string,
 	defaultSecretName string,
 	enforcedHTTPS bool,
+	hostNetworkEnabled bool,
+	hostNetworkSharedHTTPPort uint32,
+	hostNetworkSharedTLSPassthroughPort uint32,
 ) *ingressReconciler {
 	return &ingressReconciler{
 		logger: logger,
@@ -71,6 +78,10 @@ func newIngressReconciler(
 		defaultSecretNamespace:  defaultSecretNamespace,
 		defaultSecretName:       defaultSecretName,
 		enforcedHTTPS:           enforcedHTTPS,
+
+		hostNetworkEnabled:                  hostNetworkEnabled,
+		hostNetworkSharedHTTPPort:           hostNetworkSharedHTTPPort,
+		hostNetworkSharedTLSPassthroughPort: hostNetworkSharedTLSPassthroughPort,
 	}
 }
 

--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -214,7 +214,7 @@ func (r *ingressReconciler) buildSharedResources(ctx context.Context) (*ciliumv2
 			continue
 		}
 		if annotations.GetAnnotationTLSPassthroughEnabled(&item) {
-			m.TLS = append(m.TLS, ingestion.IngressPassthrough(item, r.defaultSecretNamespace, r.defaultSecretName)...)
+			m.TLS = append(m.TLS, ingestion.IngressPassthrough(item)...)
 		} else {
 			m.HTTP = append(m.HTTP, ingestion.Ingress(item, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS)...)
 		}
@@ -227,7 +227,7 @@ func (r *ingressReconciler) buildDedicatedResources(ctx context.Context, ingress
 	m := &model.Model{}
 
 	if annotations.GetAnnotationTLSPassthroughEnabled(ingress) {
-		m.TLS = append(m.TLS, ingestion.IngressPassthrough(*ingress, r.defaultSecretNamespace, r.defaultSecretName)...)
+		m.TLS = append(m.TLS, ingestion.IngressPassthrough(*ingress)...)
 	} else {
 		m.HTTP = append(m.HTTP, ingestion.Ingress(*ingress, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS)...)
 	}

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/anypb"
 	corev1 "k8s.io/api/core/v1"
@@ -59,10 +60,10 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
-		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -115,10 +116,10 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
-		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -171,10 +172,10 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
-		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -215,10 +216,10 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
-		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -285,10 +286,10 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
-		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -352,10 +353,10 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
-		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -406,10 +407,10 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
-		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -488,10 +489,10 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
-		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -560,10 +561,10 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
-		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -616,10 +617,10 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
-		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -656,10 +657,10 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
-		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -697,10 +698,10 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
-		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{"test.acme.io/"}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{"test.acme.io/"}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -782,10 +783,10 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
-		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -847,10 +848,10 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
-		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -889,10 +890,10 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
-		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -947,10 +948,10 @@ func TestReconcile(t *testing.T) {
 			}).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout)
-		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -970,6 +971,110 @@ func TestReconcile(t *testing.T) {
 		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &ciliumv2.CiliumEnvoyConfig{})
 		require.True(t, k8sApiErrors.IsNotFound(err), "CiliumEnvoyConfig should not be created")
 	})
+	t.Run("Reconcile of shared Cilium Ingress with external LB support will pass the configured port via model to the CEC Translator", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(testScheme()).
+			WithObjects(
+				&networkingv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test",
+						Annotations: map[string]string{
+							"ingress.cilium.io/loadbalancer-mode": "shared",
+						},
+					},
+					Spec: networkingv1.IngressSpec{
+						IngressClassName: model.AddressOf("cilium"),
+						DefaultBackend:   defaultBackend(),
+					},
+				},
+			).
+			Build()
+
+		cecTranslator := &fakeCECTranslator{}
+
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, nil, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, true, 55555, 55556)
+
+		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "test",
+				Name:      "test",
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		assert.Empty(t, cecTranslator.model.TLS)
+		assert.Len(t, cecTranslator.model.HTTP, 1)
+		assert.Equal(t, uint32(55555), cecTranslator.model.HTTP[0].Port)
+	})
+
+	t.Run("Reconcile of dedicated Cilium Ingress with external LB support will pass the annotated port to the CEC Translator", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(testScheme()).
+			WithObjects(
+				&networkingv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test",
+						Annotations: map[string]string{
+							"ingress.cilium.io/loadbalancer-mode": "dedicated",
+							"ingress.cilium.io/http-host-port":    "55555",
+						},
+					},
+					Spec: networkingv1.IngressSpec{
+						IngressClassName: model.AddressOf("cilium"),
+						DefaultBackend:   defaultBackend(),
+					},
+				},
+			).
+			Build()
+
+		cecTranslator := &fakeCECTranslator{}
+		dedicatedIngressTranslator := &fakeDedicatedIngressTranslator{}
+
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, true, 0, 0)
+
+		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "test",
+				Name:      "test",
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		assert.Empty(t, dedicatedIngressTranslator.model.TLS)
+		assert.Len(t, dedicatedIngressTranslator.model.HTTP, 1)
+		assert.Equal(t, uint32(55555), dedicatedIngressTranslator.model.HTTP[0].Port)
+	})
+}
+
+var _ translation.CECTranslator = &fakeCECTranslator{}
+
+type fakeCECTranslator struct {
+	model *model.Model
+}
+
+func (r *fakeCECTranslator) Translate(namespace string, name string, model *model.Model) (*ciliumv2.CiliumEnvoyConfig, error) {
+	r.model = model
+
+	return &ciliumv2.CiliumEnvoyConfig{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}}, nil
+}
+
+var _ translation.Translator = &fakeDedicatedIngressTranslator{}
+
+type fakeDedicatedIngressTranslator struct {
+	model *model.Model
+}
+
+func (r *fakeDedicatedIngressTranslator) Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *corev1.Endpoints, error) {
+	r.model = model
+
+	return &ciliumv2.CiliumEnvoyConfig{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
+		&corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
+		nil
 }
 
 func defaultBackend() *networkingv1.IngressBackend {
@@ -980,5 +1085,202 @@ func defaultBackend() *networkingv1.IngressBackend {
 				Number: 8080,
 			},
 		},
+	}
+}
+
+func TestGetSharedListenerPorts(t *testing.T) {
+	testCases := []struct {
+		desc                                string
+		hostNetworkEnabled                  bool
+		hostNetworkSharedHTTPPort           uint32
+		hostNetworkSharedTLSPassthroughPort uint32
+		expectedPassthroughPort             uint32
+		expectedInsecureHTTPPort            uint32
+		expectedSecureHTTPPort              uint32
+	}{
+		{
+			desc:                     "no external loadbalancer",
+			hostNetworkEnabled:       false,
+			expectedPassthroughPort:  443,
+			expectedInsecureHTTPPort: 80,
+			expectedSecureHTTPPort:   443,
+		},
+		{
+			desc:                                "external loadbalancer with TLS & HTTP port 0",
+			hostNetworkEnabled:                  true,
+			hostNetworkSharedTLSPassthroughPort: 0,
+			hostNetworkSharedHTTPPort:           0,
+			expectedPassthroughPort:             443,
+			expectedInsecureHTTPPort:            80,
+			expectedSecureHTTPPort:              443,
+		},
+		{
+			desc:                                "external loadbalancer with TLS port 0",
+			hostNetworkEnabled:                  true,
+			hostNetworkSharedTLSPassthroughPort: 0,
+			hostNetworkSharedHTTPPort:           55555,
+			expectedPassthroughPort:             443,
+			expectedInsecureHTTPPort:            55555,
+			expectedSecureHTTPPort:              55555,
+		},
+		{
+			desc:                                "external loadbalancer with HTTP port 0",
+			hostNetworkEnabled:                  true,
+			hostNetworkSharedTLSPassthroughPort: 55555,
+			hostNetworkSharedHTTPPort:           0,
+			expectedPassthroughPort:             55555,
+			expectedInsecureHTTPPort:            80,
+			expectedSecureHTTPPort:              443,
+		},
+		{
+			desc:                                "external loadbalancer with HTTP and TLS port set",
+			hostNetworkEnabled:                  true,
+			hostNetworkSharedTLSPassthroughPort: 55555,
+			hostNetworkSharedHTTPPort:           55556,
+			expectedPassthroughPort:             55555,
+			expectedInsecureHTTPPort:            55556,
+			expectedSecureHTTPPort:              55556,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			ir := ingressReconciler{
+				hostNetworkEnabled:                  tC.hostNetworkEnabled,
+				hostNetworkSharedHTTPPort:           tC.hostNetworkSharedHTTPPort,
+				hostNetworkSharedTLSPassthroughPort: tC.hostNetworkSharedTLSPassthroughPort,
+			}
+
+			passthrough, insecureHTTP, secureHTTP := ir.getSharedListenerPorts()
+
+			assert.Equal(t, tC.expectedPassthroughPort, passthrough)
+			assert.Equal(t, tC.expectedInsecureHTTPPort, insecureHTTP)
+			assert.Equal(t, tC.expectedSecureHTTPPort, secureHTTP)
+		})
+	}
+}
+
+func TestGetDedicatedListenerPorts(t *testing.T) {
+	testCases := []struct {
+		desc                     string
+		hostNetworkEnabled       bool
+		ingressAnnotations       map[string]string
+		expectedPassthroughPort  uint32
+		expectedInsecureHTTPPort uint32
+		expectedSecureHTTPPort   uint32
+	}{
+		{
+			desc:                     "no hostnetwork mode",
+			hostNetworkEnabled:       false,
+			expectedPassthroughPort:  443,
+			expectedInsecureHTTPPort: 80,
+			expectedSecureHTTPPort:   443,
+		},
+		{
+			desc:               "hostnetwork without TLS annotation",
+			hostNetworkEnabled: true,
+			ingressAnnotations: map[string]string{
+				"ingress.cilium.io/tls-passthrough-host-port": "55555",
+			},
+			expectedPassthroughPort:  55555,
+			expectedInsecureHTTPPort: 80,
+			expectedSecureHTTPPort:   443,
+		},
+		{
+			desc:               "hostnetwork without HTTP annotation",
+			hostNetworkEnabled: true,
+			ingressAnnotations: map[string]string{
+				"ingress.cilium.io/http-host-port": "55555",
+			},
+			expectedPassthroughPort:  443,
+			expectedInsecureHTTPPort: 55555,
+			expectedSecureHTTPPort:   55555,
+		},
+		{
+			desc:               "hostnetwork with TLS & HTTP port 0",
+			hostNetworkEnabled: true,
+			ingressAnnotations: map[string]string{
+				"ingress.cilium.io/tls-passthrough-host-port": "0",
+				"ingress.cilium.io/http-host-port":            "0",
+			},
+			expectedPassthroughPort:  443,
+			expectedInsecureHTTPPort: 80,
+			expectedSecureHTTPPort:   443,
+		},
+		{
+			desc:               "hostnetwork with TLS port 0",
+			hostNetworkEnabled: true,
+			ingressAnnotations: map[string]string{
+				"ingress.cilium.io/tls-passthrough-host-port": "0",
+				"ingress.cilium.io/http-host-port":            "55555",
+			},
+			expectedPassthroughPort:  443,
+			expectedInsecureHTTPPort: 55555,
+			expectedSecureHTTPPort:   55555,
+		},
+		{
+			desc:               "hostnetwork with HTTP port 0",
+			hostNetworkEnabled: true,
+			ingressAnnotations: map[string]string{
+				"ingress.cilium.io/tls-passthrough-host-port": "55555",
+				"ingress.cilium.io/http-host-port":            "0",
+			},
+			expectedPassthroughPort:  55555,
+			expectedInsecureHTTPPort: 80,
+			expectedSecureHTTPPort:   443,
+		},
+		{
+			desc:               "hostnetwork with invalid TLS value",
+			hostNetworkEnabled: true,
+			ingressAnnotations: map[string]string{
+				"ingress.cilium.io/tls-passthrough-host-port": "invalid",
+				"ingress.cilium.io/http-host-port":            "55555",
+			},
+			expectedPassthroughPort:  443,
+			expectedInsecureHTTPPort: 55555,
+			expectedSecureHTTPPort:   55555,
+		},
+		{
+			desc:               "hostnetwork with invalid HTTP value",
+			hostNetworkEnabled: true,
+			ingressAnnotations: map[string]string{
+				"ingress.cilium.io/tls-passthrough-host-port": "55555",
+				"ingress.cilium.io/http-host-port":            "invalid",
+			},
+			expectedPassthroughPort:  55555,
+			expectedInsecureHTTPPort: 80,
+			expectedSecureHTTPPort:   443,
+		},
+		{
+			desc:               "hostnetwork with HTTP and TLS port set",
+			hostNetworkEnabled: true,
+			ingressAnnotations: map[string]string{
+				"ingress.cilium.io/tls-passthrough-host-port": "55555",
+				"ingress.cilium.io/http-host-port":            "55556",
+			},
+			expectedPassthroughPort:  55555,
+			expectedInsecureHTTPPort: 55556,
+			expectedSecureHTTPPort:   55556,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			logger := logrus.New()
+			logger.SetOutput(io.Discard)
+			ir := ingressReconciler{
+				logger:             logger,
+				hostNetworkEnabled: tC.hostNetworkEnabled,
+			}
+
+			ingress := &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tC.ingressAnnotations,
+				},
+			}
+			passthrough, insecureHTTP, secureHTTP := ir.getDedicatedListenerPorts(ingress)
+
+			assert.Equal(t, tC.expectedPassthroughPort, passthrough)
+			assert.Equal(t, tC.expectedInsecureHTTPPort, insecureHTTP)
+			assert.Equal(t, tC.expectedSecureHTTPPort, secureHTTP)
+		})
 	}
 }

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -60,7 +60,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -116,7 +116,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -172,7 +172,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -216,7 +216,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -286,7 +286,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -353,7 +353,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -407,7 +407,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -489,7 +489,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -561,7 +561,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -617,7 +617,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -657,7 +657,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -698,7 +698,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{"test.acme.io/"}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -783,7 +783,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -848,7 +848,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -890,7 +890,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)
@@ -948,7 +948,7 @@ func TestReconcile(t *testing.T) {
 			}).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, false, false)
+		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, testDefaultTimeout, false, nil, false, false)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0, 0)

--- a/operator/pkg/model/ingestion/ingress.go
+++ b/operator/pkg/model/ingestion/ingress.go
@@ -225,7 +225,7 @@ func Ingress(ing networkingv1.Ingress, defaultSecretNamespace, defaultSecretName
 // * must have a host set
 // * rules with paths other than '/' are ignored
 // * default backends are ignored
-func IngressPassthrough(ing networkingv1.Ingress, defaultSecretNamespace, defaultSecretName string) []model.TLSListener {
+func IngressPassthrough(ing networkingv1.Ingress) []model.TLSListener {
 	// First, we make a map of TLSListeners, with the hostname
 	// as the key, so that we can make sure we match up any
 	// TLS config with rules that match it.

--- a/operator/pkg/model/ingestion/ingress_test.go
+++ b/operator/pkg/model/ingestion/ingress_test.go
@@ -2113,9 +2113,8 @@ var sslPassthruDefaultBackend = networkingv1.Ingress{
 }
 
 type passthruTestcase struct {
-	ingress       networkingv1.Ingress
-	defaultSecret bool
-	want          []model.TLSListener
+	ingress networkingv1.Ingress
+	want    []model.TLSListener
 }
 
 func TestIngressPassthrough(t *testing.T) {
@@ -2152,12 +2151,7 @@ func TestIngressPassthrough(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var listeners []model.TLSListener
-			if tc.defaultSecret {
-				listeners = IngressPassthrough(tc.ingress, defaultSecretNamespace, defaultSecretName)
-			} else {
-				listeners = IngressPassthrough(tc.ingress, "", "")
-			}
+			listeners := IngressPassthrough(tc.ingress)
 
 			assert.Equal(t, tc.want, listeners, "Listeners did not match")
 		})

--- a/operator/pkg/model/ingestion/ingress_test.go
+++ b/operator/pkg/model/ingestion/ingress_test.go
@@ -1775,9 +1775,9 @@ func TestIngress(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var listeners []model.HTTPListener
 			if tc.defaultSecret {
-				listeners = Ingress(tc.ingress, defaultSecretNamespace, defaultSecretName, tc.enforceHTTPS)
+				listeners = Ingress(tc.ingress, defaultSecretNamespace, defaultSecretName, tc.enforceHTTPS, 80, 443)
 			} else {
-				listeners = Ingress(tc.ingress, "", "", tc.enforceHTTPS)
+				listeners = Ingress(tc.ingress, "", "", tc.enforceHTTPS, 80, 443)
 			}
 
 			assert.Equal(t, tc.want, listeners, "Listeners did not match")
@@ -2151,7 +2151,7 @@ func TestIngressPassthrough(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			listeners := IngressPassthrough(tc.ingress)
+			listeners := IngressPassthrough(tc.ingress, 443)
 
 			assert.Equal(t, tc.want, listeners, "Listeners did not match")
 		})

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -78,22 +78,22 @@ type HTTPListener struct {
 	ForceHTTPtoHTTPSRedirect bool
 }
 
-func (l *HTTPListener) GetSources() []FullyQualifiedResource {
+func (l HTTPListener) GetSources() []FullyQualifiedResource {
 	return l.Sources
 }
 
-func (l *HTTPListener) GetPort() uint32 {
+func (l HTTPListener) GetPort() uint32 {
 	return l.Port
 }
 
-func (l *HTTPListener) GetAnnotations() map[string]string {
+func (l HTTPListener) GetAnnotations() map[string]string {
 	if l.Infrastructure != nil {
 		return l.Infrastructure.Annotations
 	}
 	return nil
 }
 
-func (l *HTTPListener) GetLabels() map[string]string {
+func (l HTTPListener) GetLabels() map[string]string {
 	if l.Infrastructure != nil {
 		return l.Infrastructure.Labels
 	}
@@ -130,25 +130,25 @@ type TLSListener struct {
 	Infrastructure *Infrastructure `json:"infrastructure,omitempty"`
 }
 
-func (l *TLSListener) GetAnnotations() map[string]string {
+func (l TLSListener) GetAnnotations() map[string]string {
 	if l.Infrastructure != nil {
 		return l.Infrastructure.Annotations
 	}
 	return nil
 }
 
-func (l *TLSListener) GetLabels() map[string]string {
+func (l TLSListener) GetLabels() map[string]string {
 	if l.Infrastructure != nil {
 		return l.Infrastructure.Labels
 	}
 	return nil
 }
 
-func (l *TLSListener) GetSources() []FullyQualifiedResource {
+func (l TLSListener) GetSources() []FullyQualifiedResource {
 	return l.Sources
 }
 
-func (l *TLSListener) GetPort() uint32 {
+func (l TLSListener) GetPort() uint32 {
 	return l.Port
 }
 
@@ -273,11 +273,11 @@ type HTTPRoute struct {
 	DirectResponse *DirectResponse `json:"direct_response,omitempty"`
 
 	// RequestHeaderFilter can be used to add or remove an HTTP
-	//header from an HTTP request before it is sent to the upstream target.
+	// header from an HTTP request before it is sent to the upstream target.
 	RequestHeaderFilter *HTTPHeaderFilter `json:"request_header_filter,omitempty"`
 
 	// ResponseHeaderModifier can be used to add or remove an HTTP
-	//header from an HTTP response before it is sent to the client.
+	// header from an HTTP response before it is sent to the client.
 	ResponseHeaderModifier *HTTPHeaderFilter `json:"response_header_modifier,omitempty"`
 
 	// RequestRedirect defines a schema for a filter that responds to the
@@ -302,11 +302,11 @@ type BackendHTTPFilter struct {
 	// Name is the name of the Backend, the name is having the format of "namespace:name:port"
 	Name string `json:"name"`
 	// RequestHeaderFilter can be used to add or remove an HTTP
-	//header from an HTTP request before it is sent to the upstream target.
+	// header from an HTTP request before it is sent to the upstream target.
 	RequestHeaderFilter *HTTPHeaderFilter `json:"request_header_filter,omitempty"`
 
 	// ResponseHeaderModifier can be used to add or remove an HTTP
-	//header from an HTTP response before it is sent to the client.
+	// header from an HTTP response before it is sent to the client.
 	ResponseHeaderModifier *HTTPHeaderFilter `json:"response_header_modifier,omitempty"`
 }
 

--- a/operator/pkg/model/translation/envoy_listener_test.go
+++ b/operator/pkg/model/translation/envoy_listener_test.go
@@ -12,6 +12,7 @@ import (
 	envoy_config_listener "github.com/cilium/proxy/go/envoy/config/listener/v3"
 	httpConnectionManagerv3 "github.com/cilium/proxy/go/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_extensions_transport_sockets_tls_v3 "github.com/cilium/proxy/go/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
@@ -46,7 +47,6 @@ func TestNewHTTPListener(t *testing.T) {
 		require.Nil(t, err)
 		// Default value is 0
 		require.Equal(t, uint32(0), httpConnectionManager.XffNumTrustedHops)
-
 	})
 
 	t.Run("without TLS with Proxy Protocol", func(t *testing.T) {
@@ -115,7 +115,6 @@ func TestNewHTTPListener(t *testing.T) {
 		sort.Strings(secretNames)
 		require.Equal(t, "dummy-secret-namespace/dummy-namespace-dummy-secret-1", secretNames[0])
 		require.Equal(t, "dummy-secret-namespace/dummy-namespace-dummy-secret-2", secretNames[1])
-
 	})
 }
 
@@ -152,4 +151,227 @@ func TestNewSNIListener(t *testing.T) {
 		require.Len(t, listener.GetFilterChains(), 1)
 		require.Len(t, listener.GetFilterChains()[0].FilterChainMatch.ServerNames, 2)
 	})
+}
+
+func TestGetHostNetworkListenerAddresses(t *testing.T) {
+	testCases := []struct {
+		desc                       string
+		ports                      []uint32
+		ipv4Enabled                bool
+		ipv6Enabled                bool
+		expectedPrimaryAdress      *envoy_config_core_v3.Address
+		expectedAdditionalAdresses []*envoy_config_listener.AdditionalAddress
+	}{
+		{
+			desc:                       "No ports - no address",
+			ipv4Enabled:                true,
+			ipv6Enabled:                true,
+			expectedPrimaryAdress:      nil,
+			expectedAdditionalAdresses: nil,
+		},
+		{
+			desc:                       "No IP family - no address",
+			ports:                      []uint32{55555},
+			expectedPrimaryAdress:      nil,
+			expectedAdditionalAdresses: nil,
+		},
+		{
+			desc:        "IPv4 only",
+			ports:       []uint32{55555},
+			ipv4Enabled: true,
+			ipv6Enabled: false,
+			expectedPrimaryAdress: &envoy_config_core_v3.Address{
+				Address: &envoy_config_core_v3.Address_SocketAddress{
+					SocketAddress: &envoy_config_core_v3.SocketAddress{
+						Protocol: envoy_config_core_v3.SocketAddress_TCP,
+						Address:  "0.0.0.0",
+						PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+							PortValue: 55555,
+						},
+					},
+				},
+			},
+			expectedAdditionalAdresses: nil,
+		},
+		{
+			desc:        "IPv6 only",
+			ports:       []uint32{55555},
+			ipv4Enabled: false,
+			ipv6Enabled: true,
+			expectedPrimaryAdress: &envoy_config_core_v3.Address{
+				Address: &envoy_config_core_v3.Address_SocketAddress{
+					SocketAddress: &envoy_config_core_v3.SocketAddress{
+						Protocol: envoy_config_core_v3.SocketAddress_TCP,
+						Address:  "::",
+						PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+							PortValue: 55555,
+						},
+					},
+				},
+			},
+			expectedAdditionalAdresses: nil,
+		},
+		{
+			desc:        "IPv4 & IPv6",
+			ports:       []uint32{55555},
+			ipv4Enabled: true,
+			ipv6Enabled: true,
+			expectedPrimaryAdress: &envoy_config_core_v3.Address{
+				Address: &envoy_config_core_v3.Address_SocketAddress{
+					SocketAddress: &envoy_config_core_v3.SocketAddress{
+						Protocol: envoy_config_core_v3.SocketAddress_TCP,
+						Address:  "0.0.0.0",
+						PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+							PortValue: 55555,
+						},
+					},
+				},
+			},
+			expectedAdditionalAdresses: []*envoy_config_listener.AdditionalAddress{
+				{
+					Address: &envoy_config_core_v3.Address{
+						Address: &envoy_config_core_v3.Address_SocketAddress{
+							SocketAddress: &envoy_config_core_v3.SocketAddress{
+								Protocol: envoy_config_core_v3.SocketAddress_TCP,
+								Address:  "::",
+								PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+									PortValue: 55555,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:        "IPv4 only with multiple ports",
+			ports:       []uint32{44444, 55555},
+			ipv4Enabled: true,
+			ipv6Enabled: false,
+			expectedPrimaryAdress: &envoy_config_core_v3.Address{
+				Address: &envoy_config_core_v3.Address_SocketAddress{
+					SocketAddress: &envoy_config_core_v3.SocketAddress{
+						Protocol: envoy_config_core_v3.SocketAddress_TCP,
+						Address:  "0.0.0.0",
+						PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+							PortValue: 44444,
+						},
+					},
+				},
+			},
+			expectedAdditionalAdresses: []*envoy_config_listener.AdditionalAddress{
+				{
+					Address: &envoy_config_core_v3.Address{
+						Address: &envoy_config_core_v3.Address_SocketAddress{
+							SocketAddress: &envoy_config_core_v3.SocketAddress{
+								Protocol: envoy_config_core_v3.SocketAddress_TCP,
+								Address:  "0.0.0.0",
+								PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+									PortValue: 55555,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:        "IPv6 only with multiple ports",
+			ports:       []uint32{44444, 55555},
+			ipv4Enabled: false,
+			ipv6Enabled: true,
+			expectedPrimaryAdress: &envoy_config_core_v3.Address{
+				Address: &envoy_config_core_v3.Address_SocketAddress{
+					SocketAddress: &envoy_config_core_v3.SocketAddress{
+						Protocol: envoy_config_core_v3.SocketAddress_TCP,
+						Address:  "::",
+						PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+							PortValue: 44444,
+						},
+					},
+				},
+			},
+			expectedAdditionalAdresses: []*envoy_config_listener.AdditionalAddress{
+				{
+					Address: &envoy_config_core_v3.Address{
+						Address: &envoy_config_core_v3.Address_SocketAddress{
+							SocketAddress: &envoy_config_core_v3.SocketAddress{
+								Protocol: envoy_config_core_v3.SocketAddress_TCP,
+								Address:  "::",
+								PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+									PortValue: 55555,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:        "IPv4 & IPv6 with multiple ports",
+			ports:       []uint32{44444, 55555},
+			ipv4Enabled: true,
+			ipv6Enabled: true,
+			expectedPrimaryAdress: &envoy_config_core_v3.Address{
+				Address: &envoy_config_core_v3.Address_SocketAddress{
+					SocketAddress: &envoy_config_core_v3.SocketAddress{
+						Protocol: envoy_config_core_v3.SocketAddress_TCP,
+						Address:  "0.0.0.0",
+						PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+							PortValue: 44444,
+						},
+					},
+				},
+			},
+			expectedAdditionalAdresses: []*envoy_config_listener.AdditionalAddress{
+				{
+					Address: &envoy_config_core_v3.Address{
+						Address: &envoy_config_core_v3.Address_SocketAddress{
+							SocketAddress: &envoy_config_core_v3.SocketAddress{
+								Protocol: envoy_config_core_v3.SocketAddress_TCP,
+								Address:  "::",
+								PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+									PortValue: 44444,
+								},
+							},
+						},
+					},
+				},
+				{
+					Address: &envoy_config_core_v3.Address{
+						Address: &envoy_config_core_v3.Address_SocketAddress{
+							SocketAddress: &envoy_config_core_v3.SocketAddress{
+								Protocol: envoy_config_core_v3.SocketAddress_TCP,
+								Address:  "0.0.0.0",
+								PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+									PortValue: 55555,
+								},
+							},
+						},
+					},
+				},
+				{
+					Address: &envoy_config_core_v3.Address{
+						Address: &envoy_config_core_v3.Address_SocketAddress{
+							SocketAddress: &envoy_config_core_v3.SocketAddress{
+								Protocol: envoy_config_core_v3.SocketAddress_TCP,
+								Address:  "::",
+								PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+									PortValue: 55555,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			primaryAddress, additionalAddresses := getHostNetworkListenerAddresses(tC.ports, tC.ipv4Enabled, tC.ipv6Enabled)
+
+			assert.Equal(t, tC.expectedPrimaryAdress, primaryAddress)
+			assert.Equal(t, tC.expectedAdditionalAdresses, additionalAddresses)
+		})
+	}
 }

--- a/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cilium/cilium/operator/pkg/model"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 )
 
 var (
@@ -198,7 +199,7 @@ var basicHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 }
 
 // basicHostPortHTTPListenersCiliumEnvoyConfig is the generated CiliumEnvoyConfig basic http listener model.
-func basicHostPortHTTPListenersCiliumEnvoyConfig(address string, port uint32) *ciliumv2.CiliumEnvoyConfig {
+func basicHostPortHTTPListenersCiliumEnvoyConfig(address string, port uint32, nodeLabelSelector *slim_metav1.LabelSelector) *ciliumv2.CiliumEnvoyConfig {
 	return &ciliumv2.CiliumEnvoyConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cilium-gateway-my-gateway",
@@ -216,6 +217,7 @@ func basicHostPortHTTPListenersCiliumEnvoyConfig(address string, port uint32) *c
 			},
 		},
 		Spec: ciliumv2.CiliumEnvoyConfigSpec{
+			NodeSelector: nodeLabelSelector,
 			Services: []*ciliumv2.ServiceListener{
 				{
 					Name:      "cilium-gateway-my-gateway",

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -7,8 +7,11 @@ import (
 	"testing"
 
 	envoy_config_route_v3 "github.com/cilium/proxy/go/envoy/config/route/v3"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/operator/pkg/model/translation"
@@ -29,7 +32,7 @@ func Test_translator_Translate(t *testing.T) {
 			name: "Basic HTTP Listener",
 			args: args{
 				m: &model.Model{
-					HTTP: basicHTTPListeners,
+					HTTP: basicHTTPListeners(80),
 				},
 			},
 			want: basicHTTPListenersCiliumEnvoyConfig,
@@ -209,7 +212,7 @@ func Test_translator_Translate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			trans := &gatewayAPITranslator{
-				cecTranslator: translation.NewCECTranslator("cilium-secrets", false, true, 60),
+				cecTranslator: translation.NewCECTranslator("cilium-secrets", false, true, 60, false, false, false),
 			}
 			cec, _, _, err := trans.Translate(tt.args.m)
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
@@ -310,13 +313,89 @@ func Test_translator_TranslateResource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			trans := &gatewayAPITranslator{
-				cecTranslator: translation.NewCECTranslator("cilium-secrets", false, true, 60),
+				cecTranslator: translation.NewCECTranslator("cilium-secrets", false, true, 60, false, false, false),
 			}
 			cec, _, _, err := trans.Translate(tt.args.m)
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 			for _, fn := range tt.validateFuncs {
 				require.True(t, fn(cec), "Validation failed")
 			}
+		})
+	}
+}
+
+func Test_translator_Translate_HostNetwork(t *testing.T) {
+	type args struct {
+		m *model.Model
+	}
+	tests := []struct {
+		name        string
+		args        args
+		ipv4Enabled bool
+		ipv6Enabled bool
+		want        *ciliumv2.CiliumEnvoyConfig
+		wantErr     bool
+	}{
+		{
+			name:        "Basic HTTP Listener",
+			ipv4Enabled: true,
+			args: args{
+				m: &model.Model{
+					HTTP: basicHTTPListeners(80),
+				},
+			},
+			want: basicHostPortHTTPListenersCiliumEnvoyConfig("0.0.0.0", 80),
+		},
+		{
+			name:        "Basic HTTP Listener with different port",
+			ipv4Enabled: true,
+			args: args{
+				m: &model.Model{
+					HTTP: basicHTTPListeners(55555),
+				},
+			},
+			want: basicHostPortHTTPListenersCiliumEnvoyConfig("0.0.0.0", 55555),
+		},
+		{
+			name:        "Basic HTTP Listener with different port and IPv6",
+			ipv4Enabled: false,
+			ipv6Enabled: true,
+			args: args{
+				m: &model.Model{
+					HTTP: basicHTTPListeners(55555),
+				},
+			},
+			want: basicHostPortHTTPListenersCiliumEnvoyConfig("::", 55555),
+		},
+		{
+			name:        "Basic HTTP Listener with LabelSelector",
+			ipv4Enabled: true,
+			args: args{
+				m: &model.Model{
+					HTTP: basicHTTPListeners(55555),
+				},
+			},
+			want: basicHostPortHTTPListenersCiliumEnvoyConfig("0.0.0.0", 55555),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trans := &gatewayAPITranslator{
+				cecTranslator:      translation.NewCECTranslator("cilium-secrets", false, true, 60, true, tt.ipv4Enabled, tt.ipv6Enabled),
+				hostNetworkEnabled: true,
+			}
+			cec, svc, ep, err := trans.Translate(tt.args.m)
+			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
+
+			diffOutput := cmp.Diff(tt.want, cec, protocmp.Transform())
+			if len(diffOutput) != 0 {
+				t.Errorf("CiliumEnvoyConfigs did not match:\n%s\n", diffOutput)
+			}
+
+			require.NotNil(t, svc)
+			assert.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type)
+
+			require.NotNil(t, ep)
 		})
 	}
 }

--- a/operator/pkg/model/translation/helper.go
+++ b/operator/pkg/model/translation/helper.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package translation
+
+import (
+	"strings"
+
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+// ParseNodeLabelSelector parses a given string representation of a label selector into a metav1.LabelSelector.
+// The representation is a comma-separated list of key-value pairs (key1=value1,key2=value2) that is used as MatchLabels.
+// Values not matching these rules are skipped.
+func ParseNodeLabelSelector(nodeLabelSelectorString string) *slim_metav1.LabelSelector {
+	if nodeLabelSelectorString == "" {
+		return nil
+	}
+
+	labels := map[string]string{}
+	for _, v := range strings.Split(nodeLabelSelectorString, ",") {
+		s := strings.Split(v, "=")
+		if len(s) != 2 || len(s[0]) == 0 {
+			continue
+		}
+		labels[s[0]] = s[1]
+	}
+
+	return &slim_metav1.LabelSelector{
+		MatchLabels: labels,
+	}
+}

--- a/operator/pkg/model/translation/helper_test.go
+++ b/operator/pkg/model/translation/helper_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package translation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+func TestParseNodeLabelSelector(t *testing.T) {
+	testCases := []struct {
+		desc                  string
+		input                 string
+		expectedLabelSelector *slim_metav1.LabelSelector
+	}{
+		{
+			desc:                  "Empty",
+			input:                 "",
+			expectedLabelSelector: nil,
+		},
+		{
+			desc:  "Single label value",
+			input: "a=b",
+			expectedLabelSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]slim_metav1.MatchLabelsValue{
+				"a": "b",
+			}},
+		},
+		{
+			desc:  "Multiple label values",
+			input: "a=b,c=d,e=f",
+			expectedLabelSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]slim_metav1.MatchLabelsValue{
+				"a": "b",
+				"c": "d",
+				"e": "f",
+			}},
+		},
+		{
+			desc:  "Empty key is not allowed",
+			input: "a=b,c=d,=f",
+			expectedLabelSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]slim_metav1.MatchLabelsValue{
+				"a": "b",
+				"c": "d",
+			}},
+		},
+		{
+			desc:  "Empty value",
+			input: "a=b,c=d,e=",
+			expectedLabelSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]slim_metav1.MatchLabelsValue{
+				"a": "b",
+				"c": "d",
+				"e": "",
+			}},
+		},
+		{
+			desc:  "No value",
+			input: "a=b,c=d,e",
+			expectedLabelSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]slim_metav1.MatchLabelsValue{
+				"a": "b",
+				"c": "d",
+			}},
+		},
+		{
+			desc:  "Space before value",
+			input: "a=b,c=d,e= f",
+			expectedLabelSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]slim_metav1.MatchLabelsValue{
+				"a": "b",
+				"c": "d",
+				"e": " f",
+			}},
+		},
+		{
+			desc:  "Space after value",
+			input: "a=b,c=d,e=f ",
+			expectedLabelSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]slim_metav1.MatchLabelsValue{
+				"a": "b",
+				"c": "d",
+				"e": "f ",
+			}},
+		},
+		{
+			desc:  "Space before key",
+			input: "a=b,c=d, e=f",
+			expectedLabelSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]slim_metav1.MatchLabelsValue{
+				"a":  "b",
+				"c":  "d",
+				" e": "f",
+			}},
+		},
+		{
+			desc:  "Space after key",
+			input: "a=b,c=d,e =f",
+			expectedLabelSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]slim_metav1.MatchLabelsValue{
+				"a":  "b",
+				"c":  "d",
+				"e ": "f",
+			}},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			ls := ParseNodeLabelSelector(tC.input)
+
+			assert.Equal(t, tC.expectedLabelSelector, ls)
+		})
+	}
+}

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/cilium/cilium/operator/pkg/model"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 )
 
 var socketOptions = []*envoy_config_core_v3.SocketOption{
@@ -1191,7 +1192,7 @@ var proxyProtoListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	},
 }
 
-func hostNetworkListenersCiliumEnvoyConfig(address string, port uint32) *ciliumv2.CiliumEnvoyConfig {
+func hostNetworkListenersCiliumEnvoyConfig(address string, port uint32, nodeLabelSelector *slim_metav1.LabelSelector) *ciliumv2.CiliumEnvoyConfig {
 	return &ciliumv2.CiliumEnvoyConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cilium-ingress-random-namespace-load-balancing",
@@ -1201,6 +1202,7 @@ func hostNetworkListenersCiliumEnvoyConfig(address string, port uint32) *ciliumv
 			},
 		},
 		Spec: ciliumv2.CiliumEnvoyConfigSpec{
+			NodeSelector: nodeLabelSelector,
 			Services: []*ciliumv2.ServiceListener{
 				{
 					Name:      "cilium-ingress-load-balancing",


### PR DESCRIPTION
This PR introduces support for exposing the Envoy Listeners created by the Ingress Controller and/or Gateway API directly on the host network. This is useful in some edge cases where one don't want / can't to use K8s LoadBalancer/NodePort functionality (dev environments, cluster-external loadbalancer, ...)

### Expose Envoy listeners on host network

This commit adds support for exposing the L7 Envoy Listeners directly on the host network - and no longer use Kubernetes Services of type `LoadBalancer` or `NodePort`.

The listener is exposed on all interfaces (`0.0.0.0` for IPv4 and/or `::` for IPv6).

**Enable HostNetwork support via Helm**

* Ingress Controller: `ingressController.hostNetwork.enabled=true`
* Gateway API: `gatewayAPI.hostNetwork.enabled=true`

**Configure listener port**

* Shared Ingress: configurable via Helm
  (`ingressController.hostNetwork.sharedHTTPPort` & `ingressController.hostNetwork.sharedTLSPassthroughPort`)
* Dedicated Ingress: configurable via Annotation on the resource `Ingress`
  (`ingress.cilium.io/http-host-port` & `ingress.cilium.io/tls-passthrough-host-port`)
* Gateway API: configurable via `spec.listeners.port` on the resource `Gateway`

Be aware that missconfiguration might result in port clashes.

### Expose Envoy listeners on subset of nodes

This commit adds support for exposing L7 Envoy Listeners only on a subset of Cilium Nodes. This only works in combination with the hostnetwork mode.

**Configure node labelselector via Helm**

* Ingress Controller: `ingressController.hostNetwork.nodes.matchLabels`
* Gateway API: `gatewayAPI.hostNetwork.nodes.matchLabels`

```
ingressController:
  hostNetwork:
    nodes:
      matchLabels:
        role: infra
        component: ingress
```

An empty selector selects all Nodes and continues to expose the functionality on all Cilium Nodes.

---

Please review the individual commits.

Fixes: #21390