### PR TITLE
docs: kpr: DSR-Geneve with native-routing requires tunnelProtocol

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -547,6 +547,7 @@ Geneve dispatch enabled would look as follows:
     helm install cilium |CHART_RELEASE| \\
         --namespace kube-system \\
         --set routingMode=native \\
+        --set tunnelProtocol=geneve \\
         --set kubeProxyReplacement=true \\
         --set loadBalancer.mode=dsr \\
         --set loadBalancer.dsrDispatch=geneve \\


### PR DESCRIPTION
Reflect the config change from https://github.com/cilium/cilium/pull/29051 in the kubeproxy-free docs for DSR-Geneve.

Fixes: https://github.com/cilium/cilium/issues/30845
