### PR TITLE
docs: Document NodePort BPF and iptables SNAT port collision

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1632,6 +1632,10 @@ Limitations
       host network namespace) making long-lived connections using (connected) UDP,
       you can enable ``bpf-lb-sock-hostns-only`` in order to enable the socket-LB
       feature only in the host network namespace.
+    * Cilium's BPF-based masquerading is recommended over iptables when using the
+      BPF-based NodePort. Otherwise, there is a risk for port collisions between
+      BPF and iptables SNAT, which might result in dropped NodePort
+      connections :gh-issue:`23604`.
 
 Further Readings
 ################


### PR DESCRIPTION
The collision is mentioned in https://github.com/cilium/cilium/issues/23604.