### PR TITLE
ci-e2e: restore 6.1 kernels

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -125,7 +125,7 @@ jobs:
 
           - name: '6'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.6-20240208.105738'
+            kernel: '6.1-20240208.105738'
             kube-proxy: 'none'
             kpr: 'true'
             tunnel: 'vxlan'
@@ -184,7 +184,7 @@ jobs:
 
           - name: '11'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.6-20240208.105738'
+            kernel: '6.1-20240208.105738'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -210,7 +210,7 @@ jobs:
 
           - name: '13'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.6-20240208.105738'
+            kernel: '6.1-20240208.105738'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'


### PR DESCRIPTION
I accidentally swapped out 6.0 with 6.6 instead of 6.6. Use 6.1 to have a more consistent configuration across branches.
