### PR TITLE
v1.13 Backports 2024-02-20

### DIFF
--- a/.github/actions/aws/k8s-versions.yaml
+++ b/.github/actions/aws/k8s-versions.yaml
@@ -4,9 +4,9 @@ include:
   - version: "1.23"
     region: ca-west-1
   - version: "1.24"
-    region: us-west-1
+    region: ca-west-1
   - version: "1.25"
-    region: us-east-2
+    region: us-west-2
   - version: "1.26"
-    region: ca-central-1
+    region: us-west-1
     default: true

--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -4,6 +4,7 @@ include:
   - version: "1.25"
     location: westus3
     index: 1
+    disabled: true
   - version: "1.26"
     location: westus2
     index: 2

--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -5,9 +5,9 @@ k8s:
     zone: us-west2-a
     vmIndex: 1
   - version: "1.25"
-    zone: us-west3-a
+    zone: us-west1-b
     vmIndex: 2
   - version: "1.26"
-    zone: us-east4-b
+    zone: us-west2-c
     vmIndex: 3
     default: true

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -1,3 +1,6 @@
+allowed-teams:
+  - organization-members
+
 triggers:
   /test-backport-1.13:
     workflows:

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -99,7 +99,7 @@ jobs:
           # main -> event_name = schedule
           # other stable branches -> PR-number starting with v (e.g. v1.14)
           if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
-            cp azure.json /tmp/matrix.json
+            jq '{ "include": [ .include[] | select(.disabled==null) ] }' azure.json > /tmp/matrix.json
           else
             jq '{ "include": [ .include[] | select(.default) ] }' azure.json > /tmp/matrix.json
           fi

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -4,6 +4,10 @@ name: Network performance GKE
 on:
   schedule:
     - cron: '39 0 * * 1-5'
+# For testing uncomment following lines:
+#  push:
+#    branches:
+#      - your_branch_name
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.
@@ -53,7 +57,7 @@ jobs:
         include:
           - index: 1
             name: "native"
-            mode: "native"
+            mode: "gke"
             encryption: "none"
             hubble: "false"
 
@@ -65,7 +69,7 @@ jobs:
 
           - index: 3
             name: "native-ipsec"
-            mode: "native"
+            mode: "gke"
             encryption: "ipsec"
             hubble: "false"
 
@@ -77,7 +81,7 @@ jobs:
 
           - index: 5
             name: "native-hubble"
-            mode: "native"
+            mode: "gke"
             encryption: "none"
             hubble: "true"
 
@@ -89,7 +93,7 @@ jobs:
 
           - index: 7
             name: "native-ipsec-hubble"
-            mode: "native"
+            mode: "gke"
             encryption: "ipsec"
             hubble: "true"
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -213,6 +213,7 @@
 # after the less specific paths, otherwise the ownership for the specific paths
 # is not properly picked up in Github.
 * @cilium/tophat
+/.github/ariane-config.yaml @cilium/github-sec @cilium/ci-structure
 /.github/workflows/ @cilium/github-sec @cilium/ci-structure
 /api/ @cilium/api
 /api/v1/Makefile @cilium/sig-hubble-api


### PR DESCRIPTION
 * [ ] #30756 (@marseel)
 * [x] #30795 (@brlbil)
   * :warning: minor merge conflicts because `v1.13` only lists k8s versions up to 1.26, dropped the newer ones and applied the cloud regions for the remaining versions
 * [x] #30803 (@brlbil)
 * [x] #30790 (@brlbil)

Skipped:

 * [ ] #29717 (@nathanjsweet)
   * Doesn't build using Go 1.20 due to the use of the `min` builtin.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 30756 30795 30803 30790
```
