### PR TITLE
cec: timerbased reconcile job as fallback

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -167,6 +167,7 @@ cilium-agent [flags]
       --encryption-strict-mode-cidr string                        In strict-mode encryption, all unencrypted traffic coming from this CIDR and going to this same CIDR will be dropped
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
       --endpoint-queue-size int                                   Size of EventQueue per-endpoint (default 25)
+      --envoy-config-retry-interval duration                      Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated. (default 15s)
       --envoy-config-timeout duration                             Timeout duration for Envoy Config acknowledgements (default 2m0s)
       --envoy-log string                                          Path to a separate Envoy log file, if any
       --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -42,6 +42,7 @@ cilium-agent hive [flags]
       --enable-monitor                                            Enable the monitor unix domain socket server (default true)
       --enable-service-topology                                   Enable support for service topology aware hints
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
+      --envoy-config-retry-interval duration                      Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated. (default 15s)
       --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC
       --gateway-api-secrets-namespace string                      GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API
       --gops-port uint16                                          Port for gops server to listen on (default 9890)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -48,6 +48,7 @@ cilium-agent hive dot-graph [flags]
       --enable-monitor                                            Enable the monitor unix domain socket server (default true)
       --enable-service-topology                                   Enable support for service topology aware hints
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
+      --envoy-config-retry-interval duration                      Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated. (default 15s)
       --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC
       --gateway-api-secrets-namespace string                      GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API
       --gops-port uint16                                          Port for gops server to listen on (default 9890)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1260,6 +1260,10 @@
      - Enable CiliumEnvoyConfig CRD CiliumEnvoyConfig CRD can also be implicitly enabled by other options.
      - bool
      - ``false``
+   * - :spelling:ignore:`envoyConfig.retryInterval`
+     - Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated.
+     - string
+     - ``"15s"``
    * - :spelling:ignore:`envoyConfig.secretsNamespace`
      - SecretsNamespace is the namespace in which envoy SDS will retrieve secrets from.
      - object

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -365,6 +365,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for envoy scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | envoy.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":2},"type":"RollingUpdate"}` | cilium-envoy update strategy ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#updating-a-daemonset |
 | envoyConfig.enabled | bool | `false` | Enable CiliumEnvoyConfig CRD CiliumEnvoyConfig CRD can also be implicitly enabled by other options. |
+| envoyConfig.retryInterval | string | `"15s"` | Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated. |
 | envoyConfig.secretsNamespace | object | `{"create":true,"name":"cilium-secrets"}` | SecretsNamespace is the namespace in which envoy SDS will retrieve secrets from. |
 | envoyConfig.secretsNamespace.create | bool | `true` | Create secrets namespace for CiliumEnvoyConfig CRDs. |
 | envoyConfig.secretsNamespace.name | string | `"cilium-secrets"` | The name of the secret namespace to which Cilium agents are given read access. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -245,6 +245,7 @@ data:
 
 {{- if or .Values.envoyConfig.enabled .Values.ingressController.enabled .Values.gatewayAPI.enabled (and (hasKey .Values "loadBalancer") (eq .Values.loadBalancer.l7.backend "envoy")) }}
   enable-envoy-config: "true"
+  envoy-config-retry-interval: {{ include "validateDuration" .Values.envoyConfig.retryInterval | quote }}
   {{- if .Values.envoyConfig.enabled }}
   envoy-secrets-namespace: {{ .Values.envoyConfig.secretsNamespace.name | quote }}
   {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -616,6 +616,8 @@ envoyConfig:
     create: true
     # -- The name of the secret namespace to which Cilium agents are given read access.
     name: cilium-secrets
+  # -- Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated.
+  retryInterval: 15s
 ingressController:
   # -- Enable cilium ingress controller
   # This will automatically set enable-envoy-config as well.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -613,6 +613,8 @@ envoyConfig:
     create: true
     # -- The name of the secret namespace to which Cilium agents are given read access.
     name: cilium-secrets
+  # -- Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated.
+  retryInterval: 15s
 ingressController:
   # -- Enable cilium ingress controller
   # This will automatically set enable-envoy-config as well.

--- a/pkg/ciliumenvoyconfig/cell.go
+++ b/pkg/ciliumenvoyconfig/cell.go
@@ -8,6 +8,7 @@ import (
 	"runtime/pprof"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/hive/cell"
@@ -19,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/service"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // Cell provides support for the CRD CiliumEnvoyConfig that backs Ingress, Gateway API
@@ -31,7 +33,16 @@ var Cell = cell.Module(
 	cell.ProvidePrivate(newCECManager),
 	cell.ProvidePrivate(newCECResourceParser),
 	cell.ProvidePrivate(newEnvoyServiceBackendSyncer),
+	cell.Config(cecConfig{}),
 )
+
+type cecConfig struct {
+	EnvoyConfigRetryInterval time.Duration
+}
+
+func (r cecConfig) Flags(flags *pflag.FlagSet) {
+	flags.Duration("envoy-config-retry-interval", 15*time.Second, "Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated.")
+}
 
 type reconcilerParams struct {
 	cell.In
@@ -41,6 +52,7 @@ type reconcilerParams struct {
 	JobRegistry job.Registry
 	Scope       cell.Scope
 
+	Config  cecConfig
 	Manager ciliumEnvoyConfigManager
 
 	CECResources   resource.Resource[*ciliumv2.CiliumEnvoyConfig]
@@ -85,6 +97,12 @@ func registerCECK8sReconciler(params reconcilerParams) {
 	// Observing local node events for changed labels
 	// Note: LocalNodeStore (in comparison to `resource.Resource`) doesn't provide a retry mechanism
 	jobGroup.Add(job.Observer("local-node-events", reconciler.handleLocalNodeEvent, params.LocalNodeStore))
+
+	// TimerJob periodically reconciles all existing configs.
+	// This covers the cases were the reconciliation fails after changing the labels of a node.
+	if params.Config.EnvoyConfigRetryInterval > 0 {
+		jobGroup.Add(job.Timer("reconcile-existing-configs", reconciler.reconcileExistingConfigs, params.Config.EnvoyConfigRetryInterval))
+	}
 }
 
 type managerParams struct {


### PR DESCRIPTION
Currently, there might be rare cases were changes to a node's labels lead to errors when applying the Envoy resources of a `CiliumEnvoyConfig` in the xDS cache. With the current implementation of the `LocalNodeStore`, there won't be a retry in these cases.

Therefore, in addition to the observable jobs, this PR adds a timer-job that periodically checks for un-applied configs - and tries to reconcile them.
