### PR TITLE
ci: replace v4.19 with RHEL8 kernels

### DIFF
--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -13,14 +13,14 @@ include:
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.28.6@sha256:e9e59d321795595d0eed0de48ef9fbda50388dc8bd4a9b23fb9bd869f370ec7e"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "4.19-20240215.093821@sha256:b5c40794f24509c786868b84cb17b7aeed78b9e2a171ca7774d06506576c6039"
+    kernel: "rhel8-20240215.093821@sha256:a55057ce80472f0e702924974626e49eb6dc3fff1a54dbb4a397105d76ff1045"
 
   - k8s-version: "1.27"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.27.10@sha256:e6b2f72f22a4de7b957cd5541e519a8bef3bae7261dd30c6df34cd9bdd3f8476"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "4.19-20240215.093821@sha256:b5c40794f24509c786868b84cb17b7aeed78b9e2a171ca7774d06506576c6039"
+    kernel: "rhel8-20240215.093821@sha256:a55057ce80472f0e702924974626e49eb6dc3fff1a54dbb4a397105d76ff1045"
 
   - k8s-version: "1.26"
     ip-family: "dual"

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -80,7 +80,7 @@ jobs:
 
           - name: '1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '4.19-20240215.093821'
+            kernel: 'rhel8-20240215.093821'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'
@@ -217,7 +217,7 @@ jobs:
 
           - name: '13'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '4.19-20240215.093821'
+            kernel: 'rhel8-20240215.093821'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -372,8 +372,6 @@ jobs:
                export KUBEPROXY=0
                export K8S_NODES=3
                export NO_CILIUM_ON_NODES=kind-worker2
-            elif [[ "${{ matrix.kernel }}" == 4.19-* ]]; then
-               export KERNEL=419
             elif [[ "${{ matrix.kernel }}" == 5.4-* ]]; then
                export KERNEL=54
             fi

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -78,7 +78,7 @@ jobs:
 
           - name: '1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '4.19-20240215.093821'
+            kernel: 'rhel8-20240215.093821'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -73,9 +73,6 @@ jobs:
       matrix:
         include:
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '4.19-20240215.093821'
-            ci-kernel: '419'
-          # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: '5.4-20240215.093821'
             ci-kernel: '54'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -80,7 +80,7 @@ jobs:
 
           - name: '1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '4.19-20240215.093821'
+            kernel: 'rhel8-20240215.093821'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'

--- a/Documentation/contributing/testing/e2e_legacy.rst
+++ b/Documentation/contributing/testing/e2e_legacy.rst
@@ -225,8 +225,6 @@ usage information.
       #    export KUBEPROXY=0
       #    export K8S_NODES=3
       #    export NO_CILIUM_ON_NODES=kind-worker2
-      # elif [[ "${kernel_tag}" == 4.19-* ]]; then
-      #    export KERNEL=419
       # elif [[ "${kernel_tag}" == 5.4-* ]]; then
       #    export KERNEL=54
       # fi

--- a/contrib/scripts/run-gh-ginkgo-workflow.sh
+++ b/contrib/scripts/run-gh-ginkgo-workflow.sh
@@ -163,9 +163,6 @@ run_tests() {
             KUBEPROXY=0
             NO_CILIUM_ON_NODES=kind-worker2
             ;;
-        4.19-*)
-            KERNEL=419
-            ;;
         5.4-*)
             KERNEL=54
             ;;


### PR DESCRIPTION
ci: replace v4.19 with RHEL8 kernels

    Kernel v4.19 is the oldest kernel we currently test on. With the upcoming
    minimum kernel version bump to v5.4 this configuration becomes obsolete.
    Instead of removing it, test against the RHEL8 kernel. This gives us
    coverage of the two "minimum" versions we need to support: v5.4 and whatever
    RHEL 8.6 ships.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

Updates: #30456

```release-note
Replace v4.19 with RHEL 8.6 in CI
```
