### PR TITLE
bgpv1: Remove or downgrade noisy logs

### DIFF
--- a/pkg/bgpv1/agent/controller.go
+++ b/pkg/bgpv1/agent/controller.go
@@ -189,7 +189,6 @@ func (c *Controller) Run(ctx context.Context) {
 			l.Info("Cilium BGP Control Plane Controller shut down")
 			return
 		case <-c.Sig.Sig:
-			l.Info("Cilium BGP Control Plane Controller woken for reconciliation")
 			if err := c.Reconcile(ctx); err != nil {
 				l.WithError(err).Error("Encountered error during reconciliation")
 			} else {
@@ -287,7 +286,6 @@ func (c *Controller) Reconcile(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to list CiliumBGPPeeringPolicies")
 	}
-	l.WithField("count", len(policies)).Debug("Successfully listed CiliumBGPPeeringPolicies")
 
 	// perform policy selection based on node.
 	labels := c.LocalCiliumNode.Labels
@@ -315,7 +313,6 @@ func (c *Controller) Reconcile(ctx context.Context) error {
 	}
 
 	// call bgp sub-systems required to apply this policy's BGP topology.
-	l.Debug("Asking configured BGPRouterManager to configure peering")
 	if err := c.BGPMgr.ConfigurePeers(ctx, policy, c.LocalCiliumNode); err != nil {
 		return fmt.Errorf("failed to configure BGP peers, cannot apply BGP peering policy: %w", err)
 	}

--- a/pkg/bgpv1/gobgp/server.go
+++ b/pkg/bgpv1/gobgp/server.go
@@ -101,7 +101,7 @@ func NewGoBGPServer(ctx context.Context, log *logrus.Entry, params types.ServerP
 	}
 	err := s.WatchEvent(ctx, watchRequest, func(r *gobgp.WatchEventResponse) {
 		if p := r.GetPeer(); p != nil && p.Type == gobgp.WatchEventResponse_PeerEvent_STATE {
-			logger.l.Info(p)
+			logger.l.Debug(p)
 		}
 	})
 	if err != nil {

--- a/pkg/bgpv1/manager/reconciler/neighbor.go
+++ b/pkg/bgpv1/manager/reconciler/neighbor.go
@@ -72,7 +72,6 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 		curNeigh []*v2alpha1api.CiliumBGPNeighbor = nil
 	)
 	newNeigh := p.DesiredConfig.Neighbors
-	l.Debugf("Begin reconciling peers for virtual router with local ASN %v", p.DesiredConfig.LocalASN)
 
 	metaMap := r.getMetadata(p.CurrentServer)
 	if len(metaMap) > 0 {
@@ -189,7 +188,6 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 		r.deleteMetadata(p.CurrentServer, n)
 	}
 
-	l.Infof("Done reconciling peers for virtual router with local ASN %v", p.DesiredConfig.LocalASN)
 	return nil
 }
 

--- a/pkg/bgpv1/manager/reconciler/neighbor.go
+++ b/pkg/bgpv1/manager/reconciler/neighbor.go
@@ -147,12 +147,6 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 		}
 	}
 
-	if len(toCreate) > 0 || len(toRemove) > 0 || len(toUpdate) > 0 {
-		l.Infof("Reconciling peers for virtual router with local ASN %v", p.DesiredConfig.LocalASN)
-	} else {
-		l.Debugf("No peer changes necessary for virtual router with local ASN %v", p.DesiredConfig.LocalASN)
-	}
-
 	// create new neighbors
 	for _, n := range toCreate {
 		l.Infof("Adding peer %v %v to local ASN %v", n.PeerAddress, n.PeerASN, p.DesiredConfig.LocalASN)

--- a/pkg/bgpv1/manager/reconciler/route_policy.go
+++ b/pkg/bgpv1/manager/reconciler/route_policy.go
@@ -70,7 +70,6 @@ func (r *RoutePolicyReconciler) Priority() int {
 
 func (r *RoutePolicyReconciler) Reconcile(ctx context.Context, params ReconcileParams) error {
 	l := log.WithFields(logrus.Fields{"component": "RoutePolicyReconciler"})
-	l.Infof("Begin reconciling routing policies for virtual router with local ASN %v", params.DesiredConfig.LocalASN)
 
 	if params.DesiredConfig == nil {
 		return fmt.Errorf("attempted routing policy reconciliation with nil DesiredConfig")


### PR DESCRIPTION
This PR removes or downgrades the level of some noisy logs in the BGP Control Plane. I tried to achieve the state that reconciliation without any change doesn't generate any log in the default `info` log level.

```release-note
bgpv1: Remove or downgrade noisy logs
```
