### PR TITLE
Document new minimum Linux requirements

### DIFF
--- a/Documentation/installation/requirements-generic.rst
+++ b/Documentation/installation/requirements-generic.rst
@@ -1,7 +1,7 @@
 **Requirements:**
 
 * Kubernetes must be configured to use CNI (see `Network Plugin Requirements <https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#network-plugin-requirements>`_)
-* Linux kernel >= 4.9.17
+* Linux kernel >= 5.4
 
 .. tip::
 

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -20,7 +20,7 @@ When running Cilium using the container image ``cilium/cilium``, the host
 system must meet these requirements:
 
 - Hosts with either AMD64 or AArch64 architecture
-- `Linux kernel`_ >= 4.19.57 or equivalent (e.g., 4.18 on RHEL8)
+- `Linux kernel`_ >= 5.4 or equivalent (e.g., 4.18 on RHEL 8.6)
 
 When running Cilium as a native process on your host (i.e. **not** running the
 ``cilium/cilium`` container image) these additional requirements must be met:
@@ -37,7 +37,7 @@ must be met:
 ======================== ============================== ===================
 Requirement              Minimum Version                In cilium container
 ======================== ============================== ===================
-`Linux kernel`_          >= 4.19.57 or >= 4.18 on RHEL8 no
+`Linux kernel`_          >= 5.4 or >= 4.18 on RHEL 8.6  no
 Key-Value store (etcd)   >= 3.1.0                       no
 clang+LLVM               >= 10.0                        yes
 ======================== ============================== ===================
@@ -63,28 +63,30 @@ Distribution               Minimum Version
 ========================== ====================
 `Amazon Linux 2`_          all
 `Bottlerocket OS`_         all
-`CentOS`_                  >= 8.0
-`Container-Optimized OS`_  all
-`CoreOS`_                  all
+`CentOS`_                  >= 8.6
+`Container-Optimized OS`_  >= 85
 Debian_                    >= 10 Buster
+`Fedora CoreOS`_           >= 31.20200108.3.0
 Flatcar_                   all
 LinuxKit_                  all
 Opensuse_                  Tumbleweed, >=Leap 15.4
-`RedHat Enterprise Linux`_ >= 8.0
-Ubuntu_                    >= 18.04.3
+`RedHat Enterprise Linux`_ >= 8.6
+`RedHat CoreOS`_           >= 4.12
 `Talos Linux`_             >= 1.5.0
+Ubuntu_                    >= 20.04
 ========================== ====================
 
-.. _Amazon Linux 2: https://aws.amazon.com/amazon-linux-2/
+.. _Amazon Linux 2: https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-al2.html
 .. _CentOS: https://centos.org
 .. _Container-Optimized OS: https://cloud.google.com/container-optimized-os/docs
-.. _CoreOS: https://getfedora.org/coreos?stream=stable
-.. _Debian: https://wiki.debian.org/DebianStretch
-.. _Flatcar: https://www.flatcar-linux.org/
+.. _Fedora CoreOS: https://fedoraproject.org/coreos/release-notes
+.. _Debian: https://www.debian.org/releases/
+.. _Flatcar: https://www.flatcar.org/releases
 .. _LinuxKit: https://github.com/linuxkit/linuxkit/tree/master/kernel
 .. _RedHat Enterprise Linux: https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux
-.. _Ubuntu: https://wiki.ubuntu.com/YakketyYak/ReleaseNotes#Linux_kernel_4.8
-.. _Opensuse: https://www.opensuse.org/
+.. _RedHat CoreOS: https://access.redhat.com/articles/6907891
+.. _Ubuntu: https://www.releases.ubuntu.com/
+.. _Opensuse: https://en.opensuse.org/openSUSE:Roadmap
 .. _Bottlerocket OS: https://github.com/bottlerocket-os/bottlerocket
 .. _Talos Linux: https://www.talos.dev/
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1265,6 +1265,18 @@ func initEnv(vp *viper.Viper) {
 	if err := rlimit.RemoveMemlock(); err != nil {
 		log.WithError(err).Fatal("unable to set memory resource limits")
 	}
+
+	globalsDir := option.Config.GetGlobalsDir()
+	if err := os.MkdirAll(globalsDir, defaults.StateDirRights); err != nil {
+		log.WithError(err).WithField(logfields.Path, globalsDir).Fatal("Could not create runtime directory")
+	}
+	if err := os.Chdir(option.Config.LibDir); err != nil {
+		log.WithError(err).WithField(logfields.Path, option.Config.LibDir).Fatal("Could not change to runtime directory")
+	}
+	if _, err := os.Stat(option.Config.BpfDir); os.IsNotExist(err) {
+		log.WithError(err).Fatalf("BPF template directory: NOT OK. Please run 'make install-bpf'")
+	}
+
 	linuxdatapath.CheckRequirements()
 
 	if err := pidfile.Write(defaults.PidFilePath); err != nil {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1265,7 +1265,7 @@ func initEnv(vp *viper.Viper) {
 	if err := rlimit.RemoveMemlock(); err != nil {
 		log.WithError(err).Fatal("unable to set memory resource limits")
 	}
-	linuxdatapath.CheckMinRequirements()
+	linuxdatapath.CheckRequirements()
 
 	if err := pidfile.Write(defaults.PidFilePath); err != nil {
 		log.WithField(logfields.Path, defaults.PidFilePath).WithError(err).Fatal("Failed to create Pidfile")

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -12,8 +12,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
-	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -30,17 +28,6 @@ func CheckRequirements() {
 		if _, err := os.Stat("/proc/net/if_inet6"); os.IsNotExist(err) {
 			log.Fatalf("kernel: ipv6 is enabled in agent but ipv6 is either disabled or not compiled in the kernel")
 		}
-	}
-
-	globalsDir := option.Config.GetGlobalsDir()
-	if err := os.MkdirAll(globalsDir, defaults.StateDirRights); err != nil {
-		log.WithError(err).WithField(logfields.Path, globalsDir).Fatal("Could not create runtime directory")
-	}
-	if err := os.Chdir(option.Config.LibDir); err != nil {
-		log.WithError(err).WithField(logfields.Path, option.Config.LibDir).Fatal("Could not change to runtime directory")
-	}
-	if _, err := os.Stat(option.Config.BpfDir); os.IsNotExist(err) {
-		log.WithError(err).Fatalf("BPF template directory: NOT OK. Please run 'make install-bpf'")
 	}
 
 	// bpftool checks

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -5,14 +5,9 @@ package linux
 
 import (
 	"errors"
-	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"regexp"
-	"strings"
 
-	"github.com/blang/semver/v4"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
@@ -20,60 +15,12 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/version"
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
-const (
-	minKernelVer = "4.8.0"
-	minClangVer  = "3.8.0"
-	recKernelVer = "4.9.0"
-	recClangVer  = "3.9.0"
-)
-
-var (
-	isMinKernelVer = versioncheck.MustCompile(">=" + minKernelVer)
-	isMinClangVer  = versioncheck.MustCompile(">=" + minClangVer)
-
-	isRecKernelVer = versioncheck.MustCompile(">=" + recKernelVer)
-	isRecClangVer  = versioncheck.MustCompile(">=" + recClangVer)
-)
-
-func getClangVersion(filePath string) (semver.Version, error) {
-	verOut, err := exec.Command(filePath, "--version").CombinedOutput()
-	if err != nil {
-		log.WithError(err).Fatal("clang version: NOT OK")
-	}
-	res := regexp.MustCompile(`(clang version )([^\s]*)`).FindStringSubmatch(string(verOut))
-	if len(res) != 3 {
-		log.Fatalf("clang version: NOT OK: unable to get clang's version "+
-			"from: %q", string(verOut))
-	}
-	// at this point res is []string{"clang", "version", "maj.min.patch"}
-	verStrs := strings.Split(res[2], ".")
-	if len(verStrs) < 3 {
-		return semver.Version{}, fmt.Errorf("unable to get clang version from %q", string(verOut))
-	}
-	v := strings.Join(verStrs[:3], ".")
-	// Handle Ubuntu versioning by removing the dash and everything after.
-	// F. ex. `4.0.0-1ubuntu1~16 -> 4.0.0` and `3.8.0-2ubuntu4 -> 3.8.0`.
-	v = strings.Split(v, "-")[0]
-	return versioncheck.Version(v)
-}
-
-// CheckMinRequirements checks that minimum kernel requirements are met for
+// CheckRequirements checks that minimum kernel requirements are met for
 // configuring the BPF datapath. If not, fatally exits.
-func CheckMinRequirements() {
-	kernelVersion, err := version.GetKernelVersion()
-	if err != nil {
-		log.WithError(err).Fatal("kernel version: NOT OK")
-	}
-	if !isMinKernelVer(kernelVersion) {
-		log.Fatalf("kernel version: NOT OK: minimal supported kernel "+
-			"version is %s; kernel version that is running is: %s", minKernelVer, kernelVersion)
-	}
-
-	_, err = netlink.RuleList(netlink.FAMILY_V4)
+func CheckRequirements() {
+	_, err := netlink.RuleList(netlink.FAMILY_V4)
 	if errors.Is(err, unix.EAFNOSUPPORT) {
 		log.WithError(err).Error("Policy routing:NOT OK. " +
 			"Please enable kernel configuration item CONFIG_IP_MULTIPLE_TABLES")
@@ -83,26 +30,6 @@ func CheckMinRequirements() {
 		if _, err := os.Stat("/proc/net/if_inet6"); os.IsNotExist(err) {
 			log.Fatalf("kernel: ipv6 is enabled in agent but ipv6 is either disabled or not compiled in the kernel")
 		}
-	}
-
-	if filePath, err := exec.LookPath("clang"); err != nil {
-		log.WithError(err).Fatal("clang: NOT OK")
-	} else {
-		clangVersion, err := getClangVersion(filePath)
-		if err != nil {
-			log.WithError(err).Fatal("clang: NOT OK")
-		}
-		if !isMinClangVer(clangVersion) {
-			log.Fatalf("clang version: NOT OK: minimal supported clang "+
-				"version is %s; clang version that is running is: %s", minClangVer, clangVersion)
-		}
-		//clang >= 3.9 / kernel < 4.9 - does not work
-		if isRecClangVer(clangVersion) && !isRecKernelVer(kernelVersion) {
-			log.Fatalf("clang (%s) and kernel (%s) version: NOT OK: please upgrade "+
-				"your kernel version to at least %s",
-				clangVersion, kernelVersion, recKernelVer)
-		}
-		log.Infof("clang (%s) and kernel (%s) versions: OK!", clangVersion, kernelVersion)
 	}
 
 	globalsDir := option.Config.GetGlobalsDir()


### PR DESCRIPTION
docs: update Linux requirements

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

datapath/linux: remove kernel and clang version check

    We check for a minimum kernel and clang version on start up. The kernel
    version check is dubious since the minimum version we need is 4.19. It also
    doesn't handle the fact that RHEL 8 kernels report a version of 4.18 even
    though being functionally close to a 5.4 kernel. The clang version check is
    similarly dubious, since 3.8 hasn't worked in a long time.

    Remove the check outright.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

datapath: move state directory manipulation out of CheckRequirements

    For some reason CheckRequirements creates state directories and also changes
    the working directory of the current process. Move the code into daemon
    setup, which is the only caller.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

Updates: #30456

```release-note
Increase the minimum required kernel version to v5.4 / RHEL 8.6.
```
