### PR TITLE
renovate: try to group dependency updates on single PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,9 +48,12 @@
   ],
   "pinDigests": true,
   "ignorePresets": [":prHourlyLimit2"],
-  "separateMajorMinor": true,
-  "separateMultipleMajor": true,
-  "separateMinorPatch": true,
+  // We don't want to separate major and minor upgrades in separate PRs since
+  // we can upgrade them together in a single PR.
+  "separateMajorMinor": false,
+  // We don't want to separate minor patch upgrades in separate PRs since
+  // we can upgrade them together in a single PR.
+  "separateMinorPatch": false,
   "pruneStaleBranches": true,
   "baseBranches": [
     "main",
@@ -70,28 +73,28 @@
   "stopUpdatingLabel": "renovate/stop-updating",
   "packageRules": [
     {
-      "groupName": "all github action dependencies",
-      "groupSlug": "all-github-action",
-      "matchPaths": [
-        ".github/workflows/**"
-      ],
-      "excludeDepNames": [
-        "cilium/little-vm-helper",
-        "quay.io/lvh-images/complexity-test",
-        "quay.io/lvh-images/kind",
-        "quay.io/cilium/kindest-node"
-      ],
+      // Try to group all updates for all dependencies in a single PR. More
+      // specific packageRules are followed by this one.
       "matchUpdateTypes": [
         "major",
         "minor",
-        "digest",
         "patch",
         "pin",
-        "pinDigest"
+        "pinDigest",
+        "digest",
+        "lockFileMaintenance",
+        "rollback",
+        "bump",
+        "replacement",
       ],
-      "schedule": [
-        "on monday"
-      ]
+      "groupName": "all-dependencies"
+    },
+    {
+      "groupName": "all github action dependencies",
+      "groupSlug": "all-github-action",
+      "matchPaths": [
+        ".github/**"
+      ],
     },
     {
       "matchPaths": [
@@ -112,14 +115,6 @@
       "postUpdateOptions": [
         // update source import paths on major updates
         "gomodUpdateImportPaths"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "digest",
-        "patch",
-        "pin",
-        "pinDigest"
       ],
       matchBaseBranches: [
         "main"
@@ -198,6 +193,8 @@
       ]
     },
     {
+      // Grouped these together because they require a re-creation of the base
+      // image.
       "groupName": "base-images",
       "matchFiles": [
         "images/builder/Dockerfile",
@@ -206,44 +203,6 @@
       "matchPackageNames": [
         "docker.io/library/golang"
       ],
-    },
-    {
-      // Images that directly use docker.io/library/golang for building.
-      "groupName": "golang-images",
-      "matchFiles": [
-        "contrib/backporting/Dockerfile",
-        "images/cilium-docker-plugin/Dockerfile",
-        "images/clustermesh-apiserver/Dockerfile",
-        "images/hubble-relay/Dockerfile",
-        "images/operator/Dockerfile",
-        "images/kvstoremesh/Dockerfile"
-      ],
-    },
-    {
-      // Images that directly use docker.io/library/alpine for building.
-      "groupName": "alpine-images",
-      "matchFiles": [
-        "contrib/coccinelle/Dockerfile",
-        "images/cache/Dockerfile",
-        "images/clustermesh-apiserver/Dockerfile",
-        "images/hubble-relay/Dockerfile",
-        "images/operator/Dockerfile",
-        "images/kvstoremesh/Dockerfile"
-      ],
-    },
-    {
-      "groupName": "spire-images",
-      "matchFiles": [
-        "install/kubernetes/cilium/values.yaml.tmpl"
-      ],
-      "matchPackageNames": [
-        "ghcr.io/spiffe/spire-agent",
-        "ghcr.io/spiffe/spire-server"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "allowedVersions": ">1.6"
     },
     {
       "groupName": "spire-images",
@@ -279,15 +238,6 @@
       "matchBaseBranches": [
         "v1.12"
       ],
-    },
-    {
-      "matchPackageNames": [
-        "docker.io/library/busybox"
-      ],
-      "allowedVersions": ">=1.35",
-      "matchPaths": [
-        "install/kubernetes/cilium/templates/spire/**"
-      ]
     },
     {
       "matchPackageNames": [
@@ -345,6 +295,15 @@
       "allowedVersions": "<3.17",
       "matchBaseBranches": [
         "v1.12"
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "gcr.io/etcd-development/etcd"
+      ],
+      "allowedVersions": "<3.16",
+      "matchBaseBranches": [
+        "v1.15"
       ]
     },
     {
@@ -453,20 +412,6 @@
       ],
       "matchBaseBranches": [
         "main"
-      ],
-    },
-    {
-      "groupName": "all kind-images main",
-      "groupSlug": "all-kind-images-main",
-      "matchPackageNames": [
-        "kindest/node",
-        "quay.io/cilium/kindest-node"
-      ],
-      "matchUpdateTypes": [
-        "digest",
-        "patch",
-        "pin",
-        "pinDigest"
       ],
     },
     {


### PR DESCRIPTION
Since we have tried to group all dependencies on a single PR we can remove the more specific ones such as "golang-images" and "alpine-images".

For the "spire-images", we don't need to defined an minimum "allowedVersion" for the main branch since renovate will not downgrade versions. Same logic was applied for the "docker.io/library/busybox".

For the kindest images, there is also no need to upgrade them separately since they can be grouped together with the other dependencies.