### PR TITLE
loader: move Loader interface into separate package

### DIFF
--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/linux/utime"
 	"github.com/cilium/cilium/pkg/datapath/loader"
+	loaderTypes "github.com/cilium/cilium/pkg/datapath/loader/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/datapath/types"
@@ -213,5 +214,5 @@ type datapathParams struct {
 
 	TunnelConfig tunnel.Config
 
-	Loader loader.Loader
+	Loader loaderTypes.Loader
 }

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -4,7 +4,7 @@
 package linux
 
 import (
-	"github.com/cilium/cilium/pkg/datapath/loader"
+	loader "github.com/cilium/cilium/pkg/datapath/loader/types"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/nodemap"

--- a/pkg/datapath/loader/cell.go
+++ b/pkg/datapath/loader/cell.go
@@ -4,14 +4,8 @@
 package loader
 
 import (
-	"context"
-
-	"github.com/vishvananda/netlink"
-
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
-	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
-	"github.com/cilium/cilium/pkg/datapath/tunnel"
-	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	loaderTypes "github.com/cilium/cilium/pkg/datapath/loader/types"
 	"github.com/cilium/cilium/pkg/hive/cell"
 )
 
@@ -21,24 +15,7 @@ var Cell = cell.Module(
 	cell.Provide(NewLoader),
 )
 
-type Loader interface {
-	CallsMapPath(id uint16) string
-	CompileAndLoad(ctx context.Context, ep datapath.Endpoint, stats *metrics.SpanStat) error
-	CompileOrLoad(ctx context.Context, ep datapath.Endpoint, stats *metrics.SpanStat) error
-	CustomCallsMapPath(id uint16) string
-	DetachXDP(iface netlink.Link, bpffsBase, progName string) error
-	DeviceHasTCProgramLoaded(hostInterface string, checkEgress bool) (bool, error)
-	ELFSubstitutions(ep datapath.Endpoint) (map[string]uint64, map[string]string)
-	EndpointHash(cfg datapath.EndpointConfiguration) (string, error)
-	HostDatapathInitialized() <-chan struct{}
-	Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, tunnelConfig tunnel.Config, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy) error
-	ReinitializeXDP(ctx context.Context, o datapath.BaseProgramOwner, extraCArgs []string) error
-	ReloadDatapath(ctx context.Context, ep datapath.Endpoint, stats *metrics.SpanStat) (err error)
-	RestoreTemplates(stateDir string) error
-	Unload(ep datapath.Endpoint)
-}
-
 // NewLoader returns a new loader.
-func NewLoader(sc sysctl.Sysctl) Loader {
+func NewLoader(sc sysctl.Sysctl) loaderTypes.Loader {
 	return newLoader(sc)
 }

--- a/pkg/datapath/loader/types/types.go
+++ b/pkg/datapath/loader/types/types.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/datapath/types"
+
+	"github.com/vishvananda/netlink"
+)
+
+type Loader interface {
+	CallsMapPath(id uint16) string
+	CompileAndLoad(ctx context.Context, ep types.Endpoint, stats *metrics.SpanStat) error
+	CompileOrLoad(ctx context.Context, ep types.Endpoint, stats *metrics.SpanStat) error
+	CustomCallsMapPath(id uint16) string
+	DetachXDP(iface netlink.Link, bpffsBase, progName string) error
+	DeviceHasTCProgramLoaded(hostInterface string, checkEgress bool) (bool, error)
+	ELFSubstitutions(ep types.Endpoint) (map[string]uint64, map[string]string)
+	EndpointHash(cfg types.EndpointConfiguration) (string, error)
+	HostDatapathInitialized() <-chan struct{}
+	Reinitialize(ctx context.Context, o types.BaseProgramOwner, tunnelConfig tunnel.Config, deviceMTU int, iptMgr types.IptablesManager, p types.Proxy) error
+	ReinitializeXDP(ctx context.Context, o types.BaseProgramOwner, extraCArgs []string) error
+	ReloadDatapath(ctx context.Context, ep types.Endpoint, stats *metrics.SpanStat) (err error)
+	RestoreTemplates(stateDir string) error
+	Unload(ep types.Endpoint)
+}


### PR DESCRIPTION
this will allow to import the Loader interface without importing the full loader package, which in some cases may end up generating import cycles