### PR TITLE
clustermesh: add GlobalServiceCache in clustermesh/common package

### DIFF
--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -104,7 +104,7 @@ type ClusterMesh struct {
 
 	// globalServices is a list of all global services. The datastructure
 	// is protected by its own mutex inside the structure.
-	globalServices *globalServiceCache
+	globalServices *common.GlobalServiceCache
 
 	// nodeName is the name of the local node. This is used for logging and metrics
 	nodeName string
@@ -121,7 +121,7 @@ func NewClusterMesh(lifecycle cell.Lifecycle, c Configuration) *ClusterMesh {
 	cm := &ClusterMesh{
 		conf:     c,
 		nodeName: nodeName,
-		globalServices: newGlobalServiceCache(
+		globalServices: common.NewGlobalServiceCache(
 			c.Metrics.TotalGlobalServices.WithLabelValues(c.ClusterInfo.Name, nodeName),
 		),
 	}
@@ -227,7 +227,7 @@ func (cm *ClusterMesh) synced(ctx context.Context, toWaitFn func(*remoteCluster)
 // Status returns the status of the ClusterMesh subsystem
 func (cm *ClusterMesh) Status() (status *models.ClusterMeshStatus) {
 	status = &models.ClusterMeshStatus{
-		NumGlobalServices: int64(cm.globalServices.size()),
+		NumGlobalServices: int64(cm.globalServices.Size()),
 	}
 
 	cm.common.ForEachRemoteCluster(func(rci common.RemoteCluster) error {

--- a/pkg/clustermesh/common/services.go
+++ b/pkg/clustermesh/common/services.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package common
+
+import (
+	"maps"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+	serviceStore "github.com/cilium/cilium/pkg/service/store"
+)
+
+type GlobalService struct {
+	ClusterServices map[string]*serviceStore.ClusterService
+}
+
+func newGlobalService() *GlobalService {
+	return &GlobalService{
+		ClusterServices: map[string]*serviceStore.ClusterService{},
+	}
+}
+
+type GlobalServiceCache struct {
+	mutex  lock.RWMutex
+	byName map[string]*GlobalService
+
+	// metricTotalGlobalServices is the gauge metric for total of global services
+	metricTotalGlobalServices metric.Gauge
+}
+
+func NewGlobalServiceCache(metricTotalGlobalServices metric.Gauge) *GlobalServiceCache {
+	return &GlobalServiceCache{
+		byName:                    map[string]*GlobalService{},
+		metricTotalGlobalServices: metricTotalGlobalServices,
+	}
+}
+
+// Has returns whether a given service is present in the cache.
+func (c *GlobalServiceCache) Has(svc *serviceStore.ClusterService) bool {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	if globalSvc, ok := c.byName[svc.NamespaceServiceName()]; ok {
+		_, ok = globalSvc.ClusterServices[svc.Cluster]
+		return ok
+	}
+
+	return false
+}
+
+// GetService returns the service for a specific cluster. This function does not
+// make a copy of the cluster service object and should not be mutated.
+func (c *GlobalServiceCache) GetService(key string, clusterName string) *serviceStore.ClusterService {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	if globalSvc, ok := c.byName[key]; ok {
+		if svc, ok := globalSvc.ClusterServices[clusterName]; ok {
+			return svc
+		}
+	}
+
+	return nil
+}
+
+// GetGlobalService returns a global service object. This function returns
+// a shallow copy of the GlobalService object, thus the ClusterService objects
+// should not be mutated.
+func (c *GlobalServiceCache) GetGlobalService(key string) *GlobalService {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	if globalSvc, ok := c.byName[key]; ok {
+		// We copy the global service to make this thread safe
+		newGlobalSvc := newGlobalService()
+		newGlobalSvc.ClusterServices = maps.Clone(globalSvc.ClusterServices)
+		return newGlobalSvc
+	}
+
+	return nil
+}
+
+func (c *GlobalServiceCache) OnUpdate(svc *serviceStore.ClusterService) {
+	scopedLog := log.WithFields(logrus.Fields{
+		logfields.ServiceName: svc.String(),
+		logfields.ClusterName: svc.Cluster,
+	})
+
+	c.mutex.Lock()
+
+	// Validate that the global service is known
+	globalSvc, ok := c.byName[svc.NamespaceServiceName()]
+	if !ok {
+		globalSvc = newGlobalService()
+		c.byName[svc.NamespaceServiceName()] = globalSvc
+		scopedLog.Debugf("Created global service %s", svc.NamespaceServiceName())
+		c.metricTotalGlobalServices.Set(float64(len(c.byName)))
+	}
+
+	scopedLog.Debugf("Updated service definition of remote cluster %#v", svc)
+
+	globalSvc.ClusterServices[svc.Cluster] = svc
+	c.mutex.Unlock()
+}
+
+// must be called with c.mutex held
+func (c *GlobalServiceCache) delete(globalService *GlobalService, clusterName, key string) bool {
+	scopedLog := log.WithFields(logrus.Fields{
+		logfields.ServiceName: key,
+		logfields.ClusterName: clusterName,
+	})
+
+	if _, ok := globalService.ClusterServices[clusterName]; !ok {
+		scopedLog.Debug("Ignoring delete request for unknown cluster")
+		return false
+	}
+
+	scopedLog.Debugf("Deleted service definition of remote cluster")
+	delete(globalService.ClusterServices, clusterName)
+
+	// After the last cluster service is removed, remove the global service
+	if len(globalService.ClusterServices) == 0 {
+		scopedLog.Debugf("Deleted global service %s", key)
+		delete(c.byName, key)
+		c.metricTotalGlobalServices.Set(float64(len(c.byName)))
+	}
+
+	return true
+}
+
+func (c *GlobalServiceCache) OnDelete(svc *serviceStore.ClusterService) bool {
+	scopedLog := log.WithFields(logrus.Fields{logfields.ServiceName: svc.String()})
+	scopedLog.Debug("Delete event for service")
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if globalService, ok := c.byName[svc.NamespaceServiceName()]; ok {
+		return c.delete(globalService, svc.Cluster, svc.NamespaceServiceName())
+	} else {
+		scopedLog.Debugf("Ignoring delete request for unknown global service")
+		return false
+	}
+}
+
+func (c *GlobalServiceCache) OnClusterDelete(clusterName string) {
+	scopedLog := log.WithFields(logrus.Fields{logfields.ClusterName: clusterName})
+	scopedLog.Debugf("Cluster deletion event")
+
+	c.mutex.Lock()
+	for key, globalService := range c.byName {
+		c.delete(globalService, clusterName, key)
+	}
+	c.mutex.Unlock()
+}
+
+// Size returns the number of global services in the cache
+func (c *GlobalServiceCache) Size() (num int) {
+	c.mutex.RLock()
+	num = len(c.byName)
+	c.mutex.RUnlock()
+	return
+}

--- a/pkg/clustermesh/common/services.go
+++ b/pkg/clustermesh/common/services.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -26,8 +27,9 @@ func newGlobalService() *GlobalService {
 }
 
 type GlobalServiceCache struct {
-	mutex  lock.RWMutex
-	byName map[types.NamespacedName]*GlobalService
+	mutex       lock.RWMutex
+	byName      map[types.NamespacedName]*GlobalService
+	byNamespace map[string]sets.Set[*GlobalService]
 
 	// metricTotalGlobalServices is the gauge metric for total of global services
 	metricTotalGlobalServices metric.Gauge
@@ -36,6 +38,7 @@ type GlobalServiceCache struct {
 func NewGlobalServiceCache(metricTotalGlobalServices metric.Gauge) *GlobalServiceCache {
 	return &GlobalServiceCache{
 		byName:                    map[types.NamespacedName]*GlobalService{},
+		byNamespace:               map[string]sets.Set[*GlobalService]{},
 		metricTotalGlobalServices: metricTotalGlobalServices,
 	}
 }
@@ -85,6 +88,25 @@ func (c *GlobalServiceCache) GetGlobalService(serviceNN types.NamespacedName) *G
 	return nil
 }
 
+// GetServices returns the services for a specific namespace. This function does not
+// make copy of the cluster services objects so those objects should not be mutated.
+func (c *GlobalServiceCache) GetServices(namespace string) []*serviceStore.ClusterService {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	clusterSvcs := []*serviceStore.ClusterService{}
+
+	if globalSvcs, ok := c.byNamespace[namespace]; ok {
+		for globalSvc := range globalSvcs {
+			for _, clusterSvc := range globalSvc.ClusterServices {
+				clusterSvcs = append(clusterSvcs, clusterSvc)
+			}
+		}
+	}
+
+	return clusterSvcs
+}
+
 func (c *GlobalServiceCache) OnUpdate(svc *serviceStore.ClusterService) {
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.ServiceName: svc.String(),
@@ -100,6 +122,12 @@ func (c *GlobalServiceCache) OnUpdate(svc *serviceStore.ClusterService) {
 		c.byName[svc.NamespaceServiceName()] = globalSvc
 		scopedLog.Debugf("Created global service %s", svc.NamespaceServiceName())
 		c.metricTotalGlobalServices.Set(float64(len(c.byName)))
+		globalSvcs, ok := c.byNamespace[svc.Namespace]
+		if !ok {
+			globalSvcs = sets.Set[*GlobalService]{}
+			c.byNamespace[svc.Namespace] = globalSvcs
+		}
+		globalSvcs.Insert(globalSvc)
 	}
 
 	scopedLog.Debugf("Updated service definition of remote cluster %#v", svc)
@@ -126,6 +154,10 @@ func (c *GlobalServiceCache) delete(globalService *GlobalService, clusterName st
 	// After the last cluster service is removed, remove the global service
 	if len(globalService.ClusterServices) == 0 {
 		scopedLog.Debugf("Deleted global service %s", serviceNN.String())
+		c.byNamespace[serviceNN.Namespace].Delete(globalService)
+		if len(c.byNamespace[serviceNN.Namespace]) == 0 {
+			delete(c.byNamespace, serviceNN.Namespace)
+		}
 		delete(c.byName, serviceNN)
 		c.metricTotalGlobalServices.Set(float64(len(c.byName)))
 	}

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -141,7 +141,7 @@ func (rc *remoteCluster) Remove() {
 	rc.ipCacheWatcher.Drain()
 
 	rc.mesh.conf.RemoteIdentityWatcher.RemoveRemoteIdentities(rc.name)
-	rc.mesh.globalServices.onClusterDelete(rc.name)
+	rc.mesh.globalServices.OnClusterDelete(rc.name)
 
 	if rc.config != nil {
 		rc.usedIDs.ReleaseClusterID(rc.config.ID)

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/clustermesh/common"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -156,7 +157,7 @@ func TestRemoteClusterRun(t *testing.T) {
 					StoreFactory:          store,
 					ClusterInfo:           types.ClusterInfo{MaxConnectedClusters: 255},
 				},
-				globalServices: newGlobalServiceCache(metrics.NoOpGauge),
+				globalServices: common.NewGlobalServiceCache(metrics.NoOpGauge),
 			}
 			rc := cm.NewRemoteCluster("foo", nil).(*remoteCluster)
 			ready := make(chan error)

--- a/pkg/clustermesh/services.go
+++ b/pkg/clustermesh/services.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/metrics/metric"
 	serviceStore "github.com/cilium/cilium/pkg/service/store"
 )
 
@@ -19,127 +18,6 @@ import (
 type ServiceMerger interface {
 	MergeExternalServiceUpdate(service *serviceStore.ClusterService, swg *lock.StoppableWaitGroup)
 	MergeExternalServiceDelete(service *serviceStore.ClusterService, swg *lock.StoppableWaitGroup)
-}
-
-type globalService struct {
-	clusterServices map[string]*serviceStore.ClusterService
-}
-
-func newGlobalService() *globalService {
-	return &globalService{
-		clusterServices: map[string]*serviceStore.ClusterService{},
-	}
-}
-
-type globalServiceCache struct {
-	mutex  lock.RWMutex
-	byName map[string]*globalService
-
-	// metricTotalGlobalServices is the gauge metric for total of global services
-	metricTotalGlobalServices metric.Gauge
-}
-
-func newGlobalServiceCache(metricTotalGlobalServices metric.Gauge) *globalServiceCache {
-	return &globalServiceCache{
-		byName:                    map[string]*globalService{},
-		metricTotalGlobalServices: metricTotalGlobalServices,
-	}
-}
-
-// has returns whether a given service is present in the cache.
-func (c *globalServiceCache) has(svc *serviceStore.ClusterService) bool {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-
-	if globalSvc, ok := c.byName[svc.NamespaceServiceName()]; ok {
-		_, ok = globalSvc.clusterServices[svc.Cluster]
-		return ok
-	}
-
-	return false
-}
-
-func (c *globalServiceCache) onUpdate(svc *serviceStore.ClusterService) {
-	scopedLog := log.WithFields(logrus.Fields{
-		logfields.ServiceName: svc.String(),
-		logfields.ClusterName: svc.Cluster,
-	})
-
-	c.mutex.Lock()
-
-	// Validate that the global service is known
-	globalSvc, ok := c.byName[svc.NamespaceServiceName()]
-	if !ok {
-		globalSvc = newGlobalService()
-		c.byName[svc.NamespaceServiceName()] = globalSvc
-		scopedLog.Debugf("Created global service %s", svc.NamespaceServiceName())
-		c.metricTotalGlobalServices.Set(float64(len(c.byName)))
-	}
-
-	scopedLog.Debugf("Updated service definition of remote cluster %#v", svc)
-
-	globalSvc.clusterServices[svc.Cluster] = svc
-	c.mutex.Unlock()
-}
-
-// must be called with c.mutex held
-func (c *globalServiceCache) delete(globalService *globalService, clusterName, serviceName string) bool {
-	scopedLog := log.WithFields(logrus.Fields{
-		logfields.ServiceName: serviceName,
-		logfields.ClusterName: clusterName,
-	})
-
-	if _, ok := globalService.clusterServices[clusterName]; !ok {
-		scopedLog.Debug("Ignoring delete request for unknown cluster")
-		return false
-	}
-
-	scopedLog.Debugf("Deleted service definition of remote cluster")
-	delete(globalService.clusterServices, clusterName)
-
-	// After the last cluster service is removed, remove the
-	// global service
-	if len(globalService.clusterServices) == 0 {
-		scopedLog.Debugf("Deleted global service %s", serviceName)
-		delete(c.byName, serviceName)
-		c.metricTotalGlobalServices.Set(float64(len(c.byName)))
-	}
-
-	return true
-}
-
-func (c *globalServiceCache) onDelete(svc *serviceStore.ClusterService) bool {
-	scopedLog := log.WithFields(logrus.Fields{logfields.ServiceName: svc.String()})
-	scopedLog.Debug("Delete event for service")
-
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	if globalService, ok := c.byName[svc.NamespaceServiceName()]; ok {
-		return c.delete(globalService, svc.Cluster, svc.NamespaceServiceName())
-	} else {
-		scopedLog.Debugf("Ignoring delete request for unknown global service")
-		return false
-	}
-}
-
-func (c *globalServiceCache) onClusterDelete(clusterName string) {
-	scopedLog := log.WithFields(logrus.Fields{logfields.ClusterName: clusterName})
-	scopedLog.Debugf("Cluster deletion event")
-
-	c.mutex.Lock()
-	for serviceName, globalService := range c.byName {
-		c.delete(globalService, clusterName, serviceName)
-	}
-	c.mutex.Unlock()
-}
-
-// size returns the number of global services in the cache
-func (c *globalServiceCache) size() (num int) {
-	c.mutex.RLock()
-	num = len(c.byName)
-	c.mutex.RUnlock()
-	return
 }
 
 type remoteServiceObserver struct {
@@ -159,7 +37,7 @@ func (r *remoteServiceObserver) OnUpdate(key store.Key) {
 
 		// Short-circuit the handling of non-shared services
 		if !svc.Shared {
-			if mesh.globalServices.has(svc) {
+			if mesh.globalServices.Has(svc) {
 				scopedLog.Debug("Previously shared service is no longer shared: triggering deletion event")
 				r.OnDelete(key)
 			} else {
@@ -168,7 +46,7 @@ func (r *remoteServiceObserver) OnUpdate(key store.Key) {
 			return
 		}
 
-		mesh.globalServices.onUpdate(svc)
+		mesh.globalServices.OnUpdate(svc)
 
 		if merger := mesh.conf.ServiceMerger; merger != nil {
 			merger.MergeExternalServiceUpdate(svc, r.swg)
@@ -188,7 +66,7 @@ func (r *remoteServiceObserver) OnDelete(key store.NamedKey) {
 
 		mesh := r.remoteCluster.mesh
 		// Short-circuit the deletion logic if the service was not present (i.e., not shared)
-		if !mesh.globalServices.onDelete(svc) {
+		if !mesh.globalServices.OnDelete(svc) {
 			scopedLog.Debugf("Ignoring remote service delete. Service was not shared")
 			return
 		}

--- a/pkg/service/store/store.go
+++ b/pkg/service/store/store.go
@@ -8,6 +8,8 @@ import (
 	"net/netip"
 	"path"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
@@ -85,8 +87,8 @@ func (s *ClusterService) String() string {
 }
 
 // NamespaceServiceName returns the namespace and service name
-func (s *ClusterService) NamespaceServiceName() string {
-	return s.Namespace + "/" + s.Name
+func (s *ClusterService) NamespaceServiceName() types.NamespacedName {
+	return types.NamespacedName{Name: s.Name, Namespace: s.Namespace}
 }
 
 // GetKeyName returns the kvstore key to be used for the global service


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

With the ongoing work on EndpointSlice synchronization, we need to have a `globalServiceCache` there as well so this commit is refactoring the GlobalServiceCache to be inside the common clustermesh package so that we can avoid code duplication and access to this struct outside of the pkg/clustermesh package.

It also refactor the GlobalServiceCache in a separate to use `types.NamespacedName` instead of a simple string.

```release-note
Refactor clustermesh global service cache to prepare for the endpoint slice clustermesh synchronization
```
