### PR TITLE
bpf: lb: have lb*_local() return an updated svc entry to caller

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -108,7 +108,7 @@ static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *
 		}
 #endif /* ENABLE_L7_LB */
 		ret = lb4_local(get_ct_map4(&tuple), ctx, ipv4_is_fragment(ip4),
-				ETH_HLEN, l4_off, &key, &tuple, svc, &ct_state_new,
+				ETH_HLEN, l4_off, &key, &tuple, &svc, &ct_state_new,
 				has_l4_header, false, &cluster_id, ext_err);
 
 #ifdef SERVICE_NO_BACKEND_RESPONSE
@@ -165,7 +165,7 @@ static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr
 		}
 #endif /* ENABLE_L7_LB */
 		ret = lb6_local(get_ct_map6(&tuple), ctx, ETH_HLEN, l4_off,
-				&key, &tuple, svc, &ct_state_new, false, ext_err);
+				&key, &tuple, &svc, &ct_state_new, false, ext_err);
 
 #ifdef SERVICE_NO_BACKEND_RESPONSE
 		if (ret == DROP_NO_SERVICE)

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -854,11 +854,12 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 				     int l3_off, int l4_off,
 				     struct lb6_key *key,
 				     struct ipv6_ct_tuple *tuple,
-				     const struct lb6_service *svc,
+				     struct lb6_service **__svc,
 				     struct ct_state *state,
 				     const bool skip_l3_xlate,
 				     __s8 *ext_err)
 {
+	struct lb6_service *svc = *__svc;
 	__u32 monitor; /* Deliberately ignored; regular CT will determine monitoring. */
 	__u8 flags = tuple->flags;
 	struct lb6_backend *backend;
@@ -948,6 +949,8 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 			svc = lb6_lookup_service(key, false, true);
 			if (!svc)
 				goto no_service;
+
+			*__svc = svc;
 			backend_id = lb6_select_backend_id(ctx, key, tuple, svc);
 			backend = lb6_lookup_backend(ctx, backend_id);
 			if (!backend)
@@ -1526,13 +1529,14 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 				     bool is_fragment, int l3_off, int l4_off,
 				     struct lb4_key *key,
 				     struct ipv4_ct_tuple *tuple,
-				     const struct lb4_service *svc,
+				     struct lb4_service **__svc,
 				     struct ct_state *state,
 				     bool has_l4_header,
 				     const bool skip_l3_xlate,
 				     __u32 *cluster_id __maybe_unused,
 				     __s8 *ext_err)
 {
+	struct lb4_service *svc = *__svc;
 	__u32 monitor; /* Deliberately ignored; regular CT will determine monitoring. */
 	__be32 saddr = tuple->saddr;
 	__u8 flags = tuple->flags;
@@ -1635,6 +1639,8 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 			svc = lb4_lookup_service(key, false, true);
 			if (!svc)
 				goto no_service;
+
+			*__svc = svc;
 			backend_id = lb4_select_backend_id(ctx, key, tuple, svc);
 			backend = lb4_lookup_backend(ctx, backend_id);
 			if (!backend)

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1316,7 +1316,7 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 		}
 #endif
 		ret = lb6_local(get_ct_map6(&tuple), ctx, l3_off, l4_off,
-				&key, &tuple, svc, &ct_state_new,
+				&key, &tuple, &svc, &ct_state_new,
 				skip_l3_xlate, ext_err);
 
 #ifdef SERVICE_NO_BACKEND_RESPONSE
@@ -2825,7 +2825,7 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 				return NAT_46X64_RECIRC;
 		} else {
 			ret = lb4_local(get_ct_map4(&tuple), ctx, is_fragment, l3_off, l4_off,
-					&key, &tuple, svc, &ct_state_new,
+					&key, &tuple, &svc, &ct_state_new,
 					has_l4_header, skip_l3_xlate, &cluster_id,
 					ext_err);
 #ifdef SERVICE_NO_BACKEND_RESPONSE


### PR DESCRIPTION
lb*_local() potentially looks up a fresh SVC entry. Return this entry to the caller, so that eg. nodeport_lb4() can apply its lb4_svc_is_routable() check to the correct entry.

Fixes: https://github.com/cilium/cilium/issues/25373