### PR TITLE
renovate: match rhel8 lvh image updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -384,7 +384,7 @@
         "quay.io/lvh-images/complexity-test",
         "quay.io/lvh-images/kind"
       ],
-      "versioning": "regex:^((?<compatibility>[a-z-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
+      "versioning": "regex:^((?<compatibility>[a-z0-9-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
     },
     {
       "groupName": "stable lvh-images",


### PR DESCRIPTION
Currently, the rhel8 lvh images are not updated by renovate (see e.g. commit c32ad87d4991 ("chore(deps): update all lvh-images main")) because the versioning regex is not matching the `rhel8-X.Y` format. Fix the regex so the image name format is matched as well.