### PR TITLE
require large instruction limit

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1279,6 +1279,10 @@ func initEnv(vp *viper.Viper) {
 
 	linuxdatapath.CheckRequirements()
 
+	if err := probes.CreateHeaderFiles(filepath.Join(option.Config.BpfDir, "include/bpf"), probes.ExecuteHeaderProbes()); err != nil {
+		log.WithError(err).Fatal("failed to create header files with feature macros")
+	}
+
 	if err := pidfile.Write(defaults.PidFilePath); err != nil {
 		log.WithField(logfields.Path, defaults.PidFilePath).WithError(err).Fatal("Failed to create Pidfile")
 	}

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -33,12 +33,10 @@ func CheckRequirements() {
 	if !option.Config.DryMode {
 		probeManager := probes.NewProbeManager()
 
-		// VTEP integration feature requires kernel 1m large instruction support
-		if option.Config.EnableVTEP {
-			if probes.HaveLargeInstructionLimit() != nil {
-				log.Fatalf("VXLAN Tunnel Endpoint (VTEP) Integration: requires support for large programs (Linux 5.2.0 or newer)")
-			}
+		if probes.HaveLargeInstructionLimit() != nil {
+			log.Fatalf("Require support for large programs (Linux 5.2.0 or newer)")
 		}
+
 		if err := probeManager.SystemConfigProbes(); err != nil {
 			errMsg := "BPF system config check: NOT OK."
 			// TODO(vincentmli): revisit log when GH#14314 has been resolved

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -6,7 +6,6 @@ package linux
 import (
 	"errors"
 	"os"
-	"path/filepath"
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -45,9 +44,6 @@ func CheckRequirements() {
 			// TODO(vincentmli): revisit log when GH#14314 has been resolved
 			// Warn missing required kernel config option
 			log.WithError(err).Warn(errMsg)
-		}
-		if err := probes.CreateHeaderFiles(filepath.Join(option.Config.BpfDir, "include/bpf"), probes.ExecuteHeaderProbes()); err != nil {
-			log.WithError(err).Fatal("failed to create header files with feature macros")
 		}
 	}
 }


### PR DESCRIPTION
datapath/linux: move creation of features.h to daemon startup

    Remove another side-effect from CheckRequirements.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

datapath/linux: require HAVE_LARGE_INSN_LIMIT

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

Updates: #30456
