### PR TITLE
Don't expand CIDR labels, match smartly in Labels instead

### DIFF
--- a/cilium-dbg/cmd/endpoint_labels.go
+++ b/cilium-dbg/cmd/endpoint_labels.go
@@ -62,11 +62,11 @@ func printEndpointLabels(lbls *labels.OpLabels) {
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 3, ' ', 0)
 
 	for _, v := range lbls.IdentityLabels() {
-		fmt.Fprintf(w, "%s\t%s\n", v, "Enabled")
+		fmt.Fprintf(w, "%s\t%s\n", v.String(), "Enabled")
 	}
 
 	for _, v := range lbls.Disabled {
-		fmt.Fprintf(w, "%s\t%s\n", v, "Disabled")
+		fmt.Fprintf(w, "%s\t%s\n", v.String(), "Disabled")
 	}
 	w.Flush()
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -123,7 +123,7 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 			fmt.Fprintf(fw, " * - %s\n", "(no labels)")
 		} else {
 			for _, v := range e.SecurityIdentity.Labels {
-				fmt.Fprintf(fw, " * - %s\n", v)
+				fmt.Fprintf(fw, " * - %s\n", v.String())
 			}
 		}
 	}

--- a/pkg/labels/array.go
+++ b/pkg/labels/array.go
@@ -137,6 +137,11 @@ nextLabel:
 // ignored. The inverse, however, is not true.
 // ["k8s.foo=bar"].Has("any.foo") => true
 // ["any.foo=bar"].Has("k8s.foo") => false
+//
+// If the key is of source "cidr", this will also match
+// broader keys.
+// ["cidr:1.1.1.1/32"].Has("cidr.1.0.0.0/8") => true
+// ["cidr:1.0.0.0/8"].Has("cidr.1.1.1.1/32") => false
 func (ls LabelArray) Has(key string) bool {
 	// The key is submitted in the form of `source.key=value`
 	keyLabel := parseSelectLabel(key, '.')
@@ -156,6 +161,11 @@ func (ls LabelArray) Has(key string) bool {
 // ignored. The inverse, however, is not true.
 // ["k8s.foo=bar"].Get("any.foo") => "bar"
 // ["any.foo=bar"].Get("k8s.foo") => ""
+//
+// If the key is of source "cidr", this will also match
+// broader keys.
+// ["cidr:1.1.1.1/32"].Has("cidr.1.0.0.0/8") => true
+// ["cidr:1.0.0.0/8"].Has("cidr.1.1.1.1/32") => false
 func (ls LabelArray) Get(key string) string {
 	keyLabel := parseSelectLabel(key, '.')
 	for _, l := range ls {

--- a/pkg/labels/array.go
+++ b/pkg/labels/array.go
@@ -85,7 +85,7 @@ func (ls LabelArray) Contains(needed LabelArray) bool {
 nextLabel:
 	for i := range needed {
 		for l := range ls {
-			if needed[i].matches(&ls[l]) {
+			if ls[l].Has(&needed[i]) {
 				continue nextLabel
 			}
 		}
@@ -96,13 +96,29 @@ nextLabel:
 	return true
 }
 
+// Intersects returns true if ls contains at least one label in needed.
+//
+// This has the same matching semantics as Has, namely,
+// ["k8s:foo=bar"].Intersects(["any:foo=bar"]) == true
+// ["any:foo=bar"].Intersects(["k8s:foo=bar"]) == false
+func (ls LabelArray) Intersects(needed LabelArray) bool {
+	for _, l := range ls {
+		for _, n := range needed {
+			if l.Has(&n) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // Lacks is identical to Contains but returns all missing labels
 func (ls LabelArray) Lacks(needed LabelArray) LabelArray {
 	missing := LabelArray{}
 nextLabel:
 	for i := range needed {
 		for l := range ls {
-			if needed[i].matches(&ls[l]) {
+			if ls[l].Has(&needed[l]) {
 				continue nextLabel
 			}
 		}
@@ -113,7 +129,7 @@ nextLabel:
 	return missing
 }
 
-// Has returns whether the provided key exists.
+// Has returns whether the provided key exists in the label array.
 // Implementation of the
 // github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels.Labels interface.
 //
@@ -124,18 +140,9 @@ nextLabel:
 func (ls LabelArray) Has(key string) bool {
 	// The key is submitted in the form of `source.key=value`
 	keyLabel := parseSelectLabel(key, '.')
-	if keyLabel.IsAnySource() {
-		for l := range ls {
-			if ls[l].Key == keyLabel.Key {
-				return true
-			}
-		}
-	} else {
-		for _, lsl := range ls {
-			// Note that if '=value' is part of 'key' it is ignored here
-			if lsl.Source == keyLabel.Source && lsl.Key == keyLabel.Key {
-				return true
-			}
+	for _, l := range ls {
+		if l.HasKey(&keyLabel) {
+			return true
 		}
 	}
 	return false
@@ -146,22 +153,14 @@ func (ls LabelArray) Has(key string) bool {
 // github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels.Labels interface.
 //
 // The key can be of source "any", in which case the source is
-// ignored. In other words,
+// ignored. The inverse, however, is not true.
 // ["k8s.foo=bar"].Get("any.foo") => "bar"
 // ["any.foo=bar"].Get("k8s.foo") => ""
 func (ls LabelArray) Get(key string) string {
 	keyLabel := parseSelectLabel(key, '.')
-	if keyLabel.IsAnySource() {
-		for l := range ls {
-			if ls[l].Key == keyLabel.Key {
-				return ls[l].Value
-			}
-		}
-	} else {
-		for _, lsl := range ls {
-			if lsl.Source == keyLabel.Source && lsl.Key == keyLabel.Key {
-				return lsl.Value
-			}
+	for _, l := range ls {
+		if l.HasKey(&keyLabel) {
+			return l.Value
 		}
 	}
 	return ""

--- a/pkg/labels/array.go
+++ b/pkg/labels/array.go
@@ -116,6 +116,11 @@ nextLabel:
 // Has returns whether the provided key exists.
 // Implementation of the
 // github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels.Labels interface.
+//
+// The key can be of source "any", in which case the source is
+// ignored. The inverse, however, is not true.
+// ["k8s.foo=bar"].Has("any.foo") => true
+// ["any.foo=bar"].Has("k8s.foo") => false
 func (ls LabelArray) Has(key string) bool {
 	// The key is submitted in the form of `source.key=value`
 	keyLabel := parseSelectLabel(key, '.')
@@ -139,6 +144,11 @@ func (ls LabelArray) Has(key string) bool {
 // Get returns the value for the provided key.
 // Implementation of the
 // github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels.Labels interface.
+//
+// The key can be of source "any", in which case the source is
+// ignored. In other words,
+// ["k8s.foo=bar"].Get("any.foo") => "bar"
+// ["any.foo=bar"].Get("k8s.foo") => ""
 func (ls LabelArray) Get(key string) string {
 	keyLabel := parseSelectLabel(key, '.')
 	if keyLabel.IsAnySource() {

--- a/pkg/labels/array_test.go
+++ b/pkg/labels/array_test.go
@@ -4,10 +4,12 @@
 package labels
 
 import (
+	"net/netip"
 	"sort"
 	"testing"
 
 	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/pkg/checker"
 )
@@ -291,5 +293,35 @@ func BenchmarkLabelArray_String(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = l.String()
+	}
+}
+
+// LabelArray.Has() is a specific interface
+// that is required for kubernetes selectors to work
+func TestLabelArray_Has(t *testing.T) {
+	lbls := LabelArray{
+		NewLabel("foo", "bar", "k8s"),
+		NewLabel("foo1", "bar1", "any"), // not valid, but good to capture
+		NewLabel("kube-apiserver", "", "reserved"),
+	}
+	lbls = append(lbls, GetCIDRLabels(netip.MustParsePrefix("10.1.2.0/24")).LabelArray()...)
+	lbls = append(lbls, GetCIDRLabels(netip.MustParsePrefix("2001:db8:cafe::/54")).LabelArray()...)
+	lbls.Sort()
+
+	for key, expected := range map[string]bool{
+		"any.foo":                 true,
+		"k8s.foo":                 true,
+		"k8s.foo1":                false,
+		"reserved.kube-apiserver": true,
+
+		"cidr.10.1.2.0/24": true,  // exact match
+		"cidr.10.1.0.0/22": true,  // larger cidr: OK
+		"cidr.10.1.2.0/25": false, // smaller cidr: no
+
+		"cidr.2001-db8-cafe--0/54": true,  // exact
+		"cidr.2001-db8-cafe--0/53": true,  // larger
+		"cidr.2001-db8-cafe--0/55": false, // smaller
+	} {
+		assert.Equal(t, expected, lbls.Has(key), key)
 	}
 }

--- a/pkg/labels/cidr.go
+++ b/pkg/labels/cidr.go
@@ -78,6 +78,16 @@ func IPStringToLabel(ip string) (Label, error) {
 	}
 }
 
+func LabelToPrefix(key string) (netip.Prefix, error) {
+	prefixStr := strings.Replace(key, "-", ":", -1)
+	pfx, err := netip.ParsePrefix(prefixStr)
+	if err != nil {
+		return netip.Prefix{}, fmt.Errorf("failed to parse label prefix %s: %w", key, err)
+	}
+	return pfx, nil
+
+}
+
 // GetCIDRLabels turns a CIDR into a set of labels representing the cidr itself
 // and all broader CIDRS which include the specified CIDR in them. For example:
 // CIDR: 10.0.0.0/8 =>
@@ -175,6 +185,8 @@ func computeCIDRLabels(cache *simplelru.LRU[netip.Prefix, []Label], lbls Labels,
 
 	// Compute the label for this prefix (e.g. "cidr:10.0.0.0/8")
 	prefixLabel := maskedIPToLabel(prefix.Addr().String(), ones)
+	c := netip.PrefixFrom(prefix.Addr(), ones)
+	prefixLabel.cidr = &c
 	lbls[prefixLabel.Key] = prefixLabel
 
 	// Keep computing the rest (e.g. "cidr:10.0.0.0/7", ...).

--- a/pkg/labels/cidr.go
+++ b/pkg/labels/cidr.go
@@ -8,12 +8,14 @@ import (
 	"net/netip"
 	"strconv"
 	"strings"
-	"sync"
 
-	"github.com/hashicorp/golang-lru/v2/simplelru"
-
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
+)
+
+var (
+	worldLabelNonDualStack = Label{Key: IDNameWorld, Source: LabelSourceReserved}
+	worldLabelV4           = Label{Source: LabelSourceReserved, Key: IDNameWorldIPv4}
+	worldLabelV6           = Label{Source: LabelSourceReserved, Key: IDNameWorldIPv6}
 )
 
 // maskedIPToLabelString is the base method for serializing an IP + prefix into
@@ -78,70 +80,23 @@ func IPStringToLabel(ip string) (Label, error) {
 	}
 }
 
-func LabelToPrefix(key string) (netip.Prefix, error) {
-	prefixStr := strings.Replace(key, "-", ":", -1)
-	pfx, err := netip.ParsePrefix(prefixStr)
-	if err != nil {
-		return netip.Prefix{}, fmt.Errorf("failed to parse label prefix %s: %w", key, err)
-	}
-	return pfx, nil
-
-}
-
-// GetCIDRLabels turns a CIDR into a set of labels representing the cidr itself
-// and all broader CIDRS which include the specified CIDR in them. For example:
-// CIDR: 10.0.0.0/8 =>
+// GetCIDRLabels turns a CIDR in to a specially formatted label, and returns
+// a Labels including the CIDR-specific label and the appropriate world label.
+// e.g. "10.0.0.0/8" => ["cidr:10.0.0.0/8", "reserved:world-ipv4"]
 //
-//	"cidr:10.0.0.0/8", "cidr:10.0.0.0/7", "cidr:8.0.0.0/6",
-//	"cidr:8.0.0.0/5", "cidr:0.0.0.0/4, "cidr:0.0.0.0/3",
-//	"cidr:0.0.0.0/2",  "cidr:0.0.0.0/1",  "cidr:0.0.0.0/0"
-//
-// The identity reserved:world is always added as it includes any CIDR.
+// IPv6 requires some special treatment, since ":" is special in the label selector
+// grammar. For example, "::/0" becomes "cidr:0--0/0",
 func GetCIDRLabels(prefix netip.Prefix) Labels {
-	once.Do(func() {
-		// simplelru.NewLRU fails only when given a negative size, so we can skip the error check
-		cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []Label](cidrLabelsCacheMaxSize, nil)
-	})
-
-	addr := prefix.Addr()
-	ones := prefix.Bits()
-	lbls := make(Labels, 1 /* this CIDR */ +ones /* the prefixes */ +1 /*world label*/)
-
-	// If ones is zero, then it's the default CIDR prefix /0 which should
-	// just be regarded as reserved:world. In all other cases, we need
-	// to generate the set of prefixes starting from the /0 up to the
-	// specified prefix length.
-	if ones == 0 {
-		addWorldLabel(addr, lbls)
-		return lbls
+	lbls := make(Labels, 2)
+	if prefix.Bits() > 0 {
+		l := maskedIPToLabel(prefix.Addr().String(), prefix.Bits())
+		l.cidr = &prefix
+		lbls[l.Key] = l
 	}
-
-	computeCIDRLabels(
-		cidrLabelsCache,
-		lbls,
-		nil, // avoid allocating space for the intermediate results until we need it
-		addr,
-		ones,
-	)
-	addWorldLabel(addr, lbls)
+	addWorldLabel(prefix.Addr(), lbls)
 
 	return lbls
 }
-
-var (
-	// cidrLabelsCache stores the partial computations for CIDR labels.
-	// This both avoids repeatedly computing the prefixes and makes sure the
-	// CIDR strings are reused to reduce memory usage.
-	// Stored in a lru map to limit memory usage.
-	//
-	// Stores e.g. for prefix "10.0.0.0/8" the labels ["10.0.0.0/8", ..., "0.0.0.0/0"].
-	cidrLabelsCache *simplelru.LRU[netip.Prefix, []Label]
-
-	// mutex to serialize concurrent accesses to the cidrLabelsCache.
-	mu lock.Mutex
-)
-
-const cidrLabelsCacheMaxSize = 8192
 
 func addWorldLabel(addr netip.Addr, lbls Labels) {
 	switch {
@@ -154,83 +109,11 @@ func addWorldLabel(addr netip.Addr, lbls Labels) {
 	}
 }
 
-var (
-	once sync.Once
-
-	worldLabelNonDualStack = Label{Key: IDNameWorld, Source: LabelSourceReserved}
-	worldLabelV4           = Label{Source: LabelSourceReserved, Key: IDNameWorldIPv4}
-	worldLabelV6           = Label{Source: LabelSourceReserved, Key: IDNameWorldIPv6}
-)
-
-func computeCIDRLabels(cache *simplelru.LRU[netip.Prefix, []Label], lbls Labels, results []Label, addr netip.Addr, ones int) []Label {
-	if ones < 0 {
-		return results
+func LabelToPrefix(key string) (netip.Prefix, error) {
+	prefixStr := strings.Replace(key, "-", ":", -1)
+	pfx, err := netip.ParsePrefix(prefixStr)
+	if err != nil {
+		return netip.Prefix{}, fmt.Errorf("failed to parse label prefix %s: %w", key, err)
 	}
-
-	prefix, _ := addr.Prefix(ones)
-
-	mu.Lock()
-	cachedLbls, ok := cache.Get(prefix)
-	mu.Unlock()
-	if ok {
-		for _, lbl := range cachedLbls {
-			lbls[lbl.Key] = lbl
-		}
-		if results == nil {
-			return cachedLbls
-		} else {
-			return append(results, cachedLbls...)
-		}
-	}
-
-	// Compute the label for this prefix (e.g. "cidr:10.0.0.0/8")
-	prefixLabel := maskedIPToLabel(prefix.Addr().String(), ones)
-	c := netip.PrefixFrom(prefix.Addr(), ones)
-	prefixLabel.cidr = &c
-	lbls[prefixLabel.Key] = prefixLabel
-
-	// Keep computing the rest (e.g. "cidr:10.0.0.0/7", ...).
-	results = computeCIDRLabels(
-		cache,
-		lbls,
-		append(results, prefixLabel),
-		prefix.Addr(), ones-1,
-	)
-
-	// Cache the resulting labels derived from this prefix, e.g. /8, /7, ...
-	mu.Lock()
-	cache.Add(prefix, results[len(results)-ones-1:])
-	mu.Unlock()
-
-	return results
-}
-
-// leafCIDRList is a map of CIDR to data, where only leaf CIDRs are present
-// in the map.
-type leafCIDRList[T any] map[netip.Prefix]T
-
-// insert conditionally adds a prefix to the leaf cidr list,
-// adding it only if the prefix is a leaf. Additionally, it removes
-// any now non-leaf cidr.
-func (ll leafCIDRList[T]) insert(newPrefix netip.Prefix, v T) {
-	// Check every existing leaf CIDR. Three possible cases:
-	// - an existing prefix contains this one: delete existing, add new
-	// - this new prefix contains an existing one: drop new prefix
-	// - no matches: add new
-	for existingPrefix := range ll {
-		// Is this a subset of an existing prefix? That means we've found a now non-leaf
-		// prefix -- swap it
-		if existingPrefix.Contains(newPrefix.Addr()) && existingPrefix.Bits() < newPrefix.Bits() {
-			delete(ll, existingPrefix)
-			// it is safe to stop here, since at most one prefix in the list could
-			// have contained this prefix.
-			break
-		}
-
-		// Is this a superset of an existing prefix? Then we're not a leaf; skip it
-		if newPrefix.Contains(existingPrefix.Addr()) && newPrefix.Bits() <= existingPrefix.Bits() {
-			return
-		}
-	}
-	ll[newPrefix] = v
+	return pfx, nil
 }

--- a/pkg/labels/cidr_test.go
+++ b/pkg/labels/cidr_test.go
@@ -726,3 +726,30 @@ func TestGetPrintableModel(t *testing.T) {
 		cl.GetPrintableModel(),
 	)
 }
+
+func TestLabelToPrefix(t *testing.T) {
+	for _, pfx := range []string{
+		"1.1.1.1/32",
+		"1.1.1.0/24",
+		"2001::4/128",
+		"2001::fffc/126",
+		"::/0",
+		"2001::/64",
+		"0.0.0.0/0",
+	} {
+		want, err := netip.ParsePrefix(pfx)
+		if err != nil {
+			t.Fatalf("failed to parse prefix %s: %v", pfx, err)
+		}
+		want = want.Masked()
+
+		label := maskedIPToLabel(want.Addr().String(), want.Bits())
+		have, err := LabelToPrefix(label.Key)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if have != want {
+			t.Fatalf("prefixes did not match: want %s, have %s, label %s", want, have, label.Key)
+		}
+	}
+}

--- a/pkg/labels/cidr_test.go
+++ b/pkg/labels/cidr_test.go
@@ -4,23 +4,15 @@
 package labels
 
 import (
-	"math/rand"
 	"net/netip"
-	"runtime"
-	"strconv"
-	"sync"
 	"testing"
 
-	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/pkg/option"
 )
 
 func TestGetCIDRLabels(t *testing.T) {
-	// clear the cache
-	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []Label](cidrLabelsCacheMaxSize, nil)
-
 	// save global config and restore it at the end of the test
 	enableIPv4, enableIPv6 := option.Config.EnableIPv4, option.Config.EnableIPv6
 	t.Cleanup(func() {
@@ -40,15 +32,7 @@ func TestGetCIDRLabels(t *testing.T) {
 			enableIPv6: false,
 			prefix:     netip.MustParsePrefix("192.0.2.3/32"),
 			expected: ParseLabelArray(
-				"cidr:0.0.0.0/0",
-				"cidr:128.0.0.0/1", "cidr:192.0.0.0/2", "cidr:192.0.0.0/3", "cidr:192.0.0.0/4",
-				"cidr:192.0.0.0/5", "cidr:192.0.0.0/6", "cidr:192.0.0.0/7", "cidr:192.0.0.0/8",
-				"cidr:192.0.0.0/9", "cidr:192.0.0.0/10", "cidr:192.0.0.0/11", "cidr:192.0.0.0/12",
-				"cidr:192.0.0.0/13", "cidr:192.0.0.0/14", "cidr:192.0.0.0/15", "cidr:192.0.0.0/16",
-				"cidr:192.0.0.0/17", "cidr:192.0.0.0/18", "cidr:192.0.0.0/19", "cidr:192.0.0.0/20",
-				"cidr:192.0.0.0/21", "cidr:192.0.0.0/22", "cidr:192.0.2.0/23", "cidr:192.0.2.0/24",
-				"cidr:192.0.2.0/25", "cidr:192.0.2.0/26", "cidr:192.0.2.0/27", "cidr:192.0.2.0/28",
-				"cidr:192.0.2.0/29", "cidr:192.0.2.0/30", "cidr:192.0.2.2/31", "cidr:192.0.2.3/32",
+				"cidr:192.0.2.3/32",
 				"reserved:world",
 			),
 		},
@@ -58,13 +42,7 @@ func TestGetCIDRLabels(t *testing.T) {
 			enableIPv6: false,
 			prefix:     netip.MustParsePrefix("192.0.2.0/24"),
 			expected: ParseLabelArray(
-				"cidr:0.0.0.0/0",
-				"cidr:128.0.0.0/1", "cidr:192.0.0.0/2", "cidr:192.0.0.0/3", "cidr:192.0.0.0/4",
-				"cidr:192.0.0.0/5", "cidr:192.0.0.0/6", "cidr:192.0.0.0/7", "cidr:192.0.0.0/8",
-				"cidr:192.0.0.0/9", "cidr:192.0.0.0/10", "cidr:192.0.0.0/11", "cidr:192.0.0.0/12",
-				"cidr:192.0.0.0/13", "cidr:192.0.0.0/14", "cidr:192.0.0.0/15", "cidr:192.0.0.0/16",
-				"cidr:192.0.0.0/17", "cidr:192.0.0.0/18", "cidr:192.0.0.0/19", "cidr:192.0.0.0/20",
-				"cidr:192.0.0.0/21", "cidr:192.0.0.0/22", "cidr:192.0.2.0/23", "cidr:192.0.2.0/24",
+				"cidr:192.0.2.0/24",
 				"reserved:world",
 			),
 		},
@@ -74,11 +52,7 @@ func TestGetCIDRLabels(t *testing.T) {
 			enableIPv6: false,
 			prefix:     netip.MustParsePrefix("10.0.0.0/16"),
 			expected: ParseLabelArray(
-				"cidr:0.0.0.0/0",
-				"cidr:0.0.0.0/1", "cidr:0.0.0.0/2", "cidr:0.0.0.0/3", "cidr:0.0.0.0/4",
-				"cidr:8.0.0.0/5", "cidr:8.0.0.0/6", "cidr:10.0.0.0/7", "cidr:10.0.0.0/8",
-				"cidr:10.0.0.0/9", "cidr:10.0.0.0/10", "cidr:10.0.0.0/11", "cidr:10.0.0.0/12",
-				"cidr:10.0.0.0/13", "cidr:10.0.0.0/14", "cidr:10.0.0.0/15", "cidr:10.0.0.0/16",
+				"cidr:10.0.0.0/16",
 				"reserved:world",
 			),
 		},
@@ -100,35 +74,7 @@ func TestGetCIDRLabels(t *testing.T) {
 				// Note that we convert the colons in IPv6 addresses into dashes when
 				// translating into labels, because endpointSelectors don't support
 				// colons.
-				"cidr:0--0/0",
-				"cidr:0--0/1", "cidr:0--0/2", "cidr:2000--0/3", "cidr:2000--0/4",
-				"cidr:2000--0/5", "cidr:2000--0/6", "cidr:2000--0/7", "cidr:2000--0/8",
-				"cidr:2000--0/9", "cidr:2000--0/10", "cidr:2000--0/11", "cidr:2000--0/12",
-				"cidr:2000--0/13", "cidr:2000--0/14", "cidr:2000--0/15", "cidr:2001--0/16",
-				"cidr:2001--0/17", "cidr:2001--0/18", "cidr:2001--0/19", "cidr:2001--0/20",
-				"cidr:2001-800--0/21", "cidr:2001-c00--0/22", "cidr:2001-c00--0/23", "cidr:2001-d00--0/24",
-				"cidr:2001-d80--0/25", "cidr:2001-d80--0/26", "cidr:2001-da0--0/27", "cidr:2001-db0--0/28",
-				"cidr:2001-db8--0/29", "cidr:2001-db8--0/30", "cidr:2001-db8--0/31", "cidr:2001-db8--0/32",
-				"cidr:2001-db8-8000--0/33", "cidr:2001-db8-c000--0/34", "cidr:2001-db8-c000--0/35", "cidr:2001-db8-c000--0/36",
-				"cidr:2001-db8-c800--0/37", "cidr:2001-db8-c800--0/38", "cidr:2001-db8-ca00--0/39", "cidr:2001-db8-ca00--0/40",
-				"cidr:2001-db8-ca80--0/41", "cidr:2001-db8-cac0--0/42", "cidr:2001-db8-cae0--0/43", "cidr:2001-db8-caf0--0/44",
-				"cidr:2001-db8-caf8--0/45", "cidr:2001-db8-cafc--0/46", "cidr:2001-db8-cafe--0/47", "cidr:2001-db8-cafe--0/48",
-				"cidr:2001-db8-cafe--0/49", "cidr:2001-db8-cafe--0/50", "cidr:2001-db8-cafe--0/51", "cidr:2001-db8-cafe--0/52",
-				"cidr:2001-db8-cafe--0/53", "cidr:2001-db8-cafe--0/54", "cidr:2001-db8-cafe--0/55", "cidr:2001-db8-cafe--0/56",
-				"cidr:2001-db8-cafe--0/57", "cidr:2001-db8-cafe--0/58", "cidr:2001-db8-cafe--0/59", "cidr:2001-db8-cafe--0/60",
-				"cidr:2001-db8-cafe--0/61", "cidr:2001-db8-cafe--0/62", "cidr:2001-db8-cafe--0/63", "cidr:2001-db8-cafe--0/64",
-				"cidr:2001-db8-cafe--0/65", "cidr:2001-db8-cafe--0/66", "cidr:2001-db8-cafe--0/67", "cidr:2001-db8-cafe--0/68",
-				"cidr:2001-db8-cafe-0-800--0/69", "cidr:2001-db8-cafe-0-c00--0/70", "cidr:2001-db8-cafe-0-c00--0/71", "cidr:2001-db8-cafe-0-c00--0/72",
-				"cidr:2001-db8-cafe-0-c80--0/73", "cidr:2001-db8-cafe-0-c80--0/74", "cidr:2001-db8-cafe-0-ca0--0/75", "cidr:2001-db8-cafe-0-ca0--0/76",
-				"cidr:2001-db8-cafe-0-ca8--0/77", "cidr:2001-db8-cafe-0-ca8--0/78", "cidr:2001-db8-cafe-0-caa--0/79", "cidr:2001-db8-cafe-0-cab--0/80",
-				"cidr:2001-db8-cafe-0-cab--0/81", "cidr:2001-db8-cafe-0-cab--0/82", "cidr:2001-db8-cafe-0-cab--0/83", "cidr:2001-db8-cafe-0-cab--0/84",
-				"cidr:2001-db8-cafe-0-cab--0/85", "cidr:2001-db8-cafe-0-cab--0/86", "cidr:2001-db8-cafe-0-cab--0/87", "cidr:2001-db8-cafe-0-cab--0/88",
-				"cidr:2001-db8-cafe-0-cab--0/89", "cidr:2001-db8-cafe-0-cab--0/90", "cidr:2001-db8-cafe-0-cab--0/91", "cidr:2001-db8-cafe-0-cab--0/92",
-				"cidr:2001-db8-cafe-0-cab--0/93", "cidr:2001-db8-cafe-0-cab-4--0/94", "cidr:2001-db8-cafe-0-cab-4--0/95", "cidr:2001-db8-cafe-0-cab-4--0/96",
-				"cidr:2001-db8-cafe-0-cab-4--0/97", "cidr:2001-db8-cafe-0-cab-4--0/98", "cidr:2001-db8-cafe-0-cab-4--0/99", "cidr:2001-db8-cafe-0-cab-4--0/100",
-				"cidr:2001-db8-cafe-0-cab-4-800-0/101", "cidr:2001-db8-cafe-0-cab-4-800-0/102", "cidr:2001-db8-cafe-0-cab-4-a00-0/103", "cidr:2001-db8-cafe-0-cab-4-b00-0/104",
-				"cidr:2001-db8-cafe-0-cab-4-b00-0/105", "cidr:2001-db8-cafe-0-cab-4-b00-0/106", "cidr:2001-db8-cafe-0-cab-4-b00-0/107", "cidr:2001-db8-cafe-0-cab-4-b00-0/108",
-				"cidr:2001-db8-cafe-0-cab-4-b08-0/109", "cidr:2001-db8-cafe-0-cab-4-b08-0/110", "cidr:2001-db8-cafe-0-cab-4-b0a-0/111", "cidr:2001-db8-cafe-0-cab-4-b0b-0/112",
+				"cidr:2001-db8-cafe-0-cab-4-b0b-0/112",
 				"reserved:world",
 			),
 		},
@@ -138,39 +84,7 @@ func TestGetCIDRLabels(t *testing.T) {
 			enableIPv6: true,
 			prefix:     netip.MustParsePrefix("2001:DB8::1/128"),
 			expected: ParseLabelArray(
-				"cidr:0--0/0",
-				"cidr:0--0/1", "cidr:0--0/2", "cidr:2000--0/3", "cidr:2000--0/4",
-				"cidr:2000--0/5", "cidr:2000--0/6", "cidr:2000--0/7", "cidr:2000--0/8",
-				"cidr:2000--0/9", "cidr:2000--0/10", "cidr:2000--0/11", "cidr:2000--0/12",
-				"cidr:2000--0/13", "cidr:2000--0/14", "cidr:2000--0/15", "cidr:2001--0/16",
-				"cidr:2001--0/17", "cidr:2001--0/18", "cidr:2001--0/19", "cidr:2001--0/20",
-				"cidr:2001-800--0/21", "cidr:2001-c00--0/22", "cidr:2001-c00--0/23", "cidr:2001-d00--0/24",
-				"cidr:2001-d80--0/25", "cidr:2001-d80--0/26", "cidr:2001-da0--0/27", "cidr:2001-db0--0/28",
-				"cidr:2001-db8--0/29", "cidr:2001-db8--0/30", "cidr:2001-db8--0/31", "cidr:2001-db8--0/32",
-				"cidr:2001-db8--0/33", "cidr:2001-db8--0/34", "cidr:2001-db8--0/35", "cidr:2001-db8--0/36",
-				"cidr:2001-db8--0/37", "cidr:2001-db8--0/38", "cidr:2001-db8--0/39", "cidr:2001-db8--0/40",
-				"cidr:2001-db8--0/41", "cidr:2001-db8--0/42", "cidr:2001-db8--0/43", "cidr:2001-db8--0/44",
-				"cidr:2001-db8--0/45", "cidr:2001-db8--0/46", "cidr:2001-db8--0/47", "cidr:2001-db8--0/48",
-				"cidr:2001-db8--0/49", "cidr:2001-db8--0/50", "cidr:2001-db8--0/51", "cidr:2001-db8--0/52",
-				"cidr:2001-db8--0/53", "cidr:2001-db8--0/54", "cidr:2001-db8--0/55", "cidr:2001-db8--0/56",
-				"cidr:2001-db8--0/57", "cidr:2001-db8--0/58", "cidr:2001-db8--0/59", "cidr:2001-db8--0/60",
-				"cidr:2001-db8--0/61", "cidr:2001-db8--0/62", "cidr:2001-db8--0/63", "cidr:2001-db8--0/64",
-				"cidr:2001-db8--0/65", "cidr:2001-db8--0/66", "cidr:2001-db8--0/67", "cidr:2001-db8--0/68",
-				"cidr:2001-db8--0/69", "cidr:2001-db8--0/70", "cidr:2001-db8--0/71", "cidr:2001-db8--0/72",
-				"cidr:2001-db8--0/73", "cidr:2001-db8--0/74", "cidr:2001-db8--0/75", "cidr:2001-db8--0/76",
-				"cidr:2001-db8--0/77", "cidr:2001-db8--0/78", "cidr:2001-db8--0/79", "cidr:2001-db8--0/80",
-				"cidr:2001-db8--0/81", "cidr:2001-db8--0/82", "cidr:2001-db8--0/83", "cidr:2001-db8--0/84",
-				"cidr:2001-db8--0/85", "cidr:2001-db8--0/86", "cidr:2001-db8--0/87", "cidr:2001-db8--0/88",
-				"cidr:2001-db8--0/89", "cidr:2001-db8--0/90", "cidr:2001-db8--0/91", "cidr:2001-db8--0/92",
-				"cidr:2001-db8--0/93", "cidr:2001-db8--0/94", "cidr:2001-db8--0/95", "cidr:2001-db8--0/96",
-				"cidr:2001-db8--0/97", "cidr:2001-db8--0/98", "cidr:2001-db8--0/99", "cidr:2001-db8--0/100",
-				"cidr:2001-db8--0/101", "cidr:2001-db8--0/102", "cidr:2001-db8--0/103", "cidr:2001-db8--0/104",
-				"cidr:2001-db8--0/105", "cidr:2001-db8--0/106", "cidr:2001-db8--0/107", "cidr:2001-db8--0/108",
-				"cidr:2001-db8--0/109", "cidr:2001-db8--0/110", "cidr:2001-db8--0/111", "cidr:2001-db8--0/112",
-				"cidr:2001-db8--0/113", "cidr:2001-db8--0/114", "cidr:2001-db8--0/115", "cidr:2001-db8--0/116",
-				"cidr:2001-db8--0/117", "cidr:2001-db8--0/118", "cidr:2001-db8--0/119", "cidr:2001-db8--0/120",
-				"cidr:2001-db8--0/121", "cidr:2001-db8--0/122", "cidr:2001-db8--0/123", "cidr:2001-db8--0/124",
-				"cidr:2001-db8--0/125", "cidr:2001-db8--0/126", "cidr:2001-db8--0/127", "cidr:2001-db8--1/128",
+				"cidr:2001-db8--1/128",
 				"reserved:world",
 			),
 		},
@@ -180,15 +94,7 @@ func TestGetCIDRLabels(t *testing.T) {
 			enableIPv6: true,
 			prefix:     netip.MustParsePrefix("192.0.2.3/32"),
 			expected: ParseLabelArray(
-				"cidr:0.0.0.0/0",
-				"cidr:128.0.0.0/1", "cidr:192.0.0.0/2", "cidr:192.0.0.0/3", "cidr:192.0.0.0/4",
-				"cidr:192.0.0.0/5", "cidr:192.0.0.0/6", "cidr:192.0.0.0/7", "cidr:192.0.0.0/8",
-				"cidr:192.0.0.0/9", "cidr:192.0.0.0/10", "cidr:192.0.0.0/11", "cidr:192.0.0.0/12",
-				"cidr:192.0.0.0/13", "cidr:192.0.0.0/14", "cidr:192.0.0.0/15", "cidr:192.0.0.0/16",
-				"cidr:192.0.0.0/17", "cidr:192.0.0.0/18", "cidr:192.0.0.0/19", "cidr:192.0.0.0/20",
-				"cidr:192.0.0.0/21", "cidr:192.0.0.0/22", "cidr:192.0.2.0/23", "cidr:192.0.2.0/24",
-				"cidr:192.0.2.0/25", "cidr:192.0.2.0/26", "cidr:192.0.2.0/27", "cidr:192.0.2.0/28",
-				"cidr:192.0.2.0/29", "cidr:192.0.2.0/30", "cidr:192.0.2.2/31", "cidr:192.0.2.3/32",
+				"cidr:192.0.2.3/32",
 				"reserved:world-ipv4",
 			),
 		},
@@ -198,13 +104,7 @@ func TestGetCIDRLabels(t *testing.T) {
 			enableIPv6: true,
 			prefix:     netip.MustParsePrefix("192.0.2.0/24"),
 			expected: ParseLabelArray(
-				"cidr:0.0.0.0/0",
-				"cidr:128.0.0.0/1", "cidr:192.0.0.0/2", "cidr:192.0.0.0/3", "cidr:192.0.0.0/4",
-				"cidr:192.0.0.0/5", "cidr:192.0.0.0/6", "cidr:192.0.0.0/7", "cidr:192.0.0.0/8",
-				"cidr:192.0.0.0/9", "cidr:192.0.0.0/10", "cidr:192.0.0.0/11", "cidr:192.0.0.0/12",
-				"cidr:192.0.0.0/13", "cidr:192.0.0.0/14", "cidr:192.0.0.0/15", "cidr:192.0.0.0/16",
-				"cidr:192.0.0.0/17", "cidr:192.0.0.0/18", "cidr:192.0.0.0/19", "cidr:192.0.0.0/20",
-				"cidr:192.0.0.0/21", "cidr:192.0.0.0/22", "cidr:192.0.2.0/23", "cidr:192.0.2.0/24",
+				"cidr:192.0.2.0/24",
 				"reserved:world-ipv4",
 			),
 		},
@@ -214,11 +114,7 @@ func TestGetCIDRLabels(t *testing.T) {
 			enableIPv6: true,
 			prefix:     netip.MustParsePrefix("10.0.0.0/16"),
 			expected: ParseLabelArray(
-				"cidr:0.0.0.0/0",
-				"cidr:0.0.0.0/1", "cidr:0.0.0.0/2", "cidr:0.0.0.0/3", "cidr:0.0.0.0/4",
-				"cidr:8.0.0.0/5", "cidr:8.0.0.0/6", "cidr:10.0.0.0/7", "cidr:10.0.0.0/8",
-				"cidr:10.0.0.0/9", "cidr:10.0.0.0/10", "cidr:10.0.0.0/11", "cidr:10.0.0.0/12",
-				"cidr:10.0.0.0/13", "cidr:10.0.0.0/14", "cidr:10.0.0.0/15", "cidr:10.0.0.0/16",
+				"cidr:10.0.0.0/16",
 				"reserved:world-ipv4",
 			),
 		},
@@ -237,35 +133,7 @@ func TestGetCIDRLabels(t *testing.T) {
 			enableIPv6: true,
 			prefix:     netip.MustParsePrefix("2001:db8:cafe::cab:4:b0b:0/112"),
 			expected: ParseLabelArray(
-				"cidr:0--0/0",
-				"cidr:0--0/1", "cidr:0--0/2", "cidr:2000--0/3", "cidr:2000--0/4",
-				"cidr:2000--0/5", "cidr:2000--0/6", "cidr:2000--0/7", "cidr:2000--0/8",
-				"cidr:2000--0/9", "cidr:2000--0/10", "cidr:2000--0/11", "cidr:2000--0/12",
-				"cidr:2000--0/13", "cidr:2000--0/14", "cidr:2000--0/15", "cidr:2001--0/16",
-				"cidr:2001--0/17", "cidr:2001--0/18", "cidr:2001--0/19", "cidr:2001--0/20",
-				"cidr:2001-800--0/21", "cidr:2001-c00--0/22", "cidr:2001-c00--0/23", "cidr:2001-d00--0/24",
-				"cidr:2001-d80--0/25", "cidr:2001-d80--0/26", "cidr:2001-da0--0/27", "cidr:2001-db0--0/28",
-				"cidr:2001-db8--0/29", "cidr:2001-db8--0/30", "cidr:2001-db8--0/31", "cidr:2001-db8--0/32",
-				"cidr:2001-db8-8000--0/33", "cidr:2001-db8-c000--0/34", "cidr:2001-db8-c000--0/35", "cidr:2001-db8-c000--0/36",
-				"cidr:2001-db8-c800--0/37", "cidr:2001-db8-c800--0/38", "cidr:2001-db8-ca00--0/39", "cidr:2001-db8-ca00--0/40",
-				"cidr:2001-db8-ca80--0/41", "cidr:2001-db8-cac0--0/42", "cidr:2001-db8-cae0--0/43", "cidr:2001-db8-caf0--0/44",
-				"cidr:2001-db8-caf8--0/45", "cidr:2001-db8-cafc--0/46", "cidr:2001-db8-cafe--0/47", "cidr:2001-db8-cafe--0/48",
-				"cidr:2001-db8-cafe--0/49", "cidr:2001-db8-cafe--0/50", "cidr:2001-db8-cafe--0/51", "cidr:2001-db8-cafe--0/52",
-				"cidr:2001-db8-cafe--0/53", "cidr:2001-db8-cafe--0/54", "cidr:2001-db8-cafe--0/55", "cidr:2001-db8-cafe--0/56",
-				"cidr:2001-db8-cafe--0/57", "cidr:2001-db8-cafe--0/58", "cidr:2001-db8-cafe--0/59", "cidr:2001-db8-cafe--0/60",
-				"cidr:2001-db8-cafe--0/61", "cidr:2001-db8-cafe--0/62", "cidr:2001-db8-cafe--0/63", "cidr:2001-db8-cafe--0/64",
-				"cidr:2001-db8-cafe--0/65", "cidr:2001-db8-cafe--0/66", "cidr:2001-db8-cafe--0/67", "cidr:2001-db8-cafe--0/68",
-				"cidr:2001-db8-cafe-0-800--0/69", "cidr:2001-db8-cafe-0-c00--0/70", "cidr:2001-db8-cafe-0-c00--0/71", "cidr:2001-db8-cafe-0-c00--0/72",
-				"cidr:2001-db8-cafe-0-c80--0/73", "cidr:2001-db8-cafe-0-c80--0/74", "cidr:2001-db8-cafe-0-ca0--0/75", "cidr:2001-db8-cafe-0-ca0--0/76",
-				"cidr:2001-db8-cafe-0-ca8--0/77", "cidr:2001-db8-cafe-0-ca8--0/78", "cidr:2001-db8-cafe-0-caa--0/79", "cidr:2001-db8-cafe-0-cab--0/80",
-				"cidr:2001-db8-cafe-0-cab--0/81", "cidr:2001-db8-cafe-0-cab--0/82", "cidr:2001-db8-cafe-0-cab--0/83", "cidr:2001-db8-cafe-0-cab--0/84",
-				"cidr:2001-db8-cafe-0-cab--0/85", "cidr:2001-db8-cafe-0-cab--0/86", "cidr:2001-db8-cafe-0-cab--0/87", "cidr:2001-db8-cafe-0-cab--0/88",
-				"cidr:2001-db8-cafe-0-cab--0/89", "cidr:2001-db8-cafe-0-cab--0/90", "cidr:2001-db8-cafe-0-cab--0/91", "cidr:2001-db8-cafe-0-cab--0/92",
-				"cidr:2001-db8-cafe-0-cab--0/93", "cidr:2001-db8-cafe-0-cab-4--0/94", "cidr:2001-db8-cafe-0-cab-4--0/95", "cidr:2001-db8-cafe-0-cab-4--0/96",
-				"cidr:2001-db8-cafe-0-cab-4--0/97", "cidr:2001-db8-cafe-0-cab-4--0/98", "cidr:2001-db8-cafe-0-cab-4--0/99", "cidr:2001-db8-cafe-0-cab-4--0/100",
-				"cidr:2001-db8-cafe-0-cab-4-800-0/101", "cidr:2001-db8-cafe-0-cab-4-800-0/102", "cidr:2001-db8-cafe-0-cab-4-a00-0/103", "cidr:2001-db8-cafe-0-cab-4-b00-0/104",
-				"cidr:2001-db8-cafe-0-cab-4-b00-0/105", "cidr:2001-db8-cafe-0-cab-4-b00-0/106", "cidr:2001-db8-cafe-0-cab-4-b00-0/107", "cidr:2001-db8-cafe-0-cab-4-b00-0/108",
-				"cidr:2001-db8-cafe-0-cab-4-b08-0/109", "cidr:2001-db8-cafe-0-cab-4-b08-0/110", "cidr:2001-db8-cafe-0-cab-4-b0a-0/111", "cidr:2001-db8-cafe-0-cab-4-b0b-0/112",
+				"cidr:2001-db8-cafe-0-cab-4-b0b-0/112",
 				"reserved:world-ipv6",
 			),
 		},
@@ -275,39 +143,7 @@ func TestGetCIDRLabels(t *testing.T) {
 			enableIPv6: true,
 			prefix:     netip.MustParsePrefix("2001:DB8::1/128"),
 			expected: ParseLabelArray(
-				"cidr:0--0/0",
-				"cidr:0--0/1", "cidr:0--0/2", "cidr:2000--0/3", "cidr:2000--0/4",
-				"cidr:2000--0/5", "cidr:2000--0/6", "cidr:2000--0/7", "cidr:2000--0/8",
-				"cidr:2000--0/9", "cidr:2000--0/10", "cidr:2000--0/11", "cidr:2000--0/12",
-				"cidr:2000--0/13", "cidr:2000--0/14", "cidr:2000--0/15", "cidr:2001--0/16",
-				"cidr:2001--0/17", "cidr:2001--0/18", "cidr:2001--0/19", "cidr:2001--0/20",
-				"cidr:2001-800--0/21", "cidr:2001-c00--0/22", "cidr:2001-c00--0/23", "cidr:2001-d00--0/24",
-				"cidr:2001-d80--0/25", "cidr:2001-d80--0/26", "cidr:2001-da0--0/27", "cidr:2001-db0--0/28",
-				"cidr:2001-db8--0/29", "cidr:2001-db8--0/30", "cidr:2001-db8--0/31", "cidr:2001-db8--0/32",
-				"cidr:2001-db8--0/33", "cidr:2001-db8--0/34", "cidr:2001-db8--0/35", "cidr:2001-db8--0/36",
-				"cidr:2001-db8--0/37", "cidr:2001-db8--0/38", "cidr:2001-db8--0/39", "cidr:2001-db8--0/40",
-				"cidr:2001-db8--0/41", "cidr:2001-db8--0/42", "cidr:2001-db8--0/43", "cidr:2001-db8--0/44",
-				"cidr:2001-db8--0/45", "cidr:2001-db8--0/46", "cidr:2001-db8--0/47", "cidr:2001-db8--0/48",
-				"cidr:2001-db8--0/49", "cidr:2001-db8--0/50", "cidr:2001-db8--0/51", "cidr:2001-db8--0/52",
-				"cidr:2001-db8--0/53", "cidr:2001-db8--0/54", "cidr:2001-db8--0/55", "cidr:2001-db8--0/56",
-				"cidr:2001-db8--0/57", "cidr:2001-db8--0/58", "cidr:2001-db8--0/59", "cidr:2001-db8--0/60",
-				"cidr:2001-db8--0/61", "cidr:2001-db8--0/62", "cidr:2001-db8--0/63", "cidr:2001-db8--0/64",
-				"cidr:2001-db8--0/65", "cidr:2001-db8--0/66", "cidr:2001-db8--0/67", "cidr:2001-db8--0/68",
-				"cidr:2001-db8--0/69", "cidr:2001-db8--0/70", "cidr:2001-db8--0/71", "cidr:2001-db8--0/72",
-				"cidr:2001-db8--0/73", "cidr:2001-db8--0/74", "cidr:2001-db8--0/75", "cidr:2001-db8--0/76",
-				"cidr:2001-db8--0/77", "cidr:2001-db8--0/78", "cidr:2001-db8--0/79", "cidr:2001-db8--0/80",
-				"cidr:2001-db8--0/81", "cidr:2001-db8--0/82", "cidr:2001-db8--0/83", "cidr:2001-db8--0/84",
-				"cidr:2001-db8--0/85", "cidr:2001-db8--0/86", "cidr:2001-db8--0/87", "cidr:2001-db8--0/88",
-				"cidr:2001-db8--0/89", "cidr:2001-db8--0/90", "cidr:2001-db8--0/91", "cidr:2001-db8--0/92",
-				"cidr:2001-db8--0/93", "cidr:2001-db8--0/94", "cidr:2001-db8--0/95", "cidr:2001-db8--0/96",
-				"cidr:2001-db8--0/97", "cidr:2001-db8--0/98", "cidr:2001-db8--0/99", "cidr:2001-db8--0/100",
-				"cidr:2001-db8--0/101", "cidr:2001-db8--0/102", "cidr:2001-db8--0/103", "cidr:2001-db8--0/104",
-				"cidr:2001-db8--0/105", "cidr:2001-db8--0/106", "cidr:2001-db8--0/107", "cidr:2001-db8--0/108",
-				"cidr:2001-db8--0/109", "cidr:2001-db8--0/110", "cidr:2001-db8--0/111", "cidr:2001-db8--0/112",
-				"cidr:2001-db8--0/113", "cidr:2001-db8--0/114", "cidr:2001-db8--0/115", "cidr:2001-db8--0/116",
-				"cidr:2001-db8--0/117", "cidr:2001-db8--0/118", "cidr:2001-db8--0/119", "cidr:2001-db8--0/120",
-				"cidr:2001-db8--0/121", "cidr:2001-db8--0/122", "cidr:2001-db8--0/123", "cidr:2001-db8--0/124",
-				"cidr:2001-db8--0/125", "cidr:2001-db8--0/126", "cidr:2001-db8--0/127", "cidr:2001-db8--1/128",
+				"cidr:2001-db8--1/128",
 				"reserved:world-ipv6",
 			),
 		},
@@ -319,110 +155,8 @@ func TestGetCIDRLabels(t *testing.T) {
 			lbls := GetCIDRLabels(tc.prefix)
 			lblArray := lbls.LabelArray()
 			assert.ElementsMatch(t, lblArray, tc.expected)
-
-			// compute labels twice to verify the caching behavior
-
-			lbls = GetCIDRLabels(tc.prefix)
-			lblArray = lbls.LabelArray()
-			assert.ElementsMatch(t, lblArray, tc.expected)
 		})
 	}
-}
-
-func TestCIDRLabelsCache(t *testing.T) {
-	// save global config and restore it at the end of the test
-	enableIPv4, enableIPv6 := option.Config.EnableIPv4, option.Config.EnableIPv6
-	t.Cleanup(func() {
-		option.Config.EnableIPv4, option.Config.EnableIPv6 = enableIPv4, enableIPv6
-	})
-
-	prefixes := []netip.Prefix{
-		netip.MustParsePrefix("87.151.93.239/32"), netip.MustParsePrefix("87.151.93.238/31"),
-		netip.MustParsePrefix("87.151.93.236/30"), netip.MustParsePrefix("87.151.93.232/29"),
-		netip.MustParsePrefix("87.151.93.224/28"), netip.MustParsePrefix("87.151.93.224/27"),
-		netip.MustParsePrefix("87.151.93.192/26"), netip.MustParsePrefix("87.151.93.128/25"),
-		netip.MustParsePrefix("87.151.93.0/24"), netip.MustParsePrefix("87.151.92.0/23"),
-		netip.MustParsePrefix("87.151.92.0/22"), netip.MustParsePrefix("87.151.88.0/21"),
-		netip.MustParsePrefix("87.151.80.0/20"), netip.MustParsePrefix("87.151.64.0/19"),
-		netip.MustParsePrefix("87.151.64.0/18"), netip.MustParsePrefix("87.151.0.0/17"),
-		netip.MustParsePrefix("87.151.0.0/16"), netip.MustParsePrefix("87.150.0.0/15"),
-		netip.MustParsePrefix("87.148.0.0/14"), netip.MustParsePrefix("87.144.0.0/13"),
-		netip.MustParsePrefix("87.144.0.0/12"), netip.MustParsePrefix("87.128.0.0/11"),
-		netip.MustParsePrefix("87.128.0.0/10"), netip.MustParsePrefix("87.128.0.0/9"),
-		netip.MustParsePrefix("87.0.0.0/8"), netip.MustParsePrefix("86.0.0.0/7"),
-		netip.MustParsePrefix("84.0.0.0/6"), netip.MustParsePrefix("80.0.0.0/5"),
-		netip.MustParsePrefix("80.0.0.0/4"), netip.MustParsePrefix("64.0.0.0/3"),
-		netip.MustParsePrefix("64.0.0.0/2"), netip.MustParsePrefix("0.0.0.0/1"),
-		netip.MustParsePrefix("0.0.0.0/0"),
-	}
-	cidrLabels := []string{
-		"cidr:0.0.0.0/0",
-		"cidr:0.0.0.0/1", "cidr:64.0.0.0/2", "cidr:64.0.0.0/3", "cidr:80.0.0.0/4",
-		"cidr:80.0.0.0/5", "cidr:84.0.0.0/6", "cidr:86.0.0.0/7", "cidr:87.0.0.0/8",
-		"cidr:87.128.0.0/9", "cidr:87.128.0.0/10", "cidr:87.128.0.0/11", "cidr:87.144.0.0/12",
-		"cidr:87.144.0.0/13", "cidr:87.148.0.0/14", "cidr:87.150.0.0/15", "cidr:87.151.0.0/16",
-		"cidr:87.151.0.0/17", "cidr:87.151.64.0/18", "cidr:87.151.64.0/19", "cidr:87.151.80.0/20",
-		"cidr:87.151.88.0/21", "cidr:87.151.92.0/22", "cidr:87.151.92.0/23", "cidr:87.151.93.0/24",
-		"cidr:87.151.93.128/25", "cidr:87.151.93.192/26", "cidr:87.151.93.224/27", "cidr:87.151.93.224/28",
-		"cidr:87.151.93.232/29", "cidr:87.151.93.236/30", "cidr:87.151.93.238/31", "cidr:87.151.93.239/32",
-	}
-
-	// check all the labels computing them from the largest CIDR to the smaller ones.
-	forward := func() {
-		for i := 0; i < len(prefixes); i++ {
-			lbls := GetCIDRLabels(prefixes[i])
-			lblArray := lbls.LabelArray()
-
-			var expectedLblArray LabelArray
-			if prefixes[i] == prefixes[len(prefixes)-1] { // default route "0.0.0.0/0" should become "reserved:world"
-				expectedLblArray = ParseLabelArray("reserved:world")
-			} else {
-				expectedLbls := make([]string, len(cidrLabels)-i)
-				copy(expectedLbls, cidrLabels[:len(cidrLabels)-i])
-				expectedLblArray = ParseLabelArray(append(expectedLbls, "reserved:world")...)
-			}
-
-			assert.ElementsMatch(t, lblArray, expectedLblArray)
-		}
-	}
-	// check all the labels computing them from the smallest CIDR to the larger ones.
-	backward := func() {
-		for i := 0; i < len(prefixes); i++ {
-			lbls := GetCIDRLabels(prefixes[i])
-			lblArray := lbls.LabelArray()
-
-			var expectedLblArray LabelArray
-			if prefixes[i] == prefixes[len(prefixes)-1] { // default route "0.0.0.0/0" should become "reserved:world"
-				expectedLblArray = ParseLabelArray("reserved:world")
-			} else {
-				expectedLbls := make([]string, len(cidrLabels)-i)
-				copy(expectedLbls, cidrLabels[:len(cidrLabels)-i])
-				expectedLblArray = ParseLabelArray(append(expectedLbls, "reserved:world")...)
-			}
-
-			assert.ElementsMatch(t, lblArray, expectedLblArray)
-		}
-	}
-
-	option.Config.EnableIPv4, option.Config.EnableIPv6 = true, false
-
-	// First, compute all the labels starting from the largest CIDR to the smaller ones.
-	// This will warm up the LRU cache. Then, do it the other way around to verify that
-	// the cache has been populated correctly and results are consistent.
-
-	// clear the cache
-	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []Label](cidrLabelsCacheMaxSize, nil)
-
-	forward()
-	backward()
-
-	// Now, verify that the cache is populated correctly doing the opposite.
-
-	// clear the cache
-	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []Label](cidrLabelsCacheMaxSize, nil)
-
-	backward()
-	forward()
 }
 
 func TestIPStringToLabel(t *testing.T) {
@@ -483,167 +217,6 @@ func TestIPStringToLabel(t *testing.T) {
 		} else {
 			assert.Error(t, err)
 		}
-	}
-}
-
-func TestCIDRLabelsCacheHeapUsageIPv4(t *testing.T) {
-	t.Skip()
-
-	// save global config and restore it at the end of the test
-	enableIPv4, enableIPv6 := option.Config.EnableIPv4, option.Config.EnableIPv6
-	t.Cleanup(func() {
-		option.Config.EnableIPv4, option.Config.EnableIPv6 = enableIPv4, enableIPv6
-	})
-
-	option.Config.EnableIPv4, option.Config.EnableIPv6 = true, false
-
-	// clear the cache
-	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []Label](cidrLabelsCacheMaxSize, nil)
-
-	// be sure to fill the cache
-	prefixes := make([]netip.Prefix, 0, 256*256)
-	octets := [4]byte{0, 0, 1, 1}
-	for i := 0; i < 256*256; i++ {
-		octets[0], octets[1] = byte(i/256), byte(i%256)
-		prefixes = append(prefixes, netip.PrefixFrom(netip.AddrFrom4(octets), 32))
-	}
-
-	var m1, m2 runtime.MemStats
-	// One GC does not give precise results,
-	// because concurrent sweep may be still in progress.
-	runtime.GC()
-	runtime.GC()
-	runtime.ReadMemStats(&m1)
-
-	for _, cidr := range prefixes {
-		_ = GetCIDRLabels(cidr)
-	}
-
-	runtime.GC()
-	runtime.GC()
-	runtime.ReadMemStats(&m2)
-
-	usage := m2.HeapAlloc - m1.HeapAlloc
-	t.Logf("Memoization map heap usage: %.2f KiB", float64(usage)/1024)
-}
-
-func TestCIDRLabelsCacheHeapUsageIPv6(t *testing.T) {
-	t.Skip()
-
-	// save global config and restore it at the end of the test
-	enableIPv4, enableIPv6 := option.Config.EnableIPv4, option.Config.EnableIPv6
-	t.Cleanup(func() {
-		option.Config.EnableIPv4, option.Config.EnableIPv6 = enableIPv4, enableIPv6
-	})
-
-	option.Config.EnableIPv4, option.Config.EnableIPv6 = true, true
-
-	// clear the cache
-	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []Label](cidrLabelsCacheMaxSize, nil)
-
-	// be sure to fill the cache
-	prefixes := make([]netip.Prefix, 0, 256*256)
-	octets := [16]byte{
-		0x00, 0x00, 0x00, 0xd8, 0x33, 0x33, 0x44, 0x44,
-		0x55, 0x55, 0x66, 0x66, 0x77, 0x77, 0x88, 0x88,
-	}
-	for i := 0; i < 256*256; i++ {
-		octets[15], octets[14] = byte(i/256), byte(i%256)
-		prefixes = append(prefixes, netip.PrefixFrom(netip.AddrFrom16(octets), 128))
-	}
-
-	var m1, m2 runtime.MemStats
-	// One GC does not give precise results,
-	// because concurrent sweep may be still in progress.
-	runtime.GC()
-	runtime.GC()
-	runtime.ReadMemStats(&m1)
-
-	for _, cidr := range prefixes {
-		_ = GetCIDRLabels(cidr)
-	}
-
-	runtime.GC()
-	runtime.GC()
-	runtime.ReadMemStats(&m2)
-
-	usage := m2.HeapAlloc - m1.HeapAlloc
-	t.Logf("Memoization map heap usage: %.2f KiB", float64(usage)/1024)
-}
-
-func BenchmarkGetCIDRLabels(b *testing.B) {
-	// clear the cache
-	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []Label](cidrLabelsCacheMaxSize, nil)
-
-	for _, cidr := range []netip.Prefix{
-		netip.MustParsePrefix("0.0.0.0/0"),
-		netip.MustParsePrefix("10.16.0.0/16"),
-		netip.MustParsePrefix("192.0.2.3/32"),
-		netip.MustParsePrefix("192.0.2.3/24"),
-		netip.MustParsePrefix("192.0.2.0/24"),
-		netip.MustParsePrefix("::/0"),
-		netip.MustParsePrefix("fdff::ff/128"),
-		netip.MustParsePrefix("f00d:42::ff/128"),
-		netip.MustParsePrefix("f00d:42::ff/96"),
-	} {
-		b.Run(cidr.String(), func(b *testing.B) {
-			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				_ = GetCIDRLabels(cidr)
-			}
-		})
-	}
-}
-
-// This benchmarks SortedList(). We want to benchmark this specific case, as
-// it is excercised by toFQDN policies.
-func BenchmarkLabels_SortedListCIDRIDs(b *testing.B) {
-	// clear the cache
-	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []Label](cidrLabelsCacheMaxSize, nil)
-
-	lbls := GetCIDRLabels(netip.MustParsePrefix("123.123.123.123/32"))
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = lbls.SortedList()
-	}
-}
-
-func BenchmarkGetCIDRLabelsConcurrent(b *testing.B) {
-	prefixes := make([]netip.Prefix, 0, 16)
-	octets := [4]byte{0, 0, 1, 1}
-	for i := 0; i < 16; i++ {
-		octets[0], octets[1] = byte(rand.Intn(256)), byte(rand.Intn(256))
-		prefixes = append(prefixes, netip.PrefixFrom(netip.AddrFrom4(octets), 32))
-	}
-
-	for _, goroutines := range []int{1, 2, 4, 16, 32, 48} {
-		b.Run(strconv.Itoa(goroutines), func(b *testing.B) {
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				b.StopTimer()
-				start := make(chan struct{})
-				var wg sync.WaitGroup
-
-				wg.Add(goroutines)
-				for j := 0; j < goroutines; j++ {
-					go func() {
-						defer wg.Done()
-
-						<-start
-
-						for k := 0; k < 64; k++ {
-							_ = GetCIDRLabels(prefixes[rand.Intn(len(prefixes))])
-						}
-					}()
-				}
-
-				b.StartTimer()
-				close(start)
-				wg.Wait()
-			}
-		})
 	}
 }
 
@@ -717,7 +290,7 @@ func TestGetPrintableModel(t *testing.T) {
 			"cidr:10.0.1.0/24",
 			"cidr:192.168.0.0/24",
 			"cidr:fc00:c111::5/128",
-			"cidr:fc00:c112::0/64",
+			"cidr:fc00:c112::/64",
 			"k8s:foo=bar",
 			"reserved:remote-node",
 			"reserved:world-ipv4",

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -11,6 +11,10 @@ import (
 	"slices"
 	"sort"
 	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 const (
@@ -153,6 +157,10 @@ type Label struct {
 	//
 	// +kubebuilder:validation:Optional
 	Source string `json:"source"`
+
+	// optimization for CIDR prefixes
+	// +deepequal-gen=false
+	cidr *netip.Prefix `json:"-"`
 }
 
 // Labels is a map of labels where the map's key is the same as the label's key.
@@ -237,11 +245,21 @@ func NewLabel(key string, value string, source string) Label {
 		value = ""
 	}
 
-	return Label{
+	l := Label{
 		Key:    key,
 		Value:  value,
 		Source: source,
 	}
+	if l.Source == LabelSourceCIDR {
+		c, err := LabelToPrefix(l.Key)
+		if err != nil {
+			logrus.WithField("key", l.Key).WithError(err).Error("Failed to parse CIDR label: invalid prefix.")
+		} else {
+			l.cidr = &c
+		}
+	}
+
+	return l
 }
 
 // Equals returns true if source, Key and Value are equal and false otherwise.
@@ -263,20 +281,44 @@ func (l *Label) IsReservedSource() bool {
 }
 
 // Has returns true label L contains target.
-// target may be "looser" w.r.t source, i.e.
+// target may be "looser" w.r.t source or cidr, i.e.
 // "k8s:foo=bar".Has("any:foo=bar") is true
 // "any:foo=bar".Has("k8s:foo=bar") is false
+// "cidr:10.0.0.1/32".Has("cidr:10.0.0.0/24") is true
 func (l *Label) Has(target *Label) bool {
 	return l.HasKey(target) && l.Value == target.Value
 }
 
-// HasKey returns true if l has target's key
-// target may be "looser" w.r.t source, i.e.
+// HasKey returns true if l has target's key.
+// target may be "looser" w.r.t source or cidr, i.e.
 // "k8s:foo=bar".HasKey("any:foo") is true
 // "any:foo=bar".HasKey("k8s:foo") is false
+// "cidr:10.0.0.1/32".HasKey("cidr:10.0.0.0/24") is true
+// "cidr:10.0.0.0/24".HasKey("cidr:10.0.0.1/32") is false
 func (l *Label) HasKey(target *Label) bool {
 	if !target.IsAnySource() && l.Source != target.Source {
 		return false
+	}
+
+	// Do cidr-aware matching if both sources are "cidr".
+	if target.Source == LabelSourceCIDR && l.Source == LabelSourceCIDR {
+		tc := target.cidr
+		if tc == nil {
+			v, err := LabelToPrefix(target.Key)
+			if err != nil {
+				tc = &v
+			}
+		}
+		lc := l.cidr
+		if lc == nil {
+			v, err := LabelToPrefix(l.Key)
+			if err != nil {
+				lc = &v
+			}
+		}
+		if tc != nil && lc != nil && tc.Bits() <= lc.Bits() && tc.Contains(lc.Addr()) {
+			return true
+		}
 	}
 
 	return l.Key == target.Key
@@ -337,6 +379,15 @@ func (l *Label) UnmarshalJSON(data []byte) error {
 		l.Source = aux.Source
 		l.Key = aux.Key
 		l.Value = aux.Value
+	}
+
+	if l.Source == LabelSourceCIDR {
+		c, err := LabelToPrefix(l.Key)
+		if err == nil {
+			l.cidr = &c
+		} else {
+			logrus.WithField("key", l.Key).WithError(err).Error("Failed to parse CIDR label: invalid prefix.")
+		}
 	}
 
 	return nil
@@ -666,6 +717,18 @@ func parseLabel(str string, delim byte) (lbl Label) {
 		} else {
 			lbl.Key = next[:i]
 			lbl.Value = next[i+1:]
+		}
+	}
+
+	if lbl.Source == LabelSourceCIDR {
+		if lbl.Value != "" {
+			logrus.WithField(logfields.Label, lbl.String()).Error("Invalid CIDR label: labels with source cidr cannot have values.")
+		}
+		c, err := LabelToPrefix(lbl.Key)
+		if err != nil {
+			logrus.WithField(logfields.Label, str).WithError(err).Error("Failed to parse CIDR label: invalid prefix.")
+		} else {
+			lbl.cidr = &c
 		}
 	}
 	return lbl

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -364,10 +364,19 @@ func TestLabels_Has(t *testing.T) {
 		{
 			name: "has label",
 			l: Labels{
-				"foo":   NewLabel("foo", "bar", "any"),
+				"foo":   NewLabel("foo", "bar", "k8s"),
 				"other": NewLabel("other", "bar", ""),
 			},
-			in:   NewLabel("foo", "bar", "my-source"),
+			in:   NewLabel("foo", "bar", "k8s"),
+			want: true,
+		},
+		{
+			name: "has label, any source",
+			l: Labels{
+				"foo":   NewLabel("foo", "bar", "k8s"),
+				"other": NewLabel("other", "bar", ""),
+			},
+			in:   NewLabel("foo", "bar", "any"),
 			want: true,
 		},
 		{

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -6,6 +6,7 @@ package labels
 import (
 	"encoding/json"
 	"fmt"
+	"net/netip"
 	"reflect"
 	"strings"
 	"testing"
@@ -489,4 +490,59 @@ func TestLabel_String(t *testing.T) {
 	// without value
 	l = NewLabel("io.kubernetes.pod.namespace", "", LabelSourceK8s)
 	assert.Equal(t, "k8s:io.kubernetes.pod.namespace", l.String())
+}
+
+// test that the .cidr field is correctly populated
+func TestNewLabelCIDR(t *testing.T) {
+	for _, labelSpec := range []string{
+		"cidr:0--0/0",
+		"cidr:0--0/1", "cidr:0--0/2", "cidr:2000--0/3", "cidr:2000--0/4",
+		"cidr:2000--0/5", "cidr:2000--0/6", "cidr:2000--0/7", "cidr:2000--0/8",
+		"cidr:2000--0/9", "cidr:2000--0/10", "cidr:2000--0/11", "cidr:2000--0/12",
+		"cidr:2000--0/13", "cidr:2000--0/14", "cidr:2000--0/15", "cidr:2001--0/16",
+		"cidr:2001--0/17", "cidr:2001--0/18", "cidr:2001--0/19", "cidr:2001--0/20",
+		"cidr:2001-800--0/21", "cidr:2001-c00--0/22", "cidr:2001-c00--0/23", "cidr:2001-d00--0/24",
+		"cidr:2001-d80--0/25", "cidr:2001-d80--0/26", "cidr:2001-da0--0/27", "cidr:2001-db0--0/28",
+		"cidr:2001-db8--0/29", "cidr:2001-db8--0/30", "cidr:2001-db8--0/31", "cidr:2001-db8--0/32",
+		"cidr:2001-db8--0/33", "cidr:2001-db8--0/34", "cidr:2001-db8--0/35", "cidr:2001-db8--0/36",
+		"cidr:2001-db8--0/37", "cidr:2001-db8--0/38", "cidr:2001-db8--0/39", "cidr:2001-db8--0/40",
+		"cidr:2001-db8--0/41", "cidr:2001-db8--0/42", "cidr:2001-db8--0/43", "cidr:2001-db8--0/44",
+		"cidr:2001-db8--0/45", "cidr:2001-db8--0/46", "cidr:2001-db8--0/47", "cidr:2001-db8--0/48",
+		"cidr:2001-db8--0/49", "cidr:2001-db8--0/50", "cidr:2001-db8--0/51", "cidr:2001-db8--0/52",
+		"cidr:2001-db8--0/53", "cidr:2001-db8--0/54", "cidr:2001-db8--0/55", "cidr:2001-db8--0/56",
+		"cidr:2001-db8--0/57", "cidr:2001-db8--0/58", "cidr:2001-db8--0/59", "cidr:2001-db8--0/60",
+		"cidr:2001-db8--0/61", "cidr:2001-db8--0/62", "cidr:2001-db8--0/63", "cidr:2001-db8--0/64",
+		"cidr:2001-db8--0/65", "cidr:2001-db8--0/66", "cidr:2001-db8--0/67", "cidr:2001-db8--0/68",
+		"cidr:2001-db8--0/69", "cidr:2001-db8--0/70", "cidr:2001-db8--0/71", "cidr:2001-db8--0/72",
+		"cidr:2001-db8--0/73", "cidr:2001-db8--0/74", "cidr:2001-db8--0/75", "cidr:2001-db8--0/76",
+		"cidr:2001-db8--0/77", "cidr:2001-db8--0/78", "cidr:2001-db8--0/79", "cidr:2001-db8--0/80",
+		"cidr:2001-db8--0/81", "cidr:2001-db8--0/82", "cidr:2001-db8--0/83", "cidr:2001-db8--0/84",
+		"cidr:2001-db8--0/85", "cidr:2001-db8--0/86", "cidr:2001-db8--0/87", "cidr:2001-db8--0/88",
+		"cidr:2001-db8--0/89", "cidr:2001-db8--0/90", "cidr:2001-db8--0/91", "cidr:2001-db8--0/92",
+		"cidr:2001-db8--0/93", "cidr:2001-db8--0/94", "cidr:2001-db8--0/95", "cidr:2001-db8--0/96",
+		"cidr:2001-db8--0/97", "cidr:2001-db8--0/98", "cidr:2001-db8--0/99", "cidr:2001-db8--0/100",
+		"cidr:2001-db8--0/101", "cidr:2001-db8--0/102", "cidr:2001-db8--0/103", "cidr:2001-db8--0/104",
+		"cidr:2001-db8--0/105", "cidr:2001-db8--0/106", "cidr:2001-db8--0/107", "cidr:2001-db8--0/108",
+		"cidr:2001-db8--0/109", "cidr:2001-db8--0/110", "cidr:2001-db8--0/111", "cidr:2001-db8--0/112",
+		"cidr:2001-db8--0/113", "cidr:2001-db8--0/114", "cidr:2001-db8--0/115", "cidr:2001-db8--0/116",
+		"cidr:2001-db8--0/117", "cidr:2001-db8--0/118", "cidr:2001-db8--0/119", "cidr:2001-db8--0/120",
+		"cidr:2001-db8--0/121", "cidr:2001-db8--0/122", "cidr:2001-db8--0/123", "cidr:2001-db8--0/124",
+		"cidr:2001-db8--0/125", "cidr:2001-db8--0/126", "cidr:2001-db8--0/127", "cidr:2001-db8--1/128",
+		"cidr:1.1.1.1/32",
+	} {
+		lbl := ParseLabel(labelSpec)
+		assert.Equal(t, LabelSourceCIDR, lbl.Source)
+		assert.NotNil(t, lbl.cidr)
+		ll := strings.SplitN(labelSpec, ":", 2)
+		prefixString := strings.Replace(ll[1], "-", ":", -1)
+		assert.Equal(t, netip.MustParsePrefix(prefixString).String(), lbl.cidr.String())
+	}
+
+	for _, labelSpec := range []string{
+		"reserved:world", "k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=foo",
+	} {
+		lbl := ParseLabel(labelSpec)
+		assert.NotEqual(t, LabelSourceCIDR, lbl.Source)
+		assert.Nil(t, lbl.cidr)
+	}
 }

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -53,6 +53,9 @@ const (
 	// Labels are any label, they may not be relevant to the security identity.
 	Labels = "labels"
 
+	// Label is a singular label, where relevant
+	Label = "label"
+
 	// SourceFilter is the label or node information source
 	SourceFilter = "sourceFilter"
 

--- a/pkg/policy/selectorcache_selector.go
+++ b/pkg/policy/selectorcache_selector.go
@@ -180,28 +180,8 @@ func (f *fqdnSelector) setSelectorIPs(ips []netip.Addr) {
 
 // matches returns true if the identity contains at least one label
 // that is in wantLabels.
-// This is reasonably efficient, as it relies on both arrays being sorted.
 func (f *fqdnSelector) matches(identity scIdentity) bool {
-	wantIdx := 0
-	checkIdx := 0
-
-	// Both arrays are sorted; walk through until we get a match
-	for wantIdx < len(f.wantLabels) && checkIdx < len(identity.lbls) {
-		want := f.wantLabels[wantIdx]
-		check := identity.lbls[checkIdx]
-		if want == check {
-			return true
-		}
-
-		// Not equal, bump
-		if check.Key < want.Key {
-			checkIdx++
-		} else {
-			wantIdx++
-		}
-	}
-
-	return false
+	return identity.lbls.Intersects(f.wantLabels)
 }
 
 type labelIdentitySelector struct {

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -304,8 +304,8 @@ func (ds *SelectorCacheTestSuite) TestMultipleIdentitySelectors(c *C) {
 	}, nil, wg)
 	wg.Wait()
 
-	testSelector := api.NewESFromLabels(labels.NewLabel("app", "test", labels.LabelSourceK8s))
-	test2Selector := api.NewESFromLabels(labels.NewLabel("app", "test2", labels.LabelSourceK8s))
+	testSelector := api.NewESFromLabels(labels.NewLabel("app", "test", labels.LabelSourceAny))
+	test2Selector := api.NewESFromLabels(labels.NewLabel("app", "test2", labels.LabelSourceAny))
 
 	user1 := newUser(c, "user1", sc)
 	cached := user1.AddIdentitySelector(testSelector)
@@ -342,8 +342,8 @@ func (ds *SelectorCacheTestSuite) TestIdentityUpdates(c *C) {
 	}, nil, wg)
 	wg.Wait()
 
-	testSelector := api.NewESFromLabels(labels.NewLabel("app", "test", labels.LabelSourceK8s))
-	test2Selector := api.NewESFromLabels(labels.NewLabel("app", "test2", labels.LabelSourceK8s))
+	testSelector := api.NewESFromLabels(labels.NewLabel("app", "test", labels.LabelSourceAny))
+	test2Selector := api.NewESFromLabels(labels.NewLabel("app", "test2", labels.LabelSourceAny))
 
 	user1 := newUser(c, "user1", sc)
 	cached := user1.AddIdentitySelector(testSelector)

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -298,14 +298,25 @@ func (ds *SelectorCacheTestSuite) TestMultipleIdentitySelectors(c *C) {
 
 	// Add some identities to the identity cache
 	wg := &sync.WaitGroup{}
+	li1 := identity.IdentityScopeLocal
+	li2 := li1 + 1
 	sc.UpdateIdentities(cache.IdentityCache{
 		1234: labels.Labels{"app": labels.NewLabel("app", "test", labels.LabelSourceK8s)}.LabelArray(),
 		2345: labels.Labels{"app": labels.NewLabel("app", "test2", labels.LabelSourceK8s)}.LabelArray(),
+
+		li1: labels.GetCIDRLabels(netip.MustParsePrefix("10.0.0.1/32")).LabelArray(),
+		li2: labels.GetCIDRLabels(netip.MustParsePrefix("10.0.0.0/8")).LabelArray(),
 	}, nil, wg)
 	wg.Wait()
 
 	testSelector := api.NewESFromLabels(labels.NewLabel("app", "test", labels.LabelSourceAny))
 	test2Selector := api.NewESFromLabels(labels.NewLabel("app", "test2", labels.LabelSourceAny))
+
+	// Test both exact and broader CIDR selectors
+	cidr32Selector := api.NewESFromLabels(labels.NewLabel("cidr:10.0.0.1/32", "", labels.LabelSourceCIDR))
+	cidr24Selector := api.NewESFromLabels(labels.NewLabel("cidr:10.0.0.0/24", "", labels.LabelSourceCIDR))
+	cidr8Selector := api.NewESFromLabels(labels.NewLabel("cidr:10.0.0.0/8", "", labels.LabelSourceCIDR))
+	cidr7Selector := api.NewESFromLabels(labels.NewLabel("cidr:10.0.0.0/7", "", labels.LabelSourceCIDR))
 
 	user1 := newUser(c, "user1", sc)
 	cached := user1.AddIdentitySelector(testSelector)
@@ -323,6 +334,18 @@ func (ds *SelectorCacheTestSuite) TestMultipleIdentitySelectors(c *C) {
 	selections2 := cached2.GetSelections()
 	c.Assert(len(selections2), Equals, 1)
 	c.Assert(selections2[0], Equals, identity.NumericIdentity(2345))
+
+	shouldSelect := func(sel api.EndpointSelector, wantIDs ...identity.NumericIdentity) {
+		csel := user1.AddIdentitySelector(sel)
+		selections := csel.GetSelections()
+		c.Assert(selections, checker.DeepEquals, identity.NumericIdentitySlice(wantIDs))
+		user1.RemoveSelector(csel)
+	}
+
+	shouldSelect(cidr32Selector, li1)
+	shouldSelect(cidr24Selector, li1)
+	shouldSelect(cidr8Selector, li1, li2)
+	shouldSelect(cidr7Selector, li1, li2)
 
 	user1.RemoveSelector(cached)
 	user1.RemoveSelector(cached2)


### PR DESCRIPTION
CIDR labels are expensive. Very expensive. For an IPv6 prefix, `GetCidrLabels()` can take over 2 KiB of memory.

This change refactors the label internals so that CIDR labels match when the cidr is larger as well. Then, we no longer have to expand CIDR labels at all; the matching logic handles it correctly.

Note to reviewers: Please review by commit; earlier commits add some test invariants. Another commit lightly refactors the label matching API to try and bring some sanity. Only the final two commits change any logic.