### PR TITLE
Reduce flakiness of controlplane tests

### DIFF
--- a/test/controlplane/ciliumnetworkpolicies/status_updates_gc.go
+++ b/test/controlplane/ciliumnetworkpolicies/status_updates_gc.go
@@ -243,27 +243,7 @@ func init() {
 		// We only need to test the last k8s version
 		test := suite.NewControlPlaneTest(t, "cnp-status-update-control-plane", k8sVersions[len(k8sVersions)-1])
 
-		// When running with GC disabled, the Nodes Status updates should not be deleted.
-		test.
-			UpdateObjects(initialObjects...).
-			SetupEnvironment().
-			// check that CNPs contain status updates info before starting agent and operator
-			Eventually(func() error { return validateCNPs(test) }).
-			StartAgent(func(_ *option.DaemonConfig) {}).
-			StartOperator(
-				func(operatorCfg *operatorOption.OperatorConfig) {
-				},
-				func(vp *viper.Viper) {
-					vp.Set(operatorApi.OperatorAPIServeAddr, "localhost:0")
-				},
-			).
-			Eventually(func() error { return validateCNPs(test) }).
-			StopAgent().
-			StopOperator().
-			DeleteObjects(initialObjects...).
-			ClearEnvironment()
-
-		// When running with GC enabled, the Nodes Status updates should eventually be deleted.
+		// CNP nodes status updates are deprecated and should be deleted.
 		test.
 			UpdateObjects(initialObjects...).
 			SetupEnvironment().

--- a/test/controlplane/node/ciliumnodes/ciliumnodes.go
+++ b/test/controlplane/node/ciliumnodes/ciliumnodes.go
@@ -90,7 +90,9 @@ func init() {
 				test.
 					UpdateObjectsFromFile(abs("init.yaml")).
 					SetupEnvironment().
+					RecordWatchers().
 					StartAgent(modConfig).
+					EnsureWatchers("nodes").
 					ClearEnvironment()
 
 				// Run through the test steps

--- a/test/controlplane/pod/hostport/hostport.go
+++ b/test/controlplane/pod/hostport/hostport.go
@@ -36,7 +36,9 @@ func testHostPort(t *testing.T) {
 	test.
 		UpdateObjectsFromFile(abs("init.yaml")).
 		SetupEnvironment().
+		RecordWatchers().
 		StartAgent(func(_ *option.DaemonConfig) {}).
+		EnsureWatchers("pods").
 
 		// Step 1: Create the first hostport pod.
 		// lbmap1.golden: Hostport service exists in the Datapath with hostport-1 pod as backend.

--- a/test/controlplane/services/dualstack/dualstack.go
+++ b/test/controlplane/services/dualstack/dualstack.go
@@ -40,7 +40,9 @@ func testDualStack(t *testing.T) {
 			test.
 				UpdateObjectsFromFile(abs("init.yaml")).
 				SetupEnvironment().
+				RecordWatchers().
 				StartAgent(modConfig).
+				EnsureWatchers("endpointslices", "services").
 				UpdateObjectsFromFile(abs("state1.yaml")).
 				Eventually(func() error { return validate(abs("lbmap1.golden"), test) }).
 				StopAgent().

--- a/test/controlplane/services/graceful-termination/graceful_termination.go
+++ b/test/controlplane/services/graceful-termination/graceful_termination.go
@@ -40,7 +40,9 @@ func testGracefulTermination(t *testing.T) {
 	test.
 		UpdateObjectsFromFile(abs("init.yaml")).
 		SetupEnvironment().
+		RecordWatchers().
 		StartAgent(modConfig).
+		EnsureWatchers("endpointslices", "services").
 
 		// Step 1: Initial creation of the services and backends
 		// lbmap1.golden: Shows graceful-term-svc service with an active backend

--- a/test/controlplane/services/nodeport/nodeport.go
+++ b/test/controlplane/services/nodeport/nodeport.go
@@ -40,7 +40,9 @@ func init() {
 					test.
 						UpdateObjectsFromFile(abs("init.yaml")).
 						SetupEnvironment().
+						RecordWatchers().
 						StartAgent(modConfig).
+						EnsureWatchers("endpointslices", "pods", "services").
 						UpdateObjectsFromFile(abs("state1.yaml")).
 						Eventually(func() error { return validate(test, abs("lbmap1_"+nodeName+".golden")) }).
 						StopAgent().

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -469,8 +469,6 @@ var _ watch.Interface = &filteringWatcher{}
 
 func (fw *filteringWatcher) Stop() {
 	fw.parent.Stop()
-	close(fw.events)
-	fw.events = nil
 }
 
 func (fw *filteringWatcher) ResultChan() <-chan watch.Event {
@@ -486,6 +484,7 @@ func (fw *filteringWatcher) ResultChan() <-chan watch.Event {
 				fw.events <- event
 			}
 		}
+		close(fw.events)
 	}()
 	return fw.events
 }

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -36,6 +36,7 @@ import (
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node/types"
 	agentOption "github.com/cilium/cilium/pkg/option"
 )
@@ -50,12 +51,13 @@ type ControlPlaneTest struct {
 	tempDir           string
 	validationTimeout time.Duration
 
-	nodeName       string
-	clients        *k8sClient.FakeClientset
-	trackers       []trackerAndDecoder
-	agentHandle    *agentHandle
-	operatorHandle *operatorHandle
-	Datapath       *fakeTypes.FakeDatapath
+	nodeName            string
+	clients             *k8sClient.FakeClientset
+	trackers            []trackerAndDecoder
+	agentHandle         *agentHandle
+	operatorHandle      *operatorHandle
+	Datapath            *fakeTypes.FakeDatapath
+	establishedWatchers lock.Map[string, struct{}]
 }
 
 func NewControlPlaneTest(t *testing.T, nodeName string, k8sVersion string) *ControlPlaneTest {
@@ -254,6 +256,48 @@ func (cpt *ControlPlaneTest) Get(gvr schema.GroupVersionResource, ns, name strin
 		}
 	}
 	return nil, err
+}
+
+// RecordWatchers intercepts 'Watch' calls on the fake k8s clientsets. The reason we need to do this
+// is the following: The k8s object tracker's implementation of Watch is not equivalent to Watch on
+// a real api-server, as it does not respect the ResourceVersion from whence to start the watch. As
+// a consequence, when informers (or reflectors) call ListAndWatch, they miss events which occur
+// between the end of List and the establishment of Watch.
+//
+// To decrease the likelihood of this race occurring in the control plane tests, we install a
+// mechanism to wait for watchers of specific resources: see also EnsureWatchers. This isn't a
+// complete fix - if multiple watchers for the same resource are established, this may give false
+// positives.
+func (cpt *ControlPlaneTest) RecordWatchers() *ControlPlaneTest {
+	reaction := func(action k8sTesting.Action) (handled bool, ret watch.Interface, err error) {
+		r := action.GetResource().Resource
+		if _, ok := cpt.establishedWatchers.Load(r); ok {
+			cpt.t.Logf("WARNING: Multiple watches for resource %s intercepted. This highlights a potential cause for flakes", r)
+		}
+		cpt.establishedWatchers.Store(r, struct{}{})
+		return false, nil, nil
+	}
+
+	cpt.clients.SlimFakeClientset.PrependWatchReactor("*", reaction)
+	cpt.clients.KubernetesFakeClientset.PrependWatchReactor("*", reaction)
+	cpt.clients.CiliumFakeClientset.PrependWatchReactor("*", reaction)
+	cpt.clients.APIExtFakeClientset.PrependWatchReactor("*", reaction)
+	return cpt
+}
+
+// EnsureWatchers delays progress of the test until watchers for resources have been established on
+// the clientset.
+func (cpt *ControlPlaneTest) EnsureWatchers(resources ...string) *ControlPlaneTest {
+	cpt.retry(func() error {
+		for _, resource := range resources {
+			if _, ok := cpt.establishedWatchers.Load(resource); !ok {
+				return fmt.Errorf("no watcher for %s yet", resource)
+			}
+		}
+		return nil
+	})
+
+	return cpt
 }
 
 func (cpt *ControlPlaneTest) UpdateObjectsFromFile(filename string) *ControlPlaneTest {


### PR DESCRIPTION
The control plane tests were suffering from the same race as found in #30873. Introduce a mechanism to (mostly) prevent it from happening. And while at it, also fix the send on closed channel panic of #30646 and remove an obsolete test.

Fixes: #30892
Fixes: #30807
Fixes: #30646
Fixes: #21682