### PR TITLE
daemon/k8s: take context for more graceful stop

### DIFF
--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
-	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -120,7 +119,6 @@ func (d *Daemon) getPodForEndpoint(ep *endpoint.Endpoint) error {
 	if option.Config.EnableHighScaleIPcache {
 		pod, _, _, _, _, err = d.fetchK8sMetadataForEndpoint(ep.K8sNamespace, ep.K8sPodName)
 	} else {
-		d.k8sWatcher.WaitForCacheSync(resources.K8sAPIGroupPodV1Core)
 		pod, err = d.k8sWatcher.GetCachedPod(ep.K8sNamespace, ep.K8sPodName)
 	}
 	if err != nil && k8serrors.IsNotFound(err) {

--- a/pkg/k8s/synced/resources_test.go
+++ b/pkg/k8s/synced/resources_test.go
@@ -4,6 +4,7 @@
 package synced
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -121,7 +122,7 @@ func TestWaitForCacheSyncWithTimeout(t *testing.T) {
 					})
 				}
 
-				err := r.WaitForCacheSyncWithTimeout(test.timeout, test.resourceNames...)
+				err := r.WaitForCacheSyncWithTimeout(context.TODO(), test.timeout, test.resourceNames...)
 				if test.expectErr == nil {
 					assert.NoError(err)
 				} else {

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -999,7 +999,7 @@ func (k *K8sWatcher) deletePodHostData(pod *slim_corev1.Pod) (bool, error) {
 //   - false: returns any pod in the cluster received by the pod watcher.
 func (k *K8sWatcher) GetCachedPod(namespace, name string) (*slim_corev1.Pod, error) {
 	<-k.controllersStarted
-	k.WaitForCacheSync(resources.K8sAPIGroupPodV1Core)
+	k.WaitForCacheSync(context.TODO(), resources.K8sAPIGroupPodV1Core)
 	<-k.podStoreSet
 	k.podStoreMU.RLock()
 	defer k.podStoreMU.RUnlock()


### PR DESCRIPTION
The controlplane test suite fails with fatal logs every now and then, as it tries to start and stop the agent in a relatively rapid fashion. The agent is not great at graceful shutdown, especially so when Stop is attempted while still starting up.

One of the problems is that a lot of the startup code does not take contexts, or does not respect cancellation of contexts when doing long(ish) running operations.

The following patch alleviates one such problem, the k8s subsystem initialisation, which lead to fatal logs of the following form:

    msg="Timed out waiting for pre-existing resources to be received; exiting"

with an included error of

    error="timed out after 3m0s, never received event for resource <some resource>"

My hypothesis is that this fatal log stems from an agent "instance" that was stopped in a previous (successful) control plane test. No attempt is made at ensuring that all of the many goroutines spawned at startup are cleaned up. Since the agent is spawned in-process, any leftover goroutine from previous starts can call `log.Fatal` and hence `os.Exit`, instantly killing the current process.

Pushing through the daemon context (which is cancelled on hive.Stop as part of the Stop hook of the daemonPromise) and handling it more correctly means that the k8s subsystem initialisation correctly stops upon context cancellation.