### PR TITLE
Align again conformance clustermesh matrix entries with main as the interoperability issue has been fixed

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -174,9 +174,8 @@ jobs:
             ipfamily: 'dual'
             encryption: 'wireguard'
             kube-proxy: 'iptables'
-            mode: 'clustermesh'
-            cm-auth-mode-1: 'cluster'
-            cm-auth-mode-2: 'cluster'
+            mode: 'external'
+            maxConnectedClusters: '511'
 
     steps:
       - name: Checkout context ref (trusted)


### PR DESCRIPTION
Now that a known interoperability issue between external kvstore and wireguard has been fixed \[1\], let also switch the last conformance clustermesh matrix entry to use the external kvstore, for symmetry with v1.15 and main.

\[1\]: 2e7a1c3c6db7 ("node: Fix inconsistent EncryptKey index handling")

Fixes: a5de29e58908 ("gha: extend conformance clustermesh to also cover external kvstores")
