### PR TITLE
Additionally test host firewall + KPR disabled in E2E tests

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -83,6 +83,7 @@ jobs:
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'
+            host-fw: 'true'
 
           - name: '2'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -90,6 +91,7 @@ jobs:
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'disabled'
+            host-fw: 'true'
 
           - name: '3'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -83,6 +83,7 @@ jobs:
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'
+            host-fw: 'true'
 
           - name: '2'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -90,6 +91,7 @@ jobs:
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'disabled'
+            host-fw: 'true'
 
           - name: '3'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind


### PR DESCRIPTION
Let's additionally enable host firewall on a couple of existing matrix entries associated with KPR disabled, so that we can additionally cover this configuration and prevent regressions.

~~Currently depends on an unreleased version of the Cilium CLI~~