### PR TITLE
Centralize configuration of kind version/image in GitHub Action workflows

### DIFF
--- a/.github/actions/lvh-kind/action.yaml
+++ b/.github/actions/lvh-kind/action.yaml
@@ -8,7 +8,8 @@ inputs:
   kind-params:
     required: true
     type: string
-  kind-image-vsn:
+  kind-image:
+    required: true
     type: string
   test-name:
     required: true
@@ -36,9 +37,8 @@ runs:
         provision: 'false'
         cmd: |
           cd /host
-          if [ "${{ inputs.kind-image-vsn }}" != "" ]; then
-            export IMAGE=kindest/node:${{ inputs.kind-image-vsn }}
-          fi
+
+          export IMAGE=${{ inputs.kind-image }}
           ./contrib/scripts/kind.sh ${{ inputs.kind-params }} 0.0.0.0 6443
 
     - name: Copy kubeconfig

--- a/.github/actions/set-env-variables/action.yml
+++ b/.github/actions/set-env-variables/action.yml
@@ -16,3 +16,13 @@ runs:
         echo "CILIUM_CLI_VERSION=$CILIUM_CLI_VERSION" >> $GITHUB_ENV
         echo "PUSH_TO_DOCKER_HUB=true" >> $GITHUB_ENV
         echo "GCP_PERF_RESULTS_BUCKET=gs://cilium-scale-results" >> $GITHUB_ENV
+
+        # renovate: datasource=github-releases depName=kubernetes-sigs/kind
+        KIND_VERSION="v0.22.0"
+        # renovate: datasource=docker
+        KIND_K8S_IMAGE="kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245"
+        KIND_K8S_VERSION=$(echo "$KIND_K8S_IMAGE" | sed -r 's|.+:(v[0-9a-z.-]+)(@.+)?|\1|')
+
+        echo "KIND_VERSION=$KIND_VERSION" >> $GITHUB_ENV
+        echo "KIND_K8S_IMAGE=$KIND_K8S_IMAGE" >> $GITHUB_ENV
+        echo "KIND_K8S_VERSION=$KIND_K8S_VERSION" >> $GITHUB_ENV

--- a/.github/kind-config-ipv6.yaml
+++ b/.github/kind-config-ipv6.yaml
@@ -2,7 +2,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.29.1@sha256:a0cc28af37cf39b019e2b448c54d1a3f789de32536cb5a5db61a49623e527144
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -12,7 +11,6 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: kindest/node:v1.29.1@sha256:a0cc28af37cf39b019e2b448c54d1a3f789de32536cb5a5db61a49623e527144
 networking:
   ipFamily: ipv6
   disableDefaultCNI: true

--- a/.github/kind-config.yaml
+++ b/.github/kind-config.yaml
@@ -2,7 +2,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.29.1@sha256:a0cc28af37cf39b019e2b448c54d1a3f789de32536cb5a5db61a49623e527144
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -12,7 +11,6 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: kindest/node:v1.29.1@sha256:a0cc28af37cf39b019e2b448c54d1a3f789de32536cb5a5db61a49623e527144
 networking:
   disableDefaultCNI: true
   podSubnet: "10.244.0.0/16"

--- a/.github/kind-config.yaml.tmpl
+++ b/.github/kind-config.yaml.tmpl
@@ -2,7 +2,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:${K8S_VERSION}
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -12,9 +11,7 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: kindest/node:${K8S_VERSION}
   - role: worker
-    image: kindest/node:${K8S_VERSION}
 networking:
   disableDefaultCNI: true
   ipFamily: ${IPFAMILY}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,8 +13,6 @@
     ".github/actions/lvh-kind/**",
     ".github/actions/set-env-variables/action.yml",
     ".github/workflows/**",
-    ".github/kind-config.yaml",
-    ".github/kind-config-ipv6.yaml",
     "images/**",
     "examples/hubble/*",
     "go.mod",
@@ -502,7 +500,8 @@
         "^.github/actions/set-env-variables/action\\.yml$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+_VERSION=\"(?<currentValue>.*)\""
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+_VERSION=\"(?<currentValue>.*)\"",
+        "# renovate: datasource=(?<datasource>.*?)\\s+KIND_K8S_IMAGE=\"(?<depName>.*):(?<currentValue>.*)@(?<currentDigest>sha256:[a-f0-9]+)\""
       ]
     },
     {

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -55,10 +55,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  kind_version: v0.22.0
-  # renovate: datasource=docker depName=kindest/node
-  k8s_version: v1.29.2
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
   clusterName1: cluster1-${{ github.run_id }}
@@ -301,15 +297,13 @@ jobs:
 
       - name: Generate Kind configuration files
         run: |
-          K8S_VERSION=${{ env.k8s_version }} \
-            PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_1 }} \
+          PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_1 }} \
             SVCCIDR=${{ steps.vars.outputs.kind_svc_cidr_1 }} \
             IPFAMILY=${{ matrix.ipFamily }} \
             KUBEPROXYMODE=${{ matrix.kube-proxy }} \
             envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster1.yaml
 
-          K8S_VERSION=${{ env.k8s_version }} \
-            PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_2 }} \
+          PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_2 }} \
             SVCCIDR=${{ steps.vars.outputs.kind_svc_cidr_2 }} \
             IPFAMILY=${{ matrix.ipFamily }} \
             KUBEPROXYMODE=${{ matrix.kube-proxy }} \
@@ -319,8 +313,9 @@ jobs:
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
           cluster_name: ${{ env.clusterName1 }}
-          version: ${{ env.kind_version }}
-          kubectl_version: ${{ env.k8s_version }}
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ./.github/kind-config-cluster1.yaml
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
@@ -328,8 +323,9 @@ jobs:
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
           cluster_name: ${{ env.clusterName2 }}
-          version: ${{ env.kind_version }}
-          kubectl_version: ${{ env.k8s_version }}
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ./.github/kind-config-cluster2.yaml
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -301,6 +301,7 @@ jobs:
           test-name: e2e-conformance
           kernel: ${{ matrix.kernel }}
           kind-params: "${{ steps.kind-params.outputs.params }}"
+          kind-image: ${{ env.KIND_K8S_IMAGE }}
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -58,8 +58,6 @@ concurrency:
 env:
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  kind_version: v0.22.0
   kind_config: .github/kind-config.yaml
   gateway_api_version: v1.0.0
   timeout: 5m
@@ -149,7 +147,9 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
-          version: ${{ env.kind_version }}
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
 
       - name: Install Go

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -151,6 +151,7 @@ jobs:
           node_image: ${{ env.KIND_K8S_IMAGE }}
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
+          wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Install Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -57,8 +57,6 @@ concurrency:
 env:
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  kind_version: v0.22.0
   kind_config: .github/kind-config.yaml
   timeout: 5m
 
@@ -169,7 +167,9 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
-          version: ${{ env.kind_version }}
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
 
       - name: Checkout ingress-controller-conformance

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -171,6 +171,7 @@ jobs:
           node_image: ${{ env.KIND_K8S_IMAGE }}
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
+          wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Checkout ingress-controller-conformance
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -187,6 +187,7 @@ jobs:
           test-name: e2e-conformance
           kernel: ${{ matrix.kernel }}
           kind-params: "${{ steps.kind-params.outputs.params }}"
+          kind-image: ${{ env.KIND_K8S_IMAGE }}
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.

--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -77,7 +77,7 @@ jobs:
           cat <<EOF | /usr/local/bin/kind create cluster \
             --name ${{ env.cluster_name}}           \
             --image ${{ env.KIND_K8S_IMAGE }}  \
-            -v7 --wait 1m --retain --config=-
+            -v7 --retain --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
           networking:

--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -21,13 +21,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  kind_version: v0.22.0
   cluster_name: cilium-testing
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=docker depName=kindest/node
-  k8s_version: v1.29.2
 
 jobs:
   kubernetes-e2e-net-conformance:
@@ -60,14 +56,14 @@ jobs:
         run: |
           TMP_DIR=$(mktemp -d)
           # Test binaries
-          curl -L https://dl.k8s.io/${{ env.k8s_version }}/kubernetes-test-linux-amd64.tar.gz -o ${TMP_DIR}/kubernetes-test-linux-amd64.tar.gz
+          curl -L https://dl.k8s.io/${{ env.KIND_K8S_VERSION }}/kubernetes-test-linux-amd64.tar.gz -o ${TMP_DIR}/kubernetes-test-linux-amd64.tar.gz
           tar xvzf ${TMP_DIR}/kubernetes-test-linux-amd64.tar.gz \
             --directory ${TMP_DIR} \
             --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test
           # kubectl
-          curl -L https://dl.k8s.io/${{ env.k8s_version }}/bin/linux/amd64/kubectl -o ${TMP_DIR}/kubectl
+          curl -L https://dl.k8s.io/${{ env.KIND_K8S_VERSION }}/bin/linux/amd64/kubectl -o ${TMP_DIR}/kubectl
           # kind
-          curl -Lo ${TMP_DIR}/kind https://kind.sigs.k8s.io/dl/${{ env.kind_version }}/kind-linux-amd64
+          curl -Lo ${TMP_DIR}/kind https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION }}/kind-linux-amd64
           # Install
           sudo cp ${TMP_DIR}/ginkgo /usr/local/bin/ginkgo
           sudo cp ${TMP_DIR}/e2e.test /usr/local/bin/e2e.test
@@ -80,7 +76,7 @@ jobs:
         run: |
           cat <<EOF | /usr/local/bin/kind create cluster \
             --name ${{ env.cluster_name}}           \
-            --image kindest/node:${{ env.k8s_version }}  \
+            --image ${{ env.KIND_K8S_IMAGE }}  \
             -v7 --wait 1m --retain --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -77,7 +77,7 @@ jobs:
           cat <<EOF | /usr/local/bin/kind create cluster \
             --name ${{ env.cluster_name}}           \
             --image ${{ env.KIND_K8S_IMAGE }}  \
-            -v7 --wait 1m --retain --config=-
+            -v7 --retain --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
           networking:

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -21,13 +21,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  kind_version: v0.22.0
   cluster_name: cilium-testing
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=docker depName=kindest/node
-  k8s_version: v1.29.2
 
 jobs:
   kubernetes-e2e:
@@ -60,14 +56,14 @@ jobs:
         run: |
           TMP_DIR=$(mktemp -d)
           # Test binaries
-          curl -L https://dl.k8s.io/${{ env.k8s_version }}/kubernetes-test-linux-amd64.tar.gz -o ${TMP_DIR}/kubernetes-test-linux-amd64.tar.gz
+          curl -L https://dl.k8s.io/${{ env.KIND_K8S_VERSION }}/kubernetes-test-linux-amd64.tar.gz -o ${TMP_DIR}/kubernetes-test-linux-amd64.tar.gz
           tar xvzf ${TMP_DIR}/kubernetes-test-linux-amd64.tar.gz \
             --directory ${TMP_DIR} \
             --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test
           # kubectl
-          curl -L https://dl.k8s.io/${{ env.k8s_version }}/bin/linux/amd64/kubectl -o ${TMP_DIR}/kubectl
+          curl -L https://dl.k8s.io/${{ env.KIND_K8S_VERSION }}/bin/linux/amd64/kubectl -o ${TMP_DIR}/kubectl
           # kind
-          curl -Lo ${TMP_DIR}/kind https://kind.sigs.k8s.io/dl/${{ env.kind_version }}/kind-linux-amd64
+          curl -Lo ${TMP_DIR}/kind https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION }}/kind-linux-amd64
           # Install
           sudo cp ${TMP_DIR}/ginkgo /usr/local/bin/ginkgo
           sudo cp ${TMP_DIR}/e2e.test /usr/local/bin/e2e.test
@@ -80,7 +76,7 @@ jobs:
         run: |
           cat <<EOF | /usr/local/bin/kind create cluster \
             --name ${{ env.cluster_name}}           \
-            --image kindest/node:${{ env.k8s_version }}  \
+            --image ${{ env.KIND_K8S_IMAGE }}  \
             -v7 --wait 1m --retain --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
@@ -242,4 +238,3 @@ jobs:
         uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
         with:
           junit-directory: "_artifacts"
-

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -85,6 +85,7 @@ jobs:
           node_image: ${{ env.KIND_K8S_IMAGE }}
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.KIND_CONFIG }}
+          wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Install cilium chart
         id: install-cilium

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -12,8 +12,6 @@ permissions: read-all
 
 env:
   cilium_cli_ci_version:
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  KIND_VERSION: v0.22.0
   KIND_CONFIG: .github/kind-config.yaml
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check.yaml
   TIMEOUT: 2m
@@ -84,6 +82,8 @@ jobs:
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
           version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.KIND_CONFIG }}
 
       - name: Install cilium chart

--- a/.github/workflows/conformance-kind-proxy-daemonset.yaml
+++ b/.github/workflows/conformance-kind-proxy-daemonset.yaml
@@ -85,6 +85,7 @@ jobs:
           node_image: ${{ env.KIND_K8S_IMAGE }}
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
+          wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Wait for images to be available
         timeout-minutes: 30

--- a/.github/workflows/conformance-kind-proxy-daemonset.yaml
+++ b/.github/workflows/conformance-kind-proxy-daemonset.yaml
@@ -21,8 +21,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  kind_version: v0.22.0
   kind_config: .github/kind-config.yaml
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
@@ -83,7 +81,9 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
-          version: ${{ env.kind_version }}
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
 
       - name: Wait for images to be available

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -56,8 +56,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  kind_version: v0.22.0
   kind_config: .github/kind-config.yaml
   timeout: 5m
 
@@ -171,7 +169,9 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
-          version: ${{ env.kind_version }}
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
 
       - name: Wait for images to be available

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -173,6 +173,7 @@ jobs:
           node_image: ${{ env.KIND_K8S_IMAGE }}
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
+          wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Wait for images to be available
         timeout-minutes: 30

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -55,10 +55,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  kind_version: v0.22.0
-  # renovate: datasource=docker depName=kindest/node
-  k8s_version: v1.29.2
   cilium_cli_ci_version:
 
   clusterName1: cluster1
@@ -201,15 +197,13 @@ jobs:
 
       - name: Generate Kind configuration files
         run: |
-          K8S_VERSION=${{ env.k8s_version }} \
-            PODCIDR=10.242.0.0/16,fd00:10:242::/48 \
+          PODCIDR=10.242.0.0/16,fd00:10:242::/48 \
             SVCCIDR=10.243.0.0/16,fd00:10:243::/112 \
             IPFAMILY=dual \
             KUBEPROXYMODE=${{ matrix.kube-proxy }} \
             envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster1.yaml
 
-          K8S_VERSION=${{ env.k8s_version }} \
-            PODCIDR=10.244.0.0/16,fd00:10:244::/48 \
+          PODCIDR=10.244.0.0/16,fd00:10:244::/48 \
             SVCCIDR=10.245.0.0/16,fd00:10:245::/112 \
             IPFAMILY=dual \
             KUBEPROXYMODE=${{ matrix.kube-proxy }} \
@@ -219,8 +213,9 @@ jobs:
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
           cluster_name: ${{ env.clusterName1 }}
-          version: ${{ env.kind_version }}
-          kubectl_version: ${{ env.k8s_version }}
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ./.github/kind-config-cluster1.yaml
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
@@ -228,8 +223,9 @@ jobs:
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
           cluster_name: ${{ env.clusterName2 }}
-          version: ${{ env.kind_version }}
-          kubectl_version: ${{ env.k8s_version }}
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ./.github/kind-config-cluster2.yaml
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -317,6 +317,7 @@ jobs:
           cmd: |
             cd /host/
 
+            export IMAGE=${{ env.KIND_K8S_IMAGE }}
             IP_FAM="dual"
             if [ "${{ matrix.ipv6 }}" == "false" ]; then
               IP_FAM="ipv4"

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -52,8 +52,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  # renovate: datasource=docker depName=kindest/node
-  k8s_version: v1.29.2
 
 jobs:
   commit-status-start:
@@ -257,7 +255,7 @@ jobs:
           test-name: e2e-conformance
           kernel: ${{ matrix.kernel }}
           kind-params: "${{ steps.kind-params.outputs.params }}"
-          kind-image-vsn: ${k8s_version}
+          kind-image: ${{ env.KIND_K8S_IMAGE }}
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -17,8 +17,6 @@ concurrency:
 env:
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  KIND_VERSION: v0.22.0
   KIND_CONFIG: .github/kind-config-ipv6.yaml
   # Skip external traffic (e.g. 1.1.1.1 and www.google.com) due to no support for IPv6 in github action
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
@@ -99,6 +97,8 @@ jobs:
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
           version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.KIND_CONFIG }}
 
       - name: Wait for images to be available

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -100,6 +100,7 @@ jobs:
           node_image: ${{ env.KIND_K8S_IMAGE }}
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.KIND_CONFIG }}
+          wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Wait for images to be available
         timeout-minutes: 30

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -19,8 +19,6 @@ concurrency:
 env:
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  KIND_VERSION: v0.22.0
   KIND_CONFIG: .github/kind-config.yaml
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check.yaml
   TIMEOUT: 2m
@@ -116,6 +114,8 @@ jobs:
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
           version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.KIND_CONFIG }}
 
       - name: Wait for images to be available

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -117,6 +117,7 @@ jobs:
           node_image: ${{ env.KIND_K8S_IMAGE }}
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.KIND_CONFIG }}
+          wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Wait for images to be available
         timeout-minutes: 30


### PR DESCRIPTION
Let's define kind-related variables (i.e., version, k8s image and k8s version) inside the set-env-variables action. This ensures consistency across workflows, simplify version bumps as well as the introduction of new workflows depending on them. One extra byproduct is that renovate updates will also stop requesting reviews from all the different teams owning each specific workflow. Additionally, let's also stop waiting for kind clusters to become ready, as they will never, because no CNI is present at that point.

Note: a few pull-request based workflows are currently failing, because they use the `set-env-variables` checked out from the main branch, which doesn't contain the additional variables. This will be fixed after merging this PR.

```release-note
Centralize configuration of kind version/image in GitHub Action workflows
```
