### PR TITLE
health-server: Do not cleanup health checking result on node updates.

### DIFF
--- a/pkg/health/server/prober_test.go
+++ b/pkg/health/server/prober_test.go
@@ -12,6 +12,7 @@ import (
 
 	check "github.com/cilium/checkmate"
 
+	ciliumModels "github.com/cilium/cilium/api/v1/health/models"
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/checker"
 )
@@ -146,7 +147,15 @@ func (s *HealthServerTestSuite) TestProbersetNodes(c *check.C) {
 		}},
 	}
 	c.Assert(sortNodes(nodes), checker.DeepEquals, sortNodes(expected))
-
+	// Set result of probing before updating the nodes.
+	// The result should not be deleted after node update.
+	if elem, ok := prober.results[ipString(node1.NodeElement.PrimaryAddress.IPV4.IP)]; ok {
+		elem.Icmp = &ciliumModels.ConnectivityStatus{
+			Status: "Some status",
+		}
+	} else {
+		c.Errorf("expected to find result element for node's ip %s", node1.NodeElement.PrimaryAddress.IPV4.IP)
+	}
 	// Update node 1. Node 2 should remain unaffected.
 	modifiedNodesOld := nodeMap{
 		ipString(node1.Name): node1,
@@ -163,6 +172,13 @@ func (s *HealthServerTestSuite) TestProbersetNodes(c *check.C) {
 		IP: node1HealthIP,
 	}}
 	c.Assert(sortNodes(nodes), checker.DeepEquals, sortNodes(expected))
+	if elem, ok := prober.results[ipString(node1.NodeElement.PrimaryAddress.IPV4.IP)]; !ok {
+		c.Errorf("expected to find result element for node's ip %s", node1.NodeElement.PrimaryAddress.IPV4.IP)
+	} else {
+		// Check that status was not removed when updating node
+		c.Assert(elem.Icmp, check.NotNil)
+		c.Assert(elem.Icmp.Status, checker.Equals, "Some status")
+	}
 
 	// Remove node 1. Again, Node 2 should remain.
 	removedNodes := nodeMap{

--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -341,7 +341,8 @@ func (s *Server) runActiveServices() error {
 		// OnIdle is called every ProbeInterval after sending out all icmp pings.
 		// There are a few important consideration here:
 		// (1) ICMP prober doesn't report failed probes
-		// (2) We can receive the same nodes multiple times in nodesAdded in case of updates
+		// (2) We can receive the same nodes multiple times,
+		// updated node is present in both nodesAdded and nodesRemoved
 		// (3) We need to clean icmp status to not retain stale probe results
 		// (4) We don't want to report stale nodes in metrics
 


### PR DESCRIPTION
Whenever a node was updated, healtch-checking was removing and re-adding that node. This caused it to lose information about previously performed probes, which resulted in `unknown` status for such nodes. This can happen often, especially in ENI mode, where node updates happen each time a new pod is scheduled on the node.

Backstory:
#29566 fixed issue where we were reporting deleted nodes as unhealthy, but it introduced an issue when the updating node was overriding probe status, marking such nodes status as unreachable. Fix in #30504 changed it to mark such nodes as unknown. Now we are preserving probe status on node updates.

Fixes: #29566

```release-note
Fixed issue when updated nodes were being reported with unknown connectivity status in health report
```
