### PR TITLE
pkg/ip: Updates PrefixToIps() to Limit the Number of Returned IPs

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -405,7 +405,7 @@ func parseENI(iface *ec2_types.NetworkInterface, vpcs ipamTypes.VirtualNetworkMa
 	}
 
 	for _, prefix := range iface.Ipv4Prefixes {
-		ips, e := ipPkg.PrefixToIps(aws.ToString(prefix.Ipv4Prefix))
+		ips, e := ipPkg.PrefixToIps(aws.ToString(prefix.Ipv4Prefix), 0)
 		if e != nil {
 			err = fmt.Errorf("unable to parse CIDR %s: %w", aws.ToString(prefix.Ipv4Prefix), e)
 			return

--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -450,7 +450,7 @@ func assignPrefixToENI(e *API, eni *eniTypes.ENI, prefixes int32) error {
 
 		prefixStr := pfx.String()
 		eni.Prefixes = append(eni.Prefixes, prefixStr)
-		prefixIPs, err := ip.PrefixToIps(prefixStr)
+		prefixIPs, err := ip.PrefixToIps(prefixStr, 0)
 		if err != nil {
 			return fmt.Errorf("unable to convert prefix %s to ips", prefixStr)
 		}
@@ -498,7 +498,7 @@ func (e *API) UnassignENIPrefixes(ctx context.Context, eniID string, prefixes []
 			return fmt.Errorf("Invalid CIDR block %s", prefix)
 		}
 		e.pdAllocator.Release(ipNet)
-		ips, _ := ip.PrefixToIps(prefix)
+		ips, _ := ip.PrefixToIps(prefix, 0)
 		addresses = append(addresses, ips...)
 	}
 

--- a/pkg/aws/ec2/mock/mock_test.go
+++ b/pkg/aws/ec2/mock/mock_test.go
@@ -149,7 +149,7 @@ func (e *MockSuite) TestPrefixToIps(c *check.C) {
 	subnet, err := cidrSet.AllocateNext()
 	c.Assert(err, check.IsNil)
 	subnetStr := subnet.String()
-	ips, _ := ip.PrefixToIps(subnetStr)
+	ips, _ := ip.PrefixToIps(subnetStr, 0)
 	c.Assert(ips[0], checker.Equals, "10.128.0.0")
 	c.Assert(ips[len(ips)-1], checker.Equals, "10.128.0.15")
 }

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -291,20 +291,27 @@ func PrefixCeil(numIPs int, multiple int) int {
 	return quotient
 }
 
-// PrefixToIps converts the given prefix to an array containing all IPs in the prefix / CIDR block.
-func PrefixToIps(prefixCidr string) ([]string, error) {
+// PrefixToIps converts the given prefix to an array containing IPs in the provided
+// prefix/CIDR block. When maxIPs is set to 0, the returned array will contain all IPs
+// in the given prefix. Otherwise, the returned array of IPs will be limited to the
+// value of maxIPs starting at the first IP in the provided CIDR. For example, when
+// providing 192.168.1.0/28 as a CIDR with 4 maxIPs, 192.168.1.0, 192.168.1.1,
+// 192.168.1.2, 192.168.1.3 will be returned.
+func PrefixToIps(prefixCidr string, maxIPs int) ([]string, error) {
 	var prefixIps []string
 	_, ipNet, err := net.ParseCIDR(prefixCidr)
 	if err != nil {
 		return prefixIps, err
 	}
 	netWithRange := ipNetToRange(*ipNet)
-	for ip := *netWithRange.First; !ip.Equal(*netWithRange.Last); ip = GetNextIP(ip) {
+	// Ensure last IP in the prefix is included
+	for ip := *netWithRange.First; len(prefixIps) < maxIPs || maxIPs == 0; ip = GetNextIP(ip) {
 		prefixIps = append(prefixIps, ip.String())
+		if ip.Equal(*netWithRange.Last) {
+			break
+		}
 	}
 
-	// Add the last IP
-	prefixIps = append(prefixIps, netWithRange.Last.String())
 	return prefixIps, nil
 }
 

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -1041,3 +1041,59 @@ func (s *IPTestSuite) TestMustAddrsFromIPs(c *C) {
 	}()
 	_ = MustAddrsFromIPs(nilIPs)
 }
+
+func (s *IPTestSuite) TestPrefixToIpsValidIPv4(c *C) {
+	prefix := "192.168.1.0/30"
+	expectedIPs := []string{"192.168.1.0", "192.168.1.1", "192.168.1.2", "192.168.1.3"}
+	ips, err := PrefixToIps(prefix, 0)
+	c.Assert(err, IsNil)
+	c.Assert(ips, checker.DeepEquals, expectedIPs)
+}
+
+func (s *IPTestSuite) TestPrefixToIpsValidLimitedIPv4(c *C) {
+	prefix := "192.168.1.0/28"
+	expectedIPs := []string{"192.168.1.0", "192.168.1.1", "192.168.1.2", "192.168.1.3"}
+	ips, err := PrefixToIps(prefix, 4)
+	c.Assert(err, IsNil)
+	c.Assert(ips, checker.DeepEquals, expectedIPs)
+}
+
+func (s *IPTestSuite) TestPrefixToIpsValidIPv6(c *C) {
+	prefix := "2001:DB8::/126"
+	expectedIPs := []string{"2001:db8::", "2001:db8::1", "2001:db8::2", "2001:db8::3"}
+	ips, err := PrefixToIps(prefix, 0)
+	c.Assert(err, IsNil)
+	c.Assert(ips, checker.DeepEquals, expectedIPs)
+}
+
+func (s *IPTestSuite) TestPrefixToIpsValidLimitedIPv6(c *C) {
+	prefix := "2001:DB8::/80"
+	expectedIPs := []string{"2001:db8::", "2001:db8::1", "2001:db8::2", "2001:db8::3"}
+	ips, err := PrefixToIps(prefix, 4)
+	c.Assert(err, IsNil)
+	c.Assert(ips, checker.DeepEquals, expectedIPs)
+}
+
+func (s *IPTestSuite) TestPrefixToIPsInvalidPrefix(c *C) {
+	prefix := "invalid"
+	ips, err := PrefixToIps(prefix, 0)
+	c.Assert(err, NotNil)
+	c.Assert(ips, HasLen, 0)
+}
+
+func (s *IPTestSuite) TestPrefixToIPv4sEdgeCase(c *C) {
+	prefix := "192.168.1.255/32"
+	expectedIPs := []string{"192.168.1.255"}
+	ips, err := PrefixToIps(prefix, 0)
+	c.Assert(err, IsNil)
+	c.Assert(ips, checker.DeepEquals, expectedIPs)
+}
+
+func (s *IPTestSuite) TestPrefixToIpsWithMaxIPv4sExceedingRange(c *C) {
+	prefix := "192.168.1.0/30"
+	maxIPs := 10 // Intentionally exceeding the available IPs in the prefix
+	expectedIPs := []string{"192.168.1.0", "192.168.1.1", "192.168.1.2", "192.168.1.3"}
+	ips, err := PrefixToIps(prefix, maxIPs)
+	c.Assert(err, IsNil)
+	c.Assert(ips, checker.DeepEquals, expectedIPs)
+}


### PR DESCRIPTION
Previously, PrefixToIps() would generate and return all the IP addresses in the provided CIDR. This creates performance and scalability issues when working with large IPv6 CIDRs. This PR adds the `maxIPs` parameter to limit the number of generated and returned prefixes.

Supports #19251