### PR TITLE
gha: drop unused check_url environment variable

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -57,7 +57,6 @@ env:
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   commit-status-start:

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -56,7 +56,6 @@ env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   # renovate: datasource=github-releases depName=eksctl-io/eksctl
   eksctl_version: v0.171.0
   # renovate: datasource=github-releases depName=kubernetes/kubernetes

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -65,7 +65,6 @@ env:
   clusterName2: cluster2-${{ github.run_id }}
   contextName1: kind-cluster1-${{ github.run_id }}
   contextName2: kind-cluster2-${{ github.run_id }}
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   commit-status-start:

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -52,7 +52,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   commit-status-start:

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -56,7 +56,6 @@ env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   # renovate: datasource=github-releases depName=eksctl-io/eksctl
   eksctl_version: v0.171.0
   # renovate: datasource=github-releases depName=kubernetes/kubernetes

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -58,7 +58,6 @@ env:
   vmStartupScript: .github/gcp-vm-startup.sh
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
 
 jobs:

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -50,9 +50,6 @@ concurrency:
     }}
   cancel-in-progress: true
 
-env:
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
 jobs:
   setup-vars:
     name: Setup Vars

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -56,7 +56,6 @@ env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
 
 jobs:

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -52,7 +52,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   commit-status-start:

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -41,7 +41,6 @@ env:
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
   test_name: gke-perf
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
   gcp_zone: us-east5-a
   k8s_version: 1.28

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -51,7 +51,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   # renovate: datasource=golang-version depName=go
   go-version: 1.22.0
 

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -52,7 +52,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   commit-status-start:

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -52,7 +52,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   # renovate: datasource=docker depName=kindest/node
   k8s_version: v1.29.2
 

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -56,7 +56,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   commit-status-start:


### PR DESCRIPTION
This variable used to be used in combination with the `Sibz/github-status-action` action, which we replaced with `myrotvorets/set-commit-status-action` when reworking the workflows to be triggered by Ariane \[1\]. Given it is now unused, let's get rid of the leftover environment variable, so that we also stop copying it to new workflows.

\[1\]: 9949c5a1891a ("ci: rework workflows to be triggered by Ariane")