### PR TITLE
job: avoid a race condition in TestTimer_ExitOnCloseFnCtx

### DIFF
--- a/pkg/hive/job/job_test.go
+++ b/pkg/hive/job/job_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -600,13 +601,11 @@ func TestTimer_ExitOnCloseFnCtx(t *testing.T) {
 	h := fixture(func(r Registry, s cell.Scope, l cell.Lifecycle) {
 		g := r.NewGroup(s)
 
+		var closer sync.Once
 		g.Add(
 			Timer("on-interval", func(ctx context.Context) error {
 				i++
-				if started != nil {
-					close(started)
-					started = nil
-				}
+				closer.Do(func() { close(started) })
 				<-ctx.Done()
 				return nil
 			}, 1*time.Millisecond),


### PR DESCRIPTION
The test attempted to avoid closing a channel multiple times by setting 'started' to nil. However, since the outer scope will wait on 'started', if started is set to nil before the outer scope waits, it will wait indefinitely - resulting in a time out of the test.

Fixes: daa85a0f4a (jobs,test: Fix TestTimer_ExitOnCloseFnCtx channel close panic)

Fixes: #30927 

