### PR TITLE
bandwidth: test: don't unlock OS thread too early

### DIFF
--- a/pkg/datapath/linux/bandwidth/ops_test.go
+++ b/pkg/datapath/linux/bandwidth/ops_test.go
@@ -21,7 +21,6 @@ import (
 
 func freshNetNS(t *testing.T) {
 	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
 
 	oldNetNS, err := netns.Get()
 	assert.NoError(t, err)
@@ -30,6 +29,7 @@ func freshNetNS(t *testing.T) {
 	t.Cleanup(func() {
 		testNetNS.Close()
 		netns.Set(oldNetNS)
+		runtime.UnlockOSThread()
 	})
 }
 


### PR DESCRIPTION
The idea of freshNetNS is to create a new network namespace to isolate the test from the system at large. In order to do so in Go, one must also lock the current goroutine to a specific OS thread and prevent other goroutines from being scheduled on that OS thread. Conveniently, runtime.LockOSThread does exactly that.

However, freshNetNS was flawed in that it called runtime.UnlockOSThread too early - creation of the network namespace was locked to the current OS thread, but unlocking it means that the goroutine may be scheduled to another at any point, as well as other goroutines potentially interfering with "our" network namespace, as they are scheduled on "our" OS thread.

Fix this by calling UnlockOSThread only after the test has completed, via t.Cleanup.

Fixes: 450a541849 (bandwidth: Reconciler for qdisc setup)

Fixes: #30899