### PR TITLE
policy/k8s: Add support for CIDRGroupRef in IngressDeny and EgressDeny

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -193,7 +193,8 @@ spec:
                             description: CIDRGroupRef is a reference to a CiliumCIDRGroup
                               object. A CiliumCIDRGroup contains a list of CIDRs that
                               the endpoint, subject to the rule, can (Ingress/Egress)
-                              or cannot (IngressDeny) receive connections from.
+                              or cannot (IngressDeny/EgressDeny) receive connections
+                              from.
                             maxLength: 253
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
@@ -1154,7 +1155,8 @@ spec:
                             description: CIDRGroupRef is a reference to a CiliumCIDRGroup
                               object. A CiliumCIDRGroup contains a list of CIDRs that
                               the endpoint, subject to the rule, can (Ingress/Egress)
-                              or cannot (IngressDeny) receive connections from.
+                              or cannot (IngressDeny/EgressDeny) receive connections
+                              from.
                             maxLength: 253
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
@@ -1706,7 +1708,8 @@ spec:
                             description: CIDRGroupRef is a reference to a CiliumCIDRGroup
                               object. A CiliumCIDRGroup contains a list of CIDRs that
                               the endpoint, subject to the rule, can (Ingress/Egress)
-                              or cannot (IngressDeny) receive connections from.
+                              or cannot (IngressDeny/EgressDeny) receive connections
+                              from.
                             maxLength: 253
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
@@ -2537,7 +2540,8 @@ spec:
                             description: CIDRGroupRef is a reference to a CiliumCIDRGroup
                               object. A CiliumCIDRGroup contains a list of CIDRs that
                               the endpoint, subject to the rule, can (Ingress/Egress)
-                              or cannot (IngressDeny) receive connections from.
+                              or cannot (IngressDeny/EgressDeny) receive connections
+                              from.
                             maxLength: 253
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
@@ -3136,7 +3140,8 @@ spec:
                               description: CIDRGroupRef is a reference to a CiliumCIDRGroup
                                 object. A CiliumCIDRGroup contains a list of CIDRs
                                 that the endpoint, subject to the rule, can (Ingress/Egress)
-                                or cannot (IngressDeny) receive connections from.
+                                or cannot (IngressDeny/EgressDeny) receive connections
+                                from.
                               maxLength: 253
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
@@ -4113,7 +4118,8 @@ spec:
                               description: CIDRGroupRef is a reference to a CiliumCIDRGroup
                                 object. A CiliumCIDRGroup contains a list of CIDRs
                                 that the endpoint, subject to the rule, can (Ingress/Egress)
-                                or cannot (IngressDeny) receive connections from.
+                                or cannot (IngressDeny/EgressDeny) receive connections
+                                from.
                               maxLength: 253
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
@@ -4671,7 +4677,8 @@ spec:
                               description: CIDRGroupRef is a reference to a CiliumCIDRGroup
                                 object. A CiliumCIDRGroup contains a list of CIDRs
                                 that the endpoint, subject to the rule, can (Ingress/Egress)
-                                or cannot (IngressDeny) receive connections from.
+                                or cannot (IngressDeny/EgressDeny) receive connections
+                                from.
                               maxLength: 253
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
@@ -5515,7 +5522,8 @@ spec:
                               description: CIDRGroupRef is a reference to a CiliumCIDRGroup
                                 object. A CiliumCIDRGroup contains a list of CIDRs
                                 that the endpoint, subject to the rule, can (Ingress/Egress)
-                                or cannot (IngressDeny) receive connections from.
+                                or cannot (IngressDeny/EgressDeny) receive connections
+                                from.
                               maxLength: 253
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -197,7 +197,8 @@ spec:
                             description: CIDRGroupRef is a reference to a CiliumCIDRGroup
                               object. A CiliumCIDRGroup contains a list of CIDRs that
                               the endpoint, subject to the rule, can (Ingress/Egress)
-                              or cannot (IngressDeny) receive connections from.
+                              or cannot (IngressDeny/EgressDeny) receive connections
+                              from.
                             maxLength: 253
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
@@ -1158,7 +1159,8 @@ spec:
                             description: CIDRGroupRef is a reference to a CiliumCIDRGroup
                               object. A CiliumCIDRGroup contains a list of CIDRs that
                               the endpoint, subject to the rule, can (Ingress/Egress)
-                              or cannot (IngressDeny) receive connections from.
+                              or cannot (IngressDeny/EgressDeny) receive connections
+                              from.
                             maxLength: 253
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
@@ -1710,7 +1712,8 @@ spec:
                             description: CIDRGroupRef is a reference to a CiliumCIDRGroup
                               object. A CiliumCIDRGroup contains a list of CIDRs that
                               the endpoint, subject to the rule, can (Ingress/Egress)
-                              or cannot (IngressDeny) receive connections from.
+                              or cannot (IngressDeny/EgressDeny) receive connections
+                              from.
                             maxLength: 253
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
@@ -2541,7 +2544,8 @@ spec:
                             description: CIDRGroupRef is a reference to a CiliumCIDRGroup
                               object. A CiliumCIDRGroup contains a list of CIDRs that
                               the endpoint, subject to the rule, can (Ingress/Egress)
-                              or cannot (IngressDeny) receive connections from.
+                              or cannot (IngressDeny/EgressDeny) receive connections
+                              from.
                             maxLength: 253
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
@@ -3140,7 +3144,8 @@ spec:
                               description: CIDRGroupRef is a reference to a CiliumCIDRGroup
                                 object. A CiliumCIDRGroup contains a list of CIDRs
                                 that the endpoint, subject to the rule, can (Ingress/Egress)
-                                or cannot (IngressDeny) receive connections from.
+                                or cannot (IngressDeny/EgressDeny) receive connections
+                                from.
                               maxLength: 253
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
@@ -4117,7 +4122,8 @@ spec:
                               description: CIDRGroupRef is a reference to a CiliumCIDRGroup
                                 object. A CiliumCIDRGroup contains a list of CIDRs
                                 that the endpoint, subject to the rule, can (Ingress/Egress)
-                                or cannot (IngressDeny) receive connections from.
+                                or cannot (IngressDeny/EgressDeny) receive connections
+                                from.
                               maxLength: 253
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
@@ -4675,7 +4681,8 @@ spec:
                               description: CIDRGroupRef is a reference to a CiliumCIDRGroup
                                 object. A CiliumCIDRGroup contains a list of CIDRs
                                 that the endpoint, subject to the rule, can (Ingress/Egress)
-                                or cannot (IngressDeny) receive connections from.
+                                or cannot (IngressDeny/EgressDeny) receive connections
+                                from.
                               maxLength: 253
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
@@ -5519,7 +5526,8 @@ spec:
                               description: CIDRGroupRef is a reference to a CiliumCIDRGroup
                                 object. A CiliumCIDRGroup contains a list of CIDRs
                                 that the endpoint, subject to the rule, can (Ingress/Egress)
-                                or cannot (IngressDeny) receive connections from.
+                                or cannot (IngressDeny/EgressDeny) receive connections
+                                from.
                               maxLength: 253
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string

--- a/pkg/policy/api/cidr.go
+++ b/pkg/policy/api/cidr.go
@@ -35,7 +35,8 @@ type CIDRRule struct {
 
 	// CIDRGroupRef is a reference to a CiliumCIDRGroup object.
 	// A CiliumCIDRGroup contains a list of CIDRs that the endpoint, subject to
-	// the rule, can (Ingress/Egress) or cannot (IngressDeny) receive connections from.
+	// the rule, can (Ingress/Egress) or cannot (IngressDeny/EgressDeny) receive
+	// connections from.
 	//
 	// +kubebuilder:validation:OneOf
 	CIDRGroupRef CIDRGroupRef `json:"cidrGroupRef,omitempty"`

--- a/pkg/policy/k8s/cilium_cidr_group.go
+++ b/pkg/policy/k8s/cilium_cidr_group.go
@@ -132,6 +132,13 @@ func specHasCIDRGroupRef(spec *api.Rule, cidrGroup string) bool {
 			}
 		}
 	}
+	for _, egress := range spec.EgressDeny {
+		for _, rule := range egress.ToCIDRSet {
+			if string(rule.CIDRGroupRef) == cidrGroup {
+				return true
+			}
+		}
+	}
 	return false
 }
 
@@ -165,6 +172,13 @@ func getCIDRGroupRefs(cnp *types.SlimCNP) []string {
 			}
 		}
 		for _, egress := range spec.Egress {
+			for _, rule := range egress.ToCIDRSet {
+				if len(rule.Cidr) == 0 {
+					cidrGroupRefs = append(cidrGroupRefs, string(rule.CIDRGroupRef))
+				}
+			}
+		}
+		for _, egress := range spec.EgressDeny {
 			for _, rule := range egress.ToCIDRSet {
 				if len(rule.Cidr) == 0 {
 					cidrGroupRefs = append(cidrGroupRefs, string(rule.CIDRGroupRef))
@@ -215,6 +229,9 @@ func translateSpec(spec *api.Rule, cidrsSets map[string][]api.CIDR) {
 	}
 	for i := range spec.Egress {
 		spec.Egress[i].ToCIDRSet = translateCIDRRuleSlice(spec.Egress[i].ToCIDRSet, cidrsSets)
+	}
+	for i := range spec.EgressDeny {
+		spec.EgressDeny[i].ToCIDRSet = translateCIDRRuleSlice(spec.EgressDeny[i].ToCIDRSet, cidrsSets)
 	}
 }
 

--- a/pkg/policy/k8s/cilium_cidr_group.go
+++ b/pkg/policy/k8s/cilium_cidr_group.go
@@ -118,6 +118,13 @@ func specHasCIDRGroupRef(spec *api.Rule, cidrGroup string) bool {
 			}
 		}
 	}
+	for _, ingress := range spec.IngressDeny {
+		for _, rule := range ingress.FromCIDRSet {
+			if string(rule.CIDRGroupRef) == cidrGroup {
+				return true
+			}
+		}
+	}
 	for _, egress := range spec.Egress {
 		for _, rule := range egress.ToCIDRSet {
 			if string(rule.CIDRGroupRef) == cidrGroup {
@@ -150,11 +157,15 @@ func getCIDRGroupRefs(cnp *types.SlimCNP) []string {
 				}
 			}
 		}
+		for _, ingress := range spec.IngressDeny {
+			for _, rule := range ingress.FromCIDRSet {
+				if len(rule.Cidr) == 0 {
+					cidrGroupRefs = append(cidrGroupRefs, string(rule.CIDRGroupRef))
+				}
+			}
+		}
 		for _, egress := range spec.Egress {
 			for _, rule := range egress.ToCIDRSet {
-				// If CIDR is not set, then we assume CIDRGroupRef is set due
-				// to OneOf, even if CIDRGroupRef is empty, as that's still a
-				// valid reference (although useless from a user perspective).
 				if len(rule.Cidr) == 0 {
 					cidrGroupRefs = append(cidrGroupRefs, string(rule.CIDRGroupRef))
 				}
@@ -197,63 +208,43 @@ func translateCIDRGroupRefs(cnp *types.SlimCNP, cidrsSets map[string][]api.CIDR)
 
 func translateSpec(spec *api.Rule, cidrsSets map[string][]api.CIDR) {
 	for i := range spec.Ingress {
-		var (
-			oldRules api.CIDRRuleSlice
-			refRules []api.CIDRRule
-		)
-
-		for _, rule := range spec.Ingress[i].FromCIDRSet {
-			if rule.CIDRGroupRef == "" {
-				// keep rules without a cidr group reference
-				oldRules = append(oldRules, rule)
-				continue
-			}
-			// collect all rules with references to a cidr group
-			refRules = append(refRules, rule)
-		}
-
-		// add rules for each cidr in the referenced cidr groups
-		var newRules api.CIDRRuleSlice
-		for _, refRule := range refRules {
-			cidrs, found := cidrsSets[string(refRule.CIDRGroupRef)]
-			if !found || len(cidrs) == 0 {
-				continue
-			}
-			for _, cidr := range cidrs {
-				newRules = append(newRules, api.CIDRRule{Cidr: cidr, ExceptCIDRs: refRule.ExceptCIDRs})
-			}
-		}
-
-		spec.Ingress[i].FromCIDRSet = append(oldRules, newRules...)
+		spec.Ingress[i].FromCIDRSet = translateCIDRRuleSlice(spec.Ingress[i].FromCIDRSet, cidrsSets)
+	}
+	for i := range spec.IngressDeny {
+		spec.IngressDeny[i].FromCIDRSet = translateCIDRRuleSlice(spec.IngressDeny[i].FromCIDRSet, cidrsSets)
 	}
 	for i := range spec.Egress {
-		var (
-			oldRules api.CIDRRuleSlice
-			refRules []api.CIDRRule
-		)
-
-		for _, rule := range spec.Egress[i].ToCIDRSet {
-			if rule.CIDRGroupRef == "" {
-				// keep rules without a cidr group reference
-				oldRules = append(oldRules, rule)
-				continue
-			}
-			// collect all rules with references to a cidr group
-			refRules = append(refRules, rule)
-		}
-
-		// add rules for each cidr in the referenced cidr groups
-		var newRules api.CIDRRuleSlice
-		for _, refRule := range refRules {
-			cidrs, found := cidrsSets[string(refRule.CIDRGroupRef)]
-			if !found || len(cidrs) == 0 {
-				continue
-			}
-			for _, cidr := range cidrs {
-				newRules = append(newRules, api.CIDRRule{Cidr: cidr, ExceptCIDRs: refRule.ExceptCIDRs})
-			}
-		}
-
-		spec.Egress[i].ToCIDRSet = append(oldRules, newRules...)
+		spec.Egress[i].ToCIDRSet = translateCIDRRuleSlice(spec.Egress[i].ToCIDRSet, cidrsSets)
 	}
+}
+
+func translateCIDRRuleSlice(cidrRules api.CIDRRuleSlice, cidrsSets map[string][]api.CIDR) api.CIDRRuleSlice {
+	var (
+		oldRules api.CIDRRuleSlice
+		refRules []api.CIDRRule
+	)
+
+	for _, rule := range cidrRules {
+		if rule.CIDRGroupRef == "" {
+			// keep rules without a cidr group reference
+			oldRules = append(oldRules, rule)
+			continue
+		}
+		// collect all rules with references to a cidr group
+		refRules = append(refRules, rule)
+	}
+
+	// add rules for each cidr in the referenced cidr groups
+	var newRules api.CIDRRuleSlice
+	for _, refRule := range refRules {
+		cidrs, found := cidrsSets[string(refRule.CIDRGroupRef)]
+		if !found || len(cidrs) == 0 {
+			continue
+		}
+		for _, cidr := range cidrs {
+			newRules = append(newRules, api.CIDRRule{Cidr: cidr, ExceptCIDRs: refRule.ExceptCIDRs})
+		}
+	}
+
+	return append(oldRules, newRules...)
 }

--- a/pkg/policy/k8s/cilium_cidr_group_test.go
+++ b/pkg/policy/k8s/cilium_cidr_group_test.go
@@ -41,7 +41,7 @@ func TestHasCIDRGroupRef(t *testing.T) {
 			expected:  false,
 		},
 		{
-			name: "nil Ingress and IngressDeny",
+			name: "nil Ingress and Egress",
 			cnp: &types.SlimCNP{
 				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
 					TypeMeta: metav1.TypeMeta{
@@ -81,6 +81,33 @@ func TestHasCIDRGroupRef(t *testing.T) {
 						{
 							Ingress:     []api.IngressRule{},
 							IngressDeny: []api.IngressDenyRule{},
+						},
+					},
+				},
+			},
+			cidrGroup: "cidr-group-1",
+			expected:  false,
+		},
+		{
+			name: "nil ToCidrSet rule",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						Egress:     []api.EgressRule{},
+						EgressDeny: []api.EgressDenyRule{},
+					},
+					Specs: api.Rules{
+						{
+							Egress:     []api.EgressRule{},
+							EgressDeny: []api.EgressDenyRule{},
 						},
 					},
 				},
@@ -203,6 +230,51 @@ func TestHasCIDRGroupRef(t *testing.T) {
 			expected:  true,
 		},
 		{
+			name: "CIDRGroupRef in Egress Spec",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						Egress: []api.EgressRule{
+							{
+								EgressCommonRule: api.EgressCommonRule{
+									ToCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-1",
+										},
+									},
+								},
+							},
+						},
+					},
+					Specs: api.Rules{
+						{
+							Egress: []api.EgressRule{
+								{
+									EgressCommonRule: api.EgressCommonRule{
+										ToCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-2",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cidrGroup: "cidr-group-1",
+			expected:  true,
+		},
+		{
 			name: "CIDRGroupRef in IngressDeny Spec",
 			cnp: &types.SlimCNP{
 				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
@@ -233,6 +305,51 @@ func TestHasCIDRGroupRef(t *testing.T) {
 								{
 									IngressCommonRule: api.IngressCommonRule{
 										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-2",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cidrGroup: "cidr-group-1",
+			expected:  true,
+		},
+		{
+			name: "CIDRGroupRef in EgressDeny Spec",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						EgressDeny: []api.EgressDenyRule{
+							{
+								EgressCommonRule: api.EgressCommonRule{
+									ToCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-1",
+										},
+									},
+								},
+							},
+						},
+					},
+					Specs: api.Rules{
+						{
+							EgressDeny: []api.EgressDenyRule{
+								{
+									EgressCommonRule: api.EgressCommonRule{
+										ToCIDRSet: api.CIDRRuleSlice{
 											{
 												CIDRGroupRef: "cidr-group-2",
 											},
@@ -599,7 +716,7 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 			expected: []string{"cidr-group-1"},
 		},
 		{
-			name: "nil Ingress and IngressDeny",
+			name: "nil Ingress and Egress",
 			cnp: &types.SlimCNP{
 				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
 					TypeMeta: metav1.TypeMeta{
@@ -645,6 +762,32 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name: "nil Egress and EgressDeny ToCidrSet rule",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						Egress:     []api.EgressRule{},
+						EgressDeny: []api.EgressDenyRule{},
+					},
+					Specs: api.Rules{
+						{
+							Egress:     []api.EgressRule{},
+							EgressDeny: []api.EgressDenyRule{},
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
 			name: "single FromCidrSet rule",
 			cnp: &types.SlimCNP{
 				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
@@ -673,7 +816,29 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 								IngressCommonRule: api.IngressCommonRule{
 									FromCIDRSet: api.CIDRRuleSlice{
 										{
+											CIDRGroupRef: "cidr-group-2",
+										},
+									},
+								},
+							},
+						},
+						Egress: []api.EgressRule{
+							{
+								EgressCommonRule: api.EgressCommonRule{
+									ToCIDRSet: api.CIDRRuleSlice{
+										{
 											CIDRGroupRef: "cidr-group-3",
+										},
+									},
+								},
+							},
+						},
+						EgressDeny: []api.EgressDenyRule{
+							{
+								EgressCommonRule: api.EgressCommonRule{
+									ToCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-4",
 										},
 									},
 								},
@@ -687,7 +852,7 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 									IngressCommonRule: api.IngressCommonRule{
 										FromCIDRSet: api.CIDRRuleSlice{
 											{
-												CIDRGroupRef: "cidr-group-2",
+												CIDRGroupRef: "cidr-group-5",
 											},
 										},
 									},
@@ -700,7 +865,33 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 									IngressCommonRule: api.IngressCommonRule{
 										FromCIDRSet: api.CIDRRuleSlice{
 											{
-												CIDRGroupRef: "cidr-group-4",
+												CIDRGroupRef: "cidr-group-6",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Egress: []api.EgressRule{
+								{
+									EgressCommonRule: api.EgressCommonRule{
+										ToCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-7",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							EgressDeny: []api.EgressDenyRule{
+								{
+									EgressCommonRule: api.EgressCommonRule{
+										ToCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-8",
 											},
 										},
 									},
@@ -710,7 +901,16 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 					},
 				},
 			},
-			expected: []string{"cidr-group-1", "cidr-group-2", "cidr-group-3", "cidr-group-4"},
+			expected: []string{
+				"cidr-group-1",
+				"cidr-group-2",
+				"cidr-group-3",
+				"cidr-group-4",
+				"cidr-group-5",
+				"cidr-group-6",
+				"cidr-group-7",
+				"cidr-group-8",
+			},
 		},
 		{
 			name: "single FromCidrSet rule with only CIDR",
@@ -985,7 +1185,7 @@ func TestCIDRGroupRefsTranslate(t *testing.T) {
 			},
 		},
 		{
-			name: "nil Ingress and IngressDeny",
+			name: "nil Ingress and Egress",
 			cnp: &types.SlimCNP{
 				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
 					TypeMeta: metav1.TypeMeta{
@@ -1111,6 +1311,54 @@ func TestCIDRGroupRefsTranslate(t *testing.T) {
 						{
 							Ingress:     []api.IngressRule{},
 							IngressDeny: []api.IngressDenyRule{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "nil Egress and EgressDeny ToCidrSet rule",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						Egress:     []api.EgressRule{},
+						EgressDeny: []api.EgressDenyRule{},
+					},
+					Specs: api.Rules{
+						{
+							Egress:     []api.EgressRule{},
+							EgressDeny: []api.EgressDenyRule{},
+						},
+					},
+				},
+			},
+			cidrsSets: map[string][]api.CIDR{},
+			expected: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						Egress:     []api.EgressRule{},
+						EgressDeny: []api.EgressDenyRule{},
+					},
+					Specs: api.Rules{
+						{
+							Egress:     []api.EgressRule{},
+							EgressDeny: []api.EgressDenyRule{},
 						},
 					},
 				},
@@ -1400,6 +1648,117 @@ func TestCIDRGroupRefsTranslate(t *testing.T) {
 								{
 									IngressCommonRule: api.IngressCommonRule{
 										FromCIDRSet: nil,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with EgressDeny ToCidrSet rules",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						EgressDeny: []api.EgressDenyRule{
+							{
+								EgressCommonRule: api.EgressCommonRule{
+									ToCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-1",
+										},
+									},
+								},
+							},
+						},
+					},
+					Specs: api.Rules{
+						{
+							EgressDeny: []api.EgressDenyRule{
+								{
+									EgressCommonRule: api.EgressCommonRule{
+										ToCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-2",
+											},
+										},
+									},
+								},
+								{
+									EgressCommonRule: api.EgressCommonRule{
+										ToCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-3",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cidrsSets: map[string][]api.CIDR{
+				"cidr-group-1": {"1.1.1.1/32", "2.2.2.2/32"},
+				"cidr-group-2": {"3.3.3.3/32", "4.4.4.4/32", "5.5.5.5/32"},
+				"cidr-group-3": {},
+			},
+			expected: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						EgressDeny: []api.EgressDenyRule{
+							{
+								EgressCommonRule: api.EgressCommonRule{
+									ToCIDRSet: api.CIDRRuleSlice{
+										{
+											Cidr: "1.1.1.1/32",
+										},
+										{
+											Cidr: "2.2.2.2/32",
+										},
+									},
+								},
+							},
+						},
+					},
+					Specs: api.Rules{
+						{
+							EgressDeny: []api.EgressDenyRule{
+								{
+									EgressCommonRule: api.EgressCommonRule{
+										ToCIDRSet: api.CIDRRuleSlice{
+											{
+												Cidr: "3.3.3.3/32",
+											},
+											{
+												Cidr: "4.4.4.4/32",
+											},
+											{
+												Cidr: "5.5.5.5/32",
+											},
+										},
+									},
+								},
+								{
+									EgressCommonRule: api.EgressCommonRule{
+										ToCIDRSet: nil,
 									},
 								},
 							},

--- a/pkg/policy/k8s/cilium_cidr_group_test.go
+++ b/pkg/policy/k8s/cilium_cidr_group_test.go
@@ -41,7 +41,7 @@ func TestHasCIDRGroupRef(t *testing.T) {
 			expected:  false,
 		},
 		{
-			name: "nil Ingress",
+			name: "nil Ingress and IngressDeny",
 			cnp: &types.SlimCNP{
 				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
 					TypeMeta: metav1.TypeMeta{
@@ -74,11 +74,13 @@ func TestHasCIDRGroupRef(t *testing.T) {
 						Namespace: "test-namespace",
 					},
 					Spec: &api.Rule{
-						Ingress: []api.IngressRule{},
+						Ingress:     []api.IngressRule{},
+						IngressDeny: []api.IngressDenyRule{},
 					},
 					Specs: api.Rules{
 						{
-							Ingress: []api.IngressRule{},
+							Ingress:     []api.IngressRule{},
+							IngressDeny: []api.IngressDenyRule{},
 						},
 					},
 				},
@@ -110,6 +112,17 @@ func TestHasCIDRGroupRef(t *testing.T) {
 								},
 							},
 						},
+						IngressDeny: []api.IngressDenyRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-3",
+										},
+									},
+								},
+							},
+						},
 					},
 					Specs: api.Rules{
 						{
@@ -125,14 +138,27 @@ func TestHasCIDRGroupRef(t *testing.T) {
 								},
 							},
 						},
+						{
+							IngressDeny: []api.IngressDenyRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-4",
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
-			cidrGroup: "cidr-group-3",
+			cidrGroup: "cidr-group-5",
 			expected:  false,
 		},
 		{
-			name: "CIDRGroupRef in Spec",
+			name: "CIDRGroupRef in Ingress Spec",
 			cnp: &types.SlimCNP{
 				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
 					TypeMeta: metav1.TypeMeta{
@@ -177,7 +203,52 @@ func TestHasCIDRGroupRef(t *testing.T) {
 			expected:  true,
 		},
 		{
-			name: "CIDR in Spec (Ingress)",
+			name: "CIDRGroupRef in IngressDeny Spec",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						IngressDeny: []api.IngressDenyRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-1",
+										},
+									},
+								},
+							},
+						},
+					},
+					Specs: api.Rules{
+						{
+							IngressDeny: []api.IngressDenyRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-2",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cidrGroup: "cidr-group-1",
+			expected:  true,
+		},
+		{
+			name: "CIDR in Ingress Spec",
 			cnp: &types.SlimCNP{
 				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
 					TypeMeta: metav1.TypeMeta{
@@ -222,7 +293,52 @@ func TestHasCIDRGroupRef(t *testing.T) {
 			expected:  true,
 		},
 		{
-			name: "CIDRGroupRef in Specs (Ingress)",
+			name: "CIDR in IngressDeny Spec",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						IngressDeny: []api.IngressDenyRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-1",
+										},
+									},
+								},
+							},
+						},
+					},
+					Specs: api.Rules{
+						{
+							IngressDeny: []api.IngressDenyRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												Cidr: "1.1.1.1/32",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cidrGroup: "cidr-group-1",
+			expected:  true,
+		},
+		{
+			name: "CIDRGroupRef in IngressDeny Specs",
 			cnp: &types.SlimCNP{
 				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
 					TypeMeta: metav1.TypeMeta{
@@ -267,7 +383,7 @@ func TestHasCIDRGroupRef(t *testing.T) {
 			expected:  true,
 		},
 		{
-			name: "CIDR in Spec (Egress)",
+			name: "CIDRGroupRef in Spec (Egress)",
 			cnp: &types.SlimCNP{
 				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
 					TypeMeta: metav1.TypeMeta{
@@ -341,6 +457,51 @@ func TestHasCIDRGroupRef(t *testing.T) {
 			cidrGroup: "cidr-group-2",
 			expected:  true,
 		},
+		{
+			name: "CIDRGroupRef in IngressDeny Specs",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						IngressDeny: []api.IngressDenyRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-1",
+										},
+									},
+								},
+							},
+						},
+					},
+					Specs: api.Rules{
+						{
+							IngressDeny: []api.IngressDenyRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-2",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cidrGroup: "cidr-group-2",
+			expected:  true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -376,7 +537,7 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "nil Spec with non-nil Specs",
+			name: "nil Ingress Spec with non-nil Ingress Specs",
 			cnp: &types.SlimCNP{
 				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
 					TypeMeta: metav1.TypeMeta{
@@ -407,7 +568,38 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 			expected: []string{"cidr-group-1"},
 		},
 		{
-			name: "nil Ingress",
+			name: "nil IngressDeny Spec with non-nil IngressDeny Specs",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Specs: api.Rules{
+						{
+							IngressDeny: []api.IngressDenyRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{"cidr-group-1"},
+		},
+		{
+			name: "nil Ingress and IngressDeny",
 			cnp: &types.SlimCNP{
 				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
 					TypeMeta: metav1.TypeMeta{
@@ -427,7 +619,7 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "nil FromCidrSet rule",
+			name: "nil Ingress and IngressDeny FromCidrSet rule",
 			cnp: &types.SlimCNP{
 				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
 					TypeMeta: metav1.TypeMeta{
@@ -439,11 +631,13 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 						Namespace: "test-namespace",
 					},
 					Spec: &api.Rule{
-						Ingress: []api.IngressRule{},
+						Ingress:     []api.IngressRule{},
+						IngressDeny: []api.IngressDenyRule{},
 					},
 					Specs: api.Rules{
 						{
-							Ingress: []api.IngressRule{},
+							Ingress:     []api.IngressRule{},
+							IngressDeny: []api.IngressDenyRule{},
 						},
 					},
 				},
@@ -474,6 +668,17 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 								},
 							},
 						},
+						IngressDeny: []api.IngressDenyRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-3",
+										},
+									},
+								},
+							},
+						},
 					},
 					Specs: api.Rules{
 						{
@@ -489,10 +694,23 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 								},
 							},
 						},
+						{
+							IngressDeny: []api.IngressDenyRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-4",
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
-			expected: []string{"cidr-group-1", "cidr-group-2"},
+			expected: []string{"cidr-group-1", "cidr-group-2", "cidr-group-3", "cidr-group-4"},
 		},
 		{
 			name: "single FromCidrSet rule with only CIDR",
@@ -518,6 +736,17 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 								},
 							},
 						},
+						IngressDeny: []api.IngressDenyRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-2",
+										},
+									},
+								},
+							},
+						},
 					},
 					Specs: api.Rules{
 						{
@@ -533,10 +762,23 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 								},
 							},
 						},
+						{
+							IngressDeny: []api.IngressDenyRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												Cidr: "2.2.2.2/32",
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
-			expected: []string{"cidr-group-1"},
+			expected: []string{"cidr-group-1", "cidr-group-2"},
 		},
 		{
 			name: "multiple FromCidrSet rules",
@@ -568,6 +810,20 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 								},
 							},
 						},
+						IngressDeny: []api.IngressDenyRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-6",
+										},
+										{
+											CIDRGroupRef: "cidr-group-7",
+										},
+									},
+								},
+							},
+						},
 					},
 					Specs: api.Rules{
 						{
@@ -585,6 +841,23 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 									},
 								},
 							},
+							IngressDeny: []api.IngressDenyRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-8",
+											},
+											{
+												CIDRGroupRef: "cidr-group-9",
+											},
+											{
+												CIDRGroupRef: "cidr-group-10",
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -595,6 +868,11 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 				"cidr-group-3",
 				"cidr-group-4",
 				"cidr-group-5",
+				"cidr-group-6",
+				"cidr-group-7",
+				"cidr-group-8",
+				"cidr-group-9",
+				"cidr-group-10",
 			},
 		},
 	}
@@ -707,7 +985,7 @@ func TestCIDRGroupRefsTranslate(t *testing.T) {
 			},
 		},
 		{
-			name: "nil Ingress",
+			name: "nil Ingress and IngressDeny",
 			cnp: &types.SlimCNP{
 				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
 					TypeMeta: metav1.TypeMeta{
@@ -790,7 +1068,54 @@ func TestCIDRGroupRefsTranslate(t *testing.T) {
 				},
 			},
 		},
-
+		{
+			name: "nil Ingress and IngressDeny FromCidrSet rule",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						Ingress:     []api.IngressRule{},
+						IngressDeny: []api.IngressDenyRule{},
+					},
+					Specs: api.Rules{
+						{
+							Ingress:     []api.IngressRule{},
+							IngressDeny: []api.IngressDenyRule{},
+						},
+					},
+				},
+			},
+			cidrsSets: map[string][]api.CIDR{},
+			expected: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						Ingress:     []api.IngressRule{},
+						IngressDeny: []api.IngressDenyRule{},
+					},
+					Specs: api.Rules{
+						{
+							Ingress:     []api.IngressRule{},
+							IngressDeny: []api.IngressDenyRule{},
+						},
+					},
+				},
+			},
+		},
 		{
 			name: "with FromCidrSet and ToCIDRSet rules",
 			cnp: &types.SlimCNP{
@@ -964,6 +1289,117 @@ func TestCIDRGroupRefsTranslate(t *testing.T) {
 								{
 									EgressCommonRule: api.EgressCommonRule{
 										ToCIDRSet: nil,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with IngressDeny FromCidrSet rules",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						IngressDeny: []api.IngressDenyRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-1",
+										},
+									},
+								},
+							},
+						},
+					},
+					Specs: api.Rules{
+						{
+							IngressDeny: []api.IngressDenyRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-2",
+											},
+										},
+									},
+								},
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-3",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cidrsSets: map[string][]api.CIDR{
+				"cidr-group-1": {"1.1.1.1/32", "2.2.2.2/32"},
+				"cidr-group-2": {"3.3.3.3/32", "4.4.4.4/32", "5.5.5.5/32"},
+				"cidr-group-3": {},
+			},
+			expected: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						IngressDeny: []api.IngressDenyRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											Cidr: "1.1.1.1/32",
+										},
+										{
+											Cidr: "2.2.2.2/32",
+										},
+									},
+								},
+							},
+						},
+					},
+					Specs: api.Rules{
+						{
+							IngressDeny: []api.IngressDenyRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												Cidr: "3.3.3.3/32",
+											},
+											{
+												Cidr: "4.4.4.4/32",
+											},
+											{
+												Cidr: "5.5.5.5/32",
+											},
+										},
+									},
+								},
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: nil,
 									},
 								},
 							},
@@ -1264,7 +1700,171 @@ func TestCIDRGroupRefsTranslate(t *testing.T) {
 			},
 		},
 		{
-			name: "with CIDRGroupRef and ExceptCIDRs rules",
+			name: "with mixed IngressDeny FromCidrSet rules",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						IngressDeny: []api.IngressDenyRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-1",
+										},
+										{
+											Cidr: "1.1.1.1/32",
+										},
+										{
+											CIDRGroupRef: "cidr-group-2",
+										},
+										{
+											Cidr: "2.2.2.2/32",
+										},
+										{
+											Cidr: "3.3.3.3/32",
+										},
+									},
+								},
+							},
+						},
+					},
+					Specs: api.Rules{
+						{
+							IngressDeny: []api.IngressDenyRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-3",
+											},
+											{
+												Cidr: "4.4.4.4/32",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							IngressDeny: []api.IngressDenyRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-4",
+											},
+											{
+												CIDRGroupRef: "cidr-group-5",
+											},
+											{
+												Cidr: "5.5.5.5/32",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cidrsSets: map[string][]api.CIDR{
+				"cidr-group-1": {"6.6.6.6/32", "7.7.7.7/32"},
+				"cidr-group-2": {"8.8.8.8/32"},
+				"cidr-group-3": {"9.9.9.9/32", "10.10.10.10/32"},
+				"cidr-group-4": {},
+				"cidr-group-5": {"11.11.11.11/32", "12.12.12.12/32"},
+			},
+			expected: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						IngressDeny: []api.IngressDenyRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											Cidr: "1.1.1.1/32",
+										},
+										{
+											Cidr: "2.2.2.2/32",
+										},
+										{
+											Cidr: "3.3.3.3/32",
+										},
+										{
+											Cidr: "6.6.6.6/32",
+										},
+										{
+											Cidr: "7.7.7.7/32",
+										},
+										{
+											Cidr: "8.8.8.8/32",
+										},
+									},
+								},
+							},
+						},
+					},
+					Specs: api.Rules{
+						{
+							IngressDeny: []api.IngressDenyRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												Cidr: "4.4.4.4/32",
+											},
+											{
+												Cidr: "9.9.9.9/32",
+											},
+											{
+												Cidr: "10.10.10.10/32",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							IngressDeny: []api.IngressDenyRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												Cidr: "5.5.5.5/32",
+											},
+											{
+												Cidr: "11.11.11.11/32",
+											},
+											{
+												Cidr: "12.12.12.12/32",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with Ingress CIDRGroupRef and ExceptCIDRs rules",
 			cnp: &types.SlimCNP{
 				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
 					TypeMeta: metav1.TypeMeta{
@@ -1337,6 +1937,64 @@ func TestCIDRGroupRefsTranslate(t *testing.T) {
 										{
 											Cidr:        "110.0.0.0/8",
 											ExceptCIDRs: []api.CIDR{"110.96.0.0/12", "110.112.0.0/12"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with IngressDeny CIDRGroupRef and ExceptCIDRs rules",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						IngressDeny: []api.IngressDenyRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-1",
+											ExceptCIDRs:  []api.CIDR{"10.96.0.0/12", "10.112.0.0/12"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cidrsSets: map[string][]api.CIDR{
+				"cidr-group-1": {"10.0.0.0/8"},
+			},
+			expected: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						IngressDeny: []api.IngressDenyRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											Cidr:        "10.0.0.0/8",
+											ExceptCIDRs: []api.CIDR{"10.96.0.0/12", "10.112.0.0/12"},
 										},
 									},
 								},


### PR DESCRIPTION
Current version of CNP translation lacks support for translating referenced CiliumCIDRGroup objects in IngressDeny rules, despite mentioning it in the CIDRGroupRef field docstring.

The commit adds the missing logic and extends the unit tests suite to take into account the IngressDeny rules.
