### PR TITLE
fqdn: bump stale grace period to 60 seconds

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -879,7 +879,7 @@
    * - :spelling:ignore:`dnsProxy.idleConnectionGracePeriod`
      - Time during which idle but previously active connections with expired DNS lookups are still considered alive.
      - string
-     - ``"0s"``
+     - ``"60s"``
    * - :spelling:ignore:`dnsProxy.maxDeferredConnectionDeletes`
      - Maximum number of IPs to retain for expired DNS lookups with still-active connections.
      - int

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -269,7 +269,7 @@ contributors across the globe, there is almost always someone available to help.
 | dnsProxy.dnsRejectResponseCode | string | `"refused"` | DNS response code for rejecting DNS requests, available options are '[nameError refused]'. |
 | dnsProxy.enableDnsCompression | bool | `true` | Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present. |
 | dnsProxy.endpointMaxIpPerHostname | int | `50` | Maximum number of IPs to maintain per FQDN name for each endpoint. |
-| dnsProxy.idleConnectionGracePeriod | string | `"0s"` | Time during which idle but previously active connections with expired DNS lookups are still considered alive. |
+| dnsProxy.idleConnectionGracePeriod | string | `"60s"` | Time during which idle but previously active connections with expired DNS lookups are still considered alive. |
 | dnsProxy.maxDeferredConnectionDeletes | int | `10000` | Maximum number of IPs to retain for expired DNS lookups with still-active connections. |
 | dnsProxy.minTtl | int | `0` | The minimum time, in seconds, to use DNS data for toFQDNs policies. If the upstream DNS server returns a DNS record with a shorter TTL, Cilium overwrites the TTL with this value. Setting this value to zero means that Cilium will honor the TTLs returned by the upstream DNS server. |
 | dnsProxy.preCache | string | `""` | DNS cache data at this path is preloaded on agent startup. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2859,7 +2859,7 @@ dnsProxy:
   # -- Maximum number of IPs to maintain per FQDN name for each endpoint.
   endpointMaxIpPerHostname: 50
   # -- Time during which idle but previously active connections with expired DNS lookups are still considered alive.
-  idleConnectionGracePeriod: 0s
+  idleConnectionGracePeriod: 60s
   # -- Maximum number of IPs to retain for expired DNS lookups with still-active connections.
   maxDeferredConnectionDeletes: 10000
   # -- The minimum time, in seconds, to use DNS data for toFQDNs policies. If

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2860,7 +2860,7 @@ dnsProxy:
   # -- Maximum number of IPs to maintain per FQDN name for each endpoint.
   endpointMaxIpPerHostname: 50
   # -- Time during which idle but previously active connections with expired DNS lookups are still considered alive.
-  idleConnectionGracePeriod: 0s
+  idleConnectionGracePeriod: 60s
   # -- Maximum number of IPs to retain for expired DNS lookups with still-active connections.
   maxDeferredConnectionDeletes: 10000
   # -- The minimum time, in seconds, to use DNS data for toFQDNs policies. If


### PR DESCRIPTION
The FQDN proxy will GC IP addresses that are both:
- past their DNS TTLs, and
- no longer in use by active connections

However, many applications do not immediately re-resolve names between connections, even if the TTL has expired. This can cause traffic to be dropped unexpectedly.

Previously, this was not an issue, as FQDN GC happened very rarely. This has been improved, however, by #27572 and #27870. Now, end-users occasionally being surprised by this.

This sets the default grace period to 60 seconds, in an attempt to find a good balance between application needs and security.

```release-note
The default grace period for garbage collecting FQDN IPs has been changed from 0 to 60 seconds.
```
