### PR TITLE
test: [regression] Re-enable tests on non-AKS platforms

### DIFF
--- a/test/k8s/lrp.go
+++ b/test/k8s/lrp.go
@@ -42,7 +42,7 @@ var _ = SkipDescribeIf(func() bool { return helpers.RunsOn54Kernel() && helpers.
 		kubectl.CiliumReport("cilium-dbg lrp list", "cilium-dbg service list")
 	})
 
-	SkipContextIf(func() bool { return helpers.DoesNotRunOnAKS() }, "Checks local redirect policy", func() {
+	SkipContextIf(func() bool { return helpers.RunsOnAKS() }, "Checks local redirect policy", func() {
 		const (
 			lrpServiceName = "lrp-demo-service"
 			be1Name        = "k8s1-backend"

--- a/test/k8s/pod_mac_address.go
+++ b/test/k8s/pod_mac_address.go
@@ -40,7 +40,7 @@ var _ = SkipDescribeIf(func() bool { return helpers.RunsOn54Kernel() && helpers.
 		kubectl.CiliumReport("cilium-dbg endpoint list -o jsonpath='{range [*]}{@.id}{\"=\"}{@.status.networking.mac}{\"\\n\"}{end}'")
 	})
 
-	SkipContextIf(func() bool { return helpers.DoesNotRunOnAKS() }, "Check whether the pod is created", func() {
+	SkipContextIf(func() bool { return helpers.RunsOnAKS() }, "Check whether the pod is created", func() {
 		const specificMACAddress = "specific-mac-address=specific-mac-address"
 		var podYAML string
 


### PR DESCRIPTION
The tests were incorrectly skipped on non-AKS platforms due to the regression introduced recently that flipped the conditions to skip the test on the AKS platform.

Fixes: 0a92cc57a0 (test: remove references to v4.19)

Signed-off-by: Aditi Ghag <aditi@cilium.io>

```release-note
Re-enable LRP and K8sSpecificMACAddressTests tests that were incorrectly skipped on non-AKS platforms due to a regression.
```
