### PR TITLE
bugtool: Capture memory fragmentation info from /proc

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -285,6 +285,8 @@ func catCommands() []string {
 	files := []string{
 		"/proc/sys/net/core/bpf_jit_enable",
 		"/proc/kallsyms",
+		"/proc/buddyinfo",
+		"/proc/pagetypeinfo",
 		"/etc/resolv.conf",
 		"/var/log/docker.log",
 		"/var/log/daemon.log",


### PR DESCRIPTION
This information can be useful to understand why memory allocation in the kernel may fail (ex. for maps or for XFRM). I've checked that these two files are accessible from a typical cilium-agent deployment (on GKE).