### PR TITLE
relay: drop log severity for gRPC client creation

### DIFF
--- a/pkg/hubble/relay/pool/manager.go
+++ b/pkg/hubble/relay/pool/manager.go
@@ -338,7 +338,7 @@ func (m *PeerManager) connect(p *peer, ignoreBackoff bool) {
 		scopedLog.WithFields(logrus.Fields{
 			"error":       err,
 			"next-try-in": duration,
-		}).Warning("Failed to create gRPC client")
+		}).Info("Failed to create gRPC client, retrying...")
 		return
 	}
 	p.nextConnAttempt = time.Time{}


### PR DESCRIPTION
Reduce the log severity from Warning to Info, as warning/error logs can fail CI.

The other way to solve this would be to exclude this log from failing CI, but that's 'last resort' apparently. This is mostly a proposal, happy to change approach if necessary.

Fixes: #30934

