### PR TITLE
loader: fix issue where errors cancelled compile cause error logs.

### DIFF
--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -204,6 +205,18 @@ func compile(ctx context.Context, prog *progInfo, dir *directoryInfo) (string, e
 
 	if err := compileCmd.Run(); err != nil {
 		err = fmt.Errorf("Failed to compile %s: %w", prog.Output, err)
+
+		// In linux/unix based implementations, cancelling the context for a cmd.Run() will
+		// return errors: "context cancelled" if the context is cancelled prior to the process
+		// starting and "signal: killed" if it is already running.
+		// This can mess up calling logging logic which expects the returned error to have
+		// context.Cancelled so we join this error in to fix that.
+		if errors.Is(ctx.Err(), context.Canceled) &&
+			compileCmd.ProcessState != nil &&
+			!compileCmd.ProcessState.Exited() &&
+			strings.HasSuffix(err.Error(), syscall.SIGKILL.String()) {
+			err = errors.Join(err, ctx.Err())
+		}
 
 		if !errors.Is(err, context.Canceled) {
 			log.WithFields(logrus.Fields{


### PR DESCRIPTION
On Linux/Unix based implementations, exec/cmd.Run will return either context.ContextCancelled or the error "signal: killed" depending on whether the cancellation occured while the process was running.

There's several places we check on ```is.Errors(err, context.Cancelled)``` on whether to emit high level logs about failed program compilations.  Because already running cmd.Run() doesn't return an error that satisfies this, this will result in spurious error logs about failed compilation (i.e. "signal: killed")

This meant that in cases where a compilation is legitimately cancelled, we would still log an error such as

msg="BPF template object creation failed" ... error="...: compile bpf_lxc.o: signal: killed"

This can occur occasionally in CI, which enforces no error to pass, causing failures.

example:
```
	ctx, c := context.WithTimeout(context.Background(), time.Second)
	go func() {
		time.Sleep(time.Second)
		c()
	}()
	cmd := exec.CommandContext(ctx, "sleep", "2")
	fmt.Println(cmd.Run())

	ctx, c = context.WithTimeout(context.Background(), time.Second)
	c()
	cmd = exec.CommandContext(ctx, "sleep", "2")
	fmt.Println(cmd.Run())
```

To fix this, this will join in the ctx.Err() if it is:
* context.Cancelled
* The process has not exited itself.
* The process appeared to be SIGKILL'ed.

Addresses: #30991 

