### PR TITLE
helm: Update host value for all probes for Envoy DS

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -86,7 +86,7 @@ spec:
         {{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.Version }}
         startupProbe:
           httpGet:
-            host: "localhost"
+            host: {{ .Values.ipv6.enabled | ternary "::1" "127.0.0.1" | quote }}
             path: /healthz
             port: {{ .Values.envoy.healthPort }}
             scheme: HTTP
@@ -97,7 +97,7 @@ spec:
         {{- end }}
         livenessProbe:
           httpGet:
-            host: "localhost"
+            host: {{ .Values.ipv6.enabled | ternary "::1" "127.0.0.1" | quote }}
             path: /healthz
             port: {{ .Values.envoy.healthPort }}
             scheme: HTTP
@@ -115,7 +115,7 @@ spec:
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
-            host: "localhost"
+            host: {{ .Values.ipv6.enabled | ternary "::1" "127.0.0.1" | quote }}
             path: /healthz
             port: {{ .Values.envoy.healthPort }}
             scheme: HTTP


### PR DESCRIPTION
This commit is to make sure that host value for startup/liveness and readiness probes will be:

- 127.0.0.1 for IPv4 only
- ::1 for IPv6 only, or dual stack

Fixes: #30968