### PR TITLE
egressgw: consolidate and reoptimise EgressRules

### DIFF
--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -738,7 +738,6 @@ func BenchmarkReconcileMap(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < 200; i++ {
-		manager.addMissingEgressRules()
-		manager.removeUnusedEgressRules()
+		manager.reconcileEgressRules()
 	}
 }

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -167,28 +167,6 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(gc *policyGatewayConfig)
 	return nil
 }
 
-// forEachEndpointAndCIDR iterates through each combination of endpoints and
-// destination/excluded CIDRs of the receiver policy, and for each of them it
-// calls the f callback function passing the given endpoint and CIDR, together
-// with a boolean value indicating if the CIDR belongs to the excluded ones and
-// the gatewayConfig of the receiver policy
-func (config *PolicyConfig) forEachEndpointAndCIDR(f func(netip.Addr, netip.Prefix, bool, *gatewayConfig)) {
-
-	for _, endpoint := range config.matchedEndpoints {
-		for _, endpointIP := range endpoint.ips {
-			isExcludedCIDR := false
-			for _, dstCIDR := range config.dstCIDRs {
-				f(endpointIP, dstCIDR, isExcludedCIDR, &config.gatewayConfig)
-			}
-
-			isExcludedCIDR = true
-			for _, excludedCIDR := range config.excludedCIDRs {
-				f(endpointIP, excludedCIDR, isExcludedCIDR, &config.gatewayConfig)
-			}
-		}
-	}
-}
-
 // ParseCEGP takes a CiliumEgressGatewayPolicy CR and converts to PolicyConfig,
 // the internal representation of the egress gateway policy
 func ParseCEGP(cegp *v2.CiliumEgressGatewayPolicy) (*PolicyConfig, error) {

--- a/pkg/maps/egressmap/policy.go
+++ b/pkg/maps/egressmap/policy.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/spf13/pflag"
-	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
@@ -178,14 +177,12 @@ func (k *EgressPolicyKey4) Match(sourceIP netip.Addr, destCIDR netip.Prefix) boo
 
 // GetSourceIP returns the egress policy key's source IP.
 func (k *EgressPolicyKey4) GetSourceIP() netip.Addr {
-	addr, _ := netipx.FromStdIP(k.SourceIP.IP())
-	return addr
+	return k.SourceIP.Addr()
 }
 
 // GetDestCIDR returns the egress policy key's destination CIDR.
 func (k *EgressPolicyKey4) GetDestCIDR() netip.Prefix {
-	addr, _ := netipx.FromStdIP(k.DestCIDR.IP())
-	return netip.PrefixFrom(addr, int(k.PrefixLen-PolicyStaticPrefixBits))
+	return netip.PrefixFrom(k.DestCIDR.Addr(), int(k.PrefixLen-PolicyStaticPrefixBits))
 }
 
 // New returns an egress policy value


### PR DESCRIPTION
> egressgw: consolidate and reoptimise EgressRules
> 
> The addMissingEgressRules and removeUnusedEgressRules methods are quite
> confusing to read. Consolidate these into one method.
> 
> Delete the policyMatches method and the sourceIP optimisation. Given
> that all necessary egress rules are generated in the upsert part of the
> bpf map reconciliation process, we can just dump them all into a map and
> do simple lookups.

PR best viewed in isolation, the GitHub diff is very confusing.

Justification for changes:
- One less item of state kept in the Manager (`policyConfigsBySourceIP`)
- Previous code was difficult to read
- Reduce passed around variables and hard to follow code paths
- Relatively clean inlining and removing single-use or redundant methods
- I'm pretty confident this is generally more efficient
- The resulting effect should be the same (map should contain the same contents)