### PR TITLE
linux: devices: don't force exclude 'lo'

### DIFF
--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -114,7 +114,8 @@ var Cell = cell.Module(
 		// This is temporary until DevicesController takes ownership of the
 		// device-related configuration options.
 		return linuxdatapath.DevicesConfig{
-			Devices: cfg.GetDevices(),
+			Devices:             cfg.GetDevices(),
+			DirectRoutingDevice: cfg.DirectRoutingDevice,
 		}
 	}),
 


### PR DESCRIPTION
By also looking at the direct routing device config in the device controller device selection, we can enable users to use lo as the direct routing device as in previous versions of cilium
