### PR TITLE
loader: add cilium_per_cluster_snat to the list of ignored ELF prefixes

### DIFF
--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -61,6 +61,7 @@ var ignoredELFPrefixes = []string{
 	"cilium_srv6_sid",             // Global
 	"cilium_vtep_map",             // Global
 	"cilium_per_cluster_ct",       // Global
+	"cilium_per_cluster_snat",     // Global
 	"cilium_world_cidrs4",         // Global
 	"cilium_l2_responder_v4",      // Global
 	"cilium_ratelimit",            // Global


### PR DESCRIPTION
This prevents warning messages like:

```
level=warning msg="Skipping symbol substitution" symbol=cilium_per_cluster_snat_v4_external
```

Fixes: 03c195ecc6e6 ("bpf: Introduce per-cluster NAT maps")

<!-- Description of change -->

```release-note
Fix unnecessary warning by adding cilium_per_cluster_snat to the list of ignored ELF prefixes
```
