### PR TITLE
feat: Configuring the FQDN GC interval / Zombie timeout

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -795,6 +795,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Int(option.ToFQDNsMinTTL, defaults.ToFQDNsMinTTL, "The minimum time, in seconds, to use DNS data for toFQDNs policies")
 	option.BindEnv(vp, option.ToFQDNsMinTTL)
 
+	flags.Int(option.ToFQDNsActiveConnectionsTTL, defaults.ToFQDNsActiveConnectionsTTL, "Time after which idle DNS entries will be garbage collected, following TTL expiry")
+	option.BindEnv(vp, option.ToFQDNsActiveConnectionsTTL)
+
 	flags.Int(option.ToFQDNsProxyPort, 0, "Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.")
 	option.BindEnv(vp, option.ToFQDNsProxyPort)
 

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -118,11 +118,12 @@ func (d *Daemon) updateSelectors(ctx context.Context, selectors map[policyApi.FQ
 // configured DNS proxy port (this may be 0 and so OS-assigned).
 func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, preCachePath string, ipcache fqdn.IPCache) (err error) {
 	cfg := fqdn.Config{
-		MinTTL:              option.Config.ToFQDNsMinTTL,
-		Cache:               fqdn.NewDNSCache(option.Config.ToFQDNsMinTTL),
-		UpdateSelectors:     d.updateSelectors,
-		GetEndpointsDNSInfo: d.getEndpointsDNSInfo,
-		IPCache:             ipcache,
+		MinTTL:               option.Config.ToFQDNsMinTTL,
+		ActiveConnectionsTTL: option.Config.ToFQDNsActiveConnectionsTTL,
+		Cache:                fqdn.NewDNSCache(option.Config.ToFQDNsMinTTL),
+		UpdateSelectors:      d.updateSelectors,
+		GetEndpointsDNSInfo:  d.getEndpointsDNSInfo,
+		IPCache:              ipcache,
 	}
 	// Disable cleanup tracking on the default DNS cache. This cache simply
 	// tracks which api.FQDNSelector are present in policy which apply to

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -150,6 +150,13 @@ const (
 	// This is used in DaemonConfig.Populate
 	ToFQDNsMinTTL = 0
 
+	// DNSGCJobInterval is the default value for DNS garbage collector job interval
+	DNSGCJobInterval = 1 * time.Minute
+
+	// ToFQDNsActiveConnectionsTTL is the default value for how long that connections
+	// should be idle for after the DNS TTL expires.
+	ToFQDNsActiveConnectionsTTL = int(2 * DNSGCJobInterval)
+
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost = 50

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -19,6 +19,10 @@ type Config struct {
 	// MinTTL is the time used by the poller to cache information.
 	MinTTL int
 
+	// Active Connections TTL is the time used by the GC to determines how long that
+	// connections should be idle for after the DNS TTL expires.
+	ActiveConnectionsTTL int
+
 	// Cache is where the poller stores DNS data used to generate rules.
 	// When set to nil, it uses fqdn.DefaultDNSCache, a global cache instance.
 	Cache *DNSCache

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -780,4 +780,7 @@ const (
 
 	// NetnsCookie is the Linux kernel netns cookie.
 	NetnsCookie = "netnsCookie"
+
+	// Invalid Value identifies the provided invalid value.
+	InvalidValue = "invalidValue"
 )


### PR DESCRIPTION
Configuring the FQDN GC interval based on the config provided by the user. This would determine how long that connections should be idle for after the DNS TTL expires.

Fixes: #13687