### PR TITLE
egressgw: naive port to statedb

### DIFF
--- a/pkg/egressgateway/endpoint.go
+++ b/pkg/egressgateway/endpoint.go
@@ -27,20 +27,20 @@ type endpointMetadata struct {
 // endpointID is based on endpoint's UID
 type endpointID = types.UID
 
-func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint, identityLabels labels.Labels) (*endpointMetadata, error) {
+func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint, identityLabels labels.Labels) (endpointMetadata, error) {
 	var addrs []netip.Addr
 
 	if endpoint.UID == "" {
 		// this can happen when CiliumEndpointSlices are in use - which is not supported in the EGW yet
-		return nil, fmt.Errorf("endpoint has empty UID")
+		return endpointMetadata{}, fmt.Errorf("endpoint has empty UID")
 	}
 
 	if endpoint.Networking == nil {
-		return nil, fmt.Errorf("endpoint has no networking metadata")
+		return endpointMetadata{}, fmt.Errorf("endpoint has no networking metadata")
 	}
 
 	if len(endpoint.Networking.Addressing) == 0 {
-		return nil, fmt.Errorf("failed to get valid endpoint IPs")
+		return endpointMetadata{}, fmt.Errorf("failed to get valid endpoint IPs")
 	}
 
 	for _, pair := range endpoint.Networking.Addressing {
@@ -54,10 +54,10 @@ func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint, identityLabels label
 	}
 
 	if endpoint.Identity == nil {
-		return nil, fmt.Errorf("endpoint has no identity metadata")
+		return endpointMetadata{}, fmt.Errorf("endpoint has no identity metadata")
 	}
 
-	data := &endpointMetadata{
+	data := endpointMetadata{
 		ips:    addrs,
 		labels: identityLabels.K8sStringMap(),
 		id:     endpoint.UID,

--- a/pkg/egressgateway/helpers_test.go
+++ b/pkg/egressgateway/helpers_test.go
@@ -104,7 +104,7 @@ func newCEGP(params *policyParams) (*v2.CiliumEgressGatewayPolicy, *PolicyConfig
 				},
 			},
 		},
-		policyGwConfig: &policyGatewayConfig{
+		policyGwConfig: policyGatewayConfig{
 			iface:    params.iface,
 			egressIP: addr,
 		},

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -540,7 +540,7 @@ func (manager *Manager) updatePoliciesMatchedEndpointIDs() {
 
 func (manager *Manager) regenerateGatewayConfigs() {
 	for _, policyConfig := range manager.policyConfigs {
-		policyConfig.regenerateGatewayConfig(manager)
+		policyConfig.regenerateGatewayConfig(manager.nodes)
 	}
 }
 

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -738,7 +738,6 @@ func BenchmarkReconcileMap(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < 200; i++ {
-		manager.addMissingEgressRules()
-		manager.removeUnusedEgressRules()
+		manager.reconcileEgressRules()
 	}
 }

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -56,7 +56,7 @@ type PolicyConfig struct {
 
 	policyGwConfig *policyGatewayConfig
 
-	matchedEndpoints map[endpointID]*endpointMetadata
+	matchedEndpoints map[endpointID]endpointMetadata
 	gatewayConfig    gatewayConfig
 }
 
@@ -76,11 +76,11 @@ func (config *PolicyConfig) matchesEndpointLabels(endpointInfo *endpointMetadata
 }
 
 // updateMatchedEndpointIDs update the policy's cache of matched endpoint IDs
-func (config *PolicyConfig) updateMatchedEndpointIDs(epDataStore map[endpointID]*endpointMetadata) {
-	config.matchedEndpoints = make(map[endpointID]*endpointMetadata)
+func (config *PolicyConfig) updateMatchedEndpointIDs(epDataStore map[endpointID]endpointMetadata) {
+	config.matchedEndpoints = make(map[endpointID]endpointMetadata)
 
 	for _, endpoint := range epDataStore {
-		if config.matchesEndpointLabels(endpoint) {
+		if config.matchesEndpointLabels(&endpoint) {
 			config.matchedEndpoints[endpoint.id] = endpoint
 		}
 	}
@@ -263,7 +263,7 @@ func ParseCEGP(cegp *v2.CiliumEgressGatewayPolicy) (*PolicyConfig, error) {
 		endpointSelectors: endpointSelectorList,
 		dstCIDRs:          dstCidrList,
 		excludedCIDRs:     excludedCIDRs,
-		matchedEndpoints:  make(map[endpointID]*endpointMetadata),
+		matchedEndpoints:  make(map[endpointID]endpointMetadata),
 		policyGwConfig:    policyGwc,
 		id: types.NamespacedName{
 			Name: name,

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -54,7 +54,7 @@ type PolicyConfig struct {
 	dstCIDRs          []netip.Prefix
 	excludedCIDRs     []netip.Prefix
 
-	policyGwConfig *policyGatewayConfig
+	policyGwConfig policyGatewayConfig
 
 	matchedEndpoints map[endpointID]endpointMetadata
 	gatewayConfig    gatewayConfig
@@ -110,7 +110,7 @@ func (config *PolicyConfig) regenerateGatewayConfig(nodes []nodeTypes.Node) {
 		gwc.gatewayIP = addr
 
 		if node.IsLocal() {
-			err := gwc.deriveFromPolicyGatewayConfig(policyGwc)
+			err := gwc.deriveFromPolicyGatewayConfig(&policyGwc)
 			if err != nil {
 				logger := log.WithFields(logrus.Fields{
 					logfields.CiliumEgressGatewayPolicyName: config.id,
@@ -200,7 +200,7 @@ func ParseCEGP(cegp *v2.CiliumEgressGatewayPolicy) (*PolicyConfig, error) {
 
 	// EgressIP is not a required field, ignore the error if unable to parse.
 	addr, _ := netip.ParseAddr(egressGateway.EgressIP)
-	policyGwc := &policyGatewayConfig{
+	policyGwc := policyGatewayConfig{
 		nodeSelector: api.NewESFromK8sLabelSelector("", egressGateway.NodeSelector),
 		iface:        egressGateway.Interface,
 		egressIP:     addr,

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -76,7 +76,7 @@ func (config *PolicyConfig) matchesEndpointLabels(endpointInfo *endpointMetadata
 }
 
 // updateMatchedEndpointIDs update the policy's cache of matched endpoint IDs
-func (config *PolicyConfig) updateMatchedEndpointIDs(epDataStore map[endpointID]endpointMetadata) {
+func (config *PolicyConfig) updateMatchedEndpointIDs(epDataStore []endpointMetadata) {
 	config.matchedEndpoints = make(map[endpointID]endpointMetadata)
 
 	for _, endpoint := range epDataStore {

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -167,28 +167,6 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(gc *policyGatewayConfig)
 	return nil
 }
 
-// forEachEndpointAndCIDR iterates through each combination of endpoints and
-// destination/excluded CIDRs of the receiver policy, and for each of them it
-// calls the f callback function passing the given endpoint and CIDR, together
-// with a boolean value indicating if the CIDR belongs to the excluded ones and
-// the gatewayConfig of the receiver policy
-func (config *PolicyConfig) forEachEndpointAndCIDR(f func(netip.Addr, netip.Prefix, bool, *gatewayConfig)) {
-
-	for _, endpoint := range config.matchedEndpoints {
-		for _, endpointIP := range endpoint.ips {
-			isExcludedCIDR := false
-			for _, dstCIDR := range config.dstCIDRs {
-				f(endpointIP, dstCIDR, isExcludedCIDR, &config.gatewayConfig)
-			}
-
-			isExcludedCIDR = true
-			for _, excludedCIDR := range config.excludedCIDRs {
-				f(endpointIP, excludedCIDR, isExcludedCIDR, &config.gatewayConfig)
-			}
-		}
-	}
-}
-
 // ParseCEGP takes a CiliumEgressGatewayPolicy CR and converts to PolicyConfig,
 // the internal representation of the egress gateway policy
 func ParseCEGP(cegp *v2.CiliumEgressGatewayPolicy) (*PolicyConfig, error) {

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -90,7 +90,7 @@ func (config *policyGatewayConfig) selectsNodeAsGateway(node nodeTypes.Node) boo
 	return config.nodeSelector.Matches(k8sLabels.Set(node.Labels))
 }
 
-func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager) {
+func (config *PolicyConfig) regenerateGatewayConfig(nodes []nodeTypes.Node) {
 	gwc := gatewayConfig{
 		egressIP:  netip.IPv4Unspecified(),
 		gatewayIP: GatewayNotFoundIPv4,
@@ -98,7 +98,7 @@ func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager) {
 
 	policyGwc := config.policyGwConfig
 
-	for _, node := range manager.nodes {
+	for _, node := range nodes {
 		if !policyGwc.selectsNodeAsGateway(node) {
 			continue
 		}

--- a/pkg/egressgateway/tables.go
+++ b/pkg/egressgateway/tables.go
@@ -25,3 +25,23 @@ func NewPolicyConfigTable() (statedb.RWTable[PolicyConfig], error) {
 		PolicyConfigIDIndex,
 	)
 }
+
+var (
+	EndpointMetadataIDIndex = statedb.Index[endpointMetadata, endpointID]{
+		Name: "id",
+		FromObject: func(em endpointMetadata) index.KeySet {
+			return index.NewKeySet(index.String(string(em.id)))
+		},
+		FromKey: func(eid endpointID) index.Key {
+			return index.String(string(eid))
+		},
+		Unique: true,
+	}
+)
+
+func NewEndpointMetadataTable() (statedb.RWTable[endpointMetadata], error) {
+	return statedb.NewTable[endpointMetadata](
+		"endpoint-metadata",
+		EndpointMetadataIDIndex,
+	)
+}

--- a/pkg/egressgateway/tables.go
+++ b/pkg/egressgateway/tables.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package egressgateway
+
+import (
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/index"
+)
+
+var (
+	PolicyConfigIDIndex = statedb.Index[PolicyConfig, string]{
+		Name: "id",
+		FromObject: func(p PolicyConfig) index.KeySet {
+			return index.NewKeySet(index.Stringer(p.id))
+		},
+		FromKey: index.String,
+		Unique:  true,
+	}
+)
+
+func NewPolicyConfigTable() (statedb.RWTable[PolicyConfig], error) {
+	return statedb.NewTable[PolicyConfig](
+		"policy-configs",
+		PolicyConfigIDIndex,
+	)
+}

--- a/pkg/maps/egressmap/policy.go
+++ b/pkg/maps/egressmap/policy.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/spf13/pflag"
-	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
@@ -178,14 +177,12 @@ func (k *EgressPolicyKey4) Match(sourceIP netip.Addr, destCIDR netip.Prefix) boo
 
 // GetSourceIP returns the egress policy key's source IP.
 func (k *EgressPolicyKey4) GetSourceIP() netip.Addr {
-	addr, _ := netipx.FromStdIP(k.SourceIP.IP())
-	return addr
+	return k.SourceIP.Addr()
 }
 
 // GetDestCIDR returns the egress policy key's destination CIDR.
 func (k *EgressPolicyKey4) GetDestCIDR() netip.Prefix {
-	addr, _ := netipx.FromStdIP(k.DestCIDR.IP())
-	return netip.PrefixFrom(addr, int(k.PrefixLen-PolicyStaticPrefixBits))
+	return netip.PrefixFrom(k.DestCIDR.Addr(), int(k.PrefixLen-PolicyStaticPrefixBits))
 }
 
 // New returns an egress policy value


### PR DESCRIPTION
Follows #30995 

This PR contains commits to move policy configs and endpoints used in the egress gateway manager to statedb.
There shouldn't be any behavioural changes here. No fancy business with granular state changes in this PR, that will follow.