### PR TITLE
loader: Compile separate bpf_xdp.o for xdp dev

### DIFF
--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -51,7 +51,6 @@ const (
 
 	xdpPrefix = "bpf_xdp"
 	xdpProg   = xdpPrefix + "." + string(outputSource)
-	xdpObj    = xdpPrefix + ".o"
 
 	overlayPrefix = "bpf_overlay"
 	overlayProg   = overlayPrefix + "." + string(outputSource)

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -141,7 +141,7 @@ func compileAndLoadXDPProg(ctx context.Context, xdpDev, xdpMode string, extraCAr
 	}
 	prog := &progInfo{
 		Source:     xdpProg,
-		Output:     xdpObj,
+		Output:     fmt.Sprintf("%s_%s.o", xdpPrefix, xdpDev),
 		OutputType: outputObject,
 		Options:    args,
 	}


### PR DESCRIPTION
When cilium is installed with `--helm-set=devices='{eth0,eth1}'`, agent compiles bpf_xdp.o for both devices with different preprocessor macros, such as -DNATIVE_DEV_IFINDEX. Unfortunately both compiled objects are at the same dir with the same filename, so the second output overwrites the first one. Consequently, eth1's bpf_xdp.o ends up being loaded to eth0.

This patch makes sure the bpf_xdp object has device name embedded like bpf_xdp_${dev}.o, thereby preventing object overwriting.

```release-note
Fixes bpf_xdp.o overwriting issue when multi devices are specified.
```
