### PR TITLE
fix: dedup cilium endpoint controllers

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -473,9 +473,9 @@ type policyRepoGetter interface {
 }
 
 // EndpointSyncControllerName returns the controller name to synchronize
-// endpoint in to kubernetes.
-func EndpointSyncControllerName(epID uint16) string {
-	return "sync-to-k8s-ciliumendpoint (" + strconv.FormatUint(uint64(epID), 10) + ")"
+// an endpoint into kubernetes.
+func EndpointSyncControllerName(name string) string {
+	return "sync-to-k8s-ciliumendpoint (" + name + ")"
 }
 
 // SetAllocator sets the identity allocator for this endpoint.
@@ -2295,7 +2295,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) (
 
 	// Trigger the sync-to-k8s-ciliumendpoint controller to sync the new
 	// endpoint's identity.
-	e.controllers.TriggerController(EndpointSyncControllerName(e.ID))
+	e.controllers.TriggerController(EndpointSyncControllerName(e.GetK8sNamespaceAndPodName()))
 
 	e.unlock()
 

--- a/pkg/endpointmanager/endpointsynchronizer.go
+++ b/pkg/endpointmanager/endpointsynchronizer.go
@@ -51,8 +51,8 @@ type EndpointSynchronizer struct {
 // CiliumEndpoint objects have the same name as the pod they represent.
 func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, h cell.Health) {
 	var (
-		endpointID     = e.ID
-		controllerName = endpoint.EndpointSyncControllerName(endpointID)
+		endpointKey    = e.GetK8sNamespaceAndPodName()
+		controllerName = endpoint.EndpointSyncControllerName(endpointKey)
 		scopedLog      = e.Logger(subsysEndpointSync).WithFields(logrus.Fields{
 			"controller": controllerName,
 			"endpointID": e.ID,
@@ -402,7 +402,7 @@ func updateCEPUID(scopedLog *logrus.Entry, e *endpoint.Endpoint, localCEP *ciliu
 // CEP from Kubernetes once the endpoint is stopped / removed from the
 // Cilium agent.
 func (epSync *EndpointSynchronizer) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
-	controllerName := endpoint.EndpointSyncControllerName(e.ID)
+	controllerName := endpoint.EndpointSyncControllerName(e.GetK8sNamespaceAndPodName())
 
 	scopedLog := e.Logger(subsysEndpointSync).WithField("controller", controllerName)
 

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -653,6 +653,13 @@ func (mgr *endpointManager) AddEndpoint(owner regeneration.Owner, ep *endpoint.E
 		return fmt.Errorf("Endpoint ID is already set to %d", ep.ID)
 	}
 
+	oldEP := mgr.LookupCEPName(ep.GetK8sNamespaceAndPodName())
+	if oldEP != nil {
+		// This is a container recreation event for an existing Pod.
+		// We want to merge this new endpoint with the existing endpoint.
+		ep.ID = oldEP.ID
+	}
+
 	// Updating logger to re-populate pod fields
 	// when endpoint and its logger are created pod details are not populated
 	// and all subsequent logs have empty pod details like ip addresses, k8sPodName


### PR DESCRIPTION
Fixes: #30820

This prevents an Endpoint controller from deleting a CEP object that has been claimed by another Endpoint controller.

This can happen during endpoint creation if the container sandbox creation fails and is retried (using a new container ID). Each sandbox creation attempt starts a new Endpoint controller for the same namespaced/named CEP object.

If the first Endpoint controller has not deleted the CEP object before the second Endpoint controller fetches and patches the CEP object, the UID will remain the same for the object but with a different container ID. Therefore, the CEP object should be managed by the Endpoint controller associated with the current container. At this point, the original Endpoint controller should no longer delete the CEP object.

```release-note
Map endpoint from container recreation to existing cilium endpoint and endpoint controller.
```
