### PR TITLE
Improve LocalNodeStore.Get() performance and fix possible deadlock

### DIFF
--- a/pkg/node/local_node_store.go
+++ b/pkg/node/local_node_store.go
@@ -5,6 +5,7 @@ package node
 
 import (
 	"context"
+	"io"
 	"sync"
 
 	"github.com/cilium/stream"
@@ -58,8 +59,23 @@ type LocalNodeStore struct {
 	// Changes to the local node are observable.
 	stream.Observable[LocalNode]
 
-	mu       lock.Mutex
+	// mu is the main LocalNodeStore mutex, which protects the access to the
+	// different fields during all operations. getMu, instead, is a separate
+	// mutex which is used to guard updates of the value field, as well as its
+	// access by the Get() method. The reason for using two separate mutexes
+	// being that we don't want Get() to be blocked while calling emit, as
+	// that synchronously calls into all subscribers, which is a potentially
+	// expensive operation, and a possible source of deadlocks (e.g., one of
+	// the subscribers needs to acquire another mutex, which is held by a
+	// separate goroutine trying to call LocalNodeStore.Get()). In addition,
+	// getMu also guards the complete field, as it is used by Get() to
+	// determine that the LocalNodeStore was stopped. When both mu and getMu
+	// are to be acquired together, mu shall be always acquired first.
+	mu    lock.Mutex
+	getMu lock.RWMutex
+
 	value    LocalNode
+	hasValue <-chan struct{}
 	emit     func(LocalNode)
 	complete func(error)
 }
@@ -72,11 +88,17 @@ func NewTestLocalNodeStore(mockNode LocalNode) *LocalNodeStore {
 		emit:       emit,
 		complete:   complete,
 		value:      mockNode,
+		hasValue: func() <-chan struct{} {
+			ch := make(chan struct{})
+			close(ch)
+			return ch
+		}(),
 	}
 }
 
 func NewLocalNodeStore(params LocalNodeStoreParams) (*LocalNodeStore, error) {
 	src, emit, complete := stream.Multicast[LocalNode](stream.EmitLatest)
+	hasValue := make(chan struct{})
 
 	s := &LocalNodeStore{
 		Observable: src,
@@ -86,6 +108,7 @@ func NewLocalNodeStore(params LocalNodeStoreParams) (*LocalNodeStore, error) {
 			Labels:      make(map[string]string),
 			Annotations: make(map[string]string),
 		}},
+		hasValue: hasValue,
 	}
 
 	bctx, cancel := context.WithCancel(context.Background())
@@ -116,6 +139,7 @@ func NewLocalNodeStore(params LocalNodeStoreParams) (*LocalNodeStore, error) {
 			s.emit = emit
 			s.complete = complete
 			emit(s.value)
+			close(hasValue)
 			return nil
 		},
 		OnStop: func(cell.HookContext) error {
@@ -125,8 +149,10 @@ func NewLocalNodeStore(params LocalNodeStoreParams) (*LocalNodeStore, error) {
 
 			s.mu.Lock()
 			s.complete(nil)
+			s.getMu.Lock()
 			s.complete = nil
 			s.emit = nil
+			s.getMu.Unlock()
 			s.mu.Unlock()
 
 			localNode = nil
@@ -141,17 +167,34 @@ func NewLocalNodeStore(params LocalNodeStoreParams) (*LocalNodeStore, error) {
 // e.g. in API handlers. Do not assume the value does not change over time.
 // Blocks until the store has been initialized.
 func (s *LocalNodeStore) Get(ctx context.Context) (LocalNode, error) {
-	// Subscribe to the stream of updates and take the first (latest) state.
-	return stream.First[LocalNode](ctx, s)
+	select {
+	case <-s.hasValue:
+		s.getMu.RLock()
+		defer s.getMu.RUnlock()
+
+		if s.complete == nil {
+			// Return EOF when the LocalNodeStore is stopped, to preserve the
+			// same behavior of stream.First[LocalNode].
+			return LocalNode{}, io.EOF
+		}
+
+		return s.value, nil
+
+	case <-ctx.Done():
+		return LocalNode{}, ctx.Err()
+	}
 }
 
 // Update modifies the local node with a mutator. The updated value
-// is passed to observers.
+// is passed to observers. Calling LocalNodeStore.Get() from the
+// mutation function is forbidden, and would result in a deadlock.
 func (s *LocalNodeStore) Update(update func(*LocalNode)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	s.getMu.Lock()
 	update(&s.value)
+	s.getMu.Unlock()
 
 	if s.emit != nil {
 		s.emit(s.value)

--- a/pkg/node/local_node_store_test.go
+++ b/pkg/node/local_node_store_test.go
@@ -99,3 +99,15 @@ func TestLocalNodeStore(t *testing.T) {
 		t.Fatalf("Unexpected values observed: %v, expected: %v", observed, expected)
 	}
 }
+
+func BenchmarkLocalNodeStoreGet(b *testing.B) {
+	ctx := context.Background()
+	lns := NewTestLocalNodeStore(LocalNode{})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = lns.Get(ctx)
+	}
+}


### PR DESCRIPTION
Currently, the local node store is implemented on top of an observable stream, and the Get operation leverages stream.First to retrieve the last emitted value. However, this approach suffers from two drawbacks, further detailed below: performance overhead and risk of deadlocks. To address them, let's instead implement the Get() method so that it directly returns a shallow copy of the stored LocalNode object, while making sure to preserve the existing behavior before starting the LocalNodeStore, and after stopping it.

More in detail, the possible deadlock is caused by the following series of events:

1. LocalNodeStore.Update() is triggered. stream.Multicast acquires a lock, and then synchronously calls the subscribers. Subscribers may do arbitrarily complex operations at that point, possibly acquiring other locks in the meanwhile. Let's assume that one of them blocks waiting for a given lock mu. 
2. A separate thread is currently holding the mu lock, and calls one of the global getters to, let's say, retrieve the v4 NodeInternalIP address, which in turns calls LocalNodeStore.Get() and creates a new stream.First observing the LocalNodeStore updates. However, the replay of the last event is blocked by the stream.Multicast lock held by the other thread, effectively causing a deadlock.

The subtle aspect here is that the global getters appear innocuous, and it is difficult to reason about the possibility of deadlocks. Conversely, the new approach ensures that LocalNodeStore.Get() never blocks even if any subscriber is still processing the update event.

In terms of performance, taking into account the newly introduced BenchmarkLocalNodeStoreGet benchmark, the new implementation cuts the CPU time and memory allocations by 96% and 100% respectively:

```
goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/node
cpu: 12th Gen Intel(R) Core(TM) i7-12700H
                     │    old.txt    │               new.txt                 │
                     │    sec/op     │   sec/op     vs base                  │
LocalNodeStoreGet-20   1151.00n ± 1%   44.27n ± 1%  -96.15% (p=0.000 n=10)

                     │   old.txt     │                new.txt                │
                     │     B/op      │     B/op      vs base                 │
LocalNodeStoreGet-20   1.090Ki ± 0%    0.000Ki ± 0%  -100.00% (p=0.000 n=10)

                     │  old.txt      │              new.txt                  │
                     │ allocs/op     │ allocs/op  vs base                    │
LocalNodeStoreGet-20   13.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=10)
```

Note: I've currently marked the PR as `release-note/misc`, and not marked it for backport given that the discovered deadlock also involved https://github.com/cilium/cilium/pull/30470, which got merged only recently. Happy to reconsider that decision if reviewers think that it is worth to be backported.