### PR TITLE
Handle InvalidParameterValue as well for PD fallback

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -27,6 +27,18 @@ import (
 	"github.com/cilium/cilium/pkg/spanstat"
 )
 
+const (
+	SubnetFullErrMsgStr = "There aren't sufficient free Ipv4 addresses or prefixes"
+
+	// InsufficientPrefixesInSubnetStr AWS error code for insufficient /28 prefixes in a subnet, possibly due to
+	// fragmentation
+	InsufficientPrefixesInSubnetStr = "InsufficientCidrBlocks"
+
+	// InvalidParameterValueStr sort of catch-all error code from AWS to indicate request params are invalid. Often,
+	// requires looking at the error message to get the actual reason. See SubnetFullErrMsgStr for example.
+	InvalidParameterValueStr = "InvalidParameterValue"
+)
+
 // Client represents an EC2 API client
 type Client struct {
 	ec2Client           *ec2.Client

--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -9,6 +9,7 @@ import (
 	"net"
 
 	"github.com/cilium/cilium/pkg/api/helpers"
+	"github.com/cilium/cilium/pkg/aws/ec2"
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/aws/types"
 	"github.com/cilium/cilium/pkg/ip"
@@ -20,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 
 	ec2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/smithy-go"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
@@ -433,7 +435,10 @@ func assignPrefixToENI(e *API, eni *eniTypes.ENI, prefixes int32) error {
 	}
 
 	if int(prefixes)*option.ENIPDBlockSizeIPv4 > subnet.AvailableAddresses {
-		return fmt.Errorf("subnet %s has not enough addresses available", eni.Subnet.ID)
+		return &smithy.GenericAPIError{
+			Code:    ec2.InvalidParameterValueStr,
+			Message: ec2.SubnetFullErrMsgStr,
+		}
 	}
 
 	for i := int32(0); i < prefixes; i++ {

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -40,8 +40,15 @@ const (
 	getMaximumAllocatableIPv4FailureWarningStr = "maximum allocatable ipv4 addresses will be 0 (unlimited)" +
 		" this could lead to ip allocation overflows if the max-allocate flag is not set"
 
-	// insufficientPrefixesInSubnetStr AWS error code for insufficient /28 prefixes in a subnet
+	subnetFullErrMsgStr = "There aren't sufficient free Ipv4 addresses or prefixes"
+
+	// insufficientPrefixesInSubnetStr AWS error code for insufficient /28 prefixes in a subnet, possibly due to
+	// fragmentation
 	insufficientPrefixesInSubnetStr = "InsufficientCidrBlocks"
+
+	// invalidParameterValueStr sort of catch-all error code from AWS to indicate request params are invalid. Often,
+	// requires looking at the error message to get the actual reason. See subnetFullErrMsgStr for example.
+	invalidParameterValueStr = "InvalidParameterValue"
 )
 
 type ipamNodeActions interface {
@@ -266,7 +273,9 @@ func (n *Node) PrepareIPAllocation(scopedLog *logrus.Entry) (a *ipam.AllocationA
 func isSubnetAtPrefixCapacity(err error) bool {
 	var apiErr smithy.APIError
 	if errors.As(err, &apiErr) {
-		return apiErr.ErrorCode() == insufficientPrefixesInSubnetStr
+		return apiErr.ErrorCode() == insufficientPrefixesInSubnetStr ||
+			(apiErr.ErrorCode() == invalidParameterValueStr &&
+				strings.Contains(apiErr.ErrorMessage(), subnetFullErrMsgStr))
 	}
 	return false
 }
@@ -352,7 +361,8 @@ func (n *Node) errorInstanceNotRunning(err error) (notRunning bool) {
 func isAttachmentIndexConflict(err error) bool {
 	var apiErr smithy.APIError
 	if errors.As(err, &apiErr) {
-		return apiErr.ErrorCode() == "InvalidParameterValue" && strings.Contains(apiErr.ErrorMessage(), "interface attached at device")
+		return apiErr.ErrorCode() == invalidParameterValueStr &&
+			strings.Contains(apiErr.ErrorMessage(), "interface attached at device")
 	}
 	return false
 }

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/pkg/aws/ec2"
 	"github.com/cilium/cilium/pkg/aws/eni/limits"
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -39,16 +40,6 @@ const (
 
 	getMaximumAllocatableIPv4FailureWarningStr = "maximum allocatable ipv4 addresses will be 0 (unlimited)" +
 		" this could lead to ip allocation overflows if the max-allocate flag is not set"
-
-	subnetFullErrMsgStr = "There aren't sufficient free Ipv4 addresses or prefixes"
-
-	// insufficientPrefixesInSubnetStr AWS error code for insufficient /28 prefixes in a subnet, possibly due to
-	// fragmentation
-	insufficientPrefixesInSubnetStr = "InsufficientCidrBlocks"
-
-	// invalidParameterValueStr sort of catch-all error code from AWS to indicate request params are invalid. Often,
-	// requires looking at the error message to get the actual reason. See subnetFullErrMsgStr for example.
-	invalidParameterValueStr = "InvalidParameterValue"
 )
 
 type ipamNodeActions interface {
@@ -273,9 +264,9 @@ func (n *Node) PrepareIPAllocation(scopedLog *logrus.Entry) (a *ipam.AllocationA
 func isSubnetAtPrefixCapacity(err error) bool {
 	var apiErr smithy.APIError
 	if errors.As(err, &apiErr) {
-		return apiErr.ErrorCode() == insufficientPrefixesInSubnetStr ||
-			(apiErr.ErrorCode() == invalidParameterValueStr &&
-				strings.Contains(apiErr.ErrorMessage(), subnetFullErrMsgStr))
+		return apiErr.ErrorCode() == ec2.InsufficientPrefixesInSubnetStr ||
+			(apiErr.ErrorCode() == ec2.InvalidParameterValueStr &&
+				strings.Contains(apiErr.ErrorMessage(), ec2.SubnetFullErrMsgStr))
 	}
 	return false
 }
@@ -361,7 +352,7 @@ func (n *Node) errorInstanceNotRunning(err error) (notRunning bool) {
 func isAttachmentIndexConflict(err error) bool {
 	var apiErr smithy.APIError
 	if errors.As(err, &apiErr) {
-		return apiErr.ErrorCode() == invalidParameterValueStr &&
+		return apiErr.ErrorCode() == ec2.InvalidParameterValueStr &&
 			strings.Contains(apiErr.ErrorMessage(), "interface attached at device")
 	}
 	return false


### PR DESCRIPTION
cilium#30536 prematurely concluded that AWS now uses InsufficientCidrBlocks to indicate the subnet is out of prefixes. Looks like AWS still uses `InvalidParameterValue` and `There aren't sufficient free Ipv4 addresses or prefixes` to indicate subnet is at capacity. However, when subnet is at capacity potentially due to fragmentation, `InsufficientCidrBlocks` is returned. In either case, it's worth trying to fallback since /32 IPs might still be available compared to /28. Details from the support ticket we opened with AWS for clarification


> I would like to inform you that I have received an update from our team :
> 
> 	- Client.InvalidParameterValue : There aren't sufficient free Ipv4 addresses or prefixes 
> 
> 		The exception 'Client.InvalidParameterValue : There aren't sufficient free Ipv4 addresses or prefixes' occurs when the number of requested IP addresses exceeds the number of available IP addresses in a subnet. This exception can occur during CreateNetworkInterface, AttachNetworkInterface, and AssignPrivateIpAddresses (please refer to Common client error codes section).
> 
>  			[+] [https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateNetworkInterface.html ](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateNetworkInterface.html)
>  			[+] [https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AttachNetworkInterface.html ](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AttachNetworkInterface.html)
>  			[+] [https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssignPrivateIpAddresses.html ](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssignPrivateIpAddresses.html)
>  			[+] [https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html#CommonErrors ](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html#CommonErrors)
> 
> 
> 
> 	- Client.InsufficientCidrBlocks : The specified subnet does not have enough free cidr blocks to satisfy the request
> 
> 		The exception 'Client.InsufficientCidrBlocks : The specified subnet does not have enough free cidr blocks to satisfy the request' occurs when subnet does not have any contiguous /28 blocks available as available in our public docs.
> 
>  			[+] [https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html ](https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html)
> 
> 		
> 		Even if your subnet has available IP addresses, if the subnet does not have any contiguous /28 blocks available, you will see the following error.
> 
> 		This can happen due to fragmentation of existing secondary IP addresses spread out across a subnet. To resolve this error, either create a new subnet and launch Pods there, or use an Amazon EC2 subnet CIDR reservation to reserve space within a subnet for use with prefix assignment. For more information, see Subnet CIDR reservations in the Amazon VPC User Guide.
> -------------------------------------------------------------------------------------------------------
> 
> 
> Depending on subnet IP utilization during API call, the response for API call can be reaching either of the two scenarios above.
> 
> Additional References :-
> 
> 		[+] https://repost.aws/knowledge-center/vpc-insufficient-ip-errors
> 
