### PR TITLE
daemon: Use LastSuccessInteraction instead of LastInteraction

### DIFF
--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -48,10 +48,10 @@ const (
 	// version is verified even if connectivity is given
 	k8sVersionCheckInterval = 15 * time.Minute
 
-	// k8sMinimumEventHearbeat is the time interval in which any received
+	// k8sMinimumEventHeartbeat is the time interval in which any received
 	// event will be considered proof that the apiserver connectivity is
-	// healthty
-	k8sMinimumEventHearbeat = time.Minute
+	// healthy
+	k8sMinimumEventHeartbeat = time.Minute
 )
 
 var randGen = rand.NewSafeRand(time.Now().UnixNano())
@@ -66,7 +66,7 @@ func (k *k8sVersion) cachedVersion() (string, bool) {
 	k.lock.Lock()
 	defer k.lock.Unlock()
 
-	if time.Since(k8smetrics.LastInteraction.Time()) > k8sMinimumEventHearbeat {
+	if time.Since(k8smetrics.LastSuccessInteraction.Time()) > k8sMinimumEventHeartbeat {
 		return "", false
 	}
 


### PR DESCRIPTION
cilium-agent periodically checks the connectivity to the k8s api-server by "kubernetes" probe. `cachedVersion()` returns a cached value of the k8s version to the probe if not expired or invalid.

The logic for evaluating the validity of the cache is as follows:
1. check if the api-server connectivity is healthy. If the last check was more than `k8sMinimumEventHeartbeat`(default: 1m) ago, then valid=false is returned.
2. if the api-server connectivity is given, returns valid=false if the last check was more than `k8sVersionCheckInterval`(default: 15m) ago.
3. otherwise returns the cached value and valid=true.

Currently `k8smetrics.LastInteraction.Time()` is used in the step 1, which is updated periodically regardless of whether the api-server connectivity is alive or not. This commit fixes it to use `k8smetrics.LastSuccessInteraction.Time()` instead.

```release-note
Fix the logic of the api-server connectivity check for the kubernetes probe
```
