### PR TITLE
controlplane: fix mechanism for ensuring watchers

### DIFF
--- a/test/controlplane/node/ciliumnodes/ciliumnodes.go
+++ b/test/controlplane/node/ciliumnodes/ciliumnodes.go
@@ -90,7 +90,6 @@ func init() {
 				test.
 					UpdateObjectsFromFile(abs("init.yaml")).
 					SetupEnvironment().
-					RecordWatchers().
 					StartAgent(modConfig).
 					EnsureWatchers("nodes").
 					ClearEnvironment()

--- a/test/controlplane/pod/hostport/hostport.go
+++ b/test/controlplane/pod/hostport/hostport.go
@@ -36,7 +36,6 @@ func testHostPort(t *testing.T) {
 	test.
 		UpdateObjectsFromFile(abs("init.yaml")).
 		SetupEnvironment().
-		RecordWatchers().
 		StartAgent(func(_ *option.DaemonConfig) {}).
 		EnsureWatchers("pods").
 

--- a/test/controlplane/services/dualstack/dualstack.go
+++ b/test/controlplane/services/dualstack/dualstack.go
@@ -40,7 +40,6 @@ func testDualStack(t *testing.T) {
 			test.
 				UpdateObjectsFromFile(abs("init.yaml")).
 				SetupEnvironment().
-				RecordWatchers().
 				StartAgent(modConfig).
 				EnsureWatchers("endpointslices", "services").
 				UpdateObjectsFromFile(abs("state1.yaml")).

--- a/test/controlplane/services/graceful-termination/graceful_termination.go
+++ b/test/controlplane/services/graceful-termination/graceful_termination.go
@@ -40,7 +40,6 @@ func testGracefulTermination(t *testing.T) {
 	test.
 		UpdateObjectsFromFile(abs("init.yaml")).
 		SetupEnvironment().
-		RecordWatchers().
 		StartAgent(modConfig).
 		EnsureWatchers("endpointslices", "services").
 

--- a/test/controlplane/services/nodeport/nodeport.go
+++ b/test/controlplane/services/nodeport/nodeport.go
@@ -40,7 +40,6 @@ func init() {
 					test.
 						UpdateObjectsFromFile(abs("init.yaml")).
 						SetupEnvironment().
-						RecordWatchers().
 						StartAgent(modConfig).
 						EnsureWatchers("endpointslices", "pods", "services").
 						UpdateObjectsFromFile(abs("state1.yaml")).

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -57,15 +57,16 @@ type ControlPlaneTest struct {
 	agentHandle         *agentHandle
 	operatorHandle      *operatorHandle
 	Datapath            *fakeTypes.FakeDatapath
-	establishedWatchers lock.Map[string, struct{}]
+	establishedWatchers *lock.Map[string, struct{}]
 }
 
 func NewControlPlaneTest(t *testing.T, nodeName string, k8sVersion string) *ControlPlaneTest {
 	clients, _ := k8sClient.NewFakeClientset()
-	clients.KubernetesFakeClientset = addFieldSelection(clients.KubernetesFakeClientset)
-	clients.SlimFakeClientset = addFieldSelection(clients.SlimFakeClientset)
-	clients.CiliumFakeClientset = addFieldSelection(clients.CiliumFakeClientset)
-	clients.APIExtFakeClientset = addFieldSelection(clients.APIExtFakeClientset)
+	var w lock.Map[string, struct{}]
+	clients.KubernetesFakeClientset = augmentTracker(clients.KubernetesFakeClientset, t, &w)
+	clients.SlimFakeClientset = augmentTracker(clients.SlimFakeClientset, t, &w)
+	clients.CiliumFakeClientset = augmentTracker(clients.CiliumFakeClientset, t, &w)
+	clients.APIExtFakeClientset = augmentTracker(clients.APIExtFakeClientset, t, &w)
 	fd := clients.KubernetesFakeClientset.Discovery().(*fakediscovery.FakeDiscovery)
 	fd.FakedServerVersion = toVersionInfo(k8sVersion)
 
@@ -85,10 +86,11 @@ func NewControlPlaneTest(t *testing.T, nodeName string, k8sVersion string) *Cont
 	}
 
 	return &ControlPlaneTest{
-		t:        t,
-		nodeName: nodeName,
-		clients:  clients,
-		trackers: trackers,
+		t:                   t,
+		nodeName:            nodeName,
+		clients:             clients,
+		trackers:            trackers,
+		establishedWatchers: &w,
 	}
 }
 
@@ -256,33 +258,6 @@ func (cpt *ControlPlaneTest) Get(gvr schema.GroupVersionResource, ns, name strin
 		}
 	}
 	return nil, err
-}
-
-// RecordWatchers intercepts 'Watch' calls on the fake k8s clientsets. The reason we need to do this
-// is the following: The k8s object tracker's implementation of Watch is not equivalent to Watch on
-// a real api-server, as it does not respect the ResourceVersion from whence to start the watch. As
-// a consequence, when informers (or reflectors) call ListAndWatch, they miss events which occur
-// between the end of List and the establishment of Watch.
-//
-// To decrease the likelihood of this race occurring in the control plane tests, we install a
-// mechanism to wait for watchers of specific resources: see also EnsureWatchers. This isn't a
-// complete fix - if multiple watchers for the same resource are established, this may give false
-// positives.
-func (cpt *ControlPlaneTest) RecordWatchers() *ControlPlaneTest {
-	reaction := func(action k8sTesting.Action) (handled bool, ret watch.Interface, err error) {
-		r := action.GetResource().Resource
-		if _, ok := cpt.establishedWatchers.Load(r); ok {
-			cpt.t.Logf("WARNING: Multiple watches for resource %s intercepted. This highlights a potential cause for flakes", r)
-		}
-		cpt.establishedWatchers.Store(r, struct{}{})
-		return false, nil, nil
-	}
-
-	cpt.clients.SlimFakeClientset.PrependWatchReactor("*", reaction)
-	cpt.clients.KubernetesFakeClientset.PrependWatchReactor("*", reaction)
-	cpt.clients.CiliumFakeClientset.PrependWatchReactor("*", reaction)
-	cpt.clients.APIExtFakeClientset.PrependWatchReactor("*", reaction)
-	return cpt
 }
 
 // EnsureWatchers delays progress of the test until watchers for resources have been established on
@@ -587,9 +562,19 @@ func filterList(obj k8sRuntime.Object, restrictions k8sTesting.ListRestrictions)
 	}
 }
 
-// addFieldSelection augments the fake clientset to support filtering with a field selector
-// in List and Watch actions
-func addFieldSelection[T fakeWithTracker](f T) T {
+// augmentTracker augments the fake clientset to support filtering with a field selector
+// in List and Watch actions, as well as recording which watchers have been established.
+// The reason we need to do this is the following: The k8s object tracker's implementation
+// of Watch is not equivalent to Watch on a real api-server, as it does not respect the
+// ResourceVersion from whence to start the watch. As a consequence, when informers (or
+// reflectors) call ListAndWatch, they miss events which occur between the end of List and
+// the establishment of Watch.
+//
+// To decrease the likelihood of this race occurring in the control plane tests, we
+// install a mechanism to wait for watchers of specific resources: see also
+// EnsureWatchers. This isn't a complete fix - if multiple watchers for the same resource
+// are established, this may give false positives.
+func augmentTracker[T fakeWithTracker](f T, t *testing.T, watchers *lock.Map[string, struct{}]) T {
 	o := f.Tracker()
 	objectReaction := k8sTesting.ObjectReaction(o)
 
@@ -616,6 +601,11 @@ func addFieldSelection[T fakeWithTracker](f T) T {
 			if err != nil {
 				return false, nil, err
 			}
+			if _, ok := watchers.Load(gvr.Resource); ok {
+				t.Logf("Multiple watches for resource %q intercepted. This highlights a potential cause for flakes", gvr.Resource)
+			}
+			watchers.Store(gvr.Resource, struct{}{})
+
 			fw := &filteringWatcher{
 				parent:       watch,
 				restrictions: w.GetWatchRestrictions(),


### PR DESCRIPTION
I realized that the fix for controlplane tests isn't complete. There is still a (small) race window: The current watch reaction records a watcher as established without "handling" the watch itself, i.e. it lets the default watch reaction actually call 'Watch' on the tracker. This is racy, as things can happen in the window between recordng and actually watching.

To fix this completely, call Watch ourselves, before we store the watcher. As a result, we now have to report the action as handled, otherwise the default watch reaction establishes a duplicate watch. This is unfortunate, as it is possible that upstream changes its default watch reaction, and we'll have to revisit this, but I don't know of a way we can both use the upstream watch reaction as well as avoid this race.

Fixes: ba99d74c44 (controlplane: add mechanism to wait for watchers)