### PR TITLE
container/bitlpm: Add Lookup Boolean Return Value

### DIFF
--- a/pkg/container/bitlpm/cidr.go
+++ b/pkg/container/bitlpm/cidr.go
@@ -24,10 +24,10 @@ func NewCIDRTrie[T any]() *CIDRTrie[T] {
 }
 
 // Lookup returns the longest matched value for a given address.
-func (c *CIDRTrie[T]) Lookup(addr netip.Addr) T {
+func (c *CIDRTrie[T]) Lookup(addr netip.Addr) (T, bool) {
 	if !addr.IsValid() {
 		var def T
-		return def
+		return def, false
 	}
 	bits := addr.BitLen()
 	prefix := netip.PrefixFrom(addr, bits)

--- a/pkg/container/bitlpm/cidr_test.go
+++ b/pkg/container/bitlpm/cidr_test.go
@@ -42,7 +42,7 @@ loop:
 				continue loop
 			}
 		}
-		have := trie.Lookup(prefixes[name].Addr())
+		have, _ := trie.Lookup(prefixes[name].Addr())
 		if have != name {
 			t.Errorf("Lookup(%s) returned %s want %s", prefixes[name].String(), have, name)
 		}
@@ -92,7 +92,9 @@ loop:
 			"0",
 		},
 	} {
-		assert.Equal(t, tc.v, trie.Lookup(netip.MustParsePrefix(tc.k).Addr()))
+		v, ok := trie.Lookup(netip.MustParsePrefix(tc.k).Addr())
+		assert.True(t, ok)
+		assert.Equal(t, tc.v, v)
 	}
 
 }

--- a/pkg/container/bitlpm/trie.go
+++ b/pkg/container/bitlpm/trie.go
@@ -22,9 +22,9 @@ package bitlpm
 // [least significant bit]: https://en.wikipedia.org/wiki/Bit_numbering#Least_significant_bit
 // [longest prefix match algorithm]: https://en.wikipedia.org/wiki/Longest_prefix_match
 type Trie[K, T any] interface {
-	// Lookup returns the longest prefix match to a specific
+	// Lookup returns the longest prefix match for a specific
 	// key.
-	Lookup(key K) T
+	Lookup(key K) (v T, ok bool)
 	// Ancestors iterates over every prefix-key pair that contains
 	// the prefix-key argument pair. If the Ancestors function argument
 	// returns false the iteration will stop. Ancestors will iterate
@@ -103,15 +103,19 @@ type node[K, T any] struct {
 
 // Lookup returns the value for the key with longest prefix match to the given
 // key.
-func (t *trie[K, T]) Lookup(k Key[K]) T {
+func (t *trie[K, T]) Lookup(k Key[K]) (T, bool) {
 	// default return value
-	var empty T
+	var (
+		empty T
+		ok    bool
+	)
 	ret := &empty
 	t.traverse(t.maxPrefix, k, func(currentNode *node[K, T], matchLen uint) bool {
 		ret = &currentNode.value
+		ok = true
 		return true
 	})
-	return *ret
+	return *ret, ok
 }
 
 // Ancestors calls the function argument for every prefix/key/value in the trie

--- a/pkg/container/bitlpm/unsigned.go
+++ b/pkg/container/bitlpm/unsigned.go
@@ -50,7 +50,7 @@ func (tu *trieUint[K, T]) Delete(prefix uint, k K) bool {
 	return tu.t.Delete(prefix, tu.getKey(k))
 }
 
-func (tu *trieUint[K, T]) Lookup(k K) T {
+func (tu *trieUint[K, T]) Lookup(k K) (T, bool) {
 	return tu.t.Lookup(tu.getKey(k))
 }
 

--- a/pkg/container/bitlpm/unsigned_test.go
+++ b/pkg/container/bitlpm/unsigned_test.go
@@ -241,7 +241,7 @@ func TestUnsignedLookup(t *testing.T) {
 				// purpose of the loop condition as some tests
 				// overflow uint16 causing an infinite loop.
 				for p := uint(start); p <= uint(end); p++ {
-					got := ut.Lookup(uint16(p))
+					got, _ := ut.Lookup(uint16(p))
 					if entry != got {
 						t.Fatalf("Looking up key %d, expected entry %q, but got %q", p, entry, got)
 					}
@@ -251,14 +251,14 @@ func TestUnsignedLookup(t *testing.T) {
 			start := firstRange.start
 			end := lastRange.end
 			for p := uint(0); p < uint(start); p++ {
-				got := ut.Lookup(uint16(p))
-				if got != "" {
+				got, ok := ut.Lookup(uint16(p))
+				if ok {
 					t.Fatalf("Looking up key %d, expected no entry, but got %q", p, got)
 				}
 			}
 			for p := uint(end) + 1; p <= uint(65535); p++ {
-				got := ut.Lookup(uint16(p))
-				if got != "" {
+				got, ok := ut.Lookup(uint16(p))
+				if ok {
 					t.Fatalf("Looking up key %d, expected no entry, but got %q", p, got)
 				}
 			}
@@ -633,8 +633,8 @@ func BenchmarkTrieLookup(b *testing.B) {
 	for i := uint32(0); i < 255; i++ {
 		upperOct := i << 8
 		for t := uint32(0); t < 255; t++ {
-			st := tri.Lookup(0xffff_0000 | upperOct | t)
-			if st == nil {
+			_, ok := tri.Lookup(0xffff_0000 | upperOct | t)
+			if !ok {
 				b.Fatal("expected valid lookup, but got nil")
 			}
 		}


### PR DESCRIPTION
Lookup currently returns the default value of
the bitlpm.Trie when it fails to find a match.
There are cases where comparing the
default value to the return value is logically expensive
(i.e. code needs to be written to do the comparison). 
Lookup can easily return a boolean value to indicate 
whether Lookup failed, making it easier for library
users to determine if Lookup failed.
