### PR TITLE
bpf: Fix VTEP drop check

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -342,7 +342,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 			if (!vtep)
 				goto skip_vtep;
 			if (vtep->tunnel_endpoint) {
-				if (identity_is_world_ipv4(*identity))
+				if (!identity_is_world_ipv4(*identity))
 					return DROP_INVALID_VNI;
 			}
 		}


### PR DESCRIPTION
Commit a94fa56f6713 ("Fix CIDR to World Entity Conversion Bug") seems to
have inadvertently swapped a check for "is not world" to a check for "is
world" in order to drop. This has likely broken the VTEP feature. Fix
it.

Fixes: a94fa56f6713 ("Fix CIDR to World Entity Conversion Bug")
Fixes: https://github.com/cilium/cilium/pull/22625
Fixes: https://github.com/cilium/cilium/issues/31023

```release-note
Fix bug in the VTEP feature which caused all traffic from the VTEP to be dropped with "Incorrect VNI from VTEP"
```