### PR TITLE
docs: Fix profiling related debugging instructions

### DIFF
--- a/Documentation/contributing/development/debugging.rst
+++ b/Documentation/contributing/development/debugging.rst
@@ -485,7 +485,7 @@ Inspecting profiles can help identify CPU bottlenecks and memory leaks.
 
 To capture a profile, take a :ref:`sysdump <sysdump>` of the cluster with the
 Cilium CLI or more directly, use the ``cilium-bugtool`` command that is
-included in the Cilium image:
+included in the Cilium image after enabling ``pprof`` in the Cilium ConfigMap:
 
 .. code-block:: shell-session
 


### PR DESCRIPTION
The bugtool command to collect pprof profile requires pprof config option to be enabled.

Before:

```
# cilium-bugtool --get-pprof --pprof-trace-seconds 5 cilium-bugtool --get-pprof --pprof-trace-seconds 5
Failed to create debug directory Get "http://localhost:6060/debug/pprof/trace?seconds=5": dial tcp [::1]:6060: connect: connection refused
```


After:

```
# cilium-bugtool --get-pprof --pprof-trace-seconds 5 Deleted empty directory /tmp/cilium-bugtool-20240228-235819.48+0000-UTC-1213053454/cmd Deleted empty directory /tmp/cilium-bugtool-20240228-235819.48+0000-UTC-1213053454/conf Skipping directory cilium-bugtool-20240228-235819.48+0000-UTC-1213053454 Skipping directory cmd

ARCHIVE at /tmp/cilium-bugtool-20240228-235819.48+0000-UTC-1213053454.tar

```
Signed-off-by: Aditi Ghag <aditi@cilium.io>