### PR TITLE
gateway-api: Correct the null check for GRPRRoute Match

### DIFF
--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -594,7 +594,7 @@ func toPathMatch(match gatewayv1.HTTPRouteMatch) model.StringMatch {
 }
 
 func toGRPCPathMatch(match gatewayv1alpha2.GRPCRouteMatch) model.StringMatch {
-	if match.Method.Service == nil || match.Method == nil {
+	if match.Method == nil || match.Method.Service == nil {
 		return model.StringMatch{}
 	}
 


### PR DESCRIPTION
The null check for Method should be before the check for Method.Service to avoid NPE.