### PR TITLE
bpf: explicitly pass map to policy_can_{in,e}gress{4,6}

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -480,8 +480,9 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	 * within the cluster, it must match policy or be dropped. If it's
 	 * bound for the host/outside, perform the CIDR policy check.
 	 */
-	verdict = policy_can_egress6(ctx, tuple, l4_off, SECLABEL_IPV6, *dst_sec_identity,
-				     &policy_match_type, &audited, ext_err, &proxy_port);
+	verdict = policy_can_egress6(ctx, &POLICY_MAP, tuple, l4_off, SECLABEL_IPV6,
+				     *dst_sec_identity, &policy_match_type, &audited,
+				     ext_err, &proxy_port);
 
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		auth_type = (__u8)*ext_err;
@@ -922,8 +923,9 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	 * within the cluster, it must match policy or be dropped. If it's
 	 * bound for the host/outside, perform the CIDR policy check.
 	 */
-	verdict = policy_can_egress4(ctx, tuple, l4_off, SECLABEL_IPV4, *dst_sec_identity,
-				     &policy_match_type, &audited, ext_err, &proxy_port);
+	verdict = policy_can_egress4(ctx, &POLICY_MAP, tuple, l4_off, SECLABEL_IPV4,
+				     *dst_sec_identity, &policy_match_type, &audited,
+				     ext_err, &proxy_port);
 
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		auth_type = (__u8)*ext_err;
@@ -1562,8 +1564,9 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, int ifindex, __u32 src_
 	if (skip_ingress_proxy)
 		goto skip_policy_enforcement;
 
-	verdict = policy_can_ingress6(ctx, tuple, l4_off, src_label, SECLABEL_IPV6,
-				      &policy_match_type, &audited, ext_err, proxy_port);
+	verdict = policy_can_ingress6(ctx, &POLICY_MAP, tuple, l4_off, src_label,
+				      SECLABEL_IPV6, &policy_match_type, &audited,
+				      ext_err, proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		struct remote_endpoint_info *sep = lookup_ip6_remote_endpoint(&orig_sip, 0);
 
@@ -1920,9 +1923,9 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, int ifindex, __u32 src_la
 		goto skip_policy_enforcement;
 #endif /* ENABLE_PER_PACKET_LB && !DISABLE_LOOPBACK_LB */
 
-	verdict = policy_can_ingress4(ctx, tuple, l4_off, is_untracked_fragment, src_label,
-				      SECLABEL_IPV4, &policy_match_type, &audited, ext_err,
-				      proxy_port);
+	verdict = policy_can_ingress4(ctx, &POLICY_MAP, tuple, l4_off, is_untracked_fragment,
+				      src_label, SECLABEL_IPV4, &policy_match_type, &audited,
+				      ext_err, proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		struct remote_endpoint_info *sep = lookup_ip4_remote_endpoint(orig_sip, 0);
 

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -115,9 +115,9 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 		return CTX_ACT_OK;
 
 	/* Perform policy lookup. */
-	verdict = policy_can_egress6(ctx, tuple, ct_buffer->l4_off, HOST_ID,
-				     dst_sec_identity, &policy_match_type,
-				     &audited, ext_err, &proxy_port);
+	verdict = policy_can_egress6(ctx, &POLICY_MAP, tuple, ct_buffer->l4_off, HOST_ID,
+				     dst_sec_identity, &policy_match_type, &audited, ext_err,
+				     &proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		auth_type = (__u8)*ext_err;
 		verdict = auth_lookup(ctx, HOST_ID, dst_sec_identity, tunnel_endpoint, auth_type);
@@ -235,8 +235,9 @@ __ipv6_host_policy_ingress(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 		goto out;
 
 	/* Perform policy lookup */
-	verdict = policy_can_ingress6(ctx, tuple, ct_buffer->l4_off, *src_sec_identity, HOST_ID,
-				      &policy_match_type, &audited, ext_err, &proxy_port);
+	verdict = policy_can_ingress6(ctx, &POLICY_MAP, tuple, ct_buffer->l4_off,
+				      *src_sec_identity, HOST_ID, &policy_match_type, &audited,
+				      ext_err, &proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		auth_type = (__u8)*ext_err;
 		verdict = auth_lookup(ctx, HOST_ID, *src_sec_identity, tunnel_endpoint, auth_type);
@@ -390,7 +391,7 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 		return CTX_ACT_OK;
 
 	/* Perform policy lookup. */
-	verdict = policy_can_egress4(ctx, tuple, ct_buffer->l4_off, HOST_ID,
+	verdict = policy_can_egress4(ctx, &POLICY_MAP, tuple, ct_buffer->l4_off, HOST_ID,
 				     dst_sec_identity, &policy_match_type,
 				     &audited, ext_err, &proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
@@ -404,7 +405,7 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 		ct_state_new.proxy_redirect = proxy_port > 0;
 		ct_state_new.from_l7lb = false;
 
-		/* ext_err may contain a value from __policy_can_access, and
+		/* ext_err may contain a value from __eolicy_can_access, and
 		 * ct_create4 overwrites it only if it returns an error itself.
 		 * As the error from __policy_can_access is dropped in that
 		 * case, it's OK to return ext_err from ct_create4 along with
@@ -512,9 +513,9 @@ __ipv4_host_policy_ingress(struct __ctx_buff *ctx, struct iphdr *ip4,
 #  endif
 
 	/* Perform policy lookup */
-	verdict = policy_can_ingress4(ctx, tuple, ct_buffer->l4_off, is_untracked_fragment,
-				      *src_sec_identity, HOST_ID, &policy_match_type,
-				      &audited, ext_err, &proxy_port);
+	verdict = policy_can_ingress4(ctx, &POLICY_MAP, tuple, ct_buffer->l4_off,
+				      is_untracked_fragment, *src_sec_identity, HOST_ID,
+				      &policy_match_type, &audited, ext_err, &proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		auth_type = (__u8)*ext_err;
 		verdict = auth_lookup(ctx, HOST_ID, *src_sec_identity, tunnel_endpoint, auth_type);


### PR DESCRIPTION
currently some functions in policy.h reference POLICY_MAP, assuming it's always defined. This prevents including this header in a context where the POLICY_MAP is not defined.

To overcome this, remove all the POLICY_MAP references from these functions and always pass the map explicitly in the caller.

No functional changes are introduced