### PR TITLE
xds: Avoid xds timeout due to agent restart in envoy DS mode

### DIFF
--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -327,6 +327,11 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			state := &typeStates[index]
 			watcher := s.watchers[typeURL]
 
+			if nonce == 0 && versionInfo > 0 {
+				requestLog.Debugf("xDS was restarted, setting nonce to %d", versionInfo)
+				nonce = versionInfo
+			}
+
 			// Response nonce is always the same as the response version.
 			// Request version indicates the last acked version. If the
 			// response nonce in the request is different (smaller) than


### PR DESCRIPTION
For external envoy, xds server and envoy are having different life cycles i.e. each is running in its own pod, and can be deployed or restarted independently. This commit is to handle the case that xds in cilium agent got restarted, and nonce value is always 0.

Sample error
```
2024-02-05T12:49:51.771714518Z level=warning msg="Regeneration of endpoint failed" bpfCompilation=0s bpfLoadProg=105.68356ms bpfWaitForELF="24.396µs" bpfWriteELF=1.802221ms ciliumEndpointName=cilium-test/client-56f8968958-fqdl4 containerID=245b2aaac2 containerInterface=eth0 datapathPolicyRevision=5 desiredPolicyRevision=6 endpointID=134 error="Error while configuring proxy redirects: proxy state changes failed: context canceled" identity=1713 ipv4=10.244.1.1 ipv6="fd00:10:244:1::9544" k8sPodName=cilium-test/client-56f8968958-fqdl4 mapSync=2.476505ms policyCalculation=1.240346ms prepareBuild="437.049µs" proxyConfiguration="837.119µs" proxyPolicyCalculation="234.369µs" proxyWaitForAck=2m34.697546384s reason="policy rules added" subsys=endpoint total=2m34.818201428s waitingForCTClean=270ns waitingForLock="2.605µs"
```

