### PR TITLE
iptables: Simplify proxy rules removing ingress/egress flag

### DIFF
--- a/pkg/datapath/fake/types/datapath.go
+++ b/pkg/datapath/fake/types/datapath.go
@@ -79,7 +79,7 @@ func (f *FakeDatapath) WriteEndpointConfig(io.Writer, datapath.EndpointConfigura
 	return nil
 }
 
-func (f *FakeDatapath) InstallProxyRules(context.Context, uint16, bool, bool, string) error {
+func (f *FakeDatapath) InstallProxyRules(context.Context, uint16, bool, string) error {
 	return nil
 }
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -949,7 +949,7 @@ func (m *Manager) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error {
 	return nil
 }
 
-func (m *Manager) InstallProxyRules(ctx context.Context, proxyPort uint16, ingress, localOnly bool, name string) error {
+func (m *Manager) InstallProxyRules(ctx context.Context, proxyPort uint16, localOnly bool, name string) error {
 	if m.haveBPFSocketAssign {
 		log.WithField("port", proxyPort).
 			Debug("Skipping proxy rule install due to BPF support")

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -223,7 +223,7 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 	}
 
 	// Adds new proxy rules
-	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37379, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37379, "cilium-dns-egress")
 	err := mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 
@@ -256,7 +256,7 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 	}
 
 	// Nothing to add
-	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37379, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37379, "cilium-dns-egress")
 	err = mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 
@@ -297,7 +297,7 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 	}
 
 	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
-	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37380, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37380, "cilium-dns-egress")
 	err = mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 
@@ -338,7 +338,7 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 	}
 
 	// Same port number, new IP, adds new ones, deletes stale rules. Does not touch OLD_ chains
-	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37379, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37379, "cilium-dns-egress")
 	err = mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 }
@@ -420,7 +420,7 @@ func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
 	}
 
 	// Adds new proxy rules
-	mockManager.addProxyRules(mockIp6tables, "::1", 43477, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp6tables, "::1", 43477, "cilium-dns-egress")
 	err := mockIp6tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 
@@ -453,7 +453,7 @@ func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
 	}
 
 	// Nothing to add
-	mockManager.addProxyRules(mockIp6tables, "::1", 43477, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp6tables, "::1", 43477, "cilium-dns-egress")
 	err = mockIp6tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 
@@ -494,7 +494,7 @@ func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
 	}
 
 	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
-	mockManager.addProxyRules(mockIp6tables, "::1", 43479, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp6tables, "::1", 43479, "cilium-dns-egress")
 	err = mockIp6tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 }

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -57,7 +57,7 @@ type Proxy interface {
 type IptablesManager interface {
 	// InstallProxyRules creates the necessary datapath config (e.g., iptables
 	// rules for redirecting host proxy traffic on a specific ProxyPort)
-	InstallProxyRules(ctx context.Context, proxyPort uint16, ingress, localOnly bool, name string) error
+	InstallProxyRules(ctx context.Context, proxyPort uint16, localOnly bool, name string) error
 
 	// SupportsOriginalSourceAddr tells if the datapath supports
 	// use of original source addresses in proxy upstream

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -46,7 +46,7 @@ const (
 )
 
 type DatapathUpdater interface {
-	InstallProxyRules(ctx context.Context, proxyPort uint16, ingress, localOnly bool, name string) error
+	InstallProxyRules(ctx context.Context, proxyPort uint16, localOnly bool, name string) error
 	SupportsOriginalSourceAddr() bool
 }
 
@@ -237,7 +237,7 @@ func (p *Proxy) ackProxyPort(ctx context.Context, name string, pp *ProxyPort) er
 		// Add rules for the new port
 		// This should always succeed if we have managed to start-up properly
 		scopedLog.Infof("Adding new proxy port rules for %s:%d", name, pp.proxyPort)
-		if err := p.datapathUpdater.InstallProxyRules(ctx, pp.proxyPort, pp.ingress, pp.localOnly, name); err != nil {
+		if err := p.datapathUpdater.InstallProxyRules(ctx, pp.proxyPort, pp.localOnly, name); err != nil {
 			return fmt.Errorf("cannot install proxy rules for %s: %w", name, err)
 		}
 		pp.rulesPort = pp.proxyPort
@@ -483,7 +483,7 @@ func (p *Proxy) ReinstallIPTablesRules(ctx context.Context) error {
 	for name, pp := range p.proxyPorts {
 		if pp.rulesPort > 0 {
 			// This should always succeed if we have managed to start-up properly
-			if err := p.datapathUpdater.InstallProxyRules(ctx, pp.rulesPort, pp.ingress, pp.localOnly, name); err != nil {
+			if err := p.datapathUpdater.InstallProxyRules(ctx, pp.rulesPort, pp.localOnly, name); err != nil {
 				return fmt.Errorf("cannot install proxy rules for %s: %w", name, err)
 			}
 		}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -26,7 +26,7 @@ var _ = Suite(&ProxySuite{})
 
 type MockDatapathUpdater struct{}
 
-func (m *MockDatapathUpdater) InstallProxyRules(ctx context.Context, proxyPort uint16, ingress, localOnly bool, name string) error {
+func (m *MockDatapathUpdater) InstallProxyRules(ctx context.Context, proxyPort uint16, localOnly bool, name string) error {
 	return nil
 }
 


### PR DESCRIPTION
The proxy rules installed by the iptables manager are the same regardless of the traffic direction (ingress or egress). So, there is no point in having separate functions to install them, nor passing a boolean flag indicating the traffic direction of the proxy.

The relevant interfaces and mock implementations are updated accordingly.