### PR TITLE
gha: Re-purpose Conformance Kind proxy test

### DIFF
--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -1,4 +1,4 @@
-name: Conformance Kind Envoy DaemonSet
+name: Conformance Kind Envoy Embedded
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
@@ -58,7 +58,7 @@ jobs:
             --helm-set-string=kubeProxyReplacement=true \
             --helm-set=loadBalancer.l7.backend=envoy \
             --helm-set=tls.secretsBackend=k8s \
-            --helm-set=envoy.enabled=true \
+            --helm-set=envoy.enabled=false \
             --wait=false"
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --collect-sysdump-on-failure"
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT


### PR DESCRIPTION
As Envoy DS is the default mode now, we should re-purpose the existing test to embedded mode, so that we still have required coverage.

Relates: 21fa2df60abd0f3a5627aca3265347558d170f37
Relates: https://github.com/cilium/cilium/pull/30034

