### PR TITLE
nodeipam: Add Support for Gateway and Ingress Services

### DIFF
--- a/Documentation/network/node-ipam.rst
+++ b/Documentation/network/node-ipam.rst
@@ -13,7 +13,7 @@ Node IPAM LB
 Node IPAM LoadBalancer is a feature inspired by k3s "ServiceLB" that allows you
 to "advertise" the node's IPs directly inside a Service LoadBalancer. This feature
 is especially useful if you don't control the network you are running on and can't
-use either the L2 or BGP capabilities of Cilium.
+use either the L2 Aware LB or BGP capabilities of Cilium.
 
 It works by getting the Node addresses of the selected pods and advertising them.
 It will respect the ``.spec.ipFamilies`` to decide if IPv4 or IPv6 addresses
@@ -42,3 +42,101 @@ To enable the node IPAM on an existing installation, run:
      --reuse-values \\
      --set nodeIPAM.enabled=true
    kubectl -n kube-system rollout restart deployment/cilium-operator
+
+Gateway API and Ingress Controller Considerations
+-------------------------------------------------
+
+By Spec, Kubernetes requires at least one address in the Endpoints list if Pod Label selectors are not used.
+In order to overcome this limitation, Services created for Gateway API and Ingress Controller-managed resources,
+Cilium will inject a "virtual" Endpoint of ``192.192.192.192:9999``.
+
+Because all Cilium Agents are able to process Gateway API or Ingress traffic, it is possible for the Node IPAM LB
+to allow all Nodes in the Cluster to listen for incoming connections. Setting the ``loadBalancerClass`` to ``io.cilium/node``
+will add all Nodes to the Ingress IP list in the Load Balancer Service and accept traffic on the requested ports.
+
+Selecting Nodes to Listen for Gateway and Ingress Requests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To restrict the Nodes that should listen for incoming traffic for Cilium Gateway and Ingress Services, you may
+add an annotation, ``io.cilium.nodeipam/match-labels``, to the Service. The value of the annotation is a
+`Label Selector <https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors>`__.
+
+.. note::
+   The node selector feature only works for Cilium-managed LoadBalancers for Gateways and Ingresses.
+   Applying this label has no effect on other LoadBalancer Services.
+
+
+You can test this Label Selector by using the ``kubectl get nodes`` command. For example, to exclude traffic to all
+Control Plane nodes, you may use this Label Selector: ``!node-role.kubernetes.io/control-plane``
+The Annotation would be configured as follows:
+
+.. parsed-literal::
+   io.cilium.nodeipam/match-labels="!node-role.kubernetes.io/control-plane"
+
+To verify the Nodes that would be returned, run the following command in your terminal:
+
+.. parsed-literal::
+   kubectl get nodes -l '!node-role.kubernetes.io/control-plane'
+
+   NAME          STATUS   ROLES    AGE     VERSION
+   kind-worker   Ready    <none>   6h32m   v1.29.1
+
+It is possible to combine multiple filters. For example, Nodes where the Label ``beehive.local/node`` value is
+``hive1`` or ``hive2``, the Label ``honey`` is set to ``yes``, and the Label ``bears`` does not exist would use the
+following filter Annotation:
+
+.. parsed-literal::
+   io.cilium.nodeipam/match-labels="beehive.local/node in (hive1,hive2),honey=yes,!bears"
+
+Configuring Resources for Node IPAM LB
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Ingress Controller**
+
+Use the following Helm values to enabling Node IPAM LB for the shared Ingress Controller:
+
+.. parsed-literal::
+   nodeIPAM:
+     enabled: true
+   ingressController:
+     enabled: true
+     loadbalancerMode: shared
+     service:
+       loadBalancerClass: io.cilium/node
+   # Annotation is optional. Enable to limit Load Balancer IPs to the desired Nodes.
+       annotations:
+         io.cilium.nodeipam/match-labels: "..."
+
+Node IPAM LB support for dedicated Ingress resources is not directly possible.
+See the Warning in the Gateway API section below for more details on how to possibly configure a policy to update
+your dedicated Ingresses. You will need to add the ``io.cilium.nodeipam`` prefix to the ``ingressController.ingressLBAnnotationPrefixes``
+value in your Helm Chart.
+
+Using Node IPAM LB with dedicated Ingresses has not been tested!
+
+**Gateway API**
+
+See the :doc:`servicemesh/gateway-api/gateway-api` Documentation for more fully configuring the appropriate resources.
+As an example, you can add the Annotation to the ``spec.infrastructure.annotations`` field where it will be copied to
+the created Gateway Service.
+
+.. warning::
+   Cilium does not currently support specifying the ``loadBalancerClass`` field for Gateway resources. It is possible
+   to set this value with a mutating admission webhook.
+   See this `Github Issue comment <https://github.com/cilium/cilium/issues/27493#issuecomment-1681970707>`__ for more details.
+
+To specify the annotation to be automatically copied from the Gateway to Service resource, see the following example Gateway spec:
+
+.. parsed-literal::
+   apiVersion: gateway.networking.k8s.io/v1
+   kind: Gateway
+   metadata:
+     name: my-gateway
+   spec:
+     gatewayClassName: cilium
+   # Annotation is optional. Enable to limit Load Balancer IPs to the desired Nodes.
+     infrastructure:
+       annotations:
+         io.cilium.nodeipam/match-labels: "..."
+     listeners:
+     - <...snip...>

--- a/Documentation/network/node-ipam.rst
+++ b/Documentation/network/node-ipam.rst
@@ -91,7 +91,7 @@ following filter Annotation:
 Configuring Resources for Node IPAM LB
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Ingress Controller**
+**Cilium Ingress Controller**
 
 Use the following Helm values to enabling Node IPAM LB for the shared Ingress Controller:
 
@@ -114,7 +114,7 @@ value in your Helm Chart.
 
 Using Node IPAM LB with dedicated Ingresses has not been tested!
 
-**Gateway API**
+**Cilium Gateway API**
 
 See the :doc:`servicemesh/gateway-api/gateway-api` Documentation for more fully configuring the appropriate resources.
 As an example, you can add the Annotation to the ``spec.infrastructure.annotations`` field where it will be copied to

--- a/Documentation/network/node-ipam.rst
+++ b/Documentation/network/node-ipam.rst
@@ -58,7 +58,7 @@ Selecting Nodes to Listen for Gateway and Ingress Requests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To restrict the Nodes that should listen for incoming traffic for Cilium Gateway and Ingress Services, you may
-add an annotation, ``io.cilium.nodeipam/match-labels``, to the Service. The value of the annotation is a
+add an annotation, ``io.cilium.nodeipam/match-node-labels``, to the Service. The value of the annotation is a
 `Label Selector <https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors>`__.
 
 .. note::
@@ -71,7 +71,7 @@ Control Plane nodes, you may use this Label Selector: ``!node-role.kubernetes.io
 The Annotation would be configured as follows:
 
 .. parsed-literal::
-   io.cilium.nodeipam/match-labels="!node-role.kubernetes.io/control-plane"
+   io.cilium.nodeipam/match-node-labels="!node-role.kubernetes.io/control-plane"
 
 To verify the Nodes that would be returned, run the following command in your terminal:
 
@@ -86,7 +86,7 @@ It is possible to combine multiple filters. For example, Nodes where the Label `
 following filter Annotation:
 
 .. parsed-literal::
-   io.cilium.nodeipam/match-labels="beehive.local/node in (hive1,hive2),honey=yes,!bears"
+   io.cilium.nodeipam/match-node-labels="beehive.local/node in (hive1,hive2),honey=yes,!bears"
 
 Configuring Resources for Node IPAM LB
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -105,7 +105,7 @@ Use the following Helm values to enabling Node IPAM LB for the shared Ingress Co
        loadBalancerClass: io.cilium/node
    # Annotation is optional. Enable to limit Load Balancer IPs to the desired Nodes.
        annotations:
-         io.cilium.nodeipam/match-labels: "..."
+         io.cilium.nodeipam/match-node-labels: "..."
 
 Node IPAM LB support for dedicated Ingress resources is not directly possible.
 See the Warning in the Gateway API section below for more details on how to possibly configure a policy to update
@@ -137,6 +137,6 @@ To specify the annotation to be automatically copied from the Gateway to Service
    # Annotation is optional. Enable to limit Load Balancer IPs to the desired Nodes.
      infrastructure:
        annotations:
-         io.cilium.nodeipam/match-labels: "..."
+         io.cilium.nodeipam/match-node-labels: "..."
      listeners:
      - <...snip...>

--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -139,6 +139,7 @@ are supported.
 
 By default, annotations with values beginning with:
 
+* ``lbipam.cilium.io``
 * ``service.beta.kubernetes.io``
 * ``service.kubernetes.io``
 * ``cloud.google.com``

--- a/operator/pkg/nodeipam/nodesvclb.go
+++ b/operator/pkg/nodeipam/nodesvclb.go
@@ -190,15 +190,15 @@ func (r *nodeSvcLBReconciler) getRelevantNodes(ctx context.Context, svc *corev1.
 		return []corev1.Node{}, err
 	}
 
-	relevantsNodes := []corev1.Node{}
+	var relevantNodes []corev1.Node
 	for _, node := range nodes.Items {
 		if !selectedNodes.Has(node.Name) {
 			continue
 		}
 
-		relevantsNodes = append(relevantsNodes, node)
+		relevantNodes = append(relevantNodes, node)
 	}
-	return relevantsNodes, nil
+	return relevantNodes, nil
 }
 
 // getNodeLoadBalancerIngresses get all the load balancer ingresses with the specified nodes

--- a/operator/pkg/nodeipam/nodesvclb.go
+++ b/operator/pkg/nodeipam/nodesvclb.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	nodeSvcLBClass                 = annotation.Prefix + "/node"
-	nodeSvcLBMatchLabelsAnnotation = annotation.Prefix + ".nodeipam" + "/match-labels"
+	nodeSvcLBMatchLabelsAnnotation = annotation.Prefix + ".nodeipam" + "/match-node-labels"
 )
 
 type nodeSvcLBReconciler struct {

--- a/operator/pkg/nodeipam/nodesvclb_test.go
+++ b/operator/pkg/nodeipam/nodesvclb_test.go
@@ -4,6 +4,7 @@
 package nodeipam
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -209,6 +210,64 @@ var (
 			}},
 		},
 	}
+
+	nodeSvcCiliumFixtures = []client.Object{
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node-1",
+				Labels: map[string]string{"ingress-ready": "true", "all": "true", "group": "first"},
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node-2",
+				Labels: map[string]string{"all": "true", "group": "notfirst", "test/label": "is-good"},
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: "10.0.0.2"},
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node-3",
+				Labels: map[string]string{"all": "true", "group": "notfirst"},
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: "10.0.0.3"},
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gateway",
+				Namespace: "default",
+				Labels:    map[string]string{"io.cilium.gateway/owning-gateway": "gateway"},
+			},
+			Spec: corev1.ServiceSpec{
+				Type:              corev1.ServiceTypeLoadBalancer,
+				IPFamilies:        []corev1.IPFamily{corev1.IPv4Protocol},
+				LoadBalancerClass: &nodeSvcLBClass,
+			},
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gateway",
+				Namespace: "default",
+				Labels:    map[string]string{discoveryv1.LabelServiceName: "gateway", "io.cilium.gateway/owning-gateway": "gateway"},
+			},
+			Endpoints: []discoveryv1.Endpoint{
+				{Addresses: []string{"192.192.192.192"}},
+			},
+		},
+	}
 )
 
 func stringPtr(str string) *string {
@@ -297,5 +356,114 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 		require.Len(t, svc.Status.LoadBalancer.Ingress, 2)
 		require.Equal(t, svc.Status.LoadBalancer.Ingress[0].IP, "2001:0000::1")
 		require.Equal(t, svc.Status.LoadBalancer.Ingress[1].IP, "42.0.0.2")
+	})
+}
+
+func Test_CiliumResources_Reconcile(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithObjects(nodeSvcCiliumFixtures...).
+		WithStatusSubresource(&corev1.Service{}).
+		Build()
+	r := &nodeSvcLBReconciler{Client: c, Logger: logging.DefaultLogger}
+
+	key := types.NamespacedName{
+		Name:      "gateway",
+		Namespace: "default",
+	}
+
+	t.Run("Managed Resource", func(t *testing.T) {
+		ctx := context.Background()
+		result, err := r.Reconcile(ctx, ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		svc := &corev1.Service{}
+		err = c.Get(ctx, key, svc)
+
+		require.NoError(t, err)
+		require.Len(t, svc.Status.LoadBalancer.Ingress, 3)
+		var ips []string
+		for _, v := range svc.Status.LoadBalancer.Ingress {
+			ips = append(ips, v.IP)
+		}
+		require.Equal(t, ips, []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"})
+	})
+
+	t.Run("Node Label Filter", func(t *testing.T) {
+		ctx := context.Background()
+
+		for _, param := range []struct {
+			labelFilter string
+			results     []string
+		}{
+			{labelFilter: "all=true", results: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}},
+			{labelFilter: "ingress-ready=true", results: []string{"10.0.0.1"}},
+			{labelFilter: "group=notfirst", results: []string{"10.0.0.2", "10.0.0.3"}},
+			{labelFilter: "group notin (first),test/label=is-good", results: []string{"10.0.0.2"}},
+		} {
+			svc := &corev1.Service{}
+			_ = c.Get(ctx, key, svc)
+			// Add the label to the service which should return on the first node
+			svc.Annotations = map[string]string{nodeSvcLBMatchLabelsAnnotation: param.labelFilter}
+			_ = c.Update(ctx, svc)
+			result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+
+			require.NoError(t, err)
+			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+			svc = &corev1.Service{}
+			err = c.Get(ctx, key, svc)
+
+			require.NoError(t, err)
+			require.NotNil(t, svc.Annotations[nodeSvcLBMatchLabelsAnnotation])
+			require.Len(t, svc.Status.LoadBalancer.Ingress, len(param.results))
+
+			var ips []string
+			for _, v := range svc.Status.LoadBalancer.Ingress {
+				ips = append(ips, v.IP)
+			}
+			require.Equal(t, ips, param.results)
+		}
+	})
+
+	t.Run("Bad Node Label Filter", func(t *testing.T) {
+		ctx := context.Background()
+		svc := &corev1.Service{}
+		_ = c.Get(ctx, key, svc)
+		// Add the label to the service which should return on the first node
+		svc.Annotations = map[string]string{nodeSvcLBMatchLabelsAnnotation: "this is completely/bad=!;lf"}
+		_ = c.Update(ctx, svc)
+		result, err := r.Reconcile(ctx, ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.Error(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+	})
+
+	t.Run("Ensure Warning raised if no Nodes found using configured Label selector", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := logging.DefaultLogger
+		logger.SetOutput(&buf)
+
+		r.Logger = logger
+
+		ctx := context.Background()
+		svc := &corev1.Service{}
+		_ = c.Get(ctx, key, svc)
+		// Add the label to the service which should return on the first node
+		svc.Annotations = map[string]string{nodeSvcLBMatchLabelsAnnotation: "foo=bar"}
+		_ = c.Update(ctx, svc)
+		result, err := r.Reconcile(ctx, ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+		require.Contains(t, buf.String(), "level=warning msg=\"No Nodes found with configured Label selector\"")
 	})
 }


### PR DESCRIPTION
Related to the comment here: https://github.com/cilium/cilium/pull/30038#issuecomment-1970423094

Node IPAM LB does not currently work with LB services created by Cilium for Gateway or Ingress resources. This is because the endpoint list contains a "virtual" address of `192.192.192.192:9999`. This doesn't map to any Nodes in the k8s cluster, so the Load Balancer remains in a "pending" state indefinitely.

This enhancement adds support for this scenario. If the Service contains either label (`cilium.io/ingress` or `io.cilium.gateway/owning-gateway`) indicating that it is managed by Cilium, return all nodes as LoadBalancer IPs, or filter the nodes based on an Annotation applied to the Service `io.cilium.nodeipam/match-labels`.

Services for Gateways still need to have a mutating admission webhook apply the `loadBalancerClass` value, as there is not currently a way to do this directly with the Gateway config. See #27493.

```release-note
nodeipam: add support for Gateway and Ingress Services with Node Label selector via annotation value
```

cc: @MrFreezeex
