### PR TITLE
bpf: avoid SNAT tracking for overlay traffic

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1311,9 +1311,8 @@ int cil_from_host(struct __ctx_buff *ctx)
 
 #if defined(ENABLE_ENCRYPTED_OVERLAY)
 /*
- * If the traffic is indeed overlay traffic and it should be encrypted
- * CTX_ACT_REDIRECT is returned, unless an error occurred, and the caller can
- * return this code to TC.
+ * If the traffic should be encrypted then CTX_ACT_REDIRECT is returned.
+ * Unless an error occurred, and the caller can return this code to TC.
  *
  * CTX_ACT_OK is returned if the traffic should continue normal processing.
  *
@@ -1322,22 +1321,11 @@ int cil_from_host(struct __ctx_buff *ctx)
 static __always_inline int do_encrypt_overlay(struct __ctx_buff *ctx)
 {
 	int ret = CTX_ACT_OK;
-	__u16 proto = 0;
 	struct iphdr __maybe_unused *ipv4;
 	void __maybe_unused *data, *data_end = NULL;
 
-	/* we require a valid layer 2 to proceed */
-	if (!validate_ethertype(ctx, &proto))
-		return ret;
-
-	if (proto != bpf_htons(ETH_P_IP))
-		return ret;
-
 	if (!revalidate_data(ctx, &data, &data_end, &ipv4))
 		return DROP_INVALID;
-
-	if (!vxlan_skb_is_vxlan_v4(data, data_end, ipv4, TUNNEL_PORT))
-		return ret;
 
 	if (vxlan_get_vni(data, data_end, ipv4) == ENCRYPTED_OVERLAY_ID)
 		ret = encrypt_overlay_and_redirect(ctx, data, data_end, ipv4);
@@ -1443,21 +1431,23 @@ skip_host_firewall:
 #endif
 
 #if defined(ENABLE_ENCRYPTED_OVERLAY)
-	/* Determine if this is overlay traffic that should be recirculated
-	 * to the stack for XFRM encryption.
-	 */
-	ret = do_encrypt_overlay(ctx);
-	if (ret == CTX_ACT_REDIRECT) {
-		/* we are redirecting back into the stack, so TRACE_TO_STACK
-		 * for tracepoint
+	if (ctx_is_overlay(ctx)) {
+		/* Determine if this is overlay traffic that should be recirculated
+		 * to the stack for XFRM encryption.
 		 */
-		send_trace_notify(ctx, TRACE_TO_STACK, 0, 0, 0,
-				  0, TRACE_REASON_ENCRYPT_OVERLAY, 0);
-		return ret;
+		ret = do_encrypt_overlay(ctx);
+		if (ret == CTX_ACT_REDIRECT) {
+			/* we are redirecting back into the stack, so TRACE_TO_STACK
+			 * for tracepoint
+			 */
+			send_trace_notify(ctx, TRACE_TO_STACK, 0, 0, 0,
+					  0, TRACE_REASON_ENCRYPT_OVERLAY, 0);
+			return ret;
+		}
+		if (IS_ERR(ret))
+			return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
+						      METRIC_EGRESS);
 	}
-	else if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
-					      METRIC_EGRESS);
 #endif /* ENABLE_ENCRYPTED_OVERLAY */
 
 #ifdef ENABLE_WIREGUARD

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1492,7 +1492,7 @@ skip_host_firewall:
 #endif
 
 #ifdef ENABLE_NODEPORT
-	if (!ctx_snat_done(ctx)) {
+	if (!ctx_snat_done(ctx) && !ctx_is_overlay(ctx)) {
 		/*
 		 * handle_nat_fwd tail calls in the majority of cases,
 		 * so control might never return to this program.

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -734,6 +734,7 @@ out:
 __section_entry
 int cil_to_overlay(struct __ctx_buff *ctx)
 {
+	bool snat_done __maybe_unused = ctx_snat_done(ctx);
 	struct trace_ctx __maybe_unused trace;
 	int ret = TC_ACT_OK;
 	__u32 cluster_id __maybe_unused = 0;
@@ -755,12 +756,6 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 	}
 #endif
 
-#ifdef ENABLE_NODEPORT
-	if (ctx_snat_done(ctx)) {
-		ret = CTX_ACT_OK;
-		goto out;
-	}
-
 	/* This must be after above ctx_snat_done, since the MARK_MAGIC_CLUSTER_ID
 	 * is a super set of the MARK_MAGIC_SNAT_DONE. They will never be used together,
 	 * but SNAT check should always take presedence.
@@ -768,6 +763,15 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 #ifdef ENABLE_CLUSTER_AWARE_ADDRESSING
 	cluster_id = ctx_get_cluster_id_mark(ctx);
 #endif
+
+	ctx_set_overlay_mark(ctx);
+
+#ifdef ENABLE_NODEPORT
+	if (snat_done) {
+		ret = CTX_ACT_OK;
+		goto out;
+	}
+
 	ret = handle_nat_fwd(ctx, cluster_id, &trace, &ext_err);
 out:
 #endif

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -55,7 +55,7 @@
 
 #if defined(ENCAP_IFINDEX) || defined(ENABLE_EGRESS_GATEWAY_COMMON) || \
     (defined(ENABLE_DSR) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE)
-#define HAVE_ENCAP
+#define HAVE_ENCAP	1
 
 /* NOT_VTEP_DST is passed to an encapsulation function when the
  * destination of the tunnel is not a VTEP.
@@ -727,6 +727,7 @@ enum metric_dir {
 #define MARK_MAGIC_IDENTITY		0x0F00 /* mark carries identity */
 #define MARK_MAGIC_TO_PROXY		0x0200
 #define MARK_MAGIC_SNAT_DONE		0x0300
+#define MARK_MAGIC_OVERLAY		0x0400
 
 #define MARK_MAGIC_KEY_MASK		0xFF00
 

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -234,6 +234,20 @@ static __always_inline bool ctx_snat_done(const struct __sk_buff *ctx)
 	return (ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_SNAT_DONE;
 }
 
+static __always_inline void ctx_set_overlay_mark(struct __sk_buff *ctx)
+{
+	ctx->mark &= ~MARK_MAGIC_HOST_MASK;
+	ctx->mark |= MARK_MAGIC_OVERLAY;
+}
+
+static __always_inline bool ctx_is_overlay(const struct __sk_buff *ctx)
+{
+	if (!is_defined(HAVE_ENCAP))
+		return false;
+
+	return (ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_OVERLAY;
+}
+
 #ifdef HAVE_ENCAP
 static __always_inline __maybe_unused int
 ctx_set_encap_info(struct __sk_buff *ctx, __u32 src_ip,

--- a/bpf/lib/vxlan.h
+++ b/bpf/lib/vxlan.h
@@ -11,37 +11,6 @@
 #include "lib/csum.h"
 
 /*
- * Returns true if the skb associated with data pointers is a vxlan encapsulated
- * packet.
- *
- * The determination is made by comparing the UDP destination port with
- * the tunnel_port provided to the function.
- */
-static __always_inline bool
-vxlan_skb_is_vxlan_v4(const void *data, const void *data_end,
-		      const struct iphdr *ipv4, const __u16 tunnel_port)
-{
-	struct udphdr *udp = NULL;
-	__u32 l3_size = 0;
-
-	if (ipv4->protocol != IPPROTO_UDP)
-		return false;
-
-	l3_size = ipv4->ihl * 4;
-
-	if (data + sizeof(struct ethhdr) + l3_size + sizeof(struct udphdr)
-	    + sizeof(struct vxlanhdr) > data_end)
-		return false;
-
-	udp = (struct udphdr *)(data + sizeof(struct ethhdr) + l3_size);
-
-	if (udp->dest == bpf_htons(tunnel_port))
-		return true;
-
-	return false;
-}
-
-/*
  * Returns the VNI in the native host's endian format of a xvlan encap'd packet.
  *
  * The caller must ensure the skb associated with these data buffers are infact

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -72,6 +72,9 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 		 *
 		 * This also handles IPv6, as IPv6 pkts are encapsulated w/
 		 * IPv4 tunneling.
+		 *
+		 * TODO: in v1.17, we can trust that to-overlay will mark all
+		 * traffic. Then replace this with ctx_is_overlay().
 		 */
 		if (ip4->protocol == IPPROTO_UDP) {
 			int l4_off = ETH_HLEN + ipv4_hdrlen(ip4);

--- a/bpf/tests/vxlan_helpers_tests.c
+++ b/bpf/tests/vxlan_helpers_tests.c
@@ -74,46 +74,6 @@ mk_packet(struct __ctx_buff *ctx) {
 	return 0;
 }
 
-PKTGEN("tc", "vxlan_skb_is_vxlan_v4_success")
-static __always_inline int
-pktgen_vxlan_mock_check1(struct __ctx_buff *ctx) {
-	return mk_packet(ctx);
-}
-
-CHECK("tc", "vxlan_skb_is_vxlan_v4_success")
-int check1(struct __ctx_buff *ctx)
-{
-	test_init();
-
-	void *data, *data_end = NULL;
-	struct iphdr *ipv4 = NULL;
-
-	assert(revalidate_data(ctx, &data, &data_end, &ipv4));
-	assert(vxlan_skb_is_vxlan_v4(data, data_end, ipv4, TUNNEL_PORT));
-
-	test_finish();
-}
-
-PKTGEN("tc", "vxlan_skb_is_vxlan_v4_failure")
-static __always_inline int
-pktgen_vxlan_mock_check2(struct __ctx_buff *ctx) {
-	return mk_packet(ctx);
-}
-
-CHECK("tc", "vxlan_skb_is_vxlan_v4_failure")
-int check2(struct __ctx_buff *ctx)
-{
-	test_init();
-
-	void *data, *data_end = NULL;
-	struct iphdr *ipv4 = NULL;
-
-	assert(revalidate_data(ctx, &data, &data_end, &ipv4));
-	assert(!vxlan_skb_is_vxlan_v4(data, data_end, ipv4, TUNNEL_PORT_BAD));
-
-	test_finish();
-}
-
 PKTGEN("tc", "vxlan_get_vni_success")
 static __always_inline int
 pktgen_vxlan_mock_check3(struct __ctx_buff *ctx) {

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1427,6 +1427,7 @@ func (m *Manager) installHostTrafficMarkRule(prog runnable) error {
 	// originated from the host.
 	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
 	matchFromIPSecDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
+	matchOverlay := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkOverlay, linux_defaults.MagicMarkHostMask)
 	matchFromProxy := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxy, linux_defaults.MagicMarkProxyMask)
 	matchFromProxyEPID := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxyEPID, linux_defaults.MagicMarkProxyMask)
 	matchFromDNSProxy := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIdentity, linux_defaults.MagicMarkHostMask)
@@ -1437,6 +1438,7 @@ func (m *Manager) installHostTrafficMarkRule(prog runnable) error {
 		"-A", ciliumOutputChain,
 		"-m", "mark", "!", "--mark", matchFromIPSecDecrypt, // Don't match ipsec traffic
 		"-m", "mark", "!", "--mark", matchFromIPSecEncrypt, // Don't match ipsec traffic
+		"-m", "mark", "!", "--mark", matchOverlay, // Don't match Cilium's overlay traffic
 		"-m", "mark", "!", "--mark", matchFromProxy, // Don't match proxy traffic
 		"-m", "mark", "!", "--mark", matchFromProxyEPID, // Don't match proxy traffic
 		"-m", "mark", "!", "--mark", matchFromDNSProxy, // Don't match DNS proxy egress traffic

--- a/pkg/datapath/linux/linux_defaults/mark.go
+++ b/pkg/datapath/linux/linux_defaults/mark.go
@@ -52,6 +52,12 @@ const (
 	// to a proxy.
 	MagicMarkIsToProxy uint32 = 0x0200
 
+	MagicMarkSNATDone int = 0x0300
+
+	// MagicMarkOverlay is set by the to-overlay program, and can be used
+	// to identify cilium-managed overlay traffic.
+	MagicMarkOverlay int = 0x0400
+
 	// MagicMarkProxyEgressEPID determines that the traffic is sourced from
 	// the proxy which is capturing traffic before it is subject to egress
 	// policy enforcement that must be done after the proxy. The identity


### PR DESCRIPTION
In certain configs (basically when the node-to-node IPv4 address is also chosen as IPV4_MASQUERADE) the [masquerade code](https://github.com/cilium/cilium/blob/17ade3372c38c423837add6049fc428656c4d476/bpf/lib/nat.h#L735) in `to-netdev` decides that tunnel traffic is potentially conflicting with masqueraded traffic. We thus need to reserve the packet's source port ("track it"), and potentially even SNAT it.

Creating SNAT entries for tunnel traffic makes little sense - in particular as the replies will not be addressed to the packet's source port, but to `TUNNEL_PORT`. Doing it anyway results in pressure on the CT and NAT maps.

Improve this by marking such traffic in `to-overlay`, and then bypassing the masquerading logic in `to-netdev `accordingly. Also use the mark to detect overlay traffic for the recently introduced [encrypted-overlay feature](https://github.com/cilium/cilium/pull/31073). For wireguard we're a bit more careful, to avoid missing unmarked traffic during an upgrade.

Fixes: #26908

```release-note
Skip overlay traffic in the BPF SNAT processing, and thus reduce pressure on the BPF Connection tracking and NAT maps.
```
