### PR TITLE
contrib/scripts: Remove false positives from check-go-testdata.sh

### DIFF
--- a/contrib/scripts/check-go-testdata.sh
+++ b/contrib/scripts/check-go-testdata.sh
@@ -2,4 +2,4 @@
 # Copyright Authors of Cilium
 
 make -C pkg/bpf/testdata build
-test -z "$(git status --porcelain)" || (echo "please run 'make -C pkg/bpf/testdata build' and submit your changes"; exit 1)
+test -z "$(git status pkg/bpf/testdata --porcelain)" || (echo "please run 'make -C pkg/bpf/testdata build' and submit your changes"; exit 1)


### PR DESCRIPTION
The check-go-testdata.sh script would fail on any changes in the whole repo not just the target directory.