### PR TITLE
Replace the remaining usages of the --cluster-name CLI parameter in GHA workflows

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -151,7 +151,7 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
-            --cluster-name=${{ env.name }} \
+            --helm-set cluster.name=${{ env.name }} \
             --helm-set loadBalancer.l7.backend=envoy \
             --helm-set tls.secretsBackend=k8s \
             --helm-set=azure.resourceGroup=${{ env.name }}"

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -151,7 +151,7 @@ jobs:
           # cilium-cli which is setting it to 'eni' because it auto-detects
           # the cluster as being EKS.
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
-            --cluster-name=${{ env.clusterName }} \
+            --helm-set=cluster.name=${{ env.clusterName }} \
             --helm-set=hubble.relay.enabled=true \
             --helm-set=enableIPv4Masquerade=false \
             --helm-set=cni.chainingMode=aws-cni \

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -148,7 +148,7 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
-            --cluster-name=${{ env.clusterName }} \
+            --helm-set cluster.name=${{ env.clusterName }} \
             --helm-set=hubble.relay.enabled=true \
             --helm-set loadBalancer.l7.backend=envoy \
             --helm-set tls.secretsBackend=k8s \

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -148,7 +148,7 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
-            --cluster-name=${{ env.clusterName }} \
+            --helm-set cluster.name=${{ env.clusterName }} \
             --datapath-mode=tunnel \
             --helm-set kubeProxyReplacement=true"
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --collect-sysdump-on-failure \

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -153,7 +153,7 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
-            --cluster-name=${{ env.clusterName }}-${{ matrix.config.index }} \
+            --helm-set=cluster.name=${{ env.clusterName }}-${{ matrix.config.index }} \
             --helm-set=hubble.relay.enabled=true \
             --helm-set=agentNotReadyTaintKey=ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready \
             --helm-set loadBalancer.l7.backend=envoy \

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -127,7 +127,7 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
-            --cluster-name=${{ env.clusterName }}-${{ matrix.index }} \
+            --helm-set=cluster.name=${{ env.clusterName }}-${{ matrix.index }} \
             --helm-set=agentNotReadyTaintKey=ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready \
             --helm-set=debug.enabled=false \
             --helm-set=bpf.monitorAggregation=maximum \


### PR DESCRIPTION
cilium/cilium-cli@509702fb8302 dropped the --cluster-name flag. Hence, let's replace the remaining usages with the configuration of the corresponding helm value.