### PR TITLE
iptables: Manage IP sets independently with the stateDB reconciler

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -426,6 +426,7 @@ Makefile* @cilium/build
 /pkg/common/ipsec/ @cilium/ipsec
 /pkg/completion/ @cilium/proxy
 /pkg/components/ @cilium/sig-agent
+/pkg/container/ @cilium/sig-foundations
 /pkg/container/bitlpm/ @cilium/ipcache @cilium/sig-policy
 /pkg/contexthelpers/ @cilium/kvstore
 /pkg/controller @cilium/sig-agent

--- a/pkg/container/immset.go
+++ b/pkg/container/immset.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package container
+
+import (
+	"cmp"
+	"slices"
+
+	"golang.org/x/exp/constraints"
+)
+
+// ImmSet is an immutable set optimized for a smallish (1-1000) set of items.
+// Implemented as a sorted slice.
+type ImmSet[T any] struct {
+	xs  []T
+	cmp func(T, T) int
+	eq  func(T, T) bool
+}
+
+func NewImmSet[T constraints.Ordered](items ...T) ImmSet[T] {
+	return NewImmSetFunc[T](cmp.Compare, items...)
+}
+
+func NewImmSetFunc[T any](compare func(T, T) int, items ...T) ImmSet[T] {
+	s := ImmSet[T]{items, compare, cmpToEqual(compare)}
+	slices.SortFunc(s.xs, s.cmp)
+	s.xs = slices.CompactFunc(s.xs, s.eq)
+	return s
+}
+
+// AsSlice returns the underlying slice stored in the immutable set.
+// The caller is NOT allowed to modify the slice.
+func (s ImmSet[T]) AsSlice() []T {
+	return s.xs
+}
+
+func (s ImmSet[T]) Len() int {
+	return len(s.xs)
+}
+
+func (s ImmSet[T]) Has(x T) bool {
+	_, found := slices.BinarySearchFunc(s.xs, x, s.cmp)
+	return found
+}
+
+func (s ImmSet[T]) Insert(xs ...T) ImmSet[T] {
+	xs2 := make([]T, 0, len(s.xs)+len(xs))
+	xs2 = append(xs2, s.xs...)
+	for _, x := range xs {
+		idx, found := slices.BinarySearchFunc(s.xs, x, s.cmp)
+		if !found {
+			xs2 = slices.Insert(xs2, idx, x)
+		}
+	}
+	return ImmSet[T]{xs: xs2, cmp: s.cmp, eq: s.eq}
+}
+
+func (s ImmSet[T]) Delete(xs ...T) ImmSet[T] {
+	s.xs = slices.Clone(s.xs)
+	for _, x := range xs {
+		idx, found := slices.BinarySearchFunc(s.xs, x, s.cmp)
+		if found {
+			s.xs = slices.Delete(s.xs, idx, idx+1)
+		}
+	}
+	return s
+}
+
+func (s ImmSet[T]) Union(s2 ImmSet[T]) ImmSet[T] {
+	result := make([]T, len(s.xs)+len(s2.xs))
+	copy(result, s.xs)
+	copy(result[len(s.xs):], s2.xs)
+	slices.SortFunc(s.xs, s.cmp)
+	result = slices.CompactFunc(result, s.eq)
+	return ImmSet[T]{result, s.cmp, s.eq}
+}
+
+func (s ImmSet[T]) Difference(s2 ImmSet[T]) ImmSet[T] {
+	return s.Delete(s2.xs...)
+}
+
+func (s ImmSet[T]) Equal(s2 ImmSet[T]) bool {
+	return slices.EqualFunc(s.xs, s2.xs, s.eq)
+}
+
+func cmpToEqual[T any](cmp func(T, T) int) func(T, T) bool {
+	return func(a, b T) bool {
+		return cmp(a, b) == 0
+	}
+}

--- a/pkg/container/immset_test.go
+++ b/pkg/container/immset_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package container
+
+import (
+	"math/rand/v2"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImmSetFunc(t *testing.T) {
+	// Test the ImmSet with netip.Addr.
+	a1, a2, a3 := netip.MustParseAddr("1.1.1.1"), netip.MustParseAddr("2.2.2.2"), netip.MustParseAddr("3.3.3.3")
+
+	// Empty set
+	s := NewImmSetFunc[netip.Addr](netip.Addr.Compare)
+	assert.Equal(t, 0, s.Len(), "expected 0 len for empty set")
+	assert.True(t, s.Equal(s), "expected empty set to equal itself")
+
+	s = s.Insert(a1)
+	assert.Equal(t, 1, s.Len(), "expected length of 1 after Insert")
+	s = s.Insert(a2)
+	assert.Equal(t, 2, s.Len(), "expected length of 2 after second Insert")
+	assert.ElementsMatch(t, s.AsSlice(), []netip.Addr{a1, a2})
+
+	s1 := s.Delete(a2)
+	assert.Equal(t, 2, s.Len(), "expected length of 2 for original")
+	assert.Equal(t, 1, s1.Len(), "expected length of 1 after Delete")
+
+	// Initialized set
+	s2 := NewImmSetFunc[netip.Addr](netip.Addr.Compare, a1, a2, a3)
+	assert.Equal(t, 3, s2.Len(), "expected length of 3 for initialized set")
+
+	s2 = s2.Difference(s)
+	assert.Equal(t, 1, s2.Len(), "expected length of 1 after diff")
+	assert.ElementsMatch(t, s2.AsSlice(), []netip.Addr{a3})
+
+	s2 = s2.Delete(a2 /* no-op */, a3)
+	assert.Equal(t, 0, s2.Len(), "expected length of 0 after final delete")
+
+	s2 = s2.Delete(a3)
+	assert.Equal(t, 0, s2.Len(), "expected no change in length after nop delete")
+}
+
+func TestImmSet(t *testing.T) {
+	// Empty set
+	s := NewImmSet[int]()
+	assert.Equal(t, 0, s.Len(), "expected 0 len for empty set")
+	assert.True(t, s.Equal(s), "expected empty set to equal itself")
+
+	s = s.Insert(1)
+	assert.Equal(t, 1, s.Len(), "expected length of 1 after Insert")
+	s = s.Insert(2)
+	assert.Equal(t, 2, s.Len(), "expected length of 2 after second Insert")
+	assert.ElementsMatch(t, s.AsSlice(), []int{1, 2})
+
+	s1 := s.Delete(2)
+	assert.Equal(t, 2, s.Len(), "expected length of 2 for original")
+	assert.Equal(t, 1, s1.Len(), "expected length of 1 after Delete")
+
+	// Initialized set
+	s2 := NewImmSet[int](1, 2, 3)
+	assert.Equal(t, 3, s2.Len(), "expected length of 3 for initialized set")
+
+	s2 = s2.Difference(s)
+	assert.Equal(t, 1, s2.Len(), "expected length of 1 after diff")
+	assert.ElementsMatch(t, s2.AsSlice(), []int{3})
+
+	s2 = s2.Delete(2 /* no-op */, 3)
+	assert.Equal(t, 0, s2.Len(), "expected length of 0 after final delete")
+
+	s2 = s2.Delete(3)
+	assert.Equal(t, 0, s2.Len(), "expected no change in length after nop delete")
+}
+
+func TestImmSetUnion(t *testing.T) {
+	// Overlapping sets
+	s1 := NewImmSet(1, 2, 3)
+	assert.Equal(t, 3, s1.Len(), "expected length of 3 for initialized set")
+	assert.True(t, s1.Has(1), "expected value 1 to be in the set")
+	assert.True(t, s1.Has(2), "expected value 2 to be in the set")
+	assert.True(t, s1.Has(3), "expected value 3 to be in the set")
+	assert.False(t, s1.Has(4), "expected value 4 to not be in the set")
+
+	s2 := NewImmSet(3, 4, 5)
+	assert.Equal(t, 3, s2.Len(), "expected length of 3 for initialized set")
+	assert.False(t, s2.Has(1), "expected value 1 to not be in the set")
+	assert.True(t, s2.Has(3), "expected value 3 to be in the set")
+	assert.True(t, s2.Has(4), "expected value 4 to be in the set")
+	assert.True(t, s2.Has(5), "expected value 5 to be in the set")
+
+	s3 := s1.Union(s2)
+	assert.Equal(t, 5, s3.Len(), "expected length of 5 for the union set")
+	assert.True(t, s3.Has(1), "expected value 1 to be in the set")
+	assert.True(t, s3.Has(2), "expected value 2 to be in the set")
+	assert.True(t, s3.Has(3), "expected value 3 to be in the set")
+	assert.True(t, s3.Has(4), "expected value 4 to be in the set")
+	assert.True(t, s3.Has(5), "expected value 5 to be in the set")
+
+	// Disjoint sets
+	s4 := NewImmSet(1, 2)
+	assert.Equal(t, 2, s4.Len(), "expected length of 2 for initialized set")
+	assert.True(t, s4.Has(1), "expected value 1 to be in the set")
+	assert.True(t, s4.Has(2), "expected value 2 to be in the set")
+	assert.False(t, s4.Has(3), "expected value 3 to not be in the set")
+
+	s5 := NewImmSet(3, 4)
+	assert.Equal(t, 2, s5.Len(), "expected length of 2 for initialized set")
+	assert.False(t, s5.Has(1), "expected value 1 to not be in the set")
+	assert.True(t, s5.Has(3), "expected value 3 to be in the set")
+	assert.True(t, s5.Has(4), "expected value 4 to be in the set")
+
+	s6 := s4.Union(s5)
+	assert.Equal(t, 4, s6.Len(), "expected length of 4 for the union set")
+	assert.True(t, s6.Has(1), "expected value 1 to be in the set")
+	assert.True(t, s6.Has(2), "expected value 2 to be in the set")
+	assert.True(t, s6.Has(3), "expected value 3 to be in the set")
+	assert.True(t, s6.Has(4), "expected value 4 to be in the set")
+}
+
+func benchmarkImmSetInsert(b *testing.B, numItems int) {
+	s := NewImmSet[int]()
+	for i := 0; i < numItems; i++ {
+		s = s.Insert(i)
+	}
+	for n := 0; n < b.N; n++ {
+		s.Insert(numItems)
+	}
+}
+
+func BenchmarkImmSetInsert_100(b *testing.B)   { benchmarkImmSetInsert(b, 100) }
+func BenchmarkImmSetInsert_1000(b *testing.B)  { benchmarkImmSetInsert(b, 1000) }
+func BenchmarkImmSetInsert_10000(b *testing.B) { benchmarkImmSetInsert(b, 10000) }
+
+func benchmarkImmSetDelete(b *testing.B, numItems int) {
+	s := NewImmSet[int]()
+	for i := 0; i < numItems; i++ {
+		s = s.Insert(i)
+	}
+	idx := rand.IntN(numItems)
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		s.Delete(idx)
+	}
+}
+
+func BenchmarkImmSetDelete_100(b *testing.B)   { benchmarkImmSetDelete(b, 100) }
+func BenchmarkImmSetDelete_1000(b *testing.B)  { benchmarkImmSetDelete(b, 1000) }
+func BenchmarkImmSetDelete_10000(b *testing.B) { benchmarkImmSetDelete(b, 10000) }

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -11,6 +11,7 @@ import (
 
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
+	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -48,6 +49,7 @@ var Cell = cell.Module(
 		func() egressmap.PolicyMap { return nil },
 		func() *bigtcp.Configuration { return &bigtcp.Configuration{} },
 		func() *iptables.Manager { return &iptables.Manager{} },
+		func() ipset.Manager { return &fakeTypes.IPSet{} },
 		func() types.BandwidthManager { return &fakeTypes.BandwidthManager{} },
 		func() types.IPsecKeyCustodian { return &ipsecKeyCustodian{} },
 		func() mtu.MTU { return &fakeTypes.MTU{} },

--- a/pkg/datapath/fake/types/ipset.go
+++ b/pkg/datapath/fake/types/ipset.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"net/netip"
+
+	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
+)
+
+var _ ipset.Manager = &IPSet{}
+
+type IPSet struct{}
+
+func (f *IPSet) AddToIPSet(_ string, _ ipset.Family, _ ...netip.Addr) {}
+
+func (f *IPSet) RemoveFromIPSet(name string, addrs ...netip.Addr) {}

--- a/pkg/datapath/iptables/cell.go
+++ b/pkg/datapath/iptables/cell.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
@@ -15,6 +16,11 @@ import (
 var Cell = cell.Module(
 	"iptables",
 	"Handle iptables-related configuration for Cilium",
+
+	// Manage "cilium_node_set_v4" and "cilium_node_set_v6" kernel IP sets to
+	// collect IPv4 and IPv6 node addresses (respectively) and exclude traffic to
+	// those IPs from being masqueraded.
+	ipset.Cell,
 
 	cell.Config(defaultConfig),
 	cell.ProvidePrivate(func(

--- a/pkg/datapath/iptables/ipset/cell.go
+++ b/pkg/datapath/iptables/ipset/cell.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipset
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/statedb/reconciler"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// Cell exposes methods to add and remove node IPs from the kernel IP sets.
+// The sets are in turn referenced by iptables rules to exclude traffic
+// to cluster nodes from being masqueraded.
+// There are two distinct sets, one for IPv4 addresses and one for IPv6
+// addresses.
+// Internally, the cell stores the desired IP sets state in a StateDB table
+// and uses a reconciler to update the realized state (that is, the actual
+// kernel IP sets).
+// Other sets that do not pertain to Cilium configuration are not changed
+// in any way.
+var Cell = cell.Module(
+	"ipset",
+	"Handle kernel IP sets configuration for Cilium",
+
+	cell.Provide(newIPSetManager),
+
+	cell.ProvidePrivate(
+		tables.NewIPSetTable,
+
+		reconciler.New[*tables.IPSet],
+		newReconcilerConfig,
+		newOps,
+	),
+	cell.ProvidePrivate(func(logger logrus.FieldLogger) *ipset {
+		return &ipset{
+			executable: funcExecutable(func(ctx context.Context, name string, arg ...string) ([]byte, error) {
+				return exec.CommandContext(ctx, name, arg...).Output()
+			}),
+			log: logger,
+		}
+	}),
+	cell.ProvidePrivate(func(cfg *option.DaemonConfig) config {
+		return config{NodeIPSetNeeded: cfg.NodeIpsetNeeded()}
+	}),
+)
+
+type config struct {
+	NodeIPSetNeeded bool
+}
+
+func newReconcilerConfig(
+	ops reconciler.Operations[*tables.IPSet],
+) reconciler.Config[*tables.IPSet] {
+	return reconciler.Config[*tables.IPSet]{
+		FullReconcilationInterval: 10 * time.Second,
+		RetryBackoffMinDuration:   100 * time.Millisecond,
+		RetryBackoffMaxDuration:   5 * time.Second,
+		IncrementalRoundSize:      100,
+		GetObjectStatus:           (*tables.IPSet).GetStatus,
+		WithObjectStatus:          (*tables.IPSet).WithStatus,
+		Operations:                ops,
+	}
+}

--- a/pkg/datapath/iptables/ipset/ipset.go
+++ b/pkg/datapath/iptables/ipset/ipset.go
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipset
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"net/netip"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/reconciler"
+)
+
+const (
+	CiliumNodeIPSetV4 = "cilium_node_set_v4"
+	CiliumNodeIPSetV6 = "cilium_node_set_v6"
+)
+
+type Family string
+
+const (
+	INetFamily  Family = "inet"
+	INet6Family Family = "inet6"
+)
+
+// Manager handles the kernel IP sets configuration
+type Manager interface {
+	AddToIPSet(name string, family Family, addrs ...netip.Addr)
+	RemoveFromIPSet(name string, addrs ...netip.Addr)
+}
+
+type manager struct {
+	logger  logrus.FieldLogger
+	enabled bool
+
+	db    *statedb.DB
+	table statedb.RWTable[*tables.IPSet]
+
+	ipset *ipset
+}
+
+// AddToIPSet adds the addresses to the ipset with given name and family.
+// It creates the ipset if it doesn't already exist and doesn't error out
+// if either the ipset or the IP already exist.
+func (m *manager) AddToIPSet(name string, family Family, addrs ...netip.Addr) {
+	if !m.enabled || len(addrs) == 0 {
+		return
+	}
+
+	txn := m.db.WriteTxn(m.table)
+	defer txn.Abort()
+
+	var (
+		obj   *tables.IPSet
+		found bool
+	)
+
+	obj, _, found = m.table.First(txn, tables.IPSetNameIndex.Query(name))
+	if !found {
+		obj = &tables.IPSet{
+			Name:   name,
+			Family: string(family),
+			Addrs:  tables.NewAddrSet(addrs...),
+			Status: reconciler.StatusPending(),
+		}
+	} else {
+		obj = obj.WithAddrs(addrs...) // clone object to avoid mutating the one returned by First
+		obj.Status = reconciler.StatusPending()
+	}
+	_, _, _ = m.table.Insert(txn, obj)
+	txn.Commit()
+}
+
+// RemoveFromBodeIPSet removes the addresses from the specified ipset.
+func (m *manager) RemoveFromIPSet(name string, addrs ...netip.Addr) {
+	if !m.enabled || len(addrs) == 0 {
+		return
+	}
+
+	txn := m.db.WriteTxn(m.table)
+	defer txn.Abort()
+
+	obj, _, found := m.table.First(txn, tables.IPSetNameIndex.Query(name))
+	if !found {
+		return
+	}
+	obj = obj.WithoutAddrs(addrs...) // clone object to avoid mutating the one returned by First
+	obj.Status = reconciler.StatusPending()
+	_, _, _ = m.table.Insert(txn, obj)
+	txn.Commit()
+}
+
+func newIPSetManager(
+	lc cell.Lifecycle,
+	logger logrus.FieldLogger,
+	db *statedb.DB,
+	table statedb.RWTable[*tables.IPSet],
+	cfg config,
+	ipset *ipset,
+	_ reconciler.Reconciler[*tables.IPSet], // needed to enforce the correct hive ordering
+) Manager {
+	db.RegisterTable(table)
+	mgr := &manager{
+		logger:  logger,
+		enabled: cfg.NodeIPSetNeeded,
+		db:      db,
+		table:   table,
+		ipset:   ipset,
+	}
+
+	lc.Append(cell.Hook{OnStart: mgr.onStart})
+
+	return mgr
+}
+
+func (m *manager) onStart(ctx cell.HookContext) error {
+	if !m.enabled {
+		// If node ipsets are not needed, clear the Cilium managed ones to remove possible stale entries.
+		for _, ciliumNodeIPSet := range []string{CiliumNodeIPSetV4, CiliumNodeIPSetV6} {
+			if err := m.ipset.remove(ctx, ciliumNodeIPSet); err != nil {
+				m.logger.WithError(err).Infof("Unable to remove stale ipset %s. This is usually due to a stale iptables rule referring to it. "+
+					"The set will not be removed. This is harmless and it will be removed at the next Cilium restart, when the stale iptables rule has been removed.", ciliumNodeIPSet)
+			}
+		}
+		return nil
+	}
+
+	// When NodeIPSetNeeded is set, node ipsets must be created even if empty,
+	// to avoid failures when referencing them in iptables masquerading rules.
+
+	txn := m.db.WriteTxn(m.table)
+	defer txn.Abort()
+
+	if _, _, found := m.table.First(txn, tables.IPSetNameIndex.Query(CiliumNodeIPSetV4)); !found {
+		if _, _, err := m.table.Insert(txn, &tables.IPSet{
+			Name:   CiliumNodeIPSetV4,
+			Family: string(INetFamily),
+			Addrs:  tables.NewAddrSet(),
+			Status: reconciler.StatusPending(),
+		}); err != nil {
+			return fmt.Errorf("error while inserting ipset %s entry in stateDB table", CiliumNodeIPSetV4)
+		}
+	}
+	if _, _, found := m.table.First(txn, tables.IPSetNameIndex.Query(CiliumNodeIPSetV6)); !found {
+		if _, _, err := m.table.Insert(txn, &tables.IPSet{
+			Name:   CiliumNodeIPSetV6,
+			Family: string(INet6Family),
+			Addrs:  tables.NewAddrSet(),
+			Status: reconciler.StatusPending(),
+		}); err != nil {
+			return fmt.Errorf("error while inserting ipset %s entry in stateDB table", CiliumNodeIPSetV6)
+		}
+	}
+	txn.Commit()
+
+	return nil
+}
+
+type ipset struct {
+	executable
+
+	log logrus.FieldLogger
+}
+
+func (i *ipset) create(ctx context.Context, name string, family string) error {
+	if _, err := i.run(ctx, "create", name, "iphash", "family", family, "-exist"); err != nil {
+		return fmt.Errorf("failed to create ipset %s: %w", name, err)
+	}
+	return nil
+}
+
+func (i *ipset) remove(ctx context.Context, name string) error {
+	if _, err := i.run(ctx, "list", name); err != nil {
+		// ipset does not exist, nothing to remove
+		return nil
+	}
+	if _, err := i.run(ctx, "destroy", name); err != nil {
+		return fmt.Errorf("failed to remove ipset %s: %w", name, err)
+	}
+	return nil
+}
+
+func (i *ipset) list(ctx context.Context, name string) (tables.AddrSet, error) {
+	out, err := i.run(ctx, "list", name)
+	if err != nil {
+		return tables.AddrSet{}, fmt.Errorf("failed to list ipset %s: %w", name, err)
+	}
+
+	addrs := tables.NewAddrSet()
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		line := scanner.Text()
+		addr, err := netip.ParseAddr(line)
+		if err != nil {
+			continue
+		}
+		addrs = addrs.Insert(addr)
+	}
+	if err := scanner.Err(); err != nil {
+		return tables.AddrSet{}, fmt.Errorf("failed to scan ipset %s: %w", name, err)
+	}
+	return addrs, nil
+}
+
+func (i *ipset) add(ctx context.Context, name string, addr netip.Addr) error {
+	if _, err := i.run(ctx, "add", name, addr.String(), "-exist"); err != nil {
+		return fmt.Errorf("failed to add %s to ipset %s: %w", addr, name, err)
+	}
+	return nil
+}
+
+func (i *ipset) del(ctx context.Context, name string, addr netip.Addr) error {
+	if _, err := i.run(ctx, "del", name, addr.String(), "-exist"); err != nil {
+		return fmt.Errorf("failed to del %s to ipset %s: %w", addr, name, err)
+	}
+	return nil
+}
+
+func (i *ipset) run(ctx context.Context, args ...string) ([]byte, error) {
+	i.log.Debugf("Running command %s", i.fullCommand(args...))
+	return i.exec(ctx, "ipset", args...)
+}
+
+func (i *ipset) fullCommand(args ...string) string {
+	return strings.Join(append([]string{"ipset"}, args...), " ")
+}
+
+// useful to ease the creation of a mock ipset command for testing purposes
+type executable interface {
+	exec(ctx context.Context, name string, arg ...string) ([]byte, error)
+}
+
+type funcExecutable func(ctx context.Context, name string, arg ...string) ([]byte, error)
+
+func (f funcExecutable) exec(ctx context.Context, name string, arg ...string) ([]byte, error) {
+	return f(ctx, name, arg...)
+}

--- a/pkg/datapath/iptables/ipset/ipset_test.go
+++ b/pkg/datapath/iptables/ipset/ipset_test.go
@@ -1,0 +1,443 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipset
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"html/template"
+	"io"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/reconciler"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// ipset list output template
+const textTmpl = `{{range $name, $addrs := . -}}Name: {{$name}}
+Type: hash:ip
+Revision: 6
+Header: family inet hashsize 1024 maxelem 65536 bucketsize 12 initval 0x4d9d24f1
+Size in memory: 216
+References: 0
+Number of entries: {{len $addrs.AsSlice}}
+Members:
+{{range $idx, $addr := $addrs.AsSlice -}}{{$addr}}
+{{else}}{{end}}{{end}}`
+
+func TestManager(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var mgr Manager
+
+	ipsets := make(map[string]tables.AddrSet) // mocked kernel IP sets
+	var mu lock.Mutex                         // protect the ipsets map
+
+	tmpl := template.Must(template.New("ipsets").Parse(textTmpl))
+
+	hive := hive.New(
+		statedb.Cell,
+		job.Cell,
+		reconciler.Cell,
+
+		cell.Module(
+			"ipset-manager-test",
+			"ipset-manager-test",
+
+			cell.Provide(func() config {
+				return config{NodeIPSetNeeded: true}
+			}),
+
+			cell.Provide(
+				newIPSetManager,
+				tables.NewIPSetTable,
+				reconciler.New[*tables.IPSet],
+				newReconcilerConfig,
+				newOps,
+			),
+
+			cell.Provide(func(logger logrus.FieldLogger) *ipset {
+				return &ipset{
+					executable: funcExecutable(
+						func(ctx context.Context, command string, arg ...string) ([]byte, error) {
+							mu.Lock()
+							defer mu.Unlock()
+
+							t.Logf("%s %s", command, strings.Join(arg, " "))
+
+							subCommand := arg[0]
+							name := arg[1]
+
+							switch subCommand {
+							case "create":
+								if _, found := ipsets[name]; !found {
+									ipsets[name] = tables.NewAddrSet()
+								}
+								return nil, nil
+							case "destroy":
+								if _, found := ipsets[name]; !found {
+									return nil, fmt.Errorf("ipset %s not found", name)
+								}
+								delete(ipsets, name)
+								return nil, nil
+							case "list":
+								if _, found := ipsets[name]; !found {
+									return nil, fmt.Errorf("ipset %s not found", name)
+								}
+								var bb bytes.Buffer
+								if err := tmpl.Execute(&bb, map[string]tables.AddrSet{name: ipsets[name]}); err != nil {
+									return nil, err
+								}
+								b := bb.Bytes()
+								return b, nil
+							case "add":
+								if _, found := ipsets[name]; !found {
+									return nil, fmt.Errorf("ipset %s not found", name)
+								}
+								addr := netip.MustParseAddr(arg[len(arg)-2])
+								ipsets[name] = ipsets[name].Insert(addr)
+								return nil, nil
+							case "del":
+								if _, found := ipsets[name]; !found {
+									return nil, fmt.Errorf("ipset %s not found", name)
+								}
+								addr := netip.MustParseAddr(arg[len(arg)-2])
+								if !ipsets[name].Has(addr) {
+									return nil, nil
+								}
+								ipsets[name] = ipsets[name].Delete(addr)
+								return nil, nil
+							default:
+								return nil, fmt.Errorf("unexpected ipset subcommand %s", arg[1])
+							}
+						},
+					),
+					log: logger,
+				}
+			}),
+			cell.Invoke(reconciler.Register[*tables.IPSet]),
+		),
+
+		cell.Invoke(func(m Manager) {
+			mgr = m
+		}),
+	)
+
+	testCases := []struct {
+		name     string
+		action   func()
+		expected map[string]tables.AddrSet
+	}{
+		{
+			name:   "check Cilium ipsets have been created",
+			action: func() {},
+			expected: map[string]tables.AddrSet{
+				CiliumNodeIPSetV4: tables.NewAddrSet(),
+				CiliumNodeIPSetV6: tables.NewAddrSet(),
+			},
+		},
+		{
+			name: "add an IPv4 address",
+			action: func() {
+				mgr.AddToIPSet(CiliumNodeIPSetV4, INetFamily, netip.MustParseAddr("1.1.1.1"))
+			},
+			expected: map[string]tables.AddrSet{
+				CiliumNodeIPSetV4: tables.NewAddrSet(
+					netip.MustParseAddr("1.1.1.1"),
+				),
+				CiliumNodeIPSetV6: tables.NewAddrSet(),
+			},
+		},
+		{
+			name: "add another IPv4 address",
+			action: func() {
+				mgr.AddToIPSet(CiliumNodeIPSetV4, INetFamily, netip.MustParseAddr("2.2.2.2"))
+			},
+			expected: map[string]tables.AddrSet{
+				CiliumNodeIPSetV4: tables.NewAddrSet(
+					netip.MustParseAddr("1.1.1.1"),
+					netip.MustParseAddr("2.2.2.2"),
+				),
+				CiliumNodeIPSetV6: tables.NewAddrSet(),
+			},
+		},
+		{
+			name: "add the same IPv4 address",
+			action: func() {
+				mgr.AddToIPSet(CiliumNodeIPSetV4, INetFamily, netip.MustParseAddr("2.2.2.2"))
+			},
+			expected: map[string]tables.AddrSet{
+				CiliumNodeIPSetV4: tables.NewAddrSet(
+					netip.MustParseAddr("1.1.1.1"),
+					netip.MustParseAddr("2.2.2.2"),
+				),
+				CiliumNodeIPSetV6: tables.NewAddrSet(),
+			},
+		},
+		{
+			name: "remove an IPv4 address",
+			action: func() {
+				mgr.RemoveFromIPSet(CiliumNodeIPSetV4, netip.MustParseAddr("1.1.1.1"))
+			},
+			expected: map[string]tables.AddrSet{
+				CiliumNodeIPSetV4: tables.NewAddrSet(
+					netip.MustParseAddr("2.2.2.2"),
+				),
+				CiliumNodeIPSetV6: tables.NewAddrSet(),
+			},
+		},
+		{
+			name: "remove a missing IPv4 address",
+			action: func() {
+				mgr.RemoveFromIPSet(CiliumNodeIPSetV4, netip.MustParseAddr("3.3.3.3"))
+			},
+			expected: map[string]tables.AddrSet{
+				CiliumNodeIPSetV4: tables.NewAddrSet(
+					netip.MustParseAddr("2.2.2.2"),
+				),
+				CiliumNodeIPSetV6: tables.NewAddrSet(),
+			},
+		},
+		{
+			name: "add an IPv6 address",
+			action: func() {
+				mgr.AddToIPSet(CiliumNodeIPSetV6, INet6Family, netip.MustParseAddr("cafe::1"))
+			},
+			expected: map[string]tables.AddrSet{
+				CiliumNodeIPSetV4: tables.NewAddrSet(
+					netip.MustParseAddr("2.2.2.2"),
+				),
+				CiliumNodeIPSetV6: tables.NewAddrSet(
+					netip.MustParseAddr("cafe::1"),
+				),
+			},
+		},
+		{
+			name: "remove an IPv6 address",
+			action: func() {
+				mgr.RemoveFromIPSet(CiliumNodeIPSetV6, netip.MustParseAddr("cafe::1"))
+			},
+			expected: map[string]tables.AddrSet{
+				CiliumNodeIPSetV4: tables.NewAddrSet(
+					netip.MustParseAddr("2.2.2.2"),
+				),
+				CiliumNodeIPSetV6: tables.NewAddrSet(),
+			},
+		},
+	}
+
+	time.MaxInternalTimerDelay = time.Millisecond
+	t.Cleanup(func() { time.MaxInternalTimerDelay = 0 })
+
+	assert.NoError(t, hive.Start(context.Background()))
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.action()
+			assert.Eventually(t, func() bool {
+				mu.Lock()
+				defer mu.Unlock()
+
+				if len(ipsets) != len(tc.expected) {
+					return false
+				}
+				for name, expectedAddrs := range tc.expected {
+					t.Logf("expected: %#v, actual: %#v", expectedAddrs, ipsets[name])
+					addrs, found := ipsets[name]
+					if !found || !addrs.Equal(expectedAddrs) {
+						return false
+					}
+				}
+				return true
+			}, 1*time.Second, 50*time.Millisecond)
+		})
+	}
+
+	assert.NoError(t, hive.Stop(context.Background()))
+}
+
+func TestManagerNodeIpsetNotNeeded(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	ipsets := make(map[string]tables.AddrSet) // mocked kernel IP sets
+	var mu lock.Mutex                         // protect the ipsets map
+
+	hive := hive.New(
+		statedb.Cell,
+		job.Cell,
+		reconciler.Cell,
+
+		cell.Module(
+			"ipset-manager-test",
+			"ipset-manager-test",
+
+			cell.Provide(func() config {
+				return config{NodeIPSetNeeded: false}
+			}),
+
+			cell.Provide(
+				newIPSetManager,
+				tables.NewIPSetTable,
+				reconciler.New[*tables.IPSet],
+				newReconcilerConfig,
+				newOps,
+			),
+			cell.Provide(func(logger logrus.FieldLogger) *ipset {
+				return &ipset{
+					executable: funcExecutable(func(ctx context.Context, command string, arg ...string) ([]byte, error) {
+						mu.Lock()
+						defer mu.Unlock()
+
+						t.Logf("%s %s", command, strings.Join(arg, " "))
+
+						if arg[0] == "destroy" {
+							name := arg[1]
+							if _, found := ipsets[name]; !found {
+								return nil, fmt.Errorf("ipset %s not found", name)
+							}
+							delete(ipsets, name)
+						}
+						return nil, nil
+					}),
+					log: logger,
+				}
+			}),
+			cell.Invoke(reconciler.Register[*tables.IPSet]),
+
+			// force manager instantiation
+			cell.Invoke(func(_ Manager) {}),
+		),
+	)
+
+	time.MaxInternalTimerDelay = time.Millisecond
+	t.Cleanup(func() { time.MaxInternalTimerDelay = 0 })
+
+	// create ipv4 and ipv6 node ipsets to simulate stale entries from previous Cilium run
+	withLocked(&mu, func() {
+		ipsets[CiliumNodeIPSetV4] = tables.NewAddrSet(netip.MustParseAddr("2.2.2.2"))
+		ipsets[CiliumNodeIPSetV6] = tables.NewAddrSet(netip.MustParseAddr("cafe::1"))
+	})
+
+	assert.NoError(t, hive.Start(context.Background()))
+
+	// Cilium node ipsets should have been pruned
+	withLocked(&mu, func() {
+		assert.NotContains(t, ipsets, CiliumNodeIPSetV4)
+		assert.NotContains(t, ipsets, CiliumNodeIPSetV6)
+	})
+
+	// create a custom ipset (not managed by Cilium)
+	withLocked(&mu, func() {
+		ipsets["unmanaged-ipset"] = tables.NewAddrSet()
+	})
+
+	assert.NoError(t, hive.Stop(context.Background()))
+
+	// ipset not managed by Cilium should not been pruned
+	withLocked(&mu, func() {
+		assert.Contains(t, ipsets, "unmanaged-ipset")
+	})
+}
+
+func withLocked(m *lock.Mutex, f func()) {
+	m.Lock()
+	defer m.Unlock()
+
+	f()
+}
+
+func TestIPSetList(t *testing.T) {
+	testCases := []struct {
+		name     string
+		ipsets   map[string]tables.AddrSet
+		expected tables.AddrSet
+	}{
+		{
+			name: "empty ipset",
+			ipsets: map[string]tables.AddrSet{
+				"ciliumtest": tables.NewAddrSet(),
+			},
+			expected: tables.NewAddrSet(),
+		},
+		{
+			name: "ipset with a single IP",
+			ipsets: map[string]tables.AddrSet{
+				"ciliumtest": tables.NewAddrSet(netip.MustParseAddr("1.1.1.1")),
+			},
+			expected: tables.NewAddrSet(netip.MustParseAddr("1.1.1.1")),
+		},
+		{
+			name: "ipset with multiple IPs",
+			ipsets: map[string]tables.AddrSet{
+				"ciliumtest": tables.NewAddrSet(netip.MustParseAddr("1.1.1.1"), netip.MustParseAddr("2.2.2.2")),
+			},
+			expected: tables.NewAddrSet(netip.MustParseAddr("1.1.1.1"), netip.MustParseAddr("2.2.2.2")),
+		},
+	}
+
+	fakeLogger := logrus.New()
+	fakeLogger.SetOutput(io.Discard)
+
+	tmpl := template.Must(template.New("ipsets").Parse(textTmpl))
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var bb bytes.Buffer
+			if err := tmpl.Execute(&bb, tc.ipsets); err != nil {
+				t.Fatalf("unable to execute ipset list output template: %s", err)
+			}
+			ipset := &ipset{
+				&mockExec{t, bb.Bytes(), nil},
+				fakeLogger,
+			}
+			got, err := ipset.list(context.Background(), "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !got.Equal(tc.expected) {
+				t.Fatalf("expected addresses in ipset to be %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestIPSetListInexistentIPSet(t *testing.T) {
+	fakeLogger := logrus.New()
+	fakeLogger.SetOutput(io.Discard)
+
+	expectedErr := errors.New("ipset v7.19: The set with the given name does not exist")
+	ipset := &ipset{
+		&mockExec{t, nil, expectedErr},
+		fakeLogger,
+	}
+
+	_, err := ipset.list(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+type mockExec struct {
+	t   *testing.T
+	out []byte
+	err error
+}
+
+func (e *mockExec) exec(ctx context.Context, name string, arg ...string) ([]byte, error) {
+	return e.out, e.err
+}

--- a/pkg/datapath/iptables/ipset/ops.go
+++ b/pkg/datapath/iptables/ipset/ops.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipset
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/reconciler"
+)
+
+func newOps(logger logrus.FieldLogger, ipset *ipset, cfg config) reconciler.Operations[*tables.IPSet] {
+	return &ops{
+		enabled: cfg.NodeIPSetNeeded,
+		ipset:   ipset,
+	}
+}
+
+type ops struct {
+	enabled bool
+	ipset   *ipset
+}
+
+func (ops *ops) Update(ctx context.Context, _ statedb.ReadTxn, s *tables.IPSet, changed *bool) error {
+	if !ops.enabled {
+		return nil
+	}
+
+	// create the set if does not exist
+	if err := ops.ipset.create(ctx, s.Name, string(s.Family)); err != nil {
+		return err
+	}
+
+	cur, err := ops.ipset.list(ctx, s.Name)
+	if err != nil {
+		return fmt.Errorf("failed to list ips in ipset %s: %w", s.Name, err)
+	}
+
+	if s.Addrs.Equal(cur) {
+		return nil
+	}
+
+	// reconcile the set
+	toAdd := s.Addrs.Difference(cur).AsSlice()
+	for _, addr := range toAdd {
+		if err := ops.ipset.add(ctx, s.Name, addr); err != nil {
+			return err
+		}
+	}
+	toDel := cur.Difference(s.Addrs).AsSlice()
+	for _, addr := range toDel {
+		if err := ops.ipset.del(ctx, s.Name, addr); err != nil {
+			return err
+		}
+	}
+
+	if changed != nil {
+		*changed = true
+	}
+
+	return nil
+}
+
+func (ops *ops) Delete(ctx context.Context, _ statedb.ReadTxn, s *tables.IPSet) error {
+	return ops.ipset.remove(ctx, s.Name)
+}
+
+func (ops *ops) Prune(ctx context.Context, _ statedb.ReadTxn, _ statedb.Iterator[*tables.IPSet]) error {
+	// ipsets not managed by Cilium should not be changed
+	return nil
+}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1191,7 +1191,7 @@ func (m *Manager) installForwardChainRulesIpX(prog iptablesInterface, ifName, lo
 	return nil
 }
 
-func (m *Manager) installMasqueradeRules(prog iptablesInterface, ifName, localDeliveryInterface,
+func (m *Manager) installMasqueradeRules(prog iptablesInterface, localDeliveryInterface,
 	snatDstExclusionCIDR, allocRange, hostMasqueradeIP string) error {
 	if m.sharedCfg.NodeIpsetNeeded {
 		progArgs := []string{
@@ -1583,7 +1583,7 @@ func (m *Manager) installRules(ifName string) error {
 		}
 
 		if m.sharedCfg.IptablesMasqueradingIPv4Enabled {
-			if err := m.installMasqueradeRules(ip4tables, ifName, localDeliveryInterface,
+			if err := m.installMasqueradeRules(ip4tables, localDeliveryInterface,
 				datapath.RemoteSNATDstAddrExclusionCIDRv4().String(),
 				node.GetIPv4AllocRange().String(),
 				node.GetHostMasqueradeIPv4().String(),
@@ -1599,7 +1599,7 @@ func (m *Manager) installRules(ifName string) error {
 		}
 
 		if m.sharedCfg.IptablesMasqueradingIPv6Enabled {
-			if err := m.installMasqueradeRules(ip6tables, ifName, localDeliveryInterface,
+			if err := m.installMasqueradeRules(ip6tables, localDeliveryInterface,
 				datapath.RemoteSNATDstAddrExclusionCIDRv6().String(),
 				node.GetIPv6AllocRange().String(),
 				node.GetHostMasqueradeIPv6().String(),

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/command/exec"
+	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/modules"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
@@ -31,7 +32,6 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/fqdn/proxy/ipfamily"
 	"github.com/cilium/cilium/pkg/hive/cell"
-	"github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
@@ -55,8 +55,6 @@ const (
 	ciliumForwardChain    = "CILIUM_FORWARD"
 	feederDescription     = "cilium-feeder:"
 	xfrmDescription       = "cilium-xfrm-notrack:"
-	CiliumNodeIpsetV4     = "cilium_node_set_v4"
-	CiliumNodeIpsetV6     = "cilium_node_set_v6"
 )
 
 // Minimum iptables versions supporting the -w and -w<seconds> flags
@@ -109,9 +107,8 @@ func (ipt *ipt) initArgs(waitSeconds int) {
 
 // package name is iptables so we use ip4tables internally for "iptables"
 var (
-	ip4tables = &ipt{prog: "iptables", ipset: CiliumNodeIpsetV4}
-	ip6tables = &ipt{prog: "ip6tables", ipset: CiliumNodeIpsetV6}
-	ipset     = &ipt{prog: "ipset"}
+	ip4tables = &ipt{prog: "iptables", ipset: ipset.CiliumNodeIPSetV4}
+	ip6tables = &ipt{prog: "ip6tables", ipset: ipset.CiliumNodeIPSetV6}
 )
 
 func (ipt *ipt) getProg() string {
@@ -1194,46 +1191,9 @@ func (m *Manager) installForwardChainRulesIpX(prog iptablesInterface, ifName, lo
 	return nil
 }
 
-// AddToNodeIpset adds an IP address to the ipset for cluster nodes. It creates
-// the ipset if it doesn't already exist and doesn't error if either the ipset
-// or the IP already exist.
-func (m *Manager) AddToNodeIpset(nodeIP net.IP) {
-	scopedLog := log.WithField(logfields.IPAddr, nodeIP.String())
-	ciliumNodeIpset := CiliumNodeIpsetV4
-	if ip.IsIPv6(nodeIP) {
-		ciliumNodeIpset = CiliumNodeIpsetV6
-	}
-	if err := createIpset(ciliumNodeIpset, ip.IsIPv6(nodeIP)); err != nil {
-		scopedLog.WithError(err).Errorf("Failed to create ipset %s", ciliumNodeIpset)
-		return
-	}
-	progArgs := []string{"add", ciliumNodeIpset, nodeIP.String(), "-exist"}
-	if err := ipset.runProg(progArgs); err != nil {
-		scopedLog.WithError(err).Errorf("Failed to add IP to ipset %s", ciliumNodeIpset)
-	}
-}
-
-// RemoveFromBodeIpset removes an IP address from the ipset for cluster nodes.
-func (m *Manager) RemoveFromNodeIpset(nodeIP net.IP) {
-	scopedLog := log.WithField(logfields.IPAddr, nodeIP.String())
-	ciliumNodeIpset := CiliumNodeIpsetV4
-	if ip.IsIPv6(nodeIP) {
-		ciliumNodeIpset = CiliumNodeIpsetV6
-	}
-	progArgs := []string{"del", ciliumNodeIpset, nodeIP.String(), "-exist"}
-	if err := ipset.runProg(progArgs); err != nil {
-		scopedLog.WithError(err).Errorf("Failed to remove IP from ipset %s", ciliumNodeIpset)
-	}
-}
-
 func (m *Manager) installMasqueradeRules(prog iptablesInterface, ifName, localDeliveryInterface,
 	snatDstExclusionCIDR, allocRange, hostMasqueradeIP string) error {
 	if m.sharedCfg.NodeIpsetNeeded {
-		// Exclude traffic to nodes from masquerade.
-		if err := createIpset(prog.getIpset(), prog == ip6tables); err != nil {
-			return err
-		}
-
 		progArgs := []string{
 			"-t", "nat",
 			"-A", ciliumPostNatChain,
@@ -1485,29 +1445,6 @@ func (m *Manager) installMasqueradeRules(prog iptablesInterface, ifName, localDe
 	return nil
 }
 
-func createIpset(name string, ipv6 bool) error {
-	ipsetFamily := "inet"
-	if ipv6 {
-		ipsetFamily = "inet6"
-	}
-	progArgs := []string{"create", name, "iphash", "family", ipsetFamily, "-exist"}
-	return ipset.runProg(progArgs)
-}
-
-func removeIpset(name string) error {
-	if !ipsetExists(name) {
-		return nil
-	}
-	progArgs := []string{"destroy", name}
-	return ipset.runProg(progArgs)
-}
-
-func ipsetExists(name string) bool {
-	progArgs := []string{"list", name}
-	err := ipset.runProg(progArgs)
-	return err == nil
-}
-
 func (m *Manager) installHostTrafficMarkRule(prog iptablesInterface) error {
 	// Mark all packets sourced from processes running on the host with a
 	// special marker so that we can differentiate traffic sourced locally
@@ -1605,31 +1542,6 @@ func (m *Manager) doInstallRules(ifName string, firstInitialization, install boo
 
 	if err := m.removeRules(oldCiliumPrefix); err != nil {
 		return err
-	}
-
-	// Create ipsets for node IP address only if needed. If they already exist,
-	// we will simply ignore the error.
-	// Note we don't need a backup system as for iptables rules because the
-	// contents of ipsets doesn't depend on configuration. Whether they are
-	// needed depends on the configuration, but the content doesn't.
-	if m.sharedCfg.NodeIpsetNeeded {
-		if m.sharedCfg.IptablesMasqueradingIPv4Enabled {
-			if err := createIpset(CiliumNodeIpsetV4, false); err != nil {
-				return err
-			}
-		}
-		if m.sharedCfg.IptablesMasqueradingIPv6Enabled {
-			if err := createIpset(CiliumNodeIpsetV6, true); err != nil {
-				return err
-			}
-		}
-	} else {
-		if err := removeIpset(CiliumNodeIpsetV4); err != nil {
-			return err
-		}
-		if err := removeIpset(CiliumNodeIpsetV6); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/pkg/datapath/tables/ipset.go
+++ b/pkg/datapath/tables/ipset.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tables
+
+import (
+	"net/netip"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/container"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/index"
+	"github.com/cilium/cilium/pkg/statedb/reconciler"
+)
+
+const IPSetTableName = "ipset"
+
+type AddrSet = container.ImmSet[netip.Addr]
+
+func NewAddrSet(addrs ...netip.Addr) AddrSet {
+	return container.NewImmSetFunc(
+		netip.Addr.Compare,
+		addrs...,
+	)
+}
+
+var (
+	IPSetNameIndex = statedb.Index[*IPSet, string]{
+		Name: "name",
+		FromObject: func(s *IPSet) index.KeySet {
+			return index.NewKeySet(index.String(s.Name))
+		},
+		FromKey: index.String,
+		Unique:  true,
+	}
+)
+
+func NewIPSetTable(db *statedb.DB) (statedb.RWTable[*IPSet], error) {
+	tbl, err := statedb.NewTable(
+		IPSetTableName,
+		IPSetNameIndex,
+	)
+	return tbl, err
+}
+
+func (s *IPSet) TableHeader() []string {
+	return []string{"Name", "Family", "Addrs", "Status"}
+}
+
+func (s *IPSet) TableRow() []string {
+	ss := make([]string, 0, s.Addrs.Len())
+	for _, addr := range s.Addrs.AsSlice() {
+		ss = append(ss, addr.String())
+	}
+	return []string{s.Name, s.Family, strings.Join(ss, ","), s.Status.String()}
+}
+
+type IPSet struct {
+	Name   string
+	Family string
+	Addrs  AddrSet
+
+	Status reconciler.Status
+}
+
+func (s *IPSet) GetStatus() reconciler.Status {
+	return s.Status
+}
+
+func (s *IPSet) WithStatus(newStatus reconciler.Status) *IPSet {
+	return &IPSet{
+		Name:   s.Name,
+		Family: s.Family,
+		Addrs:  s.Addrs,
+		Status: newStatus,
+	}
+}
+
+func (s *IPSet) WithAddrs(addrs ...netip.Addr) *IPSet {
+	return &IPSet{
+		Name:   s.Name,
+		Family: s.Family,
+		Addrs:  s.Addrs.Insert(addrs...),
+		Status: s.Status,
+	}
+}
+
+func (s *IPSet) WithoutAddrs(addrs ...netip.Addr) *IPSet {
+	return &IPSet{
+		Name:   s.Name,
+		Family: s.Family,
+		Addrs:  s.Addrs.Delete(addrs...),
+		Status: s.Status,
+	}
+}

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -4,9 +4,7 @@
 package manager
 
 import (
-	"net"
-
-	"github.com/cilium/cilium/pkg/datapath/iptables"
+	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -21,9 +19,6 @@ var Cell = cell.Module(
 	"node-manager",
 	"Manages the collection of Cilium nodes",
 	cell.Provide(newAllNodeManager),
-	cell.ProvidePrivate(func(iptMgr *iptables.Manager) ipsetManager {
-		return iptMgr
-	}),
 	cell.Metric(NewNodeMetrics),
 )
 
@@ -75,15 +70,10 @@ type NodeManager interface {
 	StartNodeNeighborLinkUpdater(nh datapath.NodeNeighbors)
 }
 
-type ipsetManager interface {
-	AddToNodeIpset(nodeIP net.IP)
-	RemoveFromNodeIpset(nodeIP net.IP)
-}
-
 func newAllNodeManager(
 	lc cell.Lifecycle,
 	ipCache *ipcache.IPCache,
-	ipsetMgr ipsetManager,
+	ipsetMgr ipset.Manager,
 	nodeMetrics *nodeMetrics,
 	healthScope cell.Scope,
 ) (NodeManager, error) {

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -19,12 +18,11 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
-	"github.com/cilium/cilium/pkg/datapath/iptables"
+	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/inctimer"
-	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
@@ -111,50 +109,45 @@ func (i *ipcacheMock) RemoveIdentityOverride(prefix netip.Prefix, identityLabels
 }
 
 type ipsetMock struct {
-	v4 []string
-	v6 []string
+	v4 map[string]struct{}
+	v6 map[string]struct{}
 }
 
 func newIPSetMock() *ipsetMock {
-	return &ipsetMock{}
-}
-
-func (i *ipsetMock) AddToNodeIpset(nodeIP net.IP) {
-	entry := nodeIP.String()
-	if ip.IsIPv6(nodeIP) {
-		if slices.Contains(i.v6, entry) {
-			return
-		}
-		i.v6 = append(i.v6, strings.ToLower(entry))
-	} else {
-		if slices.Contains(i.v4, entry) {
-			return
-		}
-		i.v4 = append(i.v4, entry)
+	return &ipsetMock{
+		v4: make(map[string]struct{}),
+		v6: make(map[string]struct{}),
 	}
 }
 
-func (i *ipsetMock) RemoveFromNodeIpset(nodeIP net.IP) {
-	entry := nodeIP.String()
-	if ip.IsIPv6(nodeIP) {
-		idx := slices.Index(i.v6, entry)
-		if idx != -1 {
-			i.v6 = slices.Delete(i.v6, idx, idx+1)
-		}
-	} else {
-		idx := slices.Index(i.v4, entry)
-		if idx != -1 {
-			i.v4 = slices.Delete(i.v4, idx, idx+1)
+func (i *ipsetMock) AddToIPSet(name string, family ipset.Family, addrs ...netip.Addr) {
+	for _, addr := range addrs {
+		if name == ipset.CiliumNodeIPSetV4 && family == ipset.INetFamily {
+			i.v4[addr.String()] = struct{}{}
+		} else if name == ipset.CiliumNodeIPSetV6 && family == ipset.INet6Family {
+			i.v6[addr.String()] = struct{}{}
 		}
 	}
 }
 
-func ipsetContains(ipsetMgr *ipsetMock, setName string, nodeIP string) (bool, error) {
+func (i *ipsetMock) RemoveFromIPSet(name string, addrs ...netip.Addr) {
+	for _, addr := range addrs {
+		if name == ipset.CiliumNodeIPSetV4 {
+			delete(i.v4, addr.String())
+		} else if name == ipset.CiliumNodeIPSetV6 {
+			delete(i.v6, addr.String())
+		}
+	}
+}
+
+func ipsetContains(ipsetMgr *ipsetMock, setName string, addr string) (bool, error) {
 	switch setName {
-	case iptables.CiliumNodeIpsetV4:
-		return slices.Index(ipsetMgr.v4, nodeIP) != -1, nil
-	case iptables.CiliumNodeIpsetV6:
-		return slices.Index(ipsetMgr.v6, nodeIP) != -1, nil
+	case ipset.CiliumNodeIPSetV4:
+		_, found := ipsetMgr.v4[addr]
+		return found, nil
+	case ipset.CiliumNodeIPSetV6:
+		_, found := ipsetMgr.v6[addr]
+		return found, nil
 	default:
 		return false, fmt.Errorf("unexpected ipset name %s", setName)
 	}
@@ -1019,9 +1012,9 @@ func (s *managerTestSuite) TestNodeWithSameInternalIP(c *check.C) {
 // It is inspired from TestNode() in manager_test.go.
 func (s *managerTestSuite) TestNodeIpset(c *check.C) {
 	ipsetExpect := func(ipsetMgr *ipsetMock, ip string, expected bool) {
-		setName := iptables.CiliumNodeIpsetV6
+		setName := ipset.CiliumNodeIPSetV6
 		if v4 := net.ParseIP(ip).To4(); v4 != nil {
-			setName = iptables.CiliumNodeIpsetV4
+			setName = ipset.CiliumNodeIPSetV4
 		}
 
 		found, err := ipsetContains(ipsetMgr, setName, strings.ToLower(ip))


### PR DESCRIPTION
Add an independent cell to manage IP sets and reconcile them dynamically through the stateDB generic reconciler.

The cell manages only two different sets, one related to the Node IPv4 addresses and the other one related to the Node IPv6 addresses. Other sets are not touched in any way.

When IP sets are disabled, the IP sets manager tries to clean both Cilium managed IP sets at startup, to avoid leaving stale entries from previous runs.

When IP sets are enabled, the IP sets manager exports two methods to add and remove IPs from a named set, respectively. The sets are updated in the relative stateDB table and the kernel state reconciled later using the `ipset` utility.

This is a required step in preparation for the iptables manager refactoring that allows to react to devices and local node info changes. A PoC has already been developed and can be seen [here](https://github.com/cilium/cilium/pull/31024).

**Note to the reviewers**: please review each commit individually.