### PR TITLE
hubble: fix parsing of invalid HTTP URLs

### DIFF
--- a/pkg/hubble/parser/seven/http.go
+++ b/pkg/hubble/parser/seven/http.go
@@ -29,7 +29,7 @@ func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, opts
 			headers = append(headers, &flowpb.HTTPHeader{Key: key, Value: filteredValue})
 		}
 	}
-	uri, _ := url.Parse(http.URL.String())
+	uri := cloneURL(http.URL)
 	filterURL(uri, opts.HubbleRedactSettings)
 
 	if flowType == accesslog.TypeRequest {
@@ -56,7 +56,7 @@ func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, opts
 }
 
 func (p *Parser) httpSummary(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, flow *flowpb.Flow) string {
-	uri, _ := url.Parse(http.URL.String())
+	uri := cloneURL(http.URL)
 	filterURL(uri, p.opts.HubbleRedactSettings)
 	httpRequest := http.Method + " " + uri.String()
 	switch flowType {
@@ -117,4 +117,18 @@ func filterURL(uri *url.URL, redactSettings options.HubbleRedactSettings) {
 			uri.Fragment = ""
 		}
 	}
+}
+
+// cloneURL return a copy of the given URL. Copied from src/net/http/clone.go.
+func cloneURL(u *url.URL) *url.URL {
+	if u == nil {
+		return nil
+	}
+	u2 := new(url.URL)
+	*u2 = *u
+	if u.User != nil {
+		u2.User = new(url.Userinfo)
+		*u2.User = *u.User
+	}
+	return u2
 }


### PR DESCRIPTION
Fix https://github.com/cilium/cilium/issues/31071, easier to review commit by commit as there is a couple of cosmetic renaming / moving commits.

Selecting for `v1.15` backport as the original report was based on `v1.15.1`. `v1.14` is unaffected [because we're checking for `nil`](https://github.com/cilium/cilium/blob/ee4d3cb8fc9274b78713a77c2e38b62844027fa6/pkg/hubble/parser/seven/http.go#L28-L38), and `v1.13` [didn't attempt to clone the accesslog URL before mutating it](https://github.com/cilium/cilium/blob/1a6200ed92712240d7fccd7919f9d9454fc4ec75/pkg/hubble/parser/seven/http.go#L28-L37).