### PR TITLE
fix: Delegated ipam not configure ipv6 if ipv6 disabled in agent

### DIFF
--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -104,11 +104,11 @@ func ipv6IsEnabled(ipam *models.IPAMResponse) bool {
 		return false
 	}
 
-	if ipam.HostAddressing != nil && ipam.HostAddressing.IPV6 != nil {
-		return ipam.HostAddressing.IPV6.Enabled
+	if ipam.HostAddressing == nil || ipam.HostAddressing.IPV6 == nil {
+		return false
 	}
 
-	return true
+	return ipam.HostAddressing.IPV6.Enabled
 }
 
 func ipv4IsEnabled(ipam *models.IPAMResponse) bool {
@@ -116,11 +116,11 @@ func ipv4IsEnabled(ipam *models.IPAMResponse) bool {
 		return false
 	}
 
-	if ipam.HostAddressing != nil && ipam.HostAddressing.IPV4 != nil {
-		return ipam.HostAddressing.IPV4.Enabled
+	if ipam.HostAddressing == nil || ipam.HostAddressing.IPV4 == nil {
+		return false
 	}
 
-	return true
+	return ipam.HostAddressing.IPV4.Enabled
 }
 
 func getConfigFromCiliumAgent(client *client.Client) (*models.DaemonConfigurationStatus, error) {
@@ -205,7 +205,8 @@ func allocateIPsWithDelegatedPlugin(
 		if ipv4 := ipNet.IP.To4(); ipv4 != nil {
 			ipam.Address.IPV4 = ipNet.String()
 			ipam.IPV4 = &models.IPAMAddressResponse{IP: ipv4.String()}
-		} else {
+		} else if conf.Addressing.IPV6 != nil {
+			// assign ipam ipv6 address only if agent ipv6 config is enabled
 			ipam.Address.IPV6 = ipNet.String()
 			ipam.IPV6 = &models.IPAMAddressResponse{IP: ipNet.IP.String()}
 		}
@@ -560,7 +561,7 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 			ipConfig *cniTypesV1.IPConfig
 			routes   []*cniTypes.Route
 		)
-		if ipv6IsEnabled(ipam) {
+		if ipv6IsEnabled(ipam) && conf.Addressing.IPV6 != nil {
 			ep.Addressing.IPV6 = ipam.Address.IPV6
 			ep.Addressing.IPV6PoolName = ipam.Address.IPV6PoolName
 			ep.Addressing.IPV6ExpirationUUID = ipam.IPV6.ExpirationUUID
@@ -575,7 +576,7 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 			res.Routes = append(res.Routes, routes...)
 		}
 
-		if ipv4IsEnabled(ipam) {
+		if ipv4IsEnabled(ipam) && conf.Addressing.IPV4 != nil {
 			ep.Addressing.IPV4 = ipam.Address.IPV4
 			ep.Addressing.IPV4PoolName = ipam.Address.IPV4PoolName
 			ep.Addressing.IPV4ExpirationUUID = ipam.IPV4.ExpirationUUID


### PR DESCRIPTION
Delegated ipam returns ipv6 address to cilium cni even if ipv6 disabled in cilium agent config. In this scenario, ipv6 node addressing is not set and its causing cilium cni to crash if delegated ipam returns ipv6.

Requires backport to 1.14 and 1.15 versions

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #31103 

```release-note
<!-- Fix crash of cilium-cni with delegated IPAM returning ipv6 when IPv6 is disabled in Agent -->
```
