### PR TITLE
golangci-lint: Fix goimports local prefix

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,7 +48,7 @@ linters-settings:
     enable:
       - nilness
   goimports:
-    local-prefixes: github.com/cilium/cilium
+    local-prefixes: github.com/cilium/cilium/
   staticcheck:
     go: "1.20"
   unused:


### PR DESCRIPTION
Change the prefix to github.com/cilium/cilium/ to only match packages from github.com/cilium/cilium repository.