### PR TITLE
slices: don't modify missed input slice in test

### DIFF
--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -55,7 +55,8 @@ var testCases = [...]struct {
 func TestUnique(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := Unique(tc.input)
+			input := slices.Clone(tc.input)
+			got := Unique(input)
 			assert.ElementsMatch(t, tc.expected, got)
 		})
 	}


### PR DESCRIPTION
The commit below correctly identified that modifying the test input makes the test flaky due to being dependent on the non-deterministic ordering. However, it missed adding the work-around for the first test, TestUnique.

Fixes: 32543a40b1 (slices: don't modify input slices in test)
