### PR TITLE
renovate: temporarily do not update GoBGP

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,7 +42,10 @@
     // 'google/oss-fuzz' is ignored from the updates because it's currently
     // unversioned and it would be receiving an update every time the upstream
     // repository would receive a new commit.
-    "google/oss-fuzz"
+    "google/oss-fuzz",
+    // Do not update GoBGP until https://github.com/osrg/gobgp/issues/2777
+    // is resolved and a new version is released.
+    "github.com/osrg/gobgp/v3"
   ],
   "pinDigests": true,
   "ignorePresets": [":prHourlyLimit2"],


### PR DESCRIPTION
Due to a breaking change in GoBGP `v3.24.0`, do not update GoBGP until the issue https://github.com/osrg/gobgp/issues/2777 is resolved and a new version is released.

Hit by CI in https://github.com/cilium/cilium/pull/31112