### PR TITLE
renovate: separate major.minor.patch for lvh images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -413,6 +413,18 @@
       ],
     },
     {
+      // Separate major minor and patch so that renovate can update the patch
+      // versions of the images.
+      "matchPackageNames": [
+        "quay.io/lvh-images/complexity-test",
+        "quay.io/lvh-images/kind",
+        "kindest/node",
+        "quay.io/cilium/kindest-node"
+      ],
+      "separateMajorMinor": true,
+      "separateMinorPatch": true
+    },
+    {
       // Do not allow any updates for major.minor, they will be done by maintainers
       "enabled": false,
       "matchPackageNames": [


### PR DESCRIPTION
If we don't split the major.minor and the minor.patch, renovate will not update the dependencies that are marked to have their major and minor updates done by the maintainers. Thus, this commit will split them moving forward.

Tested in https://github.com/aanm/cilium/pull/620