### PR TITLE
ClusterMesh HA

### DIFF
--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -159,7 +159,14 @@ jobs:
           --set=clustermesh.useAPIServer=${{ !matrix.external-kvstore }} \
           --set=clustermesh.maxConnectedClusters=${{ matrix.max-connected-clusters }} \
           --set=clustermesh.config.enabled=true \
-          --set=extraConfig.clustermesh-ip-identities-sync-timeout=10m"
+          --set=extraConfig.clustermesh-ip-identities-sync-timeout=10m \
+          --set=clustermesh.apiserver.readinessProbe.periodSeconds=1 \
+          --set=clustermesh.apiserver.kvstoremesh.readinessProbe.periodSeconds=1 "
+
+
+        ENABLE_CLUSTERMESH_FAILOVER=" \
+          --set=clustermesh.apiserver.updateStrategy.rollingUpdate.maxSurge=1 \
+          --set=clustermesh.apiserver.updateStrategy.rollingUpdate.maxUnavailable=0"
 
         # Run only a limited subset of tests to reduce the amount of time
         # required. The full suite is run in conformance-clustermesh.
@@ -187,6 +194,7 @@ jobs:
 
         echo "cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_ENCRYPTION}" >> $GITHUB_OUTPUT
         echo "connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS}" >> $GITHUB_OUTPUT
+        echo "enable_clustermesh_failover=${ENABLE_CLUSTERMESH_FAILOVER}" >> $GITHUB_OUTPUT
 
     - name: Install Cilium CLI
       uses: cilium/cilium-cli@de740a64da1b12dc8488cf3af2474c60d52c349e # v0.16.3
@@ -368,7 +376,6 @@ jobs:
           until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.downgrade-vars.outputs.sha }} &> /dev/null; do sleep 45s; done
         done
 
-
     - name: Install Cilium in cluster1
       id: install-cilium-cluster1
       env:
@@ -393,6 +400,7 @@ jobs:
         cilium --context ${{ env.contextName2 }} install \
           ${{ steps.newest-vars.outputs.cilium_install_defaults }} \
           ${{ steps.vars.outputs.cilium_install_defaults }} \
+          ${{ steps.vars.outputs.enable_clustermesh_failover }} \
           ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
           ${{ steps.clustermesh-vars.outputs.cilium_install_cluster2 }}
 
@@ -423,17 +431,16 @@ jobs:
           --include-conn-disrupt-test --conn-disrupt-test-setup \
           --conn-disrupt-dispatch-interval 0ms
 
-
-    - name: Upgrade Cilium in cluster1 and enable kvstoremesh
+    - name: Upgrade Cilium in cluster1
       env:
         KVSTORE_ID: 1
       run: |
         cilium --context ${{ env.contextName1 }} upgrade --reset-values \
           ${{ steps.newest-vars.outputs.cilium_install_defaults }} \
           ${{ steps.vars.outputs.cilium_install_defaults }} \
+          ${{ steps.vars.outputs.enable_clustermesh_failover }} \
           ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
-          ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }} \
-          --set clustermesh.apiserver.kvstoremesh.enabled=true
+          ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }}
 
     - name: Rollout Cilium agents in cluster2
       if: ${{ !matrix.external-kvstore }}
@@ -448,6 +455,113 @@ jobs:
         cilium --context ${{ env.contextName2 }} status --wait
         cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
         cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
+
+    - name: Restart clustermesh-apiserver and ensure client can connect to new Service
+      run: |
+        echo "Restarting clustermesh-apiserver deployments"
+        kubectl --context ${{ env.contextName2 }} -n kube-system rollout restart deployment -l k8s-app=clustermesh-apiserver
+        kubectl --context ${{ env.contextName2 }} -n kube-system rollout status deployment -l k8s-app=clustermesh-apiserver
+
+        echo "Deploying a global Service to test failover"
+        cat << EOF > echo-failover.yaml
+        apiVersion: v1
+        kind: Service
+        metadata:
+          annotations:
+            service.cilium.io/global: "true"
+          labels:
+            kind: echo
+            context: failover
+          name: echo-other-node-failover
+          namespace: cilium-test
+        spec:
+          ipFamilies:
+          - IPv4
+          - IPv6
+          ipFamilyPolicy: PreferDualStack
+          ports:
+          - name: http
+            port: 80
+            protocol: TCP
+            targetPort: 8080
+          selector:
+            name: echo-other-node
+          sessionAffinity: None
+          type: ClusterIP
+        EOF
+
+        kubectl --context ${{ env.contextName1 }} apply -f echo-failover.yaml
+        kubectl --context ${{ env.contextName2 }} apply -f echo-failover.yaml
+
+        echo "Testing client connection to global Service"
+        kubectl --context ${{ env.contextName1 }} -n cilium-test exec deploy/client -i -- curl -s -v --connect-timeout 5 --max-time 20 --retry-max-time 120 --retry-all-errors --retry 10 --fail echo-other-node-failover
+
+        # Clean up the service so that it can be re-deployed in subsequent steps
+        kubectl --context ${{ env.contextName1 }} delete -f echo-failover.yaml
+        kubectl --context ${{ env.contextName2 }} delete -f echo-failover.yaml
+
+    - name: Enable kvstoremesh on cluster1
+      env:
+        KVSTORE_ID: 1
+      run: |
+        cilium --context ${{ env.contextName1 }} upgrade --reset-values \
+          ${{ steps.newest-vars.outputs.cilium_install_defaults }} \
+          ${{ steps.vars.outputs.cilium_install_defaults }} \
+          ${{ steps.vars.outputs.enable_clustermesh_failover }} \
+          ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
+          ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }} \
+          --set clustermesh.apiserver.kvstoremesh.enabled=true
+
+    - name: Wait for cluster mesh status to be ready
+      run: |
+        cilium --context ${{ env.contextName1 }} status --wait
+        cilium --context ${{ env.contextName2 }} status --wait
+        cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
+        cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
+
+    - name: Restart clustermesh-apiserver and ensure client can connect to new Service
+      run: |
+        echo "Restarting clustermesh-apiserver deployments"
+        kubectl --context ${{ env.contextName2 }} -n kube-system rollout restart deployment -l k8s-app=clustermesh-apiserver
+        kubectl --context ${{ env.contextName2 }} -n kube-system rollout status deployment -l k8s-app=clustermesh-apiserver
+
+        echo "Deploying a global Service to test failover"
+        cat << EOF > echo-failover.yaml
+        apiVersion: v1
+        kind: Service
+        metadata:
+          annotations:
+            service.cilium.io/global: "true"
+          labels:
+            kind: echo
+            context: failover
+          name: echo-other-node-failover
+          namespace: cilium-test
+        spec:
+          ipFamilies:
+          - IPv4
+          - IPv6
+          ipFamilyPolicy: PreferDualStack
+          ports:
+          - name: http
+            port: 80
+            protocol: TCP
+            targetPort: 8080
+          selector:
+            name: echo-other-node
+          sessionAffinity: None
+          type: ClusterIP
+        EOF
+
+        kubectl --context ${{ env.contextName1 }} apply -f echo-failover.yaml
+        kubectl --context ${{ env.contextName2 }} apply -f echo-failover.yaml
+
+        echo "Testing client connection to global Service"
+        kubectl --context ${{ env.contextName1 }} -n cilium-test exec deploy/client -i -- curl -s -v --connect-timeout 5 --max-time 20 --retry-max-time 120 --retry-all-errors --retry 10 --fail echo-other-node-failover
+
+        # Clean up the service so that it can be re-deployed in subsequent steps
+        kubectl --context ${{ env.contextName1 }} delete -f echo-failover.yaml
+        kubectl --context ${{ env.contextName2 }} delete -f echo-failover.yaml
 
     - name: Gather additional troubleshooting information
       run: |

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -20,10 +20,10 @@ on:
 
   push:
     branches:
-      - main
-      - ft/main/**
+    - main
+    - ft/main/**
     paths-ignore:
-      - 'Documentation/**'
+    - 'Documentation/**'
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.
@@ -68,10 +68,10 @@ jobs:
     name: Commit Status Start
     runs-on: ubuntu-latest
     steps:
-      - name: Set initial commit status
-        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
-        with:
-          sha: ${{ inputs.SHA || github.sha }}
+    - name: Set initial commit status
+      uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+      with:
+        sha: ${{ inputs.SHA || github.sha }}
 
   upgrade-and-downgrade:
     name: "Upgrade and Downgrade Test"
@@ -84,548 +84,548 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: '1'
-            encryption: 'disabled'
-            kube-proxy: 'iptables'
-            external-kvstore: false
-            max-connected-clusters: 255
+        - name: '1'
+          encryption: 'disabled'
+          kube-proxy: 'iptables'
+          external-kvstore: false
+          max-connected-clusters: 255
 
-          - name: '2'
-            encryption: 'disabled'
-            kube-proxy: 'none'
-            external-kvstore: false
-            max-connected-clusters: 511
+        - name: '2'
+          encryption: 'disabled'
+          kube-proxy: 'none'
+          external-kvstore: false
+          max-connected-clusters: 511
 
-          # Currently, ipsec requires to synchronously regenerate the host
-          # endpoint to ensure ordering (#25735). Given that this is a blocking
-          # operation, we cannot wait for full clustermesh synchronization
-          # for an extended period of time, as that would prevent the agents from
-          # becoming ready (and new pods scheduled). This means that we will
-          # experience cross-cluster connection drops during upgrades/downgrades,
-          # given that the timeout is too low to account for the initialization
-          # of a new clustermesh-apiserver replica (while it is enough to prevent
-          # issues in case of agent restarts, if all remote clusters are ready,
-          # as well as when connecting to an external kvstore as in this case).
-          - name: '3'
-            encryption: 'ipsec'
-            kube-proxy: 'iptables'
-            external-kvstore: true
-            max-connected-clusters: 255
+        # Currently, ipsec requires to synchronously regenerate the host
+        # endpoint to ensure ordering (#25735). Given that this is a blocking
+        # operation, we cannot wait for full clustermesh synchronization
+        # for an extended period of time, as that would prevent the agents from
+        # becoming ready (and new pods scheduled). This means that we will
+        # experience cross-cluster connection drops during upgrades/downgrades,
+        # given that the timeout is too low to account for the initialization
+        # of a new clustermesh-apiserver replica (while it is enough to prevent
+        # issues in case of agent restarts, if all remote clusters are ready,
+        # as well as when connecting to an external kvstore as in this case).
+        - name: '3'
+          encryption: 'ipsec'
+          kube-proxy: 'iptables'
+          external-kvstore: true
+          max-connected-clusters: 255
 
-          - name: '4'
-            encryption: 'wireguard'
-            kube-proxy: 'iptables'
-            external-kvstore: false
-            max-connected-clusters: 511
+        - name: '4'
+          encryption: 'wireguard'
+          kube-proxy: 'iptables'
+          external-kvstore: false
+          max-connected-clusters: 511
 
     steps:
-      - name: Checkout context ref (trusted)
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          ref: ${{ inputs.context-ref || github.sha }}
-          persist-credentials: false
+    - name: Checkout context ref (trusted)
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        ref: ${{ inputs.context-ref || github.sha }}
+        persist-credentials: false
 
-      - name: Set Environment Variables
-        uses: ./.github/actions/set-env-variables
+    - name: Set Environment Variables
+      uses: ./.github/actions/set-env-variables
 
-      - name: Set up newest settings
-        id: newest-vars
-        uses: ./.github/actions/helm-default
-        with:
-          image-tag: ${{ inputs.SHA }}
-          chart-dir: ./untrusted/cilium-newest/install/kubernetes/cilium
+    - name: Set up newest settings
+      id: newest-vars
+      uses: ./.github/actions/helm-default
+      with:
+        image-tag: ${{ inputs.SHA }}
+        chart-dir: ./untrusted/cilium-newest/install/kubernetes/cilium
 
-      - name: Set up job variables
-        id: vars
-        run: |
-          CILIUM_DOWNGRADE_VERSION=$(contrib/scripts/print-downgrade-version.sh stable)
-          echo "downgrade_version=${CILIUM_DOWNGRADE_VERSION}" >> $GITHUB_OUTPUT
+    - name: Set up job variables
+      id: vars
+      run: |
+        CILIUM_DOWNGRADE_VERSION=$(contrib/scripts/print-downgrade-version.sh stable)
+        echo "downgrade_version=${CILIUM_DOWNGRADE_VERSION}" >> $GITHUB_OUTPUT
 
-          # * Hubble is disabled to avoid the performance penalty in the testing
-          #   environment due to the relatively high traffic load.
-          # * We explicitly configure the sync timeout to a higher value to
-          #   give enough time to the clustermesh-apiserver to restart after
-          #   the upgrade/downgrade before that agents regenerate the endpoints.
-          CILIUM_INSTALL_DEFAULTS=" \
-            --set=debug.enabled=true \
-            --set=bpf.monitorAggregation=none \
-            --set=hubble.enabled=false \
-            --set=routingMode=tunnel \
-            --set=tunnelProtocol=vxlan \
-            --set=ipv4.enabled=true \
-            --set=ipv6.enabled=true \
-            --set=kubeProxyReplacement=${{ matrix.kube-proxy == 'none' }} \
-            --set=bpf.masquerade=${{ matrix.kube-proxy == 'none' }} \
-            --set=clustermesh.useAPIServer=${{ !matrix.external-kvstore }} \
-            --set=clustermesh.maxConnectedClusters=${{ matrix.max-connected-clusters }} \
-            --set=clustermesh.config.enabled=true \
-            --set=extraConfig.clustermesh-ip-identities-sync-timeout=10m"
+        # * Hubble is disabled to avoid the performance penalty in the testing
+        #   environment due to the relatively high traffic load.
+        # * We explicitly configure the sync timeout to a higher value to
+        #   give enough time to the clustermesh-apiserver to restart after
+        #   the upgrade/downgrade before that agents regenerate the endpoints.
+        CILIUM_INSTALL_DEFAULTS=" \
+          --set=debug.enabled=true \
+          --set=bpf.monitorAggregation=none \
+          --set=hubble.enabled=false \
+          --set=routingMode=tunnel \
+          --set=tunnelProtocol=vxlan \
+          --set=ipv4.enabled=true \
+          --set=ipv6.enabled=true \
+          --set=kubeProxyReplacement=${{ matrix.kube-proxy == 'none' }} \
+          --set=bpf.masquerade=${{ matrix.kube-proxy == 'none' }} \
+          --set=clustermesh.useAPIServer=${{ !matrix.external-kvstore }} \
+          --set=clustermesh.maxConnectedClusters=${{ matrix.max-connected-clusters }} \
+          --set=clustermesh.config.enabled=true \
+          --set=extraConfig.clustermesh-ip-identities-sync-timeout=10m"
 
-          # Run only a limited subset of tests to reduce the amount of time
-          # required. The full suite is run in conformance-clustermesh.
-          CONNECTIVITY_TEST_DEFAULTS=" \
-            --hubble=false \
-            --flow-validation=disabled \
-            --test='no-interrupted-connections' \
-            --test='no-unexpected-packet-drops' \
-            --test='no-policies/' \
-            --test='no-policies-extra/' \
-            --test='allow-all-except-world/' \
-            --test='client-ingress/' \
-            --test='client-egress/' \
-            --test='cluster-entity-multicluster/' \
-            --test='!/pod-to-world' \
-            --test='!/pod-to-cidr' \
-            --collect-sysdump-on-failure"
+        # Run only a limited subset of tests to reduce the amount of time
+        # required. The full suite is run in conformance-clustermesh.
+        CONNECTIVITY_TEST_DEFAULTS=" \
+          --hubble=false \
+          --flow-validation=disabled \
+          --test='no-interrupted-connections' \
+          --test='no-unexpected-packet-drops' \
+          --test='no-policies/' \
+          --test='no-policies-extra/' \
+          --test='allow-all-except-world/' \
+          --test='client-ingress/' \
+          --test='client-egress/' \
+          --test='cluster-entity-multicluster/' \
+          --test='!/pod-to-world' \
+          --test='!/pod-to-cidr' \
+          --collect-sysdump-on-failure"
 
-          CILIUM_INSTALL_ENCRYPTION=""
-          if [ "${{ matrix.encryption }}" != "disabled" ]; then
-            CILIUM_INSTALL_ENCRYPTION=" \
-              --set=encryption.enabled=true \
-              --set=encryption.type=${{ matrix.encryption }}"
-          fi
+        CILIUM_INSTALL_ENCRYPTION=""
+        if [ "${{ matrix.encryption }}" != "disabled" ]; then
+          CILIUM_INSTALL_ENCRYPTION=" \
+            --set=encryption.enabled=true \
+            --set=encryption.type=${{ matrix.encryption }}"
+        fi
 
-          echo "cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_ENCRYPTION}" >> $GITHUB_OUTPUT
-          echo "connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS}" >> $GITHUB_OUTPUT
+        echo "cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_ENCRYPTION}" >> $GITHUB_OUTPUT
+        echo "connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS}" >> $GITHUB_OUTPUT
 
-      - name: Install Cilium CLI
-        uses: cilium/cilium-cli@de740a64da1b12dc8488cf3af2474c60d52c349e # v0.16.3
-        with:
-          repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
-          release-version: ${{ env.CILIUM_CLI_VERSION }}
-          ci-version: ${{ env.cilium_cli_ci_version }}
+    - name: Install Cilium CLI
+      uses: cilium/cilium-cli@de740a64da1b12dc8488cf3af2474c60d52c349e # v0.16.3
+      with:
+        repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
+        release-version: ${{ env.CILIUM_CLI_VERSION }}
+        ci-version: ${{ env.cilium_cli_ci_version }}
 
-      - name: Generate Kind configuration files
-        run: |
-          PODCIDR=10.242.0.0/16,fd00:10:242::/48 \
-            SVCCIDR=10.243.0.0/16,fd00:10:243::/112 \
-            IPFAMILY=dual \
-            KUBEPROXYMODE=${{ matrix.kube-proxy }} \
-            envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster1.yaml
+    - name: Generate Kind configuration files
+      run: |
+        PODCIDR=10.242.0.0/16,fd00:10:242::/48 \
+          SVCCIDR=10.243.0.0/16,fd00:10:243::/112 \
+          IPFAMILY=dual \
+          KUBEPROXYMODE=${{ matrix.kube-proxy }} \
+          envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster1.yaml
 
-          PODCIDR=10.244.0.0/16,fd00:10:244::/48 \
-            SVCCIDR=10.245.0.0/16,fd00:10:245::/112 \
-            IPFAMILY=dual \
-            KUBEPROXYMODE=${{ matrix.kube-proxy }} \
-            envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster2.yaml
+        PODCIDR=10.244.0.0/16,fd00:10:244::/48 \
+          SVCCIDR=10.245.0.0/16,fd00:10:245::/112 \
+          IPFAMILY=dual \
+          KUBEPROXYMODE=${{ matrix.kube-proxy }} \
+          envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster2.yaml
 
-      - name: Create Kind cluster 1
-        uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
-        with:
-          cluster_name: ${{ env.clusterName1 }}
-          version: ${{ env.KIND_VERSION }}
-          node_image: ${{ env.KIND_K8S_IMAGE }}
-          kubectl_version: ${{ env.KIND_K8S_VERSION }}
-          config: ./.github/kind-config-cluster1.yaml
-          wait: 0 # The control-plane never becomes ready, since no CNI is present
+    - name: Create Kind cluster 1
+      uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
+      with:
+        cluster_name: ${{ env.clusterName1 }}
+        version: ${{ env.KIND_VERSION }}
+        node_image: ${{ env.KIND_K8S_IMAGE }}
+        kubectl_version: ${{ env.KIND_K8S_VERSION }}
+        config: ./.github/kind-config-cluster1.yaml
+        wait: 0 # The control-plane never becomes ready, since no CNI is present
 
-      - name: Create Kind cluster 2
-        uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
-        with:
-          cluster_name: ${{ env.clusterName2 }}
-          version: ${{ env.KIND_VERSION }}
-          node_image: ${{ env.KIND_K8S_IMAGE }}
-          kubectl_version: ${{ env.KIND_K8S_VERSION }}
-          config: ./.github/kind-config-cluster2.yaml
-          wait: 0 # The control-plane never becomes ready, since no CNI is present
+    - name: Create Kind cluster 2
+      uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
+      with:
+        cluster_name: ${{ env.clusterName2 }}
+        version: ${{ env.KIND_VERSION }}
+        node_image: ${{ env.KIND_K8S_IMAGE }}
+        kubectl_version: ${{ env.KIND_K8S_VERSION }}
+        config: ./.github/kind-config-cluster2.yaml
+        wait: 0 # The control-plane never becomes ready, since no CNI is present
 
-      # Make sure that coredns uses IPv4-only upstream DNS servers also in case of clusters
-      # with IP family dual, since IPv6 ones are not reachable and cause spurious failures.
-      # Additionally, this is also required to workaround
-      # https://github.com/cilium/cilium/issues/23283#issuecomment-1597282247.
-      - name: Configure the coredns nameservers
-        run: |
-          COREDNS_PATCH="
-          spec:
-            template:
-              spec:
-                dnsPolicy: None
-                dnsConfig:
-                  nameservers:
-                  - 8.8.4.4
-                  - 8.8.8.8
+    # Make sure that coredns uses IPv4-only upstream DNS servers also in case of clusters
+    # with IP family dual, since IPv6 ones are not reachable and cause spurious failures.
+    # Additionally, this is also required to workaround
+    # https://github.com/cilium/cilium/issues/23283#issuecomment-1597282247.
+    - name: Configure the coredns nameservers
+      run: |
+        COREDNS_PATCH="
+        spec:
+          template:
+            spec:
+              dnsPolicy: None
+              dnsConfig:
+                nameservers:
+                - 8.8.4.4
+                - 8.8.8.8
+        "
+
+        kubectl --context ${{ env.contextName1 }} patch deployment -n kube-system coredns --patch="$COREDNS_PATCH"
+        kubectl --context ${{ env.contextName2 }} patch deployment -n kube-system coredns --patch="$COREDNS_PATCH"
+
+    - name: Create the IPSec secret in both clusters
+      if: matrix.encryption == 'ipsec'
+      run: |
+        SECRET="3 rfc4106(gcm(aes)) $(openssl rand -hex 20) 128"
+        kubectl --context ${{ env.contextName1 }} create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="${SECRET}"
+        kubectl --context ${{ env.contextName2 }} create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="${SECRET}"
+
+    - name: Start kvstore clusters
+      id: kvstore
+      if: matrix.external-kvstore
+      uses: ./.github/actions/kvstore
+      with:
+        clusters: 2
+
+    - name: Create the secret containing the kvstore credentials
+      if: matrix.external-kvstore
+      run: |
+        kubectl --context ${{ env.contextName1 }} create -n kube-system -f ${{ steps.kvstore.outputs.cilium_etcd_secrets_path }}
+        kubectl --context ${{ env.contextName2 }} create -n kube-system -f ${{ steps.kvstore.outputs.cilium_etcd_secrets_path }}
+
+    - name: Set clustermesh connection parameters
+      id: clustermesh-vars
+      run: |
+        # Let's retrieve in advance the parameters to mesh the two clusters, so
+        # that we don't need to do that through the CLI in a second step, as it
+        # would be reset during upgrade (as we are resetting the values).
+
+        # Explicitly configure the NodePorts to make sure that they are different
+        # in each cluster, to workaround #24692
+        PORT1=32379
+        PORT2=32380
+
+        CILIUM_INSTALL_CLUSTER1=" \
+          --set cluster.name=${{ env.clusterName1 }} \
+          --set cluster.id=1 \
+          --set clustermesh.apiserver.service.nodePort=$PORT1 \
+        "
+
+        CILIUM_INSTALL_CLUSTER2=" \
+          --set cluster.name=${{ env.clusterName2 }} \
+          --set cluster.id=${{ matrix.max-connected-clusters }} \
+          --set clustermesh.apiserver.service.nodePort=$PORT2 \
+        "
+
+        CILIUM_INSTALL_COMMON=" \
+          --set clustermesh.config.clusters[0].name=${{ env.clusterName1 }} \
+          --set clustermesh.config.clusters[1].name=${{ env.clusterName2 }} \
+        "
+
+        if [ "${{ matrix.external-kvstore }}" == "true" ]; then
+          CILIUM_INSTALL_COMMON="$CILIUM_INSTALL_COMMON \
+            ${{ steps.kvstore.outputs.cilium_install_clustermesh }}"
+        else
+          IP1=$(kubectl --context ${{ env.contextName1 }} get nodes \
+            ${{ env.clusterName1 }}-worker -o wide --no-headers | awk '{ print $6 }')
+          IP2=$(kubectl --context ${{ env.contextName2 }} get nodes \
+            ${{ env.clusterName2 }}-worker -o wide --no-headers | awk '{ print $6 }')
+
+          CILIUM_INSTALL_COMMON="$CILIUM_INSTALL_COMMON \
+            --set clustermesh.config.clusters[0].ips={$IP1} \
+            --set clustermesh.config.clusters[0].port=$PORT1 \
+            --set clustermesh.config.clusters[1].ips={$IP2} \
+            --set clustermesh.config.clusters[1].port=$PORT2 \
           "
+        fi
 
-          kubectl --context ${{ env.contextName1 }} patch deployment -n kube-system coredns --patch="$COREDNS_PATCH"
-          kubectl --context ${{ env.contextName2 }} patch deployment -n kube-system coredns --patch="$COREDNS_PATCH"
+        echo cilium_install_cluster1="$CILIUM_INSTALL_CLUSTER1 $CILIUM_INSTALL_COMMON" >> $GITHUB_OUTPUT
+        echo cilium_install_cluster2="$CILIUM_INSTALL_CLUSTER2 $CILIUM_INSTALL_COMMON" >> $GITHUB_OUTPUT
 
-      - name: Create the IPSec secret in both clusters
-        if: matrix.encryption == 'ipsec'
-        run: |
-          SECRET="3 rfc4106(gcm(aes)) $(openssl rand -hex 20) 128"
-          kubectl --context ${{ env.contextName1 }} create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="${SECRET}"
-          kubectl --context ${{ env.contextName2 }} create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="${SECRET}"
+    # Warning: since this is a privileged workflow, subsequent workflow job
+    # steps must take care not to execute untrusted code.
+    - name: Checkout pull request branch (NOT TRUSTED)
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        ref: ${{ steps.newest-vars.outputs.sha }}
+        persist-credentials: false
+        path: untrusted/cilium-newest
+        sparse-checkout: |
+          install/kubernetes/cilium
 
-      - name: Start kvstore clusters
-        id: kvstore
-        if: matrix.external-kvstore
-        uses: ./.github/actions/kvstore
-        with:
-          clusters: 2
+    - name: Checkout ${{ steps.vars.outputs.downgrade_version }} branch
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        ref: ${{ steps.vars.outputs.downgrade_version }}
+        persist-credentials: false
+        path: untrusted/cilium-downgrade
+        sparse-checkout: |
+          install/kubernetes/cilium
 
-      - name: Create the secret containing the kvstore credentials
-        if: matrix.external-kvstore
-        run: |
-          kubectl --context ${{ env.contextName1 }} create -n kube-system -f ${{ steps.kvstore.outputs.cilium_etcd_secrets_path }}
-          kubectl --context ${{ env.contextName2 }} create -n kube-system -f ${{ steps.kvstore.outputs.cilium_etcd_secrets_path }}
+    - name: Set up downgrade settings
+      id: downgrade-vars
+      run: |
+        SHA="$(cd untrusted/cilium-downgrade && git rev-parse HEAD)"
+        CILIUM_IMAGE_SETTINGS=" \
+          --chart-directory=./untrusted/cilium-downgrade/install/kubernetes/cilium \
+          --set=image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci:${SHA} \
+          --set=operator.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator-generic-ci:${SHA} \
+          --set=clustermesh.apiserver.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci:${SHA} \
+          --set=clustermesh.apiserver.kvstoremesh.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/kvstoremesh-ci:${SHA} \
+        "
+        echo "sha=${SHA}" >> $GITHUB_OUTPUT
+        echo "cilium_image_settings=${CILIUM_IMAGE_SETTINGS}" >> $GITHUB_OUTPUT
 
-      - name: Set clustermesh connection parameters
-        id: clustermesh-vars
-        run: |
-          # Let's retrieve in advance the parameters to mesh the two clusters, so
-          # that we don't need to do that through the CLI in a second step, as it
-          # would be reset during upgrade (as we are resetting the values).
+    - name: Wait for images to be available (newest)
+      timeout-minutes: 10
+      shell: bash
+      run: |
+        for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
+          until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.newest-vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+        done
 
-          # Explicitly configure the NodePorts to make sure that they are different
-          # in each cluster, to workaround #24692
-          PORT1=32379
-          PORT2=32380
+    - name: Wait for images to be available (downgrade)
+      timeout-minutes: 10
+      shell: bash
+      run: |
+        for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
+          until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.downgrade-vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+        done
 
-          CILIUM_INSTALL_CLUSTER1=" \
-            --set cluster.name=${{ env.clusterName1 }} \
-            --set cluster.id=1 \
-            --set clustermesh.apiserver.service.nodePort=$PORT1 \
-          "
 
-          CILIUM_INSTALL_CLUSTER2=" \
-            --set cluster.name=${{ env.clusterName2 }} \
-            --set cluster.id=${{ matrix.max-connected-clusters }} \
-            --set clustermesh.apiserver.service.nodePort=$PORT2 \
-          "
+    - name: Install Cilium in cluster1
+      id: install-cilium-cluster1
+      env:
+        KVSTORE_ID: 1
+      run: |
+        cilium --context ${{ env.contextName1 }} install \
+          ${{ steps.downgrade-vars.outputs.cilium_image_settings }} \
+          ${{ steps.vars.outputs.cilium_install_defaults }} \
+          ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
+          ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }}
 
-          CILIUM_INSTALL_COMMON=" \
-            --set clustermesh.config.clusters[0].name=${{ env.clusterName1 }} \
-            --set clustermesh.config.clusters[1].name=${{ env.clusterName2 }} \
-          "
+    - name: Copy the Cilium CA secret to cluster2, as they must match
+      if: ${{ !matrix.external-kvstore }}
+      run: |
+        kubectl --context ${{ env.contextName1 }} get secret -n kube-system cilium-ca -o yaml |
+          kubectl --context ${{ env.contextName2 }} create -f -
 
-          if [ "${{ matrix.external-kvstore }}" == "true" ]; then
-            CILIUM_INSTALL_COMMON="$CILIUM_INSTALL_COMMON \
-              ${{ steps.kvstore.outputs.cilium_install_clustermesh }}"
-          else
-            IP1=$(kubectl --context ${{ env.contextName1 }} get nodes \
-              ${{ env.clusterName1 }}-worker -o wide --no-headers | awk '{ print $6 }')
-            IP2=$(kubectl --context ${{ env.contextName2 }} get nodes \
-              ${{ env.clusterName2 }}-worker -o wide --no-headers | awk '{ print $6 }')
+    - name: Install Cilium in cluster2
+      env:
+        KVSTORE_ID: 2
+      run: |
+        cilium --context ${{ env.contextName2 }} install \
+          ${{ steps.newest-vars.outputs.cilium_install_defaults }} \
+          ${{ steps.vars.outputs.cilium_install_defaults }} \
+          ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
+          ${{ steps.clustermesh-vars.outputs.cilium_install_cluster2 }}
 
-            CILIUM_INSTALL_COMMON="$CILIUM_INSTALL_COMMON \
-              --set clustermesh.config.clusters[0].ips={$IP1} \
-              --set clustermesh.config.clusters[0].port=$PORT1 \
-              --set clustermesh.config.clusters[1].ips={$IP2} \
-              --set clustermesh.config.clusters[1].port=$PORT2 \
-            "
-          fi
+    - name: Wait for cluster mesh status to be ready
+      run: |
+        cilium --context ${{ env.contextName1 }} status --wait
+        cilium --context ${{ env.contextName2 }} status --wait
+        cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
+        cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
 
-          echo cilium_install_cluster1="$CILIUM_INSTALL_CLUSTER1 $CILIUM_INSTALL_COMMON" >> $GITHUB_OUTPUT
-          echo cilium_install_cluster2="$CILIUM_INSTALL_CLUSTER2 $CILIUM_INSTALL_COMMON" >> $GITHUB_OUTPUT
+    - name: Make JUnit report directory
+      run: |
+        mkdir -p cilium-junits
 
-      # Warning: since this is a privileged workflow, subsequent workflow job
-      # steps must take care not to execute untrusted code.
-      - name: Checkout pull request branch (NOT TRUSTED)
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          ref: ${{ steps.newest-vars.outputs.sha }}
-          persist-credentials: false
-          path: untrusted/cilium-newest
-          sparse-checkout: |
-            install/kubernetes/cilium
+    - name: Run connectivity test - pre-upgrade (${{ join(matrix.*, ', ') }})
+      run: |
+        cilium --context ${{ env.contextName1 }} connectivity test \
+          --multi-cluster=${{ env.contextName2 }} \
+          ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }} - pre-upgrade (${{ join(matrix.*, ', ') }}).xml" \
+          --junit-property github_job_step="Run tests pre-upgrade (${{ join(matrix.*, ', ') }})"
 
-      - name: Checkout ${{ steps.vars.outputs.downgrade_version }} branch
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          ref: ${{ steps.vars.outputs.downgrade_version }}
-          persist-credentials: false
-          path: untrusted/cilium-downgrade
-          sparse-checkout: |
-            install/kubernetes/cilium
+        # Create pods which establish long lived connections. They will be used by
+        # subsequent connectivity tests with --include-conn-disrupt-test to catch any
+        # interruption in such flows.
+        cilium --context ${{ env.contextName1 }} connectivity test \
+          --multi-cluster=${{ env.contextName2 }} --hubble=false \
+          --include-conn-disrupt-test --conn-disrupt-test-setup \
+          --conn-disrupt-dispatch-interval 0ms
 
-      - name: Set up downgrade settings
-        id: downgrade-vars
-        run: |
-          SHA="$(cd untrusted/cilium-downgrade && git rev-parse HEAD)"
-          CILIUM_IMAGE_SETTINGS=" \
-            --chart-directory=./untrusted/cilium-downgrade/install/kubernetes/cilium \
-            --set=image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci:${SHA} \
-            --set=operator.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator-generic-ci:${SHA} \
-            --set=clustermesh.apiserver.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci:${SHA} \
-            --set=clustermesh.apiserver.kvstoremesh.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/kvstoremesh-ci:${SHA} \
-          "
-          echo "sha=${SHA}" >> $GITHUB_OUTPUT
-          echo "cilium_image_settings=${CILIUM_IMAGE_SETTINGS}" >> $GITHUB_OUTPUT
 
-      - name: Wait for images to be available (newest)
-        timeout-minutes: 10
-        shell: bash
-        run: |
-          for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
-            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.newest-vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+    - name: Upgrade Cilium in cluster1 and enable kvstoremesh
+      env:
+        KVSTORE_ID: 1
+      run: |
+        cilium --context ${{ env.contextName1 }} upgrade --reset-values \
+          ${{ steps.newest-vars.outputs.cilium_install_defaults }} \
+          ${{ steps.vars.outputs.cilium_install_defaults }} \
+          ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
+          ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }} \
+          --set clustermesh.apiserver.kvstoremesh.enabled=true
+
+    - name: Rollout Cilium agents in cluster2
+      if: ${{ !matrix.external-kvstore }}
+      run: |
+        # This makes sure that the remote agents reconnect to the new instance of the
+        # clustermesh-apiserver, without waiting for the watchdog mechanism to kick in.
+        kubectl --context ${{ env.contextName2 }} rollout restart -n kube-system ds/cilium
+
+    - name: Wait for cluster mesh status to be ready
+      run: |
+        cilium --context ${{ env.contextName1 }} status --wait
+        cilium --context ${{ env.contextName2 }} status --wait
+        cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
+        cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
+
+    - name: Gather additional troubleshooting information
+      run: |
+        kubectl --context ${{ env.contextName1 }} get po -n cilium-test -o wide -l kind=test-conn-disrupt
+        kubectl --context ${{ env.contextName2 }} get po -n cilium-test -o wide -l kind=test-conn-disrupt
+        kubectl --context ${{ env.contextName1 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --timestamps
+        kubectl --context ${{ env.contextName2 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --timestamps
+        kubectl --context ${{ env.contextName2 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --previous --ignore-errors --timestamps
+
+    - name: Run connectivity test - post-upgrade (${{ join(matrix.*, ', ') }})
+      run: |
+        cilium --context ${{ env.contextName1 }} connectivity test \
+          --multi-cluster=${{ env.contextName2 }} \
+          ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --include-conn-disrupt-test \
+          --junit-file "cilium-junits/${{ env.job_name }} - post upgrade (${{ join(matrix.*, ', ') }}).xml" \
+          --junit-property github_job_step="Run tests post-upgrade (${{ join(matrix.*, ', ') }})"
+
+        # Create pods which establish long lived connections. They will be used by
+        # subsequent connectivity tests with --include-conn-disrupt-test to catch any
+        # interruption in such flows.
+        cilium --context ${{ env.contextName1 }} connectivity test \
+          --multi-cluster=${{ env.contextName2 }} --hubble=false \
+          --include-conn-disrupt-test --conn-disrupt-test-setup \
+          --conn-disrupt-dispatch-interval 0ms
+
+
+    # Perform an additional "stress" test, scaling the clustermesh-apiservers in both clusters
+    # to zero replicas, and restarting all agents. Existing connections should not be disrupted.
+    # One exception to this is represented by Cilium being in charge of handling NodePort
+    # traffic, as the simultaneous restart of the clustermesh-apiserver pods in both clusters
+    # after rolling out all agents can lead to a circular dependency (#30156).
+    - name: Scale the clustermesh-apiserver replicas to 0
+      if: ${{ !matrix.external-kvstore }}
+      run: |
+        kubectl --context ${{ env.contextName1 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
+        if [ ${{ matrix.kube-proxy }} != "none" ]; then
+          kubectl --context ${{ env.contextName2 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
+        fi
+
+    - name: Rollout Cilium agents in both clusters
+      run: |
+        kubectl --context ${{ env.contextName1 }} rollout restart -n kube-system ds/cilium
+        kubectl --context ${{ env.contextName2 }} rollout restart -n kube-system ds/cilium
+
+        # Wait until all agents successfully restarted before scaling the replicas again
+        kubectl --context ${{ env.contextName1 }} rollout status -n kube-system ds/cilium --timeout=5m
+        kubectl --context ${{ env.contextName2 }} rollout status -n kube-system ds/cilium --timeout=5m
+
+    - name: Scale the clustermesh-apiserver replicas back to 1
+      if: ${{ !matrix.external-kvstore }}
+      run: |
+        kubectl --context ${{ env.contextName1 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 1
+        kubectl --context ${{ env.contextName2 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 1
+
+    - name: Wait for cluster mesh status to be ready
+      run: |
+        cilium --context ${{ env.contextName1 }} status --wait
+        cilium --context ${{ env.contextName2 }} status --wait
+        cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
+        cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
+
+    - name: Gather additional troubleshooting information
+      run: |
+        kubectl --context ${{ env.contextName1 }} get po -n cilium-test -o wide -l kind=test-conn-disrupt
+        kubectl --context ${{ env.contextName2 }} get po -n cilium-test -o wide -l kind=test-conn-disrupt
+        kubectl --context ${{ env.contextName1 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --timestamps
+        kubectl --context ${{ env.contextName2 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --timestamps
+        kubectl --context ${{ env.contextName2 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --previous --ignore-errors --timestamps
+
+    - name: Run connectivity test - stress-test (${{ join(matrix.*, ', ') }})
+      run: |
+        # Only check that no long living connection was disrupted
+        cilium --context ${{ env.contextName1 }} connectivity test \
+          --multi-cluster=${{ env.contextName2 }} \
+          --hubble=false \
+          --flow-validation=disabled \
+          --test='no-interrupted-connections' \
+          --test='no-unexpected-packet-drops' \
+          --include-conn-disrupt-test \
+          --junit-file "cilium-junits/${{ env.job_name }} - stress test (${{ join(matrix.*, ', ') }}).xml" \
+          --junit-property github_job_step="Run tests stess-test (${{ join(matrix.*, ', ') }})"
+
+        # Create pods which establish long lived connections. They will be used by
+        # subsequent connectivity tests with --include-conn-disrupt-test to catch any
+        # interruption in such flows.
+        cilium --context ${{ env.contextName1 }} connectivity test \
+          --multi-cluster=${{ env.contextName2 }} --hubble=false \
+          --include-conn-disrupt-test --conn-disrupt-test-setup \
+          --conn-disrupt-dispatch-interval 0ms
+
+
+    - name: Downgrade Cilium in cluster1 and disable kvstoremesh
+      env:
+        KVSTORE_ID: 1
+      run: |
+        cilium --context ${{ env.contextName1 }} upgrade --reset-values \
+          ${{ steps.downgrade-vars.outputs.cilium_image_settings }} \
+          ${{ steps.vars.outputs.cilium_install_defaults }} \
+          ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
+          ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }}
+
+    - name: Rollout Cilium agents in cluster2
+      if: ${{ !matrix.external-kvstore }}
+      run: |
+        # This makes sure that the remote agents reconnect to the new instance of the
+        # clustermesh-apiserver, without waiting for the watchdog mechanism to kick in.
+        kubectl --context ${{ env.contextName2 }} rollout restart -n kube-system ds/cilium
+
+    - name: Wait for cluster mesh status to be ready
+      run: |
+        cilium --context ${{ env.contextName1 }} status --wait
+        cilium --context ${{ env.contextName2 }} status --wait
+        cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
+        cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
+
+    - name: Gather additional troubleshooting information
+      run: |
+        kubectl --context ${{ env.contextName1 }} get po -n cilium-test -o wide -l kind=test-conn-disrupt
+        kubectl --context ${{ env.contextName2 }} get po -n cilium-test -o wide -l kind=test-conn-disrupt
+        kubectl --context ${{ env.contextName1 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --timestamps
+        kubectl --context ${{ env.contextName2 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --timestamps
+        kubectl --context ${{ env.contextName2 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --previous --ignore-errors --timestamps
+
+    - name: Run connectivity test - post-downgrade (${{ join(matrix.*, ', ') }})
+      run: |
+        cilium --context ${{ env.contextName1 }} connectivity test \
+          --multi-cluster=${{ env.contextName2 }} \
+          ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --include-conn-disrupt-test \
+          --junit-file "cilium-junits/${{ env.job_name }} - post downgrade (${{ join(matrix.*, ', ') }}).xml" \
+          --junit-property github_job_step="Run tests post-downgrade (${{ join(matrix.*, ', ') }})"
+
+
+    - name: Post-test information gathering
+      if: ${{ !success() && steps.install-cilium-cluster1.outcome != 'skipped' }}
+      run: |
+        cilium --context ${{ env.contextName1 }} status
+        cilium --context ${{ env.contextName1 }} clustermesh status
+        cilium --context ${{ env.contextName2 }} status
+        cilium --context ${{ env.contextName2 }} clustermesh status
+
+        kubectl config use-context ${{ env.contextName1 }}
+        kubectl get pods --all-namespaces -o wide
+        cilium sysdump --output-filename cilium-sysdump-context1-final-${{ join(matrix.*, '-') }}
+
+        kubectl config use-context ${{ env.contextName2 }}
+        kubectl get pods --all-namespaces -o wide
+        cilium sysdump --output-filename cilium-sysdump-context2-final-${{ join(matrix.*, '-') }}
+
+        if [ "${{ matrix.external-kvstore }}" == "true" ]; then
+          for i in {1..2}; do
+            echo
+            echo "# Retrieving logs from kvstore$i docker container"
+            docker logs kvstore$i
           done
+        fi
+      shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
-      - name: Wait for images to be available (downgrade)
-        timeout-minutes: 10
-        shell: bash
-        run: |
-          for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
-            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.downgrade-vars.outputs.sha }} &> /dev/null; do sleep 45s; done
-          done
+    - name: Upload artifacts
+      if: ${{ !success() }}
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: cilium-sysdumps-${{ matrix.name }}
+        path: cilium-sysdump-*.zip
 
+    - name: Upload JUnits [junit]
+      if: ${{ always() }}
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: cilium-junits-${{ matrix.name }}
+        path: cilium-junits/*.xml
 
-      - name: Install Cilium in cluster1
-        id: install-cilium-cluster1
-        env:
-          KVSTORE_ID: 1
-        run: |
-          cilium --context ${{ env.contextName1 }} install \
-            ${{ steps.downgrade-vars.outputs.cilium_image_settings }} \
-            ${{ steps.vars.outputs.cilium_install_defaults }} \
-            ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
-            ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }}
-
-      - name: Copy the Cilium CA secret to cluster2, as they must match
-        if: ${{ !matrix.external-kvstore }}
-        run: |
-          kubectl --context ${{ env.contextName1 }} get secret -n kube-system cilium-ca -o yaml |
-            kubectl --context ${{ env.contextName2 }} create -f -
-
-      - name: Install Cilium in cluster2
-        env:
-          KVSTORE_ID: 2
-        run: |
-          cilium --context ${{ env.contextName2 }} install \
-            ${{ steps.newest-vars.outputs.cilium_install_defaults }} \
-            ${{ steps.vars.outputs.cilium_install_defaults }} \
-            ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
-            ${{ steps.clustermesh-vars.outputs.cilium_install_cluster2 }}
-
-      - name: Wait for cluster mesh status to be ready
-        run: |
-          cilium --context ${{ env.contextName1 }} status --wait
-          cilium --context ${{ env.contextName2 }} status --wait
-          cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
-          cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
-
-      - name: Make JUnit report directory
-        run: |
-          mkdir -p cilium-junits
-
-      - name: Run connectivity test - pre-upgrade (${{ join(matrix.*, ', ') }})
-        run: |
-          cilium --context ${{ env.contextName1 }} connectivity test \
-            --multi-cluster=${{ env.contextName2 }} \
-            ${{ steps.vars.outputs.connectivity_test_defaults }} \
-            --junit-file "cilium-junits/${{ env.job_name }} - pre-upgrade (${{ join(matrix.*, ', ') }}).xml" \
-            --junit-property github_job_step="Run tests pre-upgrade (${{ join(matrix.*, ', ') }})"
-
-          # Create pods which establish long lived connections. They will be used by
-          # subsequent connectivity tests with --include-conn-disrupt-test to catch any
-          # interruption in such flows.
-          cilium --context ${{ env.contextName1 }} connectivity test \
-            --multi-cluster=${{ env.contextName2 }} --hubble=false \
-            --include-conn-disrupt-test --conn-disrupt-test-setup \
-            --conn-disrupt-dispatch-interval 0ms
-
-
-      - name: Upgrade Cilium in cluster1 and enable kvstoremesh
-        env:
-          KVSTORE_ID: 1
-        run: |
-          cilium --context ${{ env.contextName1 }} upgrade --reset-values \
-            ${{ steps.newest-vars.outputs.cilium_install_defaults }} \
-            ${{ steps.vars.outputs.cilium_install_defaults }} \
-            ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
-            ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }} \
-            --set clustermesh.apiserver.kvstoremesh.enabled=true
-
-      - name: Rollout Cilium agents in cluster2
-        if: ${{ !matrix.external-kvstore }}
-        run: |
-          # This makes sure that the remote agents reconnect to the new instance of the
-          # clustermesh-apiserver, without waiting for the watchdog mechanism to kick in.
-          kubectl --context ${{ env.contextName2 }} rollout restart -n kube-system ds/cilium
-
-      - name: Wait for cluster mesh status to be ready
-        run: |
-          cilium --context ${{ env.contextName1 }} status --wait
-          cilium --context ${{ env.contextName2 }} status --wait
-          cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
-          cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
-
-      - name: Gather additional troubleshooting information
-        run: |
-          kubectl --context ${{ env.contextName1 }} get po -n cilium-test -o wide -l kind=test-conn-disrupt
-          kubectl --context ${{ env.contextName2 }} get po -n cilium-test -o wide -l kind=test-conn-disrupt
-          kubectl --context ${{ env.contextName1 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --timestamps
-          kubectl --context ${{ env.contextName2 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --timestamps
-          kubectl --context ${{ env.contextName2 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --previous --ignore-errors --timestamps
-
-      - name: Run connectivity test - post-upgrade (${{ join(matrix.*, ', ') }})
-        run: |
-          cilium --context ${{ env.contextName1 }} connectivity test \
-            --multi-cluster=${{ env.contextName2 }} \
-            ${{ steps.vars.outputs.connectivity_test_defaults }} \
-            --include-conn-disrupt-test \
-            --junit-file "cilium-junits/${{ env.job_name }} - post upgrade (${{ join(matrix.*, ', ') }}).xml" \
-            --junit-property github_job_step="Run tests post-upgrade (${{ join(matrix.*, ', ') }})"
-
-          # Create pods which establish long lived connections. They will be used by
-          # subsequent connectivity tests with --include-conn-disrupt-test to catch any
-          # interruption in such flows.
-          cilium --context ${{ env.contextName1 }} connectivity test \
-            --multi-cluster=${{ env.contextName2 }} --hubble=false \
-            --include-conn-disrupt-test --conn-disrupt-test-setup \
-            --conn-disrupt-dispatch-interval 0ms
-
-
-      # Perform an additional "stress" test, scaling the clustermesh-apiservers in both clusters
-      # to zero replicas, and restarting all agents. Existing connections should not be disrupted.
-      # One exception to this is represented by Cilium being in charge of handling NodePort
-      # traffic, as the simultaneous restart of the clustermesh-apiserver pods in both clusters
-      # after rolling out all agents can lead to a circular dependency (#30156).
-      - name: Scale the clustermesh-apiserver replicas to 0
-        if: ${{ !matrix.external-kvstore }}
-        run: |
-          kubectl --context ${{ env.contextName1 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
-          if [ ${{ matrix.kube-proxy }} != "none" ]; then
-            kubectl --context ${{ env.contextName2 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
-          fi
-
-      - name: Rollout Cilium agents in both clusters
-        run: |
-          kubectl --context ${{ env.contextName1 }} rollout restart -n kube-system ds/cilium
-          kubectl --context ${{ env.contextName2 }} rollout restart -n kube-system ds/cilium
-
-          # Wait until all agents successfully restarted before scaling the replicas again
-          kubectl --context ${{ env.contextName1 }} rollout status -n kube-system ds/cilium --timeout=5m
-          kubectl --context ${{ env.contextName2 }} rollout status -n kube-system ds/cilium --timeout=5m
-
-      - name: Scale the clustermesh-apiserver replicas back to 1
-        if: ${{ !matrix.external-kvstore }}
-        run: |
-          kubectl --context ${{ env.contextName1 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 1
-          kubectl --context ${{ env.contextName2 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 1
-
-      - name: Wait for cluster mesh status to be ready
-        run: |
-          cilium --context ${{ env.contextName1 }} status --wait
-          cilium --context ${{ env.contextName2 }} status --wait
-          cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
-          cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
-
-      - name: Gather additional troubleshooting information
-        run: |
-          kubectl --context ${{ env.contextName1 }} get po -n cilium-test -o wide -l kind=test-conn-disrupt
-          kubectl --context ${{ env.contextName2 }} get po -n cilium-test -o wide -l kind=test-conn-disrupt
-          kubectl --context ${{ env.contextName1 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --timestamps
-          kubectl --context ${{ env.contextName2 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --timestamps
-          kubectl --context ${{ env.contextName2 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --previous --ignore-errors --timestamps
-
-      - name: Run connectivity test - stress-test (${{ join(matrix.*, ', ') }})
-        run: |
-          # Only check that no long living connection was disrupted
-          cilium --context ${{ env.contextName1 }} connectivity test \
-            --multi-cluster=${{ env.contextName2 }} \
-            --hubble=false \
-            --flow-validation=disabled \
-            --test='no-interrupted-connections' \
-            --test='no-unexpected-packet-drops' \
-            --include-conn-disrupt-test \
-            --junit-file "cilium-junits/${{ env.job_name }} - stress test (${{ join(matrix.*, ', ') }}).xml" \
-            --junit-property github_job_step="Run tests stess-test (${{ join(matrix.*, ', ') }})"
-
-          # Create pods which establish long lived connections. They will be used by
-          # subsequent connectivity tests with --include-conn-disrupt-test to catch any
-          # interruption in such flows.
-          cilium --context ${{ env.contextName1 }} connectivity test \
-            --multi-cluster=${{ env.contextName2 }} --hubble=false \
-            --include-conn-disrupt-test --conn-disrupt-test-setup \
-            --conn-disrupt-dispatch-interval 0ms
-
-
-      - name: Downgrade Cilium in cluster1 and disable kvstoremesh
-        env:
-          KVSTORE_ID: 1
-        run: |
-          cilium --context ${{ env.contextName1 }} upgrade --reset-values \
-            ${{ steps.downgrade-vars.outputs.cilium_image_settings }} \
-            ${{ steps.vars.outputs.cilium_install_defaults }} \
-            ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
-            ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }}
-
-      - name: Rollout Cilium agents in cluster2
-        if: ${{ !matrix.external-kvstore }}
-        run: |
-          # This makes sure that the remote agents reconnect to the new instance of the
-          # clustermesh-apiserver, without waiting for the watchdog mechanism to kick in.
-          kubectl --context ${{ env.contextName2 }} rollout restart -n kube-system ds/cilium
-
-      - name: Wait for cluster mesh status to be ready
-        run: |
-          cilium --context ${{ env.contextName1 }} status --wait
-          cilium --context ${{ env.contextName2 }} status --wait
-          cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
-          cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
-
-      - name: Gather additional troubleshooting information
-        run: |
-          kubectl --context ${{ env.contextName1 }} get po -n cilium-test -o wide -l kind=test-conn-disrupt
-          kubectl --context ${{ env.contextName2 }} get po -n cilium-test -o wide -l kind=test-conn-disrupt
-          kubectl --context ${{ env.contextName1 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --timestamps
-          kubectl --context ${{ env.contextName2 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --timestamps
-          kubectl --context ${{ env.contextName2 }} logs -n cilium-test -l kind=test-conn-disrupt --prefix --previous --ignore-errors --timestamps
-
-      - name: Run connectivity test - post-downgrade (${{ join(matrix.*, ', ') }})
-        run: |
-          cilium --context ${{ env.contextName1 }} connectivity test \
-            --multi-cluster=${{ env.contextName2 }} \
-            ${{ steps.vars.outputs.connectivity_test_defaults }} \
-            --include-conn-disrupt-test \
-            --junit-file "cilium-junits/${{ env.job_name }} - post downgrade (${{ join(matrix.*, ', ') }}).xml" \
-            --junit-property github_job_step="Run tests post-downgrade (${{ join(matrix.*, ', ') }})"
-
-
-      - name: Post-test information gathering
-        if: ${{ !success() && steps.install-cilium-cluster1.outcome != 'skipped' }}
-        run: |
-          cilium --context ${{ env.contextName1 }} status
-          cilium --context ${{ env.contextName1 }} clustermesh status
-          cilium --context ${{ env.contextName2 }} status
-          cilium --context ${{ env.contextName2 }} clustermesh status
-
-          kubectl config use-context ${{ env.contextName1 }}
-          kubectl get pods --all-namespaces -o wide
-          cilium sysdump --output-filename cilium-sysdump-context1-final-${{ join(matrix.*, '-') }}
-
-          kubectl config use-context ${{ env.contextName2 }}
-          kubectl get pods --all-namespaces -o wide
-          cilium sysdump --output-filename cilium-sysdump-context2-final-${{ join(matrix.*, '-') }}
-
-          if [ "${{ matrix.external-kvstore }}" == "true" ]; then
-            for i in {1..2}; do
-              echo
-              echo "# Retrieving logs from kvstore$i docker container"
-              docker logs kvstore$i
-            done
-          fi
-        shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
-
-      - name: Upload artifacts
-        if: ${{ !success() }}
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
-        with:
-          name: cilium-sysdumps-${{ matrix.name }}
-          path: cilium-sysdump-*.zip
-
-      - name: Upload JUnits [junit]
-        if: ${{ always() }}
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
-        with:
-          name: cilium-junits-${{ matrix.name }}
-          path: cilium-junits/*.xml
-
-      - name: Publish Test Results As GitHub Summary
-        if: ${{ always() }}
-        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
-        with:
-          junit-directory: "cilium-junits"
+    - name: Publish Test Results As GitHub Summary
+      if: ${{ always() }}
+      uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+      with:
+        junit-directory: "cilium-junits"
 
   merge-upload:
     if: ${{ always() }}
@@ -633,22 +633,22 @@ jobs:
     runs-on: ubuntu-latest
     needs: upgrade-and-downgrade
     steps:
-      - name: Merge Sysdumps
-        if: ${{ needs.upgrade-and-downgrade.result == 'failure' }}
-        uses: actions/upload-artifact/merge@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
-        with:
-          name: cilium-sysdumps
-          pattern: cilium-sysdumps-*
-          retention-days: 5
-          delete-merged: true
-        continue-on-error: true
-      - name: Merge JUnits
-        uses: actions/upload-artifact/merge@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
-        with:
-          name: cilium-junits
-          pattern: cilium-junits-*
-          retention-days: 5
-          delete-merged: true
+    - name: Merge Sysdumps
+      if: ${{ needs.upgrade-and-downgrade.result == 'failure' }}
+      uses: actions/upload-artifact/merge@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: cilium-sysdumps
+        pattern: cilium-sysdumps-*
+        retention-days: 5
+        delete-merged: true
+      continue-on-error: true
+    - name: Merge JUnits
+      uses: actions/upload-artifact/merge@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: cilium-junits
+        pattern: cilium-junits-*
+        retention-days: 5
+        delete-merged: true
 
   commit-status-final:
     if: ${{ always() && github.event_name != 'push' }}
@@ -656,8 +656,8 @@ jobs:
     needs: upgrade-and-downgrade
     runs-on: ubuntu-latest
     steps:
-      - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
-        with:
-          sha: ${{ inputs.SHA || github.sha }}
-          status: ${{ needs.upgrade-and-downgrade.result }}
+    - name: Set final commit status
+      uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+      with:
+        sha: ${{ inputs.SHA || github.sha }}
+        status: ${{ needs.upgrade-and-downgrade.result }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -59,7 +59,7 @@ spec:
         {{- end }}
         # These need to match the equivalent arguments to etcd in the main container.
         - --etcd-cluster-name=clustermesh-apiserver
-        - --etcd-initial-cluster-token=clustermesh-apiserver
+        - --etcd-initial-cluster-token=$(INITIAL_CLUSTER_TOKEN)
         - --etcd-data-dir=/var/run/etcd
         {{- with .Values.clustermesh.apiserver.etcd.init.extraArgs }}
         {{- toYaml . | trim | nindent 8 }}
@@ -76,6 +76,10 @@ spec:
             configMapKeyRef:
               name: cilium-config
               key: cluster-name
+        - name: INITIAL_CLUSTER_TOKEN
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         {{- with .Values.clustermesh.apiserver.etcd.init.extraEnv }}
         {{- toYaml . | trim | nindent 8 }}
         {{- end }}
@@ -108,7 +112,7 @@ spec:
         # uses net.SplitHostPort() internally and it accepts the that format.
         - --listen-client-urls=https://127.0.0.1:2379,https://[$(HOSTNAME_IP)]:2379
         - --advertise-client-urls=https://[$(HOSTNAME_IP)]:2379
-        - --initial-cluster-token=clustermesh-apiserver
+        - --initial-cluster-token=$(INITIAL_CLUSTER_TOKEN)
         - --auto-compaction-retention=1
         {{- if .Values.clustermesh.apiserver.metrics.etcd.enabled }}
         - --listen-metrics-urls=http://[$(HOSTNAME_IP)]:{{ .Values.clustermesh.apiserver.metrics.etcd.port }}
@@ -121,6 +125,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: INITIAL_CLUSTER_TOKEN
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         ports:
         - name: etcd
           containerPort: 2379

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
@@ -35,4 +35,8 @@ spec:
   {{- if .Values.clustermesh.apiserver.service.internalTrafficPolicy }}
   internalTrafficPolicy: {{ .Values.clustermesh.apiserver.service.internalTrafficPolicy }}
   {{- end }}
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 600
 {{- end }}

--- a/pkg/clustermesh/common/interceptor.go
+++ b/pkg/clustermesh/common/interceptor.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"google.golang.org/grpc"
+)
+
+var (
+	ErrClusterIdMismatch   = errors.New("cluster id mismatch")
+	ErrEtcdInvalidResponse = errors.New("received an invalid etcd response")
+)
+
+// newUnaryInterceptor returns a new unary client interceptor that validates the
+// cluster ID of any received etcd responses.
+func newUnaryInterceptor(cl *clusterLock) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if err := invoker(ctx, method, req, reply, cc, opts...); err != nil {
+			return err
+		}
+		resp, ok := reply.(etcdResponse)
+		if !ok {
+			select {
+			case cl.errors <- ErrEtcdInvalidResponse:
+			default:
+			}
+			return ErrEtcdInvalidResponse
+
+		}
+		if err := cl.validateClusterId(resp.GetHeader().ClusterId); err != nil {
+			select {
+			case cl.errors <- err:
+			default:
+			}
+			return err
+		}
+		return nil
+	}
+}
+
+// newStreamInterceptor returns a new stream client interceptor that validates
+// the cluster ID of any received etcd responses.
+func newStreamInterceptor(cl *clusterLock) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		s, err := streamer(ctx, desc, cc, method, opts...)
+		if err != nil {
+			return nil, err
+		}
+		return &wrappedClientStream{
+			ClientStream: s,
+			clusterLock:  cl,
+		}, nil
+	}
+}
+
+// wrappedClientStream is a wrapper around a grpc.ClientStream that adds
+// validation for the etcd cluster ID
+type wrappedClientStream struct {
+	grpc.ClientStream
+	clusterLock *clusterLock
+}
+
+type etcdResponse interface {
+	GetHeader() *etcdserverpb.ResponseHeader
+}
+
+// RecvMsg implements the grpc.ClientStream interface, adding validation for the etcd cluster ID
+func (w *wrappedClientStream) RecvMsg(m interface{}) error {
+	if err := w.ClientStream.RecvMsg(m); err != nil {
+		return err
+	}
+
+	resp, ok := m.(etcdResponse)
+	if !ok || resp.GetHeader() == nil {
+		select {
+		case w.clusterLock.errors <- ErrEtcdInvalidResponse:
+		default:
+		}
+		return ErrEtcdInvalidResponse
+	}
+
+	if err := w.clusterLock.validateClusterId(resp.GetHeader().ClusterId); err != nil {
+		select {
+		case w.clusterLock.errors <- err:
+		default:
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (w *wrappedClientStream) SendMsg(m interface{}) error {
+	return w.ClientStream.SendMsg(m)
+}
+
+// clusterLock is a wrapper around an atomic uint64 that can only be set once. It
+// provides validation for an etcd connection to ensure that it is only used
+// for the same etcd cluster it was initially connected to. This is to prevent
+// accidentally connecting to the wrong cluster in a high availability
+// configuration utilizing mutiple active clusters.
+type clusterLock struct {
+	init      sync.Once
+	clusterId atomic.Uint64
+	errors    chan error
+}
+
+func newClusterLock() *clusterLock {
+	return &clusterLock{
+		init:      sync.Once{},
+		clusterId: atomic.Uint64{},
+		errors:    make(chan error, 1),
+	}
+}
+
+func (c *clusterLock) validateClusterId(clusterId uint64) error {
+	c.init.Do(func() {
+		c.clusterId.Store(clusterId)
+	})
+	if clusterId != c.clusterId.Load() {
+		return fmt.Errorf("%w: expected %d, got %d", ErrClusterIdMismatch, c.clusterId.Load(), clusterId)
+	}
+	return nil
+}

--- a/pkg/clustermesh/common/interceptor_test.go
+++ b/pkg/clustermesh/common/interceptor_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package common
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"google.golang.org/grpc"
+)
+
+type responseType int
+
+const (
+	status responseType = iota
+	watch
+	leaseKeepAlive
+	leaseGrant
+	invalid
+)
+
+type mockClientStream struct {
+	grpc.ClientStream
+	toClient chan *etcdResponse
+}
+
+func newMockClientStream() mockClientStream {
+	return mockClientStream{
+		toClient: make(chan *etcdResponse),
+	}
+}
+
+func (c mockClientStream) RecvMsg(msg interface{}) error {
+	return nil
+}
+
+func (c mockClientStream) Send(resp *etcdResponse) error {
+	return nil
+}
+
+func newStreamerMock(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	return newMockClientStream(), nil
+}
+
+func (u unaryResponder) recv() etcdResponse {
+	var resp unaryResponse
+	switch u.rt {
+	case status:
+		resp = unaryResponse{&etcdserverpb.StatusResponse{Header: &etcdserverpb.ResponseHeader{ClusterId: u.cid}}}
+	case leaseGrant:
+		resp = unaryResponse{&etcdserverpb.LeaseGrantResponse{Header: &etcdserverpb.ResponseHeader{ClusterId: u.cid}}}
+	case invalid:
+		resp = unaryResponse{&etcdserverpb.StatusResponse{}}
+	}
+
+	return resp
+}
+
+func (s streamResponder) recv() etcdResponse {
+	var resp streamResponse
+	switch s.rt {
+	case watch:
+		resp = streamResponse{&etcdserverpb.WatchResponse{Header: &etcdserverpb.ResponseHeader{ClusterId: s.cid}}}
+	case leaseKeepAlive:
+		resp = streamResponse{&etcdserverpb.LeaseKeepAliveResponse{Header: &etcdserverpb.ResponseHeader{ClusterId: s.cid}}}
+	case invalid:
+		resp = streamResponse{&etcdserverpb.WatchResponse{}}
+	}
+	return resp
+
+}
+
+func noopInvoker(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+	return nil
+}
+
+type unaryResponder struct {
+	rt  responseType
+	cid uint64
+}
+
+type unaryResponse struct {
+	etcdResponse
+}
+
+type streamResponder struct {
+	rt  responseType
+	cid uint64
+}
+
+type streamResponse struct {
+	etcdResponse
+}
+
+type mockResponder interface {
+	recv() etcdResponse
+}
+
+var maxId uint64 = 0xFFFFFFFFFFFFFFFF
+
+func TestInterceptors(t *testing.T) {
+	tests := []struct {
+		name             string
+		initialClusterId uint64
+		r                map[mockResponder]error
+	}{
+		{
+			name:             "healthy stream responses",
+			initialClusterId: 1,
+			r: map[mockResponder]error{
+				streamResponder{rt: watch, cid: 1}: nil,
+				streamResponder{rt: watch, cid: 1}: nil,
+				streamResponder{rt: watch, cid: 1}: nil,
+			},
+		},
+		{
+			name:             "healthy unary responses",
+			initialClusterId: 1,
+			r: map[mockResponder]error{
+				unaryResponder{rt: leaseGrant, cid: 1}: nil,
+				unaryResponder{rt: status, cid: 1}:     nil,
+			},
+		},
+		{
+			name:             "healthy stream and unary responses",
+			initialClusterId: maxId,
+			r: map[mockResponder]error{
+				unaryResponder{rt: leaseGrant, cid: maxId}: nil,
+				unaryResponder{rt: status, cid: maxId}:     nil,
+				streamResponder{rt: watch, cid: maxId}:     nil,
+				unaryResponder{rt: status, cid: maxId}:     nil,
+				streamResponder{rt: watch, cid: maxId}:     nil,
+			},
+		},
+		{
+			name:             "watch response from another cluster",
+			initialClusterId: 1,
+			r: map[mockResponder]error{
+				streamResponder{rt: watch, cid: 1}: nil,
+				streamResponder{rt: watch, cid: 2}: ErrClusterIdMismatch,
+				streamResponder{rt: watch, cid: 1}: nil,
+			},
+		},
+		{
+			name:             "status response from another cluster",
+			initialClusterId: 1,
+			r: map[mockResponder]error{
+				streamResponder{rt: watch, cid: 1}:     nil,
+				unaryResponder{rt: status, cid: maxId}: ErrClusterIdMismatch,
+				streamResponder{rt: watch, cid: 1}:     nil,
+			},
+		},
+		{
+			name:             "receive an invalid response with no header",
+			initialClusterId: 1,
+			r: map[mockResponder]error{
+				streamResponder{rt: leaseKeepAlive, cid: 1}: nil,
+				streamResponder{rt: invalid, cid: 0}:        ErrEtcdInvalidResponse,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			cl := newClusterLock()
+			checkForError := func() error {
+				select {
+				case err := <-cl.errors:
+					return err
+				default:
+					return nil
+				}
+			}
+
+			si := newStreamInterceptor(cl)
+			desc := &grpc.StreamDesc{
+				StreamName:    "test",
+				Handler:       nil,
+				ServerStreams: true,
+				ClientStreams: true,
+			}
+
+			cc := &grpc.ClientConn{}
+
+			stream, err := si(ctx, desc, cc, "test", newStreamerMock)
+			require.NoError(t, err)
+
+			unaryRecvMsg := newUnaryInterceptor(cl)
+			for responder, expectedError := range tt.r {
+				responseType := reflect.TypeOf(responder.recv())
+
+				switch {
+				case responseType.AssignableTo(reflect.TypeOf(unaryResponse{})):
+					unaryRecvMsg(ctx, "test", nil, responder.recv(), cc, noopInvoker)
+				case responseType.AssignableTo(reflect.TypeOf(streamResponse{})):
+					stream.RecvMsg(responder.recv())
+				}
+				require.ErrorIs(t, checkForError(), expectedError)
+				require.Equal(t, tt.initialClusterId, cl.clusterId.Load())
+			}
+		})
+	}
+
+}

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -46,6 +46,8 @@ type ExtraOptions struct {
 	// have an initial rate limit equal to etcd.bootstrapQps and be updated to
 	// etcd.qps after this channel is closed.
 	BootstrapComplete <-chan struct{}
+
+	DisableStatusChecks bool
 }
 
 // StatusCheckInterval returns the interval of status checks depending on the

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -678,7 +678,11 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 		close(errChan)
 		close(ec.firstSession)
 
-		go ec.statusChecker()
+		if opts != nil && opts.DisableStatusChecks {
+			ec.logger.Debug("Status checks are disabled")
+		} else {
+			go ec.statusChecker()
+		}
 
 		watcher := ec.ListAndWatch(ctx, HeartbeatPath, 128)
 


### PR DESCRIPTION
This adds support for running clustermesh-apiserver deployments with multiple replicas for high availability. Each clustermesh-apiserver pod runs its own etcd cluster. Depending on configuration, either the Cilium Agent or KVStoreMesh instance watches etcd in a remote cluster. All responses from the remote etcd cluster are intercepted and the header is inspected to retrieve the etcd cluster ID. If a failover event occurs and the cluster ID has changed, the remote connection is restarted to ensure that no events are missed and that no invalid data is retained. See individual commit messages for additional details.

```release-note
Add support for deploying clustermesh-apiserver with multiple replicas for high availability.
```