### PR TITLE
CODEOWNERS: Ensure gha review for actions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -224,6 +224,7 @@
 /.github/ariane-config.yaml @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*perf*.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure
 /.github/workflows/ @cilium/github-sec @cilium/ci-structure
+/.github/actions/ @cilium/github-sec @cilium/ci-structure
 /api/ @cilium/api
 /api/v1/Makefile @cilium/sig-hubble-api
 /api/v1/Makefile.protoc @cilium/sig-hubble-api


### PR DESCRIPTION
These were newly introduced in v1.15, but during branching we didn't
keep the codeowners for them. Make the review for these files align with
the other GHA workflow YAMLs.

Fixes: e0dc326c49898c6db246a166fbbd284362c4ea66
Fixes: https://github.com/cilium/cilium/pull/29838