### PR TITLE
IPAM: Extend CiliumNodes CRD to Track Used and Released IPv6 Addresses

### DIFF
--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -153,6 +153,9 @@ type Statistics struct {
 	// IPv4 represents IPv4-specific statistics.
 	IPv4 IPStatistics
 
+	// IPv6 represents IPv6-specific statistics.
+	IPv6 IPStatistics
+
 	// EmptyInterfaceSlots is the number of empty interface slots available
 	// for interfaces to be attached.
 	EmptyInterfaceSlots int

--- a/pkg/ipam/stats/stats.go
+++ b/pkg/ipam/stats/stats.go
@@ -8,11 +8,22 @@ package stats
 // allocate more addresses.
 type InterfaceStats struct {
 	// NodeCapacity is the current inferred total capacity for a Node to schedule
-	// addresses.
+	// IPv4 addresses.
 	//
 	// This does not account for currently used addresses.
 	NodeCapacity int
 
-	// RemainingAvailableInterfaceCount is the number of interfaces currently available.
+	// RemainingAvailableInterfaceCount is the number of interfaces currently available
+	// for IPv4 address allocation.
 	RemainingAvailableInterfaceCount int
+
+	// NodeIPv6Capacity is the current inferred total capacity for a Node to schedule
+	// IPv6 addresses.
+	//
+	// This does not account for currently used addresses.
+	NodeIPv6Capacity int
+
+	// RemainingAvailableIPv6InterfaceCount is the number of interfaces currently available
+	// for IPv6 address allocation.
+	RemainingAvailableIPv6InterfaceCount int
 }

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -119,12 +119,19 @@ type IPAMPoolSpec struct {
 //
 // This structure is embedded into v2.CiliumNode
 type IPAMSpec struct {
-	// Pool is the list of IPs available to the node for allocation. When
-	// an IP is used, the IP will remain on this list but will be added to
+	// Pool is the list of IPv4 addresses available to the node for allocation.
+	// When an IPv4 address is used, it will remain on this list but will be added to
 	// Status.IPAM.Used
 	//
 	// +optional
 	Pool AllocationMap `json:"pool,omitempty"`
+
+	// IPv6Pool is the list of IPv6 addresses available to the node for allocation.
+	// When an IPv6 address is used, it will remain on this list but will be added to
+	// Status.IPAM.IPv6Used
+	//
+	// +optional
+	IPv6Pool AllocationMap `json:"ipv6-pool,omitempty"`
 
 	// Pools contains the list of assigned IPAM pools for this node.
 	//
@@ -173,7 +180,7 @@ type IPAMSpec struct {
 	MaxAboveWatermark int `json:"max-above-watermark,omitempty"`
 }
 
-// IPReleaseStatus  defines the valid states in IP release handshake
+// IPReleaseStatus defines the valid states in IP release handshake
 //
 // +kubebuilder:validation:Enum=marked-for-release;ready-for-release;do-not-release;released
 type IPReleaseStatus string
@@ -182,11 +189,17 @@ type IPReleaseStatus string
 //
 // This structure is embedded into v2.CiliumNode
 type IPAMStatus struct {
-	// Used lists all IPs out of Spec.IPAM.Pool which have been allocated
+	// Used lists all IPv4 addresses out of Spec.IPAM.Pool which have been allocated
 	// and are in use.
 	//
 	// +optional
 	Used AllocationMap `json:"used,omitempty"`
+
+	// IPv6Used lists all IPv6 addresses out of Spec.IPAM.IPv6Pool which have been
+	// allocated and are in use.
+	//
+	// +optional
+	IPv6Used AllocationMap `json:"ipv6-used,omitempty"`
 
 	// PodCIDRs lists the status of each pod CIDR allocated to this node.
 	//
@@ -198,8 +211,8 @@ type IPAMStatus struct {
 	// +optional
 	OperatorStatus OperatorStatus `json:"operator-status,omitempty"`
 
-	// ReleaseIPs tracks the state for every IP considered for release.
-	// value can be one of the following string :
+	// ReleaseIPs tracks the state for every IPv4 address considered for release.
+	// The value can be one of the following strings:
 	// * marked-for-release : Set by operator as possible candidate for IP
 	// * ready-for-release  : Acknowledged as safe to release by agent
 	// * do-not-release     : IP already in use / not owned by the node. Set by agent
@@ -207,6 +220,16 @@ type IPAMStatus struct {
 	//
 	// +optional
 	ReleaseIPs map[string]IPReleaseStatus `json:"release-ips,omitempty"`
+
+	// ReleaseIPv6s tracks the state for every IPv6 address considered for release.
+	// The value can be one of the following strings:
+	// * marked-for-release : Set by operator as possible candidate for IP
+	// * ready-for-release  : Acknowledged as safe to release by agent
+	// * do-not-release     : IP already in use / not owned by the node. Set by agent
+	// * released           : IP successfully released. Set by operator
+	//
+	// +optional
+	ReleaseIPv6s map[string]IPReleaseStatus `json:"release-ipv6s,omitempty"`
 }
 
 // IPAMPoolRequest is a request from the agent to the operator, indicating how
@@ -274,8 +297,11 @@ type Subnet struct {
 	// Name is the subnet name
 	Name string
 
-	// CIDR is the CIDR associated with the subnet
+	// CIDR is the IPv4 CIDR associated with the subnet
 	CIDR *cidr.CIDR
+
+	// IPv6CIDR is the IPv6 CIDR associated with the subnet
+	IPv6CIDR *cidr.CIDR
 
 	// AvailabilityZone is the availability zone of the subnet
 	AvailabilityZone string
@@ -283,9 +309,13 @@ type Subnet struct {
 	// VirtualNetworkID is the virtual network the subnet is in
 	VirtualNetworkID string
 
-	// AvailableAddresses is the number of addresses available for
+	// AvailableAddresses is the number of IPv4 addresses available for
 	// allocation
 	AvailableAddresses int
+
+	// AvailableIPv6Addresses is the number of IPv6 addresses available for
+	// allocation
+	AvailableIPv6Addresses int
 
 	// Tags is the tags of the subnet
 	Tags Tags
@@ -325,6 +355,9 @@ type VirtualNetwork struct {
 
 	// CIDRs is the list of secondary IPv4 CIDR ranges associated with the VPC
 	CIDRs []string
+
+	// IPv6CIDRs is the list of IPv6 CIDR ranges associated with the VPC
+	IPv6CIDRs []string
 }
 
 // VirtualNetworkMap indexes virtual networks by their ID
@@ -346,6 +379,9 @@ type PoolQuota struct {
 
 	// AvailableIPs is the number of available IPs in the pool
 	AvailableIPs int
+
+	// AvailableIPv6s is the number of available IPv6 addresses in the pool
+	AvailableIPv6s int
 }
 
 // PoolQuotaMap is a map of pool quotas indexes by pool identifier

--- a/pkg/ipam/types/zz_generated.deepcopy.go
+++ b/pkg/ipam/types/zz_generated.deepcopy.go
@@ -138,6 +138,13 @@ func (in *IPAMSpec) DeepCopyInto(out *IPAMSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.IPv6Pool != nil {
+		in, out := &in.IPv6Pool, &out.IPv6Pool
+		*out = make(AllocationMap, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.Pools.DeepCopyInto(&out.Pools)
 	if in.PodCIDRs != nil {
 		in, out := &in.PodCIDRs, &out.PodCIDRs
@@ -167,6 +174,13 @@ func (in *IPAMStatus) DeepCopyInto(out *IPAMStatus) {
 			(*out)[key] = val
 		}
 	}
+	if in.IPv6Used != nil {
+		in, out := &in.IPv6Used, &out.IPv6Used
+		*out = make(AllocationMap, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.PodCIDRs != nil {
 		in, out := &in.PodCIDRs, &out.PodCIDRs
 		*out = make(PodCIDRMap, len(*in))
@@ -177,6 +191,13 @@ func (in *IPAMStatus) DeepCopyInto(out *IPAMStatus) {
 	out.OperatorStatus = in.OperatorStatus
 	if in.ReleaseIPs != nil {
 		in, out := &in.ReleaseIPs, &out.ReleaseIPs
+		*out = make(map[string]IPReleaseStatus, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.ReleaseIPv6s != nil {
+		in, out := &in.ReleaseIPv6s, &out.ReleaseIPv6s
 		*out = make(map[string]IPReleaseStatus, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
@@ -310,6 +331,10 @@ func (in *Subnet) DeepCopyInto(out *Subnet) {
 		in, out := &in.CIDR, &out.CIDR
 		*out = (*in).DeepCopy()
 	}
+	if in.IPv6CIDR != nil {
+		in, out := &in.IPv6CIDR, &out.IPv6CIDR
+		*out = (*in).DeepCopy()
+	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make(Tags, len(*in))
@@ -387,6 +412,11 @@ func (in *VirtualNetwork) DeepCopyInto(out *VirtualNetwork) {
 	*out = *in
 	if in.CIDRs != nil {
 		in, out := &in.CIDRs, &out.CIDRs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.IPv6CIDRs != nil {
+		in, out := &in.IPv6CIDRs, &out.IPv6CIDRs
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/ipam/types/zz_generated.deepequal.go
+++ b/pkg/ipam/types/zz_generated.deepequal.go
@@ -171,6 +171,13 @@ func (in *IPAMSpec) DeepEqual(other *IPAMSpec) bool {
 		}
 	}
 
+	if ((in.IPv6Pool != nil) && (other.IPv6Pool != nil)) || ((in.IPv6Pool == nil) != (other.IPv6Pool == nil)) {
+		in, other := &in.IPv6Pool, &other.IPv6Pool
+		if other == nil || !in.DeepEqual(other) {
+			return false
+		}
+	}
+
 	if !in.Pools.DeepEqual(&other.Pools) {
 		return false
 	}
@@ -222,6 +229,13 @@ func (in *IPAMStatus) DeepEqual(other *IPAMStatus) bool {
 		}
 	}
 
+	if ((in.IPv6Used != nil) && (other.IPv6Used != nil)) || ((in.IPv6Used == nil) != (other.IPv6Used == nil)) {
+		in, other := &in.IPv6Used, &other.IPv6Used
+		if other == nil || !in.DeepEqual(other) {
+			return false
+		}
+	}
+
 	if ((in.PodCIDRs != nil) && (other.PodCIDRs != nil)) || ((in.PodCIDRs == nil) != (other.PodCIDRs == nil)) {
 		in, other := &in.PodCIDRs, &other.PodCIDRs
 		if other == nil || !in.DeepEqual(other) {
@@ -235,6 +249,27 @@ func (in *IPAMStatus) DeepEqual(other *IPAMStatus) bool {
 
 	if ((in.ReleaseIPs != nil) && (other.ReleaseIPs != nil)) || ((in.ReleaseIPs == nil) != (other.ReleaseIPs == nil)) {
 		in, other := &in.ReleaseIPs, &other.ReleaseIPs
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for key, inValue := range *in {
+				if otherValue, present := (*other)[key]; !present {
+					return false
+				} else {
+					if inValue != otherValue {
+						return false
+					}
+				}
+			}
+		}
+	}
+
+	if ((in.ReleaseIPv6s != nil) && (other.ReleaseIPv6s != nil)) || ((in.ReleaseIPv6s == nil) != (other.ReleaseIPv6s == nil)) {
+		in, other := &in.ReleaseIPv6s, &other.ReleaseIPv6s
 		if other == nil {
 			return false
 		}
@@ -345,6 +380,9 @@ func (in *PoolQuota) DeepEqual(other *PoolQuota) bool {
 	if in.AvailableIPs != other.AvailableIPs {
 		return false
 	}
+	if in.AvailableIPv6s != other.AvailableIPv6s {
+		return false
+	}
 
 	return true
 }
@@ -394,6 +432,14 @@ func (in *Subnet) DeepEqual(other *Subnet) bool {
 		}
 	}
 
+	if (in.IPv6CIDR == nil) != (other.IPv6CIDR == nil) {
+		return false
+	} else if in.IPv6CIDR != nil {
+		if !in.IPv6CIDR.DeepEqual(other.IPv6CIDR) {
+			return false
+		}
+	}
+
 	if in.AvailabilityZone != other.AvailabilityZone {
 		return false
 	}
@@ -401,6 +447,9 @@ func (in *Subnet) DeepEqual(other *Subnet) bool {
 		return false
 	}
 	if in.AvailableAddresses != other.AvailableAddresses {
+		return false
+	}
+	if in.AvailableIPv6Addresses != other.AvailableIPv6Addresses {
 		return false
 	}
 	if ((in.Tags != nil) && (other.Tags != nil)) || ((in.Tags == nil) != (other.Tags == nil)) {
@@ -476,6 +525,23 @@ func (in *VirtualNetwork) DeepEqual(other *VirtualNetwork) bool {
 	}
 	if ((in.CIDRs != nil) && (other.CIDRs != nil)) || ((in.CIDRs == nil) != (other.CIDRs == nil)) {
 		in, other := &in.CIDRs, &other.CIDRs
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if inElement != (*other)[i] {
+					return false
+				}
+			}
+		}
+	}
+
+	if ((in.IPv6CIDRs != nil) && (other.IPv6CIDRs != nil)) || ((in.IPv6CIDRs == nil) != (other.IPv6CIDRs == nil)) {
+		in, other := &in.IPv6CIDRs, &other.IPv6CIDRs
 		if other == nil {
 			return false
 		}

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -263,6 +263,30 @@ spec:
                   can be populated by a user or it can be automatically populated
                   by an IPAM operator.
                 properties:
+                  ipv6-pool:
+                    additionalProperties:
+                      description: AllocationIP is an IP which is available for allocation,
+                        or already has been allocated
+                      properties:
+                        owner:
+                          description: "Owner is the owner of the IP. This field is
+                            set if the IP has been allocated. It will be set to the
+                            pod name or another identifier representing the usage
+                            of the IP \n The owner field is left blank for an entry
+                            in Spec.IPAM.Pool and filled out as the IP is used and
+                            also added to Status.IPAM.Used."
+                          type: string
+                        resource:
+                          description: Resource is set for both available and allocated
+                            IPs, it represents what resource the IP is associated
+                            with, e.g. in combination with AWS ENI, this will refer
+                            to the ID of the ENI
+                          type: string
+                      type: object
+                    description: IPv6Pool is the list of IPv6 addresses available
+                      to the node for allocation. When an IPv6 address is used, it
+                      will remain on this list but will be added to Status.IPAM.IPv6Used
+                    type: object
                   max-above-watermark:
                     description: MaxAboveWatermark is the maximum number of addresses
                       to allocate beyond the addresses needed to reach the PreAllocate
@@ -315,9 +339,9 @@ spec:
                             to the ID of the ENI
                           type: string
                       type: object
-                    description: Pool is the list of IPs available to the node for
-                      allocation. When an IP is used, the IP will remain on this list
-                      but will be added to Status.IPAM.Used
+                    description: Pool is the list of IPv4 addresses available to the
+                      node for allocation. When an IPv4 address is used, it will remain
+                      on this list but will be added to Status.IPAM.Used
                     type: object
                   pools:
                     description: Pools contains the list of assigned IPAM pools for
@@ -637,6 +661,29 @@ spec:
               ipam:
                 description: IPAM is the IPAM status of the node.
                 properties:
+                  ipv6-used:
+                    additionalProperties:
+                      description: AllocationIP is an IP which is available for allocation,
+                        or already has been allocated
+                      properties:
+                        owner:
+                          description: "Owner is the owner of the IP. This field is
+                            set if the IP has been allocated. It will be set to the
+                            pod name or another identifier representing the usage
+                            of the IP \n The owner field is left blank for an entry
+                            in Spec.IPAM.Pool and filled out as the IP is used and
+                            also added to Status.IPAM.Used."
+                          type: string
+                        resource:
+                          description: Resource is set for both available and allocated
+                            IPs, it represents what resource the IP is associated
+                            with, e.g. in combination with AWS ENI, this will refer
+                            to the ID of the ENI
+                          type: string
+                      type: object
+                    description: IPv6Used lists all IPv6 addresses out of Spec.IPAM.IPv6Pool
+                      which have been allocated and are in use.
+                    type: object
                   operator-status:
                     description: Operator is the Operator status of the node
                     properties:
@@ -660,7 +707,7 @@ spec:
                     type: object
                   release-ips:
                     additionalProperties:
-                      description: IPReleaseStatus  defines the valid states in IP
+                      description: IPReleaseStatus defines the valid states in IP
                         release handshake
                       enum:
                       - marked-for-release
@@ -668,11 +715,30 @@ spec:
                       - do-not-release
                       - released
                       type: string
-                    description: 'ReleaseIPs tracks the state for every IP considered
-                      for release. value can be one of the following string : * marked-for-release
-                      : Set by operator as possible candidate for IP * ready-for-release  :
-                      Acknowledged as safe to release by agent * do-not-release     :
-                      IP already in use / not owned by the node. Set by agent * released           :
+                    description: 'ReleaseIPs tracks the state for every IPv4 address
+                      considered for release. The value can be one of the following
+                      strings: * marked-for-release : Set by operator as possible
+                      candidate for IP * ready-for-release  : Acknowledged as safe
+                      to release by agent * do-not-release     : IP already in use
+                      / not owned by the node. Set by agent * released           :
+                      IP successfully released. Set by operator'
+                    type: object
+                  release-ipv6s:
+                    additionalProperties:
+                      description: IPReleaseStatus defines the valid states in IP
+                        release handshake
+                      enum:
+                      - marked-for-release
+                      - ready-for-release
+                      - do-not-release
+                      - released
+                      type: string
+                    description: 'ReleaseIPv6s tracks the state for every IPv6 address
+                      considered for release. The value can be one of the following
+                      strings: * marked-for-release : Set by operator as possible
+                      candidate for IP * ready-for-release  : Acknowledged as safe
+                      to release by agent * do-not-release     : IP already in use
+                      / not owned by the node. Set by agent * released           :
                       IP successfully released. Set by operator'
                     type: object
                   used:
@@ -695,8 +761,8 @@ spec:
                             to the ID of the ENI
                           type: string
                       type: object
-                    description: Used lists all IPs out of Spec.IPAM.Pool which have
-                      been allocated and are in use.
+                    description: Used lists all IPv4 addresses out of Spec.IPAM.Pool
+                      which have been allocated and are in use.
                     type: object
                 type: object
             type: object


### PR DESCRIPTION
Previously, IPAM API types were specific to managing an IPv4 address pool. This icommit updates the API types to support separate IPAM pool maintainers for IPv4 and IPv6.

- `pkg/ipam/node.go`: Updates the `Node` type to support IPv6 allocation statistics.
- `pkg/ipam/stats/stats.go`: Updates the `InterfaceStats` type support IPv6 interface statistics.
- `pkg/ipam/types/types.go`: Updates `IPAMSpec`, `IPAMStatus`, and `Subnet` type to support IPv6 allocation statistics.
- `ciliumnodes.yaml`: Regenerated due to newly added fields of IPAM API types.

Supports: #19251

```release-note
Adds `IPv6Pool` field to the spec of CiliumNodes CRD to list of IPv6 addresses available to the node for allocation.
Adds `IPv6Used` field to the status of CiliumNodes CRD to list all IPv6 addresses from `ciliumnodes.spec.ipam.ipv6pool` which have been allocated and are in use.
```
