### PR TITLE
metrics: Disable prometheus metrics by default

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -305,7 +305,7 @@ cilium-agent [flags]
       --preallocate-bpf-maps                                      Enable BPF map pre-allocation (default true)
       --prepend-iptables-chains                                   Prepend custom iptables chains instead of appending (default true)
       --procfs string                                             Path to the host's proc filesystem mount (default "/proc")
-      --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off) (default ":9962")
+      --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --proxy-connect-timeout uint                                Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 2)
       --proxy-gid uint                                            Group ID for proxy control plane sockets. (default 1337)
       --proxy-idle-timeout-seconds int                            Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s (default 60)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -75,7 +75,7 @@ cilium-agent hive [flags]
       --pprof-port uint16                                         Port that pprof listens on (default 6060)
       --prepend-iptables-chains                                   Prepend custom iptables chains instead of appending (default true)
       --procfs string                                             Path to the host's proc filesystem mount (default "/proc")
-      --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off) (default ":9962")
+      --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -80,7 +80,7 @@ cilium-agent hive dot-graph [flags]
       --pprof-port uint16                                         Port that pprof listens on (default 6060)
       --prepend-iptables-chains                                   Prepend custom iptables chains instead of appending (default true)
       --procfs string                                             Path to the host's proc filesystem mount (default "/proc")
-      --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off) (default ":9962")
+      --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -24,7 +24,7 @@ import (
 )
 
 var defaultRegistryConfig = RegistryConfig{
-	PrometheusServeAddr: ":9962",
+	PrometheusServeAddr: "",
 }
 
 type RegistryConfig struct {


### PR DESCRIPTION
Prior to commit c49ef45399fc9, the prometheus metrics server was
disabled by default in Cilium. Typically we would expect users to
specify in helm both `prometheus.enabled` and `prometheus.port` to
determine how to configure the prometheus server to ensure that the
prometheus port doesn't also conflict with other services that the user
is running on their nodes in their clusters.

With the refactor in the aforementioned commit, the default was set to
`:9962`. This means that even if the user installed Cilium without
prometheus settings, or explicitly configured helm with
`prometheus.enabled: false`, the prometheus metrics server would be
enabled. There is no way to turn it off via Helm currently.

This patch reverts the default back to the pre-v1.14 default.

Fixes: c49ef45399fc ("metrics: Modularize daemon metrics registry")
Fixes: https://github.com/cilium/cilium/issues/31135
