### PR TITLE
examples: Move starwars,json-mock apps to quay.io

### DIFF
--- a/examples/minikube/http-sw-app.yaml
+++ b/examples/minikube/http-sw-app.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: deathstar
-        image: docker.io/cilium/starwars
+        image: quay.io/cilium/starwars
 ---
 apiVersion: v1
 kind: Pod
@@ -47,7 +47,7 @@ metadata:
 spec:
   containers:
   - name: spaceship
-    image: docker.io/cilium/json-mock
+    image: quay.io/cilium/json-mock
 ---
 apiVersion: v1
 kind: Pod
@@ -60,4 +60,4 @@ metadata:
 spec:
   containers:
   - name: spaceship
-    image: docker.io/cilium/json-mock
+    image: quay.io/cilium/json-mock


### PR DESCRIPTION
Quay.io builds are automated for these apps, so quay.io gets updates
while docker.io tends not to get updated. Update the OCI references.

Related: https://github.com/cilium/cilium/issues/28454
Related: https://github.com/cilium/tetragon/issues/2083
