### PR TITLE
v1.15 Backports 2024-03-05

### DIFF
--- a/Documentation/security/network/encryption-wireguard.rst
+++ b/Documentation/security/network/encryption-wireguard.rst
@@ -38,10 +38,9 @@ each other via that port.
 
 .. note::
 
-   When running in the tunneling mode (i.e. with VXLAN or Geneve), pod to pod
-   traffic will be sent only over the WireGuard tunnel which means that the
-   packets will bypass the other tunnel, and thus they will be encapsulated
-   only once.
+   When running in tunnel routing mode, pod to pod traffic is encapsulated twice.
+   It is first sent to the VXLAN / Geneve tunnel interface, and then subsequently
+   also encapsulated by the WireGuard tunnel.
 
 Enable WireGuard in Cilium
 ==========================

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -333,7 +333,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 			if (!vtep)
 				goto skip_vtep;
 			if (vtep->tunnel_endpoint) {
-				if (identity_is_world_ipv4(*identity))
+				if (!identity_is_world_ipv4(*identity))
 					return DROP_INVALID_VNI;
 			}
 		}

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -285,6 +285,8 @@ func catCommands() []string {
 	files := []string{
 		"/proc/sys/net/core/bpf_jit_enable",
 		"/proc/kallsyms",
+		"/proc/buddyinfo",
+		"/proc/pagetypeinfo",
 		"/etc/resolv.conf",
 		"/var/log/docker.log",
 		"/var/log/daemon.log",

--- a/examples/kubernetes-kafka/kafka-sw-gen-traffic.sh
+++ b/examples/kubernetes-kafka/kafka-sw-gen-traffic.sh
@@ -1,20 +1,18 @@
 #!/usr/bin/env bash
 
-
 HQ_POD=$(kubectl get pods -l app=empire-hq -o jsonpath='{.items[0].metadata.name}')
 OUTPOST_8888_POD=$(kubectl get pods -l outpostid=8888 -o jsonpath='{.items[0].metadata.name}')
 OUTPOST_9999_POD=$(kubectl get pods -l outpostid=9999 -o jsonpath='{.items[0].metadata.name}')
 BACKUP_POD=$(kubectl get pods -l app=empire-backup -o jsonpath='{.items[0].metadata.name}')
 
-#generate traffic
+# generate traffic
 
 echo "producing messages"
-kubectl exec $HQ_POD sh -- -c "echo “Happy 40th Birthday to General Tagge” | ./kafka-produce.sh --topic empire-announce"
-kubectl exec $HQ_POD sh -- -c "echo “deathstar plans v3” | ./kafka-produce.sh --topic deathstar-plans"
+kubectl exec "$HQ_POD" -- sh -c 'echo "Happy 40th Birthday to General Tagge" | ./kafka-produce.sh --topic empire-announce'
+kubectl exec "$HQ_POD" -- sh -c 'echo "deathstar plans v3" | ./kafka-produce.sh --topic deathstar-plans'
 
 echo "consuming messages"
 
-kubectl exec $OUTPOST_9999_POD sh -- -c "./kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1"
-kubectl exec $OUTPOST_8888_POD sh -- -c "./kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1"
-kubectl exec $BACKUP_POD sh -- -c "./kafka-consume.sh --topic deathstar-plans --from-beginning --max-messages 1"
-
+kubectl exec "$OUTPOST_9999_POD" -- sh -c './kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1'
+kubectl exec "$OUTPOST_8888_POD" -- sh -c './kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1'
+kubectl exec "$BACKUP_POD" -- sh -c './kafka-consume.sh --topic deathstar-plans --from-beginning --max-messages 1'

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -528,7 +528,7 @@ func toPathMatch(match gatewayv1.HTTPRouteMatch) model.StringMatch {
 }
 
 func toGRPCPathMatch(match gatewayv1alpha2.GRPCRouteMatch) model.StringMatch {
-	if match.Method.Service == nil || match.Method == nil {
+	if match.Method == nil || match.Method.Service == nil {
 		return model.StringMatch{}
 	}
 

--- a/pkg/container/bitlpm/cidr.go
+++ b/pkg/container/bitlpm/cidr.go
@@ -24,10 +24,10 @@ func NewCIDRTrie[T any]() *CIDRTrie[T] {
 }
 
 // Lookup returns the longest matched value for a given address.
-func (c *CIDRTrie[T]) Lookup(addr netip.Addr) T {
+func (c *CIDRTrie[T]) Lookup(addr netip.Addr) (T, bool) {
 	if !addr.IsValid() {
 		var def T
-		return def
+		return def, false
 	}
 	bits := addr.BitLen()
 	prefix := netip.PrefixFrom(addr, bits)

--- a/pkg/container/bitlpm/cidr_test.go
+++ b/pkg/container/bitlpm/cidr_test.go
@@ -42,7 +42,7 @@ loop:
 				continue loop
 			}
 		}
-		have := trie.Lookup(prefixes[name].Addr())
+		have, _ := trie.Lookup(prefixes[name].Addr())
 		if have != name {
 			t.Errorf("Lookup(%s) returned %s want %s", prefixes[name].String(), have, name)
 		}
@@ -92,7 +92,9 @@ loop:
 			"0",
 		},
 	} {
-		assert.Equal(t, tc.v, trie.Lookup(netip.MustParsePrefix(tc.k).Addr()))
+		v, ok := trie.Lookup(netip.MustParsePrefix(tc.k).Addr())
+		assert.True(t, ok)
+		assert.Equal(t, tc.v, v)
 	}
 
 }

--- a/pkg/container/bitlpm/trie.go
+++ b/pkg/container/bitlpm/trie.go
@@ -22,9 +22,9 @@ package bitlpm
 // [least significant bit]: https://en.wikipedia.org/wiki/Bit_numbering#Least_significant_bit
 // [longest prefix match algorithm]: https://en.wikipedia.org/wiki/Longest_prefix_match
 type Trie[K, T any] interface {
-	// Lookup returns the longest prefix match to a specific
+	// Lookup returns the longest prefix match for a specific
 	// key.
-	Lookup(key K) T
+	Lookup(key K) (v T, ok bool)
 	// Ancestors iterates over every prefix-key pair that contains
 	// the prefix-key argument pair. If the Ancestors function argument
 	// returns false the iteration will stop. Ancestors will iterate
@@ -103,15 +103,19 @@ type node[K, T any] struct {
 
 // Lookup returns the value for the key with longest prefix match to the given
 // key.
-func (t *trie[K, T]) Lookup(k Key[K]) T {
+func (t *trie[K, T]) Lookup(k Key[K]) (T, bool) {
 	// default return value
-	var empty T
+	var (
+		empty T
+		ok    bool
+	)
 	ret := &empty
 	t.traverse(t.maxPrefix, k, func(currentNode *node[K, T], matchLen uint) bool {
 		ret = &currentNode.value
+		ok = true
 		return true
 	})
-	return *ret
+	return *ret, ok
 }
 
 // Ancestors calls the function argument for every prefix/key/value in the trie

--- a/pkg/container/bitlpm/unsigned.go
+++ b/pkg/container/bitlpm/unsigned.go
@@ -50,7 +50,7 @@ func (tu *trieUint[K, T]) Delete(prefix uint, k K) bool {
 	return tu.t.Delete(prefix, tu.getKey(k))
 }
 
-func (tu *trieUint[K, T]) Lookup(k K) T {
+func (tu *trieUint[K, T]) Lookup(k K) (T, bool) {
 	return tu.t.Lookup(tu.getKey(k))
 }
 

--- a/pkg/container/bitlpm/unsigned_test.go
+++ b/pkg/container/bitlpm/unsigned_test.go
@@ -241,7 +241,7 @@ func TestUnsignedLookup(t *testing.T) {
 				// purpose of the loop condition as some tests
 				// overflow uint16 causing an infinite loop.
 				for p := uint(start); p <= uint(end); p++ {
-					got := ut.Lookup(uint16(p))
+					got, _ := ut.Lookup(uint16(p))
 					if entry != got {
 						t.Fatalf("Looking up key %d, expected entry %q, but got %q", p, entry, got)
 					}
@@ -251,14 +251,14 @@ func TestUnsignedLookup(t *testing.T) {
 			start := firstRange.start
 			end := lastRange.end
 			for p := uint(0); p < uint(start); p++ {
-				got := ut.Lookup(uint16(p))
-				if got != "" {
+				got, ok := ut.Lookup(uint16(p))
+				if ok {
 					t.Fatalf("Looking up key %d, expected no entry, but got %q", p, got)
 				}
 			}
 			for p := uint(end) + 1; p <= uint(65535); p++ {
-				got := ut.Lookup(uint16(p))
-				if got != "" {
+				got, ok := ut.Lookup(uint16(p))
+				if ok {
 					t.Fatalf("Looking up key %d, expected no entry, but got %q", p, got)
 				}
 			}
@@ -633,8 +633,8 @@ func BenchmarkTrieLookup(b *testing.B) {
 	for i := uint32(0); i < 255; i++ {
 		upperOct := i << 8
 		for t := uint32(0); t < 255; t++ {
-			st := tri.Lookup(0xffff_0000 | upperOct | t)
-			if st == nil {
+			_, ok := tri.Lookup(0xffff_0000 | upperOct | t)
+			if !ok {
 				b.Fatal("expected valid lookup, but got nil")
 			}
 		}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/cidr"
@@ -269,7 +270,7 @@ type Manager struct {
 	haveSocketMatch      bool
 	haveBPFSocketAssign  bool
 	ipEarlyDemuxDisabled bool
-	CNIChainingMode      string
+	cniConfigManager     cni.CNIConfigManager
 }
 
 type params struct {
@@ -278,7 +279,8 @@ type params struct {
 	Logger    logrus.FieldLogger
 	Lifecycle cell.Lifecycle
 
-	ModulesMgr *modules.Manager
+	ModulesMgr       *modules.Manager
+	CNIConfigManager cni.CNIConfigManager
 
 	Cfg       Config
 	SharedCfg SharedConfig
@@ -286,11 +288,12 @@ type params struct {
 
 func newIptablesManager(p params) *Manager {
 	iptMgr := &Manager{
-		logger:        p.Logger,
-		modulesMgr:    p.ModulesMgr,
-		cfg:           p.Cfg,
-		sharedCfg:     p.SharedCfg,
-		haveIp6tables: true,
+		logger:           p.Logger,
+		modulesMgr:       p.ModulesMgr,
+		cfg:              p.Cfg,
+		sharedCfg:        p.SharedCfg,
+		haveIp6tables:    true,
+		cniConfigManager: p.CNIConfigManager,
 	}
 
 	p.Lifecycle.Append(iptMgr)
@@ -1074,7 +1077,7 @@ func (m *Manager) getDeliveryInterface(ifName string) string {
 	switch {
 	case m.sharedCfg.EnableEndpointRoutes:
 		// aws-cni creates container interfaces with names like eni621c0fc8425.
-		if m.CNIChainingMode == "aws-cni" {
+		if m.cniConfigManager.GetChainingMode() == "aws-cni" {
 			return "eni+"
 		}
 		return "lxc+"

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -230,6 +230,7 @@ func (l *Loader) reinitializeOverlay(ctx context.Context, tunnelConfig tunnel.Co
 	}
 	if option.Config.EnableNodePort {
 		opts = append(opts, "-DDISABLE_LOOPBACK_LB")
+		opts = append(opts, fmt.Sprintf("-DNATIVE_DEV_IFINDEX=%d", link.Attrs().Index))
 	}
 	if option.Config.IsDualStack() {
 		opts = append(opts, fmt.Sprintf("-DSECLABEL_IPV4=%d", identity.ReservedIdentityWorldIPv4))

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -327,6 +327,11 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			state := &typeStates[index]
 			watcher := s.watchers[typeURL]
 
+			if nonce == 0 && versionInfo > 0 {
+				requestLog.Debugf("xDS was restarted, setting nonce to %d", versionInfo)
+				nonce = versionInfo
+			}
+
 			// Response nonce is always the same as the response version.
 			// Request version indicates the last acked version. If the
 			// response nonce in the request is different (smaller) than

--- a/pkg/hubble/parser/seven/http.go
+++ b/pkg/hubble/parser/seven/http.go
@@ -29,7 +29,7 @@ func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, opts
 			headers = append(headers, &flowpb.HTTPHeader{Key: key, Value: filteredValue})
 		}
 	}
-	uri, _ := url.Parse(http.URL.String())
+	uri := cloneURL(http.URL)
 	filterURL(uri, opts.HubbleRedactSettings)
 
 	if flowType == accesslog.TypeRequest {
@@ -56,7 +56,7 @@ func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, opts
 }
 
 func (p *Parser) httpSummary(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, flow *flowpb.Flow) string {
-	uri, _ := url.Parse(http.URL.String())
+	uri := cloneURL(http.URL)
 	filterURL(uri, p.opts.HubbleRedactSettings)
 	httpRequest := http.Method + " " + uri.String()
 	switch flowType {
@@ -117,4 +117,18 @@ func filterURL(uri *url.URL, redactSettings options.HubbleRedactSettings) {
 			uri.Fragment = ""
 		}
 	}
+}
+
+// cloneURL return a copy of the given URL. Copied from src/net/http/clone.go.
+func cloneURL(u *url.URL) *url.URL {
+	if u == nil {
+		return nil
+	}
+	u2 := new(url.URL)
+	*u2 = *u
+	if u.User != nil {
+		u2.User = new(url.Userinfo)
+		*u2.User = *u.User
+	}
+	return u2
 }

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -785,25 +785,31 @@ var cachedGCInterval time.Duration
 
 // GetInterval returns the interval adjusted based on the deletion ratio of the
 // last run
-func GetInterval(maxDeleteRatio float64) time.Duration {
+func GetInterval(actualPrevInterval time.Duration, maxDeleteRatio float64) time.Duration {
 	if val := option.Config.ConntrackGCInterval; val != time.Duration(0) {
 		return val
 	}
 
-	prevInterval := cachedGCInterval
-	if prevInterval == time.Duration(0) {
-		prevInterval = defaults.ConntrackGCStartingInterval
+	expectedPrevInterval := cachedGCInterval
+	adjustedDeleteRatio := maxDeleteRatio
+	if expectedPrevInterval == time.Duration(0) {
+		expectedPrevInterval = defaults.ConntrackGCStartingInterval
+	} else if actualPrevInterval < expectedPrevInterval && actualPrevInterval > 0 {
+		adjustedDeleteRatio *= float64(expectedPrevInterval) / float64(actualPrevInterval)
 	}
 
-	newInterval := calculateInterval(prevInterval, maxDeleteRatio)
+	newInterval := calculateInterval(expectedPrevInterval, adjustedDeleteRatio)
 	if val := option.Config.ConntrackGCMaxInterval; val != time.Duration(0) && newInterval > val {
 		newInterval = val
 	}
 
-	if newInterval != prevInterval {
+	if newInterval != expectedPrevInterval {
 		log.WithFields(logrus.Fields{
-			"newInterval": newInterval,
-			"deleteRatio": maxDeleteRatio,
+			"expectedPrevInterval": expectedPrevInterval,
+			"actualPrevInterval":   actualPrevInterval,
+			"newInterval":          newInterval,
+			"deleteRatio":          maxDeleteRatio,
+			"adjustedDeleteRatio":  adjustedDeleteRatio,
 		}).Info("Conntrack garbage collector interval recalculated")
 	}
 

--- a/pkg/maps/ctmap/ctmap_test.go
+++ b/pkg/maps/ctmap/ctmap_test.go
@@ -46,21 +46,21 @@ func (t *CTMapTestSuite) TestCalculateInterval(c *C) {
 
 func (t *CTMapTestSuite) TestGetInterval(c *C) {
 	cachedGCInterval = time.Minute
-	c.Assert(GetInterval(0.1), Equals, time.Minute)
+	c.Assert(GetInterval(cachedGCInterval, 0.1), Equals, time.Minute)
 
 	// Setting ConntrackGCInterval overrides the calculation
 	oldInterval := option.Config.ConntrackGCInterval
 	option.Config.ConntrackGCInterval = 10 * time.Second
-	c.Assert(GetInterval(0.1), Equals, 10*time.Second)
+	c.Assert(GetInterval(cachedGCInterval, 0.1), Equals, 10*time.Second)
 	option.Config.ConntrackGCInterval = oldInterval
-	c.Assert(GetInterval(0.1), Equals, time.Minute)
+	c.Assert(GetInterval(cachedGCInterval, 0.1), Equals, time.Minute)
 
 	// Setting ConntrackGCMaxInterval limits the maximum interval
 	oldMaxInterval := option.Config.ConntrackGCMaxInterval
 	option.Config.ConntrackGCMaxInterval = 20 * time.Second
-	c.Assert(GetInterval(0.1), Equals, 20*time.Second)
+	c.Assert(GetInterval(cachedGCInterval, 0.1), Equals, 20*time.Second)
 	option.Config.ConntrackGCMaxInterval = oldMaxInterval
-	c.Assert(GetInterval(0.1), Equals, time.Minute)
+	c.Assert(GetInterval(cachedGCInterval, 0.1), Equals, time.Minute)
 
 	cachedGCInterval = time.Duration(0)
 }

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -343,7 +343,7 @@ var badLogMessages = map[string][]string{
 		failedPeerSync, policyMapSyncFix, unableRestoreRouterIP, routerIPReallocated,
 		cantFindIdentityInCache, kubeApiserverConnLost1, kubeApiserverConnLost2, heartbeatTimedOut,
 		keyAllocFailedFoundMaster, cantRecreateMasterKey, cantUpdateCRDIdentity,
-		cantDeleteFromPolicyMap},
+		cantDeleteFromPolicyMap, failedToListCRDs},
 }
 
 var ciliumCLICommands = map[string]string{


### PR DESCRIPTION
 * [x] #30778 (@learnitall)
 * [x] #31039 (@joestringer)
 * [x] #31052 (@sayboras)
 * [x] #30766 (@pippolo84)
 * [x] #31061 (@sayboras)
 * [ ] #31026 (@jrajahalme)
 * [x] #31025 (@julianwiedmann)
 * [x] #31083 (@julianwiedmann)
 * [x] #28657 (@gentoo-root)
 * [ ] #30462 (@saintdle)
 * [x] #31037 (@nathanjsweet)
 * [x] #31100 (@kaworu)
 * [x] #30966 (@pchaigno)
   :warning: minor conflict due to `deprecatedEnvoyRuntimeKey` and `noConnLimitEnvoy` log messages not listed in v1.15

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 30778 31039 31052 30766 31061 31026 31025 31083 28657 30462 31037 31100 30966
```
