### PR TITLE
[v1.15] re-introduce ICMPv6 NS responder on from-netdev

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -148,23 +148,26 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 #endif /* ENABLE_HOST_FIREWALL */
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
-	int ret, hdrlen;
-	__u8 nexthdr;
+	int ret;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	nexthdr = ip6->nexthdr;
-	hdrlen = ipv6_hdrlen(ctx, &nexthdr);
-	if (hdrlen < 0)
-		return hdrlen;
+	if (is_defined(ENABLE_HOST_FIREWALL) || !from_host) {
+		__u8 nexthdr = ip6->nexthdr;
+		int hdrlen;
 
-	if (likely(nexthdr == IPPROTO_ICMPV6)) {
-		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen, !from_host);
-		if (ret == SKIP_HOST_FIREWALL)
-			goto skip_host_firewall;
-		if (IS_ERR(ret))
-			return ret;
+		hdrlen = ipv6_hdrlen(ctx, &nexthdr);
+		if (hdrlen < 0)
+			return hdrlen;
+
+		if (likely(nexthdr == IPPROTO_ICMPV6)) {
+			ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen, !from_host);
+			if (ret == SKIP_HOST_FIREWALL)
+				goto skip_host_firewall;
+			if (IS_ERR(ret))
+				return ret;
+		}
 	}
 
 #ifdef ENABLE_NODEPORT

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -144,31 +144,28 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 #ifdef ENABLE_HOST_FIREWALL
 	struct ct_buffer6 ct_buffer = {};
 	bool need_hostfw = false;
-	__u8 nexthdr;
-	int hdrlen;
 	bool is_host_id = false;
 #endif /* ENABLE_HOST_FIREWALL */
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
-	int __maybe_unused ret;
+	int ret, hdrlen;
+	__u8 nexthdr;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-#ifdef ENABLE_HOST_FIREWALL
 	nexthdr = ip6->nexthdr;
 	hdrlen = ipv6_hdrlen(ctx, &nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 
 	if (likely(nexthdr == IPPROTO_ICMPV6)) {
-		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen);
+		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen, !from_host);
 		if (ret == SKIP_HOST_FIREWALL)
 			goto skip_host_firewall;
 		if (IS_ERR(ret))
 			return ret;
 	}
-#endif /* ENABLE_HOST_FIREWALL */
 
 #ifdef ENABLE_NODEPORT
 	if (!from_host) {
@@ -213,8 +210,10 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 		if (map_update_elem(&CT_TAIL_CALL_BUFFER6, &zero, &ct_buffer, 0) < 0)
 			return DROP_INVALID_TC_BUFFER;
 	}
+#endif /* ENABLE_HOST_FIREWALL */
 
 skip_host_firewall:
+#ifdef ENABLE_HOST_FIREWALL
 	ctx_store_meta(ctx, CB_FROM_HOST,
 		       (need_hostfw ? FROM_HOST_FLAG_NEED_HOSTFW : 0) |
 		       (is_host_id ? FROM_HOST_FLAG_HOST_ID : 0));
@@ -490,7 +489,7 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext
 		return hdrlen;
 
 	if (likely(nexthdr == IPPROTO_ICMPV6)) {
-		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen);
+		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen, false);
 		if (ret == SKIP_HOST_FIREWALL)
 			return CTX_ACT_OK;
 		if (IS_ERR(ret))

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -302,6 +302,7 @@ static __always_inline int __icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off)
 {
 	union v6addr target, router;
 	struct endpoint_info *ep;
+	union macaddr router_mac = NODE_MAC;
 
 	if (ctx_load_bytes(ctx, nh_off + ICMP6_ND_TARGET_OFFSET, target.addr,
 			   sizeof(((struct ipv6hdr *)NULL)->saddr)) < 0)
@@ -312,15 +313,27 @@ static __always_inline int __icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off)
 	BPF_V6(router, ROUTER_IP);
 
 	if (ipv6_addr_equals(&target, &router)) {
-		union macaddr router_mac = NODE_MAC;
 
 		return send_icmp6_ndisc_adv(ctx, nh_off, &router_mac, true);
 	}
 
 	ep = __lookup_ip6_endpoint(&target);
 	if (ep) {
-		union macaddr router_mac = NODE_MAC;
-
+		if (ep->flags & ENDPOINT_F_HOST) {
+			/* Target must be a node_ip, because of ENDPOINT_F_HOST flag
+			 * and target != router_ip.
+			 *
+			 * We pass these packets to stack to make sure:
+			 *
+			 * 1. The response NA has node IP as source address instead of
+			 * router IP, to address https://github.com/cilium/cilium/issues/14509.
+			 *
+			 * 2. Kernel stack can record a neighbor entry for the
+			 * source IP, to avoid bpf_fib_lookup failure as mentioned at
+			 * https://github.com/cilium/cilium/pull/30837#issuecomment-1960897445.
+			 */
+			return CTX_ACT_OK;
+		}
 		return send_icmp6_ndisc_adv(ctx, nh_off, &router_mac, false);
 	}
 
@@ -395,13 +408,17 @@ static __always_inline int icmp6_ndp_handle(struct __ctx_buff *ctx, int nh_off,
 }
 
 static __always_inline int
-icmp6_host_handle(struct __ctx_buff *ctx, int l4_off)
+icmp6_host_handle(struct __ctx_buff *ctx, int l4_off, bool handle_ns)
 {
 	__u8 type;
 
 	if (icmp6_load_type(ctx, l4_off, &type) < 0)
 		return DROP_INVALID;
 
+	if (type == ICMP6_NS_MSG_TYPE && handle_ns)
+		return icmp6_handle_ns(ctx, ETH_HLEN, METRIC_INGRESS);
+
+#ifdef ENABLE_HOST_FIREWALL
 	/* When the host firewall is enabled, we drop and allow ICMPv6 messages
 	 * according to RFC4890, except for echo request and reply messages which
 	 * are handled by host policies and can be dropped.
@@ -421,7 +438,7 @@ icmp6_host_handle(struct __ctx_buff *ctx, int l4_off)
 	 * |      ICMPv6-mult-list-done      |   CTX_ACT_OK    |  132 |
 	 * |      ICMPv6-router-solici       |   CTX_ACT_OK    |  133 |
 	 * |      ICMPv6-router-advert       |   CTX_ACT_OK    |  134 |
-	 * |     ICMPv6-neighbor-solicit     |   CTX_ACT_OK    |  135 |
+	 * |     ICMPv6-neighbor-solicit     | icmp6_handle_ns |  135 |
 	 * |      ICMPv6-neighbor-advert     |   CTX_ACT_OK    |  136 |
 	 * |     ICMPv6-redirect-message     |  CTX_ACT_DROP   |  137 |
 	 * |      ICMPv6-router-renumber     |   CTX_ACT_OK    |  138 |
@@ -463,6 +480,9 @@ icmp6_host_handle(struct __ctx_buff *ctx, int l4_off)
 		(ICMP6_MULT_RA_MSG_TYPE <= type && type <= ICMP6_MULT_RT_MSG_TYPE))
 		return SKIP_HOST_FIREWALL;
 	return DROP_FORBIDDEN_ICMP6;
+#else
+	return CTX_ACT_OK;
+#endif /* ENABLE_HOST_FIREWALL */
 }
 
 #endif

--- a/bpf/tests/ipv6_ndp_from_netdev_test.c
+++ b/bpf/tests/ipv6_ndp_from_netdev_test.c
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+#define ROUTER_IP
+#define HOST_IP
+#include "config_replacement.h"
+#undef ROUTER_IP
+#undef HOST_IP
+
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define SECCTX_FROM_IPCACHE 1
+
+#include "bpf_host.c"
+
+#include "lib/ipcache.h"
+#include "lib/endpoint.h"
+
+#define FROM_NETDEV 0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_from_netdev,
+	},
+};
+
+PKTGEN("tc", "01_ipv6_from_netdev_ns_for_pod")
+int ipv6_from_netdev_ns_for_pod_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmp6hdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_icmp6_packet(&builder,
+					    (__u8 *)mac_one, (__u8 *)mac_two,
+					    (__u8 *)v6_pod_one, (__u8 *)v6_pod_two,
+					    ICMP6_NS_MSG_TYPE);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, (__u8 *)v6_pod_three, 16);
+	if (!data)
+		return TEST_ERROR;
+
+	__u8 options[] = {0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1};
+
+	data = pktgen__push_data(&builder, (__u8 *)options, 8);
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "01_ipv6_from_netdev_ns_for_pod")
+int ipv6_from_netdev_ns_for_pod_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v6_add_entry((union v6addr *)v6_pod_three, 0, 0, 0,
+			      (__u8 *)mac_three, (__u8 *)mac_two);
+	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "01_ipv6_from_netdev_ns_for_pod")
+int ipv6_from_netdev_ns_for_pod_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct icmp6hdr *l4;
+	void *payload;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	printk("status_code: %d\n", *status_code);
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(*status_code);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IPV6))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	union macaddr node_mac = NODE_MAC;
+
+	if (memcmp(l2->h_source, (__u8 *)&node_mac.addr, ETH_ALEN) != 0)
+		test_fatal("src mac hasn't been set to node mac");
+
+	if (memcmp(l2->h_dest, (__u8 *)mac_one, ETH_ALEN) != 0)
+		test_fatal("dest mac hasn't been set to source mac");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	union v6addr router_ip;
+
+	BPF_V6(router_ip, ROUTER_IP);
+	if (memcmp((__u8 *)&l3->saddr, (__u8 *)&router_ip, 16) != 0)
+		test_fatal("src IP hasn't been set to router IP");
+
+	if (memcmp((__u8 *)&l3->daddr, (__u8 *)v6_pod_one, 16) != 0)
+		test_fatal("dest IP hasn't been set to source IP");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+
+	if ((void *)l4 + sizeof(struct icmp6hdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->icmp6_type != ICMP6_NA_MSG_TYPE)
+		test_fatal("icmp6 type hasn't been set to ICMP6_NA_MSG_TYPE");
+
+	payload = (void *)l4 + sizeof(struct icmp6hdr);
+	if ((void *)payload + 24 > data_end)
+		test_fatal("payload out of bounds");
+
+	void *target = payload;
+
+	if (memcmp(target, (__u8 *)v6_pod_three, 16) != 0)
+		test_fatal("icmp6 payload target hasn't been set properly");
+
+	void *target_lladdr = payload + 16 + 2;
+
+	if (memcmp(target_lladdr, (__u8 *)&node_mac.addr, ETH_ALEN) != 0)
+		test_fatal("icmp6 payload target_lladdr hasn't been set properly");
+
+	test_finish();
+}
+
+PKTGEN("tc", "02_ipv6_from_netdev_ns_for_node_ip")
+int ipv6_from_netdev_ns_for_node_ip_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmp6hdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_icmp6_packet(&builder,
+					    (__u8 *)mac_one, (__u8 *)mac_two,
+					    (__u8 *)v6_pod_one, (__u8 *)v6_pod_two,
+					    ICMP6_NS_MSG_TYPE);
+	if (!l4)
+		return TEST_ERROR;
+
+	union v6addr node_ip;
+
+	BPF_V6(node_ip, HOST_IP);
+	data = pktgen__push_data(&builder, (__u8 *)&node_ip, 16);
+	if (!data)
+		return TEST_ERROR;
+
+	__u8 options[] = {0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1};
+
+	data = pktgen__push_data(&builder, (__u8 *)options, 8);
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "02_ipv6_from_netdev_ns_for_node_ip")
+int ipv6_from_netdev_ns_for_node_ip_setup(struct __ctx_buff *ctx)
+{
+	union v6addr node_ip;
+
+	BPF_V6(node_ip, HOST_IP);
+	endpoint_v6_add_entry((union v6addr *)&node_ip, 0, 0, ENDPOINT_F_HOST,
+			      (__u8 *)mac_three, (__u8 *)mac_two);
+	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "02_ipv6_from_netdev_ns_for_node_ip")
+int ipv6_from_netdev_ns_for_node_ip_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct icmp6hdr *l4;
+	void *payload;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	printk("status_code: %d\n", *status_code);
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(*status_code);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IPV6))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	if (memcmp(l2->h_source, (__u8 *)mac_one, ETH_ALEN) != 0)
+		test_fatal("src mac hasn't been set to source ep's mac");
+
+	if (memcmp(l2->h_dest, (__u8 *)mac_two, ETH_ALEN) != 0)
+		test_fatal("dest mac hasn't been set to dest ep's mac");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (memcmp((__u8 *)&l3->saddr, (__u8 *)v6_pod_one, 16) != 0)
+		test_fatal("src IP was changed");
+
+	if (memcmp((__u8 *)&l3->daddr, (__u8 *)v6_pod_two, 16) != 0)
+		test_fatal("dest IP was changed");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+
+	if ((void *)l4 + sizeof(struct icmp6hdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->icmp6_type != ICMP6_NS_MSG_TYPE)
+		test_fatal("icmp6 type was changed");
+
+	payload = (void *)l4 + sizeof(struct icmp6hdr);
+	if ((void *)payload + 24 > data_end)
+		test_fatal("payload out of bounds");
+
+	union v6addr node_ip;
+
+	BPF_V6(node_ip, HOST_IP);
+	if (memcmp(payload, (__u8 *)&node_ip, 16) != 0)
+		test_fatal("icmp6 payload target was changed");
+
+	test_finish();
+}

--- a/bpf/tests/tc_nodeport_l3_dev.c
+++ b/bpf/tests/tc_nodeport_l3_dev.c
@@ -12,7 +12,6 @@
 #define ENABLE_HOST_ROUTING
 #define ENABLE_IPV4
 #define ENABLE_IPV6
-#define SKIP_ICMPV6_NS_HANDLING
 
 #define TEST_IP_LOCAL		v4_pod_one
 #define TEST_IP_REMOTE		v4_pod_two


### PR DESCRIPTION
- [x] https://github.com/cilium/cilium/pull/30837  @jschwinger233 
- [x] https://github.com/cilium/cilium/pull/31127 @julianwiedmann 

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
30837 31127
```
