### PR TITLE
v1.14 Backports 2024-03-05

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -284,6 +284,8 @@ func catCommands() []string {
 	files := []string{
 		"/proc/sys/net/core/bpf_jit_enable",
 		"/proc/kallsyms",
+		"/proc/buddyinfo",
+		"/proc/pagetypeinfo",
 		"/etc/resolv.conf",
 		"/var/log/docker.log",
 		"/var/log/daemon.log",

--- a/examples/kubernetes-kafka/kafka-sw-gen-traffic.sh
+++ b/examples/kubernetes-kafka/kafka-sw-gen-traffic.sh
@@ -1,20 +1,18 @@
 #!/usr/bin/env bash
 
-
 HQ_POD=$(kubectl get pods -l app=empire-hq -o jsonpath='{.items[0].metadata.name}')
 OUTPOST_8888_POD=$(kubectl get pods -l outpostid=8888 -o jsonpath='{.items[0].metadata.name}')
 OUTPOST_9999_POD=$(kubectl get pods -l outpostid=9999 -o jsonpath='{.items[0].metadata.name}')
 BACKUP_POD=$(kubectl get pods -l app=empire-backup -o jsonpath='{.items[0].metadata.name}')
 
-#generate traffic
+# generate traffic
 
 echo "producing messages"
-kubectl exec $HQ_POD sh -- -c "echo “Happy 40th Birthday to General Tagge” | ./kafka-produce.sh --topic empire-announce"
-kubectl exec $HQ_POD sh -- -c "echo “deathstar plans v3” | ./kafka-produce.sh --topic deathstar-plans"
+kubectl exec "$HQ_POD" -- sh -c 'echo "Happy 40th Birthday to General Tagge" | ./kafka-produce.sh --topic empire-announce'
+kubectl exec "$HQ_POD" -- sh -c 'echo "deathstar plans v3" | ./kafka-produce.sh --topic deathstar-plans'
 
 echo "consuming messages"
 
-kubectl exec $OUTPOST_9999_POD sh -- -c "./kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1"
-kubectl exec $OUTPOST_8888_POD sh -- -c "./kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1"
-kubectl exec $BACKUP_POD sh -- -c "./kafka-consume.sh --topic deathstar-plans --from-beginning --max-messages 1"
-
+kubectl exec "$OUTPOST_9999_POD" -- sh -c './kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1'
+kubectl exec "$OUTPOST_8888_POD" -- sh -c './kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1'
+kubectl exec "$BACKUP_POD" -- sh -c './kafka-consume.sh --topic deathstar-plans --from-beginning --max-messages 1'

--- a/pkg/container/bitlpm/cidr.go
+++ b/pkg/container/bitlpm/cidr.go
@@ -24,10 +24,10 @@ func NewCIDRTrie[T any]() *CIDRTrie[T] {
 }
 
 // Lookup returns the longest matched value for a given address.
-func (c *CIDRTrie[T]) Lookup(addr netip.Addr) T {
+func (c *CIDRTrie[T]) Lookup(addr netip.Addr) (T, bool) {
 	if !addr.IsValid() {
 		var def T
-		return def
+		return def, false
 	}
 	bits := addr.BitLen()
 	prefix := netip.PrefixFrom(addr, bits)

--- a/pkg/container/bitlpm/cidr_test.go
+++ b/pkg/container/bitlpm/cidr_test.go
@@ -42,7 +42,7 @@ loop:
 				continue loop
 			}
 		}
-		have := trie.Lookup(prefixes[name].Addr())
+		have, _ := trie.Lookup(prefixes[name].Addr())
 		if have != name {
 			t.Errorf("Lookup(%s) returned %s want %s", prefixes[name].String(), have, name)
 		}
@@ -92,7 +92,9 @@ loop:
 			"0",
 		},
 	} {
-		assert.Equal(t, tc.v, trie.Lookup(netip.MustParsePrefix(tc.k).Addr()))
+		v, ok := trie.Lookup(netip.MustParsePrefix(tc.k).Addr())
+		assert.True(t, ok)
+		assert.Equal(t, tc.v, v)
 	}
 
 }

--- a/pkg/container/bitlpm/trie.go
+++ b/pkg/container/bitlpm/trie.go
@@ -22,9 +22,9 @@ package bitlpm
 // [least significant bit]: https://en.wikipedia.org/wiki/Bit_numbering#Least_significant_bit
 // [longest prefix match algorithm]: https://en.wikipedia.org/wiki/Longest_prefix_match
 type Trie[K, T any] interface {
-	// Lookup returns the longest prefix match to a specific
+	// Lookup returns the longest prefix match for a specific
 	// key.
-	Lookup(key K) T
+	Lookup(key K) (v T, ok bool)
 	// Ancestors iterates over every prefix-key pair that contains
 	// the prefix-key argument pair. If the Ancestors function argument
 	// returns false the iteration will stop. Ancestors will iterate
@@ -103,15 +103,19 @@ type node[K, T any] struct {
 
 // Lookup returns the value for the key with longest prefix match to the given
 // key.
-func (t *trie[K, T]) Lookup(k Key[K]) T {
+func (t *trie[K, T]) Lookup(k Key[K]) (T, bool) {
 	// default return value
-	var empty T
+	var (
+		empty T
+		ok    bool
+	)
 	ret := &empty
 	t.traverse(t.maxPrefix, k, func(currentNode *node[K, T], matchLen uint) bool {
 		ret = &currentNode.value
+		ok = true
 		return true
 	})
-	return *ret
+	return *ret, ok
 }
 
 // Ancestors calls the function argument for every prefix/key/value in the trie

--- a/pkg/container/bitlpm/unsigned.go
+++ b/pkg/container/bitlpm/unsigned.go
@@ -50,7 +50,7 @@ func (tu *trieUint[K, T]) Delete(prefix uint, k K) bool {
 	return tu.t.Delete(prefix, tu.getKey(k))
 }
 
-func (tu *trieUint[K, T]) Lookup(k K) T {
+func (tu *trieUint[K, T]) Lookup(k K) (T, bool) {
 	return tu.t.Lookup(tu.getKey(k))
 }
 

--- a/pkg/container/bitlpm/unsigned_test.go
+++ b/pkg/container/bitlpm/unsigned_test.go
@@ -241,7 +241,7 @@ func TestUnsignedLookup(t *testing.T) {
 				// purpose of the loop condition as some tests
 				// overflow uint16 causing an infinite loop.
 				for p := uint(start); p <= uint(end); p++ {
-					got := ut.Lookup(uint16(p))
+					got, _ := ut.Lookup(uint16(p))
 					if entry != got {
 						t.Fatalf("Looking up key %d, expected entry %q, but got %q", p, entry, got)
 					}
@@ -251,14 +251,14 @@ func TestUnsignedLookup(t *testing.T) {
 			start := firstRange.start
 			end := lastRange.end
 			for p := uint(0); p < uint(start); p++ {
-				got := ut.Lookup(uint16(p))
-				if got != "" {
+				got, ok := ut.Lookup(uint16(p))
+				if ok {
 					t.Fatalf("Looking up key %d, expected no entry, but got %q", p, got)
 				}
 			}
 			for p := uint(end) + 1; p <= uint(65535); p++ {
-				got := ut.Lookup(uint16(p))
-				if got != "" {
+				got, ok := ut.Lookup(uint16(p))
+				if ok {
 					t.Fatalf("Looking up key %d, expected no entry, but got %q", p, got)
 				}
 			}
@@ -633,8 +633,8 @@ func BenchmarkTrieLookup(b *testing.B) {
 	for i := uint32(0); i < 255; i++ {
 		upperOct := i << 8
 		for t := uint32(0); t < 255; t++ {
-			st := tri.Lookup(0xffff_0000 | upperOct | t)
-			if st == nil {
+			_, ok := tri.Lookup(0xffff_0000 | upperOct | t)
+			if !ok {
 				b.Fatal("expected valid lookup, but got nil")
 			}
 		}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -236,6 +236,7 @@ func (l *Loader) reinitializeOverlay(ctx context.Context, encapProto string) err
 	}
 	if option.Config.EnableNodePort {
 		opts = append(opts, "-DDISABLE_LOOPBACK_LB")
+		opts = append(opts, fmt.Sprintf("-DNATIVE_DEV_IFINDEX=%d", link.Attrs().Index))
 	}
 
 	if err := l.replaceOverlayDatapath(ctx, opts, iface); err != nil {

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -329,6 +329,11 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			state := &typeStates[index]
 			watcher := s.watchers[typeURL]
 
+			if nonce == 0 && versionInfo > 0 {
+				requestLog.Debugf("xDS was restarted, setting nonce to %d", versionInfo)
+				nonce = versionInfo
+			}
+
 			// Response nonce is always the same as the response version.
 			// Request version indicates the last acked version. If the
 			// response nonce in the request is different (smaller) than


### PR DESCRIPTION
 * [x] #31061 (@sayboras)
 * [x] #31026 (@jrajahalme)
 * [x] #31025 (@julianwiedmann)
 * [x] #30462 (@saintdle)
 * [x] #31037 (@nathanjsweet)
 * [x] #30966 (@pchaigno)

Skipped:

 * [ ] #30766 (@pippolo84)
   - iptables manager has not been modularized in v1.14, the CNI config manager cannot be injected through hive

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 31061 31026 31025 30462 31037 30966
```
