### PR TITLE
cilium-dbg: New `encrypt flush --stale` flag

### DIFF
--- a/Documentation/cmdref/cilium-dbg_encrypt_flush.md
+++ b/Documentation/cmdref/cilium-dbg_encrypt_flush.md
@@ -20,6 +20,7 @@ cilium-dbg encrypt flush [flags]
       --node-id string   Only delete states and policies with this node ID. Decimal or hexadecimal (0x) format. If multiple filters are used, they all apply
   -o, --output string    json| yaml| jsonpath='{}'
       --spi uint8        Only delete states and policies with this SPI. If multiple filters are used, they all apply
+      --stale            Delete stale states and policies based on the current node ID map content
 ```
 
 ### Options inherited from parent commands

--- a/cilium-dbg/cmd/encrypt_flush.go
+++ b/cilium-dbg/cmd/encrypt_flush.go
@@ -75,12 +75,13 @@ func runXFRMFlush() {
 		policies, states = filterXFRMByNodeID(policies, states)
 	}
 
+	confirmationMsg := ""
 	if len(policies) == nbPolicies || len(states) == nbStates {
-		confirmationMsg := "Running this command will delete all XFRM state and/or policies. " +
+		confirmationMsg = "Running this command will delete all XFRM states and/or policies. " +
 			"It will lead to transient connectivity disruption and plain-text pod-to-pod traffic."
-		if !confirmXFRMCleanup(confirmationMsg) {
-			return
-		}
+	}
+	if confirmationMsg != "" && !confirmXFRMCleanup(confirmationMsg) {
+		return
 	}
 
 	nbDeleted := len(states)

--- a/cilium-dbg/cmd/encrypt_flush.go
+++ b/cilium-dbg/cmd/encrypt_flush.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -82,18 +83,22 @@ func runXFRMFlush() {
 		}
 	}
 
+	nbDeleted := len(states)
 	for _, state := range states {
 		if err := netlink.XfrmStateDel(&state); err != nil {
-			Fatalf("Stopped XFRM states deletion due to error: %s", err)
+			fmt.Fprintf(os.Stderr, "Failed to delete XFRM state: %s", err)
+			nbDeleted--
 		}
 	}
-	fmt.Printf("Deleted %d XFRM states.\n", len(states))
+	fmt.Printf("Deleted %d XFRM states.\n", nbDeleted)
+	nbDeleted = len(policies)
 	for _, pol := range policies {
 		if err := netlink.XfrmPolicyDel(&pol); err != nil {
-			Fatalf("Stopped XFRM policies deletion due to error: %s", err)
+			fmt.Fprintf(os.Stderr, "Failed to delete XFRM policy: %s", err)
+			nbDeleted--
 		}
 	}
-	fmt.Printf("Deleted %d XFRM policies.\n", len(policies))
+	fmt.Printf("Deleted %d XFRM policies.\n", nbDeleted)
 }
 
 func parseNodeID(nodeID string) (uint16, error) {

--- a/cilium-dbg/cmd/encrypt_flush.go
+++ b/cilium-dbg/cmd/encrypt_flush.go
@@ -16,11 +16,13 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/common/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/maps/nodemap"
 )
 
 const (
 	spiFlagName    = "spi"
 	nodeIDFlagName = "node-id"
+	staleFlagName  = "stale"
 )
 
 var encryptFlushCmd = &cobra.Command{
@@ -37,12 +39,17 @@ var (
 	spiToFilter    uint8
 	nodeIDToFilter uint16
 	nodeIDParam    string
+	cleanStale     bool
 )
 
 func runXFRMFlush() {
-	if spiToFilter == 0 && nodeIDParam == "" {
+	if spiToFilter == 0 && nodeIDParam == "" && !cleanStale {
 		flushEverything()
 		return
+	}
+
+	if cleanStale && (spiToFilter != 0 || nodeIDParam != "") {
+		Fatalf("--%s cannot be combined with other flags except for --%s", staleFlagName, forceFlagName)
 	}
 
 	if spiToFilter > linux_defaults.IPsecMaxKeyVersion {
@@ -74,11 +81,21 @@ func runXFRMFlush() {
 	if nodeIDToFilter != 0 {
 		policies, states = filterXFRMByNodeID(policies, states)
 	}
+	if cleanStale {
+		policies, states = filterStaleXFRMs(policies, states)
+	}
 
 	confirmationMsg := ""
 	if len(policies) == nbPolicies || len(states) == nbStates {
 		confirmationMsg = "Running this command will delete all XFRM states and/or policies. " +
 			"It will lead to transient connectivity disruption and plain-text pod-to-pod traffic."
+	} else if cleanStale {
+		if len(policies) == 0 && len(states) == 0 {
+			fmt.Printf("No stale XFRM states or policies found.")
+			return
+		}
+		confirmationMsg = fmt.Sprintf("This command will delete %d XFRM policies and %d XFRM states.",
+			len(policies), len(states))
 	}
 	if confirmationMsg != "" && !confirmXFRMCleanup(confirmationMsg) {
 		return
@@ -168,6 +185,44 @@ func filterXFRMs(policies []netlink.XfrmPolicy, states []netlink.XfrmState,
 	return policiesToDel, statesToDel
 }
 
+func filterStaleXFRMs(policies []netlink.XfrmPolicy, states []netlink.XfrmState) ([]netlink.XfrmPolicy, []netlink.XfrmState) {
+	bpfNodeIDs := map[uint16]bool{}
+	parse := func(key *nodemap.NodeKey, val *nodemap.NodeValue) {
+		bpfNodeIDs[val.NodeID] = true
+	}
+	nodeMap, err := nodemap.LoadNodeMap()
+	if err != nil {
+		Fatalf("Cannot load node bpf map: %s", err)
+	}
+	if err := nodeMap.IterateWithCallback(parse); err != nil {
+		Fatalf("Error dumping contents of the node ID map: %s\n", err)
+	}
+
+	policiesToDel := []netlink.XfrmPolicy{}
+	for _, pol := range policies {
+		nodeID := ipsec.GetNodeIDFromXfrmMark(pol.Mark)
+		if nodeID == 0 {
+			continue
+		}
+		if _, found := bpfNodeIDs[nodeID]; !found {
+			policiesToDel = append(policiesToDel, pol)
+		}
+	}
+
+	statesToDel := []netlink.XfrmState{}
+	for _, state := range states {
+		nodeID := ipsec.GetNodeIDFromXfrmMark(state.Mark)
+		if nodeID == 0 {
+			continue
+		}
+		if _, found := bpfNodeIDs[nodeID]; !found {
+			statesToDel = append(statesToDel, state)
+		}
+	}
+
+	return policiesToDel, statesToDel
+}
+
 func flushEverything() {
 	confirmationMsg := "Flushing all XFRM states and policies can lead to transient " +
 		"connectivity interruption and plain-text pod-to-pod traffic."
@@ -193,6 +248,7 @@ func init() {
 	encryptFlushCmd.Flags().BoolVarP(&force, forceFlagName, "f", false, "Skip confirmation")
 	encryptFlushCmd.Flags().Uint8Var(&spiToFilter, spiFlagName, 0, "Only delete states and policies with this SPI. If multiple filters are used, they all apply")
 	encryptFlushCmd.Flags().StringVar(&nodeIDParam, nodeIDFlagName, "", "Only delete states and policies with this node ID. Decimal or hexadecimal (0x) format. If multiple filters are used, they all apply")
+	encryptFlushCmd.Flags().BoolVar(&cleanStale, staleFlagName, false, "Delete stale states and policies based on the current node ID map content")
 	CncryptCmd.AddCommand(encryptFlushCmd)
 	command.AddOutputOption(encryptFlushCmd)
 }


### PR DESCRIPTION
First commit changes how we handle errors. Second commit refactors the confirmation logic. Last commit introduces the new flag.

```release-note
Introduce `cilium-dbg encrypt flush --stale` flag to remove XFRM states and policies with stale node IDs.
```