### PR TITLE
statedb: Fix read-after-write bug

### DIFF
--- a/pkg/statedb/api_handler.go
+++ b/pkg/statedb/api_handler.go
@@ -68,8 +68,8 @@ func (h *queryHandler) Handle(params restapi.GetStatedbQueryTableParams) middlew
 	})
 }
 
-func runQuery(indexTxn indexReadTxn, lowerbound bool, queryKey []byte, onObject func(object) error) {
-	iter := indexTxn.txn.Root().Iterator()
+func runQuery(indexTxn indexTxn, lowerbound bool, queryKey []byte, onObject func(object) error) {
+	iter := indexTxn.Root().Iterator()
 	if lowerbound {
 		iter.SeekLowerBound(queryKey)
 	} else {

--- a/pkg/statedb/db.go
+++ b/pkg/statedb/db.go
@@ -217,7 +217,7 @@ func (db *DB) WriteTxn(table TableMeta, tables ...TableMeta) WriteTxn {
 		db:             db,
 		rootReadTxn:    rootReadTxn,
 		modifiedTables: tableEntries,
-		writeTxns:      make(map[tableIndex]indexWriteTxn),
+		writeTxns:      make(map[tableIndex]indexTxn),
 		smus:           smus,
 		acquiredAt:     acquiredAt,
 		tableNames:     strings.Join(tableNames, "+"),

--- a/pkg/statedb/db_test.go
+++ b/pkg/statedb/db_test.go
@@ -716,7 +716,7 @@ func TestDB_ReadAfterWrite(t *testing.T) {
 
 	txn.Commit()
 
-	iter, _ = table.All(txn)
+	iter, _ = table.All(db.ReadTxn())
 	require.Len(t, Collect(iter), 1)
 }
 

--- a/pkg/statedb/db_test.go
+++ b/pkg/statedb/db_test.go
@@ -691,6 +691,35 @@ func TestDB_CompareAndSwap_CompareAndDelete(t *testing.T) {
 	wtxn.Abort()
 }
 
+func TestDB_ReadAfterWrite(t *testing.T) {
+	t.Parallel()
+
+	db, table, _ := newTestDB(t, tagsIndex)
+
+	txn := db.WriteTxn(table)
+
+	iter, _ := table.All(txn)
+	require.Len(t, Collect(iter), 0)
+
+	table.Insert(txn, testObject{ID: 1})
+
+	iter, _ = table.All(txn)
+	require.Len(t, Collect(iter), 1)
+
+	table.Delete(txn, testObject{ID: 1})
+	iter, _ = table.All(txn)
+	require.Len(t, Collect(iter), 0)
+
+	table.Insert(txn, testObject{ID: 2})
+	iter, _ = table.All(txn)
+	require.Len(t, Collect(iter), 1)
+
+	txn.Commit()
+
+	iter, _ = table.All(txn)
+	require.Len(t, Collect(iter), 1)
+}
+
 func TestWriteJSON(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/statedb/deletetracker.go
+++ b/pkg/statedb/deletetracker.go
@@ -39,7 +39,7 @@ func (dt *DeleteTracker[Obj]) getRevision() uint64 {
 // called!
 func (dt *DeleteTracker[Obj]) Deleted(txn ReadTxn, minRevision Revision) Iterator[Obj] {
 	indexTxn := txn.getTxn().mustIndexReadTxn(dt.table.Name(), GraveyardRevisionIndex)
-	iter := indexTxn.txn.Root().Iterator()
+	iter := indexTxn.Root().Iterator()
 	iter.SeekLowerBound(index.Uint64(minRevision))
 	return &iterator[Obj]{iter}
 }

--- a/pkg/statedb/graveyard.go
+++ b/pkg/statedb/graveyard.go
@@ -69,7 +69,7 @@ func graveyardWorker(db *DB, ctx context.Context, gcRateLimitInterval time.Durat
 			// to the low watermark.
 			indexTree := txn.mustIndexReadTxn(tableName, GraveyardRevisionIndex)
 
-			objIter := indexTree.txn.Root().Iterator()
+			objIter := indexTree.Root().Iterator()
 			for key, obj, ok := objIter.Next(); ok; key, obj, ok = objIter.Next() {
 				if obj.revision > lowWatermark {
 					break
@@ -95,12 +95,12 @@ func graveyardWorker(db *DB, ctx context.Context, gcRateLimitInterval time.Durat
 			tableName := meta.Name()
 			cleaningTimes[tableName].Start()
 			for _, key := range deadObjs {
-				oldObj, existed := txn.mustIndexWriteTxn(tableName, GraveyardRevisionIndex).txn.Delete(key)
+				oldObj, existed := txn.mustIndexWriteTxn(tableName, GraveyardRevisionIndex).Delete(key)
 				if existed {
 					// The dead object still existed (and wasn't replaced by a create->delete),
 					// delete it from the primary index.
 					key = meta.primary().fromObject(oldObj).First()
-					txn.mustIndexWriteTxn(tableName, GraveyardIndex).txn.Delete(key)
+					txn.mustIndexWriteTxn(tableName, GraveyardIndex).Delete(key)
 				}
 			}
 			cleaningTimes[tableName].End(true)

--- a/pkg/statedb/table.go
+++ b/pkg/statedb/table.go
@@ -134,7 +134,7 @@ func (t *genTable[Obj]) First(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint
 
 func (t *genTable[Obj]) FirstWatch(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, watch <-chan struct{}, ok bool) {
 	indexTxn := txn.getTxn().mustIndexReadTxn(t.table, q.index)
-	iter := indexTxn.txn.Root().Iterator()
+	iter := indexTxn.Root().Iterator()
 	watch = iter.SeekPrefixWatch(q.key)
 
 	var iobj object
@@ -172,7 +172,7 @@ func (t *genTable[Obj]) Last(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint6
 
 func (t *genTable[Obj]) LastWatch(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, watch <-chan struct{}, ok bool) {
 	indexTxn := txn.getTxn().mustIndexReadTxn(t.table, q.index)
-	iter := indexTxn.txn.Root().ReverseIterator()
+	iter := indexTxn.Root().ReverseIterator()
 	watch = iter.SeekPrefixWatch(q.key)
 
 	var iobj object
@@ -205,7 +205,7 @@ func (t *genTable[Obj]) LastWatch(txn ReadTxn, q Query[Obj]) (obj Obj, revision 
 
 func (t *genTable[Obj]) LowerBound(txn ReadTxn, q Query[Obj]) (Iterator[Obj], <-chan struct{}) {
 	indexTxn := txn.getTxn().mustIndexReadTxn(t.table, q.index)
-	root := indexTxn.txn.Root()
+	root := indexTxn.Root()
 
 	// Since LowerBound query may be invalidated by changes in another branch
 	// of the tree, we cannot just simply watch the node we seeked to. Instead
@@ -218,7 +218,7 @@ func (t *genTable[Obj]) LowerBound(txn ReadTxn, q Query[Obj]) (Iterator[Obj], <-
 
 func (t *genTable[Obj]) All(txn ReadTxn) (Iterator[Obj], <-chan struct{}) {
 	indexTxn := txn.getTxn().mustIndexReadTxn(t.table, t.primaryAnyIndexer.name)
-	root := indexTxn.txn.Root()
+	root := indexTxn.Root()
 	// Grab the watch channel for the root node
 	watchCh, _, _ := root.GetWatch(nil)
 	return &iterator[Obj]{root.Iterator()}, watchCh
@@ -226,7 +226,7 @@ func (t *genTable[Obj]) All(txn ReadTxn) (Iterator[Obj], <-chan struct{}) {
 
 func (t *genTable[Obj]) Get(txn ReadTxn, q Query[Obj]) (Iterator[Obj], <-chan struct{}) {
 	indexTxn := txn.getTxn().mustIndexReadTxn(t.table, q.index)
-	iter := indexTxn.txn.Root().Iterator()
+	iter := indexTxn.Root().Iterator()
 	watchCh := iter.SeekPrefixWatch(q.key)
 
 	if indexTxn.entry.unique {


### PR DESCRIPTION
statedb: Fix read-after-write bug
    
The optimization in *txn to hold the last used index read transaction
to avoid a hash map lookup was broken as the write txn used for reading
was cloned, leading to not being able to read any of the future writes
in the same transaction.

```
  txn := db.WriteTxn(table)
  table.Insert(txn, Foo{ID: 1})
  table.First(txn, IDIndex.Query(1)) // works as it caches the clone of just created indexWriteTxn
  table.Insert(txn, Foo{ID: 2})
  table.First(txn, IDIndex.Query(2)) // fails as the cloned transaction doesn't see the insert
```

    
Benchmark show that this optimization does not actually help, so solve
the problem by removing the optimization.
    
Before:
BenchmarkDB_RandomLookup-8       1000000              1471 ns/op

After:
BenchmarkDB_RandomLookup-8       1000000              1485 ns/op

Fixes: d0d4d46992bf ("statedb: Store index unique info in the index tree entry")

Note that v1.14 does not have the "StateDB v2.0", so it is not affected by this.

```release-note
Fix a bug in the StateDB library that may have caused stale read after write. This may have potentially affected the L2 announcements feature and the node address selection.
```