### PR TITLE
cli: Replace --cluster-name with --helm-set cluster.name

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -146,7 +146,7 @@ jobs:
             OWNER="${OWNER/./-}"
           fi
 
-          CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.name }} \
+          CILIUM_INSTALL_DEFAULTS="--helm-set=cluster.name=${{ env.name }} \
             --chart-directory=./untrusted/install/kubernetes/cilium \
             --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
             --helm-set=image.useDigest=false \

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -143,7 +143,7 @@ jobs:
           # Set ipam.mode=cluster-pool to overwrite the ipam value set by the
           # cilium-cli which is setting it to 'eni' because it auto-detects
           # the cluster as being EKS.
-          CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }} \
+          CILIUM_INSTALL_DEFAULTS="--helm-set=cluster.name=${{ env.clusterName }} \
             --chart-directory=./untrusted/install/kubernetes/cilium \
             --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
             --helm-set=image.useDigest=false \

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -140,7 +140,7 @@ jobs:
             OWNER="${OWNER/./-}"
           fi
 
-          CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }} \
+          CILIUM_INSTALL_DEFAULTS="--helm-set=cluster.name=${{ env.clusterName }} \
             --chart-directory=./untrusted/install/kubernetes/cilium \
             --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
             --helm-set=image.useDigest=false \

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -140,7 +140,7 @@ jobs:
             OWNER="${OWNER/./-}"
           fi
 
-          CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }} \
+          CILIUM_INSTALL_DEFAULTS="--helm-set=cluster.name=${{ env.clusterName }} \
             --datapath-mode=tunnel \
             --chart-directory=./untrusted/install/kubernetes/cilium \
             --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -145,7 +145,7 @@ jobs:
             OWNER="${OWNER/./-}"
           fi
 
-          CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }}-${{ matrix.config.index }} \
+          CILIUM_INSTALL_DEFAULTS="--helm-set=cluster.name=${{ env.clusterName }}-${{ matrix.config.index }} \
             --chart-directory=./untrusted/install/kubernetes/cilium \
             --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
             --helm-set=image.useDigest=false \

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -126,7 +126,7 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
-            --cluster-name=${{ env.clusterName }}-${{ matrix.index }} \
+            --helm-set=cluster.name=${{ env.clusterName }}-${{ matrix.index }} \
             --helm-set=agentNotReadyTaintKey=ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready \
             --helm-set=debug.enabled=false \
             --helm-set=bpf.monitorAggregation=maximum \


### PR DESCRIPTION
[ upstream commit cfb11589e9758053f92c371a8fa71185f26f3f3f ]

The --cluster-name flag got removed in cilium/cilium-cli#2351.

author backport of https://github.com/cilium/cilium/pull/31095 to v1.14 branch.