### PR TITLE
labelsfilter: Ensure entity relevant labels are always applied

### DIFF
--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -218,6 +218,7 @@ func defaultLabelPrefixCfg() *labelPrefixCfg {
 		regexp.QuoteMeta(k8sConst.PodNamespaceLabel),                    // include io.kubernetes.pod.namespace
 		regexp.QuoteMeta(k8sConst.PodNamespaceMetaLabels),               // include all namespace labels
 		regexp.QuoteMeta(k8sConst.AppKubernetes),                        // include app.kubernetes.io
+		regexp.QuoteMeta(k8sConst.PolicyLabelCluster),                   // include io.cilium.k8s.policy.cluster
 		`!io\.kubernetes`,                                               // ignore all other io.kubernetes labels
 		`!kubernetes\.io`,                                               // ignore all other kubernetes.io labels
 		"!" + regexp.QuoteMeta(k8sConst.StatefulSetPodNameLabel),        // ignore statefulset.kubernetes.io/pod-name label


### PR DESCRIPTION
Entities are special selectors used by network policies. The Cluster entity relies on the `io.cilium.k8s.policy.cluster` label to select endpoints which is removed by Cilium if a strict identity label configuration is applied. This PR adds the relevant Cilium policy label to the list of default labels so it will always be applied regardless of configuration, and includes this label to the associated test.

Fixes: #18878

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

```release-note
labelsfilter: Always apply Cluster entity specific identity-relevant label
```
