### PR TITLE
Downgrade L2 Neighbor Discovery failure log to Debug

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -689,7 +689,7 @@ func (n *linuxNodeHandler) insertNeighbor4(ctx context.Context, newNode *nodeTyp
 
 	nextHopIPv4, err := getNextHopIP(nextHopIPv4, link)
 	if err != nil {
-		scopedLog.WithError(err).Info("Unable to determine next hop address")
+		scopedLog.WithError(err).Debug("Unable to determine next hop address")
 		return
 	}
 	nextHopStr := nextHopIPv4.String()
@@ -760,7 +760,7 @@ func (n *linuxNodeHandler) insertNeighbor6(ctx context.Context, newNode *nodeTyp
 
 	nextHopIPv6, err := getNextHopIP(nextHopIPv6, link)
 	if err != nil {
-		scopedLog.WithError(err).Info("Unable to determine next hop address")
+		scopedLog.WithError(err).Debug("Unable to determine next hop address")
 		return
 	}
 	nextHopStr := nextHopIPv6.String()


### PR DESCRIPTION
Suppress the "Unable to determine next hop address" logs. While it shows the L2 neighbor resolution failure, it does not always indicate a datapath connectivity issue.

For example, when "devices=eth+" is specified and the device naming/purposing is not consistent across the nodes in the cluster, in some nodes "eth1" is a device reachable to other nodes, but in some nodes, it is not. As a result, L2 Discovery generates an "Unable to determine next hop address".

Another example is ENI mode with automatic device detection. When secondary interfaces are added, they are used for L2 Neighbor Discovery as well. However, nodes can only be reached via the primary interface through the default route in the main routing table. Thus, L2 Neighbor Discovery generates "Unable to determine next hop address" for secondary interfaces.

In both cases, it does not always mean the datapath has an issue for KPR functionality. However, the logs appear repeatedly, are noisy, and the message is error-ish, causing confusion.

This log started to appear for some users who did not see it before from v1.14.3 (#28858) and v1.15.0 (in theory). For v1.14.3, it affects KPR + Tunnel users because of f2dcc86. Before the commit, we did not perform L2 Neighbor Discovery in tunnel mode, so even if users had an interface unreachable to other nodes, the log did not appear.

For v1.15.0, it affects to the users who used to have the unreachable interface. 2058ed6a made it visible. Before the commit, some kind of the errors like EHOSTUNREACH and ENETUNREACH were not caught because FIBMatch option didn't specified. After v1.15.0, users started to see the log.

Fixes: #28858

```release-note
Downgrade L2 Neighbor Discovery failure log to Debug
```
