### PR TITLE
Avoid depending on sysctl in the kind.sh script for IPv6 determination

### DIFF
--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -9,7 +9,7 @@ default_workers=1
 default_cluster_name=""
 default_image=""
 default_kubeproxy_mode="iptables"
-if [ "$(uname 2>/dev/null)" == "Linux" ] && [ $(sysctl -n net.ipv6.conf.all.disable_ipv6) == 1 ] ; then
+if [ "$(uname 2>/dev/null)" == "Linux" ] && [ "$(</proc/sys/net/ipv6/conf/all/disable_ipv6)" == 1 ] ; then
   default_ipfamily="ipv4"
 else
   default_ipfamily="dual"


### PR DESCRIPTION
The sysctl command may not be installed, or in the default path (e.g., in case of Debian), causing errors like:

```
  ./contrib/scripts/kind.sh: line 12: sysctl: command not found
  ./contrib/scripts/kind.sh: line 12: [: ==: unary operator expected
```

Instead, let's just directly access the content of the corresponding proc file, so that we don't depend on external tools.

Fixes: f7fdeef2cc19 ("ipfamily should be set by platform configuration.")