### PR TITLE
bgpv1: Disable PodCIDR Reconciler for unsupported IPAM modes

### DIFF
--- a/Documentation/network/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane.rst
@@ -20,7 +20,6 @@ reachability within the cluster.
 Prerequisites
 -------------
 
-- Cilium must be configured with IPAM mode ``cluster-pool``, ``kubernetes``, or ``multi-pool``.
 - If you are using the older MetalLB-based :ref:`bgp` feature, it must be disabled.
 
 Installation
@@ -283,6 +282,13 @@ io.cilium.podippool.name        ``.meta.name``
 =============================== ===================
 
 For additional details regarding CiliumPodIPPools, see the :ref:`ipam_crd_multi_pool` section.
+
+Other IPAM Types
+^^^^^^^^^^^^^^^^
+
+When using other IPAM types, the BGP Control Plane does not support advertising
+PodCIDRs and specifying ``virtualRouters[*].exportPodCIDR`` doesn't take any
+effect.
 
 Advertising Service Virtual IPs
 -------------------------------

--- a/pkg/bgpv1/manager/reconciler/pod_cidr.go
+++ b/pkg/bgpv1/manager/reconciler/pod_cidr.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 type ExportPodCIDRReconcilerOut struct {
@@ -26,7 +27,13 @@ type ExportPodCIDRReconciler struct{}
 // ExportPodCIDRReconcilerMetadata keeps a list of all advertised Paths
 type ExportPodCIDRReconcilerMetadata []*types.Path
 
-func NewExportPodCIDRReconciler() ExportPodCIDRReconcilerOut {
+func NewExportPodCIDRReconciler(dc *option.DaemonConfig) ExportPodCIDRReconcilerOut {
+	// Don't provide the reconciler if the IPAM mode is not supported
+	if !types.CanAdvertisePodCIDR(dc.IPAMMode()) {
+		log.Info("Unsupported IPAM mode, disabling PodCIDR advertisements. exportPodCIDR doesn't take effect.")
+		return ExportPodCIDRReconcilerOut{}
+	}
+
 	return ExportPodCIDRReconcilerOut{
 		Reconciler: &ExportPodCIDRReconciler{},
 	}

--- a/pkg/bgpv1/manager/reconciler/pod_cidr_test.go
+++ b/pkg/bgpv1/manager/reconciler/pod_cidr_test.go
@@ -16,6 +16,7 @@ import (
 	ipamtypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 func TestExportPodCIDRReconciler(t *testing.T) {
@@ -79,6 +80,9 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 		},
 	}
 
+	// Dummy daemon config and logger
+	daemonConfig := &option.DaemonConfig{IPAM: "Kubernetes"}
+
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
 			// setup our test server, create a BgpServer, advertise the tt.advertised
@@ -100,7 +104,7 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 				t.Fatalf("failed to create test bgp server: %v", err)
 			}
 			testSC.Config = oldc
-			reconciler := NewExportPodCIDRReconciler().Reconciler.(*ExportPodCIDRReconciler)
+			reconciler := NewExportPodCIDRReconciler(daemonConfig).Reconciler.(*ExportPodCIDRReconciler)
 			podCIDRAnnouncements := reconciler.getMetadata(testSC)
 			for _, cidr := range tt.advertised {
 				advrtResp, err := testSC.Server.AdvertisePath(context.Background(), types.PathRequest{
@@ -119,7 +123,7 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 				Neighbors:     []v2alpha1api.CiliumBGPNeighbor{},
 			}
 
-			exportPodCIDRReconciler := NewExportPodCIDRReconciler().Reconciler
+			exportPodCIDRReconciler := NewExportPodCIDRReconciler(daemonConfig).Reconciler
 			params := ReconcileParams{
 				CurrentServer: testSC,
 				DesiredConfig: newc,

--- a/pkg/bgpv1/manager/reconciler/preflight_test.go
+++ b/pkg/bgpv1/manager/reconciler/preflight_test.go
@@ -20,6 +20,7 @@ import (
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 // We use similar local listen ports as the tests in the pkg/bgpv1/test package.
@@ -227,7 +228,8 @@ func TestReconcileAfterServerReinit(t *testing.T) {
 		ServiceSelector: serviceSelector,
 	}
 
-	exportPodCIDRReconciler := NewExportPodCIDRReconciler().Reconciler
+	daemonConfig := &option.DaemonConfig{IPAM: "Kubernetes"}
+	exportPodCIDRReconciler := NewExportPodCIDRReconciler(daemonConfig).Reconciler
 	params := ReconcileParams{
 		CurrentServer: testSC,
 		DesiredConfig: newc,

--- a/pkg/bgpv1/types/utils.go
+++ b/pkg/bgpv1/types/utils.go
@@ -5,9 +5,22 @@ package types
 
 import (
 	"net/netip"
+	"slices"
+
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 
 	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
 )
+
+// CanAdvertisePodCIDR returns true if the provided IPAM mode is supported for
+// advertising PodCIDR
+func CanAdvertisePodCIDR(ipam string) bool {
+	supportedIPAMs := []string{
+		ipamOption.IPAMKubernetes,
+		ipamOption.IPAMClusterPool,
+	}
+	return slices.Contains(supportedIPAMs, ipam)
+}
 
 // NewPathForPrefix returns a Path that can be used to advertise the provided
 // IP prefix by the underlying BGP implementation.


### PR DESCRIPTION
PodCIDR shouldn't take any effect for the unsupported IPAM modes. Modify ExportPodCIDRReconciler's constructor to not provide ConfigReconciler for unsupported IPAMs.


```release-note
bgpv1: Disable PodCIDR Reconciler for unsupported IPAM modes
```
