### PR TITLE
k8s_install.sh: specify the CNI version

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -524,9 +524,7 @@ case $K8S_VERSION in
         # kubeadm <= 1.24 requires conntrack to be installed, we can remove this
         # once we have upgraded the VM image version.
         sudo apt-get install -y conntrack
-        # We don't need to define dthe kubernetes CNI version once we have stable
-        # releases.
-        # KUBERNETES_CNI_VERSION="0.8.7"
+        KUBERNETES_CNI_VERSION="1.1.1"
         KUBERNETES_CNI_OS="-linux"
         K8S_FULL_VERSION="1.25.0"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri,swap"


### PR DESCRIPTION
The CNI version should be specify so that in case we have to fallback the installation of k8s via binaries it doesn't fail with the error:

```
10:29:25      k8s1-1.25: gzip: stdin: not in gzip format
10:29:25      k8s1-1.25: tar: Child returned status 1
10:29:25      k8s1-1.25: tar: Error is not recoverable: exiting now
```

Fixes: ce69afdc3ad1 ("add support for k8s 1.25.0")