### PR TITLE
[v1.14] re-introduce ICMPv6 NS responder on from-netdev 

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -167,7 +167,7 @@ jobs:
         env:
           # Disable coverage report for these test cases since they are hitting
           # https://github.com/cilium/coverbee/issues/7
-          NOCOVER_PATTERN: "inter_cluster_snat_clusterip.*|l4lb_ipip_health_check_host.o|nodeport_geneve_dsr_*|session_affinity_test.o|tc_egressgw_redirect.o|tc_egressgw_snat.o|tc_nodeport_lb4_dsr_backend.o|tc_nodeport_lb4_dsr_lb.o|tc_nodeport_lb4_nat_backend.o|tc_nodeport_lb4_nat_lb.o|tc_nodeport_lb6_dsr_backend.o|tc_nodeport_lb6_dsr_lb.o|xdp_egressgw_reply.o|xdp_nodeport_lb4_dsr_lb.o|xdp_nodeport_lb4_nat_backend.o|xdp_nodeport_lb4_nat_lb.o|xdp_nodeport_lb4_test.o|xdp_nodeport_lb6_dsr_lb.o|bpf_nat_tests.o"
+          NOCOVER_PATTERN: "inter_cluster_snat_clusterip.*|l4lb_ipip_health_check_host.o|nodeport_geneve_dsr_*|session_affinity_test.o|tc_egressgw_redirect.o|tc_egressgw_snat.o|tc_nodeport_lb4_dsr_backend.o|tc_nodeport_lb4_dsr_lb.o|tc_nodeport_lb4_nat_backend.o|tc_nodeport_lb4_nat_lb.o|tc_nodeport_lb6_dsr_backend.o|tc_nodeport_lb6_dsr_lb.o|xdp_egressgw_reply.o|xdp_nodeport_lb4_dsr_lb.o|xdp_nodeport_lb4_nat_backend.o|xdp_nodeport_lb4_nat_lb.o|xdp_nodeport_lb4_test.o|xdp_nodeport_lb6_dsr_lb.o|bpf_nat_tests.o|tc_nodeport_l3_dev.o"
         run: |
           make -C test run_bpf_tests COVER=1 NOCOVER="$NOCOVER_PATTERN" || (echo "Run 'make -C test run_bpf_tests COVER=1 NOCOVER=\"$NOCOVER_PATTERN\"' locally to investigate failures"; exit 1)
       - name: Archive code coverage results

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -149,8 +149,7 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 #endif /* ENABLE_HOST_FIREWALL */
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
-	int __maybe_unused ret;
-	int hdrlen;
+	int ret, hdrlen;
 	__u8 nexthdr;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
@@ -161,15 +160,13 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 	if (hdrlen < 0)
 		return hdrlen;
 
-#ifdef ENABLE_HOST_FIREWALL
 	if (likely(nexthdr == IPPROTO_ICMPV6)) {
-		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen);
+		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen, !from_host);
 		if (ret == SKIP_HOST_FIREWALL)
 			goto skip_host_firewall;
 		if (IS_ERR(ret))
 			return ret;
 	}
-#endif /* ENABLE_HOST_FIREWALL */
 
 #ifdef ENABLE_NODEPORT
 	if (!from_host) {
@@ -214,8 +211,10 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 		if (map_update_elem(&CT_TAIL_CALL_BUFFER6, &zero, &ct_buffer, 0) < 0)
 			return DROP_INVALID_TC_BUFFER;
 	}
+#endif /* ENABLE_HOST_FIREWALL */
 
 skip_host_firewall:
+#ifdef ENABLE_HOST_FIREWALL
 	ctx_store_meta(ctx, CB_FROM_HOST,
 		       (need_hostfw ? FROM_HOST_FLAG_NEED_HOSTFW : 0) |
 		       (is_host_id ? FROM_HOST_FLAG_HOST_ID : 0));
@@ -473,7 +472,7 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext
 		return hdrlen;
 
 	if (likely(nexthdr == IPPROTO_ICMPV6)) {
-		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen);
+		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen, false);
 		if (ret == SKIP_HOST_FIREWALL)
 			return CTX_ACT_OK;
 		if (IS_ERR(ret))

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -149,23 +149,26 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 #endif /* ENABLE_HOST_FIREWALL */
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
-	int ret, hdrlen;
-	__u8 nexthdr;
+	int ret;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	nexthdr = ip6->nexthdr;
-	hdrlen = ipv6_hdrlen(ctx, &nexthdr);
-	if (hdrlen < 0)
-		return hdrlen;
+	if (is_defined(ENABLE_HOST_FIREWALL) || !from_host) {
+		__u8 nexthdr = ip6->nexthdr;
+		int hdrlen;
 
-	if (likely(nexthdr == IPPROTO_ICMPV6)) {
-		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen, !from_host);
-		if (ret == SKIP_HOST_FIREWALL)
-			goto skip_host_firewall;
-		if (IS_ERR(ret))
-			return ret;
+		hdrlen = ipv6_hdrlen(ctx, &nexthdr);
+		if (hdrlen < 0)
+			return hdrlen;
+
+		if (likely(nexthdr == IPPROTO_ICMPV6)) {
+			ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen, !from_host);
+			if (ret == SKIP_HOST_FIREWALL)
+				goto skip_host_firewall;
+			if (IS_ERR(ret))
+				return ret;
+		}
 	}
 
 #ifdef ENABLE_NODEPORT

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -163,7 +163,7 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 
 #ifdef ENABLE_HOST_FIREWALL
 	if (likely(nexthdr == IPPROTO_ICMPV6)) {
-		ret = icmp6_host_handle(ctx);
+		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen);
 		if (ret == SKIP_HOST_FIREWALL)
 			goto skip_host_firewall;
 		if (IS_ERR(ret))
@@ -473,7 +473,7 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext
 		return hdrlen;
 
 	if (likely(nexthdr == IPPROTO_ICMPV6)) {
-		ret = icmp6_host_handle(ctx);
+		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen);
 		if (ret == SKIP_HOST_FIREWALL)
 			return CTX_ACT_OK;
 		if (IS_ERR(ret))

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -302,6 +302,7 @@ static __always_inline int __icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off)
 {
 	union v6addr target, router;
 	struct endpoint_info *ep;
+	union macaddr router_mac = NODE_MAC;
 
 	if (ctx_load_bytes(ctx, nh_off + ICMP6_ND_TARGET_OFFSET, target.addr,
 			   sizeof(((struct ipv6hdr *)NULL)->saddr)) < 0)
@@ -312,15 +313,27 @@ static __always_inline int __icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off)
 	BPF_V6(router, ROUTER_IP);
 
 	if (ipv6_addr_equals(&target, &router)) {
-		union macaddr router_mac = NODE_MAC;
 
 		return send_icmp6_ndisc_adv(ctx, nh_off, &router_mac, true);
 	}
 
 	ep = __lookup_ip6_endpoint(&target);
 	if (ep) {
-		union macaddr router_mac = NODE_MAC;
-
+		if (ep->flags & ENDPOINT_F_HOST) {
+			/* Target must be a node_ip, because of ENDPOINT_F_HOST flag
+			 * and target != router_ip.
+			 *
+			 * We pass these packets to stack to make sure:
+			 *
+			 * 1. The response NA has node IP as source address instead of
+			 * router IP, to address https://github.com/cilium/cilium/issues/14509.
+			 *
+			 * 2. Kernel stack can record a neighbor entry for the
+			 * source IP, to avoid bpf_fib_lookup failure as mentioned at
+			 * https://github.com/cilium/cilium/pull/30837#issuecomment-1960897445.
+			 */
+			return CTX_ACT_OK;
+		}
 		return send_icmp6_ndisc_adv(ctx, nh_off, &router_mac, false);
 	}
 
@@ -395,13 +408,17 @@ static __always_inline int icmp6_ndp_handle(struct __ctx_buff *ctx, int nh_off,
 }
 
 static __always_inline int
-icmp6_host_handle(struct __ctx_buff *ctx, int l4_off)
+icmp6_host_handle(struct __ctx_buff *ctx, int l4_off, bool handle_ns)
 {
 	__u8 type;
 
 	if (icmp6_load_type(ctx, l4_off, &type) < 0)
 		return DROP_INVALID;
 
+	if (type == ICMP6_NS_MSG_TYPE && handle_ns)
+		return icmp6_handle_ns(ctx, ETH_HLEN, METRIC_INGRESS);
+
+#ifdef ENABLE_HOST_FIREWALL
 	/* When the host firewall is enabled, we drop and allow ICMPv6 messages
 	 * according to RFC4890, except for echo request and reply messages which
 	 * are handled by host policies and can be dropped.
@@ -421,7 +438,7 @@ icmp6_host_handle(struct __ctx_buff *ctx, int l4_off)
 	 * |      ICMPv6-mult-list-done      |   CTX_ACT_OK    |  132 |
 	 * |      ICMPv6-router-solici       |   CTX_ACT_OK    |  133 |
 	 * |      ICMPv6-router-advert       |   CTX_ACT_OK    |  134 |
-	 * |     ICMPv6-neighbor-solicit     |   CTX_ACT_OK    |  135 |
+	 * |     ICMPv6-neighbor-solicit     | icmp6_handle_ns |  135 |
 	 * |      ICMPv6-neighbor-advert     |   CTX_ACT_OK    |  136 |
 	 * |     ICMPv6-redirect-message     |  CTX_ACT_DROP   |  137 |
 	 * |      ICMPv6-router-renumber     |   CTX_ACT_OK    |  138 |
@@ -463,6 +480,9 @@ icmp6_host_handle(struct __ctx_buff *ctx, int l4_off)
 		(ICMP6_MULT_RA_MSG_TYPE <= type && type <= ICMP6_MULT_RT_MSG_TYPE))
 		return SKIP_HOST_FIREWALL;
 	return DROP_FORBIDDEN_ICMP6;
+#else
+	return CTX_ACT_OK;
+#endif /* ENABLE_HOST_FIREWALL */
 }
 
 #endif

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1590,7 +1590,7 @@ static __always_inline int snat_v6_rewrite_ingress(struct __ctx_buff *ctx,
 			__u8 type = 0;
 			__be32 from, to;
 
-			if (ctx_load_bytes(ctx, off, &type, 1) < 0)
+			if (icmp6_load_type(ctx, off, &type) < 0)
 				return DROP_INVALID;
 			if (type == ICMPV6_ECHO_REQUEST || type == ICMPV6_ECHO_REPLY) {
 				if (ctx_store_bytes(ctx, off +
@@ -1955,7 +1955,7 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx, __u32 off)
 		/* No reasons to see a packet different than
 		 * ICMPV6_ECHO_REQUEST.
 		 */
-		if (ctx_load_bytes(ctx, icmpoff, &type, sizeof(type)) < 0 ||
+		if (icmp6_load_type(ctx, icmpoff, &type) < 0 ||
 		    type != ICMPV6_ECHO_REQUEST)
 			return DROP_INVALID;
 		if (ctx_load_bytes(ctx, icmpoff +

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -22,7 +22,6 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 	__u16 proto = 0;
 	struct ipv6hdr __maybe_unused *ip6;
 	struct iphdr __maybe_unused *ip4;
-	__u8 __maybe_unused icmp_type = 0;
 	bool from_tunnel __maybe_unused = false;
 
 	if (!validate_ethertype(ctx, &proto))
@@ -40,10 +39,15 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 		 * NA should not be sent over WG.
 		 */
 		if (ip6->nexthdr == IPPROTO_ICMPV6) {
+			__u8 icmp_type;
+
 			if (data + sizeof(*ip6) + ETH_HLEN +
 			    sizeof(struct icmp6hdr) > data_end)
 				return DROP_INVALID;
-			icmp_type = icmp6_load_type(ctx, ETH_HLEN);
+
+			if (icmp6_load_type(ctx, ETH_HLEN, &icmp_type) < 0)
+				return DROP_INVALID;
+
 			if (icmp_type == ICMP6_NA_MSG_TYPE)
 				goto out;
 		}

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -45,7 +45,8 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 			    sizeof(struct icmp6hdr) > data_end)
 				return DROP_INVALID;
 
-			if (icmp6_load_type(ctx, ETH_HLEN, &icmp_type) < 0)
+			if (icmp6_load_type(ctx, ETH_HLEN + sizeof(struct ipv6hdr),
+					    &icmp_type) < 0)
 				return DROP_INVALID;
 
 			if (icmp_type == ICMP6_NA_MSG_TYPE)

--- a/bpf/tests/ipv6_ndp_from_netdev_test.c
+++ b/bpf/tests/ipv6_ndp_from_netdev_test.c
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+#define ROUTER_IP
+#define HOST_IP
+#include "config_replacement.h"
+#undef ROUTER_IP
+#undef HOST_IP
+
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define SECCTX_FROM_IPCACHE 1
+
+#include "bpf_host.c"
+
+#define FROM_NETDEV 0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_from_netdev,
+	},
+};
+
+static __always_inline void
+endpoint_v6_add_entry(const union v6addr *addr, __u32 ifindex, __u16 lxc_id,
+		      __u32 flags, const __u8 *ep_mac_addr, const __u8 *node_mac_addr)
+{
+	struct endpoint_key key = {
+		.family = ENDPOINT_KEY_IPV6,
+	};
+
+	struct endpoint_info value = {
+		.ifindex = ifindex,
+		.lxc_id = lxc_id,
+		.flags = flags,
+	};
+
+	memcpy(&key.ip6, addr, sizeof(*addr));
+
+	if (ep_mac_addr)
+		memcpy(&value.mac, ep_mac_addr, ETH_ALEN);
+	if (node_mac_addr)
+		memcpy(&value.node_mac, node_mac_addr, ETH_ALEN);
+
+	map_update_elem(&ENDPOINTS_MAP, &key, &value, BPF_ANY);
+}
+
+PKTGEN("tc", "01_ipv6_from_netdev_ns_for_pod")
+int ipv6_from_netdev_ns_for_pod_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmp6hdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_icmp6_packet(&builder,
+					    (__u8 *)mac_one, (__u8 *)mac_two,
+					    (__u8 *)v6_pod_one, (__u8 *)v6_pod_two,
+					    ICMP6_NS_MSG_TYPE);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, (__u8 *)v6_pod_three, 16);
+	if (!data)
+		return TEST_ERROR;
+
+	__u8 options[] = {0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1};
+
+	data = pktgen__push_data(&builder, (__u8 *)options, 8);
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "01_ipv6_from_netdev_ns_for_pod")
+int ipv6_from_netdev_ns_for_pod_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v6_add_entry((union v6addr *)v6_pod_three, 0, 0, 0,
+			      (__u8 *)mac_three, (__u8 *)mac_two);
+	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "01_ipv6_from_netdev_ns_for_pod")
+int ipv6_from_netdev_ns_for_pod_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct icmp6hdr *l4;
+	void *payload;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	printk("status_code: %d\n", *status_code);
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(*status_code);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IPV6))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	union macaddr node_mac = NODE_MAC;
+
+	if (memcmp(l2->h_source, (__u8 *)&node_mac.addr, ETH_ALEN) != 0)
+		test_fatal("src mac hasn't been set to node mac");
+
+	if (memcmp(l2->h_dest, (__u8 *)mac_one, ETH_ALEN) != 0)
+		test_fatal("dest mac hasn't been set to source mac");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	union v6addr router_ip;
+
+	BPF_V6(router_ip, ROUTER_IP);
+	if (memcmp((__u8 *)&l3->saddr, (__u8 *)&router_ip, 16) != 0)
+		test_fatal("src IP hasn't been set to router IP");
+
+	if (memcmp((__u8 *)&l3->daddr, (__u8 *)v6_pod_one, 16) != 0)
+		test_fatal("dest IP hasn't been set to source IP");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+
+	if ((void *)l4 + sizeof(struct icmp6hdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->icmp6_type != ICMP6_NA_MSG_TYPE)
+		test_fatal("icmp6 type hasn't been set to ICMP6_NA_MSG_TYPE");
+
+	payload = (void *)l4 + sizeof(struct icmp6hdr);
+	if ((void *)payload + 24 > data_end)
+		test_fatal("payload out of bounds");
+
+	void *target = payload;
+
+	if (memcmp(target, (__u8 *)v6_pod_three, 16) != 0)
+		test_fatal("icmp6 payload target hasn't been set properly");
+
+	void *target_lladdr = payload + 16 + 2;
+
+	if (memcmp(target_lladdr, (__u8 *)&node_mac.addr, ETH_ALEN) != 0)
+		test_fatal("icmp6 payload target_lladdr hasn't been set properly");
+
+	test_finish();
+}
+
+PKTGEN("tc", "02_ipv6_from_netdev_ns_for_node_ip")
+int ipv6_from_netdev_ns_for_node_ip_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmp6hdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_icmp6_packet(&builder,
+					    (__u8 *)mac_one, (__u8 *)mac_two,
+					    (__u8 *)v6_pod_one, (__u8 *)v6_pod_two,
+					    ICMP6_NS_MSG_TYPE);
+	if (!l4)
+		return TEST_ERROR;
+
+	union v6addr node_ip;
+
+	BPF_V6(node_ip, HOST_IP);
+	data = pktgen__push_data(&builder, (__u8 *)&node_ip, 16);
+	if (!data)
+		return TEST_ERROR;
+
+	__u8 options[] = {0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1};
+
+	data = pktgen__push_data(&builder, (__u8 *)options, 8);
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "02_ipv6_from_netdev_ns_for_node_ip")
+int ipv6_from_netdev_ns_for_node_ip_setup(struct __ctx_buff *ctx)
+{
+	union v6addr node_ip;
+
+	BPF_V6(node_ip, HOST_IP);
+	endpoint_v6_add_entry((union v6addr *)&node_ip, 0, 0, ENDPOINT_F_HOST,
+			      (__u8 *)mac_three, (__u8 *)mac_two);
+	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "02_ipv6_from_netdev_ns_for_node_ip")
+int ipv6_from_netdev_ns_for_node_ip_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct icmp6hdr *l4;
+	void *payload;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	printk("status_code: %d\n", *status_code);
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(*status_code);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IPV6))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	if (memcmp(l2->h_source, (__u8 *)mac_one, ETH_ALEN) != 0)
+		test_fatal("src mac hasn't been set to source ep's mac");
+
+	if (memcmp(l2->h_dest, (__u8 *)mac_two, ETH_ALEN) != 0)
+		test_fatal("dest mac hasn't been set to dest ep's mac");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (memcmp((__u8 *)&l3->saddr, (__u8 *)v6_pod_one, 16) != 0)
+		test_fatal("src IP was changed");
+
+	if (memcmp((__u8 *)&l3->daddr, (__u8 *)v6_pod_two, 16) != 0)
+		test_fatal("dest IP was changed");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+
+	if ((void *)l4 + sizeof(struct icmp6hdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->icmp6_type != ICMP6_NS_MSG_TYPE)
+		test_fatal("icmp6 type was changed");
+
+	payload = (void *)l4 + sizeof(struct icmp6hdr);
+	if ((void *)payload + 24 > data_end)
+		test_fatal("payload out of bounds");
+
+	union v6addr node_ip;
+
+	BPF_V6(node_ip, HOST_IP);
+	if (memcmp(payload, (__u8 *)&node_ip, 16) != 0)
+		test_fatal("icmp6 payload target was changed");
+
+	test_finish();
+}

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -19,6 +19,7 @@
 #include <linux/if_ether.h>
 #include <linux/tcp.h>
 #include <linux/udp.h>
+#include <linux/icmpv6.h>
 
 /* A collection of pre-defined Ethernet MAC addresses, so tests can reuse them
  * without having to come up with custom addresses.
@@ -369,8 +370,10 @@ void *pktgen__push_rawhdr(struct pktgen *builder, __u16 hdrsize, enum pkt_layer 
 		return NULL;
 
 	layer = ctx_data(ctx) + builder->cur_off;
-	layer_idx = pktgen__free_layer(builder);
+	if ((void *)layer + hdrsize > ctx_data_end(ctx))
+		return NULL;
 
+	layer_idx = pktgen__free_layer(builder);
 	if (layer_idx < 0)
 		return NULL;
 
@@ -535,6 +538,13 @@ struct tcphdr *pktgen__push_default_tcphdr(struct pktgen *builder)
 	hdr->doff = 5;
 
 	return hdr;
+}
+
+static __always_inline
+__attribute__((warn_unused_result))
+struct icmp6hdr *pktgen__push_icmp6hdr(struct pktgen *builder)
+{
+	return pktgen__push_rawhdr(builder, sizeof(struct icmp6hdr), PKT_LAYER_ICMPV6);
 }
 
 /* Push an empty ESP header onto the packet */
@@ -841,6 +851,39 @@ void *pktgen__push_data(struct pktgen *builder, void *data, int len)
 	memcpy(pkt_data, data, len);
 
 	return pkt_data;
+}
+
+static __always_inline struct icmp6hdr *
+pktgen__push_ipv6_icmp6_packet(struct pktgen *builder,
+			       __u8 *smac, __u8 *dmac,
+			       __u8 *saddr, __u8 *daddr,
+			       __u8 icmp6_type)
+{
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct icmp6hdr *l4;
+
+	l2 = pktgen__push_ethhdr(builder);
+	if (!l2)
+		return NULL;
+
+	ethhdr__set_macs(l2, smac, dmac);
+
+	l3 = pktgen__push_default_ipv6hdr(builder);
+	if (!l3)
+		return NULL;
+
+	ipv6hdr__set_addrs(l3, saddr, daddr);
+
+	l4 = pktgen__push_icmp6hdr(builder);
+	if (!l4)
+		return NULL;
+
+	l4->icmp6_type = icmp6_type;
+	l4->icmp6_code = 0;
+	l4->icmp6_cksum = 0;
+
+	return l4;
 }
 
 /* Do a finishing pass on all the layers, which will set correct next layer

--- a/bpf/tests/tc_nodeport_l3_dev.c
+++ b/bpf/tests/tc_nodeport_l3_dev.c
@@ -12,7 +12,6 @@
 #define ENABLE_HOST_ROUTING
 #define ENABLE_IPV4
 #define ENABLE_IPV6
-#define SKIP_ICMPV6_NS_HANDLING
 
 #define TEST_IP_LOCAL		v4_pod_one
 #define TEST_IP_REMOTE		v4_pod_two


### PR DESCRIPTION
With a lot of conflicts with new verifier issues, this PR ends up with one additional PR https://github.com/cilium/cilium/pull/26563 to get backport easier. 

v1.14 still has bpf coverage test, and doesn't have some bpf test helpers (e.g. `endpoint_v6_add_entry`). Some pkt_gen helpers also had verifier issues(e.g. `pktgen__push_rawhdr`). I made some efforts to pass the new icmpv6 bpf test.

- [x] https://github.com/cilium/cilium/pull/26563 @julianwiedmann 
- [x] https://github.com/cilium/cilium/pull/30837  @jschwinger233 
- [x] https://github.com/cilium/cilium/pull/31127 @julianwiedmann 

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
26563 30837 31127
```