### PR TITLE
docs: Document enable-node-selector-labels flag

### DIFF
--- a/Documentation/internals/security-identities.rst
+++ b/Documentation/internals/security-identities.rst
@@ -27,16 +27,28 @@ Security identities span over several ranges, depending on the context:
 3) Identities generated from CIDR-based policies
 4) Identities generated for remote nodes (optional)
 
+Cluster-local
+~~~~~~~~~~~~~
+.. _local_scoped_identity:
+
 Cluster-local identities (1) range from ``1`` to ``2^16 - 1``. The lowest
 values, from ``1`` to ``255``, correspond to the reserved identity range.  See
 the `internal code documentation
 <https://pkg.go.dev/github.com/cilium/cilium/pkg/identity#NumericIdentity>`__
 for details.
 
+Clustermesh
+~~~~~~~~~~~
+.. _clustermesh_identity:
+
 For ClusterMesh (2), 8 bits are used as the ``cluster-id`` which identifies the
 cluster in the ClusterMesh, into the 3rd octet as shown by ``0x00FF0000``. The
 4th octet (uppermost bits) must be set to ``0`` as well. Neither of these
 constraints apply CIDR identities however, see (3).
+
+CIDR-based identity
+~~~~~~~~~~~~~~~~~~~
+.. _cidr_based_identity:
 
 CIDR identities (3) are local to each node. CIDR identities begin from ``1``
 and end at ``16777215``, however since they're shifted by ``24``, this makes
@@ -45,10 +57,15 @@ their effective range ``1 | (1 << 24)`` to ``16777215 | (1 << 24)`` or from
 generated is local to each node. In other words, the identity may not be the
 same for the same CIDR policy across two nodes.
 
+Node-local identity
+~~~~~~~~~~~~~~~~~~~
+.. _remote_node_scoped_identity:
+
 Remote-node identities (4) are also local to each node. Functionally, they
 work much the same as CIDR identities: they are local to each node, potentially
-differing across nodes on the cluster. They are only used when the option
-``policy-cidr-match-mode`` includes ``nodes``.
+differing across nodes on the cluster. They are used when the option
+``policy-cidr-match-mode`` includes ``nodes`` or when ``enable-node-selector-labels``
+is set to ``true``.
 
 Node-local identities (CIDR or remote-node) are never used for traffic
 between Cilium-managed nodes, so they do not need to fit inside of a

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -29,6 +29,9 @@ can talk to each other. Layer 3 policies can be specified using the following me
   to the local host serving the endpoints or all connectivity to outside of
   the cluster.
 
+* `Node based`: This is an extension of ``remote-node`` entity. Optionally nodes
+   can have unique identity that can be used to allow/block access only from specific ones.
+
 * `CIDR based`: This is used to describe the relationship to or from external
   services if the remote peer is not an endpoint. This requires to hardcode either
   IP addresses or subnets into the policies. This construct should be used as a
@@ -411,8 +414,8 @@ serving the particular endpoint.
 
 .. _policy-remote-node:
 
-Access to/from all nodes in the cluster
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Access to/from all nodes in the cluster (or clustermesh)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Allow all endpoints with the label ``env=dev`` to receive traffic from any host
 in the cluster that Cilium is running on.
@@ -450,6 +453,44 @@ endpoints that have the label ``role=public``.
 .. only:: epub or latex
 
         .. literalinclude:: ../../../examples/policies/l3/entities/world.json
+
+.. _policy_node_based:
+.. _Node based:
+
+Node based
+----------
+
+.. note:: Example below with ``fromNodes/toNodes`` fields will only take effect when
+     ``enable-node-selector-labels`` flag is set to true (or equivalent Helm value
+     ``nodeSelectorLabels: true``).
+
+When ``--enable-node-selector-labels=true`` is specified, every cilium-agent
+allocates a different local :ref:`security identity <arch_id_security>` for all
+other nodes. But instead of using :ref:`local scoped identity <local_scoped_identity>`
+it uses :ref:`remote-node scoped identity<remote_node_scoped_identity>` identity range.
+
+By default all labels that ``Node`` object has attached are taken into account,
+which might result in allocation of **unique** identity for each remote-node.
+For these cases it is also possible to filter only
+:ref:`security relevant labels <security relevant labels>` with ``--node-labels`` flag.
+
+This example shows how to allow all endpoints with the label ``env=prod`` to receive
+traffic **only** from control plane (labeled
+``node-role.kubernetes.io/control-plane=""``) nodes in the cluster (or clustermesh).
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../../examples/policies/l3/entities/customnodes.yaml
+     .. group-tab:: JSON
+
+        .. literalinclude:: ../../../examples/policies/l3/entities/customnodes.json
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../../../examples/policies/l3/entities/customnodes.json
 
 .. _policy_cidr:
 .. _CIDR based:

--- a/examples/policies/l3/entities/customnodes.json
+++ b/examples/policies/l3/entities/customnodes.json
@@ -1,0 +1,9 @@
+[{
+    "labels": [{"key": "name", "value": "to-prod-from-control-plane-nodes"}],
+    "endpointSelector": {"matchLabels": {"env":"prod"}},
+    "ingress": [{
+        "fromNodes": [{
+            "matchLabels": {"node-role.kubernetes.io/control-plane": ""}
+        }]
+    }]
+}]

--- a/examples/policies/l3/entities/customnodes.yaml
+++ b/examples/policies/l3/entities/customnodes.yaml
@@ -1,0 +1,12 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "to-prod-from-control-plane-nodes"
+spec:
+  endpointSelector:
+    matchLabels:
+      env: prod
+  ingress:
+    - fromNodes:
+        - matchLabels:
+            node-role.kubernetes.io/control-plane: ""


### PR DESCRIPTION
As the feature https://github.com/cilium/cilium/pull/26924 has been merged, adding a documentation.

Signed-off-by: Ondrej Blazek <ondrej.blazek@firma.seznam.cz>

```release-note
docs: Document enable-node-selector-labels flag
```
