### PR TITLE
Make BPF tests runnable on Clang 17

### DIFF
--- a/bpf/include/bpf/builtins.h
+++ b/bpf/include/bpf/builtins.h
@@ -275,7 +275,7 @@ __bpf_memcmp_builtin(const void *x, const void *y, __u64 len)
 static __always_inline __u64 __bpf_memcmp(const void *x, const void *y,
 					  __u64 len)
 {
-#if __clang_major__ >= 10
+#if __clang_major__ <= 10
 	__u64 r = 0;
 
 	if (!__builtin_constant_p(len))

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -690,7 +690,7 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 	};
 	int ret, oif = 0, ohead = 0;
 	void *data, *data_end;
-	struct ipv6hdr *ip6;
+	volatile struct ipv6hdr *ip6;
 	union v6addr addr;
 	__s8 ext_err = 0;
 	__be16 port;

--- a/bpf/tests/conntrack_test.c
+++ b/bpf/tests/conntrack_test.c
@@ -199,7 +199,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 				  CT_ENTRY_ANY, NULL, true, seen_flags, &monitor);
 		assert(res == CT_REOPENED);
 		assert(monitor == TRACE_PAYLOAD_LEN);
-		assert(timeout_in(entry, CT_CONNECTION_LIFETIME_TCP));
+		assert(timeout_in(entry, CT_SYN_TIMEOUT));
 
 		/* Label connection as new if the tuple wasn't previously tracked */
 		tuple.saddr = 123;


### PR DESCRIPTION
We want to upgrade Clang from 10 to the latest available (17 at the moment). In preparation I checked if the BPF tests would still work, which resulted in 5 tests failing. This PR fixes the 5 failing cases. 

I used a docker container with a Clang 17 instance inside to compile all BPF tests: `docker run -it --rm -v $(pwd):/cilium silkeh/clang:17 make -C /cilium/bpf/tests` 

Please see the commit messages for details on each fix.

```release-note
Make BPF tests runnable on Clang 17
```
