### PR TITLE
v1.15 Backports 2024-03-06

### DIFF
--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -4,7 +4,7 @@ include:
   - k8s-version: "1.29"
     ip-family: "dual"
     # renovate: datasource=docker
-    kube-image: "quay.io/cilium/kindest-node:v1.29.0-rc.1@sha256:6631d58da3569930cf21697c2113feb9c76bc044c1c13d98808a3695dd91d8b0"
+    kube-image: "kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
     kernel: "6.6-20240305.092417@sha256:ada5af2a40bb0bee22ca0f43415323becbe2657532b8bba5e88fafbd9083b845"
 

--- a/.github/actions/lvh-kind/action.yaml
+++ b/.github/actions/lvh-kind/action.yaml
@@ -8,7 +8,8 @@ inputs:
   kind-params:
     required: true
     type: string
-  kind-image-vsn:
+  kind-image:
+    required: true
     type: string
   test-name:
     required: true
@@ -36,9 +37,8 @@ runs:
         provision: 'false'
         cmd: |
           cd /host
-          if [ "${{ inputs.kind-image-vsn }}" != "" ]; then
-            export IMAGE=quay.io/cilium/kindest-node:${{ inputs.kind-image-vsn }}
-          fi
+
+          export IMAGE=${{ inputs.kind-image }}
           ./contrib/scripts/kind.sh ${{ inputs.kind-params }} 0.0.0.0 6443
 
     - name: Copy kubeconfig

--- a/.github/actions/set-env-variables/action.yml
+++ b/.github/actions/set-env-variables/action.yml
@@ -16,3 +16,13 @@ runs:
         echo "CILIUM_CLI_VERSION=$CILIUM_CLI_VERSION" >> $GITHUB_ENV
         echo "PUSH_TO_DOCKER_HUB=true" >> $GITHUB_ENV
         echo "GCP_PERF_RESULTS_BUCKET=gs://cilium-scale-results" >> $GITHUB_ENV
+
+        # renovate: datasource=github-releases depName=kubernetes-sigs/kind
+        KIND_VERSION="v0.22.0"
+        # renovate: datasource=docker
+        KIND_K8S_IMAGE="kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245"
+        KIND_K8S_VERSION=$(echo "$KIND_K8S_IMAGE" | sed -r 's|.+:(v[0-9a-z.-]+)(@.+)?|\1|')
+
+        echo "KIND_VERSION=$KIND_VERSION" >> $GITHUB_ENV
+        echo "KIND_K8S_IMAGE=$KIND_K8S_IMAGE" >> $GITHUB_ENV
+        echo "KIND_K8S_VERSION=$KIND_K8S_VERSION" >> $GITHUB_ENV

--- a/.github/kind-config-ipv6.yaml
+++ b/.github/kind-config-ipv6.yaml
@@ -2,7 +2,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: quay.io/cilium/kindest-node:v1.29.0-rc.1
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -12,7 +11,6 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: quay.io/cilium/kindest-node:v1.29.0-rc.1
 networking:
   ipFamily: ipv6
   disableDefaultCNI: true

--- a/.github/kind-config.yaml
+++ b/.github/kind-config.yaml
@@ -2,7 +2,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: quay.io/cilium/kindest-node:v1.29.0-rc.1
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -12,7 +11,6 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: quay.io/cilium/kindest-node:v1.29.0-rc.1
 networking:
   disableDefaultCNI: true
   podSubnet: "10.244.0.0/16"

--- a/.github/kind-config.yaml.tmpl
+++ b/.github/kind-config.yaml.tmpl
@@ -2,7 +2,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: quay.io/cilium/kindest-node:${K8S_VERSION}
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -12,9 +11,7 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: quay.io/cilium/kindest-node:${K8S_VERSION}
   - role: worker
-    image: quay.io/cilium/kindest-node:${K8S_VERSION}
 networking:
   disableDefaultCNI: true
   ipFamily: ${IPFAMILY}

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -57,7 +57,6 @@ env:
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   commit-status-start:

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -51,7 +51,6 @@ env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   # renovate: datasource=github-releases depName=eksctl-io/eksctl
   eksctl_version: v0.173.0
   # renovate: datasource=github-releases depName=kubernetes/kubernetes

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -65,7 +65,6 @@ env:
   clusterName2: cluster2-${{ github.run_id }}
   contextName1: kind-cluster1-${{ github.run_id }}
   contextName2: kind-cluster2-${{ github.run_id }}
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   commit-status-start:

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -55,10 +55,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  kind_version: v0.22.0
-  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
-  k8s_version: v1.29.0-rc.1
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
   clusterName1: cluster1-${{ github.run_id }}
@@ -301,15 +297,13 @@ jobs:
 
       - name: Generate Kind configuration files
         run: |
-          K8S_VERSION=${{ env.k8s_version }} \
-            PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_1 }} \
+          PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_1 }} \
             SVCCIDR=${{ steps.vars.outputs.kind_svc_cidr_1 }} \
             IPFAMILY=${{ matrix.ipFamily }} \
             KUBEPROXYMODE=${{ matrix.kube-proxy }} \
             envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster1.yaml
 
-          K8S_VERSION=${{ env.k8s_version }} \
-            PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_2 }} \
+          PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_2 }} \
             SVCCIDR=${{ steps.vars.outputs.kind_svc_cidr_2 }} \
             IPFAMILY=${{ matrix.ipFamily }} \
             KUBEPROXYMODE=${{ matrix.kube-proxy }} \
@@ -319,8 +313,9 @@ jobs:
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
           cluster_name: ${{ env.clusterName1 }}
-          version: ${{ env.kind_version }}
-          kubectl_version: ${{ env.k8s_version }}
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ./.github/kind-config-cluster1.yaml
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
@@ -328,8 +323,9 @@ jobs:
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
           cluster_name: ${{ env.clusterName2 }}
-          version: ${{ env.kind_version }}
-          kubectl_version: ${{ env.k8s_version }}
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ./.github/kind-config-cluster2.yaml
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -49,7 +49,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   commit-status-start:

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -298,6 +298,7 @@ jobs:
           test-name: e2e-conformance
           kernel: ${{ matrix.kernel }}
           kind-params: "${{ steps.kind-params.outputs.params }}"
+          kind-image: ${{ env.KIND_K8S_IMAGE }}
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -51,7 +51,6 @@ env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   # renovate: datasource=github-releases depName=eksctl-io/eksctl
   eksctl_version: v0.173.0
   # renovate: datasource=github-releases depName=kubernetes/kubernetes

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -53,7 +53,6 @@ env:
   vmStartupScript: .github/gcp-vm-startup.sh
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
 
 jobs:

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -152,6 +152,7 @@ jobs:
           node_image: ${{ env.KIND_K8S_IMAGE }}
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
+          wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Install Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -58,8 +58,6 @@ concurrency:
 env:
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  kind_version: v0.22.0
   kind_config: .github/kind-config.yaml
   gateway_api_version: v1.0.0
   metallb_version: 0.12.1
@@ -150,7 +148,9 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
-          version: ${{ env.kind_version }}
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
 
       - name: Install Go

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -47,9 +47,6 @@ concurrency:
     }}
   cancel-in-progress: true
 
-env:
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
 jobs:
   setup-vars:
     name: Setup Vars

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -51,7 +51,6 @@ env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
 
 jobs:

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -57,8 +57,6 @@ concurrency:
 env:
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  kind_version: v0.22.0
   kind_config: .github/kind-config.yaml
   metallb_version: 0.12.1
   timeout: 5m
@@ -170,7 +168,9 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
-          version: ${{ env.kind_version }}
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
 
       - name: Checkout ingress-controller-conformance

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -172,6 +172,7 @@ jobs:
           node_image: ${{ env.KIND_K8S_IMAGE }}
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
+          wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Checkout ingress-controller-conformance
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -49,7 +49,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   commit-status-start:

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -184,6 +184,7 @@ jobs:
           test-name: e2e-conformance
           kernel: ${{ matrix.kernel }}
           kind-params: "${{ steps.kind-params.outputs.params }}"
+          kind-image: ${{ env.KIND_K8S_IMAGE }}
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.

--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -77,7 +77,7 @@ jobs:
           cat <<EOF | /usr/local/bin/kind create cluster \
             --name ${{ env.cluster_name}}           \
             --image ${{ env.KIND_K8S_IMAGE }}  \
-            -v7 --wait 1m --retain --config=-
+            -v7 --retain --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
           networking:

--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -21,13 +21,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  kind_version: v0.22.0
   cluster_name: cilium-testing
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
-  k8s_version: v1.29.0-rc.1
 
 jobs:
   kubernetes-e2e-net-conformance:
@@ -60,14 +56,14 @@ jobs:
         run: |
           TMP_DIR=$(mktemp -d)
           # Test binaries
-          curl -L https://dl.k8s.io/${{ env.k8s_version }}/kubernetes-test-linux-amd64.tar.gz -o ${TMP_DIR}/kubernetes-test-linux-amd64.tar.gz
+          curl -L https://dl.k8s.io/${{ env.KIND_K8S_VERSION }}/kubernetes-test-linux-amd64.tar.gz -o ${TMP_DIR}/kubernetes-test-linux-amd64.tar.gz
           tar xvzf ${TMP_DIR}/kubernetes-test-linux-amd64.tar.gz \
             --directory ${TMP_DIR} \
             --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test
           # kubectl
-          curl -L https://dl.k8s.io/${{ env.k8s_version }}/bin/linux/amd64/kubectl -o ${TMP_DIR}/kubectl
+          curl -L https://dl.k8s.io/${{ env.KIND_K8S_VERSION }}/bin/linux/amd64/kubectl -o ${TMP_DIR}/kubectl
           # kind
-          curl -Lo ${TMP_DIR}/kind https://kind.sigs.k8s.io/dl/${{ env.kind_version }}/kind-linux-amd64
+          curl -Lo ${TMP_DIR}/kind https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION }}/kind-linux-amd64
           # Install
           sudo cp ${TMP_DIR}/ginkgo /usr/local/bin/ginkgo
           sudo cp ${TMP_DIR}/e2e.test /usr/local/bin/e2e.test
@@ -80,7 +76,7 @@ jobs:
         run: |
           cat <<EOF | /usr/local/bin/kind create cluster \
             --name ${{ env.cluster_name}}           \
-            --image quay.io/cilium/kindest-node:${{ env.k8s_version }}  \
+            --image ${{ env.KIND_K8S_IMAGE }}  \
             -v7 --wait 1m --retain --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4

--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -39,11 +39,12 @@ jobs:
       IP_FAMILY: ${{ matrix.ipFamily }}
 
     steps:
-      - name: Checkout main branch to access local actions
+      - name: Checkout target branch to access local actions
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.base_ref || github.ref }}
           persist-credentials: false
+
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -77,7 +77,7 @@ jobs:
           cat <<EOF | /usr/local/bin/kind create cluster \
             --name ${{ env.cluster_name}}           \
             --image ${{ env.KIND_K8S_IMAGE }}  \
-            -v7 --wait 1m --retain --config=-
+            -v7 --retain --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
           networking:

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -21,13 +21,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  kind_version: v0.22.0
   cluster_name: cilium-testing
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
-  k8s_version: v1.29.0-rc.1
 
 jobs:
   kubernetes-e2e:
@@ -60,14 +56,14 @@ jobs:
         run: |
           TMP_DIR=$(mktemp -d)
           # Test binaries
-          curl -L https://dl.k8s.io/${{ env.k8s_version }}/kubernetes-test-linux-amd64.tar.gz -o ${TMP_DIR}/kubernetes-test-linux-amd64.tar.gz
+          curl -L https://dl.k8s.io/${{ env.KIND_K8S_VERSION }}/kubernetes-test-linux-amd64.tar.gz -o ${TMP_DIR}/kubernetes-test-linux-amd64.tar.gz
           tar xvzf ${TMP_DIR}/kubernetes-test-linux-amd64.tar.gz \
             --directory ${TMP_DIR} \
             --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test
           # kubectl
-          curl -L https://dl.k8s.io/${{ env.k8s_version }}/bin/linux/amd64/kubectl -o ${TMP_DIR}/kubectl
+          curl -L https://dl.k8s.io/${{ env.KIND_K8S_VERSION }}/bin/linux/amd64/kubectl -o ${TMP_DIR}/kubectl
           # kind
-          curl -Lo ${TMP_DIR}/kind https://kind.sigs.k8s.io/dl/${{ env.kind_version }}/kind-linux-amd64
+          curl -Lo ${TMP_DIR}/kind https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION }}/kind-linux-amd64
           # Install
           sudo cp ${TMP_DIR}/ginkgo /usr/local/bin/ginkgo
           sudo cp ${TMP_DIR}/e2e.test /usr/local/bin/e2e.test
@@ -80,7 +76,7 @@ jobs:
         run: |
           cat <<EOF | /usr/local/bin/kind create cluster \
             --name ${{ env.cluster_name}}           \
-            --image quay.io/cilium/kindest-node:${{ env.k8s_version }}  \
+            --image ${{ env.KIND_K8S_IMAGE }}  \
             -v7 --wait 1m --retain --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
@@ -242,4 +238,3 @@ jobs:
         uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
         with:
           junit-directory: "_artifacts"
-

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -39,11 +39,12 @@ jobs:
       IP_FAMILY: ${{ matrix.ipFamily }}
 
     steps:
-      - name: Checkout main branch to access local actions
+      - name: Checkout target branch to access local actions
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.base_ref || github.ref }}
           persist-credentials: false
+
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -85,6 +85,7 @@ jobs:
           node_image: ${{ env.KIND_K8S_IMAGE }}
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.KIND_CONFIG }}
+          wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Install cilium chart
         id: install-cilium

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -12,8 +12,6 @@ permissions: read-all
 
 env:
   cilium_cli_ci_version:
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  KIND_VERSION: v0.22.0
   KIND_CONFIG: .github/kind-config.yaml
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check.yaml
   TIMEOUT: 2m
@@ -84,6 +82,8 @@ jobs:
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
           version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.KIND_CONFIG }}
 
       - name: Install cilium chart

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -43,11 +43,12 @@ jobs:
     name: Cyclonus Test
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout main branch to access local actions
+      - name: Checkout target branch to access local actions
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.base_ref || github.ref }}
           persist-credentials: false
+
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 

--- a/.github/workflows/conformance-kind-proxy-daemonset.yaml
+++ b/.github/workflows/conformance-kind-proxy-daemonset.yaml
@@ -85,6 +85,7 @@ jobs:
           node_image: ${{ env.KIND_K8S_IMAGE }}
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
+          wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Wait for images to be available
         timeout-minutes: 30

--- a/.github/workflows/conformance-kind-proxy-daemonset.yaml
+++ b/.github/workflows/conformance-kind-proxy-daemonset.yaml
@@ -21,8 +21,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  kind_version: v0.22.0
   kind_config: .github/kind-config.yaml
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
@@ -83,7 +81,9 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
-          version: ${{ env.kind_version }}
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
 
       - name: Wait for images to be available

--- a/.github/workflows/conformance-kind-proxy-daemonset.yaml
+++ b/.github/workflows/conformance-kind-proxy-daemonset.yaml
@@ -33,11 +33,12 @@ jobs:
     env:
       job_name: "Installation and Connectivity Test"
     steps:
-      - name: Checkout main branch to access local actions
+      - name: Checkout target branch to access local actions
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.base_ref || github.ref }}
           persist-credentials: false
+
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -56,8 +56,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  kind_version: v0.22.0
   kind_config: .github/kind-config.yaml
   timeout: 5m
 
@@ -171,7 +169,9 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
-          version: ${{ env.kind_version }}
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
 
       - name: Wait for images to be available

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -173,6 +173,7 @@ jobs:
           node_image: ${{ env.KIND_K8S_IMAGE }}
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
+          wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Wait for images to be available
         timeout-minutes: 30

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -39,7 +39,6 @@ env:
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
   test_name: gke-perf
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
   gcp_zone: us-east5-a
   k8s_version: 1.28

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -55,10 +55,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  kind_version: v0.22.0
-  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
-  k8s_version: v1.29.0-rc.1
   cilium_cli_ci_version:
 
   clusterName1: cluster1
@@ -196,15 +192,13 @@ jobs:
 
       - name: Generate Kind configuration files
         run: |
-          K8S_VERSION=${{ env.k8s_version }} \
-            PODCIDR=10.242.0.0/16,fd00:10:242::/48 \
+          PODCIDR=10.242.0.0/16,fd00:10:242::/48 \
             SVCCIDR=10.243.0.0/16,fd00:10:243::/112 \
             IPFAMILY=dual \
             KUBEPROXYMODE=${{ matrix.kube-proxy }} \
             envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster1.yaml
 
-          K8S_VERSION=${{ env.k8s_version }} \
-            PODCIDR=10.244.0.0/16,fd00:10:244::/48 \
+          PODCIDR=10.244.0.0/16,fd00:10:244::/48 \
             SVCCIDR=10.245.0.0/16,fd00:10:245::/112 \
             IPFAMILY=dual \
             KUBEPROXYMODE=${{ matrix.kube-proxy }} \
@@ -214,8 +208,9 @@ jobs:
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
           cluster_name: ${{ env.clusterName1 }}
-          version: ${{ env.kind_version }}
-          kubectl_version: ${{ env.k8s_version }}
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ./.github/kind-config-cluster1.yaml
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
@@ -223,8 +218,9 @@ jobs:
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
           cluster_name: ${{ env.clusterName2 }}
-          version: ${{ env.kind_version }}
-          kubectl_version: ${{ env.k8s_version }}
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ./.github/kind-config-cluster2.yaml
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -48,7 +48,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   # renovate: datasource=golang-version depName=go
   go-version: 1.21.8
 

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -49,7 +49,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   commit-status-start:

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -314,6 +314,7 @@ jobs:
           cmd: |
             cd /host/
 
+            export IMAGE=${{ env.KIND_K8S_IMAGE }}
             IP_FAM="dual"
             if [ "${{ matrix.ipv6 }}" == "false" ]; then
               IP_FAM="ipv4"

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -49,7 +49,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   # renovate: datasource=docker depName=quay.io/cilium/kindest-node
   k8s_version: v1.29.0-rc.1
 

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -49,8 +49,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
-  k8s_version: v1.29.0-rc.1
 
 jobs:
   commit-status-start:
@@ -279,7 +277,7 @@ jobs:
           test-name: e2e-conformance
           kernel: ${{ matrix.kernel }}
           kind-params: "${{ steps.kind-params.outputs.params }}"
-          kind-image-vsn: ${k8s_version}
+          kind-image: ${{ env.KIND_K8S_IMAGE }}
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -56,7 +56,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   commit-status-start:

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -17,8 +17,6 @@ concurrency:
 env:
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  KIND_VERSION: v0.22.0
   KIND_CONFIG: .github/kind-config-ipv6.yaml
   # Skip external traffic (e.g. 1.1.1.1 and www.google.com) due to no support for IPv6 in github action
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
@@ -99,6 +97,8 @@ jobs:
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
           version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.KIND_CONFIG }}
 
       - name: Wait for images to be available

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -100,6 +100,7 @@ jobs:
           node_image: ${{ env.KIND_K8S_IMAGE }}
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.KIND_CONFIG }}
+          wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Wait for images to be available
         timeout-minutes: 30

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -52,11 +52,12 @@ jobs:
     runs-on: ubuntu-22.04
     name: Installation and Conformance Test (ipv6)
     steps:
-      - name: Checkout main branch to access local actions
+      - name: Checkout target branch to access local actions
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.base_ref || github.ref }}
           persist-credentials: false
+
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -19,8 +19,6 @@ concurrency:
 env:
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  KIND_VERSION: v0.22.0
   KIND_CONFIG: .github/kind-config.yaml
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check.yaml
   TIMEOUT: 2m
@@ -116,6 +114,8 @@ jobs:
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
           version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.KIND_CONFIG }}
 
       - name: Wait for images to be available

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -117,6 +117,7 @@ jobs:
           node_image: ${{ env.KIND_K8S_IMAGE }}
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.KIND_CONFIG }}
+          wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Wait for images to be available
         timeout-minutes: 30

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -80,11 +80,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Installation and Conformance Test
     steps:
-      - name: Checkout main branch to access local actions
+      - name: Checkout target branch to access local actions
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.base_ref || github.ref }}
           persist-credentials: false
+
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 


### PR DESCRIPTION
 * [x] #30928 (@giorio94)
 * [x] #30916 (@giorio94)
     - :information_source: Skipped the renovate-related commit, as not relevant in stable branches.
 * [x] #31198 (@giorio94)

The last commit additionally switches the k8s version used for Ginkgo tests from `quay.io/cilium/kindest-node:v1.29.0-rc.1` to `kindest/node:v1.29.2`.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 30928 30916 31198
```
