### PR TITLE
bpf: Don't skip local delivery for plain-text packets when IPsec is enabled

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1058,8 +1058,18 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 	int ret;
 
 #ifdef ENABLE_IPSEC
-	if (!from_host && !do_decrypt(ctx, proto))
-		return CTX_ACT_OK;
+	if (!from_host) {
+		/* If the packet needs decryption, we want to send it straight to the
+		 * stack. There's no need to run service handling logic, host firewall,
+		 * etc. on an encrypted packet.
+		 * In all other cases (packet doesn't need decryption or already
+		 * decrypted), we want to run all subsequent logic here. We therefore
+		 * ignore the return value from do_decrypt.
+		 */
+		do_decrypt(ctx, proto);
+		if (ctx->mark == MARK_MAGIC_DECRYPT)
+			return CTX_ACT_OK;
+	}
 #endif
 
 	if (from_host) {


### PR DESCRIPTION
The current IPsec decryption handling in `bpf_host` is buggy: when executing `do_decrypt`, we skip all subsequent logic in the same BPF program and return to stack. That subsequent logic includes (1) all service handling logic including NAT, (2) the host policies enforcement, and (3) delivery to the destination pods.

(1) and (2) are not an issue today because KPR and the host firewall are incompatible with IPsec. (3) is also not really an issue because packets will flow through `cilium_host` where they will run through the local delivery logic again; that's however less efficient.

This commit changes the logic a bit, to not skip the subsequent BPF processing for plain-text ingressing packets. If the packet is encrypted and needs decryption, we should send it to the stack, but any other packet needs should be fully processed by `bpf_host`.

Fixes: https://github.com/cilium/cilium/pull/13238.