### PR TITLE
gha: checkout target branch instead of the default one

### DIFF
--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -39,11 +39,12 @@ jobs:
       IP_FAMILY: ${{ matrix.ipFamily }}
 
     steps:
-      - name: Checkout main branch to access local actions
+      - name: Checkout target branch to access local actions
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.base_ref || github.ref }}
           persist-credentials: false
+
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -39,11 +39,12 @@ jobs:
       IP_FAMILY: ${{ matrix.ipFamily }}
 
     steps:
-      - name: Checkout main branch to access local actions
+      - name: Checkout target branch to access local actions
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.base_ref || github.ref }}
           persist-credentials: false
+
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -43,11 +43,12 @@ jobs:
     name: Cyclonus Test
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout main branch to access local actions
+      - name: Checkout target branch to access local actions
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.base_ref || github.ref }}
           persist-credentials: false
+
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -33,11 +33,12 @@ jobs:
     env:
       job_name: "Installation and Connectivity Test"
     steps:
-      - name: Checkout main branch to access local actions
+      - name: Checkout target branch to access local actions
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.base_ref || github.ref }}
           persist-credentials: false
+
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -52,11 +52,12 @@ jobs:
     runs-on: ubuntu-22.04
     name: Installation and Conformance Test (ipv6)
     steps:
-      - name: Checkout main branch to access local actions
+      - name: Checkout target branch to access local actions
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.base_ref || github.ref }}
           persist-credentials: false
+
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -80,11 +80,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Installation and Conformance Test
     steps:
-      - name: Checkout main branch to access local actions
+      - name: Checkout target branch to access local actions
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.base_ref || github.ref }}
           persist-credentials: false
+
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 


### PR DESCRIPTION
Currently, the GHA workflows running tests triggered on pull_request and/or push events initially checkout the default branch to configure the environment variables, before retrieving the PR head. However, this is problematic on stable branches, as we then end up using the variables from the default (i.e., main) branch (e.g., Kubernetes version, Cilium CLI version), which may not be appropriate here.

Hence, let's change the initial checkout to retrieve the target (i.e., base) branch, falling back to the commit in case of push events. This ensure that we retrieve the variables from the correct branch, and matches the behavior of Ariane triggered workflows.

<!-- Description of change -->

```release-note
Checkout the target branch, instead of the default one, on pull_request based GHA test workflows
```
