### PR TITLE
gha: drop the CILIUM_CLI_MODE environment variable

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -56,7 +56,6 @@ env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
   cilium_cli_ci_version:
-  CILIUM_CLI_MODE: helm
 
 jobs:
   commit-status-start:

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -55,7 +55,6 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cilium_cli_ci_version:
-  CILIUM_CLI_MODE: helm
   # renovate: datasource=github-releases depName=eksctl-io/eksctl
   eksctl_version: v0.173.0
   # renovate: datasource=github-releases depName=kubernetes/kubernetes

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -56,7 +56,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  CILIUM_CLI_MODE: helm
   clusterName1: cluster1-${{ github.run_id }}
   clusterName2: cluster2-${{ github.run_id }}
   contextName1: kind-cluster1-${{ github.run_id }}

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -327,7 +327,6 @@ jobs:
         run: |
           kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
 
-          export CILIUM_CLI_MODE=helm
           ./cilium-cli install ${{ steps.cilium-config.outputs.config }}
           kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-server --timeout=300s
           kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-agent --timeout=300s

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -55,7 +55,6 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cilium_cli_ci_version:
-  CILIUM_CLI_MODE: helm
   # renovate: datasource=github-releases depName=eksctl-io/eksctl
   eksctl_version: v0.173.0
   # renovate: datasource=github-releases depName=kubernetes/kubernetes

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -57,7 +57,6 @@ env:
   vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-vm
   vmStartupScript: .github/gcp-vm-startup.sh
   cilium_cli_ci_version:
-  CILIUM_CLI_MODE: helm
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
 
 jobs:

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -57,7 +57,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  CILIUM_CLI_MODE: helm
   kind_config: .github/kind-config.yaml
   gateway_api_version: v1.0.0
   timeout: 5m

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -55,7 +55,6 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cilium_cli_ci_version:
-  CILIUM_CLI_MODE: helm
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
 
 jobs:

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -56,7 +56,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  CILIUM_CLI_MODE: helm
   kind_config: .github/kind-config.yaml
   timeout: 5m
 

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -223,7 +223,6 @@ jobs:
           kubectl create -n kube-system secret generic cilium-ipsec-keys \
             --from-literal=keys="3 ${key}"
 
-          export CILIUM_CLI_MODE=helm
           ./cilium-cli install ${{ steps.cilium-config.outputs.config }}
           kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-server --timeout=300s
           kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-agent --timeout=300s

--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -23,7 +23,6 @@ concurrency:
 env:
   cluster_name: cilium-testing
   cilium_cli_ci_version:
-  CILIUM_CLI_MODE: helm
 
 jobs:
   kubernetes-e2e-net-conformance:

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -23,7 +23,6 @@ concurrency:
 env:
   cluster_name: cilium-testing
   cilium_cli_ci_version:
-  CILIUM_CLI_MODE: helm
 
 jobs:
   kubernetes-e2e:

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -23,7 +23,6 @@ concurrency:
 env:
   kind_config: .github/kind-config.yaml
   cilium_cli_ci_version:
-  CILIUM_CLI_MODE: helm
 
 jobs:
   installation-and-connectivity:

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -186,7 +186,7 @@ jobs:
       - name: Install Cilium
         id: install-cilium
         run: |
-          CILIUM_CLI_MODE=helm cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
+          cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
       - name: Wait for Cilium status to be ready
         run: |

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -39,7 +39,6 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cilium_cli_ci_version:
-  CILIUM_CLI_MODE: helm
   test_name: gke-perf
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
   gcp_zone: us-east5-a

--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -37,7 +37,6 @@ env:
   test_name: node-throughput
   cluster_base_name: ${{ github.run_id }}-${{ github.run_attempt }}.k8s.local
   GCP_PERF_RESULTS_BUCKET: gs://cilium-scale-results
-  CILIUM_CLI_MODE: helm
 
 jobs:
   install-and-scaletest:

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -363,7 +363,7 @@ jobs:
           cmd: |
             cd /host/
 
-            CILIUM_CLI_MODE=helm ./cilium-cli install \
+            ./cilium-cli install \
               ${{ steps.cilium-stable-config.outputs.config }}
 
             ./cilium-cli status --wait
@@ -390,7 +390,7 @@ jobs:
           cmd: |
             cd /host/
 
-            CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
+            ./cilium-cli upgrade \
               ${{ steps.cilium-newest-config.outputs.config }}
 
             ./cilium-cli status --wait
@@ -430,7 +430,7 @@ jobs:
           cmd: |
             cd /host/
 
-            CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
+            ./cilium-cli upgrade \
               ${{ steps.cilium-stable-config.outputs.config }}
 
             ./cilium-cli status --wait

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -327,7 +327,7 @@ jobs:
 
           mkdir -p cilium-junits
 
-          CILIUM_CLI_MODE=helm ./cilium-cli install \
+          ./cilium-cli install \
             ${{ steps.cilium-stable-config.outputs.config }}
 
           ./cilium-cli status --wait
@@ -351,7 +351,7 @@ jobs:
         with:
           job-name: ipsec-upgrade-${{ matrix.name }}
           operation-cmd: |
-            CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
+            ./cilium-cli upgrade \
               ${{ steps.cilium-newest-config.outputs.config }}
 
             ./cilium-cli status --wait
@@ -364,7 +364,7 @@ jobs:
         with:
           job-name: ipsec-downgrade-${{ matrix.name }}
           operation-cmd: |
-            CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
+            ./cilium-cli upgrade \
               ${{ steps.cilium-stable-config.outputs.config }}
 
             ./cilium-cli status --wait

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -16,7 +16,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  CILIUM_CLI_MODE: helm
   KIND_CONFIG: .github/kind-config-ipv6.yaml
   # Skip external traffic (e.g. 1.1.1.1 and www.google.com) due to no support for IPv6 in github action
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check-internal.yaml

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -18,7 +18,6 @@ concurrency:
 
 env:
   cilium_cli_ci_version:
-  CILIUM_CLI_MODE: helm
   KIND_CONFIG: .github/kind-config.yaml
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check.yaml
   TIMEOUT: 2m


### PR DESCRIPTION
Starting from v0.16.0, the support for the legacy Cilium CLI mode got dropped, hence it is no longer necessary to set the dedicated environment variable.

<!-- Description of change -->

Fixes: #issue-number

```release-note
Drop the remaining references to the CILIUM_CLI_MODE environment variable in GHA workflows.
```
