### PR TITLE
pkg/endpointmanager: Extend subscribers for restored endpoints

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -823,6 +823,11 @@ func (d *Daemon) EndpointCreated(ep *endpoint.Endpoint) {
 	d.SendNotification(monitorAPI.EndpointCreateMessage(ep))
 }
 
+// EndpointRestored implements endpointmanager.Subscriber
+func (d *Daemon) EndpointRestored(ep *endpoint.Endpoint) {
+	// No-op
+}
+
 func deleteEndpointIDHandler(d *Daemon, params DeleteEndpointIDParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("DELETE /endpoint/{id} request")
 

--- a/pkg/auth/authmap_gc.go
+++ b/pkg/auth/authmap_gc.go
@@ -429,6 +429,11 @@ func (r *authMapGarbageCollector) EndpointDeleted(ep *endpoint.Endpoint, conf en
 	}
 }
 
+// EndpointRestored implements endpointmanager.Subscriber
+func (r *authMapGarbageCollector) EndpointRestored(ep *endpoint.Endpoint) {
+	// No-op
+}
+
 func (r *authMapGarbageCollector) cleanupEndpoints(_ context.Context) error {
 	if r.ciliumIdentitiesDiscovered == nil || !r.ciliumIdentitiesSynced || !r.endpointsCacheSynced {
 		return nil

--- a/pkg/datapath/garp/processor.go
+++ b/pkg/datapath/garp/processor.go
@@ -91,3 +91,8 @@ func (gp *processor) EndpointDeleted(ep *endpoint.Endpoint, conf endpoint.Delete
 
 	delete(gp.endpointIPs, ep.ID)
 }
+
+// EndpointRestored implements endpointmanager.Subscriber
+func (gp *processor) EndpointRestored(ep *endpoint.Endpoint) {
+	// No-op
+}

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -633,7 +633,17 @@ func (mgr *endpointManager) expose(ep *endpoint.Endpoint) error {
 // manager.
 func (mgr *endpointManager) RestoreEndpoint(ep *endpoint.Endpoint) error {
 	ep.SetDefaultConfiguration(true)
-	return mgr.expose(ep)
+	err := mgr.expose(ep)
+	if err != nil {
+		return err
+	}
+	mgr.mutex.RLock()
+	for s := range mgr.subscribers {
+		s.EndpointRestored(ep)
+	}
+	mgr.mutex.RUnlock()
+
+	return nil
 }
 
 // AddEndpoint takes the prepared endpoint object and starts managing it.

--- a/pkg/endpointmanager/subscribe.go
+++ b/pkg/endpointmanager/subscribe.go
@@ -20,6 +20,13 @@ type Subscriber interface {
 	// This function is being called inside a RLock, so it must not attempt
 	// to acquire a lock on the EndpointManager.
 	EndpointDeleted(ep *endpoint.Endpoint, conf endpoint.DeleteConfig)
+
+	// EndpointRestored is called at the end of endpoint restoration.
+	// Implementations must not attempt write operations on the
+	// EndpointManager from this callback.
+	// This function is being called inside a RLock, so it must not attempt
+	// to acquire a lock on the EndpointManager.
+	EndpointRestored(ep *endpoint.Endpoint)
 }
 
 func (mgr *endpointManager) Subscribe(s Subscriber) {


### PR DESCRIPTION
Enables subscribers to be notified about restored endpoints as the `EndpointCreated` is called only for newly created endpoints.

Signed-off-by: Aditi Ghag <aditi@cilium.io>