### PR TITLE
v1.15: Remove cilium/build from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -235,7 +235,6 @@
 /api/v1/peer/ @cilium/sig-hubble-api
 /api/v1/recorder/ @cilium/sig-hubble-api
 /api/v1/relay/ @cilium/sig-hubble-api
-/images @cilium/build
 /images/builder/install-protoc.sh @cilium/sig-hubble-api
 /images/builder/install-protoplugins.sh @cilium/sig-hubble-api
 /images/builder/update-cilium-builder-image.sh @cilium/github-sec


### PR DESCRIPTION
v1.15 branch doesn't need additional review of these files from @cilium/build. Remove them from CODEOWNERS in favour of tophat to reduce the number of approvals necessary to get dependency updates into the v1.15 branch.
