### PR TITLE
Hubble: fix traffic direction and is reply when IPSec is enabled

### DIFF
--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -682,6 +682,17 @@ func TestDecodeTrafficDirection(t *testing.T) {
 	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.GetTrafficDirection())
 	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
 
+	// TRACE_FROM_LXC unknown (encrypted)
+	tn = monitor.TraceNotifyV0{
+		Type:     byte(monitorAPI.MessageTypeTrace),
+		Source:   localEP,
+		ObsPoint: monitorAPI.TraceFromLxc,
+		Reason:   monitor.TraceReasonUnknown | monitor.TraceReasonEncryptMask,
+	}
+	f = parseFlow(tn, localIP, remoteIP)
+	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.GetTrafficDirection())
+	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+
 	// TRACE_TO_STACK SRV6 decap Ingress
 	tn = monitor.TraceNotifyV0{
 		Type:     byte(monitorAPI.MessageTypeTrace),
@@ -780,7 +791,17 @@ func TestDecodeIsReply(t *testing.T) {
 	assert.Nil(t, f.GetIsReply())
 	assert.Equal(t, false, f.GetReply())
 
-	// TRACE_TO_STACK SRV6 decap
+	// TRACE_FROM_LXC encrypted
+	tn = monitor.TraceNotifyV0{
+		Type:     byte(monitorAPI.MessageTypeTrace),
+		ObsPoint: monitorAPI.TraceFromLxc,
+		Reason:   monitor.TraceReasonUnknown | monitor.TraceReasonEncryptMask,
+	}
+	f = parseFlow(tn, localIP, remoteIP)
+	assert.Nil(t, f.GetIsReply())
+	assert.Equal(t, false, f.GetReply())
+
+	// TRACE_TO_STACK srv6-decap
 	tn = monitor.TraceNotifyV0{
 		Type:     byte(monitorAPI.MessageTypeTrace),
 		Source:   hostEP,
@@ -791,12 +812,34 @@ func TestDecodeIsReply(t *testing.T) {
 	assert.Nil(t, f.GetIsReply())
 	assert.Equal(t, false, f.GetReply())
 
-	// TRACE_TO_STACK SRV6 encap
+	// TRACE_TO_STACK srv6-decap (encrypted)
+	tn = monitor.TraceNotifyV0{
+		Type:     byte(monitorAPI.MessageTypeTrace),
+		Source:   hostEP,
+		ObsPoint: monitorAPI.TraceToStack,
+		Reason:   monitor.TraceReasonSRv6Decap | monitor.TraceReasonEncryptMask,
+	}
+	f = parseFlow(tn, remoteIP, localIP)
+	assert.Nil(t, f.GetIsReply())
+	assert.Equal(t, false, f.GetReply())
+
+	// TRACE_TO_STACK srv6-encap
 	tn = monitor.TraceNotifyV0{
 		Type:     byte(monitorAPI.MessageTypeTrace),
 		Source:   localEP,
 		ObsPoint: monitorAPI.TraceToStack,
 		Reason:   monitor.TraceReasonSRv6Encap,
+	}
+	f = parseFlow(tn, localIP, remoteIP)
+	assert.Nil(t, f.GetIsReply())
+	assert.Equal(t, false, f.GetReply())
+
+	// TRACE_TO_STACK srv6-encap (encrypted)
+	tn = monitor.TraceNotifyV0{
+		Type:     byte(monitorAPI.MessageTypeTrace),
+		Source:   localEP,
+		ObsPoint: monitorAPI.TraceToStack,
+		Reason:   monitor.TraceReasonSRv6Encap | monitor.TraceReasonEncryptMask,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
 	assert.Nil(t, f.GetIsReply())

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -152,7 +152,7 @@ func connState(reason uint8) string {
 }
 
 func TraceReasonIsKnown(reason uint8) bool {
-	switch reason {
+	switch reason & ^TraceReasonEncryptMask {
 	case TraceReasonUnknown:
 		return false
 	default:
@@ -161,7 +161,7 @@ func TraceReasonIsKnown(reason uint8) bool {
 }
 
 func TraceReasonIsEncap(reason uint8) bool {
-	switch reason {
+	switch reason & ^TraceReasonEncryptMask {
 	case TraceReasonSRv6Encap:
 		return true
 	default:
@@ -170,7 +170,7 @@ func TraceReasonIsEncap(reason uint8) bool {
 }
 
 func TraceReasonIsDecap(reason uint8) bool {
-	switch reason {
+	switch reason & ^TraceReasonEncryptMask {
 	case TraceReasonSRv6Decap:
 		return true
 	default:


### PR DESCRIPTION
_**Backport note**: this patch won't apply cleanly on top of v1.13 which doesn't have the SRV6 encap/decap trace reasons, in v1.13 we only need the `TraceReasonIsKnown()` change in `datapath_trace.go` and the couple of `TRACE_FROM_LXC` test cases added in `parser_test.go`._

Before this patch, Hubble would wrongly report known traffic direction and reply status when IPSec was enabled.

The Cilium datapath uses `trace_reason` to convey both the trace reason and [encryption status](https://github.com/cilium/cilium/blob/f31cbef727b3cb252d6117f48fd0bb24106d9876/bpf/lib/trace.h#L57-L60) of trace notifications.The trace reason is decoded as-is in by userspace in the [`TraceNotify.Reason` field](https://github.com/cilium/cilium/blob/f31cbef727b3cb252d6117f48fd0bb24106d9876/pkg/monitor/datapath_trace.go#L57), and users of the `Reason` field must carefully check the encrypt bit (see for example [here](https://github.com/cilium/cilium/blob/f31cbef727b3cb252d6117f48fd0bb24106d9876/pkg/monitor/datapath_trace.go#L147) or [here](https://github.com/cilium/cilium/blob/f31cbef727b3cb252d6117f48fd0bb24106d9876/pkg/hubble/parser/threefour/parser.go#L406)). Unfortunately, `TraceReasonIsKnown`, `TraceReasonIsEncap`, and `TraceReasonIsDecap` didn't take the encrypt bit into account and thus returned wrong results when the encrypt bit was set.

One proper fix would be to refactor the monitor code to provide enough helpers for users so that they would not need to directly access the `Reason` field. This will be implemented in a separate PR in order to avoid backporting refactoring commits.

Related to https://github.com/cilium/cilium/issues/31202