### PR TITLE
bgpv1: Adjust ConnectionRetryTimeSeconds to 1 in component tests

### DIFF
--- a/pkg/bgpv1/test/objects.go
+++ b/pkg/bgpv1/test/objects.go
@@ -14,6 +14,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -44,6 +45,17 @@ func newPolicyObj(conf policyConfig) v2alpha1.CiliumBGPPeeringPolicy {
 	}
 
 	if conf.virtualRouters != nil {
+		// Override ConnectRetryTimeSeconds to 1 for all neighbors
+		// unless it is specified explicitly. Otherwise, the default
+		// value of 120 seconds would timeout the tests when the
+		// initial connect fails.
+		for i, vrouter := range conf.virtualRouters {
+			for j, neigh := range vrouter.Neighbors {
+				if neigh.ConnectRetryTimeSeconds == nil {
+					conf.virtualRouters[i].Neighbors[j].ConnectRetryTimeSeconds = ptr.To[int32](1)
+				}
+			}
+		}
 		policyObj.Spec.VirtualRouters = conf.virtualRouters
 	}
 


### PR DESCRIPTION
Set ConnectionRetryTimeSeconds in the component tests to 1s in component tests unless it is specified explicitly. Otherwise, when the initial connect fails, we need to 120s for the next connection by default, which may longer than the timeout of the test itself.

Fixes: #31217

```release-note
bgpv1: Adjust ConnectionRetryTimeSeconds to 1 in component tests
```
