### PR TITLE
[v1.15] envoy: Bump golang version to 1.21.8

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1135,7 +1135,7 @@
    * - :spelling:ignore:`envoy.image`
      - Envoy container image.
      - object
-     - ``{"digest":"sha256:55fa563a00cc3646cc850d43768a1d3aca445f9b4d7c6de8684efd5e05e5bb0e","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.27.3-7b6dd65c5daf00d45586b00ad2e907010b5110a6","useDigest":true}``
+     - ``{"digest":"sha256:877ead12d08d4c04a9f67f86d3c6e542aeb7bf97e1e401aee74de456f496ac30","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.27.3-99c1c8f42c8de70fc8f6dd594f4a425cd38b6688","useDigest":true}``
    * - :spelling:ignore:`envoy.livenessProbe.failureThreshold`
      - failure threshold of liveness probe
      - int

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:00f38ffc90b09ae91c4606803
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.27.3-7b6dd65c5daf00d45586b00ad2e907010b5110a6@sha256:55fa563a00cc3646cc850d43768a1d3aca445f9b4d7c6de8684efd5e05e5bb0e as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.27.3-99c1c8f42c8de70fc8f6dd594f4a425cd38b6688@sha256:877ead12d08d4c04a9f67f86d3c6e542aeb7bf97e1e401aee74de456f496ac30 as cilium-envoy
 
 #
 # Hubble CLI

--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -43,8 +43,8 @@ export CILIUM_NODEINIT_REPO:=quay.io/cilium/startup-script
 export CILIUM_NODEINIT_VERSION:=62093c5c233ea914bfa26a10ba41f8780d9b737f
 
 export CILIUM_ENVOY_REPO:=quay.io/cilium/cilium-envoy
-export CILIUM_ENVOY_VERSION:=v1.27.3-7b6dd65c5daf00d45586b00ad2e907010b5110a6
-export CILIUM_ENVOY_DIGEST:=sha256:55fa563a00cc3646cc850d43768a1d3aca445f9b4d7c6de8684efd5e05e5bb0e
+export CILIUM_ENVOY_VERSION:=v1.27.3-99c1c8f42c8de70fc8f6dd594f4a425cd38b6688
+export CILIUM_ENVOY_DIGEST:=sha256:877ead12d08d4c04a9f67f86d3c6e542aeb7bf97e1e401aee74de456f496ac30
 
 export HUBBLE_UI_BACKEND_REPO:=quay.io/cilium/hubble-ui-backend
 export HUBBLE_UI_BACKEND_VERSION:=v0.13.0

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -333,7 +333,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:55fa563a00cc3646cc850d43768a1d3aca445f9b4d7c6de8684efd5e05e5bb0e","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.27.3-7b6dd65c5daf00d45586b00ad2e907010b5110a6","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:877ead12d08d4c04a9f67f86d3c6e542aeb7bf97e1e401aee74de456f496ac30","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.27.3-99c1c8f42c8de70fc8f6dd594f4a425cd38b6688","useDigest":true}` | Envoy container image. |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | envoy.log.format | string | `"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"` | The format string to use for laying out the log message metadata of Envoy. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2064,9 +2064,9 @@ envoy:
   image:
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.27.3-7b6dd65c5daf00d45586b00ad2e907010b5110a6"
+    tag: "v1.27.3-99c1c8f42c8de70fc8f6dd594f4a425cd38b6688"
     pullPolicy: "IfNotPresent"
-    digest: "sha256:55fa563a00cc3646cc850d43768a1d3aca445f9b4d7c6de8684efd5e05e5bb0e"
+    digest: "sha256:877ead12d08d4c04a9f67f86d3c6e542aeb7bf97e1e401aee74de456f496ac30"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.


### PR DESCRIPTION
This is to pick up the new image with updated golang version, and other dependency bump.

Related commit: https://github.com/cilium/proxy/commit/99c1c8f42c8de70fc8f6dd594f4a425cd38b6688
Related build: https://github.com/cilium/proxy/actions/runs/8179378100/job/22365327840
