### PR TITLE
[v1.14] envoy: Bump golang version to 1.21.8

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1051,7 +1051,7 @@
    * - :spelling:ignore:`envoy.image`
      - Envoy container image.
      - object
-     - ``{"digest":"sha256:f59e50109c81c141028a3315853a861c5df638d16d652064522eea91690f3f37","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.26.7-860c2219c1d3a0e531c36bd2171d0b1678bba530","useDigest":true}``
+     - ``{"digest":"sha256:39b75548447978230dedcf25da8940e4d3540c741045ef391a8e74dbb9661a86","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.26.7-bbde4095997ea57ead209f56158790d47224a0f5","useDigest":true}``
    * - :spelling:ignore:`envoy.livenessProbe.failureThreshold`
      - failure threshold of liveness probe
      - int

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:44f820035b04c6b922c8d9bf3
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.26.7-860c2219c1d3a0e531c36bd2171d0b1678bba530@sha256:f59e50109c81c141028a3315853a861c5df638d16d652064522eea91690f3f37 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.26.7-bbde4095997ea57ead209f56158790d47224a0f5@sha256:39b75548447978230dedcf25da8940e4d3540c741045ef391a8e74dbb9661a86 as cilium-envoy
 
 #
 # Hubble CLI

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -312,7 +312,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:f59e50109c81c141028a3315853a861c5df638d16d652064522eea91690f3f37","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.26.7-860c2219c1d3a0e531c36bd2171d0b1678bba530","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:39b75548447978230dedcf25da8940e4d3540c741045ef391a8e74dbb9661a86","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.26.7-bbde4095997ea57ead209f56158790d47224a0f5","useDigest":true}` | Envoy container image. |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | envoy.log.format | string | `"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"` | The format string to use for laying out the log message metadata of Envoy. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1857,9 +1857,9 @@ envoy:
   image:
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.26.7-860c2219c1d3a0e531c36bd2171d0b1678bba530"
+    tag: "v1.26.7-bbde4095997ea57ead209f56158790d47224a0f5"
     pullPolicy: "IfNotPresent"
-    digest: "sha256:f59e50109c81c141028a3315853a861c5df638d16d652064522eea91690f3f37"
+    digest: "sha256:39b75548447978230dedcf25da8940e4d3540c741045ef391a8e74dbb9661a86"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1854,9 +1854,9 @@ envoy:
   image:
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.26.7-860c2219c1d3a0e531c36bd2171d0b1678bba530"
+    tag: "v1.26.7-bbde4095997ea57ead209f56158790d47224a0f5"
     pullPolicy: "${PULL_POLICY}"
-    digest: "sha256:f59e50109c81c141028a3315853a861c5df638d16d652064522eea91690f3f37"
+    digest: "sha256:39b75548447978230dedcf25da8940e4d3540c741045ef391a8e74dbb9661a86"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.


### PR DESCRIPTION
This is to pick up the new image with updated golang version, and other dependency bump.

Related commit: https://github.com/cilium/proxy/commit/bbde4095997ea57ead209f56158790d47224a0f5
Related build: https://github.com/cilium/proxy/actions/runs/8179371187/job/22365308893

