### PR TITLE
feat: Add the http return code to metric api_processed_total

### DIFF
--- a/Documentation/configuration/api-rate-limiting.rst
+++ b/Documentation/configuration/api-rate-limiting.rst
@@ -132,17 +132,17 @@ Metrics
 
 All API calls subject to rate limiting will expose :ref:`metrics_api_rate_limiting`. Example::
 
-    cilium_api_limiter_adjustment_factor                  api_call="endpoint-create"                               0.695787
-    cilium_api_limiter_processed_requests_total           api_call="endpoint-create" outcome="success"             7.000000
-    cilium_api_limiter_processing_duration_seconds        api_call="endpoint-create" value="estimated"             2.000000
-    cilium_api_limiter_processing_duration_seconds        api_call="endpoint-create" value="mean"                  2.874443
-    cilium_api_limiter_rate_limit                         api_call="endpoint-create" value="burst"                 4.000000
-    cilium_api_limiter_rate_limit                         api_call="endpoint-create" value="limit"                 0.347894
-    cilium_api_limiter_requests_in_flight                 api_call="endpoint-create" value="in-flight"             0.000000
-    cilium_api_limiter_requests_in_flight                 api_call="endpoint-create" value="limit"                 0.000000
-    cilium_api_limiter_wait_duration_seconds              api_call="endpoint-create" value="max"                  15.000000
-    cilium_api_limiter_wait_duration_seconds              api_call="endpoint-create" value="mean"                  0.000000
-    cilium_api_limiter_wait_duration_seconds              api_call="endpoint-create" value="min"                   0.000000
+    cilium_api_limiter_adjustment_factor                  api_call="endpoint-create"                                                0.695787
+    cilium_api_limiter_processed_requests_total           api_call="endpoint-create" outcome="success" return_code="200"            7.000000
+    cilium_api_limiter_processing_duration_seconds        api_call="endpoint-create" value="estimated"                              2.000000
+    cilium_api_limiter_processing_duration_seconds        api_call="endpoint-create" value="mean"                                   2.874443
+    cilium_api_limiter_rate_limit                         api_call="endpoint-create" value="burst"                                  4.000000
+    cilium_api_limiter_rate_limit                         api_call="endpoint-create" value="limit"                                  0.347894
+    cilium_api_limiter_requests_in_flight                 api_call="endpoint-create" value="in-flight"                              0.000000
+    cilium_api_limiter_requests_in_flight                 api_call="endpoint-create" value="limit"                                  0.000000
+    cilium_api_limiter_wait_duration_seconds              api_call="endpoint-create" value="max"                                    15.000000
+    cilium_api_limiter_wait_duration_seconds              api_call="endpoint-create" value="mean"                                   0.000000
+    cilium_api_limiter_wait_duration_seconds              api_call="endpoint-create" value="min"                                    0.000000
 
 Understanding the log output
 ============================

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -573,17 +573,17 @@ Name                                                Labels                Defaul
 API Rate Limiting
 ~~~~~~~~~~~~~~~~~
 
-============================================== ================================ ========== ========================================================
-Name                                           Labels                           Default    Description
-============================================== ================================ ========== ========================================================
-``api_limiter_adjustment_factor``              ``api_call``                     Enabled    Most recent adjustment factor for automatic adjustment
-``api_limiter_processed_requests_total``       ``api_call``, ``outcome``        Enabled    Total number of API requests processed
-``api_limiter_processing_duration_seconds``    ``api_call``, ``value``          Enabled    Mean and estimated processing duration in seconds
-``api_limiter_rate_limit``                     ``api_call``, ``value``          Enabled    Current rate limiting configuration (limit and burst)
-``api_limiter_requests_in_flight``             ``api_call``  ``value``          Enabled    Current and maximum allowed number of requests in flight
-``api_limiter_wait_duration_seconds``          ``api_call``, ``value``          Enabled    Mean, min, and max wait duration
-``api_limiter_wait_history_duration_seconds``  ``api_call``                     Disabled   Histogram of wait duration per API call processed
-============================================== ================================ ========== ========================================================
+============================================== ========================================== ========== ========================================================
+Name                                           Labels                                     Default    Description
+============================================== ========================================== ========== ========================================================
+``api_limiter_adjustment_factor``              ``api_call``                               Enabled    Most recent adjustment factor for automatic adjustment
+``api_limiter_processed_requests_total``       ``api_call``, ``outcome``, ``return_code`` Enabled    Total number of API requests processed
+``api_limiter_processing_duration_seconds``    ``api_call``, ``value``                    Enabled    Mean and estimated processing duration in seconds
+``api_limiter_rate_limit``                     ``api_call``, ``value``                    Enabled    Current rate limiting configuration (limit and burst)
+``api_limiter_requests_in_flight``             ``api_call``  ``value``                    Enabled    Current and maximum allowed number of requests in flight
+``api_limiter_wait_duration_seconds``          ``api_call``, ``value``                    Enabled    Mean, min, and max wait duration
+``api_limiter_wait_history_duration_seconds``  ``api_call``                               Disabled   Histogram of wait duration per API call processed
+============================================== ========================================== ========== ========================================================
 
 cilium-operator
 ---------------
@@ -1129,15 +1129,15 @@ Name                                     Labels                                 
 API Rate Limiting
 ~~~~~~~~~~~~~~~~~
 
-============================================== ================================ ========================================================
-Name                                           Labels                           Description
-============================================== ================================ ========================================================
-``api_limiter_processed_requests_total``       ``api_call``, ``outcome``        Total number of API requests processed
-``api_limiter_processing_duration_seconds``    ``api_call``, ``value``          Mean and estimated processing duration in seconds
-``api_limiter_rate_limit``                     ``api_call``, ``value``          Current rate limiting configuration (limit and burst)
-``api_limiter_requests_in_flight``             ``api_call``  ``value``          Current and maximum allowed number of requests in flight
-``api_limiter_wait_duration_seconds``          ``api_call``, ``value``          Mean, min, and max wait duration
-============================================== ================================ ========================================================
+============================================== ========================================== ========================================================
+Name                                           Labels                                     Description
+============================================== ========================================== ========================================================
+``api_limiter_processed_requests_total``       ``api_call``, ``outcome``, ``return_code`` Total number of API requests processed
+``api_limiter_processing_duration_seconds``    ``api_call``, ``value``                    Mean and estimated processing duration in seconds
+``api_limiter_rate_limit``                     ``api_call``, ``value``                    Current rate limiting configuration (limit and burst)
+``api_limiter_requests_in_flight``             ``api_call``  ``value``                    Current and maximum allowed number of requests in flight
+``api_limiter_wait_duration_seconds``          ``api_call``, ``value``                     Mean, min, and max wait duration
+============================================== ========================================== ========================================================
 
 Controllers
 ~~~~~~~~~~~
@@ -1213,15 +1213,15 @@ Name                                     Labels                                 
 API Rate Limiting
 ~~~~~~~~~~~~~~~~~
 
-============================================== ================================ ========================================================
-Name                                           Labels                           Description
-============================================== ================================ ========================================================
-``api_limiter_processed_requests_total``       ``api_call``, ``outcome``        Total number of API requests processed
-``api_limiter_processing_duration_seconds``    ``api_call``, ``value``          Mean and estimated processing duration in seconds
-``api_limiter_rate_limit``                     ``api_call``, ``value``          Current rate limiting configuration (limit and burst)
-``api_limiter_requests_in_flight``             ``api_call``  ``value``          Current and maximum allowed number of requests in flight
-``api_limiter_wait_duration_seconds``          ``api_call``, ``value``          Mean, min, and max wait duration
-============================================== ================================ ========================================================
+============================================== ========================================== ========================================================
+Name                                           Labels                                     Description
+============================================== ========================================== ========================================================
+``api_limiter_processed_requests_total``       ``api_call``, ``outcome``, ``return_code`` Total number of API requests processed
+``api_limiter_processing_duration_seconds``    ``api_call``, ``value``                    Mean and estimated processing duration in seconds
+``api_limiter_rate_limit``                     ``api_call``, ``value``                    Current rate limiting configuration (limit and burst)
+``api_limiter_requests_in_flight``             ``api_call``  ``value``                    Current and maximum allowed number of requests in flight
+``api_limiter_wait_duration_seconds``          ``api_call``, ``value``                    Mean, min, and max wait duration
+============================================== ========================================== ========================================================
 
 Controllers
 ~~~~~~~~~~~

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -354,7 +354,7 @@ The following deprecated metrics were removed:
 Changed Metrics
 ~~~~~~~~~~~~~~~
 
-* TBD
+* The ``cilium_api_limiter_processed_requests_total`` has now label ``return_code`` to specify the http code of the request.
 
 .. _1.15_upgrade_notes:
 

--- a/pkg/api/apierror.go
+++ b/pkg/api/apierror.go
@@ -30,6 +30,11 @@ func New(code int, msg string, args ...interface{}) *APIError {
 	return &APIError{code: code, msg: msg}
 }
 
+// GetCode returns the code for the API Error.
+func (a *APIError) GetCode() int {
+	return a.code
+}
+
 // Error creates a new API error from the code and error.
 func Error(code int, err error) *APIError {
 	if err == nil {

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -763,7 +763,7 @@ func (e *etcdClient) DeletePrefix(ctx context.Context, path string) (err error) 
 
 	_, err = e.client.Delete(ctx, path, client.WithPrefix())
 	// Using lr.Error for convenience, as it matches lr.Done() when err is nil
-	lr.Error(err)
+	lr.Error(err, -1)
 
 	if err == nil {
 		e.leaseManager.ReleasePrefix(path)
@@ -829,7 +829,7 @@ reList:
 		}
 		kvs, revision, err := e.paginatedList(ctx, scopedLog, w.Prefix)
 		if err != nil {
-			lr.Error(err)
+			lr.Error(err, -1)
 			scopedLog.WithError(Hint(err)).Warn("Unable to list keys before starting watcher")
 			errLimiter.Wait(ctx)
 			continue
@@ -1132,7 +1132,7 @@ func (e *etcdClient) GetIfLocked(ctx context.Context, key string, lock KVLocker)
 	}
 
 	if err != nil {
-		lr.Error(err)
+		lr.Error(err, -1)
 		return nil, Hint(err)
 	}
 
@@ -1160,7 +1160,7 @@ func (e *etcdClient) Get(ctx context.Context, key string) (bv []byte, err error)
 
 	getR, err := e.client.Get(ctx, key)
 	if err != nil {
-		lr.Error(err)
+		lr.Error(err, -1)
 		return nil, Hint(err)
 	}
 	lr.Done()
@@ -1195,7 +1195,7 @@ func (e *etcdClient) DeleteIfLocked(ctx context.Context, key string, lock KVLock
 	}
 
 	// Using lr.Error for convenience, as it matches lr.Done() when err is nil
-	lr.Error(err)
+	lr.Error(err, -1)
 	return Hint(err)
 }
 
@@ -1214,7 +1214,7 @@ func (e *etcdClient) Delete(ctx context.Context, key string) (err error) {
 
 	_, err = e.client.Delete(ctx, key)
 	// Using lr.Error for convenience, as it matches lr.Done() when err is nil
-	lr.Error(err)
+	lr.Error(err, -1)
 
 	if err == nil {
 		e.leaseManager.Release(key)
@@ -1254,7 +1254,7 @@ func (e *etcdClient) UpdateIfLocked(ctx context.Context, key string, value []byt
 	}
 
 	// Using lr.Error for convenience, as it matches lr.Done() when err is nil
-	lr.Error(err)
+	lr.Error(err, -1)
 	return Hint(err)
 }
 
@@ -1282,7 +1282,7 @@ func (e *etcdClient) Update(ctx context.Context, key string, value []byte, lease
 	e.leaseManager.CancelIfExpired(err, leaseID)
 
 	// Using lr.Error for convenience, as it matches lr.Done() when err is nil
-	lr.Error(err)
+	lr.Error(err, -1)
 	return Hint(err)
 }
 
@@ -1300,7 +1300,7 @@ func (e *etcdClient) UpdateIfDifferentIfLocked(ctx context.Context, key string, 
 	cnds := lock.Comparator().(client.Cmp)
 	txnresp, err := e.client.Txn(ctx).If(cnds).Then(client.OpGet(key)).Commit()
 	// Using lr.Error for convenience, as it matches lr.Done() when err is nil
-	lr.Error(err)
+	lr.Error(err, -1)
 	increaseMetric(key, metricRead, "Get", duration.EndError(err).Total(), err)
 
 	// On error, attempt update blindly
@@ -1341,7 +1341,7 @@ func (e *etcdClient) UpdateIfDifferent(ctx context.Context, key string, value []
 
 	getR, err := e.client.Get(ctx, key)
 	// Using lr.Error for convenience, as it matches lr.Done() when err is nil
-	lr.Error(err)
+	lr.Error(err, -1)
 	increaseMetric(key, metricRead, "Get", duration.EndError(err).Total(), err)
 	// On error, attempt update blindly
 	if err != nil || getR.Count == 0 {
@@ -1390,7 +1390,7 @@ func (e *etcdClient) CreateOnlyIfLocked(ctx context.Context, key string, value [
 	txnresp, err := e.client.Txn(ctx).If(cnds...).Then(req).Else(opGets...).Commit()
 	increaseMetric(key, metricSet, "CreateOnlyLocked", duration.EndError(err).Total(), err)
 	if err != nil {
-		lr.Error(err)
+		lr.Error(err, -1)
 		e.leaseManager.CancelIfExpired(err, leaseID)
 		return false, Hint(err)
 	}
@@ -1449,7 +1449,7 @@ func (e *etcdClient) CreateOnly(ctx context.Context, key string, value []byte, l
 	txnresp, err := e.client.Txn(ctx).If(cond).Then(req).Commit()
 
 	if err != nil {
-		lr.Error(err)
+		lr.Error(err, -1)
 		e.leaseManager.CancelIfExpired(err, leaseID)
 		return false, Hint(err)
 	}
@@ -1478,7 +1478,7 @@ func (e *etcdClient) ListPrefixIfLocked(ctx context.Context, prefix string, lock
 		err = ErrLockLeaseExpired
 	}
 	if err != nil {
-		lr.Error(err)
+		lr.Error(err, -1)
 		return nil, Hint(err)
 	}
 	lr.Done()
@@ -1511,7 +1511,7 @@ func (e *etcdClient) ListPrefix(ctx context.Context, prefix string) (v KeyValueP
 
 	getR, err := e.client.Get(ctx, prefix, client.WithPrefix())
 	if err != nil {
-		lr.Error(err)
+		lr.Error(err, -1)
 		return nil, Hint(err)
 	}
 	lr.Done()

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1270,7 +1270,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Subsystem:  SubsystemAPILimiter,
 			Name:       "processed_requests_total",
 			Help:       "Total number of API requests processed",
-		}, []string{"api_call", LabelOutcome}),
+		}, []string{"api_call", LabelOutcome, LabelAPIReturnCode}),
 
 		EndpointPropagationDelay: metric.NewHistogramVec(metric.HistogramOpts{
 			ConfigName: Namespace + "_endpoint_propagation_delay_seconds",
@@ -1581,6 +1581,14 @@ func Error2Outcome(err error) string {
 	}
 
 	return LabelValueOutcomeSuccess
+}
+
+// LabelOutcome2Code converts a label outcome to a code
+func LabelOutcome2Code(outcome string) int {
+	if outcome == LabelValueOutcomeSuccess {
+		return 200
+	}
+	return 500
 }
 
 func BoolToFloat64(v bool) float64 {

--- a/pkg/rate/api_limiter.go
+++ b/pkg/rate/api_limiter.go
@@ -86,6 +86,8 @@ const (
 	outcomeParallelMaxWait outcome = "fail-parallel-wait"
 	outcomeLimitMaxWait    outcome = "fail-limit-wait"
 	outcomeReqCancelled    outcome = "request-cancelled"
+	outcomeErrorCode       int     = 429
+	outcomeSuccessCode     int     = 200
 )
 
 // APILimiter is an extension to x/time/rate.Limiter specifically for Cilium
@@ -464,7 +466,7 @@ func (l *APILimiter) adjustedParallelRequests() int {
 	return int(l.adjustmentLimit(newParallelRequests, float64(l.params.ParallelRequests)))
 }
 
-func (l *APILimiter) requestFinished(r *limitedRequest, err error) {
+func (l *APILimiter) requestFinished(r *limitedRequest, err error, code int) {
 	if r.finished {
 		return
 	}
@@ -546,6 +548,7 @@ func (l *APILimiter) requestFinished(r *limitedRequest, err error) {
 		AdjustmentFactor:            l.adjustmentFactor,
 		Error:                       err,
 		Outcome:                     string(r.outcome),
+		ReturnCode:                  code,
 	}
 
 	if l.limiter != nil {
@@ -575,7 +578,7 @@ func calcMeanDuration(durations []time.Duration) float64 {
 // WaitDuration() concurrently.
 type LimitedRequest interface {
 	Done()
-	Error(err error)
+	Error(err error, code int)
 	WaitDuration() time.Duration
 }
 
@@ -597,12 +600,12 @@ func (l *limitedRequest) WaitDuration() time.Duration {
 
 // Done must be called when the API request has been successfully processed
 func (l *limitedRequest) Done() {
-	l.limiter.requestFinished(l, nil)
+	l.limiter.requestFinished(l, nil, outcomeSuccessCode)
 }
 
 // Error must be called when the API request resulted in an error
-func (l *limitedRequest) Error(err error) {
-	l.limiter.requestFinished(l, err)
+func (l *limitedRequest) Error(err error, code int) {
+	l.limiter.requestFinished(l, err, code)
 }
 
 // Wait blocks until the next API call is allowed to be processed. If the
@@ -612,7 +615,7 @@ func (l *limitedRequest) Error(err error) {
 func (l *APILimiter) Wait(ctx context.Context) (LimitedRequest, error) {
 	req, err := l.wait(ctx)
 	if err != nil {
-		l.requestFinished(req, err)
+		l.requestFinished(req, err, outcomeErrorCode)
 		return nil, err
 	}
 	return req, nil
@@ -841,6 +844,7 @@ type MetricsValues struct {
 	CurrentRequestsInFlight     int
 	AdjustmentFactor            float64
 	Error                       error
+	ReturnCode                  int
 }
 
 // MetricsObserver is the interface that must be implemented to extract metrics
@@ -895,7 +899,7 @@ type dummyRequest struct{}
 
 func (d dummyRequest) WaitDuration() time.Duration { return 0 }
 func (d dummyRequest) Done()                       {}
-func (d dummyRequest) Error(err error)             {}
+func (d dummyRequest) Error(err error, code int)   {}
 
 // Wait invokes Wait() on the APILimiter with the given name. If the limiter
 // does not exist, a dummy limiter is used which will not impose any

--- a/pkg/rate/api_limiter_test.go
+++ b/pkg/rate/api_limiter_test.go
@@ -63,6 +63,7 @@ func (m *mockMetrics) ProcessedRequest(name string, v MetricsValues) {
 	me.Burst = v.Burst
 	me.CurrentRequestsInFlight = v.CurrentRequestsInFlight
 	me.AdjustmentFactor = v.AdjustmentFactor
+	me.ReturnCode = v.ReturnCode
 }
 
 func TestNewAPILimiter(t *testing.T) {
@@ -498,7 +499,7 @@ func TestAPILimiterMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, req3)
 	time.Sleep(5 * time.Millisecond)
-	req3.Error(fmt.Errorf("error"))
+	req3.Error(fmt.Errorf("error"), 500)
 	req3.Done()
 
 	a := l.Limiter("foo")

--- a/pkg/rate/metrics/metrics.go
+++ b/pkg/rate/metrics/metrics.go
@@ -4,6 +4,8 @@
 package metrics
 
 import (
+	"strconv"
+
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/rate"
 )
@@ -31,5 +33,9 @@ func (a *apiRateLimitingMetrics) ProcessedRequest(name string, v rate.MetricsVal
 		v.Outcome = metrics.Error2Outcome(v.Error)
 	}
 
-	metrics.APILimiterProcessedRequests.WithLabelValues(name, v.Outcome).Inc()
+	if v.ReturnCode == -1 {
+		v.ReturnCode = metrics.LabelOutcome2Code(v.Outcome)
+	}
+
+	metrics.APILimiterProcessedRequests.WithLabelValues(name, v.Outcome, strconv.Itoa(v.ReturnCode)).Inc()
 }


### PR DESCRIPTION

<!-- Description of change -->

Adding the return code to the `cilium_api_limiter_processed_requests_total` based on the error/success of the API call. It helps in filtering the metric based on http code as `labeloutcome` of `fail` is generic. 
Tested the changes via grafana and prometheus:
![image](https://github.com/cilium/cilium/assets/8600441/d4923363-68e2-4b97-9873-13529b050749)            
