### PR TITLE
chore: bump lvh images in CI.

### DIFF
--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -6,25 +6,25 @@ include:
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "bpf-next-20240304.012759@sha256:945a3620cdf7a9a48363582639e866d5b9f890dcc5e385370f609732ef2d8d83"
+    kernel: "bpf-next-20240307.011705@sha256:sha256:031062edd2d6c99c7ffb7b4cdd26d45f3adb086ec35f3ae9acf7290693792908"
 
   - k8s-version: "1.28"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.28.7@sha256:9bc6c451a289cf96ad0bbaf33d416901de6fd632415b076ab05f5fa7e4f65c58"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "rhel8-20240221.111541@sha256:183dc15b868bfec1fcb3d4d70e3a2e33762cd9b10e4cd4b23f778fe108cfcaa3"
+    kernel: "rhel8-20240305.092417@sha256:183dc15b868bfec1fcb3d4d70e3a2e33762cd9b10e4cd4b23f778fe108cfcaa3"
 
   - k8s-version: "1.27"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.27.11@sha256:681253009e68069b8e01aad36a1e0fa8cf18bb0ab3e5c4069b2e65cafdd70843"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "rhel8-20240221.111541@sha256:183dc15b868bfec1fcb3d4d70e3a2e33762cd9b10e4cd4b23f778fe108cfcaa3"
+    kernel: "rhel8-20240305.092417@sha256:183dc15b868bfec1fcb3d4d70e3a2e33762cd9b10e4cd4b23f778fe108cfcaa3"
 
   - k8s-version: "1.26"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.26.14@sha256:5d548739ddef37b9318c70cb977f57bf3e5015e4552be4e27e57280a8cbb8e4f"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "5.4-20240221.111541@sha256:dfeed11dcee7f3a72ff178b6af740de042c5163db75b5b0106032a80f3c86caa"
+    kernel: "5.4-20240305.092417@sha256:054026744db7305801641f276d751d6179dc5eed9a1eaa4c8b6918982e5f828e"

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -79,7 +79,7 @@ jobs:
 
           - name: '1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: 'rhel8-20240221.111541'
+            kernel: 'rhel8-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'
@@ -87,13 +87,13 @@ jobs:
 
           - name: '2'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.4-20240221.111541'
+            kernel: '5.4-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'disabled'
             host-fw: 'true'
 
-          - name: '3'
+          - name: '3'5.10-20240305.092417
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: '5.10-20240221.111541'
             kube-proxy: 'iptables'
@@ -101,7 +101,7 @@ jobs:
             tunnel: 'disabled'
             endpoint-routes: 'true'
 
-          - name: '4'
+          - name: '4'5.10-20240305.092417
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: '5.10-20240221.111541'
             kube-proxy: 'iptables'
@@ -115,7 +115,7 @@ jobs:
 
           - name: '5'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.15-20240221.111541'
+            kernel: '6.1-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -128,7 +128,7 @@ jobs:
 
           - name: '6'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.1-20240221.111541'
+            kernel: '6.1-20240305.092417'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -160,7 +160,7 @@ jobs:
             tunnel: 'geneve'
             endpoint-routes: 'true'
 
-          - name: '9'
+          - name: '9'5.10-20240305.092417
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: '5.10-20240221.111541'
             kube-proxy: 'iptables'
@@ -176,7 +176,7 @@ jobs:
 
           - name: '10'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.15-20240221.111541'
+            kernel: '6.1-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -190,7 +190,7 @@ jobs:
 
           - name: '11'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.1-20240221.111541'
+            kernel: '6.1-20240305.092417'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -218,7 +218,7 @@ jobs:
 
           - name: '13'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: 'rhel8-20240221.111541'
+            kernel: 'rhel8-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'
@@ -226,7 +226,7 @@ jobs:
 
           - name: '14'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.4-20240221.111541'
+            kernel: '5.4-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'true'
             devices: '{eth0,eth1}'

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -77,7 +77,7 @@ jobs:
 
           - name: '1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: 'rhel8-20240221.111541'
+            kernel: 'rhel8-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'
@@ -88,7 +88,7 @@ jobs:
 
           - name: '2'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.4-20240221.111541'
+            kernel: '5.4-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'disabled'
@@ -99,7 +99,7 @@ jobs:
 
           - name: '3'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20240221.111541'
+            kernel: '5.10-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'disabled'

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -72,19 +72,19 @@ jobs:
       matrix:
         include:
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '5.4-20240221.111541'
+          - kernel: '5.4-20240305.092417'
             ci-kernel: '54'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: 'rhel8-20240221.111541'
+          - kernel: 'rhel8-20240305.092417'
             ci-kernel: '54'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '5.10-20240221.111541'
+          - kernel: '5.10-20240305.092417'
             ci-kernel: '510'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '5.15-20240221.111541'
+          - kernel: '6.1-20240305.092417'
             ci-kernel: '510'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '6.1-20240221.111541'
+          - kernel: '6.1-20240305.092417'
             ci-kernel: '61'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: 'bpf-next-20240304.012759'

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -79,7 +79,7 @@ jobs:
 
           - name: '1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: 'rhel8-20240221.111541'
+            kernel: 'rhel8-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'
@@ -87,13 +87,13 @@ jobs:
 
           - name: '2'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.4-20240221.111541'
+            kernel: '5.4-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'disabled'
             host-fw: 'true'
 
-          - name: '3'
+          - name: '3'5.10-20240305.092417
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: '5.10-20240221.111541'
             kube-proxy: 'iptables'
@@ -101,7 +101,7 @@ jobs:
             tunnel: 'disabled'
             endpoint-routes: 'true'
 
-          - name: '4'
+          - name: '4'5.10-20240305.092417
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: '5.10-20240221.111541'
             kube-proxy: 'iptables'
@@ -115,7 +115,7 @@ jobs:
 
           - name: '5'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.15-20240221.111541'
+            kernel: '6.1-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -128,7 +128,7 @@ jobs:
 
           - name: '6'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.1-20240221.111541'
+            kernel: '6.1-20240305.092417'
             kube-proxy: 'none'
             kpr: 'true'
             tunnel: 'vxlan'
@@ -159,7 +159,7 @@ jobs:
             tunnel: 'geneve'
             endpoint-routes: 'true'
 
-          - name: '9'
+          - name: '9'5.10-20240305.092417
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: '5.10-20240221.111541'
             kube-proxy: 'iptables'
@@ -175,7 +175,7 @@ jobs:
 
           - name: '10'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.15-20240221.111541'
+            kernel: '6.1-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -189,7 +189,7 @@ jobs:
 
           - name: '11'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.1-20240221.111541'
+            kernel: '6.1-20240305.092417'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -217,7 +217,7 @@ jobs:
 
           - name: '14'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.4-20240221.111541'
+            kernel: '5.4-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'true'
             devices: '{eth0,eth1}'

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -78,7 +78,7 @@ jobs:
           # Define three config sets
           - config: '5.4'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.4-20240221.111541'
+            kernel: '5.4-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
@@ -86,7 +86,7 @@ jobs:
 
           - config: '5.10'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20240221.111541'
+            kernel: '5.10-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
@@ -95,7 +95,7 @@ jobs:
 
           - config: '6.1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.1-20240221.111541'
+            kernel: '6.1-20240305.092417'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'vxlan'


### PR DESCRIPTION
    chore: bump lvh images in CI.

    With issue #31040 we've been seeing strange timeouts in bpf-next.

    It seems like: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ca9ca1a5d5a980550db1001ea825f9fdfa550b83 may address this issue.
    The latest round of lvh-images [1] bpf-next contain this patch so we're going to bump these now and see if this resolves #31040.

    [1] https://github.com/cilium/little-vm-helper-images/pull/400

Addresses: #31040