### PR TITLE
Fix running tests locally in kind

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -52,7 +52,7 @@ k8s-test:
 # Match kind-image target in parent directory
 k8s-kind: export DOCKER_REGISTRY=localhost:5000
 k8s-kind:
-	@if [ -z $(FOCUS) ]; then \
+	@if [ -z "$(FOCUS)" ]; then \
 		>&2 echo "usage: FOCUS=K8sFoo make k8s-kind"; \
 		exit 1; \
 	fi

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -194,6 +194,7 @@ var (
 	kindHelmOverrides = map[string]string{
 		// To mount the cgroupv2 sub-root
 		"nodeinit.enabled": "true",
+		"image.pullPolicy": "IfNotPresent",
 	}
 
 	// helmOverrides allows overriding of cilium-agent options for


### PR DESCRIPTION
Running tests locally on a kind cluster is supposed to work with the
following commands:

    make kind
    make kind-image
    FOCUS=... make -C test k8s-kind

The last one has been apparently broken for some while, resulting in
ImagePullBackOff due to a failure to connect to localhost:5000. It
happens because these images are preloaded by `kind load`, and there is
no real registry at localhost:5000, but image.pullPolicy is set to
Always, therefore k8s ignores the preloaded image, attempts to pull it
anyway and fails in ImagePullBackOff.

Setting image.pullPolicy to IfNotPresent resolves this problem by
allowing to use the preloaded image.

```release-note
Fix running tests locally in kind.
```
