### PR TITLE
bgpv1: ExternalIP  advertisement with BGP Control Plane

### DIFF
--- a/pkg/bgpv1/manager/reconciler/service.go
+++ b/pkg/bgpv1/manager/reconciler/service.go
@@ -344,6 +344,17 @@ func (r *ServiceReconciler) svcDesiredRoutes(newc *v2alpha1api.CiliumBGPVirtualR
 				}
 				desiredRoutes = append(desiredRoutes, netip.PrefixFrom(addr, addr.BitLen()))
 			}
+		case v2alpha1api.BGPExternalIPAddr:
+			for _, extIP := range svc.Spec.ExternalIPs {
+				if extIP == "" {
+					continue
+				}
+				addr, err := netip.ParseAddr(extIP)
+				if err != nil {
+					continue
+				}
+				desiredRoutes = append(desiredRoutes, netip.PrefixFrom(addr, addr.BitLen()))
+			}
 		}
 	}
 

--- a/pkg/bgpv1/manager/reconciler/service_test.go
+++ b/pkg/bgpv1/manager/reconciler/service_test.go
@@ -23,7 +23,7 @@ import (
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 )
 
-func TestLBServiceReconcilerWithLoadBalancer(t *testing.T) {
+func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 	blueSelector := slim_metav1.LabelSelector{MatchLabels: map[string]string{"color": "blue"}}
 	redSelector := slim_metav1.LabelSelector{MatchLabels: map[string]string{"color": "red"}}
 	svc1Name := resource.Key{Name: "svc-1", Namespace: "default"}
@@ -699,7 +699,7 @@ func TestLBServiceReconcilerWithLoadBalancer(t *testing.T) {
 	}
 }
 
-func TestLBServiceReconcilerWithClusterIP(t *testing.T) {
+func TestServiceReconcilerWithClusterIP(t *testing.T) {
 	blueSelector := slim_metav1.LabelSelector{MatchLabels: map[string]string{"color": "blue"}}
 	redSelector := slim_metav1.LabelSelector{MatchLabels: map[string]string{"color": "red"}}
 	svc1Name := resource.Key{Name: "svc-1", Namespace: "default"}
@@ -1304,6 +1304,857 @@ func TestLBServiceReconcilerWithClusterIP(t *testing.T) {
 					})
 					if err != nil {
 						t.Fatalf("failed to reconcile new lb svc advertisements: %v", err)
+					}
+				})
+			}
+
+			// if we disable exports of pod cidr ensure no advertisements are
+			// still present.
+			if tt.newServiceSelector == nil && !containsLbClass(tt.upsertedServices) {
+				if len(serviceAnnouncements) > 0 {
+					t.Fatal("disabled export but advertisements still present")
+				}
+			}
+
+			log.Printf("%+v %+v", serviceAnnouncements, tt.updated)
+
+			// ensure we see tt.updated in testSC.ServiceAnnouncements
+			for svcKey, cidrs := range tt.updated {
+				for _, cidr := range cidrs {
+					prefix := netip.MustParsePrefix(cidr)
+					var seen bool
+					for _, advrt := range serviceAnnouncements[svcKey] {
+						if advrt.NLRI.String() == prefix.String() {
+							seen = true
+						}
+					}
+					if !seen {
+						t.Fatalf("failed to advertise %v", cidr)
+					}
+				}
+			}
+
+			// ensure testSC.PodCIDRAnnouncements does not contain advertisements
+			// not in tt.updated
+			for svcKey, advrts := range serviceAnnouncements {
+				for _, advrt := range advrts {
+					var seen bool
+					for _, cidr := range tt.updated[svcKey] {
+						if advrt.NLRI.String() == cidr {
+							seen = true
+						}
+					}
+					if !seen {
+						t.Fatalf("unwanted advert %+v", advrt)
+					}
+				}
+			}
+
+		})
+	}
+}
+
+func TestServiceReconcilerWithExternalIP(t *testing.T) {
+	blueSelector := slim_metav1.LabelSelector{MatchLabels: map[string]string{"color": "blue"}}
+	redSelector := slim_metav1.LabelSelector{MatchLabels: map[string]string{"color": "red"}}
+	svc1Name := resource.Key{Name: "svc-1", Namespace: "default"}
+	svc1NonDefaultName := resource.Key{Name: "svc-1", Namespace: "non-default"}
+	svc2NonDefaultName := resource.Key{Name: "svc-2", Namespace: "non-default"}
+	externalIPV4 := "192.168.0.1"
+	externalIPV4Prefix := externalIPV4 + "/32"
+	externalIPV6 := "fd00:192:168::1"
+	externalIPV6Prefix := externalIPV6 + "/128"
+
+	svc1 := &slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      svc1Name.Name,
+			Namespace: svc1Name.Namespace,
+			Labels:    blueSelector.MatchLabels,
+		},
+		Spec: slim_corev1.ServiceSpec{
+			Type: slim_corev1.ServiceTypeClusterIP,
+			ExternalIPs: []string{
+				externalIPV4,
+			},
+		},
+		Status: slim_corev1.ServiceStatus{
+			LoadBalancer: slim_corev1.LoadBalancerStatus{},
+		},
+	}
+
+	svc1TwoIngress := svc1.DeepCopy()
+	svc1TwoIngress.Spec.ExternalIPs = append(svc1TwoIngress.Spec.ExternalIPs, externalIPV6)
+	svc1RedLabel := svc1.DeepCopy()
+	svc1RedLabel.ObjectMeta.Labels = redSelector.MatchLabels
+
+	svc1NonDefault := svc1.DeepCopy()
+	svc1NonDefault.Namespace = svc1NonDefaultName.Namespace
+
+	svc1NonExternalIP := svc1.DeepCopy()
+	svc1NonExternalIP.Spec.ClusterIP = externalIPV4
+	svc1NonExternalIP.Spec.ExternalIPs = []string{}
+
+	svc1ETPLocal := svc1.DeepCopy()
+	svc1ETPLocal.Spec.ExternalTrafficPolicy = slim_corev1.ServiceExternalTrafficPolicyLocal
+
+	svc1ETPLocalTwoIngress := svc1TwoIngress.DeepCopy()
+	svc1ETPLocalTwoIngress.Spec.ExternalTrafficPolicy = slim_corev1.ServiceExternalTrafficPolicyLocal
+
+	svc1IPv6ETPLocal := svc1.DeepCopy()
+	svc1IPv6ETPLocal.Spec.ExternalIPs = append(svc1IPv6ETPLocal.Spec.ExternalIPs, externalIPV6)
+	svc1IPv6ETPLocal.Spec.ExternalTrafficPolicy = slim_corev1.ServiceExternalTrafficPolicyLocal
+
+	svc1LbClass := svc1.DeepCopy()
+	svc1LbClass.Spec.LoadBalancerClass = pointer.String(v2alpha1api.BGPLoadBalancerClass)
+
+	svc1UnsupportedClass := svc1LbClass.DeepCopy()
+	svc1UnsupportedClass.Spec.LoadBalancerClass = pointer.String("io.vendor/unsupported-class")
+
+	svc2NonDefault := &slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      svc2NonDefaultName.Name,
+			Namespace: svc2NonDefaultName.Namespace,
+			Labels:    blueSelector.MatchLabels,
+		},
+		Spec: slim_corev1.ServiceSpec{
+			Type: slim_corev1.ServiceTypeClusterIP,
+			ExternalIPs: []string{
+				externalIPV4,
+			},
+		},
+		Status: slim_corev1.ServiceStatus{
+			LoadBalancer: slim_corev1.LoadBalancerStatus{},
+		},
+	}
+
+	eps1IPv4Local := &k8s.Endpoints{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "svc-1-ipv4",
+			Namespace: "default",
+		},
+		EndpointSliceID: k8s.EndpointSliceID{
+			ServiceID: k8s.ServiceID{
+				Name:      "svc-1",
+				Namespace: "default",
+			},
+			EndpointSliceName: "svc-1-ipv4",
+		},
+		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
+			cmtypes.MustParseAddrCluster("10.0.0.1"): {
+				NodeName: "node1",
+			},
+		},
+	}
+
+	eps1IPv4Remote := &k8s.Endpoints{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "svc-1-ipv4",
+			Namespace: "default",
+		},
+		EndpointSliceID: k8s.EndpointSliceID{
+			ServiceID: k8s.ServiceID{
+				Name:      "svc-1",
+				Namespace: "default",
+			},
+			EndpointSliceName: "svc-1-ipv4",
+		},
+		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
+			cmtypes.MustParseAddrCluster("10.0.0.2"): {
+				NodeName: "node2",
+			},
+		},
+	}
+
+	eps1IPv4Mixed := &k8s.Endpoints{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "svc-1-ipv4",
+			Namespace: "default",
+		},
+		EndpointSliceID: k8s.EndpointSliceID{
+			ServiceID: k8s.ServiceID{
+				Name:      "svc-1",
+				Namespace: "default",
+			},
+			EndpointSliceName: "svc-1-ipv4",
+		},
+		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
+			cmtypes.MustParseAddrCluster("10.0.0.1"): {
+				NodeName: "node1",
+			},
+			cmtypes.MustParseAddrCluster("10.0.0.2"): {
+				NodeName: "node2",
+			},
+		},
+	}
+
+	eps1IPv6Local := &k8s.Endpoints{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "svc-1-ipv6",
+			Namespace: "default",
+		},
+		EndpointSliceID: k8s.EndpointSliceID{
+			ServiceID: k8s.ServiceID{
+				Name:      "svc-1",
+				Namespace: "default",
+			},
+			EndpointSliceName: "svc-1-ipv6",
+		},
+		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
+			cmtypes.MustParseAddrCluster("fd00:10::1"): {
+				NodeName: "node1",
+			},
+		},
+	}
+
+	eps1IPv6Remote := &k8s.Endpoints{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "svc-1-ipv6",
+			Namespace: "default",
+		},
+		EndpointSliceID: k8s.EndpointSliceID{
+			ServiceID: k8s.ServiceID{
+				Name:      "svc-1",
+				Namespace: "default",
+			},
+			EndpointSliceName: "svc-1-ipv6",
+		},
+		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
+			cmtypes.MustParseAddrCluster("fd00:10::2"): {
+				NodeName: "node2",
+			},
+		},
+	}
+
+	eps1IPv6Mixed := &k8s.Endpoints{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "svc-1-ipv4",
+			Namespace: "default",
+		},
+		EndpointSliceID: k8s.EndpointSliceID{
+			ServiceID: k8s.ServiceID{
+				Name:      "svc-1",
+				Namespace: "default",
+			},
+			EndpointSliceName: "svc-1-ipv4",
+		},
+		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
+			cmtypes.MustParseAddrCluster("fd00:10::1"): {
+				NodeName: "node1",
+			},
+			cmtypes.MustParseAddrCluster("fd00:10::2"): {
+				NodeName: "node2",
+			},
+		},
+	}
+
+	var table = []struct {
+		// name of the test case
+		name string
+		// The service selector of the vRouter
+		oldServiceSelector *slim_metav1.LabelSelector
+		// The service selector of the vRouter
+		newServiceSelector *slim_metav1.LabelSelector
+		// the advertised PodCIDR blocks the test begins with
+		advertised map[resource.Key][]string
+		// the services which will be "upserted" in the diffstore
+		upsertedServices []*slim_corev1.Service
+		// the services which will be "deleted" in the diffstore
+		deletedServices []resource.Key
+		// the endpoints which will be "upserted" in the diffstore
+		upsertedEndpoints []*k8s.Endpoints
+		// the updated PodCIDR blocks to reconcile, these are string encoded
+		// for the convenience of attaching directly to the NodeSpec.PodCIDRs
+		// field.
+		updated map[resource.Key][]string
+		// error nil or not
+		err error
+	}{
+		// Add 1 externalIP
+		{
+			name:               "svc-1-externalIP",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         make(map[resource.Key][]string),
+			upsertedServices:   []*slim_corev1.Service{svc1},
+			updated: map[resource.Key][]string{
+				svc1Name: {
+					externalIPV4Prefix,
+				},
+			},
+		},
+		// Add 2 externalIP
+		{
+			name:               "svc-2-externalIP",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         make(map[resource.Key][]string),
+			upsertedServices:   []*slim_corev1.Service{svc1TwoIngress},
+			updated: map[resource.Key][]string{
+				svc1Name: {
+					externalIPV4Prefix,
+					externalIPV6Prefix,
+				},
+			},
+		},
+		// Delete service
+		{
+			name:               "delete-svc",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised: map[resource.Key][]string{
+				svc1Name: {
+					externalIPV4Prefix,
+				},
+			},
+			deletedServices: []resource.Key{
+				svc1Name,
+			},
+			updated: map[resource.Key][]string{},
+		},
+		// Update service to no longer match
+		{
+			name:               "update-service-no-match",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised: map[resource.Key][]string{
+				svc1Name: {
+					externalIPV4Prefix,
+				},
+			},
+			upsertedServices: []*slim_corev1.Service{svc1RedLabel},
+			updated:          map[resource.Key][]string{},
+		},
+		// Update vRouter to no longer match
+		{
+			name:               "update-vrouter-selector",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &redSelector,
+			advertised: map[resource.Key][]string{
+				svc1Name: {
+					externalIPV4Prefix,
+				},
+			},
+			upsertedServices: []*slim_corev1.Service{svc1},
+			updated:          map[resource.Key][]string{},
+		},
+		// 1 -> 2 externalIP
+		{
+			name:               "update-1-to-2-externalIP",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised: map[resource.Key][]string{
+				svc1Name: {
+					externalIPV4Prefix,
+				},
+			},
+			upsertedServices: []*slim_corev1.Service{svc1TwoIngress},
+			updated: map[resource.Key][]string{
+				svc1Name: {
+					externalIPV4Prefix,
+					externalIPV6Prefix,
+				},
+			},
+		},
+		// No selector
+		{
+			name:               "no-selector",
+			oldServiceSelector: nil,
+			newServiceSelector: nil,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1},
+			updated:            map[resource.Key][]string{},
+		},
+		// Namespace selector
+		{
+			name:               "svc-namespace-selector",
+			oldServiceSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]string{"io.kubernetes.service.namespace": "default"}},
+			newServiceSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]string{"io.kubernetes.service.namespace": "default"}},
+			advertised:         map[resource.Key][]string{},
+			upsertedServices: []*slim_corev1.Service{
+				svc1,
+				svc2NonDefault,
+			},
+			updated: map[resource.Key][]string{
+				svc1Name: {
+					externalIPV4Prefix,
+				},
+			},
+		},
+		// Service name selector
+		{
+			name:               "svc-name-selector",
+			oldServiceSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]string{"io.kubernetes.service.name": "svc-1"}},
+			newServiceSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]string{"io.kubernetes.service.name": "svc-1"}},
+			advertised:         map[resource.Key][]string{},
+			upsertedServices: []*slim_corev1.Service{
+				svc1,
+			},
+			updated: map[resource.Key][]string{
+				svc1Name: {
+					externalIPV4Prefix,
+				},
+			},
+		},
+		// BGP load balancer class with matching selectors for service.
+		{
+			name:               "lb-class-and-selectors",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1LbClass},
+			updated: map[resource.Key][]string{
+				svc1Name: {
+					externalIPV4Prefix,
+				},
+			},
+		},
+		// BGP load balancer class with no selectors for service.
+		{
+			name:               "lb-class-no-selectors",
+			oldServiceSelector: nil,
+			newServiceSelector: nil,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1LbClass},
+			updated:            map[resource.Key][]string{},
+		},
+		// BGP load balancer class with selectors for a different service.
+		{
+			name:               "lb-class-with-diff-selectors",
+			oldServiceSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]string{"io.kubernetes.service.name": "svc-2"}},
+			newServiceSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]string{"io.kubernetes.service.name": "svc-2"}},
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1LbClass},
+			updated:            map[resource.Key][]string{},
+		},
+		// Unsupported load balancer class with no matching selectors for service.
+		{
+			name:               "unsupported-lb-class-with-no-selectors",
+			oldServiceSelector: nil,
+			newServiceSelector: nil,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1UnsupportedClass},
+			updated:            map[resource.Key][]string{},
+		},
+		// No-externalIP service
+		{
+			name:               "non-externalIP svc",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1NonExternalIP},
+			updated:            map[resource.Key][]string{},
+		},
+		// Service without endpoints
+		{
+			name:               "etp-local-no-endpoints",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1ETPLocal},
+			upsertedEndpoints:  []*k8s.Endpoints{},
+			updated:            map[resource.Key][]string{},
+		},
+		// externalTrafficPolicy=Local && IPv4 && single slice && local endpoint
+		{
+			name:               "etp-local-ipv4-single-slice-local",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1ETPLocal},
+			upsertedEndpoints:  []*k8s.Endpoints{eps1IPv4Local},
+			updated: map[resource.Key][]string{
+				svc1Name: {
+					externalIPV4Prefix,
+				},
+			},
+		},
+		// externalTrafficPolicy=Local && IPv4 && single slice && remote endpoint
+		{
+			name:               "etp-local-ipv4-single-slice-remote",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1ETPLocal},
+			upsertedEndpoints:  []*k8s.Endpoints{eps1IPv4Remote},
+			updated:            map[resource.Key][]string{},
+		},
+		// externalTrafficPolicy=Local && IPv4 && single slice && mixed endpoint
+		{
+			name:               "etp-local-ipv4-single-slice-mixed",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1ETPLocal},
+			upsertedEndpoints:  []*k8s.Endpoints{eps1IPv4Mixed},
+			updated: map[resource.Key][]string{
+				svc1Name: {
+					externalIPV4Prefix,
+				},
+			},
+		},
+		// externalTrafficPolicy=Local && IPv6 && single slice && local endpoint
+		{
+			name:               "etp-local-ipv6-single-slice-local",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1IPv6ETPLocal},
+			upsertedEndpoints:  []*k8s.Endpoints{eps1IPv6Local},
+			updated: map[resource.Key][]string{
+				svc1Name: {
+					externalIPV4Prefix,
+					externalIPV6Prefix,
+				},
+			},
+		},
+		// externalTrafficPolicy=Local && IPv6 && single slice && remote endpoint
+		{
+			name:               "etp-local-ipv6-single-slice-remote",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1IPv6ETPLocal},
+			upsertedEndpoints:  []*k8s.Endpoints{eps1IPv6Remote},
+			updated:            map[resource.Key][]string{},
+		},
+		// externalTrafficPolicy=Local && IPv6 && single slice && mixed endpoint
+		{
+			name:               "etp-local-ipv6-single-slice-mixed",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1IPv6ETPLocal},
+			upsertedEndpoints:  []*k8s.Endpoints{eps1IPv6Mixed},
+			updated: map[resource.Key][]string{
+				svc1Name: {
+					externalIPV4Prefix,
+					externalIPV6Prefix,
+				},
+			},
+		},
+		// externalTrafficPolicy=Local && Dual && two slices && local endpoint
+		{
+			name:               "etp-local-dual-two-slices-local",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1ETPLocalTwoIngress},
+			upsertedEndpoints: []*k8s.Endpoints{
+				eps1IPv4Local,
+				eps1IPv6Local,
+			},
+			updated: map[resource.Key][]string{
+				svc1Name: {
+					externalIPV4Prefix,
+					externalIPV6Prefix,
+				},
+			},
+		},
+		// externalTrafficPolicy=Local && Dual && two slices && remote endpoint
+		{
+			name:               "etp-local-dual-two-slices-remote",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1ETPLocalTwoIngress},
+			upsertedEndpoints: []*k8s.Endpoints{
+				eps1IPv4Remote,
+				eps1IPv6Remote,
+			},
+			updated: map[resource.Key][]string{
+				svc1Name: {},
+			},
+		},
+		// externalTrafficPolicy=Local && Dual && two slices && mixed endpoint
+		{
+			name:               "etp-local-dual-two-slices-mixed",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1ETPLocalTwoIngress},
+			upsertedEndpoints: []*k8s.Endpoints{
+				eps1IPv4Mixed,
+				eps1IPv6Mixed,
+			},
+			updated: map[resource.Key][]string{
+				svc1Name: {
+					externalIPV4Prefix,
+					externalIPV6Prefix,
+				},
+			},
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			// setup our test server, create a BgpServer, advertise the tt.advertised
+			// networks, and store each returned Advertisement in testSC.PodCIDRAnnouncements
+			srvParams := types.ServerParameters{
+				Global: types.BGPGlobal{
+					ASN:        64125,
+					RouterID:   "127.0.0.1",
+					ListenPort: -1,
+				},
+			}
+			oldc := &v2alpha1api.CiliumBGPVirtualRouter{
+				LocalASN:        64125,
+				Neighbors:       []v2alpha1api.CiliumBGPNeighbor{},
+				ServiceSelector: tt.oldServiceSelector,
+			}
+			testSC, err := instance.NewServerWithConfig(context.Background(), log, srvParams)
+			if err != nil {
+				t.Fatalf("failed to create test bgp server: %v", err)
+			}
+			testSC.Config = oldc
+
+			diffstore := store.NewFakeDiffStore[*slim_corev1.Service]()
+			for _, obj := range tt.upsertedServices {
+				diffstore.Upsert(obj)
+			}
+			for _, key := range tt.deletedServices {
+				diffstore.Delete(key)
+			}
+
+			epDiffStore := store.NewFakeDiffStore[*k8s.Endpoints]()
+			for _, obj := range tt.upsertedEndpoints {
+				epDiffStore.Upsert(obj)
+			}
+
+			reconciler := NewServiceReconciler(diffstore, epDiffStore).Reconciler.(*ServiceReconciler)
+			serviceAnnouncements := reconciler.getMetadata(testSC)
+
+			for svcKey, cidrs := range tt.advertised {
+				for _, cidr := range cidrs {
+					prefix := netip.MustParsePrefix(cidr)
+					advrtResp, err := testSC.Server.AdvertisePath(context.Background(), types.PathRequest{
+						Path: types.NewPathForPrefix(prefix),
+					})
+					if err != nil {
+						t.Fatalf("failed to advertise initial svc externalIP cidr routes: %v", err)
+					}
+
+					serviceAnnouncements[svcKey] = append(serviceAnnouncements[svcKey], advrtResp.Path)
+				}
+			}
+
+			newc := &v2alpha1api.CiliumBGPVirtualRouter{
+				LocalASN:              64125,
+				Neighbors:             []v2alpha1api.CiliumBGPNeighbor{},
+				ServiceSelector:       tt.newServiceSelector,
+				ServiceAdvertisements: []v2alpha1api.BGPServiceAddressType{v2alpha1api.BGPExternalIPAddr},
+			}
+
+			// Run the reconciler twice to ensure idempotency. This
+			// simulates the retrying behavior of the controller.
+			for i := 0; i < 2; i++ {
+				t.Run(tt.name, func(t *testing.T) {
+					err = reconciler.Reconcile(context.Background(), ReconcileParams{
+						CurrentServer: testSC,
+						DesiredConfig: newc,
+						CiliumNode: &v2api.CiliumNode{
+							ObjectMeta: meta_v1.ObjectMeta{
+								Name: "node1",
+							},
+						},
+					})
+					if err != nil {
+						t.Fatalf("failed to reconcile new externalIP svc advertisements: %v", err)
+					}
+				})
+			}
+
+			// if we disable exports of pod cidr ensure no advertisements are
+			// still present.
+			if tt.newServiceSelector == nil && !containsLbClass(tt.upsertedServices) {
+				if len(serviceAnnouncements) > 0 {
+					t.Fatal("disabled export but advertisements still present")
+				}
+			}
+
+			log.Printf("%+v %+v", serviceAnnouncements, tt.updated)
+
+			// ensure we see tt.updated in testSC.ServiceAnnouncements
+			for svcKey, cidrs := range tt.updated {
+				for _, cidr := range cidrs {
+					prefix := netip.MustParsePrefix(cidr)
+					var seen bool
+					for _, advrt := range serviceAnnouncements[svcKey] {
+						if advrt.NLRI.String() == prefix.String() {
+							seen = true
+						}
+					}
+					if !seen {
+						t.Fatalf("failed to advertise %v", cidr)
+					}
+				}
+			}
+
+			// ensure testSC.PodCIDRAnnouncements does not contain advertisements
+			// not in tt.updated
+			for svcKey, advrts := range serviceAnnouncements {
+				for _, advrt := range advrts {
+					var seen bool
+					for _, cidr := range tt.updated[svcKey] {
+						if advrt.NLRI.String() == cidr {
+							seen = true
+						}
+					}
+					if !seen {
+						t.Fatalf("unwanted advert %+v", advrt)
+					}
+				}
+			}
+
+		})
+	}
+}
+
+func TestServiceReconcilerWithExternalIPAndClusterIP(t *testing.T) {
+	blueSelector := slim_metav1.LabelSelector{MatchLabels: map[string]string{"color": "blue"}}
+	svc1Name := resource.Key{Name: "svc-1", Namespace: "default"}
+	svc1NonDefaultName := resource.Key{Name: "svc-1", Namespace: "non-default"}
+	externalIPV4 := "192.168.0.1"
+	externalIPV4Prefix := externalIPV4 + "/32"
+	clusterIPV4 := "10.0.100.1"
+	clusterIPV4Prefix := clusterIPV4 + "/32"
+	svc1 := &slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      svc1Name.Name,
+			Namespace: svc1Name.Namespace,
+			Labels:    blueSelector.MatchLabels,
+		},
+		Spec: slim_corev1.ServiceSpec{
+			Type:      slim_corev1.ServiceTypeClusterIP,
+			ClusterIP: clusterIPV4,
+			ClusterIPs: []string{
+				clusterIPV4,
+			},
+			ExternalIPs: []string{
+				externalIPV4,
+			},
+		},
+		Status: slim_corev1.ServiceStatus{
+			LoadBalancer: slim_corev1.LoadBalancerStatus{},
+		},
+	}
+
+	svc1NonDefault := svc1.DeepCopy()
+	svc1NonDefault.Namespace = svc1NonDefaultName.Namespace
+
+	svc1ExternalIPAndClusterIP := svc1.DeepCopy()
+	svc1ExternalIPAndClusterIP.Spec.ClusterIP = clusterIPV4
+	svc1ExternalIPAndClusterIP.Spec.ExternalIPs = []string{externalIPV4}
+
+	var table = []struct {
+		// name of the test case
+		name string
+		// The service selector of the vRouter
+		oldServiceSelector *slim_metav1.LabelSelector
+		// The service selector of the vRouter
+		newServiceSelector *slim_metav1.LabelSelector
+		// the advertised PodCIDR blocks the test begins with
+		advertised map[resource.Key][]string
+		// the services which will be "upserted" in the diffstore
+		upsertedServices []*slim_corev1.Service
+		// the services which will be "deleted" in the diffstore
+		deletedServices []resource.Key
+		// the endpoints which will be "upserted" in the diffstore
+		upsertedEndpoints []*k8s.Endpoints
+		// the updated PodCIDR blocks to reconcile, these are string encoded
+		// for the convenience of attaching directly to the NodeSpec.PodCIDRs
+		// field.
+		updated map[resource.Key][]string
+		// error nil or not
+		err error
+	}{
+		// externalIP and clusterIP service
+		{
+			name:               "externalIP and clusterIP svc",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1ExternalIPAndClusterIP},
+			updated: map[resource.Key][]string{
+				svc1Name: {
+					clusterIPV4Prefix,
+					externalIPV4Prefix,
+				},
+			},
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			// setup our test server, create a BgpServer, advertise the tt.advertised
+			// networks, and store each returned Advertisement in testSC.PodCIDRAnnouncements
+			srvParams := types.ServerParameters{
+				Global: types.BGPGlobal{
+					ASN:        64125,
+					RouterID:   "127.0.0.1",
+					ListenPort: -1,
+				},
+			}
+			oldc := &v2alpha1api.CiliumBGPVirtualRouter{
+				LocalASN:        64125,
+				Neighbors:       []v2alpha1api.CiliumBGPNeighbor{},
+				ServiceSelector: tt.oldServiceSelector,
+			}
+			testSC, err := instance.NewServerWithConfig(context.Background(), log, srvParams)
+			if err != nil {
+				t.Fatalf("failed to create test bgp server: %v", err)
+			}
+			testSC.Config = oldc
+
+			diffstore := store.NewFakeDiffStore[*slim_corev1.Service]()
+			for _, obj := range tt.upsertedServices {
+				diffstore.Upsert(obj)
+			}
+			for _, key := range tt.deletedServices {
+				diffstore.Delete(key)
+			}
+
+			epDiffStore := store.NewFakeDiffStore[*k8s.Endpoints]()
+			for _, obj := range tt.upsertedEndpoints {
+				epDiffStore.Upsert(obj)
+			}
+
+			reconciler := NewServiceReconciler(diffstore, epDiffStore).Reconciler.(*ServiceReconciler)
+			serviceAnnouncements := reconciler.getMetadata(testSC)
+
+			for svcKey, cidrs := range tt.advertised {
+				for _, cidr := range cidrs {
+					prefix := netip.MustParsePrefix(cidr)
+					advrtResp, err := testSC.Server.AdvertisePath(context.Background(), types.PathRequest{
+						Path: types.NewPathForPrefix(prefix),
+					})
+					if err != nil {
+						t.Fatalf("failed to advertise initial svc externalIP cidr routes: %v", err)
+					}
+
+					serviceAnnouncements[svcKey] = append(serviceAnnouncements[svcKey], advrtResp.Path)
+				}
+			}
+
+			newc := &v2alpha1api.CiliumBGPVirtualRouter{
+				LocalASN:              64125,
+				Neighbors:             []v2alpha1api.CiliumBGPNeighbor{},
+				ServiceSelector:       tt.newServiceSelector,
+				ServiceAdvertisements: []v2alpha1api.BGPServiceAddressType{v2alpha1api.BGPExternalIPAddr, v2alpha1api.BGPClusterIPAddr},
+			}
+
+			// Run the reconciler twice to ensure idempotency. This
+			// simulates the retrying behavior of the controller.
+			for i := 0; i < 2; i++ {
+				t.Run(tt.name, func(t *testing.T) {
+					err = reconciler.Reconcile(context.Background(), ReconcileParams{
+						CurrentServer: testSC,
+						DesiredConfig: newc,
+						CiliumNode: &v2api.CiliumNode{
+							ObjectMeta: meta_v1.ObjectMeta{
+								Name: "node1",
+							},
+						},
+					})
+					if err != nil {
+						t.Fatalf("failed to reconcile new externalIP svc advertisements: %v", err)
 					}
 				})
 			}

--- a/pkg/bgpv1/test/objects.go
+++ b/pkg/bgpv1/test/objects.go
@@ -114,6 +114,31 @@ func newClusterIPServiceObj(conf clusterIPSrvConfig) slim_core_v1.Service {
 	return srvObj
 }
 
+// externalIPsSrvConfig contains ExternalIPs service configuration data
+type externalIPsSrvConfig struct {
+	name       string
+	externalIP string
+}
+
+// newExternalIPServiceObj creates slim_core_v1.Service object based on externalIPsSrvConfig
+func newExternalIPServiceObj(conf externalIPsSrvConfig) slim_core_v1.Service {
+	srvObj := slim_core_v1.Service{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Name: conf.name,
+		},
+		Spec: slim_core_v1.ServiceSpec{
+			Type:        slim_core_v1.ServiceTypeClusterIP,
+			ExternalIPs: []string{conf.externalIP},
+		},
+	}
+
+	srvObj.Status = slim_core_v1.ServiceStatus{
+		LoadBalancer: slim_core_v1.LoadBalancerStatus{},
+	}
+
+	return srvObj
+}
+
 // lbSrvConfig contains lb service configuration data
 type lbPoolConfig struct {
 	name   string

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpadvertisements.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpadvertisements.yaml
@@ -213,6 +213,7 @@ spec:
                             enum:
                             - LoadBalancerIP
                             - ClusterIP
+                            - ExternalIP
                             type: string
                           minItems: 1
                           type: array

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
@@ -519,6 +519,7 @@ spec:
                         enum:
                         - LoadBalancerIP
                         - ClusterIP
+                        - ExternalIP
                         type: string
                       type: array
                     serviceSelector:

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.29.2"
+	CustomResourceDefinitionSchemaVersion = "1.29.3"
 )

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_advert_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_advert_types.go
@@ -34,7 +34,7 @@ const (
 // Note list of supported service addresses is not exhaustive and can be extended in the future.
 // Consumer of this API should be able to handle unknown values.
 //
-// +kubebuilder:validation:Enum=LoadBalancerIP;ClusterIP
+// +kubebuilder:validation:Enum=LoadBalancerIP;ClusterIP;ExternalIP
 type BGPServiceAddressType string
 
 const (
@@ -54,7 +54,7 @@ const (
 	// BGPExternalIPAddr when configured, Cilium will advertise external IP prefix of a service to BGP peers.
 	// External IP for a service is defined here
 	// https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
-	// BGPExternalIPAddr BGPServiceAddressType = "ExternalIP"
+	BGPExternalIPAddr BGPServiceAddressType = "ExternalIP"
 )
 
 // +genclient


### PR DESCRIPTION
Fixes: #29990

```release-note
Add support for ExternalIP service advertisement with BGP Control Plane
```
