### PR TITLE
bpf: use `bpf_htons` instead of using shift

### DIFF
--- a/bpf/lib/endian.h
+++ b/bpf/lib/endian.h
@@ -62,6 +62,7 @@
 #define bpf_htons(x)				\
 	(__builtin_constant_p(x) ?		\
 	 __bpf_constant_htons(x) : __bpf_htons(x))
+#define bpf_u8_to_be16(x) bpf_htons((__u16)x)
 #define bpf_ntohs(x)				\
 	(__builtin_constant_p(x) ?		\
 	 __bpf_constant_ntohs(x) : __bpf_ntohs(x))

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -69,13 +69,7 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 # endif
 
 # if defined(ENABLE_ICMP_RULE)
-			/* Convert from unsigned char to unsigned short
-			 * considering byte order(little-endian).
-			 * In the little-endian case, for example, 2byte data "AB"
-			 * convert to "BA".
-			 * Therefore, the "icmp_type" should be shifted not just casting.
-			 */
-			key.dport = (__u16)(icmphdr.type << 8);
+			key.dport = bpf_u8_to_be16(icmphdr.type);
 # endif
 		}
 		break;
@@ -87,13 +81,7 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 			if (ctx_load_bytes(ctx, off, &icmp_type, sizeof(icmp_type)) < 0)
 				return DROP_INVALID;
 
-			/* Convert from unsigned char to unsigned short
-			 * considering byte order(little-endian).
-			 * In the little-endian case, for example, 2byte data "AB"
-			 * convert to "BA".
-			 * Therefore, the "icmp_type" should be shifted not just casting.
-			 */
-			key.dport = (__u16)(icmp_type << 8);
+			key.dport = bpf_u8_to_be16(icmp_type);
 		}
 # endif
 		break;


### PR DESCRIPTION
The current implementation using shift does not take into account endianness.
`bpf_htons()` detects which endianness is used and converts the value appropriately.
Also, this PR defines `bpf_u8_to_be16()` that wraps `bpf_htons()` because converting 8-bit ICMP types to 16-bit does not depend on the host byte order.


resolves https://github.com/cilium/cilium/pull/27369#discussion_r1516958093