### PR TITLE
Fix helm template for hubble-relay prometheus annotations

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- if and .Values.hubble.relay.prometheus.enabled (not .Values.hubble.relay.prometheus.serviceMonitor.enabled) }}
-        prometheus.io/port: { { .Values.hubble.relay.prometheus.port | quote } }
+        prometheus.io/port: {{ .Values.hubble.relay.prometheus.port | quote }}
         prometheus.io/scrape: "true"
         {{- end }}
       labels:


### PR DESCRIPTION
We introduced a templating bug when adding prometheus annotations for hubble-relay. `{ { .Values.hubble.relay.prometheus.port | quote } }` will be rendered as is because of the spaces between the braces, which results in a helm templating error when enabling relay metrics without service monitors.

```
Error: YAML parse error on cilium/templates/hubble-relay/deployment.yaml: error converting YAML to JSON: yaml: invalid map key: map[interface {}]interface {}{".Values.hubble.relay.prometheus.port | quote":interface {}(nil)}
```

Fixes:  e4abda5aba37("enable Prometheus metrics for Hubble Relay")