### PR TITLE
bgpv2: fix operator flaky test cases

### DIFF
--- a/operator/pkg/bgpv2/cluster_test.go
+++ b/operator/pkg/bgpv2/cluster_test.go
@@ -87,7 +87,6 @@ var (
 )
 
 func Test_NodeLabels(t *testing.T) {
-	req := require.New(t)
 	tests := []struct {
 		description        string
 		node               *cilium_api_v2.CiliumNode
@@ -251,10 +250,18 @@ func Test_NodeLabels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
+			req := require.New(t)
+
 			f := newFixture()
 
 			f.hive.Start(ctx)
 			defer f.hive.Stop(ctx)
+
+			select {
+			case <-f.watching:
+			case <-ctx.Done():
+				req.Fail("timed out waiting for informers to sync")
+			}
 
 			// setup node
 			upsertNode(req, ctx, f, tt.node)
@@ -263,33 +270,27 @@ func Test_NodeLabels(t *testing.T) {
 			upsertBGPCC(req, ctx, f, tt.clusterConfig)
 
 			// validate node configs
-			assert.Eventually(t, func() bool {
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
 				nodeConfigs, err := f.bgpnClient.List(ctx, meta_v1.ListOptions{})
-				req.NoError(err)
+				if err != nil {
+					assert.NoError(c, err)
+					return
+				}
 
 				if tt.expectedNodeConfig == nil {
-					if len(nodeConfigs.Items) == 0 {
-						return true
-					} else {
-						return false
-					}
+					assert.Len(c, nodeConfigs.Items, 0)
+					return
 				}
 
 				nodeConfig, err := f.bgpnClient.Get(ctx, tt.expectedNodeConfig.Name, meta_v1.GetOptions{})
-				if err != nil && k8sErrors.IsNotFound(err) {
-					return false
-				}
-				req.NoError(err)
-
-				if !isSameOwner(tt.expectedNodeConfig.GetOwnerReferences(), nodeConfig.GetOwnerReferences()) {
-					return false
+				if err != nil {
+					assert.NoError(c, err)
+					return
 				}
 
-				if !tt.expectedNodeConfig.Spec.DeepEqual(&nodeConfig.Spec) {
-					return false
-				}
+				assert.True(c, isSameOwner(tt.expectedNodeConfig.GetOwnerReferences(), nodeConfig.GetOwnerReferences()))
+				assert.Equal(c, tt.expectedNodeConfig.Spec, nodeConfig.Spec)
 
-				return true
 			}, TestTimeout, 50*time.Millisecond)
 		})
 	}
@@ -297,8 +298,6 @@ func Test_NodeLabels(t *testing.T) {
 
 // Test_ClusterConfigSteps is step based test to validate the BGP node config controller
 func Test_ClusterConfigSteps(t *testing.T) {
-	req := require.New(t)
-
 	steps := []struct {
 		description         string
 		clusterConfig       *cilium_api_v2alpha1.CiliumBGPClusterConfig
@@ -522,45 +521,51 @@ func Test_ClusterConfigSteps(t *testing.T) {
 	f.hive.Start(ctx)
 	defer f.hive.Stop(ctx)
 
+	select {
+	case <-f.watching:
+	case <-ctx.Done():
+		require.Fail(t, "timed out waiting for informers to sync")
+	}
+
 	for _, step := range steps {
-		// setup nodes
-		for _, node := range step.nodes {
-			upsertNode(req, ctx, f, node)
-		}
+		t.Run(step.description, func(t *testing.T) {
+			req := require.New(t)
 
-		// upsert BGP cluster config
-		upsertBGPCC(req, ctx, f, step.clusterConfig)
-
-		// upsert node overrides
-		for _, nodeOverride := range step.nodeOverrides {
-			upsertNodeOverrides(req, ctx, f, nodeOverride)
-		}
-
-		// validate node configs
-		assert.Eventually(t, func() bool {
-			nodes, err := f.bgpnClient.List(ctx, meta_v1.ListOptions{})
-			assert.NoError(t, err)
-			if len(step.expectedNodeConfigs) != len(nodes.Items) {
-				return false
+			// setup nodes
+			for _, node := range step.nodes {
+				upsertNode(req, ctx, f, node)
 			}
 
-			for _, expectedNodeConfig := range step.expectedNodeConfigs {
-				nodeConfig, err := f.bgpnClient.Get(ctx, expectedNodeConfig.Name, meta_v1.GetOptions{})
-				if err != nil && k8sErrors.IsNotFound(err) {
-					return false
-				}
-				req.NoError(err)
+			// upsert BGP cluster config
+			upsertBGPCC(req, ctx, f, step.clusterConfig)
 
-				if expectedNodeConfig.OwnerReferences[0].Name != nodeConfig.OwnerReferences[0].Name {
-					return false
-				}
-
-				if !expectedNodeConfig.Spec.DeepEqual(&nodeConfig.Spec) {
-					return false
-				}
+			// upsert node overrides
+			for _, nodeOverride := range step.nodeOverrides {
+				upsertNodeOverrides(req, ctx, f, nodeOverride)
 			}
-			return true
-		}, TestTimeout, 50*time.Millisecond)
+
+			// validate node configs
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+				nodes, err := f.bgpnClient.List(ctx, meta_v1.ListOptions{})
+				if err != nil {
+					assert.NoError(c, err)
+					return
+				}
+
+				assert.Equal(c, len(step.expectedNodeConfigs), len(nodes.Items))
+
+				for _, expectedNodeConfig := range step.expectedNodeConfigs {
+					nodeConfig, err := f.bgpnClient.Get(ctx, expectedNodeConfig.Name, meta_v1.GetOptions{})
+					if err != nil {
+						assert.NoError(c, err)
+						return
+					}
+
+					assert.Equal(c, expectedNodeConfig.Name, nodeConfig.Name)
+					assert.Equal(c, expectedNodeConfig.Spec, nodeConfig.Spec)
+				}
+			}, TestTimeout, 50*time.Millisecond)
+		})
 	}
 }
 
@@ -573,6 +578,12 @@ func Test_Cleanup(t *testing.T) {
 
 	f.hive.Start(ctx)
 	defer f.hive.Stop(ctx)
+
+	select {
+	case <-f.watching:
+	case <-ctx.Done():
+		req.Fail("timed out waiting for informers to sync")
+	}
 
 	// create new resource
 	upsertNode(req, ctx, f, &cilium_api_v2.CiliumNode{
@@ -610,24 +621,29 @@ func Test_Cleanup(t *testing.T) {
 	})
 
 	// check for existence
-	assert.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		nodes, err := f.bgpnClient.List(ctx, meta_v1.ListOptions{})
-		assert.NoError(t, err)
-
+		if err != nil {
+			assert.NoError(c, err)
+			return
+		}
 		// expected 2 node configs
-		return 2 == len(nodes.Items)
-	}, TestTimeout, time.Second)
+		assert.Len(c, nodes.Items, 2)
+	}, TestTimeout, 50*time.Millisecond)
 
 	// delete resource
 	deleteBGPCC(req, ctx, f, "bgp-cluster-config")
 
 	// check for non-existence
-	assert.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		nodes, err := f.bgpnClient.List(ctx, meta_v1.ListOptions{})
-		assert.NoError(t, err)
+		if err != nil {
+			assert.NoError(c, err)
+			return
+		}
 
 		// expected 0 node configs
-		return 0 == len(nodes.Items)
+		assert.Len(c, nodes.Items, 0)
 	}, TestTimeout, 50*time.Millisecond)
 }
 

--- a/operator/pkg/bgpv2/fixture_test.go
+++ b/operator/pkg/bgpv2/fixture_test.go
@@ -4,6 +4,11 @@
 package bgpv2
 
 import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/watch"
+	k8sTesting "k8s.io/client-go/testing"
+
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hive/job"
@@ -23,6 +28,7 @@ var (
 )
 
 type fixture struct {
+	watching      chan struct{}
 	hive          *hive.Hive
 	fakeClientSet *k8s_client.FakeClientset
 	bgpcClient    cilium_client_v2alpha1.CiliumBGPClusterConfigInterface
@@ -34,9 +40,25 @@ type fixture struct {
 }
 
 func newFixture() *fixture {
-	f := &fixture{}
+	f := &fixture{
+		watching: make(chan struct{}),
+	}
 
 	f.fakeClientSet, _ = k8s_client.NewFakeClientset()
+
+	// make sure cilium node watcher is initialized before the test starts
+	var once sync.Once
+	f.fakeClientSet.CiliumFakeClientset.PrependWatchReactor("ciliumnodes", func(action k8sTesting.Action) (handled bool, ret watch.Interface, err error) {
+		w := action.(k8sTesting.WatchAction)
+		gvr := w.GetResource()
+		ns := w.GetNamespace()
+		watch, err := f.fakeClientSet.CiliumFakeClientset.Tracker().Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		once.Do(func() { close(f.watching) })
+		return true, watch, nil
+	})
 
 	f.bgpcClient = f.fakeClientSet.CiliumFakeClientset.CiliumV2alpha1().CiliumBGPClusterConfigs()
 	f.nodeClient = f.fakeClientSet.CiliumFakeClientset.CiliumV2().CiliumNodes()


### PR DESCRIPTION
This PR changes require.EventuallyWith approach in test cases. Also, fixes race between node watcher registration and addition of node objects.

Fixes:  #31237 #31235
