### PR TITLE
Docs: Incorrect brace expansion in curl command for Cilium CLI installation on macOS

### DIFF
--- a/Documentation/installation/cli-download.rst
+++ b/Documentation/installation/cli-download.rst
@@ -57,13 +57,13 @@ various features (e.g. clustermesh, Hubble).
 
 After successfully installing the Cilium CLI, you can verify the installation by checking the version of the Cilium CLI by running the following command:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   cilium version --client
+   $ cilium version --client
 
 You should see output similar to the following:
 
-.. code-block:: none
+.. code-block:: shell-session
 
    cilium-cli:  compiled with go1.22.0 on linux/amd64
    cilium image (default): v1.15.1

--- a/Documentation/installation/cli-download.rst
+++ b/Documentation/installation/cli-download.rst
@@ -57,13 +57,13 @@ various features (e.g. clustermesh, Hubble).
 
 After successfully installing the Cilium CLI, you can verify the installation by checking the version of the Cilium CLI by running the following command:
 
-.. code-block:: shell-session
+.. code-block:: bash
 
-   $ cilium version --client
+   cilium version --client
 
 You should see output similar to the following:
 
-.. code-block:: shell-session
+.. code-block:: none
 
    cilium-cli:  compiled with go1.22.0 on linux/amd64
    cilium image (default): v1.15.1

--- a/Documentation/installation/cli-download.rst
+++ b/Documentation/installation/cli-download.rst
@@ -1,5 +1,5 @@
 .. warning::
-  Make sure you install `cilium-cli v0.15.0 <https://github.com/cilium/cilium-cli/releases/tag/v0.15.0>`_
+  Make sure you install `cilium-cli v0.16.0 <https://github.com/cilium/cilium-cli/releases/tag/v0.16.0>`_
   or later. The rest of instructions do not work with older versions of
   cilium-cli. To confirm the cilium-cli version that's installed in your system,
   run:
@@ -26,6 +26,7 @@ various features (e.g. clustermesh, Hubble).
       sha256sum --check cilium-linux-${CLI_ARCH}.tar.gz.sha256sum
       sudo tar xzvfC cilium-linux-${CLI_ARCH}.tar.gz /usr/local/bin
       rm cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
+      cilium version --client
 
   .. group-tab:: macOS
 
@@ -34,10 +35,11 @@ various features (e.g. clustermesh, Hubble).
       CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt)
       CLI_ARCH=amd64
       if [ "$(uname -m)" = "arm64" ]; then CLI_ARCH=arm64; fi
-      curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-darwin-${CLI_ARCH}.tar.gz{,.sha256sum}
+      curl -L --fail --remote-name-all "https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-darwin-${CLI_ARCH}.tar.gz"{,.sha256sum}
       shasum -a 256 -c cilium-darwin-${CLI_ARCH}.tar.gz.sha256sum
       sudo tar xzvfC cilium-darwin-${CLI_ARCH}.tar.gz /usr/local/bin
       rm cilium-darwin-${CLI_ARCH}.tar.gz{,.sha256sum}
+      cilium version --client
 
   .. group-tab:: Other
 
@@ -52,3 +54,19 @@ various features (e.g. clustermesh, Hubble).
 
       git clone git@github.com:cilium/cilium.git
       cd cilium
+
+After successfully installing the Cilium CLI, you can verify the installation by checking the version of the Cilium CLI by running the following command:
+
+.. code-block:: bash
+
+   cilium version --client
+
+You should see output similar to the following:
+
+.. code-block:: none
+
+   cilium-cli:  compiled with go1.22.0 on linux/amd64
+   cilium image (default): v1.15.1
+   cilium image (stable): v1.15.1
+
+This output confirms that the Cilium CLI is installed correctly and displays the version of the Cilium image that is being used.


### PR DESCRIPTION
## Documentation: Incorrect brace expansion in curl command for Cilium CLI installation on macOS

**Description:**
This pull request addresses an issue with the Cilium CLI installation instructions for macOS in the [Getting Started Guide](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/#install-the-cilium-cli). The `curl` command for downloading the Cilium CLI and its SHA256 checksum file used incorrect brace expansion, resulting in a 404 error.

**Issue:**
The original command was:
`curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-darwin-${CLI_ARCH}.tar.gz{,.sha256sum}`

The braces `{}` were inside the double quotes, preventing the shell from performing the brace expansion correctly.

**Solution:**
I have corrected the command by moving the braces outside of the double quotes:
`curl -L --fail --remote-name-all "https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-darwin-${CLI_ARCH}.tar.gz"{,.sha256sum}`

This change allows the shell to perform the brace expansion correctly, enabling the download of both the tarball and the SHA256 checksum file.

**Testing:**
I have tested the corrected command on my macOS system running zsh, and it successfully downloads the required files without any 404 errors.

**Additional QOL Changes:**
- Bumped the version number for cilium cli in the warning above the install steps from `v0.15.0` to `v0.16.0`
- Added a small section to demonstrate how to validate the cilium cli install
- Added the `cilium version --client` command to the installation steps, allowing users to immediately verify the installed version of the Cilium CLI.

Fixes: [#31257](https://github.com/cilium/cilium/issues/31257)

```release-note
Fixed incorrect brace expansion in the curl command for Cilium CLI installation instructions for macOS. Added validation steps and immediate version check to the installation process.
```

Signed-off-by: Seth Stuart <joshuastuart24@gmail.com>