### PR TITLE
hive/cell/health: don't warn when reporting on stopped reporter.

### DIFF
--- a/pkg/hive/cell/structured.go
+++ b/pkg/hive/cell/structured.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"runtime"
@@ -371,6 +372,8 @@ func (s *subreporterBase) addChild(pid string, name string, isReporter bool) str
 	return id
 }
 
+var errReporterStopped = errors.New("reporter has been stopped")
+
 func (s *subreporterBase) setStatus(id string, level Level, message string, err error) error {
 	s.Lock()
 	defer s.Unlock()
@@ -380,7 +383,7 @@ func (s *subreporterBase) setStatus(id string, level Level, message string, err 
 	}
 
 	if _, ok := s.nodes[id]; !ok {
-		return fmt.Errorf("reporter %s has been stopped", id)
+		return fmt.Errorf("could not set status for reporter %s: %w", id, errReporterStopped)
 	}
 
 	n := s.nodes[id]
@@ -566,17 +569,28 @@ type subReporter struct {
 	name            string
 }
 
+const logReporterID = "reporterID"
+
 func (s *subReporter) OK(message string) {
 	if err := s.base.setStatus(s.id, StatusOK, message, nil); err != nil {
-		log.WithError(err).Warnf("could not set OK status on subreporter %q", s.id)
+		if errors.Is(err, errReporterStopped) {
+			log.WithError(err).WithField(logReporterID, s.id).Debug("could not set OK status on subreporter")
+		} else {
+			log.WithError(err).WithField(logReporterID, s.id).Warn("could not set OK status on subreporter")
+		}
 		return
 	}
+
 	s.scheduleRealize()
 }
 
 func (s *subReporter) Degraded(message string, err error) {
 	if err := s.base.setStatus(s.id, StatusDegraded, message, err); err != nil {
-		log.WithError(err).Warnf("could not set degraded status on subreporter %q", s.id)
+		if errors.Is(err, errReporterStopped) {
+			log.WithError(err).WithField(logReporterID, s.id).Debug("could not set degraded status on subreporter")
+		} else {
+			log.WithError(err).WithField(logReporterID, s.id).Warn("could not set degraded status on subreporter")
+		}
 		return
 	}
 	s.scheduleRealize()


### PR DESCRIPTION
Currently in cases where reporters emit status on stopped reporters, a warning is logged. This causes failures in CI related to endpoints, as those close their reporters after endpoint is deleted.

This scenario is probably not a valuable log for users and generally such occurances should be harmless. This moves the log to debug level.

Fixes: #31147