### PR TITLE
proxy: Re-enable proxy rule installation in tunnel mode

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -412,7 +412,7 @@ func (p *Proxy) ReinstallRoutingRules() error {
 			return err
 		}
 
-		if !option.Config.EnableIPSec || option.Config.TunnelingEnabled() {
+		if !option.Config.EnableIPSec {
 			if err := removeFromProxyRoutesIPv4(); err != nil {
 				return err
 			}
@@ -435,7 +435,7 @@ func (p *Proxy) ReinstallRoutingRules() error {
 			return err
 		}
 
-		if !option.Config.EnableIPSec || option.Config.TunnelingEnabled() {
+		if !option.Config.EnableIPSec {
 			if err := removeFromProxyRoutesIPv6(); err != nil {
 				return err
 			}


### PR DESCRIPTION
### Description

This commit is to re-enable proxy rule installation in tunnel mode, as
route 2005 was added back, and we need this rule to handle the
hairpinning trafic in Ingress L7 proxy if the backend is on the same
node.

Relates: 0ebe5162373c00f85e7ae43d0bc5d474fa08c485
Relates: https://github.com/cilium/cilium/pull/29530, https://github.com/cilium/cilium/issues/29864

Signed-off-by: Tam Mach <tam.mach@cilium.io>

### Testing

TBD