### PR TITLE
[v1.14] iptables: Read CNI chaining mode from CNI config manager

### DIFF
--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"path/filepath"
 
+	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/agentliveness"
 	"github.com/cilium/cilium/pkg/datapath/garp"
@@ -115,7 +116,7 @@ func newDatapath(params datapathParams) types.Datapath {
 				log.Fatalf("enabling IP forwarding via sysctl failed: %s", err)
 			}
 
-			iptablesManager.Init()
+			iptablesManager.Init(params.CniConfigManager)
 			return nil
 		}})
 
@@ -142,4 +143,6 @@ type datapathParams struct {
 	BpfMaps []bpf.BpfMap `group:"bpf-maps"`
 
 	NodeMap nodemap.Map
+
+	CniConfigManager cni.CNIConfigManager
 }


### PR DESCRIPTION
Author Backport of https://github.com/cilium/cilium/pull/30766

iptables does not live in its own cell in v1.14, so we cannot rely on hive dependency injection to get a reference to the CNIConfigManager. Instead, the reference is passed explicitly in the iptables `Init` method, just after its instantiation during datapath initialization.