### PR TITLE
ci-e2e: Add matrix for bpf.tproxy and ingress-controller

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -237,6 +237,17 @@ jobs:
             lb-acceleration: 'testing-only'
             ingress-controller: 'true'
 
+          - name: '15'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: 'bpf-next-20240307.011705'
+            kube-proxy: 'none'
+            kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
+            tunnel: 'disabled'
+            ingress-controller: 'true'
+            misc: 'bpf.tproxy=true'
+
     timeout-minutes: 60
     steps:
       - name: Checkout context ref (trusted)


### PR DESCRIPTION
This is to make sure that we have the coverage for bpf.tproxy enabled.
The first step is to test it with Ingress Controller enabled, we can add
more settings if required later.

Relates: #30331, #30404

Suggested-by: Marco Hofstetter <marco.hofstetter@isovalent.com>
Signed-off-by: Tam Mach <tam.mach@cilium.io>
