### PR TITLE
 proxy: Re-enable proxy rule installation in tunnel mode

### DIFF
--- a/.github/actions/gke/test-config-helm.yaml
+++ b/.github/actions/gke/test-config-helm.yaml
@@ -12,3 +12,7 @@ config:
   - type: "tunnel-ipsec"
     index: 4
     cilium-install-opts: "--helm-set=encryption.enabled=true --helm-set=encryption.type=ipsec --datapath-mode=tunnel"
+  - type: "tunnel-ingress-controller"
+    index: 5
+    cilium-install-opts: "--helm-set=kubeProxyReplacement=true --helm-set=ingressController.enabled=true"
+    nodes: 1

--- a/.github/actions/gke/test-config-schema.yaml
+++ b/.github/actions/gke/test-config-schema.yaml
@@ -4,3 +4,4 @@ testConfigItem:
   type: str()
   index: int()
   cilium-install-opts: str()
+  nodes: int(required=False)

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -55,7 +55,7 @@ concurrency:
 env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
 
 jobs:
   echo-inputs:

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -54,7 +54,7 @@ concurrency:
 
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
   # renovate: datasource=github-releases depName=eksctl-io/eksctl
   eksctl_version: v0.176.0
   # renovate: datasource=github-releases depName=kubernetes/kubernetes

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -272,10 +272,14 @@ jobs:
           fi
 
           CILIUM_INSTALL_INGRESS=""
+          # Once https://github.com/cilium/cilium/issues/31653 is fixed, we can remove tunnel check
           if [ "${{ matrix.kube-proxy }}" == "none" ]; then
-            # The ingress controller requires KPR to be enabled.
-            CILIUM_INSTALL_INGRESS="--helm-set=ingressController.enabled=true \
-              --helm-set-string=kubeProxyReplacement=true"
+            CILIUM_INSTALL_INGRESS="--helm-set=ingressController.enabled=true"
+            # Use the legacy host routing in case of tunnel disabled
+            # Related to https://github.com/cilium/cilium/pull/22006
+            if [ "${{ matrix.tunnel }}" == "disabled" ]; then
+              CILIUM_INSTALL_INGRESS+=" --helm-set=bpf.hostLegacyRouting=true"
+            fi
           fi
 
           CONNECTIVITY_TEST_DEFAULTS="--hubble=false \

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -55,7 +55,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
   clusterName1: cluster1-${{ github.run_id }}
   clusterName2: cluster2-${{ github.run_id }}
   contextName1: kind-cluster1-${{ github.run_id }}

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -51,7 +51,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
 
 jobs:
   echo-inputs:

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -54,7 +54,7 @@ concurrency:
 
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
   # renovate: datasource=github-releases depName=eksctl-io/eksctl
   eksctl_version: v0.176.0
   # renovate: datasource=github-releases depName=kubernetes/kubernetes

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -56,7 +56,7 @@ env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-vm
   vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-vm
   vmStartupScript: .github/gcp-vm-startup.sh
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
 
 jobs:

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -56,7 +56,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
   kind_config: .github/kind-config.yaml
   gateway_api_version: v1.0.0
   timeout: 5m

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -54,7 +54,7 @@ concurrency:
 
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
 
 jobs:

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -222,7 +222,7 @@ jobs:
             --cluster-ipv4-cidr="/21" \
             --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
-            --num-nodes 2 \
+            --num-nodes ${{ matrix.config.nodes || 2 }} \
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 20GB \

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -55,7 +55,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
   kind_config: .github/kind-config.yaml
   timeout: 5m
 

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -51,7 +51,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
 
 jobs:
   echo-inputs:

--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 env:
   cluster_name: cilium-testing
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
 
 jobs:
   kubernetes-e2e-net-conformance:

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 env:
   cluster_name: cilium-testing
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
 
 jobs:
   kubernetes-e2e:

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -11,7 +11,7 @@ on:
 permissions: read-all
 
 env:
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
   KIND_CONFIG: .github/kind-config.yaml
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check.yaml
   TIMEOUT: 2m

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 env:
   kind_config: .github/kind-config.yaml
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
 
 jobs:
   installation-and-connectivity:

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -55,7 +55,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
   kind_config: .github/kind-config.yaml
   timeout: 5m
 

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -38,7 +38,7 @@ concurrency:
 
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
   test_name: gke-perf
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
   gcp_zone: us-east5-a

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -55,7 +55,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
 
   clusterName1: cluster1
   clusterName2: cluster2

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -51,7 +51,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
 
 jobs:
   echo-inputs:

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -51,7 +51,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
 
 jobs:
   echo-inputs:

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -55,7 +55,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
 
 jobs:
   echo-inputs:

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
   KIND_CONFIG: .github/kind-config-ipv6.yaml
   # Skip external traffic (e.g. 1.1.1.1 and www.google.com) due to no support for IPv6 in github action
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check-internal.yaml

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: ${{ !github.event.merge_group }}
 
 env:
-  cilium_cli_ci_version:
+  cilium_cli_ci_version: b5b35301391d9e4a66df2b34165f7e86ea7d2947
   KIND_CONFIG: .github/kind-config.yaml
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check.yaml
   TIMEOUT: 2m

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -411,12 +411,12 @@ func (p *Proxy) ReinstallRoutingRules() error {
 		if err := removeFromEgressProxyRoutesIPv4(); err != nil {
 			return err
 		}
-		if !option.Config.EnableIPSec || option.Config.TunnelingEnabled() {
-			if err := removeFromIngressProxyRoutesIPv4(); err != nil {
+		if !option.Config.EnableIPSec || (option.Config.EnableIPSec && !option.Config.TunnelingEnabled()) {
+			if err := installFromProxyRoutesIPv4(node.GetInternalIPv4Router(), defaults.HostDevice); err != nil {
 				return err
 			}
 		} else {
-			if err := installFromProxyRoutesIPv4(node.GetInternalIPv4Router(), defaults.HostDevice); err != nil {
+			if err := removeFromIngressProxyRoutesIPv4(); err != nil {
 				return err
 			}
 		}
@@ -437,16 +437,16 @@ func (p *Proxy) ReinstallRoutingRules() error {
 		if err := removeFromEgressProxyRoutesIPv6(); err != nil {
 			return err
 		}
-		if !option.Config.EnableIPSec || option.Config.TunnelingEnabled() {
-			if err := removeFromIngressProxyRoutesIPv6(); err != nil {
-				return err
-			}
-		} else {
+		if !option.Config.EnableIPSec || (option.Config.EnableIPSec && !option.Config.TunnelingEnabled()) {
 			ipv6, err := getCiliumNetIPv6()
 			if err != nil {
 				return err
 			}
 			if err := installFromProxyRoutesIPv6(ipv6, defaults.HostDevice); err != nil {
+				return err
+			}
+		} else {
+			if err := removeFromIngressProxyRoutesIPv6(); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
### Description

This commit is to re-enable proxy rule installation in tunnel mode, as
route 2005 was added back, and we need this rule to handle the
hairpinning trafic in Ingress L7 proxy if the backend is on the same
node.

Relates: 0ebe5162373c00f85e7ae43d0bc5d474fa08c485
Relates: https://github.com/cilium/cilium/pull/29530, https://github.com/cilium/cilium/issues/29864

Signed-off-by: Tam Mach <tam.mach@cilium.io>