### PR TITLE
cleanup: Remove deprecated values for KPR

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -80,7 +80,7 @@ jobs:
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: '5.4-20240305.092417'
             kube-proxy: 'iptables'
-            kpr: 'disabled'
+            kpr: 'false'
             tunnel: 'disabled'
             encryption: 'ipsec'
 
@@ -88,7 +88,7 @@ jobs:
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: '5.10-20240305.092417'
             kube-proxy: 'iptables'
-            kpr: 'disabled'
+            kpr: 'false'
             tunnel: 'disabled'
             encryption: 'ipsec'
             endpoint-routes: 'true'
@@ -97,7 +97,7 @@ jobs:
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: '6.1-20240305.092417'
             kube-proxy: 'iptables'
-            kpr: 'disabled'
+            kpr: 'false'
             tunnel: 'vxlan'
             encryption: 'ipsec'
             endpoint-routes: 'false'
@@ -106,7 +106,7 @@ jobs:
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: 'bpf-next-20240309.012251'
             kube-proxy: 'iptables'
-            kpr: 'disabled'
+            kpr: 'false'
             tunnel: 'vxlan'
             encryption: 'ipsec'
             endpoint-routes: 'true'

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -440,6 +440,9 @@ Removed Options
 * The long defunct and undocumented ``single-cluster-route`` flag has been removed.
 
 * Deprecated options ``enable-k8s-event-handover`` and ``cnp-status-update-interval`` has been removed.
+* Deprecated values ``strict``, ``partial``, ``probe`` and ``disabled`` for ``kube-proxy-replacement`` flag have been
+  removed. Please use ``true`` or ``false`` instead. Please refer to :ref:`kube-proxy replacement <kubeproxy-free>`
+  for more details.
 
 Helm Options
 ~~~~~~~~~~~~
@@ -463,6 +466,9 @@ Helm Options
   ``tunnelProtocol``, and has been removed.
 
 * Values  ``enableK8sEventHandover`` and ``enableCnpStatusUpdates`` have been removed.
+
+* Deprecated values ``strict``, ``partial``, ``probe`` and ``disabled`` for ``kubeProxyReplacement`` option have been
+  removed. Please use ``true`` or ``false`` instead.
 
 Added Metrics
 ~~~~~~~~~~~~~

--- a/api/v1/models/kube_proxy_replacement.go
+++ b/api/v1/models/kube_proxy_replacement.go
@@ -41,7 +41,7 @@ type KubeProxyReplacement struct {
 	Features *KubeProxyReplacementFeatures `json:"features,omitempty"`
 
 	// mode
-	// Enum: [Disabled Strict Probe Partial True False]
+	// Enum: [True False]
 	Mode string `json:"mode,omitempty"`
 }
 
@@ -116,7 +116,7 @@ var kubeProxyReplacementTypeModePropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["Disabled","Strict","Probe","Partial","True","False"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["True","False"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -125,18 +125,6 @@ func init() {
 }
 
 const (
-
-	// KubeProxyReplacementModeDisabled captures enum value "Disabled"
-	KubeProxyReplacementModeDisabled string = "Disabled"
-
-	// KubeProxyReplacementModeStrict captures enum value "Strict"
-	KubeProxyReplacementModeStrict string = "Strict"
-
-	// KubeProxyReplacementModeProbe captures enum value "Probe"
-	KubeProxyReplacementModeProbe string = "Probe"
-
-	// KubeProxyReplacementModePartial captures enum value "Partial"
-	KubeProxyReplacementModePartial string = "Partial"
 
 	// KubeProxyReplacementModeTrue captures enum value "True"
 	KubeProxyReplacementModeTrue string = "True"

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2352,10 +2352,6 @@ definitions:
       mode:
         type: string
         enum:
-        - Disabled
-        - Strict
-        - Probe
-        - Partial
         - 'True'
         - 'False'
       devices:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -3949,10 +3949,6 @@ func init() {
         "mode": {
           "type": "string",
           "enum": [
-            "Disabled",
-            "Strict",
-            "Probe",
-            "Partial",
             "True",
             "False"
           ]
@@ -9848,10 +9844,6 @@ func init() {
         "mode": {
           "type": "string",
           "enum": [
-            "Disabled",
-            "Strict",
-            "Probe",
-            "Partial",
             "True",
             "False"
           ]

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1818,7 +1818,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 
 	d.startAgentHealthHTTPService()
 	if option.Config.KubeProxyReplacementHealthzBindAddr != "" {
-		if option.Config.KubeProxyReplacement != option.KubeProxyReplacementDisabled {
+		if option.Config.KubeProxyReplacement != option.KubeProxyReplacementFalse {
 			d.startKubeProxyHealthzHTTPService(option.Config.KubeProxyReplacementHealthzBindAddr)
 		}
 	}

--- a/daemon/cmd/kube_proxy_replacement_test.go
+++ b/daemon/cmd/kube_proxy_replacement_test.go
@@ -114,25 +114,6 @@ func (s *KPRSuite) TestInitKubeProxyReplacementOptions(c *C) {
 			},
 		},
 
-		// KPR disabled: all options disabled except host legacy routing.
-		{
-			"kpr-disabled",
-			func(cfg *kprConfig) {
-				cfg.kubeProxyReplacement = option.KubeProxyReplacementDisabled
-			},
-			kprConfig{
-				enableSocketLB:          false,
-				enableNodePort:          false,
-				enableHostPort:          false,
-				enableExternalIPs:       false,
-				enableSessionAffinity:   false,
-				enableIPSec:             false,
-				enableHostLegacyRouting: true,
-				enableSocketLBTracing:   false,
-				expectedErrorRegex:      "",
-			},
-		},
-
 		// KPR true: all options enabled, host routing disabled.
 		{
 			"kpr-true",
@@ -215,6 +196,26 @@ func (s *KPRSuite) TestInitKubeProxyReplacementOptions(c *C) {
 				enableSocketLBTracing:      true,
 			},
 		},
+
+		// KPR false: all options disabled exception socket LB tracing
+		{
+			"kpr-disabled",
+			func(cfg *kprConfig) {
+				cfg.kubeProxyReplacement = option.KubeProxyReplacementFalse
+			},
+			kprConfig{
+				enableSocketLB:          false,
+				enableNodePort:          false,
+				enableHostPort:          false,
+				enableExternalIPs:       false,
+				enableSessionAffinity:   false,
+				enableIPSec:             false,
+				enableHostLegacyRouting: false,
+				enableSocketLBTracing:   true,
+				expectedErrorRegex:      "",
+			},
+		},
+
 		// KPR false + no conntrack ipt rules: error, needs KPR
 		{
 			"kpr-false+no-conntrack-ipt-rules",

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -231,12 +231,6 @@ func (d *Daemon) getKubeProxyReplacementStatus() *models.KubeProxyReplacement {
 		mode = models.KubeProxyReplacementModeTrue
 	case option.KubeProxyReplacementFalse:
 		mode = models.KubeProxyReplacementModeFalse
-	case option.KubeProxyReplacementStrict:
-		mode = models.KubeProxyReplacementModeStrict
-	case option.KubeProxyReplacementPartial:
-		mode = models.KubeProxyReplacementModePartial
-	case option.KubeProxyReplacementDisabled:
-		mode = models.KubeProxyReplacementModeDisabled
 	}
 
 	devices, _ := datapathTables.SelectedDevices(d.devices, d.db.ReadTxn())

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -66,8 +66,8 @@
   {{- $stringValueKPR = "" -}}
 {{- end}}
 {{- $kubeProxyReplacement := (coalesce $stringValueKPR $defaultKubeProxyReplacement) -}}
-{{- if and (ne $kubeProxyReplacement "disabled") (ne $kubeProxyReplacement "partial") (ne $kubeProxyReplacement "strict") (ne $kubeProxyReplacement "true") (ne $kubeProxyReplacement "false") }}
-  {{ fail "kubeProxyReplacement must be explicitly set to a valid value (true, false, disabled (deprecated), partial (deprecated), or strict (deprecated)) to continue." }}
+{{- if and (ne $kubeProxyReplacement "true") (ne $kubeProxyReplacement "false") }}
+  {{ fail "kubeProxyReplacement must be explicitly set to a valid value (true or false) to continue." }}
 {{- end }}
 {{- $azureUsePrimaryAddress = (coalesce .Values.azure.usePrimaryAddress $azureUsePrimaryAddress) -}}
 {{- $socketLB := (coalesce .Values.socketLB .Values.hostServices) -}}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1581,7 +1581,7 @@ readinessProbe:
   # -- interval between checks of the readiness probe
   periodSeconds: 30
 # -- Configure the kube-proxy replacement in Cilium BPF datapath
-# Valid options are "true", "false", "disabled" (deprecated), "partial" (deprecated), "strict" (deprecated).
+# Valid options are "true" or "false".
 # ref: https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/
 #kubeProxyReplacement: "false"
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1581,7 +1581,7 @@ readinessProbe:
   # -- interval between checks of the readiness probe
   periodSeconds: 30
 # -- Configure the kube-proxy replacement in Cilium BPF datapath
-# Valid options are "true", "false", "disabled" (deprecated), "partial" (deprecated), "strict" (deprecated).
+# Valid options are "true" or "false".
 # ref: https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/
 #kubeProxyReplacement: "false"
 

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -99,7 +99,6 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 	}
 
 	if params.GatewayApiConfig.KubeProxyReplacement != option.KubeProxyReplacementTrue &&
-		params.GatewayApiConfig.KubeProxyReplacement != option.KubeProxyReplacementStrict &&
 		!params.GatewayApiConfig.EnableNodePort {
 		params.Logger.Warn("Gateway API support requires either kube-proxy-replacement or enable-node-port enabled")
 		return nil

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -99,7 +99,6 @@ func registerReconciler(params ingressParams) error {
 	}
 
 	if params.IngressConfig.KubeProxyReplacement != option.KubeProxyReplacementTrue &&
-		params.IngressConfig.KubeProxyReplacement != option.KubeProxyReplacementStrict &&
 		!params.IngressConfig.EnableNodePort {
 		params.Logger.Warn("Ingress Controller support requires either kube-proxy-replacement or enable-node-port enabled")
 		return nil

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -325,7 +325,7 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 	}
 	if sr.KubeProxyReplacement != nil {
 		devices := ""
-		if sr.KubeProxyReplacement.Mode != models.KubeProxyReplacementModeDisabled {
+		if sr.KubeProxyReplacement.Mode != models.KubeProxyReplacementModeFalse {
 			for i, dev := range sr.KubeProxyReplacement.DeviceList {
 				kubeProxyDevices += fmt.Sprintf("%s %s", dev.Name, strings.Join(dev.IP, " "))
 				if dev.Name == sr.KubeProxyReplacement.DirectRoutingDevice {

--- a/pkg/datapath/tunnel/cell.go
+++ b/pkg/datapath/tunnel/cell.go
@@ -33,7 +33,6 @@ var Cell = cell.Module(
 		func(dcfg *option.DaemonConfig) EnablerOut {
 			return NewEnabler(
 				(dcfg.EnableNodePort ||
-					dcfg.KubeProxyReplacement == option.KubeProxyReplacementStrict ||
 					dcfg.KubeProxyReplacement == option.KubeProxyReplacementTrue) &&
 					dcfg.LoadBalancerUsesDSR() &&
 					dcfg.LoadBalancerDSRDispatch == option.DSRDispatchGeneve,

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1266,22 +1266,12 @@ const (
 	// NodePortAccelerationBestEffort means we accelerate NodePort via native XDP in the driver (preferred), but will skip devices without driver support
 	NodePortAccelerationBestEffort = XDPModeBestEffort
 
-	// KubeProxyReplacementPartial specifies to enable only selected kube-proxy
-	// replacement features (might panic)
-	KubeProxyReplacementPartial = "partial"
-
-	// KubeProxyReplacementStrict specifies to enable all kube-proxy replacement
-	// features (might panic)
-	KubeProxyReplacementStrict = "strict"
-
-	// KubeProxyReplacementDisabled specified to completely disable kube-proxy
-	// replacement
-	KubeProxyReplacementDisabled = "disabled"
-
-	// KubeProxyReplacementTrue has the same meaning as previous "strict".
+	// KubeProxyReplacementTrue specifies to enable all kube-proxy replacement
+	// features (might panic).
 	KubeProxyReplacementTrue = "true"
 
-	// KubeProxyReplacementTrue has the same meaning as previous "partial".
+	// KubeProxyReplacementFalse specifies to enable only selected kube-proxy
+	// replacement features (might panic).
 	KubeProxyReplacementFalse = "false"
 
 	// KubeProxyReplacement healthz server bind address
@@ -4105,7 +4095,7 @@ func getDefaultMonitorQueueSize(numCPU int) int {
 func MightAutoDetectDevices() bool {
 	devices := Config.GetDevices()
 	return ((Config.EnableHostFirewall || Config.EnableWireguard || Config.EnableHighScaleIPcache) && len(devices) == 0) ||
-		(Config.KubeProxyReplacement != KubeProxyReplacementDisabled &&
+		(Config.KubeProxyReplacement != KubeProxyReplacementFalse &&
 			(len(devices) == 0 || Config.DirectRoutingDevice == ""))
 }
 


### PR DESCRIPTION
## Description

This commit is to remove all deprecated values (strict, disabled, probe
and partial) for kubeProxyReplacement.

Relates: https://github.com/cilium/cilium/pull/26036, https://github.com/cilium/cilium/pull/26496

## Testing

Testing was done with the latest cilium-cli with commit hash while waiting for the next release.

Relates: https://github.com/cilium/cilium/pull/31286