### PR TITLE
gateway-api: shorten the length of the value of the svc's label.

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -318,7 +318,7 @@ func isAttachable(_ context.Context, gw *gatewayv1.Gateway, route metav1.Object,
 func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.Gateway) error {
 	svcList := &corev1.ServiceList{}
 	if err := r.Client.List(ctx, svcList, client.MatchingLabels{
-		owningGatewayLabel: gw.GetName(),
+		owningGatewayLabel: model.Shorten(gw.GetName()),
 	}); err != nil {
 		return err
 	}

--- a/operator/pkg/model/helpers.go
+++ b/operator/pkg/model/helpers.go
@@ -4,6 +4,8 @@
 package model
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -88,4 +90,39 @@ func hostnameMatchesWildcardHostname(hostname, wildcardHostname string) bool {
 
 func AddressOf[T any](v T) *T {
 	return &v
+}
+
+// Shorten shortens the string to 63 characters.
+// this is the implicit required for all the resource naming in k8s.
+func Shorten(s string) string {
+	if len(s) > 63 {
+		return s[:52] + "-" + encodeHash(hash(s))
+	}
+	return s
+}
+
+// encodeHash encodes the first 10 characters of the hex string.
+// https://github.com/kubernetes/kubernetes/blob/f0dcf0614036d8c3cd1c9f3b3cf8df4bb1d8e44e/staging/src/k8s.io/kubectl/pkg/util/hash/hash.go#L105
+func encodeHash(hex string) string {
+	enc := []rune(hex[:10])
+	for i := range enc {
+		switch enc[i] {
+		case '0':
+			enc[i] = 'g'
+		case '1':
+			enc[i] = 'h'
+		case '3':
+			enc[i] = 'k'
+		case 'a':
+			enc[i] = 'm'
+		case 'e':
+			enc[i] = 't'
+		}
+	}
+	return string(enc)
+}
+
+// hash hashes `data` with sha256 and returns the hex string
+func hash(data string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(data)))
 }

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -4,6 +4,7 @@
 package gateway_api
 
 import (
+	"fmt"
 	"testing"
 
 	envoy_config_route_v3 "github.com/cilium/proxy/go/envoy/config/route/v3"
@@ -12,6 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/operator/pkg/model/translation"
@@ -445,6 +449,69 @@ func Test_translator_Translate_WithXffNumTrustedHops(t *testing.T) {
 			assert.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type)
 
 			require.NotNil(t, ep)
+		})
+	}
+}
+
+func Test_getService(t *testing.T) {
+	type args struct {
+		resource    *model.FullyQualifiedResource
+		allPorts    []uint32
+		labels      map[string]string
+		annotations map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *corev1.Service
+	}{
+		{
+			name: "long name - more than 64 characters",
+			args: args{
+				resource: &model.FullyQualifiedResource{
+					Name:      "test-long-long-long-long-long-long-long-long-long-long-long-long-name",
+					Namespace: "default",
+					Version:   "v1",
+					Kind:      "Gateway",
+					UID:       "57889650-380b-4c05-9a2e-3baee7fd5271",
+				},
+				allPorts: []uint32{80},
+			},
+			want: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cilium-gateway-test-long-long-long-long-long-long-lo-8tfth549c6",
+					Namespace: "default",
+					Labels: map[string]string{
+						owningGatewayLabel: "test-long-long-long-long-long-long-long-long-long-lo-4bftbgh5ht",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: gatewayv1beta1.GroupVersion.String(),
+							Kind:       "Gateway",
+							Name:       "test-long-long-long-long-long-long-long-long-long-long-long-long-name",
+							UID:        types.UID("57889650-380b-4c05-9a2e-3baee7fd5271"),
+							Controller: model.AddressOf(true),
+						},
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:     fmt.Sprintf("port-%d", 80),
+							Port:     80,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getService(tt.args.resource, tt.args.allPorts, tt.args.labels, tt.args.annotations)
+			assert.Equalf(t, tt.want, got, "getService(%v, %v, %v, %v)", tt.args.resource, tt.args.allPorts, tt.args.labels, tt.args.annotations)
+			assert.Equal(t, true, len(got.Name) <= 63, "Service name is too long")
 		})
 	}
 }


### PR DESCRIPTION
Fixes #31285

When creating a gateway-api with a name exceeding 64 characters, it is impossible to create svc.

This is because the label of svc references the name of gateway-api.


```release-note
gateway-api: shorten the length of the value of the svc's label.
```
