### PR TITLE
Fqdn proxy metrics

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -263,7 +263,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 	endMetric := func() {
 		stat.ProcessingTime.End(true)
 		stat.TotalTime.End(true)
-		if errors.As(stat.Err, &dnsproxy.ErrFailedAcquireSemaphore{}) || errors.As(stat.Err, &dnsproxy.ErrTimedOutAcquireSemaphore{}) {
+		if errors.As(stat.Err, &dnsproxy.ErrTimedOutAcquireSemaphore{}) {
 			metrics.FQDNSemaphoreRejectedTotal.Inc()
 		}
 		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, totalTime).Observe(

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -576,7 +576,6 @@ type ProxyRequestContext struct {
 	PolicyCheckTime      spanstat.SpanStat
 	PolicyGenerationTime spanstat.SpanStat
 	DataplaneTime        spanstat.SpanStat
-	Success              bool
 	Err                  error
 	DataSource           accesslog.DNSDataSource
 }
@@ -1047,7 +1046,6 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	}
 
 	scopedLog.WithField(logfields.Response, response).Debug("Received DNS response to proxied lookup")
-	stat.Success = true
 
 	scopedLog.Debug("Notifying with DNS response to original DNS query")
 	p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, response, protocol, allowed, &stat)

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -955,7 +955,6 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	case "udp":
 	case "tcp":
 	default:
-		allowed = false
 		rejectResponse(fmt.Errorf("unsupported protocol %s", protocol), "Cannot parse DNS proxy client network to select forward client", true)
 		return
 	}
@@ -1006,7 +1005,6 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 
 	stat.UpstreamTime.End(err == nil)
 	if err != nil {
-		allowed = false
 		stat.Err = err
 		if stat.IsTimeout() {
 			scopedLog.WithError(err).Warn("Timeout waiting for response to forwarded proxied DNS lookup")

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -1015,7 +1015,9 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		return
 	}
 
-	scopedLog.WithField(logfields.Response, response).Debug("Received DNS response to proxied lookup")
+	if log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		scopedLog.WithField(logfields.Response, response).Debug("Received DNS response to proxied lookup")
+	}
 
 	scopedLog.Debug("Notifying with DNS response to original DNS query")
 	p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, response, protocol, allowed, &stat)

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -876,10 +876,11 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	})
 	targetServerID := identity.NumericIdentity(0)
 	targetServerAddrStr := ""
+	allowed := false
 
 	release, err := p.handleConcurrencyLimit(scopedLog, &stat)
 	if err != nil {
-		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, targetServerID, targetServerAddrStr, request, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, targetServerID, targetServerAddrStr, request, protocol, allowed, &stat)
 		p.sendRefused(scopedLog, w, request)
 		return
 	}
@@ -895,7 +896,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.WithError(err).Error("cannot extract endpoint IP from DNS request")
 		stat.Err = fmt.Errorf("Cannot extract endpoint IP from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, targetServerID, targetServerAddrStr, request, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, targetServerID, targetServerAddrStr, request, protocol, allowed, &stat)
 		p.sendRefused(scopedLog, w, request)
 		return
 	}
@@ -905,7 +906,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.WithError(err).Error("cannot extract endpoint ID from DNS request")
 		stat.Err = fmt.Errorf("Cannot extract endpoint ID from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, targetServerID, targetServerAddrStr, request, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, targetServerID, targetServerAddrStr, request, protocol, allowed, &stat)
 		p.sendRefused(scopedLog, w, request)
 		return
 	}
@@ -920,7 +921,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		log.WithError(err).Error("cannot extract destination IP:port from DNS request")
 		stat.Err = fmt.Errorf("Cannot extract destination IP:port from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, request, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, request, protocol, allowed, &stat)
 		p.sendRefused(scopedLog, w, request)
 		return
 	}
@@ -941,14 +942,15 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	// it won't enforce any separation between results from different endpoints.
 	// This isn't ideal but we are trusting the DNS responses anyway.
 	stat.PolicyCheckTime.Start()
-	allowed, err := p.CheckAllowed(uint64(ep.ID), targetServerPort, targetServerID, targetServerIP, qname)
+	allowed, err = p.CheckAllowed(uint64(ep.ID), targetServerPort, targetServerID, targetServerIP, qname)
 	stat.PolicyCheckTime.End(err == nil)
 	switch {
 	case err != nil:
+		allowed = false
 		scopedLog.WithError(err).Error("Rejecting DNS query from endpoint due to error")
 		stat.Err = fmt.Errorf("Rejecting DNS query from endpoint due to error: %w", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, request, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, request, protocol, allowed, &stat)
 		p.sendRefused(scopedLog, w, request)
 		return
 
@@ -960,12 +962,12 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		// information for metrics.
 		stat.Err = p.sendRefused(scopedLog, w, request)
 		stat.ProcessingTime.End(true)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, request, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, request, protocol, allowed, &stat)
 		return
 	}
 
 	scopedLog.Debug("Forwarding DNS request for a name that is allowed")
-	p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, request, protocol, true, &stat)
+	p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, request, protocol, allowed, &stat)
 
 	// Keep the same L4 protocol. This handles DNS re-requests over TCP, for
 	// requests that were too large for UDP.
@@ -973,10 +975,11 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	case "udp":
 	case "tcp":
 	default:
+		allowed = false
 		scopedLog.Error("Cannot parse DNS proxy client network to select forward client")
 		stat.Err = fmt.Errorf("Cannot parse DNS proxy client network to select forward client: %w", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, request, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, request, protocol, allowed, &stat)
 		p.sendRefused(scopedLog, w, request)
 		return
 	}
@@ -1027,15 +1030,16 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 
 	stat.UpstreamTime.End(err == nil)
 	if err != nil {
+		allowed = false
 		stat.Err = err
 		if stat.IsTimeout() {
 			scopedLog.WithError(err).Warn("Timeout waiting for response to forwarded proxied DNS lookup")
-			p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, request, protocol, false, &stat)
+			p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, request, protocol, allowed, &stat)
 			return
 		}
 		scopedLog.WithError(err).Error("Cannot forward proxied DNS lookup")
 		stat.Err = fmt.Errorf("cannot forward proxied DNS lookup: %w", err)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, request, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, request, protocol, allowed, &stat)
 		p.sendRefused(scopedLog, w, request)
 		return
 	}
@@ -1044,7 +1048,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	stat.Success = true
 
 	scopedLog.Debug("Notifying with DNS response to original DNS query")
-	p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, response, protocol, true, &stat)
+	p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, response, protocol, allowed, &stat)
 
 	scopedLog.Debug("Responding to original DNS query")
 	// restore the ID to the one in the initial request so it matches what the requester expects.
@@ -1054,7 +1058,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	if err != nil {
 		scopedLog.WithError(err).Error("Cannot forward proxied DNS response")
 		stat.Err = fmt.Errorf("Cannot forward proxied DNS response: %w", err)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, response, protocol, true, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, response, protocol, allowed, &stat)
 	} else {
 		p.Lock()
 		// Add the server to the set of used DNS servers. This set is never GCd, but is limited by set

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -282,8 +282,7 @@ func (s *DNSProxyTestSuite) TestRejectFromDifferentEndpoint(c *C) {
 	// Reject a query from not endpoint 1
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID2, dstPort, dstID1, nil, query)
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed := s.proxy.CheckAllowed(epID2, dstPort, dstID1, nil, query)
 	c.Assert(allowed, Equals, false, Commentf("request was not rejected when it should be blocked"))
 }
 
@@ -301,8 +300,7 @@ func (s *DNSProxyTestSuite) TestAcceptFromMatchingEndpoint(c *C) {
 	// accept a query that matches from endpoint1
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 }
 
@@ -320,8 +318,7 @@ func (s *DNSProxyTestSuite) TestAcceptNonRegex(c *C) {
 	// accept a query that matches from endpoint1
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 }
 
@@ -339,8 +336,7 @@ func (s *DNSProxyTestSuite) TestRejectNonRegex(c *C) {
 	// reject a query for a non-regex where a . is different (i.e. ensure simple FQDNs treat . as .)
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(allowed, Equals, false, Commentf("request was not rejected when it should be blocked"))
 }
 
@@ -357,8 +353,7 @@ func (s *DNSProxyTestSuite) requestRejectNonMatchingRefusedResponse(c *C) *dns.M
 
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(allowed, Equals, false, Commentf("request was not rejected when it should be blocked"))
 
 	request := new(dns.Msg)
@@ -404,8 +399,7 @@ func (s *DNSProxyTestSuite) TestRespondViaCorrectProtocol(c *C) {
 
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	request := new(dns.Msg)
@@ -433,8 +427,7 @@ func (s *DNSProxyTestSuite) TestRespondMixedCaseInRequestResponse(c *C) {
 
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	request := new(dns.Msg)
@@ -462,9 +455,7 @@ func (s *DNSProxyTestSuite) TestCheckNoRules(c *C) {
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Error when inserting rules"))
 
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
-
+	allowed := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	l7map = policy.L7DataMap{
@@ -477,8 +468,7 @@ func (s *DNSProxyTestSuite) TestCheckNoRules(c *C) {
 	err = s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Error when inserting rules"))
 
-	allowed, err = s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 }
 
@@ -498,22 +488,19 @@ func (s *DNSProxyTestSuite) TestCheckAllowedTwiceRemovedOnce(c *C) {
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
 	err = s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Delete once, it should reject
 	err = s.proxy.UpdateAllowed(epID1, dstPort, nil)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err = s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Delete once, it should reject and not crash
 	err = s.proxy.UpdateAllowed(epID1, dstPort, nil)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err = s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 }
 
@@ -611,63 +598,51 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 
 	// Test cases
 	// Case 1 | EPID1 | DstID1 |   53 | www.ubuntu.com | Allowed
-	allowed, err := s.proxy.CheckAllowed(epID1, 53, dstID1, nil, "www.ubuntu.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed := s.proxy.CheckAllowed(epID1, 53, dstID1, nil, "www.ubuntu.com")
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Case 2 | EPID1 | DstID1 |   54 | cilium.io      | Rejected | Port 54 only allows example.com
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, nil, "cilium.io")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 54, dstID1, nil, "cilium.io")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 3 | EPID1 | DstID2 |   53 | cilium.io      | Allowed
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, nil, "cilium.io")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 53, dstID2, nil, "cilium.io")
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Case 4 | EPID1 | DstID2 |   53 | aws.amazon.com | Rejected | Only cilium.io is allowed with DstID2
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, nil, "aws.amazon.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 53, dstID2, nil, "aws.amazon.com")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 5 | EPID1 | DstID1 |   54 | example.com    | Allowed
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, nil, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 54, dstID1, nil, "example.com")
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Case 6 | EPID2 | DstID1 |   53 | cilium.io      | Rejected | EPID2 is not allowed as a source by any policy
-	allowed, err = s.proxy.CheckAllowed(epID2, 53, dstID1, nil, "cilium.io")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID2, 53, dstID1, nil, "cilium.io")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 7 | EPID3 | DstID1 |   53 | example.com    | Allowed
-	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID1, nil, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID3, 53, dstID1, nil, "example.com")
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Case 8 | EPID3 | DstID1 |   53 | aws.amazon.com | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com
-	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID1, nil, "aws.amazon.io")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID3, 53, dstID1, nil, "aws.amazon.io")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 8 | EPID3 | DstID1 |   54 | example.com    | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com
-	allowed, err = s.proxy.CheckAllowed(epID3, 54, dstID1, nil, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID3, 54, dstID1, nil, "example.com")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 9 | EPID3 | DstID2 |   53 | example.com    | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com
-	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID2, nil, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID3, 53, dstID2, nil, "example.com")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 10 | EPID3 | DstID3 |   53 | example.com    | Allowed due to wildcard match pattern
-	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID3, nil, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID3, 53, dstID3, nil, "example.com")
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Case 11 | EPID3 | DstID4 |   53 | example.com    | Allowed due to a nil rule
-	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID4, nil, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID3, 53, dstID4, nil, "example.com")
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Get rules for restoration
@@ -739,28 +714,23 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 
 	// Before restore: all rules removed above, everything is dropped
 	// Case 1 | EPID1 | DstID1 |   53 | www.ubuntu.com | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID1, dstIP1, "www.ubuntu.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 53, dstID1, dstIP1, "www.ubuntu.com")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 2 | EPID1 | DstID1 |   54 | cilium.io      | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, dstIP1, "cilium.io")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 54, dstID1, dstIP1, "cilium.io")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 3 | EPID1 | DstID2 |   53 | cilium.io      | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, dstIP2a, "cilium.io")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 53, dstID2, dstIP2a, "cilium.io")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 4 | EPID1 | DstID2 |   53 | aws.amazon.com | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, dstIP2b, "aws.amazon.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 53, dstID2, dstIP2b, "aws.amazon.com")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 5 | EPID1 | DstID1 |   54 | example.com    | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, dstIP1, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 54, dstID1, dstIP1, "example.com")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Restore rules
@@ -773,40 +743,33 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	// Same tests with 2 (WORLD) dstID to make sure it is not used, but with correct destination IP
 
 	// Case 1 | EPID1 | dstIP1 |   53 | www.ubuntu.com | Allowed due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP1, "www.ubuntu.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 53, 2, dstIP1, "www.ubuntu.com")
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Case 2 | EPID1 | dstIP1 |   54 | cilium.io      | Rejected due to restored rules | Port 54 only allows example.com
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIP1, "cilium.io")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 54, 2, dstIP1, "cilium.io")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 3 | EPID1 | dstIP2a |   53 | cilium.io      | Allowed due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP2a, "cilium.io")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 53, 2, dstIP2a, "cilium.io")
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Case 4 | EPID1 | dstIP2b |   53 | aws.amazon.com | Rejected due to restored rules | Only cilium.io is allowed with DstID2
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP2b, "aws.amazon.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 53, 2, dstIP2b, "aws.amazon.com")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 5 | EPID1 | dstIP1 |   54 | example.com    | Allowed due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIP1, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 54, 2, dstIP1, "example.com")
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// make sure random IP is not allowed
 	// Case 5 | EPID1 | random IP |   53 | example.com    | Rejected due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIPrandom, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 53, 2, dstIPrandom, "example.com")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// make sure random destination IP is allowed in a wildcard selector
 	// Case 5 | EPID1 | random IP |   54 | example.com    | Allowed due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIPrandom, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 54, 2, dstIPrandom, "example.com")
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Restore rules for epID3
@@ -856,33 +819,27 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 
 	// Before restore after marshal: previous restored rules are removed, everything is dropped
 	// Case 1 | EPID1 | DstID1 |   53 | www.ubuntu.com | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID1, dstIP1, "www.ubuntu.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 53, dstID1, dstIP1, "www.ubuntu.com")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 2 | EPID1 | DstID1 |   54 | cilium.io      | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, dstIP1, "cilium.io")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 54, dstID1, dstIP1, "cilium.io")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 3 | EPID1 | DstID2 |   53 | cilium.io      | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, dstIP2a, "cilium.io")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 53, dstID2, dstIP2a, "cilium.io")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 4 | EPID1 | DstID2 |   53 | aws.amazon.com | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, dstIP2b, "aws.amazon.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 53, dstID2, dstIP2b, "aws.amazon.com")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 5 | EPID1 | DstID1 |   54 | example.com    | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, dstIP1, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 54, dstID1, dstIP1, "example.com")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 5 | EPID1 | random IP |   54 | example.com    | Rejected
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIPrandom, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 54, 2, dstIPrandom, "example.com")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Restore Unmarshaled rules
@@ -906,40 +863,33 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	// After restoration of JSON marshaled/unmarshaled rules
 
 	// Case 1 | EPID1 | dstIP1 |   53 | www.ubuntu.com | Allowed due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP1, "www.ubuntu.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 53, 2, dstIP1, "www.ubuntu.com")
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Case 2 | EPID1 | dstIP1 |   54 | cilium.io      | Rejected due to restored rules | Port 54 only allows example.com
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIP1, "cilium.io")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 54, 2, dstIP1, "cilium.io")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 3 | EPID1 | dstIP2a |   53 | cilium.io      | Allowed due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP2a, "cilium.io")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 53, 2, dstIP2a, "cilium.io")
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Case 4 | EPID1 | dstIP2b |   53 | aws.amazon.com | Rejected due to restored rules | Only cilium.io is allowed with DstID2
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP2b, "aws.amazon.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 53, 2, dstIP2b, "aws.amazon.com")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 5 | EPID1 | dstIP1 |   54 | example.com    | Allowed due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIP1, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 54, 2, dstIP1, "example.com")
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// make sure random IP is not allowed
 	// Case 5 | EPID1 | random IP |   53 | example.com    | Rejected due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIPrandom, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 53, 2, dstIPrandom, "example.com")
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// make sure random IP is allowed on a wildcard
 	// Case 5 | EPID1 | random IP |   54 | example.com    | Allowed due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIPrandom, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	allowed = s.proxy.CheckAllowed(epID1, 54, 2, dstIPrandom, "example.com")
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	s.proxy.RemoveRestoredRules(uint16(epID1))
@@ -967,8 +917,7 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
 	for _, query := range queries {
-		allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
-		c.Assert(err, Equals, nil, Commentf("Error when checking allowed query: %q", query))
+		allowed := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 		c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed for query: %q", query))
 	}
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -1080,8 +1080,6 @@ func (s *DNSProxyTestSuite) TestProxyRequestContext_IsTimeout(c *C) {
 	p.Err = fmt.Errorf("sample err: %s", context.DeadlineExceeded)
 	c.Assert(p.IsTimeout(), Equals, false)
 
-	p.Err = ErrFailedAcquireSemaphore{}
-	c.Assert(p.IsTimeout(), Equals, true)
 	p.Err = ErrTimedOutAcquireSemaphore{
 		gracePeriod: 1 * time.Second,
 	}


### PR DESCRIPTION
The main goal of this PR was to refactor fqdn proxy a bit and to decompose:
- Updating metrics
- Generating flow
- Core FQDN proxy business logic

It's easier to review it commit-by-commit

```release-note
Fix proxy_upstream_reply_seconds metric to capture time spent in generating Hubble flows.
```
