### PR TITLE
[v1.15] Backport FQDN: fix incorrect reaping of newly-expired IPs

### DIFF
--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -518,19 +518,21 @@ func (f *GCFilter) doFiltering(srcIP, dstIP netip.Addr, srcPort, dstPort uint16,
 	return noAction
 }
 
-func doGC(m *Map, filter *GCFilter) int {
+func doGC(m *Map, filter *GCFilter) (int, error) {
 	if m.mapType.isIPv6() {
-		return int(doGC6(m, filter).deleted)
+		stats := doGC6(m, filter)
+		return int(stats.deleted), stats.dumpError
 	} else if m.mapType.isIPv4() {
-		return int(doGC4(m, filter).deleted)
+		stats := doGC4(m, filter)
+		return int(stats.deleted), stats.dumpError
 	}
 	log.Fatalf("Unsupported ct map type: %s", m.mapType.String())
-	return 0
+	return 0, fmt.Errorf("unsupported ct map type: %s", m.mapType.String())
 }
 
 // GC runs garbage collection for map m with name mapType with the given filter.
 // It returns how many items were deleted from m.
-func GC(m *Map, filter *GCFilter) int {
+func GC(m *Map, filter *GCFilter) (int, error) {
 	if filter.RemoveExpired {
 		t, _ := timestamp.GetCTCurTime(timestamp.GetClockSourceFromOptions())
 		filter.Time = uint32(t)
@@ -639,10 +641,11 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 // Flush runs garbage collection for map m with the name mapType, deleting all
 // entries. The specified map must be already opened using bpf.OpenMap().
 func (m *Map) Flush() int {
-	return doGC(m, &GCFilter{
+	d, _ := doGC(m, &GCFilter{
 		RemoveExpired: true,
 		Time:          MaxTime,
 	})
+	return d
 }
 
 // DeleteIfUpgradeNeeded attempts to open the conntrack maps associated with

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -120,6 +120,8 @@ func (gc *GC) Enable() {
 						ep.MarkDNSCTEntry(dstIP, aliveTime)
 					}
 				}
+
+				success = false
 			)
 
 			gcInterval := gcStart.Sub(gcPrev)
@@ -136,19 +138,22 @@ func (gc *GC) Enable() {
 
 			if len(eps) > 0 || initialScan {
 				gc.logger.Info("Starting initial GC of connection tracking")
-				maxDeleteRatio = gc.runGC(nil, ipv4, ipv6, triggeredBySignal, &ctmap.GCFilter{RemoveExpired: true, EmitCTEntryCB: emitEntryCB})
+				maxDeleteRatio, success = gc.runGC(nil, ipv4, ipv6, triggeredBySignal, &ctmap.GCFilter{RemoveExpired: true, EmitCTEntryCB: emitEntryCB})
 			}
 			for _, e := range eps {
 				if !e.ConntrackLocal() {
 					// Skip because GC was handled above.
 					continue
 				}
-				gc.runGC(e, ipv4, ipv6, triggeredBySignal, &ctmap.GCFilter{RemoveExpired: true, EmitCTEntryCB: emitEntryCB})
+				_, epSuccess := gc.runGC(e, ipv4, ipv6, triggeredBySignal, &ctmap.GCFilter{RemoveExpired: true, EmitCTEntryCB: emitEntryCB})
+				success = success && epSuccess
 			}
 
-			// Mark the CT GC as over in each EP DNSZombies instance
-			for _, e := range eps {
-				e.MarkCTGCTime(gcStart)
+			// Mark the CT GC as over in each EP DNSZombies instance, if we did a *full* GC run
+			if success && ipv4 == gc.ipv4 && ipv6 == gc.ipv6 {
+				for _, e := range eps {
+					e.MarkCTGCTime(gcStart)
+				}
 			}
 
 			if initialScan {
@@ -204,8 +209,9 @@ func (gc *GC) Enable() {
 // The provided endpoint is optional; if it is provided, then its map will be
 // garbage collected and any failures will be logged to the endpoint log.
 // Otherwise it will garbage-collect the global map and use the global log.
-func (gc *GC) runGC(e *endpoint.Endpoint, ipv4, ipv6, triggeredBySignal bool, filter *ctmap.GCFilter) (maxDeleteRatio float64) {
+func (gc *GC) runGC(e *endpoint.Endpoint, ipv4, ipv6, triggeredBySignal bool, filter *ctmap.GCFilter) (maxDeleteRatio float64, success bool) {
 	var maps []*ctmap.Map
+	success = true
 
 	if e == nil {
 		maps = ctmap.GlobalMaps(ipv4, ipv6)
@@ -224,6 +230,7 @@ func (gc *GC) runGC(e *endpoint.Endpoint, ipv4, ipv6, triggeredBySignal bool, fi
 			err = m.Open()
 		}
 		if err != nil {
+			success = false
 			msg := "Skipping CT garbage collection"
 			scopedLog := gc.logger.WithError(err).WithField(logfields.Path, path)
 			if os.IsNotExist(err) {
@@ -238,7 +245,11 @@ func (gc *GC) runGC(e *endpoint.Endpoint, ipv4, ipv6, triggeredBySignal bool, fi
 		}
 		defer m.Close()
 
-		deleted := ctmap.GC(m, filter)
+		deleted, err := ctmap.GC(m, filter)
+		if err != nil {
+			gc.logger.WithError(err).Error("failed to perform CT garbage collection")
+			success = false
+		}
 
 		if deleted > 0 {
 			ratio := float64(deleted) / float64(m.MaxEntries())


### PR DESCRIPTION
 - [ ] #31205 -- FQDN: fix incorrect reaping of newly-expired IPs (@squeed)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
$ for pr in 31205; do contrib/backporting/set-labels.py $pr done 1.15; done
```
