### PR TITLE
config: Remove unused `ENCRYPT_IFACE` macro

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -588,12 +588,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 
 		a := byteorder.NetIPv4ToHost32(nodeAddress)
 		cDefinesMap["IPV4_ENCRYPT_IFACE"] = fmt.Sprintf("%d", a)
-		if iface := option.Config.EncryptInterface; len(iface) != 0 {
-			link, err := netlink.LinkByName(iface[0])
-			if err == nil {
-				cDefinesMap["ENCRYPT_IFACE"] = fmt.Sprintf("%d", link.Attrs().Index)
-			}
-		}
 	}
 
 	if option.Config.EnableNodePort {


### PR DESCRIPTION
This macro is not used by the datapath since commit 3a650c32f2 ("bpf: Remove FIB lookup for IPsec"); there's no point writing it to the header file.

Fixes: https://github.com/cilium/cilium/pull/22069.