### PR TITLE
fqdn: Add Protocol to DNS Proxy Cache

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -193,7 +193,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 		// Restore old rules
 		for _, possibleEP := range possibleEndpoints {
 			// Upgrades from old ciliums have this nil
-			if possibleEP.DNSRules != nil {
+			if possibleEP.DNSRules != nil || possibleEP.DNSRulesV2 != nil {
 				proxy.DefaultDNSProxy.RestoreRules(possibleEP)
 			}
 		}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -150,13 +150,13 @@ func (e *Endpoint) writeHeaderfile(prefix string) error {
 	}
 	defer f.Cleanup()
 
-	if e.DNSRules != nil {
-		// Note: e.DNSRules is updated by syncEndpointHeaderFile and regenerateBPF
+	if e.DNSRulesV2 != nil {
+		// Note: e.DNSRulesV2 is updated by syncEndpointHeaderFile and regenerateBPF
 		// before they call into writeHeaderfile, because GetDNSRules must not be
 		// called with endpoint.mutex held.
 		e.getLogger().WithFields(logrus.Fields{
 			logfields.Path: headerPath,
-			"DNSRules":     e.DNSRules,
+			"DNSRulesV2":   e.DNSRulesV2,
 		}).Debug("writing header file with DNSRules")
 	}
 

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -525,9 +525,10 @@ func (s *EndpointSuite) TestProxyID(c *C) {
 	e := &Endpoint{ID: 123, policyRevision: 0}
 	e.UpdateLogger(nil)
 
-	id, port := e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true}, "")
+	id, port, proto := e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true}, "")
 	c.Assert(id, Not(Equals), "")
 	c.Assert(port, Equals, uint16(8080))
+	c.Assert(proto, Equals, uint8(6))
 
 	endpointID, ingress, protocol, port, listener, err := policy.ParseProxyID(id)
 	c.Assert(endpointID, Equals, uint16(123))
@@ -537,9 +538,10 @@ func (s *EndpointSuite) TestProxyID(c *C) {
 	c.Assert(listener, Equals, "")
 	c.Assert(err, IsNil)
 
-	id, port = e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true, L7Parser: policy.ParserTypeCRD}, "test-listener")
+	id, port, proto = e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true, L7Parser: policy.ParserTypeCRD}, "test-listener")
 	c.Assert(id, Not(Equals), "")
 	c.Assert(port, Equals, uint16(8080))
+	c.Assert(proto, Equals, uint8(6))
 	endpointID, ingress, protocol, port, listener, err = policy.ParseProxyID(id)
 	c.Assert(endpointID, Equals, uint16(123))
 	c.Assert(ingress, Equals, true)
@@ -549,9 +551,10 @@ func (s *EndpointSuite) TestProxyID(c *C) {
 	c.Assert(err, IsNil)
 
 	// Undefined named port
-	id, port = e.proxyID(&policy.L4Filter{PortName: "foobar", Protocol: api.ProtoTCP, Ingress: true}, "")
+	id, port, proto = e.proxyID(&policy.L4Filter{PortName: "foobar", Protocol: api.ProtoTCP, Ingress: true}, "")
 	c.Assert(id, Equals, "")
 	c.Assert(port, Equals, uint16(0))
+	c.Assert(proto, Equals, uint8(0))
 }
 
 func TestEndpoint_GetK8sPodLabels(t *testing.T) {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -89,18 +89,25 @@ func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string
 }
 
 // proxyID returns a unique string to identify a proxy mapping,
-// and the resolved destination port number, if any.
+// and the resolved destination port and protocol numbers, if any.
 // Must be called with e.mutex held.
-func (e *Endpoint) proxyID(l4 *policy.L4Filter, listener string) (string, uint16) {
+func (e *Endpoint) proxyID(l4 *policy.L4Filter, listener string) (string, uint16, uint8) {
 	port := uint16(l4.Port)
+	protocol := uint8(l4.U8Proto)
+	// Calculate protocol if it is 0 (default) and
+	// is not "ANY" (that is, it was not calculated).
+	if protocol == 0 && !l4.Protocol.IsAny() {
+		proto, _ := u8proto.ParseProtocol(string(l4.Protocol))
+		protocol = uint8(proto)
+	}
 	if port == 0 && l4.PortName != "" {
-		port = e.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
+		port = e.GetNamedPort(l4.Ingress, l4.PortName, protocol)
 		if port == 0 {
-			return "", 0
+			return "", 0, 0
 		}
 	}
 
-	return policy.ProxyID(e.ID, l4.Ingress, string(l4.Protocol), port, listener), port
+	return policy.ProxyID(e.ID, l4.Ingress, string(l4.Protocol), port, listener), port, protocol
 }
 
 var unrealizedRedirect = errors.New("Proxy port for redirect not found")

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -399,6 +399,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		SecurityIdentity:         e.SecurityIdentity,
 		Options:                  e.Options,
 		DNSRules:                 e.DNSRules,
+		DNSRulesV2:               e.DNSRulesV2,
 		DNSHistory:               e.DNSHistory,
 		DNSZombies:               e.DNSZombies,
 		K8sPodName:               e.K8sPodName,
@@ -486,6 +487,10 @@ type serializableEndpoint struct {
 	// DNSRules is the collection of current DNS rules for this endpoint.
 	DNSRules restore.DNSRules
 
+	// DNSRulesV2 is the collection of current DNS rules for this endpoint,
+	// that conform to using V2 of the PortProto key.
+	DNSRulesV2 restore.DNSRules
+
 	// DNSHistory is the collection of still-valid DNS responses intercepted for
 	// this endpoint.
 	DNSHistory *fqdn.DNSCache
@@ -559,6 +564,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.nodeMAC = r.NodeMAC
 	ep.SecurityIdentity = r.SecurityIdentity
 	ep.DNSRules = r.DNSRules
+	ep.DNSRulesV2 = r.DNSRulesV2
 	ep.DNSHistory = r.DNSHistory
 	ep.DNSZombies = r.DNSZombies
 	ep.K8sPodName = r.K8sPodName

--- a/pkg/fqdn/dnsproxy/helpers.go
+++ b/pkg/fqdn/dnsproxy/helpers.go
@@ -10,17 +10,18 @@ import (
 	"github.com/cilium/dns"
 
 	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 // lookupTargetDNSServer finds the intended DNS target server for a specific
-// request (passed in via ServeDNS). The IP:port combination is
+// request (passed in via ServeDNS). The IP:port:protocol combination is
 // returned.
-func lookupTargetDNSServer(w dns.ResponseWriter) (serverIP net.IP, serverPort restore.PortProto, addrStr string, err error) {
+func lookupTargetDNSServer(w dns.ResponseWriter) (serverIP net.IP, serverPortProto restore.PortProto, addrStr string, err error) {
 	switch addr := (w.LocalAddr()).(type) {
 	case *net.UDPAddr:
-		return addr.IP, restore.PortProto(addr.Port), addr.String(), nil
+		return addr.IP, restore.MakeV2PortProto(uint16(addr.Port), uint8(u8proto.UDP)), addr.String(), nil
 	case *net.TCPAddr:
-		return addr.IP, restore.PortProto(addr.Port), addr.String(), nil
+		return addr.IP, restore.MakeV2PortProto(uint16(addr.Port), uint8(u8proto.TCP)), addr.String(), nil
 	default:
 		return nil, 0, addr.String(), fmt.Errorf("Cannot extract address information for type %T: %+v", addr, addr)
 	}

--- a/pkg/fqdn/dnsproxy/helpers.go
+++ b/pkg/fqdn/dnsproxy/helpers.go
@@ -8,17 +8,19 @@ import (
 	"net"
 
 	"github.com/cilium/dns"
+
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 )
 
 // lookupTargetDNSServer finds the intended DNS target server for a specific
 // request (passed in via ServeDNS). The IP:port combination is
 // returned.
-func lookupTargetDNSServer(w dns.ResponseWriter) (serverIP net.IP, serverPort uint16, addrStr string, err error) {
+func lookupTargetDNSServer(w dns.ResponseWriter) (serverIP net.IP, serverPort restore.PortProto, addrStr string, err error) {
 	switch addr := (w.LocalAddr()).(type) {
 	case *net.UDPAddr:
-		return addr.IP, uint16(addr.Port), addr.String(), nil
+		return addr.IP, restore.PortProto(addr.Port), addr.String(), nil
 	case *net.TCPAddr:
-		return addr.IP, uint16(addr.Port), addr.String(), nil
+		return addr.IP, restore.PortProto(addr.Port), addr.String(), nil
 	default:
 		return nil, 0, addr.String(), fmt.Errorf("Cannot extract address information for type %T: %+v", addr, addr)
 	}

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -13,10 +13,17 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/re"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+const (
+	udpProto = uint8(u8proto.UDP)
+	tcpProto = uint8(u8proto.TCP)
 )
 
 type DNSProxyHelperTestSuite struct{}
@@ -34,6 +41,8 @@ func (s *DNSProxyHelperTestSuite) TestSetPortRulesForID(c *C) {
 	epID := uint64(1)
 	pea := perEPAllow{}
 	cache := make(regexCache)
+	udpProtoPort8053 := restore.MakeV2PortProto(8053, udpProto)
+
 	rules[new(MockCachedSelector)] = &policy.PerSelectorPolicy{
 		L7Rules: api.L7Rules{
 			DNS: []api.PortRuleDNS{
@@ -42,7 +51,8 @@ func (s *DNSProxyHelperTestSuite) TestSetPortRulesForID(c *C) {
 			},
 		},
 	}
-	err := pea.setPortRulesForID(cache, epID, 8053, rules)
+
+	err := pea.setPortRulesForID(cache, epID, udpProtoPort8053, rules)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 1)
 
@@ -56,16 +66,17 @@ func (s *DNSProxyHelperTestSuite) TestSetPortRulesForID(c *C) {
 			},
 		},
 	}
-	err = pea.setPortRulesForID(cache, epID, 8053, rules)
+
+	err = pea.setPortRulesForID(cache, epID, udpProtoPort8053, rules)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 2)
 
 	delete(rules, selector2)
-	err = pea.setPortRulesForID(cache, epID, 8053, rules)
+	err = pea.setPortRulesForID(cache, epID, udpProtoPort8053, rules)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 1)
 
-	err = pea.setPortRulesForID(cache, epID, 8053, nil)
+	err = pea.setPortRulesForID(cache, epID, udpProtoPort8053, nil)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 0)
 
@@ -79,7 +90,7 @@ func (s *DNSProxyHelperTestSuite) TestSetPortRulesForID(c *C) {
 			},
 		},
 	}
-	err = pea.setPortRulesForID(cache, epID, 8053, rules)
+	err = pea.setPortRulesForID(cache, epID, udpProtoPort8053, rules)
 
 	c.Assert(err, NotNil)
 	c.Assert(len(cache), Equals, 0)
@@ -91,34 +102,35 @@ func (s *DNSProxyHelperTestSuite) TestSetPortRulesForIDFromUnifiedFormat(c *C) {
 	epID := uint64(1)
 	pea := perEPAllow{}
 	cache := make(regexCache)
+	udpProtoPort8053 := restore.MakeV2PortProto(8053, udpProto)
 	rules[new(MockCachedSelector)] = regexp.MustCompile("^.*[.]cilium[.]io$")
 	rules[new(MockCachedSelector)] = regexp.MustCompile("^.*[.]cilium[.]io$")
 
-	err := pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, rules)
+	err := pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, rules)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 1)
 
 	selector2 := new(MockCachedSelector)
 	rules[selector2] = regexp.MustCompile("^sub[.]cilium[.]io")
-	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, rules)
+	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, rules)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 2)
 
 	delete(rules, selector2)
-	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, rules)
+	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, rules)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 1)
 
-	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, nil)
+	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, nil)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 0)
 
 	delete(rules, selector2)
-	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, rules)
+	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, rules)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 1)
 
-	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, nil)
+	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, nil)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 0)
 }

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -111,7 +111,7 @@ type DNSProxy struct {
 	// lookupTargetDNSServer extracts the originally intended target of a DNS
 	// query. It is always set to lookupTargetDNSServer in
 	// helpers.go but is modified during testing.
-	lookupTargetDNSServer func(w dns.ResponseWriter) (serverIP net.IP, serverPort uint16, addrStr string, err error)
+	lookupTargetDNSServer func(w dns.ResponseWriter) (serverIP net.IP, serverPort restore.PortProto, addrStr string, err error)
 
 	// maxIPsPerRestoredDNSRule is the maximum number of IPs to maintain for each
 	// restored DNS rule.
@@ -168,15 +168,15 @@ type regexCache map[string]*regexCacheEntry
 // perEPAllow maps EndpointIDs to ports + selectors + rules
 type perEPAllow map[uint64]portToSelectorAllow
 
-// portToSelectorAllow maps port numbers to selectors + rules
-type portToSelectorAllow map[uint16]CachedSelectorREEntry
+// portToSelectorAllow maps protocol-port numbers to selectors + rules
+type portToSelectorAllow map[restore.PortProto]CachedSelectorREEntry
 
 // CachedSelectorREEntry maps port numbers to selectors to rules, mirroring
 // policy.L7DataMap but the DNS rules are compiled into a regex
 type CachedSelectorREEntry map[policy.CachedSelector]*regexp.Regexp
 
 // structure for restored rules that can be used while Cilium agent is restoring endpoints
-type perEPRestored map[uint64]map[uint16][]restoredIPRule
+type perEPRestored map[uint64]map[restore.PortProto][]restoredIPRule
 
 // restoredIPRule is the dnsproxy internal way of representing a restored IPRule
 // where we also store the actual compiled regular expression as a, as well
@@ -200,7 +200,7 @@ func asIPRule(r *regexp.Regexp, IPs map[string]struct{}) restore.IPRule {
 
 // CheckRestored checks endpointID, destPort, destIP, and name against the restored rules,
 // and only returns true if a restored rule matches.
-func (p *DNSProxy) checkRestored(endpointID uint64, destPort uint16, destIP string, name string) bool {
+func (p *DNSProxy) checkRestored(endpointID uint64, destPort restore.PortProto, destIP string, name string) bool {
 	ipRules, exists := p.restored[endpointID][destPort]
 	if !exists {
 		return false
@@ -243,7 +243,7 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 		cs policy.CachedSelector
 	}
 
-	portToSelRegex := make(map[uint16][]selRegex)
+	portToSelRegex := make(map[restore.PortProto][]selRegex)
 	for port, entries := range p.allowed[uint64(endpointID)] {
 		nidRules := make([]selRegex, 0, len(entries))
 		// Copy the entries to avoid racy map accesses after we release the lock. We don't need
@@ -283,7 +283,7 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 					if count > p.maxIPsPerRestoredDNSRule {
 						log.WithFields(logrus.Fields{
 							logfields.EndpointID:            endpointID,
-							logfields.Port:                  port,
+							logfields.Port:                  port.Port(),
 							logfields.EndpointLabelSelector: selRegex.cs,
 							logfields.Limit:                 p.maxIPsPerRestoredDNSRule,
 							logfields.Count:                 len(nidIPs),
@@ -315,7 +315,7 @@ func (p *DNSProxy) RestoreRules(ep *endpoint.Endpoint) {
 	if ep.IPv6.IsValid() {
 		p.restoredEPs[ep.IPv6] = ep
 	}
-	restoredRules := make(map[uint16][]restoredIPRule, len(ep.DNSRules))
+	restoredRules := make(map[restore.PortProto][]restoredIPRule, len(ep.DNSRules))
 	for port, dnsRule := range ep.DNSRules {
 		ipRules := make([]restoredIPRule, 0, len(dnsRule))
 		for _, ipRule := range dnsRule {
@@ -421,7 +421,7 @@ func (c regexCache) releaseRegex(regex *regexp.Regexp) {
 
 // removeAndReleasePortRulesForID removes the old port rules for the given destPort on the given endpointID. It also
 // releases the regexes so that unused regex can be freed from memory.
-func (allow perEPAllow) removeAndReleasePortRulesForID(cache regexCache, endpointID uint64, destPort uint16) {
+func (allow perEPAllow) removeAndReleasePortRulesForID(cache regexCache, endpointID uint64, destPort restore.PortProto) {
 	epPorts, hasEpPorts := allow[endpointID]
 	if !hasEpPorts {
 		return
@@ -437,7 +437,7 @@ func (allow perEPAllow) removeAndReleasePortRulesForID(cache regexCache, endpoin
 
 // setPortRulesForID sets the matching rules for endpointID and destPort for
 // later lookups. It converts newRules into a compiled regex
-func (allow perEPAllow) setPortRulesForID(cache regexCache, endpointID uint64, destPort uint16, newRules policy.L7DataMap) error {
+func (allow perEPAllow) setPortRulesForID(cache regexCache, endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) error {
 	if len(newRules) == 0 {
 		allow.removeAndReleasePortRulesForID(cache, endpointID, destPort)
 		return nil
@@ -476,7 +476,7 @@ func (allow perEPAllow) setPortRulesForID(cache regexCache, endpointID uint64, d
 // setPortRulesForIDFromUnifiedFormat sets the matching rules for endpointID and destPort for
 // later lookups. It does not guarantee it will reuse all the provided regexes, since it will reuse
 // already existing regexes with the same pattern in case they are already in use.
-func (allow perEPAllow) setPortRulesForIDFromUnifiedFormat(cache regexCache, endpointID uint64, destPort uint16, newRules CachedSelectorREEntry) error {
+func (allow perEPAllow) setPortRulesForIDFromUnifiedFormat(cache regexCache, endpointID uint64, destPort restore.PortProto, newRules CachedSelectorREEntry) error {
 	if len(newRules) == 0 {
 		allow.removeAndReleasePortRulesForID(cache, endpointID, destPort)
 		return nil
@@ -500,7 +500,7 @@ func (allow perEPAllow) setPortRulesForIDFromUnifiedFormat(cache regexCache, end
 
 // getPortRulesForID returns a precompiled regex representing DNS rules for the
 // passed-in endpointID and destPort with setPortRulesForID
-func (allow perEPAllow) getPortRulesForID(endpointID uint64, destPort uint16) (rules CachedSelectorREEntry, exists bool) {
+func (allow perEPAllow) getPortRulesForID(endpointID uint64, destPort restore.PortProto) (rules CachedSelectorREEntry, exists bool) {
 	rules, exists = allow[endpointID][destPort]
 	return rules, exists
 }
@@ -718,7 +718,7 @@ func (p *DNSProxy) LookupEndpointByIP(ip netip.Addr) (endpoint *endpoint.Endpoin
 
 // UpdateAllowed sets newRules for endpointID and destPort. It compiles the DNS
 // rules into regexes that are then used in CheckAllowed.
-func (p *DNSProxy) UpdateAllowed(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error {
+func (p *DNSProxy) UpdateAllowed(endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) error {
 	p.Lock()
 	defer p.Unlock()
 
@@ -731,7 +731,7 @@ func (p *DNSProxy) UpdateAllowed(endpointID uint64, destPort uint16, newRules po
 }
 
 // UpdateAllowedFromSelectorRegexes sets newRules for endpointID and destPort.
-func (p *DNSProxy) UpdateAllowedFromSelectorRegexes(endpointID uint64, destPort uint16, newRules CachedSelectorREEntry) error {
+func (p *DNSProxy) UpdateAllowedFromSelectorRegexes(endpointID uint64, destPort restore.PortProto, newRules CachedSelectorREEntry) error {
 	p.Lock()
 	defer p.Unlock()
 
@@ -746,7 +746,7 @@ func (p *DNSProxy) UpdateAllowedFromSelectorRegexes(endpointID uint64, destPort 
 // CheckAllowed checks endpointID, destPort, destID, destIP, and name against the rules
 // added to the proxy or restored during restart, and only returns true if this all match
 // something that was added (via UpdateAllowed or RestoreRules) previously.
-func (p *DNSProxy) CheckAllowed(endpointID uint64, destPort uint16, destID identity.NumericIdentity, destIP net.IP, name string) (allowed bool, err error) {
+func (p *DNSProxy) CheckAllowed(endpointID uint64, destPort restore.PortProto, destID identity.NumericIdentity, destIP net.IP, name string) (allowed bool, err error) {
 	name = strings.ToLower(dns.Fqdn(name))
 	p.RLock()
 	defer p.RUnlock()

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -202,8 +202,12 @@ func asIPRule(r *regexp.Regexp, IPs map[string]struct{}) restore.IPRule {
 // and only returns true if a restored rule matches.
 func (p *DNSProxy) checkRestored(endpointID uint64, destPortProto restore.PortProto, destIP string, name string) bool {
 	ipRules, exists := p.restored[endpointID][destPortProto]
-	if !exists {
-		return false
+	if !exists && destPortProto.IsPortV2() {
+		// Check if there is a Version 1 restore.
+		ipRules, exists = p.restored[endpointID][destPortProto.ToV1()]
+		if !exists {
+			return false
+		}
 	}
 
 	for i := range ipRules {

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -316,8 +316,14 @@ func (p *DNSProxy) RestoreRules(ep *endpoint.Endpoint) {
 	if ep.IPv6.IsValid() {
 		p.restoredEPs[ep.IPv6] = ep
 	}
+	// Use V2 if it is populated, otherwise
+	// use V1.
+	dnsRules := ep.DNSRulesV2
+	if len(dnsRules) == 0 && len(ep.DNSRules) > 0 {
+		dnsRules = ep.DNSRules
+	}
 	restoredRules := make(map[restore.PortProto][]restoredIPRule, len(ep.DNSRules))
-	for pp, dnsRule := range ep.DNSRules {
+	for pp, dnsRule := range dnsRules {
 		ipRules := make([]restoredIPRule, 0, len(dnsRule))
 		for _, ipRule := range dnsRule {
 			if ipRule.Re.Pattern == nil {
@@ -341,7 +347,7 @@ func (p *DNSProxy) RestoreRules(ep *endpoint.Endpoint) {
 	}
 	p.restored[uint64(ep.ID)] = restoredRules
 
-	log.Debugf("Restored rules for endpoint %d: %v", ep.ID, ep.DNSRules)
+	log.Debugf("Restored rules for endpoint %d: %v", ep.ID, dnsRules)
 }
 
 // 'p' must be locked

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -725,7 +725,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 		udpProtoPort53: restore.IPRules{
 			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID1Selector], map[string]struct{}{"::": {}}),
 			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID2Selector], map[string]struct{}{"127.0.0.1": {}, "127.0.0.2": {}}),
-		}.Sort(),
+		}.Sort(nil),
 		udpProtoPort54: restore.IPRules{
 			asIPRule(s.proxy.allowed[epID1][udpProtoPort54][cachedWildcardSelector], nil),
 		},
@@ -734,12 +734,12 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 		},
 	}
 	restored1, _ := s.proxy.GetRules(uint16(epID1))
-	restored1.Sort()
+	restored1.Sort(nil)
 	c.Assert(restored1, checker.DeepEquals, expected1)
 
 	expected2 := restore.DNSRules{}
 	restored2, _ := s.proxy.GetRules(uint16(epID2))
-	restored2.Sort()
+	restored2.Sort(nil)
 	c.Assert(restored2, checker.DeepEquals, expected2)
 
 	expected3 := restore.DNSRules{
@@ -747,13 +747,13 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 			asIPRule(s.proxy.allowed[epID3][udpProtoPort53][cachedDstID1Selector], map[string]struct{}{"::": {}}),
 			asIPRule(s.proxy.allowed[epID3][udpProtoPort53][cachedDstID3Selector], map[string]struct{}{}),
 			asIPRule(s.proxy.allowed[epID3][udpProtoPort53][cachedDstID4Selector], map[string]struct{}{}),
-		}.Sort(),
+		}.Sort(nil),
 		tcpProtoPort53: restore.IPRules{
 			asIPRule(s.proxy.allowed[epID3][tcpProtoPort53][cachedDstID3Selector], map[string]struct{}{}),
 		},
 	}
 	restored3, _ := s.proxy.GetRules(uint16(epID3))
-	restored3.Sort()
+	restored3.Sort(nil)
 	c.Assert(restored3, checker.DeepEquals, expected3)
 
 	// Test with limited set of allowed IPs
@@ -764,7 +764,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 		udpProtoPort53: restore.IPRules{
 			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID1Selector], map[string]struct{}{}),
 			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID2Selector], map[string]struct{}{"127.0.0.2": {}}),
-		}.Sort(),
+		}.Sort(nil),
 		udpProtoPort54: restore.IPRules{
 			asIPRule(s.proxy.allowed[epID1][udpProtoPort54][cachedWildcardSelector], nil),
 		},
@@ -773,7 +773,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 		},
 	}
 	restored1b, _ := s.proxy.GetRules(uint16(epID1))
-	restored1b.Sort()
+	restored1b.Sort(nil)
 	c.Assert(restored1b, checker.DeepEquals, expected1b)
 
 	// unlimited again
@@ -953,7 +953,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	// Restore Unmarshaled rules
 	var rules restore.DNSRules
 	err = json.Unmarshal(jsn, &rules)
-	rules = rules.Sort()
+	rules = rules.Sort(nil)
 	c.Assert(err, Equals, nil, Commentf("Could not unmarshal restored rules from json"))
 	c.Assert(rules, checker.DeepEquals, expected1)
 
@@ -1058,7 +1058,7 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 
 	// Get restored rules
 	restored, _ := s.proxy.GetRules(uint16(epID1))
-	restored.Sort()
+	restored.Sort(nil)
 
 	// remove rules
 	err = s.proxy.UpdateAllowed(epID1, dstPortProto, nil)

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -826,7 +826,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 
 	// Restore rules
 	ep1 := endpoint.NewTestEndpointWithState(c, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
-	ep1.DNSRules = restored1
+	ep1.DNSRulesV2 = restored1
 	s.proxy.RestoreRules(ep1)
 	_, exists = s.proxy.restored[epID1]
 	c.Assert(exists, Equals, true)
@@ -872,7 +872,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 
 	// Restore rules for epID3
 	ep3 := endpoint.NewTestEndpointWithState(c, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID3), endpoint.StateReady)
-	ep3.DNSRules = restored3
+	ep3.DNSRulesV2 = restored3
 	s.proxy.RestoreRules(ep3)
 	_, exists = s.proxy.restored[epID3]
 	c.Assert(exists, Equals, true)
@@ -963,7 +963,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(err, Equals, nil, Commentf("Could not marshal restored rules to json"))
 	c.Assert(string(jsn2), Equals, pretty.String())
 
-	ep1.DNSRules = rules
+	ep1.DNSRulesV2 = rules
 	s.proxy.RestoreRules(ep1)
 	_, exists = s.proxy.restored[epID1]
 	c.Assert(exists, Equals, true)
@@ -1079,7 +1079,7 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 	ep1 := endpoint.NewTestEndpointWithState(c, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
 	ep1.IPv4 = netip.MustParseAddr("127.0.0.1")
 	ep1.IPv6 = netip.MustParseAddr("::1")
-	ep1.DNSRules = restored
+	ep1.DNSRulesV2 = restored
 	s.proxy.RestoreRules(ep1)
 	_, exists := s.proxy.restored[epID1]
 	c.Assert(exists, Equals, true)
@@ -1112,7 +1112,7 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 		restore.IPRule{Re: restore.RuleRegex{Pattern: &invalidRePattern}},
 		restore.IPRule{Re: restore.RuleRegex{Pattern: &validRePattern}},
 	)
-	ep1.DNSRules = restored
+	ep1.DNSRulesV2 = restored
 	s.proxy.RestoreRules(ep1)
 	_, exists = s.proxy.restored[epID1]
 	c.Assert(exists, Equals, true)

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -149,14 +150,18 @@ var (
 
 	cachedWildcardSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, api.WildcardEndpointSelector)
 
-	epID1   = uint64(111)
-	epID2   = uint64(222)
-	epID3   = uint64(333)
-	dstID1  = identity.NumericIdentity(1001)
-	dstID2  = identity.NumericIdentity(2002)
-	dstID3  = identity.NumericIdentity(3003)
-	dstID4  = identity.NumericIdentity(4004)
-	dstPort = restore.PortProto(53) // Set below when we setup the server!
+	epID1            = uint64(111)
+	epID2            = uint64(222)
+	epID3            = uint64(333)
+	dstID1           = identity.NumericIdentity(1001)
+	dstID2           = identity.NumericIdentity(2002)
+	dstID3           = identity.NumericIdentity(3003)
+	dstID4           = identity.NumericIdentity(4004)
+	dstPortProto     = restore.MakeV2PortProto(53, udpProto) // Set below when we setup the server!
+	udpProtoPort53   = dstPortProto
+	udpProtoPort54   = restore.MakeV2PortProto(54, udpProto)
+	udpProtoPort8053 = restore.MakeV2PortProto(8053, udpProto)
+	tcpProtoPort53   = restore.MakeV2PortProto(53, tcpProto)
 )
 
 func (s *DNSProxyTestSuite) SetUpTest(c *C) {
@@ -227,16 +232,16 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 	c.Assert(s.dnsServer.Listener, Not(IsNil), Commentf("DNS server missing a Listener"))
 	DNSServerListenerAddr := (s.dnsServer.Listener.Addr()).(*net.TCPAddr)
 	c.Assert(DNSServerListenerAddr, Not(IsNil), Commentf("DNS server missing a Listener address"))
-	s.proxy.lookupTargetDNSServer = func(w dns.ResponseWriter) (serverIP net.IP, serverPort restore.PortProto, addrStr string, err error) {
-		return DNSServerListenerAddr.IP, restore.PortProto(DNSServerListenerAddr.Port), DNSServerListenerAddr.String(), nil
+	s.proxy.lookupTargetDNSServer = func(w dns.ResponseWriter) (serverIP net.IP, serverPortProto restore.PortProto, addrStr string, err error) {
+		return DNSServerListenerAddr.IP, restore.MakeV2PortProto(uint16(DNSServerListenerAddr.Port), uint8(u8proto.UDP)), DNSServerListenerAddr.String(), nil
 	}
-	dstPort = restore.PortProto(DNSServerListenerAddr.Port)
+	dstPortProto = restore.MakeV2PortProto(uint16(DNSServerListenerAddr.Port), udpProto)
 }
 
 func (s *DNSProxyTestSuite) TearDownTest(c *C) {
 	for epID := range s.proxy.allowed {
-		for port := range s.proxy.allowed[epID] {
-			s.proxy.UpdateAllowed(epID, port, nil)
+		for pp := range s.proxy.allowed[epID] {
+			s.proxy.UpdateAllowed(epID, pp, nil)
 		}
 	}
 	for epID := range s.proxy.restored {
@@ -264,9 +269,9 @@ func (s *DNSProxyTestSuite) TestRejectFromDifferentEndpoint(c *C) {
 	query := name
 
 	// Reject a query from not endpoint 1
-	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
+	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID2, dstPort, dstID1, nil, query)
+	allowed, err := s.proxy.CheckAllowed(epID2, dstPortProto, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was not rejected when it should be blocked"))
 }
@@ -283,9 +288,9 @@ func (s *DNSProxyTestSuite) TestAcceptFromMatchingEndpoint(c *C) {
 	query := name
 
 	// accept a query that matches from endpoint1
-	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
+	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
+	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 }
@@ -302,9 +307,9 @@ func (s *DNSProxyTestSuite) TestAcceptNonRegex(c *C) {
 	query := name
 
 	// accept a query that matches from endpoint1
-	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
+	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
+	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 }
@@ -321,9 +326,9 @@ func (s *DNSProxyTestSuite) TestRejectNonRegex(c *C) {
 	query := "ciliumXio."
 
 	// reject a query for a non-regex where a . is different (i.e. ensure simple FQDNs treat . as .)
-	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
+	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
+	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was not rejected when it should be blocked"))
 }
@@ -339,9 +344,9 @@ func (s *DNSProxyTestSuite) requestRejectNonMatchingRefusedResponse(c *C) *dns.M
 	}
 	query := "notcilium.io."
 
-	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
+	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
+	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was not rejected when it should be blocked"))
 
@@ -385,9 +390,9 @@ func (s *DNSProxyTestSuite) TestRespondViaCorrectProtocol(c *C) {
 	}
 	query := name
 
-	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
+	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
+	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
@@ -413,9 +418,9 @@ func (s *DNSProxyTestSuite) TestRespondMixedCaseInRequestResponse(c *C) {
 	}
 	query := "CILIUM.io."
 
-	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
+	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
+	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
@@ -442,10 +447,10 @@ func (s *DNSProxyTestSuite) TestCheckNoRules(c *C) {
 	}
 	query := name
 
-	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
+	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	c.Assert(err, Equals, nil, Commentf("Error when inserting rules"))
 
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
+	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
@@ -457,10 +462,10 @@ func (s *DNSProxyTestSuite) TestCheckNoRules(c *C) {
 			},
 		},
 	}
-	err = s.proxy.UpdateAllowed(epID1, dstPort, l7map)
+	err = s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	c.Assert(err, Equals, nil, Commentf("Error when inserting rules"))
 
-	allowed, err = s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
+	allowed, err = s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 }
@@ -477,25 +482,25 @@ func (s *DNSProxyTestSuite) TestCheckAllowedTwiceRemovedOnce(c *C) {
 	query := name
 
 	// Add the rule twice
-	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
+	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	err = s.proxy.UpdateAllowed(epID1, dstPort, l7map)
+	err = s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
+	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Delete once, it should reject
-	err = s.proxy.UpdateAllowed(epID1, dstPort, nil)
+	err = s.proxy.UpdateAllowed(epID1, dstPortProto, nil)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err = s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
+	allowed, err = s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Delete once, it should reject and not crash
-	err = s.proxy.UpdateAllowed(epID1, dstPort, nil)
+	err = s.proxy.UpdateAllowed(epID1, dstPortProto, nil)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err = s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
+	allowed, err = s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 }
@@ -505,41 +510,49 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	// selector in L7DataMap), destination port (set in the redirect itself) and
 	// the DNS name.
 	// The rules approximate:
-	// +------+--------+---------+----------------+
-	// | From |   To   | DstPort |    DNSNames    |
-	// +======+========+=========+================+
-	// | EP1  | DstID1 |      53 | *.ubuntu.com   |
-	// | EP1  | DstID1 |      53 | aws.amazon.com |
-	// | EP1  | DstID2 |      53 | cilium.io      |
-	// | EP1  | *      |      54 | example.com    |
-	// | EP3  | DstID1 |      53 | example.com    |
-	// | EP3  | DstID3 |      53 | *              |
-	// | EP3  | DstID4 |      53 | nil            |
-	// +------+--------+---------+----------------+
+	// +------+--------+---------+----------+----------------+
+	// | From |   To   | DstPort | Protocol |    DNSNames    |
+	// +======+========+=========+===========================+
+	// | EP1  | DstID1 |      53 |    UDP   | *.ubuntu.com   |
+	// | EP1  | DstID1 |      53 |    TCP   | sub.ubuntu.com |
+	// | EP1  | DstID1 |      53 |    UDP   | aws.amazon.com |
+	// | EP1  | DstID2 |      53 |    UDP   | cilium.io      |
+	// | EP1  | *      |      54 |    UDP   | example.com    |
+	// | EP3  | DstID1 |      53 |    UDP   | example.com    |
+	// | EP3  | DstID3 |      53 |    UDP   | *              |
+	// | EP3  | DstID3 |      53 |    TCP   | example.com    |
+	// | EP3  | DstID4 |      53 |    UDP   | nil            |
+	// +------+--------+---------+---------------------------+
 	//
 	// Cases:
-	// +------+-------+--------+------+----------------+----------+----------------------------------------------------------------+
-	// | Case | From  |   To   | Port |     Query      | Outcome  |                             Reason                             |
-	// +------+-------+--------+------+----------------+----------+----------------------------------------------------------------+
-	// |    1 | EPID1 | DstID1 |   53 | www.ubuntu.com | Allowed  |                                                                |
-	// |    2 | EPID1 | DstID1 |   54 | cilium.io      | Rejected | Port 54 only allows example.com                                |
-	// |    3 | EPID1 | DstID2 |   53 | cilium.io      | Allowed  |                                                                |
-	// |    4 | EPID1 | DstID2 |   53 | aws.amazon.com | Rejected | Only cilium.io is allowed with DstID2                          |
-	// |    5 | EPID1 | DstID1 |   54 | example.com    | Allowed  |                                                                |
-	// |    6 | EPID2 | DstID1 |   53 | cilium.io      | Rejected | EPID2 is not allowed as a source by any policy                 |
-	// |    7 | EPID3 | DstID1 |   53 | example.com    | Allowed  |                                                                |
-	// |    8 | EPID3 | DstID1 |   53 | aws.amazon.com | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com |
-	// |    8 | EPID3 | DstID1 |   54 | example.com    | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com |
-	// |    9 | EPID3 | DstID2 |   53 | example.com    | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com |
-	// |   10 | EPID3 | DstID3 |   53 | example.com    | Allowed  | Allowed due to wildcard match pattern                          |
-	// |   11 | EPID3 | DstID4 |   53 | example.com    | Allowed  | Allowed due to a nil rule                                      |
-	// +------+-------+--------+------+----------------+----------+----------------------------------------------------------------+
+	// +------+-------+--------+------+---------------------------+----------+----------------------------------------------------------------+
+	// | Case | From  |   To   | Port | Protocol |     Query      | Outcome  |                             Reason                             |
+	// +------+-------+--------+------+----------+----------------+----------+----------------------------------------------------------------+
+	// |    1 | EPID1 | DstID1 |   53 |    UDP   | www.ubuntu.com | Allowed  |                                                                |
+	// |    2 | EPID1 | DstID1 |   53 |    TCP   | www.ubuntu.com | Rejected | Protocol TCP only allows "sub.ubuntu.com"                      |
+	// |    3 | EPID1 | DstID1 |   53 |    TCP   | sub.ubuntu.com | Allowed  |                                                                |
+	// |    4 | EPID1 | DstID1 |   53 |    UDP   | sub.ubuntu.com | Allowed  |                                                                |
+	// |    5 | EPID1 | DstID1 |   54 |    UDP   | cilium.io      | Rejected | Port 54 only allows example.com                                |
+	// |    6 | EPID1 | DstID2 |   53 |    UDP   | cilium.io      | Allowed  |                                                                |
+	// |    7 | EPID1 | DstID2 |   53 |    UDP   | aws.amazon.com | Rejected | Only cilium.io is allowed with DstID2                          |
+	// |    8 | EPID1 | DstID1 |   54 |    UDP   | example.com    | Allowed  |                                                                |
+	// |    9 | EPID2 | DstID1 |   53 |    UDP   | cilium.io      | Rejected | EPID2 is not allowed as a source by any policy                 |
+	// |   10 | EPID3 | DstID1 |   53 |    UDP   | example.com    | Allowed  |                                                                |
+	// |   11 | EPID3 | DstID1 |   53 |    UDP   | aws.amazon.com | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com |
+	// |   12 | EPID3 | DstID1 |   54 |    UDP   | example.com    | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com |
+	// |   13 | EPID3 | DstID2 |   53 |    UDP   | example.com    | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com |
+	// |   14 | EPID3 | DstID3 |   53 |    UDP   | example.com    | Allowed  | Allowed due to wildcard match pattern                          |
+	// |   15 | EPID3 | DstID3 |   53 |    TCP   | example.com    | Allowed  |                                                                |
+	// |   16 | EPID3 | DstID3 |   53 |    TCP   | amazon.com     | Rejected | TCP protocol only allows "example.com"                         |
+	// |   17 | EPID3 | DstID4 |   53 |    TCP   | example.com    | Rejected | "example.com" only allowed for DstID3                          |
+	// |   18 | EPID3 | DstID4 |   53 |    UDP   | example.com    | Allowed  | Allowed due to a nil rule                                      |
+	// +------+-------+--------+------+----------------+----------+----------+----------------------------------------------------------------+
 
 	// Setup rules
-	//	| EP1  | DstID1 |      53 | *.ubuntu.com   |
-	//	| EP1  | DstID1 |      53 | aws.amazon.com |
-	//	| EP1  | DstID2 |      53 | cilium.io      |
-	err := s.proxy.UpdateAllowed(epID1, 53, policy.L7DataMap{
+	//	| EP1  | DstID1 |      53 |  UDP  | *.ubuntu.com   |
+	//	| EP1  | DstID1 |      53 |  UDP  | aws.amazon.com |
+	//	| EP1  | DstID2 |      53 |  UDP  | cilium.io      |
+	err := s.proxy.UpdateAllowed(epID1, udpProtoPort53, policy.L7DataMap{
 		cachedDstID1Selector: &policy.PerSelectorPolicy{
 			L7Rules: api.L7Rules{
 				DNS: []api.PortRuleDNS{
@@ -558,8 +571,20 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	})
 	c.Assert(err, Equals, nil, Commentf("Could not update with port 53 rules"))
 
-	//	| EP1  | DstID1 |      54 | example.com    |
-	err = s.proxy.UpdateAllowed(epID1, 54, policy.L7DataMap{
+	//      | EP1  | DstID1 |      53 |  TCP  | sub.ubuntu.com |
+	err = s.proxy.UpdateAllowed(epID1, tcpProtoPort53, policy.L7DataMap{
+		cachedDstID1Selector: &policy.PerSelectorPolicy{
+			L7Rules: api.L7Rules{
+				DNS: []api.PortRuleDNS{
+					{MatchPattern: "sub.ubuntu.com."},
+				},
+			},
+		},
+	})
+	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
+
+	//	| EP1  | DstID1 |      54 |  UDP  | example.com    |
+	err = s.proxy.UpdateAllowed(epID1, udpProtoPort54, policy.L7DataMap{
 		cachedWildcardSelector: &policy.PerSelectorPolicy{
 			L7Rules: api.L7Rules{
 				DNS: []api.PortRuleDNS{
@@ -570,10 +595,10 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	})
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
 
-	// | EP3  | DstID1 |      53 | example.com    |
-	// | EP3  | DstID3 |      53 | *              |
-	// | EP3  | DstID4 |      53 | nil            |
-	err = s.proxy.UpdateAllowed(epID3, 53, policy.L7DataMap{
+	// | EP3  | DstID1 |      53 |  UDP  | example.com    |
+	// | EP3  | DstID3 |      53 |  UDP  | *              |
+	// | EP3  | DstID4 |      53 |  UDP  | nil            |
+	err = s.proxy.UpdateAllowed(epID3, udpProtoPort53, policy.L7DataMap{
 		cachedDstID1Selector: &policy.PerSelectorPolicy{
 			L7Rules: api.L7Rules{
 				DNS: []api.PortRuleDNS{
@@ -592,75 +617,120 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	})
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
 
+	// | EP3  | DstID3 |      53 |  TCP  | example.com    |
+	err = s.proxy.UpdateAllowed(epID3, tcpProtoPort53, policy.L7DataMap{
+		cachedDstID3Selector: &policy.PerSelectorPolicy{
+			L7Rules: api.L7Rules{
+				DNS: []api.PortRuleDNS{
+					{MatchPattern: "example.com"},
+				},
+			},
+		},
+	})
+	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
+
 	// Test cases
-	// Case 1 | EPID1 | DstID1 |   53 | www.ubuntu.com | Allowed
-	allowed, err := s.proxy.CheckAllowed(epID1, 53, dstID1, nil, "www.ubuntu.com")
+	// Case 1 | EPID1 | DstID1 |   53 |  UDP  | www.ubuntu.com | Allowed
+	allowed, err := s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID1, nil, "www.ubuntu.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
-	// Case 2 | EPID1 | DstID1 |   54 | cilium.io      | Rejected | Port 54 only allows example.com
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, nil, "cilium.io")
+	// Case 2 | EPID1 | DstID1 |   53 |    TCP   | www.ubuntu.com | Rejected | Protocol TCP only allows "sub.ubuntu.com"
+	allowed, err = s.proxy.CheckAllowed(epID1, tcpProtoPort53, dstID1, nil, "www.ubuntu.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
-	// Case 3 | EPID1 | DstID2 |   53 | cilium.io      | Allowed
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, nil, "cilium.io")
+	// Case 3 | EPID1 | DstID1 |   53 |    TCP   | sub.ubuntu.com | Allowed
+	allowed, err = s.proxy.CheckAllowed(epID1, tcpProtoPort53, dstID1, nil, "sub.ubuntu.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
-	// Case 4 | EPID1 | DstID2 |   53 | aws.amazon.com | Rejected | Only cilium.io is allowed with DstID2
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, nil, "aws.amazon.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
-	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
-
-	// Case 5 | EPID1 | DstID1 |   54 | example.com    | Allowed
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, nil, "example.com")
+	// Case 4 | EPID1 | DstID1 |   53 |    UDP   | sub.ubuntu.com | Allowed
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID1, nil, "sub.ubuntu.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
-	// Case 6 | EPID2 | DstID1 |   53 | cilium.io      | Rejected | EPID2 is not allowed as a source by any policy
-	allowed, err = s.proxy.CheckAllowed(epID2, 53, dstID1, nil, "cilium.io")
+	// Case 5 | EPID1 | DstID1 |   54 |  UDP  | cilium.io      | Rejected | Port 54 only allows example.com
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, dstID1, nil, "cilium.io")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
-	// Case 7 | EPID3 | DstID1 |   53 | example.com    | Allowed
-	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID1, nil, "example.com")
+	// Case 6 | EPID1 | DstID2 |   53 |  UDP  | cilium.io      | Allowed
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID2, nil, "cilium.io")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
-	// Case 8 | EPID3 | DstID1 |   53 | aws.amazon.com | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com
-	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID1, nil, "aws.amazon.io")
+	// Case 7 | EPID1 | DstID2 |   53 |  UDP  | aws.amazon.com | Rejected | Only cilium.io is allowed with DstID2
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID2, nil, "aws.amazon.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
-	// Case 8 | EPID3 | DstID1 |   54 | example.com    | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com
-	allowed, err = s.proxy.CheckAllowed(epID3, 54, dstID1, nil, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
-	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
-
-	// Case 9 | EPID3 | DstID2 |   53 | example.com    | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com
-	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID2, nil, "example.com")
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
-	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
-
-	// Case 10 | EPID3 | DstID3 |   53 | example.com    | Allowed due to wildcard match pattern
-	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID3, nil, "example.com")
+	// Case 8 | EPID1 | DstID1 |   54 |  UDP  | example.com    | Allowed
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, dstID1, nil, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
-	// Case 11 | EPID3 | DstID4 |   53 | example.com    | Allowed due to a nil rule
-	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID4, nil, "example.com")
+	// Case 9 | EPID2 | DstID1 |   53 |  UDP  | cilium.io      | Rejected | EPID2 is not allowed as a source by any policy
+	allowed, err = s.proxy.CheckAllowed(epID2, udpProtoPort53, dstID1, nil, "cilium.io")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 10 | EPID3 | DstID1 |   53 |  UDP  | example.com    | Allowed
+	allowed, err = s.proxy.CheckAllowed(epID3, udpProtoPort53, dstID1, nil, "example.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
+
+	// Case 11 | EPID3 | DstID1 |   53 |  UDP  | aws.amazon.com | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com
+	allowed, err = s.proxy.CheckAllowed(epID3, udpProtoPort53, dstID1, nil, "aws.amazon.io")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 12 | EPID3 | DstID1 |   54 |  UDP  | example.com    | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com
+	allowed, err = s.proxy.CheckAllowed(epID3, udpProtoPort54, dstID1, nil, "example.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 13 | EPID3 | DstID2 |   53 |  UDP  | example.com    | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com
+	allowed, err = s.proxy.CheckAllowed(epID3, udpProtoPort53, dstID2, nil, "example.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 14 | EPID3 | DstID3 |   53 |  UDP  | example.com    | Allowed due to wildcard match pattern
+	allowed, err = s.proxy.CheckAllowed(epID3, udpProtoPort53, dstID3, nil, "example.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
+
+	// Case 15 | EPID3 | DstID3 |   53 |    TCP   | example.com    | Allowed
+	allowed, err = s.proxy.CheckAllowed(epID3, tcpProtoPort53, dstID3, nil, "example.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
+
+	// Case 16 | EPID3 | DstID3 |   53 |    TCP   | amazon.com     | Rejected | TCP protocol only allows "example.com"
+	allowed, err = s.proxy.CheckAllowed(epID3, tcpProtoPort53, dstID3, nil, "amazon.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 17 | EPID3 | DstID4 |   53 |    TCP   | example.com    | Rejected | "example.com" only allowed for DstID3
+	allowed, err = s.proxy.CheckAllowed(epID3, tcpProtoPort53, dstID4, nil, "example.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 18 | EPID3 | DstID4 |   53 |  UDP  | example.com    | Allowed due to a nil rule
+	allowed, err = s.proxy.CheckAllowed(epID3, udpProtoPort53, dstID4, nil, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Get rules for restoration
 	expected1 := restore.DNSRules{
-		53: restore.IPRules{
-			asIPRule(s.proxy.allowed[epID1][53][cachedDstID1Selector], map[string]struct{}{"::": {}}),
-			asIPRule(s.proxy.allowed[epID1][53][cachedDstID2Selector], map[string]struct{}{"127.0.0.1": {}, "127.0.0.2": {}}),
+		udpProtoPort53: restore.IPRules{
+			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID1Selector], map[string]struct{}{"::": {}}),
+			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID2Selector], map[string]struct{}{"127.0.0.1": {}, "127.0.0.2": {}}),
 		}.Sort(),
-		54: restore.IPRules{
-			asIPRule(s.proxy.allowed[epID1][54][cachedWildcardSelector], nil),
+		udpProtoPort54: restore.IPRules{
+			asIPRule(s.proxy.allowed[epID1][udpProtoPort54][cachedWildcardSelector], nil),
+		},
+		tcpProtoPort53: restore.IPRules{
+			asIPRule(s.proxy.allowed[epID1][tcpProtoPort53][cachedDstID1Selector], map[string]struct{}{"::": {}}),
 		},
 	}
 	restored1, _ := s.proxy.GetRules(uint16(epID1))
@@ -673,11 +743,14 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(restored2, checker.DeepEquals, expected2)
 
 	expected3 := restore.DNSRules{
-		53: restore.IPRules{
-			asIPRule(s.proxy.allowed[epID3][53][cachedDstID1Selector], map[string]struct{}{"::": {}}),
-			asIPRule(s.proxy.allowed[epID3][53][cachedDstID3Selector], map[string]struct{}{}),
-			asIPRule(s.proxy.allowed[epID3][53][cachedDstID4Selector], map[string]struct{}{}),
+		udpProtoPort53: restore.IPRules{
+			asIPRule(s.proxy.allowed[epID3][udpProtoPort53][cachedDstID1Selector], map[string]struct{}{"::": {}}),
+			asIPRule(s.proxy.allowed[epID3][udpProtoPort53][cachedDstID3Selector], map[string]struct{}{}),
+			asIPRule(s.proxy.allowed[epID3][udpProtoPort53][cachedDstID4Selector], map[string]struct{}{}),
 		}.Sort(),
+		tcpProtoPort53: restore.IPRules{
+			asIPRule(s.proxy.allowed[epID3][tcpProtoPort53][cachedDstID3Selector], map[string]struct{}{}),
+		},
 	}
 	restored3, _ := s.proxy.GetRules(uint16(epID3))
 	restored3.Sort()
@@ -688,12 +761,15 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	s.proxy.usedServers = map[string]struct{}{"127.0.0.2": {}}
 
 	expected1b := restore.DNSRules{
-		53: restore.IPRules{
-			asIPRule(s.proxy.allowed[epID1][53][cachedDstID1Selector], map[string]struct{}{}),
-			asIPRule(s.proxy.allowed[epID1][53][cachedDstID2Selector], map[string]struct{}{"127.0.0.2": {}}),
+		udpProtoPort53: restore.IPRules{
+			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID1Selector], map[string]struct{}{}),
+			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID2Selector], map[string]struct{}{"127.0.0.2": {}}),
 		}.Sort(),
-		54: restore.IPRules{
-			asIPRule(s.proxy.allowed[epID1][54][cachedWildcardSelector], nil),
+		udpProtoPort54: restore.IPRules{
+			asIPRule(s.proxy.allowed[epID1][udpProtoPort54][cachedWildcardSelector], nil),
+		},
+		tcpProtoPort53: restore.IPRules{
+			asIPRule(s.proxy.allowed[epID1][tcpProtoPort53][cachedDstID1Selector], map[string]struct{}{}),
 		},
 	}
 	restored1b, _ := s.proxy.GetRules(uint16(epID1))
@@ -703,15 +779,17 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	// unlimited again
 	s.proxy.usedServers = oldUsed
 
-	s.proxy.UpdateAllowed(epID1, 53, nil)
-	s.proxy.UpdateAllowed(epID1, 54, nil)
+	s.proxy.UpdateAllowed(epID1, udpProtoPort53, nil)
+	s.proxy.UpdateAllowed(epID1, udpProtoPort54, nil)
+	s.proxy.UpdateAllowed(epID1, tcpProtoPort53, nil)
 	_, exists := s.proxy.allowed[epID1]
 	c.Assert(exists, Equals, false)
 
 	_, exists = s.proxy.allowed[epID2]
 	c.Assert(exists, Equals, false)
 
-	s.proxy.UpdateAllowed(epID3, 53, nil)
+	s.proxy.UpdateAllowed(epID3, udpProtoPort53, nil)
+	s.proxy.UpdateAllowed(epID3, tcpProtoPort53, nil)
 	_, exists = s.proxy.allowed[epID3]
 	c.Assert(exists, Equals, false)
 
@@ -721,28 +799,28 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	dstIPrandom := net.ParseIP("127.0.0.42")
 
 	// Before restore: all rules removed above, everything is dropped
-	// Case 1 | EPID1 | DstID1 |   53 | www.ubuntu.com | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID1, dstIP1, "www.ubuntu.com")
+	// Case 1 | EPID1 | DstID1 |   53 |  UDP  | www.ubuntu.com | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID1, dstIP1, "www.ubuntu.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
-	// Case 2 | EPID1 | DstID1 |   54 | cilium.io      | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, dstIP1, "cilium.io")
+	// Case 2 | EPID1 | DstID1 |   54 |  UDP  | cilium.io      | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, dstID1, dstIP1, "cilium.io")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
-	// Case 3 | EPID1 | DstID2 |   53 | cilium.io      | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, dstIP2a, "cilium.io")
+	// Case 3 | EPID1 | DstID2 |   53 |  UDP  | cilium.io      | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID2, dstIP2a, "cilium.io")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
-	// Case 4 | EPID1 | DstID2 |   53 | aws.amazon.com | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, dstIP2b, "aws.amazon.com")
+	// Case 4 | EPID1 | DstID2 |   53 |  UDP  | aws.amazon.com | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID2, dstIP2b, "aws.amazon.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
-	// Case 5 | EPID1 | DstID1 |   54 | example.com    | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, dstIP1, "example.com")
+	// Case 5 | EPID1 | DstID1 |   54 |  UDP  | example.com    | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, dstID1, dstIP1, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
@@ -755,40 +833,40 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 
 	// Same tests with 2 (WORLD) dstID to make sure it is not used, but with correct destination IP
 
-	// Case 1 | EPID1 | dstIP1 |   53 | www.ubuntu.com | Allowed due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP1, "www.ubuntu.com")
+	// Case 1 | EPID1 | dstIP1 |   53 |  UDP  | www.ubuntu.com | Allowed due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, 2, dstIP1, "www.ubuntu.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
-	// Case 2 | EPID1 | dstIP1 |   54 | cilium.io      | Rejected due to restored rules | Port 54 only allows example.com
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIP1, "cilium.io")
+	// Case 2 | EPID1 | dstIP1 |   54 |  UDP  | cilium.io      | Rejected due to restored rules | Port 54 only allows example.com
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, 2, dstIP1, "cilium.io")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
-	// Case 3 | EPID1 | dstIP2a |   53 | cilium.io      | Allowed due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP2a, "cilium.io")
+	// Case 3 | EPID1 | dstIP2a |   53 |  UDP  | cilium.io      | Allowed due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, 2, dstIP2a, "cilium.io")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
-	// Case 4 | EPID1 | dstIP2b |   53 | aws.amazon.com | Rejected due to restored rules | Only cilium.io is allowed with DstID2
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP2b, "aws.amazon.com")
+	// Case 4 | EPID1 | dstIP2b |   53 |  UDP  | aws.amazon.com | Rejected due to restored rules | Only cilium.io is allowed with DstID2
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, 2, dstIP2b, "aws.amazon.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
-	// Case 5 | EPID1 | dstIP1 |   54 | example.com    | Allowed due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIP1, "example.com")
+	// Case 5 | EPID1 | dstIP1 |   54 |  UDP  | example.com    | Allowed due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, 2, dstIP1, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// make sure random IP is not allowed
-	// Case 5 | EPID1 | random IP |   53 | example.com    | Rejected due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIPrandom, "example.com")
+	// Case 5 | EPID1 | random IP |   53 |  UDP  | example.com    | Rejected due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, 2, dstIPrandom, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// make sure random destination IP is allowed in a wildcard selector
-	// Case 5 | EPID1 | random IP |   54 | example.com    | Allowed due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIPrandom, "example.com")
+	// Case 5 | EPID1 | random IP |   54 |  UDP  | example.com    | Allowed due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, 2, dstIPrandom, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
@@ -800,7 +878,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(exists, Equals, true)
 
 	// Set empty ruleset, check that restored rules were deleted in epID3
-	err = s.proxy.UpdateAllowed(epID3, 53, nil)
+	err = s.proxy.UpdateAllowed(epID3, udpProtoPort53, nil)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
 
 	_, exists = s.proxy.restored[epID3]
@@ -816,16 +894,20 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 
 	expected := `
 	{
-		"53": [{
-			"Re":  "^(?:[-a-zA-Z0-9_]*[.]ubuntu[.]com[.]|aws[.]amazon[.]com[.])$",
-			"IPs": {"::": {}}
-		}, {
-			"Re":  "^(?:cilium[.]io[.])$",
-			"IPs": {"127.0.0.1": {}, "127.0.0.2": {}}
+		"` + restore.MakeV2PortProto(53, tcpProto).String() + `":[{
+			"Re":"^(?:sub[.]ubuntu[.]com[.])$",
+			"IPs":{"::":{}}
 		}],
-		"54": [{
-			"Re":  "^(?:example[.]com[.])$",
-			"IPs": null
+		"` + restore.MakeV2PortProto(53, udpProto).String() + `":[{
+			"Re":"^(?:[-a-zA-Z0-9_]*[.]ubuntu[.]com[.]|aws[.]amazon[.]com[.])$",
+			"IPs":{"::":{}}
+		},{
+			"Re":"^(?:cilium[.]io[.])$",
+			"IPs":{"127.0.0.1":{},"127.0.0.2":{}}
+		}],
+		"` + restore.MakeV2PortProto(54, udpProto).String() + `":[{
+			"Re":"^(?:example[.]com[.])$",
+			"IPs":null
 		}]
 	}`
 	pretty := new(bytes.Buffer)
@@ -838,33 +920,33 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(exists, Equals, false)
 
 	// Before restore after marshal: previous restored rules are removed, everything is dropped
-	// Case 1 | EPID1 | DstID1 |   53 | www.ubuntu.com | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID1, dstIP1, "www.ubuntu.com")
+	// Case 1 | EPID1 | DstID1 |   53 |  UDP  | www.ubuntu.com | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID1, dstIP1, "www.ubuntu.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
-	// Case 2 | EPID1 | DstID1 |   54 | cilium.io      | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, dstIP1, "cilium.io")
+	// Case 2 | EPID1 | DstID1 |   54 |  UDP  | cilium.io      | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, dstID1, dstIP1, "cilium.io")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
-	// Case 3 | EPID1 | DstID2 |   53 | cilium.io      | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, dstIP2a, "cilium.io")
+	// Case 3 | EPID1 | DstID2 |   53 |  UDP  | cilium.io      | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID2, dstIP2a, "cilium.io")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
-	// Case 4 | EPID1 | DstID2 |   53 | aws.amazon.com | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, dstIP2b, "aws.amazon.com")
+	// Case 4 | EPID1 | DstID2 |   53 |  UDP  | aws.amazon.com | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID2, dstIP2b, "aws.amazon.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
-	// Case 5 | EPID1 | DstID1 |   54 | example.com    | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, dstIP1, "example.com")
+	// Case 5 | EPID1 | DstID1 |   54 |  UDP  | example.com    | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, dstID1, dstIP1, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
-	// Case 5 | EPID1 | random IP |   54 | example.com    | Rejected
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIPrandom, "example.com")
+	// Case 5 | EPID1 | random IP |   54 |  UDP  | example.com    | Rejected
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, 2, dstIPrandom, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
@@ -888,40 +970,40 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 
 	// After restoration of JSON marshaled/unmarshaled rules
 
-	// Case 1 | EPID1 | dstIP1 |   53 | www.ubuntu.com | Allowed due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP1, "www.ubuntu.com")
+	// Case 1 | EPID1 | dstIP1 |   53 |  UDP  | www.ubuntu.com | Allowed due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, 2, dstIP1, "www.ubuntu.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
-	// Case 2 | EPID1 | dstIP1 |   54 | cilium.io      | Rejected due to restored rules | Port 54 only allows example.com
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIP1, "cilium.io")
+	// Case 2 | EPID1 | dstIP1 |   54 |  UDP  | cilium.io      | Rejected due to restored rules | Port 54 only allows example.com
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, 2, dstIP1, "cilium.io")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
-	// Case 3 | EPID1 | dstIP2a |   53 | cilium.io      | Allowed due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP2a, "cilium.io")
+	// Case 3 | EPID1 | dstIP2a |   53 |  UDP  | cilium.io      | Allowed due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, 2, dstIP2a, "cilium.io")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
-	// Case 4 | EPID1 | dstIP2b |   53 | aws.amazon.com | Rejected due to restored rules | Only cilium.io is allowed with DstID2
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP2b, "aws.amazon.com")
+	// Case 4 | EPID1 | dstIP2b |   53 |  UDP  | aws.amazon.com | Rejected due to restored rules | Only cilium.io is allowed with DstID2
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, 2, dstIP2b, "aws.amazon.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
-	// Case 5 | EPID1 | dstIP1 |   54 | example.com    | Allowed due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIP1, "example.com")
+	// Case 5 | EPID1 | dstIP1 |   54 |  UDP  | example.com    | Allowed due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, 2, dstIP1, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// make sure random IP is not allowed
-	// Case 5 | EPID1 | random IP |   53 | example.com    | Rejected due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIPrandom, "example.com")
+	// Case 5 | EPID1 | random IP |   53 |  UDP  | example.com    | Rejected due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, 2, dstIPrandom, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// make sure random IP is allowed on a wildcard
-	// Case 5 | EPID1 | random IP |   54 | example.com    | Allowed due to restored rules
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIPrandom, "example.com")
+	// Case 5 | EPID1 | random IP |   54 |  UDP  | example.com    | Allowed due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, 2, dstIPrandom, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
@@ -947,10 +1029,10 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 	queries := []string{name, strings.ReplaceAll(pattern, "*", "sub")}
 
 	c.TestName()
-	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
+	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
 	for _, query := range queries {
-		allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
+		allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, nil, query)
 		c.Assert(err, Equals, nil, Commentf("Error when checking allowed query: %q", query))
 		c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed for query: %q", query))
 	}
@@ -979,7 +1061,7 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 	restored.Sort()
 
 	// remove rules
-	err = s.proxy.UpdateAllowed(epID1, dstPort, nil)
+	err = s.proxy.UpdateAllowed(epID1, dstPortProto, nil)
 	c.Assert(err, Equals, nil, Commentf("Could not remove rules"))
 
 	// 2nd request, refused due to no rules
@@ -1022,11 +1104,11 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 	// extract the port the DNS-server is listening on by looking at the restored rules. The port is non-deterministic
 	// since it's listening on :0
 	c.Assert(len(restored), Equals, 1, Commentf("GetRules is expected to return rules for one port but returned for %d", len(restored)))
-	port := maps.Keys(restored)[0]
+	portProto := maps.Keys(restored)[0]
 
 	// Insert one valid and one invalid pattern and ensure that the valid one works
 	// and that the invalid one doesn't interfere with the other rules.
-	restored[port] = append(restored[port],
+	restored[portProto] = append(restored[portProto],
 		restore.IPRule{Re: restore.RuleRegex{Pattern: &invalidRePattern}},
 		restore.IPRule{Re: restore.RuleRegex{Pattern: &validRePattern}},
 	)
@@ -1143,14 +1225,14 @@ func Benchmark_perEPAllow_setPortRulesForID(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for epID := uint64(0); epID < nEPs; epID++ {
-			pea.setPortRulesForID(c, epID, 8053, nil)
+			pea.setPortRulesForID(c, epID, udpProtoPort8053, nil)
 		}
 		b.StartTimer()
 		for epID, rules := range rulesPerEP {
 			if epID >= nEPsAtOnce {
-				pea.setPortRulesForID(c, uint64(epID)-nEPsAtOnce, 8053, nil)
+				pea.setPortRulesForID(c, uint64(epID)-nEPsAtOnce, udpProtoPort8053, nil)
 			}
-			pea.setPortRulesForID(c, uint64(epID), 8053, rules)
+			pea.setPortRulesForID(c, uint64(epID), udpProtoPort8053, rules)
 		}
 		b.StopTimer()
 	}
@@ -1160,7 +1242,7 @@ func Benchmark_perEPAllow_setPortRulesForID(b *testing.B) {
 	b.ReportMetric(float64(getMemStats().HeapInuse-initialHeap), "B(HeapInUse)/op")
 
 	for epID := uint64(0); epID < nEPs; epID++ {
-		pea.setPortRulesForID(c, epID, 8053, nil)
+		pea.setPortRulesForID(c, epID, udpProtoPort8053, nil)
 	}
 	if len(pea) > 0 {
 		b.Fail()
@@ -1168,7 +1250,7 @@ func Benchmark_perEPAllow_setPortRulesForID(b *testing.B) {
 	b.StopTimer()
 	// Remove all the inserted rules to ensure the cache goes down to zero entries
 	for epID := uint64(0); epID < 20; epID++ {
-		pea.setPortRulesForID(c, epID, 8053, nil)
+		pea.setPortRulesForID(c, epID, udpProtoPort8053, nil)
 	}
 	if len(pea) > 0 || len(c) > 0 {
 		b.Fail()
@@ -1259,14 +1341,14 @@ func Benchmark_perEPAllow_setPortRulesForID_large(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for epID := uint64(0); epID < numEPs; epID++ {
-			pea.setPortRulesForID(c, epID, 8053, rules)
+			pea.setPortRulesForID(c, epID, udpProtoPort8053, rules)
 		}
 	}
 	b.StopTimer()
 
 	// Uncomment to see the HeapInUse from only the regexp cache
 	// for epID := uint64(0); epID < numEPs; epID++ {
-	//	 pea.setPortRulesForID(epID, 8053, nil)
+	//	 pea.setPortRulesForID(epID, udpProtoPort8053, nil)
 	// }
 
 	// Explicitly run gc to ensure we measure what we want
@@ -1281,7 +1363,7 @@ func Benchmark_perEPAllow_setPortRulesForID_large(b *testing.B) {
 	fmt.Printf("\tNumGC = %v\n", m.NumGC)
 	// Remove all the inserted rules to ensure both indexes go to zero entries
 	for epID := uint64(0); epID < numEPs; epID++ {
-		pea.setPortRulesForID(c, epID, 8053, nil)
+		pea.setPortRulesForID(c, epID, udpProtoPort8053, nil)
 	}
 	if len(pea) > 0 || len(c) > 0 {
 		b.Fail()

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -156,7 +156,7 @@ var (
 	dstID2  = identity.NumericIdentity(2002)
 	dstID3  = identity.NumericIdentity(3003)
 	dstID4  = identity.NumericIdentity(4004)
-	dstPort = uint16(53) // Set below when we setup the server!
+	dstPort = restore.PortProto(53) // Set below when we setup the server!
 )
 
 func (s *DNSProxyTestSuite) SetUpTest(c *C) {
@@ -227,10 +227,10 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 	c.Assert(s.dnsServer.Listener, Not(IsNil), Commentf("DNS server missing a Listener"))
 	DNSServerListenerAddr := (s.dnsServer.Listener.Addr()).(*net.TCPAddr)
 	c.Assert(DNSServerListenerAddr, Not(IsNil), Commentf("DNS server missing a Listener address"))
-	s.proxy.lookupTargetDNSServer = func(w dns.ResponseWriter) (serverIP net.IP, serverPort uint16, addrStr string, err error) {
-		return DNSServerListenerAddr.IP, uint16(DNSServerListenerAddr.Port), DNSServerListenerAddr.String(), nil
+	s.proxy.lookupTargetDNSServer = func(w dns.ResponseWriter) (serverIP net.IP, serverPort restore.PortProto, addrStr string, err error) {
+		return DNSServerListenerAddr.IP, restore.PortProto(DNSServerListenerAddr.Port), DNSServerListenerAddr.String(), nil
 	}
-	dstPort = uint16(DNSServerListenerAddr.Port)
+	dstPort = restore.PortProto(DNSServerListenerAddr.Port)
 }
 
 func (s *DNSProxyTestSuite) TearDownTest(c *C) {

--- a/pkg/fqdn/proxy/proxy.go
+++ b/pkg/fqdn/proxy/proxy.go
@@ -12,7 +12,7 @@ import (
 type DNSProxier interface {
 	GetRules(uint16) (restore.DNSRules, error)
 	RemoveRestoredRules(uint16)
-	UpdateAllowed(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error
+	UpdateAllowed(endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) error
 	GetBindPort() uint16
 	SetRejectReply(string)
 	RestoreRules(op *endpoint.Endpoint)
@@ -28,7 +28,7 @@ func (m MockFQDNProxy) GetRules(u uint16) (restore.DNSRules, error) {
 func (m MockFQDNProxy) RemoveRestoredRules(u uint16) {
 }
 
-func (m MockFQDNProxy) UpdateAllowed(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error {
+func (m MockFQDNProxy) UpdateAllowed(endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) error {
 	return nil
 }
 

--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -12,8 +12,54 @@ import (
 	"sort"
 )
 
-// DNSRules contains IP-based DNS rules for a set of ports (e.g., 53)
-type DNSRules map[uint16]IPRules
+// PortProtoV2 is 1 value at bit position 24.
+const PortProtoV2 = 1 << 24
+
+// PortProto is uint32 that encodes two different
+// versions of port protocol keys. Version 1 is protocol
+// agnostic and (naturally) encodes no values at bit
+// positions 16-31. Version 2 encodes protocol at bit
+// positions 16-23, and bit position 24 encodes a 1
+// value to indicate that it is Version 2. Both versions
+// encode the port at the
+// bit positions 0-15.
+//
+// This works because Version 1 will naturally encode
+// no values at postions 16-31 as the original Version 1
+// was a uint16. Version 2 enforces a 1 value at the 24th
+// bit position, so it will alway be legible.
+type PortProto uint32
+
+// MakeV2PortProto returns a Version 2 port protocol.
+func MakeV2PortProto(port uint16, proto uint8) PortProto {
+	return PortProto(PortProtoV2 | (uint32(proto) << 16) | uint32(port))
+}
+
+// IsPortV2 returns true if the PortProto
+// is Version 2.
+func (pp PortProto) IsPortV2() bool {
+	return PortProtoV2&pp == PortProtoV2
+}
+
+// Port returns the port of the PortProto
+func (pp PortProto) Port() uint16 {
+	return uint16(pp & 0x0000_ffff)
+}
+
+// Protocol returns the protocol of the
+// PortProto. It returns "0" for Version 1.
+func (pp PortProto) Protocol() uint8 {
+	return uint8((pp & 0xff_0000) >> 16)
+}
+
+// ToV1 returns the Version 1 (that is, "port")
+// version of the PortProto.
+func (pp PortProto) ToV1() PortProto {
+	return pp & 0x0000_ffff
+}
+
+// DNSRules contains IP-based DNS rules for a set of port-protocols (e.g., UDP/53)
+type DNSRules map[PortProto]IPRules
 
 // IPRules is an unsorted collection of IPrules
 type IPRules []IPRule

--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -11,6 +11,7 @@ package restore
 import (
 	"fmt"
 	"sort"
+	"testing"
 )
 
 // PortProtoV2 is 1 value at bit position 24.
@@ -84,7 +85,7 @@ type RuleRegex struct {
 
 // Sort is only used for testing
 // Sorts in place, but returns IPRules for convenience
-func (r IPRules) Sort() IPRules {
+func (r IPRules) Sort(_ *testing.T) IPRules {
 	sort.SliceStable(r, func(i, j int) bool {
 		if r[i].Re.Pattern != nil && r[j].Re.Pattern != nil {
 			return *r[i].Re.Pattern < *r[j].Re.Pattern
@@ -100,10 +101,10 @@ func (r IPRules) Sort() IPRules {
 
 // Sort is only used for testing
 // Sorts in place, but returns DNSRules for convenience
-func (r DNSRules) Sort() DNSRules {
+func (r DNSRules) Sort(_ *testing.T) DNSRules {
 	for pp, ipRules := range r {
 		if len(ipRules) > 0 {
-			ipRules = ipRules.Sort()
+			ipRules = ipRules.Sort(nil)
 			r[pp] = ipRules
 		}
 	}

--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -9,6 +9,7 @@
 package restore
 
 import (
+	"fmt"
 	"sort"
 )
 
@@ -58,6 +59,12 @@ func (pp PortProto) ToV1() PortProto {
 	return pp & 0x0000_ffff
 }
 
+// String returns the decimal representation
+// of PortProtocol in string form.
+func (pp PortProto) String() string {
+	return fmt.Sprintf("%d", pp)
+}
+
 // DNSRules contains IP-based DNS rules for a set of port-protocols (e.g., UDP/53)
 type DNSRules map[PortProto]IPRules
 
@@ -94,10 +101,10 @@ func (r IPRules) Sort() IPRules {
 // Sort is only used for testing
 // Sorts in place, but returns DNSRules for convenience
 func (r DNSRules) Sort() DNSRules {
-	for port, ipRules := range r {
+	for pp, ipRules := range r {
 		if len(ipRules) > 0 {
 			ipRules = ipRules.Sort()
-			r[port] = ipRules
+			r[pp] = ipRules
 		}
 	}
 	return r

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1459,5 +1459,6 @@ type ProxyPolicy interface {
 	GetL7Parser() L7ParserType
 	GetIngress() bool
 	GetPort() uint16
+	GetProtocol() uint8
 	GetListener() string
 }

--- a/pkg/policy/visibility.go
+++ b/pkg/policy/visibility.go
@@ -212,6 +212,11 @@ func (v *VisibilityMetadata) GetPort() uint16 {
 	return v.Port
 }
 
+// GetProtocol returns the protocol where the VisibilityMetadata applies.
+func (v *VisibilityMetadata) GetProtocol() uint8 {
+	return uint8(v.Proto)
+}
+
 // GetListener returns the optional listener name.
 func (l4 *VisibilityMetadata) GetListener() string {
 	return ""

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -43,7 +43,7 @@ func (dr *dnsRedirect) setRules(wg *completion.WaitGroup, newRules policy.L7Data
 		"newRules":           newRules,
 		logfields.EndpointID: dr.redirect.endpointID,
 	}).Debug("DNS Proxy updating matchNames in allowed list during UpdateRules")
-	if err := dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, restore.PortProto(dr.redirect.dstPort), newRules); err != nil {
+	if err := dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPortProto, newRules); err != nil {
 		return err
 	}
 	dr.currentRules = copyRules(dr.redirect.rules)
@@ -66,7 +66,7 @@ func (dr *dnsRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc,
 // Close the redirect.
 func (dr *dnsRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc) {
 	return func() {
-		dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, restore.PortProto(dr.redirect.dstPort), nil)
+		dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPortProto, nil)
 		dr.redirect.localEndpoint.OnDNSPolicyUpdateLocked(nil)
 		dr.currentRules = nil
 	}, nil

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -586,7 +586,7 @@ func (p *Proxy) createNewRedirect(
 		return 0, proxyTypeNotFoundError(types.ProxyType(l4.GetL7Parser()), l4.GetListener(), l4.GetIngress()), nil, nil
 	}
 
-	redirect := newRedirect(localEndpoint, ppName, pp, l4.GetPort())
+	redirect := newRedirect(localEndpoint, ppName, pp, l4.GetPort(), l4.GetProtocol())
 	_ = redirect.updateRules(l4) // revertFunc not used because revert will remove whole redirect
 	// Rely on create*Redirect to update rules, unlike the update case above.
 

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	endpointtest "github.com/cilium/cilium/pkg/proxy/endpoint/test"
 	"github.com/cilium/cilium/pkg/proxy/types"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -195,6 +196,10 @@ func (p *fakeProxyPolicy) GetIngress() bool {
 
 func (p *fakeProxyPolicy) GetPort() uint16 {
 	return uint16(80)
+}
+
+func (p *fakeProxyPolicy) GetProtocol() uint8 {
+	return uint8(u8proto.UDP)
 }
 
 func (p *fakeProxyPolicy) GetListener() string {

--- a/pkg/proxy/redirect.go
+++ b/pkg/proxy/redirect.go
@@ -5,6 +5,7 @@ package proxy
 
 import (
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
@@ -33,7 +34,7 @@ type Redirect struct {
 	// is safe to read these fields without locking the mutex
 	name           string
 	listener       *ProxyPort
-	dstPort        uint16
+	dstPortProto   restore.PortProto
 	endpointID     uint64
 	localEndpoint  endpoint.EndpointUpdater
 	implementation RedirectImplementation
@@ -44,11 +45,11 @@ type Redirect struct {
 	rules policy.L7DataMap
 }
 
-func newRedirect(localEndpoint endpoint.EndpointUpdater, name string, listener *ProxyPort, dstPort uint16) *Redirect {
+func newRedirect(localEndpoint endpoint.EndpointUpdater, name string, listener *ProxyPort, port uint16, proto uint8) *Redirect {
 	return &Redirect{
 		name:          name,
 		listener:      listener,
-		dstPort:       dstPort,
+		dstPortProto:  restore.MakeV2PortProto(port, proto),
 		endpointID:    localEndpoint.GetID(),
 		localEndpoint: localEndpoint,
 	}


### PR DESCRIPTION
DNS Proxy indexes domain selectors by port
only. In cases where protocols collide on port
the DNS proxy may have a more restrictive selector than it should because it does not merge port
protocols for L7 policies (only ports).

Refactor all users of the DNS Proxy are updated
to add protocol to any DNS Proxy entries, and all
tests are updated to test for port-protocol
merge errors.

```release-note
fqdn: Fixed bug that caused DNS Proxy to be overly restrictive on allowed DNS selectors.
```