### PR TITLE
bgpv1: Add the documentation for using serviceAdvertisements

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1426,6 +1426,8 @@ With, on node1:
     10.69.0.66 dev eno1 lladdr 96:eb:75:fd:89:fd extern_learn  REACHABLE
     10.69.0.130 dev eno2 lladdr 52:54:00:a6:62:56 extern_learn  REACHABLE
 
+.. _external_access_to_clusterip_services:
+
 External Access To ClusterIP Services
 *************************************
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -34,6 +34,7 @@ Dinan
 Dockerfile
 Dockerfiles
 Donenfeld
+ECMP
 ENI
 Efx
 Engleder
@@ -487,6 +488,7 @@ mainboard
 makefile
 mana
 masq
+matchExpressions
 matchLabels
 matchPattern
 maxUnavailable
@@ -782,4 +784,3 @@ xt
 xwing
 yaml
 zsh
-matchExpressions


### PR DESCRIPTION
Related to https://github.com/cilium/cilium/pull/31245
Related to https://github.com/cilium/cilium/pull/30963
```release-note
Add the documentation for using `serviceAdvertisements`
```
