### PR TITLE
[v1.14] Backport FQDN: fix incorrect reaping of newly-expired IPs

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -332,7 +332,17 @@ func (c *DNSCache) GC(now time.Time, zombies *DNSZombieMappings) (affectedNames 
 		} {
 			for ip, entries := range m {
 				for _, entry := range entries {
-					zombies.Upsert(entry.ExpirationTime, ip.String(), entry.Name)
+					// Set the expiration time to either the GC or the expiration time
+					// of the DNS lookup if it is in the future.
+					// This can be the case when entries are not expired, but they are
+					// over limit. We preserve this time so that, in the event that
+					// non-expired names are GC'd, they will be less preferentially reaped
+					// by zombies.
+					expireTime := now
+					if entry.ExpirationTime.After(expireTime) {
+						expireTime = entry.ExpirationTime
+					}
+					zombies.Upsert(expireTime, ip.String(), entry.Name)
 				}
 			}
 		}
@@ -733,6 +743,10 @@ type DNSZombieMapping struct {
 	// When DNSZombieMappings.lastCTGCUpdate is earlier than DeletePendingAt a
 	// zombie is alive.
 	DeletePendingAt time.Time `json:"delete-pending-at,omitempty"`
+
+	// revisionAddedAt is the GCRevision at which this entry was added.
+	// garbage collection must run 2 times before the zombie is eligible for deletion
+	revisionAddedAt uint64 `json:"-"`
 }
 
 // DeepCopy returns a copy of zombie that does not share any internal pointers
@@ -755,7 +769,11 @@ type DNSZombieMappings struct {
 	lock.Mutex
 	deletes        map[netip.Addr]*DNSZombieMapping
 	lastCTGCUpdate time.Time
-	max            int // max allowed zombies
+	// ctGCRevision is a serial number tracking the number of conntrack
+	// garbage collection runs. It is used to ensure that entries
+	// are not reaped until CT GC has run at least twice.
+	ctGCRevision uint64
+	max          int // max allowed zombies
 
 	// perHostLimit is the number of maximum number of IP per host.
 	perHostLimit int
@@ -784,6 +802,7 @@ func (zombies *DNSZombieMappings) Upsert(expiryTime time.Time, ipStr string, qna
 			Names:           slices.Unique(qname),
 			IP:              netip.MustParseAddr(ipStr),
 			DeletePendingAt: expiryTime,
+			revisionAddedAt: zombies.ctGCRevision,
 		}
 		zombies.deletes[addr] = zombie
 	} else {
@@ -797,12 +816,27 @@ func (zombies *DNSZombieMappings) Upsert(expiryTime time.Time, ipStr string, qna
 }
 
 // isConnectionAlive returns true if 'zombie' is considered alive.
-// Zombie is considered dead if both of these conditions apply:
+// Zombie is considered dead if all of these conditions apply:
 // 1. CT GC has run after the DNS Expiry time and grace period (lastCTGCUpdate > DeletePendingAt + GracePeriod), and
-// 2. The CG GC run did not mark the Zombie alive (lastCTGCUpdate > AliveAt)
+// 2. The CT GC run did not mark the Zombie alive (lastCTGCUpdate > AliveAt)
+// 3. CT GC has run at least 2 times since Zombie was entered
 // otherwise the Zombie is alive.
+//
+// We wait for 2 complete GC runs, because this entry may have been added in the middle of a GC run,
+// in which case it may not have been marked alive. We need to wait for GC to finish at least 2 times
+// before we can safely consider it dead.
 func (zombies *DNSZombieMappings) isConnectionAlive(zombie *DNSZombieMapping) bool {
-	return !(zombies.lastCTGCUpdate.After(zombie.DeletePendingAt) && zombies.lastCTGCUpdate.After(zombie.AliveAt))
+	if !zombies.lastCTGCUpdate.After(zombie.DeletePendingAt.Add(option.Config.ToFQDNsIdleConnectionGracePeriod)) {
+		return true
+	}
+	if !zombies.lastCTGCUpdate.After(zombie.AliveAt) {
+		return true
+	}
+	if zombies.ctGCRevision < (zombie.revisionAddedAt + 2) {
+		return true
+	}
+	return false
+
 }
 
 // getAliveNames returns all the names that are alive.
@@ -1009,6 +1043,7 @@ func (zombies *DNSZombieMappings) MarkAlive(now time.Time, ip netip.Addr) {
 func (zombies *DNSZombieMappings) SetCTGCTime(ctGCStart time.Time) {
 	zombies.Lock()
 	zombies.lastCTGCUpdate = ctGCStart
+	zombies.ctGCRevision++
 	zombies.Unlock()
 }
 
@@ -1161,9 +1196,10 @@ func (zombies *DNSZombieMappings) UnmarshalJSON(raw []byte) error {
 	}
 	zombies.deletes = aux.Deletes
 
-	// Reset the alive time to ensure no deletes happen until we run CT GC again
+	// Reset the alive time & conntrack revision to ensure no deletes happen until we run CT GC again
 	for _, zombie := range zombies.deletes {
 		zombie.AliveAt = time.Time{}
+		zombie.revisionAddedAt = zombies.ctGCRevision
 	}
 	return nil
 }

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -609,12 +609,13 @@ func (ds *DNSCacheTestSuite) TestOverlimitAfterDeleteForwardEntry(c *C) {
 	c.Assert(affectedNames, HasLen, 0)
 }
 
-func assertZombiesContain(c *C, zombies []*DNSZombieMapping, mappings map[string][]string) {
-	c.Assert(zombies, HasLen, len(mappings), Commentf("Different number of zombies than expected: %+v", zombies))
+func assertZombiesContain(c *C, zombies []*DNSZombieMapping, expected map[string][]string) {
+	c.Helper()
+	c.Assert(zombies, HasLen, len(expected), Commentf("Different number of zombies than expected: %+v", zombies))
 
 	for _, zombie := range zombies {
-		names, exists := mappings[zombie.IP.String()]
-		c.Assert(exists, Equals, true, Commentf("Missing expected zombie"))
+		names, exists := expected[zombie.IP.String()]
+		c.Assert(exists, Equals, true, Commentf("Unexpected zombie %s in zombies", zombie.IP.String()))
 
 		sort.Strings(zombie.Names)
 		sort.Strings(names)
@@ -637,8 +638,10 @@ func (ds *DNSCacheTestSuite) TestZombiesSiblingsGC(c *C) {
 
 	// Mark 1.1.1.2 alive which should also keep 1.1.1.1 alive since they
 	// have the same name
+	now = now.Add(5 * time.Minute)
+	zombies.SetCTGCTime(now)
 	now = now.Add(time.Second)
-	zombies.MarkAlive(now, netip.MustParseAddr("1.1.1.2"))
+	zombies.MarkAlive(now.Add(time.Second), netip.MustParseAddr("1.1.1.2"))
 	zombies.SetCTGCTime(now)
 
 	alive, dead := zombies.GC()
@@ -676,9 +679,20 @@ func (ds *DNSCacheTestSuite) TestZombiesGC(c *C) {
 		"2.2.2.2": {"somethingelse.com"},
 	})
 
+	// Even when not marking alive, running CT GC the first time is ignored;
+	// we must always complete 2 GC cycles before allowing a name to be dead
+	now = now.Add(5 * time.Minute)
+	zombies.SetCTGCTime(now)
+	alive, dead = zombies.GC()
+	c.Assert(dead, HasLen, 0)
+	assertZombiesContain(c, alive, map[string][]string{
+		"1.1.1.1": {"test.com", "anotherthing.com"},
+		"2.2.2.2": {"somethingelse.com"},
+	})
+
 	// Cause 1.1.1.1 to die by not marking it alive before the second GC
 	//zombies.MarkAlive(now, netip.MustParseAddr("1.1.1.1"))
-	now = now.Add(time.Second)
+	now = now.Add(5 * time.Minute)
 	// Mark 2.2.2.2 alive with 1 second grace period
 	zombies.MarkAlive(now.Add(time.Second), netip.MustParseAddr("2.2.2.2"))
 	zombies.SetCTGCTime(now)
@@ -711,7 +725,10 @@ func (ds *DNSCacheTestSuite) TestZombiesGC(c *C) {
 	})
 
 	// Cause all zombies but 2.2.2.2 to die
-	now = now.Add(time.Second)
+	now = now.Add(5 * time.Minute)
+	zombies.SetCTGCTime(now)
+	now = now.Add(5 * time.Minute)
+	zombies.MarkAlive(now.Add(time.Second), netip.MustParseAddr("2.2.2.2"))
 	zombies.SetCTGCTime(now)
 	alive, dead = zombies.GC()
 	c.Assert(alive, HasLen, 1)
@@ -723,7 +740,7 @@ func (ds *DNSCacheTestSuite) TestZombiesGC(c *C) {
 	})
 
 	// Cause all zombies to die
-	now = now.Add(time.Second)
+	now = now.Add(2 * time.Second)
 	zombies.SetCTGCTime(now)
 	alive, dead = zombies.GC()
 	c.Assert(alive, HasLen, 0)
@@ -986,7 +1003,19 @@ func (ds *DNSCacheTestSuite) TestZombiesDumpAlive(c *C) {
 		"3.3.3.3": {"example.org"},
 	})
 
+	// Simulate an interleaved CTGC and DNS GC
+	// Ensure that two GC runs must progress before
+	// marking zombies dead.
 	now = now.Add(time.Second)
+	zombies.SetCTGCTime(now)
+	alive = zombies.DumpAlive(nil)
+	assertZombiesContain(c, alive, map[string][]string{
+		"1.1.1.1": {"test.com"},
+		"2.2.2.2": {"example.com"},
+		"3.3.3.3": {"example.org"},
+	})
+
+	now = now.Add(5 * time.Minute) // Need to step the clock 5 minutes ahead here, to account for the grace period
 	zombies.MarkAlive(now, netip.MustParseAddr("1.1.1.1"))
 	zombies.MarkAlive(now, netip.MustParseAddr("2.2.2.2"))
 	zombies.SetCTGCTime(now)
@@ -1126,10 +1155,10 @@ func validateZombieSort(t *testing.T, zombies []*DNSZombieMapping) {
 	logFailure := func(t *testing.T, zs []*DNSZombieMapping, prop string, i, j int) {
 		t.Helper()
 		t.Logf("order property fail %v: want zombie[i] < zombie[j]", prop)
-		t.Log("zombie[i]: ", zombies[i])
-		t.Log("zombie[j]: ", zombies[j])
+		t.Log("zombie[i]: ", zs[i])
+		t.Log("zombie[j]: ", zs[j])
 		t.Log("all mappings: ")
-		for i, z := range zombies {
+		for i, z := range zs {
 			t.Log(fmt.Sprintf("%2d", i), z)
 		}
 	}

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -580,19 +580,21 @@ func (f *GCFilter) doFiltering(srcIP, dstIP netip.Addr, srcPort, dstPort uint16,
 	return noAction
 }
 
-func doGC(m *Map, filter *GCFilter) int {
+func doGC(m *Map, filter *GCFilter) (int, error) {
 	if m.mapType.isIPv6() {
-		return int(doGC6(m, filter).deleted)
+		stats := doGC6(m, filter)
+		return int(stats.deleted), stats.dumpError
 	} else if m.mapType.isIPv4() {
-		return int(doGC4(m, filter).deleted)
+		stats := doGC4(m, filter)
+		return int(stats.deleted), stats.dumpError
 	}
 	log.Fatalf("Unsupported ct map type: %s", m.mapType.String())
-	return 0
+	return 0, fmt.Errorf("unsupported ct map type: %s", m.mapType.String())
 }
 
 // GC runs garbage collection for map m with name mapType with the given filter.
 // It returns how many items were deleted from m.
-func GC(m *Map, filter *GCFilter) int {
+func GC(m *Map, filter *GCFilter) (int, error) {
 	if filter.RemoveExpired {
 		t, _ := timestamp.GetCTCurTime(timestamp.GetClockSourceFromOptions())
 		filter.Time = uint32(t)
@@ -697,10 +699,11 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 // Flush runs garbage collection for map m with the name mapType, deleting all
 // entries. The specified map must be already opened using bpf.OpenMap().
 func (m *Map) Flush() int {
-	return doGC(m, &GCFilter{
+	d, _ := doGC(m, &GCFilter{
 		RemoveExpired: true,
 		Time:          MaxTime,
 	})
+	return d
 }
 
 // DeleteIfUpgradeNeeded attempts to open the conntrack maps associated with


### PR DESCRIPTION
- [ ] #31205 -- FQDN: fix incorrect reaping of newly-expired IPs (@squeed)

Once this PR is merged, a GitHub action will update the labels of these PRs:

```upstream-prs
$ for pr in 31205; do contrib/backporting/set-labels.py $pr done 1.14; done
```