### PR TITLE
datapath, bpf: Remove unnecessary IPsec code

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1231,13 +1231,6 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 				return err
 			}
 			n.enableNeighDiscovery = len(ifaceNames) != 0 // No need to arping for L2-less devices
-		case n.nodeConfig.EnableIPSec && !option.Config.TunnelingEnabled() &&
-			len(option.Config.EncryptInterface) != 0:
-			// When FIB lookup is not supported we need to pick an
-			// interface so pick first interface in the list. On
-			// kernels with FIB lookup helpers we do a lookup from
-			// the datapath side and ignore this value.
-			ifaceNames = append(ifaceNames, option.Config.EncryptInterface[0])
 		}
 
 		if n.enableNeighDiscovery {


### PR DESCRIPTION
Commit 891fa78474 ("bpf: Delete obsolete do_netdev_encrypt_pools()") removed the special code we had to rewrite the IPsec outer header. The code removed in the present commit is therefore not required anymore.

Fixes: https://github.com/cilium/cilium/pull/28063.