### PR TITLE
Fix IPsec support for `--devices`

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -121,6 +121,31 @@ jobs:
             key-one: 'cbc(aes)'
             key-two: 'gcm(aes)'
 
+          - name: '5'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: '5.4-20240305.092417'
+            kube-proxy: 'iptables'
+            kpr: 'false'
+            tunnel: 'disabled'
+            encryption: 'ipsec'
+            encryption-node: 'false'
+            devices: 'eth0'
+            key-one: 'cbc(aes)'
+            key-two: 'cbc(aes)'
+
+          - name: '6'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: '5.10-20240305.092417'
+            kube-proxy: 'iptables'
+            kpr: 'false'
+            tunnel: 'disabled'
+            encryption: 'ipsec'
+            encryption-node: 'false'
+            endpoint-routes: 'true'
+            devices: 'eth0'
+            key-one: 'gcm(aes)'
+            key-two: 'gcm(aes)'
+
     timeout-minutes: 75
     steps:
       - name: Checkout context ref (trusted)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1402,6 +1402,7 @@ func initEnv(vp *viper.Viper) {
 	if option.Config.EnableIPSec &&
 		!option.Config.TunnelingEnabled() &&
 		len(option.Config.EncryptInterface) == 0 &&
+		len(option.Config.GetDevices()) == 0 &&
 		option.Config.IPAM != ipamOption.IPAMENI {
 		link, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
 		if err != nil {

--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -31,11 +31,14 @@ func (n *linuxNodeHandler) getDefaultEncryptionInterface() string {
 	if option.Config.TunnelingEnabled() {
 		return n.datapathConfig.TunnelDevice
 	}
-	iface := ""
-	if len(option.Config.EncryptInterface) > 0 {
-		iface = option.Config.EncryptInterface[0]
+	devices := option.Config.GetDevices()
+	if len(devices) > 0 {
+		return devices[0]
 	}
-	return iface
+	if len(option.Config.EncryptInterface) > 0 {
+		return option.Config.EncryptInterface[0]
+	}
+	return ""
 }
 
 func (n *linuxNodeHandler) getLinkLocalIP(family int) (net.IP, error) {

--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -27,7 +27,10 @@ import (
 // there is only a single interface so choosing [0] works by choosing the only
 // interface. However EKS, uses multiple interfaces, but fortunately for us
 // in EKS any interface would work so pick the [0] index here as well.
-func getDefaultEncryptionInterface() string {
+func (n *linuxNodeHandler) getDefaultEncryptionInterface() string {
+	if option.Config.TunnelingEnabled() {
+		return n.datapathConfig.TunnelDevice
+	}
 	iface := ""
 	if len(option.Config.EncryptInterface) > 0 {
 		iface = option.Config.EncryptInterface[0]
@@ -35,8 +38,8 @@ func getDefaultEncryptionInterface() string {
 	return iface
 }
 
-func getLinkLocalIP(family int) (net.IP, error) {
-	iface := getDefaultEncryptionInterface()
+func (n *linuxNodeHandler) getLinkLocalIP(family int) (net.IP, error) {
+	iface := n.getDefaultEncryptionInterface()
 	link, err := netlink.LinkByName(iface)
 	if err != nil {
 		return nil, err
@@ -48,12 +51,12 @@ func getLinkLocalIP(family int) (net.IP, error) {
 	return addr[0].IPNet.IP, nil
 }
 
-func getV4LinkLocalIP() (net.IP, error) {
-	return getLinkLocalIP(netlink.FAMILY_V4)
+func (n *linuxNodeHandler) getV4LinkLocalIP() (net.IP, error) {
+	return n.getLinkLocalIP(netlink.FAMILY_V4)
 }
 
-func getV6LinkLocalIP() (net.IP, error) {
-	return getLinkLocalIP(netlink.FAMILY_V6)
+func (n *linuxNodeHandler) getV6LinkLocalIP() (net.IP, error) {
+	return n.getLinkLocalIP(netlink.FAMILY_V6)
 }
 
 func upsertIPsecLog(err error, spec string, loc, rem *net.IPNet, spi uint8, nodeID uint16) error {
@@ -158,7 +161,7 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, nodeID uint1
 				_ = route.Delete(n.createNodeIPSecInRoute(localCIDR.IPNet))
 			}
 
-			localNodeInternalIP, err := getV4LinkLocalIP()
+			localNodeInternalIP, err := n.getV4LinkLocalIP()
 			if err != nil {
 				log.WithError(err).Error("Failed to get local IPv4 for IPsec configuration")
 				errs = errors.Join(errs, fmt.Errorf("failed to get local ipv4 for ipsec link: %w", err))
@@ -199,7 +202,7 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, nodeID uint1
 			// Check if we should use the NodeInternalIPs instead of the
 			// CiliumInternalIPs for the IPsec encapsulation.
 			if !option.Config.UseCiliumInternalIPForIPsec {
-				localIP, err = getV4LinkLocalIP()
+				localIP, err = n.getV4LinkLocalIP()
 				if err != nil {
 					log.WithError(err).Error("Failed to get local IPv4 for IPsec configuration")
 				}
@@ -252,7 +255,7 @@ func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, nodeID uint1
 				_ = route.Delete(n.createNodeIPSecInRoute(localCIDR.IPNet))
 			}
 
-			localNodeInternalIP, err := getV6LinkLocalIP()
+			localNodeInternalIP, err := n.getV6LinkLocalIP()
 			if err != nil {
 				log.WithError(err).Error("Failed to get local IPv6 for IPsec configuration")
 				errs = errors.Join(errs, fmt.Errorf("failed to get local ipv6 for ipsec link: %w", err))
@@ -283,7 +286,7 @@ func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, nodeID uint1
 			// Check if we should use the NodeInternalIPs instead of the
 			// CiliumInternalIPs for the IPsec encapsulation.
 			if !option.Config.UseCiliumInternalIPForIPsec {
-				localIP, err = getV6LinkLocalIP()
+				localIP, err = n.getV6LinkLocalIP()
 				if err != nil {
 					log.WithError(err).Error("Failed to get local IPv6 for IPsec configuration")
 					errs = errors.Join(errs, fmt.Errorf("failed to get local ipv6 for ipsec link: %w", err))
@@ -354,13 +357,7 @@ func (n *linuxNodeHandler) removeEncryptRules() error {
 }
 
 func (n *linuxNodeHandler) createNodeIPSecInRoute(ip *net.IPNet) route.Route {
-	var device string
-
-	if !option.Config.TunnelingEnabled() {
-		device = option.Config.EncryptInterface[0]
-	} else {
-		device = n.datapathConfig.TunnelDevice
-	}
+	device := n.getDefaultEncryptionInterface()
 	return route.Route{
 		Nexthop: nil,
 		Device:  device,

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -926,40 +926,6 @@ func (n *linuxNodeHandler) DeleteMiscNeighbor(oldNode *nodeTypes.Node) {
 	n.deleteNeighbor(oldNode)
 }
 
-// getDefaultEncryptionInterface() is needed to find the interface used when
-// populating neighbor table and doing arpRequest. For most configurations
-// there is only a single interface so choosing [0] works by choosing the only
-// interface. However EKS, uses multiple interfaces, but fortunately for us
-// in EKS any interface would work so pick the [0] index here as well.
-func getDefaultEncryptionInterface() string {
-	iface := ""
-	if len(option.Config.EncryptInterface) > 0 {
-		iface = option.Config.EncryptInterface[0]
-	}
-	return iface
-}
-
-func getLinkLocalIP(family int) (net.IP, error) {
-	iface := getDefaultEncryptionInterface()
-	link, err := netlink.LinkByName(iface)
-	if err != nil {
-		return nil, err
-	}
-	addr, err := netlink.AddrList(link, family)
-	if err != nil {
-		return nil, err
-	}
-	return addr[0].IPNet.IP, nil
-}
-
-func getV4LinkLocalIP() (net.IP, error) {
-	return getLinkLocalIP(netlink.FAMILY_V4)
-}
-
-func getV6LinkLocalIP() (net.IP, error) {
-	return getLinkLocalIP(netlink.FAMILY_V6)
-}
-
 // Must be called with linuxNodeHandler.mutex held.
 func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAddition bool) error {
 	var (

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -744,6 +744,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestNodeChurnXFRMLeaks(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer removeDevice(externalNodeDevice)
 	option.Config.EncryptInterface = []string{externalNodeDevice}
+	option.Config.RoutingMode = option.RoutingModeNative
 
 	// Cover the XFRM configuration for subnet encryption: IPAM modes AKS and EKS.
 	_, ipv4PodSubnets, err := net.ParseCIDR("4.4.0.0/16")

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -170,7 +170,9 @@ func cleanIngressQdisc() error {
 
 // reinitializeIPSec is used to recompile and load encryption network programs.
 func (l *loader) reinitializeIPSec(ctx context.Context) error {
-	if !option.Config.EnableIPSec {
+	// If devices are specified, then we are relying on autodetection and don't
+	// need the code below, specific to EncryptInterface.
+	if !option.Config.EnableIPSec || len(option.Config.GetDevices()) > 0 {
 		return nil
 	}
 


### PR DESCRIPTION
The first two commits are refactoring commits. The third fixes the support for `--devices` in IPsec. Fourth commit covers this in end-to-end IPsec tests.

```release-note
Fix a bug that could cause local packet delivery to be skipped, leading to lower performance, when IPsec was enabled and `--devices` provided.
```
