### PR TITLE
envoy: move config values from global config into hive cell

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -83,6 +83,7 @@ cilium-agent [flags]
       --devices strings                                           List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'
       --direct-routing-device string                              Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
       --disable-endpoint-crd                                      Disable use of CiliumEndpoint CRD
+      --disable-envoy-version-check                               Do not perform Envoy version check
       --disable-iptables-feeder-rules strings                     Chains to ignore when installing feeder rules.
       --dns-max-ips-per-restored-rule int                         Maximum number of IPs to maintain for each restored DNS rule (default 1000)
       --dns-policy-unload-on-shutdown                             Unload DNS policy rules on graceful shutdown
@@ -310,6 +311,7 @@ cilium-agent [flags]
       --prepend-iptables-chains                                   Prepend custom iptables chains instead of appending (default true)
       --procfs string                                             Path to the host's proc filesystem mount (default "/proc")
       --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
+      --proxy-admin-port int                                      Port to serve Envoy admin interface on.
       --proxy-connect-timeout uint                                Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 2)
       --proxy-gid uint                                            Group ID for proxy control plane sockets. (default 1337)
       --proxy-idle-timeout-seconds int                            Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s (default 60)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -24,6 +24,7 @@ cilium-agent hive [flags]
       --cni-external-routing                                      Whether the chained CNI plugin handles routing on the node
       --cni-log-file string                                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
       --controller-group-metrics strings                          List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --disable-envoy-version-check                               Do not perform Envoy version check
       --disable-iptables-feeder-rules strings                     Chains to ignore when installing feeder rules.
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
@@ -44,10 +45,17 @@ cilium-agent hive [flags]
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
       --envoy-config-retry-interval duration                      Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated. (default 15s)
       --envoy-config-timeout duration                             Timeout that determines how long to wait for Envoy to N/ACK CiliumEnvoyConfig resources (default 2m0s)
+      --envoy-log string                                          Path to a separate Envoy log file, if any
       --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC
       --gateway-api-secrets-namespace string                      GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API
       --gops-port uint16                                          Port for gops server to listen on (default 9890)
   -h, --help                                                      help for hive
+      --http-idle-timeout uint                                    Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
+      --http-max-grpc-timeout uint                                Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
+      --http-normalize-path                                       Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution. (default true)
+      --http-request-timeout uint                                 Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
+      --http-retry-count uint                                     Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                   Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --ingress-secrets-namespace string                          IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --iptables-random-fully                                     Set iptables flag random-fully on masquerading rules
@@ -76,6 +84,13 @@ cilium-agent hive [flags]
       --prepend-iptables-chains                                   Prepend custom iptables chains instead of appending (default true)
       --procfs string                                             Path to the host's proc filesystem mount (default "/proc")
       --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
+      --proxy-admin-port int                                      Port to serve Envoy admin interface on.
+      --proxy-connect-timeout uint                                Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 2)
+      --proxy-gid uint                                            Group ID for proxy control plane sockets. (default 1337)
+      --proxy-idle-timeout-seconds int                            Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s (default 60)
+      --proxy-max-connection-duration-seconds int                 Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
+      --proxy-max-requests-per-connection int                     Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
+      --proxy-prometheus-port int                                 Port to serve Envoy metrics on. Default 0 (disabled).
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -30,6 +30,7 @@ cilium-agent hive dot-graph [flags]
       --cni-external-routing                                      Whether the chained CNI plugin handles routing on the node
       --cni-log-file string                                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
       --controller-group-metrics strings                          List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --disable-envoy-version-check                               Do not perform Envoy version check
       --disable-iptables-feeder-rules strings                     Chains to ignore when installing feeder rules.
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
@@ -50,9 +51,16 @@ cilium-agent hive dot-graph [flags]
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
       --envoy-config-retry-interval duration                      Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated. (default 15s)
       --envoy-config-timeout duration                             Timeout that determines how long to wait for Envoy to N/ACK CiliumEnvoyConfig resources (default 2m0s)
+      --envoy-log string                                          Path to a separate Envoy log file, if any
       --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC
       --gateway-api-secrets-namespace string                      GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API
       --gops-port uint16                                          Port for gops server to listen on (default 9890)
+      --http-idle-timeout uint                                    Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
+      --http-max-grpc-timeout uint                                Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
+      --http-normalize-path                                       Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution. (default true)
+      --http-request-timeout uint                                 Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
+      --http-retry-count uint                                     Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                   Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --ingress-secrets-namespace string                          IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --iptables-random-fully                                     Set iptables flag random-fully on masquerading rules
@@ -81,6 +89,13 @@ cilium-agent hive dot-graph [flags]
       --prepend-iptables-chains                                   Prepend custom iptables chains instead of appending (default true)
       --procfs string                                             Path to the host's proc filesystem mount (default "/proc")
       --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
+      --proxy-admin-port int                                      Port to serve Envoy admin interface on.
+      --proxy-connect-timeout uint                                Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 2)
+      --proxy-gid uint                                            Group ID for proxy control plane sockets. (default 1337)
+      --proxy-idle-timeout-seconds int                            Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s (default 60)
+      --proxy-max-connection-duration-seconds int                 Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
+      --proxy-max-requests-per-connection int                     Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
+      --proxy-prometheus-port int                                 Port to serve Envoy metrics on. Default 0 (disabled).
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -365,9 +365,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableWellKnownIdentities, defaults.EnableWellKnownIdentities, "Enable well-known identities for known Kubernetes components")
 	option.BindEnv(vp, option.EnableWellKnownIdentities)
 
-	flags.String(option.EnvoyLog, "", "Path to a separate Envoy log file, if any")
-	option.BindEnv(vp, option.EnvoyLog)
-
 	flags.Bool(option.EnableIPSecName, defaults.EnableIPSec, "Enable IPSec support")
 	option.BindEnv(vp, option.EnableIPSecName)
 
@@ -412,51 +409,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 
 	flags.Bool(option.EncryptionStrictModeAllowRemoteNodeIdentities, false, "Allows unencrypted traffic from pods to remote node identities within the strict mode CIDR. This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap.")
 	option.BindEnv(vp, option.EncryptionStrictModeAllowRemoteNodeIdentities)
-
-	flags.Bool(option.HTTPNormalizePath, true, "Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution.")
-	option.BindEnv(vp, option.HTTPNormalizePath)
-
-	flags.String(option.HTTP403Message, "", "Message returned in proxy L7 403 body")
-	flags.MarkHidden(option.HTTP403Message)
-	option.BindEnv(vp, option.HTTP403Message)
-
-	flags.Uint(option.HTTPRequestTimeout, 60*60, "Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited")
-	option.BindEnv(vp, option.HTTPRequestTimeout)
-
-	flags.Uint(option.HTTPIdleTimeout, 0, "Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)")
-	option.BindEnv(vp, option.HTTPIdleTimeout)
-
-	flags.Uint(option.HTTPMaxGRPCTimeout, 0, "Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A \"grpc-timeout\" header may override this with a shorter value; defaults to 0 (unlimited)")
-	option.BindEnv(vp, option.HTTPMaxGRPCTimeout)
-
-	flags.Uint(option.HTTPRetryCount, 3, "Number of retries performed after a forwarded request attempt fails")
-	option.BindEnv(vp, option.HTTPRetryCount)
-
-	flags.Uint(option.HTTPRetryTimeout, 0, "Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)")
-	option.BindEnv(vp, option.HTTPRetryTimeout)
-
-	flags.Uint(option.ProxyConnectTimeout, 2, "Time after which a TCP connect attempt is considered failed unless completed (in seconds)")
-	option.BindEnv(vp, option.ProxyConnectTimeout)
-
-	flags.Uint(option.ProxyGID, 1337, "Group ID for proxy control plane sockets.")
-	option.BindEnv(vp, option.ProxyGID)
-
-	flags.Int(option.ProxyPrometheusPort, 0, "Port to serve Envoy metrics on. Default 0 (disabled).")
-	option.BindEnv(vp, option.ProxyPrometheusPort)
-
-	flags.Int(option.ProxyMaxRequestsPerConnection, 0, "Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)")
-	option.BindEnv(vp, option.ProxyMaxRequestsPerConnection)
-
-	flags.Int64(option.ProxyMaxConnectionDuration, 0, "Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)")
-	option.BindEnv(vp, option.ProxyMaxConnectionDuration)
-
-	flags.Int64(option.ProxyIdleTimeout, 60, "Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s")
-	option.BindEnv(vp, option.ProxyIdleTimeout)
-
-	flags.Bool(option.DisableEnvoyVersionCheck, false, "Do not perform Envoy binary version check on startup")
-	flags.MarkHidden(option.DisableEnvoyVersionCheck)
-	// Disable version check if Envoy build is disabled
-	option.BindEnvWithLegacyEnvFallback(vp, option.DisableEnvoyVersionCheck, "CILIUM_DISABLE_ENVOY_BUILD")
 
 	flags.Var(option.NewNamedMapOptions(option.FixedIdentityMapping, &option.Config.FixedIdentityMapping, option.Config.FixedIdentityMappingValidator),
 		option.FixedIdentityMapping, "Key-value for the fixed identity mapping which allows to use reserved label for fixed identities, e.g. 128=kv-store,129=kube-dns")

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -30,6 +30,7 @@ var Cell = cell.Module(
 	"envoy-proxy",
 	"Envoy proxy and control-plane",
 
+	cell.Config(envoyProxyConfig{}),
 	cell.Config(secretSyncConfig{}),
 	cell.Provide(newEnvoyXDSServer),
 	cell.Provide(newEnvoyAdminClient),
@@ -39,6 +40,42 @@ var Cell = cell.Module(
 	cell.Invoke(registerEnvoyVersionCheck),
 	cell.Invoke(registerSecretSyncer),
 )
+
+type envoyProxyConfig struct {
+	DisableEnvoyVersionCheck          bool
+	ProxyPrometheusPort               int
+	ProxyAdminPort                    int
+	EnvoyLog                          string
+	ProxyConnectTimeout               uint
+	ProxyGID                          uint
+	ProxyMaxRequestsPerConnection     int
+	ProxyMaxConnectionDurationSeconds int
+	ProxyIdleTimeoutSeconds           int
+	HTTPNormalizePath                 bool
+	HTTPRequestTimeout                uint
+	HTTPIdleTimeout                   uint
+	HTTPMaxGRPCTimeout                uint
+	HTTPRetryCount                    uint
+	HTTPRetryTimeout                  uint
+}
+
+func (r envoyProxyConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool("disable-envoy-version-check", false, "Do not perform Envoy version check")
+	flags.Int("proxy-prometheus-port", 0, "Port to serve Envoy metrics on. Default 0 (disabled).")
+	flags.Int("proxy-admin-port", 0, "Port to serve Envoy admin interface on.")
+	flags.String("envoy-log", "", "Path to a separate Envoy log file, if any")
+	flags.Uint("proxy-connect-timeout", 2, "Time after which a TCP connect attempt is considered failed unless completed (in seconds)")
+	flags.Uint("proxy-gid", 1337, "Group ID for proxy control plane sockets.")
+	flags.Int("proxy-max-requests-per-connection", 0, "Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)")
+	flags.Int("proxy-max-connection-duration-seconds", 0, "Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)")
+	flags.Int("proxy-idle-timeout-seconds", 60, "Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s")
+	flags.Bool("http-normalize-path", true, "Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution.")
+	flags.Uint("http-request-timeout", 60*60, "Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited")
+	flags.Uint("http-idle-timeout", 0, "Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)")
+	flags.Uint("http-max-grpc-timeout", 0, "Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A \"grpc-timeout\" header may override this with a shorter value; defaults to 0 (unlimited)")
+	flags.Uint("http-retry-count", 3, "Number of retries performed after a forwarded request attempt fails")
+	flags.Uint("http-retry-timeout", 0, "Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)")
+}
 
 type secretSyncConfig struct {
 	EnvoySecretsNamespace string
@@ -65,6 +102,8 @@ type xdsServerParams struct {
 	IPCache            *ipcache.IPCache
 	LocalEndpointStore *LocalEndpointStore
 
+	EnvoyProxyConfig envoyProxyConfig
+
 	// Depend on access log server to enforce init order.
 	// This ensures that the access log server is ready before it gets used by the
 	// Cilium Envoy filter after receiving the resources via xDS server.
@@ -76,7 +115,19 @@ type xdsServerParams struct {
 }
 
 func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
-	xdsServer, err := newXDSServer(GetSocketDir(option.Config.RunDir), params.IPCache, params.LocalEndpointStore)
+	xdsServer, err := newXDSServer(
+		params.IPCache,
+		params.LocalEndpointStore,
+		xdsServerConfig{
+			envoySocketDir:     GetSocketDir(option.Config.RunDir),
+			proxyGID:           int(params.EnvoyProxyConfig.ProxyGID),
+			httpRequestTimeout: int(params.EnvoyProxyConfig.HTTPRequestTimeout),
+			httpIdleTimeout:    params.EnvoyProxyConfig.ProxyIdleTimeoutSeconds,
+			httpMaxGRPCTimeout: int(params.EnvoyProxyConfig.HTTPMaxGRPCTimeout),
+			httpRetryCount:     int(params.EnvoyProxyConfig.HTTPRetryCount),
+			httpRetryTimeout:   int(params.EnvoyProxyConfig.HTTPRetryTimeout),
+			httpNormalizePath:  params.EnvoyProxyConfig.HTTPNormalizePath,
+		})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Envoy xDS server: %w", err)
 	}
@@ -87,13 +138,13 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 	}
 
 	params.Lifecycle.Append(cell.Hook{
-		OnStart: func(startContext cell.HookContext) error {
+		OnStart: func(_ cell.HookContext) error {
 			if err := xdsServer.start(); err != nil {
 				return fmt.Errorf("failed to start Envoy xDS server: %w", err)
 			}
 			return nil
 		},
-		OnStop: func(stopContext cell.HookContext) error {
+		OnStop: func(_ cell.HookContext) error {
 			xdsServer.stop()
 			return nil
 		},
@@ -101,8 +152,15 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 
 	if !option.Config.ExternalEnvoyProxy {
 		return &onDemandXdsStarter{
-			XDSServer: xdsServer,
-			runDir:    option.Config.RunDir,
+			XDSServer:                xdsServer,
+			runDir:                   option.Config.RunDir,
+			envoyLogPath:             params.EnvoyProxyConfig.EnvoyLog,
+			metricsListenerPort:      params.EnvoyProxyConfig.ProxyPrometheusPort,
+			adminListenerPort:        params.EnvoyProxyConfig.ProxyAdminPort,
+			connectTimeout:           int64(params.EnvoyProxyConfig.ProxyConnectTimeout),
+			maxRequestsPerConnection: uint32(params.EnvoyProxyConfig.ProxyMaxRequestsPerConnection),
+			maxConnectionDuration:    time.Duration(params.EnvoyProxyConfig.ProxyMaxConnectionDurationSeconds) * time.Second,
+			idleTimeout:              time.Duration(params.EnvoyProxyConfig.ProxyIdleTimeoutSeconds) * time.Second,
 		}, nil
 	}
 
@@ -118,6 +176,7 @@ type accessLogServerParams struct {
 
 	Lifecycle          cell.Lifecycle
 	LocalEndpointStore *LocalEndpointStore
+	EnvoyProxyConfig   envoyProxyConfig
 }
 
 func newEnvoyAccessLogServer(params accessLogServerParams) *AccessLogServer {
@@ -126,16 +185,16 @@ func newEnvoyAccessLogServer(params accessLogServerParams) *AccessLogServer {
 		return nil
 	}
 
-	accessLogServer := newAccessLogServer(GetSocketDir(option.Config.RunDir), params.LocalEndpointStore)
+	accessLogServer := newAccessLogServer(GetSocketDir(option.Config.RunDir), params.EnvoyProxyConfig.ProxyGID, params.LocalEndpointStore)
 
 	params.Lifecycle.Append(cell.Hook{
-		OnStart: func(startContext cell.HookContext) error {
+		OnStart: func(_ cell.HookContext) error {
 			if err := accessLogServer.start(); err != nil {
 				return fmt.Errorf("failed to start Envoy AccessLog server: %w", err)
 			}
 			return nil
 		},
-		OnStop: func(stopContext cell.HookContext) error {
+		OnStop: func(_ cell.HookContext) error {
 			accessLogServer.stop()
 			return nil
 		},
@@ -151,11 +210,12 @@ type versionCheckParams struct {
 	Logger           logrus.FieldLogger
 	JobRegistry      job.Registry
 	Scope            cell.Scope
+	EnvoyProxyConfig envoyProxyConfig
 	EnvoyAdminClient *EnvoyAdminClient
 }
 
 func registerEnvoyVersionCheck(params versionCheckParams) {
-	if !option.Config.EnableL7Proxy || option.Config.DisableEnvoyVersionCheck {
+	if !option.Config.EnableL7Proxy || params.EnvoyProxyConfig.DisableEnvoyVersionCheck {
 		return
 	}
 
@@ -200,7 +260,7 @@ func newArtifactCopier(lifecycle cell.Lifecycle) *ArtifactCopier {
 	}
 
 	lifecycle.Append(cell.Hook{
-		OnStart: func(startContext cell.HookContext) error {
+		OnStart: func(_ cell.HookContext) error {
 			if err := artifactCopier.Copy(); err != nil {
 				return fmt.Errorf("failed to copy artifacts to envoy: %w", err)
 			}

--- a/pkg/envoy/embedded_envoy_test.go
+++ b/pkg/envoy/embedded_envoy_test.go
@@ -12,14 +12,11 @@ import (
 
 	. "github.com/cilium/checkmate"
 
-	"github.com/spf13/viper"
-
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy/xds"
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
@@ -42,9 +39,6 @@ func (s *EnvoySuite) waitForProxyCompletion() error {
 }
 
 func (s *EnvoySuite) TestEnvoy(c *C) {
-	option.Config.Populate(viper.GetViper())
-	option.Config.ProxyConnectTimeout = 1
-	c.Assert(option.Config.ProxyConnectTimeout, Not(Equals), 0)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -64,7 +58,12 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 
 	localEndpointStore := newLocalEndpointStore()
 
-	xdsServer, err := newXDSServer(testRunDir, testipcache.NewMockIPCache(), localEndpointStore)
+	xdsServer, err := newXDSServer(testipcache.NewMockIPCache(), localEndpointStore,
+		xdsServerConfig{
+			envoySocketDir:    testRunDir,
+			proxyGID:          1337,
+			httpNormalizePath: true,
+		})
 	c.Assert(xdsServer, NotNil)
 	c.Assert(err, IsNil)
 
@@ -72,14 +71,19 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 	c.Assert(err, IsNil)
 	defer xdsServer.stop()
 
-	accessLogServer := newAccessLogServer(testRunDir, localEndpointStore)
+	accessLogServer := newAccessLogServer(testRunDir, 1337, localEndpointStore)
 	c.Assert(accessLogServer, NotNil)
 	err = accessLogServer.start()
 	c.Assert(err, IsNil)
 	defer accessLogServer.stop()
 
 	// launch debug variant of the Envoy proxy
-	envoyProxy, err := startEmbeddedEnvoy(testRunDir, filepath.Join(testRunDir, "cilium-envoy.log"), 0)
+	envoyProxy, err := startEmbeddedEnvoy(embeddedEnvoyConfig{
+		runDir:         testRunDir,
+		logPath:        filepath.Join(testRunDir, "cilium-envoy.log"),
+		baseID:         0,
+		connectTimeout: 1,
+	})
 	c.Assert(envoyProxy, NotNil)
 	c.Assert(err, IsNil)
 	log.Debug("started Envoy")
@@ -157,21 +161,30 @@ func (s *EnvoySuite) TestEnvoyNACK(c *C) {
 
 	localEndpointStore := newLocalEndpointStore()
 
-	xdsServer, err := newXDSServer(testRunDir, testipcache.NewMockIPCache(), localEndpointStore)
+	xdsServer, err := newXDSServer(testipcache.NewMockIPCache(), localEndpointStore,
+		xdsServerConfig{
+			envoySocketDir:    testRunDir,
+			proxyGID:          1337,
+			httpNormalizePath: true,
+		})
 	c.Assert(xdsServer, NotNil)
 	c.Assert(err, IsNil)
 	err = xdsServer.start()
 	c.Assert(err, IsNil)
 	defer xdsServer.stop()
 
-	accessLogServer := newAccessLogServer(testRunDir, localEndpointStore)
+	accessLogServer := newAccessLogServer(testRunDir, 1337, localEndpointStore)
 	c.Assert(accessLogServer, NotNil)
 	err = accessLogServer.start()
 	c.Assert(err, IsNil)
 	defer accessLogServer.stop()
 
 	// launch debug variant of the Envoy proxy
-	envoyProxy, err := startEmbeddedEnvoy(testRunDir, filepath.Join(testRunDir, "cilium-envoy.log"), 42)
+	envoyProxy, err := startEmbeddedEnvoy(embeddedEnvoyConfig{
+		runDir:  testRunDir,
+		logPath: filepath.Join(testRunDir, "cilium-envoy.log"),
+		baseID:  42,
+	})
 	c.Assert(envoyProxy, NotNil)
 	c.Assert(err, IsNil)
 	log.Debug("started Envoy")

--- a/pkg/envoy/xds_server_ondemand.go
+++ b/pkg/envoy/xds_server_ondemand.go
@@ -9,14 +9,22 @@ import (
 
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type onDemandXdsStarter struct {
 	XDSServer
 
-	runDir    string
+	runDir                   string
+	envoyLogPath             string
+	metricsListenerPort      int
+	adminListenerPort        int
+	connectTimeout           int64
+	maxRequestsPerConnection uint32
+	maxConnectionDuration    time.Duration
+	idleTimeout              time.Duration
+
 	envoyOnce sync.Once
 }
 
@@ -51,22 +59,30 @@ func (o *onDemandXdsStarter) startEmbeddedEnvoy(wg *completion.WaitGroup) error 
 
 	o.envoyOnce.Do(func() {
 		// Start embedded Envoy on first invocation
-		_, startErr = startEmbeddedEnvoy(o.runDir, option.Config.EnvoyLogPath, 0)
+		_, startErr = startEmbeddedEnvoy(embeddedEnvoyConfig{
+			runDir:                   o.runDir,
+			logPath:                  o.envoyLogPath,
+			baseID:                   0,
+			connectTimeout:           o.connectTimeout,
+			maxRequestsPerConnection: o.maxRequestsPerConnection,
+			maxConnectionDuration:    o.maxConnectionDuration,
+			idleTimeout:              o.idleTimeout,
+		})
 
 		// Add Prometheus listener if the port is (properly) configured
-		if option.Config.ProxyPrometheusPort < 0 || option.Config.ProxyPrometheusPort > 65535 {
-			log.WithField(logfields.Port, option.Config.ProxyPrometheusPort).Error("Envoy: Invalid configured proxy-prometheus-port")
-		} else if option.Config.ProxyPrometheusPort != 0 {
+		if o.metricsListenerPort < 0 || o.metricsListenerPort > 65535 {
+			log.WithField(logfields.Port, o.metricsListenerPort).Error("Envoy: Invalid configured proxy-prometheus-port")
+		} else if o.metricsListenerPort != 0 {
 			// We could do this in the bootstrap config as with the Envoy DaemonSet,
 			// but then a failure to bind to the configured port would fail starting Envoy.
-			o.XDSServer.AddMetricsListener(uint16(option.Config.ProxyPrometheusPort), wg)
+			o.XDSServer.AddMetricsListener(uint16(o.metricsListenerPort), wg)
 		}
 
 		// Add Admin listener if the port is (properly) configured
-		if option.Config.ProxyAdminPort < 0 || option.Config.ProxyAdminPort > 65535 {
-			log.WithField(logfields.Port, option.Config.ProxyAdminPort).Error("Envoy: Invalid configured proxy-admin-port")
-		} else if option.Config.ProxyAdminPort != 0 {
-			o.XDSServer.AddAdminListener(uint16(option.Config.ProxyAdminPort), wg)
+		if o.adminListenerPort < 0 || o.adminListenerPort > 65535 {
+			log.WithField(logfields.Port, o.adminListenerPort).Error("Envoy: Invalid configured proxy-admin-port")
+		} else if o.adminListenerPort != 0 {
+			o.XDSServer.AddAdminListener(uint16(o.adminListenerPort), wg)
 		}
 	})
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2291,9 +2291,6 @@ type DaemonConfig struct {
 	// Enables BGP control plane features.
 	EnableBGPControlPlane bool
 
-	// EnvoySecretNamespaces for TLS secrets. Used by CiliumEnvoyConfig via SDS.
-	EnvoySecretNamespaces []string
-
 	// BPFMapEventBuffers has configuration on what BPF map event buffers to enabled
 	// and configuration options for those.
 	BPFMapEventBuffers          map[string]string

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -127,9 +127,6 @@ const (
 	// direct routing mode (only required by BPF NodePort)
 	DirectRoutingDevice = "direct-routing-device"
 
-	// DisableEnvoyVersionCheck do not perform Envoy binary version check on startup
-	DisableEnvoyVersionCheck = "disable-envoy-version-check"
-
 	// EnablePolicy enables policy enforcement in the agent.
 	EnablePolicy = "enable-policy"
 
@@ -154,27 +151,8 @@ const (
 	// EncryptNode enables node IP encryption
 	EncryptNode = "encrypt-node"
 
-	// EnvoyLog sets the path to a separate Envoy log file, if any
-	EnvoyLog = "envoy-log"
-
 	// GopsPort is the TCP port for the gops server.
 	GopsPort = "gops-port"
-
-	// ProxyAdminPort specifies the port to serve Cilium Envoy Admin API on.
-	ProxyAdminPort = "proxy-admin-port"
-
-	// ProxyPrometheusPort specifies the port to serve Cilium host proxy metrics on.
-	ProxyPrometheusPort = "proxy-prometheus-port"
-
-	// ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for the proxy
-	ProxyMaxRequestsPerConnection = "proxy-max-requests-per-connection"
-
-	// ProxyMaxConnectionDuration specifies the max_connection_duration setting for the proxy in seconds
-	ProxyMaxConnectionDuration = "proxy-max-connection-duration-seconds"
-
-	// ProxyIdleTimeout specifies the idle_timeout setting (in seconds), which applies
-	// for the connection from proxy to upstream cluster
-	ProxyIdleTimeout = "proxy-idle-timeout-seconds"
 
 	// FixedIdentityMapping is the key-value for the fixed identity mapping
 	// which allows to use reserved label for fixed identities
@@ -1213,42 +1191,9 @@ const (
 	RoutingModeTunnel = "tunnel"
 )
 
-// Envoy option names
 const (
-	// HTTPNormalizePath switches on Envoy HTTP path normalization options, which currently
-	// includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and
-	// redirecting for paths that contain escaped slashes. These are necessary to keep path based
-	// access control functional, and should not interfere with normal operation. Set this to
-	// false only with caution.
-	HTTPNormalizePath = "http-normalize-path"
-
 	// HTTP403Message specifies the response body for 403 responses, defaults to "Access denied"
 	HTTP403Message = "http-403-msg"
-
-	// HTTPRequestTimeout specifies the time in seconds after which forwarded requests time out
-	HTTPRequestTimeout = "http-request-timeout"
-
-	// HTTPIdleTimeout spcifies the time in seconds if http stream being idle after which the
-	// request times out
-	HTTPIdleTimeout = "http-idle-timeout"
-
-	// HTTPMaxGRPCTimeout specifies the maximum time in seconds that limits the values of
-	// "grpc-timeout" headers being honored.
-	HTTPMaxGRPCTimeout = "http-max-grpc-timeout"
-
-	// HTTPRetryCount specifies the number of retries performed after a forwarded request fails
-	HTTPRetryCount = "http-retry-count"
-
-	// HTTPRetryTimeout is the time in seconds before an uncompleted request is retried.
-	HTTPRetryTimeout = "http-retry-timeout"
-
-	// ProxyConnectTimeout specifies the time in seconds after which a TCP connection attempt
-	// is considered timed out
-	ProxyConnectTimeout = "proxy-connect-timeout"
-
-	// ProxyGID specifies the group ID that has access to unix domain sockets opened by Cilium
-	// agent for proxy configuration and access logging.
-	ProxyGID = "proxy-gid"
 
 	// ReadCNIConfiguration reads the CNI configuration file and extracts
 	// Cilium relevant information. This can be used to pass per node
@@ -1572,65 +1517,9 @@ type DaemonConfig struct {
 	// RunInterval. Zero means unlimited.
 	MaxControllerInterval int
 
-	// HTTPNormalizePath switches on Envoy HTTP path normalization options, which currently
-	// includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and
-	// redirecting for paths that contain escaped slashes. These are necessary to keep path based
-	// access control functional, and should not interfere with normal operation. Set this to
-	// false only with caution.
-	HTTPNormalizePath bool
-
 	// HTTP403Message is the error message to return when a HTTP 403 is returned
 	// by the proxy, if L7 policy is configured.
 	HTTP403Message string
-
-	// HTTPRequestTimeout is the time in seconds after which Envoy responds with an
-	// error code on a request that has not yet completed. This needs to be longer
-	// than the HTTPIdleTimeout
-	HTTPRequestTimeout int
-
-	// HTTPIdleTimeout is the time in seconds of a HTTP stream having no traffic after
-	// which Envoy responds with an error code. This needs to be shorter than the
-	// HTTPRequestTimeout
-	HTTPIdleTimeout int
-
-	// HTTPMaxGRPCTimeout is the upper limit to which "grpc-timeout" headers in GRPC
-	// requests are honored by Envoy. If 0 there is no limit. GRPC requests are not
-	// bound by the HTTPRequestTimeout, but ARE affected by the idle timeout!
-	HTTPMaxGRPCTimeout int
-
-	// HTTPRetryCount is the upper limit on how many times Envoy retries failed requests.
-	HTTPRetryCount int
-
-	// HTTPRetryTimeout is the time in seconds before an uncompleted request is retried.
-	HTTPRetryTimeout int
-
-	// ProxyConnectTimeout is the time in seconds after which Envoy considers a TCP
-	// connection attempt to have timed out.
-	ProxyConnectTimeout int
-
-	// ProxyGID specifies the group ID that has access to unix domain sockets opened by Cilium
-	// agent for proxy configuration and access logging.
-	ProxyGID int
-
-	// ProxyAdminPort specifies the port to serve Envoy admin on.
-	ProxyAdminPort int
-
-	// ProxyPrometheusPort specifies the port to serve Envoy metrics on.
-	ProxyPrometheusPort int
-
-	// ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for the proxy
-	ProxyMaxRequestsPerConnection int
-
-	// ProxyMaxConnectionDuration specifies the max_connection_duration setting for the proxy
-	ProxyMaxConnectionDuration time.Duration
-
-	// ProxyIdleTimeout specifies the idle_timeout setting (in seconds), which applies
-	// for the connection from proxy to upstream cluster
-	ProxyIdleTimeout time.Duration
-
-	// EnvoyLogPath specifies where to store the Envoy proxy logs when Envoy
-	// runs in the same container as Cilium.
-	EnvoyLogPath string
 
 	ProcFs string
 
@@ -1747,8 +1636,6 @@ type DaemonConfig struct {
 	EnableTracing                 bool
 	EnableIPIPTermination         bool
 	EnableUnreachableRoutes       bool
-	EnvoyLog                      string
-	DisableEnvoyVersionCheck      bool
 	FixedIdentityMapping          map[string]string
 	FixedIdentityMappingValidator func(val string) (string, error) `json:"-"`
 	IPv4Range                     string
@@ -3079,13 +2966,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableLocalRedirectPolicy = vp.GetBool(EnableLocalRedirectPolicy)
 	c.EncryptInterface = vp.GetStringSlice(EncryptInterface)
 	c.EncryptNode = vp.GetBool(EncryptNode)
-	c.EnvoyLogPath = vp.GetString(EnvoyLog)
-	c.HTTPNormalizePath = vp.GetBool(HTTPNormalizePath)
-	c.HTTPIdleTimeout = vp.GetInt(HTTPIdleTimeout)
-	c.HTTPMaxGRPCTimeout = vp.GetInt(HTTPMaxGRPCTimeout)
-	c.HTTPRequestTimeout = vp.GetInt(HTTPRequestTimeout)
-	c.HTTPRetryCount = vp.GetInt(HTTPRetryCount)
-	c.HTTPRetryTimeout = vp.GetInt(HTTPRetryTimeout)
 	c.IdentityChangeGracePeriod = vp.GetDuration(IdentityChangeGracePeriod)
 	c.IdentityRestoreGracePeriod = vp.GetDuration(IdentityRestoreGracePeriod)
 	c.IPAM = vp.GetString(IPAM)
@@ -3137,13 +3017,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.MTU = vp.GetInt(MTUName)
 	c.PreAllocateMaps = vp.GetBool(PreAllocateMapsName)
 	c.ProcFs = vp.GetString(ProcFs)
-	c.ProxyConnectTimeout = vp.GetInt(ProxyConnectTimeout)
-	c.ProxyGID = vp.GetInt(ProxyGID)
-	c.ProxyAdminPort = vp.GetInt(ProxyAdminPort)
-	c.ProxyPrometheusPort = vp.GetInt(ProxyPrometheusPort)
-	c.ProxyMaxRequestsPerConnection = vp.GetInt(ProxyMaxRequestsPerConnection)
-	c.ProxyMaxConnectionDuration = time.Duration(vp.GetInt64(ProxyMaxConnectionDuration))
-	c.ProxyIdleTimeout = time.Duration(vp.GetInt64(ProxyIdleTimeout))
 	c.RestoreState = vp.GetBool(Restore)
 	c.RouteMetric = vp.GetInt(RouteMetric)
 	c.RunDir = vp.GetString(StateDir)
@@ -3542,12 +3415,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.UseCiliumInternalIPForIPsec = vp.GetBool(UseCiliumInternalIPForIPsec)
 	c.BypassIPAvailabilityUponRestore = vp.GetBool(BypassIPAvailabilityUponRestore)
 	c.EnableK8sTerminatingEndpoint = vp.GetBool(EnableK8sTerminatingEndpoint)
-
-	// Disable Envoy version check if L7 proxy is disabled.
-	c.DisableEnvoyVersionCheck = vp.GetBool(DisableEnvoyVersionCheck)
-	if !c.EnableL7Proxy {
-		c.DisableEnvoyVersionCheck = true
-	}
 
 	// VTEP integration enable option
 	c.EnableVTEP = vp.GetBool(EnableVTEP)


### PR DESCRIPTION
Currently, most of the Envoy related config values are in the global config struct.

This PR moves the config properties into the Envoy Hive Cell - at least the one that are possible (only used by the components of the Envoy Cell)