### PR TITLE
[v1.14] bgpv1: Disable PodCIDR Reconciler for unsupported IPAM modes

### DIFF
--- a/pkg/bgpv1/manager/reconcile.go
+++ b/pkg/bgpv1/manager/reconcile.go
@@ -17,6 +17,7 @@ import (
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/option"
 	ciliumslices "github.com/cilium/cilium/pkg/slices"
 
 	"github.com/sirupsen/logrus"
@@ -352,7 +353,12 @@ type ExportPodCIDRReconcilerOut struct {
 
 type ExportPodCIDRReconciler struct{}
 
-func NewExportPodCIDRReconciler() ExportPodCIDRReconcilerOut {
+func NewExportPodCIDRReconciler(dc *option.DaemonConfig) ExportPodCIDRReconcilerOut {
+	// Don't provide the reconciler if the IPAM mode is not supported
+	if !types.CanAdvertisePodCIDR(dc.IPAMMode()) {
+		log.Info("Unsupported IPAM mode, disabling PodCIDR advertisements. exportPodCIDR doesn't take effect.")
+		return ExportPodCIDRReconcilerOut{}
+	}
 	return ExportPodCIDRReconcilerOut{
 		Reconciler: &ExportPodCIDRReconciler{},
 	}

--- a/pkg/bgpv1/types/utils.go
+++ b/pkg/bgpv1/types/utils.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"slices"
+
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+)
+
+// CanAdvertisePodCIDR returns true if the provided IPAM mode is supported for
+// advertising PodCIDR
+func CanAdvertisePodCIDR(ipam string) bool {
+	supportedIPAMs := []string{
+		ipamOption.IPAMKubernetes,
+		ipamOption.IPAMClusterPool,
+	}
+	return slices.Contains(supportedIPAMs, ipam)
+}


### PR DESCRIPTION
Manual backport of https://github.com/cilium/cilium/pull/31181.

```release-note
bgpv1: Disable PodCIDR Reconciler for unsupported IPAM modes
```
