### PR TITLE
gateway-api: fixed RequestRedirect picks wrong port with multiple listeners

### DIFF
--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -1415,6 +1415,7 @@ var requestRedirectHTTPListeners = []model.HTTPListener{
 				},
 				RequestRedirect: &model.HTTPRequestRedirectFilter{
 					Hostname: model.AddressOf("example.com"),
+					Port:     model.AddressOf(int32(80)),
 				},
 			},
 			{
@@ -1425,6 +1426,7 @@ var requestRedirectHTTPListeners = []model.HTTPListener{
 				},
 				RequestRedirect: &model.HTTPRequestRedirectFilter{
 					StatusCode: model.AddressOf(301),
+					Port:       model.AddressOf(int32(80)),
 				},
 			},
 			{
@@ -1441,6 +1443,7 @@ var requestRedirectHTTPListeners = []model.HTTPListener{
 				RequestRedirect: &model.HTTPRequestRedirectFilter{
 					Hostname:   model.AddressOf("example.com"),
 					StatusCode: model.AddressOf(301),
+					Port:       model.AddressOf(int32(80)),
 				},
 			},
 		},

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -213,6 +213,15 @@ func Test_translator_Translate(t *testing.T) {
 			},
 			want: mirrorHTTPListenersCiliumEnvoyConfig,
 		},
+		{
+			name: "Conformance/HTTPRouteRequestRedirectWithMultiHTTPListeners",
+			args: args{
+				m: &model.Model{
+					HTTP: requestRedirectWithMultiHTTPListeners,
+				},
+			},
+			want: requestRedirectWithMultiHTTPListenersCiliumEnvoyConfig,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes: #29099

If RequestRedirect does not specify a port. The port of the listener is used by default.



```release-note
gateway-api: fixed RequestRedirect picks wrong port with multiple listeners
```
