### PR TITLE
lxcmap: Fix comment about byte-order

### DIFF
--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -95,13 +95,10 @@ func GetBPFValue(e EndpointFrontend) (*EndpointInfo, error) {
 
 	info := &EndpointInfo{
 		IfIndex: uint32(e.GetIfIndex()),
-		// Store security identity in network byte order so it can be
-		// written into the packet without an additional byte order
-		// conversion.
 		LxcID:   uint16(e.GetID()),
 		MAC:     mac,
 		NodeMAC: nodeMAC,
-		SecID:   e.GetIdentity().Uint32(),
+		SecID:   e.GetIdentity().Uint32(), // Host byte-order
 	}
 
 	return info, nil


### PR DESCRIPTION
```
It was many and many a year ago,
  In a kingdom by the BEES,
That a MAP there lived whom you may know
  By the name of LXC;
And this MAP it lived with no other thought
  Than to ROUTE and ROUTE efficiently.

In GIT logs I discover when it was created,
  A field--SECURITY IDENTITY--
In a style that has yet to be dated,
  An ENDIANNESS known as "BE".
Yet some time later the field had faded, leaving
  A remark with one guarantee:
The field so related, no longer updated,
  is formed "this" way. Most certainly!

As years and years and oh they passed,
  This remark it remained silently,
Until a day no-one would forecast,
  The field was restored--and rightfully.
And so set the trap, set with the MAP!
  Whenceforth I was deceived:
For the utterance was renewed at last,
  In a way that lied to me.

Amidst a review of some code so UPDATED,
  I a-raised an enquiry,
To understand what I had conflated,
  That elderly comment about "BE".
And so we translated,
And demarcated,
  All CODE related to SEC_ID..
Until we were persuaded,
Perhaps frustrated,
  The field was little endian!

And so we regale you, with our tale,
  To state but this to thee,
Care of comments that may be stale--
  Truth is not always what you see!
```

Related: a15be077a34ad9d2a8f208e4b736c25ce3a15306
Related: 0d513f3ae2a29119c864309cd1198468e70a13c2
Related: bd7b7af6322182e952d8be134d47a4a55ecad2c4
Reported-by: @ldelossa
