### PR TITLE
bpf: xdp: remove unused set_encrypt_dip()

### DIFF
--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -19,12 +19,6 @@ get_identity(struct xdp_md *ctx __maybe_unused)
 }
 
 static __always_inline __maybe_unused void
-set_encrypt_dip(struct xdp_md *ctx __maybe_unused,
-		__be32 ip_endpoint __maybe_unused)
-{
-}
-
-static __always_inline __maybe_unused void
 set_identity_mark(struct xdp_md *ctx __maybe_unused, __u32 identity __maybe_unused,
 		  __u32 magic __maybe_unused)
 {


### PR DESCRIPTION
4c7cce1bf044 ("bpf: Remove IP_POOLS IPsec code") removed the skb helper. Also clean up the (unused) XDP variant.
