### PR TITLE
iptables: Unit tests cleanup

### DIFF
--- a/pkg/datapath/iptables/custom_chain.go
+++ b/pkg/datapath/iptables/custom_chain.go
@@ -94,7 +94,7 @@ var ciliumChains = []customChain{
 	},
 }
 
-func (c *customChain) exists(prog iptablesInterface) (bool, error) {
+func (c *customChain) exists(prog runnable) (bool, error) {
 	args := []string{"-t", c.table, "-S", c.name}
 
 	output, err := prog.runProgOutput(args)
@@ -121,7 +121,7 @@ func (c *customChain) exists(prog iptablesInterface) (bool, error) {
 	return true, nil
 }
 
-func (c *customChain) doAdd(prog iptablesInterface) error {
+func (c *customChain) doAdd(prog runnable) error {
 	args := []string{"-t", c.table, "-N", c.name}
 
 	output, err := prog.runProgOutput(args)
@@ -147,7 +147,7 @@ func (c *customChain) add(ipv4, ipv6 bool) error {
 	return nil
 }
 
-func (c *customChain) doRename(prog iptablesInterface, newName string) error {
+func (c *customChain) doRename(prog runnable, newName string) error {
 	if exists, err := c.exists(prog); err != nil {
 		return err
 	} else if !exists {

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -79,12 +79,16 @@ const (
 	waitString = "-w"
 )
 
-type iptablesInterface interface {
-	getProg() string
-	getIpset() string
-	getVersion() (semver.Version, error)
+type runnable interface {
 	runProgOutput(args []string) (string, error)
 	runProg(args []string) error
+}
+
+type iptablesInterface interface {
+	runnable
+
+	getProg() string
+	getIpset() string
 }
 
 type ipt struct {
@@ -196,7 +200,7 @@ func isDisabledChain(disableIptablesFeederRules []string, chain string) bool {
 	return false
 }
 
-func (m *Manager) removeCiliumRules(table string, prog iptablesInterface, match string) error {
+func (m *Manager) removeCiliumRules(table string, prog runnable, match string) error {
 	rules, err := prog.runProgOutput([]string{"-t", table, "-S"})
 	if err != nil {
 		return err
@@ -472,7 +476,7 @@ func (m *Manager) inboundProxyRedirectRule(cmd string) []string {
 		"--set-mark", toProxyMark}
 }
 
-func (m *Manager) iptProxyRule(rules string, prog iptablesInterface, l4proto, ip string, proxyPort uint16, name string) error {
+func (m *Manager) iptProxyRule(rules string, prog runnable, l4proto, ip string, proxyPort uint16, name string) error {
 	// Match
 	port := uint32(byteorder.HostToNetwork16(proxyPort)) << 16
 	markMatch := fmt.Sprintf("%#x", linux_defaults.MagicMarkIsToProxy|port)
@@ -724,7 +728,7 @@ func (m *Manager) copyProxyRules(oldChain string, match string) error {
 
 // Redirect packets to the host proxy via TPROXY, as directed by the Cilium
 // datapath bpf programs via skb marks.
-func (m *Manager) addProxyRules(prog iptablesInterface, ip string, proxyPort uint16, name string) error {
+func (m *Manager) addProxyRules(prog runnable, ip string, proxyPort uint16, name string) error {
 	rules, err := prog.runProgOutput([]string{"-t", "mangle", "-S"})
 	if err != nil {
 		return err
@@ -761,7 +765,7 @@ func (m *Manager) addProxyRules(prog iptablesInterface, ip string, proxyPort uin
 	return nil
 }
 
-func (m *Manager) endpointNoTrackRules(prog iptablesInterface, cmd string, IP string, port *lb.L4Addr) error {
+func (m *Manager) endpointNoTrackRules(prog runnable, cmd string, IP string, port *lb.L4Addr) error {
 	var err error
 
 	protocol := strings.ToLower(port.Protocol)
@@ -1016,7 +1020,7 @@ func (m *Manager) GetProxyPort(name string) uint16 {
 	return m.doGetProxyPort(prog, name)
 }
 
-func (m *Manager) doGetProxyPort(prog iptablesInterface, name string) uint16 {
+func (m *Manager) doGetProxyPort(prog runnable, name string) uint16 {
 	rules, err := prog.runProgOutput([]string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain})
 	if err != nil {
 		return 0
@@ -1074,7 +1078,7 @@ func (m *Manager) installForwardChainRules(ifName, localDeliveryInterface, forwa
 	return nil
 }
 
-func (m *Manager) installForwardChainRulesIpX(prog iptablesInterface, ifName, localDeliveryInterface, forwardChain string) error {
+func (m *Manager) installForwardChainRulesIpX(prog runnable, ifName, localDeliveryInterface, forwardChain string) error {
 	// While kube-proxy does change the policy of the iptables FORWARD chain
 	// it doesn't seem to handle all cases, e.g. host network pods that use
 	// the node IP which would still end up in default DENY. Similarly, for
@@ -1404,7 +1408,7 @@ func (m *Manager) installMasqueradeRules(prog iptablesInterface, localDeliveryIn
 	return nil
 }
 
-func (m *Manager) installHostTrafficMarkRule(prog iptablesInterface) error {
+func (m *Manager) installHostTrafficMarkRule(prog runnable) error {
 	// Mark all packets sourced from processes running on the host with a
 	// special marker so that we can differentiate traffic sourced locally
 	// vs. traffic from the outside world that was masqueraded to appear
@@ -1607,7 +1611,7 @@ func (m *Manager) installRules(ifName string) error {
 	return nil
 }
 
-func (m *Manager) ciliumNoTrackXfrmRules(prog iptablesInterface, input string) error {
+func (m *Manager) ciliumNoTrackXfrmRules(prog runnable, input string) error {
 	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
 	matchFromIPSecDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
 
@@ -1686,7 +1690,7 @@ func (m *Manager) addCiliumNoTrackXfrmRules() (err error) {
 	return nil
 }
 
-func (m *Manager) addNoTrackPodTrafficRules(prog iptablesInterface, podsCIDR string) error {
+func (m *Manager) addNoTrackPodTrafficRules(prog runnable, podsCIDR string) error {
 	for _, chain := range []string{ciliumPreRawChain, ciliumOutputRawChain} {
 		if err := prog.runProg([]string{
 			"-t", "raw",

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-
-	"github.com/blang/semver/v4"
 )
 
 type expectation struct {
@@ -31,10 +29,6 @@ func (ipt *mockIptables) getProg() string {
 
 func (ipt *mockIptables) getIpset() string {
 	return ipt.ipset
-}
-
-func (ipt *mockIptables) getVersion() (semver.Version, error) {
-	return semver.Version{}, nil
 }
 
 func (ipt *mockIptables) runProgOutput(args []string) (out string, err error) {

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -9,16 +9,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
-	check "github.com/cilium/checkmate"
 )
-
-func Test(t *testing.T) {
-	check.TestingT(t)
-}
-
-type iptablesTestSuite struct{}
-
-var _ = check.Suite(&iptablesTestSuite{})
 
 type expectation struct {
 	args string
@@ -27,7 +18,7 @@ type expectation struct {
 }
 
 type mockIptables struct {
-	c            *check.C
+	t            *testing.T
 	prog         string
 	ipset        string
 	expectations []expectation
@@ -52,11 +43,11 @@ func (ipt *mockIptables) runProgOutput(args []string) (out string, err error) {
 	ipt.index++
 
 	if len(ipt.expectations) < ipt.index {
-		ipt.c.Errorf("%d: Unexpected %s %s", i, ipt.prog, a)
+		ipt.t.Errorf("%d: Unexpected %s %s", i, ipt.prog, a)
 		return "", fmt.Errorf("Unexpected %s %s", ipt.prog, a)
 	}
 	if a != ipt.expectations[i].args {
-		ipt.c.Errorf("%d: Unexpected %s (%q != %q)", i, ipt.prog, a, ipt.expectations[i].args)
+		ipt.t.Errorf("%d: Unexpected %s (%q != %q)", i, ipt.prog, a, ipt.expectations[i].args)
 		return "", fmt.Errorf("Unexpected %s %s", ipt.prog, a)
 	}
 	out = string(ipt.expectations[i].out)
@@ -68,7 +59,7 @@ func (ipt *mockIptables) runProgOutput(args []string) (out string, err error) {
 func (ipt *mockIptables) runProg(args []string) error {
 	out, err := ipt.runProgOutput(args)
 	if len(out) > 0 {
-		ipt.c.Errorf("%d: Unexpected output for %s %s", ipt.index-1, ipt.prog, strings.Join(args, " "))
+		ipt.t.Errorf("%d: Unexpected output for %s %s", ipt.index-1, ipt.prog, strings.Join(args, " "))
 	}
 	return err
 }
@@ -95,8 +86,8 @@ var mockManager = &Manager{
 	},
 }
 
-func (s *iptablesTestSuite) TestRenameCustomChain(c *check.C) {
-	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+func TestRenameCustomChain(t *testing.T) {
+	mockIp4tables := &mockIptables{t: t, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
 		{
 			args: "-t mangle -S CILIUM_PRE_mangle",
@@ -111,17 +102,21 @@ func (s *iptablesTestSuite) TestRenameCustomChain(c *check.C) {
 	}
 	chain.doRename(mockIp4tables, "OLD_CILIUM_PRE_mangle")
 	err := mockIp4tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+	mockIp6tables := &mockIptables{t: t, prog: "ip6tables"}
 	mockIp6tables.expectations = mockIp4tables.expectations
 	chain.doRename(mockIp6tables, "OLD_CILIUM_PRE_mangle")
 	err = mockIp6tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
-func (s *iptablesTestSuite) TestCopyProxyRulesv4(c *check.C) {
-	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+func TestCopyProxyRulesv4(t *testing.T) {
+	mockIp4tables := &mockIptables{t: t, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
 		{
 			args: "-t mangle -S",
@@ -152,11 +147,13 @@ func (s *iptablesTestSuite) TestCopyProxyRulesv4(c *check.C) {
 	// Copies DNS proxy rules from OLD_CILIUM_PRE_mangle to CILIUM_PRE_mangle
 	mockManager.doCopyProxyRules(mockIp4tables, "mangle", tproxyMatch, "cilium-dns-egress", "OLD_"+ciliumPreMangleChain, ciliumPreMangleChain)
 	err := mockIp4tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
-func (s *iptablesTestSuite) TestCopyProxyRulesv6(c *check.C) {
-	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+func TestCopyProxyRulesv6(t *testing.T) {
+	mockIp6tables := &mockIptables{t: t, prog: "ip6tables"}
 	mockIp6tables.expectations = []expectation{
 		{
 			args: "-t mangle -S",
@@ -187,11 +184,13 @@ func (s *iptablesTestSuite) TestCopyProxyRulesv6(c *check.C) {
 	// Copies DNS proxy rules from OLD_CILIUM_PRE_mangle to CILIUM_PRE_mangle
 	mockManager.doCopyProxyRules(mockIp6tables, "mangle", tproxyMatch, "cilium-dns-egress", "OLD_"+ciliumPreMangleChain, ciliumPreMangleChain)
 	err := mockIp6tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
-func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
-	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+func TestAddProxyRulesv4(t *testing.T) {
+	mockIp4tables := &mockIptables{t: t, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
 		{
 			args: "-t mangle -S",
@@ -225,7 +224,9 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 	// Adds new proxy rules
 	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37379, "cilium-dns-egress")
 	err := mockIp4tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	mockIp4tables.expectations = []expectation{
 		{
@@ -258,7 +259,9 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 	// Nothing to add
 	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37379, "cilium-dns-egress")
 	err = mockIp4tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	mockIp4tables.expectations = []expectation{
 		{
@@ -299,7 +302,9 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
 	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37380, "cilium-dns-egress")
 	err = mockIp4tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	mockIp4tables.expectations = []expectation{
 		{
@@ -340,11 +345,13 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 	// Same port number, new IP, adds new ones, deletes stale rules. Does not touch OLD_ chains
 	mockManager.addProxyRules(mockIp4tables, "127.0.0.1", 37379, "cilium-dns-egress")
 	err = mockIp4tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
-func (s *iptablesTestSuite) TestGetProxyPort(c *check.C) {
-	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+func TestGetProxyPort(t *testing.T) {
+	mockIp4tables := &mockIptables{t: t, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
 		{
 			args: "-t mangle -n -L CILIUM_PRE_mangle",
@@ -362,8 +369,12 @@ TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd7a90
 
 	// Finds the latest port number if multiple rules for the same proxy name
 	port := mockManager.doGetProxyPort(mockIp4tables, "cilium-dns-egress")
-	c.Assert(port, check.Equals, uint16(43479))
-	c.Assert(mockIp4tables.checkExpectations(), check.IsNil)
+	if port != uint16(43479) {
+		t.Fatalf("expected port number %d, got %d", uint16(43479), port)
+	}
+	if err := mockIp4tables.checkExpectations(); err != nil {
+		t.Fatal(err)
+	}
 
 	// Now test the proxy port fetch when the proxy is not DNS. It should
 	// fallback to 0.0.0.0 instead of localhost.
@@ -383,12 +394,16 @@ TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd7a90
 	}
 
 	port = mockManager.doGetProxyPort(mockIp4tables, "cilium-random-proxy")
-	c.Assert(port, check.Equals, uint16(43479))
-	c.Assert(mockIp4tables.checkExpectations(), check.IsNil)
+	if port != uint16(43479) {
+		t.Fatalf("expected port number %d, got %d", uint16(43479), port)
+	}
+	if err := mockIp4tables.checkExpectations(); err != nil {
+		t.Fatal(err)
+	}
 }
 
-func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
-	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+func TestAddProxyRulesv6(t *testing.T) {
+	mockIp6tables := &mockIptables{t: t, prog: "ip6tables"}
 	mockIp6tables.expectations = []expectation{
 		{
 			args: "-t mangle -S",
@@ -422,7 +437,9 @@ func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
 	// Adds new proxy rules
 	mockManager.addProxyRules(mockIp6tables, "::1", 43477, "cilium-dns-egress")
 	err := mockIp6tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	mockIp6tables.expectations = []expectation{
 		{
@@ -455,7 +472,9 @@ func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
 	// Nothing to add
 	mockManager.addProxyRules(mockIp6tables, "::1", 43477, "cilium-dns-egress")
 	err = mockIp6tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	mockIp6tables.expectations = []expectation{
 		{
@@ -496,11 +515,13 @@ func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
 	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
 	mockManager.addProxyRules(mockIp6tables, "::1", 43479, "cilium-dns-egress")
 	err = mockIp6tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
-func (s *iptablesTestSuite) TestRemoveCiliumRulesv4(c *check.C) {
-	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+func TestRemoveCiliumRulesv4(t *testing.T) {
+	mockIp4tables := &mockIptables{t: t, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
 		{
 			args: "-t mangle -S",
@@ -543,11 +564,13 @@ func (s *iptablesTestSuite) TestRemoveCiliumRulesv4(c *check.C) {
 	// Only removes Cilium chains with the OLD_ prefix
 	mockManager.removeCiliumRules("mangle", mockIp4tables, oldCiliumPrefix+"CILIUM_")
 	err := mockIp4tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
-func (s *iptablesTestSuite) TestRemoveCiliumRulesv6(c *check.C) {
-	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+func TestRemoveCiliumRulesv6(t *testing.T) {
+	mockIp6tables := &mockIptables{t: t, prog: "ip6tables"}
 	mockIp6tables.expectations = []expectation{
 		{
 			args: "-t mangle -S",
@@ -590,5 +613,7 @@ func (s *iptablesTestSuite) TestRemoveCiliumRulesv6(c *check.C) {
 	// Only removes Cilium chains with the OLD_ prefix
 	mockManager.removeCiliumRules("mangle", mockIp6tables, oldCiliumPrefix+"CILIUM_")
 	err := mockIp6tables.checkExpectations()
-	c.Assert(err, check.IsNil)
+	if err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
Small cleanup to iptables unit tests to:

- migrate from gopkg.in/check.v1 to standard Go testing framework
- trim down the `iptablesInterface` and simplify mocking

**Note to the reviewers**: better reviewed commit by commit

~Depends on https://github.com/cilium/cilium/pull/31068 and https://github.com/cilium/cilium/pull/31099~