### PR TITLE
kind: reset sysctl net.ipv4.ip_unprivileged_port_start to 1024

### DIFF
--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 default_controlplanes=1
 default_workers=1
-default_cluster_name=""
+default_cluster_name="kind"
 default_image=""
 default_kubeproxy_mode="iptables"
 if [ "$(uname 2>/dev/null)" == "Linux" ] && [ "$(</proc/sys/net/ipv6/conf/all/disable_ipv6)" == 1 ] ; then
@@ -108,9 +108,8 @@ fi
 
 kind_cmd="kind create cluster"
 
-if [[ -n "${cluster_name}" ]]; then
-  kind_cmd+=" --name ${cluster_name}"
-fi
+kind_cmd+=" --name ${cluster_name}"
+
 if [[ -n "${image}" ]]; then
   kind_cmd+=" --image ${image}"
 fi
@@ -259,6 +258,11 @@ set +e
 kubectl taint nodes --all node-role.kubernetes.io/control-plane-
 kubectl taint nodes --all node-role.kubernetes.io/master-
 set -e
+
+# Set start of unprivileged port range to 1024
+# Docker defaults to 0
+# https://github.com/moby/moby/pull/41030
+kind get nodes --name $cluster_name | xargs -I container_name docker exec container_name sysctl -w net.ipv4.ip_unprivileged_port_start=1024
 
 echo
 if [[ -n "${kubeconfig}" ]]; then


### PR DESCRIPTION
Curently, kind clusters running with docker have sysctl `net.ipv4.ip_unprivileged_port_start` set to `0`. This is the
default of docker.

```
root@kind-worker:/home/cilium# sysctl net.ipv4.ip_unprivileged_port_start
net.ipv4.ip_unprivileged_port_start = 0
```

This can lead to wrong assumptions and differ from the default of most k8s setups - where binding to privileged ports (<1024) requires the capability `NET_BIND_SERVICE`.

Therefore, this commit resets the sysctl `net.ipv4.ip_unprivileged_port_start` to `1024`. This way the dev environment matches the default on most k8s environments.