### PR TITLE
iptables: Add rules runtime reconciliation

### DIFF
--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -616,7 +616,7 @@ func (d *Daemon) startIPAM(node agentK8s.LocalCiliumNodeResource) {
 	bootstrapStats.ipam.Start()
 	log.Info("Initializing node addressing")
 	// Set up ipam conf after init() because we might be running d.conf.KVStoreIPv4Registration
-	d.ipam = ipam.NewIPAM(d.datapath.LocalNodeAddressing(), option.Config, d.nodeDiscovery, d.k8sWatcher, node, d.mtuConfig, d.clientset)
+	d.ipam = ipam.NewIPAM(d.datapath.LocalNodeAddressing(), option.Config, d.nodeDiscovery, d.nodeLocalStore, d.k8sWatcher, node, d.mtuConfig, d.clientset)
 	if d.ipamMetadata != nil {
 		d.ipam.WithMetadata(d.ipamMetadata)
 	}

--- a/daemon/cmd/local_node_sync.go
+++ b/daemon/cmd/local_node_sync.go
@@ -96,6 +96,9 @@ func (ini *localNodeSynchronizer) initFromConfig(ctx context.Context, n *node.Lo
 	n.ClusterID = ini.Config.ClusterID
 	n.Name = nodeTypes.GetName()
 
+	n.IPv4NativeRoutingCIDR = ini.Config.IPv4NativeRoutingCIDR
+	n.IPv6NativeRoutingCIDR = ini.Config.IPv6NativeRoutingCIDR
+
 	// If there is one device specified, use it to derive better default
 	// allocation prefixes
 	node.SetDefaultPrefix(ini.Config, ini.Config.DirectRoutingDevice, n)

--- a/pkg/datapath/fake/types/datapath.go
+++ b/pkg/datapath/fake/types/datapath.go
@@ -6,6 +6,7 @@ package types
 import (
 	"context"
 	"io"
+	"net/netip"
 
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
@@ -79,28 +80,21 @@ func (f *FakeDatapath) WriteEndpointConfig(io.Writer, datapath.EndpointConfigura
 	return nil
 }
 
-func (f *FakeDatapath) InstallProxyRules(context.Context, uint16, bool, string) error {
-	return nil
+func (f *FakeDatapath) InstallProxyRules(uint16, bool, string) {
 }
 
 func (f *FakeDatapath) SupportsOriginalSourceAddr() bool {
 	return false
 }
 
-func (f *FakeDatapath) InstallRules(ctx context.Context, ifName string, quiet, install bool) error {
-	return nil
-}
-
 func (m *FakeDatapath) GetProxyPort(name string) uint16 {
 	return 0
 }
 
-func (m *FakeDatapath) InstallNoTrackRules(IP string, port uint16, ipv6 bool) error {
-	return nil
+func (m *FakeDatapath) InstallNoTrackRules(ip netip.Addr, port uint16) {
 }
 
-func (m *FakeDatapath) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error {
-	return nil
+func (m *FakeDatapath) RemoveNoTrackRules(ip netip.Addr, port uint16) {
 }
 
 func (f *FakeDatapath) Loader() datapath.Loader {

--- a/pkg/datapath/iptables/cell.go
+++ b/pkg/datapath/iptables/cell.go
@@ -6,7 +6,6 @@ package iptables
 import (
 	"github.com/spf13/pflag"
 
-	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/option"
@@ -31,8 +30,6 @@ var Cell = cell.Module(
 			NodeIpsetNeeded:                 cfg.NodeIpsetNeeded(),
 			IptablesMasqueradingIPv4Enabled: cfg.IptablesMasqueradingIPv4Enabled(),
 			IptablesMasqueradingIPv6Enabled: cfg.IptablesMasqueradingIPv6Enabled(),
-			IPv4NativeRoutingCIDR:           cfg.GetIPv4NativeRoutingCIDR(),
-			IPv6NativeRoutingCIDR:           cfg.GetIPv6NativeRoutingCIDR(),
 
 			EnableIPv4:                  cfg.EnableIPv4,
 			EnableIPv6:                  cfg.EnableIPv6,
@@ -85,8 +82,6 @@ type SharedConfig struct {
 	NodeIpsetNeeded                 bool
 	IptablesMasqueradingIPv4Enabled bool
 	IptablesMasqueradingIPv6Enabled bool
-	IPv4NativeRoutingCIDR           *cidr.CIDR
-	IPv6NativeRoutingCIDR           *cidr.CIDR
 
 	EnableIPv4                  bool
 	EnableIPv6                  bool

--- a/pkg/datapath/iptables/cell.go
+++ b/pkg/datapath/iptables/cell.go
@@ -32,6 +32,7 @@ var Cell = cell.Module(
 			IptablesMasqueradingIPv4Enabled: cfg.IptablesMasqueradingIPv4Enabled(),
 			IptablesMasqueradingIPv6Enabled: cfg.IptablesMasqueradingIPv6Enabled(),
 			IPv4NativeRoutingCIDR:           cfg.GetIPv4NativeRoutingCIDR(),
+			IPv6NativeRoutingCIDR:           cfg.GetIPv6NativeRoutingCIDR(),
 
 			EnableIPv4:                  cfg.EnableIPv4,
 			EnableIPv6:                  cfg.EnableIPv6,
@@ -44,6 +45,7 @@ var Cell = cell.Module(
 			MasqueradeInterfaces:        cfg.MasqueradeInterfaces,
 			EnableMasqueradeRouteSource: cfg.EnableMasqueradeRouteSource,
 			EnableL7Proxy:               cfg.EnableL7Proxy,
+			InstallIptRules:             cfg.InstallIptRules,
 		}
 	}),
 	cell.Provide(newIptablesManager),
@@ -84,6 +86,7 @@ type SharedConfig struct {
 	IptablesMasqueradingIPv4Enabled bool
 	IptablesMasqueradingIPv6Enabled bool
 	IPv4NativeRoutingCIDR           *cidr.CIDR
+	IPv6NativeRoutingCIDR           *cidr.CIDR
 
 	EnableIPv4                  bool
 	EnableIPv6                  bool
@@ -96,4 +99,5 @@ type SharedConfig struct {
 	MasqueradeInterfaces        []string
 	EnableMasqueradeRouteSource bool
 	EnableL7Proxy               bool
+	InstallIptRules             bool
 }

--- a/pkg/datapath/iptables/reconciler.go
+++ b/pkg/datapath/iptables/reconciler.go
@@ -29,24 +29,31 @@ type desiredState struct {
 }
 
 type localNodeInfo struct {
-	internalIPv4  net.IP
-	internalIPv6  net.IP
-	ipv4AllocCIDR string
-	ipv6AllocCIDR string
+	internalIPv4          net.IP
+	internalIPv6          net.IP
+	ipv4AllocCIDR         string
+	ipv6AllocCIDR         string
+	ipv4NativeRoutingCIDR string
+	ipv6NativeRoutingCIDR string
 }
 
 func (lni localNodeInfo) equal(other localNodeInfo) bool {
 	if lni.internalIPv4.Equal(other.internalIPv4) &&
 		lni.internalIPv6.Equal(other.internalIPv6) &&
 		lni.ipv4AllocCIDR == other.ipv4AllocCIDR &&
-		lni.ipv6AllocCIDR == other.ipv6AllocCIDR {
+		lni.ipv6AllocCIDR == other.ipv6AllocCIDR &&
+		lni.ipv4NativeRoutingCIDR == other.ipv4NativeRoutingCIDR &&
+		lni.ipv6NativeRoutingCIDR == other.ipv6NativeRoutingCIDR {
 		return true
 	}
 	return false
 }
 
 func toLocalNodeInfo(n node.LocalNode) localNodeInfo {
-	var v4AllocCIDR, v6AllocCIDR string
+	var (
+		v4AllocCIDR, v6AllocCIDR                 string
+		v4NativeRoutingCIDR, v6NativeRoutingCIDR string
+	)
 
 	if n.IPv4AllocCIDR != nil {
 		v4AllocCIDR = n.IPv4AllocCIDR.String()
@@ -54,12 +61,20 @@ func toLocalNodeInfo(n node.LocalNode) localNodeInfo {
 	if n.IPv6AllocCIDR != nil {
 		v6AllocCIDR = n.IPv6AllocCIDR.String()
 	}
+	if n.IPv4NativeRoutingCIDR != nil {
+		v4NativeRoutingCIDR = n.IPv4NativeRoutingCIDR.String()
+	}
+	if n.IPv6NativeRoutingCIDR != nil {
+		v6NativeRoutingCIDR = n.IPv6NativeRoutingCIDR.String()
+	}
 
 	return localNodeInfo{
-		internalIPv4:  n.GetCiliumInternalIP(false),
-		internalIPv6:  n.GetCiliumInternalIP(true),
-		ipv4AllocCIDR: v4AllocCIDR,
-		ipv6AllocCIDR: v6AllocCIDR,
+		internalIPv4:          n.GetCiliumInternalIP(false),
+		internalIPv6:          n.GetCiliumInternalIP(true),
+		ipv4AllocCIDR:         v4AllocCIDR,
+		ipv6AllocCIDR:         v6AllocCIDR,
+		ipv4NativeRoutingCIDR: v4NativeRoutingCIDR,
+		ipv6NativeRoutingCIDR: v6NativeRoutingCIDR,
 	}
 }
 

--- a/pkg/datapath/iptables/reconciler.go
+++ b/pkg/datapath/iptables/reconciler.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package iptables
+
+import (
+	"context"
+	"net"
+	"net/netip"
+
+	"github.com/cilium/stream"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type desiredState struct {
+	installRules bool
+
+	devices       sets.Set[string]
+	localNodeInfo localNodeInfo
+	proxies       sets.Set[proxyInfo]
+	noTrackPods   sets.Set[noTrackPodInfo]
+}
+
+type localNodeInfo struct {
+	internalIPv4  net.IP
+	internalIPv6  net.IP
+	ipv4AllocCIDR string
+	ipv6AllocCIDR string
+}
+
+func (lni localNodeInfo) equal(other localNodeInfo) bool {
+	if lni.internalIPv4.Equal(other.internalIPv4) &&
+		lni.internalIPv6.Equal(other.internalIPv6) &&
+		lni.ipv4AllocCIDR == other.ipv4AllocCIDR &&
+		lni.ipv6AllocCIDR == other.ipv6AllocCIDR {
+		return true
+	}
+	return false
+}
+
+func toLocalNodeInfo(n node.LocalNode) localNodeInfo {
+	var v4AllocCIDR, v6AllocCIDR string
+
+	if n.IPv4AllocCIDR != nil {
+		v4AllocCIDR = n.IPv4AllocCIDR.String()
+	}
+	if n.IPv6AllocCIDR != nil {
+		v6AllocCIDR = n.IPv6AllocCIDR.String()
+	}
+
+	return localNodeInfo{
+		internalIPv4:  n.GetCiliumInternalIP(false),
+		internalIPv6:  n.GetCiliumInternalIP(true),
+		ipv4AllocCIDR: v4AllocCIDR,
+		ipv6AllocCIDR: v6AllocCIDR,
+	}
+}
+
+type proxyInfo struct {
+	name        string
+	port        uint16
+	isLocalOnly bool
+}
+
+type noTrackPodInfo struct {
+	ip   netip.Addr
+	port uint16
+}
+
+func reconciliationLoop(
+	ctx context.Context,
+	log logrus.FieldLogger,
+	health cell.HealthReporter,
+	installIptRules bool,
+	params *reconcilerParams,
+	updateRules func(state desiredState, firstInit bool) error,
+) error {
+	// The minimum interval between reconciliation attempts
+	const minReconciliationInterval = 200 * time.Millisecond
+
+	state := desiredState{
+		installRules: installIptRules,
+		proxies:      sets.New[proxyInfo](),
+		noTrackPods:  sets.New[noTrackPodInfo](),
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	localNodeEvents := stream.ToChannel(ctx, params.localNodeStore)
+	state.localNodeInfo = toLocalNodeInfo(<-localNodeEvents)
+
+	devices, devicesWatch := tables.SelectedDevices(params.devices, params.db.ReadTxn())
+	state.devices = sets.New(tables.DeviceNames(devices)...)
+
+	// Use a ticker to limit how often the desired state is reconciled to avoid doing
+	// lots of operations when e.g. ipset updates.
+	ticker := time.NewTicker(minReconciliationInterval)
+	defer ticker.Stop()
+
+	// stateChanged is true when the desired state has changed or when reconciling it
+	// has failed. It's set to false when reconciling succeeds.
+	stateChanged := true
+
+	firstInit := true
+
+	if err := updateRules(state, firstInit); err != nil {
+		health.Degraded("iptables rules update failed", err)
+		// Keep stateChanged=true and firstInit=true to try again on the next tick.
+	} else {
+		health.OK("iptables rules update completed")
+		firstInit = false
+		stateChanged = false
+	}
+
+stop:
+	for {
+		select {
+		case <-ctx.Done():
+			break stop
+		case <-devicesWatch:
+			devices, devicesWatch = tables.SelectedDevices(params.devices, params.db.ReadTxn())
+			newDevices := sets.New(tables.DeviceNames(devices)...)
+			if newDevices.Equal(state.devices) {
+				continue
+			}
+			state.devices = newDevices
+			stateChanged = true
+		case localNode, ok := <-localNodeEvents:
+			if !ok {
+				break stop
+			}
+			localNodeInfo := toLocalNodeInfo(localNode)
+			if localNodeInfo.equal(state.localNodeInfo) {
+				continue
+			}
+			state.localNodeInfo = localNodeInfo
+			stateChanged = true
+		case proxyInfo, ok := <-params.proxies:
+			if !ok {
+				break stop
+			}
+			if state.proxies.Has(proxyInfo) {
+				continue
+			}
+			state.proxies.Insert(proxyInfo)
+			stateChanged = true
+		case noTrackPod, ok := <-params.addNoTrackPod:
+			if !ok {
+				break stop
+			}
+			if state.noTrackPods.Has(noTrackPod) {
+				continue
+			}
+			state.noTrackPods.Insert(noTrackPod)
+			stateChanged = true
+		case noTrackPod, ok := <-params.delNoTrackPod:
+			if !ok {
+				break stop
+			}
+			if !state.noTrackPods.Has(noTrackPod) {
+				continue
+			}
+			state.noTrackPods.Delete(noTrackPod)
+			stateChanged = true
+		case <-ticker.C:
+			if !stateChanged {
+				continue
+			}
+
+			if err := updateRules(state, firstInit); err != nil {
+				log.WithError(err).Warning("iptables rules full reconciliation failed, will retry a full reconciliation")
+				health.Degraded("iptables rules full reconciliation failed", err)
+				// Keep stateChanged=true to try again on the next tick.
+			} else {
+				health.OK("iptables rules full reconciliation completed")
+				firstInit = false
+				stateChanged = false
+			}
+		}
+	}
+
+	cancel()
+
+	// drain channels
+	for range localNodeEvents {
+	}
+	for range params.proxies {
+	}
+	for range params.addNoTrackPod {
+	}
+	for range params.delNoTrackPod {
+	}
+
+	return nil
+}

--- a/pkg/datapath/iptables/reconciler.go
+++ b/pkg/datapath/iptables/reconciler.go
@@ -256,12 +256,15 @@ stop:
 				health.OK("iptables rules full reconciliation completed")
 				firstInit = false
 				stateChanged = false
-				// close all channels waiting for reconciliation
-				for _, ch := range updatedChs {
-					close(ch)
-				}
-				updatedChs = updatedChs[:0]
 			}
+
+			// close all channels waiting for reconciliation
+			// do this even in case of a failed reconciliation, to avoid
+			// blocking consumer goroutines indefinitely.
+			for _, ch := range updatedChs {
+				close(ch)
+			}
+			updatedChs = updatedChs[:0]
 		}
 	}
 

--- a/pkg/datapath/iptables/reconciler_test.go
+++ b/pkg/datapath/iptables/reconciler_test.go
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package iptables
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"net"
+	"net/netip"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	"github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func TestReconciliationLoop(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var (
+		db      *statedb.DB
+		devices statedb.RWTable[*tables.Device]
+		store   *node.LocalNodeStore
+		health  cell.HealthReporter
+		params  *reconcilerParams
+	)
+	h := hive.New(
+		cell.Module(
+			"iptables-reconciler-test",
+			"iptables-reconciler-test",
+
+			statedb.Cell,
+			cell.Provide(
+				tables.NewDeviceTable,
+				statedb.RWTable[*tables.Device].ToTable,
+				func() *node.LocalNodeStore { return node.NewTestLocalNodeStore(node.LocalNode{}) },
+			),
+			cell.Invoke(func(
+				db_ *statedb.DB,
+				devices_ statedb.RWTable[*tables.Device],
+				store_ *node.LocalNodeStore,
+				scope cell.Scope,
+			) {
+				db = db_
+				devices = devices_
+				store = store_
+				db.RegisterTable(devices_)
+				health = cell.GetHealthReporter(scope, "iptables-reconciler-test")
+				params = &reconcilerParams{
+					localNodeStore: store_,
+					db:             db_,
+					devices:        devices_,
+					proxies:        make(chan reconciliationRequest[proxyInfo]),
+					addNoTrackPod:  make(chan reconciliationRequest[noTrackPodInfo]),
+					delNoTrackPod:  make(chan reconciliationRequest[noTrackPodInfo]),
+				}
+			}),
+		),
+	)
+
+	var (
+		state desiredState
+		mu    lock.Mutex
+	)
+
+	updateFunc := func(newState desiredState, firstInit bool) error {
+		mu.Lock()
+		defer mu.Unlock()
+
+		// copy newState to avoid a race with the reconciler mutating it
+		// and the test asserting the expected values with Eventually
+		state = newState.deepCopy()
+
+		return nil
+	}
+	updateProxyFunc := func(proxyPort uint16, localOnly bool, name string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		state.proxies[name] = proxyInfo{
+			name:        name,
+			port:        proxyPort,
+			isLocalOnly: localOnly,
+		}
+		return nil
+	}
+	installNoTrackFunc := func(addr netip.Addr, port uint16) error {
+		mu.Lock()
+		defer mu.Unlock()
+		state.noTrackPods.Insert(noTrackPodInfo{
+			ip:   addr,
+			port: port,
+		})
+		return nil
+	}
+	removeNoTrackFunc := func(addr netip.Addr, port uint16) error {
+		mu.Lock()
+		defer mu.Unlock()
+		state.noTrackPods.Delete(noTrackPodInfo{
+			ip:   addr,
+			port: port,
+		})
+		return nil
+	}
+
+	testCases := []struct {
+		name     string
+		action   func()
+		expected desiredState
+	}{
+		{
+			name: "initial state",
+			action: func() {
+				store.Update(func(n *node.LocalNode) {
+					n.IPAddresses = []types.Address{
+						{
+							IP:   netip.MustParseAddr("1.1.1.1").AsSlice(),
+							Type: addressing.NodeCiliumInternalIP,
+						},
+					}
+					n.IPv4AllocCIDR = cidr.MustParseCIDR("5.5.5.0/24")
+					n.IPv6AllocCIDR = cidr.MustParseCIDR("2001:aaaa::/96")
+				})
+
+				txn := db.WriteTxn(devices)
+				if _, _, err := devices.Insert(txn, &tables.Device{
+					Index:    1,
+					Name:     "test-1",
+					Selected: true,
+				}); err != nil {
+					t.Fatal(err)
+				}
+				txn.Commit()
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("1.1.1.1"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("5.5.5.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("2001:aaaa::/96").String(),
+				},
+			},
+		},
+		{
+			name: "devices update",
+			action: func() {
+				txn := db.WriteTxn(devices)
+				devices.Insert(txn, &tables.Device{
+					Index:    2,
+					Name:     "test-2",
+					Selected: true,
+				})
+				txn.Commit()
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1", "test-2"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("1.1.1.1"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("5.5.5.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("2001:aaaa::/96").String(),
+				},
+			},
+		},
+		{
+			name: "local node update",
+			action: func() {
+				store.Update(func(n *node.LocalNode) {
+					n.IPAddresses = []types.Address{
+						{
+							IP:   netip.MustParseAddr("2.2.2.2").AsSlice(),
+							Type: addressing.NodeCiliumInternalIP,
+						},
+					}
+					n.IPv4AllocCIDR = cidr.MustParseCIDR("6.6.6.0/24")
+					n.IPv6AllocCIDR = cidr.MustParseCIDR("3002:bbbb::/96")
+				})
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1", "test-2"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("2.2.2.2"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("6.6.6.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("3002:bbbb::/96").String(),
+				},
+			},
+		},
+		{
+			name: "add first proxy",
+			action: func() {
+				params.proxies <- reconciliationRequest[proxyInfo]{
+					info: proxyInfo{
+						name:        "proxy-test-1",
+						port:        9090,
+						isLocalOnly: true,
+					},
+					updated: make(chan struct{}),
+				}
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1", "test-2"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("2.2.2.2"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("6.6.6.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("3002:bbbb::/96").String(),
+				},
+				proxies: map[string]proxyInfo{
+					"proxy-test-1": {
+						name:        "proxy-test-1",
+						port:        9090,
+						isLocalOnly: true,
+					},
+				},
+			},
+		},
+		{
+			name: "add second proxy",
+			action: func() {
+				params.proxies <- reconciliationRequest[proxyInfo]{
+					info: proxyInfo{
+						name:        "proxy-test-2",
+						port:        9091,
+						isLocalOnly: false,
+					},
+					updated: make(chan struct{}),
+				}
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1", "test-2"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("2.2.2.2"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("6.6.6.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("3002:bbbb::/96").String(),
+				},
+				proxies: map[string]proxyInfo{
+					"proxy-test-1": {
+						name:        "proxy-test-1",
+						port:        9090,
+						isLocalOnly: true,
+					},
+					"proxy-test-2": {
+						name:        "proxy-test-2",
+						port:        9091,
+						isLocalOnly: false,
+					},
+				},
+			},
+		},
+		{
+			name: "add no track pods",
+			action: func() {
+				params.addNoTrackPod <- reconciliationRequest[noTrackPodInfo]{
+					info: noTrackPodInfo{
+						ip:   netip.MustParseAddr("1.2.3.4"),
+						port: 10001,
+					},
+					updated: make(chan struct{}),
+				}
+				params.addNoTrackPod <- reconciliationRequest[noTrackPodInfo]{
+					info: noTrackPodInfo{
+						ip:   netip.MustParseAddr("11.22.33.44"),
+						port: 10002,
+					},
+					updated: make(chan struct{}),
+				}
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1", "test-2"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("2.2.2.2"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("6.6.6.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("3002:bbbb::/96").String(),
+				},
+				proxies: map[string]proxyInfo{
+					"proxy-test-1": {
+						name:        "proxy-test-1",
+						port:        9090,
+						isLocalOnly: true,
+					},
+					"proxy-test-2": {
+						name:        "proxy-test-2",
+						port:        9091,
+						isLocalOnly: false,
+					},
+				},
+				noTrackPods: sets.New(
+					noTrackPodInfo{netip.MustParseAddr("1.2.3.4"), 10001},
+					noTrackPodInfo{netip.MustParseAddr("11.22.33.44"), 10002},
+				),
+			},
+		},
+		{
+			name: "remove no track pod",
+			action: func() {
+				params.delNoTrackPod <- reconciliationRequest[noTrackPodInfo]{
+					info: noTrackPodInfo{
+						ip:   netip.MustParseAddr("1.2.3.4"),
+						port: 10001,
+					},
+					updated: make(chan struct{}),
+				}
+			},
+			expected: desiredState{
+				installRules: true,
+				devices:      sets.New("test-1", "test-2"),
+				localNodeInfo: localNodeInfo{
+					internalIPv4:  net.ParseIP("2.2.2.2"),
+					ipv4AllocCIDR: cidr.MustParseCIDR("6.6.6.0/24").String(),
+					ipv6AllocCIDR: cidr.MustParseCIDR("3002:bbbb::/96").String(),
+				},
+				proxies: map[string]proxyInfo{
+					"proxy-test-1": {
+						name:        "proxy-test-1",
+						port:        9090,
+						isLocalOnly: true,
+					},
+					"proxy-test-2": {
+						name:        "proxy-test-2",
+						port:        9091,
+						isLocalOnly: false,
+					},
+				},
+				noTrackPods: sets.New(
+					noTrackPodInfo{netip.MustParseAddr("11.22.33.44"), 10002},
+				),
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	assert.NoError(t, h.Start(ctx))
+
+	// apply initial state
+	testCases[0].action()
+
+	// start the reconciliation loop
+	errs := make(chan error)
+	go func() {
+		defer close(errs)
+		errs <- reconciliationLoop(ctx, log, health, true, params, updateFunc, updateProxyFunc, installNoTrackFunc, removeNoTrackFunc)
+	}()
+
+	// wait for reconciler to react to the initial state
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		if err := assertIptablesState(state, testCases[0].expected); err != nil {
+			t.Logf("assertIptablesState: %s", err)
+			return false
+		}
+		return true
+	}, 10*time.Second, 10*time.Millisecond, "initial state not reconciled. %v", testCases[0].expected)
+
+	// test all the remaining steps
+	for _, tc := range testCases[1:] {
+		t.Run(tc.name, func(t *testing.T) {
+			// apply the action to update the state
+			tc.action()
+
+			// wait for reconciler to react to the update
+			assert.Eventuallyf(t, func() bool {
+				mu.Lock()
+				defer mu.Unlock()
+				if err := assertIptablesState(state, tc.expected); err != nil {
+					t.Logf("assertIptablesState: %s", err)
+					return false
+				}
+				return true
+			}, 10*time.Second, 10*time.Millisecond, "expected state not reached. %v", tc.expected)
+		})
+	}
+
+	assert.NoError(t, h.Stop(ctx))
+
+	close(params.proxies)
+	close(params.addNoTrackPod)
+	close(params.delNoTrackPod)
+	cancel()
+	assert.NoError(t, <-errs)
+}
+
+func assertIptablesState(current, expected desiredState) error {
+	if current.installRules != expected.installRules {
+		return fmt.Errorf("expected installRules to be %t, found %t",
+			expected.installRules, current.installRules)
+	}
+	if !current.devices.Equal(expected.devices) {
+		return fmt.Errorf("expected devices names to be %v, found %v",
+			expected.devices.UnsortedList(), current.devices.UnsortedList())
+	}
+	if !current.localNodeInfo.equal(expected.localNodeInfo) {
+		return fmt.Errorf("expected local node info to be %v, found %v",
+			expected.localNodeInfo, current.localNodeInfo)
+	}
+	if len(current.proxies) != 0 && len(expected.proxies) != 0 &&
+		!reflect.DeepEqual(current.proxies, expected.proxies) {
+		return fmt.Errorf("expected proxies info to be %v, found %v",
+			expected.proxies, current.proxies)
+	}
+	if !current.noTrackPods.Equal(expected.noTrackPods) {
+		return fmt.Errorf("expected no tracking pods info to be %v, found %v",
+			expected.noTrackPods.UnsortedList(), current.noTrackPods.UnsortedList())
+	}
+	return nil
+}
+
+func (s desiredState) deepCopy() desiredState {
+	ipv4 := make(net.IP, len(s.localNodeInfo.internalIPv4))
+	copy(ipv4, s.localNodeInfo.internalIPv4)
+	ipv6 := make(net.IP, len(s.localNodeInfo.internalIPv6))
+	copy(ipv6, s.localNodeInfo.internalIPv6)
+	return desiredState{
+		installRules: s.installRules,
+		devices:      s.devices.Clone(),
+		localNodeInfo: localNodeInfo{
+			internalIPv4:          ipv4,
+			internalIPv6:          ipv6,
+			ipv4AllocCIDR:         s.localNodeInfo.ipv4AllocCIDR,
+			ipv6AllocCIDR:         s.localNodeInfo.ipv6AllocCIDR,
+			ipv4NativeRoutingCIDR: s.localNodeInfo.ipv4NativeRoutingCIDR,
+			ipv6NativeRoutingCIDR: s.localNodeInfo.ipv6NativeRoutingCIDR,
+		},
+		proxies:     maps.Clone(s.proxies),
+		noTrackPods: s.noTrackPods.Clone(),
+	}
+}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -480,17 +480,9 @@ func (l *loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		return err
 	}
 
-	if err := iptMgr.InstallRules(ctx, defaults.HostDevice, firstInitialization, option.Config.InstallIptRules); err != nil {
-		return err
-	}
-
 	// Reinstall proxy rules for any running proxies if needed
 	if option.Config.EnableL7Proxy {
 		if err := p.ReinstallRoutingRules(); err != nil {
-			return err
-		}
-
-		if err := p.ReinstallIPTablesRules(ctx); err != nil {
 			return err
 		}
 	}

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -57,7 +57,7 @@ type Proxy interface {
 type IptablesManager interface {
 	// InstallProxyRules creates the necessary datapath config (e.g., iptables
 	// rules for redirecting host proxy traffic on a specific ProxyPort)
-	InstallProxyRules(proxyPort uint16, isLocalOnly bool, name string)
+	InstallProxyRules(proxyPort uint16, localOnly bool, name string)
 
 	// SupportsOriginalSourceAddr tells if the datapath supports
 	// use of original source addresses in proxy upstream

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"net/netip"
 
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
@@ -50,20 +51,18 @@ type PreFilter interface {
 // a proxy.
 type Proxy interface {
 	ReinstallRoutingRules() error
-	ReinstallIPTablesRules(ctx context.Context) error
 }
 
 // IptablesManager manages iptables rules.
 type IptablesManager interface {
 	// InstallProxyRules creates the necessary datapath config (e.g., iptables
 	// rules for redirecting host proxy traffic on a specific ProxyPort)
-	InstallProxyRules(ctx context.Context, proxyPort uint16, localOnly bool, name string) error
+	InstallProxyRules(proxyPort uint16, isLocalOnly bool, name string)
 
 	// SupportsOriginalSourceAddr tells if the datapath supports
 	// use of original source addresses in proxy upstream
 	// connections.
 	SupportsOriginalSourceAddr() bool
-	InstallRules(ctx context.Context, ifName string, quiet, install bool) error
 
 	// GetProxyPort fetches the existing proxy port configured for the
 	// specified listener. Used early in bootstrap to reopen proxy ports.
@@ -78,8 +77,8 @@ type IptablesManager interface {
 	// will be executed to install NOTRACK rules.  The rules installed by
 	// this function is very specific, for now, the only user is
 	// node-local-dns pods.
-	InstallNoTrackRules(IP string, port uint16, ipv6 bool) error
+	InstallNoTrackRules(ip netip.Addr, port uint16)
 
 	// See comments for InstallNoTrackRules.
-	RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error
+	RemoveNoTrackRules(ip netip.Addr, port uint16)
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2496,14 +2496,10 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 		}).Debug("Deleting endpoint NOTRACK rules")
 
 		if e.IPv4.IsValid() {
-			if err := e.owner.Datapath().RemoveNoTrackRules(e.IPv4.String(), e.noTrackPort, false); err != nil {
-				errs = append(errs, fmt.Errorf("unable to delete endpoint NOTRACK ipv4 rules: %w", err))
-			}
+			e.owner.Datapath().RemoveNoTrackRules(e.IPv4, e.noTrackPort)
 		}
 		if e.IPv6.IsValid() {
-			if err := e.owner.Datapath().RemoveNoTrackRules(e.IPv6.String(), e.noTrackPort, true); err != nil {
-				errs = append(errs, fmt.Errorf("unable to delete endpoint NOTRACK ipv6 rules: %w", err))
-			}
+			e.owner.Datapath().RemoveNoTrackRules(e.IPv6, e.noTrackPort)
 		}
 	}
 

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -158,22 +158,18 @@ func (ev *EndpointNoTrackEvent) Handle(res chan interface{}) {
 		log.Debug("Updating NOTRACK rules")
 		if e.IPv4.IsValid() {
 			if port > 0 {
-				err = e.owner.Datapath().InstallNoTrackRules(e.IPv4.String(), port, false)
-				log.WithError(err).Warn("Error installing iptable NOTRACK rules")
+				e.owner.Datapath().InstallNoTrackRules(e.IPv4, port)
 			}
 			if e.noTrackPort > 0 {
-				err = e.owner.Datapath().RemoveNoTrackRules(e.IPv4.String(), e.noTrackPort, false)
-				log.WithError(err).Warn("Error removing iptable NOTRACK rules")
+				e.owner.Datapath().RemoveNoTrackRules(e.IPv4, e.noTrackPort)
 			}
 		}
 		if e.IPv6.IsValid() {
 			if port > 0 {
-				e.owner.Datapath().InstallNoTrackRules(e.IPv6.String(), port, true)
-				log.WithError(err).Warn("Error installing iptable NOTRACK rules")
+				e.owner.Datapath().InstallNoTrackRules(e.IPv6, port)
 			}
 			if e.noTrackPort > 0 {
-				err = e.owner.Datapath().RemoveNoTrackRules(e.IPv6.String(), e.noTrackPort, true)
-				log.WithError(err).Warn("Error removing iptable NOTRACK rules")
+				e.owner.Datapath().RemoveNoTrackRules(e.IPv6, e.noTrackPort)
 			}
 		}
 		e.noTrackPort = port

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -15,6 +15,7 @@ import (
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/mtu"
+	"github.com/cilium/cilium/pkg/node"
 )
 
 type ownerMock struct{}
@@ -42,7 +43,8 @@ var mtuMock = mtu.NewConfiguration(0, false, false, false, false, 1500, nil)
 
 func (s *IPAMSuite) TestAllocatedIPDump(c *C) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
 	allocv4, allocv6, status := ipam.Dump()
 	c.Assert(status, Not(Equals), "")
@@ -61,7 +63,8 @@ func (s *IPAMSuite) TestExpirationTimer(c *C) {
 	timeout := 50 * time.Millisecond
 
 	fakeAddressing := fakeTypes.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
 	err := ipam.AllocateIP(ip, "foo", PoolDefault())
 	c.Assert(err, IsNil)
@@ -126,7 +129,8 @@ func (s *IPAMSuite) TestAllocateNextWithExpiration(c *C) {
 	timeout := 50 * time.Millisecond
 
 	fakeAddressing := fakeTypes.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
 	// Allocate IPs and test expiration timer. 'pool' is empty in order to test
 	// that the allocated pool is passed to StartExpirationTimer

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -18,6 +18,7 @@ import (
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/trigger"
 )
@@ -97,7 +98,8 @@ func (s *IPAMSuite) TestMarkForReleaseNoAllocate(c *C) {
 		sharedNodeStore = newFakeNodeStore(conf, c)
 		sharedNodeStore.ownNode = cn
 	})
-	ipam := NewIPAM(fakeAddressing, conf, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
+	ipam := NewIPAM(fakeAddressing, conf, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 	sharedNodeStore.updateLocalNodeResource(cn)
 
 	// Allocate the first 3 IPs

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -68,7 +69,7 @@ type Metadata interface {
 }
 
 // NewIPAM returns a new IP address manager
-func NewIPAM(nodeAddressing types.NodeAddressing, c *option.DaemonConfig, owner Owner, k8sEventReg K8sEventRegister, node agentK8s.LocalCiliumNodeResource, mtuConfig MtuConfiguration, clientset client.Clientset) *IPAM {
+func NewIPAM(nodeAddressing types.NodeAddressing, c *option.DaemonConfig, owner Owner, localNodeStore *node.LocalNodeStore, k8sEventReg K8sEventRegister, node agentK8s.LocalCiliumNodeResource, mtuConfig MtuConfiguration, clientset client.Clientset) *IPAM {
 	ipam := &IPAM{
 		nodeAddressing:   nodeAddressing,
 		config:           c,
@@ -104,11 +105,11 @@ func NewIPAM(nodeAddressing types.NodeAddressing, c *option.DaemonConfig, owner 
 	case ipamOption.IPAMCRD, ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
 		log.Info("Initializing CRD-based IPAM")
 		if c.IPv6Enabled() {
-			ipam.IPv6Allocator = newCRDAllocator(IPv6, c, owner, clientset, k8sEventReg, mtuConfig)
+			ipam.IPv6Allocator = newCRDAllocator(IPv6, c, owner, localNodeStore, clientset, k8sEventReg, mtuConfig)
 		}
 
 		if c.IPv4Enabled() {
-			ipam.IPv4Allocator = newCRDAllocator(IPv4, c, owner, clientset, k8sEventReg, mtuConfig)
+			ipam.IPv4Allocator = newCRDAllocator(IPv4, c, owner, localNodeStore, clientset, k8sEventReg, mtuConfig)
 		}
 	case ipamOption.IPAMDelegatedPlugin:
 		log.Info("Initializing no-op IPAM since we're using a CNI delegated plugin")

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -16,6 +16,7 @@ import (
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -129,7 +130,8 @@ func (f fakePoolAllocator) RestoreFinished() {}
 
 func (s *IPAMSuite) TestLock(c *C) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
 	// Since the IPs we have allocated to the endpoints might or might not
 	// be in the allocrange specified in cilium, we need to specify them
@@ -151,7 +153,8 @@ func (s *IPAMSuite) TestLock(c *C) {
 
 func (s *IPAMSuite) TestExcludeIP(c *C) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
 	ipv4 = ipv4.Next()
@@ -182,7 +185,8 @@ func (s *IPAMSuite) TestDeriveFamily(c *C) {
 
 func (s *IPAMSuite) TestIPAMMetadata(c *C) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 	ipam.IPv4Allocator = newFakePoolAllocator(map[string]string{
 		"default": "10.10.0.0/16",
 		"test":    "192.168.178.0/24",
@@ -259,7 +263,8 @@ func (s *IPAMSuite) TestLegacyAllocatorIPAMMetadata(c *C) {
 	// AllocationResult is always set to PoolDefault(), regardless of the requested
 	// pool
 	fakeAddressing := fakeTypes.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 	ipam.WithMetadata(fakeMetadataFunc(func(owner string, family Family) (pool string, err error) {
 		return "some-pool", nil
 	}))

--- a/pkg/node/local_node_store.go
+++ b/pkg/node/local_node_store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/stream"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node/types"
@@ -26,6 +27,10 @@ type LocalNode struct {
 	UID k8stypes.UID
 	// ID of the node assigned by the cloud provider.
 	ProviderID string
+	// v4 CIDR in which pod IPs are routable
+	IPv4NativeRoutingCIDR *cidr.CIDR
+	// v6 CIDR in which pod IPs are routable
+	IPv6NativeRoutingCIDR *cidr.CIDR
 }
 
 // LocalNodeSynchronizer specifies how to build, and keep synchronized the local

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -46,7 +46,7 @@ const (
 )
 
 type DatapathUpdater interface {
-	InstallProxyRules(ctx context.Context, proxyPort uint16, localOnly bool, name string) error
+	InstallProxyRules(proxyPort uint16, localOnly bool, name string)
 	SupportsOriginalSourceAddr() bool
 }
 
@@ -235,9 +235,7 @@ func (p *Proxy) ackProxyPort(ctx context.Context, name string, pp *ProxyPort) er
 		// Add rules for the new port
 		// This should always succeed if we have managed to start-up properly
 		scopedLog.Infof("Adding new proxy port rules for %s:%d", name, pp.proxyPort)
-		if err := p.datapathUpdater.InstallProxyRules(ctx, pp.proxyPort, pp.localOnly, name); err != nil {
-			return fmt.Errorf("cannot install proxy rules for %s: %w", name, err)
-		}
+		p.datapathUpdater.InstallProxyRules(pp.proxyPort, pp.localOnly, name)
 		pp.rulesPort = pp.proxyPort
 	}
 	pp.nRedirects++
@@ -471,23 +469,6 @@ func getCiliumNetIPv6() (net.IP, error) {
 	}
 
 	return nil, fmt.Errorf("failed to find valid IPv6 address for cilium_net")
-}
-
-// ReinstallIPTablesRules is called by daemon reconfiguration to reinstall
-// proxy ports rules that were removed during the removal of all Cilium rules.
-func (p *Proxy) ReinstallIPTablesRules(ctx context.Context) error {
-	p.mutex.RLock()
-	defer p.mutex.RUnlock()
-	for name, pp := range p.proxyPorts {
-		if pp.rulesPort > 0 {
-			// This should always succeed if we have managed to start-up properly
-			if err := p.datapathUpdater.InstallProxyRules(ctx, pp.rulesPort, pp.localOnly, name); err != nil {
-				return fmt.Errorf("cannot install proxy rules for %s: %w", name, err)
-			}
-		}
-	}
-
-	return nil
 }
 
 // CreateOrUpdateRedirect creates or updates a L4 redirect with corresponding

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -26,8 +26,7 @@ var _ = Suite(&ProxySuite{})
 
 type MockDatapathUpdater struct{}
 
-func (m *MockDatapathUpdater) InstallProxyRules(ctx context.Context, proxyPort uint16, localOnly bool, name string) error {
-	return nil
+func (m *MockDatapathUpdater) InstallProxyRules(proxyPort uint16, localOnly bool, name string) {
 }
 
 func (m *MockDatapathUpdater) SupportsOriginalSourceAddr() bool {


### PR DESCRIPTION
As an attempt to make the agent sensitive to runtime changes, the iptables manager reinstalls all the iptables rules, including the ones related to the proxies, when the datapath is explicitly reinitialized.

This approach does not consider the updates to the external facing network devices, that are read only once at the module startup through the daemon configuration options.

This PR adds a reconciler to update the rules following any updates to the external facing network devices or to the local node.  The reconciler listens for those updates and independently rewrites all the rules accordingly, keeping into account proxy rules and no track pod rules too.

This reconciler is not based on the stateDB generic one but is designed from scratch for this specific case. This is needed since the order in which the iptables rules are installed in the chains matters, and the stateDB generic reconciler does not care about ordering.

To migrate to this new asynchronous reconciliation approach, the manager is reworked so that the methods exposed do not immediately reconcile the rules, but collect the desired state and ask the underlying reconciler to rewrite the rules accordingly.

With this new iptables manager implementation the rules reinstallation request from the datapath reinitilization is not needed anymore, hence it is removed.

For more details, please refer to the individual commit messages.

**Note to the reviewers**: please review per commit.

Related: https://github.com/cilium/cilium/pull/30024

Depends on ~https://github.com/cilium/cilium/pull/31068~, ~https://github.com/cilium/cilium/pull/31099~ and ~https://github.com/cilium/cilium/pull/31368~