### PR TITLE
chore: update json-mock image source in examples

### DIFF
--- a/examples/kubernetes-dns/dns-sw-app.yaml
+++ b/examples/kubernetes-dns/dns-sw-app.yaml
@@ -9,4 +9,4 @@ metadata:
 spec:
   containers:
   - name: mediabot
-    image: docker.io/cilium/json-mock
+    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603

--- a/examples/minikube/http-sw-app.yaml
+++ b/examples/minikube/http-sw-app.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: deathstar
-        image: docker.io/cilium/starwars
+        image: quay.io/cilium/starwars:v2.1@sha256:833d915ec68fca3ce83668fc5dae97c455b2134d8f23ef96586f55b894cfb1e8
 ---
 apiVersion: v1
 kind: Pod
@@ -47,7 +47,7 @@ metadata:
 spec:
   containers:
   - name: spaceship
-    image: docker.io/cilium/json-mock
+    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
 ---
 apiVersion: v1
 kind: Pod
@@ -60,4 +60,4 @@ metadata:
 spec:
   containers:
   - name: spaceship
-    image: docker.io/cilium/json-mock
+    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603


### PR DESCRIPTION
Replaced `docker.io/cilium/json-mock` with `quay.io/cilium/json-mock`
pinned with current latest (1.3.8) 
The docker source is deprecated and doesn't provide arm64 builds

I had issues running `examples/kubernetes-dns/dns-sw-app` and `examples/minikube/http-sw-app` when following the docs in an ARM environment:
`exec /bin/bash: exec format error`

This was addressed in #24173, but it seems like that fix missed these 2 examples since they didn't have an explicit version tag provided?

-- --

Fixes: #24170