### PR TITLE
bgpv2/ci: added watch reactor for bgp cluster config

### DIFF
--- a/operator/pkg/bgpv2/fixture_test.go
+++ b/operator/pkg/bgpv2/fixture_test.go
@@ -4,8 +4,10 @@
 package bgpv2
 
 import (
+	"context"
 	"sync"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/watch"
 	k8sTesting "k8s.io/client-go/testing"
 
@@ -28,7 +30,6 @@ var (
 )
 
 type fixture struct {
-	watching      chan struct{}
 	hive          *hive.Hive
 	fakeClientSet *k8s_client.FakeClientset
 	bgpcClient    cilium_client_v2alpha1.CiliumBGPClusterConfigInterface
@@ -39,16 +40,16 @@ type fixture struct {
 	bgpnClient cilium_client_v2alpha1.CiliumBGPNodeConfigInterface
 }
 
-func newFixture() *fixture {
-	f := &fixture{
-		watching: make(chan struct{}),
-	}
+func newFixture(ctx context.Context, req *require.Assertions) (*fixture, func()) {
+	var (
+		onceCN, onceBGPCC   sync.Once
+		cnWatch, bgpccWatch = make(chan struct{}), make(chan struct{})
+	)
 
+	f := &fixture{}
 	f.fakeClientSet, _ = k8s_client.NewFakeClientset()
 
-	// make sure cilium node watcher is initialized before the test starts
-	var once sync.Once
-	f.fakeClientSet.CiliumFakeClientset.PrependWatchReactor("ciliumnodes", func(action k8sTesting.Action) (handled bool, ret watch.Interface, err error) {
+	watchReactorFn := func(action k8sTesting.Action) (handled bool, ret watch.Interface, err error) {
 		w := action.(k8sTesting.WatchAction)
 		gvr := w.GetResource()
 		ns := w.GetNamespace()
@@ -56,14 +57,40 @@ func newFixture() *fixture {
 		if err != nil {
 			return false, nil, err
 		}
-		once.Do(func() { close(f.watching) })
+
+		switch w.GetResource().Resource {
+		case "ciliumnodes":
+			onceCN.Do(func() { close(cnWatch) })
+		case "ciliumbgpclusterconfigs":
+			onceBGPCC.Do(func() { close(bgpccWatch) })
+		default:
+			return false, watch, nil
+		}
+
 		return true, watch, nil
-	})
+	}
+
+	// make sure watchers are initialized before the test starts
+	watchersReadyFn := func() {
+		select {
+		case <-cnWatch:
+		case <-ctx.Done():
+			req.Fail("cilium node watcher is not initialized")
+		}
+
+		select {
+		case <-bgpccWatch:
+		case <-ctx.Done():
+			req.Fail("cilium bgp cluster config watcher is not initialized")
+		}
+	}
 
 	f.bgpcClient = f.fakeClientSet.CiliumFakeClientset.CiliumV2alpha1().CiliumBGPClusterConfigs()
 	f.nodeClient = f.fakeClientSet.CiliumFakeClientset.CiliumV2().CiliumNodes()
 	f.bgpnClient = f.fakeClientSet.CiliumFakeClientset.CiliumV2alpha1().CiliumBGPNodeConfigs()
 	f.bgpncoClient = f.fakeClientSet.CiliumFakeClientset.CiliumV2alpha1().CiliumBGPNodeConfigOverrides()
+
+	f.fakeClientSet.CiliumFakeClientset.PrependWatchReactor("*", watchReactorFn)
 
 	f.hive = hive.New(
 		cell.Provide(func(lc cell.Lifecycle, c k8s_client.Clientset) resource.Resource[*cilium_api_v2alpha1.CiliumBGPClusterConfig] {
@@ -115,5 +142,5 @@ func newFixture() *fixture {
 	// enable BGPv2
 	hive.AddConfigOverride(f.hive, func(cfg *Config) { cfg.BGPv2Enabled = true })
 
-	return f
+	return f, watchersReadyFn
 }


### PR DESCRIPTION
Wait for BGPClusterConfig and CiliumNodes watcher to initialize before starting the tests.

Fixes: #31054, #31363