### PR TITLE
ci: Bump lvh-kind ssh-startup-wait-retries

### DIFF
--- a/.github/actions/lvh-kind/action.yaml
+++ b/.github/actions/lvh-kind/action.yaml
@@ -28,6 +28,7 @@ runs:
         mem: 12G
         install-dependencies: 'true'
         port-forward: '6443:6443'
+        ssh-startup-wait-retries: 600
         cmd: |
           git config --global --add safe.directory /host
 


### PR DESCRIPTION
Recently, we frequently see the CI failure with lvh-kind startup failure with exit code 41. This indicates the timeout of the task waiting for the SSH startup. Bump the timeout (retry) to 600 (10min) as a workaround.

Fixes: #31336

```release-note
ci: Bump lvh-kind ssh-startup-wait-retries
```
