### PR TITLE
ipsec: minor cleanups

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -772,9 +772,6 @@ enum metric_dir {
 #define DSR_IPV6_OPT_LEN	(sizeof(struct dsr_opt_v6) - 4)
 #define DSR_IPV6_EXT_LEN	((sizeof(struct dsr_opt_v6) - 8) / 8)
 
-/* We cap key index at 4 bits because mark value is used to map ctx to key */
-#define MAX_KEY_INDEX 15
-
 /* encrypt_config is the current encryption context on the node */
 struct encrypt_config {
 	__u8 encrypt_key;

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -17,6 +17,7 @@
 /* We cap key index at 4 bits because mark value is used to map ctx to key */
 #define MAX_KEY_INDEX 15
 
+#ifdef ENABLE_IPSEC
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__type(key, __u32);
@@ -24,6 +25,7 @@ struct {
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, 1);
 } ENCRYPT_MAP __section_maps_btf;
+#endif
 
 static __always_inline __u8 get_min_encrypt_key(__u8 peer_key __maybe_unused)
 {

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -14,6 +14,17 @@
 #include "lib/eps.h"
 #include "lib/vxlan.h"
 
+/* We cap key index at 4 bits because mark value is used to map ctx to key */
+#define MAX_KEY_INDEX 15
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__type(key, __u32);
+	__type(value, struct encrypt_config);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, 1);
+} ENCRYPT_MAP __section_maps_btf;
+
 static __always_inline __u8 get_min_encrypt_key(__u8 peer_key __maybe_unused)
 {
 #ifdef ENABLE_IPSEC

--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -202,14 +202,6 @@ struct {
 } IPCACHE_MAP __section_maps_btf;
 
 struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__type(key, __u32);
-	__type(value, struct encrypt_config);
-	__uint(pinning, LIBBPF_PIN_BY_NAME);
-	__uint(max_entries, 1);
-} ENCRYPT_MAP __section_maps_btf;
-
-struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, struct node_key);
 	__type(value, __u16);

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -226,7 +226,11 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	cDefinesMap["WORLD_CIDRS4_MAP_SIZE"] = fmt.Sprintf("%d", worldcidrsmap.MapMaxEntries)
 	cDefinesMap["POLICY_PROG_MAP_SIZE"] = fmt.Sprintf("%d", policymap.PolicyCallMaxEntries)
 	cDefinesMap["L2_RESPONSER_MAP4_SIZE"] = fmt.Sprintf("%d", l2respondermap.DefaultMaxEntries)
-	cDefinesMap["ENCRYPT_MAP"] = encrypt.MapName
+
+	if option.Config.EnableIPSec {
+		cDefinesMap["ENCRYPT_MAP"] = encrypt.MapName
+	}
+
 	cDefinesMap["L2_RESPONDER_MAP4"] = l2respondermap.MapName
 	cDefinesMap["CT_CONNECTION_LIFETIME_TCP"] = fmt.Sprintf("%d", int64(option.Config.CTMapEntriesTimeoutTCP.Seconds()))
 	cDefinesMap["CT_CONNECTION_LIFETIME_NONTCP"] = fmt.Sprintf("%d", int64(option.Config.CTMapEntriesTimeoutAny.Seconds()))


### PR DESCRIPTION
Tiny bit of IPsec cleanup, to clarify the usage of the `ENCRYPT_MAP` and improve the CODEOWNERS scope.
