### PR TITLE
Fix propagation of pod label change to endpoint labels in presence of filtered labels

### DIFF
--- a/pkg/k8s/labels_test.go
+++ b/pkg/k8s/labels_test.go
@@ -4,7 +4,6 @@
 package k8s
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -73,68 +72,4 @@ func TestGetPodMetadata(t *testing.T) {
 			require.Equal(t, expectedLabels, labels)
 		})
 	})
-}
-
-func Test_filterPodLabels(t *testing.T) {
-	expectedLabels := map[string]string{
-		"app":                         "test",
-		"io.kubernetes.pod.namespace": "default",
-	}
-	type args struct {
-		labels map[string]string
-	}
-	tests := []struct {
-		name string
-		args args
-		want map[string]string
-	}{
-		{
-			name: "normal scenario",
-			args: args{
-				labels: map[string]string{
-					"app":                         "test",
-					"io.kubernetes.pod.namespace": "default",
-				},
-			},
-			want: expectedLabels,
-		},
-		{
-			name: "having cilium owned namespace labels",
-			args: args{
-				labels: map[string]string{
-					"app":                         "test",
-					"io.kubernetes.pod.namespace": "default",
-					"io.cilium.k8s.namespace.labels.foo.bar/baz":                 "malicious-pod-level-override",
-					"io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name": "kube-system",
-				},
-			},
-			want: expectedLabels,
-		},
-		{
-			name: "having cilium owned policy labels",
-			args: args{
-				labels: map[string]string{
-					"app":                                 "test",
-					"io.kubernetes.pod.namespace":         "default",
-					"io.cilium.k8s.policy.name":           "admin",
-					"io.cilium.k8s.policy.cluster":        "admin-cluster",
-					"io.cilium.k8s.policy.derived-from":   "admin",
-					"io.cilium.k8s.policy.namespace":      "kube-system",
-					"io.cilium.k8s.policy.serviceaccount": "admin-serviceaccount",
-					"io.cilium.k8s.policy.uuid":           "6eadee3e-0121-11ed-b58d-fc3497a92ef6",
-				},
-			},
-			want: map[string]string{
-				"app":                         "test",
-				"io.kubernetes.pod.namespace": "default",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := filterPodLabels(tt.args.labels); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("filterPodLabels() = %v, want %v", got, tt.want)
-			}
-		})
-	}
 }

--- a/pkg/k8s/utils/utils.go
+++ b/pkg/k8s/utils/utils.go
@@ -246,9 +246,9 @@ func SanitizePodLabels(podLabels map[string]string, namespace nameLabelsGetter, 
 	return sanitizedLabels
 }
 
-// StripPodSpecialLabels strips labels that are not supposed to be coming from a k8s pod object
+// StripPodSpecialLabels strips labels that are not supposed to be coming from a k8s pod object update.
 func StripPodSpecialLabels(labels map[string]string) map[string]string {
-	sanitizedLabels := make(map[string]string)
+	sanitizedLabels := filterPodLabels(labels)
 	forbiddenKeys := map[string]struct{}{
 		k8sconst.PodNamespaceMetaLabels:    {},
 		k8sconst.PolicyLabelServiceAccount: {},

--- a/pkg/k8s/utils/utils_test.go
+++ b/pkg/k8s/utils/utils_test.go
@@ -400,3 +400,58 @@ func TestSanitizePodLabels(t *testing.T) {
 		t.Errorf("Expected service account label to be deleted, got %s instead", sa)
 	}
 }
+
+func Test_filterPodLabels(t *testing.T) {
+	expectedLabels := map[string]string{
+		"app":                         "test",
+		"io.kubernetes.pod.namespace": "default",
+	}
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   map[string]string
+	}{
+		{
+			name: "normal scenario",
+			labels: map[string]string{
+				"app":                         "test",
+				"io.kubernetes.pod.namespace": "default",
+			},
+			want: expectedLabels,
+		},
+		{
+			name: "having cilium owned namespace labels",
+			labels: map[string]string{
+				"app":                         "test",
+				"io.kubernetes.pod.namespace": "default",
+				"io.cilium.k8s.namespace.labels.foo.bar/baz":                 "malicious-pod-level-override",
+				"io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name": "kube-system",
+			},
+			want: expectedLabels,
+		},
+		{
+			name: "having cilium owned policy labels",
+			labels: map[string]string{
+				"app":                                 "test",
+				"io.kubernetes.pod.namespace":         "default",
+				"io.cilium.k8s.policy.name":           "admin",
+				"io.cilium.k8s.policy.cluster":        "admin-cluster",
+				"io.cilium.k8s.policy.derived-from":   "admin",
+				"io.cilium.k8s.policy.namespace":      "kube-system",
+				"io.cilium.k8s.policy.serviceaccount": "admin-serviceaccount",
+				"io.cilium.k8s.policy.uuid":           "6eadee3e-0121-11ed-b58d-fc3497a92ef6",
+			},
+			want: map[string]string{
+				"app":                         "test",
+				"io.kubernetes.pod.namespace": "default",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := filterPodLabels(tt.labels); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("filterPodLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -401,7 +401,7 @@ func (k *K8sWatcher) updateK8sPodV1(oldK8sPod, newK8sPod *slim_corev1.Pod) error
 
 	for _, podEP := range podEPs {
 		if labelsChanged {
-			err := updateEndpointLabels(podEP, oldPodLabels, newPodLabels)
+			err := podEP.UpdateLabelsFrom(oldPodLabels, newPodLabels, labels.LabelSourceK8s)
 			if err != nil {
 				return err
 			}
@@ -518,10 +518,6 @@ func updateCiliumEndpointLabels(clientset client.Clientset, ep *endpoint.Endpoin
 				return nil
 			},
 		})
-}
-
-func updateEndpointLabels(ep *endpoint.Endpoint, oldLbls, newLbls map[string]string) error {
-	return ep.UpdateLabelsFrom(oldLbls, newLbls, labels.LabelSourceK8s)
 }
 
 func (k *K8sWatcher) deleteK8sPodV1(pod *slim_corev1.Pod) error {

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -413,7 +413,7 @@ func (k *K8sWatcher) updateK8sPodV1(oldK8sPod, newK8sPod *slim_corev1.Pod) error
 			}
 
 			// Synchronize Pod labels with CiliumEndpoint labels if there is a change.
-			updateCiliumEndpointLabels(k.clientset, podEP, newPodLabels)
+			updateCiliumEndpointLabels(k.clientset, podEP, newK8sPod.Labels)
 		}
 
 		if annotationsChanged {

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -403,6 +403,12 @@ func (k *K8sWatcher) updateK8sPodV1(oldK8sPod, newK8sPod *slim_corev1.Pod) error
 		if labelsChanged {
 			err := podEP.UpdateLabelsFrom(oldPodLabels, newPodLabels, labels.LabelSourceK8s)
 			if err != nil {
+				log.WithFields(logrus.Fields{
+					logfields.K8sPodName:   newK8sPod.ObjectMeta.Name,
+					logfields.K8sNamespace: newK8sPod.ObjectMeta.Namespace,
+					logfields.EndpointID:   podEP.GetID(),
+					logfields.Labels:       newPodLabels,
+				}).WithError(err).Warning("Unable to update endpoint labels on pod update")
 				return err
 			}
 


### PR DESCRIPTION
This change fixes a bug reported by a user where pod label updates were not always reflected in the respective endpoint and `CiliumEndpoint` CRD when filtered labels are present.

Currently `io.cilium.k8s.*`  pod labels are only filtered out on pod creation. On pod update, they are currently not filtered which leads to a situation where no pod label update is reflected in the endpoint anymore in case of a filtered label `io.cilium.k8s.*` label set on the pod:
    
    $ cat <<EOF | kubectl apply -f -
    apiVersion: v1
    kind: Pod
    metadata:
      name: foo
      namespace: default
      labels:
        app: foobar
        io.cilium.k8s.something: bazbar
    spec:
      containers:
      - name: nginx
        image: nginx:1.25.4
        ports:
        - containerPort: 80
    EOF
    $ kubectl -n kube-system exec -it cilium-nnnn -- cilium-dbg endpoint list
    ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                                              IPv6                  IPv4           STATUS
               ENFORCEMENT        ENFORCEMENT
    252        Disabled           Disabled          50316      k8s:app=foobar                                                           fd00:10:244:1::8b69   10.244.1.78    ready
                                                               k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=default
                                                               k8s:io.cilium.k8s.policy.cluster=kind-kind
                                                               k8s:io.cilium.k8s.policy.serviceaccount=default
                                                               k8s:io.kubernetes.pod.namespace=default
    $ kubectl label pods foo app=nothing --overwrite
    $ kubectl describe pod foo
    [...]
    Labels:           app=nothing
                      io.cilium.k8s.something=bazbar
    [...]
    $ kubectl describe cep foo
    [...]
    Labels:       app=foobar
                  io.cilium.k8s.something=bazbar
    [...]
    $ kubectl -n kube-system exec -it cilium-nnnn -- cilium-dbg endpoint list
    ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                                              IPv6                  IPv4           STATUS
               ENFORCEMENT        ENFORCEMENT
    252        Disabled           Disabled          50316      k8s:app=foobar                                                           fd00:10:244:1::8b69   10.244.1.78    ready
                                                               k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=default
                                                               k8s:io.cilium.k8s.policy.cluster=kind-kind
                                                               k8s:io.cilium.k8s.policy.serviceaccount=default
                                                               k8s:io.kubernetes.pod.namespace=default
    1285       Disabled           Disabled          1          reserved:host                                                                                                 ready
    1297       Disabled           Disabled          4          reserved:health                                                          fd00:10:244:1::ebfb   10.244.1.222   ready
    
Note that the `app` label didn't change from `foobar` to `nothing` in the endpoint and the CiliumEndpoint CRD
    
This is because the filtered labels are passed wrongly passed to `(*Endpoint).ModifyIdentityLabels` which in turn calls `e.OpLabels.ModifyIdentityLabels` which checks whether all of the deleted labels (which contains the filtered label on pod update for the example above) were present before, i.e. on pod creation. This check fails however because the labels were filtered out on pod creation.
    
Fix this issue by also filtering out the filtered labels on pod update and thus allowing the label update to successfully complete in the presence of filtered labels.

After this change, the labels are correctly updated on the endpoint and the CiliumEndpoint CRD:
    
    $ kubectl label pods foo app=nothing --overwrite
    $ kubectl describe pod foo
    [...]
    Labels:           app=nothing
                      io.cilium.k8s.something=bazbar
    [...]
    $ kubectl describe cep foo
    [...]
    Labels:       app=nothing
                  io.cilium.k8s.something=bazbar
    [...]
    $ kubectl -n kube-system exec -it cilium-x2x5r -- cilium-dbg endpoint list
    ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                                              IPv6                  IPv4           STATUS
               ENFORCEMENT        ENFORCEMENT
    57         Disabled           Disabled          56486      k8s:app=nothing                                                          fd00:10:244:1::71b7   10.244.1.187   ready
                                                               k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=default
                                                               k8s:io.cilium.k8s.policy.cluster=kind-kind
                                                               k8s:io.cilium.k8s.policy.serviceaccount=default
                                                               k8s:io.kubernetes.pod.namespace=default
    201        Disabled           Disabled          4          reserved:health                                                          fd00:10:244:1::c8de   10.244.1.221   ready
    956        Disabled           Disabled          1          reserved:host                                                                                                 ready

See individual commits for details.

```release-note
Fix a bug where pod label updates are not reflected in endpoint labels in presence of filtered labels.
```