### PR TITLE
node: correctly propagate source for CiliumInternalIP ipcache metadata

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -449,7 +449,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			Source: n.Source,
 		})
 		resource := ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindNode, "", n.Name)
-		m.upsertIntoIDMD(prefix, remoteHostIdentity, resource)
+		m.upsertIntoIDMD(prefix, remoteHostIdentity, resource, n.Source)
 
 		// Upsert() will return true if the ipcache entry is owned by
 		// the source of the node update that triggered this node
@@ -587,11 +587,11 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 // upsertIntoIDMD upserts the given CIDR into the ipcache.identityMetadata
 // (IDMD) map. The given node identity determines which labels are associated
 // with the CIDR.
-func (m *Manager) upsertIntoIDMD(prefix netip.Prefix, id identity.NumericIdentity, rid ipcacheTypes.ResourceID) {
+func (m *Manager) upsertIntoIDMD(prefix netip.Prefix, id identity.NumericIdentity, rid ipcacheTypes.ResourceID, src source.Source) {
 	if id == identity.ReservedIdentityHost {
-		m.ipcache.UpsertLabels(prefix, labels.LabelHost, source.Local, rid)
+		m.ipcache.UpsertLabels(prefix, labels.LabelHost, src, rid)
 	} else {
-		m.ipcache.UpsertLabels(prefix, labels.LabelRemoteNode, source.CustomResource, rid)
+		m.ipcache.UpsertLabels(prefix, labels.LabelRemoteNode, src, rid)
 	}
 }
 


### PR DESCRIPTION
Upon reception of a node update event, we first upsert the CiliumInternalIP address into the ipcache, and then associate it with the relevant metadata (i.e., labels) based on the identity. However, while the first upsertion propagates the source from the triggering event (e.g., custom-resource or kvstore), the latter hard-codes the source depending on the identity: local if ID=host, and custom-resource if ID=custom-resource.

This hard-coded value is problematic in two main cases:

* When kvstore is used, as the kvstore source has higher precedence than the custom-resource one. This means that the ipcache upsertion subsequently triggered by InjectLabels gets aborted as of lower priority, causing an increase in the ipcache_errors_total metric at best, and possible policies issues otherwise.

* When --enable-remote-node-identity=false, that is remote node identities are disabled, remote nodes are associated with the host identity. Based on the hard-coded values mentioned above, the metadata is then associated with source=local. In turn, this will prevent any further updates for that node from the CRDs or kvstore from taking effect, as having lower priority. Hence, continuing to use stale information (e.g., tunnel endpoint and key ID) upon subsequent changes.

Let's fix this by correctly propagating the source during metadata upsertion as well, matching the behavior of ipcache upsertion.

Note that this issue afflicts v1.13 only. In v1.12, we [manually triggered label injection](https://github.com/cilium/cilium/blob/bbb03106d55e4c124b2538e0326f8bb38e9000da/pkg/node/manager/manager.go#L564) for the current source only. In v1.14, the logic was refactored, and there's a [single UpsertMetadata call](https://github.com/cilium/cilium/blob/cf6e022edbedc39c35237330ab85c158ff17f207/pkg/node/manager/manager.go#L489-L495) with the correct source.

<!-- Description of change -->

```release-note
Fix bug leading to missed ipcache updates for the CiliumInternalIP when `--enable-remote-node-identity=false`, and unnecessary `ipcache_errors_total` metric increase if Cilium operates in kvstore mode.
```
