### PR TITLE
Miscellaneous cleanups around node discovery

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -493,7 +493,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		params.K8sResourceSynced,
 		params.K8sAPIGroups,
 		d.endpointManager,
-		d.nodeDiscovery,
+		params.NodeManager,
 		&d,
 		d.policy,
 		d.svc,

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -126,7 +126,7 @@ func (k *K8sWatcher) onCiliumNodeInsert(ciliumNode *cilium_v2.CiliumNode) bool {
 		return false
 	}
 	n := types.ParseCiliumNode(ciliumNode)
-	k.nodeDiscoverManager.NodeUpdated(n)
+	k.nodeManager.NodeUpdated(n)
 	return true
 }
 
@@ -145,7 +145,7 @@ func (k *K8sWatcher) onCiliumNodeDelete(ciliumNode *cilium_v2.CiliumNode) {
 		return
 	}
 	n := types.ParseCiliumNode(ciliumNode)
-	k.nodeDiscoverManager.NodeDeleted(n)
+	k.nodeManager.NodeDeleted(n)
 }
 
 // GetCiliumNode returns the CiliumNode "nodeName" from the local Resource[T] store. If the

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -115,11 +115,9 @@ type endpointManager interface {
 	UpdatePolicyMaps(context.Context, *sync.WaitGroup) *sync.WaitGroup
 }
 
-type nodeDiscoverManager interface {
-	WaitForLocalNodeInit()
+type nodeManager interface {
 	NodeDeleted(n nodeTypes.Node)
 	NodeUpdated(n nodeTypes.Node)
-	ClusterSizeDependantInterval(baseInterval time.Duration) time.Duration
 }
 
 type policyManager interface {
@@ -187,7 +185,7 @@ type K8sWatcher struct {
 
 	endpointManager endpointManager
 
-	nodeDiscoverManager   nodeDiscoverManager
+	nodeManager           nodeManager
 	policyManager         policyManager
 	policyRepository      policyRepository
 	svcManager            svcManager
@@ -225,7 +223,7 @@ func NewK8sWatcher(
 	k8sResourceSynced *synced.Resources,
 	k8sAPIGroups *synced.APIGroups,
 	endpointManager endpointManager,
-	nodeDiscoverManager nodeDiscoverManager,
+	nodeManager nodeManager,
 	policyManager policyManager,
 	policyRepository policyRepository,
 	svcManager svcManager,
@@ -245,7 +243,7 @@ func NewK8sWatcher(
 		k8sAPIGroups:          k8sAPIGroups,
 		K8sSvcCache:           serviceCache,
 		endpointManager:       endpointManager,
-		nodeDiscoverManager:   nodeDiscoverManager,
+		nodeManager:           nodeManager,
 		policyManager:         policyManager,
 		policyRepository:      policyRepository,
 		svcManager:            svcManager,

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -243,18 +243,6 @@ func (n *NodeDiscovery) WaitForLocalNodeInit() {
 	<-n.localStateInitialized
 }
 
-func (n *NodeDiscovery) NodeDeleted(node nodeTypes.Node) {
-	n.Manager.NodeDeleted(node)
-}
-
-func (n *NodeDiscovery) NodeUpdated(node nodeTypes.Node) {
-	n.Manager.NodeUpdated(node)
-}
-
-func (n *NodeDiscovery) ClusterSizeDependantInterval(baseInterval time.Duration) time.Duration {
-	return n.Manager.ClusterSizeDependantInterval(baseInterval)
-}
-
 func (n *NodeDiscovery) updateLocalNode(ln *node.LocalNode) {
 	if option.Config.KVStore != "" && !option.Config.JoinCluster {
 		n.ctrlmgr.UpdateController(


### PR DESCRIPTION
Please refer to the individual commit messages for additional details.

* Directly depend on `NodeManager` in `CiliumNode` watcher;
* Drop the now unused relay methods from `NodeDiscovery`.