### PR TITLE
node: ignore kvstore node events for the local node

### DIFF
--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -57,7 +57,7 @@ func NewNodeObserver(manager NodeManager) *NodeObserver {
 }
 
 func (o *NodeObserver) OnUpdate(k store.Key) {
-	if n, ok := k.(*nodeTypes.Node); ok {
+	if n, ok := k.(*nodeTypes.Node); ok && !n.IsLocal() {
 		nodeCopy := n.DeepCopy()
 		nodeCopy.Source = source.KVStore
 		o.manager.NodeUpdated(*nodeCopy)
@@ -65,7 +65,7 @@ func (o *NodeObserver) OnUpdate(k store.Key) {
 }
 
 func (o *NodeObserver) OnDelete(k store.NamedKey) {
-	if n, ok := k.(*nodeTypes.Node); ok {
+	if n, ok := k.(*nodeTypes.Node); ok && !n.IsLocal() {
 		nodeCopy := n.DeepCopy()
 		nodeCopy.Source = source.KVStore
 		o.manager.NodeDeleted(*nodeCopy)


### PR DESCRIPTION
Let's not propagate node updated/deleted events received from the kvstore for the local node to the NodeManager. This matches the behavior of the corresponding CiliumNode watcher, and prevents the unnecessary increase of the ipcache_errors_total (cannot_overwrite_by_source) metric, caused by information with source=local always taking precedence.

<!-- Description of change -->

```release-note
Ignore kvstore node events for the local node, to avoid unnecessarily increasing the ipcache_errors_total (cannot_overwrite_by_source) metric.
```
