### PR TITLE
ipam: Remove unused variable

### DIFF
--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -21,8 +21,6 @@ var (
 	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ipam")
 )
 
-type ErrAllocation error
-
 // Family is the type describing all address families support by the IP
 // allocation manager
 type Family string


### PR DESCRIPTION
Even though this variable is exported, none of the code uses it which
makes it safe to remove.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
