### PR TITLE
Add "node-map-max" to allow configuring nodemap size.

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -56,6 +56,7 @@ cilium-agent [flags]
       --bpf-map-dynamic-size-ratio float                          Ratio (0.0-1.0] of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps (default 0.0025)
       --bpf-nat-global-max int                                    Maximum number of entries for the global BPF NAT table (default 524288)
       --bpf-neigh-global-max int                                  Maximum number of entries for the global BPF neighbor table (default 524288)
+      --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --bpf-policy-map-max int                                    Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
       --bpf-root string                                           Path to BPF filesystem
       --bpf-sock-rev-map-max int                                  Maximum number of entries for the SockRevNAT BPF map (default 262144)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -13,6 +13,7 @@ cilium-agent hive [flags]
 ```
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
       --api-rate-limit stringToString                             API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default [])
+      --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --cluster-id uint32                                         Unique identifier of the cluster
       --cluster-name string                                       Name of the cluster (default "default")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -19,6 +19,7 @@ cilium-agent hive dot-graph [flags]
 ```
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
       --api-rate-limit stringToString                             API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default [])
+      --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --cluster-id uint32                                         Unique identifier of the cluster
       --cluster-name string                                       Name of the cluster (default "default")

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -364,8 +364,12 @@
      - Configure the maximum number of entries for the neighbor table.
      - int
      - ``524288``
+   * - :spelling:ignore:`bpf.nodeMapMax`
+     - Configures the maximum number of entries for the node table.
+     - int
+     - ``nil``
    * - :spelling:ignore:`bpf.policyMapMax`
-     - Configure the maximum number of entries in endpoint policy map (per endpoint).
+     - Configure the maximum number of entries in endpoint policy map (per endpoint). @schema type: [null, integer] @schema
      - int
      - ``16384``
    * - :spelling:ignore:`bpf.preallocateMaps`

--- a/Documentation/network/ebpf/maps.rst
+++ b/Documentation/network/ebpf/maps.rst
@@ -33,6 +33,7 @@ IPv4 Masq                node             16k             Max 16k IPv4 cidrs use
 IPv6 Masq                node             16k             Max 16k IPv6 cidrs used by BPF-based ip-masq-agent
 Service Source Ranges    node             64k             Max 64k cumulative LB source ranges across all services
 Egress Policy            endpoint         16k             Max 16k endpoints across all destination CIDRs across all clusters 
+Node                     node             16k             Max 16k distinct node IPs (IPv4 & IPv6) across all clusters.
 ======================== ================ =============== =====================================================
 
 For some BPF maps, the upper capacity limit can be overridden using command

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -141,7 +141,8 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.monitorInterval | string | `"5s"` | Configure the typical time between monitor notifications for active connections. |
 | bpf.natMax | int | `524288` | Configure the maximum number of entries for the NAT table. |
 | bpf.neighMax | int | `524288` | Configure the maximum number of entries for the neighbor table. |
-| bpf.policyMapMax | int | `16384` | Configure the maximum number of entries in endpoint policy map (per endpoint). |
+| bpf.nodeMapMax | int | `nil` | Configures the maximum number of entries for the node table. |
+| bpf.policyMapMax | int | `16384` | Configure the maximum number of entries in endpoint policy map (per endpoint). @schema type: [null, integer] @schema |
 | bpf.preallocateMaps | bool | `false` | Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency. |
 | bpf.root | string | `"/sys/fs/bpf"` | Configure the mount point for the BPF filesystem |
 | bpf.tproxy | bool | `false` | Configure the eBPF-based TPROXY to reduce reliance on iptables rules for implementing Layer 7 policy. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -375,6 +375,11 @@ data:
   enable-host-legacy-routing: "true"
 {{- end }}
 
+{{- if .Values.bpf.nodeMapMax }}
+  # node-map-max specifies the maximum number of entries for the node map.
+  bpf-node-map-max: {{ .Values.bpf.nodeMapMax | quote }}
+{{- end }}
+
 {{- if .Values.bpf.authMapMax }}
   # bpf-auth-map-max specifies the maximum number of entries in the auth map
   bpf-auth-map-max: {{ .Values.bpf.authMapMax | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -589,6 +589,12 @@
             "integer"
           ]
         },
+        "nodeMapMax": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
         "policyMapMax": {
           "type": [
             "null",

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -475,7 +475,13 @@ bpf:
   # @schema
   # type: [null, integer]
   # @schema
+  # @default -- `16384`
+  # -- (int) Configures the maximum number of entries for the node table.
+  nodeMapMax: ~
   # -- Configure the maximum number of entries in endpoint policy map (per endpoint).
+  # @schema
+  # type: [null, integer]
+  # @schema
   policyMapMax: 16384
   # @schema
   # type: [null, number]

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -473,7 +473,13 @@ bpf:
   # @schema
   # type: [null, integer]
   # @schema
+  # @default -- `16384`
+  # -- (int) Configures the maximum number of entries for the node table.
+  nodeMapMax: ~
   # -- Configure the maximum number of entries in endpoint policy map (per endpoint).
+  # @schema
+  # type: [null, integer]
+  # @schema
   policyMapMax: 16384
   # @schema
   # type: [null, number]

--- a/pkg/datapath/linux/config/cell.go
+++ b/pkg/datapath/linux/config/cell.go
@@ -10,12 +10,14 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/maps/nodemap"
 )
 
 type WriterParams struct {
 	cell.In
 
 	Log                logrus.FieldLogger
+	NodeMap            nodemap.Map
 	NodeAddressing     datapath.NodeAddressing
 	NodeExtraDefines   []dpdef.Map `group:"header-node-defines"`
 	NodeExtraDefineFns []dpdef.Fn  `group:"header-node-define-fns"`

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -66,6 +66,7 @@ import (
 // It manages writing of configuration of datapath program headerfiles.
 type HeaderfileWriter struct {
 	log                logrus.FieldLogger
+	nodeMap            nodemap.Map
 	nodeAddressing     datapath.NodeAddressing
 	nodeExtraDefines   dpdef.Map
 	nodeExtraDefineFns []dpdef.Fn
@@ -80,6 +81,7 @@ func NewHeaderfileWriter(p WriterParams) (datapath.ConfigWriter, error) {
 		}
 	}
 	return &HeaderfileWriter{
+		nodeMap:            p.NodeMap,
 		nodeAddressing:     p.NodeAddressing,
 		nodeExtraDefines:   merged,
 		nodeExtraDefineFns: p.NodeExtraDefineFns,
@@ -185,7 +187,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	cDefinesMap["IPCACHE_MAP"] = ipcachemap.Name
 	cDefinesMap["IPCACHE_MAP_SIZE"] = fmt.Sprintf("%d", ipcachemap.MaxEntries)
 	cDefinesMap["NODE_MAP"] = nodemap.MapName
-	cDefinesMap["NODE_MAP_SIZE"] = fmt.Sprintf("%d", nodemap.MaxEntries)
+	cDefinesMap["NODE_MAP_SIZE"] = fmt.Sprintf("%d", h.nodeMap.Size())
 	cDefinesMap["SRV6_VRF_MAP4"] = srv6map.VRFMapName4
 	cDefinesMap["SRV6_VRF_MAP6"] = srv6map.VRFMapName6
 	cDefinesMap["SRV6_POLICY_MAP4"] = srv6map.PolicyMapName4

--- a/pkg/datapath/loader/hash_test.go
+++ b/pkg/datapath/loader/hash_test.go
@@ -16,6 +16,8 @@ import (
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/maps/nodemap"
+	"github.com/cilium/cilium/pkg/maps/nodemap/fake"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -32,6 +34,7 @@ var (
 func (s *LoaderTestSuite) TesthashDatapath(c *C) {
 	var cfg datapath.ConfigWriter
 	hv := hive.New(
+		provideNodemap,
 		cell.Provide(
 			fakeTypes.NewNodeAddressing,
 			func() datapath.BandwidthManager { return &fakeTypes.BandwidthManager{} },
@@ -81,3 +84,7 @@ func (s *LoaderTestSuite) TesthashDatapath(c *C) {
 	c.Assert(h.String(), Not(Equals), baseHash)
 	c.Assert(h.String(), Not(Equals), dummyHash)
 }
+
+var provideNodemap = cell.Provide(func() nodemap.Map {
+	return fake.NewFakeNodeMap()
+})

--- a/pkg/maps/nodemap/cell.go
+++ b/pkg/maps/nodemap/cell.go
@@ -4,6 +4,8 @@
 package nodemap
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -32,7 +34,11 @@ var defaultConfig = Config{
 	NodeMapMax: DefaultMaxEntries,
 }
 
-func newNodeMap(lifecycle cell.Lifecycle, conf Config) bpf.MapOut[Map] {
+func newNodeMap(lifecycle cell.Lifecycle, conf Config) (bpf.MapOut[Map], error) {
+	if conf.NodeMapMax < DefaultMaxEntries {
+		return bpf.MapOut[Map]{}, fmt.Errorf("creating node map: bpf-node-map-max cannot be less than %d (%d)",
+			DefaultMaxEntries, conf.NodeMapMax)
+	}
 	nodeMap := newMap(MapName, conf)
 
 	lifecycle.Append(cell.Hook{
@@ -44,5 +50,5 @@ func newNodeMap(lifecycle cell.Lifecycle, conf Config) bpf.MapOut[Map] {
 		},
 	})
 
-	return bpf.NewMapOut(Map(nodeMap))
+	return bpf.NewMapOut(Map(nodeMap)), nil
 }

--- a/pkg/maps/nodemap/fake/node_map.go
+++ b/pkg/maps/nodemap/fake/node_map.go
@@ -27,6 +27,10 @@ func (f fakeNodeMap) Update(ip net.IP, nodeID uint16) error {
 	return nil
 }
 
+func (f fakeNodeMap) Size() uint32 {
+	return nodemap.DefaultMaxEntries
+}
+
 func (f fakeNodeMap) Delete(ip net.IP) error {
 	delete(f.ids, ip.String())
 	return nil

--- a/pkg/maps/nodemap/node_map_privileged_test.go
+++ b/pkg/maps/nodemap/node_map_privileged_test.go
@@ -33,7 +33,7 @@ func (k *NodeMapTestSuite) SetUpSuite(c *C) {
 }
 
 func (k *NodeMapTestSuite) TestNodeMap(c *C) {
-	nodeMap := newMap("test_cilium_node_map")
+	nodeMap := newMap("test_cilium_node_map", defaultConfig)
 	err := nodeMap.init()
 	c.Assert(err, IsNil)
 	defer nodeMap.bpfMap.Unpin()


### PR DESCRIPTION
Using the node-map-max flag, one can now override the default 16k node map size.
This may be needed for large clusters, where the number of distinct node IPs in the cluster exceeds the standard size.

In helm, this will allow overriding the size using `bpf.nodeMapMax: <size>`