### PR TITLE
Convert Pods, CEP, and KVStore IPcache handling over to async API

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -514,6 +514,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		d.bwManager,
 		d.db,
 		d.nodeAddrs,
+		params.IdentityAllocator,
 	)
 	params.NodeDiscovery.RegisterK8sGetters(d.k8sWatcher)
 

--- a/daemon/cmd/ipcache.go
+++ b/daemon/cmd/ipcache.go
@@ -58,7 +58,7 @@ type ipCacheDumpListener struct {
 // OnIPIdentityCacheChange is called by DumpToListenerLocked
 func (ipc *ipCacheDumpListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 	cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP, oldID *ipcache.Identity,
-	newID ipcache.Identity, encryptKey uint8, k8sMeta *ipcache.K8sMetadata) {
+	newID ipcache.Identity, encryptKey uint8, k8sMeta *ipcachetypes.K8sMetadata) {
 	cidr := cidrCluster.AsIPNet()
 
 	// only capture entries which are a subnet of cidrFilter

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -120,11 +120,12 @@ func newPolicyTrifecta(params policyParams) (policyOut, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	ipc := ipcache.NewIPCache(&ipcache.Configuration{
-		Context:           ctx,
-		IdentityAllocator: idAlloc,
-		PolicyHandler:     iao.policy.GetSelectorCache(),
-		DatapathHandler:   params.EndpointManager,
-		CacheStatus:       params.CacheStatus,
+		Context:             ctx,
+		IdentityAllocator:   idAlloc,
+		PolicyHandler:       iao.policy.GetSelectorCache(),
+		PolicyUpdateHandler: policyUpdater,
+		DatapathHandler:     params.EndpointManager,
+		CacheStatus:         params.CacheStatus,
 	})
 
 	params.Lifecycle.Append(cell.Hook{

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -22,6 +23,7 @@ import (
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -55,6 +57,16 @@ func (f *fakeIPCache) Delete(string, source.Source) bool { return false }
 func (f *fakeIPCache) Upsert(string, net.IP, uint8, *ipcachetypes.K8sMetadata, ipcache.Identity) (bool, error) {
 	f.updates.Add(1)
 	return false, nil
+}
+
+// TODO: Implement
+func (f *fakeIPCache) UpsertMetadata(prefix netip.Prefix, src source.Source, resource ipcachetypes.ResourceID, aux ...ipcache.IPMetadata) {
+}
+func (f *fakeIPCache) RemoveMetadata(prefix netip.Prefix, resource ipcachetypes.ResourceID, aux ...ipcache.IPMetadata) {
+}
+func (f *fakeIPCache) OverrideIdentity(prefix netip.Prefix, identityLabels labels.Labels, src source.Source, resource ipcachetypes.ResourceID) {
+}
+func (f *fakeIPCache) RemoveIdentityOverride(prefix netip.Prefix, identityLabels labels.Labels, resource ipcachetypes.ResourceID) {
 }
 
 func TestRemoteClusterRun(t *testing.T) {

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -51,7 +52,7 @@ func (w *remoteEtcdClientWrapper) ListAndWatch(ctx context.Context, prefix strin
 type fakeIPCache struct{ updates atomic.Int32 }
 
 func (f *fakeIPCache) Delete(string, source.Source) bool { return false }
-func (f *fakeIPCache) Upsert(string, net.IP, uint8, *ipcache.K8sMetadata, ipcache.Identity) (bool, error) {
+func (f *fakeIPCache) Upsert(string, net.IP, uint8, *ipcachetypes.K8sMetadata, ipcache.Identity) (bool, error) {
 	f.updates.Add(1)
 	return false, nil
 }

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	ipcacheMap "github.com/cilium/cilium/pkg/maps/ipcache"
@@ -54,7 +55,7 @@ func NewListener(m Map, mn monitorNotify) *BPFListener {
 
 func (l *BPFListener) notifyMonitor(modType ipcache.CacheModification,
 	cidr net.IPNet, oldHostIP, newHostIP net.IP, oldID *ipcache.Identity,
-	newID ipcache.Identity, encryptKey uint8, k8sMeta *ipcache.K8sMetadata) {
+	newID ipcache.Identity, encryptKey uint8, k8sMeta *ipcachetypes.K8sMetadata) {
 	var (
 		k8sNamespace, k8sPodName string
 		newIdentity, oldIdentity uint32
@@ -97,7 +98,7 @@ func (l *BPFListener) notifyMonitor(modType ipcache.CacheModification,
 // is not required to upsert the new pair.
 func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrCluster cmtypes.PrefixCluster,
 	oldHostIP, newHostIP net.IP, oldID *ipcache.Identity, newID ipcache.Identity,
-	encryptKey uint8, k8sMeta *ipcache.K8sMetadata) {
+	encryptKey uint8, k8sMeta *ipcachetypes.K8sMetadata) {
 	cidr := cidrCluster.AsIPNet()
 
 	scopedLog := log

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/envoy/xds"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -96,7 +97,7 @@ func (cache *NPHDSCache) HandleResourceVersionAck(ackVersion uint64, nackVersion
 // IP/ID mappings.
 func (cache *NPHDSCache) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrCluster cmtypes.PrefixCluster,
 	oldHostIP, newHostIP net.IP, oldID *ipcache.Identity, newID ipcache.Identity,
-	encryptKey uint8, k8sMeta *ipcache.K8sMetadata,
+	encryptKey uint8, k8sMeta *ipcachetypes.K8sMetadata,
 ) {
 	cidr := cidrCluster.AsIPNet()
 

--- a/pkg/hubble/parser/getters/getters.go
+++ b/pkg/hubble/parser/getters/getters.go
@@ -10,6 +10,7 @@ import (
 	cgroupManager "github.com/cilium/cilium/pkg/cgroups/manager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/labels"
 	policyTypes "github.com/cilium/cilium/pkg/policy/types"
@@ -40,7 +41,7 @@ type IdentityGetter interface {
 // IPGetter fetches per-IP metadata
 type IPGetter interface {
 	// GetK8sMetadata returns Kubernetes metadata for the given IP address.
-	GetK8sMetadata(ip netip.Addr) *ipcache.K8sMetadata
+	GetK8sMetadata(ip netip.Addr) *ipcachetypes.K8sMetadata
 	// LookupSecIDByIP returns the corresponding security identity that
 	// the specified IP maps to as well as if the corresponding entry exists.
 	LookupSecIDByIP(ip netip.Addr) (ipcache.Identity, bool)

--- a/pkg/hubble/parser/seven/http_test.go
+++ b/pkg/hubble/parser/seven/http_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
-	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -66,9 +66,9 @@ func TestDecodeL7HTTPRequest(t *testing.T) {
 		},
 	}
 	IPGetter := &testutils.FakeIPGetter{
-		OnGetK8sMetadata: func(ip netip.Addr) *ipcache.K8sMetadata {
+		OnGetK8sMetadata: func(ip netip.Addr) *ipcachetypes.K8sMetadata {
 			if ip == netip.MustParseAddr(fakeDestinationEndpoint.IPv4) {
-				return &ipcache.K8sMetadata{
+				return &ipcachetypes.K8sMetadata{
 					Namespace: "default",
 					PodName:   "pod-1234",
 				}
@@ -181,9 +181,9 @@ func TestDecodeL7HTTPRecordResponse(t *testing.T) {
 		},
 	}
 	IPGetter := &testutils.FakeIPGetter{
-		OnGetK8sMetadata: func(ip netip.Addr) *ipcache.K8sMetadata {
+		OnGetK8sMetadata: func(ip netip.Addr) *ipcachetypes.K8sMetadata {
 			if ip == netip.MustParseAddr(fakeDestinationEndpoint.IPv4) {
-				return &ipcache.K8sMetadata{
+				return &ipcachetypes.K8sMetadata{
 					Namespace: "default",
 					PodName:   "pod-1234",
 				}

--- a/pkg/hubble/parser/sock/parser_test.go
+++ b/pkg/hubble/parser/sock/parser_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/testutils"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -132,20 +133,20 @@ func TestDecodeSockEvent(t *testing.T) {
 		},
 	}
 	ipGetter := &testutils.FakeIPGetter{
-		OnGetK8sMetadata: func(ip netip.Addr) *ipcache.K8sMetadata {
+		OnGetK8sMetadata: func(ip netip.Addr) *ipcachetypes.K8sMetadata {
 			switch ip.String() {
 			case xwingIPv4, xwingIPv6:
-				return &ipcache.K8sMetadata{
+				return &ipcachetypes.K8sMetadata{
 					PodName:   xwingPodName,
 					Namespace: xwingPodNamespace,
 				}
 			case deathstarIPv4, deathstarIPv6:
-				return &ipcache.K8sMetadata{
+				return &ipcachetypes.K8sMetadata{
 					PodName:   deathstarPodName,
 					Namespace: deathstarPodNamespace,
 				}
 			case deathstarAltIPv4, deathstarAltIPv6:
-				return &ipcache.K8sMetadata{
+				return &ipcachetypes.K8sMetadata{
 					PodName:   deathstarAltPodName,
 					Namespace: deathstarAltPodNamespace,
 				}

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/testutils"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -112,9 +113,9 @@ func TestL34Decode(t *testing.T) {
 		},
 	}
 	ipGetter := &testutils.FakeIPGetter{
-		OnGetK8sMetadata: func(ip netip.Addr) *ipcache.K8sMetadata {
+		OnGetK8sMetadata: func(ip netip.Addr) *ipcachetypes.K8sMetadata {
 			if ip == netip.MustParseAddr("192.168.60.11") {
-				return &ipcache.K8sMetadata{
+				return &ipcachetypes.K8sMetadata{
 					Namespace: "remote",
 					PodName:   "pod-192.168.60.11",
 				}

--- a/pkg/hubble/testutils/fake.go
+++ b/pkg/hubble/testutils/fake.go
@@ -24,6 +24,7 @@ import (
 	poolTypes "github.com/cilium/cilium/pkg/hubble/relay/pool/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/labels"
 	policyTypes "github.com/cilium/cilium/pkg/policy/types"
@@ -342,12 +343,12 @@ var NoopLinkGetter = FakeLinkGetter{}
 
 // FakeIPGetter is used for unit tests that needs IPGetter.
 type FakeIPGetter struct {
-	OnGetK8sMetadata  func(ip netip.Addr) *ipcache.K8sMetadata
+	OnGetK8sMetadata  func(ip netip.Addr) *ipcachetypes.K8sMetadata
 	OnLookupSecIDByIP func(ip netip.Addr) (ipcache.Identity, bool)
 }
 
 // GetK8sMetadata implements FakeIPGetter.GetK8sMetadata.
-func (f *FakeIPGetter) GetK8sMetadata(ip netip.Addr) *ipcache.K8sMetadata {
+func (f *FakeIPGetter) GetK8sMetadata(ip netip.Addr) *ipcachetypes.K8sMetadata {
 	if f.OnGetK8sMetadata != nil {
 		return f.OnGetK8sMetadata(ip)
 	}
@@ -364,7 +365,7 @@ func (f *FakeIPGetter) LookupSecIDByIP(ip netip.Addr) (ipcache.Identity, bool) {
 
 // NoopIPGetter always returns an empty response.
 var NoopIPGetter = FakeIPGetter{
-	OnGetK8sMetadata: func(ip netip.Addr) *ipcache.K8sMetadata {
+	OnGetK8sMetadata: func(ip netip.Addr) *ipcachetypes.K8sMetadata {
 		return nil
 	},
 	OnLookupSecIDByIP: func(ip netip.Addr) (ipcache.Identity, bool) {

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -433,7 +433,7 @@ func (m *CachingIdentityAllocator) AllocateIdentity(ctx context.Context, lbls la
 	// were successfully synced
 	err = m.WaitForInitialGlobalIdentities(ctx)
 	if err != nil {
-		return nil, false, err
+		return nil, false, &ErrGlobalIdentitiesNotReady{cause: err.Error()}
 	}
 
 	if m.IdentityAllocator == nil {
@@ -695,7 +695,7 @@ func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Ide
 	// were successfully synced
 	err = m.WaitForInitialGlobalIdentities(ctx)
 	if err != nil {
-		return false, err
+		return false, &ErrGlobalIdentitiesNotReady{cause: err.Error()}
 	}
 
 	if m.IdentityAllocator == nil {
@@ -804,4 +804,14 @@ func mapLabels(allocatorKey allocator.AllocatorKey) labels.Labels {
 	}
 
 	return idLabels
+}
+
+// ErrGlobalIdentitiesNotReady is an error that represents global identities
+// allocation is not yet ready to be used by the identity allocator.
+type ErrGlobalIdentitiesNotReady struct {
+	cause string
+}
+
+func (e *ErrGlobalIdentitiesNotReady) Error() string {
+	return "global identities not yet ready: " + e.cause
 }

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -37,6 +37,10 @@ var (
 	// IdentitiesPath is the path to where identities are stored in the
 	// key-value store.
 	IdentitiesPath = path.Join(kvstore.BaseKeyPrefix, "state", "identities", "v1")
+
+	// ErrAllocatorUninitialized is an error that occurs when the identity
+	// allocator is not yet initialized.
+	ErrAllocatorUninitialized = errors.New("allocator not initialized")
 )
 
 // The filename for the local allocator checkpoont. This is periodically
@@ -433,7 +437,7 @@ func (m *CachingIdentityAllocator) AllocateIdentity(ctx context.Context, lbls la
 	}
 
 	if m.IdentityAllocator == nil {
-		return nil, false, fmt.Errorf("allocator not initialized")
+		return nil, false, ErrAllocatorUninitialized
 	}
 
 	idp, allocated, isNewLocally, err := m.IdentityAllocator.Allocate(ctx, &key.GlobalIdentity{LabelArray: lbls.LabelArray()})
@@ -695,7 +699,7 @@ func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Ide
 	}
 
 	if m.IdentityAllocator == nil {
-		return false, fmt.Errorf("allocator not initialized")
+		return false, ErrAllocatorUninitialized
 	}
 
 	// Rely on the eventual Kv-Store events for delete

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -453,7 +453,7 @@ var (
 		ReservedIdentityWorld:      labels.LabelWorld,
 		ReservedIdentityWorldIPv4:  labels.LabelWorldIPv4,
 		ReservedIdentityWorldIPv6:  labels.LabelWorldIPv6,
-		ReservedIdentityUnmanaged:  labels.NewLabelsFromModel([]string{"reserved:" + labels.IDNameUnmanaged}),
+		ReservedIdentityUnmanaged:  labels.LabelUnmanaged,
 		ReservedIdentityHealth:     labels.LabelHealth,
 		ReservedIdentityInit:       labels.NewLabelsFromModel([]string{"reserved:" + labels.IDNameInit}),
 		ReservedIdentityRemoteNode: labels.LabelRemoteNode,

--- a/pkg/ipcache/fake/ipcache.go
+++ b/pkg/ipcache/fake/ipcache.go
@@ -7,6 +7,7 @@ import (
 	"net"
 
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/source"
 )
 
@@ -32,7 +33,7 @@ func NewIPCache(events bool) *IPCache {
 	}
 }
 
-func (i *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, error) {
+func (i *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcachetypes.K8sMetadata, newIdentity ipcache.Identity) (bool, error) {
 	i.Events <- NodeEvent{EventUpsert, net.ParseIP(ip)}
 	return false, nil
 }

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -74,6 +74,7 @@ type Configuration struct {
 	// Accessors to other subsystems, provided by the daemon
 	cache.IdentityAllocator
 	ipcacheTypes.PolicyHandler
+	ipcacheTypes.PolicyUpdateHandler
 	ipcacheTypes.DatapathHandler
 	k8s.CacheStatus
 }
@@ -222,6 +223,15 @@ func (ipc *IPCache) GetK8sMetadata(ip netip.Addr) *ipcacheTypes.K8sMetadata {
 	ipc.mutex.RLock()
 	defer ipc.mutex.RUnlock()
 	return ipc.getK8sMetadata(ip.String())
+}
+
+// GetK8sMetadata returns Kubernetes metadata for the given IP address,
+// accepting string for ease of integration with the rest of the code.
+// The returned pointer should *never* be modified.
+func (ipc *IPCache) GetK8sMetadataByString(ip string) *ipcacheTypes.K8sMetadata {
+	ipc.mutex.RLock()
+	defer ipc.mutex.RUnlock()
+	return ipc.getK8sMetadata(ip)
 }
 
 // getK8sMetadata returns Kubernetes metadata for the given IP address.

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -593,11 +593,11 @@ func (ipc *IPCache) RemoveLabels(cidr netip.Prefix, lbls labels.Labels, resource
 // with users of other APIs such as UpsertLabels(), UpsertMetadata() and other
 // variations on inserting metadata into the IPCache.
 func (ipc *IPCache) OverrideIdentity(prefix netip.Prefix, identityLabels labels.Labels, src source.Source, resource ipcacheTypes.ResourceID) {
-	ipc.UpsertMetadata(prefix, src, resource, overrideIdentity(true), identityLabels)
+	ipc.UpsertMetadata(prefix, src, resource, ipcacheTypes.OverrideIdentity(true), identityLabels)
 }
 
 func (ipc *IPCache) RemoveIdentityOverride(cidr netip.Prefix, identityLabels labels.Labels, resource ipcacheTypes.ResourceID) {
-	ipc.RemoveMetadata(cidr, resource, overrideIdentity(true), identityLabels)
+	ipc.RemoveMetadata(cidr, resource, ipcacheTypes.OverrideIdentity(true), identityLabels)
 }
 
 // WaitForRevision will block until the desired revision has been reached (or passed).

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -349,6 +349,11 @@ func (ipc *IPCache) upsertLocked(
 	// Endpoint IP identities take precedence over CIDR identities, so if the
 	// IP is a full CIDR prefix and there's an existing equivalent endpoint IP,
 	// don't notify the listeners.
+	//
+	// TODO: Rework this logic to leverage the cluster-aware metadata from
+	// ipc.metadata. Likely, the metadata will need to be passed to this
+	// function given that the metadata mutex must be taken before the ipcache
+	// mutex, which the latter is already taken at this point in the code.
 	if cidrCluster, err = cmtypes.ParsePrefixCluster(ip); err == nil {
 		if cidrCluster.IsSingleIP() {
 			if _, endpointIPFound := ipc.ipToIdentityCache[cidrCluster.AddrCluster().String()]; endpointIPFound {

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -18,6 +18,7 @@ import (
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/source"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
@@ -111,7 +112,7 @@ func TestIPCache(t *testing.T) {
 	require.Equal(t, false, exists)
 
 	hostIP := net.ParseIP("192.168.1.10")
-	k8sMeta := &K8sMetadata{
+	k8sMeta := &ipcachetypes.K8sMetadata{
 		Namespace: "default",
 		PodName:   "podname",
 	}
@@ -195,7 +196,7 @@ func TestIPCache(t *testing.T) {
 	// Assert IPCache entry is overwritten when a different pod (different
 	// k8sMeta) with the same IP as what's already inside the IPCache is
 	// inserted.
-	_, err = IPIdentityCache.Upsert("10.1.1.250", net.ParseIP("10.0.0.1"), 0, &K8sMetadata{
+	_, err = IPIdentityCache.Upsert("10.1.1.250", net.ParseIP("10.0.0.1"), 0, &ipcachetypes.K8sMetadata{
 		Namespace: "ns-1",
 		PodName:   "pod1",
 	}, Identity{
@@ -206,7 +207,7 @@ func TestIPCache(t *testing.T) {
 	_, exists = IPIdentityCache.LookupByPrefix("10.1.1.250/32")
 	require.Equal(t, true, exists)
 	// Insert different pod now.
-	_, err = IPIdentityCache.Upsert("10.1.1.250", net.ParseIP("10.0.0.2"), 0, &K8sMetadata{
+	_, err = IPIdentityCache.Upsert("10.1.1.250", net.ParseIP("10.0.0.2"), 0, &ipcachetypes.K8sMetadata{
 		Namespace: "ns-1",
 		PodName:   "pod2",
 	}, Identity{
@@ -248,7 +249,7 @@ func TestIPCacheNamedPorts(t *testing.T) {
 	namedPortsChanged := IPIdentityCache.Delete(endpointIP, source.KVStore)
 	require.Equal(t, false, namedPortsChanged)
 
-	meta := K8sMetadata{
+	meta := ipcachetypes.K8sMetadata{
 		Namespace: "default",
 		PodName:   "app1",
 		NamedPorts: types.NamedPortMap{
@@ -302,7 +303,7 @@ func TestIPCacheNamedPorts(t *testing.T) {
 	endpointIP2 := "10.0.0.16"
 	identity2 := (identityPkg.NumericIdentity(70))
 
-	meta2 := K8sMetadata{
+	meta2 := ipcachetypes.K8sMetadata{
 		Namespace: "testing",
 		PodName:   "app2",
 		NamedPorts: types.NamedPortMap{
@@ -367,7 +368,7 @@ func TestIPCacheNamedPorts(t *testing.T) {
 	require.Equal(t, false, exists)
 
 	hostIP := net.ParseIP("192.168.1.10")
-	k8sMeta := &K8sMetadata{
+	k8sMeta := &ipcachetypes.K8sMetadata{
 		Namespace: "default",
 		PodName:   "podname",
 	}
@@ -521,7 +522,7 @@ func BenchmarkIPCacheUpsert10000(b *testing.B) {
 }
 
 func benchmarkIPCacheUpsert(b *testing.B, num int) {
-	meta := K8sMetadata{
+	meta := ipcachetypes.K8sMetadata{
 		Namespace: "default",
 		PodName:   "app",
 		NamedPorts: types.NamedPortMap{
@@ -585,7 +586,7 @@ func newDummyListener(ipc *IPCache) *dummyListener {
 
 func (dl *dummyListener) OnIPIdentityCacheChange(modType CacheModification,
 	cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP, oldID *Identity,
-	newID Identity, encryptKey uint8, k8sMeta *K8sMetadata) {
+	newID Identity, encryptKey uint8, k8sMeta *ipcachetypes.K8sMetadata) {
 
 	switch modType {
 	case Upsert:

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -16,6 +16,7 @@ import (
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/kvstore"
 	storepkg "github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
@@ -172,7 +173,7 @@ type IPIdentityWatcher struct {
 }
 
 type IPCacher interface {
-	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8sMetadata, newIdentity Identity) (bool, error)
+	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcachetypes.K8sMetadata, newIdentity Identity) (bool, error)
 	Delete(IP string, source source.Source) (namedPortsChanged bool)
 }
 
@@ -299,9 +300,9 @@ func (iw *IPIdentityWatcher) OnUpdate(k storepkg.Key) {
 
 	iw.log.WithField(logfields.IPAddr, ip).Debug("Observed upsertion event")
 
-	var k8sMeta *K8sMetadata
+	var k8sMeta *ipcachetypes.K8sMetadata
 	if ipIDPair.K8sNamespace != "" || ipIDPair.K8sPodName != "" || len(ipIDPair.NamedPorts) > 0 {
-		k8sMeta = &K8sMetadata{
+		k8sMeta = &ipcachetypes.K8sMetadata{
 			Namespace:  ipIDPair.K8sNamespace,
 			PodName:    ipIDPair.K8sPodName,
 			NamedPorts: make(types.NamedPortMap, len(ipIDPair.NamedPorts)),

--- a/pkg/ipcache/kvstore_test.go
+++ b/pkg/ipcache/kvstore_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/identity"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/kvstore"
 	storepkg "github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/source"
@@ -31,7 +32,7 @@ func NewEvent(ev, ip string, source source.Source) event { return event{ev, ip, 
 func NewFakeIPCache() *fakeIPCache                       { return &fakeIPCache{events: make(chan event)} }
 func NewFakeBackend() *fakeBackend                       { return &fakeBackend{} }
 
-func (m *fakeIPCache) Upsert(ip string, _ net.IP, _ uint8, _ *K8sMetadata, id Identity) (bool, error) {
+func (m *fakeIPCache) Upsert(ip string, _ net.IP, _ uint8, _ *ipcachetypes.K8sMetadata, id Identity) (bool, error) {
 	m.events <- NewEvent("upsert", ip, id.Source)
 	return true, nil
 }

--- a/pkg/ipcache/kvstore_test.go
+++ b/pkg/ipcache/kvstore_test.go
@@ -6,6 +6,7 @@ package ipcache
 import (
 	"context"
 	"net"
+	"net/netip"
 	"sync"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ import (
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/kvstore"
 	storepkg "github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/source"
 )
 
@@ -40,6 +42,16 @@ func (m *fakeIPCache) Upsert(ip string, _ net.IP, _ uint8, _ *ipcachetypes.K8sMe
 func (m *fakeIPCache) Delete(ip string, source source.Source) (namedPortsChanged bool) {
 	m.events <- NewEvent("delete", ip, source)
 	return true
+}
+
+// TODO: Implement
+func (m *fakeIPCache) UpsertMetadata(prefix netip.Prefix, src source.Source, resource ipcachetypes.ResourceID, aux ...IPMetadata) {
+}
+func (m *fakeIPCache) RemoveMetadata(prefix netip.Prefix, resource ipcachetypes.ResourceID, aux ...IPMetadata) {
+}
+func (m *fakeIPCache) OverrideIdentity(prefix netip.Prefix, identityLabels labels.Labels, src source.Source, resource ipcachetypes.ResourceID) {
+}
+func (m *fakeIPCache) RemoveIdentityOverride(prefix netip.Prefix, identityLabels labels.Labels, resource ipcachetypes.ResourceID) {
 }
 
 func (fb *fakeBackend) ListAndWatch(ctx context.Context, prefix string, _ int) *kvstore.Watcher {

--- a/pkg/ipcache/listener.go
+++ b/pkg/ipcache/listener.go
@@ -7,6 +7,7 @@ import (
 	"net"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 )
 
 // CacheModification represents the type of operation performed upon IPCache.
@@ -31,5 +32,5 @@ type IPIdentityMappingListener interface {
 	// k8sMeta contains the Kubernetes pod namespace and name behind the IP
 	// and may be nil.
 	OnIPIdentityCacheChange(modType CacheModification, cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP,
-		oldID *Identity, newID Identity, encryptKey uint8, k8sMeta *K8sMetadata)
+		oldID *Identity, newID Identity, encryptKey uint8, k8sMeta *ipcachetypes.K8sMetadata)
 }

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -360,7 +360,7 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 				identity: Identity{
 					ID:                  newID.ID,
 					Source:              prefixInfo.Source(),
-					createdFromMetadata: true,
+					createdFromMetadata: newID.ReferenceCount != -1, // See resolveIdentity().
 				},
 				tunnelPeer: prefixInfo.TunnelPeer().IP(),
 				encryptKey: prefixInfo.EncryptKey().Uint8(),
@@ -586,8 +586,8 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 					ID:             restoredIdentity,
 					Labels:         labels.NewFrom(nil),
 					LabelArray:     labels.LabelArray{},
-					ReferenceCount: 1,
-				}, true, nil
+					ReferenceCount: -1, // Denote that this is not a real identity.
+				}, false, nil
 			}
 			return id, false, nil
 		}

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -28,12 +28,6 @@ import (
 // means it needs to be deep-copied via (*resourceInfo).DeepCopy().
 type prefixInfo map[ipcachetypes.ResourceID]*resourceInfo
 
-// IdentityOverride can be used to override the identity of a given prefix.
-// Must be provided together with a set of labels. Any other labels associated
-// with this prefix are ignored while an override is present.
-// This type implements ipcache.IPMetadata
-type overrideIdentity bool
-
 // resourceInfo is all of the information that has been collected from a given
 // resource (types.ResourceID) about this IP. Each field must have a 'zero'
 // value that indicates that it should be ignored for purposes of merging
@@ -41,7 +35,7 @@ type overrideIdentity bool
 type resourceInfo struct {
 	labels           labels.Labels
 	source           source.Source
-	identityOverride overrideIdentity
+	identityOverride ipcachetypes.OverrideIdentity
 
 	tunnelPeer        ipcachetypes.TunnelPeer
 	encryptKey        ipcachetypes.EncryptKey
@@ -73,7 +67,7 @@ func (m *resourceInfo) merge(info IPMetadata, src source.Source) {
 	switch info := info.(type) {
 	case labels.Labels:
 		m.labels = labels.NewFrom(info)
-	case overrideIdentity:
+	case ipcachetypes.OverrideIdentity:
 		m.identityOverride = info
 	case ipcachetypes.TunnelPeer:
 		m.tunnelPeer = info
@@ -95,7 +89,7 @@ func (m *resourceInfo) unmerge(info IPMetadata) {
 	switch info.(type) {
 	case labels.Labels:
 		m.labels = nil
-	case overrideIdentity:
+	case ipcachetypes.OverrideIdentity:
 		m.identityOverride = false
 	case ipcachetypes.TunnelPeer:
 		m.tunnelPeer = ipcachetypes.TunnelPeer{}

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -288,7 +288,7 @@ func (s prefixInfo) logConflicts(scopedLog *logrus.Entry) {
 		}
 
 		if info.tunnelPeer.IsValid() {
-			if tunnelPeer.IsValid() {
+			if tunnelPeer.IsValid() && info.tunnelPeer != tunnelPeer {
 				if option.Config.TunnelingEnabled() {
 					scopedLog.WithFields(logrus.Fields{
 						logfields.TunnelPeer:            tunnelPeer.String(),
@@ -305,7 +305,7 @@ func (s prefixInfo) logConflicts(scopedLog *logrus.Entry) {
 		}
 
 		if info.encryptKey.IsValid() {
-			if encryptKey.IsValid() {
+			if encryptKey.IsValid() && info.encryptKey != encryptKey {
 				scopedLog.WithFields(logrus.Fields{
 					logfields.Key:                 encryptKey.String(),
 					logfields.Resource:            encryptKeyResourceID,
@@ -320,7 +320,7 @@ func (s prefixInfo) logConflicts(scopedLog *logrus.Entry) {
 		}
 
 		if info.requestedIdentity.IsValid() {
-			if requestedID.IsValid() {
+			if requestedID.IsValid() && info.requestedIdentity != requestedID {
 				scopedLog.WithFields(logrus.Fields{
 					logfields.Identity:            requestedID,
 					logfields.Resource:            requestedIDResourceID,

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/types"
 )
 
 // PolicyHandler is responsible for handling identity updates into the core
@@ -106,4 +107,33 @@ func (id RequestedIdentity) IsValid() bool {
 
 func (id RequestedIdentity) ID() identity.NumericIdentity {
 	return identity.NumericIdentity(id)
+}
+
+// K8sMetadata contains Kubernetes pod information of the IP
+type K8sMetadata struct {
+	// Namespace is the Kubernetes namespace of the pod behind the IP
+	Namespace string
+	// PodName is the Kubernetes pod name behind the IP
+	PodName string
+	// NamedPorts is the set of named ports for the pod
+	NamedPorts types.NamedPortMap
+}
+
+// Equal returns true if two K8sMetadata pointers contain the same data or are
+// both nil.
+func (m *K8sMetadata) Equal(o *K8sMetadata) bool {
+	if m == o {
+		return true
+	} else if m == nil || o == nil {
+		return false
+	}
+	if len(m.NamedPorts) != len(o.NamedPorts) {
+		return false
+	}
+	for k, v := range m.NamedPorts {
+		if v2, ok := o.NamedPorts[k]; !ok || v != v2 {
+			return false
+		}
+	}
+	return m.Namespace == o.Namespace && m.PodName == o.PodName
 }

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -71,6 +71,16 @@ func NewResourceID(kind ResourceKind, namespace, name string) ResourceID {
 	return ResourceID(str.String())
 }
 
+// IdentityOverride can be used to override the identity of a given prefix.
+// Must be provided together with a set of labels. Any other labels associated
+// with this prefix are ignored while an override is present.
+// This type implements ipcache.IPMetadata
+type OverrideIdentity bool
+
+func (o OverrideIdentity) IsValid() bool {
+	return o != false
+}
+
 // TunnelPeer is the IP address of the host associated with this prefix. This is
 // typically used to establish a tunnel, e.g. in tunnel mode or for encryption.
 // This type implements ipcache.IPMetadata

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -180,7 +181,7 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 		return
 	}
 
-	k8sMeta := &ipcache.K8sMetadata{
+	k8sMeta := &ipcachetypes.K8sMetadata{
 		Namespace:  endpoint.Namespace,
 		PodName:    endpoint.Name,
 		NamedPorts: make(ciliumTypes.NamedPortMap, len(endpoint.NamedPorts)),

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -193,17 +193,13 @@ func (k *K8sWatcher) upsertEndpointIPCacheMetadata(endpoint *types.CiliumEndpoin
 		if pair.IPV4 != "" {
 			ipsAdded = append(ipsAdded, pair.IPV4)
 			prefix := ip.IPToNetPrefix(net.ParseIP(pair.IPV4))
-			k.ipcache.OverrideIdentity(
-				prefix,
-				epLabels,
-				source.CustomResource,
-				rid,
-			)
 			k.ipcache.UpsertMetadata(
 				prefix,
 				source.CustomResource,
 				rid,
 				// Metadata:
+				epLabels,
+				ipcachetypes.OverrideIdentity(true),
 				ipcachetypes.TunnelPeer{Addr: nodeIP},
 				ipcachetypes.EncryptKey(encryptionKey),
 				ipcachetypes.RequestedIdentity(id),
@@ -214,17 +210,13 @@ func (k *K8sWatcher) upsertEndpointIPCacheMetadata(endpoint *types.CiliumEndpoin
 		if pair.IPV6 != "" {
 			ipsAdded = append(ipsAdded, pair.IPV6)
 			prefix := ip.IPToNetPrefix(net.ParseIP(pair.IPV6))
-			k.ipcache.OverrideIdentity(
-				prefix,
-				epLabels,
-				source.CustomResource,
-				rid,
-			)
 			k.ipcache.UpsertMetadata(
 				prefix,
 				source.CustomResource,
 				rid,
 				// Metadata:
+				epLabels,
+				ipcachetypes.OverrideIdentity(true),
 				ipcachetypes.TunnelPeer{Addr: nodeIP},
 				ipcachetypes.EncryptKey(encryptionKey),
 				ipcachetypes.RequestedIdentity(id),
@@ -281,15 +273,12 @@ func (k *K8sWatcher) removeEndpointIPCacheMetadata(endpoint *types.CiliumEndpoin
 		}
 		if !v4Added {
 			prefix := ip.IPToNetPrefix(net.ParseIP(oldPair.IPV4))
-			k.ipcache.RemoveIdentityOverride(
-				prefix,
-				epLabels,
-				rid,
-			)
 			k.ipcache.RemoveMetadata(
 				prefix,
 				rid,
 				// Metadata:
+				epLabels,
+				ipcachetypes.OverrideIdentity(true),
 				ipcachetypes.TunnelPeer{Addr: nodeIP},
 				ipcachetypes.EncryptKey(encryptionKey),
 				ipcachetypes.RequestedIdentity(id),
@@ -298,15 +287,12 @@ func (k *K8sWatcher) removeEndpointIPCacheMetadata(endpoint *types.CiliumEndpoin
 		}
 		if !v6Added {
 			prefix := ip.IPToNetPrefix(net.ParseIP(oldPair.IPV6))
-			k.ipcache.RemoveIdentityOverride(
-				prefix,
-				epLabels,
-				rid,
-			)
 			k.ipcache.RemoveMetadata(
 				prefix,
 				rid,
 				// Metadata:
+				epLabels,
+				ipcachetypes.OverrideIdentity(true),
 				ipcachetypes.TunnelPeer{Addr: nodeIP},
 				ipcachetypes.EncryptKey(encryptionKey),
 				ipcachetypes.RequestedIdentity(id),

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -9,7 +9,6 @@ import (
 	"net/netip"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -24,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
 	ciliumTypes "github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/informer"
@@ -866,7 +867,7 @@ func (k *K8sWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPodIP
 
 	hostKey := node.GetEndpointEncryptKeyIndex()
 
-	k8sMeta := &ipcache.K8sMetadata{
+	k8sMeta := &ipcachetypes.K8sMetadata{
 		Namespace: newPod.Namespace,
 		PodName:   newPod.Name,
 	}

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -130,8 +130,12 @@ type ipcacheManager interface {
 	Delete(IP string, source source.Source) (namedPortsChanged bool)
 
 	UpsertLabels(prefix netip.Prefix, lbls labels.Labels, src source.Source, resource ipcacheTypes.ResourceID)
+	RemoveLabels(cidr netip.Prefix, lbls labels.Labels, resource ipcacheTypes.ResourceID)
+	UpsertMetadata(prefix netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata)
+	RemoveMetadata(prefix netip.Prefix, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata)
 	RemoveLabelsExcluded(lbls labels.Labels, toExclude map[netip.Prefix]struct{}, resource ipcacheTypes.ResourceID)
-	DeleteOnMetadataMatch(IP string, source source.Source, namespace, name string) (namedPortsChanged bool)
+	OverrideIdentity(prefix netip.Prefix, identityLabels labels.Labels, src source.Source, resource ipcacheTypes.ResourceID)
+	RemoveIdentityOverride(prefix netip.Prefix, identityLabels labels.Labels, resource ipcacheTypes.ResourceID)
 }
 
 type K8sWatcher struct {

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -125,7 +125,7 @@ type cgroupManager interface {
 
 type ipcacheManager interface {
 	// GH-21142: Re-evaluate the need for these APIs
-	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (namedPortsChanged bool, err error)
+	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcacheTypes.K8sMetadata, newIdentity ipcache.Identity) (namedPortsChanged bool, err error)
 	LookupByIP(IP string) (ipcache.Identity, bool)
 	Delete(IP string, source source.Source) (namedPortsChanged bool)
 

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -409,6 +409,7 @@ func Test_addK8sSVCs_ClusterIP(t *testing.T) {
 		nil,
 		db,
 		nodeAddrs,
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -562,6 +563,7 @@ func TestChangeSVCPort(t *testing.T) {
 		nil,
 		db,
 		nodeAddrs,
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1044,6 +1046,7 @@ func Test_addK8sSVCs_NodePort(t *testing.T) {
 		nil,
 		db,
 		nodeAddrs,
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1360,6 +1363,7 @@ func Test_addK8sSVCs_GH9576_1(t *testing.T) {
 		nil,
 		db,
 		nodeAddrs,
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1669,6 +1673,7 @@ func Test_addK8sSVCs_GH9576_2(t *testing.T) {
 		nil,
 		db,
 		nodeAddrs,
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -2592,6 +2597,7 @@ func Test_addK8sSVCs_ExternalIPs(t *testing.T) {
 		nil,
 		db,
 		nodeAddrs,
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -2638,6 +2644,7 @@ func Test_No_Resources_InitK8sSubsystem(t *testing.T) {
 		testipcache.NewMockIPCache(),
 		nil,
 		emptyResources,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -84,6 +84,9 @@ const (
 
 var (
 	// LabelHealth is the label used for health.
+	LabelUnmanaged = Labels{IDNameUnmanaged: NewLabel(IDNameUnmanaged, "", LabelSourceReserved)}
+
+	// LabelHealth is the label used for health.
 	LabelHealth = Labels{IDNameHealth: NewLabel(IDNameHealth, "", LabelSourceReserved)}
 
 	// LabelHost is the label used for the host endpoint.

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -65,7 +65,7 @@ func AddrOrPrefixToIP(ip string) (netip.Prefix, error) {
 	return prefix, err
 }
 
-func (i *ipcacheMock) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, error) {
+func (i *ipcacheMock) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcacheTypes.K8sMetadata, newIdentity ipcache.Identity) (bool, error) {
 	addr, err := AddrOrPrefixToIP(ip)
 	if err != nil {
 		i.events <- nodeEvent{fmt.Sprintf("upsert failed: %s", err), addr}

--- a/pkg/testutils/ipcache/ipcache.go
+++ b/pkg/testutils/ipcache/ipcache.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
-	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/types"
@@ -41,14 +41,25 @@ func (m *MockIPCache) Delete(IP string, source source.Source) (namedPortsChanged
 	return false
 }
 
-func (m *MockIPCache) UpsertLabels(prefix netip.Prefix, lbls labels.Labels, src source.Source, resource ipcacheTypes.ResourceID) {
+func (m *MockIPCache) UpsertLabels(prefix netip.Prefix, lbls labels.Labels, src source.Source, resource ipcachetypes.ResourceID) {
 }
 
-func (m *MockIPCache) RemoveLabelsExcluded(lbls labels.Labels, toExclude map[netip.Prefix]struct{}, resource ipcacheTypes.ResourceID) {
+func (m *MockIPCache) RemoveLabels(cidr netip.Prefix, lbls labels.Labels, resource ipcachetypes.ResourceID) {
 }
 
-func (m *MockIPCache) DeleteOnMetadataMatch(IP string, source source.Source, namespace, name string) (namedPortsChanged bool) {
-	return false
+func (m *MockIPCache) UpsertMetadata(prefix netip.Prefix, src source.Source, resource ipcachetypes.ResourceID, aux ...ipcache.IPMetadata) {
+}
+
+func (m *MockIPCache) RemoveMetadata(prefix netip.Prefix, resource ipcachetypes.ResourceID, aux ...ipcache.IPMetadata) {
+}
+
+func (m *MockIPCache) RemoveLabelsExcluded(lbls labels.Labels, toExclude map[netip.Prefix]struct{}, resource ipcachetypes.ResourceID) {
+}
+
+func (m *MockIPCache) OverrideIdentity(prefix netip.Prefix, identityLabels labels.Labels, src source.Source, resource ipcachetypes.ResourceID) {
+}
+
+func (m *MockIPCache) RemoveIdentityOverride(prefix netip.Prefix, identityLabels labels.Labels, resource ipcachetypes.ResourceID) {
 }
 
 func (m *MockIPCache) UpsertPrefixes(prefixes []netip.Prefix, src source.Source, resource ipcachetypes.ResourceID) uint64 {

--- a/pkg/testutils/ipcache/ipcache.go
+++ b/pkg/testutils/ipcache/ipcache.go
@@ -33,7 +33,7 @@ func (m *MockIPCache) LookupByIP(IP string) (ipcache.Identity, bool) {
 	return ipcache.Identity{}, false
 }
 
-func (m *MockIPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (namedPortsChanged bool, err error) {
+func (m *MockIPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcachetypes.K8sMetadata, newIdentity ipcache.Identity) (namedPortsChanged bool, err error) {
 	return false, nil
 }
 
@@ -51,11 +51,11 @@ func (m *MockIPCache) DeleteOnMetadataMatch(IP string, source source.Source, nam
 	return false
 }
 
-func (m *MockIPCache) UpsertPrefixes(prefixes []netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID) uint64 {
+func (m *MockIPCache) UpsertPrefixes(prefixes []netip.Prefix, src source.Source, resource ipcachetypes.ResourceID) uint64 {
 	return 0
 }
 
-func (m *MockIPCache) RemovePrefixes(prefixes []netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID) {
+func (m *MockIPCache) RemovePrefixes(prefixes []netip.Prefix, src source.Source, resource ipcachetypes.ResourceID) {
 }
 
 func NewMockIPCache() *MockIPCache {

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -528,7 +529,7 @@ func loadOrGeneratePrivKey(filePath string) (key wgtypes.Key, err error) {
 
 // OnIPIdentityCacheChange implements ipcache.IPIdentityMappingListener
 func (a *Agent) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP,
-	_ *ipcache.Identity, _ ipcache.Identity, _ uint8, _ *ipcache.K8sMetadata) {
+	_ *ipcache.Identity, _ ipcache.Identity, _ uint8, _ *ipcachetypes.K8sMetadata) {
 	ipnet := cidrCluster.AsIPNet()
 
 	// This function is invoked from the IPCache with the


### PR DESCRIPTION
- **identity, labels: Define unmanaged reserved label**
- **identities/cache: Define allocator uninitialized error type**
- **identities/cache: Define error for global identities not yet ready**
- **allocator,ipcache: Error out if global identity alloc is uninitialized**
- **ipcache: Move K8sMetadata to types subpackage**
- **k8s/watchers: Extract named ports convenience function in pod watcher**
- **k8s/watchers: Extract ipcache operations helper functions**
- **daemon, ipcache, k8s: Move pod and CEP watcher to async ipcache**
- **wip: ipcache: Convert kvstore watcher to async ipcache API**

Commits 1-7 are all preparatory. Commit 8 is the main commit. Commit 9 is marked with TODOs for kvstore support.

Related: https://github.com/cilium/cilium/issues/21142
