### PR TITLE
loader: add message if error is ENOTSUP

### DIFF
--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -745,6 +745,9 @@ func ensureDevice(sysctl sysctl.Sysctl, attrs netlink.Link) (netlink.Link, error
 	l, err := netlink.LinkByName(name)
 	if err != nil {
 		if err := netlink.LinkAdd(attrs); err != nil {
+			if errors.Is(err, unix.ENOTSUP) {
+				err = fmt.Errorf("%w, maybe kernel module for %s is not available?", err, attrs.Type())
+			}
 			return nil, fmt.Errorf("creating device %s: %w", name, err)
 		}
 


### PR DESCRIPTION
I was trying to install cilium in a machine without a vxlan module available. Add a helpful message for the next time this happens.

Tested by running:
> PRIVILEGED_TESTS=1 go test  -test.v -test.run TestSetupTunnelDevice

on said machine, and got the following output:
...

```
        Error:          Received unexpected error: setting up vxlan device: creating vxlan device: creating device cilium_vxlan: operation not supported, maybe module for vxlan is not loaded?
	Test:           TestSetupTunnelDevice/Vxlan
```
