### PR TITLE
secret-sync: improve logging

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -766,4 +766,6 @@ const (
 
 	// Entries specifies the number of KVStore entries
 	Entries = "entries"
+	// Action is the summarized action from a reconciliation.
+	Action = "action"
 )


### PR DESCRIPTION
Currently, the Cilium Operator log might contain some confusing messages about syncing K8s Secrets that arent meant to be synced at all.

```
2024-03-15T06:31:11.667921121Z level=info msg="Syncing secrets" controller=secret-syncer resource=kube-system/onepassword-credentials subsys=secret-sync
2024-03-15T06:31:11.667931655Z level=info msg="Successfully synced secrets" controller=secret-syncer resource=kube-system/onepassword-credentials subsys=secret-sync
```

Even though these secrets aren't actually synced, the log contains these messages.

Therefore, this commit improves the logging.

- Rephrasing the log messages to log the start and end of a reconciliation loop (without mentioning the word "sync")
- Add a debug message that logs the actual sync (creation/update) of relevant K8s Secrets.
- Add the secretsNamespace as logfield to the log messages for creation and deletion of synced Secrets
- Add the actual action of the reconciliiatio as logfield to the log message "Successfully reconciled Secret"

This results in the following example logs.

Secret that doesn't get synced.

```
level=info msg="Reconciling secret" controller=secret-syncer resource=kube-system/sh.helm.release.v1.cilium.v1 subsys=secret-sync
level=info msg="Successfully reconciled Secret" action=ignored controller=secret-syncer resource=kube-system/sh.helm.release.v1.cilium.v1 subsys=secret-sync
```

Deleting a Secret that was never synced.

```
level=info msg="Reconciling secret" controller=secret-syncer resource=test-ingress-tls/test-tls subsys=secret-sync
level=debug msg="Unable to get Secret - either deleted or not yet available" controller=secret-syncer error="Secret \"test-tls\" not found" resource=test-ingress-tls/test-tls subsys=secret-sync
level=info msg="Successfully reconciled Secret" action=ignored controller=secret-syncer resource=test-ingress-tls/test-tls subsys=secret-sync
```

Syncing a K8s Secret

```
level=info msg="Reconciling secret" controller=secret-syncer resource=test-ingress-tls/test-tls subsys=secret-sync
level=debug msg="Syncing secret" controller=secret-syncer resource=test-ingress-tls/test-tls secretNamespace=cilium-secrets subsys=secret-sync
level=info msg="Successfully reconciled Secret" action=synced controller=secret-syncer resource=test-ingress-tls/test-tls subsys=secret-sync
```

Cleaning up a synced secret

```
level=info msg="Reconciling secret" controller=secret-syncer resource=test-ingress-tls/test-tls subsys=secret-sync
level=debug msg="Delete synced secret" controller=secret-syncer resource=test-ingress-tls/test-tls secretNamespace=cilium-secrets subsys=secret-sync
level=info msg="Successfully reconciled Secret" action=synced controller=secret-syncer resource=test-ingress-tls/test-tls subsys=secret-sync
```

The log levels are more or less kept as is: logging the start and end of a reconciliation on`info` and the actual inner actions on `debug`

Suggested-by: Marco Iorio <marco.iorio@isovalent.com> (Thanks @giorio94)
