### PR TITLE
k8s: wait for expected CRD version

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -757,4 +757,13 @@ const (
 
 	// EtcdQPSLimit is the QPS limit for an etcd client.
 	EtcdQPSLimit = "etcdQPSLimit"
+
+	// CRD represents a CRD.
+	CRD = "crd"
+
+	// Version is the version of an object.
+	Version = "version"
+
+	// ExpectedVersion is the expected version of an object.
+	ExpectedVersion = "expectedVersion"
 )


### PR DESCRIPTION
Currently, Cilium agents explicitly wait for all expected CRDs to be present before proceeding with the subsequent steps. However, no check is performed on the version, which can be problematic on upgrade, as new agents may start before the Cilium operator managed to update the CRDs in case the schema changed. In turn, causing the first operations to act against the old schema, potentially dropping the content of new fields. Let's prevent this issue by explicitly ensuring that the version of the detected CRDs match at least the expected one, and continue waiting otherwise. This gives the operator time to perform the update.

<!-- Description of change -->

```release-note
Additionally wait for CRDs to match expected version on agents startup.
```
