### PR TITLE
bpf: fix go testdata check in ci

### DIFF
--- a/contrib/scripts/check-go-testdata.sh
+++ b/contrib/scripts/check-go-testdata.sh
@@ -1,5 +1,8 @@
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
+
+set -e
 
 make -C pkg/bpf/testdata build
 test -z "$(git status pkg/bpf/testdata --porcelain)" || (echo "please run 'make -C pkg/bpf/testdata build' and submit your changes"; exit 1)

--- a/pkg/bpf/testdata/Makefile
+++ b/pkg/bpf/testdata/Makefile
@@ -6,4 +6,4 @@ CILIUM_BUILDER_IMAGE=$(shell cat $(ROOT_DIR)/images/cilium/Dockerfile | grep "AR
 
 ##@ Default
 build:
-	docker run -it --rm -v $(ROOT_DIR):/cilium $(CILIUM_BUILDER_IMAGE) clang -target bpf -Wall -O2 -g -I -I/usr/include -I/cilium/bpf -I/cilium/bpf/include -c /cilium/pkg/bpf/testdata/unreachable-tailcall.c -o /cilium/pkg/bpf/testdata/unreachable-tailcall.o
+	docker run --rm -v $(ROOT_DIR):/cilium $(CILIUM_BUILDER_IMAGE) clang -target bpf -Wall -O2 -g -I -I/usr/include -I/cilium/bpf -I/cilium/bpf/include -c /cilium/pkg/bpf/testdata/unreachable-tailcall.c -o /cilium/pkg/bpf/testdata/unreachable-tailcall.o


### PR DESCRIPTION
Currently, check-go-testdata.sh doesn't work as expected on CI.

It reports the following error and the GitHub action (Go Precheck) succeeds without error.

```
contrib/scripts/check-go-testdata.sh
make[1]: Entering directory '/home/runner/work/cilium/cilium/src/github.com/cilium/cilium/pkg/bpf/testdata'
docker run -it --rm -v /home/runner/work/cilium/cilium/src/github.com/cilium/cilium:/cilium quay.io/cilium/cilium-builder:819a4f1e57eaacb6aabfc6a1a39d11d4fd794a88@sha256:24781dc80f2be2d8fd66b0ce1405e1f117a3a0ef388758b1ede7831778e3a4f7 clang -target bpf -Wall -O2 -g -I -I/usr/include -I/cilium/bpf -I/cilium/bpf/include -c /cilium/pkg/bpf/testdata/unreachable-tailcall.c -o /cilium/pkg/bpf/testdata/unreachable-tailcall.o
the input device is not a TTY
make[1]: *** [Makefile:9: build] Error 1
make[1]: Leaving directory '/home/runner/work/cilium/cilium/src/github.com/cilium/cilium/pkg/bpf/testdata'
```

e.g. https://github.com/cilium/cilium/actions/runs/8295433371/job/22702464815

This commit fixes the following issues:

- Don't execute docker interactively
- Use 'set -e' in check script
- Use proper shebang

Fixes: https://github.com/cilium/cilium/pull/30467