### PR TITLE
gha: disable fail-fast on integration tests

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -67,6 +67,7 @@ jobs:
   integration-test:
     name: Integration Test
     strategy:
+      fail-fast: false
       matrix:
         arch: [ubuntu-22.04, ubuntu-22.04-arm64]
     runs-on: ${{ matrix.arch }}


### PR DESCRIPTION
So that the failure of one matrix entry (e.g., caused by a flake) doesn't cancel the other ongoing tests, if any.