### PR TITLE
k8s/utils: correctly filter out labels in StripPodSpecialLabels

### DIFF
--- a/pkg/k8s/utils/utils.go
+++ b/pkg/k8s/utils/utils.go
@@ -248,23 +248,15 @@ func SanitizePodLabels(podLabels map[string]string, namespace nameLabelsGetter, 
 
 // StripPodSpecialLabels strips labels that are not supposed to be coming from a k8s pod object update.
 func StripPodSpecialLabels(labels map[string]string) map[string]string {
-	sanitizedLabels := filterPodLabels(labels)
-	forbiddenKeys := map[string]struct{}{
-		k8sconst.PodNamespaceMetaLabels:    {},
-		k8sconst.PolicyLabelServiceAccount: {},
-		k8sconst.PolicyLabelCluster:        {},
-		k8sconst.PodNamespaceLabel:         {},
-	}
-	for k, v := range labels {
+	sanitizedLabels := make(map[string]string)
+	for k, v := range filterPodLabels(labels) {
 		// If the key contains the prefix for namespace labels then we will
 		// ignore it.
 		if strings.HasPrefix(k, k8sconst.PodNamespaceMetaLabels) {
 			continue
 		}
-		// If the key belongs to any of the forbiddenKeys then we will ignore
-		// it.
-		_, ok := forbiddenKeys[k]
-		if ok {
+		// Also ignore it if the key is a kubernetes namespace label.
+		if k == k8sconst.PodNamespaceLabel {
 			continue
 		}
 		sanitizedLabels[k] = v

--- a/pkg/k8s/utils/utils_test.go
+++ b/pkg/k8s/utils/utils_test.go
@@ -401,6 +401,54 @@ func TestSanitizePodLabels(t *testing.T) {
 	}
 }
 
+func TestStripPodLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   map[string]string
+	}{
+		{
+			name: "no stripped labels",
+			labels: map[string]string{
+				"app": "foo",
+			},
+			want: map[string]string{
+				"app": "foo",
+			},
+		},
+		{
+			name: "Cilium owned label",
+			labels: map[string]string{
+				"app":                            "foo",
+				"io.cilium.k8s.policy.namespace": "kube-system",
+				"io.cilium.k8s.something":        "cilium internal",
+				"io.cilium.k8s.namespace.labels.foo.bar/baz": "foobar",
+			},
+			want: map[string]string{
+				"app": "foo",
+			},
+		},
+		{
+			name: "K8s namespace label",
+			labels: map[string]string{
+				"app":                         "foo",
+				"io.kubernetes.pod.namespace": "default",
+			},
+			want: map[string]string{
+				"app": "foo",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StripPodSpecialLabels(tt.labels); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("StripPodSpecialLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_filterPodLabels(t *testing.T) {
 	expectedLabels := map[string]string{
 		"app":                         "test",


### PR DESCRIPTION
Filter the labels before iterating them, otherwise they are added to `sanitizedLabels` again. Also remove forbidden keys prefixed with `io.cilium.k8s` because they are already filtered out by `filterPodLabels` and inline the check for kubernetes namespace labels.

Fixes: ed4e6505c059 ("k8s/utils: filter out cilium-owned labels on pod update")