### PR TITLE
Hubble: add possibility to export flows to container logs

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -203,7 +203,7 @@ cilium-agent [flags]
       --hubble-export-file-compress                               Compress rotated Hubble export files.
       --hubble-export-file-max-backups int                        Number of rotated Hubble export files to keep. (default 5)
       --hubble-export-file-max-size-mb int                        Size in MB at which to rotate Hubble export file. (default 10)
-      --hubble-export-file-path string                            Filepath to write Hubble events to.
+      --hubble-export-file-path stdout                            Filepath to write Hubble events to. By specifying stdout the flows are logged instead of written to a rotated file.
       --hubble-flowlogs-config-path string                        Filepath with configuration of hubble flowlogs
       --hubble-listen-address string                              An additional address for Hubble server to listen to, e.g. ":4244"
       --hubble-metrics strings                                    List of Hubble metrics to enable.

--- a/Documentation/observability/hubble-exporter.rst
+++ b/Documentation/observability/hubble-exporter.rst
@@ -50,6 +50,9 @@ Verify that flow logs are stored in target files:
 Once you have configured the Hubble Exporter, you can configure your logging solution to consume
 logs from your Hubble export file path.
 
+To get Hubble flows directly exported to the logs instead of written to a rotated file, 
+``stdout`` can be defined as ``hubble-export-file-path``.
+
 To disable the static configuration, you must remove the ``hubble-export-file-path`` key in the
 ``cilium-config`` ConfigMap and manually clean up the log files created in the specified
 location in the container. The below command will restart the Cilium pods. If you edit the

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -875,7 +875,7 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(option.HubbleFlowlogsConfigFilePath, "", "Filepath with configuration of hubble flowlogs")
 	option.BindEnv(vp, option.HubbleFlowlogsConfigFilePath)
 
-	flags.String(option.HubbleExportFilePath, exporteroption.Default.Path, "Filepath to write Hubble events to.")
+	flags.String(option.HubbleExportFilePath, exporteroption.Default.Path, "Filepath to write Hubble events to. By specifying `stdout` the flows are logged instead of written to a rotated file.")
 	option.BindEnv(vp, option.HubbleExportFilePath)
 
 	flags.Int(option.HubbleExportFileMaxSizeMB, exporteroption.Default.MaxSizeMB, "Size in MB at which to rotate Hubble export file.")

--- a/pkg/hubble/exporter/exporter.go
+++ b/pkg/hubble/exporter/exporter.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/cilium/lumberjack/v2"
 	"github.com/sirupsen/logrus"
@@ -44,11 +45,17 @@ func NewExporter(
 		}
 	}
 	logger.WithField("options", opts).Info("Configuring Hubble event exporter")
-	writer := &lumberjack.Logger{
-		Filename:   opts.Path,
-		MaxSize:    opts.MaxSizeMB,
-		MaxBackups: opts.MaxBackups,
-		Compress:   opts.Compress,
+	var writer io.WriteCloser
+	// If hubble-export-file-path is set to "stdout", use os.Stdout as the writer.
+	if opts.Path == "stdout" {
+		writer = os.Stdout
+	} else {
+		writer = &lumberjack.Logger{
+			Filename:   opts.Path,
+			MaxSize:    opts.MaxSizeMB,
+			MaxBackups: opts.MaxBackups,
+			Compress:   opts.Compress,
+		}
 	}
 	return newExporter(ctx, logger, writer, opts)
 }


### PR DESCRIPTION
This is a modification of the static exporter for flow logs which allows setting the `hubble-export-file-path` to `stdout`. This triggers not the creation of rotating files but the direct output to logs.

The benefit is the possibility to ship flow logs to a SIEM for continuous analysis without the deployment of a separate daemonset like used here: https://github.com/cilium/hubble-otel

I am happy for any suggestions.