### PR TITLE
bgpv1:  Local internalTrafficPolicy support for ClusterIP advertisements

### DIFF
--- a/Documentation/network/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane.rst
@@ -305,9 +305,14 @@ defaults to the ``LoadBalancerIP`` service. You can also specify the ``.serviceA
 field to advertise specific service types, with options such as ``LoadBalancerIP``,
 ``ClusterIP`` and ``ExternalIP``.
 
+It is worth noting that when you configure ``virtualRouters[*].serviceAdvertisements`` as ``ClusterIP``,
+the BGP Control Plane only considers the configuration of the service's ``.spec.internalTrafficPolicy`` and ignores
+the configuration of ``.spec.externalTrafficPolicy``.
+For ``ExternalIP`` and ``LoadBalancerIP``, it only considers the configuration of
+the service's ``.spec.externalTrafficPolicy`` and ignores the configuration of ``.spec.internalTrafficPolicy``.
+
 The ``.serviceSelector`` field is a label selector that selects Services matching
 the specified ``.matchLabels`` or ``.matchExpressions``.
-
 
 When your upstream router supports Equal Cost Multi Path(ECMP), you can use
 this feature to load balance traffic to the Service across multiple nodes by

--- a/pkg/bgpv1/manager/reconciler/service_test.go
+++ b/pkg/bgpv1/manager/reconciler/service_test.go
@@ -739,15 +739,16 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 	svc1NonClusterIP := svc1.DeepCopy()
 	svc1NonClusterIP.Spec.ClusterIP = "None"
 	svc1NonClusterIP.Spec.ClusterIPs = append(svc1NonClusterIP.Spec.ClusterIPs, "None")
-	svc1ETPLocal := svc1.DeepCopy()
-	svc1ETPLocal.Spec.ExternalTrafficPolicy = slim_corev1.ServiceExternalTrafficPolicyLocal
+	svc1ITPLocal := svc1.DeepCopy()
+	internalTrafficPolicyLocal := slim_corev1.ServiceInternalTrafficPolicyLocal
+	svc1ITPLocal.Spec.InternalTrafficPolicy = &internalTrafficPolicyLocal
 
-	svc1ETPLocalTwoIngress := svc1TwoIngress.DeepCopy()
-	svc1ETPLocalTwoIngress.Spec.ExternalTrafficPolicy = slim_corev1.ServiceExternalTrafficPolicyLocal
+	svc1ITPLocalTwoIngress := svc1TwoIngress.DeepCopy()
+	svc1ITPLocalTwoIngress.Spec.InternalTrafficPolicy = &internalTrafficPolicyLocal
 
-	svc1IPv6ETPLocal := svc1.DeepCopy()
-	svc1IPv6ETPLocal.Spec.ClusterIPs = append(svc1IPv6ETPLocal.Spec.ClusterIPs, clusterIPV6)
-	svc1IPv6ETPLocal.Spec.ExternalTrafficPolicy = slim_corev1.ServiceExternalTrafficPolicyLocal
+	svc1IPv6ITPLocal := svc1.DeepCopy()
+	svc1IPv6ITPLocal.Spec.ClusterIPs = append(svc1IPv6ITPLocal.Spec.ClusterIPs, clusterIPV6)
+	svc1IPv6ITPLocal.Spec.InternalTrafficPolicy = &internalTrafficPolicyLocal
 
 	svc1LbClass := svc1.DeepCopy()
 	svc1LbClass.Spec.LoadBalancerClass = pointer.String(v2alpha1api.BGPLoadBalancerClass)
@@ -1096,17 +1097,17 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 			oldServiceSelector: &blueSelector,
 			newServiceSelector: &blueSelector,
 			advertised:         map[resource.Key][]string{},
-			upsertedServices:   []*slim_corev1.Service{svc1ETPLocal},
+			upsertedServices:   []*slim_corev1.Service{svc1ITPLocal},
 			upsertedEndpoints:  []*k8s.Endpoints{},
 			updated:            map[resource.Key][]string{},
 		},
-		// externalTrafficPolicy=Local && IPv4 && single slice && local endpoint
+		// internalTrafficPolicyLocal=Local && IPv4 && single slice && local endpoint
 		{
-			name:               "etp-local-ipv4-single-slice-local",
+			name:               "itp-local-ipv4-single-slice-local",
 			oldServiceSelector: &blueSelector,
 			newServiceSelector: &blueSelector,
 			advertised:         map[resource.Key][]string{},
-			upsertedServices:   []*slim_corev1.Service{svc1ETPLocal},
+			upsertedServices:   []*slim_corev1.Service{svc1ITPLocal},
 			upsertedEndpoints:  []*k8s.Endpoints{eps1IPv4Local},
 			updated: map[resource.Key][]string{
 				svc1Name: {
@@ -1114,23 +1115,23 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 				},
 			},
 		},
-		// externalTrafficPolicy=Local && IPv4 && single slice && remote endpoint
+		// internalTrafficPolicyLocal=Local && IPv4 && single slice && remote endpoint
 		{
-			name:               "etp-local-ipv4-single-slice-remote",
+			name:               "itp-local-ipv4-single-slice-remote",
 			oldServiceSelector: &blueSelector,
 			newServiceSelector: &blueSelector,
 			advertised:         map[resource.Key][]string{},
-			upsertedServices:   []*slim_corev1.Service{svc1ETPLocal},
+			upsertedServices:   []*slim_corev1.Service{svc1ITPLocal},
 			upsertedEndpoints:  []*k8s.Endpoints{eps1IPv4Remote},
 			updated:            map[resource.Key][]string{},
 		},
-		// externalTrafficPolicy=Local && IPv4 && single slice && mixed endpoint
+		// internalTrafficPolicyLocal=Local && IPv4 && single slice && mixed endpoint
 		{
-			name:               "etp-local-ipv4-single-slice-mixed",
+			name:               "itp-local-ipv4-single-slice-mixed",
 			oldServiceSelector: &blueSelector,
 			newServiceSelector: &blueSelector,
 			advertised:         map[resource.Key][]string{},
-			upsertedServices:   []*slim_corev1.Service{svc1ETPLocal},
+			upsertedServices:   []*slim_corev1.Service{svc1ITPLocal},
 			upsertedEndpoints:  []*k8s.Endpoints{eps1IPv4Mixed},
 			updated: map[resource.Key][]string{
 				svc1Name: {
@@ -1138,13 +1139,13 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 				},
 			},
 		},
-		// externalTrafficPolicy=Local && IPv6 && single slice && local endpoint
+		// internalTrafficPolicyLocal=Local && IPv6 && single slice && local endpoint
 		{
-			name:               "etp-local-ipv6-single-slice-local",
+			name:               "itp-local-ipv6-single-slice-local",
 			oldServiceSelector: &blueSelector,
 			newServiceSelector: &blueSelector,
 			advertised:         map[resource.Key][]string{},
-			upsertedServices:   []*slim_corev1.Service{svc1IPv6ETPLocal},
+			upsertedServices:   []*slim_corev1.Service{svc1IPv6ITPLocal},
 			upsertedEndpoints:  []*k8s.Endpoints{eps1IPv6Local},
 			updated: map[resource.Key][]string{
 				svc1Name: {
@@ -1153,23 +1154,23 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 				},
 			},
 		},
-		// externalTrafficPolicy=Local && IPv6 && single slice && remote endpoint
+		// internalTrafficPolicyLocal=Local && IPv6 && single slice && remote endpoint
 		{
-			name:               "etp-local-ipv6-single-slice-remote",
+			name:               "itp-local-ipv6-single-slice-remote",
 			oldServiceSelector: &blueSelector,
 			newServiceSelector: &blueSelector,
 			advertised:         map[resource.Key][]string{},
-			upsertedServices:   []*slim_corev1.Service{svc1IPv6ETPLocal},
+			upsertedServices:   []*slim_corev1.Service{svc1IPv6ITPLocal},
 			upsertedEndpoints:  []*k8s.Endpoints{eps1IPv6Remote},
 			updated:            map[resource.Key][]string{},
 		},
-		// externalTrafficPolicy=Local && IPv6 && single slice && mixed endpoint
+		// internalTrafficPolicyLocal=Local && IPv6 && single slice && mixed endpoint
 		{
-			name:               "etp-local-ipv6-single-slice-mixed",
+			name:               "itp-local-ipv6-single-slice-mixed",
 			oldServiceSelector: &blueSelector,
 			newServiceSelector: &blueSelector,
 			advertised:         map[resource.Key][]string{},
-			upsertedServices:   []*slim_corev1.Service{svc1IPv6ETPLocal},
+			upsertedServices:   []*slim_corev1.Service{svc1IPv6ITPLocal},
 			upsertedEndpoints:  []*k8s.Endpoints{eps1IPv6Mixed},
 			updated: map[resource.Key][]string{
 				svc1Name: {
@@ -1178,13 +1179,13 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 				},
 			},
 		},
-		// externalTrafficPolicy=Local && Dual && two slices && local endpoint
+		// internalTrafficPolicyLocal=Local && Dual && two slices && local endpoint
 		{
-			name:               "etp-local-dual-two-slices-local",
+			name:               "itp-local-dual-two-slices-local",
 			oldServiceSelector: &blueSelector,
 			newServiceSelector: &blueSelector,
 			advertised:         map[resource.Key][]string{},
-			upsertedServices:   []*slim_corev1.Service{svc1ETPLocalTwoIngress},
+			upsertedServices:   []*slim_corev1.Service{svc1ITPLocalTwoIngress},
 			upsertedEndpoints: []*k8s.Endpoints{
 				eps1IPv4Local,
 				eps1IPv6Local,
@@ -1196,13 +1197,13 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 				},
 			},
 		},
-		// externalTrafficPolicy=Local && Dual && two slices && remote endpoint
+		// internalTrafficPolicyLocal=Local && Dual && two slices && remote endpoint
 		{
-			name:               "etp-local-dual-two-slices-remote",
+			name:               "itp-local-dual-two-slices-remote",
 			oldServiceSelector: &blueSelector,
 			newServiceSelector: &blueSelector,
 			advertised:         map[resource.Key][]string{},
-			upsertedServices:   []*slim_corev1.Service{svc1ETPLocalTwoIngress},
+			upsertedServices:   []*slim_corev1.Service{svc1ITPLocalTwoIngress},
 			upsertedEndpoints: []*k8s.Endpoints{
 				eps1IPv4Remote,
 				eps1IPv6Remote,
@@ -1211,13 +1212,13 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 				svc1Name: {},
 			},
 		},
-		// externalTrafficPolicy=Local && Dual && two slices && mixed endpoint
+		// internalTrafficPolicyLocal=Local && Dual && two slices && mixed endpoint
 		{
-			name:               "etp-local-dual-two-slices-mixed",
+			name:               "itp-local-dual-two-slices-mixed",
 			oldServiceSelector: &blueSelector,
 			newServiceSelector: &blueSelector,
 			advertised:         map[resource.Key][]string{},
-			upsertedServices:   []*slim_corev1.Service{svc1ETPLocalTwoIngress},
+			upsertedServices:   []*slim_corev1.Service{svc1ITPLocalTwoIngress},
 			upsertedEndpoints: []*k8s.Endpoints{
 				eps1IPv4Mixed,
 				eps1IPv6Mixed,


### PR DESCRIPTION
Fixes: #31389

```release-note
bgpv1: Add Local internalTrafficPolicy support for ClusterIP advertisements
```
