### PR TITLE
docs: Correct dynamic hubble exporter sample configs example

### DIFF
--- a/Documentation/observability/hubble-exporter.rst
+++ b/Documentation/observability/hubble-exporter.rst
@@ -257,6 +257,7 @@ Sample dynamic flow logs configs:
   hubble:
     export:
       dynamic:
+        enabled: true
         config:
           enabled: true
           content:


### PR DESCRIPTION
This commit corrects the sample dynamic flow logs configs for hubble exporter. This inserts `dynamic.enabled: true` in helm values because `dynamic.enabled` is false by default.
