### PR TITLE
envoy: register secret syncer even if only CEC is enabled

### DIFF
--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -286,16 +286,10 @@ type syncerParams struct {
 }
 
 func registerSecretSyncer(params syncerParams) error {
-	if !params.Config.EnableIngressController && !params.Config.EnableGatewayAPI {
-		return nil
-	}
-
-	secretSyncer := newSecretSyncer(params.Logger, params.XdsServer)
-
 	// Create a Secret Resource for each namespace.
 	// The Cilium Agent only has permissions on the specific namespaces.
 	// Note that the different features can use the same namespace for
-	// their TLS.
+	// their TLS secrets.
 	namespaces := map[string]struct{}{}
 
 	for namespace, cond := range map[string]func() bool{
@@ -319,6 +313,9 @@ func registerSecretSyncer(params syncerParams) error {
 	)
 
 	params.Lifecycle.Append(jobGroup)
+
+	secretSyncer := newSecretSyncer(params.Logger, params.XdsServer)
+
 	for ns := range namespaces {
 		jobGroup.Add(job.Observer(
 			fmt.Sprintf("k8s-secrets-resource-events-%s", ns),

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -286,6 +286,10 @@ type syncerParams struct {
 }
 
 func registerSecretSyncer(params syncerParams) error {
+	if !params.K8sClientset.IsEnabled() {
+		return nil
+	}
+
 	// Create a Secret Resource for each namespace.
 	// The Cilium Agent only has permissions on the specific namespaces.
 	// Note that the different features can use the same namespace for


### PR DESCRIPTION
Currently, the Envoy SecretSyncer (K8s TLS Secret -> Envoy SDS) only gets registered if either Ingress Controller or Gateway API is enabled.

Hence Secrets aren't available via SDS in cases where only CiliumEnvoyConfig is enabled (`--enable-envoy-config`).

This commit fixes this by registering the SecretSyncer also in cases where only CiliumEnvoyConfig is enabled (without Ingress Controller and/or Gateway API being enabled).

In addition, the SecretSyncer only gets initialized if Cilium is running in a K8s cluster (clientset enabled).

This results in the following envoy module jobs if only CEC (but not Ingress & Gateway API) is enabled.

```
root@kind-worker:/home/cilium# cilium status --verbose
...
Modules Health:
agent
├── controlplane
...
│   ├── envoy-proxy
│   │   ├── ...
│   │   └── observer-job-k8s-secrets-resource-events-cilium-secrets    [OK] Primed (1s, x1)
...
```

Fixes: https://github.com/cilium/cilium/pull/26005