### PR TITLE
envoy: cleanup istio specifics

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1424,7 +1424,6 @@ func (e *Endpoint) GetDisableLegacyIdentifiers() bool {
 	e.unconditionalRLock()
 	defer e.runlock()
 	return e.disableLegacyIdentifiers
-
 }
 
 func (e *Endpoint) setState(toState State, reason string) bool {
@@ -2535,10 +2534,7 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 	return errs
 }
 
-// WaitForFirstRegeneration waits for specific conditions before returning:
-// * if the endpoint has a sidecar proxy, it waits for the endpoint's BPF
-// program to be generated for the first time.
-// * otherwise, waits for the endpoint to complete its first full regeneration.
+// WaitForFirstRegeneration waits for the endpoint to complete its first full regeneration.
 func (e *Endpoint) WaitForFirstRegeneration(ctx context.Context) error {
 	e.getLogger().Info("Waiting for endpoint to be generated")
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -122,10 +122,6 @@ func (e *Endpoint) LookupRedirectPort(ingress bool, protocol string, port uint16
 func (e *Endpoint) updateNetworkPolicy(proxyWaitGroup *completion.WaitGroup) (reterr error, revertFunc revert.RevertFunc) {
 	// Skip updating the NetworkPolicy if no identity has been computed for this
 	// endpoint.
-	// This breaks a circular dependency between configuring NetworkPolicies in
-	// sidecar Envoy proxies and those proxies needing network connectivity
-	// to get their initial configuration, which is required for them to ACK
-	// the NetworkPolicies.
 	if e.SecurityIdentity == nil {
 		return nil, nil
 	}
@@ -698,7 +694,6 @@ func (e *Endpoint) Regenerate(regenMetadata *regeneration.ExternalRegenerationMe
 	}
 
 	go func() {
-
 		// Free up resources with context.
 		defer cFunc()
 

--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -47,7 +47,6 @@ type EndpointInfoSource interface {
 	GetIPv6Address() string
 	GetIdentity() identity.NumericIdentity
 	GetLabels() []string
-	HasSidecarProxy() bool
 	ConntrackName() string
 	ConntrackNameLocked() string
 }

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -93,14 +93,13 @@ func (s *AccessLogServer) newSocketListener() (*net.UnixListener, error) {
 	}
 	accessLogListener.SetUnlinkOnClose(true)
 
-	// Make the socket accessible by owner and group only. Group access is needed for Istio
-	// sidecar proxies.
+	// Make the socket accessible by owner and group only.
 	if err = os.Chmod(s.socketPath, 0660); err != nil {
 		return nil, fmt.Errorf("failed to change mode of access log listen socket at %s: %w", s.socketPath, err)
 	}
 	// Change the group to ProxyGID allowing access from any process from that group.
 	if err = os.Chown(s.socketPath, -1, int(s.proxyGID)); err != nil {
-		log.WithError(err).Warningf("Envoy: Failed to change the group of access log listen socket at %s, sidecar proxies may not work", s.socketPath)
+		log.WithError(err).Warningf("Envoy: Failed to change the group of access log listen socket at %s", s.socketPath)
 	}
 	return accessLogListener, nil
 }

--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -104,9 +104,8 @@ func startEmbeddedEnvoy(config embeddedEnvoyConfig) (*EmbeddedEnvoy, error) {
 	bootstrapFilePath := filepath.Join(config.runDir, "envoy", "bootstrap.pb")
 
 	writeBootstrapConfigFile(bootstrapConfig{
-		// Use the same structure as Istio's pilot-agent for the node ID: nodeType~ipAddress~proxyId~domain
 		filePath:                 bootstrapFilePath,
-		nodeId:                   "host~127.0.0.1~no-id~localdomain",
+		nodeId:                   "host~127.0.0.1~no-id~localdomain", // node id format inherited from Istio
 		cluster:                  ingressClusterName,
 		adminPath:                getAdminSocketPath(GetSocketDir(config.runDir)),
 		xdsSock:                  getXDSSocketPath(GetSocketDir(config.runDir)),

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -75,14 +75,12 @@ func newNPHDSCache(ipcache IPCacheEventSource) NPHDSCache {
 	return NPHDSCache{Cache: xds.NewCache(), ipcache: ipcache}
 }
 
-var (
-	observerOnce = sync.Once{}
-)
+var observerOnce = sync.Once{}
 
 // HandleResourceVersionAck is required to implement ResourceVersionAckObserver.
 // We use this to start the IP Cache listener on the first ACK so that we only
-// start the IP Cache listener if there is an Envoy node that uses NPHDS (e.g.,
-// Istio node, or host proxy running on kernel w/o LPM bpf map support).
+// start the IP Cache listener if there is an Envoy node that uses NPHDS
+// (e.g. Cilium host proxy running on kernel w/o LPM bpf map support).
 func (cache *NPHDSCache) HandleResourceVersionAck(ackVersion uint64, nackVersion uint64, nodeIP string, resourceNames []string, typeURL string, detail string) {
 	// Start caching for IP/ID mappings on the first indication someone wants them
 	observerOnce.Do(func() {
@@ -98,7 +96,8 @@ func (cache *NPHDSCache) HandleResourceVersionAck(ackVersion uint64, nackVersion
 // IP/ID mappings.
 func (cache *NPHDSCache) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrCluster cmtypes.PrefixCluster,
 	oldHostIP, newHostIP net.IP, oldID *ipcache.Identity, newID ipcache.Identity,
-	encryptKey uint8, k8sMeta *ipcache.K8sMetadata) {
+	encryptKey uint8, k8sMeta *ipcache.K8sMetadata,
+) {
 	cidr := cidrCluster.AsIPNet()
 
 	cidrStr := cidr.String()

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -25,9 +25,7 @@ func (pe *ProxyError) Error() string {
 	return pe.Err.Error() + ": " + pe.Detail
 }
 
-var (
-	ErrNackReceived = errors.New("NACK received")
-)
+var ErrNackReceived = errors.New("NACK received")
 
 // ResourceVersionAckObserver defines the HandleResourceVersionAck method
 // which is called whenever a node acknowledges having applied a version of
@@ -102,8 +100,8 @@ type AckingResourceMutatorWrapper struct {
 	version uint64
 
 	// ackedVersions is the last version acked by a node for this cache.
-	// The key is the IPv4 address in string format for an Istio sidecar,
-	// or "127.0.0.1" for the host proxy.
+	// The key is the IPv4 address of the Envoy instance in string format.
+	// e.g. "127.0.0.1" for the host proxy.
 	ackedVersions map[string]uint64
 
 	// pendingCompletions is the list of updates that are pending completion.

--- a/pkg/envoy/xds/node.go
+++ b/pkg/envoy/xds/node.go
@@ -10,21 +10,20 @@ import (
 	"strings"
 )
 
-// IstioNodeToIP extract the IP address from an Envoy node identifier
-// configured by Istio's pilot-agent.
+// EnvoyNodeIdToIP extracts the IP address from an Envoy node identifier.
 //
-// Istio's pilot-agent structures the nodeId as the concatenation of the
+// The NodeID is structured as the concatenation of the
 // following parts separated by ~:
 //
-// - node type: one of "sidecar", "ingress", or "router"
+// - node type
 // - node IP address
-// - node ID: the unique platform-specific sidecar proxy ID
+// - node ID
 // - node domain: the DNS domain suffix for short hostnames, e.g. "default.svc.cluster.local"
 //
 // For instance:
 //
-//	"sidecar~10.1.1.0~v0.default~default.svc.cluster.local"
-func IstioNodeToIP(nodeId string) (string, error) {
+//	"host~127.0.0.1~no-id~localdomain"
+func EnvoyNodeIdToIP(nodeId string) (string, error) {
 	if nodeId == "" {
 		return "", errors.New("nodeId is empty")
 	}

--- a/pkg/envoy/xds/node_test.go
+++ b/pkg/envoy/xds/node_test.go
@@ -11,17 +11,17 @@ type NodeSuite struct{}
 
 var _ = Suite(&NodeSuite{})
 
-func (s *NodeSuite) TestIstioNodeToIP(c *C) {
+func (s *NodeSuite) TestEnvoyNodeToIP(c *C) {
 	var ip string
 	var err error
 
-	ip, err = IstioNodeToIP("sidecar~10.1.1.0~v0.default~default.svc.cluster.local")
+	ip, err = EnvoyNodeIdToIP("host~127.0.0.1~no-id~localdomain")
 	c.Assert(err, IsNil)
-	c.Check(ip, Equals, "10.1.1.0")
+	c.Check(ip, Equals, "127.0.0.1")
 
-	_, err = IstioNodeToIP("sidecar~10.1.1.0~v0.default")
+	_, err = EnvoyNodeIdToIP("host~127.0.0.1~localdomain")
 	c.Assert(err, Not(IsNil))
 
-	_, err = IstioNodeToIP("sidecar~not-an-ip~v0.default~default.svc.cluster.local")
+	_, err = EnvoyNodeIdToIP("host~not-an-ip~v0.default~default.svc.cluster.local")
 	c.Assert(err, Not(IsNil))
 }

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -192,7 +192,8 @@ type perTypeStreamState struct {
 
 // processRequestStream processes the requests in an xDS stream from a channel.
 func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Entry, stream Stream,
-	reqCh <-chan *envoy_service_discovery.DiscoveryRequest, defaultTypeURL string) error {
+	reqCh <-chan *envoy_service_discovery.DiscoveryRequest, defaultTypeURL string,
+) error {
 	// The request state for every type URL.
 	typeStates := make([]perTypeStreamState, len(s.watchers))
 	defer func() {
@@ -276,7 +277,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				id := req.GetNode().GetId()
 				streamLog = streamLog.WithField(logfields.XDSClientNode, id)
 				var err error
-				nodeIP, err = IstioNodeToIP(id)
+				nodeIP, err = EnvoyNodeIdToIP(id)
 				if err != nil {
 					streamLog.WithError(err).Error("invalid Node in xDS request")
 					return ErrInvalidNodeFormat

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -43,9 +43,9 @@ const (
 var (
 	DeferredCompletion = errors.New("Deferred completion")
 	nodes              = map[string]*envoy_config_core.Node{
-		node0: {Id: "sidecar~10.0.0.0~node0~bar"},
-		node1: {Id: "sidecar~10.0.0.1~node1~bar"},
-		node2: {Id: "sidecar~10.0.0.2~node2~bar"},
+		node0: {Id: "node0~10.0.0.0~node0~bar"},
+		node1: {Id: "node1~10.0.0.1~node1~bar"},
+		node2: {Id: "node2~10.0.0.2~node2~bar"},
 	}
 )
 
@@ -116,7 +116,8 @@ func (c *ResponseMatchesChecker) Check(params []interface{}, names []string) (re
 // parameters.
 var ResponseMatches Checker = &ResponseMatchesChecker{
 	&CheckerInfo{Name: "ResponseMatches", Params: []string{
-		"response", "VersionInfo", "Resources", "Canary", "TypeUrl"}},
+		"response", "VersionInfo", "Resources", "Canary", "TypeUrl",
+	}},
 }
 
 var resources = []*envoy_config_route.RouteConfiguration{

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1667,7 +1667,6 @@ type DaemonConfig struct {
 	PreAllocateMaps         bool
 	IPv6NodeAddr            string
 	IPv4NodeAddr            string
-	SidecarIstioProxyImage  string
 	SocketPath              string
 	TracePayloadlen         int
 	Version                 string

--- a/pkg/proxy/endpoint/test/updater_mock.go
+++ b/pkg/proxy/endpoint/test/updater_mock.go
@@ -12,31 +12,41 @@ import (
 
 type ProxyUpdaterMock struct {
 	lock.RWMutex
-	Id           uint64
-	Ipv4         string
-	Ipv6         string
-	Labels       []string
-	Identity     identity.NumericIdentity
-	SidecarProxy bool
+	Id       uint64
+	Ipv4     string
+	Ipv6     string
+	Labels   []string
+	Identity identity.NumericIdentity
 }
 
 func (m *ProxyUpdaterMock) UnconditionalRLock() { m.RWMutex.RLock() }
-func (m *ProxyUpdaterMock) RUnlock()            { m.RWMutex.RUnlock() }
 
-func (m *ProxyUpdaterMock) GetID() uint64                               { return m.Id }
-func (m *ProxyUpdaterMock) GetIPv4Address() string                      { return m.Ipv4 }
-func (m *ProxyUpdaterMock) GetIPv6Address() string                      { return m.Ipv6 }
-func (m *ProxyUpdaterMock) GetLabels() []string                         { return m.Labels }
-func (m *ProxyUpdaterMock) GetEgressPolicyEnabledLocked() bool          { return true }
-func (m *ProxyUpdaterMock) GetIngressPolicyEnabledLocked() bool         { return true }
+func (m *ProxyUpdaterMock) RUnlock() { m.RWMutex.RUnlock() }
+
+func (m *ProxyUpdaterMock) GetID() uint64 { return m.Id }
+
+func (m *ProxyUpdaterMock) GetIPv4Address() string { return m.Ipv4 }
+
+func (m *ProxyUpdaterMock) GetIPv6Address() string { return m.Ipv6 }
+
+func (m *ProxyUpdaterMock) GetLabels() []string { return m.Labels }
+
+func (m *ProxyUpdaterMock) GetEgressPolicyEnabledLocked() bool { return true }
+
+func (m *ProxyUpdaterMock) GetIngressPolicyEnabledLocked() bool { return true }
+
 func (m *ProxyUpdaterMock) GetIdentityLocked() identity.NumericIdentity { return m.Identity }
-func (m *ProxyUpdaterMock) GetNamedPort(bool, string, uint8) uint16     { return 0 }
-func (m *ProxyUpdaterMock) HasSidecarProxy() bool                       { return m.SidecarProxy }
-func (m *ProxyUpdaterMock) ConntrackName() string                       { return m.ConntrackNameLocked() }
-func (m *ProxyUpdaterMock) ConntrackNameLocked() string                 { return "global" }
+
+func (m *ProxyUpdaterMock) GetNamedPort(bool, string, uint8) uint16 { return 0 }
+
+func (m *ProxyUpdaterMock) ConntrackName() string { return m.ConntrackNameLocked() }
+
+func (m *ProxyUpdaterMock) ConntrackNameLocked() string { return "global" }
 
 func (m *ProxyUpdaterMock) OnProxyPolicyUpdate(policyRevision uint64) {}
+
 func (m *ProxyUpdaterMock) UpdateProxyStatistics(proxyTypet, l4Protocol string, port, proxyPort uint16, ingress, request bool,
 	verdict accesslog.FlowVerdict) {
 }
+
 func (m *ProxyUpdaterMock) OnDNSPolicyUpdateLocked(rules restore.DNSRules) {}


### PR DESCRIPTION
As a follow up of #30130, this commit removes Istio sidecar specific implementations and/or comments from the Envoy module.