### PR TITLE
[v1.14 - Author backport] envoy: enable k8s secret watch even if only CEC is enabled

### DIFF
--- a/pkg/k8s/utils/utils.go
+++ b/pkg/k8s/utils/utils.go
@@ -69,6 +69,12 @@ type ServiceConfiguration interface {
 	K8sServiceProxyNameValue() string
 }
 
+// EnvoyConfigConfiguration is the required configuration for GetServiceAndEndpointListOptionsModifier
+type EnvoyConfigConfiguration interface {
+	// K8sEnvoyConfigEnabled returns true if CiliumEnvoyConfig feature is enabled in Cilium
+	K8sEnvoyConfigEnabled() bool
+}
+
 // IngressConfiguration is the required configuration for GetServiceAndEndpointListOptionsModifier
 type IngressConfiguration interface {
 	// K8sIngressControllerEnabled returns true if ingress controller feature is enabled in Cilium

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -179,6 +179,7 @@ type bgpSpeakerManager interface {
 
 	OnUpdateEndpoints(eps *k8s.Endpoints) error
 }
+
 type EgressGatewayManager interface {
 	OnAddEgressPolicy(config egressgateway.PolicyConfig)
 	OnDeleteEgressPolicy(configID types.NamespacedName)
@@ -480,9 +481,9 @@ func (k *K8sWatcher) resourceGroups() (beforeNodeInitGroups, afterNodeInitGroups
 		k8sGroups = append(k8sGroups, k8sAPIGroupNetworkingV1Core)
 	}
 
-	if k.cfg.K8sIngressControllerEnabled() || k.cfg.K8sGatewayAPIEnabled() {
-		// While Ingress controller is part of operator, we need to watch
-		// TLS secrets in pre-defined namespace for populating Envoy xDS SDS cache.
+	if k.cfg.K8sEnvoyConfigEnabled() || k.cfg.K8sIngressControllerEnabled() || k.cfg.K8sGatewayAPIEnabled() {
+		// Watch K8s TLS secrets in pre-defined namespace(s) for populating Envoy xDS SDS cache.
+		// Used by Ingress Controller, Gateway API and/or plain CiliumEnvoyConfig.
 		k8sGroups = append(k8sGroups, resources.K8sAPIGroupSecretV1Core)
 	}
 
@@ -543,6 +544,7 @@ func (k *K8sWatcher) InitK8sSubsystem(ctx context.Context, cachesSynced chan str
 // WatcherConfiguration is the required configuration for enableK8sWatchers
 type WatcherConfiguration interface {
 	utils.ServiceConfiguration
+	utils.EnvoyConfigConfiguration
 	utils.IngressConfiguration
 	utils.GatewayAPIConfiguration
 	utils.PolicyConfiguration

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -42,6 +42,10 @@ func (f *fakeWatcherConfiguration) K8sServiceProxyNameValue() string {
 	return ""
 }
 
+func (f *fakeWatcherConfiguration) K8sEnvoyConfigEnabled() bool {
+	return false
+}
+
 func (f *fakeWatcherConfiguration) K8sIngressControllerEnabled() bool {
 	return false
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2730,6 +2730,11 @@ func (c *DaemonConfig) K8sNetworkPolicyEnabled() bool {
 	return c.EnableK8sNetworkPolicy
 }
 
+// K8sEnvoyConfigEnabled returns true if CiliumEnvoyConfig feature is enabled in Cilium
+func (c *DaemonConfig) K8sEnvoyConfigEnabled() bool {
+	return c.EnableEnvoyConfig
+}
+
 // K8sIngressControllerEnabled returns true if ingress controller feature is enabled in Cilium
 func (c *DaemonConfig) K8sIngressControllerEnabled() bool {
 	return c.EnableIngressController


### PR DESCRIPTION
Manual backport of #31447

Currently, the K8s Secret watch (used by Envoy SecretSync (K8s TLS Secret -> Envoy SDS)) is only active if either Ingress Controller or Gateway API is enabled.

Hence Secrets aren't available via SDS in cases where only CiliumEnvoyConfig is enabled (`--enable-envoy-config`).

This commit fixes this by enabling the K8s Secret watch also in cases where only CiliumEnvoyConfig is enabled (without Ingress Controller and/or Gateway API being enabled).

Before:

```
root@kind-control-plane:/home/cilium# cilium status --verbose
...
Kubernetes APIs:        ["EndpointSliceOrEndpoint", "cilium/v2::CiliumClusterwideEnvoyConfig", "cilium/v2::CiliumClusterwideNetworkPolicy", "cilium/v2::CiliumEndpoint", "cilium/v2::CiliumEnvoyConfig", "cilium/v2::CiliumNetworkPolicy", "cilium/v2::CiliumNode", "cilium/v2alpha1::CiliumCIDRGroup", "core/v1::Namespace", "core/v1::Pods", "core/v1::Service", "networking.k8s.io/v1::NetworkPolicy"]
...
```

(without `"core/v1::Secrets"`)

After:

```
root@kind-worker:/home/cilium# cilium status --verbose
...
Kubernetes APIs:        ["EndpointSliceOrEndpoint", "cilium/v2::CiliumClusterwideEnvoyConfig", "cilium/v2::CiliumClusterwideNetworkPolicy", "cilium/v2::CiliumEndpoint", "cilium/v2::CiliumEnvoyConfig", "cilium/v2::CiliumNetworkPolicy", "cilium/v2::CiliumNode", "cilium/v2alpha1::CiliumCIDRGroup", "core/v1::Namespace", "core/v1::Pods", "core/v1::Secrets", "core/v1::Service", "networking.k8s.io/v1::NetworkPolicy"]
...
```

(with `"core/v1::Secrets"`)

Fixes: #26005
