### PR TITLE
cni: Use batch endpoint deletion API in chaining plugin

### DIFF
--- a/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
+++ b/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
@@ -245,8 +245,8 @@ func (f *GenericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.Plug
 }
 
 func (f *GenericVethChainer) Delete(ctx context.Context, pluginCtx chainingapi.PluginContext, delClient *lib.DeletionFallbackClient) (err error) {
-	id := endpointid.NewCNIAttachmentID(pluginCtx.Args.ContainerID, pluginCtx.Args.IfName)
-	if err := delClient.EndpointDelete(id); err != nil {
+	req := &models.EndpointBatchDeleteRequest{ContainerID: pluginCtx.Args.ContainerID}
+	if err := delClient.EndpointDeleteMany(req); err != nil {
 		pluginCtx.Logger.WithError(err).Warning("Errors encountered while deleting endpoint")
 	}
 	return nil


### PR DESCRIPTION
This commit is to leverage new batch endpoint deletion API instead of singular endpoint deletion based on ID. The main reason is to provide backward compatibility on upgrade path.

The current CNI attachment ID requires a valid containerIfName attribute, however, the endpoints created by old cilium versions (e.g. <1.15) are not having such details. Any CNI DEL command for these endpoints will lead to invalid lookup (e.g. DeleteEndpointIDNotFoundCode), and prevent cleaning up of related resources such as IP addresses.

The impact is only limited to CNI chaining mode, as batch endpoint deletion API is already used cilium-cni/cmd/cmd.go as part of #27351.

Old endpoint details without (or empty) ContainerIfName

```json
{
  "ID": 423,
  "ContainerName": "",
  "dockerID": "415beb119c4b0910f62634510e921a447893195ebedc30ca0e9cd5bf02569645",
  "DockerNetworkID": "",
  "DockerEndpointID": "",
  "IfName": "eni22524e9e591",
  "IfIndex": 13,
  "ContainerIfName": "",
  "DisableLegacyIdentifiers": false,
  ...
}
```

New endpoint details with valid ContainerIfName (e.g. eth0)

```json
{
  "ID": 3627,
  "ContainerName": "",
  "dockerID": "f89ccf654b878248442981d4c56fe3f50fa127f922b46ee6dccc94ae10e94b79",
  "DockerNetworkID": "",
  "DockerEndpointID": "",
  "IfName": "enia67a2d3c27d",
  "IfIndex": 45,
  "ContainerIfName": "eth0",
  "DisableLegacyIdentifiers": false,
  ...
}
```

Relates: #26894, #27351 
Suggested-by: Sebastian Wicki <sebastian@isovalent.com>