### PR TITLE
bgpv1: BGP Control Plane metrics

### DIFF
--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/manager"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/reconciler"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/store"
+	"github.com/cilium/cilium/pkg/bgpv1/metrics"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	ipam_option "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -67,8 +68,12 @@ var Cell = cell.Module(
 	// Provides the reconcilers used by the route manager to update the config
 	reconciler.ConfigReconcilers,
 
-	// Invoke bgp controller to trigger the constructor.
-	cell.Invoke(func(*agent.Controller) {}),
+	cell.Invoke(
+		// Invoke bgp controller to trigger the constructor.
+		func(*agent.Controller) {},
+		// Register the metrics collector
+		metrics.RegisterCollector,
+	),
 )
 
 func newBGPPeeringPolicyResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig) resource.Resource[*v2alpha1api.CiliumBGPPeeringPolicy] {

--- a/pkg/bgpv1/metrics/metrics.go
+++ b/pkg/bgpv1/metrics/metrics.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+import (
+	"context"
+	"net/netip"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/bgpv1/types"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+const (
+	LabelVRouter  = "vrouter"
+	LabelNeighbor = "neighbor"
+	LabelAfi      = "afi"
+	LabelSafi     = "safi"
+
+	metricsSubsystem = "bgp_control_plane"
+)
+
+type collector struct {
+	SessionState          *prometheus.Desc
+	TotalAdvertisedRoutes *prometheus.Desc
+	TotalReceivedRoutes   *prometheus.Desc
+
+	in collectorIn
+}
+
+type collectorIn struct {
+	cell.In
+
+	Logger        logrus.FieldLogger
+	DaemonConfig  *option.DaemonConfig
+	Registry      *metrics.Registry
+	RouterManager agent.BGPRouterManager
+}
+
+// RegisterCollector registers the BGP Control Plane metrics collector to the
+// global prometheus registry. We don't rely on the cell.Metric because the
+// collectors we can provide through cell.Metric needs to implement
+// prometheus.Collector per metric which is not optimal in our case. We can
+// retrieve the multiple metrics from the single call to
+// RouterManager.GetPeers() and it is wasteful to call the same function
+// multiple times for each metric. Thus, we provide a raw Collector through
+// MustRegister interface. We may want to revisit this in the future.
+func RegisterCollector(in collectorIn) {
+	// Don't provide the collector if BGP control plane is disabled
+	if !in.DaemonConfig.EnableBGPControlPlane {
+		return
+	}
+	in.Registry.MustRegister(&collector{
+		SessionState: prometheus.NewDesc(
+			prometheus.BuildFQName(metrics.Namespace, metricsSubsystem, "session_state"),
+			"Current state of the BGP session with the peer, Up = 1 or Down = 0",
+			[]string{LabelVRouter, LabelNeighbor}, nil,
+		),
+		TotalAdvertisedRoutes: prometheus.NewDesc(
+			prometheus.BuildFQName(metrics.Namespace, metricsSubsystem, "advertised_routes"),
+			"Number of routes advertised to the peer",
+			[]string{LabelVRouter, LabelNeighbor, LabelAfi, LabelSafi}, nil,
+		),
+		TotalReceivedRoutes: prometheus.NewDesc(
+			prometheus.BuildFQName(metrics.Namespace, metricsSubsystem, "received_routes"),
+			"Number of routes received from the peer",
+			[]string{LabelVRouter, LabelNeighbor, LabelAfi, LabelSafi}, nil,
+		),
+		in: in,
+	})
+}
+
+func (c *collector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.SessionState
+	ch <- c.TotalAdvertisedRoutes
+	ch <- c.TotalReceivedRoutes
+}
+
+func (c *collector) Collect(ch chan<- prometheus.Metric) {
+	// We defensively set a 5 sec timeout here. When the underlying router
+	// is not responsive, we cannot make a progress. 5 sec is chosen to be
+	// a too long time that we should never hit for normal cases. We should
+	// revisit this timeout when the metrics collection starts to involve a
+	// network communication.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	peers, err := c.in.RouterManager.GetPeers(ctx)
+	cancel()
+	if err != nil {
+		c.in.Logger.WithError(err).Error("Failed to retrieve BGP peer information. Metrics is not collected.")
+		return
+	}
+
+	for _, peer := range peers {
+		if peer == nil {
+			continue
+		}
+
+		vrouterLabel := strconv.FormatInt(peer.LocalAsn, 10)
+
+		addr, err := netip.ParseAddr(peer.PeerAddress)
+		if err != nil {
+			continue
+		}
+
+		neighborLabel := netip.AddrPortFrom(addr, uint16(peer.PeerPort)).String()
+
+		// Collect session state metrics
+		var up float64
+		if peer.SessionState == types.SessionEstablished.String() {
+			up = 1
+		} else {
+			up = 0
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.SessionState,
+			prometheus.GaugeValue,
+			up,
+			vrouterLabel,
+			neighborLabel,
+		)
+
+		// Collect route metrics per address family
+		for _, family := range peer.Families {
+			if family == nil {
+				continue
+			}
+			ch <- prometheus.MustNewConstMetric(
+				c.TotalAdvertisedRoutes,
+				prometheus.GaugeValue,
+				float64(family.Advertised),
+				vrouterLabel,
+				neighborLabel,
+				family.Afi,
+				family.Safi,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.TotalReceivedRoutes,
+				prometheus.GaugeValue,
+				float64(family.Received),
+				vrouterLabel,
+				neighborLabel,
+				family.Afi,
+				family.Safi,
+			)
+		}
+	}
+}

--- a/pkg/bgpv1/test/fixtures.go
+++ b/pkg/bgpv1/test/fixtures.go
@@ -30,6 +30,7 @@ import (
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	clientset_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/typed/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -183,6 +184,7 @@ func newFixture(conf fixtureConfig) *fixture {
 			f.bgp = bgp
 		}),
 
+		metrics.Cell,
 		job.Cell,
 		bgpv1.Cell,
 	}


### PR DESCRIPTION
Implement following initial metrics for BGP Control Plane.

1. cilium_bgp_control_plane_session_state

Gauge that shows session state per vrouter/neighbor. Established (1) or Not Established (0).

2. cilium_bgp_control_plane_advertised_routes

Gauge that shows the number of advertised routes per vrouter/neighbor/afi/safi.

3. cilium_bgp_control_plane_received_routes

Gauge that shows the number of received routes per vrouter/neighbor/afi/safi.

Example:

```
ks exec -it cilium-whfmh -- cilium-dbg metrics list --match-pattern cilium_bgp
Metric                                       Labels                                                                      Value
cilium_bgp_control_plane_advertised_routes   afi="ipv4" neighbor="[fd00:10:0:1::1]:179" safi="unicast" vrouter="65001"   1.000000
cilium_bgp_control_plane_advertised_routes   afi="ipv6" neighbor="[fd00:10:0:1::1]:179" safi="unicast" vrouter="65001"   1.000000
cilium_bgp_control_plane_received_routes     afi="ipv4" neighbor="[fd00:10:0:1::1]:179" safi="unicast" vrouter="65001"   2.000000
cilium_bgp_control_plane_received_routes     afi="ipv6" neighbor="[fd00:10:0:1::1]:179" safi="unicast" vrouter="65001"   2.000000
cilium_bgp_control_plane_session_state       neighbor="[fd00:10:0:1::1]:179" vrouter="65001"                             1.000000
```

Fixes: https://github.com/cilium/cilium/issues/22010

```release-note
bgpv1: BGP Control Plane metrics
```
