### PR TITLE
ingress/gateway-api: stable address order for Ingress hostnetwork listener addresses

### DIFF
--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -95,7 +95,7 @@ func WithHostNetworkPort[T model.Listener](listeners []T, ipv4Enabled bool, ipv6
 			ports = append(ports, hl.GetPort())
 		}
 
-		listener.Address, listener.AdditionalAddresses = getHostNetworkListenerAddresses(slices.Unique(ports), ipv4Enabled, ipv6Enabled)
+		listener.Address, listener.AdditionalAddresses = getHostNetworkListenerAddresses(slices.SortedUnique(ports), ipv4Enabled, ipv6Enabled)
 
 		return listener
 	}


### PR DESCRIPTION
Currently, the order of the HostNetwork listener addresses depends on the order of the listeners. This might lead to inconsistent CEC generation that can lead to unnecessary reconciliations.

Therefore, this commit fixes this by sorting the listener ports before processing.

Fixes: https://github.com/cilium/cilium/pull/30840