### PR TITLE
deflake endpointmanager tests

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -200,7 +200,6 @@ func (ds *DaemonSuite) TearDownTest(c *C) {
 	ctx := context.Background()
 
 	controller.NewManager().RemoveAllAndWait()
-	ds.d.endpointManager.RemoveAll(c)
 
 	// It's helpful to keep the directories around if a test failed; only delete
 	// them if tests succeed.

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -200,7 +200,7 @@ func (ds *DaemonSuite) TearDownTest(c *C) {
 	ctx := context.Background()
 
 	controller.NewManager().RemoveAllAndWait()
-	ds.d.endpointManager.RemoveAll()
+	ds.d.endpointManager.RemoveAll(c)
 
 	// It's helpful to keep the directories around if a test failed; only delete
 	// them if tests succeed.

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -139,7 +139,7 @@ type Allocator struct {
 	initialListDone waitChan
 
 	// idPool maintains a pool of available ids for allocation.
-	idPool idpool.IDPool
+	idPool *idpool.IDPool
 
 	// enableMasterKeyProtection if true, causes master keys that are still in
 	// local use to be automatically re-created

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -71,7 +71,7 @@ type linuxNodeHandler struct {
 
 	nodeMap nodemap.Map
 	// Pool of available IDs for nodes.
-	nodeIDs idpool.IDPool
+	nodeIDs *idpool.IDPool
 	// Node-scoped unique IDs for the nodes.
 	nodeIDsByIPs map[string]uint16
 	// reverse map of the above

--- a/pkg/endpointmanager/allocator.go
+++ b/pkg/endpointmanager/allocator.go
@@ -5,7 +5,6 @@ package endpointmanager
 
 import (
 	"fmt"
-	"testing"
 
 	"github.com/cilium/cilium/pkg/idpool"
 )
@@ -22,14 +21,6 @@ type epIDAllocator struct {
 func newEPIDAllocator() *epIDAllocator {
 	return &epIDAllocator{
 		pool: idpool.NewIDPool(minID, maxID),
-	}
-}
-
-// reallocatePool starts over with a new pool. This function is only used for
-// tests and its implementation is not optimized for production.
-func (a *epIDAllocator) reallocatePool(t testing.TB) {
-	for i := uint16(minID); i <= uint16(maxID); i++ {
-		a.release(i)
 	}
 }
 

--- a/pkg/endpointmanager/allocator.go
+++ b/pkg/endpointmanager/allocator.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package idallocator
+package endpointmanager
 
 import (
 	"fmt"
@@ -15,26 +15,26 @@ const (
 	maxID = idpool.ID(4095)
 )
 
-type IDAllocator struct {
+type epIDAllocator struct {
 	pool *idpool.IDPool
 }
 
-func New() *IDAllocator {
-	return &IDAllocator{
+func newEPIDAllocator() *epIDAllocator {
+	return &epIDAllocator{
 		pool: idpool.NewIDPool(minID, maxID),
 	}
 }
 
-// ReallocatePool starts over with a new pool. This function is only used for
+// reallocatePool starts over with a new pool. This function is only used for
 // tests and its implementation is not optimized for production.
-func (a *IDAllocator) ReallocatePool(t testing.TB) {
+func (a *epIDAllocator) reallocatePool(t testing.TB) {
 	for i := uint16(minID); i <= uint16(maxID); i++ {
-		a.Release(i)
+		a.release(i)
 	}
 }
 
-// Allocate returns a new random ID from the pool
-func (a *IDAllocator) Allocate() uint16 {
+// allocate returns a new random ID from the pool
+func (a *epIDAllocator) allocate() uint16 {
 	id := a.pool.AllocateID()
 
 	// Out of endpoint IDs
@@ -45,9 +45,9 @@ func (a *IDAllocator) Allocate() uint16 {
 	return uint16(id)
 }
 
-// Reuse grabs a specific endpoint ID for reuse. This can be used when
+// reuse grabs a specific endpoint ID for reuse. This can be used when
 // restoring endpoints.
-func (a *IDAllocator) Reuse(id uint16) error {
+func (a *epIDAllocator) reuse(id uint16) error {
 	if idpool.ID(id) < minID {
 		return fmt.Errorf("unable to reuse endpoint: %d < %d", id, minID)
 	}
@@ -66,8 +66,8 @@ func (a *IDAllocator) Reuse(id uint16) error {
 	return nil
 }
 
-// Release releases an endpoint ID that was previously allocated or reused
-func (a *IDAllocator) Release(id uint16) error {
+// release releases an endpoint ID that was previously allocated or reused
+func (a *epIDAllocator) release(id uint16) error {
 	if !a.pool.Insert(idpool.ID(id)) {
 		return fmt.Errorf("Unable to release endpoint ID %d", id)
 	}

--- a/pkg/endpointmanager/allocator_test.go
+++ b/pkg/endpointmanager/allocator_test.go
@@ -9,6 +9,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// reallocatePool starts over with a new pool. This function is only used for
+// tests and its implementation is not optimized for production.
+func (a *epIDAllocator) reallocatePool(t testing.TB) {
+	for i := uint16(minID); i <= uint16(maxID); i++ {
+		a.release(i)
+	}
+}
+
 func TestAllocation(t *testing.T) {
 	p := newEPIDAllocator()
 

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"net/netip"
 	"sync"
-	"testing"
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -119,9 +118,6 @@ type EndpointsModify interface {
 	// RemoveEndpoint stops the active handling of events by the specified endpoint,
 	// and prevents the endpoint from being globally acccessible via other packages.
 	RemoveEndpoint(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error
-
-	// RemoveAll removes all endpoints from the global maps.
-	RemoveAll(testing.TB)
 }
 
 type EndpointManager interface {

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net/netip"
 	"sync"
+	"testing"
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -120,7 +121,7 @@ type EndpointsModify interface {
 	RemoveEndpoint(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error
 
 	// RemoveAll removes all endpoints from the global maps.
-	RemoveAll()
+	RemoveAll(testing.TB)
 }
 
 type EndpointManager interface {

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -38,7 +38,8 @@ func (s *EndpointManagerSuite) TestmarkAndSweep(c *C) {
 	allEndpointIDs := append(healthyEndpointIDs, endpointIDToDelete)
 	for _, id := range allEndpointIDs {
 		ep := endpoint.NewTestEndpointWithState(c, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), id, endpoint.StateReady)
-		mgr.expose(ep)
+		err := mgr.expose(ep)
+		c.Assert(err, IsNil)
 	}
 	c.Assert(len(mgr.GetEndpoints()), Equals, len(allEndpointIDs))
 

--- a/pkg/endpointmanager/idallocator/allocator.go
+++ b/pkg/endpointmanager/idallocator/allocator.go
@@ -5,6 +5,7 @@ package idallocator
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/cilium/cilium/pkg/idpool"
 )
@@ -14,21 +15,27 @@ const (
 	maxID = idpool.ID(4095)
 )
 
-var (
-	pool = idpool.NewIDPool(minID, maxID)
-)
+type IDAllocator struct {
+	pool *idpool.IDPool
+}
+
+func New() *IDAllocator {
+	return &IDAllocator{
+		pool: idpool.NewIDPool(minID, maxID),
+	}
+}
 
 // ReallocatePool starts over with a new pool. This function is only used for
 // tests and its implementation is not optimized for production.
-func ReallocatePool() {
+func (a *IDAllocator) ReallocatePool(t testing.TB) {
 	for i := uint16(minID); i <= uint16(maxID); i++ {
-		Release(i)
+		a.Release(i)
 	}
 }
 
 // Allocate returns a new random ID from the pool
-func Allocate() uint16 {
-	id := pool.AllocateID()
+func (a *IDAllocator) Allocate() uint16 {
+	id := a.pool.AllocateID()
 
 	// Out of endpoint IDs
 	if id == idpool.NoID {
@@ -40,7 +47,7 @@ func Allocate() uint16 {
 
 // Reuse grabs a specific endpoint ID for reuse. This can be used when
 // restoring endpoints.
-func Reuse(id uint16) error {
+func (a *IDAllocator) Reuse(id uint16) error {
 	if idpool.ID(id) < minID {
 		return fmt.Errorf("unable to reuse endpoint: %d < %d", id, minID)
 	}
@@ -52,7 +59,7 @@ func Reuse(id uint16) error {
 		return nil
 	}
 
-	if !pool.Remove(idpool.ID(id)) {
+	if !a.pool.Remove(idpool.ID(id)) {
 		return fmt.Errorf("endpoint ID %d is already in use", id)
 	}
 
@@ -60,8 +67,8 @@ func Reuse(id uint16) error {
 }
 
 // Release releases an endpoint ID that was previously allocated or reused
-func Release(id uint16) error {
-	if !pool.Insert(idpool.ID(id)) {
+func (a *IDAllocator) Release(id uint16) error {
+	if !a.pool.Insert(idpool.ID(id)) {
 		return fmt.Errorf("Unable to release endpoint ID %d", id)
 	}
 

--- a/pkg/endpointmanager/idallocator/allocator_test.go
+++ b/pkg/endpointmanager/idallocator/allocator_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 func TestAllocation(t *testing.T) {
-	ReallocatePool()
+	p := New()
 
 	idsReturned := map[uint16]struct{}{}
 
 	for i := minID; i <= maxID; i++ {
-		id := Allocate()
+		id := p.Allocate()
 		assert.NotZero(t, id)
 
 		// check if same ID is returned more than once
@@ -25,28 +25,28 @@ func TestAllocation(t *testing.T) {
 	}
 
 	// We should be out of allocations
-	assert.Zero(t, Allocate())
+	assert.Zero(t, p.Allocate())
 }
 
 func TestReuse(t *testing.T) {
-	ReallocatePool()
+	p := New()
 
 	// Reusing IDs greater than the maxID is allowed
-	assert.Nil(t, Reuse(uint16(maxID+10)))
+	assert.Nil(t, p.Reuse(uint16(maxID+10)))
 
 	// Reusing IDs lesser than the minID is not allowed
-	assert.NotNil(t, Reuse(uint16(minID-1)))
+	assert.NotNil(t, p.Reuse(uint16(minID-1)))
 
 	idsReturned := map[uint16]struct{}{}
 
-	assert.Nil(t, Reuse(uint16(2)))
+	assert.Nil(t, p.Reuse(uint16(2)))
 	idsReturned[uint16(2)] = struct{}{}
 
-	assert.Nil(t, Reuse(uint16(8)))
+	assert.Nil(t, p.Reuse(uint16(8)))
 	idsReturned[uint16(8)] = struct{}{}
 
 	for i := minID; i <= maxID-2; i++ {
-		id := Allocate()
+		id := p.Allocate()
 		assert.NotZero(t, id)
 
 		// check if same ID is returned more than once
@@ -56,41 +56,41 @@ func TestReuse(t *testing.T) {
 	}
 
 	// We should be out of allocations
-	assert.Zero(t, Allocate())
+	assert.Zero(t, p.Allocate())
 
 	// 2nd reuse should fail
-	assert.NotNil(t, Reuse(uint16(2)))
+	assert.NotNil(t, p.Reuse(uint16(2)))
 
 	// reuse of allocated id should fail
-	assert.NotNil(t, Reuse(uint16(3)))
+	assert.NotNil(t, p.Reuse(uint16(3)))
 
 	// release 5
-	assert.Nil(t, Release(uint16(5)))
+	assert.Nil(t, p.Release(uint16(5)))
 	delete(idsReturned, uint16(5))
 
 	// release 6
-	assert.Nil(t, Release(uint16(6)))
+	assert.Nil(t, p.Release(uint16(6)))
 	delete(idsReturned, uint16(6))
 
 	// reuse 5 after release
-	assert.Nil(t, Reuse(uint16(5)))
+	assert.Nil(t, p.Reuse(uint16(5)))
 	idsReturned[uint16(5)] = struct{}{}
 
 	// allocate only available id 6
-	assert.Equal(t, uint16(6), Allocate())
+	assert.Equal(t, uint16(6), p.Allocate())
 }
 
 func TestRelease(t *testing.T) {
-	ReallocatePool()
+	p := New()
 
 	for i := minID; i <= maxID; i++ {
-		assert.Nil(t, Reuse(uint16(i)))
+		assert.Nil(t, p.Reuse(uint16(i)))
 	}
 
 	// must be out of IDs
-	assert.Zero(t, Allocate())
+	assert.Zero(t, p.Allocate())
 
 	for i := minID; i <= maxID; i++ {
-		assert.Nil(t, Release(uint16(i)))
+		assert.Nil(t, p.Release(uint16(i)))
 	}
 }

--- a/pkg/endpointmanager/idallocator/allocator_test.go
+++ b/pkg/endpointmanager/idallocator/allocator_test.go
@@ -6,100 +6,91 @@ package idallocator
 import (
 	"testing"
 
-	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/assert"
 )
 
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) { TestingT(t) }
-
-type IDSuite struct{}
-
-var _ = Suite(&IDSuite{})
-
-func (s *IDSuite) TestAllocation(c *C) {
+func TestAllocation(t *testing.T) {
 	ReallocatePool()
 
 	idsReturned := map[uint16]struct{}{}
 
 	for i := minID; i <= maxID; i++ {
 		id := Allocate()
-		c.Assert(id, Not(Equals), uint16(0))
+		assert.NotZero(t, id)
 
 		// check if same ID is returned more than once
-		_, ok := idsReturned[id]
-		c.Assert(ok, Equals, false)
+		assert.NotContains(t, idsReturned, id)
 
 		idsReturned[id] = struct{}{}
 	}
 
 	// We should be out of allocations
-	c.Assert(Allocate(), Equals, uint16(0))
+	assert.Zero(t, Allocate())
 }
 
-func (s *IDSuite) TestReuse(c *C) {
+func TestReuse(t *testing.T) {
 	ReallocatePool()
 
 	// Reusing IDs greater than the maxID is allowed
-	c.Assert(Reuse(uint16(maxID+10)), IsNil)
+	assert.Nil(t, Reuse(uint16(maxID+10)))
 
 	// Reusing IDs lesser than the minID is not allowed
-	c.Assert(Reuse(uint16(minID-1)), Not(IsNil))
+	assert.NotNil(t, Reuse(uint16(minID-1)))
 
 	idsReturned := map[uint16]struct{}{}
 
-	c.Assert(Reuse(uint16(2)), IsNil)
+	assert.Nil(t, Reuse(uint16(2)))
 	idsReturned[uint16(2)] = struct{}{}
 
-	c.Assert(Reuse(uint16(8)), IsNil)
+	assert.Nil(t, Reuse(uint16(8)))
 	idsReturned[uint16(8)] = struct{}{}
 
 	for i := minID; i <= maxID-2; i++ {
 		id := Allocate()
-		c.Assert(id, Not(Equals), uint16(0))
+		assert.NotZero(t, id)
 
 		// check if same ID is returned more than once
-		_, ok := idsReturned[id]
-		c.Assert(ok, Equals, false)
+		assert.NotContains(t, idsReturned, id)
 
 		idsReturned[id] = struct{}{}
 	}
 
 	// We should be out of allocations
-	c.Assert(Allocate(), Equals, uint16(0))
+	assert.Zero(t, Allocate())
 
 	// 2nd reuse should fail
-	c.Assert(Reuse(uint16(2)), Not(IsNil))
+	assert.NotNil(t, Reuse(uint16(2)))
 
 	// reuse of allocated id should fail
-	c.Assert(Reuse(uint16(3)), Not(IsNil))
+	assert.NotNil(t, Reuse(uint16(3)))
 
 	// release 5
-	c.Assert(Release(uint16(5)), IsNil)
+	assert.Nil(t, Release(uint16(5)))
 	delete(idsReturned, uint16(5))
 
 	// release 6
-	c.Assert(Release(uint16(6)), IsNil)
+	assert.Nil(t, Release(uint16(6)))
 	delete(idsReturned, uint16(6))
 
 	// reuse 5 after release
-	c.Assert(Reuse(uint16(5)), IsNil)
+	assert.Nil(t, Reuse(uint16(5)))
 	idsReturned[uint16(5)] = struct{}{}
 
 	// allocate only available id 6
-	c.Assert(Allocate(), Equals, uint16(6))
+	assert.Equal(t, uint16(6), Allocate())
 }
 
-func (s *IDSuite) TestRelease(c *C) {
+func TestRelease(t *testing.T) {
 	ReallocatePool()
 
 	for i := minID; i <= maxID; i++ {
-		c.Assert(Reuse(uint16(i)), IsNil)
+		assert.Nil(t, Reuse(uint16(i)))
 	}
 
 	// must be out of IDs
-	c.Assert(Allocate(), Equals, uint16(0))
+	assert.Zero(t, Allocate())
 
 	for i := minID; i <= maxID; i++ {
-		c.Assert(Release(uint16(i)), IsNil)
+		assert.Nil(t, Release(uint16(i)))
 	}
 }

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/netip"
 	"sync"
-	"testing"
 
 	"github.com/sirupsen/logrus"
 
@@ -431,15 +430,6 @@ func (mgr *endpointManager) removeEndpoint(ep *endpoint.Endpoint, conf endpoint.
 // and prevents the endpoint from being globally acccessible via other packages.
 func (mgr *endpointManager) RemoveEndpoint(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
 	return mgr.deleteEndpoint(ep, conf)
-}
-
-// RemoveAll removes all endpoints from the global maps.
-func (mgr *endpointManager) RemoveAll(t testing.TB) {
-	mgr.mutex.Lock()
-	defer mgr.mutex.Unlock()
-	mgr.epIDAllocator.reallocatePool(t)
-	mgr.endpoints = map[uint16]*endpoint.Endpoint{}
-	mgr.endpointsAux = map[string]*endpoint.Endpoint{}
 }
 
 // lookupCiliumID looks up endpoint by endpoint ID

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -17,7 +17,6 @@ import (
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
-	"github.com/cilium/cilium/pkg/endpointmanager/idallocator"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/lock"
@@ -420,7 +419,6 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 		} else {
 			c.Assert(got, IsNil, Commentf("Test Name: %s", tt.name))
 		}
-		idallocator.ReallocatePool()
 	}
 }
 
@@ -761,7 +759,7 @@ func (s *EndpointManagerSuite) TestRemove(c *C) {
 	for _, tt := range tests {
 		tt.preTestRun()
 
-		mgr.RemoveAll()
+		mgr.RemoveAll(c)
 		c.Assert(len(mgr.endpoints), Equals, 0, Commentf("Test Name: %s", tt.name))
 		c.Assert(len(mgr.endpointsAux), Equals, 0, Commentf("Test Name: %s", tt.name))
 		tt.postTestRun()

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -36,6 +36,15 @@ func (mgr *endpointManager) waitEndpointRemoved(ep *endpoint.Endpoint, conf endp
 	return nil
 }
 
+// RemoveAll removes all endpoints from the global maps.
+func (mgr *endpointManager) RemoveAll(t testing.TB) {
+	mgr.mutex.Lock()
+	defer mgr.mutex.Unlock()
+	mgr.epIDAllocator.reallocatePool(t)
+	mgr.endpoints = map[uint16]*endpoint.Endpoint{}
+	mgr.endpointsAux = map[string]*endpoint.Endpoint{}
+}
+
 // WaitEndpointRemoved waits until all operations associated with Remove of
 // the endpoint have been completed.
 // Note: only used for unit tests, to avoid ep.Delete()

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -445,7 +445,7 @@ func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 			name: "existing cilium ID",
 			preTestRun: func() {
 				ep.ID = 1
-				mgr.expose(ep)
+				c.Assert(mgr.expose(ep), IsNil)
 			},
 			setupArgs: func() args {
 				return args{
@@ -499,7 +499,7 @@ func (s *EndpointManagerSuite) TestLookupCNIAttachmentID(c *C) {
 		ContainerInterfaceName: "bar",
 	})
 	c.Assert(err, IsNil)
-	mgr.expose(ep)
+	c.Assert(mgr.expose(ep), IsNil)
 
 	good := mgr.LookupCNIAttachmentID("foo:bar")
 	c.Assert(good, checker.DeepEquals, ep)
@@ -531,7 +531,7 @@ func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 			name: "existing LookupIPv4",
 			preTestRun: func() {
 				ep.IPv4 = netip.MustParseAddr("127.0.0.1")
-				mgr.expose(ep)
+				c.Assert(mgr.expose(ep), IsNil)
 			},
 			setupArgs: func() args {
 				return args{
@@ -599,7 +599,7 @@ func (s *EndpointManagerSuite) TestLookupCEPName(c *C) {
 				K8sPodName:   "foo",
 			},
 			preTestRun: func(ep *endpoint.Endpoint) {
-				mgr.expose(ep)
+				c.Assert(mgr.expose(ep), IsNil)
 			},
 			setupArgs: func() args {
 				return args{
@@ -624,7 +624,7 @@ func (s *EndpointManagerSuite) TestLookupCEPName(c *C) {
 				DisableLegacyIdentifiers: true,
 			},
 			preTestRun: func(ep *endpoint.Endpoint) {
-				mgr.expose(ep)
+				c.Assert(mgr.expose(ep), IsNil)
 			},
 			setupArgs: func() args {
 				return args{
@@ -747,7 +747,7 @@ func (s *EndpointManagerSuite) TestRemove(c *C) {
 			name: "Updating all references",
 			preTestRun: func() {
 				ep.ID = 1
-				mgr.expose(ep)
+				c.Assert(mgr.expose(ep), IsNil)
 			},
 			setupArgs: func() args {
 				return args{}
@@ -786,7 +786,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 			preTestRun: func() {
 				ep.ID = 1
 				ep.Options = option.NewIntOptions(&endpoint.EndpointMutableOptionLibrary)
-				mgr.expose(ep)
+				c.Assert(mgr.expose(ep), IsNil)
 			},
 			setupWant: func() want {
 				return want{
@@ -806,7 +806,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 				ep.ID = 1
 				ep.Options = option.NewIntOptions(&endpoint.EndpointMutableOptionLibrary)
 				ep.Options.SetIfUnset(option.ConntrackLocal, option.OptionEnabled)
-				mgr.expose(ep)
+				c.Assert(mgr.expose(ep), IsNil)
 			},
 			setupWant: func() want {
 				return want{
@@ -854,7 +854,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			preTestRun: func() {
 				ep.ID = 1
 				ep.SetPolicyRevision(5)
-				mgr.expose(ep)
+				c.Assert(mgr.expose(ep), IsNil)
 			},
 			setupArgs: func() args {
 				return args{
@@ -878,7 +878,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			preTestRun: func() {
 				ep.ID = 1
 				ep.SetPolicyRevision(5)
-				mgr.expose(ep)
+				c.Assert(mgr.expose(ep), IsNil)
 			},
 			setupArgs: func() args {
 				ctx, cancel := context.WithTimeout(context.Background(), 0)
@@ -904,7 +904,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			preTestRun: func() {
 				ep.ID = 1
 				ep.SetPolicyRevision(4)
-				mgr.expose(ep)
+				c.Assert(mgr.expose(ep), IsNil)
 			},
 			setupArgs: func() args {
 				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)

--- a/pkg/endpointmanager/policymap_pressure_test.go
+++ b/pkg/endpointmanager/policymap_pressure_test.go
@@ -17,15 +17,15 @@ func TestPolicyMapPressure(t *testing.T) {
 	assert := assert.New(t)
 	policyMapPressureMinInterval = 0
 	p := newPolicyMapPressure()
-	p.gauge = &fakeGague{}
-	assert.Equal(float64(0), p.gauge.(*fakeGague).Load())
+	p.gauge = &fakeGauge{}
+	assert.Equal(float64(0), p.gauge.(*fakeGauge).Load())
 	p.Update(endpoint.PolicyMapPressureEvent{
 		EndpointID: 1,
 		Value:      .5,
 	})
 	assertMetricEq := func(expected float64) {
 		assert.Eventually(func() bool {
-			return p.gauge.(*fakeGague).Load() == expected
+			return p.gauge.(*fakeGauge).Load() == expected
 		}, time.Second, 1*time.Millisecond)
 	}
 	assertMetricEq(.5)
@@ -38,15 +38,15 @@ func TestPolicyMapPressure(t *testing.T) {
 	assertMetricEq(.5)
 }
 
-type fakeGague struct {
+type fakeGauge struct {
 	lastValue atomic.Value
 }
 
-func (f *fakeGague) Set(value float64) {
+func (f *fakeGauge) Set(value float64) {
 	f.lastValue.Store(value)
 }
 
-func (f *fakeGague) Load() float64 {
+func (f *fakeGauge) Load() float64 {
 	v := f.lastValue.Load()
 	if v == nil {
 		return 0

--- a/pkg/hubble/recorder/service.go
+++ b/pkg/hubble/recorder/service.go
@@ -44,7 +44,7 @@ const (
 type Service struct {
 	recorder *recorder.Recorder
 	dispatch *sink.Dispatch
-	ruleIDs  idpool.IDPool
+	ruleIDs  *idpool.IDPool
 	opts     recorderoption.Options
 }
 

--- a/pkg/idpool/idpool.go
+++ b/pkg/idpool/idpool.go
@@ -65,8 +65,8 @@ type IDPool struct {
 }
 
 // NewIDPool returns a new ID pool
-func NewIDPool(minID ID, maxID ID) IDPool {
-	return IDPool{
+func NewIDPool(minID ID, maxID ID) *IDPool {
+	return &IDPool{
 		minID:   minID,
 		maxID:   maxID,
 		idCache: newIDCache(minID, maxID),

--- a/pkg/idpool/idpool_test.go
+++ b/pkg/idpool/idpool_test.go
@@ -26,7 +26,7 @@ func (s *IDPoolTestSuite) TestLeaseAvailableID(c *C) {
 	minID, maxID := 1, 5
 	p := NewIDPool(ID(minID), ID(maxID))
 
-	leaseAllIDs(&p, minID, maxID, c)
+	leaseAllIDs(p, minID, maxID, c)
 }
 
 func (s *IDPoolTestSuite) TestInsertIDs(c *C) {
@@ -39,7 +39,7 @@ func (s *IDPoolTestSuite) TestInsertIDs(c *C) {
 		c.Assert(p.Insert(ID(i)), Equals, false)
 	}
 
-	leaseAllIDs(&p, minID-1, maxID+1, c)
+	leaseAllIDs(p, minID-1, maxID+1, c)
 }
 
 func (s *IDPoolTestSuite) TestInsertRemoveIDs(c *C) {
@@ -107,7 +107,7 @@ func (s *IDPoolTestSuite) TestReleaseID(c *C) {
 
 	// Lease all ids. This time, remove them before
 	// releasing them.
-	leaseAllIDs(&p, minID, maxID, c)
+	leaseAllIDs(p, minID, maxID, c)
 	for i := minID; i <= maxID; i++ {
 		c.Assert(p.Remove(ID(i)), Equals, false)
 	}
@@ -122,40 +122,40 @@ func (s *IDPoolTestSuite) TestOperationsOnAvailableIDs(c *C) {
 
 	// Leasing available IDs should move its state to leased.
 	p0 := NewIDPool(ID(minID), ID(maxID))
-	leaseAllIDs(&p0, minID, maxID, c)
+	leaseAllIDs(p0, minID, maxID, c)
 	// Check all IDs are in leased state.
 	for i := minID; i <= maxID; i++ {
 		c.Assert(p0.Release(ID(i)), Equals, true)
 	}
-	leaseAllIDs(&p0, minID, maxID, c)
+	leaseAllIDs(p0, minID, maxID, c)
 
 	// Releasing available IDs should not have any effect.
 	p1 := NewIDPool(ID(minID), ID(maxID))
 	for i := minID; i <= maxID; i++ {
 		c.Assert(p1.Release(ID(i)), Equals, false)
 	}
-	leaseAllIDs(&p1, minID, maxID, c)
+	leaseAllIDs(p1, minID, maxID, c)
 
 	// Using available IDs should not have any effect.
 	p2 := NewIDPool(ID(minID), ID(maxID))
 	for i := minID; i <= maxID; i++ {
 		c.Assert(p2.Use(ID(i)), Equals, false)
 	}
-	leaseAllIDs(&p2, minID, maxID, c)
+	leaseAllIDs(p2, minID, maxID, c)
 
 	// Inserting available IDs should not have any effect.
 	p3 := NewIDPool(ID(minID), ID(maxID))
 	for i := minID; i <= maxID; i++ {
 		c.Assert(p3.Insert(ID(i)), Equals, false)
 	}
-	leaseAllIDs(&p3, minID, maxID, c)
+	leaseAllIDs(p3, minID, maxID, c)
 
 	// Removing available IDs should make them unavailable.
 	p4 := NewIDPool(ID(minID), ID(maxID))
 	for i := minID; i <= maxID; i++ {
 		c.Assert(p4.Remove(ID(i)), Equals, true)
 	}
-	leaseAllIDs(&p4, minID, minID-1, c)
+	leaseAllIDs(p4, minID, minID-1, c)
 	for i := minID; i <= maxID; i++ {
 		c.Assert(p4.Release(ID(i)), Equals, false)
 	}
@@ -165,8 +165,8 @@ func (s *IDPoolTestSuite) TestOperationsOnLeasedIDs(c *C) {
 	minID, maxID := 1, 5
 	var poolWithAllIDsLeased = func() *IDPool {
 		p := NewIDPool(ID(minID), ID(maxID))
-		leaseAllIDs(&p, minID, maxID, c)
-		return &p
+		leaseAllIDs(p, minID, maxID, c)
+		return p
 	}
 
 	// Releasing leased IDs should make it available again.
@@ -216,7 +216,7 @@ func (s *IDPoolTestSuite) TestOperationsOnUnavailableIDs(c *C) {
 		for i := minID; i <= maxID; i++ {
 			c.Assert(p.Remove(ID(i)), Equals, true)
 		}
-		return &p
+		return p
 	}
 
 	// Releasing unavailable IDs should not have any effect.


### PR DESCRIPTION
This series of patches deflakes the endpoint manager tests. Four different flakes were observed when running just the `endpointmanager` pkg test in a loop, after this PR I achieved `31m55s: 46344 runs so far, 0 failures` which implies a high likelihood that any potentially remaining flakes are highly unlikely to occur.

There was a trivial data race in the pressure metrics _test_, fixed by using an atomic value.

This PR refactors the endpointmanager EP identifier allocation logic away from using a single, global identity pool, as that inherently causes flakes in tests sharing that pool. Specifically, there was a call to `mgr.expose` which did not check the error - the error was that in the global pool, one of the identities `[1, 3, 5, 7]` had already been allocated, and hence the exposing failed. Fixed by creating a new allocation pool for each new manager.

Further tests also didn't check `expose` errors, but these were inconsequential once the global ID pool was removed. Fixed the checks anyway, for good measure.

In addition, `TestLookup` would fail iff the EP allocated would by chance get ID `1234`.

The commits attempt to be somewhat readable in sequence, but the whole change isn't massive either.

Fixes: #26630
Fixes: #28878
Fixes: #27837
