### PR TITLE
ingress/gateway-api: sort virtual hosts in CEC

### DIFF
--- a/operator/pkg/model/translation/cec_translator.go
+++ b/operator/pkg/model/translation/cec_translator.go
@@ -4,7 +4,9 @@
 package translation
 
 import (
+	"cmp"
 	"fmt"
+	goslices "slices"
 	"sort"
 
 	envoy_config_cluster_v3 "github.com/cilium/proxy/go/envoy/config/cluster/v3"
@@ -292,6 +294,7 @@ func (i *cecTranslator) getEnvoyHTTPRouteConfiguration(m *model.Model) []ciliumv
 		// the route name should match the value in http connection manager
 		// otherwise the request will be dropped by envoy
 		routeName := fmt.Sprintf("listener-%s", port)
+		goslices.SortStableFunc(virtualhosts, func(a, b *envoy_config_route_v3.VirtualHost) int { return cmp.Compare(a.Name, b.Name) })
 		rc, _ := NewRouteConfiguration(routeName, virtualhosts)
 		res = append(res, rc)
 	}

--- a/operator/pkg/model/translation/fixture_test.go
+++ b/operator/pkg/model/translation/fixture_test.go
@@ -315,22 +315,22 @@ var hostRulesExpectedConfigEnforceHTTPS = []*envoy_config_route_v3.RouteConfigur
 		Name: "listener-insecure",
 		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
 			{
-				Name:    "foo.bar.com",
-				Domains: domainsHelper("foo.bar.com"),
-				Routes: []*envoy_config_route_v3.Route{
-					{
-						Match:  envoyRouteMatchRootPath(),
-						Action: envoyHTTPSRouteRedirect(),
-					},
-				},
-			},
-			{
 				Name:    "*.foo.com",
 				Domains: domainsHelper("*.foo.com"),
 				Routes: []*envoy_config_route_v3.Route{
 					{
 						Match:  withAuthority(envoyRouteMatchRootPath(), "^[^.]+[.]foo[.]com$"),
 						Action: envoyRouteAction("random-namespace", "wildcard-foo-com", "8080"),
+					},
+				},
+			},
+			{
+				Name:    "foo.bar.com",
+				Domains: domainsHelper("foo.bar.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyHTTPSRouteRedirect(),
 					},
 				},
 			},
@@ -573,7 +573,8 @@ var pathRulesExpectedConfig = []*envoy_config_route_v3.RouteConfiguration{
 					{
 						Match:  envoyRouteMatchPrefixPath("/aaa"),
 						Action: envoyRouteAction("random-namespace", "aaa-prefix", "8080"),
-					}},
+					},
+				},
 			},
 			{
 				Name:    "trailing-slash-path-rules",
@@ -1019,6 +1020,24 @@ var complexIngressExpectedConfigEnforceHTTPS = []*envoy_config_route_v3.RouteCon
 		Name: "listener-insecure",
 		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
 			{
+				Name:    "*",
+				Domains: domainsHelper("*"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchExactPath("/dummy-path"),
+						Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
+					},
+					{
+						Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
+						Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
+					},
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("dummy-namespace", "default-backend", "8080"),
+					},
+				},
+			},
+			{
 				Name:    "another-very-secure.server.com",
 				Domains: domainsHelper("another-very-secure.server.com"),
 				Routes: []*envoy_config_route_v3.Route{
@@ -1051,24 +1070,6 @@ var complexIngressExpectedConfigEnforceHTTPS = []*envoy_config_route_v3.RouteCon
 					{
 						Match:  envoyRouteMatchRootPath(),
 						Action: envoyHTTPSRouteRedirect(),
-					},
-				},
-			},
-			{
-				Name:    "*",
-				Domains: domainsHelper("*"),
-				Routes: []*envoy_config_route_v3.Route{
-					{
-						Match:  envoyRouteMatchExactPath("/dummy-path"),
-						Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
-					},
-					{
-						Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
-						Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
-					},
-					{
-						Match:  envoyRouteMatchRootPath(),
-						Action: envoyRouteAction("dummy-namespace", "default-backend", "8080"),
 					},
 				},
 			},
@@ -1270,16 +1271,6 @@ var multipleRouteHostnamesExpectedConfig = []*envoy_config_route_v3.RouteConfigu
 		Name: "listener-insecure",
 		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
 			{
-				Name:    "foo.example.com",
-				Domains: domainsHelper("foo.example.com"),
-				Routes: []*envoy_config_route_v3.Route{
-					{
-						Match:  envoyRouteMatchRootPath(),
-						Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
-					},
-				},
-			},
-			{
 				Name:    "bar.example.com",
 				Domains: domainsHelper("bar.example.com"),
 				Routes: []*envoy_config_route_v3.Route{
@@ -1296,6 +1287,16 @@ var multipleRouteHostnamesExpectedConfig = []*envoy_config_route_v3.RouteConfigu
 					{
 						Match:  envoyRouteMatchRootPath(),
 						Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
+					},
+				},
+			},
+			{
+				Name:    "foo.example.com",
+				Domains: domainsHelper("foo.example.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
 					},
 				},
 			},

--- a/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
@@ -1323,24 +1323,16 @@ var hostnameIntersectionHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyCo
 					Name: "listener-insecure",
 					VirtualHosts: []*envoy_config_route_v3.VirtualHost{
 						{
-							Name:    "very.specific.com",
-							Domains: []string{"very.specific.com", "very.specific.com:*"},
+							Name:    "*.anotherwildcard.io",
+							Domains: []string{"*.anotherwildcard.io", "*.anotherwildcard.io:*"},
 							Routes: []*envoy_config_route_v3.Route{
 								{
 									Match: &envoy_config_route_v3.RouteMatch{
 										PathSpecifier: &envoy_config_route_v3.RouteMatch_PathSeparatedPrefix{
-											PathSeparatedPrefix: "/s1",
+											PathSeparatedPrefix: "/s4",
 										},
 									},
 									Action: routeActionBackendV1,
-								},
-								{
-									Match: &envoy_config_route_v3.RouteMatch{
-										PathSpecifier: &envoy_config_route_v3.RouteMatch_PathSeparatedPrefix{
-											PathSeparatedPrefix: "/s3",
-										},
-									},
-									Action: routeActionBackendV3,
 								},
 							},
 						},
@@ -1387,16 +1379,24 @@ var hostnameIntersectionHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyCo
 							},
 						},
 						{
-							Name:    "*.anotherwildcard.io",
-							Domains: []string{"*.anotherwildcard.io", "*.anotherwildcard.io:*"},
+							Name:    "very.specific.com",
+							Domains: []string{"very.specific.com", "very.specific.com:*"},
 							Routes: []*envoy_config_route_v3.Route{
 								{
 									Match: &envoy_config_route_v3.RouteMatch{
 										PathSpecifier: &envoy_config_route_v3.RouteMatch_PathSeparatedPrefix{
-											PathSeparatedPrefix: "/s4",
+											PathSeparatedPrefix: "/s1",
 										},
 									},
 									Action: routeActionBackendV1,
+								},
+								{
+									Match: &envoy_config_route_v3.RouteMatch{
+										PathSpecifier: &envoy_config_route_v3.RouteMatch_PathSeparatedPrefix{
+											PathSeparatedPrefix: "/s3",
+										},
+									},
+									Action: routeActionBackendV3,
 								},
 							},
 						},
@@ -1561,34 +1561,6 @@ var listenerHostNameMatchingCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 					Name: "listener-insecure",
 					VirtualHosts: []*envoy_config_route_v3.VirtualHost{
 						{
-							Name:    "bar.com",
-							Domains: []string{"bar.com", "bar.com:*"},
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match: &envoy_config_route_v3.RouteMatch{
-										PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
-											Prefix: "/",
-										},
-									},
-									Action: routeActionBackendV1,
-								},
-							},
-						},
-						{
-							Name:    "foo.bar.com",
-							Domains: []string{"foo.bar.com", "foo.bar.com:*"},
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match: &envoy_config_route_v3.RouteMatch{
-										PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
-											Prefix: "/",
-										},
-									},
-									Action: routeActionBackendV2,
-								},
-							},
-						},
-						{
 							Name:    "*.bar.com",
 							Domains: []string{"*.bar.com", "*.bar.com:*"},
 							Routes: []*envoy_config_route_v3.Route{
@@ -1613,6 +1585,34 @@ var listenerHostNameMatchingCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 										},
 									},
 									Action: routeActionBackendV3,
+								},
+							},
+						},
+						{
+							Name:    "bar.com",
+							Domains: []string{"bar.com", "bar.com:*"},
+							Routes: []*envoy_config_route_v3.Route{
+								{
+									Match: &envoy_config_route_v3.RouteMatch{
+										PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
+											Prefix: "/",
+										},
+									},
+									Action: routeActionBackendV1,
+								},
+							},
+						},
+						{
+							Name:    "foo.bar.com",
+							Domains: []string{"foo.bar.com", "foo.bar.com:*"},
+							Routes: []*envoy_config_route_v3.Route{
+								{
+									Match: &envoy_config_route_v3.RouteMatch{
+										PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
+											Prefix: "/",
+										},
+									},
+									Action: routeActionBackendV2,
 								},
 							},
 						},

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
@@ -479,20 +479,6 @@ var hostRulesListenersEnforceHTTPSCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfi
 					Name: "listener-insecure",
 					VirtualHosts: []*envoy_config_route_v3.VirtualHost{
 						{
-							Name:    "foo.bar.com",
-							Domains: []string{"foo.bar.com", "foo.bar.com:*"},
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match: &envoy_config_route_v3.RouteMatch{
-										PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
-											Prefix: "/",
-										},
-									},
-									Action: toHTTPSRedirectAction(),
-								},
-							},
-						},
-						{
 							Name:    "*.foo.com",
 							Domains: []string{"*.foo.com", "*.foo.com:*"},
 							Routes: []*envoy_config_route_v3.Route{
@@ -518,6 +504,20 @@ var hostRulesListenersEnforceHTTPSCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfi
 										QueryParameters: []*envoy_config_route_v3.QueryParameterMatcher{},
 									},
 									Action: toRouteAction("random-namespace", "wildcard-foo-com", "8080"),
+								},
+							},
+						},
+						{
+							Name:    "foo.bar.com",
+							Domains: []string{"foo.bar.com", "foo.bar.com:*"},
+							Routes: []*envoy_config_route_v3.Route{
+								{
+									Match: &envoy_config_route_v3.RouteMatch{
+										PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
+											Prefix: "/",
+										},
+									},
+									Action: toHTTPSRedirectAction(),
 								},
 							},
 						},


### PR DESCRIPTION
Currently, while translating K8s Ingress or Gateway API resources into Envoy resources, the virtualhosts aren't sorted. This leads to situations (especially in combination with Shared Ingress) where the order of the virtual hosts isn't guaranteed (depends on the order of the Shared Ingresses) - resulting in unnecessary reconciliations.

Therefore, this commit orders the virtualhosts within a Envoy RouteConfiguration by their name. This makes the translation deterministic.

It influences the [Envoy route matching process](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/route_matching) - but the order of the virtual hosts should only be relevant if a request host header matches multiple virtual hosts on the same "level".

```
Domain search order:
- Exact domain names: www.foo.com.
- Suffix domain wildcards: *.foo.com or *-bar.foo.com.
- Prefix domain wildcards: foo.* or foo-*.
- Special wildcard * matching any domain.
```

https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-msg-config-route-v3-virtualhost
