### PR TITLE
ingress: sort all shared ingresses during model generation

### DIFF
--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -4,8 +4,10 @@
 package ingress
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -217,7 +219,12 @@ func (r *ingressReconciler) buildSharedResources(ctx context.Context) (*ciliumv2
 	passthroughPort, insecureHTTPPort, secureHTTPPort := r.getSharedListenerPorts()
 
 	m := &model.Model{}
-	for _, item := range ingressList.Items {
+	allSharedIngresses := ingressList.Items
+	slices.SortStableFunc(allSharedIngresses, func(a, b networkingv1.Ingress) int {
+		return cmp.Compare(a.Namespace+"/"+a.Name, b.Namespace+"/"+b.Name)
+	})
+
+	for _, item := range allSharedIngresses {
 		if !isCiliumManagedIngress(ctx, r.client, r.logger, item) || r.isEffectiveLoadbalancerModeDedicated(&item) || item.GetDeletionTimestamp() != nil {
 			continue
 		}


### PR DESCRIPTION
Currently, when building the model for shared Ingress, all Ingresses in the cluster are listed and processed. The order of the Ingresses can differ and potentially influence the generated CiliumEnvoyConfig. This can lead to unnecessary reconciles. (Even though the internal translation already handles a stable CiliumEnvoyConfig generation where possible.)

In addition to the existing stable translation logic, this commit sorts all shared Ingresses by their namespace and name before processing. This way a consistent translation is more likely to be guaranteed.

Related to: https://github.com/cilium/cilium/pull/31493
Related to: https://github.com/cilium/cilium/pull/31572