### PR TITLE
cilium-dbg: listing load-balancing configurations displays L7LB proxy port

### DIFF
--- a/cilium-dbg/cmd/bpf_lb_list.go
+++ b/cilium-dbg/cmd/bpf_lb_list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/loadbalancer"
@@ -96,7 +97,11 @@ func dumpSVC(serviceList map[string][]string) {
 			if svcKey.IsIPv6() {
 				ip = "[::]"
 			}
-			entry = fmt.Sprintf("%s:%d (%d) (%d) [%s]", ip, 0, revNATID, backendSlot, flags)
+			extra := ""
+			if flags.IsL7LB() {
+				extra = fmt.Sprintf("(L7LB Proxy Port: %d)", byteorder.NetworkToHost16(uint16(svcVal.GetBackendID())))
+			}
+			entry = fmt.Sprintf("%s:%d (%d) (%d) [%s] %s", ip, 0, revNATID, backendSlot, flags, extra)
 		} else if backend, found := backendMap[backendID]; !found {
 			entry = fmt.Sprintf("backend %d not found", backendID)
 		} else {

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -151,6 +151,10 @@ func (s ServiceFlags) SVCType() SVCType {
 	}
 }
 
+func (s ServiceFlags) IsL7LB() bool {
+	return s&serviceFlagL7LoadBalancer != 0
+}
+
 // SVCExtTrafficPolicy returns a service traffic policy from the flags
 func (s ServiceFlags) SVCExtTrafficPolicy() SVCTrafficPolicy {
 	switch {


### PR DESCRIPTION
Currently, listing the load-balancing configuration doesn't display the L7LB Proxy Port for services of type `l7-load-balancer`.

```
> cilium-dbg bpf lb list
SERVICE ADDRESS     BACKEND ADDRESS (REVNAT_ID) (SLOT)
...
10.96.193.7:443     0.0.0.0:0 (30) (0) [ClusterIP, non-routable, l7-load-balancer]
```

The only way of retrieving the L7LB proxy port is to list the frontends (`cilium-dbg bpf lb list --frontends`) and manually convert the backend id (union type) to the L7LB proxy port.

Therefore, this commit addsd the L7LB proxy port to the output of `cilium-dbg bpf lb list` if the service is of type L7 LoadBalancer. The `--frontends` subcommand still displays the unmapped backend id.

```
> cilium-dbg bpf lb list
SERVICE ADDRESS     BACKEND ADDRESS (REVNAT_ID) (SLOT)
10.96.0.1:443       172.18.0.3:6443 (1) (1)
                    0.0.0.0:0 (1) (0) [ClusterIP, non-routable]
10.96.252.10:443    172.18.0.2:4244 (22) (1)
                    0.0.0.0:0 (22) (0) [ClusterIP, InternalLocal, non-routable]
10.96.155.44:80     0.0.0.0:0 (14) (0) [ClusterIP, non-routable]
                    10.244.1.211:80 (14) (1)
172.18.0.2:32646    0.0.0.0:0 (33) (0) [NodePort, l7-load-balancer] (L7LB Proxy Port: 15735)
10.96.193.7:443     0.0.0.0:0 (30) (0) [ClusterIP, non-routable, l7-load-balancer] (L7LB Proxy Port: 15735)
10.96.122.45:80     10.244.1.250:80 (26) (1)
                    0.0.0.0:0 (26) (0) [ClusterIP, non-routable]
10.96.102.137:80    0.0.0.0:0 (23) (0) [ClusterIP, non-routable]
                    10.244.1.126:4245 (23) (1)
10.96.108.180:443   0.0.0.0:0 (17) (0) [ClusterIP, non-routable, l7-load-balancer] (L7LB Proxy Port: 17731)
172.18.255.1:80     0.0.0.0:0 (25) (0) [LoadBalancer, l7-load-balancer] (L7LB Proxy Port: 17731)
0.0.0.0:32646       0.0.0.0:0 (34) (0) [NodePort, non-routable, l7-load-balancer] (L7LB Proxy Port: 15735)
0.0.0.0:31012       0.0.0.0:0 (21) (0) [NodePort, non-routable, l7-load-balancer] (L7LB Proxy Port: 17731)
```
