### PR TITLE
xdp: If xdp is disabled, don't unload (potentially) other apps' xdp code

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -265,10 +265,10 @@ func (l *loader) reinitializeOverlay(ctx context.Context, tunnelConfig tunnel.Co
 }
 
 func (l *loader) reinitializeXDPLocked(ctx context.Context, extraCArgs []string) error {
-	l.maybeUnloadObsoleteXDPPrograms(option.Config.GetDevices(), option.Config.XDPMode, bpf.CiliumPath())
 	if option.Config.XDPMode == option.XDPModeDisabled {
 		return nil
 	}
+	l.maybeUnloadObsoleteXDPPrograms(option.Config.GetDevices(), option.Config.XDPMode, bpf.CiliumPath())
 	for _, dev := range option.Config.GetDevices() {
 		// When WG & encrypt-node are on, the devices include cilium_wg0 to attach bpf_host
 		// so that NodePort's rev-{S,D}NAT translations happens for a reply from the remote node.


### PR DESCRIPTION
There are cases where k8s apps may be doing xdp related stuff. However if xdp is disabled in cilium, cilium may unload those xdp programs that may have been loaded in. This fixes the case such that those programs aren't unloaded.