### PR TITLE
gha: fix coredns logs retrieval in conformance-clustermesh

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -498,8 +498,8 @@ jobs:
           kubectl get pods --all-namespaces -o wide
           cilium sysdump --output-filename cilium-sysdump-context2-final-${{ join(matrix.*, '-') }}
 
-          kubectl --context ${{ env.contextName1 }} logs -n kube-system -l k8s-app=kube-dns --prefix --timestamps
-          kubectl --context ${{ env.contextName2 }} logs -n kube-system -l k8s-app=kube-dns --prefix --timestamps
+          kubectl --context ${{ env.contextName1 }} logs -n kube-system -l k8s-app=kube-dns --prefix --timestamps --tail=-1
+          kubectl --context ${{ env.contextName2 }} logs -n kube-system -l k8s-app=kube-dns --prefix --timestamps --tail=-1
 
           if [ "${{ matrix.mode }}" == "external" ]; then
             for i in {1..2}; do


### PR DESCRIPTION
The amount of log lines to display is limited to 10 by default when using a label selector. Let's switch to unlimited.

> --tail=-1:
    Lines of recent log file to display. Defaults to -1 with no selector,
    showing all log lines otherwise 10, if a selector is provided.

Fixes: b1774e1240e3 ("gha: retrieve additional coredns-related troubleshooting info")