### PR TITLE
Revert "daemon: Forbid IPv6 BPF masquerading with the host firewall"

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1384,13 +1384,6 @@ func initEnv(vp *viper.Viper) {
 		}
 	}
 
-	if option.Config.EnableIPv6Masquerade && option.Config.EnableBPFMasquerade && option.Config.EnableHostFirewall {
-		// We should be able to support this, but we first need to
-		// check how this plays in the datapath if BPF-masquerading is
-		// enabled for IPv4 only or IPv6 only.
-		log.Fatal("IPv6 BPF masquerade is not supported along with the host firewall.")
-	}
-
 	if option.Config.EnableHighScaleIPcache {
 		if option.Config.TunnelingEnabled() {
 			log.Fatal("The high-scale IPcache mode requires native routing.")

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -609,14 +609,9 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 			// Need to install Cilium w/ host fw prior to the host policy preparation
 			// step.
-			options := map[string]string{
+			deploymentManager.DeployCilium(map[string]string{
 				"hostFirewall.enabled": "true",
-			}
-			if helpers.RunsWithKubeProxyReplacement() {
-				// BPF IPv6 masquerade not currently supported with host firewall - GH-26074
-				options["enableIPv6Masquerade"] = "false"
-			}
-			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
+			}, DeployCiliumOptionsAndDNS)
 
 			hostPolicy := helpers.ManifestGet(kubectl.BasePath(), "host-policies.yaml")
 			prepareHostPolicyEnforcement(kubectl, hostPolicy)
@@ -645,11 +640,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 				options["gke.enabled"] = "false"
 				options["tunnelProtocol"] = "vxlan"
 			}
-			if helpers.RunsWithKubeProxyReplacement() {
-				// BPF IPv6 masquerade not currently supported with host firewall - GH-26074
-				options["enableIPv6Masquerade"] = "false"
-			}
-			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			testHostFirewall(kubectl)
 		})
@@ -665,11 +655,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 				options["gke.enabled"] = "false"
 				options["tunnelProtocol"] = "vxlan"
 			}
-			if helpers.RunsWithKubeProxyReplacement() {
-				// BPF IPv6 masquerade not currently supported with host firewall - GH-26074
-				options["enableIPv6Masquerade"] = "false"
-			}
-			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			testHostFirewall(kubectl)
 		})
@@ -686,11 +671,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 			} else {
 				options["autoDirectNodeRoutes"] = "true"
 			}
-			if helpers.RunsWithKubeProxyReplacement() {
-				// BPF IPv6 masquerade not currently supported with host firewall - GH-26074
-				options["enableIPv6Masquerade"] = "false"
-			}
-			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			testHostFirewall(kubectl)
 		})
@@ -704,11 +684,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 			if !helpers.RunsOnGKE() {
 				options["autoDirectNodeRoutes"] = "true"
 			}
-			if helpers.RunsWithKubeProxyReplacement() {
-				// BPF IPv6 masquerade not currently supported with host firewall - GH-26074
-				options["enableIPv6Masquerade"] = "false"
-			}
-			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			testHostFirewall(kubectl)
 		})

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -426,17 +426,13 @@ var _ = SkipDescribeIf(func() bool {
 			)
 
 			BeforeAll(func() {
-				opts := map[string]string{
-					"routingMode":          "native",
-					"autoDirectNodeRoutes": "true",
+				RedeployCiliumWithMerge(kubectl, ciliumFilename, daemonCfg,
+					map[string]string{
+						"routingMode":          "native",
+						"autoDirectNodeRoutes": "true",
 
-					"hostFirewall.enabled": "true",
-				}
-				if helpers.RunsWithKubeProxyReplacement() {
-					// BPF IPv6 masquerade not currently supported with host firewall - GH-26074
-					opts["enableIPv6Masquerade"] = "false"
-				}
-				RedeployCiliumWithMerge(kubectl, ciliumFilename, daemonCfg, opts)
+						"hostFirewall.enabled": "true",
+					})
 
 				By("Retrieving backend pod and outside node IP addresses")
 				outsideNodeName, outsideIP = kubectl.GetNodeInfo(kubectl.GetFirstNodeWithoutCiliumLabel())

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -641,14 +641,9 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			var ccnpHostPolicy string
 
 			BeforeAll(func() {
-				options := map[string]string{
+				DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 					"hostFirewall.enabled": "true",
-				}
-				if helpers.RunsWithKubeProxyReplacement() {
-					// BPF IPv6 masquerade not currently supported with host firewall - GH-26074
-					options["enableIPv6Masquerade"] = "false"
-				}
-				DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
+				})
 
 				originalCCNPHostPolicy := helpers.ManifestGet(kubectl.BasePath(), hostPolicyFilename)
 				res := kubectl.ExecMiddle("mktemp")


### PR DESCRIPTION
This reverts commit 934e1f2df26c5b27348e7804e6f78b6553c65813.

Since commit 9c1031e31719 ("bpf: fix missing ipv6 ct entry for snated traffic"), IPv6 BPF masquerading and the host firewall are compatible in the datapath. Let's allow them to be used together, and use the combination in tests.

CC: @oblazek 
Supersedes: #26323

```release-note
Allow the Host Firewall and IPv6 BPF masquerading to be used together.
```
