### PR TITLE
ingress: Set the default value for max_stream_timeout

### DIFF
--- a/operator/pkg/model/translation/cec_translator_test.go
+++ b/operator/pkg/model/translation/cec_translator_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/cilium/cilium/operator/pkg/model"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -573,6 +574,9 @@ func envoyRouteAction(namespace, backend, port string) *envoy_config_route_v3.Ro
 		Route: &envoy_config_route_v3.RouteAction{
 			ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
 				Cluster: fmt.Sprintf("%s:%s:%s", namespace, backend, port),
+			},
+			MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+				MaxStreamDuration: &durationpb.Duration{Seconds: 0},
 			},
 		},
 	}

--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -320,6 +320,11 @@ func requestMirrorMutation(mirrors []*model.HTTPRequestMirror) routeActionMutati
 func timeoutMutation(backend *time.Duration, request *time.Duration) routeActionMutation {
 	return func(route *envoy_config_route_v3.Route_Route) *envoy_config_route_v3.Route_Route {
 		if backend == nil && request == nil {
+			route.Route.MaxStreamDuration = &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+				MaxStreamDuration: &durationpb.Duration{
+					Seconds: 0,
+				},
+			}
 			return route
 		}
 		minTimeout := backend

--- a/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
@@ -3046,6 +3046,9 @@ var backendRefsRequestHeaderModifierHTTPListenersCiliumEnvoyConfig = &ciliumv2.C
 												},
 											},
 										},
+										MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+											MaxStreamDuration: &durationpb.Duration{Seconds: 0},
+										},
 									},
 								},
 							},
@@ -3108,6 +3111,9 @@ var backendRefsRequestHeaderModifierHTTPListenersCiliumEnvoyConfig = &ciliumv2.C
 													},
 												},
 											},
+										},
+										MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+											MaxStreamDuration: &durationpb.Duration{Seconds: 0},
 										},
 									},
 								},
@@ -3181,6 +3187,9 @@ var backendRefsRequestHeaderModifierHTTPListenersCiliumEnvoyConfig = &ciliumv2.C
 													},
 												},
 											},
+										},
+										MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+											MaxStreamDuration: &durationpb.Duration{Seconds: 0},
 										},
 									},
 								},
@@ -3693,6 +3702,9 @@ var backendRefsResponseHeaderModifierHTTPListenersCiliumEnvoyConfig = &ciliumv2.
 												},
 											},
 										},
+										MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+											MaxStreamDuration: &durationpb.Duration{Seconds: 0},
+										},
 									},
 								},
 							},
@@ -3755,6 +3767,9 @@ var backendRefsResponseHeaderModifierHTTPListenersCiliumEnvoyConfig = &ciliumv2.
 													},
 												},
 											},
+										},
+										MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+											MaxStreamDuration: &durationpb.Duration{Seconds: 0},
 										},
 									},
 								},
@@ -3828,6 +3843,9 @@ var backendRefsResponseHeaderModifierHTTPListenersCiliumEnvoyConfig = &ciliumv2.
 													},
 												},
 											},
+										},
+										MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+											MaxStreamDuration: &durationpb.Duration{Seconds: 0},
 										},
 									},
 								},
@@ -4733,6 +4751,9 @@ var rewriteHostHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 											HostRewriteSpecifier: &envoy_config_route_v3.RouteAction_HostRewriteLiteral{
 												HostRewriteLiteral: "one.example.org",
 											},
+											MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+												MaxStreamDuration: &durationpb.Duration{Seconds: 0},
+											},
 										},
 									},
 								},
@@ -4749,6 +4770,9 @@ var rewriteHostHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 											},
 											HostRewriteSpecifier: &envoy_config_route_v3.RouteAction_HostRewriteLiteral{
 												HostRewriteLiteral: "example.org",
+											},
+											MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+												MaxStreamDuration: &durationpb.Duration{Seconds: 0},
 											},
 										},
 									},
@@ -4940,6 +4964,9 @@ var rewritePathHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 												Cluster: fmt.Sprintf("%s:%s:%s", "gateway-conformance-infra", "infra-backend-v1", "8080"),
 											},
 											PrefixRewrite: "/prefix",
+											MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+												MaxStreamDuration: &durationpb.Duration{Seconds: 0},
+											},
 										},
 									},
 									RequestHeadersToAdd: []*envoy_config_core_v3.HeaderValueOption{
@@ -4984,6 +5011,9 @@ var rewritePathHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 												},
 												Substitution: "/test",
 											},
+											MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+												MaxStreamDuration: &durationpb.Duration{Seconds: 0},
+											},
 										},
 									},
 									RequestHeadersToAdd: []*envoy_config_core_v3.HeaderValueOption{
@@ -5023,6 +5053,9 @@ var rewritePathHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 												Cluster: fmt.Sprintf("%s:%s:%s", "gateway-conformance-infra", "infra-backend-v1", "8080"),
 											},
 											PrefixRewrite: "/one",
+											MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+												MaxStreamDuration: &durationpb.Duration{Seconds: 0},
+											},
 										},
 									},
 								},
@@ -5042,6 +5075,9 @@ var rewritePathHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 													Regex: "^/.*$",
 												},
 												Substitution: "/one",
+											},
+											MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+												MaxStreamDuration: &durationpb.Duration{Seconds: 0},
 											},
 										},
 									},
@@ -5163,6 +5199,9 @@ var mirrorHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 													},
 												},
 											},
+											MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+												MaxStreamDuration: &durationpb.Duration{Seconds: 0},
+											},
 										},
 									},
 								},
@@ -5277,6 +5316,9 @@ func toRouteAction(namespace, name, port string) *envoy_config_route_v3.Route_Ro
 		Route: &envoy_config_route_v3.RouteAction{
 			ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
 				Cluster: fmt.Sprintf("%s:%s:%s", namespace, name, port),
+			},
+			MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+				MaxStreamDuration: &durationpb.Duration{Seconds: 0},
 			},
 		},
 	}

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
@@ -105,6 +105,9 @@ func toRouteAction(namespace, name, port string) *envoy_config_route_v3.Route_Ro
 			ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
 				Cluster: fmt.Sprintf("%s:%s:%s", namespace, name, port),
 			},
+			MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+				MaxStreamDuration: &durationpb.Duration{Seconds: 0},
+			},
 		},
 	}
 }


### PR DESCRIPTION
For all routes in CiliumeEnvoyConfigs, set the timeout to 0s to disable the [route upstream timeout](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-timeout). This timeout defaults to 15 seconds if not set and [is not compatible with streaming responses.](https://www.envoyproxy.io/docs/envoy/latest/faq/configuration/timeouts#route-timeouts)

Something changed in the 1.15 release that changed the behavior of envoy, making it so the default 15 second upstream timeout is now enforced, making streaming responses unusable. This is a breaking change in behavior that I'm not sure how to nail down. This PR maybe way off but its the simplest way I could find to enforce the disabling of this particular timeout.

<details>
  <summary>Easy Way to Reproduce 15 Second Timeout</summary>

  Here is a simple script to spin up a local kind cluster, install cilium and an app named httpbin to test with.

```bash
#!/bin/bash

cat << EOF > kind-cluster-config.toml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
- role: worker
  extraPortMappings:
  - containerPort: 30000
    hostPort: 8080
networking:
  disableDefaultCNI: true
EOF

kind create cluster --config kind-cluster-config.toml
rm kind-cluster-config.toml

helm repo add cilium https://helm.cilium.io/
helm upgrade cilium cilium/cilium --version 1.15.2 --install \
   --namespace kube-system \
   --set image.pullPolicy=IfNotPresent \
   --set ipam.mode=kubernetes \
   --set ingressController.enabled=true \
   --set ingressController.service.type=NodePort \
   --set ingressController.service.insecureNodePort=30000 \
   --set ingressController.loadbalancerMode=shared

cat <<'EOF' | kubectl apply -f -
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: httpbin
  name: httpbin
spec:
  replicas: 1
  selector:
    matchLabels:
      app: httpbin
  template:
    metadata:
      labels:
        app: httpbin
    spec:
      containers:
      - env:
        - name: MAX_DURATION
          value: 300s
        image: mccutchen/go-httpbin
        name: go-httpbin
        ports:
        - containerPort: 8080
          name: http
          protocol: TCP
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: httpbin
  name: httpbin
spec:
  ports:
  - name: 8080-8080
    port: 8080
    protocol: TCP
    targetPort: 8080
  selector:
    app: httpbin
  type: ClusterIP
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: httpbin
  namespace: default
spec:
  ingressClassName: cilium
  rules:
  - host: httpbin.test.com
    http:
      paths:
      - backend:
          service:
            name: httpbin
            port:
              number: 8080
        path: /
        pathType: Prefix
EOF

```

When the resources are healthy run curls against the httpbin app causing the app to take more than 15 seconds to respond or finish a streaming response.

```
# make the http response take 20 seconds sending 20 bytes, returning headers immediately
curl -v -H 'Host:httpbin.test.com' 'http://localhost:8080/drip?duration=20&numbytes=20&&delay=0'
# returns a 200 but then the tcp connection is terminated before the response is completed
```

```
# make the http response take 40 seconds sending 20 bytes, not sending headers for 20 seconds
curl -v -H 'Host:httpbin.test.com' 'http://localhost:8080/drip?duration=20&numbytes=20&&delay=20'
# returns a 408
```

Redeploy the helm chart with a 14 release and the responses are completed (no 15s timeout)

</details>

This is a blocker for our usage of cilium so if this code change is in the wrong direction please let me know. I'd be happy to put more effort into a different solution if some guidance is provided. Thanks