### PR TITLE
azure: disable two assertions in TestIpamManyNodes.

### DIFF
--- a/pkg/azure/ipam/ipam_test.go
+++ b/pkg/azure/ipam/ipam_test.go
@@ -281,7 +281,8 @@ type nodeState struct {
 }
 
 // TestIpamManyNodes tests IP allocation of 100 nodes across 3 subnets
-func (e *IPAMSuite) TestIpamManyNodes(c *check.C) {
+// TODO: Fix https://github.com/cilium/cilium/issues/31466 and re-enable this test.
+/*func (e *IPAMSuite) TestIpamManyNodes(c *check.C) {
 	const (
 		numNodes    = 100
 		minAllocate = 10
@@ -327,6 +328,7 @@ func (e *IPAMSuite) TestIpamManyNodes(c *check.C) {
 
 		node := mngr.Get(s.name)
 		c.Assert(node, check.Not(check.IsNil))
+
 		if node.Stats().AvailableIPs != minAllocate {
 			c.Errorf("Node %s allocation mismatch. expected: %d allocated: %d", s.name, minAllocate, node.Stats().AvailableIPs)
 			c.Fail()
@@ -355,7 +357,7 @@ func (e *IPAMSuite) TestIpamManyNodes(c *check.C) {
 
 	c.Assert(metrics.ResyncCount(), check.Not(check.Equals), 0)
 	c.Assert(metrics.AvailableInterfaces(), check.Not(check.Equals), 0)
-}
+}*/
 
 func benchmarkAllocWorker(c *check.C, workers int64, delay time.Duration, rateLimit float64, burst int) {
 	api := apimock.NewAPI(testSubnets, []*ipamTypes.VirtualNetwork{testVnet})


### PR DESCRIPTION
These have been [persistently flakey for quite a while](https://github.com/cilium/cilium/issues?q=is%3Aissue+TestIpamManyNodes+), several fixes have been made but some variation of this keeps coming back.

The problem is the chaotic nature of the azure ipam implementation, specifically:

* Several triggers, that can trigger other triggers, some in a circular fashion (i.e. resyncNodes, maintainIPPool, etc).
* Plus, complex interleaving locking (with circular references between *node and *NodeManager). It's clear that there's something wrong with calls to (*node).recalculate() and the rest of the maintain IP pool logic.

This is consistently causing CI failures, so I'm going to disable this for now.

Addresses: #31466