### PR TITLE
[v1.15] test: Remove duplicate Cilium deployments in some datapath config tests

### DIFF
--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -672,7 +672,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 				options["enableIPv6Masquerade"] = "false"
 			}
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
-			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			testHostFirewall(kubectl)
 		})
 
@@ -691,7 +690,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 				// BPF IPv6 masquerade not currently supported with host firewall - GH-26074
 				options["enableIPv6Masquerade"] = "false"
 			}
-			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			testHostFirewall(kubectl)
 		})
@@ -713,7 +711,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 				options["enableIPv6Masquerade"] = "false"
 			}
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
-			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			testHostFirewall(kubectl)
 		})
 
@@ -730,7 +727,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 				// BPF IPv6 masquerade not currently supported with host firewall - GH-26074
 				options["enableIPv6Masquerade"] = "false"
 			}
-			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			testHostFirewall(kubectl)
 		})


### PR DESCRIPTION
When disabling IPv6 BPF masquerading in datapath configuration tests using the host firewall, we accidentally duplicated the command to deploy Cilium for some of the tests. Let's clean this up to avoid slowing down the tests.

Fixes: 934e1f2df26c ("daemon: Forbid IPv6 BPF masquerading with the host firewall")

Partial backport from #31511.