### PR TITLE
lint: Remove temp variable in the 'for' loop

### DIFF
--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -330,7 +330,6 @@ func runAll(commands []string, cmdDir string, k8sPods []string) {
 			continue
 		}
 
-		cmd := cmd // https://golang.org/doc/faq#closures_and_goroutines
 		err := wp.Submit(cmd, func(_ context.Context) error {
 			if strings.Contains(cmd, "xfrm state") {
 				//  Output of 'ip -s xfrm state' needs additional processing to replace

--- a/operator/pkg/gateway-api/controller.go
+++ b/operator/pkg/gateway-api/controller.go
@@ -66,7 +66,6 @@ func getGatewaysForSecret(ctx context.Context, c client.Client, obj client.Objec
 
 	var gateways []*gatewayv1.Gateway
 	for _, gw := range gwList.Items {
-		gwCopy := gw
 		for _, l := range gw.Spec.Listeners {
 			if l.TLS == nil {
 				continue
@@ -78,7 +77,7 @@ func getGatewaysForSecret(ctx context.Context, c client.Client, obj client.Objec
 				}
 				ns := helpers.NamespaceDerefOr(cert.Namespace, gw.GetNamespace())
 				if string(cert.Name) == obj.GetName() && ns == obj.GetNamespace() {
-					gateways = append(gateways, &gwCopy)
+					gateways = append(gateways, &gw)
 				}
 			}
 		}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1275,8 +1275,7 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 				ipv4CIDRs := info.GetIPv4CIDRs()
 				ipv4PodSubnets := make([]*net.IPNet, 0, len(ipv4CIDRs))
 				for _, c := range ipv4CIDRs {
-					cidr := c // create a copy to be able to take a reference
-					ipv4PodSubnets = append(ipv4PodSubnets, &cidr)
+					ipv4PodSubnets = append(ipv4PodSubnets, &c)
 				}
 				n.nodeConfig.IPv4PodSubnets = ipv4PodSubnets
 			}

--- a/pkg/datapath/linux/routing/migrate.go
+++ b/pkg/datapath/linux/routing/migrate.go
@@ -488,14 +488,13 @@ func (m *migrator) copyRoutes(routes []netlink.Route, from, to int) (revert.Reve
 	// gateway." with an errno of ENETUNREACH.
 	for _, r := range routes {
 		if r.Scope == netlink.SCOPE_LINK {
-			route := r
-			route.Table = to
-			if err := m.rpdb.RouteReplace(&route); err != nil {
+			r.Table = to
+			if err := m.rpdb.RouteReplace(&r); err != nil {
 				return revertStack, fmt.Errorf("unable to replace link scoped route under table ID: %w", err)
 			}
 
 			revertStack.Push(func() error {
-				if err := m.rpdb.RouteDel(&route); err != nil {
+				if err := m.rpdb.RouteDel(&r); err != nil {
 					return fmt.Errorf("failed to revert route upsert: %w", err)
 				}
 				return nil
@@ -509,14 +508,13 @@ func (m *migrator) copyRoutes(routes []netlink.Route, from, to int) (revert.Reve
 			continue
 		}
 
-		route := r
-		route.Table = to
-		if err := m.rpdb.RouteReplace(&route); err != nil {
+		r.Table = to
+		if err := m.rpdb.RouteReplace(&r); err != nil {
 			return revertStack, fmt.Errorf("unable to replace route under table ID: %w", err)
 		}
 
 		revertStack.Push(func() error {
-			if err := m.rpdb.RouteDel(&route); err != nil {
+			if err := m.rpdb.RouteDel(&r); err != nil {
 				return fmt.Errorf("failed to revert route upsert: %w", err)
 			}
 			return nil

--- a/pkg/hubble/relay/observer/observer.go
+++ b/pkg/hubble/relay/observer/observer.go
@@ -278,7 +278,6 @@ func (fc *flowCollector) collect(ctx context.Context, g *errgroup.Group, peers [
 		}
 		connected = append(connected, p.Name)
 		fc.connectedNodes[p.Name] = struct{}{}
-		p := p
 		g.Go(func() error {
 			// retrieveFlowsFromPeer returns blocks until the peer finishes
 			// the request by closing the connection, an error occurs,

--- a/pkg/hubble/relay/observer/server.go
+++ b/pkg/hubble/relay/observer/server.go
@@ -169,7 +169,6 @@ func (s *Server) GetNodes(ctx context.Context, req *observerpb.GetNodesRequest) 
 			continue
 		}
 		n.State = relaypb.NodeState_NODE_CONNECTED
-		p := p
 		g.Go(func() error {
 			n := n
 			client := s.opts.ocb.observerClient(&p)
@@ -215,7 +214,6 @@ func (s *Server) GetNamespaces(ctx context.Context, req *observerpb.GetNamespace
 			continue
 		}
 
-		p := p
 		g.Go(func() error {
 			client := s.opts.ocb.observerClient(&p)
 			nsResp, err := client.GetNamespaces(ctx, req)
@@ -273,7 +271,7 @@ func (s *Server) ServerStatus(ctx context.Context, req *observerpb.ServerStatusR
 			mu.Unlock()
 			continue
 		}
-		p := p
+
 		g.Go(func() error {
 			client := s.opts.ocb.observerClient(&p)
 			status, err := client.ServerStatus(ctx, req)

--- a/pkg/k8s/identitybackend/identity_test.go
+++ b/pkg/k8s/identitybackend/identity_test.go
@@ -195,7 +195,6 @@ func TestGetIdentity(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 			_, client := k8sClient.NewFakeClientset()

--- a/pkg/k8s/synced/resources_test.go
+++ b/pkg/k8s/synced/resources_test.go
@@ -115,9 +115,8 @@ func TestWaitForCacheSyncWithTimeout(t *testing.T) {
 				// Schedule resource events to happen after specified duration.
 				for resourceName, waitForEvent := range test.resourceNamesToEvent {
 					// schedule an event.
-					rname := resourceName
 					time.AfterFunc(waitForEvent, func() {
-						r.SetEventTimestamp(rname)
+						r.SetEventTimestamp(resourceName)
 					})
 				}
 

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -931,7 +931,6 @@ func TestCount(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, k := range mapsexp.Keys(cache)[:size/4] {
-		k := k
 		if err := m.Delete(k); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/statedb/fuzz_test.go
+++ b/pkg/statedb/fuzz_test.go
@@ -278,7 +278,6 @@ func TestDB_Fuzz(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(numWorkers)
 	for i := 0; i < numWorkers; i++ {
-		i := i
 		go func() {
 			fuzzWorker(&actionLog, i, numIterations)
 			wg.Done()

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1992,7 +1992,6 @@ func (kub *Kubectl) ValidateServicePlumbing(namespace, service string) error {
 
 	g, _ := errgroup.WithContext(context.TODO())
 	for _, ciliumPod := range ciliumPods {
-		ciliumPod := ciliumPod
 		g.Go(func() error {
 			var err error
 			// The plumbing of Kubernetes services typically lags


### PR DESCRIPTION
### Description

Since golang 1.22+, temp variable in the for loop can be removed. There is new linter copyloopvar in latest golangci-lint, however, there are a lot of false positive now, so probably after a few versions, we can enable it in .golangci.yaml.

### Reference

(copied the below comment from Tobias)

> For future reference: more details on the for loop behavior change in https://tip.golang.org/doc/go1.22#language and https://tip.golang.org/wiki/RangefuncExperiment
