### PR TITLE
images/builder: get rid of annoying git ownership warnings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Cilium",
-  "image": "quay.io/cilium/cilium-builder:819a4f1e57eaacb6aabfc6a1a39d11d4fd794a88@sha256:24781dc80f2be2d8fd66b0ce1405e1f117a3a0ef388758b1ede7831778e3a4f7",
+  "image": "quay.io/cilium/cilium-builder:6429423a819df54c36dbc44c4bd559baa10f0ce3@sha256:630504dbaa8267bc373986e90142ee8d182770cfe9804a3f7a58b31c102e2049",
   "workspaceFolder": "/go/src/github.com/cilium/cilium",
   "workspaceMount": "source=${localWorkspaceFolder},target=/go/src/github.com/cilium/cilium,type=bind",
   "features": {

--- a/api/v1/Makefile
+++ b/api/v1/Makefile
@@ -3,7 +3,7 @@
 include ../../Makefile.defs
 
 # Update this via images/scripts/update-cilium-builder-image.sh
-CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:819a4f1e57eaacb6aabfc6a1a39d11d4fd794a88@sha256:24781dc80f2be2d8fd66b0ce1405e1f117a3a0ef388758b1ede7831778e3a4f7
+CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:6429423a819df54c36dbc44c4bd559baa10f0ce3@sha256:630504dbaa8267bc373986e90142ee8d182770cfe9804a3f7a58b31c102e2049
 
 .PHONY: proto
 proto:

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -60,6 +60,10 @@ RUN CGO_ENABLED=0 go install github.com/go-delve/delve/cmd/dlv@latest
 
 WORKDIR /go/src/github.com/cilium/cilium/images/builder
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium/images/builder \
+    ./install-gitconfig.sh
+
+WORKDIR /go/src/github.com/cilium/cilium/images/builder
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium/images/builder \
     --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/go/pkg \
     ./build-debug-wrapper.sh

--- a/images/builder/install-gitconfig.sh
+++ b/images/builder/install-gitconfig.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+set -o nounset
+
+cat << EOF > "$HOME/.gitconfig"
+[safe]
+	directory = *
+EOF

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:819a4f1e57eaacb6aabfc6a1a39d11d4fd794a88@sha256:24781dc80f2be2d8fd66b0ce1405e1f117a3a0ef388758b1ede7831778e3a4f7
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:6429423a819df54c36dbc44c4bd559baa10f0ce3@sha256:630504dbaa8267bc373986e90142ee8d182770cfe9804a3f7a58b31c102e2049
 ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:fc827f3017004337e4a6fa71f481fa148e177242@sha256:8d60345a66aa4595ea8607880f612c908c639b3fa69ea015a649f67f447cc51f
 ARG CILIUM_ENVOY_IMAGE=quay.io/cilium/cilium-envoy:v1.28.1-0a4c2d1a90a7e13116bed4b0c1d4aacaf0e49686@sha256:9c45b847f0d6689b537000257dc26a1db3799fd40cb2d430397fd0aec375a562
 

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -12,7 +12,7 @@
 # https://raw.githubusercontent.com/GoogleContainerTools/distroless/main/cosign.pub
 ARG BASE_IMAGE=gcr.io/distroless/static-debian11:nonroot@sha256:55c636171053dbc8ae07a280023bd787d2921f10e569f3e319f1539076dbba11
 ARG GOLANG_IMAGE=docker.io/library/golang:1.22.1@sha256:34ce21a9696a017249614876638ea37ceca13cdd88f582caad06f87a8aa45bf3
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:819a4f1e57eaacb6aabfc6a1a39d11d4fd794a88@sha256:24781dc80f2be2d8fd66b0ce1405e1f117a3a0ef388758b1ede7831778e3a4f7
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:6429423a819df54c36dbc44c4bd559baa10f0ce3@sha256:630504dbaa8267bc373986e90142ee8d182770cfe9804a3f7a58b31c102e2049
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -4,7 +4,7 @@
 ARG BASE_IMAGE=scratch
 ARG GOLANG_IMAGE=docker.io/library/golang:1.22.1@sha256:34ce21a9696a017249614876638ea37ceca13cdd88f582caad06f87a8aa45bf3
 ARG ALPINE_IMAGE=docker.io/library/alpine:3.19.1@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:819a4f1e57eaacb6aabfc6a1a39d11d4fd794a88@sha256:24781dc80f2be2d8fd66b0ce1405e1f117a3a0ef388758b1ede7831778e3a4f7
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:6429423a819df54c36dbc44c4bd559baa10f0ce3@sha256:630504dbaa8267bc373986e90142ee8d182770cfe9804a3f7a58b31c102e2049
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with

--- a/test/k8s/manifests/demo-customcalls.yaml
+++ b/test/k8s/manifests/demo-customcalls.yaml
@@ -99,7 +99,7 @@ metadata:
 spec:
   containers:
   - name: cilium-builder
-    image: quay.io/cilium/cilium-builder:819a4f1e57eaacb6aabfc6a1a39d11d4fd794a88@sha256:24781dc80f2be2d8fd66b0ce1405e1f117a3a0ef388758b1ede7831778e3a4f7
+    image: quay.io/cilium/cilium-builder:6429423a819df54c36dbc44c4bd559baa10f0ce3@sha256:630504dbaa8267bc373986e90142ee8d182770cfe9804a3f7a58b31c102e2049
     workingDir: /cilium
     command: ["/bin/sh", "-c"]
     args:


### PR DESCRIPTION
Begone, cumbersome git warnings caused by including Makefile.defs:

```
fatal: detected dubious ownership in repository at '/src'
To add an exception for this directory, call:

	git config --global --add safe.directory /src
```

cilium-builder will be run as root in various contexts, and git repos will be mounted under random paths, so we can't reasonably target them. Just stop the warnings, they're useless in this context.