### PR TITLE
docs: aks: avoid overlapping service and pod CIDRs

### DIFF
--- a/Documentation/installation/requirements-aks.rst
+++ b/Documentation/installation/requirements-aks.rst
@@ -22,3 +22,6 @@ Encapsulation Cluster Pool Kubernetes CRD
 * The AKS cluster must be created with ``--network-plugin none``. See the
   `Bring your own CNI <https://docs.microsoft.com/en-us/azure/aks/use-byo-cni?tabs=azure-cli>`_
   documentation for more details about BYOCNI prerequisites / implications.
+
+* Make sure that you set a cluster pool IPAM pod CIDR that does not overlap with the default service
+  CIDR of AKS. For example, you can use ``--helm-set ipam.operator.clusterPoolIPv4PodCIDRList=192.168.0.0/16``.


### PR DESCRIPTION
See https://github.com/cilium/cilium/pull/31504 for context.

I'm not super sure I'm doing this in the right context, as I don't really understand all the different AKS modes of operation.

The default service CIDR of AKS clusters is 10.0.0.0/16 [1]. Cilium's default pod CIDR in cluster pool IPAM is 10.0.0.0/8, which overlaps. This can lead to "fun" situations in which e.g. the kube-dns service ClusterIP is the same as the hubble-relay pod IP, or similar shenanigans. This usually breaks the cluster utterly.

The fix is relatively straight-forward: set a pod CIDR for cilium which does not overlap with defaults of AKS. We chose 192.168.0.0/16 as this is what is recommended in [2].

[1]: https://learn.microsoft.com/en-us/azure/aks/configure-kubenet#create-an-aks-cluster-with-system-assigned-managed-identities
[2]: https://learn.microsoft.com/en-us/azure/aks/azure-cni-powered-by-cilium#option-1-assign-ip-addresses-from-an-overlay-network
