### PR TITLE
gha: checkout target branch in multi pool workflow

### DIFF
--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -31,11 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - name: Checkout main branch to access local actions
+      - name: Checkout target branch to access local actions
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.base_ref || github.ref }}
           persist-credentials: false
+
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 


### PR DESCRIPTION
Additionally apply the same changes introduced in 1abe5287d37e ("gha: checkout target branch instead of the default one") to the Conformance Multi Pool IPAM workflow as well, which had been missed earlier as triggered by Ariane on newer branches.
