### PR TITLE
proxy: remove unused ifaces and code for proxy <-> endpoint interaction

### DIFF
--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -8,10 +8,8 @@ import (
 
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
-	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
 
 // Owner is the interface defines the requirements for anybody owning policies.
@@ -37,30 +35,4 @@ type Owner interface {
 	// RemoveRestoredDNSRules removes any restored DNS rules for
 	// this endpoint from the DNS proxy.
 	RemoveRestoredDNSRules(epID uint16)
-}
-
-// EndpointInfoSource returns information about an endpoint being proxied.
-// The read lock must be held when calling any method.
-type EndpointInfoSource interface {
-	GetID() uint64
-	GetIPv4Address() string
-	GetIPv6Address() string
-	GetIdentity() identity.NumericIdentity
-	GetLabels() []string
-	ConntrackName() string
-	ConntrackNameLocked() string
-}
-
-// EndpointUpdater returns information about an endpoint being proxied and
-// is called back to update the endpoint when proxy events occur.
-// This is a subset of `Endpoint`.
-type EndpointUpdater interface {
-	EndpointInfoSource
-	// OnProxyPolicyUpdate is called when the proxy acknowledges that it
-	// has applied a policy.
-	OnProxyPolicyUpdate(policyRevision uint64)
-
-	// UpdateProxyStatistics updates the Endpoint's proxy statistics to account
-	// for a new observed flow with the given characteristics.
-	UpdateProxyStatistics(proxyType, l4Protocol string, port, proxyPort uint16, ingress, request bool, verdict accesslog.FlowVerdict)
 }

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -14,11 +14,9 @@ import (
 
 	apiv1 "github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/checker"
-	"github.com/cilium/cilium/pkg/completion"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
-	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager/idallocator"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/hive/cell"
@@ -26,7 +24,6 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/revert"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
@@ -61,21 +58,6 @@ func (s *EndpointManagerSuite) SetUpSuite(c *C) {
 func (s *EndpointManagerSuite) GetPolicyRepository() *policy.Repository {
 	return s.repo
 }
-
-func (s *EndpointManagerSuite) UpdateProxyRedirect(e regeneration.EndpointUpdater, l4 *policy.L4Filter, wg *completion.WaitGroup) (uint16, error, revert.FinalizeFunc, revert.RevertFunc) {
-	return 0, nil, nil, nil
-}
-
-func (s *EndpointManagerSuite) RemoveProxyRedirect(e regeneration.EndpointInfoSource, id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc) {
-	return nil, nil, nil
-}
-
-func (s *EndpointManagerSuite) UpdateNetworkPolicy(e regeneration.EndpointUpdater, vis *policy.VisibilityPolicy, policy *policy.L4Policy,
-	proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
-	return nil, nil
-}
-
-func (s *EndpointManagerSuite) RemoveNetworkPolicy(e regeneration.EndpointInfoSource) {}
 
 func (s *EndpointManagerSuite) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), error) {
 	return nil, nil
@@ -751,10 +733,8 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 func (s *EndpointManagerSuite) TestRemove(c *C) {
 	mgr := New(&dummyEpSyncher{}, nil, nil)
 	ep := endpoint.NewTestEndpointWithState(c, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 7, endpoint.StateReady)
-	type args struct {
-	}
-	type want struct {
-	}
+	type args struct{}
+	type want struct{}
 	tests := []struct {
 		name        string
 		setupArgs   func() args

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -37,14 +37,11 @@ func (d *DummySelectorCacheUser) IdentitySelectionUpdated(selector policy.Cached
 var (
 	_        = Suite(&ServerSuite{})
 	IPv4Addr = "10.1.1.1"
-	Identity = identity.NumericIdentity(123)
 
 	ep endpoint.EndpointUpdater = &test.ProxyUpdaterMock{
-		Id:       1000,
-		Ipv4:     "10.0.0.1",
-		Ipv6:     "f00d::1",
-		Labels:   []string{"id.foo", "id.bar"},
-		Identity: Identity,
+		Id:   1000,
+		Ipv4: "10.0.0.1",
+		Ipv6: "f00d::1",
 	}
 )
 

--- a/pkg/proxy/endpoint/test/updater_mock.go
+++ b/pkg/proxy/endpoint/test/updater_mock.go
@@ -5,23 +5,14 @@ package test
 
 import (
 	"github.com/cilium/cilium/pkg/fqdn/restore"
-	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
 
 type ProxyUpdaterMock struct {
-	lock.RWMutex
-	Id       uint64
-	Ipv4     string
-	Ipv6     string
-	Labels   []string
-	Identity identity.NumericIdentity
+	Id   uint64
+	Ipv4 string
+	Ipv6 string
 }
-
-func (m *ProxyUpdaterMock) UnconditionalRLock() { m.RWMutex.RLock() }
-
-func (m *ProxyUpdaterMock) RUnlock() { m.RWMutex.RUnlock() }
 
 func (m *ProxyUpdaterMock) GetID() uint64 { return m.Id }
 
@@ -29,17 +20,7 @@ func (m *ProxyUpdaterMock) GetIPv4Address() string { return m.Ipv4 }
 
 func (m *ProxyUpdaterMock) GetIPv6Address() string { return m.Ipv6 }
 
-func (m *ProxyUpdaterMock) GetLabels() []string { return m.Labels }
-
-func (m *ProxyUpdaterMock) GetEgressPolicyEnabledLocked() bool { return true }
-
-func (m *ProxyUpdaterMock) GetIngressPolicyEnabledLocked() bool { return true }
-
-func (m *ProxyUpdaterMock) GetIdentityLocked() identity.NumericIdentity { return m.Identity }
-
 func (m *ProxyUpdaterMock) GetNamedPort(bool, string, uint8) uint16 { return 0 }
-
-func (m *ProxyUpdaterMock) ConntrackName() string { return m.ConntrackNameLocked() }
 
 func (m *ProxyUpdaterMock) ConntrackNameLocked() string { return "global" }
 

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy"
 	endpointtest "github.com/cilium/cilium/pkg/proxy/endpoint/test"
 	"github.com/cilium/cilium/pkg/proxy/types"
@@ -213,11 +212,9 @@ func (s *ProxySuite) TestCreateOrUpdateRedirectMissingListener(c *C) {
 	p := createProxy(10000, 20000, 0, mockDatapathUpdater, nil, nil)
 
 	ep := &endpointtest.ProxyUpdaterMock{
-		Id:       1000,
-		Ipv4:     "10.0.0.1",
-		Ipv6:     "f00d::1",
-		Labels:   []string{"id.foo", "id.bar"},
-		Identity: identity.NumericIdentity(123),
+		Id:   1000,
+		Ipv4: "10.0.0.1",
+		Ipv6: "f00d::1",
 	}
 
 	l4 := &fakeProxyPolicy{}


### PR DESCRIPTION
This PR removes unused interfaces and code for the proxy <-> endpoint interaction.

They have been probably missed during previous proxy refactorings.
