### PR TITLE
.github: eks: switch from ca-west-1 to ca-central-1 for 1.24 tuple.

### DIFF
--- a/.github/actions/aws/k8s-versions.yaml
+++ b/.github/actions/aws/k8s-versions.yaml
@@ -2,7 +2,7 @@
 ---
 include:
   - version: "1.24"
-    region: ca-west-1
+    region: ca-central-1
   - version: "1.25"
     region: us-west-2
   - version: "1.26"


### PR DESCRIPTION
Recently there's been failures running EKS clusters with k8s 1.24:

`Error: --region=ca-west-1 is not supported - use one of: us-west-1, ...`

This could be related to ca-west being a newer region and not having as much capacity. To improve CI, this will switch this to ca-central which is older and should be more stable.

Example: https://github.com/cilium/cilium/actions/runs/8389964679/job/22977315758