### PR TITLE
loader: clean up tcx bpf_links created by newer Cilium versions

### DIFF
--- a/pkg/bpf/bpffs_linux.go
+++ b/pkg/bpf/bpffs_linux.go
@@ -6,6 +6,7 @@
 package bpf
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -62,6 +63,15 @@ func CiliumPath() string {
 // Use this for ensuring the existence of directories on bpffs.
 func MkdirBPF(path string) error {
 	return os.MkdirAll(path, 0755)
+}
+
+// Remove path ignoring ErrNotExist.
+func Remove(path string) error {
+	err := os.RemoveAll(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("removing bpffs directory at %s: %w", path, err)
+	}
+	return err
 }
 
 func tcPathFromMountInfo(name string) string {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -209,11 +209,17 @@ func (l *loader) reinitializeIPSec(ctx context.Context) error {
 			log.WithError(err).WithField(logfields.Interface, iface).Warn("Rpfilter could not be disabled, node to node encryption may fail")
 		}
 
+		device, err := netlink.LinkByName(iface)
+		if err != nil {
+			return fmt.Errorf("retrieving device %s: %w", iface, err)
+		}
+
 		finalize, err := replaceDatapath(ctx,
 			replaceDatapathOptions{
 				device:   iface,
 				elf:      networkObj,
 				programs: progs,
+				linkDir:  bpffsDeviceLinksDir(bpf.CiliumPath(), device),
 			},
 		)
 		if err != nil {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -209,7 +209,13 @@ func (l *loader) reinitializeIPSec(ctx context.Context) error {
 			log.WithError(err).WithField(logfields.Interface, iface).Warn("Rpfilter could not be disabled, node to node encryption may fail")
 		}
 
-		finalize, err := replaceDatapath(ctx, iface, networkObj, progs, "")
+		finalize, err := replaceDatapath(ctx,
+			replaceDatapathOptions{
+				device:   iface,
+				elf:      networkObj,
+				programs: progs,
+			},
+		)
 		if err != nil {
 			log.WithField(logfields.Interface, iface).WithError(err).Error("Load encryption network failed")
 			// collect errors, but keep trying replacing other interfaces.

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -388,7 +388,13 @@ func (l *loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 		{progName: symbolToHostEp, direction: dirIngress},
 		{progName: symbolFromHostEp, direction: dirEgress},
 	}
-	finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, progs, "")
+	finalize, err := replaceDatapath(ctx,
+		replaceDatapathOptions{
+			device:   ep.InterfaceName(),
+			elf:      objPath,
+			programs: progs,
+		},
+	)
 	if err != nil {
 		scopedLog := ep.Logger(subsystem).WithFields(logrus.Fields{
 			logfields.Path: objPath,
@@ -420,7 +426,13 @@ func (l *loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 		{progName: symbolToHostEp, direction: dirIngress},
 	}
 
-	finalize, err = replaceDatapath(ctx, defaults.SecondHostDevice, secondDevObjPath, progs, "")
+	finalize, err = replaceDatapath(ctx,
+		replaceDatapathOptions{
+			device:   defaults.SecondHostDevice,
+			elf:      secondDevObjPath,
+			programs: progs,
+		},
+	)
 	if err != nil {
 		scopedLog := ep.Logger(subsystem).WithFields(logrus.Fields{
 			logfields.Path: objPath,
@@ -465,7 +477,13 @@ func (l *loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 			}
 		}
 
-		finalize, err := replaceDatapath(ctx, device, netdevObjPath, progs, "")
+		finalize, err := replaceDatapath(ctx,
+			replaceDatapathOptions{
+				device:   device,
+				elf:      netdevObjPath,
+				programs: progs,
+			},
+		)
 		if err != nil {
 			scopedLog := ep.Logger(subsystem).WithFields(logrus.Fields{
 				logfields.Path: objPath,
@@ -514,7 +532,13 @@ func (l *loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 			}
 		}
 
-		finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, progs, "")
+		finalize, err := replaceDatapath(ctx,
+			replaceDatapathOptions{
+				device:   ep.InterfaceName(),
+				elf:      objPath,
+				programs: progs,
+			},
+		)
 		if err != nil {
 			scopedLog := ep.Logger(subsystem).WithFields(logrus.Fields{
 				logfields.Path: objPath,
@@ -560,7 +584,13 @@ func (l *loader) replaceOverlayDatapath(ctx context.Context, cArgs []string, ifa
 		{progName: symbolToOverlay, direction: dirEgress},
 	}
 
-	finalize, err := replaceDatapath(ctx, iface, overlayObj, progs, "")
+	finalize, err := replaceDatapath(ctx,
+		replaceDatapathOptions{
+			device:   iface,
+			elf:      overlayObj,
+			programs: progs,
+		},
+	)
 	if err != nil {
 		log.WithField(logfields.Interface, iface).WithError(err).Fatal("Load overlay network failed")
 	}

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -184,23 +184,17 @@ func (s *LoaderTestSuite) TestReload(c *C) {
 		{progName: symbolFromEndpoint, direction: dirIngress},
 		{progName: symbolToEndpoint, direction: dirEgress},
 	}
-	finalize, err := replaceDatapath(ctx,
-		replaceDatapathOptions{
-			device:   ep.InterfaceName(),
-			elf:      objPath,
-			programs: progs,
-		},
-	)
+	opts := replaceDatapathOptions{
+		device:   ep.InterfaceName(),
+		elf:      objPath,
+		programs: progs,
+		linkDir:  testutils.TempBPFFS(c),
+	}
+	finalize, err := replaceDatapath(ctx, opts)
 	c.Assert(err, IsNil)
 	finalize()
 
-	finalize, err = replaceDatapath(ctx,
-		replaceDatapathOptions{
-			device:   ep.InterfaceName(),
-			elf:      objPath,
-			programs: progs,
-		},
-	)
+	finalize, err = replaceDatapath(ctx, opts)
 
 	c.Assert(err, IsNil)
 	finalize()
@@ -343,6 +337,7 @@ func BenchmarkReplaceDatapath(b *testing.B) {
 	}
 
 	objPath := fmt.Sprintf("%s/%s", dirInfo.Output, endpointObj)
+	linkDir := testutils.TempBPFFS(b)
 	progs := []progDefinition{{progName: symbolFromEndpoint, direction: dirIngress}}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -351,6 +346,7 @@ func BenchmarkReplaceDatapath(b *testing.B) {
 				device:   ep.InterfaceName(),
 				elf:      objPath,
 				programs: progs,
+				linkDir:  linkDir,
 			},
 		)
 		if err != nil {

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -184,11 +184,24 @@ func (s *LoaderTestSuite) TestReload(c *C) {
 		{progName: symbolFromEndpoint, direction: dirIngress},
 		{progName: symbolToEndpoint, direction: dirEgress},
 	}
-	finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, progs, "")
+	finalize, err := replaceDatapath(ctx,
+		replaceDatapathOptions{
+			device:   ep.InterfaceName(),
+			elf:      objPath,
+			programs: progs,
+		},
+	)
 	c.Assert(err, IsNil)
 	finalize()
 
-	finalize, err = replaceDatapath(ctx, ep.InterfaceName(), objPath, progs, "")
+	finalize, err = replaceDatapath(ctx,
+		replaceDatapathOptions{
+			device:   ep.InterfaceName(),
+			elf:      objPath,
+			programs: progs,
+		},
+	)
+
 	c.Assert(err, IsNil)
 	finalize()
 }
@@ -333,7 +346,13 @@ func BenchmarkReplaceDatapath(b *testing.B) {
 	progs := []progDefinition{{progName: symbolFromEndpoint, direction: dirIngress}}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, progs, "")
+		finalize, err := replaceDatapath(ctx,
+			replaceDatapathOptions{
+				device:   ep.InterfaceName(),
+				elf:      objPath,
+				programs: progs,
+			},
+		)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -61,6 +61,13 @@ type progDefinition struct {
 	direction string
 }
 
+type replaceDatapathOptions struct {
+	device   string           // name of the netlink interface we attach to
+	elf      string           // path to object file
+	programs []progDefinition // programs that we want to attach/replace
+	xdpMode  string           // XDP driver mode, only applies when attaching XDP programs
+}
+
 // replaceDatapath replaces the qdisc and BPF program for an endpoint or XDP program.
 //
 // When successful, returns a finalizer to allow the map cleanup operation to be
@@ -74,25 +81,25 @@ type progDefinition struct {
 // For example, this is the case with from-netdev and to-netdev. If eth0:to-netdev
 // gets its program and maps replaced and unpinned, its eth0:from-netdev counterpart
 // will miss tail calls (and drop packets) until it has been replaced as well.
-func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDefinition, xdpMode string) (_ func(), err error) {
+func replaceDatapath(ctx context.Context, opts replaceDatapathOptions) (_ func(), err error) {
 	// Avoid unnecessarily loading a prog.
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 
-	link, err := netlink.LinkByName(ifName)
+	link, err := netlink.LinkByName(opts.device)
 	if err != nil {
-		return nil, fmt.Errorf("getting interface %s by name: %w", ifName, err)
+		return nil, fmt.Errorf("getting interface %s by name: %w", opts.device, err)
 	}
 
-	l := log.WithField("device", ifName).WithField("objPath", objPath).
+	l := log.WithField("device", opts.device).WithField("objPath", opts.elf).
 		WithField("ifindex", link.Attrs().Index)
 
 	// Load the ELF from disk.
 	l.Debug("Loading CollectionSpec from ELF")
-	spec, err := bpf.LoadCollectionSpec(objPath)
+	spec, err := bpf.LoadCollectionSpec(opts.elf)
 	if err != nil {
-		return nil, fmt.Errorf("loading eBPF ELF: %w", err)
+		return nil, fmt.Errorf("loading eBPF ELF %s: %w", opts.elf, err)
 	}
 
 	revert := func() {
@@ -103,7 +110,7 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 		}
 	}
 
-	for _, prog := range progs {
+	for _, prog := range opts.programs {
 		if spec.Programs[prog.progName] == nil {
 			return nil, fmt.Errorf("no program %s found in eBPF ELF", prog.progName)
 		}
@@ -154,14 +161,14 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 	// bpffs in the process.
 	finalize := func() {}
 	pinPath := bpf.TCGlobalsPath()
-	opts := ebpf.CollectionOptions{
+	collOpts := ebpf.CollectionOptions{
 		Maps: ebpf.MapOptions{PinPath: pinPath},
 	}
 	if err := bpf.MkdirBPF(pinPath); err != nil {
 		return nil, fmt.Errorf("creating bpffs pin path: %w", err)
 	}
 	l.Debug("Loading Collection into kernel")
-	coll, err := bpf.LoadCollection(spec, opts)
+	coll, err := bpf.LoadCollection(spec, collOpts)
 	if errors.Is(err, ebpf.ErrMapIncompatible) {
 		// Temporarily rename bpffs pins of maps whose definitions have changed in
 		// a new version of a datapath ELF.
@@ -179,7 +186,7 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 
 		// Retry loading the Collection after starting map migration.
 		l.Debug("Retrying loading Collection into kernel after map migration")
-		coll, err = bpf.LoadCollection(spec, opts)
+		coll, err = bpf.LoadCollection(spec, collOpts)
 	}
 	var ve *ebpf.VerifierError
 	if errors.As(err, &ve) {
@@ -221,16 +228,16 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 
 	// Finally, attach the endpoint's tc or xdp entry points to allow traffic to
 	// flow in.
-	for _, prog := range progs {
+	for _, prog := range opts.programs {
 		scopedLog := l.WithField("progName", prog.progName).WithField("direction", prog.direction)
-		if xdpMode != "" {
+		if opts.xdpMode != "" {
 			linkDir := bpffsDeviceLinksDir(bpf.CiliumPath(), link)
 			if err := bpf.MkdirBPF(linkDir); err != nil {
 				return nil, fmt.Errorf("creating bpffs link dir for device %s: %w", link.Attrs().Name, err)
 			}
 
 			scopedLog.Debug("Attaching XDP program to interface")
-			err = attachXDPProgram(link, coll.Programs[prog.progName], prog.progName, linkDir, xdpConfigModeToFlag(xdpMode))
+			err = attachXDPProgram(link, coll.Programs[prog.progName], prog.progName, linkDir, xdpConfigModeToFlag(opts.xdpMode))
 		} else {
 			scopedLog.Debug("Attaching TC program to interface")
 			err = attachTCProgram(link, coll.Programs[prog.progName], prog.progName, directionToParent(prog.direction))

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/vishvananda/netlink"
@@ -66,6 +67,7 @@ type replaceDatapathOptions struct {
 	elf      string           // path to object file
 	programs []progDefinition // programs that we want to attach/replace
 	xdpMode  string           // XDP driver mode, only applies when attaching XDP programs
+	linkDir  string           // path to bpffs dir holding bpf_links for the device/endpoint
 }
 
 // replaceDatapath replaces the qdisc and BPF program for an endpoint or XDP program.
@@ -85,6 +87,10 @@ func replaceDatapath(ctx context.Context, opts replaceDatapathOptions) (_ func()
 	// Avoid unnecessarily loading a prog.
 	if err := ctx.Err(); err != nil {
 		return nil, err
+	}
+
+	if opts.linkDir == "" {
+		return nil, errors.New("opts.linkDir not set in replaceDatapath")
 	}
 
 	link, err := netlink.LinkByName(opts.device)
@@ -230,17 +236,17 @@ func replaceDatapath(ctx context.Context, opts replaceDatapathOptions) (_ func()
 	// flow in.
 	for _, prog := range opts.programs {
 		scopedLog := l.WithField("progName", prog.progName).WithField("direction", prog.direction)
-		if opts.xdpMode != "" {
-			linkDir := bpffsDeviceLinksDir(bpf.CiliumPath(), link)
-			if err := bpf.MkdirBPF(linkDir); err != nil {
-				return nil, fmt.Errorf("creating bpffs link dir for device %s: %w", link.Attrs().Name, err)
-			}
 
+		if err := bpf.MkdirBPF(opts.linkDir); err != nil {
+			return nil, fmt.Errorf("creating bpffs link dir for device %s: %w", link.Attrs().Name, err)
+		}
+
+		if opts.xdpMode != "" {
 			scopedLog.Debug("Attaching XDP program to interface")
-			err = attachXDPProgram(link, coll.Programs[prog.progName], prog.progName, linkDir, xdpConfigModeToFlag(opts.xdpMode))
+			err = attachXDPProgram(link, coll.Programs[prog.progName], prog.progName, opts.linkDir, xdpConfigModeToFlag(opts.xdpMode))
 		} else {
 			scopedLog.Debug("Attaching TC program to interface")
-			err = attachTCProgram(link, coll.Programs[prog.progName], prog.progName, directionToParent(prog.direction))
+			err = attachTCProgram(link, coll.Programs[prog.progName], prog.progName, opts.linkDir, directionToParent(prog.direction))
 		}
 
 		if err != nil {
@@ -283,9 +289,22 @@ func resolveAndInsertCalls(coll *ebpf.Collection, mapName string, calls []ebpf.M
 }
 
 // attachTCProgram attaches the TC program 'prog' to link.
-func attachTCProgram(link netlink.Link, prog *ebpf.Program, progName string, qdiscParent uint32) error {
+func attachTCProgram(link netlink.Link, prog *ebpf.Program, progName, bpffsDir string, qdiscParent uint32) error {
 	if prog == nil {
 		return errors.New("cannot attach a nil program")
+	}
+
+	// Remove tcx bpf_links created by newer versions of Cilium. They cannot be
+	// overwritten by netlink-based tc attachments, as tcx is a separate hook
+	// altogether. Remove the tcx link first to avoid tc programs being run twice
+	// for every packet. This cannot be done seamlessly and will cause a small
+	// window of connection interruption.
+	pin := filepath.Join(bpffsDir, progName)
+	if err := os.Remove(pin); err == nil {
+		log.WithField("device", link.Attrs().Name).WithField("pinPath", pin).
+			Info("Removed tcx link before legacy tc downgrade, possible connectivity interruption")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("unpinning defunct link %s: %w", pin, err)
 	}
 
 	if err := replaceQdisc(link); err != nil {

--- a/pkg/datapath/loader/netlink_test.go
+++ b/pkg/datapath/loader/netlink_test.go
@@ -370,7 +370,8 @@ func TestAttachRemoveTCProgram(t *testing.T) {
 
 		prog := mustTCProgram(t)
 
-		err = attachTCProgram(dummy, prog, "test", directionToParent(dirEgress))
+		bpffs := testutils.TempBPFFS(t)
+		err = attachTCProgram(dummy, prog, "test", bpffsDeviceLinksDir(bpffs, dummy), directionToParent(dirEgress))
 		require.NoError(t, err)
 
 		filters, err := netlink.FilterList(dummy, directionToParent(dirEgress))

--- a/pkg/datapath/loader/paths.go
+++ b/pkg/datapath/loader/paths.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 
 	"github.com/vishvananda/netlink"
+
+	datapath "github.com/cilium/cilium/pkg/datapath/types"
 )
 
 // bpffsDevicesDir returns the path to the 'devices' directory on bpffs, usually
@@ -18,6 +20,15 @@ func bpffsDevicesDir(base string) string {
 	return filepath.Join(base, "devices")
 }
 
+// bpffsDeviceDir returns the path to the per-device directory on bpffs, usually
+// /sys/fs/bpf/cilium/devices/<device>. It does not ensure the directory exists.
+//
+// base is typically set to /sys/fs/bpf/cilium, but can be a temp directory
+// during tests.
+func bpffsDeviceDir(base string, device netlink.Link) string {
+	return filepath.Join(bpffsDevicesDir(base), device.Attrs().Name)
+}
+
 // bpffsDeviceLinksDir returns the bpffs path to the per-device links directory,
 // usually /sys/fs/bpf/cilium/devices/<device>/links. It does not ensure the
 // directory exists.
@@ -25,5 +36,34 @@ func bpffsDevicesDir(base string) string {
 // base is typically set to /sys/fs/bpf/cilium, but can be a temp directory
 // during tests.
 func bpffsDeviceLinksDir(base string, device netlink.Link) string {
-	return filepath.Join(bpffsDevicesDir(base), device.Attrs().Name, "links")
+	return filepath.Join(bpffsDeviceDir(base, device), "links")
+}
+
+// bpffsEndpointsDir returns the path to the 'endpoints' directory on bpffs, usually
+// /sys/fs/bpf/cilium/endpoints. It does not ensure the directory exists.
+//
+// base is typically set to /sys/fs/bpf/cilium, but can be a temp directory
+// during tests.
+func bpffsEndpointsDir(base string) string {
+	return filepath.Join(base, "endpoints")
+}
+
+// bpffsEndpointDir returns the path to the per-endpoint directory on bpffs,
+// usually /sys/fs/bpf/cilium/endpoints/<endpoint-id>. It does not ensure the
+// directory exists.
+//
+// base is typically set to /sys/fs/bpf/cilium, but can be a temp directory
+// during tests.
+func bpffsEndpointDir(base string, ep datapath.Endpoint) string {
+	return filepath.Join(bpffsEndpointsDir(base), ep.StringID())
+}
+
+// bpffsEndpointLinksDir returns the bpffs path to the per-endpoint links directory,
+// usually /sys/fs/bpf/cilium/endpoints/<endpoint-id>/links. It does not ensure the
+// directory exists.
+//
+// base is typically set to /sys/fs/bpf/cilium, but can be a temp directory
+// during tests.
+func bpffsEndpointLinksDir(base string, ep datapath.Endpoint) string {
+	return filepath.Join(bpffsEndpointDir(base, ep), "links")
 }

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -155,7 +155,14 @@ func compileAndLoadXDPProg(ctx context.Context, xdpDev, xdpMode string, extraCAr
 	}
 
 	progs := []progDefinition{{progName: symbolFromHostNetdevXDP, direction: ""}}
-	finalize, err := replaceDatapath(ctx, xdpDev, objPath, progs, xdpMode)
+	finalize, err := replaceDatapath(ctx,
+		replaceDatapathOptions{
+			device:   xdpDev,
+			elf:      objPath,
+			programs: progs,
+			xdpMode:  xdpMode,
+		},
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -154,6 +154,11 @@ func compileAndLoadXDPProg(ctx context.Context, xdpDev, xdpMode string, extraCAr
 		return err
 	}
 
+	iface, err := netlink.LinkByName(xdpDev)
+	if err != nil {
+		return fmt.Errorf("retrieving device %s: %w", xdpDev, err)
+	}
+
 	progs := []progDefinition{{progName: symbolFromHostNetdevXDP, direction: ""}}
 	finalize, err := replaceDatapath(ctx,
 		replaceDatapathOptions{
@@ -161,6 +166,7 @@ func compileAndLoadXDPProg(ctx context.Context, xdpDev, xdpMode string, extraCAr
 			elf:      objPath,
 			programs: progs,
 			xdpMode:  xdpMode,
+			linkDir:  bpffsDeviceLinksDir(bpf.CiliumPath(), iface),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
This PR represents the backportable part of https://github.com/cilium/cilium/pull/30103 and needs to be merged and backported independently in order for the downgrade path (and tests) to work.

```release-note
Remove tcx links created by Cilium 1.16 onwards
```
