### PR TITLE
proxy: configurable portrange

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -318,6 +318,8 @@ cilium-agent [flags]
       --proxy-idle-timeout-seconds int                            Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s (default 60)
       --proxy-max-connection-duration-seconds int                 Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
       --proxy-max-requests-per-connection int                     Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
+      --proxy-portrange-max uint16                                End of port range that is used to allocate ports for L7 proxies. (default 20000)
+      --proxy-portrange-min uint16                                Start of port range that is used to allocate ports for L7 proxies. (default 10000)
       --proxy-prometheus-port int                                 Port to serve Envoy metrics on. Default 0 (disabled).
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --restore                                                   Restores state, if possible, from previous daemon (default true)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -92,6 +92,8 @@ cilium-agent hive [flags]
       --proxy-idle-timeout-seconds int                            Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s (default 60)
       --proxy-max-connection-duration-seconds int                 Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
       --proxy-max-requests-per-connection int                     Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
+      --proxy-portrange-max uint16                                End of port range that is used to allocate ports for L7 proxies. (default 20000)
+      --proxy-portrange-min uint16                                Start of port range that is used to allocate ports for L7 proxies. (default 10000)
       --proxy-prometheus-port int                                 Port to serve Envoy metrics on. Default 0 (disabled).
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -97,6 +97,8 @@ cilium-agent hive dot-graph [flags]
       --proxy-idle-timeout-seconds int                            Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s (default 60)
       --proxy-max-connection-duration-seconds int                 Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
       --proxy-max-requests-per-connection int                     Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
+      --proxy-portrange-max uint16                                End of port range that is used to allocate ports for L7 proxies. (default 20000)
+      --proxy-portrange-min uint16                                Start of port range that is used to allocate ports for L7 proxies. (default 10000)
       --proxy-prometheus-port int                                 Port to serve Envoy metrics on. Default 0 (disabled).
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")

--- a/pkg/proxy/cell.go
+++ b/pkg/proxy/cell.go
@@ -4,6 +4,8 @@
 package proxy
 
 import (
+	"github.com/spf13/pflag"
+
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/hive/cell"
@@ -20,30 +22,28 @@ var Cell = cell.Module(
 	"l7-proxy",
 	"L7 Proxy provides support for L7 network policies",
 
-	cell.Provide(func() ProxyConfig { return DefaultProxyConfig }),
-
 	cell.Provide(newProxy),
 	cell.Provide(newEnvoyProxyIntegration),
 	cell.Provide(newDNSProxyIntegration),
 	cell.ProvidePrivate(endpoint.NewEndpointInfoRegistry),
+	cell.Config(ProxyConfig{}),
 )
 
 type ProxyConfig struct {
-	MinPort, MaxPort uint16
-	DNSProxyPort     uint16
+	ProxyPortrangeMin uint16
+	ProxyPortrangeMax uint16
+	DNSProxyPort      uint16
 }
 
-var DefaultProxyConfig = ProxyConfig{
-	MinPort: 10000,
-	MaxPort: 20000,
-	// The default value for the DNS proxy port is set to 0 to allocate a random
-	// port.
-	DNSProxyPort: 0,
+func (r ProxyConfig) Flags(flags *pflag.FlagSet) {
+	flags.Uint16("proxy-portrange-min", 10000, "Start of port range that is used to allocate ports for L7 proxies.")
+	flags.Uint16("proxy-portrange-max", 20000, "End of port range that is used to allocate ports for L7 proxies.")
 }
 
 type proxyParams struct {
 	cell.In
 
+	Config                ProxyConfig
 	Datapath              datapath.Datapath
 	EndpointInfoRegistry  logger.EndpointInfoRegistry
 	MonitorAgent          monitoragent.Agent
@@ -51,7 +51,7 @@ type proxyParams struct {
 	DNSProxyIntegration   *dnsProxyIntegration
 }
 
-func newProxy(params proxyParams, cfg ProxyConfig) *Proxy {
+func newProxy(params proxyParams) *Proxy {
 	if !option.Config.EnableL7Proxy {
 		log.Info("L7 proxies are disabled")
 		if option.Config.EnableEnvoyConfig {
@@ -62,7 +62,7 @@ func newProxy(params proxyParams, cfg ProxyConfig) *Proxy {
 
 	configureProxyLogger(params.EndpointInfoRegistry, params.MonitorAgent, option.Config.AgentLabels)
 
-	return createProxy(cfg.MinPort, cfg.MaxPort, cfg.DNSProxyPort, params.Datapath, params.EnvoyProxyIntegration, params.DNSProxyIntegration)
+	return createProxy(params.Config.ProxyPortrangeMin, params.Config.ProxyPortrangeMax, params.Config.DNSProxyPort, params.Datapath, params.EnvoyProxyIntegration, params.DNSProxyIntegration)
 }
 
 type envoyProxyIntegrationParams struct {

--- a/pkg/proxy/cell.go
+++ b/pkg/proxy/cell.go
@@ -32,7 +32,6 @@ var Cell = cell.Module(
 type ProxyConfig struct {
 	ProxyPortrangeMin uint16
 	ProxyPortrangeMax uint16
-	DNSProxyPort      uint16
 }
 
 func (r ProxyConfig) Flags(flags *pflag.FlagSet) {
@@ -62,7 +61,7 @@ func newProxy(params proxyParams) *Proxy {
 
 	configureProxyLogger(params.EndpointInfoRegistry, params.MonitorAgent, option.Config.AgentLabels)
 
-	return createProxy(params.Config.ProxyPortrangeMin, params.Config.ProxyPortrangeMax, params.Config.DNSProxyPort, params.Datapath, params.EnvoyProxyIntegration, params.DNSProxyIntegration)
+	return createProxy(params.Config.ProxyPortrangeMin, params.Config.ProxyPortrangeMax, params.Datapath, params.EnvoyProxyIntegration, params.DNSProxyIntegration)
 }
 
 type envoyProxyIntegrationParams struct {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -114,7 +114,6 @@ type Proxy struct {
 func createProxy(
 	minPort uint16,
 	maxPort uint16,
-	dnsProxyPort uint16,
 	datapathUpdater DatapathUpdater,
 	envoyIntegration *envoyProxyIntegration,
 	dnsIntegration *dnsProxyIntegration,
@@ -125,13 +124,13 @@ func createProxy(
 		redirects:        make(map[string]*Redirect),
 		datapathUpdater:  datapathUpdater,
 		allocatedPorts:   make(map[uint16]bool),
-		proxyPorts:       defaultProxyPortMap(dnsProxyPort),
+		proxyPorts:       defaultProxyPortMap(),
 		envoyIntegration: envoyIntegration,
 		dnsIntegration:   dnsIntegration,
 	}
 }
 
-func defaultProxyPortMap(dnsProxyPort uint16) map[string]*ProxyPort {
+func defaultProxyPortMap() map[string]*ProxyPort {
 	return map[string]*ProxyPort{
 		"cilium-http-egress": {
 			proxyType: types.ProxyTypeHTTP,
@@ -147,7 +146,6 @@ func defaultProxyPortMap(dnsProxyPort uint16) map[string]*ProxyPort {
 			proxyType: types.ProxyTypeDNS,
 			ingress:   false,
 			localOnly: true,
-			proxyPort: dnsProxyPort,
 		},
 		"cilium-proxylib-egress": {
 			proxyType: types.ProxyTypeAny,

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -42,7 +42,7 @@ func (s *ProxySuite) TestPortAllocator(c *C) {
 	err := os.MkdirAll(socketDir, 0700)
 	c.Assert(err, IsNil)
 
-	p := createProxy(10000, 20000, 0, mockDatapathUpdater, nil, nil)
+	p := createProxy(10000, 20000, mockDatapathUpdater, nil, nil)
 
 	port, err := p.AllocateProxyPort("listener1", false, true)
 	c.Assert(err, IsNil)
@@ -210,7 +210,7 @@ func (s *ProxySuite) TestCreateOrUpdateRedirectMissingListener(c *C) {
 	err := os.MkdirAll(socketDir, 0700)
 	c.Assert(err, IsNil)
 
-	p := createProxy(10000, 20000, 0, mockDatapathUpdater, nil, nil)
+	p := createProxy(10000, 20000, mockDatapathUpdater, nil, nil)
 
 	ep := &endpointtest.ProxyUpdaterMock{
 		Id:       1000,


### PR DESCRIPTION
Currently, the proxy port range for proxy port allocation is hardcoded to `10000` - `20000`.

This commit introduces a proper Hive Config for the Cell. This way the range is configurable via the flags `--proxy-portrange-min` & `--proxy-portrange-max`.

In addition, the unused field `DNSProxyPort` has been removed from the `config` struct.