### PR TITLE
endpoint: store state in ep_config.json

### DIFF
--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/netip"
 	"os"
+	"path/filepath"
 	"sort"
 	"sync"
 	"time"
@@ -22,6 +23,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/identity"
@@ -199,7 +201,8 @@ func prepareEndpointDirs() (cleanup func(), err error) {
 	}
 	return func() {
 		for _, testEPDir := range testDirs {
-			os.RemoveAll(fmt.Sprintf("%s/ep_config.h", testEPDir))
+			os.RemoveAll(filepath.Join(testEPDir, common.CHeaderFileName))
+			os.RemoveAll(filepath.Join(testEPDir, common.EndpointStateFileName))
 			time.Sleep(1 * time.Second)
 			os.RemoveAll(testEPDir)
 			os.RemoveAll(fmt.Sprintf("%s_backup", testEPDir))

--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -10,6 +10,10 @@ const (
 	// particular endpoint.
 	CHeaderFileName = "ep_config.h"
 
+	// EndpointStateFileName is used as the file name for the JSON representation
+	// of endpoint state.
+	EndpointStateFileName = "ep_config.json"
+
 	// PossibleCPUSysfsPath is used to retrieve the number of CPUs for per-CPU maps.
 	PossibleCPUSysfsPath = "/sys/devices/system/cpu/possible"
 )

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -103,23 +103,8 @@ func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, policyGe
 			logfields.EndpointID: epDirName,
 			logfields.Path:       cHeaderFile,
 		})
-		// This function checks the presence of a bug previously observed: the
-		// file was sometimes only found after the second check.
-		// We can remove this if we haven't seen the issue occur after a while.
-		headerFileExists := func() error {
-			_, fileExists := os.Stat(cHeaderFile)
-			for i := 0; i < 2 && fileExists != nil; i++ {
-				time.Sleep(100 * time.Millisecond)
-				_, err := os.Stat(cHeaderFile)
-				if (fileExists == nil) != (err == nil) {
-					scopedLog.WithError(err).Warn("BUG: stat() has unstable behavior")
-				}
-				fileExists = err
-			}
-			return fileExists
-		}
 
-		if err := headerFileExists(); err != nil {
+		if _, err := os.Stat(cHeaderFile); err != nil {
 			scopedLog.WithError(err).Warn("C header file not found. Ignoring endpoint")
 			continue
 		}


### PR DESCRIPTION
endpoint: remove stat retry on restore

    Commit d81a5cdea5 ("pkg/endpoint: Simplify search for C header file") 
    retained earlier retry behaviour around stat, with a comment saying that we
    can remove the logic if the bug hasn't manifested in a while.

    That was in 2020. The time to remove the check is now.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

endpoint: store state in ep_config.json

    On startup, the agent attemps to restore existing endpoint state from disk.
    It does this by reading the per Endpoint ep_config.h, parsing that file for
    a line containing a magic string and then decoding a base64 encoded JSON
    blob from that. ep_config.h is in turn used by the loader to compile the per
    endpoint BPF programs. In effect, the concern of persisting endpoint state
    is mixed up with how we compile per endpoint programs.

    Instead, write the JSON state into a separate ep_config.json file in
    addition to ep_config.h. The old behaviour is retained so that downgrades do
    not lose endpoint state unnecessarily.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>