### PR TITLE
multicast: modify list operations from iterator to batch lookup.

### DIFF
--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -22,61 +22,61 @@ import (
 )
 
 var ignoredELFPrefixes = []string{
-	"2/",                          // Calls within the endpoint
-	"HOST_IP",                     // Global
-	"IPV6_NODEPORT",               // Global
-	"ROUTER_IP",                   // Global
-	"SNAT_IPV6_EXTERNAL",          // Global
-	"cilium_auth_map",             // Global
-	"cilium_call_policy",          // Global
-	"cilium_egresscall_policy",    // Global
-	"cilium_capture",              // Global
-	"cilium_ct",                   // All CT maps, including local
-	"cilium_encrypt_state",        // Global
-	"cilium_events",               // Global
-	"cilium_ipcache",              // Global
-	"cilium_ktime",                // Global
-	"cilium_lb",                   // Global
-	"cilium_lxc",                  // Global
-	"cilium_metrics",              // Global
-	"cilium_nodeport_neigh",       // All nodeport neigh maps
-	"cilium_node_map",             // Global
-	"cilium_policy",               // All policy maps
-	"cilium_proxy",                // Global
-	"cilium_runtime_config",       // Global
-	"cilium_signals",              // Global
-	"cilium_snat",                 // All SNAT maps
-	"cilium_tail_call_buffer",     // Global
-	"cilium_tunnel",               // Global
-	"cilium_ipv4_frag_datagrams",  // Global
-	"cilium_ipmasq",               // Global
-	"cilium_throttle",             // Global
-	"cilium_egress_gw_policy_v4",  // Global
-	"cilium_srv6_policy_v4",       // Global
-	"cilium_srv6_policy_v6",       // Global
-	"cilium_srv6_vrf_v4",          // Global
-	"cilium_srv6_vrf_v6",          // Global
-	"cilium_srv6_state_v4",        // Global
-	"cilium_srv6_state_v6",        // Global
-	"cilium_srv6_sid",             // Global
-	"cilium_vtep_map",             // Global
-	"cilium_per_cluster_ct",       // Global
-	"cilium_per_cluster_snat",     // Global
-	"cilium_world_cidrs4",         // Global
-	"cilium_l2_responder_v4",      // Global
-	"cilium_ratelimit",            // Global
-	"cilium_mcast_group_v4_outer", // Global
-	"tc",                          // Program Section
-	"xdp",                         // Program Section
-	".BTF",                        // Debug
-	".BTF.ext",                    // Debug
-	".debug_ranges",               // Debug
-	".debug_info",                 // Debug
-	".debug_line",                 // Debug
-	".debug_frame",                // Debug
-	".debug_loc",                  // Debug
-	".debug_addr",                 // Debug
-	".debug_str_offsets",          // Debug
+	"2/",                              // Calls within the endpoint
+	"HOST_IP",                         // Global
+	"IPV6_NODEPORT",                   // Global
+	"ROUTER_IP",                       // Global
+	"SNAT_IPV6_EXTERNAL",              // Global
+	"cilium_auth_map",                 // Global
+	"cilium_call_policy",              // Global
+	"cilium_egresscall_policy",        // Global
+	"cilium_capture",                  // Global
+	"cilium_ct",                       // All CT maps, including local
+	"cilium_encrypt_state",            // Global
+	"cilium_events",                   // Global
+	"cilium_ipcache",                  // Global
+	"cilium_ktime",                    // Global
+	"cilium_lb",                       // Global
+	"cilium_lxc",                      // Global
+	"cilium_metrics",                  // Global
+	"cilium_nodeport_neigh",           // All nodeport neigh maps
+	"cilium_node_map",                 // Global
+	"cilium_policy",                   // All policy maps
+	"cilium_proxy",                    // Global
+	"cilium_runtime_config",           // Global
+	"cilium_signals",                  // Global
+	"cilium_snat",                     // All SNAT maps
+	"cilium_tail_call_buffer",         // Global
+	"cilium_tunnel",                   // Global
+	"cilium_ipv4_frag_datagrams",      // Global
+	"cilium_ipmasq",                   // Global
+	"cilium_throttle",                 // Global
+	"cilium_egress_gw_policy_v4",      // Global
+	"cilium_srv6_policy_v4",           // Global
+	"cilium_srv6_policy_v6",           // Global
+	"cilium_srv6_vrf_v4",              // Global
+	"cilium_srv6_vrf_v6",              // Global
+	"cilium_srv6_state_v4",            // Global
+	"cilium_srv6_state_v6",            // Global
+	"cilium_srv6_sid",                 // Global
+	"cilium_vtep_map",                 // Global
+	"cilium_per_cluster_ct",           // Global
+	"cilium_per_cluster_snat",         // Global
+	"cilium_world_cidrs4",             // Global
+	"cilium_l2_responder_v4",          // Global
+	"cilium_ratelimit",                // Global
+	"cilium_mcast_group_outer_v4_map", // Global
+	"tc",                              // Program Section
+	"xdp",                             // Program Section
+	".BTF",                            // Debug
+	".BTF.ext",                        // Debug
+	".debug_ranges",                   // Debug
+	".debug_info",                     // Debug
+	".debug_line",                     // Debug
+	".debug_frame",                    // Debug
+	".debug_loc",                      // Debug
+	".debug_addr",                     // Debug
+	".debug_str_offsets",              // Debug
 	// Endpoint IPv6 address. It's possible for the template object to have
 	// these symbols while the endpoint doesn't, if IPv6 was just enabled and
 	// the endpoint restored.


### PR DESCRIPTION
This change modifying how groups and subsribers are listed. Current approach takes very long time to list bpf map data.

Also, fixing typo in multicast group map name in ELF ignore prefixes.

### Performance test
Added 255 groups and compare time to list them.

```
root@clab-multicast-devel-worker2:/home/cilium# for i in {1..255} ; do cilium bpf multicast group add 229.0.0.$i; done
```

With iterator, output is returned in ~6-7 seconds.
```
root@clab-multicast-devel-worker2:/home/cilium# time cilium-dbg bpf multicast group ls > /dev/null

real    0m6.646s
user    0m0.043s
sys     0m0.036s
root@clab-multicast-devel-worker2:/home/cilium#
```

With BatchLookup, output is returned in sub second range.
```
root@clab-multicast-devel-worker3:/home/cilium# time cilium-dbg bpf multicast group ls > /dev/null

real    0m0.039s
user    0m0.028s
sys     0m0.016s
root@clab-multicast-devel-worker3:/home/cilium#
```

