### PR TITLE
[v1.13] .github: eks: switch from ca-west-1 to ca-central-1 for 1.24 tuple.

### DIFF
--- a/.github/actions/aws/k8s-versions.yaml
+++ b/.github/actions/aws/k8s-versions.yaml
@@ -4,7 +4,7 @@ include:
   - version: "1.23"
     region: ca-west-1
   - version: "1.24"
-    region: ca-west-1
+    region: ca-central-1
   - version: "1.25"
     region: us-west-2
   - version: "1.26"


### PR DESCRIPTION
[v1.13] backport of https://github.com/cilium/cilium/pull/31549.  Running CI on main with change doesn't appear to affect it since recent versions of cilium don't test on 1.24 anymore. Validating this preemptively to ensure it works - before we backport to all branches.