### PR TITLE
v1.15 Backports 2024-03-24

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -154,7 +154,8 @@ jobs:
             --helm-set cluster.name=${{ env.name }} \
             --helm-set loadBalancer.l7.backend=envoy \
             --helm-set tls.secretsBackend=k8s \
-            --helm-set=azure.resourceGroup=${{ env.name }}"
+            --helm-set=azure.resourceGroup=${{ env.name }} \
+            --helm-set ipam.operator.clusterPoolIPv4PodCIDRList=192.168.0.0/16" # To avoid clashing with the default Service CIDR of AKS (10.0.0.0/16)
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled \
             --hubble=false --collect-sysdump-on-failure --external-target bing.com --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8"
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT

--- a/cilium-dbg/cmd/bpf_lb_list.go
+++ b/cilium-dbg/cmd/bpf_lb_list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/loadbalancer"
@@ -96,7 +97,11 @@ func dumpSVC(serviceList map[string][]string) {
 			if svcKey.IsIPv6() {
 				ip = "[::]"
 			}
-			entry = fmt.Sprintf("%s:%d (%d) (%d) [%s]", ip, 0, revNATID, backendSlot, flags)
+			extra := ""
+			if flags.IsL7LB() {
+				extra = fmt.Sprintf("(L7LB Proxy Port: %d)", byteorder.NetworkToHost16(uint16(svcVal.GetBackendID())))
+			}
+			entry = fmt.Sprintf("%s:%d (%d) (%d) [%s] %s", ip, 0, revNATID, backendSlot, flags, extra)
 		} else if backend, found := backendMap[backendID]; !found {
 			entry = fmt.Sprintf("backend %d not found", backendID)
 		} else {

--- a/examples/kubernetes-dns/dns-sw-app.yaml
+++ b/examples/kubernetes-dns/dns-sw-app.yaml
@@ -9,4 +9,4 @@ metadata:
 spec:
   containers:
   - name: mediabot
-    image: docker.io/cilium/json-mock
+    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603

--- a/examples/minikube/http-sw-app.yaml
+++ b/examples/minikube/http-sw-app.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: deathstar
-        image: docker.io/cilium/starwars
+        image: quay.io/cilium/starwars:v2.1@sha256:833d915ec68fca3ce83668fc5dae97c455b2134d8f23ef96586f55b894cfb1e8
 ---
 apiVersion: v1
 kind: Pod
@@ -47,7 +47,7 @@ metadata:
 spec:
   containers:
   - name: spaceship
-    image: docker.io/cilium/json-mock
+    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
 ---
 apiVersion: v1
 kind: Pod
@@ -60,4 +60,4 @@ metadata:
 spec:
   containers:
   - name: spaceship
-    image: docker.io/cilium/json-mock
+    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603

--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/manager"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/reconciler"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/store"
+	"github.com/cilium/cilium/pkg/bgpv1/metrics"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	ipam_option "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -67,8 +68,12 @@ var Cell = cell.Module(
 	// Provides the reconcilers used by the route manager to update the config
 	reconciler.ConfigReconcilers,
 
-	// Invoke bgp controller to trigger the constructor.
-	cell.Invoke(func(*agent.Controller) {}),
+	cell.Invoke(
+		// Invoke bgp controller to trigger the constructor.
+		func(*agent.Controller) {},
+		// Register the metrics collector
+		metrics.RegisterCollector,
+	),
 )
 
 func newBGPPeeringPolicyResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig) resource.Resource[*v2alpha1api.CiliumBGPPeeringPolicy] {

--- a/pkg/bgpv1/metrics/metrics.go
+++ b/pkg/bgpv1/metrics/metrics.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+import (
+	"context"
+	"net/netip"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/bgpv1/types"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+const (
+	LabelVRouter  = "vrouter"
+	LabelNeighbor = "neighbor"
+	LabelAfi      = "afi"
+	LabelSafi     = "safi"
+
+	metricsSubsystem = "bgp_control_plane"
+)
+
+type collector struct {
+	SessionState          *prometheus.Desc
+	TotalAdvertisedRoutes *prometheus.Desc
+	TotalReceivedRoutes   *prometheus.Desc
+
+	in collectorIn
+}
+
+type collectorIn struct {
+	cell.In
+
+	Logger        logrus.FieldLogger
+	DaemonConfig  *option.DaemonConfig
+	Registry      *metrics.Registry
+	RouterManager agent.BGPRouterManager
+}
+
+// RegisterCollector registers the BGP Control Plane metrics collector to the
+// global prometheus registry. We don't rely on the cell.Metric because the
+// collectors we can provide through cell.Metric needs to implement
+// prometheus.Collector per metric which is not optimal in our case. We can
+// retrieve the multiple metrics from the single call to
+// RouterManager.GetPeers() and it is wasteful to call the same function
+// multiple times for each metric. Thus, we provide a raw Collector through
+// MustRegister interface. We may want to revisit this in the future.
+func RegisterCollector(in collectorIn) {
+	// Don't provide the collector if BGP control plane is disabled
+	if !in.DaemonConfig.EnableBGPControlPlane {
+		return
+	}
+	in.Registry.MustRegister(&collector{
+		SessionState: prometheus.NewDesc(
+			prometheus.BuildFQName(metrics.Namespace, metricsSubsystem, "session_state"),
+			"Current state of the BGP session with the peer, Up = 1 or Down = 0",
+			[]string{LabelVRouter, LabelNeighbor}, nil,
+		),
+		TotalAdvertisedRoutes: prometheus.NewDesc(
+			prometheus.BuildFQName(metrics.Namespace, metricsSubsystem, "advertised_routes"),
+			"Number of routes advertised to the peer",
+			[]string{LabelVRouter, LabelNeighbor, LabelAfi, LabelSafi}, nil,
+		),
+		TotalReceivedRoutes: prometheus.NewDesc(
+			prometheus.BuildFQName(metrics.Namespace, metricsSubsystem, "received_routes"),
+			"Number of routes received from the peer",
+			[]string{LabelVRouter, LabelNeighbor, LabelAfi, LabelSafi}, nil,
+		),
+		in: in,
+	})
+}
+
+func (c *collector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.SessionState
+	ch <- c.TotalAdvertisedRoutes
+	ch <- c.TotalReceivedRoutes
+}
+
+func (c *collector) Collect(ch chan<- prometheus.Metric) {
+	// We defensively set a 5 sec timeout here. When the underlying router
+	// is not responsive, we cannot make a progress. 5 sec is chosen to be
+	// a too long time that we should never hit for normal cases. We should
+	// revisit this timeout when the metrics collection starts to involve a
+	// network communication.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	peers, err := c.in.RouterManager.GetPeers(ctx)
+	cancel()
+	if err != nil {
+		c.in.Logger.WithError(err).Error("Failed to retrieve BGP peer information. Metrics is not collected.")
+		return
+	}
+
+	for _, peer := range peers {
+		if peer == nil {
+			continue
+		}
+
+		vrouterLabel := strconv.FormatInt(peer.LocalAsn, 10)
+
+		addr, err := netip.ParseAddr(peer.PeerAddress)
+		if err != nil {
+			continue
+		}
+
+		neighborLabel := netip.AddrPortFrom(addr, uint16(peer.PeerPort)).String()
+
+		// Collect session state metrics
+		var up float64
+		if peer.SessionState == types.SessionEstablished.String() {
+			up = 1
+		} else {
+			up = 0
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.SessionState,
+			prometheus.GaugeValue,
+			up,
+			vrouterLabel,
+			neighborLabel,
+		)
+
+		// Collect route metrics per address family
+		for _, family := range peer.Families {
+			if family == nil {
+				continue
+			}
+			ch <- prometheus.MustNewConstMetric(
+				c.TotalAdvertisedRoutes,
+				prometheus.GaugeValue,
+				float64(family.Advertised),
+				vrouterLabel,
+				neighborLabel,
+				family.Afi,
+				family.Safi,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.TotalReceivedRoutes,
+				prometheus.GaugeValue,
+				float64(family.Received),
+				vrouterLabel,
+				neighborLabel,
+				family.Afi,
+				family.Safi,
+			)
+		}
+	}
+}

--- a/pkg/bgpv1/test/fixtures.go
+++ b/pkg/bgpv1/test/fixtures.go
@@ -30,6 +30,7 @@ import (
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	clientset_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/typed/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -182,6 +183,7 @@ func newFixture(conf fixtureConfig) *fixture {
 			f.bgp = bgp
 		}),
 
+		metrics.Cell,
 		job.Cell,
 		bgpv1.Cell,
 	)

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -682,6 +682,17 @@ func TestDecodeTrafficDirection(t *testing.T) {
 	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.GetTrafficDirection())
 	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
 
+	// TRACE_FROM_LXC unknown (encrypted)
+	tn = monitor.TraceNotifyV0{
+		Type:     byte(monitorAPI.MessageTypeTrace),
+		Source:   localEP,
+		ObsPoint: monitorAPI.TraceFromLxc,
+		Reason:   monitor.TraceReasonUnknown | monitor.TraceReasonEncryptMask,
+	}
+	f = parseFlow(tn, localIP, remoteIP)
+	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.GetTrafficDirection())
+	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+
 	// TRACE_TO_STACK SRV6 decap Ingress
 	tn = monitor.TraceNotifyV0{
 		Type:     byte(monitorAPI.MessageTypeTrace),
@@ -780,7 +791,17 @@ func TestDecodeIsReply(t *testing.T) {
 	assert.Nil(t, f.GetIsReply())
 	assert.Equal(t, false, f.GetReply())
 
-	// TRACE_TO_STACK SRV6 decap
+	// TRACE_FROM_LXC encrypted
+	tn = monitor.TraceNotifyV0{
+		Type:     byte(monitorAPI.MessageTypeTrace),
+		ObsPoint: monitorAPI.TraceFromLxc,
+		Reason:   monitor.TraceReasonUnknown | monitor.TraceReasonEncryptMask,
+	}
+	f = parseFlow(tn, localIP, remoteIP)
+	assert.Nil(t, f.GetIsReply())
+	assert.Equal(t, false, f.GetReply())
+
+	// TRACE_TO_STACK srv6-decap
 	tn = monitor.TraceNotifyV0{
 		Type:     byte(monitorAPI.MessageTypeTrace),
 		Source:   hostEP,
@@ -791,12 +812,34 @@ func TestDecodeIsReply(t *testing.T) {
 	assert.Nil(t, f.GetIsReply())
 	assert.Equal(t, false, f.GetReply())
 
-	// TRACE_TO_STACK SRV6 encap
+	// TRACE_TO_STACK srv6-decap (encrypted)
+	tn = monitor.TraceNotifyV0{
+		Type:     byte(monitorAPI.MessageTypeTrace),
+		Source:   hostEP,
+		ObsPoint: monitorAPI.TraceToStack,
+		Reason:   monitor.TraceReasonSRv6Decap | monitor.TraceReasonEncryptMask,
+	}
+	f = parseFlow(tn, remoteIP, localIP)
+	assert.Nil(t, f.GetIsReply())
+	assert.Equal(t, false, f.GetReply())
+
+	// TRACE_TO_STACK srv6-encap
 	tn = monitor.TraceNotifyV0{
 		Type:     byte(monitorAPI.MessageTypeTrace),
 		Source:   localEP,
 		ObsPoint: monitorAPI.TraceToStack,
 		Reason:   monitor.TraceReasonSRv6Encap,
+	}
+	f = parseFlow(tn, localIP, remoteIP)
+	assert.Nil(t, f.GetIsReply())
+	assert.Equal(t, false, f.GetReply())
+
+	// TRACE_TO_STACK srv6-encap (encrypted)
+	tn = monitor.TraceNotifyV0{
+		Type:     byte(monitorAPI.MessageTypeTrace),
+		Source:   localEP,
+		ObsPoint: monitorAPI.TraceToStack,
+		Reason:   monitor.TraceReasonSRv6Encap | monitor.TraceReasonEncryptMask,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
 	assert.Nil(t, f.GetIsReply())

--- a/pkg/hubble/relay/pool/client_test.go
+++ b/pkg/hubble/relay/pool/client_test.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package pool
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/cilium/cilium/pkg/crypto/certloader"
+	hubbleopts "github.com/cilium/cilium/pkg/hubble/server/serveroption"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func TestGRPCClientConnBuilder_CertificateChange(t *testing.T) {
+	cert, ca := newTestCAandCert(t)
+
+	fTLSb := &fakeTLSConfigBuilder{
+		cert: &cert,
+		ca:   ca,
+	}
+	cb := GRPCClientConnBuilder{
+		DialTimeout: 5 * time.Second,
+		Options: []grpc.DialOption{
+			grpc.WithBlock(),
+			grpc.FailOnNonTempDialError(true),
+			grpc.WithReturnConnectionError(),
+		},
+		TLSConfig: fTLSb,
+	}
+	dir, err := os.MkdirTemp("", t.Name())
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	list, err := net.Listen("unix", filepath.Join(dir, "relay.sock"))
+	require.NoError(t, err)
+	addr := list.Addr().String()
+
+	s := newTestServer(cert, ca)
+	go s.Serve(list)
+
+	clientConn, err := cb.ClientConn(fmt.Sprintf("unix://%s", list.Addr().String()), "foo.test.cilium.io")
+	require.NoError(t, err)
+	hc := healthpb.NewHealthClient(clientConn)
+	_, err = hc.Check(context.TODO(), &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+
+	cert, ca = newTestCAandCert(t)
+
+	s.Stop()
+	// Start server with new cert on same socket
+	list, err = net.Listen("unix", addr)
+	require.NoError(t, err)
+	s = newTestServer(cert, ca)
+	go s.Serve(list)
+	defer s.Stop()
+
+	// Update client certificate
+	fTLSb.set(&cert, ca)
+
+	require.Eventually(t, func() bool {
+		_, err = hc.Check(context.TODO(), &healthpb.HealthCheckRequest{})
+		if err != nil {
+			t.Logf("Error %q conn state %q", err.Error(), clientConn.GetState().String())
+		}
+		return err == nil
+	}, 20*time.Second, 100*time.Millisecond)
+
+}
+
+var _ certloader.ClientConfigBuilder = &fakeTLSConfigBuilder{}
+
+type fakeTLSConfigBuilder struct {
+	mu   lock.Mutex
+	cert *tls.Certificate
+	ca   *x509.CertPool
+}
+
+// ClientConfig implements certloader.ClientConfigBuilder.
+func (f *fakeTLSConfigBuilder) ClientConfig(base *tls.Config) *tls.Config {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	c := base.Clone()
+	c.RootCAs = f.ca
+	c.GetClientCertificate = func(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		return f.cert, nil
+	}
+	return c
+}
+
+func (f *fakeTLSConfigBuilder) set(cert *tls.Certificate, ca *x509.CertPool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ca = ca
+	f.cert = cert
+}
+
+// IsMutualTLS implements certloader.ClientConfigBuilder.
+func (*fakeTLSConfigBuilder) IsMutualTLS() bool {
+	return true
+}
+
+// newTestCAandCert create a new CA and a sigend certificate
+func newTestCAandCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+
+	ca := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	caKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	require.NoError(t, err)
+	caRaw, err := x509.CreateCertificate(rand.Reader, ca, ca, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caPEM := new(bytes.Buffer)
+	pem.Encode(caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caRaw,
+	})
+	certpool := x509.NewCertPool()
+	certpool.AppendCertsFromPEM(caPEM.Bytes())
+
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName: "*.test.cilium.io",
+		},
+		DNSNames:    []string{"*.test.cilium.io"},
+		IPAddresses: []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().AddDate(10, 0, 0),
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+	}
+	certKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	require.NoError(t, err)
+	certRaw, err := x509.CreateCertificate(rand.Reader, cert, ca, &certKey.PublicKey, caKey)
+	require.NoError(t, err)
+	certPEM := new(bytes.Buffer)
+	err = pem.Encode(certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certRaw,
+	})
+	require.NoError(t, err)
+	certPrivKeyPEM := new(bytes.Buffer)
+	err = pem.Encode(certPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certKey),
+	})
+	require.NoError(t, err)
+	serverCert, err := tls.X509KeyPair(certPEM.Bytes(), certPrivKeyPEM.Bytes())
+	require.NoError(t, err)
+
+	return serverCert, certpool
+}
+
+func newTestServer(cert tls.Certificate, ca *x509.CertPool) *grpc.Server {
+	serverOpts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(&tls.Config{ //nolint:gosec
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      ca,
+		ServerName:   "foo.test.cilium.io",
+		MinVersion:   hubbleopts.MinTLSVersion,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    ca,
+	}))}
+	s := grpc.NewServer(serverOpts...)
+	svc := health.NewServer()
+	svc.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	healthpb.RegisterHealthServer(s, svc)
+	return s
+}

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -151,6 +151,10 @@ func (s ServiceFlags) SVCType() SVCType {
 	}
 }
 
+func (s ServiceFlags) IsL7LB() bool {
+	return s&serviceFlagL7LoadBalancer != 0
+}
+
 // SVCExtTrafficPolicy returns a service traffic policy from the flags
 func (s ServiceFlags) SVCExtTrafficPolicy() SVCTrafficPolicy {
 	switch {

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -152,7 +152,7 @@ func connState(reason uint8) string {
 }
 
 func TraceReasonIsKnown(reason uint8) bool {
-	switch reason {
+	switch reason & ^TraceReasonEncryptMask {
 	case TraceReasonUnknown:
 		return false
 	default:
@@ -161,7 +161,7 @@ func TraceReasonIsKnown(reason uint8) bool {
 }
 
 func TraceReasonIsEncap(reason uint8) bool {
-	switch reason {
+	switch reason & ^TraceReasonEncryptMask {
 	case TraceReasonSRv6Encap:
 		return true
 	default:
@@ -170,7 +170,7 @@ func TraceReasonIsEncap(reason uint8) bool {
 }
 
 func TraceReasonIsDecap(reason uint8) bool {
-	switch reason {
+	switch reason & ^TraceReasonEncryptMask {
 	case TraceReasonSRv6Decap:
 		return true
 	default:


### PR DESCRIPTION
 * [x] #31211 (@kaworu)
 * [x] #31504 (@bimmlerd)
 * [x] #31376 (@glrf)
    * :warning:  The test  TestGRPCClientConnBuilder_CertificateChange is failing consistently, do we need to bump google.golang.org/grpc to v1.62.1 to fix it ?
    * Thanks to Alex for pushing the fix
 * [x] #31503 (@mhofstetter)
 * [ ] #31373 (@loomkoom)
 * [x] #31469 (@YutaroHayakawa)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 31211 31504 31376 31503 31373 31469
```
