### PR TITLE
ingress/gateway-api: stable envoy listener filterchain sort-order

### DIFF
--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -309,7 +309,11 @@ func NewSNIListenerWithDefaults(name string, backendsForHost map[string][]string
 func NewSNIListener(name string, backendsForHost map[string][]string, mutatorFunc ...ListenerMutator) (ciliumv2.XDSResource, error) {
 	var filterChains []*envoy_config_listener.FilterChain
 
-	for backend, hostNames := range backendsForHost {
+	orderedBackends := maps.Keys(backendsForHost)
+	goslices.Sort(orderedBackends)
+
+	for _, backend := range orderedBackends {
+		hostNames := backendsForHost[backend]
 		filterChains = append(filterChains, &envoy_config_listener.FilterChain{
 			FilterChainMatch: toFilterChainMatch(hostNames),
 			Filters: []*envoy_config_listener.Filter{

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -4,7 +4,9 @@
 package translation
 
 import (
+	"cmp"
 	"fmt"
+	goslices "slices"
 	"syscall"
 
 	envoy_config_core_v3 "github.com/cilium/proxy/go/envoy/config/core/v3"
@@ -14,6 +16,7 @@ import (
 	httpConnectionManagerv3 "github.com/cilium/proxy/go/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_extensions_filters_network_tcp_v3 "github.com/cilium/proxy/go/envoy/extensions/filters/network/tcp_proxy/v3"
 	envoy_extensions_transport_sockets_tls_v3 "github.com/cilium/proxy/go/envoy/extensions/transport_sockets/tls/v3"
+	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
@@ -184,7 +187,11 @@ func NewHTTPListener(name string, ciliumSecretNamespace string, tls map[model.TL
 		},
 	})
 
-	for secret, hostNames := range tls {
+	orderedSecrets := maps.Keys(tls)
+	goslices.SortStableFunc(orderedSecrets, func(a, b model.TLSSecret) int { return cmp.Compare(a.Namespace+"/"+a.Name, b.Namespace+"/"+b.Name) })
+
+	for _, secret := range orderedSecrets {
+		hostNames := tls[secret]
 		secureHttpConnectionManagerName := fmt.Sprintf("%s-secure", name)
 		secureHttpConnectionManager, err := NewHTTPConnectionManager(
 			secureHttpConnectionManagerName,


### PR DESCRIPTION
Currently, while translating K8s Ingress or Gateway API resources into Envoy resources, the filterchains of the Listeners are in random order. This leads to situations (especially in combination with Shared Ingress) where the order of the filterchains isn't guaranteed - resulting in unnecessary reconciliations.

This PR introduces a stable sort order of the filterchains for the HTTP- and TLS listeners.