### PR TITLE
Fix azure ipam flake caused by instance resync race condition.

### DIFF
--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -70,6 +70,8 @@ func (m *InstancesManager) GetPoolQuota() (quota ipamTypes.PoolQuotaMap) {
 // cache in the instanceManager. It returns the time when the resync has
 // started or time.Time{} if it did not complete.
 func (m *InstancesManager) Resync(ctx context.Context) time.Time {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	resyncStart := time.Now()
 
 	vnets, subnets, err := m.api.GetVpcsAndSubnets(ctx)
@@ -90,11 +92,9 @@ func (m *InstancesManager) Resync(ctx context.Context) time.Time {
 		"numSubnets":         len(subnets),
 	}).Info("Synchronized Azure IPAM information")
 
-	m.mutex.Lock()
 	m.instances = instances
 	m.vnets = vnets
 	m.subnets = subnets
-	m.mutex.Unlock()
 
 	return resyncStart
 }

--- a/pkg/azure/ipam/ipam_test.go
+++ b/pkg/azure/ipam/ipam_test.go
@@ -282,79 +282,92 @@ type nodeState struct {
 
 // TestIpamManyNodes tests IP allocation of 100 nodes across 3 subnets
 func (e *IPAMSuite) TestIpamManyNodes(c *check.C) {
-	const (
-		numNodes    = 100
-		minAllocate = 10
-	)
+	for _, test := range []struct {
+		numNodes, minAllocate, concurrency int
+	}{
+		{numNodes: 100, minAllocate: 10, concurrency: 10},
+		// The code being tested is prone to race conditions, increasing the number
+		// of nodes seems to actually hide these bugs (presumably due to a higher
+		// chance that racey tasks get corrected by another trigger).
+		// Thus we test using a smaller node/addr domain to help catch regressions.
+		{numNodes: 2, minAllocate: 1, concurrency: 10},
+	} {
+		c.Run(fmt.Sprintf("numNodes=%d, minAllocate=%d", test.numNodes, test.minAllocate), func(t *testing.T) {
+			var (
+				numNodes    = 2
+				minAllocate = 1
+			)
+			api := apimock.NewAPI(testSubnets, []*ipamTypes.VirtualNetwork{testVnet})
+			instances := NewInstancesManager(api)
+			c.Assert(instances, check.Not(check.IsNil))
 
-	api := apimock.NewAPI(testSubnets, []*ipamTypes.VirtualNetwork{testVnet})
-	instances := NewInstancesManager(api)
-	c.Assert(instances, check.Not(check.IsNil))
+			k8sapi := newK8sMock()
+			metrics := metricsmock.NewMockMetrics()
+			mngr, err := ipam.NewNodeManager(instances, k8sapi, metrics, int64(test.concurrency), false, false)
+			c.Assert(err, check.IsNil)
+			c.Assert(mngr, check.Not(check.IsNil))
 
-	k8sapi := newK8sMock()
-	metrics := metricsmock.NewMockMetrics()
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metrics, 10, false, false)
-	c.Assert(err, check.IsNil)
-	c.Assert(mngr, check.Not(check.IsNil))
+			state := make([]*nodeState, numNodes)
+			allInstances := ipamTypes.NewInstanceMap()
 
-	state := make([]*nodeState, numNodes)
-	allInstances := ipamTypes.NewInstanceMap()
+			for i := range state {
+				resource := &types.AzureInterface{
+					Name:          "eth0",
+					SecurityGroup: "sg1",
+					Addresses:     []types.AzureAddress{},
+					State:         types.StateSucceeded,
+				}
+				resource.SetID(fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d/networkInterfaces/vmss11", i))
+				allInstances.Update(fmt.Sprintf("vm%d", i), ipamTypes.InterfaceRevision{
+					Resource: resource.DeepCopy(),
+				})
+			}
 
-	for i := range state {
-		resource := &types.AzureInterface{
-			Name:          "eth0",
-			SecurityGroup: "sg1",
-			Addresses:     []types.AzureAddress{},
-			State:         types.StateSucceeded,
-		}
-		resource.SetID(fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d/networkInterfaces/vmss11", i))
-		allInstances.Update(fmt.Sprintf("vm%d", i), ipamTypes.InterfaceRevision{
-			Resource: resource.DeepCopy(),
+			api.UpdateInstances(allInstances)
+			instances.Resync(context.TODO())
+
+			for i := range state {
+				state[i] = &nodeState{name: fmt.Sprintf("node%d", i), instanceName: fmt.Sprintf("vm%d", i)}
+				state[i].cn = newCiliumNode(state[i].name, state[i].instanceName, 1, minAllocate)
+				mngr.Upsert(state[i].cn)
+			}
+
+			for _, s := range state {
+				c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, s.name, 0) }, 5*time.Second), check.IsNil)
+
+				node := mngr.Get(s.name)
+				c.Assert(node, check.Not(check.IsNil))
+				if node.Stats().IPv4.AvailableIPs != minAllocate {
+					c.Errorf("Node %s allocation mismatch. expected: %d allocated: %d", s.name, minAllocate, node.Stats().IPv4.AvailableIPs)
+					c.Fail()
+				}
+				c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
+			}
+
+			// The above check returns as soon as the address requirements are met.
+			// The metrics may still be outdated, resync all nodes to update
+			// metrics.
+			mngr.Resync(context.TODO(), time.Now())
+
+			c.Assert(metrics.Nodes("total"), check.Equals, numNodes)
+			c.Assert(metrics.Nodes("in-deficit"), check.Equals, 0)
+			c.Assert(metrics.Nodes("at-capacity"), check.Equals, 0)
+
+			c.Assert(metrics.AllocatedIPs("available"), check.Equals, numNodes*minAllocate)
+			c.Assert(metrics.AllocatedIPs("needed"), check.Equals, 0)
+			c.Assert(metrics.AllocatedIPs("used"), check.Equals, 0)
+
+			// All subnets must have been used for allocation
+			for _, subnet := range subnets {
+				c.Assert(metrics.GetAllocationAttempts("createInterfaceAndAllocateIP", "success", subnet.ID), check.Not(check.Equals), 0)
+				c.Assert(metrics.IPAllocations(subnet.ID), check.Not(check.Equals), 0)
+			}
+
+			c.Assert(metrics.ResyncCount(), check.Not(check.Equals), 0)
+			c.Assert(metrics.AvailableInterfaces(), check.Not(check.Equals), 0)
 		})
+
 	}
-
-	api.UpdateInstances(allInstances)
-	instances.Resync(context.TODO())
-
-	for i := range state {
-		state[i] = &nodeState{name: fmt.Sprintf("node%d", i), instanceName: fmt.Sprintf("vm%d", i)}
-		state[i].cn = newCiliumNode(state[i].name, state[i].instanceName, 1, minAllocate)
-		mngr.Upsert(state[i].cn)
-	}
-
-	for _, s := range state {
-		c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, s.name, 0) }, 5*time.Second), check.IsNil)
-
-		node := mngr.Get(s.name)
-		c.Assert(node, check.Not(check.IsNil))
-		if node.Stats().IPv4.AvailableIPs != minAllocate {
-			c.Errorf("Node %s allocation mismatch. expected: %d allocated: %d", s.name, minAllocate, node.Stats().IPv4.AvailableIPs)
-			c.Fail()
-		}
-		c.Assert(node.Stats().IPv4.UsedIPs, check.Equals, 0)
-	}
-
-	// The above check returns as soon as the address requirements are met.
-	// The metrics may still be outdated, resync all nodes to update
-	// metrics.
-	mngr.Resync(context.TODO(), time.Now())
-
-	c.Assert(metrics.Nodes("total"), check.Equals, numNodes)
-	c.Assert(metrics.Nodes("in-deficit"), check.Equals, 0)
-	c.Assert(metrics.Nodes("at-capacity"), check.Equals, 0)
-
-	c.Assert(metrics.AllocatedIPs("available"), check.Equals, numNodes*minAllocate)
-	c.Assert(metrics.AllocatedIPs("needed"), check.Equals, 0)
-	c.Assert(metrics.AllocatedIPs("used"), check.Equals, 0)
-
-	// All subnets must have been used for allocation
-	for _, subnet := range subnets {
-		c.Assert(metrics.GetAllocationAttempts("createInterfaceAndAllocateIP", "success", subnet.ID), check.Not(check.Equals), 0)
-		c.Assert(metrics.IPAllocations(subnet.ID), check.Not(check.Equals), 0)
-	}
-
-	c.Assert(metrics.ResyncCount(), check.Not(check.Equals), 0)
-	c.Assert(metrics.AvailableInterfaces(), check.Not(check.Equals), 0)
 }
 
 func benchmarkAllocWorker(c *check.C, workers int64, delay time.Duration, rateLimit float64, burst int) {


### PR DESCRIPTION
TestIpamManyNodes fails occasionally with unexpected available IP counts.
This appears to be an underlying bug in the azure/ipam implementation. This results from two racing resyncInstance calls racing to update the cached instances list.

This moves the azure API implementation lock to encompass the entire operation Resync operation - such that getting instances/subnets assigning them is atomic.

This shouldn't have any risk of deadlocks as azure api doesn't have any references to node or node manager.