### PR TITLE
helm: Remove pipe in value comments to avoid breaking Helm reference

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2125,7 +2125,7 @@
      - list
      - ``["lbipam.cilium.io","service.beta.kubernetes.io","service.kubernetes.io","cloud.google.com"]``
    * - :spelling:ignore:`ingressController.loadbalancerMode`
-     - Default ingress load balancer mode Supported values: shared, dedicated For granular control, use the following annotations on the ingress resource ingress.cilium.io/loadbalancer-mode: shared
+     - Default ingress load balancer mode Supported values: shared, dedicated For granular control, use the following annotations on the ingress resource: "ingress.cilium.io/loadbalancer-mode: dedicated" (or "shared").
      - string
      - ``"dedicated"``
    * - :spelling:ignore:`ingressController.secretsNamespace`

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -581,7 +581,7 @@ contributors across the globe, there is almost always someone available to help.
 | ingressController.hostNetwork.sharedHTTPPort | int | `0` | Configure a specific port on the host network that gets used for the shared HTTP listener. This is used for HTTP and HTTPS. |
 | ingressController.hostNetwork.sharedTLSPassthroughPort | int | `0` | Configure a specific port on the host network that gets used for the shared TLS passthrough listener |
 | ingressController.ingressLBAnnotationPrefixes | list | `["lbipam.cilium.io","service.beta.kubernetes.io","service.kubernetes.io","cloud.google.com"]` | IngressLBAnnotations are the annotation and label prefixes, which are used to filter annotations and/or labels to propagate from Ingress to the Load Balancer service |
-| ingressController.loadbalancerMode | string | `"dedicated"` | Default ingress load balancer mode Supported values: shared, dedicated For granular control, use the following annotations on the ingress resource ingress.cilium.io/loadbalancer-mode: shared|dedicated, |
+| ingressController.loadbalancerMode | string | `"dedicated"` | Default ingress load balancer mode Supported values: shared, dedicated For granular control, use the following annotations on the ingress resource: "ingress.cilium.io/loadbalancer-mode: dedicated" (or "shared"). |
 | ingressController.secretsNamespace | object | `{"create":true,"name":"cilium-secrets","sync":true}` | SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from. |
 | ingressController.secretsNamespace.create | bool | `true` | Create secrets namespace for Ingress. |
 | ingressController.secretsNamespace.name | string | `"cilium-secrets"` | Name of Ingress secret namespace. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -713,8 +713,8 @@ ingressController:
   default: false
   # -- Default ingress load balancer mode
   # Supported values: shared, dedicated
-  # For granular control, use the following annotations on the ingress resource
-  # ingress.cilium.io/loadbalancer-mode: shared|dedicated,
+  # For granular control, use the following annotations on the ingress resource:
+  # "ingress.cilium.io/loadbalancer-mode: dedicated" (or "shared").
   loadbalancerMode: dedicated
   # -- Enforce https for host having matching TLS host in Ingress.
   # Incoming traffic to http listener will return 308 http error code with respective location in header.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -711,8 +711,8 @@ ingressController:
   default: false
   # -- Default ingress load balancer mode
   # Supported values: shared, dedicated
-  # For granular control, use the following annotations on the ingress resource
-  # ingress.cilium.io/loadbalancer-mode: shared|dedicated,
+  # For granular control, use the following annotations on the ingress resource:
+  # "ingress.cilium.io/loadbalancer-mode: dedicated" (or "shared").
   loadbalancerMode: dedicated
   # -- Enforce https for host having matching TLS host in Ingress.
   # Incoming traffic to http listener will return 308 http error code with respective location in header.


### PR DESCRIPTION
Pipe characters (`|`) in the value files break the formatting of the generated Helm reference (the last portion of the string is missing). This is because the helm-docs tool that we use does not escape them when building the tables with pipes as column separator ([ref][0]); on top of that, we parse this table with Awk in Documentation/Makefile, using pipes as delimiters. I see no trivial way to work around these issue, let's just remove the pipe.

[0]: https://github.com/norwoodj/helm-docs/issues/118

Discovered while reviewing #30514.