### PR TITLE
pkg/nodediscovery,daemon: modularize node discovery

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
+	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/option"
 	policyK8s "github.com/cilium/cilium/pkg/policy/k8s"
 	"github.com/cilium/cilium/pkg/pprof"
@@ -244,6 +245,10 @@ var (
 
 		// The device reloader reloads the datapath when the devices change at runtime.
 		cell.Invoke(registerDeviceReloader),
+
+		// The node discovery cell provides the local node configuration and node discovery
+		// which communicate changes in local node information to the API server or KVStore.
+		nodediscovery.Cell,
 	)
 )
 

--- a/daemon/cmd/cells_test.go
+++ b/daemon/cmd/cells_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 var goleakOptions = []goleak.Option{
@@ -32,6 +33,11 @@ func TestAgentCell(t *testing.T) {
 	defer metrics.Reinitialize()
 
 	logging.SetLogLevelToDebug()
+
+	// Populate config with default values normally set by Viper flag defaults
+	option.Config.IPv4ServiceRange = AutoCIDR
+	option.Config.IPv6ServiceRange = AutoCIDR
+
 	err := hive.New(Agent).Populate()
 	assert.NoError(t, err, "Populate()")
 }

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -414,8 +414,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		metrics.Identity.WithLabelValues(identity.ReservedIdentityType).Inc()
 	})
 
-	nd := nodediscovery.NewNodeDiscovery(params.NodeManager, params.Clientset, params.LocalNodeStore, params.MTU, params.CNIConfigManager.GetCustomNetConf())
-
 	d := Daemon{
 		ctx:               ctx,
 		clientset:         params.Clientset,
@@ -426,7 +424,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		datapath:          params.Datapath,
 		deviceManager:     params.DeviceManager,
 		devices:           params.Devices,
-		nodeDiscovery:     nd,
+		nodeDiscovery:     params.NodeDiscovery,
 		nodeLocalStore:    params.LocalNodeStore,
 		endpointCreations: newEndpointCreationManager(params.Clientset),
 		apiLimiterSet:     params.APILimiterSet,
@@ -518,7 +516,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		params.ServiceCache,
 		d.bwManager,
 	)
-	nd.RegisterK8sGetters(d.k8sWatcher)
+	params.NodeDiscovery.RegisterK8sGetters(d.k8sWatcher)
 
 	if option.Config.BGPAnnounceLBIP || option.Config.BGPAnnouncePodCIDR {
 		switch option.Config.IPAMMode() {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -87,6 +87,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pidfile"
 	"github.com/cilium/cilium/pkg/policy"
@@ -1635,6 +1636,7 @@ type daemonParams struct {
 	Sysctl              sysctl.Sysctl
 	SyncHostIPs         *syncHostIPs
 	LRPManager          *redirectpolicy.Manager
+	NodeDiscovery       *nodediscovery.NodeDiscovery
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
+	"github.com/cilium/cilium/daemon/cmd/cni/fake"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/mtu"
@@ -18,7 +19,6 @@ import (
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/option"
-	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 )
 
 type GetNodesSuite struct {
@@ -76,7 +76,8 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "create a client ID and store it locally",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, nil, &mtuConfig, &cnitypes.NetConf{})
+				lnc, _ := nodediscovery.NewLocalNodeConfig(&mtuConfig, option.Config)
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, nil, lnc, &fake.FakeCNIConfigManager{})
 				return args{
 					params: GetClusterNodesParams{
 						ClientID: &zero,
@@ -107,7 +108,8 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes diff from a client that was already present",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, nil, &mtuConfig, &cnitypes.NetConf{})
+				lnc, _ := nodediscovery.NewLocalNodeConfig(&mtuConfig, option.Config)
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, nil, lnc, &fake.FakeCNIConfigManager{})
 				return args{
 					params: GetClusterNodesParams{
 						ClientID: &clientIDs[0],
@@ -160,7 +162,8 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes from an expired client, it should be ok because the clean up only happens when on insertion",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, nil, &mtuConfig, &cnitypes.NetConf{})
+				lnc, _ := nodediscovery.NewLocalNodeConfig(&mtuConfig, option.Config)
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, nil, lnc, &fake.FakeCNIConfigManager{})
 				return args{
 					params: GetClusterNodesParams{
 						ClientID: &clientIDs[0],
@@ -214,7 +217,8 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes for a new client, the expired client should be deleted",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, nil, &mtuConfig, &cnitypes.NetConf{})
+				lnc, _ := nodediscovery.NewLocalNodeConfig(&mtuConfig, option.Config)
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, nil, lnc, &fake.FakeCNIConfigManager{})
 				return args{
 					params: GetClusterNodesParams{
 						ClientID: &zero,
@@ -263,7 +267,8 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes for a new client, however the randomizer allocated an existing clientID, so we should return a empty clientID",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, nil, &mtuConfig, &cnitypes.NetConf{})
+				lnc, _ := nodediscovery.NewLocalNodeConfig(&mtuConfig, option.Config)
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, nil, lnc, &fake.FakeCNIConfigManager{})
 				return args{
 					params: GetClusterNodesParams{
 						ClientID: &zero,
@@ -312,7 +317,8 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes for a client that does not want to have diffs, leave all other stored clients alone",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, nil, &mtuConfig, &cnitypes.NetConf{})
+				lnc, _ := nodediscovery.NewLocalNodeConfig(&mtuConfig, option.Config)
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, nil, lnc, &fake.FakeCNIConfigManager{})
 				return args{
 					params: GetClusterNodesParams{},
 					daemon: &Daemon{
@@ -416,9 +422,10 @@ func (g *GetNodesSuite) Test_cleanupClients(c *C) {
 		args := tt.setupArgs()
 		want := tt.setupWanted()
 		h := &getNodes{clients: args.clients}
+		lnc, _ := nodediscovery.NewLocalNodeConfig(&mtuConfig, option.Config)
 		h.cleanupClients(
 			&Daemon{
-				nodeDiscovery: nodediscovery.NewNodeDiscovery(nm, nil, nil, &mtuConfig, &cnitypes.NetConf{}),
+				nodeDiscovery: nodediscovery.NewNodeDiscovery(nm, nil, nil, lnc, &fake.FakeCNIConfigManager{}),
 			})
 		c.Assert(h.clients, checker.DeepEquals, want.clients)
 	}

--- a/pkg/nodediscovery/cell.go
+++ b/pkg/nodediscovery/cell.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nodediscovery
+
+import "github.com/cilium/cilium/pkg/hive/cell"
+
+// The node discovery cell provides the local node configuration and node discovery
+// which communicate changes in local node information to the API server or KVStore.
+var Cell = cell.Module(
+	"nodediscovery",
+	"Communicate changes in local node information to the API server or KVStore",
+
+	// Node discovery communicates changes in local node information to the API server or KVStore
+	cell.Provide(NewNodeDiscovery),
+	// LocalNodeConfig provides a subset of the DaemonConfig with a little pre-processing
+	cell.Provide(NewLocalNodeConfig),
+)

--- a/pkg/nodediscovery/localnodeconfig.go
+++ b/pkg/nodediscovery/localnodeconfig.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nodediscovery
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/cidr"
+	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/mtu"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+func NewLocalNodeConfig(mtu mtu.MTU, config *option.DaemonConfig) (datapath.LocalNodeConfiguration, error) {
+	auxPrefixes := []*cidr.CIDR{}
+
+	if config.IPv4ServiceRange != AutoCIDR {
+		serviceCIDR, err := cidr.ParseCIDR(config.IPv4ServiceRange)
+		if err != nil {
+			return datapath.LocalNodeConfiguration{}, fmt.Errorf("Invalid IPv4 service prefix %q: %v", config.IPv4ServiceRange, err)
+		}
+
+		auxPrefixes = append(auxPrefixes, serviceCIDR)
+	}
+
+	if config.IPv6ServiceRange != AutoCIDR {
+		serviceCIDR, err := cidr.ParseCIDR(config.IPv6ServiceRange)
+		if err != nil {
+			return datapath.LocalNodeConfiguration{}, fmt.Errorf("Invalid IPv6 service prefix %q: %v", config.IPv6ServiceRange, err)
+		}
+
+		auxPrefixes = append(auxPrefixes, serviceCIDR)
+	}
+
+	return datapath.LocalNodeConfiguration{
+		MtuConfig:               mtu,
+		EnableIPv4:              config.EnableIPv4,
+		EnableIPv6:              config.EnableIPv6,
+		EnableEncapsulation:     config.TunnelingEnabled(),
+		EnableAutoDirectRouting: config.EnableAutoDirectRouting,
+		EnableLocalNodeRoute: config.EnableLocalNodeRoute &&
+			config.IPAM != ipamOption.IPAMENI &&
+			config.IPAM != ipamOption.IPAMAzure &&
+			config.IPAM != ipamOption.IPAMAlibabaCloud,
+		AuxiliaryPrefixes: auxPrefixes,
+		EnableIPSec:       config.EnableIPSec,
+		EncryptNode:       config.EncryptNode,
+		IPv4PodSubnets:    config.IPv4PodSubnets,
+		IPv6PodSubnets:    config.IPv6PodSubnets,
+	}, nil
+}


### PR DESCRIPTION
This commit modularizes the node discovery package. Before node discovery was created by the daemon, but since all parameters needed are already in hive we can create the node discovery in the hive to.

We also split off the creation of local node config into its own cell since there are a few components such as the loader that are interested in the local node config without needing the full node discovery.

```release-note
modularize node discovery
```
