### PR TITLE
ci-e2e: Sync jobs list between tests-e2e-upgrade and conformance-e2e

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -131,6 +131,7 @@ jobs:
             kernel: '6.1-20240305.092417'
             kube-proxy: 'none'
             kpr: 'true'
+            devices: '{eth0,eth1}'
             tunnel: 'vxlan'
             lb-mode: 'snat'
             egress-gateway: 'true'
@@ -215,6 +216,14 @@ jobs:
             egress-gateway: 'true'
             ingress-controller: 'true'
 
+          - name: '13'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: 'rhel8-20240305.092417'
+            kube-proxy: 'iptables'
+            kpr: 'false'
+            tunnel: 'vxlan'
+            misc: 'policyCIDRMatchMode=nodes'
+
           - name: '14'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: '5.4-20240305.092417'
@@ -226,6 +235,18 @@ jobs:
             lb-mode: 'snat'
             egress-gateway: 'true'
             lb-acceleration: 'testing-only'
+            ingress-controller: 'true'
+
+          - name: '15'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: 'bpf-next-20240307.011705'
+            kube-proxy: 'none'
+            kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
+            tunnel: 'disabled'
+            ingress-controller: 'true'
+            misc: 'bpf.tproxy=true'
 
           - name: '16'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind


### PR DESCRIPTION
We want to keep the list in both files synchronised, but over time we let the two versions diverge. Let's synchronise them now.

Fixes: 0b4d94edf7e7 ("ci-e2e: add job testing node cidr feature")
Fixes: 9311af0ff7bf ("ci-e2e: Enable Ingress Controller test for more setup")
Fixes: 0e673607c70b ("conformance-e2e: Explicitly set devices to fix e2e tests")
Fixes: 5884af16935b ("ci-e2e: Add matrix for bpf.tproxy")