### PR TITLE
ci-e2e: Add e2e test with WireGuard + Host Firewall

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -248,6 +248,19 @@ jobs:
             ingress-controller: 'true'
             misc: 'bpf.tproxy=true'
 
+          - name: '16'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: '5.15-20240305.092417'
+            kube-proxy: 'none'
+            kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
+            tunnel: 'vxlan'
+            lb-mode: 'snat'
+            encryption: 'wireguard'
+            encryption-node: 'false'
+            host-fw: 'true'
+
     timeout-minutes: 60
     steps:
       - name: Checkout context ref (trusted)

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -227,6 +227,18 @@ jobs:
             egress-gateway: 'true'
             lb-acceleration: 'testing-only'
 
+          - name: '16'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: '5.15-20240305.092417'
+            kube-proxy: 'none'
+            kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
+            tunnel: 'vxlan'
+            lb-mode: 'snat'
+            encryption: 'wireguard'
+            encryption-node: 'false'
+            host-fw: 'true'
 
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
To get more coverage about the host firewall, let's add a new job in the e2e test suites to run it alongside WireGuard encryption.