### PR TITLE
bpf: lb: remove extra SVC lookup when backend lookup fails

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -97,7 +97,7 @@ static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *
 
 	lb4_fill_key(&key, &tuple);
 
-	svc = lb4_lookup_service(&key, is_defined(ENABLE_NODEPORT), false);
+	svc = lb4_lookup_service(&key, is_defined(ENABLE_NODEPORT));
 	if (svc) {
 #if defined(ENABLE_L7_LB)
 		if (lb4_svc_is_l7loadbalancer(svc)) {
@@ -154,7 +154,7 @@ static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr
 	 * the CT entry for destination endpoints where we can't encode the
 	 * state in the address.
 	 */
-	svc = lb6_lookup_service(&key, is_defined(ENABLE_NODEPORT), false);
+	svc = lb6_lookup_service(&key, is_defined(ENABLE_NODEPORT));
 	if (svc) {
 #if defined(ENABLE_L7_LB)
 		if (lb6_svc_is_l7loadbalancer(svc)) {

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -202,7 +202,7 @@ sock4_wildcard_lookup(struct lb4_key *key __maybe_unused,
 	return NULL;
 wildcard_lookup:
 	key->address = 0;
-	return lb4_lookup_service(key, true, false);
+	return lb4_lookup_service(key, true);
 }
 #endif /* ENABLE_NODEPORT */
 
@@ -315,7 +315,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	 * service entries via wildcarded lookup for NodePort and
 	 * HostPort services.
 	 */
-	svc = lb4_lookup_service(&key, true, false);
+	svc = lb4_lookup_service(&key, true);
 	if (!svc)
 		svc = sock4_wildcard_lookup_full(&key, in_hostns);
 	if (!svc)
@@ -488,7 +488,7 @@ static __always_inline int __sock4_post_bind(struct bpf_sock *ctx,
 	    !ctx_in_hostns(ctx_full, NULL))
 		return 0;
 
-	svc = lb4_lookup_service(&key, true, false);
+	svc = lb4_lookup_service(&key, true);
 	if (!svc)
 		/* Perform a wildcard lookup for the case where the caller
 		 * tries to bind to loopback or an address with host identity
@@ -591,7 +591,7 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 			.dport		= val->port,
 		};
 
-		svc = lb4_lookup_service(&svc_key, true, false);
+		svc = lb4_lookup_service(&svc_key, true);
 		if (!svc)
 			svc = sock4_wildcard_lookup_full(&svc_key,
 						ctx_in_hostns(ctx_full, NULL));
@@ -767,7 +767,7 @@ sock6_wildcard_lookup(struct lb6_key *key __maybe_unused,
 	return NULL;
 wildcard_lookup:
 	memset(&key->address, 0, sizeof(key->address));
-	return lb6_lookup_service(key, true, false);
+	return lb6_lookup_service(key, true);
 }
 #endif /* ENABLE_NODEPORT */
 
@@ -862,7 +862,7 @@ static __always_inline int __sock6_post_bind(struct bpf_sock *ctx)
 
 	ctx_get_v6_src_address(ctx, &key.address);
 
-	svc = lb6_lookup_service(&key, true, false);
+	svc = lb6_lookup_service(&key, true);
 	if (!svc) {
 		svc = sock6_wildcard_lookup(&key, false, false, true);
 		if (!svc)
@@ -997,7 +997,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	ctx_get_v6_address(ctx, &key.address);
 	memcpy(&orig_key, &key, sizeof(key));
 
-	svc = lb6_lookup_service(&key, true, false);
+	svc = lb6_lookup_service(&key, true);
 	if (!svc)
 		svc = sock6_wildcard_lookup_full(&key, in_hostns);
 	if (!svc)
@@ -1183,7 +1183,7 @@ static __always_inline int __sock6_xlate_rev(struct bpf_sock_addr *ctx)
 			.dport		= val->port,
 		};
 
-		svc = lb6_lookup_service(&svc_key, true, false);
+		svc = lb6_lookup_service(&svc_key, true);
 		if (!svc)
 			svc = sock6_wildcard_lookup_full(&svc_key,
 						ctx_in_hostns(ctx, NULL));

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -928,9 +928,6 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 			if (backend && !state->syn)
 				break;
 
-			svc = lb6_lookup_service(key, false, true);
-			if (!svc)
-				goto no_service;
 			backend_id = lb6_select_backend_id(ctx, key, tuple, svc);
 			backend = lb6_lookup_backend(ctx, backend_id);
 			if (!backend)
@@ -1576,9 +1573,6 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 			if (backend && !state->syn)
 				break;
 
-			svc = lb4_lookup_service(key, false, true);
-			if (!svc)
-				goto no_service;
 			backend_id = lb4_select_backend_id(ctx, key, tuple, svc);
 			backend = lb4_lookup_backend(ctx, backend_id);
 			if (!backend)

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -597,7 +597,7 @@ lb6_to_lb4_service(const struct lb6_service *svc __maybe_unused)
 
 static __always_inline
 struct lb6_service *lb6_lookup_service(struct lb6_key *key,
-	   const bool scope_switch, const bool check_svc_backends)
+				       const bool scope_switch)
 {
 	struct lb6_service *svc;
 
@@ -606,16 +606,12 @@ struct lb6_service *lb6_lookup_service(struct lb6_key *key,
 	svc = map_lookup_elem(&LB6_SERVICES_MAP_V2, key);
 	if (svc) {
 		if (!scope_switch || !lb6_svc_is_two_scopes(svc))
-			/* Packets for L7 LB are redirected even when there are no backends. */
-			return (svc->count || !check_svc_backends ||
-				lb6_svc_is_l7loadbalancer(svc)) ? svc : NULL;
+			return svc;
 		key->scope = LB_LOOKUP_SCOPE_INT;
 		svc = map_lookup_elem(&LB6_SERVICES_MAP_V2, key);
-		if (svc && (svc->count || !check_svc_backends || lb6_svc_is_l7loadbalancer(svc)))
-			return svc;
 	}
 
-	return NULL;
+	return svc;
 }
 
 static __always_inline struct lb6_backend *__lb6_lookup_backend(__u32 backend_id)
@@ -1007,7 +1003,7 @@ static __always_inline void lb6_ctx_restore_state(struct __ctx_buff *ctx,
  */
 static __always_inline
 struct lb6_service *lb6_lookup_service(struct lb6_key *key __maybe_unused,
-	   const bool scope_switch __maybe_unused, const bool check_svc_backends __maybe_unused)
+				       const bool scope_switch __maybe_unused)
 {
 	return NULL;
 }
@@ -1219,7 +1215,7 @@ lb4_to_lb6_service(const struct lb4_service *svc __maybe_unused)
 
 static __always_inline
 struct lb4_service *lb4_lookup_service(struct lb4_key *key,
-				  const bool scope_switch, const bool check_svc_backends)
+				       const bool scope_switch)
 {
 	struct lb4_service *svc;
 
@@ -1228,16 +1224,12 @@ struct lb4_service *lb4_lookup_service(struct lb4_key *key,
 	svc = map_lookup_elem(&LB4_SERVICES_MAP_V2, key);
 	if (svc) {
 		if (!scope_switch || !lb4_svc_is_two_scopes(svc))
-			/* Packets for L7 LB are redirected even when there are no backends. */
-			return (svc->count || !check_svc_backends || lb4_to_lb6_service(svc) ||
-				lb4_svc_is_l7loadbalancer(svc)) ? svc : NULL;
+			return svc;
 		key->scope = LB_LOOKUP_SCOPE_INT;
 		svc = map_lookup_elem(&LB4_SERVICES_MAP_V2, key);
-		if (svc && (svc->count || !check_svc_backends || lb4_svc_is_l7loadbalancer(svc)))
-			return svc;
 	}
 
-	return NULL;
+	return svc;
 }
 
 static __always_inline struct lb4_backend *__lb4_lookup_backend(__u32 backend_id)

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1424,7 +1424,7 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 
 	lb6_fill_key(&key, &tuple);
 
-	svc = lb6_lookup_service(&key, false, false);
+	svc = lb6_lookup_service(&key, false);
 	if (svc) {
 		return nodeport_svc_lb6(ctx, &tuple, svc, &key, ip6, l3_off,
 					l4_off, src_sec_identity, ext_err);
@@ -2962,7 +2962,7 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 
 	lb4_fill_key(&key, &tuple);
 
-	svc = lb4_lookup_service(&key, false, false);
+	svc = lb4_lookup_service(&key, false);
 	if (svc) {
 		return nodeport_svc_lb4(ctx, &tuple, svc, &key, ip4, l3_off,
 					has_l4_header, l4_off,


### PR DESCRIPTION
This cleans up an additional `lb*_lookup_service()` in an unlikely error path. This is fragile, as we don't return the resulting service entry to the caller, who wants to apply various checks to the entry.

Historically this seems to originate from a concern that the service gets updated while the datapath is processing the entry. If the backend lookup fails, we want to go back and fetch an updated entry with the **actual** set of backends. But in today's code, that concern should no longer apply. See the patch description for detailed reasoning.

So let's get rid of this fragile code section.