### PR TITLE
BGPv2: Updates CiliumBGPNodeConfigOverride Type

### DIFF
--- a/operator/pkg/bgpv2/cluster.go
+++ b/operator/pkg/bgpv2/cluster.go
@@ -66,7 +66,7 @@ func (b *BGPResourceManager) upsertNodeConfig(ctx context.Context, config *v2alp
 	var overrideInstances []v2alpha1.CiliumBGPNodeConfigInstanceOverride
 	overrides := b.nodeConfigOverrideStore.List()
 	for _, override := range overrides {
-		if override.Spec.NodeRef == nodeName {
+		if override.Name == nodeName {
 			overrideInstances = override.Spec.BGPInstances
 			break
 		}

--- a/operator/pkg/bgpv2/cluster_test.go
+++ b/operator/pkg/bgpv2/cluster_test.go
@@ -51,7 +51,6 @@ var (
 	}
 
 	nodeOverride1 = cilium_api_v2alpha1.CiliumBGPNodeConfigOverrideSpec{
-		NodeRef: "node-1",
 		BGPInstances: []cilium_api_v2alpha1.CiliumBGPNodeConfigInstanceOverride{
 			{
 				Name:      "cluster-1-instance-65001",
@@ -385,7 +384,7 @@ func Test_ClusterConfigSteps(t *testing.T) {
 			nodeOverrides: []*cilium_api_v2alpha1.CiliumBGPNodeConfigOverride{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{
-						Name: "node-1-override",
+						Name: "node-1",
 					},
 
 					Spec: nodeOverride1,

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpnodeconfigoverrides.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpnodeconfigoverrides.yaml
@@ -27,9 +27,11 @@ spec:
     name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: CiliumBGPNodeConfigOverride is used to overrides some of the
-          BGP configurations which are node local. Users can user this resource to
-          override auto-generated BGP settings for the node.
+        description: CiliumBGPNodeConfigOverride specifies configuration overrides
+          for a CiliumBGPNodeConfig. It allows fine-tuning of BGP behavior on a per-node
+          basis. For the override to be effective, the names in CiliumBGPNodeConfigOverride
+          and CiliumBGPNodeConfig must match exactly. This matching ensures that specific
+          node configurations are applied correctly and only where intended.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -105,13 +107,8 @@ spec:
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
-              nodeRef:
-                description: NodeRef is the name of the node for which the BGP configuration
-                  is overridden.
-                type: string
             required:
             - bgpInstances
-            - nodeRef
             type: object
         required:
         - metadata

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_node_override_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_node_override_types.go
@@ -14,8 +14,10 @@ import (
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type=date
 // +kubebuilder:storageversion
 
-// CiliumBGPNodeConfigOverride is used to overrides some of the BGP configurations which are node local.
-// Users can user this resource to override auto-generated BGP settings for the node.
+// CiliumBGPNodeConfigOverride specifies configuration overrides for a CiliumBGPNodeConfig.
+// It allows fine-tuning of BGP behavior on a per-node basis. For the override to be effective,
+// the names in CiliumBGPNodeConfigOverride and CiliumBGPNodeConfig must match exactly. This
+// matching ensures that specific node configurations are applied correctly and only where intended.
 type CiliumBGPNodeConfigOverride struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
@@ -40,11 +42,6 @@ type CiliumBGPNodeConfigOverrideList struct {
 }
 
 type CiliumBGPNodeConfigOverrideSpec struct {
-	// NodeRef is the name of the node for which the BGP configuration is overridden.
-	//
-	// +kubebuilder:validation:Required
-	NodeRef string `json:"nodeRef"`
-
 	// BGPInstances is a list of BGP instances to override.
 	//
 	// +kubebuilder:validation:Required

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
@@ -538,9 +538,6 @@ func (in *CiliumBGPNodeConfigOverrideSpec) DeepEqual(other *CiliumBGPNodeConfigO
 		return false
 	}
 
-	if in.NodeRef != other.NodeRef {
-		return false
-	}
 	if ((in.BGPInstances != nil) && (other.BGPInstances != nil)) || ((in.BGPInstances == nil) != (other.BGPInstances == nil)) {
 		in, other := &in.BGPInstances, &other.BGPInstances
 		if other == nil {


### PR DESCRIPTION
Previously, CiliumBGPNodeConfigOverrideSpec included the `nodeRef` field for referencing the name of a CiliumBGPNodeConfig to override. This approach introduces the potential for conflicts by multiple CiliumBGPNodeConfigOverride resources referencing the same CiliumBGPNodeConfig.

This PR removes the `nodeRef` field and updates the CiliumBGPNodeConfigOverride spec so users understand that the name of the CiliumBGPNodeConfig and CiliumBGPNodeConfigOverride must match for the configuration overrides to be applied.
