### PR TITLE
.github: use helm defaults for clustermesh upgrade and netperf gke.

### DIFF
--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -113,6 +113,13 @@ jobs:
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 
+      - name: Get Cilium's default values
+        id: default_vars
+        uses: ./.github/actions/helm-default
+        with:
+          image-tag: ${{ inputs.SHA }}
+          chart-dir: ./untrusted/install/kubernetes/cilium
+
       - name: Set up job variables
         id: vars
         run: |
@@ -126,6 +133,7 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
+            ${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=cluster.name=${{ env.clusterName }}-${{ matrix.index }} \
             --helm-set=agentNotReadyTaintKey=ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready \
             --helm-set=debug.enabled=false \

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -147,8 +147,6 @@ jobs:
           #   give enough time to the clustermesh-apiserver to restart after
           #   the upgrade/downgrade before that agents regenerate the endpoints.
           CILIUM_INSTALL_DEFAULTS=" \
-            --set=debug.enabled=true \
-            --set=bpf.monitorAggregation=none \
             --set=hubble.enabled=false \
             --set=routingMode=tunnel \
             --set=tunnelProtocol=vxlan \
@@ -342,15 +340,14 @@ jobs:
         id: downgrade-vars
         run: |
           SHA="$(cd untrusted/cilium-downgrade && git rev-parse HEAD)"
-          CILIUM_IMAGE_SETTINGS=" \
-            --chart-directory=./untrusted/cilium-downgrade/install/kubernetes/cilium \
-            --set=image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci:${SHA} \
-            --set=operator.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator-generic-ci:${SHA} \
-            --set=clustermesh.apiserver.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci:${SHA} \
-            --set=clustermesh.apiserver.kvstoremesh.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/kvstoremesh-ci:${SHA} \
-          "
           echo "sha=${SHA}" >> $GITHUB_OUTPUT
-          echo "cilium_image_settings=${CILIUM_IMAGE_SETTINGS}" >> $GITHUB_OUTPUT
+
+      - name: Get Cilium's default values
+        id: downgrade-default-vars
+        uses: ./.github/actions/helm-default
+        with:
+          image-tag: ${{ outputs.downgrade-vars.outputs.sha }}
+          chart-dir: ./untrusted/cilium-downgrade/install/kubernetes/cilium
 
       - name: Wait for images to be available (newest)
         timeout-minutes: 10
@@ -375,7 +372,7 @@ jobs:
           KVSTORE_ID: 1
         run: |
           cilium --context ${{ env.contextName1 }} install \
-            ${{ steps.downgrade-vars.outputs.cilium_image_settings }} \
+            ${{ steps.downgrade-default-vars.outputs.cilium_install_defaults }} \
             ${{ steps.vars.outputs.cilium_install_defaults }} \
             ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
             ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }}
@@ -545,7 +542,7 @@ jobs:
           KVSTORE_ID: 1
         run: |
           cilium --context ${{ env.contextName1 }} upgrade --reset-values \
-            ${{ steps.downgrade-vars.outputs.cilium_image_settings }} \
+            ${{ steps.downgrade-default-vars.outputs.cilium_install_defaults }} \
             ${{ steps.vars.outputs.cilium_install_defaults }} \
             ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
             ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }}


### PR DESCRIPTION
Almost all workflows use the helm-defaults action to bootstrap values from ciliums helm charts. Clustermesh upgrade partially uses these (only for cluster 2). To make things more consistent, and to allow for changing default configuration across all workflows, this adds the helm-default cilium_install_defaults to net-perf-gke and test-clustermesh-upgrade.
