### PR TITLE
cilium-dbg: fix exported command name

### DIFF
--- a/cilium-dbg/cmd/encrypt.go
+++ b/cilium-dbg/cmd/encrypt.go
@@ -7,12 +7,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// CncryptCmd represents the encrypt command
-var CncryptCmd = &cobra.Command{
+// EncryptCmd represents the encrypt command
+var EncryptCmd = &cobra.Command{
 	Use:   "encrypt",
 	Short: "Manage transparent encryption",
 }
 
 func init() {
-	RootCmd.AddCommand(CncryptCmd)
+	RootCmd.AddCommand(EncryptCmd)
 }

--- a/cilium-dbg/cmd/encrypt_flush.go
+++ b/cilium-dbg/cmd/encrypt_flush.go
@@ -249,6 +249,6 @@ func init() {
 	encryptFlushCmd.Flags().Uint8Var(&spiToFilter, spiFlagName, 0, "Only delete states and policies with this SPI. If multiple filters are used, they all apply")
 	encryptFlushCmd.Flags().StringVar(&nodeIDParam, nodeIDFlagName, "", "Only delete states and policies with this node ID. Decimal or hexadecimal (0x) format. If multiple filters are used, they all apply")
 	encryptFlushCmd.Flags().BoolVar(&cleanStale, staleFlagName, false, "Delete stale states and policies based on the current node ID map content")
-	CncryptCmd.AddCommand(encryptFlushCmd)
+	EncryptCmd.AddCommand(encryptFlushCmd)
 	command.AddOutputOption(encryptFlushCmd)
 }

--- a/cilium-dbg/cmd/encrypt_status.go
+++ b/cilium-dbg/cmd/encrypt_status.go
@@ -51,7 +51,7 @@ var encryptStatusCmd = &cobra.Command{
 }
 
 func init() {
-	CncryptCmd.AddCommand(encryptStatusCmd)
+	EncryptCmd.AddCommand(encryptStatusCmd)
 	command.AddOutputOption(encryptStatusCmd)
 }
 


### PR DESCRIPTION
The encrypt command is currently exported as CncryptCmd due to a typo by yours truly.

Fixes: 447c911a8e ("cilium: export intermediate cobra.Commands")
