### PR TITLE
Rename rev_nat_id to svc_id

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -968,7 +968,7 @@ struct ct_entry {
 	      reserved2:1,	/* unused since v1.14 */
 	      from_tunnel:1,	/* Connection is over tunnel */
 	      reserved3:5;
-	__u16 rev_nat_index;
+	__u16 svc_id;
 	/* In the kernel ifindex is u32, so we need to check in cilium-agent
 	 * that ifindex of a NodePort device is <= MAX(u16).
 	 * Unused when HAVE_FIB_INDEX is available.
@@ -1007,7 +1007,7 @@ struct lb6_service {
 		__u32 l7_lb_proxy_port;	/* In host byte order, only when flags2 && SVC_FLAG_L7LOADBALANCER */
 	};
 	__u16 count;
-	__u16 rev_nat_index;
+	__u16 svc_id;
 	__u8 flags;
 	__u8 flags2;
 	__u8 pad[2];
@@ -1045,7 +1045,7 @@ struct ipv6_revnat_tuple {
 struct ipv6_revnat_entry {
 	union v6addr address;
 	__be16 port;
-	__u16 rev_nat_index;
+	__u16 svc_id;
 };
 
 struct lb4_key {
@@ -1067,7 +1067,7 @@ struct lb4_service {
 	 * slots (otherwise zero).
 	 */
 	__u16 count;
-	__u16 rev_nat_index;	/* Reverse NAT ID in lb4_reverse_nat */
+	__u16 svc_id;	/* Reverse NAT ID in lb4_reverse_nat */
 	__u8 flags;
 	__u8 flags2;
 	__u8  pad[2];
@@ -1104,7 +1104,7 @@ struct ipv4_revnat_tuple {
 struct ipv4_revnat_entry {
 	__be32 address;
 	__be16 port;
-	__u16 rev_nat_index;
+	__u16 svc_id;
 };
 
 union lb4_affinity_client_id {
@@ -1114,7 +1114,7 @@ union lb4_affinity_client_id {
 
 struct lb4_affinity_key {
 	union lb4_affinity_client_id client_id;
-	__u16 rev_nat_id;
+	__u16 svc_id;
 	__u8 netns_cookie:1,
 	     reserved:7;
 	__u8 pad1;
@@ -1128,7 +1128,7 @@ union lb6_affinity_client_id {
 
 struct lb6_affinity_key {
 	union lb6_affinity_client_id client_id;
-	__u16 rev_nat_id;
+	__u16 svc_id;
 	__u8 netns_cookie:1,
 	     reserved:7;
 	__u8 pad1;
@@ -1143,12 +1143,12 @@ struct lb_affinity_val {
 
 struct lb_affinity_match {
 	__u32 backend_id;
-	__u16 rev_nat_id;
+	__u16 svc_id;
 	__u16 pad;
 } __packed;
 
 struct ct_state {
-	__u16 rev_nat_index;
+	__u16 svc_id;
 #ifndef DISABLE_LOOPBACK_LB
 	__u16 loopback:1,
 #else
@@ -1183,14 +1183,14 @@ static __always_inline bool ct_state_is_from_l7lb(const struct ct_state *ct_stat
 
 struct lb4_src_range_key {
 	struct bpf_lpm_trie_key lpm_key;
-	__u16 rev_nat_id;
+	__u16 svc_id;
 	__u16 pad;
 	__u32 addr;
 };
 
 struct lb6_src_range_key {
 	struct bpf_lpm_trie_key lpm_key;
-	__u16 rev_nat_id;
+	__u16 svc_id;
 	__u16 pad;
 	union v6addr addr;
 };

--- a/bpf/lib/dbg.h
+++ b/bpf/lib/dbg.h
@@ -62,7 +62,7 @@ enum {
 				 * arg2: direction
 				 * arg3: scope
 				 */
-	DBG_CT_CREATED4,        /* arg1: (unused << 16) | rev_nat_index
+	DBG_CT_CREATED4,        /* arg1: (unused << 16) | svc_id
 				 * arg2: src sec-id
 				 * arg3: unused
 				 */
@@ -74,7 +74,7 @@ enum {
 				 * arg2: direction
 				 * arg3: scope
 				 */
-	DBG_CT_CREATED6,        /* arg1: (unused << 16) | rev_nat_index
+	DBG_CT_CREATED6,        /* arg1: (unused << 16) | svc_id
 				 * arg2: src sec-id
 				 * arg3: unused
 				 */
@@ -101,8 +101,8 @@ enum {
 				 * arg2: identity
 				 * arg3: unused
 				 */
-	DBG_LB_STALE_CT,	/* arg1: svc rev_nat_id
-				 * arg2: stale CT rev_nat_id
+	DBG_LB_STALE_CT,	/* arg1: svc svc_id
+				 * arg2: stale CT svc_id
 				 * arg3: unused
 				 */
 	DBG_INHERIT_IDENTITY,	/* arg1: ctx->mark

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -818,14 +818,14 @@ nodeport_rev_dnat_get_info_ipv6(struct __ctx_buff *ctx,
 {
 	struct ipv6_nat_entry *dsr_entry __maybe_unused;
 	struct ipv6_ct_tuple dsr_tuple __maybe_unused;
-	__u16 rev_nat_index = 0;
+	__u16 svc_id = 0;
 
 	if (!ct_has_nodeport_egress_entry6(get_ct_map6(tuple), tuple,
-					   &rev_nat_index, is_defined(ENABLE_DSR)))
+					   &svc_id, is_defined(ENABLE_DSR)))
 		return NULL;
 
-	if (rev_nat_index)
-		return lb6_lookup_rev_nat_entry(ctx, rev_nat_index);
+	if (svc_id)
+		return lb6_lookup_rev_nat_entry(ctx, svc_id);
 
 #ifdef ENABLE_DSR
 	dsr_tuple = *tuple;
@@ -952,7 +952,7 @@ nodeport_rev_dnat_ingress_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 		if (unlikely(ret != CTX_ACT_OK))
 			return ret;
 
-		ret = lb6_rev_nat(ctx, l4_off, ct_state.rev_nat_index,
+		ret = lb6_rev_nat(ctx, l4_off, ct_state.svc_id,
 				  &tuple);
 		if (IS_ERR(ret))
 			return ret;
@@ -1388,7 +1388,7 @@ skip_service_lookup:
 		__ipv6_ct_tuple_reverse(&tuple);
 
 		/* only match CT entries that belong to the same service: */
-		ct_state.rev_nat_index = ct_state_svc.rev_nat_index;
+		ct_state.svc_id = ct_state_svc.svc_id;
 
 		ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
 				      CT_EGRESS, SCOPE_FORWARD, CT_ENTRY_NODEPORT,
@@ -2346,14 +2346,14 @@ nodeport_rev_dnat_get_info_ipv4(struct __ctx_buff *ctx,
 {
 	struct ipv4_nat_entry *dsr_entry __maybe_unused;
 	struct ipv4_ct_tuple dsr_tuple __maybe_unused;
-	__u16 rev_nat_index = 0;
+	__u16 svc_id = 0;
 
 	if (!ct_has_nodeport_egress_entry4(get_ct_map4(tuple), tuple,
-					   &rev_nat_index, is_defined(ENABLE_DSR)))
+					   &svc_id, is_defined(ENABLE_DSR)))
 		return NULL;
 
-	if (rev_nat_index)
-		return lb4_lookup_rev_nat_entry(ctx, rev_nat_index);
+	if (svc_id)
+		return lb4_lookup_rev_nat_entry(ctx, svc_id);
 
 #ifdef ENABLE_DSR
 	dsr_tuple = *tuple;
@@ -2442,7 +2442,7 @@ nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 			      CT_ENTRY_NODEPORT, &ct_state, &trace->monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
-		ret = lb4_rev_nat(ctx, l3_off, l4_off, ct_state.rev_nat_index, false,
+		ret = lb4_rev_nat(ctx, l3_off, l4_off, ct_state.svc_id, false,
 				  &tuple, has_l4_header);
 		if (IS_ERR(ret))
 			return ret;
@@ -2947,7 +2947,7 @@ skip_service_lookup:
 		__ipv4_ct_tuple_reverse(&tuple);
 
 		/* only match CT entries that belong to the same service: */
-		ct_state.rev_nat_index = ct_state_svc.rev_nat_index;
+		ct_state.svc_id = ct_state_svc.svc_id;
 
 		/* Cache is_fragment in advance, lb4_local may invalidate ip4. */
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, is_fragment,

--- a/bpf/tests/host_only_socket_lb_test.c
+++ b/bpf/tests/host_only_socket_lb_test.c
@@ -43,7 +43,7 @@ int my_get_netns_cookie(__maybe_unused const struct bpf_sock_addr *addr)
 	.value = { \
 		.flags = SVC_FLAG_ROUTABLE, \
 		.count = 1, \
-		.rev_nat_index = 1, \
+		.svc_id = 1, \
 		.backend_id = (_beid) \
 	} \
 }

--- a/bpf/tests/lib/lb.h
+++ b/bpf/tests/lib/lb.h
@@ -3,7 +3,7 @@
 
 #ifdef ENABLE_IPV4
 static __always_inline void
-lb_v4_add_service(__be32 addr, __be16 port, __u16 backend_count, __u16 rev_nat_index)
+lb_v4_add_service(__be32 addr, __be16 port, __u16 backend_count, __u16 svc_id)
 {
 	struct lb4_key svc_key = {
 		.address = addr,
@@ -13,7 +13,7 @@ lb_v4_add_service(__be32 addr, __be16 port, __u16 backend_count, __u16 rev_nat_i
 	struct lb4_service svc_value = {
 		.count = backend_count,
 		.flags = SVC_FLAG_ROUTABLE,
-		.rev_nat_index = rev_nat_index,
+		.svc_id = svc_id,
 	};
 	map_update_elem(&LB4_SERVICES_MAP_V2, &svc_key, &svc_value, BPF_ANY);
 	/* Register with both scopes: */
@@ -25,7 +25,7 @@ lb_v4_add_service(__be32 addr, __be16 port, __u16 backend_count, __u16 rev_nat_i
 		.address = addr,
 		.port = port,
 	};
-	map_update_elem(&LB4_REVERSE_NAT_MAP, &rev_nat_index, &revnat_value, BPF_ANY);
+	map_update_elem(&LB4_REVERSE_NAT_MAP, &svc_id, &revnat_value, BPF_ANY);
 }
 
 static __always_inline void
@@ -61,7 +61,7 @@ lb_v4_add_backend(__be32 svc_addr, __be16 svc_port, __u16 backend_slot,
 #ifdef ENABLE_IPV6
 static __always_inline void
 lb_v6_add_service(const union v6addr *addr, __be16 port, __u16 backend_count,
-		  __u16 rev_nat_index)
+		  __u16 svc_id)
 {
 	struct lb6_key svc_key = {
 		.dport = port,
@@ -70,7 +70,7 @@ lb_v6_add_service(const union v6addr *addr, __be16 port, __u16 backend_count,
 	struct lb6_service svc_value = {
 		.count = backend_count,
 		.flags = SVC_FLAG_ROUTABLE,
-		.rev_nat_index = rev_nat_index,
+		.svc_id = svc_id,
 	};
 
 	memcpy(&svc_key.address, addr, sizeof(*addr));
@@ -84,7 +84,7 @@ lb_v6_add_service(const union v6addr *addr, __be16 port, __u16 backend_count,
 	};
 
 	memcpy(&revnat_value.address, addr, sizeof(*addr));
-	map_update_elem(&LB6_REVERSE_NAT_MAP, &rev_nat_index, &revnat_value, BPF_ANY);
+	map_update_elem(&LB6_REVERSE_NAT_MAP, &svc_id, &revnat_value, BPF_ANY);
 }
 
 static __always_inline void

--- a/bpf/tests/session_affinity_test.c
+++ b/bpf/tests/session_affinity_test.c
@@ -46,7 +46,7 @@ struct {
 #define BACKEND_IP2 IPV4(10, 0, 3, 1)
 #define FRONTEND_PORT bpf_htons(80)
 #define BACKEND_PORT bpf_htons(8080)
-#define REV_NAT_INDEX 123
+#define SERVICE_ID 123
 #define BACKEND_ID1 7
 #define BACKEND_ID2 42
 
@@ -98,7 +98,7 @@ static __always_inline int craft_packet(struct __ctx_buff *ctx)
 		.value = {						\
 			.flags = SVC_FLAG_ROUTABLE | SVC_FLAG_AFFINITY, \
 			.count = 2,					\
-			.rev_nat_index = REV_NAT_INDEX,			\
+			.svc_id = SERVICE_ID,			\
 			.backend_id = (_beid)				\
 		}							\
 	}
@@ -133,7 +133,7 @@ int test1_setup(struct __ctx_buff *ctx)
 	};
 	struct lb4_affinity_key aff_key = {
 		.client_id = {.client_ip = CLIENT_IP},
-		.rev_nat_id = REV_NAT_INDEX,
+		.svc_id = SERVICE_ID,
 		.netns_cookie = 0x0,
 	};
 	struct lb_affinity_val aff_value = {
@@ -142,7 +142,7 @@ int test1_setup(struct __ctx_buff *ctx)
 	};
 	struct lb_affinity_match match_key = {
 		.backend_id = BACKEND_ID2,
-		.rev_nat_id = REV_NAT_INDEX,
+		.svc_id = SERVICE_ID,
 	};
 	int ret;
 	int zero = 0;

--- a/bpf/tests/skip_tunnel_nodeport_revnat.c
+++ b/bpf/tests/skip_tunnel_nodeport_revnat.c
@@ -207,11 +207,11 @@ setup(struct __ctx_buff *ctx, bool v4, bool flag_skip_tunnel)
 		 * The conntrack entry is used to understand that the packet being received is a reply.
 		 * This will put the packet to where it needs to be in the revDNAT stack.
 		 * NodePort related traffic requires that the CT state is flagged with the node_port field
-		 * and that a rev_nat_index is set.
+		 * and that a svc_id is set.
 		 */
 		struct ct_state ct_state = {
 			.node_port = true,
-			.rev_nat_index = 123,
+			.svc_id = 123,
 		};
 
 		/*
@@ -245,7 +245,7 @@ setup(struct __ctx_buff *ctx, bool v4, bool flag_skip_tunnel)
 
 		struct ct_state ct_state = {
 			.node_port = true,
-			.rev_nat_index = 123,
+			.svc_id = 123,
 		};
 		ipv6_ct_tuple_swap_addrs(&otuple);
 		ct_create6(get_ct_map6(&otuple), NULL, &otuple, ctx, CT_EGRESS, &ct_state, NULL);

--- a/cilium-dbg/cmd/bpf_lb_list.go
+++ b/cilium-dbg/cmd/bpf_lb_list.go
@@ -88,7 +88,7 @@ func dumpSVC(serviceList map[string][]string) {
 		svc := svcKey.String()
 		svcKey = svcKey.ToHost()
 		backendSlot := svcKey.GetBackendSlot()
-		revNATID := svcVal.GetRevNat()
+		ServiceID := svcVal.GetSvcID()
 		backendID := svcVal.GetBackendID()
 		flags := loadbalancer.ServiceFlags(svcVal.GetFlags())
 
@@ -101,7 +101,7 @@ func dumpSVC(serviceList map[string][]string) {
 			if flags.IsL7LB() {
 				extra = fmt.Sprintf("(L7LB Proxy Port: %d)", byteorder.NetworkToHost16(uint16(svcVal.GetBackendID())))
 			}
-			entry = fmt.Sprintf("%s:%d (%d) (%d) [%s] %s", ip, 0, revNATID, backendSlot, flags, extra)
+			entry = fmt.Sprintf("%s:%d (%d) (%d) [%s] %s", ip, 0, ServiceID, backendSlot, flags, extra)
 		} else if backend, found := backendMap[backendID]; !found {
 			entry = fmt.Sprintf("backend %d not found", backendID)
 		} else {
@@ -110,7 +110,7 @@ func dumpSVC(serviceList map[string][]string) {
 				fmtStr = "[%s]:%d (%d) (%d)"
 			}
 			entry = fmt.Sprintf(fmtStr, backend.GetAddress(),
-				backend.GetPort(), revNATID, backendSlot)
+				backend.GetPort(), ServiceID, backendSlot)
 		}
 
 		serviceList[svc] = append(serviceList[svc], entry)

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -544,7 +544,7 @@ type CtEntry struct {
 	Lifetime  uint32 `align:"lifetime"`
 	Flags     uint16 `align:"rx_closing"`
 	// RevNAT is in network byte order
-	RevNAT           uint16 `align:"rev_nat_index"`
+	RevNAT           uint16 `align:"svc_id"`
 	IfIndex          uint16 `align:"ifindex"`
 	TxFlagsSeen      uint8  `align:"tx_flags_seen"`
 	RxFlagsSeen      uint8  `align:"rx_flags_seen"`

--- a/pkg/maps/lbmap/affinity.go
+++ b/pkg/maps/lbmap/affinity.go
@@ -67,7 +67,7 @@ func initAffinity(params InitParams) {
 
 type AffinityMatchKey struct {
 	BackendID loadbalancer.BackendID `align:"backend_id"`
-	RevNATID  uint16                 `align:"rev_nat_id"`
+	ServiceID uint16                 `align:"svc_id"`
 	Pad       uint16                 `align:"pad"`
 }
 
@@ -76,17 +76,17 @@ type AffinityMatchValue struct {
 }
 
 // NewAffinityMatchKey creates the AffinityMatch key
-func NewAffinityMatchKey(revNATID uint16, backendID loadbalancer.BackendID) *AffinityMatchKey {
+func NewAffinityMatchKey(ServiceID uint16, backendID loadbalancer.BackendID) *AffinityMatchKey {
 	return &AffinityMatchKey{
 		BackendID: backendID,
-		RevNATID:  revNATID,
+		ServiceID: ServiceID,
 	}
 }
 
 // String converts the key into a human readable string format
 func (k *AffinityMatchKey) String() string {
 	kHost := k.ToHost()
-	return fmt.Sprintf("%d %d", kHost.BackendID, kHost.RevNATID)
+	return fmt.Sprintf("%d %d", kHost.BackendID, kHost.ServiceID)
 }
 
 func (k *AffinityMatchKey) New() bpf.MapKey { return &AffinityMatchKey{} }
@@ -98,23 +98,23 @@ func (v *AffinityMatchValue) New() bpf.MapValue { return &AffinityMatchValue{} }
 // ToNetwork returns the key in the network byte order
 func (k *AffinityMatchKey) ToNetwork() *AffinityMatchKey {
 	n := *k
-	// For some reasons rev_nat_index is stored in network byte order in
+	// For some reasons svc_id is stored in network byte order in
 	// the SVC BPF maps
-	n.RevNATID = byteorder.HostToNetwork16(n.RevNATID)
+	n.ServiceID = byteorder.HostToNetwork16(n.ServiceID)
 	return &n
 }
 
 // ToHost returns the key in the host byte order
 func (k *AffinityMatchKey) ToHost() *AffinityMatchKey {
 	h := *k
-	h.RevNATID = byteorder.NetworkToHost16(h.RevNATID)
+	h.ServiceID = byteorder.NetworkToHost16(h.ServiceID)
 	return &h
 }
 
 // Affinity4Key is the Go representation of lb4_affinity_key
 type Affinity4Key struct {
 	ClientID    uint64 `align:"client_id"`
-	RevNATID    uint16 `align:"rev_nat_id"`
+	ServiceID   uint16 `align:"svc_id"`
 	NetNSCookie uint8  `align:"netns_cookie"`
 	Pad1        uint8  `align:"pad1"`
 	Pad2        uint32 `align:"pad2"`
@@ -123,7 +123,7 @@ type Affinity4Key struct {
 // Affinity6Key is the Go representation of lb6_affinity_key
 type Affinity6Key struct {
 	ClientID    types.IPv6 `align:"client_id"`
-	RevNATID    uint16     `align:"rev_nat_id"`
+	ServiceID   uint16     `align:"svc_id"`
 	NetNSCookie uint8      `align:"netns_cookie"`
 	Pad1        uint8      `align:"pad1"`
 	Pad2        uint32     `align:"pad2"`
@@ -138,14 +138,14 @@ type AffinityValue struct {
 
 // String converts the key into a human readable string format.
 func (k *Affinity4Key) String() string {
-	return fmt.Sprintf("%d %d %d", k.ClientID, k.NetNSCookie, k.RevNATID)
+	return fmt.Sprintf("%d %d %d", k.ClientID, k.NetNSCookie, k.ServiceID)
 }
 
 func (k *Affinity4Key) New() bpf.MapKey { return &Affinity4Key{} }
 
 // String converts the key into a human readable string format.
 func (k *Affinity6Key) String() string {
-	return fmt.Sprintf("%d %d %d", k.ClientID, k.NetNSCookie, k.RevNATID)
+	return fmt.Sprintf("%d %d %d", k.ClientID, k.NetNSCookie, k.ServiceID)
 }
 
 func (k *Affinity6Key) New() bpf.MapKey { return &Affinity6Key{} }

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -293,7 +293,7 @@ func (k *Service4Key) ToHost() ServiceKey {
 type Service4Value struct {
 	BackendID uint32    `align:"$union0"`
 	Count     uint16    `align:"count"`
-	RevNat    uint16    `align:"rev_nat_index"`
+	SvcID     uint16    `align:"svc_id"`
 	Flags     uint8     `align:"flags"`
 	Flags2    uint8     `align:"flags2"`
 	Pad       pad2uint8 `align:"pad"`
@@ -303,14 +303,14 @@ func (s *Service4Value) New() bpf.MapValue { return &Service4Value{} }
 
 func (s *Service4Value) String() string {
 	sHost := s.ToHost().(*Service4Value)
-	return fmt.Sprintf("%d %d (%d) [0x%x 0x%x]", sHost.BackendID, sHost.Count, sHost.RevNat, sHost.Flags, sHost.Flags2)
+	return fmt.Sprintf("%d %d (%d) [0x%x 0x%x]", sHost.BackendID, sHost.Count, sHost.SvcID, sHost.Flags, sHost.Flags2)
 }
 
 func (s *Service4Value) SetCount(count int)   { s.Count = uint16(count) }
 func (s *Service4Value) GetCount() int        { return int(s.Count) }
-func (s *Service4Value) SetRevNat(id int)     { s.RevNat = uint16(id) }
-func (s *Service4Value) GetRevNat() int       { return int(s.RevNat) }
-func (s *Service4Value) RevNatKey() RevNatKey { return &RevNat4Key{s.RevNat} }
+func (s *Service4Value) SetSvcID(id int)      { s.SvcID = uint16(id) }
+func (s *Service4Value) GetSvcID() int        { return int(s.SvcID) }
+func (s *Service4Value) RevNatKey() RevNatKey { return &RevNat4Key{s.SvcID} }
 func (s *Service4Value) SetFlags(flags uint16) {
 	s.Flags = uint8(flags & 0xff)
 	s.Flags2 = uint8(flags >> 8)
@@ -341,14 +341,14 @@ func (s *Service4Value) GetBackendID() loadbalancer.BackendID {
 
 func (s *Service4Value) ToNetwork() ServiceValue {
 	n := *s
-	n.RevNat = byteorder.HostToNetwork16(n.RevNat)
+	n.SvcID = byteorder.HostToNetwork16(n.SvcID)
 	return &n
 }
 
 // ToHost converts Service4Value to host byte order.
 func (s *Service4Value) ToHost() ServiceValue {
 	h := *s
-	h.RevNat = byteorder.NetworkToHost16(h.RevNat)
+	h.SvcID = byteorder.NetworkToHost16(h.SvcID)
 	return &h
 }
 
@@ -554,9 +554,9 @@ type SockRevNat4Key struct {
 
 // SockRevNat4Value is an entry in the reverse NAT sock map.
 type SockRevNat4Value struct {
-	Address     types.IPv4 `align:"address"`
-	Port        int16      `align:"port"`
-	RevNatIndex uint16     `align:"rev_nat_index"`
+	Address   types.IPv4 `align:"address"`
+	Port      int16      `align:"port"`
+	ServiceID uint16     `align:"svc_id"`
 }
 
 func (k *SockRevNat4Key) Map() *bpf.Map { return SockRevNat4Map }
@@ -579,7 +579,7 @@ func (k *SockRevNat4Key) New() bpf.MapKey { return &SockRevNat4Key{} }
 
 // String converts the value into a human readable string format.
 func (v *SockRevNat4Value) String() string {
-	return fmt.Sprintf("[%s]:%d, %d", v.Address, v.Port, v.RevNatIndex)
+	return fmt.Sprintf("[%s]:%d, %d", v.Address, v.Port, v.ServiceID)
 }
 
 func (v *SockRevNat4Value) New() bpf.MapValue { return &SockRevNat4Value{} }

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -192,7 +192,7 @@ func (k *Service6Key) ToHost() ServiceKey {
 type Service6Value struct {
 	BackendID uint32    `align:"$union0"`
 	Count     uint16    `align:"count"`
-	RevNat    uint16    `align:"rev_nat_index"`
+	SvcID     uint16    `align:"svc_id"`
 	Flags     uint8     `align:"flags"`
 	Flags2    uint8     `align:"flags2"`
 	Pad       pad2uint8 `align:"pad"`
@@ -202,14 +202,14 @@ func (s *Service6Value) New() bpf.MapValue { return &Service6Value{} }
 
 func (s *Service6Value) String() string {
 	sHost := s.ToHost().(*Service6Value)
-	return fmt.Sprintf("%d %d (%d) [0x%x 0x%x]", sHost.BackendID, sHost.Count, sHost.RevNat, sHost.Flags, sHost.Flags2)
+	return fmt.Sprintf("%d %d (%d) [0x%x 0x%x]", sHost.BackendID, sHost.Count, sHost.SvcID, sHost.Flags, sHost.Flags2)
 }
 
 func (s *Service6Value) SetCount(count int)   { s.Count = uint16(count) }
 func (s *Service6Value) GetCount() int        { return int(s.Count) }
-func (s *Service6Value) SetRevNat(id int)     { s.RevNat = uint16(id) }
-func (s *Service6Value) GetRevNat() int       { return int(s.RevNat) }
-func (s *Service6Value) RevNatKey() RevNatKey { return &RevNat6Key{s.RevNat} }
+func (s *Service6Value) SetSvcID(id int)      { s.SvcID = uint16(id) }
+func (s *Service6Value) GetSvcID() int        { return int(s.SvcID) }
+func (s *Service6Value) RevNatKey() RevNatKey { return &RevNat6Key{s.SvcID} }
 func (s *Service6Value) SetFlags(flags uint16) {
 	s.Flags = uint8(flags & 0xff)
 	s.Flags2 = uint8(flags >> 8)
@@ -239,14 +239,14 @@ func (s *Service6Value) GetBackendID() loadbalancer.BackendID {
 
 func (s *Service6Value) ToNetwork() ServiceValue {
 	n := *s
-	n.RevNat = byteorder.HostToNetwork16(n.RevNat)
+	n.SvcID = byteorder.HostToNetwork16(n.SvcID)
 	return &n
 }
 
 // ToHost converts Service6Value to host byte order.
 func (s *Service6Value) ToHost() ServiceValue {
 	h := *s
-	h.RevNat = byteorder.NetworkToHost16(h.RevNat)
+	h.SvcID = byteorder.NetworkToHost16(h.SvcID)
 	return &h
 }
 
@@ -454,9 +454,9 @@ const SizeofSockRevNat6Key = int(unsafe.Sizeof(SockRevNat6Key{}))
 
 // SockRevNat6Value is an entry in the reverse NAT sock map.
 type SockRevNat6Value struct {
-	address     types.IPv6 `align:"address"`
-	port        int16      `align:"port"`
-	revNatIndex uint16     `align:"rev_nat_index"`
+	address types.IPv6 `align:"address"`
+	port    int16      `align:"port"`
+	svcID   uint16     `align:"svc_id"`
 }
 
 // SizeofSockRevNat6Value is the size of type SockRevNat6Value.
@@ -484,7 +484,7 @@ func (k *SockRevNat6Key) New() bpf.MapKey { return &SockRevNat6Key{} }
 
 // String converts the value into a human readable string format.
 func (v *SockRevNat6Value) String() string {
-	return fmt.Sprintf("[%s]:%d, %d", v.address, v.port, v.revNatIndex)
+	return fmt.Sprintf("[%s]:%d, %d", v.address, v.port, v.svcID)
 }
 
 func (v *SockRevNat6Value) New() bpf.MapValue { return &SockRevNat6Value{} }

--- a/pkg/maps/lbmap/maglev.go
+++ b/pkg/maps/lbmap/maglev.go
@@ -104,7 +104,7 @@ func deleteMapIfMNotMatch(mapName string, tableSize uint32) (bool, error) {
 
 // updateMaglevTable creates a new inner Maglev map containing the given backend IDs
 // and sets it as the active lookup table for the given service ID.
-func updateMaglevTable(ipv6 bool, revNATID uint16, backendIDs []loadbalancer.BackendID) error {
+func updateMaglevTable(ipv6 bool, ServiceID uint16, backendIDs []loadbalancer.BackendID) error {
 	outer := maglevOuter4Map
 	if ipv6 {
 		outer = maglevOuter6Map
@@ -124,7 +124,7 @@ func updateMaglevTable(ipv6 bool, revNATID uint16, backendIDs []loadbalancer.Bac
 		return fmt.Errorf("updating backends: %w", err)
 	}
 
-	if err := outer.UpdateService(revNATID, inner); err != nil {
+	if err := outer.UpdateService(ServiceID, inner); err != nil {
 		return fmt.Errorf("updating service: %w", err)
 	}
 
@@ -132,13 +132,13 @@ func updateMaglevTable(ipv6 bool, revNATID uint16, backendIDs []loadbalancer.Bac
 }
 
 // deleteMaglevTable deletes the inner Maglev lookup table for the given service ID.
-func deleteMaglevTable(ipv6 bool, revNATID uint16) error {
+func deleteMaglevTable(ipv6 bool, ServiceID uint16) error {
 	outerMap := maglevOuter4Map
 	if ipv6 {
 		outerMap = maglevOuter6Map
 	}
 
-	outerKey := MaglevOuterKey{RevNatID: revNATID}
+	outerKey := MaglevOuterKey{ServiceID: ServiceID}
 	if err := outerMap.Delete(outerKey.toNetwork()); err != nil {
 		return err
 	}

--- a/pkg/maps/lbmap/maglev_outer_map.go
+++ b/pkg/maps/lbmap/maglev_outer_map.go
@@ -20,21 +20,21 @@ type MaglevOuterMap struct {
 // UpdateService sets the given inner map to be the Maglev lookup table for
 // the service with the given id.
 func (m *MaglevOuterMap) UpdateService(id uint16, inner *MaglevInnerMap) error {
-	key := MaglevOuterKey{RevNatID: id}.toNetwork()
+	key := MaglevOuterKey{ServiceID: id}.toNetwork()
 	val := MaglevOuterVal{FD: uint32(inner.FD())}
 	return m.Map.Update(key, val, 0)
 }
 
 // MaglevOuterKey is the key of a maglev outer map.
 type MaglevOuterKey struct {
-	RevNatID uint16
+	ServiceID uint16
 }
 
 // toNetwork converts a maglev outer map's key to network byte order.
 // The key is in network byte order in the eBPF maps.
 func (k MaglevOuterKey) toNetwork() MaglevOuterKey {
 	return MaglevOuterKey{
-		RevNatID: byteorder.HostToNetwork16(k.RevNatID),
+		ServiceID: byteorder.HostToNetwork16(k.ServiceID),
 	}
 }
 
@@ -102,7 +102,7 @@ func (m *MaglevOuterMap) TableSize() (uint32, error) {
 
 // GetService gets the maglev backend lookup table for the given service id.
 func (m *MaglevOuterMap) GetService(id uint16) (*MaglevInnerMap, error) {
-	key := MaglevOuterKey{RevNatID: id}.toNetwork()
+	key := MaglevOuterKey{ServiceID: id}.toNetwork()
 	var val MaglevOuterVal
 
 	err := m.Lookup(key, &val)
@@ -148,9 +148,9 @@ func (m *MaglevOuterMap) DumpBackends(ipv6 bool) (map[string][]string, error) {
 
 		// The service ID is read from the map in network byte order,
 		// convert to host byte order before displaying to the user.
-		key.RevNatID = byteorder.NetworkToHost16(key.RevNatID)
+		key.ServiceID = byteorder.NetworkToHost16(key.ServiceID)
 
-		out[fmt.Sprintf("[%d]/%s", key.RevNatID, which)] = []string{backends}
+		out[fmt.Sprintf("[%d]/%s", key.ServiceID, which)] = []string{backends}
 	}
 
 	return out, nil

--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -66,10 +66,10 @@ type ServiceValue interface {
 	GetCount() int
 
 	// Set reverse NAT identifier
-	SetRevNat(int)
+	SetSvcID(int)
 
 	// Get reverse NAT identifier
-	GetRevNat() int
+	GetSvcID() int
 
 	// Set flags
 	SetFlags(uint16)
@@ -180,7 +180,7 @@ func svcFrontend(svcKey ServiceKey, svcValue ServiceValue) *loadbalancer.L3n4Add
 	feL3n4Addr := loadbalancer.NewL3n4Addr(loadbalancer.NONE, feAddrCluster, svcKey.GetPort(), svcKey.GetScope())
 	feL3n4AddrID := &loadbalancer.L3n4AddrID{
 		L3n4Addr: *feL3n4Addr,
-		ID:       loadbalancer.ID(svcValue.GetRevNat()),
+		ID:       loadbalancer.ID(svcValue.GetSvcID()),
 	}
 	return feL3n4AddrID
 }

--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -394,7 +394,7 @@ func (n *DebugMsg) Message(linkMonitor getters.LinkGetter) string {
 	case DbgIPIDMapSucceed6:
 		return fmt.Sprintf("Successfully mapped addr.p4=[::%s] to identity=%d", ip6Str(n.Arg1), n.Arg2)
 	case DbgLbStaleCT:
-		return fmt.Sprintf("Stale CT entry found stale_ct.rev_nat_id=%d, svc.rev_nat_id=%d", n.Arg2, n.Arg1)
+		return fmt.Sprintf("Stale CT entry found stale_ct.svc_id=%d, svc.svc_id=%d", n.Arg2, n.Arg1)
 	case DbgInheritIdentity:
 		return fmt.Sprintf("Inheriting identity=%d from stack", n.Arg1)
 	case DbgSkLookup4:

--- a/pkg/testutils/mockmaps/lbmap.go
+++ b/pkg/testutils/mockmaps/lbmap.go
@@ -183,33 +183,33 @@ func (m *LBMockMap) DumpBackendMaps() ([]*lb.Backend, error) {
 	return list, nil
 }
 
-func (m *LBMockMap) AddAffinityMatch(revNATID uint16, backendID lb.BackendID) error {
+func (m *LBMockMap) AddAffinityMatch(ServiceID uint16, backendID lb.BackendID) error {
 	m.Lock()
 	defer m.Unlock()
-	if _, ok := m.AffinityMatch[revNATID]; !ok {
-		m.AffinityMatch[revNATID] = map[lb.BackendID]struct{}{}
+	if _, ok := m.AffinityMatch[ServiceID]; !ok {
+		m.AffinityMatch[ServiceID] = map[lb.BackendID]struct{}{}
 	}
-	if _, ok := m.AffinityMatch[revNATID][backendID]; ok {
+	if _, ok := m.AffinityMatch[ServiceID][backendID]; ok {
 		return fmt.Errorf("Backend %d already exists in %d affinity map",
-			backendID, revNATID)
+			backendID, ServiceID)
 	}
-	m.AffinityMatch[revNATID][backendID] = struct{}{}
+	m.AffinityMatch[ServiceID][backendID] = struct{}{}
 	return nil
 }
 
-func (m *LBMockMap) DeleteAffinityMatch(revNATID uint16, backendID lb.BackendID) error {
+func (m *LBMockMap) DeleteAffinityMatch(ServiceID uint16, backendID lb.BackendID) error {
 	m.Lock()
 	defer m.Unlock()
-	if _, ok := m.AffinityMatch[revNATID]; !ok {
-		return fmt.Errorf("Affinity map for %d does not exist", revNATID)
+	if _, ok := m.AffinityMatch[ServiceID]; !ok {
+		return fmt.Errorf("Affinity map for %d does not exist", ServiceID)
 	}
-	if _, ok := m.AffinityMatch[revNATID][backendID]; !ok {
+	if _, ok := m.AffinityMatch[ServiceID][backendID]; !ok {
 		return fmt.Errorf("Backend %d does not exist in %d affinity map",
-			backendID, revNATID)
+			backendID, ServiceID)
 	}
-	delete(m.AffinityMatch[revNATID], backendID)
-	if len(m.AffinityMatch[revNATID]) == 0 {
-		delete(m.AffinityMatch, revNATID)
+	delete(m.AffinityMatch[ServiceID], backendID)
+	if len(m.AffinityMatch[ServiceID]) == 0 {
+		delete(m.AffinityMatch, ServiceID)
 	}
 	return nil
 }
@@ -218,15 +218,15 @@ func (m *LBMockMap) DumpAffinityMatches() (datapathTypes.BackendIDByServiceIDSet
 	return m.AffinityMatch, nil
 }
 
-func (m *LBMockMap) UpdateSourceRanges(revNATID uint16, prevRanges []*cidr.CIDR,
+func (m *LBMockMap) UpdateSourceRanges(ServiceID uint16, prevRanges []*cidr.CIDR,
 	ranges []*cidr.CIDR, ipv6 bool) error {
 	m.Lock()
 	defer m.Unlock()
 
 	if len(prevRanges) == 0 {
-		m.SourceRanges[revNATID] = []*cidr.CIDR{}
+		m.SourceRanges[ServiceID] = []*cidr.CIDR{}
 	}
-	if len(prevRanges) != len(m.SourceRanges[revNATID]) {
+	if len(prevRanges) != len(m.SourceRanges[ServiceID]) {
 		return fmt.Errorf("Inconsistent view of source ranges")
 	}
 	srcRanges := []*cidr.CIDR{}
@@ -236,7 +236,7 @@ func (m *LBMockMap) UpdateSourceRanges(revNATID uint16, prevRanges []*cidr.CIDR,
 		}
 		srcRanges = append(srcRanges, cidr)
 	}
-	m.SourceRanges[revNATID] = srcRanges
+	m.SourceRanges[ServiceID] = srcRanges
 
 	return nil
 }


### PR DESCRIPTION
(Cilium Developer Summit)
> Aleks: I need help understanding eBPF code. What is rev_nat_id? It seems to be set to svc_id?
> Martynas: Yes, rev_nat_id is always set to svc_id. In fact, it is the same.
> Aleks: That's surprising and confusing.
> Martynas: Correct, feel free to send a PR renaming rev_nat_id to svc_id.

This is the PR.

```release-note
Rename rev_nat_id to svc_id
```
