### PR TITLE
test/verifier: Sort BPF program names for stable output

### DIFF
--- a/test/verifier/verifier_test.go
+++ b/test/verifier/verifier_test.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -248,7 +249,14 @@ func TestVerifier(t *testing.T) {
 
 					// Print verifier stats appearing on the last line of the log, e.g.
 					// 'processed 12248 insns (limit 1000000) ...'.
-					for n, p := range coll.Programs {
+					// Sort by program names for stable output.
+					names := make([]string, 0, len(coll.Programs))
+					for n := range coll.Programs {
+						names = append(names, n)
+					}
+					sort.Strings(names)
+					for _, n := range names {
+						p := coll.Programs[n]
 						p.VerifierLog = strings.TrimRight(p.VerifierLog, "\n")
 						// Offset points at the last newline, increment by 1 to skip it.
 						// Turn a -1 into a 0 if there are no newlines in the log.


### PR DESCRIPTION
Repeated runs of `go test ./test/verifier` print program complexity in random order. Sorting by external wrappers is not feasibly, because there are groups (each object file compiled with a certain set of defines) that need to be sorted individually. Make the output stable.