### PR TITLE
cilium-health: Fix broken retry loop in `cilium-health-ep` controller

### DIFF
--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -23,6 +23,11 @@ import (
 
 var healthControllerGroup = controller.NewGroup("cilium-health")
 
+const (
+	controllerInterval    = 60 * time.Second
+	successfulPingTimeout = 3 * time.Minute
+)
+
 func (d *Daemon) initHealth(spec *healthApi.Spec, cleaner *daemonCleanup, sysctl sysctl.Sysctl) {
 	// Launch cilium-health in the same process (and namespace) as cilium.
 	log.Info("Launching Cilium health daemon")
@@ -53,6 +58,7 @@ func (d *Daemon) initHealth(spec *healthApi.Spec, cleaner *daemonCleanup, sysctl
 
 	// Wait for the API, then launch the controller
 	var client *health.Client
+	var lastSuccessfulPing time.Time
 
 	controller.NewManager().UpdateController(
 		defaults.HealthEPName,
@@ -64,9 +70,17 @@ func (d *Daemon) initHealth(spec *healthApi.Spec, cleaner *daemonCleanup, sysctl
 				if client != nil {
 					err = client.PingEndpoint()
 				}
-				// On the first initialization, or on
-				// error, restart the health EP.
-				if client == nil || err != nil {
+
+				// Reset lastSuccessfulPing if err is nil, which happens
+				// a) if we successfully pinged the endpoint above
+				// b) on first initialization, i.e. we have not attempted to ping yet
+				if err == nil {
+					lastSuccessfulPing = time.Now()
+				}
+
+				// On the first initialization (client == nil), or if we have not
+				// successfully pinged it since successfulPingTimeout, restart the health EP.
+				if client == nil || time.Since(lastSuccessfulPing) > successfulPingTimeout {
 					var launchErr error
 					d.cleanupHealthEndpoint()
 
@@ -98,7 +112,7 @@ func (d *Daemon) initHealth(spec *healthApi.Spec, cleaner *daemonCleanup, sysctl
 				d.cleanupHealthEndpoint()
 				return err
 			},
-			RunInterval: 60 * time.Second,
+			RunInterval: controllerInterval,
 			Context:     d.ctx,
 		},
 	)


### PR DESCRIPTION
This commit fixes a bug in the `cilium-health-ep` controller restart logic where it did not give the cilium-health endpoint enough time to startup before it was re-created.

For context, the `cilium-health-ep` performs two tasks:

  1. Launch the cilium-health endpoint when the controller is started for the first time.
  2. Ping the cilium-health endpoint, and if it does not reply, destroy and re-create it.

The controller has a `RunInterval` of 60 seconds and a default `ErrorRetryBaseDuration` of 1 second. This means that after launching the initial cilium-health endpoint, we wait for 60 seconds before we attempt to ping it. If that ping succeeds, we then keep pinging the health endpoint every 60 seconds.

However, if a ping fails, the controller deletes the existing endpoint and creates a new one. Because the controller then also returns an error, it is immediately re-run after one second, because in the failure case a controller retries with an interval of `consecutiveErrors * ErrorRetryBaseDuration`.

This meant that after a failed ping, we deleted the unreachable endpoint, recreated a new one, and after 1s would immediately try to ping it. Because the newly launched endpoint will is unlikely to be reachable after just one second (it requires a full endpoint regeneration with BPF compilation), the `cilium-health-ep` logic would declare the still starting endpoint as dead and re-create it. This loop would continue endlessly, causing lots of unnecessary CPU churn, until enough consecutive errors have happened for the wait time between launch and the first ping to be long enough for a cilium-health endpoint to be fully regenerated.

This commit attempts to fix the logic by not immediately killing a unreachable health endpoint and instead waiting for three minutes to pass before we attempt to try again. Three minutes should hopefully be enough time for the initial endpoint regeneration to succeed.
