### PR TITLE
workflows: Debug info for key rotations

### DIFF
--- a/.github/actions/ipsec-key-rotate/action.yaml
+++ b/.github/actions/ipsec-key-rotate/action.yaml
@@ -58,7 +58,7 @@ runs:
             if [[ $keys_in_use == $exp_nb_keys ]]; then
               break
             fi
-            echo "Waiting until key rotation starts (seeing $keys_in_use keys)"
+            echo "Waiting until key rotation starts (seeing $keys_in_use keys, expected $exp_nb_keys)"
             sleep 30s
           done
 
@@ -75,6 +75,6 @@ runs:
             if [[ $keys_in_use == $exp_nb_keys ]]; then
               break
             fi
-            echo "Waiting until key rotation completes (seeing $keys_in_use keys)"
+            echo "Waiting until key rotation completes (seeing $keys_in_use keys, expected $exp_nb_keys)"
             sleep 30s
           done


### PR DESCRIPTION
During the key rotations, we compare the number of keys to the expected number to know where we are in the process (started the rotation or finished it). The expected number of keys depends on the configuration so let's print it in the logs to help debug.