### PR TITLE
workflows: Fix expected IPsec keys during rotation

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -312,7 +312,7 @@ jobs:
             exp_nb_keys=2
             # If IPv6 is disabled, we expect one key per remote node.
             # Otherwise, we expect two.
-            if [ "${{ matrix.ipv6 }}" == "false" ]; then
+            if [[ "${{ matrix.ipv6 }}" == "false" ]]; then
               if [[ "${{ matrix.key-type-one }}" == "+" ]]; then
                 ((exp_nb_keys+=3))
               fi


### PR DESCRIPTION
The key rotation test was failing because we were expecting an incorrect number of keys for the start of the rotation period. This commit fixes it by fixing the condition to compute that number of keys.

This is only happening on v1.13 because that's the only place where we have this IPv6-specific condition.