### PR TITLE
test/verifier: Keep existing environment when running make

### DIFF
--- a/test/verifier/verifier_test.go
+++ b/test/verifier/verifier_test.go
@@ -165,7 +165,7 @@ func TestVerifier(t *testing.T) {
 					name := fmt.Sprintf("%s_%s", bpfProgram.name, configName)
 					cmd := exec.Command("make", "-C", "bpf", "clean", fmt.Sprintf("%s.o", bpfProgram.name))
 					cmd.Dir = *ciliumBasePath
-					cmd.Env = append(cmd.Env,
+					cmd.Env = append(os.Environ(),
 						fmt.Sprintf("%s=%s", bpfProgram.macroName, datapathConfig),
 						fmt.Sprintf("KERNEL=%s", kernelVersion),
 					)


### PR DESCRIPTION
Don't purge the environment when running `make -C bpf` in the verifier tests, because unsetting $PATH and $HOME has numerous undesired side effects:

1. Go is not found in complexity-test little-vm-helper images.
2. Git can't find its config in complexity-test LVH images.
3. The user can't override the path to clang.
