### PR TITLE
docs: Document `No node ID found` drops in case of remote node deletion

### DIFF
--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -298,12 +298,12 @@ errors.
  * In addition to the above XFRM errors, packet drops of type ``No node ID
    found`` (code 197) may also occur under normal operations. These drops can
    happen if a pod attempts to send traffic to a pod on a new node for which
-   the Cilium agent didn't yet receive the CiliumNode object. It can also
-   happen if the IP address of the destination node changed and the agent
-   didn't receive the updated CiliumNode object yet. In both cases, the IPsec
-   configuration in the kernel isn't ready yet, so Cilium drops the packets at
-   the source. These drops will stop once the CiliumNode information is
-   propagated across the cluster.
+   the Cilium agent didn't yet receive the CiliumNode object or to a pod on a
+   node that was recently deleted. It can also happen if the IP address of the
+   destination node changed and the agent didn't receive the updated CiliumNode
+   object yet. In both cases, the IPsec configuration in the kernel isn't ready
+   yet, so Cilium drops the packets at the source. These drops will stop once
+   the CiliumNode information is propagated across the cluster.
 
 Disabling Encryption
 ====================


### PR DESCRIPTION
While testing cluster scale downs, we noticed that under constant traffic load, we sometimes had drops of type `No node ID found`. We confirmed that these are expected when the remote node was just deleted, the delete event received by the local agent, but a local pod is still sending traffic to pods on that node. In that case, the node is removed from the node ID map, but information on pods hosted by that node may still be present.

This pull request documents it with the other expected reasons for `No node ID found` drops.