### PR TITLE
workflows: ipsec-e2e: add missing key types for some configs

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -140,6 +140,8 @@ jobs:
             devices: 'eth0'
             key-one: 'cbc(aes)'
             key-two: 'cbc(aes)'
+            key-type-one: '+'
+            key-type-two: '+'
 
           - name: '6'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -153,6 +155,8 @@ jobs:
             devices: 'eth0'
             key-one: 'gcm(aes)'
             key-two: 'gcm(aes)'
+            key-type-one: '+'
+            key-type-two: '+'
 
     timeout-minutes: 75
     steps:


### PR DESCRIPTION
These configs were recent additions, and missed the introduction of the key-type-* parameters. Add them now.