### PR TITLE
workflows: Cover IPsec encrypted overlay mode in end-to-end tests

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -31,6 +31,9 @@ inputs:
   encryption-node:
     description: 'Enable node-to-node encryption (WireGuard only)'
     default: false
+  encryption-overlay:
+    description: 'Encrypt the overlay itself (IPsec only)'
+    default: false
   egress-gateway:
     description: 'Enable egress gateway'
     default: false
@@ -137,6 +140,9 @@ runs:
             ENCRYPT="--helm-set=encryption.enabled=true --helm-set=encryption.type=${{ inputs.encryption }}"
             if [ "${{ inputs.encryption-node }}" != "" ]; then
               ENCRYPT+=" --helm-set=encryption.nodeEncryption=${{ inputs.encryption-node }}"
+            fi
+            if [ "${{ inputs.encryption-overlay }}" != "" ]; then
+              ENCRYPT+=" --helm-set=encryption.ipsec.encryptedOverlay=${{ inputs.encryption-overlay }}"
             fi
           fi
 

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -158,6 +158,20 @@ jobs:
             key-type-one: '+'
             key-type-two: '+'
 
+          - name: '7'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: '5.15-20240305.092417'
+            kube-proxy: 'iptables'
+            kpr: 'false'
+            tunnel: 'vxlan'
+            encryption: 'ipsec'
+            encryption-node: 'false'
+            encryption-overlay: 'true'
+            key-one: 'gcm(aes)'
+            key-two: 'gcm(aes)'
+            key-type-one: '+'
+            key-type-two: '+'
+
     timeout-minutes: 75
     steps:
       - name: Checkout context ref (trusted)
@@ -194,6 +208,7 @@ jobs:
           lb-acceleration: ${{ matrix.lb-acceleration }}
           encryption: ${{ matrix.encryption }}
           encryption-node: ${{ matrix.encryption-node }}
+          encryption-overlay: ${{ matrix.encryption-overlay }}
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
           ingress-controller: ${{ matrix.ingress-controller }}

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       max-parallel: 16
       matrix:
-        config: ['5.4', '5.10', '6.1', 'bpf-next']
+        config: ['5.4', '5.10', '6.1', '5.15', 'bpf-next']
         mode: ['minor', 'patch']
         include:
           # Define three config sets
@@ -92,6 +92,16 @@ jobs:
             tunnel: 'disabled'
             encryption: 'ipsec'
             endpoint-routes: 'true'
+
+          - config: '5.15'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: '5.15-20240305.092417'
+            kube-proxy: 'iptables'
+            kpr: 'disabled'
+            tunnel: 'vxlan'
+            encryption: 'ipsec'
+            encryption-overlay: 'true'
+            endpoint-routes: 'false'
 
           - config: '6.1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -143,6 +153,14 @@ jobs:
           - config: 'bpf-next'
             mode: 'patch'
             name: '8'
+
+          - config: '5.15'
+            mode: 'minor'
+            name: '9'
+
+          - config: '5.15'
+            mode: 'patch'
+            name: '10'
 
     timeout-minutes: 70
     steps:
@@ -231,6 +249,7 @@ jobs:
           lb-acceleration: ${{ matrix.lb-acceleration }}
           encryption: ${{ matrix.encryption }}
           encryption-node: ${{ matrix.encryption-node }}
+          encryption-overlay: ${{ matrix.encryption-overlay }}
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
           mutual-auth: false
@@ -251,6 +270,7 @@ jobs:
           lb-acceleration: ${{ matrix.lb-acceleration }}
           encryption: ${{ matrix.encryption }}
           encryption-node: ${{ matrix.encryption-node }}
+          encryption-overlay: ${{ matrix.encryption-overlay }}
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
           mutual-auth: false


### PR DESCRIPTION
Encrypted overlay was introduced in https://github.com/cilium/cilium/pull/31073. As the name indicates, with that feature, Cilium will also encrypt the overlay itself (i.e., the VXLAN headers). This pull request covers this configuration in the two IPsec workflows.