### PR TITLE
ipset: Rework the reconciler to use batch ops

### DIFF
--- a/daemon/cmd/cells_test.go
+++ b/daemon/cmd/cells_test.go
@@ -23,6 +23,8 @@ var goleakOptions = []goleak.Option{
 	// Ignore goroutines started by the policy trifecta, see [newPolicyTrifecta].
 	goleak.IgnoreTopFunction("github.com/cilium/cilium/pkg/identity/cache.(*identityWatcher).watch.func1"),
 	goleak.IgnoreTopFunction("github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter"),
+	// Ignore goroutine started by the ipset reconciler rate limiter
+	goleak.IgnoreTopFunction("github.com/cilium/cilium/pkg/rate.NewLimiter.func1"),
 }
 
 // TestAgentCell verifies that the Agent hive can be instantiated with

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/daemon/cmd/cni/fake"
 	"github.com/cilium/cilium/pkg/checker"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node/manager"
@@ -43,7 +44,7 @@ func (g *GetNodesSuite) SetUpTest(c *C) {
 
 func (g *GetNodesSuite) SetUpSuite(c *C) {
 	var err error
-	nm, err = manager.New(fakeConfig, nil, nil, nil, manager.NewNodeMetrics(), cell.TestScope())
+	nm, err = manager.New(fakeConfig, nil, &fakeTypes.IPSet{}, nil, manager.NewNodeMetrics(), cell.TestScope())
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -33,4 +33,6 @@ var Cell = cell.Module(
 
 	cell.Metric(NewMetrics),
 	cell.Metric(common.MetricsProvider(subsystem)),
+
+	cell.Invoke(ipsetSyncer),
 )

--- a/pkg/clustermesh/ipsetsyncer.go
+++ b/pkg/clustermesh/ipsetsyncer.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package clustermesh
+
+import (
+	"context"
+	"runtime/pprof"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+)
+
+func ipsetSyncer(
+	logger logrus.FieldLogger,
+	lc cell.Lifecycle,
+	jobRegistry job.Registry,
+	scope cell.Scope,
+	cm *ClusterMesh,
+	ipsetMgr ipset.Manager,
+) {
+	if cm == nil {
+		return
+	}
+
+	initializer := ipsetMgr.NewInitializer()
+
+	jg := jobRegistry.NewGroup(
+		scope,
+		job.WithLogger(logger),
+		job.WithPprofLabels(pprof.Labels("cell", "clustermesh-ipset-syncer")),
+	)
+	jg.Add(job.OneShot("clustermesh-ipset-syncer", func(ctx context.Context, _ cell.HealthReporter) error {
+		// wait for initial nodes listing from all remote clusters
+		// before allowing stale ipset entries deletion
+		if err := cm.NodesSynced(ctx); err != nil {
+			return err
+		}
+		initializer.InitDone()
+		return nil
+	}))
+
+	lc.Append(jg)
+}

--- a/pkg/datapath/fake/types/ipset.go
+++ b/pkg/datapath/fake/types/ipset.go
@@ -13,6 +13,14 @@ var _ ipset.Manager = &IPSet{}
 
 type IPSet struct{}
 
+func (f *IPSet) NewInitializer() ipset.Initializer { return &initializer{} }
+
 func (f *IPSet) AddToIPSet(_ string, _ ipset.Family, _ ...netip.Addr) {}
 
 func (f *IPSet) RemoveFromIPSet(name string, addrs ...netip.Addr) {}
+
+type initializer struct {
+}
+
+func (i *initializer) InitDone() {
+}

--- a/pkg/datapath/iptables/ipset/cell.go
+++ b/pkg/datapath/iptables/ipset/cell.go
@@ -38,6 +38,9 @@ var Cell = cell.Module(
 		reconciler.New[*tables.IPSetEntry],
 		newReconcilerConfig,
 		newOps,
+		func(ops *ops) reconciler.Operations[*tables.IPSetEntry] {
+			return ops
+		},
 	),
 	cell.ProvidePrivate(func(logger logrus.FieldLogger) *ipset {
 		return &ipset{
@@ -60,7 +63,7 @@ func newReconcilerConfig(
 	ops reconciler.Operations[*tables.IPSetEntry],
 ) reconciler.Config[*tables.IPSetEntry] {
 	return reconciler.Config[*tables.IPSetEntry]{
-		FullReconcilationInterval: 10 * time.Second,
+		FullReconcilationInterval: 30 * time.Minute,
 		RetryBackoffMinDuration:   100 * time.Millisecond,
 		RetryBackoffMaxDuration:   5 * time.Second,
 		IncrementalRoundSize:      100,

--- a/pkg/datapath/iptables/ipset/cell.go
+++ b/pkg/datapath/iptables/ipset/cell.go
@@ -6,12 +6,14 @@ package ipset
 import (
 	"context"
 	"os/exec"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/statedb/reconciler"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -38,14 +40,13 @@ var Cell = cell.Module(
 		reconciler.New[*tables.IPSetEntry],
 		newReconcilerConfig,
 		newOps,
-		func(ops *ops) reconciler.Operations[*tables.IPSetEntry] {
-			return ops
-		},
 	),
 	cell.ProvidePrivate(func(logger logrus.FieldLogger) *ipset {
 		return &ipset{
-			executable: funcExecutable(func(ctx context.Context, name string, arg ...string) ([]byte, error) {
-				return exec.CommandContext(ctx, name, arg...).Output()
+			executable: funcExecutable(func(ctx context.Context, name string, stdin string, arg ...string) ([]byte, error) {
+				cmd := exec.CommandContext(ctx, name, arg...)
+				cmd.Stdin = strings.NewReader(stdin)
+				return cmd.Output()
 			}),
 			log: logger,
 		}
@@ -59,16 +60,22 @@ type config struct {
 	NodeIPSetNeeded bool
 }
 
-func newReconcilerConfig(
-	ops reconciler.Operations[*tables.IPSetEntry],
-) reconciler.Config[*tables.IPSetEntry] {
+func newReconcilerConfig(ops *ops) reconciler.Config[*tables.IPSetEntry] {
 	return reconciler.Config[*tables.IPSetEntry]{
 		FullReconcilationInterval: 30 * time.Minute,
 		RetryBackoffMinDuration:   100 * time.Millisecond,
 		RetryBackoffMaxDuration:   5 * time.Second,
-		IncrementalRoundSize:      100,
 		GetObjectStatus:           (*tables.IPSetEntry).GetStatus,
 		WithObjectStatus:          (*tables.IPSetEntry).WithStatus,
 		Operations:                ops,
+		BatchOperations:           ops,
+
+		// Set the maximum batch size to 100, and limit the incremental
+		// reconciliation to once every 10ms, giving us maximum throughput
+		// of 1000/10 * 100 = 10000 per second.
+		IncrementalRoundSize: 100,
+
+		// Set the rate limiter to accumulate a batch of entries to reconcile.
+		RateLimiter: rate.NewLimiter(10*time.Millisecond, 1),
 	}
 }

--- a/pkg/datapath/iptables/ipset/cell.go
+++ b/pkg/datapath/iptables/ipset/cell.go
@@ -35,7 +35,7 @@ var Cell = cell.Module(
 	cell.ProvidePrivate(
 		tables.NewIPSetTable,
 
-		reconciler.New[*tables.IPSet],
+		reconciler.New[*tables.IPSetEntry],
 		newReconcilerConfig,
 		newOps,
 	),
@@ -57,15 +57,15 @@ type config struct {
 }
 
 func newReconcilerConfig(
-	ops reconciler.Operations[*tables.IPSet],
-) reconciler.Config[*tables.IPSet] {
-	return reconciler.Config[*tables.IPSet]{
+	ops reconciler.Operations[*tables.IPSetEntry],
+) reconciler.Config[*tables.IPSetEntry] {
+	return reconciler.Config[*tables.IPSetEntry]{
 		FullReconcilationInterval: 10 * time.Second,
 		RetryBackoffMinDuration:   100 * time.Millisecond,
 		RetryBackoffMaxDuration:   5 * time.Second,
 		IncrementalRoundSize:      100,
-		GetObjectStatus:           (*tables.IPSet).GetStatus,
-		WithObjectStatus:          (*tables.IPSet).WithStatus,
+		GetObjectStatus:           (*tables.IPSetEntry).GetStatus,
+		WithObjectStatus:          (*tables.IPSetEntry).WithStatus,
 		Operations:                ops,
 	}
 }

--- a/pkg/datapath/iptables/ipset/ipset_test.go
+++ b/pkg/datapath/iptables/ipset/ipset_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
@@ -35,9 +36,9 @@ Revision: 6
 Header: family inet hashsize 1024 maxelem 65536 bucketsize 12 initval 0x4d9d24f1
 Size in memory: 216
 References: 0
-Number of entries: {{len $addrs.AsSlice}}
+Number of entries: {{len $addrs}}
 Members:
-{{range $idx, $addr := $addrs.AsSlice -}}{{$addr}}
+{{range $addr, $_ := $addrs -}}{{$addr}}
 {{else}}{{end}}{{end}}`
 
 func TestManager(t *testing.T) {
@@ -45,8 +46,8 @@ func TestManager(t *testing.T) {
 
 	var mgr Manager
 
-	ipsets := make(map[string]tables.AddrSet) // mocked kernel IP sets
-	var mu lock.Mutex                         // protect the ipsets map
+	ipsets := make(map[string]AddrSet) // mocked kernel IP sets
+	var mu lock.Mutex                  // protect the ipsets map
 
 	tmpl := template.Must(template.New("ipsets").Parse(textTmpl))
 
@@ -66,7 +67,7 @@ func TestManager(t *testing.T) {
 			cell.Provide(
 				newIPSetManager,
 				tables.NewIPSetTable,
-				reconciler.New[*tables.IPSet],
+				reconciler.New[*tables.IPSetEntry],
 				newReconcilerConfig,
 				newOps,
 			),
@@ -86,7 +87,7 @@ func TestManager(t *testing.T) {
 							switch subCommand {
 							case "create":
 								if _, found := ipsets[name]; !found {
-									ipsets[name] = tables.NewAddrSet()
+									ipsets[name] = AddrSet{}
 								}
 								return nil, nil
 							case "destroy":
@@ -100,7 +101,7 @@ func TestManager(t *testing.T) {
 									return nil, fmt.Errorf("ipset %s not found", name)
 								}
 								var bb bytes.Buffer
-								if err := tmpl.Execute(&bb, map[string]tables.AddrSet{name: ipsets[name]}); err != nil {
+								if err := tmpl.Execute(&bb, map[string]AddrSet{name: ipsets[name]}); err != nil {
 									return nil, err
 								}
 								b := bb.Bytes()
@@ -140,14 +141,14 @@ func TestManager(t *testing.T) {
 	testCases := []struct {
 		name     string
 		action   func()
-		expected map[string]tables.AddrSet
+		expected map[string]AddrSet
 	}{
 		{
 			name:   "check Cilium ipsets have been created",
 			action: func() {},
-			expected: map[string]tables.AddrSet{
-				CiliumNodeIPSetV4: tables.NewAddrSet(),
-				CiliumNodeIPSetV6: tables.NewAddrSet(),
+			expected: map[string]AddrSet{
+				CiliumNodeIPSetV4: {},
+				CiliumNodeIPSetV6: {},
 			},
 		},
 		{
@@ -155,11 +156,11 @@ func TestManager(t *testing.T) {
 			action: func() {
 				mgr.AddToIPSet(CiliumNodeIPSetV4, INetFamily, netip.MustParseAddr("1.1.1.1"))
 			},
-			expected: map[string]tables.AddrSet{
-				CiliumNodeIPSetV4: tables.NewAddrSet(
+			expected: map[string]AddrSet{
+				CiliumNodeIPSetV4: sets.New(
 					netip.MustParseAddr("1.1.1.1"),
 				),
-				CiliumNodeIPSetV6: tables.NewAddrSet(),
+				CiliumNodeIPSetV6: {},
 			},
 		},
 		{
@@ -167,12 +168,12 @@ func TestManager(t *testing.T) {
 			action: func() {
 				mgr.AddToIPSet(CiliumNodeIPSetV4, INetFamily, netip.MustParseAddr("2.2.2.2"))
 			},
-			expected: map[string]tables.AddrSet{
-				CiliumNodeIPSetV4: tables.NewAddrSet(
+			expected: map[string]AddrSet{
+				CiliumNodeIPSetV4: sets.New(
 					netip.MustParseAddr("1.1.1.1"),
 					netip.MustParseAddr("2.2.2.2"),
 				),
-				CiliumNodeIPSetV6: tables.NewAddrSet(),
+				CiliumNodeIPSetV6: {},
 			},
 		},
 		{
@@ -180,12 +181,12 @@ func TestManager(t *testing.T) {
 			action: func() {
 				mgr.AddToIPSet(CiliumNodeIPSetV4, INetFamily, netip.MustParseAddr("2.2.2.2"))
 			},
-			expected: map[string]tables.AddrSet{
-				CiliumNodeIPSetV4: tables.NewAddrSet(
+			expected: map[string]AddrSet{
+				CiliumNodeIPSetV4: sets.New(
 					netip.MustParseAddr("1.1.1.1"),
 					netip.MustParseAddr("2.2.2.2"),
 				),
-				CiliumNodeIPSetV6: tables.NewAddrSet(),
+				CiliumNodeIPSetV6: {},
 			},
 		},
 		{
@@ -193,11 +194,11 @@ func TestManager(t *testing.T) {
 			action: func() {
 				mgr.RemoveFromIPSet(CiliumNodeIPSetV4, netip.MustParseAddr("1.1.1.1"))
 			},
-			expected: map[string]tables.AddrSet{
-				CiliumNodeIPSetV4: tables.NewAddrSet(
+			expected: map[string]AddrSet{
+				CiliumNodeIPSetV4: sets.New(
 					netip.MustParseAddr("2.2.2.2"),
 				),
-				CiliumNodeIPSetV6: tables.NewAddrSet(),
+				CiliumNodeIPSetV6: {},
 			},
 		},
 		{
@@ -205,11 +206,11 @@ func TestManager(t *testing.T) {
 			action: func() {
 				mgr.RemoveFromIPSet(CiliumNodeIPSetV4, netip.MustParseAddr("3.3.3.3"))
 			},
-			expected: map[string]tables.AddrSet{
-				CiliumNodeIPSetV4: tables.NewAddrSet(
+			expected: map[string]AddrSet{
+				CiliumNodeIPSetV4: sets.New(
 					netip.MustParseAddr("2.2.2.2"),
 				),
-				CiliumNodeIPSetV6: tables.NewAddrSet(),
+				CiliumNodeIPSetV6: {},
 			},
 		},
 		{
@@ -217,11 +218,11 @@ func TestManager(t *testing.T) {
 			action: func() {
 				mgr.AddToIPSet(CiliumNodeIPSetV6, INet6Family, netip.MustParseAddr("cafe::1"))
 			},
-			expected: map[string]tables.AddrSet{
-				CiliumNodeIPSetV4: tables.NewAddrSet(
+			expected: map[string]AddrSet{
+				CiliumNodeIPSetV4: sets.New(
 					netip.MustParseAddr("2.2.2.2"),
 				),
-				CiliumNodeIPSetV6: tables.NewAddrSet(
+				CiliumNodeIPSetV6: sets.New(
 					netip.MustParseAddr("cafe::1"),
 				),
 			},
@@ -231,11 +232,11 @@ func TestManager(t *testing.T) {
 			action: func() {
 				mgr.RemoveFromIPSet(CiliumNodeIPSetV6, netip.MustParseAddr("cafe::1"))
 			},
-			expected: map[string]tables.AddrSet{
-				CiliumNodeIPSetV4: tables.NewAddrSet(
+			expected: map[string]AddrSet{
+				CiliumNodeIPSetV4: sets.New(
 					netip.MustParseAddr("2.2.2.2"),
 				),
-				CiliumNodeIPSetV6: tables.NewAddrSet(),
+				CiliumNodeIPSetV6: {},
 			},
 		},
 	}
@@ -273,8 +274,8 @@ func TestManager(t *testing.T) {
 func TestManagerNodeIpsetNotNeeded(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	ipsets := make(map[string]tables.AddrSet) // mocked kernel IP sets
-	var mu lock.Mutex                         // protect the ipsets map
+	ipsets := make(map[string]AddrSet) // mocked kernel IP sets
+	var mu lock.Mutex                  // protect the ipsets map
 
 	hive := hive.New(
 		statedb.Cell,
@@ -292,7 +293,7 @@ func TestManagerNodeIpsetNotNeeded(t *testing.T) {
 			cell.Provide(
 				newIPSetManager,
 				tables.NewIPSetTable,
-				reconciler.New[*tables.IPSet],
+				reconciler.New[*tables.IPSetEntry],
 				newReconcilerConfig,
 				newOps,
 			),
@@ -327,26 +328,41 @@ func TestManagerNodeIpsetNotNeeded(t *testing.T) {
 
 	// create ipv4 and ipv6 node ipsets to simulate stale entries from previous Cilium run
 	withLocked(&mu, func() {
-		ipsets[CiliumNodeIPSetV4] = tables.NewAddrSet(netip.MustParseAddr("2.2.2.2"))
-		ipsets[CiliumNodeIPSetV6] = tables.NewAddrSet(netip.MustParseAddr("cafe::1"))
+		ipsets[CiliumNodeIPSetV4] = sets.New(netip.MustParseAddr("2.2.2.2"))
+		ipsets[CiliumNodeIPSetV6] = sets.New(netip.MustParseAddr("cafe::1"))
 	})
 
 	assert.NoError(t, hive.Start(context.Background()))
 
-	// Cilium node ipsets should have been pruned
+	// Cilium node ipsets should eventually be pruned
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if _, found := ipsets[CiliumNodeIPSetV4]; found {
+			return false
+		}
+		if _, found := ipsets[CiliumNodeIPSetV6]; found {
+			return false
+		}
+
+		return true
+	}, 1*time.Second, 50*time.Millisecond)
+
+	// create a custom ipset (not managed by Cilium)
+	withLocked(&mu, func() {
+		ipsets["unmanaged-ipset"] = AddrSet{}
+	})
+
+	assert.NoError(t, hive.Stop(context.Background()))
+
+	// ipset managed by Cilium should not have been created again
 	withLocked(&mu, func() {
 		assert.NotContains(t, ipsets, CiliumNodeIPSetV4)
 		assert.NotContains(t, ipsets, CiliumNodeIPSetV6)
 	})
 
-	// create a custom ipset (not managed by Cilium)
-	withLocked(&mu, func() {
-		ipsets["unmanaged-ipset"] = tables.NewAddrSet()
-	})
-
-	assert.NoError(t, hive.Stop(context.Background()))
-
-	// ipset not managed by Cilium should not been pruned
+	// ipset not managed by Cilium should not have been pruned
 	withLocked(&mu, func() {
 		assert.Contains(t, ipsets, "unmanaged-ipset")
 	})
@@ -362,29 +378,29 @@ func withLocked(m *lock.Mutex, f func()) {
 func TestIPSetList(t *testing.T) {
 	testCases := []struct {
 		name     string
-		ipsets   map[string]tables.AddrSet
-		expected tables.AddrSet
+		ipsets   map[string]AddrSet
+		expected AddrSet
 	}{
 		{
 			name: "empty ipset",
-			ipsets: map[string]tables.AddrSet{
-				"ciliumtest": tables.NewAddrSet(),
+			ipsets: map[string]AddrSet{
+				"ciliumtest": {},
 			},
-			expected: tables.NewAddrSet(),
+			expected: AddrSet{},
 		},
 		{
 			name: "ipset with a single IP",
-			ipsets: map[string]tables.AddrSet{
-				"ciliumtest": tables.NewAddrSet(netip.MustParseAddr("1.1.1.1")),
+			ipsets: map[string]AddrSet{
+				"ciliumtest": sets.New(netip.MustParseAddr("1.1.1.1")),
 			},
-			expected: tables.NewAddrSet(netip.MustParseAddr("1.1.1.1")),
+			expected: sets.New(netip.MustParseAddr("1.1.1.1")),
 		},
 		{
 			name: "ipset with multiple IPs",
-			ipsets: map[string]tables.AddrSet{
-				"ciliumtest": tables.NewAddrSet(netip.MustParseAddr("1.1.1.1"), netip.MustParseAddr("2.2.2.2")),
+			ipsets: map[string]AddrSet{
+				"ciliumtest": sets.New(netip.MustParseAddr("1.1.1.1"), netip.MustParseAddr("2.2.2.2")),
 			},
-			expected: tables.NewAddrSet(netip.MustParseAddr("1.1.1.1"), netip.MustParseAddr("2.2.2.2")),
+			expected: sets.New(netip.MustParseAddr("1.1.1.1"), netip.MustParseAddr("2.2.2.2")),
 		},
 	}
 

--- a/pkg/datapath/iptables/ipset/ipset_test.go
+++ b/pkg/datapath/iptables/ipset/ipset_test.go
@@ -71,6 +71,9 @@ func TestManager(t *testing.T) {
 				newReconcilerConfig,
 				newOps,
 			),
+			cell.Provide(func(ops *ops) reconciler.Operations[*tables.IPSetEntry] {
+				return ops
+			}),
 
 			cell.Provide(func(logger logrus.FieldLogger) *ipset {
 				return &ipset{
@@ -297,6 +300,9 @@ func TestManagerNodeIpsetNotNeeded(t *testing.T) {
 				newReconcilerConfig,
 				newOps,
 			),
+			cell.Provide(func(ops *ops) reconciler.Operations[*tables.IPSetEntry] {
+				return ops
+			}),
 			cell.Provide(func(logger logrus.FieldLogger) *ipset {
 				return &ipset{
 					executable: funcExecutable(func(ctx context.Context, command string, arg ...string) ([]byte, error) {

--- a/pkg/datapath/iptables/ipset/ops.go
+++ b/pkg/datapath/iptables/ipset/ops.go
@@ -5,16 +5,19 @@ package ipset
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/netip"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/statedb/reconciler"
 )
 
-func newOps(logger logrus.FieldLogger, ipset *ipset, cfg config) reconciler.Operations[*tables.IPSet] {
+func newOps(logger logrus.FieldLogger, ipset *ipset, cfg config) reconciler.Operations[*tables.IPSetEntry] {
 	return &ops{
 		enabled: cfg.NodeIPSetNeeded,
 		ipset:   ipset,
@@ -26,37 +29,18 @@ type ops struct {
 	ipset   *ipset
 }
 
-func (ops *ops) Update(ctx context.Context, _ statedb.ReadTxn, s *tables.IPSet, changed *bool) error {
+func (ops *ops) Update(ctx context.Context, _ statedb.ReadTxn, entry *tables.IPSetEntry, changed *bool) error {
 	if !ops.enabled {
 		return nil
 	}
 
 	// create the set if does not exist
-	if err := ops.ipset.create(ctx, s.Name, string(s.Family)); err != nil {
+	if err := ops.ipset.create(ctx, entry.Name, string(entry.Family)); err != nil {
 		return err
 	}
 
-	cur, err := ops.ipset.list(ctx, s.Name)
-	if err != nil {
-		return fmt.Errorf("failed to list ips in ipset %s: %w", s.Name, err)
-	}
-
-	if s.Addrs.Equal(cur) {
-		return nil
-	}
-
-	// reconcile the set
-	toAdd := s.Addrs.Difference(cur).AsSlice()
-	for _, addr := range toAdd {
-		if err := ops.ipset.add(ctx, s.Name, addr); err != nil {
-			return err
-		}
-	}
-	toDel := cur.Difference(s.Addrs).AsSlice()
-	for _, addr := range toDel {
-		if err := ops.ipset.del(ctx, s.Name, addr); err != nil {
-			return err
-		}
+	if err := ops.ipset.add(ctx, entry.Name, entry.Addr); err != nil {
+		return err
 	}
 
 	if changed != nil {
@@ -66,11 +50,69 @@ func (ops *ops) Update(ctx context.Context, _ statedb.ReadTxn, s *tables.IPSet, 
 	return nil
 }
 
-func (ops *ops) Delete(ctx context.Context, _ statedb.ReadTxn, s *tables.IPSet) error {
-	return ops.ipset.remove(ctx, s.Name)
+func (ops *ops) Delete(ctx context.Context, _ statedb.ReadTxn, entry *tables.IPSetEntry) error {
+	if !ops.enabled {
+		return nil
+	}
+
+	// check that the set exists
+	if _, err := ops.ipset.list(ctx, entry.Name); err != nil {
+		return nil
+	}
+	return ops.ipset.del(ctx, entry.Name, entry.Addr)
 }
 
-func (ops *ops) Prune(ctx context.Context, _ statedb.ReadTxn, _ statedb.Iterator[*tables.IPSet]) error {
-	// ipsets not managed by Cilium should not be changed
+func (ops *ops) Prune(ctx context.Context, _ statedb.ReadTxn, iter statedb.Iterator[*tables.IPSetEntry]) error {
+	if !ops.enabled {
+		return nil
+	}
+
+	desiredV4Set, desiredV6Set := sets.Set[netip.Addr]{}, sets.Set[netip.Addr]{}
+	statedb.ProcessEach(iter, func(obj *tables.IPSetEntry, _ uint64) error {
+		if obj.Name == CiliumNodeIPSetV4 {
+			desiredV4Set.Insert(obj.Addr)
+		} else if obj.Name == CiliumNodeIPSetV6 {
+			desiredV6Set.Insert(obj.Addr)
+		}
+		return nil
+	})
+
+	return errors.Join(
+		reconcile(ctx, ops.ipset, CiliumNodeIPSetV4, INetFamily, desiredV4Set),
+		reconcile(ctx, ops.ipset, CiliumNodeIPSetV6, INet6Family, desiredV6Set),
+	)
+}
+
+func reconcile(
+	ctx context.Context,
+	ipset *ipset,
+	name string,
+	family Family,
+	desired sets.Set[netip.Addr],
+) error {
+	// create the IP set if it doesn't exist
+	if err := ipset.create(ctx, name, string(family)); err != nil {
+		return fmt.Errorf("unable to create ipset %s: %w", name, err)
+	}
+
+	curSet, err := ipset.list(ctx, name)
+	if err != nil {
+		return fmt.Errorf("unable to list ipset %s: %w", name, err)
+	}
+
+	toDel := curSet.Difference(desired)
+	for addr := range toDel {
+		if err := ipset.del(ctx, name, addr); err != nil {
+			return fmt.Errorf("unable to delete addr %s from ipset %s: %w", name, addr, err)
+		}
+	}
+
+	toAdd := desired.Difference(curSet)
+	for addr := range toAdd {
+		if err := ipset.add(ctx, name, addr); err != nil {
+			return fmt.Errorf("unable to add addr %s from ipset %s: %w", name, addr, err)
+		}
+	}
+
 	return nil
 }

--- a/pkg/datapath/tables/ipset.go
+++ b/pkg/datapath/tables/ipset.go
@@ -5,91 +5,65 @@ package tables
 
 import (
 	"net/netip"
-	"strings"
 
-	"github.com/cilium/cilium/pkg/container"
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/statedb/index"
 	"github.com/cilium/cilium/pkg/statedb/reconciler"
 )
 
-const IPSetTableName = "ipset"
+const IPSetsTableName = "ipsets"
 
-type AddrSet = container.ImmSet[netip.Addr]
-
-func NewAddrSet(addrs ...netip.Addr) AddrSet {
-	return container.NewImmSetFunc(
-		netip.Addr.Compare,
-		addrs...,
-	)
+type IPSetEntryKey struct {
+	Name string
+	Addr netip.Addr
 }
 
-var (
-	IPSetNameIndex = statedb.Index[*IPSet, string]{
-		Name: "name",
-		FromObject: func(s *IPSet) index.KeySet {
-			return index.NewKeySet(index.String(s.Name))
-		},
-		FromKey: index.String,
-		Unique:  true,
-	}
-)
+func (k IPSetEntryKey) Key() index.Key {
+	return append(index.NetIPAddr(k.Addr), []byte(k.Name)...)
+}
 
-func NewIPSetTable(db *statedb.DB) (statedb.RWTable[*IPSet], error) {
+var IPSetEntryIndex = statedb.Index[*IPSetEntry, IPSetEntryKey]{
+	Name: IPSetsTableName,
+	FromObject: func(s *IPSetEntry) index.KeySet {
+		return index.NewKeySet(IPSetEntryKey{s.Name, s.Addr}.Key())
+	},
+	FromKey: IPSetEntryKey.Key,
+	Unique:  true,
+}
+
+func NewIPSetTable(db *statedb.DB) (statedb.RWTable[*IPSetEntry], error) {
 	tbl, err := statedb.NewTable(
-		IPSetTableName,
-		IPSetNameIndex,
+		IPSetsTableName,
+		IPSetEntryIndex,
 	)
 	return tbl, err
 }
 
-func (s *IPSet) TableHeader() []string {
-	return []string{"Name", "Family", "Addrs", "Status"}
+func (s *IPSetEntry) TableHeader() []string {
+	return []string{"Name", "Family", "Addr", "Status"}
 }
 
-func (s *IPSet) TableRow() []string {
-	ss := make([]string, 0, s.Addrs.Len())
-	for _, addr := range s.Addrs.AsSlice() {
-		ss = append(ss, addr.String())
-	}
-	return []string{s.Name, s.Family, strings.Join(ss, ","), s.Status.String()}
+func (s *IPSetEntry) TableRow() []string {
+	return []string{s.Name, s.Family, s.Addr.String(), s.Status.String()}
 }
 
-type IPSet struct {
+type IPSetEntry struct {
 	Name   string
 	Family string
-	Addrs  AddrSet
+	Addr   netip.Addr
 
 	Status reconciler.Status
 }
 
-func (s *IPSet) GetStatus() reconciler.Status {
+func (s *IPSetEntry) GetStatus() reconciler.Status {
 	return s.Status
 }
 
-func (s *IPSet) WithStatus(newStatus reconciler.Status) *IPSet {
-	return &IPSet{
+func (s *IPSetEntry) WithStatus(newStatus reconciler.Status) *IPSetEntry {
+	return &IPSetEntry{
 		Name:   s.Name,
 		Family: s.Family,
-		Addrs:  s.Addrs,
+		Addr:   s.Addr,
 		Status: newStatus,
-	}
-}
-
-func (s *IPSet) WithAddrs(addrs ...netip.Addr) *IPSet {
-	return &IPSet{
-		Name:   s.Name,
-		Family: s.Family,
-		Addrs:  s.Addrs.Insert(addrs...),
-		Status: s.Status,
-	}
-}
-
-func (s *IPSet) WithoutAddrs(addrs ...netip.Addr) *IPSet {
-	return &IPSet{
-		Name:   s.Name,
-		Family: s.Family,
-		Addrs:  s.Addrs.Delete(addrs...),
-		Status: s.Status,
 	}
 }

--- a/pkg/datapath/tables/ipset.go
+++ b/pkg/datapath/tables/ipset.go
@@ -36,7 +36,10 @@ func NewIPSetTable(db *statedb.DB) (statedb.RWTable[*IPSetEntry], error) {
 		IPSetsTableName,
 		IPSetEntryIndex,
 	)
-	return tbl, err
+	if err != nil {
+		return nil, err
+	}
+	return tbl, db.RegisterTable(tbl)
 }
 
 func (s *IPSetEntry) TableHeader() []string {

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -60,6 +60,7 @@ func (k *K8sWatcher) ciliumNodeInit(ctx context.Context, asyncControllers *sync.
 				switch event.Kind {
 				case resource.Sync:
 					synced.Store(true)
+					k.nodeManager.NodeSync()
 				case resource.Upsert:
 					var needUpdate bool
 					oldObj, ok := cache[event.Key]

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -118,6 +118,7 @@ type endpointManager interface {
 type nodeManager interface {
 	NodeDeleted(n nodeTypes.Node)
 	NodeUpdated(n nodeTypes.Node)
+	NodeSync()
 }
 
 type policyManager interface {

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -55,6 +55,9 @@ type NodeManager interface {
 	// NodeDeleted is called when the store detects a deletion of a node
 	NodeDeleted(n types.Node)
 
+	// NodeSync is called when the store completes the initial nodes listing
+	NodeSync()
+
 	// ClusterSizeDependantInterval returns a time.Duration that is dependent on
 	// the cluster size, i.e. the number of nodes that have been discovered. This
 	// can be used to control sync intervals of shared or centralized resources to

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -124,6 +124,15 @@ func newIPSetMock() *ipsetMock {
 	}
 }
 
+type ipsetInitializerMock struct{}
+
+func (i *ipsetInitializerMock) InitDone() {
+}
+
+func (i *ipsetMock) NewInitializer() ipset.Initializer {
+	return &ipsetInitializerMock{}
+}
+
 func (i *ipsetMock) AddToIPSet(name string, family ipset.Family, addrs ...netip.Addr) {
 	for _, addr := range addrs {
 		if name == ipset.CiliumNodeIPSetV4 && family == ipset.INetFamily {

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -80,6 +80,9 @@ type NodeManager interface {
 
 	// NodeDeleted is called when the store detects a deletion of a node
 	NodeDeleted(n nodeTypes.Node)
+
+	// NodeSync is called when the store completes the initial nodes listing
+	NodeSync()
 }
 
 // NodeRegistrar is a wrapper around store.SharedStore.
@@ -198,6 +201,9 @@ func (nr *NodeRegistrar) RegisterNode(n *nodeTypes.Node, manager NodeManager) er
 	}
 
 	nr.SharedStore = nodeStore
+
+	manager.NodeSync()
+
 	return nil
 }
 

--- a/pkg/statedb/reconciler/incremental.go
+++ b/pkg/statedb/reconciler/incremental.go
@@ -261,6 +261,12 @@ func (round *incrementalRound[Obj]) processSingle(obj Obj, rev statedb.Revision,
 }
 
 func (round *incrementalRound[Obj]) commitStatus() <-chan struct{} {
+	if len(round.results) == 0 {
+		// Nothing to commit.
+		_, watch := round.table.All(round.txn)
+		return watch
+	}
+
 	wtxn := round.db.WriteTxn(round.table)
 	defer wtxn.Commit()
 

--- a/pkg/statedb/reconciler/reconciler.go
+++ b/pkg/statedb/reconciler/reconciler.go
@@ -113,6 +113,9 @@ func (r *reconciler[Obj]) loop(ctx context.Context, health cell.HealthReporter) 
 		defer fullReconTicker.Stop()
 		fullReconTickerChan = fullReconTicker.C
 	}
+	if r.Config.RateLimiter != nil {
+		defer r.Config.RateLimiter.Stop()
+	}
 
 	tableWatchChan := closedWatchChannel
 	revision := statedb.Revision(0)


### PR DESCRIPTION
Rework the ipset table to store a single address per entry. Consequently, rewrite the ipset reconciler to:

- use batch operations and `ipset restore`
- delete addresses only in DeleteBatch and Prune operations

Finally, introduce the concept of an ipset manager initializer, to delay the addresses pruning during agent restart, before the initial nodes listing from k8s or kvstore is completed.

Refer to the individual commit messages and the related issue for further details.

Fixes: https://github.com/cilium/cilium/issues/31537