### PR TITLE
Refactor InitK8sSubsystem and adding unit tests

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -795,7 +795,8 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 
 		// Launch the K8s watchers in parallel as we continue to process other
 		// daemon options.
-		d.k8sWatcher.InitK8sSubsystem(d.ctx, params.CacheStatus)
+		resources, cacheOnly := d.k8sWatcher.ResourceGroups()
+		d.k8sWatcher.InitK8sSubsystem(d.ctx, resources, cacheOnly, params.CacheStatus)
 		bootstrapStats.k8sInit.End(true)
 	} else {
 		close(params.CacheStatus)

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -469,7 +469,6 @@ func (k *K8sWatcher) ResourceGroups() (resourceGroups, waitForCachesOnly []strin
 // already been registered.
 func (k *K8sWatcher) InitK8sSubsystem(ctx context.Context, resources []string, cachesOnly []string, cachesSynced chan struct{}) {
 	log.Info("Enabling k8s event listener")
-	// resources, waitForCachesOnly := k.resourceGroups()
 	if err := k.enableK8sWatchers(ctx, resources); err != nil {
 		if !errors.Is(err, context.Canceled) {
 			log.WithError(err).Fatal("Unable to start K8s watchers for Cilium")


### PR DESCRIPTION
# Description

The current implementation of the `InitK8sSubsystem` function hardcodes the resources it will watch and sync. This is rather rigid and prevents development of effective unit-tests. Also, it's unclear from the function signature what exact resources are being watched/synced. Making this explicit will be helpful for the caller.

In this change:
- modifying the function to take as input the resources to watch and others to sync
- Adding unit tests

Fixes: N/A

# Testing Done

- Build and ran UTs locally
- Tested manually on Kind