### PR TITLE
api: Upgrade go-swagger version to v0.30.5

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -66,7 +66,11 @@ CILIUM_BUILDER_IMAGE=$(shell cat $(ROOT_DIR)/images/cilium/Dockerfile | grep "AR
 export CILIUM_CLI ?= cilium
 export KUBECTL ?= kubectl
 
-SWAGGER_VERSION := v0.30.3
+# Till the self-hosted renovate PR #30185 is merged, we might need to run the below
+# command locally for any version update.
+# make generate-api generate-health-api generate-hubble-api generate-operator-api
+# renovate: datasource=docker depName=quay.io/goswagger/swagger
+SWAGGER_VERSION := v0.30.5
 SWAGGER := $(CONTAINER_ENGINE) run -u $(shell id -u):$(shell id -g) --rm -v $(ROOT_DIR):$(ROOT_DIR) -w $(ROOT_DIR) --entrypoint swagger quay.io/goswagger/swagger:$(SWAGGER_VERSION)
 
 # go build/test/clean flags

--- a/api/v1/client/bgp/get_bgp_peers_responses.go
+++ b/api/v1/client/bgp/get_bgp_peers_responses.go
@@ -45,7 +45,7 @@ func (o *GetBgpPeersReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /bgp/peers] GetBgpPeers", response, response.Code())
 	}
 }
 
@@ -86,6 +86,11 @@ func (o *GetBgpPeersOK) IsServerError() bool {
 // IsCode returns true when this get bgp peers o k response a status code equal to that given
 func (o *GetBgpPeersOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get bgp peers o k response
+func (o *GetBgpPeersOK) Code() int {
+	return 200
 }
 
 func (o *GetBgpPeersOK) Error() string {
@@ -149,6 +154,11 @@ func (o *GetBgpPeersInternalServerError) IsCode(code int) bool {
 	return code == 500
 }
 
+// Code gets the status code for the get bgp peers internal server error response
+func (o *GetBgpPeersInternalServerError) Code() int {
+	return 500
+}
+
 func (o *GetBgpPeersInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /bgp/peers][%d] getBgpPeersInternalServerError  %+v", 500, o.Payload)
 }
@@ -208,6 +218,11 @@ func (o *GetBgpPeersDisabled) IsServerError() bool {
 // IsCode returns true when this get bgp peers disabled response a status code equal to that given
 func (o *GetBgpPeersDisabled) IsCode(code int) bool {
 	return code == 501
+}
+
+// Code gets the status code for the get bgp peers disabled response
+func (o *GetBgpPeersDisabled) Code() int {
+	return 501
 }
 
 func (o *GetBgpPeersDisabled) Error() string {

--- a/api/v1/client/bgp/get_bgp_route_policies_responses.go
+++ b/api/v1/client/bgp/get_bgp_route_policies_responses.go
@@ -45,7 +45,7 @@ func (o *GetBgpRoutePoliciesReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /bgp/route-policies] GetBgpRoutePolicies", response, response.Code())
 	}
 }
 
@@ -86,6 +86,11 @@ func (o *GetBgpRoutePoliciesOK) IsServerError() bool {
 // IsCode returns true when this get bgp route policies o k response a status code equal to that given
 func (o *GetBgpRoutePoliciesOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get bgp route policies o k response
+func (o *GetBgpRoutePoliciesOK) Code() int {
+	return 200
 }
 
 func (o *GetBgpRoutePoliciesOK) Error() string {
@@ -149,6 +154,11 @@ func (o *GetBgpRoutePoliciesInternalServerError) IsCode(code int) bool {
 	return code == 500
 }
 
+// Code gets the status code for the get bgp route policies internal server error response
+func (o *GetBgpRoutePoliciesInternalServerError) Code() int {
+	return 500
+}
+
 func (o *GetBgpRoutePoliciesInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /bgp/route-policies][%d] getBgpRoutePoliciesInternalServerError  %+v", 500, o.Payload)
 }
@@ -208,6 +218,11 @@ func (o *GetBgpRoutePoliciesDisabled) IsServerError() bool {
 // IsCode returns true when this get bgp route policies disabled response a status code equal to that given
 func (o *GetBgpRoutePoliciesDisabled) IsCode(code int) bool {
 	return code == 501
+}
+
+// Code gets the status code for the get bgp route policies disabled response
+func (o *GetBgpRoutePoliciesDisabled) Code() int {
+	return 501
 }
 
 func (o *GetBgpRoutePoliciesDisabled) Error() string {

--- a/api/v1/client/bgp/get_bgp_routes_responses.go
+++ b/api/v1/client/bgp/get_bgp_routes_responses.go
@@ -45,7 +45,7 @@ func (o *GetBgpRoutesReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /bgp/routes] GetBgpRoutes", response, response.Code())
 	}
 }
 
@@ -86,6 +86,11 @@ func (o *GetBgpRoutesOK) IsServerError() bool {
 // IsCode returns true when this get bgp routes o k response a status code equal to that given
 func (o *GetBgpRoutesOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get bgp routes o k response
+func (o *GetBgpRoutesOK) Code() int {
+	return 200
 }
 
 func (o *GetBgpRoutesOK) Error() string {
@@ -149,6 +154,11 @@ func (o *GetBgpRoutesInternalServerError) IsCode(code int) bool {
 	return code == 500
 }
 
+// Code gets the status code for the get bgp routes internal server error response
+func (o *GetBgpRoutesInternalServerError) Code() int {
+	return 500
+}
+
 func (o *GetBgpRoutesInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /bgp/routes][%d] getBgpRoutesInternalServerError  %+v", 500, o.Payload)
 }
@@ -208,6 +218,11 @@ func (o *GetBgpRoutesDisabled) IsServerError() bool {
 // IsCode returns true when this get bgp routes disabled response a status code equal to that given
 func (o *GetBgpRoutesDisabled) IsCode(code int) bool {
 	return code == 501
+}
+
+// Code gets the status code for the get bgp routes disabled response
+func (o *GetBgpRoutesDisabled) Code() int {
+	return 501
 }
 
 func (o *GetBgpRoutesDisabled) Error() string {

--- a/api/v1/client/daemon/get_cgroup_dump_metadata_responses.go
+++ b/api/v1/client/daemon/get_cgroup_dump_metadata_responses.go
@@ -39,7 +39,7 @@ func (o *GetCgroupDumpMetadataReader) ReadResponse(response runtime.ClientRespon
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /cgroup-dump-metadata] GetCgroupDumpMetadata", response, response.Code())
 	}
 }
 
@@ -80,6 +80,11 @@ func (o *GetCgroupDumpMetadataOK) IsServerError() bool {
 // IsCode returns true when this get cgroup dump metadata o k response a status code equal to that given
 func (o *GetCgroupDumpMetadataOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get cgroup dump metadata o k response
+func (o *GetCgroupDumpMetadataOK) Code() int {
+	return 200
 }
 
 func (o *GetCgroupDumpMetadataOK) Error() string {
@@ -143,6 +148,11 @@ func (o *GetCgroupDumpMetadataFailure) IsServerError() bool {
 // IsCode returns true when this get cgroup dump metadata failure response a status code equal to that given
 func (o *GetCgroupDumpMetadataFailure) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the get cgroup dump metadata failure response
+func (o *GetCgroupDumpMetadataFailure) Code() int {
+	return 500
 }
 
 func (o *GetCgroupDumpMetadataFailure) Error() string {

--- a/api/v1/client/daemon/get_cluster_nodes_responses.go
+++ b/api/v1/client/daemon/get_cluster_nodes_responses.go
@@ -33,7 +33,7 @@ func (o *GetClusterNodesReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /cluster/nodes] GetClusterNodes", response, response.Code())
 	}
 }
 
@@ -74,6 +74,11 @@ func (o *GetClusterNodesOK) IsServerError() bool {
 // IsCode returns true when this get cluster nodes o k response a status code equal to that given
 func (o *GetClusterNodesOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get cluster nodes o k response
+func (o *GetClusterNodesOK) Code() int {
+	return 200
 }
 
 func (o *GetClusterNodesOK) Error() string {

--- a/api/v1/client/daemon/get_config_responses.go
+++ b/api/v1/client/daemon/get_config_responses.go
@@ -33,7 +33,7 @@ func (o *GetConfigReader) ReadResponse(response runtime.ClientResponse, consumer
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /config] GetConfig", response, response.Code())
 	}
 }
 
@@ -74,6 +74,11 @@ func (o *GetConfigOK) IsServerError() bool {
 // IsCode returns true when this get config o k response a status code equal to that given
 func (o *GetConfigOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get config o k response
+func (o *GetConfigOK) Code() int {
+	return 200
 }
 
 func (o *GetConfigOK) Error() string {

--- a/api/v1/client/daemon/get_debuginfo_responses.go
+++ b/api/v1/client/daemon/get_debuginfo_responses.go
@@ -39,7 +39,7 @@ func (o *GetDebuginfoReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /debuginfo] GetDebuginfo", response, response.Code())
 	}
 }
 
@@ -80,6 +80,11 @@ func (o *GetDebuginfoOK) IsServerError() bool {
 // IsCode returns true when this get debuginfo o k response a status code equal to that given
 func (o *GetDebuginfoOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get debuginfo o k response
+func (o *GetDebuginfoOK) Code() int {
+	return 200
 }
 
 func (o *GetDebuginfoOK) Error() string {
@@ -143,6 +148,11 @@ func (o *GetDebuginfoFailure) IsServerError() bool {
 // IsCode returns true when this get debuginfo failure response a status code equal to that given
 func (o *GetDebuginfoFailure) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the get debuginfo failure response
+func (o *GetDebuginfoFailure) Code() int {
+	return 500
 }
 
 func (o *GetDebuginfoFailure) Error() string {

--- a/api/v1/client/daemon/get_health_responses.go
+++ b/api/v1/client/daemon/get_health_responses.go
@@ -33,7 +33,7 @@ func (o *GetHealthReader) ReadResponse(response runtime.ClientResponse, consumer
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /health] GetHealth", response, response.Code())
 	}
 }
 
@@ -74,6 +74,11 @@ func (o *GetHealthOK) IsServerError() bool {
 // IsCode returns true when this get health o k response a status code equal to that given
 func (o *GetHealthOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get health o k response
+func (o *GetHealthOK) Code() int {
+	return 200
 }
 
 func (o *GetHealthOK) Error() string {

--- a/api/v1/client/daemon/get_healthz_responses.go
+++ b/api/v1/client/daemon/get_healthz_responses.go
@@ -33,7 +33,7 @@ func (o *GetHealthzReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /healthz] GetHealthz", response, response.Code())
 	}
 }
 
@@ -74,6 +74,11 @@ func (o *GetHealthzOK) IsServerError() bool {
 // IsCode returns true when this get healthz o k response a status code equal to that given
 func (o *GetHealthzOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get healthz o k response
+func (o *GetHealthzOK) Code() int {
+	return 200
 }
 
 func (o *GetHealthzOK) Error() string {

--- a/api/v1/client/daemon/get_map_name_events_responses.go
+++ b/api/v1/client/daemon/get_map_name_events_responses.go
@@ -38,7 +38,7 @@ func (o *GetMapNameEventsReader) ReadResponse(response runtime.ClientResponse, c
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /map/{name}/events] GetMapNameEvents", response, response.Code())
 	}
 }
 
@@ -82,6 +82,11 @@ func (o *GetMapNameEventsOK) IsServerError() bool {
 // IsCode returns true when this get map name events o k response a status code equal to that given
 func (o *GetMapNameEventsOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get map name events o k response
+func (o *GetMapNameEventsOK) Code() int {
+	return 200
 }
 
 func (o *GetMapNameEventsOK) Error() string {
@@ -142,6 +147,11 @@ func (o *GetMapNameEventsNotFound) IsServerError() bool {
 // IsCode returns true when this get map name events not found response a status code equal to that given
 func (o *GetMapNameEventsNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the get map name events not found response
+func (o *GetMapNameEventsNotFound) Code() int {
+	return 404
 }
 
 func (o *GetMapNameEventsNotFound) Error() string {

--- a/api/v1/client/daemon/get_map_name_responses.go
+++ b/api/v1/client/daemon/get_map_name_responses.go
@@ -39,7 +39,7 @@ func (o *GetMapNameReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /map/{name}] GetMapName", response, response.Code())
 	}
 }
 
@@ -80,6 +80,11 @@ func (o *GetMapNameOK) IsServerError() bool {
 // IsCode returns true when this get map name o k response a status code equal to that given
 func (o *GetMapNameOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get map name o k response
+func (o *GetMapNameOK) Code() int {
+	return 200
 }
 
 func (o *GetMapNameOK) Error() string {
@@ -142,6 +147,11 @@ func (o *GetMapNameNotFound) IsServerError() bool {
 // IsCode returns true when this get map name not found response a status code equal to that given
 func (o *GetMapNameNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the get map name not found response
+func (o *GetMapNameNotFound) Code() int {
+	return 404
 }
 
 func (o *GetMapNameNotFound) Error() string {

--- a/api/v1/client/daemon/get_map_responses.go
+++ b/api/v1/client/daemon/get_map_responses.go
@@ -33,7 +33,7 @@ func (o *GetMapReader) ReadResponse(response runtime.ClientResponse, consumer ru
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /map] GetMap", response, response.Code())
 	}
 }
 
@@ -74,6 +74,11 @@ func (o *GetMapOK) IsServerError() bool {
 // IsCode returns true when this get map o k response a status code equal to that given
 func (o *GetMapOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get map o k response
+func (o *GetMapOK) Code() int {
+	return 200
 }
 
 func (o *GetMapOK) Error() string {

--- a/api/v1/client/daemon/get_node_ids_responses.go
+++ b/api/v1/client/daemon/get_node_ids_responses.go
@@ -33,7 +33,7 @@ func (o *GetNodeIdsReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /node/ids] GetNodeIds", response, response.Code())
 	}
 }
 
@@ -74,6 +74,11 @@ func (o *GetNodeIdsOK) IsServerError() bool {
 // IsCode returns true when this get node ids o k response a status code equal to that given
 func (o *GetNodeIdsOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get node ids o k response
+func (o *GetNodeIdsOK) Code() int {
+	return 200
 }
 
 func (o *GetNodeIdsOK) Error() string {

--- a/api/v1/client/daemon/patch_config_responses.go
+++ b/api/v1/client/daemon/patch_config_responses.go
@@ -51,7 +51,7 @@ func (o *PatchConfigReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PATCH /config] PatchConfig", response, response.Code())
 	}
 }
 
@@ -91,6 +91,11 @@ func (o *PatchConfigOK) IsServerError() bool {
 // IsCode returns true when this patch config o k response a status code equal to that given
 func (o *PatchConfigOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the patch config o k response
+func (o *PatchConfigOK) Code() int {
+	return 200
 }
 
 func (o *PatchConfigOK) Error() string {
@@ -143,6 +148,11 @@ func (o *PatchConfigBadRequest) IsServerError() bool {
 // IsCode returns true when this patch config bad request response a status code equal to that given
 func (o *PatchConfigBadRequest) IsCode(code int) bool {
 	return code == 400
+}
+
+// Code gets the status code for the patch config bad request response
+func (o *PatchConfigBadRequest) Code() int {
+	return 400
 }
 
 func (o *PatchConfigBadRequest) Error() string {
@@ -205,6 +215,11 @@ func (o *PatchConfigForbidden) IsCode(code int) bool {
 	return code == 403
 }
 
+// Code gets the status code for the patch config forbidden response
+func (o *PatchConfigForbidden) Code() int {
+	return 403
+}
+
 func (o *PatchConfigForbidden) Error() string {
 	return fmt.Sprintf("[PATCH /config][%d] patchConfigForbidden ", 403)
 }
@@ -255,6 +270,11 @@ func (o *PatchConfigFailure) IsServerError() bool {
 // IsCode returns true when this patch config failure response a status code equal to that given
 func (o *PatchConfigFailure) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the patch config failure response
+func (o *PatchConfigFailure) Code() int {
+	return 500
 }
 
 func (o *PatchConfigFailure) Error() string {

--- a/api/v1/client/endpoint/delete_endpoint_id_responses.go
+++ b/api/v1/client/endpoint/delete_endpoint_id_responses.go
@@ -63,7 +63,7 @@ func (o *DeleteEndpointIDReader) ReadResponse(response runtime.ClientResponse, c
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /endpoint/{id}] DeleteEndpointID", response, response.Code())
 	}
 }
 
@@ -103,6 +103,11 @@ func (o *DeleteEndpointIDOK) IsServerError() bool {
 // IsCode returns true when this delete endpoint Id o k response a status code equal to that given
 func (o *DeleteEndpointIDOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the delete endpoint Id o k response
+func (o *DeleteEndpointIDOK) Code() int {
+	return 200
 }
 
 func (o *DeleteEndpointIDOK) Error() string {
@@ -155,6 +160,11 @@ func (o *DeleteEndpointIDErrors) IsServerError() bool {
 // IsCode returns true when this delete endpoint Id errors response a status code equal to that given
 func (o *DeleteEndpointIDErrors) IsCode(code int) bool {
 	return code == 206
+}
+
+// Code gets the status code for the delete endpoint Id errors response
+func (o *DeleteEndpointIDErrors) Code() int {
+	return 206
 }
 
 func (o *DeleteEndpointIDErrors) Error() string {
@@ -220,6 +230,11 @@ func (o *DeleteEndpointIDInvalid) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the delete endpoint Id invalid response
+func (o *DeleteEndpointIDInvalid) Code() int {
+	return 400
+}
+
 func (o *DeleteEndpointIDInvalid) Error() string {
 	return fmt.Sprintf("[DELETE /endpoint/{id}][%d] deleteEndpointIdInvalid  %+v", 400, o.Payload)
 }
@@ -280,6 +295,11 @@ func (o *DeleteEndpointIDForbidden) IsCode(code int) bool {
 	return code == 403
 }
 
+// Code gets the status code for the delete endpoint Id forbidden response
+func (o *DeleteEndpointIDForbidden) Code() int {
+	return 403
+}
+
 func (o *DeleteEndpointIDForbidden) Error() string {
 	return fmt.Sprintf("[DELETE /endpoint/{id}][%d] deleteEndpointIdForbidden ", 403)
 }
@@ -331,6 +351,11 @@ func (o *DeleteEndpointIDNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the delete endpoint Id not found response
+func (o *DeleteEndpointIDNotFound) Code() int {
+	return 404
+}
+
 func (o *DeleteEndpointIDNotFound) Error() string {
 	return fmt.Sprintf("[DELETE /endpoint/{id}][%d] deleteEndpointIdNotFound ", 404)
 }
@@ -380,6 +405,11 @@ func (o *DeleteEndpointIDTooManyRequests) IsServerError() bool {
 // IsCode returns true when this delete endpoint Id too many requests response a status code equal to that given
 func (o *DeleteEndpointIDTooManyRequests) IsCode(code int) bool {
 	return code == 429
+}
+
+// Code gets the status code for the delete endpoint Id too many requests response
+func (o *DeleteEndpointIDTooManyRequests) Code() int {
+	return 429
 }
 
 func (o *DeleteEndpointIDTooManyRequests) Error() string {

--- a/api/v1/client/endpoint/delete_endpoint_responses.go
+++ b/api/v1/client/endpoint/delete_endpoint_responses.go
@@ -55,7 +55,7 @@ func (o *DeleteEndpointReader) ReadResponse(response runtime.ClientResponse, con
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /endpoint] DeleteEndpoint", response, response.Code())
 	}
 }
 
@@ -95,6 +95,11 @@ func (o *DeleteEndpointOK) IsServerError() bool {
 // IsCode returns true when this delete endpoint o k response a status code equal to that given
 func (o *DeleteEndpointOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the delete endpoint o k response
+func (o *DeleteEndpointOK) Code() int {
+	return 200
 }
 
 func (o *DeleteEndpointOK) Error() string {
@@ -147,6 +152,11 @@ func (o *DeleteEndpointErrors) IsServerError() bool {
 // IsCode returns true when this delete endpoint errors response a status code equal to that given
 func (o *DeleteEndpointErrors) IsCode(code int) bool {
 	return code == 206
+}
+
+// Code gets the status code for the delete endpoint errors response
+func (o *DeleteEndpointErrors) Code() int {
+	return 206
 }
 
 func (o *DeleteEndpointErrors) Error() string {
@@ -209,6 +219,11 @@ func (o *DeleteEndpointInvalid) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the delete endpoint invalid response
+func (o *DeleteEndpointInvalid) Code() int {
+	return 400
+}
+
 func (o *DeleteEndpointInvalid) Error() string {
 	return fmt.Sprintf("[DELETE /endpoint][%d] deleteEndpointInvalid ", 400)
 }
@@ -260,6 +275,11 @@ func (o *DeleteEndpointNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the delete endpoint not found response
+func (o *DeleteEndpointNotFound) Code() int {
+	return 404
+}
+
 func (o *DeleteEndpointNotFound) Error() string {
 	return fmt.Sprintf("[DELETE /endpoint][%d] deleteEndpointNotFound ", 404)
 }
@@ -309,6 +329,11 @@ func (o *DeleteEndpointTooManyRequests) IsServerError() bool {
 // IsCode returns true when this delete endpoint too many requests response a status code equal to that given
 func (o *DeleteEndpointTooManyRequests) IsCode(code int) bool {
 	return code == 429
+}
+
+// Code gets the status code for the delete endpoint too many requests response
+func (o *DeleteEndpointTooManyRequests) Code() int {
+	return 429
 }
 
 func (o *DeleteEndpointTooManyRequests) Error() string {

--- a/api/v1/client/endpoint/get_endpoint_id_config_responses.go
+++ b/api/v1/client/endpoint/get_endpoint_id_config_responses.go
@@ -45,7 +45,7 @@ func (o *GetEndpointIDConfigReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /endpoint/{id}/config] GetEndpointIDConfig", response, response.Code())
 	}
 }
 
@@ -86,6 +86,11 @@ func (o *GetEndpointIDConfigOK) IsServerError() bool {
 // IsCode returns true when this get endpoint Id config o k response a status code equal to that given
 func (o *GetEndpointIDConfigOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get endpoint Id config o k response
+func (o *GetEndpointIDConfigOK) Code() int {
+	return 200
 }
 
 func (o *GetEndpointIDConfigOK) Error() string {
@@ -150,6 +155,11 @@ func (o *GetEndpointIDConfigNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the get endpoint Id config not found response
+func (o *GetEndpointIDConfigNotFound) Code() int {
+	return 404
+}
+
 func (o *GetEndpointIDConfigNotFound) Error() string {
 	return fmt.Sprintf("[GET /endpoint/{id}/config][%d] getEndpointIdConfigNotFound ", 404)
 }
@@ -199,6 +209,11 @@ func (o *GetEndpointIDConfigTooManyRequests) IsServerError() bool {
 // IsCode returns true when this get endpoint Id config too many requests response a status code equal to that given
 func (o *GetEndpointIDConfigTooManyRequests) IsCode(code int) bool {
 	return code == 429
+}
+
+// Code gets the status code for the get endpoint Id config too many requests response
+func (o *GetEndpointIDConfigTooManyRequests) Code() int {
+	return 429
 }
 
 func (o *GetEndpointIDConfigTooManyRequests) Error() string {

--- a/api/v1/client/endpoint/get_endpoint_id_healthz_responses.go
+++ b/api/v1/client/endpoint/get_endpoint_id_healthz_responses.go
@@ -51,7 +51,7 @@ func (o *GetEndpointIDHealthzReader) ReadResponse(response runtime.ClientRespons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /endpoint/{id}/healthz] GetEndpointIDHealthz", response, response.Code())
 	}
 }
 
@@ -92,6 +92,11 @@ func (o *GetEndpointIDHealthzOK) IsServerError() bool {
 // IsCode returns true when this get endpoint Id healthz o k response a status code equal to that given
 func (o *GetEndpointIDHealthzOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get endpoint Id healthz o k response
+func (o *GetEndpointIDHealthzOK) Code() int {
+	return 200
 }
 
 func (o *GetEndpointIDHealthzOK) Error() string {
@@ -156,6 +161,11 @@ func (o *GetEndpointIDHealthzInvalid) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the get endpoint Id healthz invalid response
+func (o *GetEndpointIDHealthzInvalid) Code() int {
+	return 400
+}
+
 func (o *GetEndpointIDHealthzInvalid) Error() string {
 	return fmt.Sprintf("[GET /endpoint/{id}/healthz][%d] getEndpointIdHealthzInvalid ", 400)
 }
@@ -207,6 +217,11 @@ func (o *GetEndpointIDHealthzNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the get endpoint Id healthz not found response
+func (o *GetEndpointIDHealthzNotFound) Code() int {
+	return 404
+}
+
 func (o *GetEndpointIDHealthzNotFound) Error() string {
 	return fmt.Sprintf("[GET /endpoint/{id}/healthz][%d] getEndpointIdHealthzNotFound ", 404)
 }
@@ -256,6 +271,11 @@ func (o *GetEndpointIDHealthzTooManyRequests) IsServerError() bool {
 // IsCode returns true when this get endpoint Id healthz too many requests response a status code equal to that given
 func (o *GetEndpointIDHealthzTooManyRequests) IsCode(code int) bool {
 	return code == 429
+}
+
+// Code gets the status code for the get endpoint Id healthz too many requests response
+func (o *GetEndpointIDHealthzTooManyRequests) Code() int {
+	return 429
 }
 
 func (o *GetEndpointIDHealthzTooManyRequests) Error() string {

--- a/api/v1/client/endpoint/get_endpoint_id_labels_responses.go
+++ b/api/v1/client/endpoint/get_endpoint_id_labels_responses.go
@@ -45,7 +45,7 @@ func (o *GetEndpointIDLabelsReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /endpoint/{id}/labels] GetEndpointIDLabels", response, response.Code())
 	}
 }
 
@@ -86,6 +86,11 @@ func (o *GetEndpointIDLabelsOK) IsServerError() bool {
 // IsCode returns true when this get endpoint Id labels o k response a status code equal to that given
 func (o *GetEndpointIDLabelsOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get endpoint Id labels o k response
+func (o *GetEndpointIDLabelsOK) Code() int {
+	return 200
 }
 
 func (o *GetEndpointIDLabelsOK) Error() string {
@@ -150,6 +155,11 @@ func (o *GetEndpointIDLabelsNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the get endpoint Id labels not found response
+func (o *GetEndpointIDLabelsNotFound) Code() int {
+	return 404
+}
+
 func (o *GetEndpointIDLabelsNotFound) Error() string {
 	return fmt.Sprintf("[GET /endpoint/{id}/labels][%d] getEndpointIdLabelsNotFound ", 404)
 }
@@ -199,6 +209,11 @@ func (o *GetEndpointIDLabelsTooManyRequests) IsServerError() bool {
 // IsCode returns true when this get endpoint Id labels too many requests response a status code equal to that given
 func (o *GetEndpointIDLabelsTooManyRequests) IsCode(code int) bool {
 	return code == 429
+}
+
+// Code gets the status code for the get endpoint Id labels too many requests response
+func (o *GetEndpointIDLabelsTooManyRequests) Code() int {
+	return 429
 }
 
 func (o *GetEndpointIDLabelsTooManyRequests) Error() string {

--- a/api/v1/client/endpoint/get_endpoint_id_log_responses.go
+++ b/api/v1/client/endpoint/get_endpoint_id_log_responses.go
@@ -51,7 +51,7 @@ func (o *GetEndpointIDLogReader) ReadResponse(response runtime.ClientResponse, c
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /endpoint/{id}/log] GetEndpointIDLog", response, response.Code())
 	}
 }
 
@@ -92,6 +92,11 @@ func (o *GetEndpointIDLogOK) IsServerError() bool {
 // IsCode returns true when this get endpoint Id log o k response a status code equal to that given
 func (o *GetEndpointIDLogOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get endpoint Id log o k response
+func (o *GetEndpointIDLogOK) Code() int {
+	return 200
 }
 
 func (o *GetEndpointIDLogOK) Error() string {
@@ -154,6 +159,11 @@ func (o *GetEndpointIDLogInvalid) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the get endpoint Id log invalid response
+func (o *GetEndpointIDLogInvalid) Code() int {
+	return 400
+}
+
 func (o *GetEndpointIDLogInvalid) Error() string {
 	return fmt.Sprintf("[GET /endpoint/{id}/log][%d] getEndpointIdLogInvalid ", 400)
 }
@@ -205,6 +215,11 @@ func (o *GetEndpointIDLogNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the get endpoint Id log not found response
+func (o *GetEndpointIDLogNotFound) Code() int {
+	return 404
+}
+
 func (o *GetEndpointIDLogNotFound) Error() string {
 	return fmt.Sprintf("[GET /endpoint/{id}/log][%d] getEndpointIdLogNotFound ", 404)
 }
@@ -254,6 +269,11 @@ func (o *GetEndpointIDLogTooManyRequests) IsServerError() bool {
 // IsCode returns true when this get endpoint Id log too many requests response a status code equal to that given
 func (o *GetEndpointIDLogTooManyRequests) IsCode(code int) bool {
 	return code == 429
+}
+
+// Code gets the status code for the get endpoint Id log too many requests response
+func (o *GetEndpointIDLogTooManyRequests) Code() int {
+	return 429
 }
 
 func (o *GetEndpointIDLogTooManyRequests) Error() string {

--- a/api/v1/client/endpoint/get_endpoint_id_responses.go
+++ b/api/v1/client/endpoint/get_endpoint_id_responses.go
@@ -51,7 +51,7 @@ func (o *GetEndpointIDReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /endpoint/{id}] GetEndpointID", response, response.Code())
 	}
 }
 
@@ -92,6 +92,11 @@ func (o *GetEndpointIDOK) IsServerError() bool {
 // IsCode returns true when this get endpoint Id o k response a status code equal to that given
 func (o *GetEndpointIDOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get endpoint Id o k response
+func (o *GetEndpointIDOK) Code() int {
+	return 200
 }
 
 func (o *GetEndpointIDOK) Error() string {
@@ -157,6 +162,11 @@ func (o *GetEndpointIDInvalid) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the get endpoint Id invalid response
+func (o *GetEndpointIDInvalid) Code() int {
+	return 400
+}
+
 func (o *GetEndpointIDInvalid) Error() string {
 	return fmt.Sprintf("[GET /endpoint/{id}][%d] getEndpointIdInvalid  %+v", 400, o.Payload)
 }
@@ -217,6 +227,11 @@ func (o *GetEndpointIDNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the get endpoint Id not found response
+func (o *GetEndpointIDNotFound) Code() int {
+	return 404
+}
+
 func (o *GetEndpointIDNotFound) Error() string {
 	return fmt.Sprintf("[GET /endpoint/{id}][%d] getEndpointIdNotFound ", 404)
 }
@@ -266,6 +281,11 @@ func (o *GetEndpointIDTooManyRequests) IsServerError() bool {
 // IsCode returns true when this get endpoint Id too many requests response a status code equal to that given
 func (o *GetEndpointIDTooManyRequests) IsCode(code int) bool {
 	return code == 429
+}
+
+// Code gets the status code for the get endpoint Id too many requests response
+func (o *GetEndpointIDTooManyRequests) Code() int {
+	return 429
 }
 
 func (o *GetEndpointIDTooManyRequests) Error() string {

--- a/api/v1/client/endpoint/get_endpoint_responses.go
+++ b/api/v1/client/endpoint/get_endpoint_responses.go
@@ -45,7 +45,7 @@ func (o *GetEndpointReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /endpoint] GetEndpoint", response, response.Code())
 	}
 }
 
@@ -86,6 +86,11 @@ func (o *GetEndpointOK) IsServerError() bool {
 // IsCode returns true when this get endpoint o k response a status code equal to that given
 func (o *GetEndpointOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get endpoint o k response
+func (o *GetEndpointOK) Code() int {
+	return 200
 }
 
 func (o *GetEndpointOK) Error() string {
@@ -148,6 +153,11 @@ func (o *GetEndpointNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the get endpoint not found response
+func (o *GetEndpointNotFound) Code() int {
+	return 404
+}
+
 func (o *GetEndpointNotFound) Error() string {
 	return fmt.Sprintf("[GET /endpoint][%d] getEndpointNotFound ", 404)
 }
@@ -197,6 +207,11 @@ func (o *GetEndpointTooManyRequests) IsServerError() bool {
 // IsCode returns true when this get endpoint too many requests response a status code equal to that given
 func (o *GetEndpointTooManyRequests) IsCode(code int) bool {
 	return code == 429
+}
+
+// Code gets the status code for the get endpoint too many requests response
+func (o *GetEndpointTooManyRequests) Code() int {
+	return 429
 }
 
 func (o *GetEndpointTooManyRequests) Error() string {

--- a/api/v1/client/endpoint/patch_endpoint_id_config_responses.go
+++ b/api/v1/client/endpoint/patch_endpoint_id_config_responses.go
@@ -63,7 +63,7 @@ func (o *PatchEndpointIDConfigReader) ReadResponse(response runtime.ClientRespon
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PATCH /endpoint/{id}/config] PatchEndpointIDConfig", response, response.Code())
 	}
 }
 
@@ -103,6 +103,11 @@ func (o *PatchEndpointIDConfigOK) IsServerError() bool {
 // IsCode returns true when this patch endpoint Id config o k response a status code equal to that given
 func (o *PatchEndpointIDConfigOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the patch endpoint Id config o k response
+func (o *PatchEndpointIDConfigOK) Code() int {
+	return 200
 }
 
 func (o *PatchEndpointIDConfigOK) Error() string {
@@ -156,6 +161,11 @@ func (o *PatchEndpointIDConfigInvalid) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the patch endpoint Id config invalid response
+func (o *PatchEndpointIDConfigInvalid) Code() int {
+	return 400
+}
+
 func (o *PatchEndpointIDConfigInvalid) Error() string {
 	return fmt.Sprintf("[PATCH /endpoint/{id}/config][%d] patchEndpointIdConfigInvalid ", 400)
 }
@@ -205,6 +215,11 @@ func (o *PatchEndpointIDConfigForbidden) IsServerError() bool {
 // IsCode returns true when this patch endpoint Id config forbidden response a status code equal to that given
 func (o *PatchEndpointIDConfigForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the patch endpoint Id config forbidden response
+func (o *PatchEndpointIDConfigForbidden) Code() int {
+	return 403
 }
 
 func (o *PatchEndpointIDConfigForbidden) Error() string {
@@ -258,6 +273,11 @@ func (o *PatchEndpointIDConfigNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the patch endpoint Id config not found response
+func (o *PatchEndpointIDConfigNotFound) Code() int {
+	return 404
+}
+
 func (o *PatchEndpointIDConfigNotFound) Error() string {
 	return fmt.Sprintf("[PATCH /endpoint/{id}/config][%d] patchEndpointIdConfigNotFound ", 404)
 }
@@ -307,6 +327,11 @@ func (o *PatchEndpointIDConfigTooManyRequests) IsServerError() bool {
 // IsCode returns true when this patch endpoint Id config too many requests response a status code equal to that given
 func (o *PatchEndpointIDConfigTooManyRequests) IsCode(code int) bool {
 	return code == 429
+}
+
+// Code gets the status code for the patch endpoint Id config too many requests response
+func (o *PatchEndpointIDConfigTooManyRequests) Code() int {
+	return 429
 }
 
 func (o *PatchEndpointIDConfigTooManyRequests) Error() string {
@@ -359,6 +384,11 @@ func (o *PatchEndpointIDConfigFailed) IsServerError() bool {
 // IsCode returns true when this patch endpoint Id config failed response a status code equal to that given
 func (o *PatchEndpointIDConfigFailed) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the patch endpoint Id config failed response
+func (o *PatchEndpointIDConfigFailed) Code() int {
+	return 500
 }
 
 func (o *PatchEndpointIDConfigFailed) Error() string {

--- a/api/v1/client/endpoint/patch_endpoint_id_labels_responses.go
+++ b/api/v1/client/endpoint/patch_endpoint_id_labels_responses.go
@@ -57,7 +57,7 @@ func (o *PatchEndpointIDLabelsReader) ReadResponse(response runtime.ClientRespon
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PATCH /endpoint/{id}/labels] PatchEndpointIDLabels", response, response.Code())
 	}
 }
 
@@ -97,6 +97,11 @@ func (o *PatchEndpointIDLabelsOK) IsServerError() bool {
 // IsCode returns true when this patch endpoint Id labels o k response a status code equal to that given
 func (o *PatchEndpointIDLabelsOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the patch endpoint Id labels o k response
+func (o *PatchEndpointIDLabelsOK) Code() int {
+	return 200
 }
 
 func (o *PatchEndpointIDLabelsOK) Error() string {
@@ -150,6 +155,11 @@ func (o *PatchEndpointIDLabelsForbidden) IsCode(code int) bool {
 	return code == 403
 }
 
+// Code gets the status code for the patch endpoint Id labels forbidden response
+func (o *PatchEndpointIDLabelsForbidden) Code() int {
+	return 403
+}
+
 func (o *PatchEndpointIDLabelsForbidden) Error() string {
 	return fmt.Sprintf("[PATCH /endpoint/{id}/labels][%d] patchEndpointIdLabelsForbidden ", 403)
 }
@@ -199,6 +209,11 @@ func (o *PatchEndpointIDLabelsNotFound) IsServerError() bool {
 // IsCode returns true when this patch endpoint Id labels not found response a status code equal to that given
 func (o *PatchEndpointIDLabelsNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the patch endpoint Id labels not found response
+func (o *PatchEndpointIDLabelsNotFound) Code() int {
+	return 404
 }
 
 func (o *PatchEndpointIDLabelsNotFound) Error() string {
@@ -252,6 +267,11 @@ func (o *PatchEndpointIDLabelsTooManyRequests) IsCode(code int) bool {
 	return code == 429
 }
 
+// Code gets the status code for the patch endpoint Id labels too many requests response
+func (o *PatchEndpointIDLabelsTooManyRequests) Code() int {
+	return 429
+}
+
 func (o *PatchEndpointIDLabelsTooManyRequests) Error() string {
 	return fmt.Sprintf("[PATCH /endpoint/{id}/labels][%d] patchEndpointIdLabelsTooManyRequests ", 429)
 }
@@ -302,6 +322,11 @@ func (o *PatchEndpointIDLabelsUpdateFailed) IsServerError() bool {
 // IsCode returns true when this patch endpoint Id labels update failed response a status code equal to that given
 func (o *PatchEndpointIDLabelsUpdateFailed) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the patch endpoint Id labels update failed response
+func (o *PatchEndpointIDLabelsUpdateFailed) Code() int {
+	return 500
 }
 
 func (o *PatchEndpointIDLabelsUpdateFailed) Error() string {

--- a/api/v1/client/endpoint/patch_endpoint_id_responses.go
+++ b/api/v1/client/endpoint/patch_endpoint_id_responses.go
@@ -63,7 +63,7 @@ func (o *PatchEndpointIDReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PATCH /endpoint/{id}] PatchEndpointID", response, response.Code())
 	}
 }
 
@@ -103,6 +103,11 @@ func (o *PatchEndpointIDOK) IsServerError() bool {
 // IsCode returns true when this patch endpoint Id o k response a status code equal to that given
 func (o *PatchEndpointIDOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the patch endpoint Id o k response
+func (o *PatchEndpointIDOK) Code() int {
+	return 200
 }
 
 func (o *PatchEndpointIDOK) Error() string {
@@ -155,6 +160,11 @@ func (o *PatchEndpointIDInvalid) IsServerError() bool {
 // IsCode returns true when this patch endpoint Id invalid response a status code equal to that given
 func (o *PatchEndpointIDInvalid) IsCode(code int) bool {
 	return code == 400
+}
+
+// Code gets the status code for the patch endpoint Id invalid response
+func (o *PatchEndpointIDInvalid) Code() int {
+	return 400
 }
 
 func (o *PatchEndpointIDInvalid) Error() string {
@@ -217,6 +227,11 @@ func (o *PatchEndpointIDForbidden) IsCode(code int) bool {
 	return code == 403
 }
 
+// Code gets the status code for the patch endpoint Id forbidden response
+func (o *PatchEndpointIDForbidden) Code() int {
+	return 403
+}
+
 func (o *PatchEndpointIDForbidden) Error() string {
 	return fmt.Sprintf("[PATCH /endpoint/{id}][%d] patchEndpointIdForbidden ", 403)
 }
@@ -266,6 +281,11 @@ func (o *PatchEndpointIDNotFound) IsServerError() bool {
 // IsCode returns true when this patch endpoint Id not found response a status code equal to that given
 func (o *PatchEndpointIDNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the patch endpoint Id not found response
+func (o *PatchEndpointIDNotFound) Code() int {
+	return 404
 }
 
 func (o *PatchEndpointIDNotFound) Error() string {
@@ -319,6 +339,11 @@ func (o *PatchEndpointIDTooManyRequests) IsCode(code int) bool {
 	return code == 429
 }
 
+// Code gets the status code for the patch endpoint Id too many requests response
+func (o *PatchEndpointIDTooManyRequests) Code() int {
+	return 429
+}
+
 func (o *PatchEndpointIDTooManyRequests) Error() string {
 	return fmt.Sprintf("[PATCH /endpoint/{id}][%d] patchEndpointIdTooManyRequests ", 429)
 }
@@ -369,6 +394,11 @@ func (o *PatchEndpointIDFailed) IsServerError() bool {
 // IsCode returns true when this patch endpoint Id failed response a status code equal to that given
 func (o *PatchEndpointIDFailed) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the patch endpoint Id failed response
+func (o *PatchEndpointIDFailed) Code() int {
+	return 500
 }
 
 func (o *PatchEndpointIDFailed) Error() string {

--- a/api/v1/client/endpoint/put_endpoint_id_responses.go
+++ b/api/v1/client/endpoint/put_endpoint_id_responses.go
@@ -63,7 +63,7 @@ func (o *PutEndpointIDReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /endpoint/{id}] PutEndpointID", response, response.Code())
 	}
 }
 
@@ -104,6 +104,11 @@ func (o *PutEndpointIDCreated) IsServerError() bool {
 // IsCode returns true when this put endpoint Id created response a status code equal to that given
 func (o *PutEndpointIDCreated) IsCode(code int) bool {
 	return code == 201
+}
+
+// Code gets the status code for the put endpoint Id created response
+func (o *PutEndpointIDCreated) Code() int {
+	return 201
 }
 
 func (o *PutEndpointIDCreated) Error() string {
@@ -169,6 +174,11 @@ func (o *PutEndpointIDInvalid) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the put endpoint Id invalid response
+func (o *PutEndpointIDInvalid) Code() int {
+	return 400
+}
+
 func (o *PutEndpointIDInvalid) Error() string {
 	return fmt.Sprintf("[PUT /endpoint/{id}][%d] putEndpointIdInvalid  %+v", 400, o.Payload)
 }
@@ -229,6 +239,11 @@ func (o *PutEndpointIDForbidden) IsCode(code int) bool {
 	return code == 403
 }
 
+// Code gets the status code for the put endpoint Id forbidden response
+func (o *PutEndpointIDForbidden) Code() int {
+	return 403
+}
+
 func (o *PutEndpointIDForbidden) Error() string {
 	return fmt.Sprintf("[PUT /endpoint/{id}][%d] putEndpointIdForbidden ", 403)
 }
@@ -278,6 +293,11 @@ func (o *PutEndpointIDExists) IsServerError() bool {
 // IsCode returns true when this put endpoint Id exists response a status code equal to that given
 func (o *PutEndpointIDExists) IsCode(code int) bool {
 	return code == 409
+}
+
+// Code gets the status code for the put endpoint Id exists response
+func (o *PutEndpointIDExists) Code() int {
+	return 409
 }
 
 func (o *PutEndpointIDExists) Error() string {
@@ -331,6 +351,11 @@ func (o *PutEndpointIDTooManyRequests) IsCode(code int) bool {
 	return code == 429
 }
 
+// Code gets the status code for the put endpoint Id too many requests response
+func (o *PutEndpointIDTooManyRequests) Code() int {
+	return 429
+}
+
 func (o *PutEndpointIDTooManyRequests) Error() string {
 	return fmt.Sprintf("[PUT /endpoint/{id}][%d] putEndpointIdTooManyRequests ", 429)
 }
@@ -381,6 +406,11 @@ func (o *PutEndpointIDFailed) IsServerError() bool {
 // IsCode returns true when this put endpoint Id failed response a status code equal to that given
 func (o *PutEndpointIDFailed) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the put endpoint Id failed response
+func (o *PutEndpointIDFailed) Code() int {
+	return 500
 }
 
 func (o *PutEndpointIDFailed) Error() string {

--- a/api/v1/client/ipam/delete_ipam_ip_responses.go
+++ b/api/v1/client/ipam/delete_ipam_ip_responses.go
@@ -63,7 +63,7 @@ func (o *DeleteIpamIPReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /ipam/{ip}] DeleteIpamIP", response, response.Code())
 	}
 }
 
@@ -103,6 +103,11 @@ func (o *DeleteIpamIPOK) IsServerError() bool {
 // IsCode returns true when this delete ipam Ip o k response a status code equal to that given
 func (o *DeleteIpamIPOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the delete ipam Ip o k response
+func (o *DeleteIpamIPOK) Code() int {
+	return 200
 }
 
 func (o *DeleteIpamIPOK) Error() string {
@@ -156,6 +161,11 @@ func (o *DeleteIpamIPInvalid) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the delete ipam Ip invalid response
+func (o *DeleteIpamIPInvalid) Code() int {
+	return 400
+}
+
 func (o *DeleteIpamIPInvalid) Error() string {
 	return fmt.Sprintf("[DELETE /ipam/{ip}][%d] deleteIpamIpInvalid ", 400)
 }
@@ -205,6 +215,11 @@ func (o *DeleteIpamIPForbidden) IsServerError() bool {
 // IsCode returns true when this delete ipam Ip forbidden response a status code equal to that given
 func (o *DeleteIpamIPForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the delete ipam Ip forbidden response
+func (o *DeleteIpamIPForbidden) Code() int {
+	return 403
 }
 
 func (o *DeleteIpamIPForbidden) Error() string {
@@ -258,6 +273,11 @@ func (o *DeleteIpamIPNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the delete ipam Ip not found response
+func (o *DeleteIpamIPNotFound) Code() int {
+	return 404
+}
+
 func (o *DeleteIpamIPNotFound) Error() string {
 	return fmt.Sprintf("[DELETE /ipam/{ip}][%d] deleteIpamIpNotFound ", 404)
 }
@@ -308,6 +328,11 @@ func (o *DeleteIpamIPFailure) IsServerError() bool {
 // IsCode returns true when this delete ipam Ip failure response a status code equal to that given
 func (o *DeleteIpamIPFailure) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the delete ipam Ip failure response
+func (o *DeleteIpamIPFailure) Code() int {
+	return 500
 }
 
 func (o *DeleteIpamIPFailure) Error() string {
@@ -368,6 +393,11 @@ func (o *DeleteIpamIPDisabled) IsServerError() bool {
 // IsCode returns true when this delete ipam Ip disabled response a status code equal to that given
 func (o *DeleteIpamIPDisabled) IsCode(code int) bool {
 	return code == 501
+}
+
+// Code gets the status code for the delete ipam Ip disabled response
+func (o *DeleteIpamIPDisabled) Code() int {
+	return 501
 }
 
 func (o *DeleteIpamIPDisabled) Error() string {

--- a/api/v1/client/ipam/post_ipam_ip_responses.go
+++ b/api/v1/client/ipam/post_ipam_ip_responses.go
@@ -63,7 +63,7 @@ func (o *PostIpamIPReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /ipam/{ip}] PostIpamIP", response, response.Code())
 	}
 }
 
@@ -103,6 +103,11 @@ func (o *PostIpamIPOK) IsServerError() bool {
 // IsCode returns true when this post ipam Ip o k response a status code equal to that given
 func (o *PostIpamIPOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the post ipam Ip o k response
+func (o *PostIpamIPOK) Code() int {
+	return 200
 }
 
 func (o *PostIpamIPOK) Error() string {
@@ -156,6 +161,11 @@ func (o *PostIpamIPInvalid) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the post ipam Ip invalid response
+func (o *PostIpamIPInvalid) Code() int {
+	return 400
+}
+
 func (o *PostIpamIPInvalid) Error() string {
 	return fmt.Sprintf("[POST /ipam/{ip}][%d] postIpamIpInvalid ", 400)
 }
@@ -205,6 +215,11 @@ func (o *PostIpamIPForbidden) IsServerError() bool {
 // IsCode returns true when this post ipam Ip forbidden response a status code equal to that given
 func (o *PostIpamIPForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the post ipam Ip forbidden response
+func (o *PostIpamIPForbidden) Code() int {
+	return 403
 }
 
 func (o *PostIpamIPForbidden) Error() string {
@@ -258,6 +273,11 @@ func (o *PostIpamIPExists) IsCode(code int) bool {
 	return code == 409
 }
 
+// Code gets the status code for the post ipam Ip exists response
+func (o *PostIpamIPExists) Code() int {
+	return 409
+}
+
 func (o *PostIpamIPExists) Error() string {
 	return fmt.Sprintf("[POST /ipam/{ip}][%d] postIpamIpExists ", 409)
 }
@@ -308,6 +328,11 @@ func (o *PostIpamIPFailure) IsServerError() bool {
 // IsCode returns true when this post ipam Ip failure response a status code equal to that given
 func (o *PostIpamIPFailure) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the post ipam Ip failure response
+func (o *PostIpamIPFailure) Code() int {
+	return 500
 }
 
 func (o *PostIpamIPFailure) Error() string {
@@ -368,6 +393,11 @@ func (o *PostIpamIPDisabled) IsServerError() bool {
 // IsCode returns true when this post ipam Ip disabled response a status code equal to that given
 func (o *PostIpamIPDisabled) IsCode(code int) bool {
 	return code == 501
+}
+
+// Code gets the status code for the post ipam Ip disabled response
+func (o *PostIpamIPDisabled) Code() int {
+	return 501
 }
 
 func (o *PostIpamIPDisabled) Error() string {

--- a/api/v1/client/ipam/post_ipam_responses.go
+++ b/api/v1/client/ipam/post_ipam_responses.go
@@ -45,7 +45,7 @@ func (o *PostIpamReader) ReadResponse(response runtime.ClientResponse, consumer 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /ipam] PostIpam", response, response.Code())
 	}
 }
 
@@ -86,6 +86,11 @@ func (o *PostIpamCreated) IsServerError() bool {
 // IsCode returns true when this post ipam created response a status code equal to that given
 func (o *PostIpamCreated) IsCode(code int) bool {
 	return code == 201
+}
+
+// Code gets the status code for the post ipam created response
+func (o *PostIpamCreated) Code() int {
+	return 201
 }
 
 func (o *PostIpamCreated) Error() string {
@@ -150,6 +155,11 @@ func (o *PostIpamForbidden) IsCode(code int) bool {
 	return code == 403
 }
 
+// Code gets the status code for the post ipam forbidden response
+func (o *PostIpamForbidden) Code() int {
+	return 403
+}
+
 func (o *PostIpamForbidden) Error() string {
 	return fmt.Sprintf("[POST /ipam][%d] postIpamForbidden ", 403)
 }
@@ -200,6 +210,11 @@ func (o *PostIpamFailure) IsServerError() bool {
 // IsCode returns true when this post ipam failure response a status code equal to that given
 func (o *PostIpamFailure) IsCode(code int) bool {
 	return code == 502
+}
+
+// Code gets the status code for the post ipam failure response
+func (o *PostIpamFailure) Code() int {
+	return 502
 }
 
 func (o *PostIpamFailure) Error() string {

--- a/api/v1/client/metrics/get_metrics_responses.go
+++ b/api/v1/client/metrics/get_metrics_responses.go
@@ -39,7 +39,7 @@ func (o *GetMetricsReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /metrics/] GetMetrics", response, response.Code())
 	}
 }
 
@@ -80,6 +80,11 @@ func (o *GetMetricsOK) IsServerError() bool {
 // IsCode returns true when this get metrics o k response a status code equal to that given
 func (o *GetMetricsOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get metrics o k response
+func (o *GetMetricsOK) Code() int {
+	return 200
 }
 
 func (o *GetMetricsOK) Error() string {
@@ -140,6 +145,11 @@ func (o *GetMetricsInternalServerError) IsServerError() bool {
 // IsCode returns true when this get metrics internal server error response a status code equal to that given
 func (o *GetMetricsInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the get metrics internal server error response
+func (o *GetMetricsInternalServerError) Code() int {
+	return 500
 }
 
 func (o *GetMetricsInternalServerError) Error() string {

--- a/api/v1/client/policy/delete_fqdn_cache_responses.go
+++ b/api/v1/client/policy/delete_fqdn_cache_responses.go
@@ -45,7 +45,7 @@ func (o *DeleteFqdnCacheReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /fqdn/cache] DeleteFqdnCache", response, response.Code())
 	}
 }
 
@@ -85,6 +85,11 @@ func (o *DeleteFqdnCacheOK) IsServerError() bool {
 // IsCode returns true when this delete fqdn cache o k response a status code equal to that given
 func (o *DeleteFqdnCacheOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the delete fqdn cache o k response
+func (o *DeleteFqdnCacheOK) Code() int {
+	return 200
 }
 
 func (o *DeleteFqdnCacheOK) Error() string {
@@ -137,6 +142,11 @@ func (o *DeleteFqdnCacheBadRequest) IsServerError() bool {
 // IsCode returns true when this delete fqdn cache bad request response a status code equal to that given
 func (o *DeleteFqdnCacheBadRequest) IsCode(code int) bool {
 	return code == 400
+}
+
+// Code gets the status code for the delete fqdn cache bad request response
+func (o *DeleteFqdnCacheBadRequest) Code() int {
+	return 400
 }
 
 func (o *DeleteFqdnCacheBadRequest) Error() string {
@@ -197,6 +207,11 @@ func (o *DeleteFqdnCacheForbidden) IsServerError() bool {
 // IsCode returns true when this delete fqdn cache forbidden response a status code equal to that given
 func (o *DeleteFqdnCacheForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the delete fqdn cache forbidden response
+func (o *DeleteFqdnCacheForbidden) Code() int {
+	return 403
 }
 
 func (o *DeleteFqdnCacheForbidden) Error() string {

--- a/api/v1/client/policy/delete_policy_responses.go
+++ b/api/v1/client/policy/delete_policy_responses.go
@@ -57,7 +57,7 @@ func (o *DeletePolicyReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /policy] DeletePolicy", response, response.Code())
 	}
 }
 
@@ -98,6 +98,11 @@ func (o *DeletePolicyOK) IsServerError() bool {
 // IsCode returns true when this delete policy o k response a status code equal to that given
 func (o *DeletePolicyOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the delete policy o k response
+func (o *DeletePolicyOK) Code() int {
+	return 200
 }
 
 func (o *DeletePolicyOK) Error() string {
@@ -163,6 +168,11 @@ func (o *DeletePolicyInvalid) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the delete policy invalid response
+func (o *DeletePolicyInvalid) Code() int {
+	return 400
+}
+
 func (o *DeletePolicyInvalid) Error() string {
 	return fmt.Sprintf("[DELETE /policy][%d] deletePolicyInvalid  %+v", 400, o.Payload)
 }
@@ -223,6 +233,11 @@ func (o *DeletePolicyForbidden) IsCode(code int) bool {
 	return code == 403
 }
 
+// Code gets the status code for the delete policy forbidden response
+func (o *DeletePolicyForbidden) Code() int {
+	return 403
+}
+
 func (o *DeletePolicyForbidden) Error() string {
 	return fmt.Sprintf("[DELETE /policy][%d] deletePolicyForbidden ", 403)
 }
@@ -272,6 +287,11 @@ func (o *DeletePolicyNotFound) IsServerError() bool {
 // IsCode returns true when this delete policy not found response a status code equal to that given
 func (o *DeletePolicyNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the delete policy not found response
+func (o *DeletePolicyNotFound) Code() int {
+	return 404
 }
 
 func (o *DeletePolicyNotFound) Error() string {
@@ -324,6 +344,11 @@ func (o *DeletePolicyFailure) IsServerError() bool {
 // IsCode returns true when this delete policy failure response a status code equal to that given
 func (o *DeletePolicyFailure) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the delete policy failure response
+func (o *DeletePolicyFailure) Code() int {
+	return 500
 }
 
 func (o *DeletePolicyFailure) Error() string {

--- a/api/v1/client/policy/get_fqdn_cache_id_responses.go
+++ b/api/v1/client/policy/get_fqdn_cache_id_responses.go
@@ -45,7 +45,7 @@ func (o *GetFqdnCacheIDReader) ReadResponse(response runtime.ClientResponse, con
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /fqdn/cache/{id}] GetFqdnCacheID", response, response.Code())
 	}
 }
 
@@ -86,6 +86,11 @@ func (o *GetFqdnCacheIDOK) IsServerError() bool {
 // IsCode returns true when this get fqdn cache Id o k response a status code equal to that given
 func (o *GetFqdnCacheIDOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get fqdn cache Id o k response
+func (o *GetFqdnCacheIDOK) Code() int {
+	return 200
 }
 
 func (o *GetFqdnCacheIDOK) Error() string {
@@ -149,6 +154,11 @@ func (o *GetFqdnCacheIDBadRequest) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the get fqdn cache Id bad request response
+func (o *GetFqdnCacheIDBadRequest) Code() int {
+	return 400
+}
+
 func (o *GetFqdnCacheIDBadRequest) Error() string {
 	return fmt.Sprintf("[GET /fqdn/cache/{id}][%d] getFqdnCacheIdBadRequest  %+v", 400, o.Payload)
 }
@@ -207,6 +217,11 @@ func (o *GetFqdnCacheIDNotFound) IsServerError() bool {
 // IsCode returns true when this get fqdn cache Id not found response a status code equal to that given
 func (o *GetFqdnCacheIDNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the get fqdn cache Id not found response
+func (o *GetFqdnCacheIDNotFound) Code() int {
+	return 404
 }
 
 func (o *GetFqdnCacheIDNotFound) Error() string {

--- a/api/v1/client/policy/get_fqdn_cache_responses.go
+++ b/api/v1/client/policy/get_fqdn_cache_responses.go
@@ -45,7 +45,7 @@ func (o *GetFqdnCacheReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /fqdn/cache] GetFqdnCache", response, response.Code())
 	}
 }
 
@@ -86,6 +86,11 @@ func (o *GetFqdnCacheOK) IsServerError() bool {
 // IsCode returns true when this get fqdn cache o k response a status code equal to that given
 func (o *GetFqdnCacheOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get fqdn cache o k response
+func (o *GetFqdnCacheOK) Code() int {
+	return 200
 }
 
 func (o *GetFqdnCacheOK) Error() string {
@@ -149,6 +154,11 @@ func (o *GetFqdnCacheBadRequest) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the get fqdn cache bad request response
+func (o *GetFqdnCacheBadRequest) Code() int {
+	return 400
+}
+
 func (o *GetFqdnCacheBadRequest) Error() string {
 	return fmt.Sprintf("[GET /fqdn/cache][%d] getFqdnCacheBadRequest  %+v", 400, o.Payload)
 }
@@ -207,6 +217,11 @@ func (o *GetFqdnCacheNotFound) IsServerError() bool {
 // IsCode returns true when this get fqdn cache not found response a status code equal to that given
 func (o *GetFqdnCacheNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the get fqdn cache not found response
+func (o *GetFqdnCacheNotFound) Code() int {
+	return 404
 }
 
 func (o *GetFqdnCacheNotFound) Error() string {

--- a/api/v1/client/policy/get_fqdn_names_responses.go
+++ b/api/v1/client/policy/get_fqdn_names_responses.go
@@ -39,7 +39,7 @@ func (o *GetFqdnNamesReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /fqdn/names] GetFqdnNames", response, response.Code())
 	}
 }
 
@@ -80,6 +80,11 @@ func (o *GetFqdnNamesOK) IsServerError() bool {
 // IsCode returns true when this get fqdn names o k response a status code equal to that given
 func (o *GetFqdnNamesOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get fqdn names o k response
+func (o *GetFqdnNamesOK) Code() int {
+	return 200
 }
 
 func (o *GetFqdnNamesOK) Error() string {
@@ -143,6 +148,11 @@ func (o *GetFqdnNamesBadRequest) IsServerError() bool {
 // IsCode returns true when this get fqdn names bad request response a status code equal to that given
 func (o *GetFqdnNamesBadRequest) IsCode(code int) bool {
 	return code == 400
+}
+
+// Code gets the status code for the get fqdn names bad request response
+func (o *GetFqdnNamesBadRequest) Code() int {
+	return 400
 }
 
 func (o *GetFqdnNamesBadRequest) Error() string {

--- a/api/v1/client/policy/get_identity_endpoints_responses.go
+++ b/api/v1/client/policy/get_identity_endpoints_responses.go
@@ -39,7 +39,7 @@ func (o *GetIdentityEndpointsReader) ReadResponse(response runtime.ClientRespons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /identity/endpoints] GetIdentityEndpoints", response, response.Code())
 	}
 }
 
@@ -80,6 +80,11 @@ func (o *GetIdentityEndpointsOK) IsServerError() bool {
 // IsCode returns true when this get identity endpoints o k response a status code equal to that given
 func (o *GetIdentityEndpointsOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get identity endpoints o k response
+func (o *GetIdentityEndpointsOK) Code() int {
+	return 200
 }
 
 func (o *GetIdentityEndpointsOK) Error() string {
@@ -140,6 +145,11 @@ func (o *GetIdentityEndpointsNotFound) IsServerError() bool {
 // IsCode returns true when this get identity endpoints not found response a status code equal to that given
 func (o *GetIdentityEndpointsNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the get identity endpoints not found response
+func (o *GetIdentityEndpointsNotFound) Code() int {
+	return 404
 }
 
 func (o *GetIdentityEndpointsNotFound) Error() string {

--- a/api/v1/client/policy/get_identity_id_responses.go
+++ b/api/v1/client/policy/get_identity_id_responses.go
@@ -57,7 +57,7 @@ func (o *GetIdentityIDReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /identity/{id}] GetIdentityID", response, response.Code())
 	}
 }
 
@@ -98,6 +98,11 @@ func (o *GetIdentityIDOK) IsServerError() bool {
 // IsCode returns true when this get identity Id o k response a status code equal to that given
 func (o *GetIdentityIDOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get identity Id o k response
+func (o *GetIdentityIDOK) Code() int {
+	return 200
 }
 
 func (o *GetIdentityIDOK) Error() string {
@@ -162,6 +167,11 @@ func (o *GetIdentityIDBadRequest) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the get identity Id bad request response
+func (o *GetIdentityIDBadRequest) Code() int {
+	return 400
+}
+
 func (o *GetIdentityIDBadRequest) Error() string {
 	return fmt.Sprintf("[GET /identity/{id}][%d] getIdentityIdBadRequest ", 400)
 }
@@ -211,6 +221,11 @@ func (o *GetIdentityIDNotFound) IsServerError() bool {
 // IsCode returns true when this get identity Id not found response a status code equal to that given
 func (o *GetIdentityIDNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the get identity Id not found response
+func (o *GetIdentityIDNotFound) Code() int {
+	return 404
 }
 
 func (o *GetIdentityIDNotFound) Error() string {
@@ -263,6 +278,11 @@ func (o *GetIdentityIDUnreachable) IsServerError() bool {
 // IsCode returns true when this get identity Id unreachable response a status code equal to that given
 func (o *GetIdentityIDUnreachable) IsCode(code int) bool {
 	return code == 520
+}
+
+// Code gets the status code for the get identity Id unreachable response
+func (o *GetIdentityIDUnreachable) Code() int {
+	return 520
 }
 
 func (o *GetIdentityIDUnreachable) Error() string {
@@ -324,6 +344,11 @@ func (o *GetIdentityIDInvalidStorageFormat) IsServerError() bool {
 // IsCode returns true when this get identity Id invalid storage format response a status code equal to that given
 func (o *GetIdentityIDInvalidStorageFormat) IsCode(code int) bool {
 	return code == 521
+}
+
+// Code gets the status code for the get identity Id invalid storage format response
+func (o *GetIdentityIDInvalidStorageFormat) Code() int {
+	return 521
 }
 
 func (o *GetIdentityIDInvalidStorageFormat) Error() string {

--- a/api/v1/client/policy/get_identity_responses.go
+++ b/api/v1/client/policy/get_identity_responses.go
@@ -51,7 +51,7 @@ func (o *GetIdentityReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /identity] GetIdentity", response, response.Code())
 	}
 }
 
@@ -92,6 +92,11 @@ func (o *GetIdentityOK) IsServerError() bool {
 // IsCode returns true when this get identity o k response a status code equal to that given
 func (o *GetIdentityOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get identity o k response
+func (o *GetIdentityOK) Code() int {
+	return 200
 }
 
 func (o *GetIdentityOK) Error() string {
@@ -154,6 +159,11 @@ func (o *GetIdentityNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the get identity not found response
+func (o *GetIdentityNotFound) Code() int {
+	return 404
+}
+
 func (o *GetIdentityNotFound) Error() string {
 	return fmt.Sprintf("[GET /identity][%d] getIdentityNotFound ", 404)
 }
@@ -204,6 +214,11 @@ func (o *GetIdentityUnreachable) IsServerError() bool {
 // IsCode returns true when this get identity unreachable response a status code equal to that given
 func (o *GetIdentityUnreachable) IsCode(code int) bool {
 	return code == 520
+}
+
+// Code gets the status code for the get identity unreachable response
+func (o *GetIdentityUnreachable) Code() int {
+	return 520
 }
 
 func (o *GetIdentityUnreachable) Error() string {
@@ -265,6 +280,11 @@ func (o *GetIdentityInvalidStorageFormat) IsServerError() bool {
 // IsCode returns true when this get identity invalid storage format response a status code equal to that given
 func (o *GetIdentityInvalidStorageFormat) IsCode(code int) bool {
 	return code == 521
+}
+
+// Code gets the status code for the get identity invalid storage format response
+func (o *GetIdentityInvalidStorageFormat) Code() int {
+	return 521
 }
 
 func (o *GetIdentityInvalidStorageFormat) Error() string {

--- a/api/v1/client/policy/get_ip_responses.go
+++ b/api/v1/client/policy/get_ip_responses.go
@@ -45,7 +45,7 @@ func (o *GetIPReader) ReadResponse(response runtime.ClientResponse, consumer run
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /ip] GetIP", response, response.Code())
 	}
 }
 
@@ -86,6 +86,11 @@ func (o *GetIPOK) IsServerError() bool {
 // IsCode returns true when this get Ip o k response a status code equal to that given
 func (o *GetIPOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get Ip o k response
+func (o *GetIPOK) Code() int {
+	return 200
 }
 
 func (o *GetIPOK) Error() string {
@@ -149,6 +154,11 @@ func (o *GetIPBadRequest) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the get Ip bad request response
+func (o *GetIPBadRequest) Code() int {
+	return 400
+}
+
 func (o *GetIPBadRequest) Error() string {
 	return fmt.Sprintf("[GET /ip][%d] getIpBadRequest  %+v", 400, o.Payload)
 }
@@ -207,6 +217,11 @@ func (o *GetIPNotFound) IsServerError() bool {
 // IsCode returns true when this get Ip not found response a status code equal to that given
 func (o *GetIPNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the get Ip not found response
+func (o *GetIPNotFound) Code() int {
+	return 404
 }
 
 func (o *GetIPNotFound) Error() string {

--- a/api/v1/client/policy/get_policy_responses.go
+++ b/api/v1/client/policy/get_policy_responses.go
@@ -39,7 +39,7 @@ func (o *GetPolicyReader) ReadResponse(response runtime.ClientResponse, consumer
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /policy] GetPolicy", response, response.Code())
 	}
 }
 
@@ -80,6 +80,11 @@ func (o *GetPolicyOK) IsServerError() bool {
 // IsCode returns true when this get policy o k response a status code equal to that given
 func (o *GetPolicyOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get policy o k response
+func (o *GetPolicyOK) Code() int {
+	return 200
 }
 
 func (o *GetPolicyOK) Error() string {
@@ -142,6 +147,11 @@ func (o *GetPolicyNotFound) IsServerError() bool {
 // IsCode returns true when this get policy not found response a status code equal to that given
 func (o *GetPolicyNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the get policy not found response
+func (o *GetPolicyNotFound) Code() int {
+	return 404
 }
 
 func (o *GetPolicyNotFound) Error() string {

--- a/api/v1/client/policy/get_policy_selectors_responses.go
+++ b/api/v1/client/policy/get_policy_selectors_responses.go
@@ -33,7 +33,7 @@ func (o *GetPolicySelectorsReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /policy/selectors] GetPolicySelectors", response, response.Code())
 	}
 }
 
@@ -74,6 +74,11 @@ func (o *GetPolicySelectorsOK) IsServerError() bool {
 // IsCode returns true when this get policy selectors o k response a status code equal to that given
 func (o *GetPolicySelectorsOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get policy selectors o k response
+func (o *GetPolicySelectorsOK) Code() int {
+	return 200
 }
 
 func (o *GetPolicySelectorsOK) Error() string {

--- a/api/v1/client/policy/put_policy_responses.go
+++ b/api/v1/client/policy/put_policy_responses.go
@@ -57,7 +57,7 @@ func (o *PutPolicyReader) ReadResponse(response runtime.ClientResponse, consumer
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /policy] PutPolicy", response, response.Code())
 	}
 }
 
@@ -98,6 +98,11 @@ func (o *PutPolicyOK) IsServerError() bool {
 // IsCode returns true when this put policy o k response a status code equal to that given
 func (o *PutPolicyOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the put policy o k response
+func (o *PutPolicyOK) Code() int {
+	return 200
 }
 
 func (o *PutPolicyOK) Error() string {
@@ -163,6 +168,11 @@ func (o *PutPolicyInvalidPolicy) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the put policy invalid policy response
+func (o *PutPolicyInvalidPolicy) Code() int {
+	return 400
+}
+
 func (o *PutPolicyInvalidPolicy) Error() string {
 	return fmt.Sprintf("[PUT /policy][%d] putPolicyInvalidPolicy  %+v", 400, o.Payload)
 }
@@ -223,6 +233,11 @@ func (o *PutPolicyForbidden) IsCode(code int) bool {
 	return code == 403
 }
 
+// Code gets the status code for the put policy forbidden response
+func (o *PutPolicyForbidden) Code() int {
+	return 403
+}
+
 func (o *PutPolicyForbidden) Error() string {
 	return fmt.Sprintf("[PUT /policy][%d] putPolicyForbidden ", 403)
 }
@@ -273,6 +288,11 @@ func (o *PutPolicyInvalidPath) IsServerError() bool {
 // IsCode returns true when this put policy invalid path response a status code equal to that given
 func (o *PutPolicyInvalidPath) IsCode(code int) bool {
 	return code == 460
+}
+
+// Code gets the status code for the put policy invalid path response
+func (o *PutPolicyInvalidPath) Code() int {
+	return 460
 }
 
 func (o *PutPolicyInvalidPath) Error() string {
@@ -334,6 +354,11 @@ func (o *PutPolicyFailure) IsServerError() bool {
 // IsCode returns true when this put policy failure response a status code equal to that given
 func (o *PutPolicyFailure) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the put policy failure response
+func (o *PutPolicyFailure) Code() int {
+	return 500
 }
 
 func (o *PutPolicyFailure) Error() string {

--- a/api/v1/client/prefilter/delete_prefilter_responses.go
+++ b/api/v1/client/prefilter/delete_prefilter_responses.go
@@ -51,7 +51,7 @@ func (o *DeletePrefilterReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /prefilter] DeletePrefilter", response, response.Code())
 	}
 }
 
@@ -92,6 +92,11 @@ func (o *DeletePrefilterOK) IsServerError() bool {
 // IsCode returns true when this delete prefilter o k response a status code equal to that given
 func (o *DeletePrefilterOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the delete prefilter o k response
+func (o *DeletePrefilterOK) Code() int {
+	return 200
 }
 
 func (o *DeletePrefilterOK) Error() string {
@@ -156,6 +161,11 @@ func (o *DeletePrefilterForbidden) IsCode(code int) bool {
 	return code == 403
 }
 
+// Code gets the status code for the delete prefilter forbidden response
+func (o *DeletePrefilterForbidden) Code() int {
+	return 403
+}
+
 func (o *DeletePrefilterForbidden) Error() string {
 	return fmt.Sprintf("[DELETE /prefilter][%d] deletePrefilterForbidden ", 403)
 }
@@ -206,6 +216,11 @@ func (o *DeletePrefilterInvalidCIDR) IsServerError() bool {
 // IsCode returns true when this delete prefilter invalid c Id r response a status code equal to that given
 func (o *DeletePrefilterInvalidCIDR) IsCode(code int) bool {
 	return code == 461
+}
+
+// Code gets the status code for the delete prefilter invalid c Id r response
+func (o *DeletePrefilterInvalidCIDR) Code() int {
+	return 461
 }
 
 func (o *DeletePrefilterInvalidCIDR) Error() string {
@@ -267,6 +282,11 @@ func (o *DeletePrefilterFailure) IsServerError() bool {
 // IsCode returns true when this delete prefilter failure response a status code equal to that given
 func (o *DeletePrefilterFailure) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the delete prefilter failure response
+func (o *DeletePrefilterFailure) Code() int {
+	return 500
 }
 
 func (o *DeletePrefilterFailure) Error() string {

--- a/api/v1/client/prefilter/get_prefilter_responses.go
+++ b/api/v1/client/prefilter/get_prefilter_responses.go
@@ -39,7 +39,7 @@ func (o *GetPrefilterReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /prefilter] GetPrefilter", response, response.Code())
 	}
 }
 
@@ -80,6 +80,11 @@ func (o *GetPrefilterOK) IsServerError() bool {
 // IsCode returns true when this get prefilter o k response a status code equal to that given
 func (o *GetPrefilterOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get prefilter o k response
+func (o *GetPrefilterOK) Code() int {
+	return 200
 }
 
 func (o *GetPrefilterOK) Error() string {
@@ -143,6 +148,11 @@ func (o *GetPrefilterFailure) IsServerError() bool {
 // IsCode returns true when this get prefilter failure response a status code equal to that given
 func (o *GetPrefilterFailure) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the get prefilter failure response
+func (o *GetPrefilterFailure) Code() int {
+	return 500
 }
 
 func (o *GetPrefilterFailure) Error() string {

--- a/api/v1/client/prefilter/patch_prefilter_responses.go
+++ b/api/v1/client/prefilter/patch_prefilter_responses.go
@@ -51,7 +51,7 @@ func (o *PatchPrefilterReader) ReadResponse(response runtime.ClientResponse, con
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PATCH /prefilter] PatchPrefilter", response, response.Code())
 	}
 }
 
@@ -92,6 +92,11 @@ func (o *PatchPrefilterOK) IsServerError() bool {
 // IsCode returns true when this patch prefilter o k response a status code equal to that given
 func (o *PatchPrefilterOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the patch prefilter o k response
+func (o *PatchPrefilterOK) Code() int {
+	return 200
 }
 
 func (o *PatchPrefilterOK) Error() string {
@@ -156,6 +161,11 @@ func (o *PatchPrefilterForbidden) IsCode(code int) bool {
 	return code == 403
 }
 
+// Code gets the status code for the patch prefilter forbidden response
+func (o *PatchPrefilterForbidden) Code() int {
+	return 403
+}
+
 func (o *PatchPrefilterForbidden) Error() string {
 	return fmt.Sprintf("[PATCH /prefilter][%d] patchPrefilterForbidden ", 403)
 }
@@ -206,6 +216,11 @@ func (o *PatchPrefilterInvalidCIDR) IsServerError() bool {
 // IsCode returns true when this patch prefilter invalid c Id r response a status code equal to that given
 func (o *PatchPrefilterInvalidCIDR) IsCode(code int) bool {
 	return code == 461
+}
+
+// Code gets the status code for the patch prefilter invalid c Id r response
+func (o *PatchPrefilterInvalidCIDR) Code() int {
+	return 461
 }
 
 func (o *PatchPrefilterInvalidCIDR) Error() string {
@@ -267,6 +282,11 @@ func (o *PatchPrefilterFailure) IsServerError() bool {
 // IsCode returns true when this patch prefilter failure response a status code equal to that given
 func (o *PatchPrefilterFailure) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the patch prefilter failure response
+func (o *PatchPrefilterFailure) Code() int {
+	return 500
 }
 
 func (o *PatchPrefilterFailure) Error() string {

--- a/api/v1/client/recorder/delete_recorder_id_responses.go
+++ b/api/v1/client/recorder/delete_recorder_id_responses.go
@@ -51,7 +51,7 @@ func (o *DeleteRecorderIDReader) ReadResponse(response runtime.ClientResponse, c
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /recorder/{id}] DeleteRecorderID", response, response.Code())
 	}
 }
 
@@ -91,6 +91,11 @@ func (o *DeleteRecorderIDOK) IsServerError() bool {
 // IsCode returns true when this delete recorder Id o k response a status code equal to that given
 func (o *DeleteRecorderIDOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the delete recorder Id o k response
+func (o *DeleteRecorderIDOK) Code() int {
+	return 200
 }
 
 func (o *DeleteRecorderIDOK) Error() string {
@@ -144,6 +149,11 @@ func (o *DeleteRecorderIDForbidden) IsCode(code int) bool {
 	return code == 403
 }
 
+// Code gets the status code for the delete recorder Id forbidden response
+func (o *DeleteRecorderIDForbidden) Code() int {
+	return 403
+}
+
 func (o *DeleteRecorderIDForbidden) Error() string {
 	return fmt.Sprintf("[DELETE /recorder/{id}][%d] deleteRecorderIdForbidden ", 403)
 }
@@ -193,6 +203,11 @@ func (o *DeleteRecorderIDNotFound) IsServerError() bool {
 // IsCode returns true when this delete recorder Id not found response a status code equal to that given
 func (o *DeleteRecorderIDNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the delete recorder Id not found response
+func (o *DeleteRecorderIDNotFound) Code() int {
+	return 404
 }
 
 func (o *DeleteRecorderIDNotFound) Error() string {
@@ -245,6 +260,11 @@ func (o *DeleteRecorderIDFailure) IsServerError() bool {
 // IsCode returns true when this delete recorder Id failure response a status code equal to that given
 func (o *DeleteRecorderIDFailure) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the delete recorder Id failure response
+func (o *DeleteRecorderIDFailure) Code() int {
+	return 500
 }
 
 func (o *DeleteRecorderIDFailure) Error() string {

--- a/api/v1/client/recorder/get_recorder_id_responses.go
+++ b/api/v1/client/recorder/get_recorder_id_responses.go
@@ -39,7 +39,7 @@ func (o *GetRecorderIDReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /recorder/{id}] GetRecorderID", response, response.Code())
 	}
 }
 
@@ -80,6 +80,11 @@ func (o *GetRecorderIDOK) IsServerError() bool {
 // IsCode returns true when this get recorder Id o k response a status code equal to that given
 func (o *GetRecorderIDOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get recorder Id o k response
+func (o *GetRecorderIDOK) Code() int {
+	return 200
 }
 
 func (o *GetRecorderIDOK) Error() string {
@@ -142,6 +147,11 @@ func (o *GetRecorderIDNotFound) IsServerError() bool {
 // IsCode returns true when this get recorder Id not found response a status code equal to that given
 func (o *GetRecorderIDNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the get recorder Id not found response
+func (o *GetRecorderIDNotFound) Code() int {
+	return 404
 }
 
 func (o *GetRecorderIDNotFound) Error() string {

--- a/api/v1/client/recorder/get_recorder_masks_responses.go
+++ b/api/v1/client/recorder/get_recorder_masks_responses.go
@@ -33,7 +33,7 @@ func (o *GetRecorderMasksReader) ReadResponse(response runtime.ClientResponse, c
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /recorder/masks] GetRecorderMasks", response, response.Code())
 	}
 }
 
@@ -74,6 +74,11 @@ func (o *GetRecorderMasksOK) IsServerError() bool {
 // IsCode returns true when this get recorder masks o k response a status code equal to that given
 func (o *GetRecorderMasksOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get recorder masks o k response
+func (o *GetRecorderMasksOK) Code() int {
+	return 200
 }
 
 func (o *GetRecorderMasksOK) Error() string {

--- a/api/v1/client/recorder/get_recorder_responses.go
+++ b/api/v1/client/recorder/get_recorder_responses.go
@@ -33,7 +33,7 @@ func (o *GetRecorderReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /recorder] GetRecorder", response, response.Code())
 	}
 }
 
@@ -74,6 +74,11 @@ func (o *GetRecorderOK) IsServerError() bool {
 // IsCode returns true when this get recorder o k response a status code equal to that given
 func (o *GetRecorderOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get recorder o k response
+func (o *GetRecorderOK) Code() int {
+	return 200
 }
 
 func (o *GetRecorderOK) Error() string {

--- a/api/v1/client/recorder/put_recorder_id_responses.go
+++ b/api/v1/client/recorder/put_recorder_id_responses.go
@@ -51,7 +51,7 @@ func (o *PutRecorderIDReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /recorder/{id}] PutRecorderID", response, response.Code())
 	}
 }
 
@@ -91,6 +91,11 @@ func (o *PutRecorderIDOK) IsServerError() bool {
 // IsCode returns true when this put recorder Id o k response a status code equal to that given
 func (o *PutRecorderIDOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the put recorder Id o k response
+func (o *PutRecorderIDOK) Code() int {
+	return 200
 }
 
 func (o *PutRecorderIDOK) Error() string {
@@ -144,6 +149,11 @@ func (o *PutRecorderIDCreated) IsCode(code int) bool {
 	return code == 201
 }
 
+// Code gets the status code for the put recorder Id created response
+func (o *PutRecorderIDCreated) Code() int {
+	return 201
+}
+
 func (o *PutRecorderIDCreated) Error() string {
 	return fmt.Sprintf("[PUT /recorder/{id}][%d] putRecorderIdCreated ", 201)
 }
@@ -193,6 +203,11 @@ func (o *PutRecorderIDForbidden) IsServerError() bool {
 // IsCode returns true when this put recorder Id forbidden response a status code equal to that given
 func (o *PutRecorderIDForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the put recorder Id forbidden response
+func (o *PutRecorderIDForbidden) Code() int {
+	return 403
 }
 
 func (o *PutRecorderIDForbidden) Error() string {
@@ -245,6 +260,11 @@ func (o *PutRecorderIDFailure) IsServerError() bool {
 // IsCode returns true when this put recorder Id failure response a status code equal to that given
 func (o *PutRecorderIDFailure) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the put recorder Id failure response
+func (o *PutRecorderIDFailure) Code() int {
+	return 500
 }
 
 func (o *PutRecorderIDFailure) Error() string {

--- a/api/v1/client/service/delete_service_id_responses.go
+++ b/api/v1/client/service/delete_service_id_responses.go
@@ -51,7 +51,7 @@ func (o *DeleteServiceIDReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /service/{id}] DeleteServiceID", response, response.Code())
 	}
 }
 
@@ -91,6 +91,11 @@ func (o *DeleteServiceIDOK) IsServerError() bool {
 // IsCode returns true when this delete service Id o k response a status code equal to that given
 func (o *DeleteServiceIDOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the delete service Id o k response
+func (o *DeleteServiceIDOK) Code() int {
+	return 200
 }
 
 func (o *DeleteServiceIDOK) Error() string {
@@ -144,6 +149,11 @@ func (o *DeleteServiceIDForbidden) IsCode(code int) bool {
 	return code == 403
 }
 
+// Code gets the status code for the delete service Id forbidden response
+func (o *DeleteServiceIDForbidden) Code() int {
+	return 403
+}
+
 func (o *DeleteServiceIDForbidden) Error() string {
 	return fmt.Sprintf("[DELETE /service/{id}][%d] deleteServiceIdForbidden ", 403)
 }
@@ -193,6 +203,11 @@ func (o *DeleteServiceIDNotFound) IsServerError() bool {
 // IsCode returns true when this delete service Id not found response a status code equal to that given
 func (o *DeleteServiceIDNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the delete service Id not found response
+func (o *DeleteServiceIDNotFound) Code() int {
+	return 404
 }
 
 func (o *DeleteServiceIDNotFound) Error() string {
@@ -245,6 +260,11 @@ func (o *DeleteServiceIDFailure) IsServerError() bool {
 // IsCode returns true when this delete service Id failure response a status code equal to that given
 func (o *DeleteServiceIDFailure) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the delete service Id failure response
+func (o *DeleteServiceIDFailure) Code() int {
+	return 500
 }
 
 func (o *DeleteServiceIDFailure) Error() string {

--- a/api/v1/client/service/get_lrp_responses.go
+++ b/api/v1/client/service/get_lrp_responses.go
@@ -33,7 +33,7 @@ func (o *GetLrpReader) ReadResponse(response runtime.ClientResponse, consumer ru
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /lrp] GetLrp", response, response.Code())
 	}
 }
 
@@ -74,6 +74,11 @@ func (o *GetLrpOK) IsServerError() bool {
 // IsCode returns true when this get lrp o k response a status code equal to that given
 func (o *GetLrpOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get lrp o k response
+func (o *GetLrpOK) Code() int {
+	return 200
 }
 
 func (o *GetLrpOK) Error() string {

--- a/api/v1/client/service/get_service_id_responses.go
+++ b/api/v1/client/service/get_service_id_responses.go
@@ -39,7 +39,7 @@ func (o *GetServiceIDReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /service/{id}] GetServiceID", response, response.Code())
 	}
 }
 
@@ -80,6 +80,11 @@ func (o *GetServiceIDOK) IsServerError() bool {
 // IsCode returns true when this get service Id o k response a status code equal to that given
 func (o *GetServiceIDOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get service Id o k response
+func (o *GetServiceIDOK) Code() int {
+	return 200
 }
 
 func (o *GetServiceIDOK) Error() string {
@@ -142,6 +147,11 @@ func (o *GetServiceIDNotFound) IsServerError() bool {
 // IsCode returns true when this get service Id not found response a status code equal to that given
 func (o *GetServiceIDNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the get service Id not found response
+func (o *GetServiceIDNotFound) Code() int {
+	return 404
 }
 
 func (o *GetServiceIDNotFound) Error() string {

--- a/api/v1/client/service/get_service_responses.go
+++ b/api/v1/client/service/get_service_responses.go
@@ -33,7 +33,7 @@ func (o *GetServiceReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /service] GetService", response, response.Code())
 	}
 }
 
@@ -74,6 +74,11 @@ func (o *GetServiceOK) IsServerError() bool {
 // IsCode returns true when this get service o k response a status code equal to that given
 func (o *GetServiceOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get service o k response
+func (o *GetServiceOK) Code() int {
+	return 200
 }
 
 func (o *GetServiceOK) Error() string {

--- a/api/v1/client/service/put_service_id_responses.go
+++ b/api/v1/client/service/put_service_id_responses.go
@@ -69,7 +69,7 @@ func (o *PutServiceIDReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /service/{id}] PutServiceID", response, response.Code())
 	}
 }
 
@@ -109,6 +109,11 @@ func (o *PutServiceIDOK) IsServerError() bool {
 // IsCode returns true when this put service Id o k response a status code equal to that given
 func (o *PutServiceIDOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the put service Id o k response
+func (o *PutServiceIDOK) Code() int {
+	return 200
 }
 
 func (o *PutServiceIDOK) Error() string {
@@ -162,6 +167,11 @@ func (o *PutServiceIDCreated) IsCode(code int) bool {
 	return code == 201
 }
 
+// Code gets the status code for the put service Id created response
+func (o *PutServiceIDCreated) Code() int {
+	return 201
+}
+
 func (o *PutServiceIDCreated) Error() string {
 	return fmt.Sprintf("[PUT /service/{id}][%d] putServiceIdCreated ", 201)
 }
@@ -211,6 +221,11 @@ func (o *PutServiceIDForbidden) IsServerError() bool {
 // IsCode returns true when this put service Id forbidden response a status code equal to that given
 func (o *PutServiceIDForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the put service Id forbidden response
+func (o *PutServiceIDForbidden) Code() int {
+	return 403
 }
 
 func (o *PutServiceIDForbidden) Error() string {
@@ -263,6 +278,11 @@ func (o *PutServiceIDInvalidFrontend) IsServerError() bool {
 // IsCode returns true when this put service Id invalid frontend response a status code equal to that given
 func (o *PutServiceIDInvalidFrontend) IsCode(code int) bool {
 	return code == 460
+}
+
+// Code gets the status code for the put service Id invalid frontend response
+func (o *PutServiceIDInvalidFrontend) Code() int {
+	return 460
 }
 
 func (o *PutServiceIDInvalidFrontend) Error() string {
@@ -326,6 +346,11 @@ func (o *PutServiceIDInvalidBackend) IsCode(code int) bool {
 	return code == 461
 }
 
+// Code gets the status code for the put service Id invalid backend response
+func (o *PutServiceIDInvalidBackend) Code() int {
+	return 461
+}
+
 func (o *PutServiceIDInvalidBackend) Error() string {
 	return fmt.Sprintf("[PUT /service/{id}][%d] putServiceIdInvalidBackend  %+v", 461, o.Payload)
 }
@@ -387,6 +412,11 @@ func (o *PutServiceIDFailure) IsCode(code int) bool {
 	return code == 500
 }
 
+// Code gets the status code for the put service Id failure response
+func (o *PutServiceIDFailure) Code() int {
+	return 500
+}
+
 func (o *PutServiceIDFailure) Error() string {
 	return fmt.Sprintf("[PUT /service/{id}][%d] putServiceIdFailure  %+v", 500, o.Payload)
 }
@@ -446,6 +476,11 @@ func (o *PutServiceIDUpdateBackendFailure) IsServerError() bool {
 // IsCode returns true when this put service Id update backend failure response a status code equal to that given
 func (o *PutServiceIDUpdateBackendFailure) IsCode(code int) bool {
 	return code == 501
+}
+
+// Code gets the status code for the put service Id update backend failure response
+func (o *PutServiceIDUpdateBackendFailure) Code() int {
+	return 501
 }
 
 func (o *PutServiceIDUpdateBackendFailure) Error() string {

--- a/api/v1/client/statedb/get_statedb_dump_responses.go
+++ b/api/v1/client/statedb/get_statedb_dump_responses.go
@@ -32,7 +32,7 @@ func (o *GetStatedbDumpReader) ReadResponse(response runtime.ClientResponse, con
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /statedb/dump] GetStatedbDump", response, response.Code())
 	}
 }
 
@@ -76,6 +76,11 @@ func (o *GetStatedbDumpOK) IsServerError() bool {
 // IsCode returns true when this get statedb dump o k response a status code equal to that given
 func (o *GetStatedbDumpOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get statedb dump o k response
+func (o *GetStatedbDumpOK) Code() int {
+	return 200
 }
 
 func (o *GetStatedbDumpOK) Error() string {

--- a/api/v1/client/statedb/get_statedb_query_table_responses.go
+++ b/api/v1/client/statedb/get_statedb_query_table_responses.go
@@ -46,7 +46,7 @@ func (o *GetStatedbQueryTableReader) ReadResponse(response runtime.ClientRespons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /statedb/query/{table}] GetStatedbQueryTable", response, response.Code())
 	}
 }
 
@@ -90,6 +90,11 @@ func (o *GetStatedbQueryTableOK) IsServerError() bool {
 // IsCode returns true when this get statedb query table o k response a status code equal to that given
 func (o *GetStatedbQueryTableOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get statedb query table o k response
+func (o *GetStatedbQueryTableOK) Code() int {
+	return 200
 }
 
 func (o *GetStatedbQueryTableOK) Error() string {
@@ -153,6 +158,11 @@ func (o *GetStatedbQueryTableBadRequest) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the get statedb query table bad request response
+func (o *GetStatedbQueryTableBadRequest) Code() int {
+	return 400
+}
+
 func (o *GetStatedbQueryTableBadRequest) Error() string {
 	return fmt.Sprintf("[GET /statedb/query/{table}][%d] getStatedbQueryTableBadRequest  %+v", 400, o.Payload)
 }
@@ -211,6 +221,11 @@ func (o *GetStatedbQueryTableNotFound) IsServerError() bool {
 // IsCode returns true when this get statedb query table not found response a status code equal to that given
 func (o *GetStatedbQueryTableNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the get statedb query table not found response
+func (o *GetStatedbQueryTableNotFound) Code() int {
+	return 404
 }
 
 func (o *GetStatedbQueryTableNotFound) Error() string {

--- a/api/v1/health/client/connectivity/get_status_responses.go
+++ b/api/v1/health/client/connectivity/get_status_responses.go
@@ -33,7 +33,7 @@ func (o *GetStatusReader) ReadResponse(response runtime.ClientResponse, consumer
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /status] GetStatus", response, response.Code())
 	}
 }
 
@@ -74,6 +74,11 @@ func (o *GetStatusOK) IsServerError() bool {
 // IsCode returns true when this get status o k response a status code equal to that given
 func (o *GetStatusOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get status o k response
+func (o *GetStatusOK) Code() int {
+	return 200
 }
 
 func (o *GetStatusOK) Error() string {

--- a/api/v1/health/client/connectivity/put_status_probe_responses.go
+++ b/api/v1/health/client/connectivity/put_status_probe_responses.go
@@ -45,7 +45,7 @@ func (o *PutStatusProbeReader) ReadResponse(response runtime.ClientResponse, con
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /status/probe] PutStatusProbe", response, response.Code())
 	}
 }
 
@@ -86,6 +86,11 @@ func (o *PutStatusProbeOK) IsServerError() bool {
 // IsCode returns true when this put status probe o k response a status code equal to that given
 func (o *PutStatusProbeOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the put status probe o k response
+func (o *PutStatusProbeOK) Code() int {
+	return 200
 }
 
 func (o *PutStatusProbeOK) Error() string {
@@ -150,6 +155,11 @@ func (o *PutStatusProbeForbidden) IsCode(code int) bool {
 	return code == 403
 }
 
+// Code gets the status code for the put status probe forbidden response
+func (o *PutStatusProbeForbidden) Code() int {
+	return 403
+}
+
 func (o *PutStatusProbeForbidden) Error() string {
 	return fmt.Sprintf("[PUT /status/probe][%d] putStatusProbeForbidden ", 403)
 }
@@ -200,6 +210,11 @@ func (o *PutStatusProbeFailed) IsServerError() bool {
 // IsCode returns true when this put status probe failed response a status code equal to that given
 func (o *PutStatusProbeFailed) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the put status probe failed response
+func (o *PutStatusProbeFailed) Code() int {
+	return 500
 }
 
 func (o *PutStatusProbeFailed) Error() string {

--- a/api/v1/health/client/restapi/get_healthz_responses.go
+++ b/api/v1/health/client/restapi/get_healthz_responses.go
@@ -39,7 +39,7 @@ func (o *GetHealthzReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /healthz] GetHealthz", response, response.Code())
 	}
 }
 
@@ -80,6 +80,11 @@ func (o *GetHealthzOK) IsServerError() bool {
 // IsCode returns true when this get healthz o k response a status code equal to that given
 func (o *GetHealthzOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get healthz o k response
+func (o *GetHealthzOK) Code() int {
+	return 200
 }
 
 func (o *GetHealthzOK) Error() string {
@@ -143,6 +148,11 @@ func (o *GetHealthzFailed) IsServerError() bool {
 // IsCode returns true when this get healthz failed response a status code equal to that given
 func (o *GetHealthzFailed) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the get healthz failed response
+func (o *GetHealthzFailed) Code() int {
+	return 500
 }
 
 func (o *GetHealthzFailed) Error() string {

--- a/api/v1/health/models/endpoint_status.go
+++ b/api/v1/health/models/endpoint_status.go
@@ -113,6 +113,11 @@ func (m *EndpointStatus) ContextValidate(ctx context.Context, formats strfmt.Reg
 func (m *EndpointStatus) contextValidatePrimaryAddress(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PrimaryAddress != nil {
+
+		if swag.IsZero(m.PrimaryAddress) { // not required
+			return nil
+		}
+
 		if err := m.PrimaryAddress.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("primary-address")
@@ -131,6 +136,11 @@ func (m *EndpointStatus) contextValidateSecondaryAddresses(ctx context.Context, 
 	for i := 0; i < len(m.SecondaryAddresses); i++ {
 
 		if m.SecondaryAddresses[i] != nil {
+
+			if swag.IsZero(m.SecondaryAddresses[i]) { // not required
+				return nil
+			}
+
 			if err := m.SecondaryAddresses[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("secondary-addresses" + "." + strconv.Itoa(i))

--- a/api/v1/health/models/health_response.go
+++ b/api/v1/health/models/health_response.go
@@ -106,6 +106,10 @@ func (m *HealthResponse) ContextValidate(ctx context.Context, formats strfmt.Reg
 
 func (m *HealthResponse) contextValidateCilium(ctx context.Context, formats strfmt.Registry) error {
 
+	if swag.IsZero(m.Cilium) { // not required
+		return nil
+	}
+
 	if err := m.Cilium.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("cilium")
@@ -121,6 +125,11 @@ func (m *HealthResponse) contextValidateCilium(ctx context.Context, formats strf
 func (m *HealthResponse) contextValidateSystemLoad(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SystemLoad != nil {
+
+		if swag.IsZero(m.SystemLoad) { // not required
+			return nil
+		}
+
 		if err := m.SystemLoad.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("system-load")

--- a/api/v1/health/models/health_status_response.go
+++ b/api/v1/health/models/health_status_response.go
@@ -116,6 +116,11 @@ func (m *HealthStatusResponse) ContextValidate(ctx context.Context, formats strf
 func (m *HealthStatusResponse) contextValidateLocal(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Local != nil {
+
+		if swag.IsZero(m.Local) { // not required
+			return nil
+		}
+
 		if err := m.Local.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("local")
@@ -134,6 +139,11 @@ func (m *HealthStatusResponse) contextValidateNodes(ctx context.Context, formats
 	for i := 0; i < len(m.Nodes); i++ {
 
 		if m.Nodes[i] != nil {
+
+			if swag.IsZero(m.Nodes[i]) { // not required
+				return nil
+			}
+
 			if err := m.Nodes[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("nodes" + "." + strconv.Itoa(i))

--- a/api/v1/health/models/host_status.go
+++ b/api/v1/health/models/host_status.go
@@ -114,6 +114,11 @@ func (m *HostStatus) ContextValidate(ctx context.Context, formats strfmt.Registr
 func (m *HostStatus) contextValidatePrimaryAddress(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PrimaryAddress != nil {
+
+		if swag.IsZero(m.PrimaryAddress) { // not required
+			return nil
+		}
+
 		if err := m.PrimaryAddress.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("primary-address")
@@ -132,6 +137,11 @@ func (m *HostStatus) contextValidateSecondaryAddresses(ctx context.Context, form
 	for i := 0; i < len(m.SecondaryAddresses); i++ {
 
 		if m.SecondaryAddresses[i] != nil {
+
+			if swag.IsZero(m.SecondaryAddresses[i]) { // not required
+				return nil
+			}
+
 			if err := m.SecondaryAddresses[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("secondary-addresses" + "." + strconv.Itoa(i))

--- a/api/v1/health/models/node_status.go
+++ b/api/v1/health/models/node_status.go
@@ -140,6 +140,11 @@ func (m *NodeStatus) ContextValidate(ctx context.Context, formats strfmt.Registr
 func (m *NodeStatus) contextValidateEndpoint(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Endpoint != nil {
+
+		if swag.IsZero(m.Endpoint) { // not required
+			return nil
+		}
+
 		if err := m.Endpoint.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("endpoint")
@@ -156,6 +161,11 @@ func (m *NodeStatus) contextValidateEndpoint(ctx context.Context, formats strfmt
 func (m *NodeStatus) contextValidateHealthEndpoint(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.HealthEndpoint != nil {
+
+		if swag.IsZero(m.HealthEndpoint) { // not required
+			return nil
+		}
+
 		if err := m.HealthEndpoint.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("health-endpoint")
@@ -172,6 +182,11 @@ func (m *NodeStatus) contextValidateHealthEndpoint(ctx context.Context, formats 
 func (m *NodeStatus) contextValidateHost(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Host != nil {
+
+		if swag.IsZero(m.Host) { // not required
+			return nil
+		}
+
 		if err := m.Host.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("host")

--- a/api/v1/health/models/path_status.go
+++ b/api/v1/health/models/path_status.go
@@ -109,6 +109,11 @@ func (m *PathStatus) ContextValidate(ctx context.Context, formats strfmt.Registr
 func (m *PathStatus) contextValidateHTTP(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.HTTP != nil {
+
+		if swag.IsZero(m.HTTP) { // not required
+			return nil
+		}
+
 		if err := m.HTTP.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("http")
@@ -125,6 +130,11 @@ func (m *PathStatus) contextValidateHTTP(ctx context.Context, formats strfmt.Reg
 func (m *PathStatus) contextValidateIcmp(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Icmp != nil {
+
+		if swag.IsZero(m.Icmp) { // not required
+			return nil
+		}
+
 		if err := m.Icmp.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("icmp")

--- a/api/v1/health/server/restapi/cilium_health_api_api.go
+++ b/api/v1/health/server/restapi/cilium_health_api_api.go
@@ -325,6 +325,6 @@ func (o *CiliumHealthAPIAPI) AddMiddlewareFor(method, path string, builder middl
 	}
 	o.Init()
 	if h, ok := o.handlers[um][path]; ok {
-		o.handlers[method][path] = builder(h)
+		o.handlers[um][path] = builder(h)
 	}
 }

--- a/api/v1/models/b_p_f_map.go
+++ b/api/v1/models/b_p_f_map.go
@@ -88,6 +88,11 @@ func (m *BPFMap) contextValidateCache(ctx context.Context, formats strfmt.Regist
 	for i := 0; i < len(m.Cache); i++ {
 
 		if m.Cache[i] != nil {
+
+			if swag.IsZero(m.Cache[i]) { // not required
+				return nil
+			}
+
 			if err := m.Cache[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("cache" + "." + strconv.Itoa(i))

--- a/api/v1/models/b_p_f_map_list.go
+++ b/api/v1/models/b_p_f_map_list.go
@@ -85,6 +85,11 @@ func (m *BPFMapList) contextValidateMaps(ctx context.Context, formats strfmt.Reg
 	for i := 0; i < len(m.Maps); i++ {
 
 		if m.Maps[i] != nil {
+
+			if swag.IsZero(m.Maps[i]) { // not required
+				return nil
+			}
+
 			if err := m.Maps[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("maps" + "." + strconv.Itoa(i))

--- a/api/v1/models/b_p_f_map_status.go
+++ b/api/v1/models/b_p_f_map_status.go
@@ -90,6 +90,11 @@ func (m *BPFMapStatus) contextValidateMaps(ctx context.Context, formats strfmt.R
 	for i := 0; i < len(m.Maps); i++ {
 
 		if m.Maps[i] != nil {
+
+			if swag.IsZero(m.Maps[i]) { // not required
+				return nil
+			}
+
 			if err := m.Maps[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("maps" + "." + strconv.Itoa(i))

--- a/api/v1/models/bgp_path.go
+++ b/api/v1/models/bgp_path.go
@@ -152,6 +152,11 @@ func (m *BgpPath) ContextValidate(ctx context.Context, formats strfmt.Registry) 
 func (m *BgpPath) contextValidateFamily(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Family != nil {
+
+		if swag.IsZero(m.Family) { // not required
+			return nil
+		}
+
 		if err := m.Family.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("family")
@@ -168,6 +173,11 @@ func (m *BgpPath) contextValidateFamily(ctx context.Context, formats strfmt.Regi
 func (m *BgpPath) contextValidateNlri(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Nlri != nil {
+
+		if swag.IsZero(m.Nlri) { // not required
+			return nil
+		}
+
 		if err := m.Nlri.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("nlri")
@@ -186,6 +196,11 @@ func (m *BgpPath) contextValidatePathAttributes(ctx context.Context, formats str
 	for i := 0; i < len(m.PathAttributes); i++ {
 
 		if m.PathAttributes[i] != nil {
+
+			if swag.IsZero(m.PathAttributes[i]) { // not required
+				return nil
+			}
+
 			if err := m.PathAttributes[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("path-attributes" + "." + strconv.Itoa(i))

--- a/api/v1/models/bgp_peer.go
+++ b/api/v1/models/bgp_peer.go
@@ -191,6 +191,11 @@ func (m *BgpPeer) contextValidateFamilies(ctx context.Context, formats strfmt.Re
 	for i := 0; i < len(m.Families); i++ {
 
 		if m.Families[i] != nil {
+
+			if swag.IsZero(m.Families[i]) { // not required
+				return nil
+			}
+
 			if err := m.Families[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("families" + "." + strconv.Itoa(i))
@@ -209,6 +214,11 @@ func (m *BgpPeer) contextValidateFamilies(ctx context.Context, formats strfmt.Re
 func (m *BgpPeer) contextValidateGracefulRestart(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.GracefulRestart != nil {
+
+		if swag.IsZero(m.GracefulRestart) { // not required
+			return nil
+		}
+
 		if err := m.GracefulRestart.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("graceful-restart")

--- a/api/v1/models/bgp_route.go
+++ b/api/v1/models/bgp_route.go
@@ -94,6 +94,11 @@ func (m *BgpRoute) contextValidatePaths(ctx context.Context, formats strfmt.Regi
 	for i := 0; i < len(m.Paths); i++ {
 
 		if m.Paths[i] != nil {
+
+			if swag.IsZero(m.Paths[i]) { // not required
+				return nil
+			}
+
 			if err := m.Paths[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("paths" + "." + strconv.Itoa(i))

--- a/api/v1/models/bgp_route_policy.go
+++ b/api/v1/models/bgp_route_policy.go
@@ -143,6 +143,11 @@ func (m *BgpRoutePolicy) contextValidateStatements(ctx context.Context, formats 
 	for i := 0; i < len(m.Statements); i++ {
 
 		if m.Statements[i] != nil {
+
+			if swag.IsZero(m.Statements[i]) { // not required
+				return nil
+			}
+
 			if err := m.Statements[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("statements" + "." + strconv.Itoa(i))

--- a/api/v1/models/bgp_route_policy_statement.go
+++ b/api/v1/models/bgp_route_policy_statement.go
@@ -152,6 +152,11 @@ func (m *BgpRoutePolicyStatement) contextValidateMatchPrefixes(ctx context.Conte
 	for i := 0; i < len(m.MatchPrefixes); i++ {
 
 		if m.MatchPrefixes[i] != nil {
+
+			if swag.IsZero(m.MatchPrefixes[i]) { // not required
+				return nil
+			}
+
 			if err := m.MatchPrefixes[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("match-prefixes" + "." + strconv.Itoa(i))

--- a/api/v1/models/c_id_r_policy.go
+++ b/api/v1/models/c_id_r_policy.go
@@ -124,6 +124,11 @@ func (m *CIDRPolicy) contextValidateEgress(ctx context.Context, formats strfmt.R
 	for i := 0; i < len(m.Egress); i++ {
 
 		if m.Egress[i] != nil {
+
+			if swag.IsZero(m.Egress[i]) { // not required
+				return nil
+			}
+
 			if err := m.Egress[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("egress" + "." + strconv.Itoa(i))
@@ -144,6 +149,11 @@ func (m *CIDRPolicy) contextValidateIngress(ctx context.Context, formats strfmt.
 	for i := 0; i < len(m.Ingress); i++ {
 
 		if m.Ingress[i] != nil {
+
+			if swag.IsZero(m.Ingress[i]) { // not required
+				return nil
+			}
+
 			if err := m.Ingress[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("ingress" + "." + strconv.Itoa(i))

--- a/api/v1/models/cgroup_dump_metadata.go
+++ b/api/v1/models/cgroup_dump_metadata.go
@@ -85,6 +85,11 @@ func (m *CgroupDumpMetadata) contextValidatePodMetadatas(ctx context.Context, fo
 	for i := 0; i < len(m.PodMetadatas); i++ {
 
 		if m.PodMetadatas[i] != nil {
+
+			if swag.IsZero(m.PodMetadatas[i]) { // not required
+				return nil
+			}
+
 			if err := m.PodMetadatas[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("pod-metadatas" + "." + strconv.Itoa(i))

--- a/api/v1/models/cgroup_pod_metadata.go
+++ b/api/v1/models/cgroup_pod_metadata.go
@@ -94,6 +94,11 @@ func (m *CgroupPodMetadata) contextValidateContainers(ctx context.Context, forma
 	for i := 0; i < len(m.Containers); i++ {
 
 		if m.Containers[i] != nil {
+
+			if swag.IsZero(m.Containers[i]) { // not required
+				return nil
+			}
+
 			if err := m.Containers[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("containers" + "." + strconv.Itoa(i))

--- a/api/v1/models/cluster_mesh_status.go
+++ b/api/v1/models/cluster_mesh_status.go
@@ -90,6 +90,11 @@ func (m *ClusterMeshStatus) contextValidateClusters(ctx context.Context, formats
 	for i := 0; i < len(m.Clusters); i++ {
 
 		if m.Clusters[i] != nil {
+
+			if swag.IsZero(m.Clusters[i]) { // not required
+				return nil
+			}
+
 			if err := m.Clusters[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("clusters" + "." + strconv.Itoa(i))

--- a/api/v1/models/cluster_node_status.go
+++ b/api/v1/models/cluster_node_status.go
@@ -128,6 +128,11 @@ func (m *ClusterNodeStatus) contextValidateNodesAdded(ctx context.Context, forma
 	for i := 0; i < len(m.NodesAdded); i++ {
 
 		if m.NodesAdded[i] != nil {
+
+			if swag.IsZero(m.NodesAdded[i]) { // not required
+				return nil
+			}
+
 			if err := m.NodesAdded[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("nodes-added" + "." + strconv.Itoa(i))
@@ -148,6 +153,11 @@ func (m *ClusterNodeStatus) contextValidateNodesRemoved(ctx context.Context, for
 	for i := 0; i < len(m.NodesRemoved); i++ {
 
 		if m.NodesRemoved[i] != nil {
+
+			if swag.IsZero(m.NodesRemoved[i]) { // not required
+				return nil
+			}
+
 			if err := m.NodesRemoved[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("nodes-removed" + "." + strconv.Itoa(i))

--- a/api/v1/models/cluster_nodes_response.go
+++ b/api/v1/models/cluster_nodes_response.go
@@ -88,6 +88,11 @@ func (m *ClusterNodesResponse) contextValidateNodes(ctx context.Context, formats
 	for i := 0; i < len(m.Nodes); i++ {
 
 		if m.Nodes[i] != nil {
+
+			if swag.IsZero(m.Nodes[i]) { // not required
+				return nil
+			}
+
 			if err := m.Nodes[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("nodes" + "." + strconv.Itoa(i))

--- a/api/v1/models/cluster_status.go
+++ b/api/v1/models/cluster_status.go
@@ -118,6 +118,11 @@ func (m *ClusterStatus) ContextValidate(ctx context.Context, formats strfmt.Regi
 func (m *ClusterStatus) contextValidateCiliumHealth(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.CiliumHealth != nil {
+
+		if swag.IsZero(m.CiliumHealth) { // not required
+			return nil
+		}
+
 		if err := m.CiliumHealth.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ciliumHealth")
@@ -136,6 +141,11 @@ func (m *ClusterStatus) contextValidateNodes(ctx context.Context, formats strfmt
 	for i := 0; i < len(m.Nodes); i++ {
 
 		if m.Nodes[i] != nil {
+
+			if swag.IsZero(m.Nodes[i]) { // not required
+				return nil
+			}
+
 			if err := m.Nodes[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("nodes" + "." + strconv.Itoa(i))

--- a/api/v1/models/controller_status.go
+++ b/api/v1/models/controller_status.go
@@ -131,6 +131,11 @@ func (m *ControllerStatus) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *ControllerStatus) contextValidateConfiguration(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Configuration != nil {
+
+		if swag.IsZero(m.Configuration) { // not required
+			return nil
+		}
+
 		if err := m.Configuration.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("configuration")
@@ -147,6 +152,11 @@ func (m *ControllerStatus) contextValidateConfiguration(ctx context.Context, for
 func (m *ControllerStatus) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
+
+		if swag.IsZero(m.Status) { // not required
+			return nil
+		}
+
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")

--- a/api/v1/models/controller_statuses.go
+++ b/api/v1/models/controller_statuses.go
@@ -57,6 +57,11 @@ func (m ControllerStatuses) ContextValidate(ctx context.Context, formats strfmt.
 	for i := 0; i < len(m); i++ {
 
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))

--- a/api/v1/models/daemon_configuration.go
+++ b/api/v1/models/daemon_configuration.go
@@ -108,6 +108,11 @@ func (m *DaemonConfiguration) ContextValidate(ctx context.Context, formats strfm
 func (m *DaemonConfiguration) contextValidateSpec(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Spec != nil {
+
+		if swag.IsZero(m.Spec) { // not required
+			return nil
+		}
+
 		if err := m.Spec.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("spec")
@@ -124,6 +129,11 @@ func (m *DaemonConfiguration) contextValidateSpec(ctx context.Context, formats s
 func (m *DaemonConfiguration) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
+
+		if swag.IsZero(m.Status) { // not required
+			return nil
+		}
+
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")

--- a/api/v1/models/daemon_configuration_spec.go
+++ b/api/v1/models/daemon_configuration_spec.go
@@ -129,6 +129,10 @@ func (m *DaemonConfigurationSpec) ContextValidate(ctx context.Context, formats s
 
 func (m *DaemonConfigurationSpec) contextValidateOptions(ctx context.Context, formats strfmt.Registry) error {
 
+	if swag.IsZero(m.Options) { // not required
+		return nil
+	}
+
 	if err := m.Options.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("options")

--- a/api/v1/models/daemon_configuration_status.go
+++ b/api/v1/models/daemon_configuration_status.go
@@ -291,6 +291,11 @@ func (m *DaemonConfigurationStatus) ContextValidate(ctx context.Context, formats
 func (m *DaemonConfigurationStatus) contextValidateAddressing(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Addressing != nil {
+
+		if swag.IsZero(m.Addressing) { // not required
+			return nil
+		}
+
 		if err := m.Addressing.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("addressing")
@@ -306,6 +311,10 @@ func (m *DaemonConfigurationStatus) contextValidateAddressing(ctx context.Contex
 
 func (m *DaemonConfigurationStatus) contextValidateDatapathMode(ctx context.Context, formats strfmt.Registry) error {
 
+	if swag.IsZero(m.DatapathMode) { // not required
+		return nil
+	}
+
 	if err := m.DatapathMode.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("datapathMode")
@@ -319,6 +328,10 @@ func (m *DaemonConfigurationStatus) contextValidateDatapathMode(ctx context.Cont
 }
 
 func (m *DaemonConfigurationStatus) contextValidateImmutable(ctx context.Context, formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Immutable) { // not required
+		return nil
+	}
 
 	if err := m.Immutable.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
@@ -335,6 +348,11 @@ func (m *DaemonConfigurationStatus) contextValidateImmutable(ctx context.Context
 func (m *DaemonConfigurationStatus) contextValidateKvstoreConfiguration(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.KvstoreConfiguration != nil {
+
+		if swag.IsZero(m.KvstoreConfiguration) { // not required
+			return nil
+		}
+
 		if err := m.KvstoreConfiguration.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kvstoreConfiguration")
@@ -351,6 +369,11 @@ func (m *DaemonConfigurationStatus) contextValidateKvstoreConfiguration(ctx cont
 func (m *DaemonConfigurationStatus) contextValidateMasqueradeProtocols(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.MasqueradeProtocols != nil {
+
+		if swag.IsZero(m.MasqueradeProtocols) { // not required
+			return nil
+		}
+
 		if err := m.MasqueradeProtocols.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("masqueradeProtocols")
@@ -367,6 +390,11 @@ func (m *DaemonConfigurationStatus) contextValidateMasqueradeProtocols(ctx conte
 func (m *DaemonConfigurationStatus) contextValidateNodeMonitor(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.NodeMonitor != nil {
+
+		if swag.IsZero(m.NodeMonitor) { // not required
+			return nil
+		}
+
 		if err := m.NodeMonitor.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("nodeMonitor")
@@ -383,6 +411,11 @@ func (m *DaemonConfigurationStatus) contextValidateNodeMonitor(ctx context.Conte
 func (m *DaemonConfigurationStatus) contextValidateRealized(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Realized != nil {
+
+		if swag.IsZero(m.Realized) { // not required
+			return nil
+		}
+
 		if err := m.Realized.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realized")

--- a/api/v1/models/debug_info.go
+++ b/api/v1/models/debug_info.go
@@ -228,6 +228,11 @@ func (m *DebugInfo) ContextValidate(ctx context.Context, formats strfmt.Registry
 func (m *DebugInfo) contextValidateCiliumStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.CiliumStatus != nil {
+
+		if swag.IsZero(m.CiliumStatus) { // not required
+			return nil
+		}
+
 		if err := m.CiliumStatus.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cilium-status")
@@ -244,6 +249,11 @@ func (m *DebugInfo) contextValidateCiliumStatus(ctx context.Context, formats str
 func (m *DebugInfo) contextValidateEncryption(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Encryption != nil {
+
+		if swag.IsZero(m.Encryption) { // not required
+			return nil
+		}
+
 		if err := m.Encryption.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("encryption")
@@ -262,6 +272,11 @@ func (m *DebugInfo) contextValidateEndpointList(ctx context.Context, formats str
 	for i := 0; i < len(m.EndpointList); i++ {
 
 		if m.EndpointList[i] != nil {
+
+			if swag.IsZero(m.EndpointList[i]) { // not required
+				return nil
+			}
+
 			if err := m.EndpointList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("endpoint-list" + "." + strconv.Itoa(i))
@@ -280,6 +295,11 @@ func (m *DebugInfo) contextValidateEndpointList(ctx context.Context, formats str
 func (m *DebugInfo) contextValidatePolicy(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Policy != nil {
+
+		if swag.IsZero(m.Policy) { // not required
+			return nil
+		}
+
 		if err := m.Policy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("policy")
@@ -298,6 +318,11 @@ func (m *DebugInfo) contextValidateServiceList(ctx context.Context, formats strf
 	for i := 0; i < len(m.ServiceList); i++ {
 
 		if m.ServiceList[i] != nil {
+
+			if swag.IsZero(m.ServiceList[i]) { // not required
+				return nil
+			}
+
 			if err := m.ServiceList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("service-list" + "." + strconv.Itoa(i))
@@ -390,6 +415,11 @@ func (m *DebugInfoEncryption) ContextValidate(ctx context.Context, formats strfm
 func (m *DebugInfoEncryption) contextValidateWireguard(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Wireguard != nil {
+
+		if swag.IsZero(m.Wireguard) { // not required
+			return nil
+		}
+
 		if err := m.Wireguard.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("encryption" + "." + "wireguard")

--- a/api/v1/models/encryption_status.go
+++ b/api/v1/models/encryption_status.go
@@ -165,6 +165,11 @@ func (m *EncryptionStatus) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *EncryptionStatus) contextValidateIpsec(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Ipsec != nil {
+
+		if swag.IsZero(m.Ipsec) { // not required
+			return nil
+		}
+
 		if err := m.Ipsec.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ipsec")
@@ -181,6 +186,11 @@ func (m *EncryptionStatus) contextValidateIpsec(ctx context.Context, formats str
 func (m *EncryptionStatus) contextValidateWireguard(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Wireguard != nil {
+
+		if swag.IsZero(m.Wireguard) { // not required
+			return nil
+		}
+
 		if err := m.Wireguard.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("wireguard")

--- a/api/v1/models/endpoint.go
+++ b/api/v1/models/endpoint.go
@@ -108,6 +108,11 @@ func (m *Endpoint) ContextValidate(ctx context.Context, formats strfmt.Registry)
 func (m *Endpoint) contextValidateSpec(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Spec != nil {
+
+		if swag.IsZero(m.Spec) { // not required
+			return nil
+		}
+
 		if err := m.Spec.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("spec")
@@ -124,6 +129,11 @@ func (m *Endpoint) contextValidateSpec(ctx context.Context, formats strfmt.Regis
 func (m *Endpoint) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
+
+		if swag.IsZero(m.Status) { // not required
+			return nil
+		}
+
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")

--- a/api/v1/models/endpoint_change_request.go
+++ b/api/v1/models/endpoint_change_request.go
@@ -225,6 +225,11 @@ func (m *EndpointChangeRequest) ContextValidate(ctx context.Context, formats str
 func (m *EndpointChangeRequest) contextValidateAddressing(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Addressing != nil {
+
+		if swag.IsZero(m.Addressing) { // not required
+			return nil
+		}
+
 		if err := m.Addressing.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("addressing")
@@ -241,6 +246,11 @@ func (m *EndpointChangeRequest) contextValidateAddressing(ctx context.Context, f
 func (m *EndpointChangeRequest) contextValidateDatapathConfiguration(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.DatapathConfiguration != nil {
+
+		if swag.IsZero(m.DatapathConfiguration) { // not required
+			return nil
+		}
+
 		if err := m.DatapathConfiguration.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("datapath-configuration")
@@ -271,6 +281,7 @@ func (m *EndpointChangeRequest) contextValidateLabels(ctx context.Context, forma
 func (m *EndpointChangeRequest) contextValidateState(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.State != nil {
+
 		if err := m.State.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")

--- a/api/v1/models/endpoint_configuration_spec.go
+++ b/api/v1/models/endpoint_configuration_spec.go
@@ -105,6 +105,11 @@ func (m *EndpointConfigurationSpec) ContextValidate(ctx context.Context, formats
 func (m *EndpointConfigurationSpec) contextValidateLabelConfiguration(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.LabelConfiguration != nil {
+
+		if swag.IsZero(m.LabelConfiguration) { // not required
+			return nil
+		}
+
 		if err := m.LabelConfiguration.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("label-configuration")
@@ -119,6 +124,10 @@ func (m *EndpointConfigurationSpec) contextValidateLabelConfiguration(ctx contex
 }
 
 func (m *EndpointConfigurationSpec) contextValidateOptions(ctx context.Context, formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Options) { // not required
+		return nil
+	}
 
 	if err := m.Options.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/api/v1/models/endpoint_configuration_status.go
+++ b/api/v1/models/endpoint_configuration_status.go
@@ -132,6 +132,10 @@ func (m *EndpointConfigurationStatus) ContextValidate(ctx context.Context, forma
 
 func (m *EndpointConfigurationStatus) contextValidateError(ctx context.Context, formats strfmt.Registry) error {
 
+	if swag.IsZero(m.Error) { // not required
+		return nil
+	}
+
 	if err := m.Error.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("error")
@@ -145,6 +149,10 @@ func (m *EndpointConfigurationStatus) contextValidateError(ctx context.Context, 
 }
 
 func (m *EndpointConfigurationStatus) contextValidateImmutable(ctx context.Context, formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Immutable) { // not required
+		return nil
+	}
 
 	if err := m.Immutable.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
@@ -161,6 +169,11 @@ func (m *EndpointConfigurationStatus) contextValidateImmutable(ctx context.Conte
 func (m *EndpointConfigurationStatus) contextValidateRealized(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Realized != nil {
+
+		if swag.IsZero(m.Realized) { // not required
+			return nil
+		}
+
 		if err := m.Realized.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realized")

--- a/api/v1/models/endpoint_health.go
+++ b/api/v1/models/endpoint_health.go
@@ -133,6 +133,10 @@ func (m *EndpointHealth) ContextValidate(ctx context.Context, formats strfmt.Reg
 
 func (m *EndpointHealth) contextValidateBpf(ctx context.Context, formats strfmt.Registry) error {
 
+	if swag.IsZero(m.Bpf) { // not required
+		return nil
+	}
+
 	if err := m.Bpf.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("bpf")
@@ -147,6 +151,10 @@ func (m *EndpointHealth) contextValidateBpf(ctx context.Context, formats strfmt.
 
 func (m *EndpointHealth) contextValidateOverallHealth(ctx context.Context, formats strfmt.Registry) error {
 
+	if swag.IsZero(m.OverallHealth) { // not required
+		return nil
+	}
+
 	if err := m.OverallHealth.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("overallHealth")
@@ -160,6 +168,10 @@ func (m *EndpointHealth) contextValidateOverallHealth(ctx context.Context, forma
 }
 
 func (m *EndpointHealth) contextValidatePolicy(ctx context.Context, formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Policy) { // not required
+		return nil
+	}
 
 	if err := m.Policy.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/api/v1/models/endpoint_networking.go
+++ b/api/v1/models/endpoint_networking.go
@@ -130,6 +130,11 @@ func (m *EndpointNetworking) contextValidateAddressing(ctx context.Context, form
 	for i := 0; i < len(m.Addressing); i++ {
 
 		if m.Addressing[i] != nil {
+
+			if swag.IsZero(m.Addressing[i]) { // not required
+				return nil
+			}
+
 			if err := m.Addressing[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("addressing" + "." + strconv.Itoa(i))
@@ -148,6 +153,11 @@ func (m *EndpointNetworking) contextValidateAddressing(ctx context.Context, form
 func (m *EndpointNetworking) contextValidateHostAddressing(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.HostAddressing != nil {
+
+		if swag.IsZero(m.HostAddressing) { // not required
+			return nil
+		}
+
 		if err := m.HostAddressing.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("host-addressing")

--- a/api/v1/models/endpoint_policy.go
+++ b/api/v1/models/endpoint_policy.go
@@ -160,6 +160,11 @@ func (m *EndpointPolicy) ContextValidate(ctx context.Context, formats strfmt.Reg
 func (m *EndpointPolicy) contextValidateCidrPolicy(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.CidrPolicy != nil {
+
+		if swag.IsZero(m.CidrPolicy) { // not required
+			return nil
+		}
+
 		if err := m.CidrPolicy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cidr-policy")
@@ -176,6 +181,11 @@ func (m *EndpointPolicy) contextValidateCidrPolicy(ctx context.Context, formats 
 func (m *EndpointPolicy) contextValidateL4(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.L4 != nil {
+
+		if swag.IsZero(m.L4) { // not required
+			return nil
+		}
+
 		if err := m.L4.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("l4")
@@ -190,6 +200,10 @@ func (m *EndpointPolicy) contextValidateL4(ctx context.Context, formats strfmt.R
 }
 
 func (m *EndpointPolicy) contextValidatePolicyEnabled(ctx context.Context, formats strfmt.Registry) error {
+
+	if swag.IsZero(m.PolicyEnabled) { // not required
+		return nil
+	}
 
 	if err := m.PolicyEnabled.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/api/v1/models/endpoint_policy_status.go
+++ b/api/v1/models/endpoint_policy_status.go
@@ -148,6 +148,11 @@ func (m *EndpointPolicyStatus) contextValidateProxyStatistics(ctx context.Contex
 	for i := 0; i < len(m.ProxyStatistics); i++ {
 
 		if m.ProxyStatistics[i] != nil {
+
+			if swag.IsZero(m.ProxyStatistics[i]) { // not required
+				return nil
+			}
+
 			if err := m.ProxyStatistics[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("proxy-statistics" + "." + strconv.Itoa(i))
@@ -166,6 +171,11 @@ func (m *EndpointPolicyStatus) contextValidateProxyStatistics(ctx context.Contex
 func (m *EndpointPolicyStatus) contextValidateRealized(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Realized != nil {
+
+		if swag.IsZero(m.Realized) { // not required
+			return nil
+		}
+
 		if err := m.Realized.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realized")
@@ -182,6 +192,11 @@ func (m *EndpointPolicyStatus) contextValidateRealized(ctx context.Context, form
 func (m *EndpointPolicyStatus) contextValidateSpec(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Spec != nil {
+
+		if swag.IsZero(m.Spec) { // not required
+			return nil
+		}
+
 		if err := m.Spec.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("spec")

--- a/api/v1/models/endpoint_status.go
+++ b/api/v1/models/endpoint_status.go
@@ -390,6 +390,11 @@ func (m *EndpointStatus) contextValidateControllers(ctx context.Context, formats
 func (m *EndpointStatus) contextValidateExternalIdentifiers(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ExternalIdentifiers != nil {
+
+		if swag.IsZero(m.ExternalIdentifiers) { // not required
+			return nil
+		}
+
 		if err := m.ExternalIdentifiers.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("external-identifiers")
@@ -406,6 +411,11 @@ func (m *EndpointStatus) contextValidateExternalIdentifiers(ctx context.Context,
 func (m *EndpointStatus) contextValidateHealth(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Health != nil {
+
+		if swag.IsZero(m.Health) { // not required
+			return nil
+		}
+
 		if err := m.Health.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("health")
@@ -422,6 +432,11 @@ func (m *EndpointStatus) contextValidateHealth(ctx context.Context, formats strf
 func (m *EndpointStatus) contextValidateIdentity(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Identity != nil {
+
+		if swag.IsZero(m.Identity) { // not required
+			return nil
+		}
+
 		if err := m.Identity.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("identity")
@@ -438,6 +453,11 @@ func (m *EndpointStatus) contextValidateIdentity(ctx context.Context, formats st
 func (m *EndpointStatus) contextValidateLabels(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Labels != nil {
+
+		if swag.IsZero(m.Labels) { // not required
+			return nil
+		}
+
 		if err := m.Labels.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("labels")
@@ -482,6 +502,11 @@ func (m *EndpointStatus) contextValidateNamedPorts(ctx context.Context, formats 
 func (m *EndpointStatus) contextValidateNetworking(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Networking != nil {
+
+		if swag.IsZero(m.Networking) { // not required
+			return nil
+		}
+
 		if err := m.Networking.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("networking")
@@ -498,6 +523,11 @@ func (m *EndpointStatus) contextValidateNetworking(ctx context.Context, formats 
 func (m *EndpointStatus) contextValidatePolicy(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Policy != nil {
+
+		if swag.IsZero(m.Policy) { // not required
+			return nil
+		}
+
 		if err := m.Policy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("policy")
@@ -514,6 +544,11 @@ func (m *EndpointStatus) contextValidatePolicy(ctx context.Context, formats strf
 func (m *EndpointStatus) contextValidateRealized(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Realized != nil {
+
+		if swag.IsZero(m.Realized) { // not required
+			return nil
+		}
+
 		if err := m.Realized.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realized")
@@ -530,6 +565,7 @@ func (m *EndpointStatus) contextValidateRealized(ctx context.Context, formats st
 func (m *EndpointStatus) contextValidateState(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.State != nil {
+
 		if err := m.State.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")

--- a/api/v1/models/endpoint_status_change.go
+++ b/api/v1/models/endpoint_status_change.go
@@ -132,6 +132,10 @@ func (m *EndpointStatusChange) ContextValidate(ctx context.Context, formats strf
 
 func (m *EndpointStatusChange) contextValidateState(ctx context.Context, formats strfmt.Registry) error {
 
+	if swag.IsZero(m.State) { // not required
+		return nil
+	}
+
 	if err := m.State.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("state")

--- a/api/v1/models/endpoint_status_log.go
+++ b/api/v1/models/endpoint_status_log.go
@@ -57,6 +57,11 @@ func (m EndpointStatusLog) ContextValidate(ctx context.Context, formats strfmt.R
 	for i := 0; i < len(m); i++ {
 
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))

--- a/api/v1/models/frontend_mapping.go
+++ b/api/v1/models/frontend_mapping.go
@@ -115,6 +115,11 @@ func (m *FrontendMapping) contextValidateBackends(ctx context.Context, formats s
 	for i := 0; i < len(m.Backends); i++ {
 
 		if m.Backends[i] != nil {
+
+			if swag.IsZero(m.Backends[i]) { // not required
+				return nil
+			}
+
 			if err := m.Backends[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("backends" + "." + strconv.Itoa(i))
@@ -133,6 +138,11 @@ func (m *FrontendMapping) contextValidateBackends(ctx context.Context, formats s
 func (m *FrontendMapping) contextValidateFrontendAddress(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.FrontendAddress != nil {
+
+		if swag.IsZero(m.FrontendAddress) { // not required
+			return nil
+		}
+
 		if err := m.FrontendAddress.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("frontend-address")

--- a/api/v1/models/hubble_status.go
+++ b/api/v1/models/hubble_status.go
@@ -168,6 +168,11 @@ func (m *HubbleStatus) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *HubbleStatus) contextValidateMetrics(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Metrics != nil {
+
+		if swag.IsZero(m.Metrics) { // not required
+			return nil
+		}
+
 		if err := m.Metrics.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("metrics")
@@ -184,6 +189,11 @@ func (m *HubbleStatus) contextValidateMetrics(ctx context.Context, formats strfm
 func (m *HubbleStatus) contextValidateObserver(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Observer != nil {
+
+		if swag.IsZero(m.Observer) { // not required
+			return nil
+		}
+
 		if err := m.Observer.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("observer")

--- a/api/v1/models/identity_endpoints.go
+++ b/api/v1/models/identity_endpoints.go
@@ -78,6 +78,11 @@ func (m *IdentityEndpoints) ContextValidate(ctx context.Context, formats strfmt.
 func (m *IdentityEndpoints) contextValidateIdentity(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Identity != nil {
+
+		if swag.IsZero(m.Identity) { // not required
+			return nil
+		}
+
 		if err := m.Identity.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("identity")

--- a/api/v1/models/ip_a_m_response.go
+++ b/api/v1/models/ip_a_m_response.go
@@ -170,6 +170,7 @@ func (m *IPAMResponse) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *IPAMResponse) contextValidateAddress(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Address != nil {
+
 		if err := m.Address.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("address")
@@ -186,6 +187,7 @@ func (m *IPAMResponse) contextValidateAddress(ctx context.Context, formats strfm
 func (m *IPAMResponse) contextValidateHostAddressing(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.HostAddressing != nil {
+
 		if err := m.HostAddressing.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("host-addressing")
@@ -202,6 +204,11 @@ func (m *IPAMResponse) contextValidateHostAddressing(ctx context.Context, format
 func (m *IPAMResponse) contextValidateIPV4(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.IPV4 != nil {
+
+		if swag.IsZero(m.IPV4) { // not required
+			return nil
+		}
+
 		if err := m.IPV4.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ipv4")
@@ -218,6 +225,11 @@ func (m *IPAMResponse) contextValidateIPV4(ctx context.Context, formats strfmt.R
 func (m *IPAMResponse) contextValidateIPV6(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.IPV6 != nil {
+
+		if swag.IsZero(m.IPV6) { // not required
+			return nil
+		}
+
 		if err := m.IPV6.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ipv6")

--- a/api/v1/models/ip_a_m_status.go
+++ b/api/v1/models/ip_a_m_status.go
@@ -85,6 +85,10 @@ func (m *IPAMStatus) ContextValidate(ctx context.Context, formats strfmt.Registr
 
 func (m *IPAMStatus) contextValidateAllocations(ctx context.Context, formats strfmt.Registry) error {
 
+	if swag.IsZero(m.Allocations) { // not required
+		return nil
+	}
+
 	if err := m.Allocations.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("allocations")

--- a/api/v1/models/ip_list_entry.go
+++ b/api/v1/models/ip_list_entry.go
@@ -116,6 +116,11 @@ func (m *IPListEntry) ContextValidate(ctx context.Context, formats strfmt.Regist
 func (m *IPListEntry) contextValidateMetadata(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Metadata != nil {
+
+		if swag.IsZero(m.Metadata) { // not required
+			return nil
+		}
+
 		if err := m.Metadata.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("metadata")

--- a/api/v1/models/kube_proxy_replacement.go
+++ b/api/v1/models/kube_proxy_replacement.go
@@ -177,6 +177,11 @@ func (m *KubeProxyReplacement) contextValidateDeviceList(ctx context.Context, fo
 	for i := 0; i < len(m.DeviceList); i++ {
 
 		if m.DeviceList[i] != nil {
+
+			if swag.IsZero(m.DeviceList[i]) { // not required
+				return nil
+			}
+
 			if err := m.DeviceList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("deviceList" + "." + strconv.Itoa(i))
@@ -195,6 +200,11 @@ func (m *KubeProxyReplacement) contextValidateDeviceList(ctx context.Context, fo
 func (m *KubeProxyReplacement) contextValidateFeatures(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Features != nil {
+
+		if swag.IsZero(m.Features) { // not required
+			return nil
+		}
+
 		if err := m.Features.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("features")
@@ -574,6 +584,11 @@ func (m *KubeProxyReplacementFeatures) ContextValidate(ctx context.Context, form
 func (m *KubeProxyReplacementFeatures) contextValidateExternalIPs(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ExternalIPs != nil {
+
+		if swag.IsZero(m.ExternalIPs) { // not required
+			return nil
+		}
+
 		if err := m.ExternalIPs.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("features" + "." + "externalIPs")
@@ -590,6 +605,11 @@ func (m *KubeProxyReplacementFeatures) contextValidateExternalIPs(ctx context.Co
 func (m *KubeProxyReplacementFeatures) contextValidateGracefulTermination(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.GracefulTermination != nil {
+
+		if swag.IsZero(m.GracefulTermination) { // not required
+			return nil
+		}
+
 		if err := m.GracefulTermination.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("features" + "." + "gracefulTermination")
@@ -606,6 +626,11 @@ func (m *KubeProxyReplacementFeatures) contextValidateGracefulTermination(ctx co
 func (m *KubeProxyReplacementFeatures) contextValidateHostPort(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.HostPort != nil {
+
+		if swag.IsZero(m.HostPort) { // not required
+			return nil
+		}
+
 		if err := m.HostPort.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("features" + "." + "hostPort")
@@ -622,6 +647,11 @@ func (m *KubeProxyReplacementFeatures) contextValidateHostPort(ctx context.Conte
 func (m *KubeProxyReplacementFeatures) contextValidateHostReachableServices(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.HostReachableServices != nil {
+
+		if swag.IsZero(m.HostReachableServices) { // not required
+			return nil
+		}
+
 		if err := m.HostReachableServices.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("features" + "." + "hostReachableServices")
@@ -638,6 +668,11 @@ func (m *KubeProxyReplacementFeatures) contextValidateHostReachableServices(ctx 
 func (m *KubeProxyReplacementFeatures) contextValidateNat46X64(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Nat46X64 != nil {
+
+		if swag.IsZero(m.Nat46X64) { // not required
+			return nil
+		}
+
 		if err := m.Nat46X64.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("features" + "." + "nat46X64")
@@ -654,6 +689,11 @@ func (m *KubeProxyReplacementFeatures) contextValidateNat46X64(ctx context.Conte
 func (m *KubeProxyReplacementFeatures) contextValidateNodePort(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.NodePort != nil {
+
+		if swag.IsZero(m.NodePort) { // not required
+			return nil
+		}
+
 		if err := m.NodePort.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("features" + "." + "nodePort")
@@ -670,6 +710,11 @@ func (m *KubeProxyReplacementFeatures) contextValidateNodePort(ctx context.Conte
 func (m *KubeProxyReplacementFeatures) contextValidateSessionAffinity(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SessionAffinity != nil {
+
+		if swag.IsZero(m.SessionAffinity) { // not required
+			return nil
+		}
+
 		if err := m.SessionAffinity.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("features" + "." + "sessionAffinity")
@@ -686,6 +731,11 @@ func (m *KubeProxyReplacementFeatures) contextValidateSessionAffinity(ctx contex
 func (m *KubeProxyReplacementFeatures) contextValidateSocketLB(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SocketLB != nil {
+
+		if swag.IsZero(m.SocketLB) { // not required
+			return nil
+		}
+
 		if err := m.SocketLB.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("features" + "." + "socketLB")
@@ -702,6 +752,11 @@ func (m *KubeProxyReplacementFeatures) contextValidateSocketLB(ctx context.Conte
 func (m *KubeProxyReplacementFeatures) contextValidateSocketLBTracing(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SocketLBTracing != nil {
+
+		if swag.IsZero(m.SocketLBTracing) { // not required
+			return nil
+		}
+
 		if err := m.SocketLBTracing.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("features" + "." + "socketLBTracing")
@@ -986,6 +1041,11 @@ func (m *KubeProxyReplacementFeaturesNat46X64) ContextValidate(ctx context.Conte
 func (m *KubeProxyReplacementFeaturesNat46X64) contextValidateGateway(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Gateway != nil {
+
+		if swag.IsZero(m.Gateway) { // not required
+			return nil
+		}
+
 		if err := m.Gateway.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("features" + "." + "nat46X64" + "." + "gateway")
@@ -1002,6 +1062,11 @@ func (m *KubeProxyReplacementFeaturesNat46X64) contextValidateGateway(ctx contex
 func (m *KubeProxyReplacementFeaturesNat46X64) contextValidateService(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Service != nil {
+
+		if swag.IsZero(m.Service) { // not required
+			return nil
+		}
+
 		if err := m.Service.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("features" + "." + "nat46X64" + "." + "service")

--- a/api/v1/models/l4_policy.go
+++ b/api/v1/models/l4_policy.go
@@ -124,6 +124,11 @@ func (m *L4Policy) contextValidateEgress(ctx context.Context, formats strfmt.Reg
 	for i := 0; i < len(m.Egress); i++ {
 
 		if m.Egress[i] != nil {
+
+			if swag.IsZero(m.Egress[i]) { // not required
+				return nil
+			}
+
 			if err := m.Egress[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("egress" + "." + strconv.Itoa(i))
@@ -144,6 +149,11 @@ func (m *L4Policy) contextValidateIngress(ctx context.Context, formats strfmt.Re
 	for i := 0; i < len(m.Ingress); i++ {
 
 		if m.Ingress[i] != nil {
+
+			if swag.IsZero(m.Ingress[i]) { // not required
+				return nil
+			}
+
 			if err := m.Ingress[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("ingress" + "." + strconv.Itoa(i))

--- a/api/v1/models/l_r_p_backend.go
+++ b/api/v1/models/l_r_p_backend.go
@@ -78,6 +78,11 @@ func (m *LRPBackend) ContextValidate(ctx context.Context, formats strfmt.Registr
 func (m *LRPBackend) contextValidateBackendAddress(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.BackendAddress != nil {
+
+		if swag.IsZero(m.BackendAddress) { // not required
+			return nil
+		}
+
 		if err := m.BackendAddress.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("backend-address")

--- a/api/v1/models/l_r_p_spec.go
+++ b/api/v1/models/l_r_p_spec.go
@@ -103,6 +103,11 @@ func (m *LRPSpec) contextValidateFrontendMappings(ctx context.Context, formats s
 	for i := 0; i < len(m.FrontendMappings); i++ {
 
 		if m.FrontendMappings[i] != nil {
+
+			if swag.IsZero(m.FrontendMappings[i]) { // not required
+				return nil
+			}
+
 			if err := m.FrontendMappings[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("frontend-mappings" + "." + strconv.Itoa(i))

--- a/api/v1/models/label_array.go
+++ b/api/v1/models/label_array.go
@@ -57,6 +57,11 @@ func (m LabelArray) ContextValidate(ctx context.Context, formats strfmt.Registry
 	for i := 0; i < len(m); i++ {
 
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))

--- a/api/v1/models/label_configuration.go
+++ b/api/v1/models/label_configuration.go
@@ -105,6 +105,11 @@ func (m *LabelConfiguration) ContextValidate(ctx context.Context, formats strfmt
 func (m *LabelConfiguration) contextValidateSpec(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Spec != nil {
+
+		if swag.IsZero(m.Spec) { // not required
+			return nil
+		}
+
 		if err := m.Spec.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("spec")
@@ -121,6 +126,11 @@ func (m *LabelConfiguration) contextValidateSpec(ctx context.Context, formats st
 func (m *LabelConfiguration) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
+
+		if swag.IsZero(m.Status) { // not required
+			return nil
+		}
+
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")

--- a/api/v1/models/label_configuration_status.go
+++ b/api/v1/models/label_configuration_status.go
@@ -187,6 +187,11 @@ func (m *LabelConfigurationStatus) contextValidateDisabled(ctx context.Context, 
 func (m *LabelConfigurationStatus) contextValidateRealized(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Realized != nil {
+
+		if swag.IsZero(m.Realized) { // not required
+			return nil
+		}
+
 		if err := m.Realized.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realized")

--- a/api/v1/models/masquerading.go
+++ b/api/v1/models/masquerading.go
@@ -147,6 +147,11 @@ func (m *Masquerading) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *Masquerading) contextValidateEnabledProtocols(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.EnabledProtocols != nil {
+
+		if swag.IsZero(m.EnabledProtocols) { // not required
+			return nil
+		}
+
 		if err := m.EnabledProtocols.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("enabledProtocols")

--- a/api/v1/models/modules_health.go
+++ b/api/v1/models/modules_health.go
@@ -85,6 +85,11 @@ func (m *ModulesHealth) contextValidateModules(ctx context.Context, formats strf
 	for i := 0; i < len(m.Modules); i++ {
 
 		if m.Modules[i] != nil {
+
+			if swag.IsZero(m.Modules[i]) { // not required
+				return nil
+			}
+
 			if err := m.Modules[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("modules" + "." + strconv.Itoa(i))

--- a/api/v1/models/name_manager.go
+++ b/api/v1/models/name_manager.go
@@ -88,6 +88,11 @@ func (m *NameManager) contextValidateFQDNPolicySelectors(ctx context.Context, fo
 	for i := 0; i < len(m.FQDNPolicySelectors); i++ {
 
 		if m.FQDNPolicySelectors[i] != nil {
+
+			if swag.IsZero(m.FQDNPolicySelectors[i]) { // not required
+				return nil
+			}
+
 			if err := m.FQDNPolicySelectors[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("FQDNPolicySelectors" + "." + strconv.Itoa(i))

--- a/api/v1/models/named_ports.go
+++ b/api/v1/models/named_ports.go
@@ -61,6 +61,11 @@ func (m NamedPorts) ContextValidate(ctx context.Context, formats strfmt.Registry
 	for i := 0; i < len(m); i++ {
 
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))

--- a/api/v1/models/node_addressing.go
+++ b/api/v1/models/node_addressing.go
@@ -107,6 +107,11 @@ func (m *NodeAddressing) ContextValidate(ctx context.Context, formats strfmt.Reg
 func (m *NodeAddressing) contextValidateIPV4(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.IPV4 != nil {
+
+		if swag.IsZero(m.IPV4) { // not required
+			return nil
+		}
+
 		if err := m.IPV4.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ipv4")
@@ -123,6 +128,11 @@ func (m *NodeAddressing) contextValidateIPV4(ctx context.Context, formats strfmt
 func (m *NodeAddressing) contextValidateIPV6(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.IPV6 != nil {
+
+		if swag.IsZero(m.IPV6) { // not required
+			return nil
+		}
+
 		if err := m.IPV6.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ipv6")

--- a/api/v1/models/node_element.go
+++ b/api/v1/models/node_element.go
@@ -183,6 +183,11 @@ func (m *NodeElement) ContextValidate(ctx context.Context, formats strfmt.Regist
 func (m *NodeElement) contextValidateHealthEndpointAddress(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.HealthEndpointAddress != nil {
+
+		if swag.IsZero(m.HealthEndpointAddress) { // not required
+			return nil
+		}
+
 		if err := m.HealthEndpointAddress.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("health-endpoint-address")
@@ -199,6 +204,11 @@ func (m *NodeElement) contextValidateHealthEndpointAddress(ctx context.Context, 
 func (m *NodeElement) contextValidateIngressAddress(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.IngressAddress != nil {
+
+		if swag.IsZero(m.IngressAddress) { // not required
+			return nil
+		}
+
 		if err := m.IngressAddress.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ingress-address")
@@ -215,6 +225,11 @@ func (m *NodeElement) contextValidateIngressAddress(ctx context.Context, formats
 func (m *NodeElement) contextValidatePrimaryAddress(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PrimaryAddress != nil {
+
+		if swag.IsZero(m.PrimaryAddress) { // not required
+			return nil
+		}
+
 		if err := m.PrimaryAddress.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("primary-address")
@@ -233,6 +248,11 @@ func (m *NodeElement) contextValidateSecondaryAddresses(ctx context.Context, for
 	for i := 0; i < len(m.SecondaryAddresses); i++ {
 
 		if m.SecondaryAddresses[i] != nil {
+
+			if swag.IsZero(m.SecondaryAddresses[i]) { // not required
+				return nil
+			}
+
 			if err := m.SecondaryAddresses[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("secondary-addresses" + "." + strconv.Itoa(i))

--- a/api/v1/models/prefilter.go
+++ b/api/v1/models/prefilter.go
@@ -105,6 +105,11 @@ func (m *Prefilter) ContextValidate(ctx context.Context, formats strfmt.Registry
 func (m *Prefilter) contextValidateSpec(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Spec != nil {
+
+		if swag.IsZero(m.Spec) { // not required
+			return nil
+		}
+
 		if err := m.Spec.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("spec")
@@ -121,6 +126,11 @@ func (m *Prefilter) contextValidateSpec(ctx context.Context, formats strfmt.Regi
 func (m *Prefilter) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
+
+		if swag.IsZero(m.Status) { // not required
+			return nil
+		}
+
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")

--- a/api/v1/models/prefilter_status.go
+++ b/api/v1/models/prefilter_status.go
@@ -75,6 +75,11 @@ func (m *PrefilterStatus) ContextValidate(ctx context.Context, formats strfmt.Re
 func (m *PrefilterStatus) contextValidateRealized(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Realized != nil {
+
+		if swag.IsZero(m.Realized) { // not required
+			return nil
+		}
+
 		if err := m.Realized.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realized")

--- a/api/v1/models/proxy_statistics.go
+++ b/api/v1/models/proxy_statistics.go
@@ -138,6 +138,11 @@ func (m *ProxyStatistics) ContextValidate(ctx context.Context, formats strfmt.Re
 func (m *ProxyStatistics) contextValidateStatistics(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Statistics != nil {
+
+		if swag.IsZero(m.Statistics) { // not required
+			return nil
+		}
+
 		if err := m.Statistics.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("statistics")

--- a/api/v1/models/proxy_status.go
+++ b/api/v1/models/proxy_status.go
@@ -151,6 +151,11 @@ func (m *ProxyStatus) contextValidateRedirects(ctx context.Context, formats strf
 	for i := 0; i < len(m.Redirects); i++ {
 
 		if m.Redirects[i] != nil {
+
+			if swag.IsZero(m.Redirects[i]) { // not required
+				return nil
+			}
+
 			if err := m.Redirects[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("redirects" + "." + strconv.Itoa(i))

--- a/api/v1/models/recorder.go
+++ b/api/v1/models/recorder.go
@@ -105,6 +105,11 @@ func (m *Recorder) ContextValidate(ctx context.Context, formats strfmt.Registry)
 func (m *Recorder) contextValidateSpec(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Spec != nil {
+
+		if swag.IsZero(m.Spec) { // not required
+			return nil
+		}
+
 		if err := m.Spec.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("spec")
@@ -121,6 +126,11 @@ func (m *Recorder) contextValidateSpec(ctx context.Context, formats strfmt.Regis
 func (m *Recorder) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
+
+		if swag.IsZero(m.Status) { // not required
+			return nil
+		}
+
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")

--- a/api/v1/models/recorder_mask.go
+++ b/api/v1/models/recorder_mask.go
@@ -75,6 +75,11 @@ func (m *RecorderMask) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *RecorderMask) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
+
+		if swag.IsZero(m.Status) { // not required
+			return nil
+		}
+
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")

--- a/api/v1/models/recorder_mask_status.go
+++ b/api/v1/models/recorder_mask_status.go
@@ -75,6 +75,11 @@ func (m *RecorderMaskStatus) ContextValidate(ctx context.Context, formats strfmt
 func (m *RecorderMaskStatus) contextValidateRealized(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Realized != nil {
+
+		if swag.IsZero(m.Realized) { // not required
+			return nil
+		}
+
 		if err := m.Realized.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realized")

--- a/api/v1/models/recorder_spec.go
+++ b/api/v1/models/recorder_spec.go
@@ -108,6 +108,11 @@ func (m *RecorderSpec) contextValidateFilters(ctx context.Context, formats strfm
 	for i := 0; i < len(m.Filters); i++ {
 
 		if m.Filters[i] != nil {
+
+			if swag.IsZero(m.Filters[i]) { // not required
+				return nil
+			}
+
 			if err := m.Filters[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("filters" + "." + strconv.Itoa(i))

--- a/api/v1/models/recorder_status.go
+++ b/api/v1/models/recorder_status.go
@@ -75,6 +75,11 @@ func (m *RecorderStatus) ContextValidate(ctx context.Context, formats strfmt.Reg
 func (m *RecorderStatus) contextValidateRealized(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Realized != nil {
+
+		if swag.IsZero(m.Realized) { // not required
+			return nil
+		}
+
 		if err := m.Realized.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realized")

--- a/api/v1/models/remote_cluster.go
+++ b/api/v1/models/remote_cluster.go
@@ -155,6 +155,11 @@ func (m *RemoteCluster) ContextValidate(ctx context.Context, formats strfmt.Regi
 func (m *RemoteCluster) contextValidateConfig(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Config != nil {
+
+		if swag.IsZero(m.Config) { // not required
+			return nil
+		}
+
 		if err := m.Config.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("config")
@@ -171,6 +176,11 @@ func (m *RemoteCluster) contextValidateConfig(ctx context.Context, formats strfm
 func (m *RemoteCluster) contextValidateSynced(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Synced != nil {
+
+		if swag.IsZero(m.Synced) { // not required
+			return nil
+		}
+
 		if err := m.Synced.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("synced")

--- a/api/v1/models/request_response_statistics.go
+++ b/api/v1/models/request_response_statistics.go
@@ -107,6 +107,11 @@ func (m *RequestResponseStatistics) ContextValidate(ctx context.Context, formats
 func (m *RequestResponseStatistics) contextValidateRequests(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Requests != nil {
+
+		if swag.IsZero(m.Requests) { // not required
+			return nil
+		}
+
 		if err := m.Requests.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("requests")
@@ -123,6 +128,11 @@ func (m *RequestResponseStatistics) contextValidateRequests(ctx context.Context,
 func (m *RequestResponseStatistics) contextValidateResponses(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Responses != nil {
+
+		if swag.IsZero(m.Responses) { // not required
+			return nil
+		}
+
 		if err := m.Responses.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("responses")

--- a/api/v1/models/selector_cache.go
+++ b/api/v1/models/selector_cache.go
@@ -57,6 +57,11 @@ func (m SelectorCache) ContextValidate(ctx context.Context, formats strfmt.Regis
 	for i := 0; i < len(m); i++ {
 
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))

--- a/api/v1/models/service.go
+++ b/api/v1/models/service.go
@@ -105,6 +105,11 @@ func (m *Service) ContextValidate(ctx context.Context, formats strfmt.Registry) 
 func (m *Service) contextValidateSpec(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Spec != nil {
+
+		if swag.IsZero(m.Spec) { // not required
+			return nil
+		}
+
 		if err := m.Spec.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("spec")
@@ -121,6 +126,11 @@ func (m *Service) contextValidateSpec(ctx context.Context, formats strfmt.Regist
 func (m *Service) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
+
+		if swag.IsZero(m.Status) { // not required
+			return nil
+		}
+
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")

--- a/api/v1/models/service_spec.go
+++ b/api/v1/models/service_spec.go
@@ -157,6 +157,11 @@ func (m *ServiceSpec) contextValidateBackendAddresses(ctx context.Context, forma
 	for i := 0; i < len(m.BackendAddresses); i++ {
 
 		if m.BackendAddresses[i] != nil {
+
+			if swag.IsZero(m.BackendAddresses[i]) { // not required
+				return nil
+			}
+
 			if err := m.BackendAddresses[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("backend-addresses" + "." + strconv.Itoa(i))
@@ -175,6 +180,11 @@ func (m *ServiceSpec) contextValidateBackendAddresses(ctx context.Context, forma
 func (m *ServiceSpec) contextValidateFlags(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Flags != nil {
+
+		if swag.IsZero(m.Flags) { // not required
+			return nil
+		}
+
 		if err := m.Flags.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("flags")
@@ -191,6 +201,7 @@ func (m *ServiceSpec) contextValidateFlags(ctx context.Context, formats strfmt.R
 func (m *ServiceSpec) contextValidateFrontendAddress(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.FrontendAddress != nil {
+
 		if err := m.FrontendAddress.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("frontend-address")

--- a/api/v1/models/service_status.go
+++ b/api/v1/models/service_status.go
@@ -75,6 +75,11 @@ func (m *ServiceStatus) ContextValidate(ctx context.Context, formats strfmt.Regi
 func (m *ServiceStatus) contextValidateRealized(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Realized != nil {
+
+		if swag.IsZero(m.Realized) { // not required
+			return nil
+		}
+
 		if err := m.Realized.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realized")

--- a/api/v1/models/status_response.go
+++ b/api/v1/models/status_response.go
@@ -855,6 +855,11 @@ func (m *StatusResponse) ContextValidate(ctx context.Context, formats strfmt.Reg
 func (m *StatusResponse) contextValidateAuthCertificateProvider(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.AuthCertificateProvider != nil {
+
+		if swag.IsZero(m.AuthCertificateProvider) { // not required
+			return nil
+		}
+
 		if err := m.AuthCertificateProvider.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("auth-certificate-provider")
@@ -871,6 +876,11 @@ func (m *StatusResponse) contextValidateAuthCertificateProvider(ctx context.Cont
 func (m *StatusResponse) contextValidateBandwidthManager(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.BandwidthManager != nil {
+
+		if swag.IsZero(m.BandwidthManager) { // not required
+			return nil
+		}
+
 		if err := m.BandwidthManager.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("bandwidth-manager")
@@ -887,6 +897,11 @@ func (m *StatusResponse) contextValidateBandwidthManager(ctx context.Context, fo
 func (m *StatusResponse) contextValidateBpfMaps(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.BpfMaps != nil {
+
+		if swag.IsZero(m.BpfMaps) { // not required
+			return nil
+		}
+
 		if err := m.BpfMaps.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("bpf-maps")
@@ -903,6 +918,11 @@ func (m *StatusResponse) contextValidateBpfMaps(ctx context.Context, formats str
 func (m *StatusResponse) contextValidateCilium(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Cilium != nil {
+
+		if swag.IsZero(m.Cilium) { // not required
+			return nil
+		}
+
 		if err := m.Cilium.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cilium")
@@ -919,6 +939,11 @@ func (m *StatusResponse) contextValidateCilium(ctx context.Context, formats strf
 func (m *StatusResponse) contextValidateClockSource(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ClockSource != nil {
+
+		if swag.IsZero(m.ClockSource) { // not required
+			return nil
+		}
+
 		if err := m.ClockSource.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("clock-source")
@@ -935,6 +960,11 @@ func (m *StatusResponse) contextValidateClockSource(ctx context.Context, formats
 func (m *StatusResponse) contextValidateCluster(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Cluster != nil {
+
+		if swag.IsZero(m.Cluster) { // not required
+			return nil
+		}
+
 		if err := m.Cluster.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cluster")
@@ -951,6 +981,11 @@ func (m *StatusResponse) contextValidateCluster(ctx context.Context, formats str
 func (m *StatusResponse) contextValidateClusterMesh(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ClusterMesh != nil {
+
+		if swag.IsZero(m.ClusterMesh) { // not required
+			return nil
+		}
+
 		if err := m.ClusterMesh.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cluster-mesh")
@@ -967,6 +1002,11 @@ func (m *StatusResponse) contextValidateClusterMesh(ctx context.Context, formats
 func (m *StatusResponse) contextValidateCniChaining(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.CniChaining != nil {
+
+		if swag.IsZero(m.CniChaining) { // not required
+			return nil
+		}
+
 		if err := m.CniChaining.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cni-chaining")
@@ -983,6 +1023,11 @@ func (m *StatusResponse) contextValidateCniChaining(ctx context.Context, formats
 func (m *StatusResponse) contextValidateCniFile(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.CniFile != nil {
+
+		if swag.IsZero(m.CniFile) { // not required
+			return nil
+		}
+
 		if err := m.CniFile.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cni-file")
@@ -999,6 +1044,11 @@ func (m *StatusResponse) contextValidateCniFile(ctx context.Context, formats str
 func (m *StatusResponse) contextValidateContainerRuntime(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ContainerRuntime != nil {
+
+		if swag.IsZero(m.ContainerRuntime) { // not required
+			return nil
+		}
+
 		if err := m.ContainerRuntime.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("container-runtime")
@@ -1029,6 +1079,11 @@ func (m *StatusResponse) contextValidateControllers(ctx context.Context, formats
 func (m *StatusResponse) contextValidateEncryption(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Encryption != nil {
+
+		if swag.IsZero(m.Encryption) { // not required
+			return nil
+		}
+
 		if err := m.Encryption.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("encryption")
@@ -1045,6 +1100,11 @@ func (m *StatusResponse) contextValidateEncryption(ctx context.Context, formats 
 func (m *StatusResponse) contextValidateHostFirewall(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.HostFirewall != nil {
+
+		if swag.IsZero(m.HostFirewall) { // not required
+			return nil
+		}
+
 		if err := m.HostFirewall.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("host-firewall")
@@ -1061,6 +1121,11 @@ func (m *StatusResponse) contextValidateHostFirewall(ctx context.Context, format
 func (m *StatusResponse) contextValidateHostRouting(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.HostRouting != nil {
+
+		if swag.IsZero(m.HostRouting) { // not required
+			return nil
+		}
+
 		if err := m.HostRouting.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("host-routing")
@@ -1077,6 +1142,11 @@ func (m *StatusResponse) contextValidateHostRouting(ctx context.Context, formats
 func (m *StatusResponse) contextValidateHubble(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Hubble != nil {
+
+		if swag.IsZero(m.Hubble) { // not required
+			return nil
+		}
+
 		if err := m.Hubble.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("hubble")
@@ -1093,6 +1163,11 @@ func (m *StatusResponse) contextValidateHubble(ctx context.Context, formats strf
 func (m *StatusResponse) contextValidateIdentityRange(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.IdentityRange != nil {
+
+		if swag.IsZero(m.IdentityRange) { // not required
+			return nil
+		}
+
 		if err := m.IdentityRange.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("identity-range")
@@ -1109,6 +1184,11 @@ func (m *StatusResponse) contextValidateIdentityRange(ctx context.Context, forma
 func (m *StatusResponse) contextValidateIpam(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Ipam != nil {
+
+		if swag.IsZero(m.Ipam) { // not required
+			return nil
+		}
+
 		if err := m.Ipam.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ipam")
@@ -1125,6 +1205,11 @@ func (m *StatusResponse) contextValidateIpam(ctx context.Context, formats strfmt
 func (m *StatusResponse) contextValidateIPV4BigTCP(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.IPV4BigTCP != nil {
+
+		if swag.IsZero(m.IPV4BigTCP) { // not required
+			return nil
+		}
+
 		if err := m.IPV4BigTCP.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ipv4-big-tcp")
@@ -1141,6 +1226,11 @@ func (m *StatusResponse) contextValidateIPV4BigTCP(ctx context.Context, formats 
 func (m *StatusResponse) contextValidateIPV6BigTCP(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.IPV6BigTCP != nil {
+
+		if swag.IsZero(m.IPV6BigTCP) { // not required
+			return nil
+		}
+
 		if err := m.IPV6BigTCP.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ipv6-big-tcp")
@@ -1157,6 +1247,11 @@ func (m *StatusResponse) contextValidateIPV6BigTCP(ctx context.Context, formats 
 func (m *StatusResponse) contextValidateKubeProxyReplacement(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.KubeProxyReplacement != nil {
+
+		if swag.IsZero(m.KubeProxyReplacement) { // not required
+			return nil
+		}
+
 		if err := m.KubeProxyReplacement.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kube-proxy-replacement")
@@ -1173,6 +1268,11 @@ func (m *StatusResponse) contextValidateKubeProxyReplacement(ctx context.Context
 func (m *StatusResponse) contextValidateKubernetes(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Kubernetes != nil {
+
+		if swag.IsZero(m.Kubernetes) { // not required
+			return nil
+		}
+
 		if err := m.Kubernetes.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kubernetes")
@@ -1189,6 +1289,11 @@ func (m *StatusResponse) contextValidateKubernetes(ctx context.Context, formats 
 func (m *StatusResponse) contextValidateKvstore(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Kvstore != nil {
+
+		if swag.IsZero(m.Kvstore) { // not required
+			return nil
+		}
+
 		if err := m.Kvstore.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kvstore")
@@ -1205,6 +1310,11 @@ func (m *StatusResponse) contextValidateKvstore(ctx context.Context, formats str
 func (m *StatusResponse) contextValidateMasquerading(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Masquerading != nil {
+
+		if swag.IsZero(m.Masquerading) { // not required
+			return nil
+		}
+
 		if err := m.Masquerading.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("masquerading")
@@ -1221,6 +1331,11 @@ func (m *StatusResponse) contextValidateMasquerading(ctx context.Context, format
 func (m *StatusResponse) contextValidateNodeMonitor(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.NodeMonitor != nil {
+
+		if swag.IsZero(m.NodeMonitor) { // not required
+			return nil
+		}
+
 		if err := m.NodeMonitor.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("nodeMonitor")
@@ -1237,6 +1352,11 @@ func (m *StatusResponse) contextValidateNodeMonitor(ctx context.Context, formats
 func (m *StatusResponse) contextValidateProxy(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Proxy != nil {
+
+		if swag.IsZero(m.Proxy) { // not required
+			return nil
+		}
+
 		if err := m.Proxy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("proxy")
@@ -1253,6 +1373,11 @@ func (m *StatusResponse) contextValidateProxy(ctx context.Context, formats strfm
 func (m *StatusResponse) contextValidateSrv6(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Srv6 != nil {
+
+		if swag.IsZero(m.Srv6) { // not required
+			return nil
+		}
+
 		if err := m.Srv6.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("srv6")

--- a/api/v1/models/trace_selector.go
+++ b/api/v1/models/trace_selector.go
@@ -109,6 +109,11 @@ func (m *TraceSelector) ContextValidate(ctx context.Context, formats strfmt.Regi
 func (m *TraceSelector) contextValidateFrom(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.From != nil {
+
+		if swag.IsZero(m.From) { // not required
+			return nil
+		}
+
 		if err := m.From.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("from")
@@ -125,6 +130,11 @@ func (m *TraceSelector) contextValidateFrom(ctx context.Context, formats strfmt.
 func (m *TraceSelector) contextValidateTo(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.To != nil {
+
+		if swag.IsZero(m.To) { // not required
+			return nil
+		}
+
 		if err := m.To.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("to")

--- a/api/v1/models/trace_to.go
+++ b/api/v1/models/trace_to.go
@@ -115,6 +115,11 @@ func (m *TraceTo) contextValidateDports(ctx context.Context, formats strfmt.Regi
 	for i := 0; i < len(m.Dports); i++ {
 
 		if m.Dports[i] != nil {
+
+			if swag.IsZero(m.Dports[i]) { // not required
+				return nil
+			}
+
 			if err := m.Dports[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("dports" + "." + strconv.Itoa(i))

--- a/api/v1/models/wireguard_interface.go
+++ b/api/v1/models/wireguard_interface.go
@@ -99,6 +99,11 @@ func (m *WireguardInterface) contextValidatePeers(ctx context.Context, formats s
 	for i := 0; i < len(m.Peers); i++ {
 
 		if m.Peers[i] != nil {
+
+			if swag.IsZero(m.Peers[i]) { // not required
+				return nil
+			}
+
 			if err := m.Peers[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("peers" + "." + strconv.Itoa(i))

--- a/api/v1/models/wireguard_status.go
+++ b/api/v1/models/wireguard_status.go
@@ -90,6 +90,11 @@ func (m *WireguardStatus) contextValidateInterfaces(ctx context.Context, formats
 	for i := 0; i < len(m.Interfaces); i++ {
 
 		if m.Interfaces[i] != nil {
+
+			if swag.IsZero(m.Interfaces[i]) { // not required
+				return nil
+			}
+
 			if err := m.Interfaces[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("interfaces" + "." + strconv.Itoa(i))

--- a/api/v1/operator/client/metrics/get_metrics_responses.go
+++ b/api/v1/operator/client/metrics/get_metrics_responses.go
@@ -39,7 +39,7 @@ func (o *GetMetricsReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /metrics/] GetMetrics", response, response.Code())
 	}
 }
 
@@ -80,6 +80,11 @@ func (o *GetMetricsOK) IsServerError() bool {
 // IsCode returns true when this get metrics o k response a status code equal to that given
 func (o *GetMetricsOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get metrics o k response
+func (o *GetMetricsOK) Code() int {
+	return 200
 }
 
 func (o *GetMetricsOK) Error() string {
@@ -140,6 +145,11 @@ func (o *GetMetricsFailed) IsServerError() bool {
 // IsCode returns true when this get metrics failed response a status code equal to that given
 func (o *GetMetricsFailed) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the get metrics failed response
+func (o *GetMetricsFailed) Code() int {
+	return 500
 }
 
 func (o *GetMetricsFailed) Error() string {

--- a/api/v1/operator/client/operator/get_healthz_responses.go
+++ b/api/v1/operator/client/operator/get_healthz_responses.go
@@ -43,7 +43,7 @@ func (o *GetHealthzReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /healthz] GetHealthz", response, response.Code())
 	}
 }
 
@@ -84,6 +84,11 @@ func (o *GetHealthzOK) IsServerError() bool {
 // IsCode returns true when this get healthz o k response a status code equal to that given
 func (o *GetHealthzOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get healthz o k response
+func (o *GetHealthzOK) Code() int {
+	return 200
 }
 
 func (o *GetHealthzOK) Error() string {
@@ -147,6 +152,11 @@ func (o *GetHealthzInternalServerError) IsCode(code int) bool {
 	return code == 500
 }
 
+// Code gets the status code for the get healthz internal server error response
+func (o *GetHealthzInternalServerError) Code() int {
+	return 500
+}
+
 func (o *GetHealthzInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /healthz][%d] getHealthzInternalServerError  %+v", 500, o.Payload)
 }
@@ -206,6 +216,11 @@ func (o *GetHealthzNotImplemented) IsServerError() bool {
 // IsCode returns true when this get healthz not implemented response a status code equal to that given
 func (o *GetHealthzNotImplemented) IsCode(code int) bool {
 	return code == 501
+}
+
+// Code gets the status code for the get healthz not implemented response
+func (o *GetHealthzNotImplemented) Code() int {
+	return 501
 }
 
 func (o *GetHealthzNotImplemented) Error() string {

--- a/api/v1/operator/server/restapi/cilium_operator_api.go
+++ b/api/v1/operator/server/restapi/cilium_operator_api.go
@@ -323,6 +323,6 @@ func (o *CiliumOperatorAPI) AddMiddlewareFor(method, path string, builder middle
 	}
 	o.Init()
 	if h, ok := o.handlers[um][path]; ok {
-		o.handlers[method][path] = builder(h)
+		o.handlers[um][path] = builder(h)
 	}
 }

--- a/api/v1/server/restapi/cilium_api_api.go
+++ b/api/v1/server/restapi/cilium_api_api.go
@@ -991,6 +991,6 @@ func (o *CiliumAPIAPI) AddMiddlewareFor(method, path string, builder middleware.
 	}
 	o.Init()
 	if h, ok := o.handlers[um][path]; ok {
-		o.handlers[method][path] = builder(h)
+		o.handlers[um][path] = builder(h)
 	}
 }


### PR DESCRIPTION
Also to add the renovate configuration for auto update version later. Just a note we might still need to run `make generate-api` manually till the work with self-hosted renovate with post-hook is done.

https://github.com/cilium/cilium/pull/30185

