### PR TITLE
helm: Bump minimum k8s version to v1.21+

### DIFF
--- a/install/kubernetes/cilium/Chart.yaml
+++ b/install/kubernetes/cilium/Chart.yaml
@@ -4,7 +4,7 @@ displayName: Cilium
 home: https://cilium.io/
 version: 1.16.0-dev
 appVersion: 1.16.0-dev
-kubeVersion: ">= 1.16.0-0"
+kubeVersion: ">= 1.21.0-0"
 icon: https://cdn.jsdelivr.net/gh/cilium/cilium@main/Documentation/images/logo-solo.svg
 description: eBPF-based Networking, Security, and Observability
 keywords:

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -18,7 +18,7 @@ efficient and flexible.
 
 ## Prerequisites
 
-* Kubernetes: `>= 1.16.0-0`
+* Kubernetes: `>= 1.21.0-0`
 * Helm: `>= 3.0`
 
 ## Getting Started


### PR DESCRIPTION
This commit is to bump minimum k8s version to v1.21. Ideally, we should
bump to v1.26 as per our support matrix, but some CI jobs are still with the older
versions as per below linked PR, hence I think v1.21 is a good balance.

Relates: https://github.com/cilium/cilium/pull/29888
Relates: https://github.com/cilium/cilium/issues/30106
