### PR TITLE
test: Update KPR value in ipsec upgrade jobs

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -97,7 +97,7 @@ jobs:
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: '5.15-20240305.092417'
             kube-proxy: 'iptables'
-            kpr: 'disabled'
+            kpr: 'false'
             tunnel: 'vxlan'
             encryption: 'ipsec'
             encryption-overlay: 'true'


### PR DESCRIPTION
There is a merge race between the below two PRs, which leads to failure in CI job for ipsec upgrade config 5.15.

https://github.com/cilium/cilium/actions/runs/8461160283/job/23180526103
```
Error: Unable to upgrade Cilium: execution error at (cilium/templates/cilium-configmap.yaml:70:5): kubeProxyReplacement must be explicitly set to a valid value (true or false) to continue.
```

Relates: #31637, #https://github.com/cilium/cilium/pull/31637

