### PR TITLE
ingress: add a new annotation for dedicated LoadBalancerClass

### DIFF
--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -79,6 +79,10 @@ Supported Ingress Annotations
        | ``shared``.
      - | ``dedicated``
        | (from Helm chart)
+   * - ``ingress.cilium.io/loadbalancer-class``
+     - | The loadbalancer class for the ingress.
+       | Only applicable when ``loadbalancer-mode`` is set to ``dedicated``.
+     - unspecified
    * - ``ingress.cilium.io/service-type``
      - | The Service type for dedicated Ingress.
        | Applicable values are ``LoadBalancer``

--- a/operator/pkg/ingress/annotations/annotations.go
+++ b/operator/pkg/ingress/annotations/annotations.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	LBModeAnnotation           = annotation.IngressPrefix + "/loadbalancer-mode"
+	LBClassAnnotation          = annotation.IngressPrefix + "/loadbalancer-class"
 	ServiceTypeAnnotation      = annotation.IngressPrefix + "/service-type"
 	InsecureNodePortAnnotation = annotation.IngressPrefix + "/insecure-node-port"
 	SecureNodePortAnnotation   = annotation.IngressPrefix + "/secure-node-port"
@@ -51,6 +52,16 @@ const (
 func GetAnnotationIngressLoadbalancerMode(ingress *networkingv1.Ingress) string {
 	value, _ := annotation.Get(ingress, LBModeAnnotation, LBModeAnnotationAlias)
 	return value
+}
+
+// GetAnnotationLoadBalancerClass returns the loadbalancer class from the ingress if possible.
+// Defaults to nil
+func GetAnnotationLoadBalancerClass(ingress *networkingv1.Ingress) *string {
+	val, exists := annotation.Get(ingress, LBClassAnnotation)
+	if !exists {
+		return nil
+	}
+	return &val
 }
 
 // GetAnnotationServiceType returns the service type for the ingress if possible.

--- a/operator/pkg/ingress/annotations/annotations_test.go
+++ b/operator/pkg/ingress/annotations/annotations_test.go
@@ -493,6 +493,60 @@ func TestGetAnnotationEnforceHTTPSEnabled(t *testing.T) {
 	}
 }
 
+func TestGetAnnotationLoadBalancerClass(t *testing.T) {
+	type args struct {
+		ingress *networkingv1.Ingress
+	}
+	tests := []struct {
+		name string
+		args args
+		want *string
+	}{
+		{
+			name: "no load balancer class annotation",
+			args: args{
+				ingress: &networkingv1.Ingress{},
+			},
+			want: nil,
+		},
+		{
+			name: "load balancer class annotation present",
+			args: args{
+				ingress: &networkingv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"ingress.cilium.io/loadbalancer-class": "foo",
+						},
+					},
+				},
+			},
+			want: stringp("foo"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetAnnotationLoadBalancerClass(tt.args.ingress)
+			if !isStringpEqual(got, tt.want) {
+				t.Errorf("GetAnnotationLoadBalancerClass() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func uint32p(u uint32) *uint32 {
 	return &u
+}
+
+func stringp(s string) *string {
+	return &s
+}
+
+func isStringpEqual(a, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }

--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -269,6 +269,13 @@ func (r *ingressReconciler) buildDedicatedResources(ctx context.Context, ingress
 
 	r.propagateIngressAnnotationsAndLabels(ingress, &svc.ObjectMeta)
 
+	if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
+		lbClass := annotations.GetAnnotationLoadBalancerClass(ingress)
+		if lbClass != nil {
+			svc.Spec.LoadBalancerClass = lbClass
+		}
+	}
+
 	// Explicitly set the controlling OwnerReference on the CiliumEnvoyConfig
 	if err := controllerutil.SetControllerReference(ingress, cec, r.client.Scheme()); err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to set controller reference on CiliumEnvoyConfig: %w", err)


### PR DESCRIPTION
<!-- Description of change -->

This adds a way to configure the `LoadBalancerClass` on dedicated LB created by the operator, via an annotation on the ingress

```release-note
Added a new annotation `ingress.cilium.io/loadbalancer-class` to control the `LoadBalancerClass` of a dedicated LB via the ingress. 
```
