### PR TITLE
ci/ipsec: Print more info to debug credentials removal check failures

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -222,10 +222,11 @@ jobs:
         run: |
           # For private repositories requiring authentication, check that we
           # can no longer fetch from the repository.
-          if ! curl -sL \
+          if ! curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${{ github.repository }}" | \
+            tee /dev/stderr | \
             jq --exit-status '.private == false'; then
             echo 'Checking whether "git fetch" succeeds'
             if git fetch origin HEAD; then


### PR DESCRIPTION
In commit 6fee46f9e753 ("ci/ipsec: Fix downgrade version retrieval") we added a check to make sure that GitHub credentials are removed before pulling the untrusted branch from the Pull Request's author. It appears that this check occasionally fails and causes the whole job to abort. But Cilium's repository _is_ public, and it's unclear why `.private == false` does not evaluate to `false` as we expected in that case. Did the curl request fail? Did the reply miss the expected .private field? We'll probably loosen the check as a workaround, but before that it would be interesting to understand better what's going on. Here we remove the `-s` flag from curl and print the reply from the GitHub API request, so we can better understand what's going on next time we observe a failure.

Related: https://github.com/cilium/cilium/issues/31552