### PR TITLE
loader: only detach Cilium-owned XDP programs when XDP is disabled

### DIFF
--- a/pkg/datapath/loader/netlink_test.go
+++ b/pkg/datapath/loader/netlink_test.go
@@ -42,9 +42,10 @@ func mustTCProgram(t *testing.T) *ebpf.Program {
 	return p
 }
 
-func mustXDPProgram(t *testing.T) *ebpf.Program {
+func mustXDPProgram(t *testing.T, name string) *ebpf.Program {
 	p, err := ebpf.NewProgram(&ebpf.ProgramSpec{
 		Type: ebpf.XDP,
+		Name: name,
 		Instructions: asm.Instructions{
 			asm.Mov.Imm(asm.R0, 0),
 			asm.Return(),


### PR DESCRIPTION
Currently, even when Cilium's XDP features are disabled, the Cilium agent will still attempt to detach a program attached to the legacy netlink XDP hook on managed interfaces.

This is so the agent does the right thing when a user first enables and then disables an XDP feature, where the user would expect Cilium's XDP programs to be removed. However, this is at odds with users wanting to run their own XDP programs on Cilium-managed interfaces. Even with XDP disabled, the agent will unconditionally remove any XDP programs.

This patch narrows down this behaviour by checking the name of the program attached to the legacy XDP hook before detaching it. If the kernel-provided name is not a prefix of the name expected by the agent, the program is left on the interface. Note that with XDP enabled, legacy XDP programs will always be replaced with Cilium programs.

Supersedes https://github.com/cilium/cilium/pull/31507.

```release-note
Only detach Cilium-owned legacy XDP programs when XDP is disabled
```
