### PR TITLE
feat/make etcd user config standarized w/ mesh config

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
@@ -1,5 +1,6 @@
 {{- if and
   (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer)
+  ( .Values.clustermesh.config.enabled )
   (ne .Values.clustermesh.apiserver.tls.authMode "legacy")
 }}
 ---


### PR DESCRIPTION
This MR standardizes the user remote config map generation to be inline w/ `cilium-clustermesh` and `cilium-kvstoremesh` in the sense that user remote config map should only be auto generate if `clustermesh.config.enabled` explicitely enabled.

This standardizes mesh configurations across all 3 config resources.

Fixes: N/A
