### PR TITLE
[v1.14] gha: Enable Ingress Controller tests in conformance-e2e

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -40,6 +40,9 @@ inputs:
   mutual-auth:
     description: 'Enable mTLS-based Mutual Authentication'
     default: true
+  ingress-controller:
+    description: 'Enable ingress controller, required kubeProxyReplacement'
+    default: false
   devices:
     description: 'List of native devices to attach datapath programs'
     default: ''
@@ -141,5 +144,12 @@ runs:
             HOST_FW="--helm-set=hostFirewall.enabled=true"
           fi
 
-          CONFIG="${DEFAULTS} ${IMAGE} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
+          if [ "${{ inputs.kpr }}" == "true" ]; then
+            if [ "${{ inputs.ingress-controller }}" == "true" ]; then
+              INGRESS_CONTROLLER="--helm-set=ingressController.enabled=true"
+              INGRESS_CONTROLLER+=" --helm-set=ingressController.service.type=NodePort"
+            fi
+          fi
+        
+          CONFIG="${DEFAULTS} ${IMAGE} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION} ${INGRESS_CONTROLLER}"
           echo "config=${CONFIG}" >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -144,6 +144,7 @@ jobs:
             lb-mode: 'snat'
             egress-gateway: 'true'
             lb-acceleration: 'testing-only'
+            ingress-controller: 'true'
 
           - name: '8'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -193,6 +194,7 @@ jobs:
             encryption-node: 'true'
             lb-mode: 'snat'
             egress-gateway: 'true'
+            ingress-controller: 'true'
 
           - name: '12'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -206,6 +208,7 @@ jobs:
             encryption-node: 'true'
             lb-mode: 'snat'
             egress-gateway: 'true'
+            ingress-controller: 'true'
 
           - name: '13'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -234,6 +237,7 @@ jobs:
             lb-mode: 'snat'
             egress-gateway: 'true'
             misc: 'encryption.wireguard.encapsulate=true'
+            ingress-controller: 'true'
 
           - name: '16'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -286,6 +290,7 @@ jobs:
           encryption-node: ${{ matrix.encryption-node }}
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
+          ingress-controller: ${{ matrix.ingress-controller }}
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@a9579d1afc528b085930c5237a69ee77b2c2be76 # v0.16.4


### PR DESCRIPTION
This is a manual backport of the following PRs to v1.14:

 - https://github.com/cilium/cilium/pull/29130
 - https://github.com/cilium/cilium/pull/30657

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 29130 30657
```