### PR TITLE
ingress: remove json struct tags from internal ingress translation model

### DIFF
--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -13,8 +13,8 @@ import (
 // Model holds an abstracted data model representing the translation
 // of various types of Kubernetes config to Cilium config.
 type Model struct {
-	HTTP           []HTTPListener           `json:"http,omitempty"`
-	TLSPassthrough []TLSPassthroughListener `json:"tlspassthrough,omitempty"`
+	HTTP           []HTTPListener
+	TLSPassthrough []TLSPassthroughListener
 }
 
 func (m *Model) GetListeners() []Listener {
@@ -47,28 +47,28 @@ type Listener interface {
 //   - Port
 type HTTPListener struct {
 	// Name of the HTTPListener
-	Name string `json:"name,omitempty"`
+	Name string
 	// Sources is a slice of fully qualified resources this HTTPListener is sourced
 	// from.
-	Sources []FullyQualifiedResource `json:"sources,omitempty"`
+	Sources []FullyQualifiedResource
 	// IPAddress that the listener should listen on.
 	// The string must be parseable as an IP address.
-	Address string `json:"address,omitempty"`
+	Address string
 	// Port on which the service can be expected to be accessed by clients.
-	Port uint32 `json:"port,omitempty"`
+	Port uint32
 	// Hostname that the listener should match.
 	// Wildcards are supported in prefix or suffix forms, or the special wildcard `*`.
 	// An empty list means that the Listener should match all hostnames.
-	Hostname string `json:"hostname,omitempty"`
+	Hostname string
 	// TLS Certificate information. If omitted, then the listener is a cleartext HTTP listener.
-	TLS []TLSSecret `json:"tls,omitempty"`
+	TLS []TLSSecret
 	// Routes associated with HTTP traffic to the service.
 	// An empty list means that traffic will not be routed.
-	Routes []HTTPRoute `json:"routes,omitempty"`
+	Routes []HTTPRoute
 	// Service configuration
-	Service *Service `json:"service,omitempty"`
+	Service *Service
 	// Infrastructure configuration
-	Infrastructure *Infrastructure `json:"infrastructure,omitempty"`
+	Infrastructure *Infrastructure
 	// ForceHTTPtoHTTPSRedirect enforces that, for HTTPListeners that have a
 	// TLS field set and create a HTTPS listener, an equivalent plaintext HTTP
 	// listener will be created that redirects requests from HTTP to HTTPS.
@@ -108,26 +108,26 @@ func (l HTTPListener) GetLabels() map[string]string {
 //   - Port
 type TLSPassthroughListener struct {
 	// Name of the TLSListener
-	Name string `json:"name,omitempty"`
+	Name string
 	// Sources is a slice of fully qualified resources this TLSListener is sourced
 	// from.
-	Sources []FullyQualifiedResource `json:"sources,omitempty"`
+	Sources []FullyQualifiedResource
 	// IPAddress that the listener should listen on.
 	// The string must be parseable as an IP address.
-	Address string `json:"address,omitempty"`
+	Address string
 	// Port on which the service can be expected to be accessed by clients.
-	Port uint32 `json:"port,omitempty"`
+	Port uint32
 	// Hostname that the listener should match.
 	// Wildcards are supported in prefix or suffix forms, or the special wildcard `*`.
 	// An empty list means that the Listener should match all hostnames.
-	Hostname string `json:"hostname,omitempty"`
+	Hostname string
 	// Routes associated with traffic to the service.
 	// An empty list means that traffic will not be routed.
-	Routes []TLSPassthroughRoute `json:"routes,omitempty"`
+	Routes []TLSPassthroughRoute
 	// Service configuration
-	Service *Service `json:"service,omitempty"`
+	Service *Service
 	// Infrastructure configuration
-	Infrastructure *Infrastructure `json:"infrastructure,omitempty"`
+	Infrastructure *Infrastructure
 }
 
 func (l TLSPassthroughListener) GetAnnotations() map[string]string {
@@ -156,37 +156,37 @@ func (l TLSPassthroughListener) GetPort() uint32 {
 type Service struct {
 	// Type is the type of service that is being used for Listener (e.g. Load Balancer or Node port)
 	// Defaults to Load Balancer type
-	Type string `json:"serviceType,omitempty"`
+	Type string
 	// InsecureNodePort is the back-end port of the service that is being used for HTTP Listener
 	// Applicable only if Type is Node NodePort
-	InsecureNodePort *uint32 `json:"insecureNodePort,omitempty"`
+	InsecureNodePort *uint32
 	// SecureNodePort is the back-end port of the service that is being used for HTTPS Listener
 	// Applicable only if Type is Node NodePort
-	SecureNodePort *uint32 `json:"secureNodePort,omitempty"`
+	SecureNodePort *uint32
 }
 
 // FullyQualifiedResource stores the full details of a Kubernetes resource, including
 // the Group, Version, and Kind.
 // Namespace must be set to the empty string for cluster-scoped resources.
 type FullyQualifiedResource struct {
-	Name      string `json:"name,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
-	Group     string `json:"group,omitempty"`
-	Version   string `json:"version,omitempty"`
-	Kind      string `json:"kind,omitempty"`
-	UID       string `json:"uuid,omitempty"`
+	Name      string
+	Namespace string
+	Group     string
+	Version   string
+	Kind      string
+	UID       string
 }
 
 // TLSSecret holds a reference to a secret containing a TLS keypair.
 type TLSSecret struct {
-	Name      string `json:"name,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
+	Name      string
+	Namespace string
 }
 
 // DirectResponse holds configuration for a direct response.
 type DirectResponse struct {
-	StatusCode int    `json:"status_code,omitempty"`
-	Body       string `json:"payload,omitempty"`
+	StatusCode int
+	Body       string
 }
 
 // Header is a key-value pair.
@@ -199,40 +199,40 @@ type Header struct {
 type HTTPHeaderFilter struct {
 	// HeadersToAdd is a list of headers to add to the request.
 	// Existing headers with the same name will be appended to.
-	HeadersToAdd []Header `json:"headers_to_add,omitempty"`
+	HeadersToAdd []Header
 	// HeadersToSet is a list of headers to set in the request.
 	// Existing headers will be overwritten.
-	HeadersToSet []Header `json:"headers_to_set,omitempty"`
+	HeadersToSet []Header
 	// HeadersToRemove is a list of headers to remove from the request.
-	HeadersToRemove []string `json:"headers_to_remove,omitempty"`
+	HeadersToRemove []string
 }
 
 // HTTPRequestRedirectFilter holds configuration for a request redirect.
 type HTTPRequestRedirectFilter struct {
 	// Scheme is the scheme to be used in the value of the `Location` header in
 	// the response. When empty, the scheme of the request is used.
-	Scheme *string `json:"scheme,omitempty"`
+	Scheme *string
 
 	// Hostname is the hostname to be used in the value of the `Location`
 	// header in the response.
 	// When empty, the hostname of the request is used.
-	Hostname *string `json:"hostname,omitempty"`
+	Hostname *string
 
 	// Path defines parameters used to modify the path of the incoming request.
 	// The modified path is then used to construct the `Location` header. When
 	// empty, the request path is used as-is.
-	Path *StringMatch `json:"path,omitempty"`
+	Path *StringMatch
 
 	// Port is the port to be used in the value of the `Location`
 	// header in the response.
 	// When empty, port (if specified) of the request is used.
-	Port *int32 `json:"port,omitempty"`
+	Port *int32
 
 	// StatusCode is the HTTP status code to be used in response.
 	//
 	// Note that values may be added to this enum, implementations
 	// must ensure that unknown values will not cause a crash.
-	StatusCode *int `json:"statusCode,omitempty"`
+	StatusCode *int
 }
 
 // HTTPURLRewriteFilter defines a filter that modifies a request during
@@ -241,83 +241,83 @@ type HTTPRequestRedirectFilter struct {
 type HTTPURLRewriteFilter struct {
 	// Hostname is the value to be used to replace the Host header value during
 	// forwarding.
-	HostName *string `json:"hostname,omitempty"`
+	HostName *string
 
 	// Path is the values to be used to replace the path
-	Path *StringMatch `json:"path,omitempty"`
+	Path *StringMatch
 }
 
 // HTTPRequestMirror defines configuration for the RequestMirror filter.
 type HTTPRequestMirror struct {
 	// Backend is the backend handling the requests
-	Backend *Backend `json:"backend,omitempty"`
+	Backend *Backend
 }
 
 // HTTPRoute holds all the details needed to route HTTP traffic to a backend.
 type HTTPRoute struct {
-	Name string `json:"name,omitempty"`
+	Name string
 	// Hostnames that the route should match
-	Hostnames []string `json:"hostnames,omitempty"`
+	Hostnames []string
 	// PathMatch specifies that the HTTPRoute should match a path.
-	PathMatch StringMatch `json:"path_match,omitempty"`
+	PathMatch StringMatch
 	// HeadersMatch specifies that the HTTPRoute should match a set of headers.
-	HeadersMatch []KeyValueMatch `json:"headers_match,omitempty"`
+	HeadersMatch []KeyValueMatch
 	// QueryParamsMatch specifies that the HTTPRoute should match a set of query parameters.
-	QueryParamsMatch []KeyValueMatch `json:"query_params_match,omitempty"`
-	Method           *string         `json:"method,omitempty"`
+	QueryParamsMatch []KeyValueMatch
+	Method           *string
 	// Backend is the backend handling the requests
-	Backends []Backend `json:"backends,omitempty"`
+	Backends []Backend
 	// BackendHTTPFilters can be used to add or remove HTTP
-	BackendHTTPFilters []*BackendHTTPFilter `json:"backend_http_filters,omitempty"`
+	BackendHTTPFilters []*BackendHTTPFilter
 	// DirectResponse instructs the proxy to respond directly to the client.
-	DirectResponse *DirectResponse `json:"direct_response,omitempty"`
+	DirectResponse *DirectResponse
 
 	// RequestHeaderFilter can be used to add or remove an HTTP
 	// header from an HTTP request before it is sent to the upstream target.
-	RequestHeaderFilter *HTTPHeaderFilter `json:"request_header_filter,omitempty"`
+	RequestHeaderFilter *HTTPHeaderFilter
 
 	// ResponseHeaderModifier can be used to add or remove an HTTP
 	// header from an HTTP response before it is sent to the client.
-	ResponseHeaderModifier *HTTPHeaderFilter `json:"response_header_modifier,omitempty"`
+	ResponseHeaderModifier *HTTPHeaderFilter
 
 	// RequestRedirect defines a schema for a filter that responds to the
 	// request with an HTTP redirection.
-	RequestRedirect *HTTPRequestRedirectFilter `json:"requestRedirect,omitempty"`
+	RequestRedirect *HTTPRequestRedirectFilter
 
 	// Rewrite defines a schema for a filter that modifies the URL of the request.
-	Rewrite *HTTPURLRewriteFilter `json:"rewrite,omitempty"`
+	Rewrite *HTTPURLRewriteFilter
 
 	// RequestMirrors defines a schema for a filter that mirrors HTTP requests
 	// Unlike other filter, multiple request mirrors are supported
-	RequestMirrors []*HTTPRequestMirror `json:"request_mirror,omitempty"`
+	RequestMirrors []*HTTPRequestMirror
 
 	// IsGRPC is an indicator if this route is related to GRPC
-	IsGRPC bool `json:"is_grpc,omitempty"`
+	IsGRPC bool
 
 	// Timeout holds the timeout configuration for a route.
-	Timeout Timeout `json:"timeout,omitempty"`
+	Timeout Timeout
 }
 
 type BackendHTTPFilter struct {
 	// Name is the name of the Backend, the name is having the format of "namespace:name:port"
-	Name string `json:"name"`
+	Name string
 	// RequestHeaderFilter can be used to add or remove an HTTP
 	// header from an HTTP request before it is sent to the upstream target.
-	RequestHeaderFilter *HTTPHeaderFilter `json:"request_header_filter,omitempty"`
+	RequestHeaderFilter *HTTPHeaderFilter
 
 	// ResponseHeaderModifier can be used to add or remove an HTTP
 	// header from an HTTP response before it is sent to the client.
-	ResponseHeaderModifier *HTTPHeaderFilter `json:"response_header_modifier,omitempty"`
+	ResponseHeaderModifier *HTTPHeaderFilter
 }
 
 // Infrastructure holds the labels and annotations configuration,
 // which will be propagated to LB service.
 type Infrastructure struct {
 	// Labels is a map of labels to be propagated to LB service.
-	Labels map[string]string `json:"labels,omitempty"`
+	Labels map[string]string
 
 	// Annotations is a map of annotations to be propagated to LB service.
-	Annotations map[string]string `json:"annotations,omitempty"`
+	Annotations map[string]string
 }
 
 // GetMatchKey returns the key to be used for matching the backend.
@@ -357,11 +357,11 @@ func (r *HTTPRoute) GetMatchKey() string {
 
 // TLSPassthroughRoute holds all the details needed to route TLS traffic to a backend.
 type TLSPassthroughRoute struct {
-	Name string `json:"name,omitempty"`
+	Name string
 	// Hostnames that the route should match
-	Hostnames []string `json:"hostnames,omitempty"`
+	Hostnames []string
 	// Backend is the backend handling the requests
-	Backends []Backend `json:"backends,omitempty"`
+	Backends []Backend
 }
 
 // StringMatch describes various types of string matching.
@@ -369,9 +369,9 @@ type TLSPassthroughRoute struct {
 // If no fields are set, all paths should match (no path match criteria should
 // be generated for Envoy.)
 type StringMatch struct {
-	Prefix string `json:"prefix,omitempty"`
-	Exact  string `json:"exact,omitempty"`
-	Regex  string `json:"regex,omitempty"`
+	Prefix string
+	Exact  string
+	Regex  string
 }
 
 func (sm StringMatch) String() string {
@@ -390,8 +390,8 @@ func (sm StringMatch) String() string {
 }
 
 type KeyValueMatch struct {
-	Key   string      `json:"key,omitempty"`
-	Match StringMatch `json:"match,omitempty"`
+	Key   string
+	Match StringMatch
 }
 
 func (kv KeyValueMatch) String() string {
@@ -406,26 +406,26 @@ func (kv KeyValueMatch) String() string {
 // Backend holds a Kubernetes Service that points to a backend for traffic.
 type Backend struct {
 	// Name of the Service.
-	Name string `json:"name,omitempty"`
+	Name string
 	// Namespace of the Service.
-	Namespace string `json:"namespace,omitempty"`
+	Namespace string
 	// Port contains the details of the port on the Service to connect to
 	// If unset, the same port as the top-level Listener will be used.
-	Port *BackendPort `json:"port,omitempty"`
+	Port *BackendPort
 
 	// Weight specifies the percentage of traffic to send to this backend.
 	// This is computed as weight/(sum of all weights in backends) * 100.
-	Weight *int32 `json:"weight,omitempty"`
+	Weight *int32
 }
 
 // BackendPort holds the details of what port on the Service to connect to.
 // Only one of Port or Name can be set.
 type BackendPort struct {
 	// Port holds the numeric port to connect to.
-	Port uint32 `json:"port,omitempty"`
+	Port uint32
 	// Name holds a string which will be used to connect to the port with a
 	// matching spec.ports[].name in the target Service.
-	Name string `json:"name,omitempty"`
+	Name string
 }
 
 // GetPort return the string representation of the port (either the port number or the port name)


### PR DESCRIPTION
The internal ingress translation model (Gateway API / Ingresss controller -> internal model -> Envoy resources) contains Go struct tags for json. These aren't used - hence, lets remove them.