### PR TITLE
fix 'mismatch' typos in error messages

### DIFF
--- a/pkg/clustermesh/types/option_test.go
+++ b/pkg/clustermesh/types/option_test.go
@@ -170,7 +170,7 @@ func TestValidateRemoteConfig(t *testing.T) {
 			assertion: assert.Error,
 		},
 		{
-			name:      "Invalid config, MaxConnectedClusters mistmatch (ClusterMesh255)",
+			name:      "Invalid config, MaxConnectedClusters mismatch (ClusterMesh255)",
 			cfg:       &CiliumClusterConfig{ID: 511, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 511}},
 			mcc:       255,
 			mode:      BackwardCompatible,
@@ -184,7 +184,7 @@ func TestValidateRemoteConfig(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name:      "Invalid config, MaxConnectedClusters mistmatch (ClusterMesh511)",
+			name:      "Invalid config, MaxConnectedClusters mismatch (ClusterMesh511)",
 			cfg:       &CiliumClusterConfig{ID: 511, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 255}},
 			mcc:       511,
 			mode:      BackwardCompatible,

--- a/test/runtime/assertion_helpers.go
+++ b/test/runtime/assertion_helpers.go
@@ -57,5 +57,5 @@ func ExpectCiliumNotRunning(vm *helpers.SSHMeta) {
 func ExpectDockerContainersMatchCiliumEndpoints(vm *helpers.SSHMeta) {
 	ExpectWithOffset(1, vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 	ExpectWithOffset(1, vm.ValidateEndpointsAreCorrect(helpers.CiliumDockerNetwork)).To(BeNil(),
-		"Docker containers mistmach with Cilium Endpoints")
+		"Docker containers mismatch with Cilium Endpoints")
 }


### PR DESCRIPTION
As the subject says.