### PR TITLE
Add support for multiple clustermesh-apiserver replicas (ClusterMesh HA)

### DIFF
--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -159,7 +159,11 @@ jobs:
             --set=clustermesh.useAPIServer=${{ !matrix.external-kvstore }} \
             --set=clustermesh.maxConnectedClusters=${{ matrix.max-connected-clusters }} \
             --set=clustermesh.config.enabled=true \
-            --set=extraConfig.clustermesh-ip-identities-sync-timeout=10m"
+            --set=extraConfig.clustermesh-ip-identities-sync-timeout=10m \
+            --set=clustermesh.apiserver.readinessProbe.periodSeconds=1 \
+            --set=clustermesh.apiserver.kvstoremesh.readinessProbe.periodSeconds=1 \
+            --set=clustermesh.apiserver.updateStrategy.rollingUpdate.maxSurge=1 `# Use surge update strategy to enable clients to failover` \
+            --set=clustermesh.apiserver.updateStrategy.rollingUpdate.maxUnavailable=0"
 
           # Run only a limited subset of tests to reduce the amount of time
           # required. The full suite is run in conformance-clustermesh.
@@ -424,7 +428,7 @@ jobs:
             --conn-disrupt-dispatch-interval 0ms
 
 
-      - name: Upgrade Cilium in cluster1 and enable kvstoremesh
+      - name: Upgrade Cilium in cluster1
         env:
           KVSTORE_ID: 1
         run: |
@@ -432,15 +436,7 @@ jobs:
             ${{ steps.newest-vars.outputs.cilium_install_defaults }} \
             ${{ steps.vars.outputs.cilium_install_defaults }} \
             ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
-            ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }} \
-            --set clustermesh.apiserver.kvstoremesh.enabled=true
-
-      - name: Rollout Cilium agents in cluster2
-        if: ${{ !matrix.external-kvstore }}
-        run: |
-          # This makes sure that the remote agents reconnect to the new instance of the
-          # clustermesh-apiserver, without waiting for the watchdog mechanism to kick in.
-          kubectl --context ${{ env.contextName2 }} rollout restart -n kube-system ds/cilium
+            ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }}
 
       - name: Wait for cluster mesh status to be ready
         run: |
@@ -448,6 +444,91 @@ jobs:
           cilium --context ${{ env.contextName2 }} status --wait
           cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
           cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
+
+      - name: Write the Service manifest for testing failover
+        if: ${{ !matrix.external-kvstore }}
+        run: |
+          cat << EOF > echo-failover.yaml
+          apiVersion: v1
+          kind: Service
+          metadata:
+            annotations:
+              service.cilium.io/global: "true"
+            labels:
+              kind: echo
+              context: failover
+            name: echo-other-node-failover
+            namespace: cilium-test
+          spec:
+            ipFamilies:
+            - IPv4
+            - IPv6
+            ipFamilyPolicy: PreferDualStack
+            ports:
+            - name: http
+              port: 80
+              protocol: TCP
+              targetPort: 8080
+            selector:
+              name: echo-other-node
+            sessionAffinity: None
+            type: ClusterIP
+          EOF
+
+      - name: Restart clustermesh-apiserver and ensure client can connect to new Service
+        if: ${{ !matrix.external-kvstore }}
+        run: |
+          echo "Restarting clustermesh-apiserver deployments"
+          kubectl --context ${{ env.contextName2 }} -n kube-system rollout restart deployment -l k8s-app=clustermesh-apiserver
+          kubectl --context ${{ env.contextName2 }} -n kube-system rollout status deployment -l k8s-app=clustermesh-apiserver
+
+          echo "Deploying a global Service to test failover"
+          kubectl --context ${{ env.contextName1 }} apply -f echo-failover.yaml
+          kubectl --context ${{ env.contextName2 }} apply -f echo-failover.yaml
+
+          echo "Testing client connection to global Service"
+          kubectl --context ${{ env.contextName1 }} -n cilium-test exec deploy/client -i -- curl -s -v --connect-timeout 2 --max-time 5 --retry-max-time 60 --retry-all-errors --retry 10 --output /dev/null --fail echo-other-node-failover
+
+          # Clean up the service so that it can be re-deployed in subsequent steps
+          kubectl --context ${{ env.contextName1 }} delete -f echo-failover.yaml
+          kubectl --context ${{ env.contextName2 }} delete -f echo-failover.yaml
+
+      - name: Enable kvstoremesh on cluster1
+        if: ${{ !matrix.external-kvstore }}
+        env:
+          KVSTORE_ID: 1
+        run: |
+          cilium --context ${{ env.contextName1 }} upgrade --reset-values \
+            ${{ steps.newest-vars.outputs.cilium_install_defaults }} \
+            ${{ steps.vars.outputs.cilium_install_defaults }} \
+            ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }} \
+            --set clustermesh.apiserver.kvstoremesh.enabled=true
+
+      - name: Wait for cluster mesh status to be ready
+        if: ${{ !matrix.external-kvstore }}
+        run: |
+          cilium --context ${{ env.contextName1 }} status --wait
+          cilium --context ${{ env.contextName2 }} status --wait
+          cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
+          cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
+
+      - name: Restart clustermesh-apiserver and ensure client can connect to new Service
+        if: ${{ !matrix.external-kvstore }}
+        run: |
+          echo "Restarting clustermesh-apiserver deployments"
+          kubectl --context ${{ env.contextName2 }} -n kube-system rollout restart deployment -l k8s-app=clustermesh-apiserver
+          kubectl --context ${{ env.contextName2 }} -n kube-system rollout status deployment -l k8s-app=clustermesh-apiserver
+
+          echo "Deploying a global Service to test failover"
+          kubectl --context ${{ env.contextName1 }} apply -f echo-failover.yaml
+          kubectl --context ${{ env.contextName2 }} apply -f echo-failover.yaml
+
+          echo "Testing client connection to global Service"
+          kubectl --context ${{ env.contextName1 }} -n cilium-test exec deploy/client -i -- curl -s -v --connect-timeout 2 --max-time 5 --retry-max-time 60 --retry-all-errors --retry 10 --output /dev/null --fail echo-other-node-failover
+
+          # Clean up the service so that it can be re-deployed in subsequent steps
+          kubectl --context ${{ env.contextName1 }} delete -f echo-failover.yaml
+          kubectl --context ${{ env.contextName2 }} delete -f echo-failover.yaml
 
       - name: Gather additional troubleshooting information
         run: |
@@ -549,13 +630,6 @@ jobs:
             ${{ steps.vars.outputs.cilium_install_defaults }} \
             ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
             ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }}
-
-      - name: Rollout Cilium agents in cluster2
-        if: ${{ !matrix.external-kvstore }}
-        run: |
-          # This makes sure that the remote agents reconnect to the new instance of the
-          # clustermesh-apiserver, without waiting for the watchdog mechanism to kick in.
-          kubectl --context ${{ env.contextName2 }} rollout restart -n kube-system ds/cilium
 
       - name: Wait for cluster mesh status to be ready
         run: |

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -59,7 +59,7 @@ spec:
         {{- end }}
         # These need to match the equivalent arguments to etcd in the main container.
         - --etcd-cluster-name=clustermesh-apiserver
-        - --etcd-initial-cluster-token=clustermesh-apiserver
+        - --etcd-initial-cluster-token=$(INITIAL_CLUSTER_TOKEN)
         - --etcd-data-dir=/var/run/etcd
         {{- with .Values.clustermesh.apiserver.etcd.init.extraArgs }}
         {{- toYaml . | trim | nindent 8 }}
@@ -76,6 +76,10 @@ spec:
             configMapKeyRef:
               name: cilium-config
               key: cluster-name
+        - name: INITIAL_CLUSTER_TOKEN
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         {{- with .Values.clustermesh.apiserver.etcd.init.extraEnv }}
         {{- toYaml . | trim | nindent 8 }}
         {{- end }}
@@ -108,7 +112,7 @@ spec:
         # uses net.SplitHostPort() internally and it accepts the that format.
         - --listen-client-urls=https://127.0.0.1:2379,https://[$(HOSTNAME_IP)]:2379
         - --advertise-client-urls=https://[$(HOSTNAME_IP)]:2379
-        - --initial-cluster-token=clustermesh-apiserver
+        - --initial-cluster-token=$(INITIAL_CLUSTER_TOKEN)
         - --auto-compaction-retention=1
         {{- if .Values.clustermesh.apiserver.metrics.etcd.enabled }}
         - --listen-metrics-urls=http://[$(HOSTNAME_IP)]:{{ .Values.clustermesh.apiserver.metrics.etcd.port }}
@@ -121,6 +125,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: INITIAL_CLUSTER_TOKEN
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         ports:
         - name: etcd
           containerPort: 2379

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
@@ -35,4 +35,5 @@ spec:
   {{- if .Values.clustermesh.apiserver.service.internalTrafficPolicy }}
   internalTrafficPolicy: {{ .Values.clustermesh.apiserver.service.internalTrafficPolicy }}
   {{- end }}
+  sessionAffinity: ClientIP
 {{- end }}

--- a/pkg/clustermesh/common/interceptor.go
+++ b/pkg/clustermesh/common/interceptor.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"google.golang.org/grpc"
+)
+
+var (
+	ErrClusterIDChanged    = errors.New("etcd cluster ID has changed")
+	ErrEtcdInvalidResponse = errors.New("received an invalid etcd response")
+)
+
+// newUnaryInterceptor returns a new unary client interceptor that validates the
+// cluster ID of any received etcd responses.
+func newUnaryInterceptor(cl *clusterLock) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if err := invoker(ctx, method, req, reply, cc, opts...); err != nil {
+			return err
+		}
+		return validateReply(cl, reply)
+	}
+}
+
+// newStreamInterceptor returns a new stream client interceptor that validates
+// the cluster ID of any received etcd responses.
+func newStreamInterceptor(cl *clusterLock) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		s, err := streamer(ctx, desc, cc, method, opts...)
+		if err != nil {
+			return nil, err
+		}
+		return &wrappedClientStream{
+			ClientStream: s,
+			clusterLock:  cl,
+		}, nil
+	}
+}
+
+// wrappedClientStream is a wrapper around a grpc.ClientStream that adds
+// validation for the etcd cluster ID
+type wrappedClientStream struct {
+	grpc.ClientStream
+	clusterLock *clusterLock
+}
+
+// RecvMsg implements the grpc.ClientStream interface, adding validation for the etcd cluster ID
+func (w *wrappedClientStream) RecvMsg(m interface{}) error {
+	if err := w.ClientStream.RecvMsg(m); err != nil {
+		return err
+	}
+
+	return validateReply(w.clusterLock, m)
+}
+
+type etcdResponse interface {
+	GetHeader() *etcdserverpb.ResponseHeader
+}
+
+func validateReply(cl *clusterLock, reply any) error {
+	resp, ok := reply.(etcdResponse)
+	if !ok || resp.GetHeader() == nil {
+		select {
+		case cl.errors <- ErrEtcdInvalidResponse:
+		default:
+		}
+		return ErrEtcdInvalidResponse
+	}
+
+	if err := cl.validateClusterId(resp.GetHeader().ClusterId); err != nil {
+		select {
+		case cl.errors <- err:
+		default:
+		}
+		return err
+	}
+	return nil
+}
+
+// clusterLock is a wrapper around an atomic uint64 that can only be set once. It
+// provides validation for an etcd connection to ensure that it is only used
+// for the same etcd cluster it was initially connected to. This is to prevent
+// accidentally connecting to the wrong cluster in a high availability
+// configuration utilizing mutiple active clusters.
+type clusterLock struct {
+	etcdClusterID atomic.Uint64
+	errors        chan error
+}
+
+func newClusterLock() *clusterLock {
+	return &clusterLock{
+		etcdClusterID: atomic.Uint64{},
+		errors:        make(chan error, 1),
+	}
+}
+
+func (c *clusterLock) validateClusterId(clusterId uint64) error {
+	// If the cluster ID has not been set, set it to the received cluster ID
+	c.etcdClusterID.CompareAndSwap(0, clusterId)
+
+	if clusterId != c.etcdClusterID.Load() {
+		return fmt.Errorf("%w: expected %d, got %d", ErrClusterIDChanged, c.etcdClusterID.Load(), clusterId)
+	}
+	return nil
+}

--- a/pkg/clustermesh/common/interceptor_test.go
+++ b/pkg/clustermesh/common/interceptor_test.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"google.golang.org/grpc"
+)
+
+type responseType int
+
+const (
+	status responseType = iota
+	watch
+	leaseKeepAlive
+	leaseGrant
+	invalid
+)
+
+type mockClientStream struct {
+	grpc.ClientStream
+	toClient chan *etcdResponse
+}
+
+func newMockClientStream() mockClientStream {
+	return mockClientStream{
+		toClient: make(chan *etcdResponse),
+	}
+}
+
+func (c mockClientStream) RecvMsg(msg interface{}) error {
+	return nil
+}
+
+func (c mockClientStream) Send(resp *etcdResponse) error {
+	return nil
+}
+
+func newStreamerMock(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	return newMockClientStream(), nil
+}
+
+func (u unaryResponder) recv() etcdResponse {
+	var resp unaryResponse
+	switch u.rt {
+	case status:
+		resp = unaryResponse{&etcdserverpb.StatusResponse{Header: &etcdserverpb.ResponseHeader{ClusterId: u.cid}}}
+	case leaseGrant:
+		resp = unaryResponse{&etcdserverpb.LeaseGrantResponse{Header: &etcdserverpb.ResponseHeader{ClusterId: u.cid}}}
+	case invalid:
+		resp = unaryResponse{&etcdserverpb.StatusResponse{}}
+	}
+
+	return resp
+}
+
+func (s streamResponder) recv() etcdResponse {
+	var resp streamResponse
+	switch s.rt {
+	case watch:
+		resp = streamResponse{&etcdserverpb.WatchResponse{Header: &etcdserverpb.ResponseHeader{ClusterId: s.cid}}}
+	case leaseKeepAlive:
+		resp = streamResponse{&etcdserverpb.LeaseKeepAliveResponse{Header: &etcdserverpb.ResponseHeader{ClusterId: s.cid}}}
+	case invalid:
+		resp = streamResponse{&etcdserverpb.WatchResponse{}}
+	}
+	return resp
+
+}
+
+func noopInvoker(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+	return nil
+}
+
+type unaryResponder struct {
+	rt       responseType
+	cid      uint64
+	expError error
+}
+
+func (u unaryResponder) expectedErr() error {
+	return u.expError
+}
+
+type unaryResponse struct {
+	etcdResponse
+}
+
+type streamResponder struct {
+	rt       responseType
+	cid      uint64
+	expError error
+}
+
+func (s streamResponder) expectedErr() error {
+	return s.expError
+}
+
+type streamResponse struct {
+	etcdResponse
+}
+
+type mockResponder interface {
+	recv() etcdResponse
+	expectedErr() error
+}
+
+var maxId uint64 = 0xFFFFFFFFFFFFFFFF
+
+func TestInterceptors(t *testing.T) {
+	tests := []struct {
+		name             string
+		initialClusterId uint64
+		r                []mockResponder
+	}{
+		{
+			name:             "healthy stream responses",
+			initialClusterId: 1,
+			r: []mockResponder{
+				streamResponder{rt: watch, cid: 1, expError: nil},
+				streamResponder{rt: watch, cid: 1, expError: nil},
+				streamResponder{rt: watch, cid: 1, expError: nil},
+			},
+		},
+		{
+			name:             "healthy unary responses",
+			initialClusterId: 1,
+			r: []mockResponder{
+				unaryResponder{rt: leaseGrant, cid: 1, expError: nil},
+				unaryResponder{rt: status, cid: 1, expError: nil},
+			},
+		},
+		{
+			name:             "healthy stream and unary responses",
+			initialClusterId: maxId,
+			r: []mockResponder{
+				unaryResponder{rt: leaseGrant, cid: maxId, expError: nil},
+				unaryResponder{rt: status, cid: maxId, expError: nil},
+				streamResponder{rt: watch, cid: maxId, expError: nil},
+				unaryResponder{rt: status, cid: maxId, expError: nil},
+				streamResponder{rt: watch, cid: maxId, expError: nil},
+			},
+		},
+		{
+			name:             "watch response from another cluster",
+			initialClusterId: 1,
+			r: []mockResponder{
+				streamResponder{rt: watch, cid: 1, expError: nil},
+				streamResponder{rt: watch, cid: 2, expError: ErrClusterIDChanged},
+				streamResponder{rt: watch, cid: 1, expError: nil},
+			},
+		},
+		{
+			name:             "status response from another cluster",
+			initialClusterId: 1,
+			r: []mockResponder{
+				streamResponder{rt: watch, cid: 1, expError: nil},
+				unaryResponder{rt: status, cid: maxId, expError: ErrClusterIDChanged},
+				streamResponder{rt: watch, cid: 1, expError: nil},
+			},
+		},
+		{
+			name:             "receive an invalid response with no header",
+			initialClusterId: 1,
+			r: []mockResponder{
+				streamResponder{rt: leaseKeepAlive, cid: 1, expError: nil},
+				streamResponder{rt: invalid, cid: 0, expError: ErrEtcdInvalidResponse},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			cl := newClusterLock()
+			checkForError := func() error {
+				select {
+				case err := <-cl.errors:
+					return err
+				default:
+					return nil
+				}
+			}
+
+			si := newStreamInterceptor(cl)
+			desc := &grpc.StreamDesc{
+				StreamName:    "test",
+				Handler:       nil,
+				ServerStreams: true,
+				ClientStreams: true,
+			}
+
+			cc := &grpc.ClientConn{}
+
+			stream, err := si(ctx, desc, cc, "test", newStreamerMock)
+			require.NoError(t, err)
+
+			unaryRecvMsg := newUnaryInterceptor(cl)
+			for _, responder := range tt.r {
+
+				switch response := responder.recv().(type) {
+				case unaryResponse:
+					unaryRecvMsg(ctx, "test", nil, response, cc, noopInvoker)
+				case streamResponse:
+					stream.RecvMsg(responder.recv())
+				}
+				require.ErrorIs(t, checkForError(), responder.expectedErr())
+				require.Equal(t, tt.initialClusterId, cl.etcdClusterID.Load())
+			}
+		})
+	}
+
+}

--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -138,10 +139,20 @@ func (rc *remoteCluster) restartRemoteConnection() {
 			DoFunc: func(ctx context.Context) error {
 				rc.releaseOldConnection()
 
-				extraOpts := rc.makeExtraOpts()
+				clusterLock := newClusterLock()
+
+				extraOpts := rc.makeExtraOpts(clusterLock)
 
 				backend, errChan := kvstore.NewClient(ctx, kvstore.EtcdBackendName,
 					rc.makeEtcdOpts(), &extraOpts)
+
+				ctx, cancel := context.WithCancel(ctx)
+				rc.wg.Add(1)
+				go func() {
+					rc.watchdog(ctx, backend, clusterLock)
+					cancel()
+					rc.wg.Done()
+				}()
 
 				// Block until either an error is returned or
 				// the channel is closed due to success of the
@@ -153,6 +164,7 @@ func (rc *remoteCluster) restartRemoteConnection() {
 						backend.Close(ctx)
 					}
 					rc.logger.WithError(err).Warning("Unable to establish etcd connection to remote cluster")
+					cancel()
 					return err
 				}
 
@@ -160,7 +172,7 @@ func (rc *remoteCluster) restartRemoteConnection() {
 				rc.backend = backend
 				rc.mutex.Unlock()
 
-				rc.logger.Info("Connection to remote cluster established")
+				rc.logger.WithField(logfields.EtcdClusterID, clusterLock.etcdClusterID.Load()).Info("Connection to remote cluster established")
 
 				config, err := rc.getClusterConfig(ctx, backend, rc.ClusterConfigRequired())
 				if err == nil && config == nil {
@@ -169,15 +181,9 @@ func (rc *remoteCluster) restartRemoteConnection() {
 					rc.logger.Info("Found remote cluster configuration")
 				} else {
 					rc.logger.WithError(err).Warning("Unable to get remote cluster configuration")
+					cancel()
 					return err
 				}
-
-				ctx, cancel := context.WithCancel(ctx)
-				rc.wg.Add(1)
-				go func() {
-					rc.watchdog(ctx, backend)
-					rc.wg.Done()
-				}()
 
 				ready := make(chan error)
 
@@ -210,22 +216,29 @@ func (rc *remoteCluster) restartRemoteConnection() {
 	)
 }
 
-func (rc *remoteCluster) watchdog(ctx context.Context, backend kvstore.BackendOperations) {
+func (rc *remoteCluster) watchdog(ctx context.Context, backend kvstore.BackendOperations, clusterLock *clusterLock) {
+	handleErr := func(err error) {
+		rc.logger.WithError(err).Warning("Error observed on etcd connection, reconnecting etcd")
+		rc.mutex.Lock()
+		rc.failures++
+		rc.lastFailure = time.Now()
+		rc.metricLastFailureTimestamp.SetToCurrentTime()
+		rc.metricTotalFailures.Set(float64(rc.failures))
+		rc.metricReadinessStatus.Set(metrics.BoolToFloat64(rc.isReadyLocked()))
+		rc.mutex.Unlock()
+
+		rc.restartRemoteConnection()
+	}
+
 	select {
 	case err, ok := <-backend.StatusCheckErrors():
 		if ok && err != nil {
-			rc.logger.WithError(err).Warning("Error observed on etcd connection, reconnecting etcd")
-			rc.mutex.Lock()
-			rc.failures++
-			rc.lastFailure = time.Now()
-			rc.metricLastFailureTimestamp.SetToCurrentTime()
-			rc.metricTotalFailures.Set(float64(rc.failures))
-			rc.metricReadinessStatus.Set(metrics.BoolToFloat64(rc.isReadyLocked()))
-			rc.mutex.Unlock()
-
-			rc.restartRemoteConnection()
+			handleErr(err)
 		}
-
+	case err, ok := <-clusterLock.errors:
+		if ok && err != nil {
+			handleErr(err)
+		}
 	case <-ctx.Done():
 		return
 	}
@@ -318,8 +331,11 @@ func (rc *remoteCluster) makeEtcdOpts() map[string]string {
 	return opts
 }
 
-func (rc *remoteCluster) makeExtraOpts() kvstore.ExtraOptions {
+func (rc *remoteCluster) makeExtraOpts(clusterLock *clusterLock) kvstore.ExtraOptions {
 	var dialOpts []grpc.DialOption
+
+	dialOpts = append(dialOpts, grpc.WithStreamInterceptor(newStreamInterceptor(clusterLock)), grpc.WithUnaryInterceptor(newUnaryInterceptor(clusterLock)))
+
 	if rc.serviceIPGetter != nil {
 		// Allow to resolve service names without depending on the DNS. This prevents the need
 		// for setting the DNSPolicy to ClusterFirstWithHostNet when running in host network.
@@ -331,6 +347,7 @@ func (rc *remoteCluster) makeExtraOpts() kvstore.ExtraOptions {
 		ClusterName:                  rc.name,
 		ClusterSizeDependantInterval: rc.clusterSizeDependantInterval,
 		DialOption:                   dialOpts,
+		NoEndpointStatusChecks:       true,
 	}
 }
 

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -46,6 +46,9 @@ type ExtraOptions struct {
 	// have an initial rate limit equal to etcd.bootstrapQps and be updated to
 	// etcd.qps after this channel is closed.
 	BootstrapComplete <-chan struct{}
+
+	// NoEndpointStatusChecks disables the status checks for the endpoints
+	NoEndpointStatusChecks bool
 }
 
 // StatusCheckInterval returns the interval of status checks depending on the

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1038,18 +1038,6 @@ func (e *etcdClient) statusChecker() {
 
 		quorumError := e.isConnectedAndHasQuorum(ctx)
 
-		endpoints := e.client.Endpoints()
-		for _, ep := range endpoints {
-			st, err := e.determineEndpointStatus(ctx, ep)
-			if err == nil {
-				ok++
-			}
-
-			newStatus = append(newStatus, st)
-		}
-
-		allConnected := len(endpoints) == ok
-
 		e.RWMutex.RLock()
 		lastHeartbeat := e.lastHeartbeat
 		e.RWMutex.RUnlock()
@@ -1058,6 +1046,26 @@ func (e *etcdClient) statusChecker() {
 			recordQuorumError("no event received")
 			quorumError = fmt.Errorf("%s since last heartbeat update has been received", heartbeatDelta)
 		}
+
+		endpoints := e.client.Endpoints()
+		if e.extraOptions != nil && e.extraOptions.NoEndpointStatusChecks {
+			newStatus = append(newStatus, "endpoint status checks are disabled")
+
+			if quorumError == nil {
+				ok = len(endpoints)
+			}
+		} else {
+			for _, ep := range endpoints {
+				st, err := e.determineEndpointStatus(ctx, ep)
+				if err == nil {
+					ok++
+				}
+
+				newStatus = append(newStatus, st)
+			}
+		}
+
+		allConnected := len(endpoints) == ok
 
 		quorumString := "true"
 		if quorumError != nil {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -768,4 +768,7 @@ const (
 	Entries = "entries"
 	// Action is the summarized action from a reconciliation.
 	Action = "action"
+
+	// EtcdClusterID is the ID of the etcd cluster
+	EtcdClusterID = "etcdClusterID"
 )


### PR DESCRIPTION
This adds support for running clustermesh-apiserver deployments with multiple replicas for high availability.

Each clustermesh-apiserver pod runs its own etcd cluster. Depending on configuration, either the Cilium Agent or KVStoreMesh instance watches etcd in a remote cluster. All responses from the remote etcd cluster are intercepted and the header is inspected to retrieve the etcd cluster ID. If a failover event occurs and the cluster ID has changed, the remote connection is restarted to ensure that no events are missed and that no invalid data is retained. See individual commit messages for additional details.

```release-note
Add support for deploying clustermesh-apiserver with multiple replicas for high availability.
```