### PR TITLE
xfrm: add rules for encrypt overlay

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2481,7 +2481,8 @@ func (c *DaemonConfig) TunnelingEnabled() bool {
 // devices to implement some features.
 func (c *DaemonConfig) AreDevicesRequired() bool {
 	return c.EnableNodePort || c.EnableHostFirewall || c.EnableWireguard ||
-		c.EnableHighScaleIPcache || c.EnableL2Announcements || c.ForceDeviceRequired
+		c.EnableHighScaleIPcache || c.EnableL2Announcements || c.ForceDeviceRequired ||
+		c.EnableIPSecEncryptedOverlay
 }
 
 // MasqueradingEnabled returns true if either IPv4 or IPv6 masquerading is enabled.


### PR DESCRIPTION
This pull requests updates XFRM policies to work with Encrypted Overlay. 

When `encryption.ipsec.EncryptedOverlay` is enabled VXLAN traffic will be encrypted with IPSec/ESP.

In this scenario our XFRM hooks will see VXLAN packets instead of pod-to-pod traffic. 

Therefore, we must include XFRM policies and state which match on the source and destination of our VXLAN packets. 
This will be the underlay addresses of each remote node. 

```release-note
ipsec: support EncryptedOverlay XFRM policies 
```
