### PR TITLE
BGP: Adds Support for CiliumBGPNodeConfig and CiliumBGPNodeConfigOverride Resources

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -15,7 +15,6 @@ cilium-operator-alibabacloud [flags]
       --auto-create-cilium-pod-ip-pools map                  Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
       --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -11,7 +11,6 @@ cilium-operator-alibabacloud hive [flags]
 ### Options
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
       --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -17,7 +17,6 @@ cilium-operator-alibabacloud hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
       --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -18,7 +18,6 @@ cilium-operator-aws [flags]
       --aws-use-primary-address                              Allows for using primary address of the ENI for allocations on the node
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
       --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -11,7 +11,6 @@ cilium-operator-aws hive [flags]
 ### Options
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
       --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -17,7 +17,6 @@ cilium-operator-aws hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
       --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -18,7 +18,6 @@ cilium-operator-azure [flags]
       --azure-user-assigned-identity-id string               ID of the user assigned identity used to auth with the Azure API
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
       --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -11,7 +11,6 @@ cilium-operator-azure hive [flags]
 ### Options
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
       --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -17,7 +17,6 @@ cilium-operator-azure hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
       --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -14,7 +14,6 @@ cilium-operator-generic [flags]
       --auto-create-cilium-pod-ip-pools map                  Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
       --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -11,7 +11,6 @@ cilium-operator-generic hive [flags]
 ### Options
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
       --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -17,7 +17,6 @@ cilium-operator-generic hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
       --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -23,7 +23,6 @@ cilium-operator [flags]
       --azure-user-assigned-identity-id string               ID of the user assigned identity used to auth with the Azure API
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
       --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -11,7 +11,6 @@ cilium-operator hive [flags]
 ### Options
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
       --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -17,7 +17,6 @@ cilium-operator hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
       --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
       --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -269,11 +269,11 @@
      - bool
      - ``false``
    * - :spelling:ignore:`bgpControlPlane`
-     - This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs.
+     - This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy or v2 CRDs.
      - object
      - ``{"enabled":false,"secretsNamespace":{"create":false,"name":"kube-system"},"v2Enabled":false}``
    * - :spelling:ignore:`bgpControlPlane.enabled`
-     - Enables the BGP control plane.
+     - Enables the BGP control plane with CiliumBGPPeeringPolicy.
      - bool
      - ``false``
    * - :spelling:ignore:`bgpControlPlane.secretsNamespace`

--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -74,6 +74,14 @@ var (
 					},
 				)
 			},
+			func(lc cell.Lifecycle, cs client.Clientset) (LocalCiliumBGPNodeConfigResource, error) {
+				return k8s.CiliumBGPNodeConfigResource(
+					lc, cs,
+					func(opts *metav1.ListOptions) {
+						opts.FieldSelector = fields.ParseSelectorOrDie("metadata.name=" + nodeTypes.GetName()).String()
+					},
+				)
+			},
 			func(lc cell.Lifecycle, cs client.Clientset) (LocalPodResource, error) {
 				return k8s.PodResource(
 					lc, cs,
@@ -138,6 +146,10 @@ type LocalNodeResource resource.Resource[*slim_corev1.Node]
 // CiliumNode object associated with the node we are currently running on.
 type LocalCiliumNodeResource resource.Resource[*cilium_api_v2.CiliumNode]
 
+// LocalCiliumBGPNodeConfigResource is a resource.Resource[*cilium_api_v2alpha1.CiliumBGPBNodeConfig] but one which will only
+// stream updates for the CiliumBGPNodeConfig object associated with the node we are currently running on.
+type LocalCiliumBGPNodeConfigResource resource.Resource[*cilium_api_v2alpha1.CiliumBGPNodeConfig]
+
 // LocalPodResource is a resource.Resource[*slim_corev1.Pod] but one which will only stream updates for pod
 // objects scheduled on the node we are currently running on.
 type LocalPodResource resource.Resource[*slim_corev1.Pod]
@@ -158,6 +170,7 @@ type Resources struct {
 	Endpoints                        EndpointsNonHeadless
 	LocalNode                        LocalNodeResource
 	LocalCiliumNode                  LocalCiliumNodeResource
+	LocalCiliumBGPNodeConfig         LocalCiliumBGPNodeConfigResource
 	LocalPods                        LocalPodResource
 	Namespaces                       resource.Resource[*slim_corev1.Namespace]
 	NetworkPolicies                  resource.Resource[*slim_networkingv1.NetworkPolicy]

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -117,8 +117,8 @@ contributors across the globe, there is almost always someone available to help.
 | bgp.announce.loadbalancerIP | bool | `false` | Enable allocation and announcement of service LoadBalancer IPs |
 | bgp.announce.podCIDR | bool | `false` | Enable announcement of node pod CIDR |
 | bgp.enabled | bool | `false` | Enable BGP support inside Cilium; embeds a new ConfigMap for BGP inside cilium-agent and cilium-operator |
-| bgpControlPlane | object | `{"enabled":false,"secretsNamespace":{"create":false,"name":"kube-system"},"v2Enabled":false}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs. |
-| bgpControlPlane.enabled | bool | `false` | Enables the BGP control plane. |
+| bgpControlPlane | object | `{"enabled":false,"secretsNamespace":{"create":false,"name":"kube-system"},"v2Enabled":false}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy or v2 CRDs. |
+| bgpControlPlane.enabled | bool | `false` | Enables the BGP control plane with CiliumBGPPeeringPolicy. |
 | bgpControlPlane.secretsNamespace | object | `{"create":false,"name":"kube-system"}` | SecretsNamespace is the namespace which BGP support will retrieve secrets from. |
 | bgpControlPlane.secretsNamespace.create | bool | `false` | Create secrets namespace for BGP secrets. |
 | bgpControlPlane.secretsNamespace.name | string | `"kube-system"` | The name of the secret namespace to which Cilium agents are given read access |

--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -96,6 +96,7 @@ rules:
   - ciliumloadbalancerippools
   - ciliumbgppeeringpolicies
   - ciliumbgpnodeconfigs
+  - ciliumbgpnodeconfigoverrides
   - ciliumbgpadvertisements
   - ciliumbgppeerconfigs
   - ciliumclusterwideenvoyconfigs

--- a/install/kubernetes/cilium/templates/cilium-agent/role.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/role.yaml
@@ -95,7 +95,7 @@ rules:
   - watch
 {{- end}}
 
-{{- if and .Values.agent (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create .Values.bgpControlPlane.enabled .Values.bgpControlPlane.secretsNamespace.name }}
+{{- if and .Values.agent (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create (or .Values.bgpControlPlane.enabled .Values.bgpControlPlane.v2Enabled) .Values.bgpControlPlane.secretsNamespace.name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
@@ -90,7 +90,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 {{- end}}
 
-{{- if and .Values.agent (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create .Values.bgpControlPlane.enabled .Values.bgpControlPlane.secretsNamespace.name}}
+{{- if and .Values.agent (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create (or .Values.bgpControlPlane.enabled .Values.bgpControlPlane.v2Enabled) .Values.bgpControlPlane.secretsNamespace.name}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1117,10 +1117,18 @@ data:
 
 {{- if .Values.bgpControlPlane.enabled }}
   enable-bgp-control-plane: "true"
-  bgp-secrets-namespace: {{ .Values.bgpControlPlane.secretsNamespace.name | quote }}
-  bgp-v2-api-enabled: {{ .Values.bgpControlPlane.v2Enabled | quote }}
 {{- else }}
   enable-bgp-control-plane: "false"
+{{- end }}
+
+{{- if .Values.bgpControlPlane.v2Enabled }}
+  enable-bgp-v2-control-plane: "true"
+{{- else }}
+  enable-bgp-v2-control-plane: "false"
+{{- end }}
+
+{{- if or .Values.bgpControlPlane.enabled .Values.bgpControlPlane.v2Enabled }}
+  bgp-secrets-namespace: {{ .Values.bgpControlPlane.secretsNamespace.name | quote }}
 {{- end }}
 
 {{- if .Values.pmtuDiscovery.enabled }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -96,6 +96,7 @@ rules:
   - ciliumloadbalancerippools
   - ciliumbgppeeringpolicies
   - ciliumbgpnodeconfigs
+  - ciliumbgpnodeconfigoverrides
   - ciliumbgpadvertisements
   - ciliumbgppeerconfigs
   - ciliumclusterwideenvoyconfigs

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -398,9 +398,9 @@ bgp:
     # -- Enable announcement of node pod CIDR
     podCIDR: false
 # -- This feature set enables virtual BGP routers to be created via
-# CiliumBGPPeeringPolicy CRDs.
+# CiliumBGPPeeringPolicy or v2 CRDs.
 bgpControlPlane:
-  # -- Enables the BGP control plane.
+  # -- Enables the BGP control plane with CiliumBGPPeeringPolicy.
   enabled: false
   # -- Enable the BGPv2 APIs.
   v2Enabled: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -396,9 +396,9 @@ bgp:
     # -- Enable announcement of node pod CIDR
     podCIDR: false
 # -- This feature set enables virtual BGP routers to be created via
-# CiliumBGPPeeringPolicy CRDs.
+# CiliumBGPPeeringPolicy or v2 CRDs.
 bgpControlPlane:
-  # -- Enables the BGP control plane.
+  # -- Enables the BGP control plane with CiliumBGPPeeringPolicy.
   enabled: false
   # -- Enable the BGPv2 APIs.
   v2Enabled: false

--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -82,15 +82,3 @@ func CiliumBGPClusterConfigResource(lc cell.Lifecycle, cs client.Clientset, opts
 	)
 	return resource.New[*cilium_api_v2alpha1.CiliumBGPClusterConfig](lc, lw, resource.WithMetric("CiliumBGPClusterConfig")), nil
 }
-
-func CiliumBGPNodeConfigOverrideResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumBGPNodeConfigOverride], error) {
-	if !cs.IsEnabled() {
-		return nil, nil
-	}
-
-	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumBGPNodeConfigOverrideList](cs.CiliumV2alpha1().CiliumBGPNodeConfigOverrides()),
-		opts...,
-	)
-	return resource.New[*cilium_api_v2alpha1.CiliumBGPNodeConfigOverride](lc, lw, resource.WithMetric("CiliumBGPNodeConfigOverride")), nil
-}

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -39,7 +39,7 @@ var (
 			k8s.CiliumBGPAdvertisementResource,
 			k8s.CiliumBGPPeerConfigResource,
 			k8s.CiliumBGPNodeConfigResource,
-			CiliumBGPNodeConfigOverrideResource,
+			k8s.CiliumBGPNodeConfigOverrideResource,
 			CiliumEndpointResource,
 			CiliumEndpointSliceResource,
 			CiliumNodeResource,

--- a/operator/pkg/bgpv2/cell.go
+++ b/operator/pkg/bgpv2/cell.go
@@ -5,26 +5,10 @@ package bgpv2
 
 import (
 	"github.com/cilium/hive/cell"
-	"github.com/spf13/pflag"
-)
-
-const (
-	// BGPv2Enabled is the name of the flag that enables BGPv2 APIs in Cilium.
-	BGPv2Enabled = "bgp-v2-api-enabled"
 )
 
 var Cell = cell.Module(
 	"bgp-cp-operator",
 	"BGP Control Plane Operator",
-	cell.Config(Config{}),
 	cell.Invoke(registerBGPResourceManager),
 )
-
-type Config struct {
-	BGPv2Enabled bool `mapstructure:"bgp-v2-api-enabled"`
-}
-
-// Flags implements cell.Flagger interface.
-func (cfg Config) Flags(flags *pflag.FlagSet) {
-	flags.Bool(BGPv2Enabled, cfg.BGPv2Enabled, "Enables BGPv2 APIs in Cilium")
-}

--- a/operator/pkg/bgpv2/fixture_test.go
+++ b/operator/pkg/bgpv2/fixture_test.go
@@ -125,8 +125,9 @@ func newFixture(ctx context.Context, req *require.Assertions) (*fixture, func())
 
 		cell.Provide(func() *option.DaemonConfig {
 			return &option.DaemonConfig{
-				EnableBGPControlPlane: true,
-				Debug:                 true,
+				EnableBGPControlPlane:   true,
+				EnableBGPV2ControlPlane: true,
+				Debug:                   true,
 			}
 		}),
 
@@ -136,9 +137,6 @@ func newFixture(ctx context.Context, req *require.Assertions) (*fixture, func())
 
 		Cell,
 	)
-
-	// enable BGPv2
-	hive.AddConfigOverride(f.hive, func(cfg *Config) { cfg.BGPv2Enabled = true })
 
 	return f, watchersReadyFn
 }

--- a/operator/pkg/bgpv2/manager.go
+++ b/operator/pkg/bgpv2/manager.go
@@ -45,7 +45,6 @@ type BGPParams struct {
 	DaemonConfig *option.DaemonConfig
 	JobGroup     job.Group
 	Health       cell.Health
-	Config       Config
 
 	// resource tracking
 	ClusterConfigResource      resource.Resource[*cilium_api_v2alpha1.CiliumBGPClusterConfig]
@@ -79,8 +78,8 @@ type BGPResourceManager struct {
 
 // registerBGPResourceManager creates a new BGPResourceManager operator instance.
 func registerBGPResourceManager(p BGPParams) *BGPResourceManager {
-	// if BGPResourceManager Control Plane is not enabled or BGPv2 API is not enabled, return nil
-	if !p.DaemonConfig.BGPControlPlaneEnabled() || !p.Config.BGPv2Enabled {
+	// If BGPv2 control plane is disabled, return nil
+	if !p.DaemonConfig.BGPControlPlaneV2Enabled() {
 		return nil
 	}
 

--- a/pkg/bgpv1/manager/reconcilerv2/neighbor.go
+++ b/pkg/bgpv1/manager/reconcilerv2/neighbor.go
@@ -181,8 +181,11 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 			ok  bool
 		)
 
-		config, err := r.getPeerConfig(n.PeerConfigRef.Name)
-		if err != nil {
+		var err error
+		config := new(v2alpha1.CiliumBGPPeerConfigSpec)
+		if n.PeerConfigRef == nil {
+			config.SetDefaults()
+		} else if config, err = r.getPeerConfig(n.PeerConfigRef.Name); err != nil {
 			return err
 		}
 

--- a/pkg/bgpv1/manager/reconcilerv2/peer_advertisements.go
+++ b/pkg/bgpv1/manager/reconcilerv2/peer_advertisements.go
@@ -65,6 +65,11 @@ func (p *CiliumPeerAdvertisement) GetConfiguredAdvertisements(conf *v2alpha1.Cil
 	for _, peer := range conf.Peers {
 		lp := l.WithField(types.PeerLogField, peer.Name)
 
+		if peer.PeerConfigRef == nil {
+			lp.Debugf("ConfigRef not found, skipping peer %s", peer.Name)
+			continue
+		}
+
 		peerConfig, exist, err := p.peerConfig.GetByKey(resource.Key{Name: peer.PeerConfigRef.Name})
 		if err != nil {
 			if errors.Is(err, store.ErrStoreUninitialized) {

--- a/pkg/bgpv1/manager/reconcilerv2/peer_advertisements_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/peer_advertisements_test.go
@@ -290,6 +290,24 @@ func Test_GetAdvertisements(t *testing.T) {
 			expectedAdverts: map[string]PeerFamilyAdvertisements{},
 		},
 		{
+			name:       "Peer config reference does not exist for peer in BGPNodeInstance",
+			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{},
+			advertisements: []*v2alpha1.CiliumBGPAdvertisement{
+				redAdvert,
+			},
+			reqBGPNodeInstance: &v2alpha1.CiliumBGPNodeInstance{
+				Name:     "bgp-65001",
+				LocalASN: ptr.To[int64](65001),
+				Peers: []v2alpha1.CiliumBGPNodePeer{
+					{
+						Name: "red-peer-65001",
+					},
+				},
+			},
+			reqAdvertTypes:  []v2alpha1.BGPAdvertisementType{v2alpha1.BGPPodCIDRAdvert},
+			expectedAdverts: map[string]PeerFamilyAdvertisements{},
+		},
+		{
 			name: "Expecting PodCIDR advertisement for single peer",
 			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{
 				redPeerConfig,

--- a/pkg/bgpv1/manager/reconcilerv2/reconcilers.go
+++ b/pkg/bgpv1/manager/reconcilerv2/reconcilers.go
@@ -34,6 +34,7 @@ type ConfigReconciler interface {
 var ConfigReconcilers = cell.ProvidePrivate(
 	NewPreflightReconciler,
 	NewNeighborReconciler,
+	NewCiliumPeerAdvertisement,
 	NewPodCIDRReconciler,
 	NewPodIPPoolReconciler,
 	NewServiceReconciler,

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -546,6 +546,9 @@ const (
 	// Enable BGP control plane features.
 	EnableBGPControlPlane = false
 
+	// Enable BGP v2 control plane features.
+	EnableBGPV2ControlPlane = false
+
 	// EnableK8sNetworkPolicy enables support for K8s NetworkPolicy.
 	EnableK8sNetworkPolicy = true
 

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -215,6 +215,18 @@ func CiliumBGPNodeConfigResource(lc cell.Lifecycle, cs client.Clientset, opts ..
 	return resource.New[*cilium_api_v2alpha1.CiliumBGPNodeConfig](lc, lw, resource.WithMetric("CiliumBGPNodeConfig")), nil
 }
 
+func CiliumBGPNodeConfigOverrideResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumBGPNodeConfigOverride], error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumBGPNodeConfigOverrideList](cs.CiliumV2alpha1().CiliumBGPNodeConfigOverrides()),
+		opts...,
+	)
+	return resource.New[*cilium_api_v2alpha1.CiliumBGPNodeConfigOverride](lc, lw, resource.WithMetric("CiliumBGPNodeConfigOverride")), nil
+}
+
 func CiliumBGPAdvertisementResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumBGPAdvertisement], error) {
 	if !cs.IsEnabled() {
 		return nil, nil

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -65,7 +65,8 @@ func agentCRDResourceNames() []string {
 	}
 	if option.Config.EnableBGPControlPlane {
 		result = append(result, CRDResourceName(v2alpha1.BGPPName))
-		// BGPv2 CRDs
+	}
+	if option.Config.EnableBGPV2ControlPlane {
 		result = append(result, CRDResourceName(v2alpha1.BGPCCName))
 		result = append(result, CRDResourceName(v2alpha1.BGPAName))
 		result = append(result, CRDResourceName(v2alpha1.BGPPCName))

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1160,8 +1160,11 @@ const (
 	// filters to be inserted prior to the cilium filter.
 	TCFilterPriority = "bpf-filter-priority"
 
-	// Flag to enable BGP control plane features
+	// Flag to enable BGPv1 control plane features
 	EnableBGPControlPlane = "enable-bgp-control-plane"
+
+	// Flag to enable BGPv2 control plane features
+	EnableBGPV2ControlPlane = "enable-bgp-v2-control-plane"
 
 	// EnableRuntimeDeviceDetection is the name of the option to enable detection
 	// of new and removed datapath devices during the agent runtime.
@@ -2332,6 +2335,9 @@ type DaemonConfig struct {
 	// Enables BGP control plane features.
 	EnableBGPControlPlane bool
 
+	// Enables BGP v2 control plane features.
+	EnableBGPV2ControlPlane bool
+
 	// BPFMapEventBuffers has configuration on what BPF map event buffers to enabled
 	// and configuration options for those.
 	BPFMapEventBuffers          map[string]string
@@ -2422,12 +2428,13 @@ var (
 
 		K8sEnableLeasesFallbackDiscovery: defaults.K8sEnableLeasesFallbackDiscovery,
 
-		ExternalClusterIP:      defaults.ExternalClusterIP,
-		EnableVTEP:             defaults.EnableVTEP,
-		EnableBGPControlPlane:  defaults.EnableBGPControlPlane,
-		EnableK8sNetworkPolicy: defaults.EnableK8sNetworkPolicy,
-		PolicyCIDRMatchMode:    defaults.PolicyCIDRMatchMode,
-		MaxConnectedClusters:   defaults.MaxConnectedClusters,
+		ExternalClusterIP:       defaults.ExternalClusterIP,
+		EnableVTEP:              defaults.EnableVTEP,
+		EnableBGPControlPlane:   defaults.EnableBGPControlPlane,
+		EnableBGPV2ControlPlane: defaults.EnableBGPV2ControlPlane,
+		EnableK8sNetworkPolicy:  defaults.EnableK8sNetworkPolicy,
+		PolicyCIDRMatchMode:     defaults.PolicyCIDRMatchMode,
+		MaxConnectedClusters:    defaults.MaxConnectedClusters,
 
 		BPFEventsDropEnabled:          defaults.BPFEventsDropEnabled,
 		BPFEventsPolicyVerdictEnabled: defaults.BPFEventsPolicyVerdictEnabled,
@@ -3488,6 +3495,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 
 	// Enable BGP control plane features
 	c.EnableBGPControlPlane = vp.GetBool(EnableBGPControlPlane)
+	c.EnableBGPV2ControlPlane = vp.GetBool(EnableBGPV2ControlPlane)
 
 	// To support K8s NetworkPolicy
 	c.EnableK8sNetworkPolicy = vp.GetBool(EnableK8sNetworkPolicy)
@@ -3969,6 +3977,22 @@ func (c *DaemonConfig) StoreInFile(dir string) error {
 
 func (c *DaemonConfig) BGPControlPlaneEnabled() bool {
 	return c.EnableBGPControlPlane
+}
+
+func (c *DaemonConfig) BGPControlPlaneV2Enabled() bool {
+	return c.EnableBGPV2ControlPlane
+}
+
+func (c *DaemonConfig) BGPEnabled() bool {
+	return c.EnableBGPControlPlane || c.EnableBGPV2ControlPlane
+}
+
+func (c *DaemonConfig) BGPOnlyV1Enabled() bool {
+	return c.EnableBGPControlPlane && !c.EnableBGPV2ControlPlane
+}
+
+func (c *DaemonConfig) BGPOnlyV2Enabled() bool {
+	return !c.EnableBGPControlPlane && c.EnableBGPV2ControlPlane
 }
 
 func (c *DaemonConfig) IsDualStack() bool {


### PR DESCRIPTION
Previously, the BGP control plane would not process the CiliumBGPNodeConfig and CiliumBGPNodeConfigOverride resources. This PR adds support for reconciling CiliumBGPNodeConfig and CiliumBGPNodeConfigOverride into the appropriate configuration of a BGPRouterManager implementation needed to peer with BGP speakers and advertise prefixes.

```release-note
Removes the `bgp-v2-api-enabled` operator flag in favor of `enable-bgp-v2-control-plane` from the daemon config.
```

__Note:__ This PR includes commit 7b1b039fa91b2f1ced6dd9680a80ce0a3803d58b from https://github.com/cilium/cilium/pull/31598. When https://github.com/cilium/cilium/pull/31598 is merged, I will rebase to remove commit 7b1b039fa91b2f1ced6dd9680a80ce0a3803d58b from this PR.