### PR TITLE
cni: Allow text-ts log format value

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -36,7 +36,7 @@ const (
 	// we want to use (possible values: text or json)
 	DefaultLogFormat LogFormat = LogFormatText
 
-	// DefaultLogFormat is the string representation of the default logrus.Formatter
+	// DefaultLogFormatTimestamp is the string representation of the default logrus.Formatter
 	// including timestamps.
 	// We don't use this for general runtime logs since kubernetes log capture handles those.
 	// This is only used for applications such as CNI which is written to disk so we have no
@@ -85,7 +85,7 @@ type LogOptions map[string]string
 // settings.
 func initializeDefaultLogger() (logger *logrus.Logger) {
 	logger = logrus.New()
-	logger.SetFormatter(GetFormatter(DefaultLogFormat))
+	logger.SetFormatter(GetFormatter(DefaultLogFormatTimestamp))
 	logger.SetLevel(DefaultLogLevel)
 	return
 }
@@ -112,16 +112,16 @@ func (o LogOptions) GetLogLevel() (level logrus.Level) {
 func (o LogOptions) GetLogFormat() LogFormat {
 	formatOpt, ok := o[FormatOpt]
 	if !ok {
-		return DefaultLogFormat
+		return DefaultLogFormatTimestamp
 	}
 
 	formatOpt = strings.ToLower(formatOpt)
-	re := regexp.MustCompile(`^(text|json|json-ts)$`)
+	re := regexp.MustCompile(`^(text|text-ts|json|json-ts)$`)
 	if !re.MatchString(formatOpt) {
 		logrus.WithError(
-			fmt.Errorf("incorrect log format configured '%s', expected 'text', 'json' or 'json-ts'", formatOpt),
+			fmt.Errorf("incorrect log format configured '%s', expected 'text', 'text-ts', 'json' or 'json-ts'", formatOpt),
 		).Warning("Ignoring user-configured log format")
-		return DefaultLogFormat
+		return DefaultLogFormatTimestamp
 	}
 
 	return LogFormat(formatOpt)
@@ -149,7 +149,7 @@ func SetLogFormat(logFormat LogFormat) {
 
 // SetDefaultLogFormat updates the DefaultLogger with the DefaultLogFormat
 func SetDefaultLogFormat() {
-	DefaultLogger.SetFormatter(GetFormatter(DefaultLogFormat))
+	DefaultLogger.SetFormatter(GetFormatter(DefaultLogFormatTimestamp))
 }
 
 // AddHooks adds additional logrus hook to default logger

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -40,7 +40,7 @@ func (s *LoggingSuite) TestGetLogFormat(c *C) {
 	c.Assert(opts.GetLogFormat(), Equals, LogFormatJSON)
 
 	opts[FormatOpt] = "Invalid"
-	c.Assert(opts.GetLogFormat(), Equals, DefaultLogFormat)
+	c.Assert(opts.GetLogFormat(), Equals, DefaultLogFormatTimestamp)
 
 	opts[FormatOpt] = "JSON-TS"
 	c.Assert(opts.GetLogFormat(), Equals, LogFormatJSONTimestamp)


### PR DESCRIPTION
### Description

The new log format (e.g. text-ts) is added recently in the below commit, so we need to allow it in regex. Additionally, text-ts is used as the default value if not specified or invalid.

Fixes: a099bf1571f1a090ccfd6ccbba545828a6b3b63c

### Testing

A quick validation is done by checking cilium-cni.log as per below

<details>
<summary>Sample CNI log</summary>

```
time="2024-03-30T03:44:04Z" level=warning msg="Errors encountered while deleting endpoint" containerID=602c74abc749a26ea7cf68316ea42bb94e0018d243a67d4144754b7b461e9244 error="[DELETE /endpoint][404] deleteEndpointNotFound " eventUUID=ed588318-8a35-49e5-a24b-1f5e061dc6aa subsys=cilium-cni
time="2024-03-30T03:44:04Z" level=debug msg="Processing CNI DEL request &skel.CmdArgs{ContainerID:\"46885c8d75614f3f4cccb7431960d333843659269512dbbac645ff3ceccf638b\", Netns:\"/var/run/netns/cni-3821158e-66fd-6d5c-6b30-572f23a2d5f5\", IfName:\"eth0\", Args:\"K8S_POD_UID=44083a1a-7b8f-46d0-865e-32c0f98ccd44;IgnoreUnknown=1;K8S_POD_NAMESPACE=default;K8S_POD_NAME=hello-t16-01-j06-28529503-85cxv;K8S_POD_INFRA_CONTAINER_ID=46885c8d75614f3f4cccb7431960d333843659269512dbbac645ff3ceccf638b\", Path:\"/opt/cni/bin\", StdinData:[]uint8{0x7b, 0x22, 0x63, 0x68, 0x61, 0x69, 0x6e, 0x69, 0x6e, 0x67, 0x2d, 0x6d, 0x6f, 0x64, 0x65, 0x22, 0x3a, 0x22, 0x61, 0x77, 0x73, 0x2d, 0x63, 0x6e, 0x69, 0x22, 0x2c, 0x22, 0x63, 0x6e, 0x69, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x22, 0x3a, 0x22, 0x30, 0x2e, 0x34, 0x2e, 0x30, 0x22, 0x2c, 0x22, 0x65, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x2d, 0x64, 0x65, 0x62, 0x75, 0x67, 0x22, 0x3a, 0x74, 0x72, 0x75, 0x65, 0x2c, 0x22, 0x6c, 0x6f, 0x67, 0x2d, 0x66, 0x69, 0x6c, 0x65, 0x22, 0x3a, 0x22, 0x2f, 0x76, 0x61, 0x72, 0x2f, 0x72, 0x75, 0x6e, 0x2f, 0x63, 0x69, 0x6c, 0x69, 0x75, 0x6d, 0x2f, 0x63, 0x69, 0x6c, 0x69, 0x75, 0x6d, 0x2d, 0x63, 0x6e, 0x69, 0x2e, 0x6c, 0x6f, 0x67, 0x22, 0x2c, 0x22, 0x6e, 0x61, 0x6d, 0x65, 0x22, 0x3a, 0x22, 0x61, 0x77, 0x73, 0x2d, 0x63, 0x6e, 0x69, 0x22, 0x2c, 0x22, 0x74, 0x79, 0x70, 0x65, 0x22, 0x3a, 0x22, 0x63, 0x69, 0x6c, 0x69, 0x75, 0x6d, 0x2d, 0x63, 0x6e, 0x69, 0x22, 0x7d}}" eventUUID=050c7993-7675-4c3d-afa2-06856790b4b1 subsys=cilium-cni
time="2024-03-30T03:44:04Z" level=debug msg="CNI NetConf: &types.NetConf{NetConf:types.NetConf{CNIVersion:\"0.4.0\", Name:\"aws-cni\", Type:\"cilium-cni\", Capabilities:map[string]bool(nil), IPAM:types.IPAM{Type:\"\"}, DNS:types.DNS{Nameservers:[]string(nil), Domain:\"\", Search:[]string(nil), Options:[]string(nil)}, RawPrevResult:map[string]interface {}(nil), PrevResult:types.Result(nil)}, MTU:0, Args:types.Args{}, ENI:types.ENISpec{InstanceID:\"\", InstanceType:\"\", MinAllocate:0, PreAllocate:0, MaxAboveWatermark:0, FirstInterfaceIndex:(*int)(nil), SecurityGroups:[]string(nil), SecurityGroupTags:map[string]string(nil), SubnetIDs:[]string(nil), SubnetTags:map[string]string(nil), NodeSubnetID:\"\", VpcID:\"\", AvailabilityZone:\"\", ExcludeInterfaceTags:map[string]string(nil), DeleteOnTermination:(*bool)(nil), UsePrimaryAddress:(*bool)(nil), DisablePrefixDelegation:(*bool)(nil)}, Azure:types.AzureSpec{InterfaceName:\"\"}, IPAM:types.IPAM{IPAM:types.IPAM{Type:\"\"}, IPAMSpec:types.IPAMSpec{Pool:types.AllocationMap(nil), Pools:types.IPAMPoolSpec{Requested:[]types.IPAMPoolRequest(nil), Allocated:[]types.IPAMPoolAllocation(nil)}, PodCIDRs:[]string(nil), MinAllocate:0, MaxAllocate:0, PreAllocate:0, MaxAboveWatermark:0, PodCIDRAllocationThreshold:0, PodCIDRReleaseThreshold:0}}, AlibabaCloud:types.Spec{InstanceType:\"\", AvailabilityZone:\"\", VPCID:\"\", CIDRBlock:\"\", VSwitches:[]string(nil), VSwitchTags:map[string]string(nil), SecurityGroups:[]string(nil), SecurityGroupTags:map[string]string(nil)}, EnableDebug:true, LogFormat:\"\", LogFile:\"/var/run/cilium/cilium-cni.log\", ChainingMode:\"aws-cni\"}" eventUUID=050c7993-7675-4c3d-afa2-06856790b4b1 subsys=cilium-cni
time="2024-03-30T03:44:04Z" level=debug msg="CNI Args: &types.ArgsSpec{CommonArgs:types.CommonArgs{IgnoreUnknown:true}, K8S_POD_NAME:\"hello-t16-01-j06-28529503-85cxv\", K8S_POD_NAMESPACE:\"default\"}" eventUUID=050c7993-7675-4c3d-afa2-06856790b4b1 subsys=cilium-cni
time="2024-03-30T03:44:04Z" level=info msg="Using chained plugin aws-cni" containerID=46885c8d75614f3f4cccb7431960d333843659269512dbbac645ff3ceccf638b eventUUID=050c7993-7675-4c3d-afa2-06856790b4b1 subsys=cilium-cni
time="2024-03-30T03:44:04Z" level=warning msg="Errors encountered while deleting endpoint" containerID=46885c8d75614f3f4cccb7431960d333843659269512dbbac645ff3ceccf638b error="[DELETE /endpoint][404] deleteEndpointNotFound " eventUUID=050c7993-7675-4c3d-afa2-06856790b4b1 subsys=cilium-cni
```

</details>