### PR TITLE
ingress: request timeout control via operator flag & annotation

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -73,6 +73,7 @@ cilium-operator-alibabacloud [flags]
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -52,6 +52,7 @@ cilium-operator-alibabacloud hive [flags]
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -57,6 +57,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -81,6 +81,7 @@ cilium-operator-aws [flags]
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -52,6 +52,7 @@ cilium-operator-aws hive [flags]
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -57,6 +57,7 @@ cilium-operator-aws hive dot-graph [flags]
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -76,6 +76,7 @@ cilium-operator-azure [flags]
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -52,6 +52,7 @@ cilium-operator-azure hive [flags]
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -57,6 +57,7 @@ cilium-operator-azure hive dot-graph [flags]
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -72,6 +72,7 @@ cilium-operator-generic [flags]
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -52,6 +52,7 @@ cilium-operator-generic hive [flags]
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -57,6 +57,7 @@ cilium-operator-generic hive dot-graph [flags]
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -86,6 +86,7 @@ cilium-operator [flags]
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -52,6 +52,7 @@ cilium-operator hive [flags]
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -57,6 +57,7 @@ cilium-operator hive dot-graph [flags]
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.

--- a/operator/pkg/ingress/annotations/annotations.go
+++ b/operator/pkg/ingress/annotations/annotations.go
@@ -4,7 +4,9 @@
 package annotations
 
 import (
+	"fmt"
 	"strconv"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -21,6 +23,7 @@ const (
 	HostListenerPortAnnotation = annotation.IngressPrefix + "/host-listener-port"
 	TLSPassthroughAnnotation   = annotation.IngressPrefix + "/tls-passthrough"
 	ForceHTTPSAnnotation       = annotation.IngressPrefix + "/force-https"
+	RequestTimeoutAnnotation   = annotation.IngressPrefix + "/request-timeout"
 
 	LBModeAnnotationAlias           = annotation.Prefix + ".ingress" + "/loadbalancer-mode"
 	ServiceTypeAnnotationAlias      = annotation.Prefix + ".ingress" + "/service-type"
@@ -58,6 +61,21 @@ func GetAnnotationServiceType(ingress *networkingv1.Ingress) string {
 		return string(corev1.ServiceTypeLoadBalancer)
 	}
 	return val
+}
+
+// GetAnnotationRequestTimeout retrieves the RequestTimeout annotation's value.
+func GetAnnotationRequestTimeout(ingress *networkingv1.Ingress) (*time.Duration, error) {
+	val, exists := annotation.Get(ingress, RequestTimeoutAnnotation)
+	if !exists {
+		return nil, nil
+	}
+
+	d, err := time.ParseDuration(val)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse duration %q: %w", val, err)
+	}
+
+	return &d, nil
 }
 
 // GetAnnotationSecureNodePort returns the secure node port for the ingress if possible.

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -5,6 +5,7 @@ package ingress
 
 import (
 	"context"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -39,6 +40,7 @@ type ingressReconciler struct {
 	defaultSecretNamespace  string
 	defaultSecretName       string
 	enforcedHTTPS           bool
+	defaultRequestTimeout   time.Duration
 
 	hostNetworkEnabled    bool
 	hostNetworkSharedPort uint32
@@ -59,6 +61,7 @@ func newIngressReconciler(
 	defaultSecretNamespace string,
 	defaultSecretName string,
 	enforcedHTTPS bool,
+	defaultRequestTimeout time.Duration,
 	hostNetworkEnabled bool,
 	hostNetworkSharedPort uint32,
 ) *ingressReconciler {
@@ -76,6 +79,7 @@ func newIngressReconciler(
 		defaultSecretNamespace:  defaultSecretNamespace,
 		defaultSecretName:       defaultSecretName,
 		enforcedHTTPS:           enforcedHTTPS,
+		defaultRequestTimeout:   defaultRequestTimeout,
 
 		hostNetworkEnabled:    hostNetworkEnabled,
 		hostNetworkSharedPort: hostNetworkSharedPort,

--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -232,7 +232,7 @@ func (r *ingressReconciler) buildSharedResources(ctx context.Context) (*ciliumv2
 		if annotations.GetAnnotationTLSPassthroughEnabled(&item) {
 			m.TLSPassthrough = append(m.TLSPassthrough, ingestion.IngressPassthrough(item, passthroughPort)...)
 		} else {
-			m.HTTP = append(m.HTTP, ingestion.Ingress(item, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS, insecureHTTPPort, secureHTTPPort)...)
+			m.HTTP = append(m.HTTP, ingestion.Ingress(item, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS, insecureHTTPPort, secureHTTPPort, r.defaultRequestTimeout)...)
 		}
 	}
 
@@ -259,7 +259,7 @@ func (r *ingressReconciler) buildDedicatedResources(ctx context.Context, ingress
 	if annotations.GetAnnotationTLSPassthroughEnabled(ingress) {
 		m.TLSPassthrough = append(m.TLSPassthrough, ingestion.IngressPassthrough(*ingress, passthroughPort)...)
 	} else {
-		m.HTTP = append(m.HTTP, ingestion.Ingress(*ingress, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS, insecureHTTPPort, secureHTTPPort)...)
+		m.HTTP = append(m.HTTP, ingestion.Ingress(*ingress, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS, insecureHTTPPort, secureHTTPPort, r.defaultRequestTimeout)...)
 	}
 
 	cec, svc, ep, err := r.dedicatedTranslator.Translate(m)

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -37,6 +38,7 @@ const (
 	testDefaultSecretNamespace          = ""
 	testDefaultSecretName               = ""
 	testDefaultTimeout                  = 60
+	testIngressDefaultRequestTimeout    = time.Duration(0)
 )
 
 func TestReconcile(t *testing.T) {
@@ -63,7 +65,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -119,7 +121,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -175,7 +177,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -219,7 +221,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -289,7 +291,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -356,7 +358,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -410,7 +412,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -492,7 +494,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -564,7 +566,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -620,7 +622,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -660,7 +662,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -701,7 +703,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{"test.acme.io/"}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{"test.acme.io/"}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -786,7 +788,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -851,7 +853,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -893,7 +895,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -951,7 +953,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -993,7 +995,7 @@ func TestReconcile(t *testing.T) {
 
 		cecTranslator := &fakeCECTranslator{}
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, nil, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, true, 55555)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, nil, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, true, 55555)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -1033,7 +1035,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := &fakeCECTranslator{}
 		dedicatedIngressTranslator := &fakeDedicatedIngressTranslator{}
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, true, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, true, 0)
 
 		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{

--- a/operator/pkg/model/ingestion/ingress_test.go
+++ b/operator/pkg/model/ingestion/ingress_test.go
@@ -5,6 +5,7 @@ package ingestion
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -32,6 +33,11 @@ var defaultSecretName = "default-secret-name"
 // Add the ingress objects in
 // https://github.com/kubernetes-sigs/ingress-controller-conformance/tree/master/features
 // as test fixtures
+
+// default timeout for the ingress conformance tests
+var listenerDefaultTimeout = model.Timeout{
+	Request: nil,
+}
 
 // Just a default backend should produce one simple listener.
 var defaultBackend = networkingv1.Ingress{
@@ -111,6 +117,38 @@ var defaultBackendListeners = []model.HTTPListener{
 							Port: 8080,
 						},
 					},
+				},
+				Timeout: listenerDefaultTimeout,
+			},
+		},
+	},
+}
+
+var defaultBackendListenersWithRequestTimeout = []model.HTTPListener{
+	{
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "load-balancing",
+				Namespace: "random-namespace",
+				Version:   "v1",
+				Kind:      "Ingress",
+			},
+		},
+		Port:     80,
+		Hostname: "*",
+		Routes: []model.HTTPRoute{
+			{
+				Backends: []model.Backend{
+					{
+						Name:      "default-backend",
+						Namespace: "random-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+				Timeout: model.Timeout{
+					Request: model.AddressOf(time.Second * 10),
 				},
 			},
 		},
@@ -208,6 +246,7 @@ var hostRulesListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 	},
@@ -237,6 +276,7 @@ var hostRulesListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 	},
@@ -272,6 +312,7 @@ var hostRulesListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 	},
@@ -450,6 +491,7 @@ var pathRulesListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 	},
@@ -479,6 +521,7 @@ var pathRulesListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -493,6 +536,7 @@ var pathRulesListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 	},
@@ -522,6 +566,7 @@ var pathRulesListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -536,6 +581,7 @@ var pathRulesListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -550,6 +596,7 @@ var pathRulesListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 	},
@@ -579,6 +626,7 @@ var pathRulesListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -593,6 +641,7 @@ var pathRulesListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 	},
@@ -693,6 +742,7 @@ var complexIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -707,6 +757,7 @@ var complexIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -721,6 +772,7 @@ var complexIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 	},
@@ -753,6 +805,7 @@ var complexIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -767,6 +820,7 @@ var complexIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -781,6 +835,7 @@ var complexIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 	},
@@ -813,6 +868,7 @@ var complexIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -827,6 +883,7 @@ var complexIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -841,6 +898,7 @@ var complexIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 	},
@@ -873,6 +931,7 @@ var complexIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -887,6 +946,7 @@ var complexIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -901,6 +961,7 @@ var complexIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 	},
@@ -1002,6 +1063,7 @@ var complexNodePortIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -1016,6 +1078,7 @@ var complexNodePortIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -1030,6 +1093,7 @@ var complexNodePortIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 		Service: &model.Service{
@@ -1067,6 +1131,7 @@ var complexNodePortIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -1081,6 +1146,7 @@ var complexNodePortIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -1095,6 +1161,7 @@ var complexNodePortIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 		Service: &model.Service{
@@ -1132,6 +1199,7 @@ var complexNodePortIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -1146,6 +1214,7 @@ var complexNodePortIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -1160,6 +1229,7 @@ var complexNodePortIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 		Service: &model.Service{
@@ -1197,6 +1267,7 @@ var complexNodePortIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -1211,6 +1282,7 @@ var complexNodePortIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -1225,6 +1297,7 @@ var complexNodePortIngressListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 		Service: &model.Service{
@@ -1325,6 +1398,7 @@ var multiplePathTypesListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -1339,6 +1413,7 @@ var multiplePathTypesListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 			{
 				PathMatch: model.StringMatch{
@@ -1353,6 +1428,7 @@ var multiplePathTypesListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 	},
@@ -1450,6 +1526,7 @@ var hostRulesForceHTTPSenabledListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 	},
@@ -1479,6 +1556,7 @@ var hostRulesForceHTTPSenabledListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 	},
@@ -1515,6 +1593,7 @@ var hostRulesForceHTTPSenabledListeners = []model.HTTPListener{
 						},
 					},
 				},
+				Timeout: listenerDefaultTimeout,
 			},
 		},
 	},
@@ -1585,6 +1664,108 @@ var hostRulesForceHTTPSdisabled = networkingv1.Ingress{
 	},
 }
 
+var requestTimeoutAnnotationIngress = networkingv1.Ingress{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "load-balancing-request-timeout-annotation",
+		Namespace: "random-namespace",
+		Annotations: map[string]string{
+			"ingress.cilium.io/request-timeout": "10s",
+		},
+	},
+	Spec: networkingv1.IngressSpec{
+		IngressClassName: stringp("cilium"),
+		DefaultBackend: &networkingv1.IngressBackend{
+			Service: &networkingv1.IngressServiceBackend{
+				Name: "default-backend",
+				Port: networkingv1.ServiceBackendPort{
+					Number: 8080,
+				},
+			},
+		},
+	},
+}
+
+var requestTimeoutAnnotationListeners = []model.HTTPListener{
+	{
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "load-balancing-request-timeout-annotation",
+				Namespace: "random-namespace",
+				Version:   "v1",
+				Kind:      "Ingress",
+			},
+		},
+		Port:     80,
+		Hostname: "*",
+		Routes: []model.HTTPRoute{
+			{
+				Backends: []model.Backend{
+					{
+						Name:      "default-backend",
+						Namespace: "random-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+				Timeout: model.Timeout{
+					Request: model.AddressOf(time.Second * 10),
+				},
+			},
+		},
+	},
+}
+
+var requestTimeoutInvalidIngress = networkingv1.Ingress{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "load-balancing-request-timeout-invalid-annotation",
+		Namespace: "random-namespace",
+		Annotations: map[string]string{
+			"ingress.cilium.io/request-timeout": "invalid-duration",
+		},
+	},
+	Spec: networkingv1.IngressSpec{
+		IngressClassName: stringp("cilium"),
+		DefaultBackend: &networkingv1.IngressBackend{
+			Service: &networkingv1.IngressServiceBackend{
+				Name: "default-backend",
+				Port: networkingv1.ServiceBackendPort{
+					Number: 8080,
+				},
+			},
+		},
+	},
+}
+
+var requestTimeoutInvalidListeners = []model.HTTPListener{
+	{
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "load-balancing-request-timeout-invalid-annotation",
+				Namespace: "random-namespace",
+				Version:   "v1",
+				Kind:      "Ingress",
+			},
+		},
+		Port:     80,
+		Hostname: "*",
+		Routes: []model.HTTPRoute{
+			{
+				Backends: []model.Backend{
+					{
+						Name:      "default-backend",
+						Namespace: "random-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+				Timeout: listenerDefaultTimeout,
+			},
+		},
+	},
+}
+
 func stringp(in string) *string {
 	return &in
 }
@@ -1640,10 +1821,11 @@ func removeIngressHTTPRuleValues(ing networkingv1.Ingress) networkingv1.Ingress 
 }
 
 type testcase struct {
-	ingress       networkingv1.Ingress
-	defaultSecret bool
-	enforceHTTPS  bool
-	want          []model.HTTPListener
+	ingress        networkingv1.Ingress
+	defaultSecret  bool
+	enforceHTTPS   bool
+	requestTimeout time.Duration
+	want           []model.HTTPListener
 }
 
 func TestIngress(t *testing.T) {
@@ -1769,15 +1951,28 @@ func TestIngress(t *testing.T) {
 			want:         hostRulesForceHTTPSenabledListeners,
 			enforceHTTPS: true,
 		},
+		"request-timeout flag present with no annotation": {
+			ingress:        defaultBackend,
+			want:           defaultBackendListenersWithRequestTimeout,
+			requestTimeout: time.Second * 10,
+		},
+		"request-timeout annotation present": {
+			ingress: requestTimeoutAnnotationIngress,
+			want:    requestTimeoutAnnotationListeners,
+		},
+		"request-timeout annotation present but invalid": {
+			ingress: requestTimeoutInvalidIngress,
+			want:    requestTimeoutInvalidListeners,
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			var listeners []model.HTTPListener
 			if tc.defaultSecret {
-				listeners = Ingress(tc.ingress, defaultSecretNamespace, defaultSecretName, tc.enforceHTTPS, 80, 443)
+				listeners = Ingress(tc.ingress, defaultSecretNamespace, defaultSecretName, tc.enforceHTTPS, 80, 443, tc.requestTimeout)
 			} else {
-				listeners = Ingress(tc.ingress, "", "", tc.enforceHTTPS, 80, 443)
+				listeners = Ingress(tc.ingress, "", "", tc.enforceHTTPS, 80, 443, tc.requestTimeout)
 			}
 
 			assert.Equal(t, tc.want, listeners, "Listeners did not match")


### PR DESCRIPTION
This PR introduces more control over request timeout, with operator flag `--ingress-default-request-timeout` or ingress annotation `ingress.cilium.io/request-timeout`.
The annotation will be used first, then the operator flag and will fallback to no timeout at all.

Related to: #31514