### PR TITLE
docs,test: Update the latest program type link

### DIFF
--- a/Documentation/contributing/testing/bpf.rst
+++ b/Documentation/contributing/testing/bpf.rst
@@ -45,7 +45,7 @@ used for sharing code for example.
 Each ``.c`` file must at least have one ``CHECK`` program. The ``CHECK`` macro replaces the ``SEC`` which is
 typically used in BPF programs. The ``CHECK`` macro takes two arguments, the first being the program
 type (for example ``xdp`` or ``tc``. See `the list of recognized types in the Go library
-<https://github.com/cilium/ebpf/blob/49ebb13083886fc350167f2cde067e094a2b5037/elf_reader.go#L1074>`__),
+<https://github.com/cilium/ebpf/blob/v0.13.2/elf_sections.go#L9>`__),
 the second being the name of the test which will appear in the output. All macros are defined in 
 ``bpf/tests/common.h``, so all programs should start by including this file: ``#include "common.h"``.
 


### PR DESCRIPTION
Use the eBPF github release tag (referred in go.mod) to format the link, to easily keep the information updated.

```release-note
docs: Update link to cilium/ebpf's list of eBPF program types
```