### PR TITLE
route: Also compare ip rule mask for lookupRule

### DIFF
--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -399,6 +399,10 @@ func lookupRule(spec Rule, family int) (bool, error) {
 			continue
 		}
 
+		if spec.Mask != 0 && r.Mask != spec.Mask {
+			continue
+		}
+
 		if spec.Protocol != 0 && r.Protocol != spec.Protocol {
 			continue
 		}

--- a/pkg/datapath/linux/route/route_linux_test.go
+++ b/pkg/datapath/linux/route/route_linux_test.go
@@ -124,6 +124,12 @@ func testReplaceRule(c *C, mark int, from, to *net.IPNet, table int) {
 	c.Assert(err, IsNil)
 	c.Assert(exists, Equals, true)
 
+	rule.Mask++
+	exists, err = lookupRule(rule, netlink.FAMILY_V4)
+	c.Assert(err, IsNil)
+	c.Assert(exists, Equals, false)
+	rule.Mask--
+
 	err = DeleteRule(netlink.FAMILY_V4, rule)
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
Previously lookupRule("fwmark 0xa00/0xe00 lookup 2005") doesn't work when "fwmark 0xa00/0xf00 lookup 2005" is installed because lookupRule() doesn't check rule mask. This commit fixes it.
