### PR TITLE
helm: Adding initContainer to Envoy Daemonset

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1152,6 +1152,10 @@
      - Additional envoy hostPath mounts.
      - list
      - ``[]``
+   * - :spelling:ignore:`envoy.extraInitContainers`
+     - Additional initContainers added to the cilium Envoy DaemonSet.
+     - list
+     - ``[]``
    * - :spelling:ignore:`envoy.extraVolumeMounts`
      - Additional envoy volumeMounts.
      - list

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -384,6 +384,7 @@ impactful
 ingressing
 init
 initContainer
+initContainers
 initialDelaySeconds
 inlined
 inlines

--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -60,6 +60,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.envoy.extraInitContainers }}
+      initContainers:
+      {{- toYaml .Values.envoy.extraInitContainers | nindent 6 }}
+      {{- end }}
       containers:
       - name: cilium-envoy
         image: {{ include "cilium.image" .Values.envoy.image | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1750,6 +1750,10 @@
           "items": {},
           "type": "array"
         },
+        "extraInitContainers": {
+          "items": {},
+          "type": "array"
+        },
         "extraVolumeMounts": {
           "items": {},
           "type": "array"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2036,6 +2036,8 @@ envoy:
     useDigest: true
   # -- Additional containers added to the cilium Envoy DaemonSet.
   extraContainers: []
+  # -- Additional initContainers added to the cilium Envoy DaemonSet.
+  extraInitContainers: []
   # -- Additional envoy container arguments.
   extraArgs: []
   # -- Additional envoy container environment variables.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2037,6 +2037,8 @@ envoy:
     useDigest: true
   # -- Additional containers added to the cilium Envoy DaemonSet.
   extraContainers: []
+  # -- Additional initContainers added to the cilium Envoy DaemonSet.
+  extraInitContainers: []
   # -- Additional envoy container arguments.
   extraArgs: []
   # -- Additional envoy container environment variables.


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Currently, it's not possible to set an initContainer in the helmchart. This is useful, for example, to load a wasm binary into a volume and then mount that volume to the envoy container. 

```release-note
adding initContainer to Envoy Daemonset
```
