### PR TITLE
[v1.13] fqdn: Add Protocol to DNS Proxy Cache

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -366,7 +366,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 		// Restore old rules
 		for _, possibleEP := range possibleEndpoints {
 			// Upgrades from old ciliums have this nil
-			if possibleEP.DNSRules != nil {
+			if possibleEP.DNSRules != nil || possibleEP.DNSRulesV2 != nil {
 				proxy.DefaultDNSProxy.RestoreRules(possibleEP)
 			}
 		}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -155,13 +155,13 @@ func (e *Endpoint) writeHeaderfile(prefix string) error {
 	}
 	defer f.Cleanup()
 
-	if e.DNSRules != nil {
-		// Note: e.DNSRules is updated by syncEndpointHeaderFile and regenerateBPF
+	if e.DNSRulesV2 != nil {
+		// Note: e.DNSRulesV2 is updated by syncEndpointHeaderFile and regenerateBPF
 		// before they call into writeHeaderfile, because GetDNSRules must not be
 		// called with endpoint.mutex held.
 		e.getLogger().WithFields(logrus.Fields{
 			logfields.Path: headerPath,
-			"DNSRules":     e.DNSRules,
+			"DNSRulesV2":   e.DNSRulesV2,
 		}).Debug("writing header file with DNSRules")
 	}
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -194,6 +194,31 @@ func (e *Endpoint) writeHeaderfile(prefix string) error {
 	return err
 }
 
+// proxyPolicy implements policy.ProxyPolicy interface, and passes most of the calls
+// to policy.L4Filter, but re-implements GetPort() to return the resolved named port,
+// instead of returning a 0 port number.
+type proxyPolicy struct {
+	*policy.L4Filter
+	port     uint16
+	protocol uint8
+}
+
+// newProxyPolicy returns a new instance of proxyPolicy by value
+func (e *Endpoint) newProxyPolicy(l4 *policy.L4Filter, port uint16, proto uint8) proxyPolicy {
+	return proxyPolicy{L4Filter: l4, port: port, protocol: proto}
+}
+
+// GetPort returns the destination port number on which the proxy policy applies
+// This version properly returns the port resolved from a named port, if any.
+func (p *proxyPolicy) GetPort() uint16 {
+	return p.port
+}
+
+// GetProtocol returns the destination protocol number on which the proxy policy applies
+func (p *proxyPolicy) GetProtocol() uint8 {
+	return p.protocol
+}
+
 // addNewRedirectsFromDesiredPolicy must be called while holding the endpoint lock for
 // writing. On success, returns nil; otherwise, returns an error indicating the
 // problem that occurred while adding an l7 redirect for the specified policy.
@@ -240,7 +265,7 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 				var finalizeFunc revert.FinalizeFunc
 				var revertFunc revert.RevertFunc
 
-				proxyID := e.proxyID(l4)
+				proxyID, dstPort, dstProto := e.proxyID(l4)
 				if proxyID == "" {
 					// Skip redirects for which a proxyID cannot be created.
 					// This may happen due to the named port mapping not
@@ -252,7 +277,8 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 				}
 
 				var err error
-				redirectPort, err, finalizeFunc, revertFunc = e.proxy.CreateOrUpdateRedirect(e.aliveCtx, l4, proxyID, e, proxyWaitGroup)
+				pp := e.newProxyPolicy(l4, dstPort, dstProto)
+				redirectPort, err, finalizeFunc, revertFunc = e.proxy.CreateOrUpdateRedirect(e.aliveCtx, &pp, proxyID, e, proxyWaitGroup)
 				if err != nil {
 					// Skip redirects that can not be created or updated.  This
 					// can happen when a listener is missing, for example when

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -58,6 +58,7 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/trigger"
 	"github.com/cilium/cilium/pkg/types"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 const (
@@ -202,8 +203,16 @@ type Endpoint struct {
 	status *EndpointStatus
 
 	// DNSRules is the collection of current endpoint-specific DNS proxy
-	// rules. These can be restored during Cilium restart.
+	// rules that conform to using restore.PortProto V1 (that is, they do
+	// **not** take protocol into account). These can be restored during
+	// Cilium restart.
+	// TODO: This can be removed when 1.16 is deprecated.
 	DNSRules restore.DNSRules
+
+	// DNSRulesV2 is the collection of current endpoint-specific DNS proxy
+	// rules that conform to using restore.PortProto V2 (that is, they take
+	// protocol into account). These can be restored during Cilium restart.
+	DNSRulesV2 restore.DNSRules
 
 	// DNSHistory is the collection of still-valid DNS responses intercepted for
 	// this endpoint.
@@ -465,6 +474,7 @@ func createEndpoint(owner regeneration.Owner, policyGetter policyRepoGetter, nam
 		ifName:           ifName,
 		OpLabels:         labels.NewOpLabels(),
 		DNSRules:         nil,
+		DNSRulesV2:       nil,
 		DNSHistory:       fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
 		DNSZombies:       fqdn.NewDNSZombieMappings(option.Config.ToFQDNsMaxDeferredConnectionDeletes, option.Config.ToFQDNsMaxIPsPerHost),
 		state:            "",
@@ -1437,7 +1447,16 @@ func (e *Endpoint) OnProxyPolicyUpdate(revision uint64) {
 
 // OnDNSPolicyUpdateLocked is called when the Endpoint's DNS policy has been updated
 func (e *Endpoint) OnDNSPolicyUpdateLocked(rules restore.DNSRules) {
-	e.DNSRules = rules
+	e.DNSRulesV2 = rules
+	// Keep V1 in tact in case of a downgrade.
+	e.DNSRules = make(restore.DNSRules)
+	for pp, rules := range rules {
+		proto := pp.Protocol()
+		// Filter out non-UDP/TCP protocol
+		if proto == uint8(u8proto.TCP) || proto == uint8(u8proto.UDP) {
+			e.DNSRules[pp.ToV1()] = rules
+		}
+	}
 }
 
 // getProxyStatisticsLocked gets the ProxyStatistics for the flows with the

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -76,17 +76,25 @@ func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string
 	return port
 }
 
-// proxyID returns a unique string to identify a proxy mapping.
+// proxyID returns a unique string to identify a proxy mapping,
+// and the resolved destination port and protocol numbers, if any.
 // Must be called with e.mutex held.
-func (e *Endpoint) proxyID(l4 *policy.L4Filter) string {
+func (e *Endpoint) proxyID(l4 *policy.L4Filter) (string, uint16, uint8) {
 	port := uint16(l4.Port)
+	protocol := uint8(l4.U8Proto)
+	// Calculate protocol if it is 0 (default) and
+	// is not "ANY" (that is, it was not calculated).
+	if protocol == 0 && !l4.Protocol.IsAny() {
+		proto, _ := u8proto.ParseProtocol(string(l4.Protocol))
+		protocol = uint8(proto)
+	}
 	if port == 0 && l4.PortName != "" {
-		port = e.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
+		port = e.GetNamedPort(l4.Ingress, l4.PortName, protocol)
 		if port == 0 {
-			return ""
+			return "", 0, 0
 		}
 	}
-	return policy.ProxyID(e.ID, l4.Ingress, string(l4.Protocol), port)
+	return policy.ProxyID(e.ID, l4.Ingress, string(l4.Protocol), port), port, protocol
 }
 
 // lookupRedirectPort returns the redirect L4 proxy port for the given L4

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -393,6 +393,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		SecurityIdentity:      e.SecurityIdentity,
 		Options:               e.Options,
 		DNSRules:              e.DNSRules,
+		DNSRulesV2:            e.DNSRulesV2,
 		DNSHistory:            e.DNSHistory,
 		DNSZombies:            e.DNSZombies,
 		K8sPodName:            e.K8sPodName,
@@ -466,6 +467,10 @@ type serializableEndpoint struct {
 	// DNSRules is the collection of current DNS rules for this endpoint.
 	DNSRules restore.DNSRules
 
+	// DNSRulesV2 is the collection of current DNS rules for this endpoint,
+	// that conform to using V2 of the PortProto key.
+	DNSRulesV2 restore.DNSRules
+
 	// DNSHistory is the collection of still-valid DNS responses intercepted for
 	// this endpoint.
 	DNSHistory *fqdn.DNSCache
@@ -532,6 +537,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.nodeMAC = r.NodeMAC
 	ep.SecurityIdentity = r.SecurityIdentity
 	ep.DNSRules = r.DNSRules
+	ep.DNSRulesV2 = r.DNSRulesV2
 	ep.DNSHistory = r.DNSHistory
 	ep.DNSZombies = r.DNSZombies
 	ep.K8sPodName = r.K8sPodName

--- a/pkg/fqdn/dnsproxy/helpers.go
+++ b/pkg/fqdn/dnsproxy/helpers.go
@@ -10,17 +10,18 @@ import (
 	"github.com/cilium/dns"
 
 	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 // lookupTargetDNSServer finds the intended DNS target server for a specific
-// request (passed in via ServeDNS). The IP:port combination is
+// request (passed in via ServeDNS). The IP:port:protocol combination is
 // returned.
-func lookupTargetDNSServer(w dns.ResponseWriter) (serverIP net.IP, serverPort restore.PortProto, addrStr string, err error) {
+func lookupTargetDNSServer(w dns.ResponseWriter) (serverIP net.IP, serverPortProto restore.PortProto, addrStr string, err error) {
 	switch addr := (w.LocalAddr()).(type) {
 	case *net.UDPAddr:
-		return addr.IP, restore.PortProto(addr.Port), addr.String(), nil
+		return addr.IP, restore.MakeV2PortProto(uint16(addr.Port), uint8(u8proto.UDP)), addr.String(), nil
 	case *net.TCPAddr:
-		return addr.IP, restore.PortProto(addr.Port), addr.String(), nil
+		return addr.IP, restore.MakeV2PortProto(uint16(addr.Port), uint8(u8proto.TCP)), addr.String(), nil
 	default:
 		return nil, 0, addr.String(), fmt.Errorf("Cannot extract address information for type %T: %+v", addr, addr)
 	}

--- a/pkg/fqdn/dnsproxy/helpers.go
+++ b/pkg/fqdn/dnsproxy/helpers.go
@@ -8,17 +8,19 @@ import (
 	"net"
 
 	"github.com/cilium/dns"
+
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 )
 
 // lookupTargetDNSServer finds the intended DNS target server for a specific
 // request (passed in via ServeDNS). The IP:port combination is
 // returned.
-func lookupTargetDNSServer(w dns.ResponseWriter) (serverIP net.IP, serverPort uint16, addrStr string, err error) {
+func lookupTargetDNSServer(w dns.ResponseWriter) (serverIP net.IP, serverPort restore.PortProto, addrStr string, err error) {
 	switch addr := (w.LocalAddr()).(type) {
 	case *net.UDPAddr:
-		return addr.IP, uint16(addr.Port), addr.String(), nil
+		return addr.IP, restore.PortProto(addr.Port), addr.String(), nil
 	case *net.TCPAddr:
-		return addr.IP, uint16(addr.Port), addr.String(), nil
+		return addr.IP, restore.PortProto(addr.Port), addr.String(), nil
 	default:
 		return nil, 0, addr.String(), fmt.Errorf("Cannot extract address information for type %T: %+v", addr, addr)
 	}

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -13,9 +13,16 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/re"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+const (
+	udpProto = uint8(u8proto.UDP)
+	tcpProto = uint8(u8proto.TCP)
 )
 
 type DNSProxyHelperTestSuite struct{}
@@ -33,6 +40,8 @@ func (s *DNSProxyHelperTestSuite) TestSetPortRulesForID(c *C) {
 	epID := uint64(1)
 	pea := perEPAllow{}
 	cache := make(regexCache)
+	udpProtoPort8053 := restore.MakeV2PortProto(8053, udpProto)
+
 	rules[new(MockCachedSelector)] = &policy.PerSelectorPolicy{
 		L7Rules: api.L7Rules{
 			DNS: []api.PortRuleDNS{
@@ -41,7 +50,8 @@ func (s *DNSProxyHelperTestSuite) TestSetPortRulesForID(c *C) {
 			},
 		},
 	}
-	err := pea.setPortRulesForID(cache, epID, 8053, rules)
+
+	err := pea.setPortRulesForID(cache, epID, udpProtoPort8053, rules)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 1)
 
@@ -55,16 +65,17 @@ func (s *DNSProxyHelperTestSuite) TestSetPortRulesForID(c *C) {
 			},
 		},
 	}
-	err = pea.setPortRulesForID(cache, epID, 8053, rules)
+
+	err = pea.setPortRulesForID(cache, epID, udpProtoPort8053, rules)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 2)
 
 	delete(rules, selector2)
-	err = pea.setPortRulesForID(cache, epID, 8053, rules)
+	err = pea.setPortRulesForID(cache, epID, udpProtoPort8053, rules)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 1)
 
-	err = pea.setPortRulesForID(cache, epID, 8053, nil)
+	err = pea.setPortRulesForID(cache, epID, udpProtoPort8053, nil)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 0)
 
@@ -78,7 +89,7 @@ func (s *DNSProxyHelperTestSuite) TestSetPortRulesForID(c *C) {
 			},
 		},
 	}
-	err = pea.setPortRulesForID(cache, epID, 8053, rules)
+	err = pea.setPortRulesForID(cache, epID, udpProtoPort8053, rules)
 
 	c.Assert(err, NotNil)
 	c.Assert(len(cache), Equals, 0)
@@ -90,34 +101,35 @@ func (s *DNSProxyHelperTestSuite) TestSetPortRulesForIDFromUnifiedFormat(c *C) {
 	epID := uint64(1)
 	pea := perEPAllow{}
 	cache := make(regexCache)
+	udpProtoPort8053 := restore.MakeV2PortProto(8053, udpProto)
 	rules[new(MockCachedSelector)] = regexp.MustCompile("^.*[.]cilium[.]io$")
 	rules[new(MockCachedSelector)] = regexp.MustCompile("^.*[.]cilium[.]io$")
 
-	err := pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, rules)
+	err := pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, rules)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 1)
 
 	selector2 := new(MockCachedSelector)
 	rules[selector2] = regexp.MustCompile("^sub[.]cilium[.]io")
-	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, rules)
+	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, rules)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 2)
 
 	delete(rules, selector2)
-	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, rules)
+	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, rules)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 1)
 
-	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, nil)
+	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, nil)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 0)
 
 	delete(rules, selector2)
-	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, rules)
+	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, rules)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 1)
 
-	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, nil)
+	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, nil)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(cache), Equals, 0)
 }

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -114,7 +114,7 @@ type DNSProxy struct {
 	// lookupTargetDNSServer extracts the originally intended target of a DNS
 	// query. It is always set to lookupTargetDNSServer in
 	// helpers.go but is modified during testing.
-	lookupTargetDNSServer func(w dns.ResponseWriter) (serverIP net.IP, serverPort uint16, addrStr string, err error)
+	lookupTargetDNSServer func(w dns.ResponseWriter) (serverIP net.IP, serverPort restore.PortProto, addrStr string, err error)
 
 	// maxIPsPerRestoredDNSRule is the maximum number of IPs to maintain for each
 	// restored DNS rule.
@@ -171,15 +171,15 @@ type regexCache map[string]*regexCacheEntry
 // perEPAllow maps EndpointIDs to ports + selectors + rules
 type perEPAllow map[uint64]portToSelectorAllow
 
-// portToSelectorAllow maps port numbers to selectors + rules
-type portToSelectorAllow map[uint16]CachedSelectorREEntry
+// portToSelectorAllow maps protocol-port numbers to selectors + rules
+type portToSelectorAllow map[restore.PortProto]CachedSelectorREEntry
 
 // CachedSelectorREEntry maps port numbers to selectors to rules, mirroring
 // policy.L7DataMap but the DNS rules are compiled into a regex
 type CachedSelectorREEntry map[policy.CachedSelector]*regexp.Regexp
 
 // structure for restored rules that can be used while Cilium agent is restoring endpoints
-type perEPRestored map[uint64]map[uint16][]restoredIPRule
+type perEPRestored map[uint64]map[restore.PortProto][]restoredIPRule
 
 // restoredIPRule is the dnsproxy internal way of representing a restored IPRule
 // where we also store the actual compiled regular expression as a, as well
@@ -203,7 +203,7 @@ func asIPRule(r *regexp.Regexp, IPs map[string]struct{}) restore.IPRule {
 
 // CheckRestored checks endpointID, destPort, destIP, and name against the restored rules,
 // and only returns true if a restored rule matches.
-func (p *DNSProxy) checkRestored(endpointID uint64, destPort uint16, destIP string, name string) bool {
+func (p *DNSProxy) checkRestored(endpointID uint64, destPort restore.PortProto, destIP string, name string) bool {
 	ipRules, exists := p.restored[endpointID][destPort]
 	if !exists {
 		return false
@@ -246,7 +246,7 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 		cs policy.CachedSelector
 	}
 
-	portToSelRegex := make(map[uint16][]selRegex)
+	portToSelRegex := make(map[restore.PortProto][]selRegex)
 	for port, entries := range p.allowed[uint64(endpointID)] {
 		var nidRules = make([]selRegex, 0, len(entries))
 		// Copy the entries to avoid racy map accesses after we release the lock. We don't need
@@ -286,7 +286,7 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 					if count > p.maxIPsPerRestoredDNSRule {
 						log.WithFields(logrus.Fields{
 							logfields.EndpointID:            endpointID,
-							logfields.Port:                  port,
+							logfields.Port:                  port.Port(),
 							logfields.EndpointLabelSelector: selRegex.cs,
 							logfields.Limit:                 p.maxIPsPerRestoredDNSRule,
 							logfields.Count:                 len(nidIPs),
@@ -318,7 +318,7 @@ func (p *DNSProxy) RestoreRules(ep *endpoint.Endpoint) {
 	if ep.IPv6.IsValid() {
 		p.restoredEPs[ep.IPv6.String()] = ep
 	}
-	restoredRules := make(map[uint16][]restoredIPRule, len(ep.DNSRules))
+	restoredRules := make(map[restore.PortProto][]restoredIPRule, len(ep.DNSRules))
 	for port, dnsRule := range ep.DNSRules {
 		ipRules := make([]restoredIPRule, 0, len(dnsRule))
 		for _, ipRule := range dnsRule {
@@ -424,7 +424,7 @@ func (c regexCache) releaseRegex(regex *regexp.Regexp) {
 
 // removeAndReleasePortRulesForID removes the old port rules for the given destPort on the given endpointID. It also
 // releases the regexes so that unused regex can be freed from memory.
-func (allow perEPAllow) removeAndReleasePortRulesForID(cache regexCache, endpointID uint64, destPort uint16) {
+func (allow perEPAllow) removeAndReleasePortRulesForID(cache regexCache, endpointID uint64, destPort restore.PortProto) {
 	epPorts, hasEpPorts := allow[endpointID]
 	if !hasEpPorts {
 		return
@@ -440,7 +440,7 @@ func (allow perEPAllow) removeAndReleasePortRulesForID(cache regexCache, endpoin
 
 // setPortRulesForID sets the matching rules for endpointID and destPort for
 // later lookups. It converts newRules into a compiled regex
-func (allow perEPAllow) setPortRulesForID(cache regexCache, endpointID uint64, destPort uint16, newRules policy.L7DataMap) error {
+func (allow perEPAllow) setPortRulesForID(cache regexCache, endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) error {
 	if len(newRules) == 0 {
 		allow.removeAndReleasePortRulesForID(cache, endpointID, destPort)
 		return nil
@@ -479,7 +479,7 @@ func (allow perEPAllow) setPortRulesForID(cache regexCache, endpointID uint64, d
 // setPortRulesForIDFromUnifiedFormat sets the matching rules for endpointID and destPort for
 // later lookups. It does not guarantee it will reuse all the provided regexes, since it will reuse
 // already existing regexes with the same pattern in case they are already in use.
-func (allow perEPAllow) setPortRulesForIDFromUnifiedFormat(cache regexCache, endpointID uint64, destPort uint16, newRules CachedSelectorREEntry) error {
+func (allow perEPAllow) setPortRulesForIDFromUnifiedFormat(cache regexCache, endpointID uint64, destPort restore.PortProto, newRules CachedSelectorREEntry) error {
 	if len(newRules) == 0 {
 		allow.removeAndReleasePortRulesForID(cache, endpointID, destPort)
 		return nil
@@ -503,7 +503,7 @@ func (allow perEPAllow) setPortRulesForIDFromUnifiedFormat(cache regexCache, end
 
 // getPortRulesForID returns a precompiled regex representing DNS rules for the
 // passed-in endpointID and destPort with setPortRulesForID
-func (allow perEPAllow) getPortRulesForID(endpointID uint64, destPort uint16) (rules CachedSelectorREEntry, exists bool) {
+func (allow perEPAllow) getPortRulesForID(endpointID uint64, destPort restore.PortProto) (rules CachedSelectorREEntry, exists bool) {
 	rules, exists = allow[endpointID][destPort]
 	return rules, exists
 }
@@ -710,7 +710,7 @@ func (p *DNSProxy) LookupEndpointByIP(ip net.IP) (endpoint *endpoint.Endpoint, e
 
 // UpdateAllowed sets newRules for endpointID and destPort. It compiles the DNS
 // rules into regexes that are then used in CheckAllowed.
-func (p *DNSProxy) UpdateAllowed(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error {
+func (p *DNSProxy) UpdateAllowed(endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) error {
 	p.Lock()
 	defer p.Unlock()
 
@@ -723,7 +723,7 @@ func (p *DNSProxy) UpdateAllowed(endpointID uint64, destPort uint16, newRules po
 }
 
 // UpdateAllowedFromSelectorRegexes sets newRules for endpointID and destPort.
-func (p *DNSProxy) UpdateAllowedFromSelectorRegexes(endpointID uint64, destPort uint16, newRules CachedSelectorREEntry) error {
+func (p *DNSProxy) UpdateAllowedFromSelectorRegexes(endpointID uint64, destPort restore.PortProto, newRules CachedSelectorREEntry) error {
 	p.Lock()
 	defer p.Unlock()
 
@@ -738,7 +738,7 @@ func (p *DNSProxy) UpdateAllowedFromSelectorRegexes(endpointID uint64, destPort 
 // CheckAllowed checks endpointID, destPort, destID, destIP, and name against the rules
 // added to the proxy or restored during restart, and only returns true if this all match
 // something that was added (via UpdateAllowed or RestoreRules) previously.
-func (p *DNSProxy) CheckAllowed(endpointID uint64, destPort uint16, destID identity.NumericIdentity, destIP net.IP, name string) (allowed bool, err error) {
+func (p *DNSProxy) CheckAllowed(endpointID uint64, destPort restore.PortProto, destID identity.NumericIdentity, destIP net.IP, name string) (allowed bool, err error) {
 	name = strings.ToLower(dns.Fqdn(name))
 	p.RLock()
 	defer p.RUnlock()

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -205,8 +205,12 @@ func asIPRule(r *regexp.Regexp, IPs map[string]struct{}) restore.IPRule {
 // and only returns true if a restored rule matches.
 func (p *DNSProxy) checkRestored(endpointID uint64, destPortProto restore.PortProto, destIP string, name string) bool {
 	ipRules, exists := p.restored[endpointID][destPortProto]
-	if !exists {
-		return false
+	if !exists && destPortProto.IsPortV2() {
+		// Check if there is a Version 1 restore.
+		ipRules, exists = p.restored[endpointID][destPortProto.ToV1()]
+		if !exists {
+			return false
+		}
 	}
 
 	for i := range ipRules {

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -319,8 +319,14 @@ func (p *DNSProxy) RestoreRules(ep *endpoint.Endpoint) {
 	if ep.IPv6.IsValid() {
 		p.restoredEPs[ep.IPv6.String()] = ep
 	}
+	// Use V2 if it is populated, otherwise
+	// use V1.
+	dnsRules := ep.DNSRulesV2
+	if len(dnsRules) == 0 && len(ep.DNSRules) > 0 {
+		dnsRules = ep.DNSRules
+	}
 	restoredRules := make(map[restore.PortProto][]restoredIPRule, len(ep.DNSRules))
-	for pp, dnsRule := range ep.DNSRules {
+	for pp, dnsRule := range dnsRules {
 		ipRules := make([]restoredIPRule, 0, len(dnsRule))
 		for _, ipRule := range dnsRule {
 			if ipRule.Re.Pattern == nil {
@@ -344,7 +350,7 @@ func (p *DNSProxy) RestoreRules(ep *endpoint.Endpoint) {
 	}
 	p.restored[uint64(ep.ID)] = restoredRules
 
-	log.Debugf("Restored rules for endpoint %d: %v", ep.ID, ep.DNSRules)
+	log.Debugf("Restored rules for endpoint %d: %v", ep.ID, dnsRules)
 }
 
 // 'p' must be locked

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -168,11 +168,11 @@ type regexCacheEntry struct {
 // have the same set of rules, or the same rule applies to multiple endpoints.
 type regexCache map[string]*regexCacheEntry
 
-// perEPAllow maps EndpointIDs to ports + selectors + rules
-type perEPAllow map[uint64]portToSelectorAllow
+// perEPAllow maps EndpointIDs to protocols + ports + selectors + rules
+type perEPAllow map[uint64]portProtoToSelectorAllow
 
-// portToSelectorAllow maps protocol-port numbers to selectors + rules
-type portToSelectorAllow map[restore.PortProto]CachedSelectorREEntry
+// portProtoToSelectorAllow maps protocol-port numbers to selectors + rules
+type portProtoToSelectorAllow map[restore.PortProto]CachedSelectorREEntry
 
 // CachedSelectorREEntry maps port numbers to selectors to rules, mirroring
 // policy.L7DataMap but the DNS rules are compiled into a regex
@@ -203,8 +203,8 @@ func asIPRule(r *regexp.Regexp, IPs map[string]struct{}) restore.IPRule {
 
 // CheckRestored checks endpointID, destPort, destIP, and name against the restored rules,
 // and only returns true if a restored rule matches.
-func (p *DNSProxy) checkRestored(endpointID uint64, destPort restore.PortProto, destIP string, name string) bool {
-	ipRules, exists := p.restored[endpointID][destPort]
+func (p *DNSProxy) checkRestored(endpointID uint64, destPortProto restore.PortProto, destIP string, name string) bool {
+	ipRules, exists := p.restored[endpointID][destPortProto]
 	if !exists {
 		return false
 	}
@@ -246,15 +246,15 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 		cs policy.CachedSelector
 	}
 
-	portToSelRegex := make(map[restore.PortProto][]selRegex)
-	for port, entries := range p.allowed[uint64(endpointID)] {
-		var nidRules = make([]selRegex, 0, len(entries))
+	portProtoToSelRegex := make(map[restore.PortProto][]selRegex)
+	for pp, entries := range p.allowed[uint64(endpointID)] {
+		nidRules := make([]selRegex, 0, len(entries))
 		// Copy the entries to avoid racy map accesses after we release the lock. We don't need
 		// constant time access, hence a preallocated slice instead of another map.
 		for cs, regex := range entries {
 			nidRules = append(nidRules, selRegex{cs: cs, re: regex})
 		}
-		portToSelRegex[port] = nidRules
+		portProtoToSelRegex[pp] = nidRules
 	}
 
 	// We've read what we need from the proxy. The following IPCache lookups _must_ occur outside of
@@ -262,7 +262,7 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 	p.RUnlock()
 
 	restored := make(restore.DNSRules)
-	for port, selRegexes := range portToSelRegex {
+	for pp, selRegexes := range portProtoToSelRegex {
 		var ipRules restore.IPRules
 		for _, selRegex := range selRegexes {
 			if selRegex.cs.IsWildcard() {
@@ -286,7 +286,8 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 					if count > p.maxIPsPerRestoredDNSRule {
 						log.WithFields(logrus.Fields{
 							logfields.EndpointID:            endpointID,
-							logfields.Port:                  port.Port(),
+							logfields.Port:                  pp.Port(),
+							logfields.Protocol:              pp.Protocol(),
 							logfields.EndpointLabelSelector: selRegex.cs,
 							logfields.Limit:                 p.maxIPsPerRestoredDNSRule,
 							logfields.Count:                 len(nidIPs),
@@ -299,7 +300,7 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 			}
 			ipRules = append(ipRules, asIPRule(selRegex.re, ips))
 		}
-		restored[port] = ipRules
+		restored[pp] = ipRules
 	}
 
 	return restored, nil
@@ -319,7 +320,7 @@ func (p *DNSProxy) RestoreRules(ep *endpoint.Endpoint) {
 		p.restoredEPs[ep.IPv6.String()] = ep
 	}
 	restoredRules := make(map[restore.PortProto][]restoredIPRule, len(ep.DNSRules))
-	for port, dnsRule := range ep.DNSRules {
+	for pp, dnsRule := range ep.DNSRules {
 		ipRules := make([]restoredIPRule, 0, len(dnsRule))
 		for _, ipRule := range dnsRule {
 			if ipRule.Re.Pattern == nil {
@@ -339,7 +340,7 @@ func (p *DNSProxy) RestoreRules(ep *endpoint.Endpoint) {
 			}
 			ipRules = append(ipRules, rule)
 		}
-		restoredRules[port] = ipRules
+		restoredRules[pp] = ipRules
 	}
 	p.restored[uint64(ep.ID)] = restoredRules
 
@@ -424,25 +425,26 @@ func (c regexCache) releaseRegex(regex *regexp.Regexp) {
 
 // removeAndReleasePortRulesForID removes the old port rules for the given destPort on the given endpointID. It also
 // releases the regexes so that unused regex can be freed from memory.
-func (allow perEPAllow) removeAndReleasePortRulesForID(cache regexCache, endpointID uint64, destPort restore.PortProto) {
-	epPorts, hasEpPorts := allow[endpointID]
-	if !hasEpPorts {
+
+func (allow perEPAllow) removeAndReleasePortRulesForID(cache regexCache, endpointID uint64, destPortProto restore.PortProto) {
+	epPortProtos, hasEpPortProtos := allow[endpointID]
+	if !hasEpPortProtos {
 		return
 	}
-	for _, m := range epPorts[destPort] {
+	for _, m := range epPortProtos[destPortProto] {
 		cache.releaseRegex(m)
 	}
-	delete(epPorts, destPort)
-	if len(epPorts) == 0 {
+	delete(epPortProtos, destPortProto)
+	if len(epPortProtos) == 0 {
 		delete(allow, endpointID)
 	}
 }
 
 // setPortRulesForID sets the matching rules for endpointID and destPort for
 // later lookups. It converts newRules into a compiled regex
-func (allow perEPAllow) setPortRulesForID(cache regexCache, endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) error {
+func (allow perEPAllow) setPortRulesForID(cache regexCache, endpointID uint64, destPortProto restore.PortProto, newRules policy.L7DataMap) error {
 	if len(newRules) == 0 {
-		allow.removeAndReleasePortRulesForID(cache, endpointID, destPort)
+		allow.removeAndReleasePortRulesForID(cache, endpointID, destPortProto)
 		return nil
 	}
 	cse := make(CachedSelectorREEntry, len(newRules))
@@ -466,22 +468,22 @@ func (allow perEPAllow) setPortRulesForID(cache regexCache, endpointID uint64, d
 		}
 		return err
 	}
-	allow.removeAndReleasePortRulesForID(cache, endpointID, destPort)
-	epPorts, exist := allow[endpointID]
+	allow.removeAndReleasePortRulesForID(cache, endpointID, destPortProto)
+	epPortProtos, exist := allow[endpointID]
 	if !exist {
-		epPorts = make(portToSelectorAllow)
-		allow[endpointID] = epPorts
+		epPortProtos = make(portProtoToSelectorAllow)
+		allow[endpointID] = epPortProtos
 	}
-	epPorts[destPort] = cse
+	epPortProtos[destPortProto] = cse
 	return nil
 }
 
 // setPortRulesForIDFromUnifiedFormat sets the matching rules for endpointID and destPort for
 // later lookups. It does not guarantee it will reuse all the provided regexes, since it will reuse
 // already existing regexes with the same pattern in case they are already in use.
-func (allow perEPAllow) setPortRulesForIDFromUnifiedFormat(cache regexCache, endpointID uint64, destPort restore.PortProto, newRules CachedSelectorREEntry) error {
+func (allow perEPAllow) setPortRulesForIDFromUnifiedFormat(cache regexCache, endpointID uint64, destPortProto restore.PortProto, newRules CachedSelectorREEntry) error {
 	if len(newRules) == 0 {
-		allow.removeAndReleasePortRulesForID(cache, endpointID, destPort)
+		allow.removeAndReleasePortRulesForID(cache, endpointID, destPortProto)
 		return nil
 	}
 	cse := make(CachedSelectorREEntry, len(newRules))
@@ -491,21 +493,21 @@ func (allow perEPAllow) setPortRulesForIDFromUnifiedFormat(cache regexCache, end
 		cse[selector] = cache.lookupOrInsertRegex(providedRegex)
 	}
 
-	allow.removeAndReleasePortRulesForID(cache, endpointID, destPort)
-	epPorts, exist := allow[endpointID]
+	allow.removeAndReleasePortRulesForID(cache, endpointID, destPortProto)
+	epPortProtos, exist := allow[endpointID]
 	if !exist {
-		epPorts = make(portToSelectorAllow)
-		allow[endpointID] = epPorts
+		epPortProtos = make(portProtoToSelectorAllow)
+		allow[endpointID] = epPortProtos
 	}
-	epPorts[destPort] = cse
+	epPortProtos[destPortProto] = cse
 	return nil
 }
 
 // getPortRulesForID returns a precompiled regex representing DNS rules for the
 // passed-in endpointID and destPort with setPortRulesForID
-func (allow perEPAllow) getPortRulesForID(endpointID uint64, destPort restore.PortProto) (rules CachedSelectorREEntry, exists bool) {
-	rules, exists = allow[endpointID][destPort]
-	return rules, exists
+func (allow perEPAllow) getPortRulesForID(endpointID uint64, destPortProto restore.PortProto) (rules CachedSelectorREEntry, exists bool) {
+	rules, exists = allow[endpointID][destPortProto]
+	return
 }
 
 // LookupEndpointIDByIPFunc wraps logic to lookup an endpoint with any backend.
@@ -710,11 +712,11 @@ func (p *DNSProxy) LookupEndpointByIP(ip net.IP) (endpoint *endpoint.Endpoint, e
 
 // UpdateAllowed sets newRules for endpointID and destPort. It compiles the DNS
 // rules into regexes that are then used in CheckAllowed.
-func (p *DNSProxy) UpdateAllowed(endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) error {
+func (p *DNSProxy) UpdateAllowed(endpointID uint64, destPortProto restore.PortProto, newRules policy.L7DataMap) error {
 	p.Lock()
 	defer p.Unlock()
 
-	err := p.allowed.setPortRulesForID(p.cache, endpointID, destPort, newRules)
+	err := p.allowed.setPortRulesForID(p.cache, endpointID, destPortProto, newRules)
 	if err == nil {
 		// Rules were updated based on policy, remove restored rules
 		p.removeRestoredRulesLocked(endpointID)
@@ -723,11 +725,11 @@ func (p *DNSProxy) UpdateAllowed(endpointID uint64, destPort restore.PortProto, 
 }
 
 // UpdateAllowedFromSelectorRegexes sets newRules for endpointID and destPort.
-func (p *DNSProxy) UpdateAllowedFromSelectorRegexes(endpointID uint64, destPort restore.PortProto, newRules CachedSelectorREEntry) error {
+func (p *DNSProxy) UpdateAllowedFromSelectorRegexes(endpointID uint64, destPortProto restore.PortProto, newRules CachedSelectorREEntry) error {
 	p.Lock()
 	defer p.Unlock()
 
-	err := p.allowed.setPortRulesForIDFromUnifiedFormat(p.cache, endpointID, destPort, newRules)
+	err := p.allowed.setPortRulesForIDFromUnifiedFormat(p.cache, endpointID, destPortProto, newRules)
 	if err == nil {
 		// Rules were updated based on policy, remove restored rules
 		p.removeRestoredRulesLocked(endpointID)
@@ -735,17 +737,17 @@ func (p *DNSProxy) UpdateAllowedFromSelectorRegexes(endpointID uint64, destPort 
 	return err
 }
 
-// CheckAllowed checks endpointID, destPort, destID, destIP, and name against the rules
+// CheckAllowed checks endpointID, destPortProto, destID, destIP, and name against the rules
 // added to the proxy or restored during restart, and only returns true if this all match
 // something that was added (via UpdateAllowed or RestoreRules) previously.
-func (p *DNSProxy) CheckAllowed(endpointID uint64, destPort restore.PortProto, destID identity.NumericIdentity, destIP net.IP, name string) (allowed bool, err error) {
+func (p *DNSProxy) CheckAllowed(endpointID uint64, destPortProto restore.PortProto, destID identity.NumericIdentity, destIP net.IP, name string) (allowed bool, err error) {
 	name = strings.ToLower(dns.Fqdn(name))
 	p.RLock()
 	defer p.RUnlock()
 
-	epAllow, exists := p.allowed.getPortRulesForID(endpointID, destPort)
+	epAllow, exists := p.allowed.getPortRulesForID(endpointID, destPortProto)
 	if !exists {
-		return p.checkRestored(endpointID, destPort, destIP.String(), name), nil
+		return p.checkRestored(endpointID, destPortProto, destIP.String(), name), nil
 	}
 
 	for selector, regex := range epAllow {
@@ -921,7 +923,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		logfields.Identity:   ep.GetIdentity(),
 	})
 
-	targetServerIP, targetServerPort, targetServerAddr, err := p.lookupTargetDNSServer(w)
+	targetServerIP, targetServerPortProto, targetServerAddr, err := p.lookupTargetDNSServer(w)
 	if err != nil {
 		log.WithError(err).Error("cannot extract destination IP:port from DNS request")
 		stat.Err = fmt.Errorf("Cannot extract destination IP:port from DNS request: %w", err)
@@ -945,7 +947,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	// it won't enforce any separation between results from different endpoints.
 	// This isn't ideal but we are trusting the DNS responses anyway.
 	stat.PolicyCheckTime.Start()
-	allowed, err := p.CheckAllowed(uint64(ep.ID), targetServerPort, targetServerID, targetServerIP, qname)
+	allowed, err := p.CheckAllowed(uint64(ep.ID), targetServerPortProto, targetServerID, targetServerIP, qname)
 	stat.PolicyCheckTime.End(err == nil)
 	switch {
 	case err != nil:

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -175,7 +175,7 @@ var (
 	dstID2  = identity.NumericIdentity(2002)
 	dstID3  = identity.NumericIdentity(3003)
 	dstID4  = identity.NumericIdentity(4004)
-	dstPort = uint16(53) // Set below when we setup the server!
+	dstPort = restore.PortProto(53) // Set below when we setup the server!
 )
 
 func (s *DNSProxyTestSuite) SetUpTest(c *C) {
@@ -247,10 +247,10 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 	c.Assert(s.dnsServer.Listener, Not(IsNil), Commentf("DNS server missing a Listener"))
 	DNSServerListenerAddr := (s.dnsServer.Listener.Addr()).(*net.TCPAddr)
 	c.Assert(DNSServerListenerAddr, Not(IsNil), Commentf("DNS server missing a Listener address"))
-	s.proxy.lookupTargetDNSServer = func(w dns.ResponseWriter) (serverIP net.IP, serverPort uint16, addrStr string, err error) {
-		return DNSServerListenerAddr.IP, uint16(DNSServerListenerAddr.Port), DNSServerListenerAddr.String(), nil
+	s.proxy.lookupTargetDNSServer = func(w dns.ResponseWriter) (serverIP net.IP, serverPort restore.PortProto, addrStr string, err error) {
+		return DNSServerListenerAddr.IP, restore.PortProto(DNSServerListenerAddr.Port), DNSServerListenerAddr.String(), nil
 	}
-	dstPort = uint16(DNSServerListenerAddr.Port)
+	dstPort = restore.PortProto(DNSServerListenerAddr.Port)
 }
 
 func (s *DNSProxyTestSuite) TearDownTest(c *C) {

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -745,7 +745,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 		udpProtoPort53: restore.IPRules{
 			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID1Selector], map[string]struct{}{"::": {}}),
 			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID2Selector], map[string]struct{}{"127.0.0.1": {}, "127.0.0.2": {}}),
-		}.Sort(),
+		}.Sort(nil),
 		udpProtoPort54: restore.IPRules{
 			asIPRule(s.proxy.allowed[epID1][udpProtoPort54][cachedWildcardSelector], nil),
 		},
@@ -754,12 +754,12 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 		},
 	}
 	restored1, _ := s.proxy.GetRules(uint16(epID1))
-	restored1.Sort()
+	restored1.Sort(nil)
 	c.Assert(restored1, checker.DeepEquals, expected1)
 
 	expected2 := restore.DNSRules{}
 	restored2, _ := s.proxy.GetRules(uint16(epID2))
-	restored2.Sort()
+	restored2.Sort(nil)
 	c.Assert(restored2, checker.DeepEquals, expected2)
 
 	expected3 := restore.DNSRules{
@@ -767,13 +767,13 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 			asIPRule(s.proxy.allowed[epID3][udpProtoPort53][cachedDstID1Selector], map[string]struct{}{"::": {}}),
 			asIPRule(s.proxy.allowed[epID3][udpProtoPort53][cachedDstID3Selector], map[string]struct{}{}),
 			asIPRule(s.proxy.allowed[epID3][udpProtoPort53][cachedDstID4Selector], map[string]struct{}{}),
-		}.Sort(),
+		}.Sort(nil),
 		tcpProtoPort53: restore.IPRules{
 			asIPRule(s.proxy.allowed[epID3][tcpProtoPort53][cachedDstID3Selector], map[string]struct{}{}),
 		},
 	}
 	restored3, _ := s.proxy.GetRules(uint16(epID3))
-	restored3.Sort()
+	restored3.Sort(nil)
 	c.Assert(restored3, checker.DeepEquals, expected3)
 
 	// Test with limited set of allowed IPs
@@ -784,7 +784,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 		udpProtoPort53: restore.IPRules{
 			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID1Selector], map[string]struct{}{}),
 			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID2Selector], map[string]struct{}{"127.0.0.2": {}}),
-		}.Sort(),
+		}.Sort(nil),
 		udpProtoPort54: restore.IPRules{
 			asIPRule(s.proxy.allowed[epID1][udpProtoPort54][cachedWildcardSelector], nil),
 		},
@@ -793,7 +793,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 		},
 	}
 	restored1b, _ := s.proxy.GetRules(uint16(epID1))
-	restored1b.Sort()
+	restored1b.Sort(nil)
 	c.Assert(restored1b, checker.DeepEquals, expected1b)
 
 	// unlimited again
@@ -973,7 +973,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	// Restore Unmarshaled rules
 	var rules restore.DNSRules
 	err = json.Unmarshal(jsn, &rules)
-	rules = rules.Sort()
+	rules = rules.Sort(nil)
 	c.Assert(err, Equals, nil, Commentf("Could not unmarshal restored rules from json"))
 	c.Assert(rules, checker.DeepEquals, expected1)
 
@@ -1078,7 +1078,7 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 
 	// Get restored rules
 	restored, _ := s.proxy.GetRules(uint16(epID1))
-	restored.Sort()
+	restored.Sort(nil)
 
 	// remove rules
 	err = s.proxy.UpdateAllowed(epID1, dstPortProto, nil)

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -846,7 +846,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 
 	// Restore rules
 	ep1 := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
-	ep1.DNSRules = restored1
+	ep1.DNSRulesV2 = restored1
 	s.proxy.RestoreRules(ep1)
 	_, exists = s.proxy.restored[epID1]
 	c.Assert(exists, Equals, true)
@@ -892,7 +892,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 
 	// Restore rules for epID3
 	ep3 := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID3), endpoint.StateReady)
-	ep3.DNSRules = restored3
+	ep3.DNSRulesV2 = restored3
 	s.proxy.RestoreRules(ep3)
 	_, exists = s.proxy.restored[epID3]
 	c.Assert(exists, Equals, true)
@@ -983,7 +983,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(err, Equals, nil, Commentf("Could not marshal restored rules to json"))
 	c.Assert(string(jsn2), Equals, pretty.String())
 
-	ep1.DNSRules = rules
+	ep1.DNSRulesV2 = rules
 	s.proxy.RestoreRules(ep1)
 	_, exists = s.proxy.restored[epID1]
 	c.Assert(exists, Equals, true)
@@ -1099,7 +1099,7 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 	ep1 := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
 	ep1.IPv4 = netip.MustParseAddr("127.0.0.1")
 	ep1.IPv6 = netip.MustParseAddr("::1")
-	ep1.DNSRules = restored
+	ep1.DNSRulesV2 = restored
 	s.proxy.RestoreRules(ep1)
 	_, exists := s.proxy.restored[epID1]
 	c.Assert(exists, Equals, true)
@@ -1132,7 +1132,7 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 		restore.IPRule{Re: restore.RuleRegex{Pattern: &invalidRePattern}},
 		restore.IPRule{Re: restore.RuleRegex{Pattern: &validRePattern}},
 	)
-	ep1.DNSRules = restored
+	ep1.DNSRulesV2 = restored
 	s.proxy.RestoreRules(ep1)
 	_, exists = s.proxy.restored[epID1]
 	c.Assert(exists, Equals, true)

--- a/pkg/fqdn/proxy/proxy.go
+++ b/pkg/fqdn/proxy/proxy.go
@@ -12,7 +12,7 @@ import (
 type DNSProxier interface {
 	GetRules(uint16) (restore.DNSRules, error)
 	RemoveRestoredRules(uint16)
-	UpdateAllowed(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error
+	UpdateAllowed(endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) error
 	GetBindPort() uint16
 	SetRejectReply(string)
 	RestoreRules(op *endpoint.Endpoint)
@@ -29,7 +29,7 @@ func (m MockFQDNProxy) RemoveRestoredRules(u uint16) {
 	return
 }
 
-func (m MockFQDNProxy) UpdateAllowed(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error {
+func (m MockFQDNProxy) UpdateAllowed(endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) error {
 	return nil
 }
 

--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -12,8 +12,54 @@ import (
 	"sort"
 )
 
-// DNSRules contains IP-based DNS rules for a set of ports (e.g., 53)
-type DNSRules map[uint16]IPRules
+// PortProtoV2 is 1 value at bit position 24.
+const PortProtoV2 = 1 << 24
+
+// PortProto is uint32 that encodes two different
+// versions of port protocol keys. Version 1 is protocol
+// agnostic and (naturally) encodes no values at bit
+// positions 16-31. Version 2 encodes protocol at bit
+// positions 16-23, and bit position 24 encodes a 1
+// value to indicate that it is Version 2. Both versions
+// encode the port at the
+// bit positions 0-15.
+//
+// This works because Version 1 will naturally encode
+// no values at postions 16-31 as the original Version 1
+// was a uint16. Version 2 enforces a 1 value at the 24th
+// bit position, so it will alway be legible.
+type PortProto uint32
+
+// MakeV2PortProto returns a Version 2 port protocol.
+func MakeV2PortProto(port uint16, proto uint8) PortProto {
+	return PortProto(PortProtoV2 | (uint32(proto) << 16) | uint32(port))
+}
+
+// IsPortV2 returns true if the PortProto
+// is Version 2.
+func (pp PortProto) IsPortV2() bool {
+	return PortProtoV2&pp == PortProtoV2
+}
+
+// Port returns the port of the PortProto
+func (pp PortProto) Port() uint16 {
+	return uint16(pp & 0x0000_ffff)
+}
+
+// Protocol returns the protocol of the
+// PortProto. It returns "0" for Version 1.
+func (pp PortProto) Protocol() uint8 {
+	return uint8((pp & 0xff_0000) >> 16)
+}
+
+// ToV1 returns the Version 1 (that is, "port")
+// version of the PortProto.
+func (pp PortProto) ToV1() PortProto {
+	return pp & 0x0000_ffff
+}
+
+// DNSRules contains IP-based DNS rules for a set of port-protocols (e.g., UDP/53)
+type DNSRules map[PortProto]IPRules
 
 // IPRules is an unsorted collection of IPrules
 type IPRules []IPRule

--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -11,6 +11,7 @@ package restore
 import (
 	"fmt"
 	"sort"
+	"testing"
 )
 
 // PortProtoV2 is 1 value at bit position 24.
@@ -84,7 +85,7 @@ type RuleRegex struct {
 
 // Sort is only used for testing
 // Sorts in place, but returns IPRules for convenience
-func (r IPRules) Sort() IPRules {
+func (r IPRules) Sort(_ *testing.T) IPRules {
 	sort.SliceStable(r, func(i, j int) bool {
 		if r[i].Re.Pattern != nil && r[j].Re.Pattern != nil {
 			return *r[i].Re.Pattern < *r[j].Re.Pattern
@@ -100,10 +101,10 @@ func (r IPRules) Sort() IPRules {
 
 // Sort is only used for testing
 // Sorts in place, but returns DNSRules for convenience
-func (r DNSRules) Sort() DNSRules {
+func (r DNSRules) Sort(_ *testing.T) DNSRules {
 	for pp, ipRules := range r {
 		if len(ipRules) > 0 {
-			ipRules = ipRules.Sort()
+			ipRules = ipRules.Sort(nil)
 			r[pp] = ipRules
 		}
 	}

--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -9,6 +9,7 @@
 package restore
 
 import (
+	"fmt"
 	"sort"
 )
 
@@ -58,6 +59,12 @@ func (pp PortProto) ToV1() PortProto {
 	return pp & 0x0000_ffff
 }
 
+// String returns the decimal representation
+// of PortProtocol in string form.
+func (pp PortProto) String() string {
+	return fmt.Sprintf("%d", pp)
+}
+
 // DNSRules contains IP-based DNS rules for a set of port-protocols (e.g., UDP/53)
 type DNSRules map[PortProto]IPRules
 
@@ -94,10 +101,10 @@ func (r IPRules) Sort() IPRules {
 // Sort is only used for testing
 // Sorts in place, but returns DNSRules for convenience
 func (r DNSRules) Sort() DNSRules {
-	for port, ipRules := range r {
+	for pp, ipRules := range r {
 		if len(ipRules) > 0 {
 			ipRules = ipRules.Sort()
-			r[port] = ipRules
+			r[pp] = ipRules
 		}
 	}
 	return r

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1257,5 +1257,6 @@ type ProxyPolicy interface {
 	GetL7Parser() L7ParserType
 	GetIngress() bool
 	GetPort() uint16
+	GetProtocol() uint8
 	GetListener() string
 }

--- a/pkg/policy/visibility.go
+++ b/pkg/policy/visibility.go
@@ -212,6 +212,11 @@ func (v *VisibilityMetadata) GetPort() uint16 {
 	return v.Port
 }
 
+// GetProtocol returns the protocol where the VisibilityMetadata applies.
+func (v *VisibilityMetadata) GetProtocol() uint8 {
+	return uint8(v.Proto)
+}
+
 // GetListener returns the optional listener name.
 func (l4 *VisibilityMetadata) GetListener() string {
 	return ""

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -45,7 +45,7 @@ func (dr *dnsRedirect) setRules(wg *completion.WaitGroup, newRules policy.L7Data
 		"newRules":           newRules,
 		logfields.EndpointID: dr.redirect.endpointID,
 	}).Debug("DNS Proxy updating matchNames in allowed list during UpdateRules")
-	if err := dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, restore.PortProto(dr.redirect.dstPort), newRules); err != nil {
+	if err := dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPortProto, newRules); err != nil {
 		return err
 	}
 	dr.currentRules = copyRules(dr.redirect.rules)
@@ -68,7 +68,7 @@ func (dr *dnsRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc,
 // Close the redirect.
 func (dr *dnsRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc) {
 	return func() {
-		dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, restore.PortProto(dr.redirect.dstPort), nil)
+		dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPortProto, nil)
 		dr.redirect.localEndpoint.OnDNSPolicyUpdateLocked(nil)
 		dr.currentRules = nil
 	}, nil

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/fqdn/proxy"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/logger"
@@ -34,7 +35,7 @@ type dnsRedirect struct {
 type proxyRuleUpdater interface {
 	// UpdateAllowed updates the rules in the DNS proxy with newRules for the
 	// endpointID and destPort.
-	UpdateAllowed(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error
+	UpdateAllowed(endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) error
 }
 
 // setRules replaces old l7 rules of a redirect with new ones.
@@ -44,7 +45,7 @@ func (dr *dnsRedirect) setRules(wg *completion.WaitGroup, newRules policy.L7Data
 		"newRules":           newRules,
 		logfields.EndpointID: dr.redirect.endpointID,
 	}).Debug("DNS Proxy updating matchNames in allowed list during UpdateRules")
-	if err := dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPort, newRules); err != nil {
+	if err := dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, restore.PortProto(dr.redirect.dstPort), newRules); err != nil {
 		return err
 	}
 	dr.currentRules = copyRules(dr.redirect.rules)
@@ -67,7 +68,7 @@ func (dr *dnsRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc,
 // Close the redirect.
 func (dr *dnsRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc) {
 	return func() {
-		dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPort, nil)
+		dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, restore.PortProto(dr.redirect.dstPort), nil)
 		dr.redirect.localEndpoint.OnDNSPolicyUpdateLocked(nil)
 		dr.currentRules = nil
 	}, nil

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -564,8 +564,8 @@ func (p *Proxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolic
 		return 0, err, nil, nil
 	}
 
-	redir := newRedirect(localEndpoint, ppName, pp, l4.GetPort())
-	redir.updateRules(l4)
+	redir := newRedirect(localEndpoint, ppName, pp, l4.GetPort(), l4.GetProtocol())
+	_ = redir.updateRules(l4) // revertFunc not used because revert will remove whole redirect
 	// Rely on create*Redirect to update rules, unlike the update case above.
 
 	for nRetry := 0; nRetry < redirectCreationAttempts; nRetry++ {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/logger"
 	"github.com/cilium/cilium/pkg/proxy/logger/test"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
+	"github.com/cilium/cilium/pkg/u8proto"
 
 	. "gopkg.in/check.v1"
 )
@@ -190,6 +191,10 @@ func (p *fakeProxyPolicy) GetIngress() bool {
 
 func (p *fakeProxyPolicy) GetPort() uint16 {
 	return uint16(80)
+}
+
+func (p *fakeProxyPolicy) GetProtocol() uint8 {
+	return uint8(u8proto.UDP)
 }
 
 func (p *fakeProxyPolicy) GetListener() string {

--- a/pkg/proxy/redirect.go
+++ b/pkg/proxy/redirect.go
@@ -5,6 +5,7 @@ package proxy
 
 import (
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/logger"
@@ -44,7 +45,7 @@ type Redirect struct {
 	// is safe to read these fields without locking the mutex
 	name           string
 	listener       *ProxyPort
-	dstPort        uint16
+	dstPortProto   restore.PortProto
 	endpointID     uint64
 	localEndpoint  logger.EndpointUpdater
 	implementation RedirectImplementation
@@ -55,11 +56,11 @@ type Redirect struct {
 	rules policy.L7DataMap
 }
 
-func newRedirect(localEndpoint logger.EndpointUpdater, name string, listener *ProxyPort, dstPort uint16) *Redirect {
+func newRedirect(localEndpoint logger.EndpointUpdater, name string, listener *ProxyPort, port uint16, proto uint8) *Redirect {
 	return &Redirect{
 		name:          name,
 		listener:      listener,
-		dstPort:       dstPort,
+		dstPortProto:  restore.MakeV2PortProto(port, proto),
 		endpointID:    localEndpoint.GetID(),
 		localEndpoint: localEndpoint,
 	}


### PR DESCRIPTION
DNS Proxy indexes domain selectors by port
only. In cases where protocols collide on port
the DNS proxy may have a more restrictive selector than it should because it does not merge port
protocols for L7 policies (only ports).

Refactor all users of the DNS Proxy are updated
to add protocol to any DNS Proxy entries, and all
tests are updated to test for port-protocol
merge errors.
```release-note
fqdn: Fixed bug that caused DNS Proxy to be overly restrictive on allowed DNS selectors.
```
