### PR TITLE
signal: remove spare debug logs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -521,6 +521,7 @@ Makefile* @cilium/build
 /pkg/resiliency @cilium/sig-agent
 /pkg/safeio @cilium/sig-agent
 /pkg/service @cilium/sig-lb
+/pkg/signal @cilium/sig-datapath
 /pkg/slices @cilium/sig-foundations
 /pkg/socketlb @cilium/loader
 /pkg/source @cilium/ipcache

--- a/pkg/maps/signalmap/cell.go
+++ b/pkg/maps/signalmap/cell.go
@@ -38,8 +38,6 @@ func newMap(log logrus.FieldLogger, lifecycle cell.Lifecycle) bpf.MapOut[Map] {
 	possibleCPUs := common.GetNumPossibleCPUs(log)
 	signalmap := initMap(possibleCPUs)
 
-	log.Debugf("signalmap.newMap: %v", signalmap)
-
 	lifecycle.Append(cell.Hook{
 		OnStart: func(startCtx cell.HookContext) error {
 			return signalmap.open()

--- a/pkg/signal/cell.go
+++ b/pkg/signal/cell.go
@@ -19,8 +19,6 @@ var Cell = cell.Module(
 func provideSignalManager(lifecycle cell.Lifecycle, signalMap signalmap.Map) SignalManager {
 	sm := newSignalManager(signalMap)
 
-	log.Debugf("newSignalManager: %v", sm)
-
 	lifecycle.Append(cell.Hook{
 		OnStart: func(startCtx cell.HookContext) error {
 			return sm.start()


### PR DESCRIPTION
These debug logs were likely used during development of commit 25c00b0970cc ("signal: Generalize for multiple targets") but don't add much value now and only clutter the logs. Remove them.