### PR TITLE
gha: Clean-up renovate config for integration test

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -97,15 +97,6 @@
       ],
     },
     {
-      "matchPaths": [
-        ".github/workflows/integration-test.yaml"
-      ],
-      matchPackageNames: [
-        "ubuntu"
-      ],
-      "allowedVersions": "20.04"
-    },
-    {
       "groupName": "all go dependencies main",
       "groupSlug": "all-go-deps-main",
       "matchFiles": [


### PR DESCRIPTION
Just a note that the integration test workflow is already running with ubuntu 22.04 runners.

Relates: https://github.com/cilium/cilium/issues/22834
Relates: https://github.com/cilium/cilium/issues/22834#issuecomment-1699097697
