### PR TITLE
bpf: tests: don't define HAVE_ENCAP in IPsec tests

### DIFF
--- a/bpf/tests/ipsec_from_host_tunnel.c
+++ b/bpf/tests/ipsec_from_host_tunnel.c
@@ -2,7 +2,6 @@
 /* Copyright Authors of Cilium */
 
 #define TUNNEL_MODE
-#define HAVE_ENCAP
 #define ENABLE_ROUTING
 
 #define EXPECTED_STATUS_CODE CTX_ACT_REDIRECT

--- a/bpf/tests/ipsec_from_host_tunnel_endpoint.c
+++ b/bpf/tests/ipsec_from_host_tunnel_endpoint.c
@@ -2,7 +2,6 @@
 /* Copyright Authors of Cilium */
 
 #define TUNNEL_MODE
-#define HAVE_ENCAP
 #define ENABLE_ENDPOINT_ROUTES 1
 
 #define EXPECTED_STATUS_CODE CTX_ACT_REDIRECT

--- a/bpf/tests/ipsec_from_lxc_tunnel.c
+++ b/bpf/tests/ipsec_from_lxc_tunnel.c
@@ -2,7 +2,6 @@
 /* Copyright Authors of Cilium */
 
 #define TUNNEL_MODE
-#define HAVE_ENCAP
 #define ENABLE_ROUTING
 
 #define EXPECTED_DEST_MAC mac_two

--- a/bpf/tests/ipsec_from_lxc_tunnel_endpoint.c
+++ b/bpf/tests/ipsec_from_lxc_tunnel_endpoint.c
@@ -2,7 +2,6 @@
 /* Copyright Authors of Cilium */
 
 #define TUNNEL_MODE
-#define HAVE_ENCAP
 #define USE_BPF_PROG_FOR_INGRESS_POLICY 1
 #define ENABLE_ENDPOINT_ROUTES 1
 

--- a/bpf/tests/ipsec_from_network_generic.h
+++ b/bpf/tests/ipsec_from_network_generic.h
@@ -1,6 +1,16 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
+#define NODE_ID 2333
+#define ENCRYPT_KEY 3
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_IPSEC
+#define TUNNEL_MODE
+#define ENCAP_IFINDEX 4
+#define DEST_IFINDEX 5
+#define DEST_LXC_ID 200
+
 #include "common.h"
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
@@ -13,17 +23,6 @@
 #undef SECLABEL
 #undef SECLABEL_IPV4
 #undef SECLABEL_IPV6
-
-#define NODE_ID 2333
-#define ENCRYPT_KEY 3
-#define ENABLE_IPV4
-#define ENABLE_IPV6
-#define ENABLE_IPSEC
-#define TUNNEL_MODE
-#define HAVE_ENCAP
-#define ENCAP_IFINDEX 4
-#define DEST_IFINDEX 5
-#define DEST_LXC_ID 200
 
 #define ctx_redirect mock_ctx_redirect
 int mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused, int ifindex, __u32 flags)

--- a/bpf/tests/ipsec_from_overlay_generic.h
+++ b/bpf/tests/ipsec_from_overlay_generic.h
@@ -1,6 +1,16 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
+#define NODE_ID 2333
+#define ENCRYPT_KEY 3
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_IPSEC
+#define TUNNEL_MODE
+#define ENCAP_IFINDEX 4
+#define DEST_IFINDEX 5
+#define DEST_LXC_ID 200
+
 #include "common.h"
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
@@ -13,17 +23,6 @@
 #undef SECLABEL
 #undef SECLABEL_IPV4
 #undef SECLABEL_IPV6
-
-#define NODE_ID 2333
-#define ENCRYPT_KEY 3
-#define ENABLE_IPV4
-#define ENABLE_IPV6
-#define ENABLE_IPSEC
-#define TUNNEL_MODE
-#define HAVE_ENCAP
-#define ENCAP_IFINDEX 4
-#define DEST_IFINDEX 5
-#define DEST_LXC_ID 200
 
 #define skb_change_type mock_skb_change_type
 int mock_skb_change_type(__maybe_unused struct __sk_buff *skb, __u32 type)


### PR DESCRIPTION
This is an internal macro that's selected by common.h (based on TUNNEL_MODE and a few other config options). There should be no need to explicitly set it.