### PR TITLE
bpf/test: Adjust mock function to reflect changes in tail_ipvX_policy

### DIFF
--- a/bpf/tests/ipsec_from_overlay_generic.h
+++ b/bpf/tests/ipsec_from_overlay_generic.h
@@ -48,8 +48,8 @@ int mock_skb_get_tunnel_key(__maybe_unused struct __sk_buff *skb,
 __section("mock-handle-policy")
 int mock_handle_policy(struct __ctx_buff *ctx __maybe_unused)
 {
-	/* https://github.com/cilium/cilium/blob/b825f4e47e7eea9908ec8324591d7cc95238e1b8/bpf/bpf_lxc.c#L1927 */
-#if !defined(ENABLE_ROUTING) && defined(TUNNEL_MODE) && !defined(ENABLE_NODEPORT)
+	/* https://github.com/cilium/cilium/blob/v1.16.0-pre.1/bpf/bpf_lxc.c#L2040 */
+#if !defined(ENABLE_ROUTING) && !defined(ENABLE_NODEPORT)
 	return TC_ACT_OK;
 #else
 	return TC_ACT_REDIRECT;


### PR DESCRIPTION
https://github.com/cilium/cilium/commit/0cd9780648d834c772f656f99c2c0a2911b5d804 (bpf: lxc: fine-tune from_tunnel path in ingress tail-call) removed `define(TUNNEL_MODE)` in tail_ipvX_policy(), this commit makes sure the bpf mock function for that has the same behavior.


