### PR TITLE
[v1.15] Author backport of #31493

### DIFF
--- a/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
@@ -1056,24 +1056,16 @@ var hostnameIntersectionHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyCo
 					Name: "listener-insecure",
 					VirtualHosts: []*envoy_config_route_v3.VirtualHost{
 						{
-							Name:    "very.specific.com",
-							Domains: []string{"very.specific.com", "very.specific.com:*"},
+							Name:    "*.anotherwildcard.io",
+							Domains: []string{"*.anotherwildcard.io", "*.anotherwildcard.io:*"},
 							Routes: []*envoy_config_route_v3.Route{
 								{
 									Match: &envoy_config_route_v3.RouteMatch{
 										PathSpecifier: &envoy_config_route_v3.RouteMatch_PathSeparatedPrefix{
-											PathSeparatedPrefix: "/s1",
+											PathSeparatedPrefix: "/s4",
 										},
 									},
 									Action: routeActionBackendV1,
-								},
-								{
-									Match: &envoy_config_route_v3.RouteMatch{
-										PathSpecifier: &envoy_config_route_v3.RouteMatch_PathSeparatedPrefix{
-											PathSeparatedPrefix: "/s3",
-										},
-									},
-									Action: routeActionBackendV3,
 								},
 							},
 						},
@@ -1120,16 +1112,24 @@ var hostnameIntersectionHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyCo
 							},
 						},
 						{
-							Name:    "*.anotherwildcard.io",
-							Domains: []string{"*.anotherwildcard.io", "*.anotherwildcard.io:*"},
+							Name:    "very.specific.com",
+							Domains: []string{"very.specific.com", "very.specific.com:*"},
 							Routes: []*envoy_config_route_v3.Route{
 								{
 									Match: &envoy_config_route_v3.RouteMatch{
 										PathSpecifier: &envoy_config_route_v3.RouteMatch_PathSeparatedPrefix{
-											PathSeparatedPrefix: "/s4",
+											PathSeparatedPrefix: "/s1",
 										},
 									},
 									Action: routeActionBackendV1,
+								},
+								{
+									Match: &envoy_config_route_v3.RouteMatch{
+										PathSpecifier: &envoy_config_route_v3.RouteMatch_PathSeparatedPrefix{
+											PathSeparatedPrefix: "/s3",
+										},
+									},
+									Action: routeActionBackendV3,
 								},
 							},
 						},
@@ -1294,34 +1294,6 @@ var listenerHostNameMatchingCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 					Name: "listener-insecure",
 					VirtualHosts: []*envoy_config_route_v3.VirtualHost{
 						{
-							Name:    "bar.com",
-							Domains: []string{"bar.com", "bar.com:*"},
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match: &envoy_config_route_v3.RouteMatch{
-										PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
-											Prefix: "/",
-										},
-									},
-									Action: routeActionBackendV1,
-								},
-							},
-						},
-						{
-							Name:    "foo.bar.com",
-							Domains: []string{"foo.bar.com", "foo.bar.com:*"},
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match: &envoy_config_route_v3.RouteMatch{
-										PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
-											Prefix: "/",
-										},
-									},
-									Action: routeActionBackendV2,
-								},
-							},
-						},
-						{
 							Name:    "*.bar.com",
 							Domains: []string{"*.bar.com", "*.bar.com:*"},
 							Routes: []*envoy_config_route_v3.Route{
@@ -1346,6 +1318,34 @@ var listenerHostNameMatchingCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 										},
 									},
 									Action: routeActionBackendV3,
+								},
+							},
+						},
+						{
+							Name:    "bar.com",
+							Domains: []string{"bar.com", "bar.com:*"},
+							Routes: []*envoy_config_route_v3.Route{
+								{
+									Match: &envoy_config_route_v3.RouteMatch{
+										PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
+											Prefix: "/",
+										},
+									},
+									Action: routeActionBackendV1,
+								},
+							},
+						},
+						{
+							Name:    "foo.bar.com",
+							Domains: []string{"foo.bar.com", "foo.bar.com:*"},
+							Routes: []*envoy_config_route_v3.Route{
+								{
+									Match: &envoy_config_route_v3.RouteMatch{
+										PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
+											Prefix: "/",
+										},
+									},
+									Action: routeActionBackendV2,
 								},
 							},
 						},

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
@@ -462,20 +462,6 @@ var hostRulesListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 					Name: "listener-insecure",
 					VirtualHosts: []*envoy_config_route_v3.VirtualHost{
 						{
-							Name:    "foo.bar.com",
-							Domains: []string{"foo.bar.com", "foo.bar.com:*"},
-							Routes: []*envoy_config_route_v3.Route{
-								{
-									Match: &envoy_config_route_v3.RouteMatch{
-										PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
-											Prefix: "/",
-										},
-									},
-									Action: toHTTPSRedirectAction(),
-								},
-							},
-						},
-						{
 							Name:    "*.foo.com",
 							Domains: []string{"*.foo.com", "*.foo.com:*"},
 							Routes: []*envoy_config_route_v3.Route{
@@ -501,6 +487,20 @@ var hostRulesListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 										QueryParameters: []*envoy_config_route_v3.QueryParameterMatcher{},
 									},
 									Action: toRouteAction("random-namespace", "wildcard-foo-com", "8080"),
+								},
+							},
+						},
+						{
+							Name:    "foo.bar.com",
+							Domains: []string{"foo.bar.com", "foo.bar.com:*"},
+							Routes: []*envoy_config_route_v3.Route{
+								{
+									Match: &envoy_config_route_v3.RouteMatch{
+										PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
+											Prefix: "/",
+										},
+									},
+									Action: toHTTPSRedirectAction(),
 								},
 							},
 						},

--- a/operator/pkg/model/translation/translator.go
+++ b/operator/pkg/model/translation/translator.go
@@ -4,7 +4,9 @@
 package translation
 
 import (
+	"cmp"
 	"fmt"
+	goslices "slices"
 	"sort"
 
 	envoy_config_cluster_v3 "github.com/cilium/proxy/go/envoy/config/cluster/v3"
@@ -251,6 +253,7 @@ func (i *defaultTranslator) getEnvoyHTTPRouteConfiguration(m *model.Model) []cil
 		// the route name should match the value in http connection manager
 		// otherwise the request will be dropped by envoy
 		routeName := fmt.Sprintf("listener-%s", port)
+		goslices.SortStableFunc(virtualhosts, func(a, b *envoy_config_route_v3.VirtualHost) int { return cmp.Compare(a.Name, b.Name) })
 		rc, _ := NewRouteConfiguration(routeName, virtualhosts)
 		res = append(res, rc)
 	}


### PR DESCRIPTION
Currently, while translating K8s Ingress or Gateway API resources into Envoy resources, the virtualhosts aren't sorted. This leads to situations (especially in combination with Shared Ingress) where the order of the virtual hosts isn't guaranteed.

Therefore, this commit orders the virtualhosts within a Envoy RouteConfiguration by their name. This influences the Envoy route matching process (https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/route_matching), but only by making it constant and not random.

Backport of #31493 (Original PR changed the virtual host order in unit-tests that aren't present on v1.15) 

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 31493
```
