### PR TITLE
[v1.13] fix aws region being used twice

### DIFF
--- a/.github/actions/aws/k8s-versions.yaml
+++ b/.github/actions/aws/k8s-versions.yaml
@@ -2,9 +2,9 @@
 ---
 include:
   - version: "1.23"
-    region: ca-west-1
+    region: ca-central-1
   - version: "1.24"
-    region: ca-west-1
+    region: us-east-1
   - version: "1.25"
     region: us-west-2
   - version: "1.26"


### PR DESCRIPTION
When backporting ca-west-1 region used twice in tested aws k8s versions
Also, ca-west-1 region is not supported by the eksctl tool used in testing
This PR replaces ca-west-1 regions with ca-central-1 and us-east-1

Action run (cluster provisioning works): https://github.com/cilium/cilium/actions/runs/8537420316 

