### PR TITLE
[v1.14] fix unsupported aws region

### DIFF
--- a/.github/actions/aws/k8s-versions.yaml
+++ b/.github/actions/aws/k8s-versions.yaml
@@ -2,7 +2,7 @@
 ---
 include:
   - version: "1.24"
-    region: ca-west-1
+    region: ca-central-1
   - version: "1.25"
     region: us-west-2
   - version: "1.26"


### PR DESCRIPTION
ca-west-1 is not supported with the version of eksctl tool used in testing
this PR changes the region to the supported ca-central-1 region

successful action run: https://github.com/cilium/cilium/actions/runs/8536819416
