### PR TITLE
Remove superfluous nolint comments

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -1370,14 +1370,12 @@ func Benchmark_perEPAllow_setPortRulesForID_large(b *testing.B) {
 	}
 }
 
-//nolint:unused // Used in benchmark above, false-positive in golangci-lint v1.48.0.
 func getMemStats() runtime.MemStats {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
 	return m
 }
 
-//nolint:unused // Used in benchmark above, false-positive in golangci-lint v1.48.0.
 func bToMb(b uint64) uint64 {
 	return b / 1024 / 1024
 }

--- a/test/controlplane/node/ciliumnodes/ciliumnodes.go
+++ b/test/controlplane/node/ciliumnodes/ciliumnodes.go
@@ -11,10 +11,10 @@ import (
 	"reflect"
 	"testing"
 
-	v1 "k8s.io/api/core/v1" // nolint: golint
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2" // nolint: golint
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/test/controlplane"
 	"github.com/cilium/cilium/test/controlplane/suite"


### PR DESCRIPTION
The false positives of these being unused got fixed in recent linter releases and are no longer flagged in golangci-lint v1.57.1 which is currently used in main.