### PR TITLE
service: Update for L7 LB while locked

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -332,6 +332,9 @@ const (
 	// BackendSlot is the backend slot number in a service BPF map
 	BackendSlot = "backendSlot"
 
+	// ProxyName is the name of a proxy (e.g., "Envoy")
+	ProxyName = "proxyName"
+
 	// L7LBProxyPort is the port number of the Envoy listener a L7 LB service redirects traffic to for load balancing.
 	L7LBProxyPort = "l7LBProxyPort"
 


### PR DESCRIPTION
Keep service manager locked while updating services after L7 LB redirection updates. This removes the race where a service would be re-upserted while having been (concurrently) removed.

Fixes: #18894

Reported-by: Jussi Maki <joamaki@isovalent.com>

```release-note
Fixed a race condition in service updates for L7 LB.
```
