### PR TITLE
cilium-dbg: avoid leaking file resources

### DIFF
--- a/cilium-dbg/cmd/debuginfo.go
+++ b/cilium-dbg/cmd/debuginfo.go
@@ -456,6 +456,7 @@ func writeMarkdown(data []byte, path string) {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not create file %s", path)
+		os.Exit(1)
 	}
 	w := tabwriter.NewWriter(f, 5, 0, 3, ' ', 0)
 	w.Write(data)

--- a/cilium-dbg/cmd/debuginfo.go
+++ b/cilium-dbg/cmd/debuginfo.go
@@ -460,6 +460,7 @@ func writeMarkdown(data []byte, path string) {
 	}
 	w := tabwriter.NewWriter(f, 5, 0, 3, ' ', 0)
 	w.Write(data)
+	f.Close()
 }
 
 func writeFile(data []byte, path string) {
@@ -469,6 +470,7 @@ func writeFile(data []byte, path string) {
 		os.Exit(1)
 	}
 	f.Write(data)
+	f.Close()
 }
 
 func writeJSON(data []byte, path string) {
@@ -477,6 +479,8 @@ func writeJSON(data []byte, path string) {
 		fmt.Fprintf(os.Stderr, "Could not create file %s", path)
 		os.Exit(1)
 	}
+
+	defer f.Close()
 
 	db := &models.DebugInfo{}
 


### PR DESCRIPTION
Files opened using `os.Open{,File}` need to be closed manually using `os.(*File).Close` to avoid leaking `os.(*File)` instances and file descriptors.