### PR TITLE
Use Clang from cilium-builder image to build BPF code in CI

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -81,29 +81,6 @@ jobs:
           # renovate: datasource=golang-version depName=go
           go-version: 1.22.2
 
-      - name: Set clang directory
-        id: set_clang_dir
-        run: echo "clang_dir=$HOME/.clang" >> $GITHUB_OUTPUT
-
-      - name: Cache LLVM and Clang
-        id: cache-llvm
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        with:
-          path: ${{ steps.set_clang_dir.outputs.clang_dir }}
-          key: llvm-10.0
-
-      - name: Install LLVM and Clang prerequisites
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libtinfo5
-
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@dec985c8d7b46a2f363ea1a78f660c946a3349ea # v2.0.1
-        with:
-          version: "10.0"
-          directory: ${{ steps.set_clang_dir.outputs.clang_dir }}
-          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
-
       # Building Cilium as precondition to generate documentation artifacts.
       - name: Build Cilium
         run: |

--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -85,44 +85,13 @@ jobs:
         env:
           COCCINELLE_HOME: /usr/local/lib/coccinelle
 
-  set_clang_dir:
-    name: Set clang directory
-    runs-on: ubuntu-latest
-    outputs:
-      clang_dir: ${{ steps.set_dir.outputs.clang_dir }}
-    steps:
-    - name: Set directory
-      id: set_dir
-      run: echo "clang_dir=$HOME/.clang" >> $GITHUB_OUTPUT
-
   # Runs only if code under bpf/ is changed.
   build_all:
-    needs: [check_changes, set_clang_dir]
+    needs: [check_changes]
     if: ${{ needs.check_changes.outputs.bpf-tree == 'true' || needs.check_changes.outputs.workflow-description == 'true' }}
     name: Build Datapath
     runs-on: ubuntu-22.04
     steps:
-      - name: Install Go
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-        with:
-          # renovate: datasource=golang-version depName=go
-          go-version: 1.22.2
-      - name: Cache LLVM and Clang
-        id: cache-llvm
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        with:
-          path: ${{ needs.set_clang_dir.outputs.clang_dir }}
-          key: llvm-10.0
-      - name: Install LLVM and Clang prerequisites
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libtinfo5
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@dec985c8d7b46a2f363ea1a78f660c946a3349ea # v2.0.1
-        with:
-          version: "10.0"
-          directory: ${{ needs.set_clang_dir.outputs.clang_dir }}
-          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
@@ -132,10 +101,10 @@ jobs:
         env:
           V: 0
         run: |
-          make --quiet -C bpf build_all || (echo "Run 'make -C bpf build_all' locally to investigate build breakages"; exit 1)
+          contrib/scripts/builder.sh make --quiet -C bpf build_all -j $(nproc) || (echo "Run 'make -C bpf build_all' locally to investigate build breakages"; exit 1)
 
   bpf_tests:
-    needs: [check_changes, set_clang_dir]
+    needs: [check_changes]
     if: ${{ needs.check_changes.outputs.bpf-tree == 'true' || needs.check_changes.outputs.bpf-tests-runner == 'true' || needs.check_changes.outputs.workflow-description == 'true' }}
     name: BPF unit/integration Tests
     runs-on: ubuntu-22.04

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -68,7 +68,7 @@ jobs:
             ${{ github.event.pull_request.commits_url }})
           PR_FIRST_SHA=$(echo "$PR_COMMITS_API_JSON" | jq -r ".[0].sha")
           PR_PARENT_SHA=$(git rev-parse "${PR_FIRST_SHA}^")
-          git rebase --exec "make build -j $(nproc)" $PR_PARENT_SHA
+          git rebase --exec "contrib/scripts/builder.sh make build -j $(nproc)" $PR_PARENT_SHA
 
       - name: Check bpf code changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -88,7 +88,7 @@ jobs:
             ${{ github.event.pull_request.commits_url }})
           PR_FIRST_SHA=$(echo "$PR_COMMITS_API_JSON" | jq -r ".[0].sha")
           PR_PARENT_SHA=$(git rev-parse "${PR_FIRST_SHA}^")
-          git rebase --exec "make -C bpf build_all -j $(nproc)" $PR_PARENT_SHA
+          git rebase --exec "contrib/scripts/builder.sh make -C bpf build_all -j $(nproc)" $PR_PARENT_SHA
 
       - name: Check test code changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -109,7 +109,7 @@ jobs:
             ${{ github.event.pull_request.commits_url }})
           PR_FIRST_SHA=$(echo "$PR_COMMITS_API_JSON" | jq -r ".[0].sha")
           PR_PARENT_SHA=$(git rev-parse "${PR_FIRST_SHA}^")
-          git rebase --exec "make -C test build -j $(nproc) && make -C test build-darwin" $PR_PARENT_SHA
+          git rebase --exec "make -C test build -j $(nproc) && make -C test build-darwin -j $(nproc)" $PR_PARENT_SHA
 
       - name: Failed commit during the build
         if: ${{ failure() }}

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -122,10 +122,18 @@ jobs:
 
             git config --global --add safe.directory /host
             uname -a
+
             # The LVH image might ship with an arbitrary Go toolchain version,
             # install the same Go toolchain version as current HEAD.
             CGO_ENABLED=0 GOPROXY=direct GOSUMDB= go install golang.org/dl/go${{ env.go-version }}@latest
             go${{ env.go-version }} download
+
+            # The LVH image ships with LLVM taken from a release Cilium version.
+            # Replace it with the one extracted from the cilium-builder image.
+            /bootstrap/deb-docker.sh # Install docker first.
+            /host/contrib/scripts/extract-llvm.sh /tmp/llvm
+            mv /tmp/llvm/usr/local/bin/{clang,llc} /bin/
+            rm -r /tmp/llvm
 
       - name: Run verifier tests
         uses: cilium/little-vm-helper@a4311c6d054de3008bdf9195b0fabf6ee60d8bdd # v0.0.17

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -42,7 +42,7 @@ endif
 # documentation to be generated correctly.
 cilium-build:
 ifndef SKIP_BUILD
-	make -C ../ build
+	../contrib/scripts/builder.sh env MAKEFLAGS="$(MAKEFLAGS)" make build
 else
 	echo "SKIP_BUILD set, assuming all build artifacts are already present."
 endif

--- a/Makefile
+++ b/Makefile
@@ -561,14 +561,12 @@ help: ## Display help for the Makefile, from https://www.thapaliya.com/en/writin
 	$(call print_help_line,"docker-operator-*-image","Build platform specific cilium-operator images(alibabacloud, aws, azure, generic)")
 	$(call print_help_line,"docker-*-image-unstripped","Build unstripped version of above docker images(cilium, hubble-relay, operator etc.)")
 
-.PHONY: help clean clean-container dev-doctor force generate-api generate-health-api generate-operator-api generate-hubble-api install licenses-all veryclean
+.PHONY: help clean clean-container dev-doctor force generate-api generate-health-api generate-operator-api generate-hubble-api install licenses-all veryclean run_bpf_tests run-builder
 force :;
 
 run_bpf_tests: ## Build and run the BPF unit tests using the cilium-builder container image.
-	docker run --rm --privileged \
-		-v $$(pwd):/src -w /src \
-		$(CILIUM_BUILDER_IMAGE) \
+	DOCKER_ARGS=--privileged contrib/scripts/builder.sh \
 		"make" "-j$(shell nproc)" "-C" "bpf/tests/" "all" "run"
 
 run-builder: ## Drop into a shell inside a container running the cilium-builder image.
-	docker run -it --rm -v $$(pwd):/go/src/github.com/cilium/cilium $(CILIUM_BUILDER_IMAGE) bash
+	DOCKER_ARGS=-it contrib/scripts/builder.sh bash

--- a/contrib/scripts/builder.sh
+++ b/contrib/scripts/builder.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eu
+
+cd "$(dirname "$0")/../.."
+
+CILIUM_BUILDER_IMAGE=$(cat images/cilium/Dockerfile | grep '^ARG CILIUM_BUILDER_IMAGE=' | cut -d '=' -f 2)
+
+docker run --rm \
+	-v "$PWD":/go/src/github.com/cilium/cilium \
+	-w /go/src/github.com/cilium/cilium \
+	${DOCKER_ARGS:+"$DOCKER_ARGS"} \
+	"$CILIUM_BUILDER_IMAGE" \
+	"$@"

--- a/contrib/scripts/extract-llvm.sh
+++ b/contrib/scripts/extract-llvm.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eu
+
+OUT=${1:-"$PWD"}
+
+cd "$(dirname "$0")/../.."
+
+IMAGE=$(cat images/cilium/Dockerfile | grep '^ARG CILIUM_BUILDER_IMAGE=' | cut -d '=' -f 2)
+NAME=$(docker create "$IMAGE" /bin/true)
+trap 'docker rm "$NAME" > /dev/null' EXIT
+mkdir -p "$OUT"
+docker export "$NAME" | tar x -C "$OUT"


### PR DESCRIPTION
Many workflows in the CI use a hardcoded Clang 10.0 version, which in addition differs from the actual Clang used by Cilium, because the latter has some patches on top. Migrate to building inside cilium-builder or extracting clang from cilium-builder where possible in a straightforward way. Some gaps remain for the future work.

Also clean up a duplicating workflow and some leftovers from https://github.com/cilium/cilium/pull/31526 (previous work on integrating cilium-builder into the workflow that runs `make run_bpf_tests`).

Field-tested in https://github.com/cilium/cilium/pull/31729, where an LLVM upgrade [revealed](https://github.com/cilium/cilium/pull/31729/commits/2a5e69f35d542ce1fb3a696eacbd88fad1813733) workflows that were tied to Clang 10.

```release-note
Use Clang from cilium-builder image to build BPF code in CI
```
