### PR TITLE
Loader reconciliation preparatory changes

### DIFF
--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -89,7 +89,7 @@ func (c *ConfigModifyEvent) configModify(params PatchConfigParams, resChan chan 
 	if changes > 0 {
 		// Only recompile if configuration has changed.
 		log.Debug("daemon configuration has changed; recompiling base programs")
-		if err := d.Datapath().Orchestrator().Reinitialize(d.ctx, d.tunnelConfig, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
+		if err := d.Datapath().Orchestrator().Reinitialize(d.ctx); err != nil {
 			msg := fmt.Errorf("Unable to recompile base programs: %w", err)
 			// Revert configuration changes
 			option.Config.ConfigPatchMutex.Lock()

--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -89,7 +89,7 @@ func (c *ConfigModifyEvent) configModify(params PatchConfigParams, resChan chan 
 	if changes > 0 {
 		// Only recompile if configuration has changed.
 		log.Debug("daemon configuration has changed; recompiling base programs")
-		if err := d.Datapath().Orchestrator().Reinitialize(d.ctx, d, d.tunnelConfig, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
+		if err := d.Datapath().Orchestrator().Reinitialize(d.ctx, d.tunnelConfig, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
 			msg := fmt.Errorf("Unable to recompile base programs: %w", err)
 			// Revert configuration changes
 			option.Config.ConfigPatchMutex.Lock()

--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -89,7 +89,7 @@ func (c *ConfigModifyEvent) configModify(params PatchConfigParams, resChan chan 
 	if changes > 0 {
 		// Only recompile if configuration has changed.
 		log.Debug("daemon configuration has changed; recompiling base programs")
-		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.tunnelConfig, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
+		if err := d.Datapath().Orchestrator().Reinitialize(d.ctx, d, d.tunnelConfig, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
 			msg := fmt.Errorf("Unable to recompile base programs: %w", err)
 			// Revert configuration changes
 			option.Config.ConfigPatchMutex.Lock()

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -130,7 +130,7 @@ type Daemon struct {
 
 	// Used to synchronize generation of daemon's BPF programs and endpoint BPF
 	// programs.
-	compilationMutex *lock.RWMutex
+	compilationLock datapath.CompilationLock
 
 	clustermesh *clustermesh.ClusterMesh
 
@@ -230,8 +230,8 @@ func (d *Daemon) GetOptions() *option.IntOptions {
 
 // GetCompilationLock returns the mutex responsible for synchronizing compilation
 // of BPF programs.
-func (d *Daemon) GetCompilationLock() *lock.RWMutex {
-	return d.compilationMutex
+func (d *Daemon) GetCompilationLock() datapath.CompilationLock {
+	return d.compilationLock
 }
 
 func (d *Daemon) init() error {
@@ -415,7 +415,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		clientset:         params.Clientset,
 		db:                params.DB,
 		buildEndpointSem:  semaphore.NewWeighted(int64(numWorkerThreads())),
-		compilationMutex:  new(lock.RWMutex),
+		compilationLock:   params.CompilationLock,
 		mtuConfig:         params.MTU,
 		datapath:          params.Datapath,
 		deviceManager:     params.DeviceManager,

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -447,6 +447,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		tunnelConfig:         params.TunnelConfig,
 		bwManager:            params.BandwidthManager,
 		lrpManager:           params.LRPManager,
+		preFilter:            params.Prefilter,
 	}
 
 	d.configModifyQueue = eventqueue.NewEventQueueBuffered("config-modify-queue", ConfigModifyQueueSize)

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -245,7 +245,7 @@ func (d *Daemon) init() error {
 	}
 
 	if !option.Config.DryMode {
-		if err := d.Datapath().Orchestrator().Reinitialize(d.ctx, d, d.tunnelConfig, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
+		if err := d.Datapath().Orchestrator().Reinitialize(d.ctx, d.tunnelConfig, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
 			return fmt.Errorf("failed while reinitializing datapath: %w", err)
 		}
 
@@ -453,7 +453,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	d.configModifyQueue = eventqueue.NewEventQueueBuffered("config-modify-queue", ConfigModifyQueueSize)
 	d.configModifyQueue.Run()
 
-	d.rec, err = recorder.NewRecorder(d.ctx, &d)
+	d.rec, err = recorder.NewRecorder(d.ctx, params.Datapath.Loader())
 	if err != nil {
 		log.WithError(err).Error("error while initializing BPF pcap recorder")
 		return nil, nil, fmt.Errorf("error while initializing BPF pcap recorder: %w", err)
@@ -1015,7 +1015,7 @@ func (d *Daemon) Close() {
 // endpoints may or may not have successfully regenerated.
 func (d *Daemon) TriggerReloadWithoutCompile(reason string) (*sync.WaitGroup, error) {
 	log.Debugf("BPF reload triggered from %s", reason)
-	if err := d.Datapath().Orchestrator().Reinitialize(d.ctx, d, d.tunnelConfig, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
+	if err := d.Datapath().Orchestrator().Reinitialize(d.ctx, d.tunnelConfig, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
 		return nil, fmt.Errorf("unable to recompile base programs from %s: %w", reason, err)
 	}
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -245,7 +245,7 @@ func (d *Daemon) init() error {
 	}
 
 	if !option.Config.DryMode {
-		if err := d.Datapath().Orchestrator().Reinitialize(d.ctx, d.tunnelConfig, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
+		if err := d.Datapath().Orchestrator().Reinitialize(d.ctx); err != nil {
 			return fmt.Errorf("failed while reinitializing datapath: %w", err)
 		}
 
@@ -1015,7 +1015,7 @@ func (d *Daemon) Close() {
 // endpoints may or may not have successfully regenerated.
 func (d *Daemon) TriggerReloadWithoutCompile(reason string) (*sync.WaitGroup, error) {
 	log.Debugf("BPF reload triggered from %s", reason)
-	if err := d.Datapath().Orchestrator().Reinitialize(d.ctx, d.tunnelConfig, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
+	if err := d.Datapath().Orchestrator().Reinitialize(d.ctx); err != nil {
 		return nil, fmt.Errorf("unable to recompile base programs from %s: %w", reason, err)
 	}
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -245,7 +245,7 @@ func (d *Daemon) init() error {
 	}
 
 	if !option.Config.DryMode {
-		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.tunnelConfig, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
+		if err := d.Datapath().Orchestrator().Reinitialize(d.ctx, d, d.tunnelConfig, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
 			return fmt.Errorf("failed while reinitializing datapath: %w", err)
 		}
 
@@ -1014,7 +1014,7 @@ func (d *Daemon) Close() {
 // endpoints may or may not have successfully regenerated.
 func (d *Daemon) TriggerReloadWithoutCompile(reason string) (*sync.WaitGroup, error) {
 	log.Debugf("BPF reload triggered from %s", reason)
-	if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.tunnelConfig, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
+	if err := d.Datapath().Orchestrator().Reinitialize(d.ctx, d, d.tunnelConfig, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
 		return nil, fmt.Errorf("unable to recompile base programs from %s: %w", reason, err)
 	}
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1644,6 +1644,7 @@ type daemonParams struct {
 	LRPManager          *redirectpolicy.Manager
 	NodeDiscovery       *nodediscovery.NodeDiscovery
 	Prefilter           datapath.PreFilter
+	CompilationLock     datapath.CompilationLock
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1643,6 +1643,7 @@ type daemonParams struct {
 	SyncHostIPs         *syncHostIPs
 	LRPManager          *redirectpolicy.Manager
 	NodeDiscovery       *nodediscovery.NodeDiscovery
+	Prefilter           datapath.PreFilter
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -22,6 +22,7 @@ import (
 	fakecni "github.com/cilium/cilium/daemon/cmd/cni/fake"
 	"github.com/cilium/cilium/pkg/controller"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/envoy"
@@ -154,6 +155,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 			func() ctmapgc.Enabler { return ctmapgc.NewFake() },
 		),
 		fakeDatapath.Cell,
+		prefilter.Cell,
 		monitorAgent.Cell,
 		ControlPlane,
 		metrics.Cell,

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -106,11 +106,6 @@ func clearCiliumVeths() error {
 	return nil
 }
 
-// SetPrefilter sets the preftiler for the given daemon.
-func (d *Daemon) SetPrefilter(preFilter datapath.PreFilter) {
-	d.preFilter = preFilter
-}
-
 // EndpointMapManager is a wrapper around an endpointmanager as well as the
 // filesystem for removing maps related to endpoints from the filesystem.
 type EndpointMapManager struct {

--- a/daemon/cmd/prefilter.go
+++ b/daemon/cmd/prefilter.go
@@ -17,7 +17,7 @@ import (
 func getPrefilterHandler(d *Daemon, params GetPrefilterParams) middleware.Responder {
 	var list []string
 	var revision int64
-	if d.preFilter == nil {
+	if !d.preFilter.Enabled() {
 		msg := fmt.Errorf("Prefilter is not enabled in daemon")
 		return api.Error(GetPrefilterFailureCode, msg)
 	}
@@ -36,7 +36,7 @@ func getPrefilterHandler(d *Daemon, params GetPrefilterParams) middleware.Respon
 }
 
 func patchPrefilterHandler(d *Daemon, params PatchPrefilterParams) middleware.Responder {
-	if d.preFilter == nil {
+	if !d.preFilter.Enabled() {
 		msg := fmt.Errorf("Prefilter is not enabled in daemon")
 		return api.Error(PatchPrefilterFailureCode, msg)
 	}
@@ -59,7 +59,7 @@ func patchPrefilterHandler(d *Daemon, params PatchPrefilterParams) middleware.Re
 }
 
 func deletePrefilterHandler(d *Daemon, params DeletePrefilterParams) middleware.Responder {
-	if d.preFilter == nil {
+	if !d.preFilter.Enabled() {
 		msg := fmt.Errorf("Prefilter is not enabled in daemon")
 		return api.Error(DeletePrefilterFailureCode, msg)
 	}

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	loaderTypes "github.com/cilium/cilium/pkg/datapath/loader/types"
 	"github.com/cilium/cilium/pkg/datapath/orchestrator"
+	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/datapath/types"
@@ -127,6 +128,9 @@ var Cell = cell.Module(
 
 	// Provides the loader, which compiles and loads the datapath programs.
 	loader.Cell,
+
+	// Provides prefilter, a means of configuring XDP pre-filters for DDoS-mitigation.
+	prefilter.Cell,
 )
 
 func newWireguardAgent(lc cell.Lifecycle, sysctl sysctl.Sysctl) *wg.Agent {

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/datapath/types"
-	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/maps"
 	"github.com/cilium/cilium/pkg/maps/eventsmap"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
@@ -116,10 +115,6 @@ var Cell = cell.Module(
 
 	orchestrator.Cell,
 
-	cell.Provide(func(dp types.Datapath) types.NodeIDHandler {
-		return dp.NodeIDs()
-	}),
-
 	// DevicesController manages the devices and routes tables
 	linuxdatapath.DevicesControllerCell,
 
@@ -131,6 +126,9 @@ var Cell = cell.Module(
 
 	// Provides prefilter, a means of configuring XDP pre-filters for DDoS-mitigation.
 	prefilter.Cell,
+
+	// Provides node handler, which handles node events.
+	cell.Provide(linuxdatapath.NewNodeHandler),
 )
 
 func newWireguardAgent(lc cell.Lifecycle, sysctl sysctl.Sysctl) *wg.Agent {
@@ -162,11 +160,6 @@ func newWireguardAgent(lc cell.Lifecycle, sysctl sysctl.Sysctl) *wg.Agent {
 }
 
 func newDatapath(params datapathParams) types.Datapath {
-	datapathConfig := linuxdatapath.DatapathConfiguration{
-		HostDevice:   defaults.HostDevice,
-		TunnelDevice: params.TunnelConfig.DeviceName(),
-	}
-
 	datapath := linuxdatapath.NewDatapath(linuxdatapath.DatapathParams{
 		ConfigWriter:   params.ConfigWriter,
 		RuleManager:    params.IptablesManager,
@@ -179,7 +172,10 @@ func newDatapath(params datapathParams) types.Datapath {
 		DB:             params.DB,
 		Devices:        params.Devices,
 		Orchestrator:   params.Orchestrator,
-	}, datapathConfig)
+		NodeHandler:    params.NodeHandler,
+		NodeIDHandler:  params.NodeIDHandler,
+		NodeNeighbors:  params.NodeNeighbors,
+	})
 
 	params.LC.Append(cell.Hook{
 		OnStart: func(cell.HookContext) error {
@@ -227,4 +223,10 @@ type datapathParams struct {
 	NodeManager nodeManager.NodeManager
 
 	Orchestrator types.Orchestrator
+
+	NodeHandler types.NodeHandler
+
+	NodeIDHandler types.NodeIDHandler
+
+	NodeNeighbors types.NodeNeighbors
 }

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/utime"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	loaderTypes "github.com/cilium/cilium/pkg/datapath/loader/types"
+	"github.com/cilium/cilium/pkg/datapath/orchestrator"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/datapath/types"
@@ -112,6 +113,8 @@ var Cell = cell.Module(
 	// MTU provides the MTU configuration of the node.
 	mtu.Cell,
 
+	orchestrator.Cell,
+
 	cell.Provide(func(dp types.Datapath) types.NodeIDHandler {
 		return dp.NodeIDs()
 	}),
@@ -171,6 +174,7 @@ func newDatapath(params datapathParams) types.Datapath {
 		NodeManager:    params.NodeManager,
 		DB:             params.DB,
 		Devices:        params.Devices,
+		Orchestrator:   params.Orchestrator,
 	}, datapathConfig)
 
 	params.LC.Append(cell.Hook{
@@ -217,4 +221,6 @@ type datapathParams struct {
 	Loader loaderTypes.Loader
 
 	NodeManager nodeManager.NodeManager
+
+	Orchestrator types.Orchestrator
 }

--- a/pkg/datapath/fake/types/datapath.go
+++ b/pkg/datapath/fake/types/datapath.go
@@ -172,6 +172,6 @@ func (f *FakeLoader) DeviceHasTCProgramLoaded(hostInterface string, checkEgress 
 
 type FakeOrchestrator struct{}
 
-func (f *FakeOrchestrator) Reinitialize(ctx context.Context, tunnelConfig tunnel.Config, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
+func (f *FakeOrchestrator) Reinitialize(ctx context.Context) error {
 	return nil
 }

--- a/pkg/datapath/fake/types/datapath.go
+++ b/pkg/datapath/fake/types/datapath.go
@@ -117,6 +117,10 @@ func (f *FakeDatapath) BandwidthManager() datapath.BandwidthManager {
 	return &BandwidthManager{}
 }
 
+func (f *FakeDatapath) Orchestrator() datapath.Orchestrator {
+	return &FakeOrchestrator{}
+}
+
 // Loader is an interface to abstract out loading of datapath programs.
 type FakeLoader struct {
 }
@@ -163,4 +167,10 @@ func (f *FakeLoader) RestoreTemplates(stateDir string) error {
 
 func (f *FakeLoader) DeviceHasTCProgramLoaded(hostInterface string, checkEgress bool) (bool, error) {
 	return false, nil
+}
+
+type FakeOrchestrator struct{}
+
+func (f *FakeOrchestrator) Reinitialize(ctx context.Context, owner datapath.BaseProgramOwner, tunnelConfig tunnel.Config, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
+	return nil
 }

--- a/pkg/datapath/fake/types/datapath.go
+++ b/pkg/datapath/fake/types/datapath.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils/mockmaps"
 )
 
@@ -66,7 +67,7 @@ func (f *FakeDatapath) WriteNodeConfig(io.Writer, *datapath.LocalNodeConfigurati
 }
 
 // WriteNetdevConfig pretends to write the netdev configuration to a writer.
-func (f *FakeDatapath) WriteNetdevConfig(io.Writer, datapath.DeviceConfiguration) error {
+func (f *FakeDatapath) WriteNetdevConfig(io.Writer, *option.IntOptions) error {
 	return nil
 }
 
@@ -133,7 +134,7 @@ func (f *FakeLoader) ReloadDatapath(ctx context.Context, ep datapath.Endpoint, s
 	panic("implement me")
 }
 
-func (f *FakeLoader) ReinitializeXDP(ctx context.Context, o datapath.BaseProgramOwner, extraCArgs []string) error {
+func (f *FakeLoader) ReinitializeXDP(ctx context.Context, extraCArgs []string) error {
 	panic("implement me")
 }
 
@@ -153,7 +154,7 @@ func (f *FakeLoader) CustomCallsMapPath(id uint16) string {
 }
 
 // Reinitialize does nothing.
-func (f *FakeLoader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, tunnelConfig tunnel.Config, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
+func (f *FakeLoader) Reinitialize(ctx context.Context, tunnelConfig tunnel.Config, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
 	return nil
 }
 
@@ -171,6 +172,6 @@ func (f *FakeLoader) DeviceHasTCProgramLoaded(hostInterface string, checkEgress 
 
 type FakeOrchestrator struct{}
 
-func (f *FakeOrchestrator) Reinitialize(ctx context.Context, owner datapath.BaseProgramOwner, tunnelConfig tunnel.Config, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
+func (f *FakeOrchestrator) Reinitialize(ctx context.Context, tunnelConfig tunnel.Config, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
 	return nil
 }

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -943,8 +943,8 @@ is_l3; })`))
 	return macByIfIndexMacro.String(), isL3DevMacro, nil
 }
 
-func (h *HeaderfileWriter) writeNetdevConfig(w io.Writer, cfg datapath.DeviceConfiguration) {
-	fmt.Fprint(w, cfg.GetOptions().GetFmtList())
+func (h *HeaderfileWriter) writeNetdevConfig(w io.Writer, opts *option.IntOptions) {
+	fmt.Fprint(w, opts.GetFmtList())
 
 	if option.Config.EnableEndpointRoutes {
 		fmt.Fprint(w, "#define USE_BPF_PROG_FOR_INGRESS_POLICY 1\n")
@@ -952,9 +952,9 @@ func (h *HeaderfileWriter) writeNetdevConfig(w io.Writer, cfg datapath.DeviceCon
 }
 
 // WriteNetdevConfig writes the BPF configuration for the endpoint to a writer.
-func (h *HeaderfileWriter) WriteNetdevConfig(w io.Writer, cfg datapath.DeviceConfiguration) error {
+func (h *HeaderfileWriter) WriteNetdevConfig(w io.Writer, opts *option.IntOptions) error {
 	fw := bufio.NewWriter(w)
-	h.writeNetdevConfig(fw, cfg)
+	h.writeNetdevConfig(fw, opts)
 	return fw.Flush()
 }
 
@@ -1112,7 +1112,7 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, devices []*tabl
 	// Local delivery metrics should always be set for endpoint programs.
 	fmt.Fprint(fw, "#define LOCAL_DELIVERY_METRICS 1\n")
 
-	h.writeNetdevConfig(fw, e)
+	h.writeNetdevConfig(fw, e.GetOptions())
 
 	return fw.Flush()
 }

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -137,7 +137,7 @@ func (s *ConfigSuite) TestWriteNodeConfig(c *C) {
 
 func (s *ConfigSuite) TestWriteNetdevConfig(c *C) {
 	writeConfig(c, "netdev", func(w io.Writer, dp datapath.ConfigWriter) error {
-		return dp.WriteNetdevConfig(w, &dummyDevCfg)
+		return dp.WriteNetdevConfig(w, dummyDevCfg.GetOptions())
 	})
 }
 

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -33,6 +33,7 @@ type linuxDatapath struct {
 	wgAgent        datapath.WireguardAgent
 	lbmap          datapath.LBMap
 	bwmgr          datapath.BandwidthManager
+	orchestrator   datapath.Orchestrator
 }
 
 type DatapathParams struct {
@@ -47,6 +48,7 @@ type DatapathParams struct {
 	NodeManager    manager.NodeManager
 	DB             *statedb.DB
 	Devices        statedb.Table[*tables.Device]
+	Orchestrator   datapath.Orchestrator
 }
 
 // NewDatapath creates a new Linux datapath
@@ -60,6 +62,7 @@ func NewDatapath(p DatapathParams, cfg DatapathConfiguration) datapath.Datapath 
 		wgAgent:         p.WGAgent,
 		lbmap:           lbmap.New(),
 		bwmgr:           p.BWManager,
+		orchestrator:    p.Orchestrator,
 	}
 
 	dp.node = NewNodeHandler(cfg, dp.nodeAddressing, p.NodeMap, p.MTU, p.NodeManager, p.DB, p.Devices)
@@ -107,4 +110,8 @@ func (l *linuxDatapath) BandwidthManager() datapath.BandwidthManager {
 
 func (l *linuxDatapath) DeleteEndpointBandwidthLimit(epID uint16) error {
 	return l.bwmgr.DeleteEndpointBandwidthLimit(epID)
+}
+
+func (l *linuxDatapath) Orchestrator() datapath.Orchestrator {
+	return l.orchestrator
 }

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -26,9 +26,10 @@ type DatapathConfiguration struct {
 type linuxDatapath struct {
 	datapath.ConfigWriter
 	datapath.IptablesManager
-	node           *linuxNodeHandler
+	nodeHandler    datapath.NodeHandler
+	nodeIDHandler  datapath.NodeIDHandler
+	nodeNeighbors  datapath.NodeNeighbors
 	nodeAddressing datapath.NodeAddressing
-	config         DatapathConfiguration
 	loader         loader.Loader
 	wgAgent        datapath.WireguardAgent
 	lbmap          datapath.LBMap
@@ -49,23 +50,27 @@ type DatapathParams struct {
 	DB             *statedb.DB
 	Devices        statedb.Table[*tables.Device]
 	Orchestrator   datapath.Orchestrator
+	NodeHandler    datapath.NodeHandler
+	NodeIDHandler  datapath.NodeIDHandler
+	NodeNeighbors  datapath.NodeNeighbors
 }
 
 // NewDatapath creates a new Linux datapath
-func NewDatapath(p DatapathParams, cfg DatapathConfiguration) datapath.Datapath {
+func NewDatapath(p DatapathParams) datapath.Datapath {
 	dp := &linuxDatapath{
 		ConfigWriter:    p.ConfigWriter,
 		IptablesManager: p.RuleManager,
 		nodeAddressing:  p.NodeAddressing,
-		config:          cfg,
 		loader:          p.Loader,
 		wgAgent:         p.WGAgent,
 		lbmap:           lbmap.New(),
 		bwmgr:           p.BWManager,
 		orchestrator:    p.Orchestrator,
+		nodeHandler:     p.NodeHandler,
+		nodeIDHandler:   p.NodeIDHandler,
+		nodeNeighbors:   p.NodeNeighbors,
 	}
 
-	dp.node = NewNodeHandler(cfg, dp.nodeAddressing, p.NodeMap, p.MTU, p.NodeManager, p.DB, p.Devices)
 	return dp
 }
 
@@ -75,15 +80,15 @@ func (l *linuxDatapath) Name() string {
 
 // Node returns the handler for node events
 func (l *linuxDatapath) Node() datapath.NodeHandler {
-	return l.node
+	return l.nodeHandler
 }
 
 func (l *linuxDatapath) NodeIDs() datapath.NodeIDHandler {
-	return l.node
+	return l.nodeIDHandler
 }
 
 func (l *linuxDatapath) NodeNeighbors() datapath.NodeNeighbors {
-	return l.node
+	return l.nodeNeighbors
 }
 
 // LocalNodeAddressing returns the node addressing implementation of the local

--- a/pkg/datapath/linux/datapath_test.go
+++ b/pkg/datapath/linux/datapath_test.go
@@ -18,7 +18,6 @@ type linuxTestSuite struct{}
 var _ = check.Suite(&linuxTestSuite{})
 
 func (s *linuxTestSuite) TestNewDatapath(c *check.C) {
-	dp := NewDatapath(DatapathParams{}, DatapathConfiguration{})
+	dp := NewDatapath(DatapathParams{})
 	c.Assert(dp, check.Not(check.IsNil))
-	c.Assert(dp.Node(), check.Not(check.IsNil))
 }

--- a/pkg/datapath/linux/fuzz_test.go
+++ b/pkg/datapath/linux/fuzz_test.go
@@ -23,7 +23,7 @@ func FuzzNodeHandler(f *testing.F) {
 		}
 		dpConfig := DatapathConfiguration{HostDevice: "veth0"}
 		fakeNodeAddressing := fakeTypes.NewNodeAddressing()
-		linuxNodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil, &fakeTypes.MTU{}, new(mockEnqueuer), nil, nil)
+		linuxNodeHandler := newNodeHandler(dpConfig, fakeNodeAddressing, nil, &fakeTypes.MTU{}, new(mockEnqueuer), nil, nil)
 		if linuxNodeHandler == nil {
 			panic("Should not be nil")
 		}

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -219,14 +219,13 @@ func (s *linuxPrivilegedBaseTestSuite) TestUpdateNodeRoute(c *check.C) {
 		DevicesControllerCell,
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
+			linuxNodeHandler = newNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 	tlog := hivetest.Logger(c)
 	c.Assert(h.Start(tlog, context.TODO()), check.IsNil)
 	defer func() { c.Assert(h.Stop(tlog, context.TODO()), check.IsNil) }()
 
-	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4: s.enableIPv4,
 		EnableIPv6: s.enableIPv6,
@@ -280,7 +279,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestAuxiliaryPrefixes(c *check.C) {
 		DevicesControllerCell,
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
+			linuxNodeHandler = newNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 	tlog := hivetest.Logger(c)
@@ -375,7 +374,7 @@ func (s *linuxPrivilegedBaseTestSuite) commonNodeUpdateEncapsulation(c *check.C,
 		DevicesControllerCell,
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
+			linuxNodeHandler = newNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 	tlog := hivetest.Logger(c)
@@ -655,7 +654,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateIDs(c *check.C) {
 		DevicesControllerCell,
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodeMap, &s.mtuConfig, new(mockEnqueuer), db, devices)
+			linuxNodeHandler = newNodeHandler(dpConfig, s.nodeAddressing, nodeMap, &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 
@@ -815,7 +814,7 @@ func (s *linuxPrivilegedBaseTestSuite) testNodeChurnXFRMLeaksWithConfig(c *check
 		DevicesControllerCell,
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
+			linuxNodeHandler = newNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 
@@ -916,7 +915,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateDirectRouting(c *check.C) {
 		DevicesControllerCell,
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
+			linuxNodeHandler = newNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 
@@ -1143,7 +1142,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestAgentRestartOptionChanges(c *check.C)
 		DevicesControllerCell,
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
+			linuxNodeHandler = newNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 
@@ -1265,7 +1264,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeValidationDirectRouting(c *check.
 		DevicesControllerCell,
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
+			linuxNodeHandler = newNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 
@@ -1436,7 +1435,7 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		DevicesControllerCell,
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: "veth0"}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, mq, db, devices)
+			linuxNodeHandler = newNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, mq, db, devices)
 			mq.nh = linuxNodeHandler
 		}),
 	)
@@ -2196,7 +2195,7 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 		DevicesControllerCell,
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: "veth0"}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, mq, db, devices)
+			linuxNodeHandler = newNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, mq, db, devices)
 			mq.nh = linuxNodeHandler
 		}),
 	)
@@ -2481,7 +2480,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		DevicesControllerCell,
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: "veth0"}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, mq, db, devices)
+			linuxNodeHandler = newNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, mq, db, devices)
 			mq.nh = linuxNodeHandler
 		}),
 	)
@@ -3239,7 +3238,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 		DevicesControllerCell,
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: "veth0"}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, mq, db, devices)
+			linuxNodeHandler = newNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, mq, db, devices)
 			mq.nh = linuxNodeHandler
 		}),
 	)
@@ -3439,7 +3438,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdate(c *check.C, config da
 		DevicesControllerCell,
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
+			linuxNodeHandler = newNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 
@@ -3546,7 +3545,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdateNOP(c *check.C, config
 		DevicesControllerCell,
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
+			linuxNodeHandler = newNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 
@@ -3625,7 +3624,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeValidateImplementation(c *ch
 		DevicesControllerCell,
 		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
 			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
+			linuxNodeHandler = newNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMapV2(), &s.mtuConfig, new(mockEnqueuer), db, devices)
 		}),
 	)
 

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -77,7 +77,7 @@ func (s *linuxTestSuite) TestCreateNodeRoute(c *check.C) {
 
 	fakeNodeAddressing := fakeTypes.NewNodeAddressing()
 
-	nodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil, &mtuConfig, new(mockEnqueuer), nil, nil)
+	nodeHandler := newNodeHandler(dpConfig, fakeNodeAddressing, nil, &mtuConfig, new(mockEnqueuer), nil, nil)
 
 	c1 := cidr.MustParseCIDR("10.10.0.0/16")
 	generatedRoute, err := nodeHandler.createNodeRouteSpec(c1, false)

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -313,8 +313,8 @@ func (l *loader) ReinitializeXDP(ctx context.Context, o datapath.BaseProgramOwne
 	nativeDevices, _ := tables.SelectedDevices(l.devices, l.db.ReadTxn())
 	devices := tables.DeviceNames(nativeDevices)
 
-	o.GetCompilationLock().Lock()
-	defer o.GetCompilationLock().Unlock()
+	l.compilationLock.Lock()
+	defer l.compilationLock.Unlock()
 	return l.reinitializeXDPLocked(ctx, extraCArgs, devices)
 }
 
@@ -332,8 +332,8 @@ func (l *loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 
 	// Lock so that endpoints cannot be built while we are compile base programs.
-	o.GetCompilationLock().Lock()
-	defer o.GetCompilationLock().Unlock()
+	l.compilationLock.Lock()
+	defer l.compilationLock.Unlock()
 	defer func() { firstInitialization = false }()
 
 	l.init(o.Datapath(), o.LocalConfig())

--- a/pkg/datapath/loader/cell.go
+++ b/pkg/datapath/loader/cell.go
@@ -16,6 +16,7 @@ var Cell = cell.Module(
 
 	cell.Config(DefaultConfig),
 	cell.Provide(NewLoader),
+	cell.Provide(newCompilationLock),
 )
 
 // NewLoader returns a new loader.

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -24,6 +24,8 @@ import (
 	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
+	"github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -381,4 +383,12 @@ func compileOverlay(ctx context.Context, opts []string) error {
 		return err
 	}
 	return nil
+}
+
+type compilationLock struct {
+	lock.RWMutex
+}
+
+func newCompilationLock() types.CompilationLock {
+	return &compilationLock{}
 }

--- a/pkg/datapath/loader/hash.go
+++ b/pkg/datapath/loader/hash.go
@@ -11,6 +11,7 @@ import (
 	"io"
 
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
@@ -49,7 +50,7 @@ func hashDatapath(c datapath.ConfigWriter, nodeCfg *datapath.LocalNodeConfigurat
 		_ = c.WriteNodeConfig(d, nodeCfg)
 	}
 	if netdevCfg != nil {
-		_ = c.WriteNetdevConfig(d, netdevCfg)
+		_ = c.WriteNetdevConfig(d, option.Config.Opts)
 	}
 	if epCfg != nil {
 		_ = c.WriteTemplateConfig(d, epCfg)

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -88,6 +88,7 @@ type loader struct {
 	db        *statedb.DB
 	nodeAddrs statedb.Table[tables.NodeAddress]
 	devices   statedb.Table[*tables.Device]
+	prefilter datapath.PreFilter
 }
 
 type Params struct {
@@ -98,6 +99,7 @@ type Params struct {
 	NodeAddrs statedb.Table[tables.NodeAddress]
 	Sysctl    sysctl.Sysctl
 	Devices   statedb.Table[*tables.Device]
+	Prefilter datapath.PreFilter
 }
 
 // newLoader returns a new loader.
@@ -109,6 +111,7 @@ func newLoader(p Params) *loader {
 		sysctl:            p.Sysctl,
 		devices:           p.Devices,
 		hostDpInitialized: make(chan struct{}),
+		prefilter:         p.Prefilter,
 	}
 }
 

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -84,22 +84,24 @@ type loader struct {
 	hostDpInitializedOnce sync.Once
 	hostDpInitialized     chan struct{}
 
-	sysctl    sysctl.Sysctl
-	db        *statedb.DB
-	nodeAddrs statedb.Table[tables.NodeAddress]
-	devices   statedb.Table[*tables.Device]
-	prefilter datapath.PreFilter
+	sysctl          sysctl.Sysctl
+	db              *statedb.DB
+	nodeAddrs       statedb.Table[tables.NodeAddress]
+	devices         statedb.Table[*tables.Device]
+	prefilter       datapath.PreFilter
+	compilationLock datapath.CompilationLock
 }
 
 type Params struct {
 	cell.In
 
-	Config    Config
-	DB        *statedb.DB
-	NodeAddrs statedb.Table[tables.NodeAddress]
-	Sysctl    sysctl.Sysctl
-	Devices   statedb.Table[*tables.Device]
-	Prefilter datapath.PreFilter
+	Config          Config
+	DB              *statedb.DB
+	NodeAddrs       statedb.Table[tables.NodeAddress]
+	Sysctl          sysctl.Sysctl
+	Devices         statedb.Table[*tables.Device]
+	Prefilter       datapath.PreFilter
+	CompilationLock datapath.CompilationLock
 }
 
 // newLoader returns a new loader.
@@ -112,6 +114,7 @@ func newLoader(p Params) *loader {
 		devices:           p.Devices,
 		hostDpInitialized: make(chan struct{}),
 		prefilter:         p.Prefilter,
+		compilationLock:   p.CompilationLock,
 	}
 }
 

--- a/pkg/datapath/loader/types/types.go
+++ b/pkg/datapath/loader/types/types.go
@@ -22,8 +22,8 @@ type Loader interface {
 	ELFSubstitutions(ep types.Endpoint) (map[string]uint64, map[string]string)
 	EndpointHash(cfg types.EndpointConfiguration) (string, error)
 	HostDatapathInitialized() <-chan struct{}
-	Reinitialize(ctx context.Context, o types.BaseProgramOwner, tunnelConfig tunnel.Config, deviceMTU int, iptMgr types.IptablesManager, p types.Proxy) error
-	ReinitializeXDP(ctx context.Context, o types.BaseProgramOwner, extraCArgs []string) error
+	Reinitialize(ctx context.Context, tunnelConfig tunnel.Config, deviceMTU int, iptMgr types.IptablesManager, p types.Proxy) error
+	ReinitializeXDP(ctx context.Context, extraCArgs []string) error
 	ReloadDatapath(ctx context.Context, ep types.Endpoint, stats *metrics.SpanStat) (err error)
 	RestoreTemplates(stateDir string) error
 	Unload(ep types.Endpoint)

--- a/pkg/datapath/orchestrator/cells.go
+++ b/pkg/datapath/orchestrator/cells.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package orchestrator
+
+import (
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/datapath/types"
+)
+
+var Cell = cell.Module(
+	"orchestrator",
+	"Orchestrator",
+
+	cell.Provide(NewOrchestrator),
+)
+
+func NewOrchestrator(params orchestratorParams) types.Orchestrator {
+	return newOrchestrator(params)
+}

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/cilium/hive/cell"
 
+	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/loader/types"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
-	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/mtu"
+	"github.com/cilium/cilium/pkg/proxy"
 )
 
 type orchestrator struct {
@@ -20,7 +22,11 @@ type orchestrator struct {
 type orchestratorParams struct {
 	cell.In
 
-	Loader types.Loader
+	Loader          types.Loader
+	TunnelConfig    tunnel.Config
+	MTU             mtu.MTU
+	IPTablesManager *iptables.Manager
+	Proxy           *proxy.Proxy
 }
 
 func newOrchestrator(params orchestratorParams) *orchestrator {
@@ -29,6 +35,12 @@ func newOrchestrator(params orchestratorParams) *orchestrator {
 	}
 }
 
-func (o *orchestrator) Reinitialize(ctx context.Context, tunnelConfig tunnel.Config, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
-	return o.params.Loader.Reinitialize(ctx, tunnelConfig, deviceMTU, iptMgr, p)
+func (o *orchestrator) Reinitialize(ctx context.Context) error {
+	return o.params.Loader.Reinitialize(
+		ctx,
+		o.params.TunnelConfig,
+		o.params.MTU.GetDeviceMTU(),
+		o.params.IPTablesManager,
+		o.params.Proxy,
+	)
 }

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package orchestrator
+
+import (
+	"context"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/datapath/loader/types"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	datapath "github.com/cilium/cilium/pkg/datapath/types"
+)
+
+type orchestrator struct {
+	params orchestratorParams
+}
+
+type orchestratorParams struct {
+	cell.In
+
+	Loader types.Loader
+}
+
+func newOrchestrator(params orchestratorParams) *orchestrator {
+	return &orchestrator{
+		params: params,
+	}
+}
+
+func (o *orchestrator) Reinitialize(ctx context.Context, owner datapath.BaseProgramOwner, tunnelConfig tunnel.Config, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
+	return o.params.Loader.Reinitialize(ctx, owner, tunnelConfig, deviceMTU, iptMgr, p)
+}

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -29,6 +29,6 @@ func newOrchestrator(params orchestratorParams) *orchestrator {
 	}
 }
 
-func (o *orchestrator) Reinitialize(ctx context.Context, owner datapath.BaseProgramOwner, tunnelConfig tunnel.Config, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
-	return o.params.Loader.Reinitialize(ctx, owner, tunnelConfig, deviceMTU, iptMgr, p)
+func (o *orchestrator) Reinitialize(ctx context.Context, tunnelConfig tunnel.Config, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
+	return o.params.Loader.Reinitialize(ctx, tunnelConfig, deviceMTU, iptMgr, p)
 }

--- a/pkg/datapath/prefilter/cell.go
+++ b/pkg/datapath/prefilter/cell.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package prefilter
+
+import "github.com/cilium/hive/cell"
+
+// Cell provides prefilter, a means of configuring XDP pre-filters for DDoS-mitigation.
+var Cell = cell.Module(
+	"prefilter",
+	"Provides a means of configuring XDP pre-filters for DDoS-mitigation",
+
+	cell.Provide(NewPreFilter),
+)

--- a/pkg/datapath/types/config.go
+++ b/pkg/datapath/types/config.go
@@ -102,7 +102,7 @@ type ConfigWriter interface {
 	// of configurable options to the specified writer. Options specified
 	// here will apply to base programs and not to endpoints, though
 	// endpoints may have equivalent configurable options.
-	WriteNetdevConfig(io.Writer, DeviceConfiguration) error
+	WriteNetdevConfig(io.Writer, *option.IntOptions) error
 
 	// WriteTemplateConfig writes the implementation-specific configuration
 	// of configurable options for BPF templates to the specified writer.

--- a/pkg/datapath/types/datapath.go
+++ b/pkg/datapath/types/datapath.go
@@ -32,4 +32,6 @@ type Datapath interface {
 	LBMap() LBMap
 
 	BandwidthManager() BandwidthManager
+
+	Orchestrator() Orchestrator
 }

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
-	"github.com/cilium/cilium/pkg/lock"
 )
 
 // Loader is an interface to abstract out loading of datapath programs.
@@ -32,7 +31,6 @@ type Loader interface {
 // BaseProgramOwner is any type for which a loader is building base programs.
 type BaseProgramOwner interface {
 	DeviceConfiguration
-	GetCompilationLock() *lock.RWMutex
 	Datapath() Datapath
 	LocalConfig() *LocalNodeConfiguration
 }
@@ -80,4 +78,18 @@ type IptablesManager interface {
 
 	// See comments for InstallNoTrackRules.
 	RemoveNoTrackRules(ip netip.Addr, port uint16)
+}
+
+// CompilationLock is a interface over a mutex, it is used by both the loader, deamon
+// and endpoint manager to lock the compilation process. This is a bit of a layer violation
+// since certain methods on the loader such as CompileAndLoad and CompileOrLoad expect the
+// lock to be taken before being called.
+//
+// Once we have moved header file generation from the endpoint manager into the loader, we can
+// remove this interface and have the loader manage the lock internally.
+type CompilationLock interface {
+	Lock()
+	Unlock()
+	RLock()
+	RUnlock()
 }

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -73,7 +73,7 @@ type IptablesManager interface {
 	RemoveNoTrackRules(ip netip.Addr, port uint16)
 }
 
-// CompilationLock is a interface over a mutex, it is used by both the loader, deamon
+// CompilationLock is a interface over a mutex, it is used by both the loader, daemon
 // and endpoint manager to lock the compilation process. This is a bit of a layer violation
 // since certain methods on the loader such as CompileAndLoad and CompileOrLoad expect the
 // lock to be taken before being called.

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -35,11 +35,11 @@ type BaseProgramOwner interface {
 	GetCompilationLock() *lock.RWMutex
 	Datapath() Datapath
 	LocalConfig() *LocalNodeConfiguration
-	SetPrefilter(pf PreFilter)
 }
 
 // PreFilter an interface for an XDP pre-filter.
 type PreFilter interface {
+	Enabled() bool
 	WriteConfig(fw io.Writer)
 	Dump(to []string) ([]string, int64)
 	Insert(revision int64, cidrs []net.IPNet) error

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -19,20 +19,13 @@ type Loader interface {
 	CustomCallsMapPath(id uint16) string
 	CompileOrLoad(ctx context.Context, ep Endpoint, stats *metrics.SpanStat) error
 	ReloadDatapath(ctx context.Context, ep Endpoint, stats *metrics.SpanStat) error
-	ReinitializeXDP(ctx context.Context, o BaseProgramOwner, extraCArgs []string) error
+	ReinitializeXDP(ctx context.Context, extraCArgs []string) error
 	EndpointHash(cfg EndpointConfiguration) (string, error)
 	Unload(ep Endpoint)
-	Reinitialize(ctx context.Context, o BaseProgramOwner, tunnelConfig tunnel.Config, deviceMTU int, iptMgr IptablesManager, p Proxy) error
+	Reinitialize(ctx context.Context, tunnelConfig tunnel.Config, deviceMTU int, iptMgr IptablesManager, p Proxy) error
 	HostDatapathInitialized() <-chan struct{}
 	RestoreTemplates(stateDir string) error
 	DeviceHasTCProgramLoaded(hostInterface string, checkEgress bool) (bool, error)
-}
-
-// BaseProgramOwner is any type for which a loader is building base programs.
-type BaseProgramOwner interface {
-	DeviceConfiguration
-	Datapath() Datapath
-	LocalConfig() *LocalNodeConfiguration
 }
 
 // PreFilter an interface for an XDP pre-filter.

--- a/pkg/datapath/types/orchestrator.go
+++ b/pkg/datapath/types/orchestrator.go
@@ -10,5 +10,5 @@ import (
 )
 
 type Orchestrator interface {
-	Reinitialize(ctx context.Context, owner BaseProgramOwner, tunnelConfig tunnel.Config, deviceMTU int, iptMgr IptablesManager, p Proxy) error
+	Reinitialize(ctx context.Context, tunnelConfig tunnel.Config, deviceMTU int, iptMgr IptablesManager, p Proxy) error
 }

--- a/pkg/datapath/types/orchestrator.go
+++ b/pkg/datapath/types/orchestrator.go
@@ -5,10 +5,8 @@ package types
 
 import (
 	"context"
-
-	"github.com/cilium/cilium/pkg/datapath/tunnel"
 )
 
 type Orchestrator interface {
-	Reinitialize(ctx context.Context, tunnelConfig tunnel.Config, deviceMTU int, iptMgr IptablesManager, p Proxy) error
+	Reinitialize(ctx context.Context) error
 }

--- a/pkg/datapath/types/orchestrator.go
+++ b/pkg/datapath/types/orchestrator.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+)
+
+type Orchestrator interface {
+	Reinitialize(ctx context.Context, owner BaseProgramOwner, tunnelConfig tunnel.Config, deviceMTU int, iptMgr IptablesManager, p Proxy) error
+}

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -37,7 +37,7 @@ func BenchmarkWriteHeaderfile(b *testing.B) {
 		NodeAddressing: nil,
 		NodeMap:        nil,
 		ConfigWriter:   &config.HeaderfileWriter{},
-	}, linux.DatapathConfiguration{})
+	})
 
 	targetComments := func(w io.Writer) error {
 		return e.writeInformationalComments(w)

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -50,7 +50,7 @@ type EndpointSuite struct {
 	OnGetNamedPorts           func() (npm types.NamedPortMultiMap)
 	OnQueueEndpointBuild      func(ctx context.Context, epID uint64) (func(), error)
 	OnRemoveFromEndpointQueue func(epID uint64)
-	OnGetCompilationLock      func() *lock.RWMutex
+	OnGetCompilationLock      func() datapath.CompilationLock
 	OnSendNotification        func(msg monitorAPI.AgentNotifyMessage) error
 }
 
@@ -92,7 +92,7 @@ func (s *EndpointSuite) QueueEndpointBuild(ctx context.Context, epID uint64) (fu
 	return nil, nil
 }
 
-func (s *EndpointSuite) GetCompilationLock() *lock.RWMutex {
+func (s *EndpointSuite) GetCompilationLock() datapath.CompilationLock {
 	return nil
 }
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
@@ -101,7 +100,7 @@ func (d *DummyOwner) QueueEndpointBuild(ctx context.Context, epID uint64) (func(
 }
 
 // GetCompilationLock does nothing.
-func (d *DummyOwner) GetCompilationLock() *lock.RWMutex {
+func (d *DummyOwner) GetCompilationLock() datapath.CompilationLock {
 	return nil
 }
 

--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -8,7 +8,6 @@ import (
 
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
-	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
 
@@ -19,7 +18,7 @@ type Owner interface {
 
 	// GetCompilationLock returns the mutex responsible for synchronizing compilation
 	// of BPF programs.
-	GetCompilationLock() *lock.RWMutex
+	GetCompilationLock() datapath.CompilationLock
 
 	// SendNotification is called to emit an agent notification
 	SendNotification(msg monitorAPI.AgentNotifyMessage) error

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
-	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
@@ -71,7 +70,7 @@ func (s *EndpointManagerSuite) QueueEndpointBuild(ctx context.Context, epID uint
 	return nil, nil
 }
 
-func (s *EndpointManagerSuite) GetCompilationLock() *lock.RWMutex {
+func (s *EndpointManagerSuite) GetCompilationLock() datapath.CompilationLock {
 	return nil
 }
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
@@ -73,7 +72,7 @@ func (s *DNSProxyTestSuite) QueueEndpointBuild(ctx context.Context, epID uint64)
 	return nil, nil
 }
 
-func (s *DNSProxyTestSuite) GetCompilationLock() *lock.RWMutex {
+func (s *DNSProxyTestSuite) GetCompilationLock() datapath.CompilationLock {
 	return nil
 }
 

--- a/pkg/proxy/cell.go
+++ b/pkg/proxy/cell.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/spf13/pflag"
 
-	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/envoy"
 	monitoragent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/option"
@@ -43,7 +43,7 @@ type proxyParams struct {
 	cell.In
 
 	Config                ProxyConfig
-	Datapath              datapath.Datapath
+	IPTablesManager       *iptables.Manager
 	EndpointInfoRegistry  logger.EndpointInfoRegistry
 	MonitorAgent          monitoragent.Agent
 	EnvoyProxyIntegration *envoyProxyIntegration
@@ -61,15 +61,15 @@ func newProxy(params proxyParams) *Proxy {
 
 	configureProxyLogger(params.EndpointInfoRegistry, params.MonitorAgent, option.Config.AgentLabels)
 
-	return createProxy(params.Config.ProxyPortrangeMin, params.Config.ProxyPortrangeMax, params.Datapath, params.EnvoyProxyIntegration, params.DNSProxyIntegration)
+	return createProxy(params.Config.ProxyPortrangeMin, params.Config.ProxyPortrangeMax, params.IPTablesManager, params.EnvoyProxyIntegration, params.DNSProxyIntegration)
 }
 
 type envoyProxyIntegrationParams struct {
 	cell.In
 
-	Datapath    datapath.Datapath
-	XdsServer   envoy.XDSServer
-	AdminClient *envoy.EnvoyAdminClient
+	IPTablesManager *iptables.Manager
+	XdsServer       envoy.XDSServer
+	AdminClient     *envoy.EnvoyAdminClient
 }
 
 func newEnvoyProxyIntegration(params envoyProxyIntegrationParams) *envoyProxyIntegration {
@@ -78,9 +78,9 @@ func newEnvoyProxyIntegration(params envoyProxyIntegrationParams) *envoyProxyInt
 	}
 
 	return &envoyProxyIntegration{
-		xdsServer:   params.XdsServer,
-		datapath:    params.Datapath,
-		adminClient: params.AdminClient,
+		xdsServer:       params.XdsServer,
+		iptablesManager: params.IPTablesManager,
+		adminClient:     params.AdminClient,
 	}
 }
 

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/completion"
-	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
@@ -26,9 +26,9 @@ type envoyRedirect struct {
 }
 
 type envoyProxyIntegration struct {
-	adminClient *envoy.EnvoyAdminClient
-	xdsServer   envoy.XDSServer
-	datapath    datapath.Datapath
+	adminClient     *envoy.EnvoyAdminClient
+	xdsServer       envoy.XDSServer
+	iptablesManager *iptables.Manager
 }
 
 // createRedirect creates a redirect with corresponding proxy configuration. This will launch a proxy instance.
@@ -54,7 +54,7 @@ func (p *envoyProxyIntegration) handleEnvoyRedirect(r *Redirect, wg *completion.
 		adminClient:  p.adminClient,
 	}
 
-	mayUseOriginalSourceAddr := p.datapath.SupportsOriginalSourceAddr()
+	mayUseOriginalSourceAddr := p.iptablesManager.SupportsOriginalSourceAddr()
 	// Only use original source address for egress
 	if l.ingress {
 		mayUseOriginalSourceAddr = false

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -17,6 +17,7 @@ import (
 	fakecni "github.com/cilium/cilium/daemon/cmd/cni/fake"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
+	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	fqdnproxy "github.com/cilium/cilium/pkg/fqdn/proxy"
 	"github.com/cilium/cilium/pkg/hive"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -71,6 +72,7 @@ func (h *agentHandle) setupCiliumAgentHive(clientset k8sClient.Clientset, extraC
 			func() gc.Enabler { return gc.NewFake() },
 		),
 		fakeDatapath.Cell,
+		prefilter.Cell,
 		monitorAgent.Cell,
 		metrics.Cell,
 		store.Cell,

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -17,6 +17,7 @@ import (
 	fakecni "github.com/cilium/cilium/daemon/cmd/cni/fake"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
+	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	fqdnproxy "github.com/cilium/cilium/pkg/fqdn/proxy"
 	"github.com/cilium/cilium/pkg/hive"
@@ -73,6 +74,7 @@ func (h *agentHandle) setupCiliumAgentHive(clientset k8sClient.Clientset, extraC
 		),
 		fakeDatapath.Cell,
 		prefilter.Cell,
+		loader.Cell,
 		monitorAgent.Cell,
 		metrics.Cell,
 		store.Cell,


### PR DESCRIPTION
We are slowly moving towards a loader that is resilient and reconciles whenever device changes are detected. Currently we have datapath logic to detect device changes, this needs to be reported up all the way to the Daemon which then pushes Reinitilization requests all the way down to the loader. This PR contains a number of preparatory changes that will make it easier for a followup PR to make the datapath / loader reconcile without going through the daemon, based on the devices table.

This PR removes the `BaseProgramOwner` which was one big layer violation. All dependencies the loader needs are now passed via Hive. Only the actual Reinitialize calling still exists, which will be replaced by device based reconciliation in a followup.