### PR TITLE
endpoint: skip Envoy incremental updates if no Envoy redirects (try 2) 

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1162,31 +1162,20 @@ func (e *Endpoint) ApplyPolicyMapChanges(proxyWaitGroup *completion.WaitGroup) e
 
 	e.PolicyDebug(nil, "ApplyPolicyMapChanges")
 
-	changed, err := e.applyPolicyMapChanges()
+	err := e.applyPolicyMapChanges()
 	if err != nil {
 		return err
 	}
 
-	// Only update Envoy if there are envoy redirects and there were queued incremental changes.
-	// This is safe to do here, since a PolicyMapChange cannot
-	// cause an envoy redirect to appear or disappear. It only allows for
-	// incremental updates. Thus, we don't need to worry about stale
-	// policy not being cleaned up.
-	if changed && (e.desiredPolicy.L4Policy.HasEnvoyRedirect() || e.isIngress) {
-		// Ignoring the revertFunc; keep all successful changes even if some fail.
-		e.getLogger().Debug("Endpoint has envoy redirects, applying changes to Envoy")
-		err, _ = e.updateNetworkPolicy(proxyWaitGroup)
-	} else {
-		e.getLogger().Debug("Endpoint has no envoy redirects, skipping Envoy update")
-	}
+	// Ignoring the revertFunc; keep all successful changes even if some fail.
+	err, _ = e.updateNetworkPolicy(proxyWaitGroup)
 
 	return err
 }
 
 // applyPolicyMapChanges applies any incremental policy map changes
 // collected on the desired policy.
-// Returns true if any changes were applied
-func (e *Endpoint) applyPolicyMapChanges() (bool, error) {
+func (e *Endpoint) applyPolicyMapChanges() error {
 	errors := 0
 
 	e.PolicyDebug(nil, "applyPolicyMapChanges")
@@ -1247,17 +1236,16 @@ func (e *Endpoint) applyPolicyMapChanges() (bool, error) {
 	}
 
 	if errors > 0 {
-		return true, fmt.Errorf("updating desired PolicyMap state failed")
+		return fmt.Errorf("updating desired PolicyMap state failed")
 	}
 	if len(adds)+len(deletes) > 0 {
 		e.getLogger().WithFields(logrus.Fields{
 			logfields.AddedPolicyID:   adds,
 			logfields.DeletedPolicyID: deletes,
 		}).Debug("Applied policy map updates due identity changes")
-		return true, nil
 	}
 
-	return false, nil
+	return nil
 }
 
 // syncPolicyMap updates the bpf policy map state based on the
@@ -1266,7 +1254,7 @@ func (e *Endpoint) applyPolicyMapChanges() (bool, error) {
 func (e *Endpoint) syncPolicyMap() error {
 	// Apply pending policy map changes first so that desired map is up-to-date before
 	// we diff the maps below.
-	_, err := e.applyPolicyMapChanges()
+	err := e.applyPolicyMapChanges()
 	if err != nil {
 		return err
 	}
@@ -1374,7 +1362,7 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 
 	// Apply pending policy map changes first so that desired map is up-to-date before
 	// we diff the maps below.
-	_, err := e.applyPolicyMapChanges()
+	err := e.applyPolicyMapChanges()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This commit fixes a bug introduced by #31454.

It removes the check that skips updating Envoy when there are no pending PolicyMap changes. This is because there are cases where endpoint regeneration will flush incremental changes, but not apply them to Envoy.

The basic flow is:

1. thread 1: `e.regenerate() -> e.updateNetworkPolicy()` pushes policy to Envoy
2. thread 2: Generates an incremental update
3. thread 1: `e.regenerate() -> e.applyPolicyMapChanges()` consumes incremental update but **does not apply it to envoy**
4. thread 1: unlocks endpoint, returns
5. thread 2: `e.ApplyPolicyMapChanges()` consumes incremental update, applies to envoy

However, in this case, there is no pending incremental update **for the BPF maps**. The previous version of this code also skipped updating Envoy, which was incorrect.