### PR TITLE
etcd: fix lock leases reporting in status

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1079,7 +1079,7 @@ func (e *etcdClient) statusChecker() {
 		default:
 			e.latestErrorStatus = nil
 			e.latestStatusSnapshot = fmt.Sprintf("etcd: %d/%d connected, leases=%d, lock leases=%d, has-quorum=%s: %s",
-				ok, len(endpoints), e.leaseManager.TotalLeases(), e.leaseManager.TotalLeases(), quorumString, strings.Join(newStatus, "; "))
+				ok, len(endpoints), e.leaseManager.TotalLeases(), e.lockLeaseManager.TotalLeases(), quorumString, strings.Join(newStatus, "; "))
 		}
 
 		e.statusLock.Unlock()


### PR DESCRIPTION
Status was incorrectly reporting the number of generic leases twice, rather than generic and lock leases. Let's fix it.

Fixes: c6eb358b7bab ("etcd: switch lock session to lease manager")

<!-- Description of change -->

```release-note
Fix incorrect reporting of the number of etcd lock leases in cilium-dbg status.
```
