### PR TITLE
endpoint / ApplyPolicyMapChanges: fix incorrect comment

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1167,7 +1167,7 @@ func (e *Endpoint) ApplyPolicyMapChanges(proxyWaitGroup *completion.WaitGroup) e
 		return err
 	}
 
-	// Only update Envoy if there are envoy redirects and there were queued incremental changes.
+	// Only update Envoy if there are envoy redirects.
 	// This is safe to do here, since a PolicyMapChange cannot
 	// cause an envoy redirect to appear or disappear. It only allows for
 	// incremental updates. Thus, we don't need to worry about stale


### PR DESCRIPTION
This comment incorrectly referenced some now-reverted behavior. Remove this now so we don't confuse ourselves.

Fixes: #31775
