### PR TITLE
loader: remove CompileAndLoad

### DIFF
--- a/pkg/datapath/fake/types/datapath.go
+++ b/pkg/datapath/fake/types/datapath.go
@@ -121,10 +121,6 @@ func (f *FakeDatapath) BandwidthManager() datapath.BandwidthManager {
 type FakeLoader struct {
 }
 
-func (f *FakeLoader) CompileAndLoad(ctx context.Context, ep datapath.Endpoint, stats *metrics.SpanStat) error {
-	panic("implement me")
-}
-
 func (f *FakeLoader) CompileOrLoad(ctx context.Context, ep datapath.Endpoint, stats *metrics.SpanStat) error {
 	panic("implement me")
 }

--- a/pkg/datapath/loader/cache_test.go
+++ b/pkg/datapath/loader/cache_test.go
@@ -29,25 +29,27 @@ func TestObjectCache(t *testing.T) {
 	cache := newObjectCache(configWriterForTest(t), nil, tmpDir)
 	realEP := testutils.NewTestEndpoint()
 
+	dir := getDirs(t)
+
 	// First run should compile and generate the object.
-	_, isNew, err := cache.fetchOrCompile(ctx, &realEP, nil)
+	_, isNew, err := cache.fetchOrCompile(ctx, &realEP, dir, nil)
 	require.Nil(t, err)
 	require.Equal(t, isNew, true)
 
 	// Same EP should not be compiled twice.
-	_, isNew, err = cache.fetchOrCompile(ctx, &realEP, nil)
+	_, isNew, err = cache.fetchOrCompile(ctx, &realEP, dir, nil)
 	require.Nil(t, err)
 	require.Equal(t, isNew, false)
 
 	// Changing the ID should not generate a new object.
 	realEP.Id++
-	_, isNew, err = cache.fetchOrCompile(ctx, &realEP, nil)
+	_, isNew, err = cache.fetchOrCompile(ctx, &realEP, dir, nil)
 	require.Nil(t, err)
 	require.Equal(t, isNew, false)
 
 	// Changing a setting on the EP should generate a new object.
 	realEP.Opts.SetBool("foo", true)
-	_, isNew, err = cache.fetchOrCompile(ctx, &realEP, nil)
+	_, isNew, err = cache.fetchOrCompile(ctx, &realEP, dir, nil)
 	require.Nil(t, err)
 	require.Equal(t, isNew, true)
 }
@@ -111,7 +113,7 @@ func TestObjectCacheParallel(t *testing.T) {
 				ep := testutils.NewTestEndpoint()
 				opt := fmt.Sprintf("OPT%d", i/test.divisor)
 				ep.Opts.SetBool(opt, true)
-				file, isNew, err := cache.fetchOrCompile(ctx, &ep, nil)
+				file, isNew, err := cache.fetchOrCompile(ctx, &ep, getDirs(t), nil)
 				path := ""
 				if file != nil {
 					path = file.Name()

--- a/pkg/datapath/loader/cache_test.go
+++ b/pkg/datapath/loader/cache_test.go
@@ -33,24 +33,24 @@ func TestObjectCache(t *testing.T) {
 
 	// First run should compile and generate the object.
 	_, isNew, err := cache.fetchOrCompile(ctx, &realEP, dir, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, isNew, true)
 
 	// Same EP should not be compiled twice.
 	_, isNew, err = cache.fetchOrCompile(ctx, &realEP, dir, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, isNew, false)
 
 	// Changing the ID should not generate a new object.
 	realEP.Id++
 	_, isNew, err = cache.fetchOrCompile(ctx, &realEP, dir, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, isNew, false)
 
 	// Changing a setting on the EP should generate a new object.
 	realEP.Opts.SetBool("foo", true)
 	_, isNew, err = cache.fetchOrCompile(ctx, &realEP, dir, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, isNew, true)
 }
 
@@ -132,7 +132,7 @@ func TestObjectCacheParallel(t *testing.T) {
 		used := make(map[string]int, test.builds)
 		for i := 0; i < test.builds; i++ {
 			result, err := receiveResult(t, results)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			used[result.path] = used[result.path] + 1
 			if result.compiled {

--- a/pkg/datapath/loader/compile_test.go
+++ b/pkg/datapath/loader/compile_test.go
@@ -34,10 +34,10 @@ func TestCompile(t *testing.T) {
 		name := fmt.Sprintf("%s:%s", prog.OutputType, prog.Output)
 		t.Run(name, func(t *testing.T) {
 			path, err := compile(context.Background(), prog, dirs)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			stat, err := os.Stat(path)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.False(t, stat.IsDir())
 			require.NotZero(t, stat.Size())
 		})

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -95,7 +95,7 @@ func testCompileOrLoad(t *testing.T, ep *testutils.TestEndpoint) {
 
 	l := newTestLoader(t)
 	err := l.compileOrLoad(ctx, ep, getEpDirs(ep), stats)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 // TestCompileOrLoadDefaultEndpoint checks that the datapath can be compiled
@@ -129,7 +129,7 @@ func TestReload(t *testing.T) {
 
 	dirInfo := getEpDirs(&ep)
 	err := compileDatapath(ctx, dirInfo, false, log)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	objPath := fmt.Sprintf("%s/%s", dirInfo.Output, endpointObj)
 	progs := []progDefinition{
@@ -143,12 +143,12 @@ func TestReload(t *testing.T) {
 		linkDir:  testutils.TempBPFFS(t),
 	}
 	finalize, err := replaceDatapath(ctx, opts)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	finalize()
 
 	finalize, err = replaceDatapath(ctx, opts)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	finalize()
 }
 
@@ -174,7 +174,7 @@ func testCompileFailure(t *testing.T, ep *testutils.TestEndpoint) {
 	for err == nil && time.Now().Before(timeout) {
 		err = l.compileOrLoad(ctx, ep, getEpDirs(ep), stats)
 	}
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 // TestCompileFailureDefaultEndpoint attempts to compile then cancels the

--- a/pkg/datapath/loader/template_test.go
+++ b/pkg/datapath/loader/template_test.go
@@ -24,9 +24,9 @@ func TestWrap(t *testing.T) {
 
 	// Write the configuration that should be the same, and verify it is.
 	err := cfg.WriteTemplateConfig(&realEPBuffer, &realEP)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = cfg.WriteTemplateConfig(&templateBuffer, template)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, realEPBuffer.String(), templateBuffer.String())
 
 	// Write with the static data, and verify that the buffers differ.
@@ -36,9 +36,9 @@ func TestWrap(t *testing.T) {
 	realEPBuffer.Reset()
 	templateBuffer.Reset()
 	err = cfg.WriteEndpointConfig(&realEPBuffer, &realEP)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = cfg.WriteEndpointConfig(&templateBuffer, template)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.NotEqual(t, realEPBuffer.String(), templateBuffer.String())
 }

--- a/pkg/datapath/loader/types/types.go
+++ b/pkg/datapath/loader/types/types.go
@@ -15,7 +15,6 @@ import (
 
 type Loader interface {
 	CallsMapPath(id uint16) string
-	CompileAndLoad(ctx context.Context, ep types.Endpoint, stats *metrics.SpanStat) error
 	CompileOrLoad(ctx context.Context, ep types.Endpoint, stats *metrics.SpanStat) error
 	CustomCallsMapPath(id uint16) string
 	DetachXDP(iface netlink.Link, bpffsBase, progName string) error

--- a/pkg/datapath/loader/util_test.go
+++ b/pkg/datapath/loader/util_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
+	"github.com/cilium/cilium/pkg/maps/callsmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -33,11 +35,18 @@ func setupCompilationDirectories(tb testing.TB) {
 		fmt.Sprintf("-I%s", filepath.Join(bpfDir, "include")),
 	}
 
+	oldElfMapPrefixes := elfMapPrefixes
+	elfMapPrefixes = []string{
+		fmt.Sprintf("test_%s", policymap.MapName),
+		fmt.Sprintf("test_%s", callsmap.MapName),
+	}
+
 	tb.Cleanup(func() {
 		option.Config.DryMode = false
 		option.Config.BpfDir = ""
 		option.Config.StateDir = ""
 		testIncludes = nil
+		elfMapPrefixes = oldElfMapPrefixes
 	})
 }
 

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -18,7 +18,6 @@ import (
 type Loader interface {
 	CallsMapPath(id uint16) string
 	CustomCallsMapPath(id uint16) string
-	CompileAndLoad(ctx context.Context, ep Endpoint, stats *metrics.SpanStat) error
 	CompileOrLoad(ctx context.Context, ep Endpoint, stats *metrics.SpanStat) error
 	ReloadDatapath(ctx context.Context, ep Endpoint, stats *metrics.SpanStat) error
 	ReinitializeXDP(ctx context.Context, o BaseProgramOwner, extraCArgs []string) error

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -662,11 +662,7 @@ func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (compilati
 		}
 
 		// Compile and install BPF programs for this endpoint
-		if datapathRegenCtxt.regenerationLevel == regeneration.RegenerateWithDatapathRebuild {
-			err = e.owner.Datapath().Loader().CompileAndLoad(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache, &stats.datapathRealization)
-			e.getLogger().WithError(err).Info("Regenerated endpoint BPF program")
-			compilationExecuted = true
-		} else if datapathRegenCtxt.regenerationLevel == regeneration.RegenerateWithDatapathRewrite {
+		if datapathRegenCtxt.regenerationLevel == regeneration.RegenerateWithDatapathRewrite {
 			err = e.owner.Datapath().Loader().CompileOrLoad(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache, &stats.datapathRealization)
 			if err == nil {
 				e.getLogger().Info("Rewrote endpoint BPF program")

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1075,16 +1075,10 @@ func (e *Endpoint) Update(cfg *models.EndpointConfigurationSpec) error {
 		RegenerationLevel: regeneration.RegenerateWithoutDatapath,
 	}
 
-	// If configuration options are provided, we only regenerate if necessary.
-	// Otherwise always regenerate.
-	if cfg.Options == nil {
-		regenCtx.RegenerationLevel = regeneration.RegenerateWithDatapathRebuild
-		regenCtx.Reason = "endpoint was manually regenerated via API"
-	} else if e.updateAndOverrideEndpointOptions(om) || e.status.CurrentStatus() != OK {
+	// Only regenerate if necessary.
+	if cfg.Options == nil || e.updateAndOverrideEndpointOptions(om) || e.status.CurrentStatus() != OK {
 		regenCtx.RegenerationLevel = regeneration.RegenerateWithDatapathRewrite
-	}
 
-	if regenCtx.RegenerationLevel > regeneration.RegenerateWithoutDatapath {
 		e.getLogger().Debug("need to regenerate endpoint; checking state before" +
 			" attempting to regenerate")
 

--- a/pkg/endpoint/regeneration/regeneration_context.go
+++ b/pkg/endpoint/regeneration/regeneration_context.go
@@ -24,9 +24,6 @@ const (
 	// RegenerateWithDatapathRewrite indicates that the datapath must be
 	// recompiled and reloaded to implement this regeneration.
 	RegenerateWithDatapathRewrite
-	// RegenerateWithDatapathRebuild indicates that the datapath must be
-	// fully recompiled and reloaded without using any cached templates.
-	RegenerateWithDatapathRebuild
 )
 
 // String converts a DatapathRegenerationLevel into a human-readable string.
@@ -40,8 +37,6 @@ func (r DatapathRegenerationLevel) String() string {
 		return "reload"
 	case RegenerateWithDatapathRewrite:
 		return "rewrite+load"
-	case RegenerateWithDatapathRebuild:
-		return "compile+load"
 	default:
 		break
 	}


### PR DESCRIPTION
loader: remove unused CompileAndLoad mode

    Endpoint calls into the loader in different "modes", depending on how much
    the configuration has changed.

    1. ReloadDatapath: re-attach programs without compiling them.

    2. CompileOrLoad: re-attach a program, possibly retrieving it
      a cache.

    3. CompileAndLoad: re-attach a program without retrieving it
      from cache.

    CompileAndLoad does completely bypass the cache, but at the same time
    doesn't invalidate it. The following sequence of calls would therefore reuse
    an old (cached) program:

        CompileOrLoad()
       CompileAndLoad()
       CompileOrLoad() // back to the cached program from above

    According to Joe Stringer, CompileAndLoad mode was meant as an escape hatch
    to debug caching bugs. This never really materialised so we can simplify the
    loader by removing the code path outright.

    Tests for CompileAndLoad are simply changed to call CompileOrLoad.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

loader: use require helpers for errors

    Use require.Error and require.NoError instead of the Nil variants. This
    leads to more readable error messages.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
