### PR TITLE
[v1.14] bpf: avoid SNAT tracking for overlay traffic

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1492,7 +1492,8 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 			if (allow_vlan(ctx->ifindex, vlan_id))
 				return CTX_ACT_OK;
 			else
-				return send_drop_notify_error(ctx, 0, DROP_VLAN_FILTERED,
+				return send_drop_notify_error(ctx, src_sec_identity,
+							      DROP_VLAN_FILTERED,
 							      CTX_ACT_DROP, METRIC_EGRESS);
 		}
 	}
@@ -1503,7 +1504,8 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 
 		ctx->mark = 0;
 		tail_call_dynamic(ctx, &POLICY_EGRESSCALL_MAP, lxc_id);
-		return send_drop_notify_error(ctx, 0, DROP_MISSED_TAIL_CALL,
+		return send_drop_notify_error(ctx, src_sec_identity,
+					      DROP_MISSED_TAIL_CALL,
 					      CTX_ACT_DROP, METRIC_EGRESS);
 	}
 #endif
@@ -1541,8 +1543,9 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 	}
 out:
 	if (IS_ERR(ret))
-		return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_EGRESS);
+		return send_drop_notify_error_ext(ctx, src_sec_identity,
+						  ret, ext_err, CTX_ACT_DROP,
+						  METRIC_EGRESS);
 #endif /* ENABLE_HOST_FIREWALL */
 
 #if defined(ENABLE_BANDWIDTH_MANAGER)
@@ -1570,8 +1573,8 @@ out:
 	if (ret == CTX_ACT_REDIRECT)
 		return ret;
 	else if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
-					      METRIC_EGRESS);
+		return send_drop_notify_error(ctx, src_sec_identity, ret,
+					      CTX_ACT_DROP, METRIC_EGRESS);
 #endif /* ENABLE_WIREGUARD */
 
 #ifdef ENABLE_SRV6
@@ -1606,8 +1609,8 @@ out:
 
 __maybe_unused exit:
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
-					      METRIC_EGRESS);
+		return send_drop_notify_error(ctx, src_sec_identity, ret,
+					      CTX_ACT_DROP, METRIC_EGRESS);
 	send_trace_notify(ctx, TRACE_TO_NETWORK, 0, 0, 0,
 			  0, trace.reason, trace.monitor);
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1586,7 +1586,7 @@ out:
 #endif
 
 #ifdef ENABLE_NODEPORT
-	if (!ctx_snat_done(ctx)) {
+	if (!ctx_snat_done(ctx) && !ctx_is_overlay(ctx)) {
 		/*
 		 * handle_nat_fwd tail calls in the majority of cases,
 		 * so control might never return to this program.

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -485,7 +485,8 @@ int tail_handle_ipv6_from_netdev(struct __ctx_buff *ctx)
 
 # ifdef ENABLE_HOST_FIREWALL
 static __always_inline int
-handle_to_netdev_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext_err)
+handle_to_netdev_ipv6(struct __ctx_buff *ctx, __u32 src_sec_identity,
+		      struct trace_ctx *trace, __s8 *ext_err)
 {
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
@@ -509,9 +510,8 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext
 			return ret;
 	}
 
-	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_HOST)
-		srcid = HOST_ID;
-	srcid = resolve_srcid_ipv6(ctx, ip6, srcid, &ipcache_srcid, true);
+	srcid = resolve_srcid_ipv6(ctx, ip6, src_sec_identity,
+				   &ipcache_srcid, true);
 
 	/* to-netdev is attached to the egress path of the native device. */
 	return ipv6_host_policy_egress(ctx, srcid, ipcache_srcid, ip6, trace, ext_err);
@@ -939,19 +939,18 @@ int tail_handle_ipv4_from_netdev(struct __ctx_buff *ctx)
 
 #ifdef ENABLE_HOST_FIREWALL
 static __always_inline int
-handle_to_netdev_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext_err)
+handle_to_netdev_ipv4(struct __ctx_buff *ctx, __u32 src_sec_identity,
+		      struct trace_ctx *trace, __s8 *ext_err)
 {
 	void *data, *data_end;
 	struct iphdr *ip4;
 	__u32 src_id = 0, ipcache_srcid = 0;
 
-	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_HOST)
-		src_id = HOST_ID;
-
 	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
-	src_id = resolve_srcid_ipv4(ctx, ip4, src_id, &ipcache_srcid, true);
+	src_id = resolve_srcid_ipv4(ctx, ip4, src_sec_identity,
+				    &ipcache_srcid, true);
 
 	/* We need to pass the srcid from ipcache to host firewall. See
 	 * comment in ipv4_host_policy_egress() for details.
@@ -1469,16 +1468,21 @@ int cil_from_host(struct __ctx_buff *ctx)
 __section_entry
 int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 {
+	__u32 magic = ctx->mark & MARK_MAGIC_HOST_MASK;
 	struct trace_ctx trace = {
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = 0,
 	};
 	__u32 __maybe_unused vlan_id;
+	__u32 src_sec_identity = 0;
 	int ret = CTX_ACT_OK;
 #ifdef ENABLE_HOST_FIREWALL
 	__s8 ext_err = 0;
 	__u16 proto = 0;
 #endif
+
+	if (magic == MARK_MAGIC_HOST || magic == MARK_MAGIC_OVERLAY)
+		src_sec_identity = HOST_ID;
 
 	/* Filter allowed vlan id's and pass them back to kernel.
 	 */
@@ -1494,17 +1498,13 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 	}
 
 #if defined(ENABLE_L7_LB)
-	{
-		__u32 magic = ctx->mark & MARK_MAGIC_HOST_MASK;
+	if (magic == MARK_MAGIC_PROXY_EGRESS_EPID) {
+		__u32 lxc_id = get_epid(ctx);
 
-		if (magic == MARK_MAGIC_PROXY_EGRESS_EPID) {
-			__u32 lxc_id = get_epid(ctx);
-
-			ctx->mark = 0;
-			tail_call_dynamic(ctx, &POLICY_EGRESSCALL_MAP, lxc_id);
-			return send_drop_notify_error(ctx, 0, DROP_MISSED_TAIL_CALL,
-						      CTX_ACT_DROP, METRIC_EGRESS);
-		}
+		ctx->mark = 0;
+		tail_call_dynamic(ctx, &POLICY_EGRESSCALL_MAP, lxc_id);
+		return send_drop_notify_error(ctx, 0, DROP_MISSED_TAIL_CALL,
+					      CTX_ACT_DROP, METRIC_EGRESS);
 	}
 #endif
 
@@ -1524,12 +1524,14 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 # endif
 # ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		ret = handle_to_netdev_ipv6(ctx, &trace, &ext_err);
+		ret = handle_to_netdev_ipv6(ctx, src_sec_identity,
+					    &trace, &ext_err);
 		break;
 # endif
 # ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP): {
-		ret = handle_to_netdev_ipv4(ctx, &trace, &ext_err);
+		ret = handle_to_netdev_ipv4(ctx, src_sec_identity,
+					    &trace, &ext_err);
 		break;
 	}
 # endif

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -49,7 +49,7 @@
 
 #if defined(ENCAP_IFINDEX) || defined(ENABLE_EGRESS_GATEWAY) || \
     (defined(ENABLE_DSR) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE)
-#define HAVE_ENCAP
+#define HAVE_ENCAP	1
 
 /* NOT_VTEP_DST is passed to an encapsulation function when the
  * destination of the tunnel is not a VTEP.
@@ -675,6 +675,7 @@ enum metric_dir {
 #define MARK_MAGIC_IDENTITY		0x0F00 /* mark carries identity */
 #define MARK_MAGIC_TO_PROXY		0x0200
 #define MARK_MAGIC_SNAT_DONE		0x0300
+#define MARK_MAGIC_OVERLAY		0x0400
 
 #define MARK_MAGIC_KEY_MASK		0xFF00
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -969,8 +969,7 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 	if (IS_ERR(ret))
 		goto drop_err;
 
-	if (is_defined(IS_BPF_HOST))
-		ctx_snat_done_set(ctx);
+	ctx_snat_done_set(ctx);
 
 #ifdef TUNNEL_MODE
 	if (tunnel_endpoint) {
@@ -2362,8 +2361,10 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 	if (IS_ERR(ret))
 		goto drop_err;
 
-	if (is_defined(IS_BPF_HOST))
-		ctx_snat_done_set(ctx);
+	/* This is also needed for from-overlay, to avoid a second SNAT by
+	 * to-overlay or to-netdev.
+	 */
+	ctx_snat_done_set(ctx);
 
 #ifdef TUNNEL_MODE
 	if (tunnel_endpoint) {

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -189,6 +189,20 @@ static __always_inline bool ctx_snat_done(const struct __sk_buff *ctx)
 	return (ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_SNAT_DONE;
 }
 
+static __always_inline void ctx_set_overlay_mark(struct __sk_buff *ctx)
+{
+	ctx->mark &= ~MARK_MAGIC_HOST_MASK;
+	ctx->mark |= MARK_MAGIC_OVERLAY;
+}
+
+static __always_inline bool ctx_is_overlay(const struct __sk_buff *ctx)
+{
+	if (!is_defined(HAVE_ENCAP))
+		return false;
+
+	return (ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_OVERLAY;
+}
+
 #ifdef HAVE_ENCAP
 static __always_inline __maybe_unused int
 ctx_set_encap_info(struct __sk_buff *ctx, __u32 src_ip,

--- a/bpf/tests/ipsec_from_host_test.c
+++ b/bpf/tests/ipsec_from_host_test.c
@@ -1,22 +1,21 @@
 // SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 /* Copyright Authors of Cilium */
 
-#include "common.h"
-#include <bpf/ctx/skb.h>
-#include "pktgen.h"
-#define ROUTER_IP
-#include "config_replacement.h"
-#undef ROUTER_IP
-
 #define NODE_ID 2333
 #define ENCRYPT_KEY 3
 #define ENABLE_IPV4
 #define ENABLE_IPV6
 #define ENABLE_IPSEC
 #define TUNNEL_MODE
-#define HAVE_ENCAP
 #define ENCAP_IFINDEX 4
 #define SECCTX_FROM_IPCACHE 1
+
+#include "common.h"
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+#define ROUTER_IP
+#include "config_replacement.h"
+#undef ROUTER_IP
 
 #define skb_set_tunnel_key mock_skb_set_tunnel_key
 #define ctx_redirect mock_ctx_redirect

--- a/bpf/tests/ipsec_from_lxc_test.c
+++ b/bpf/tests/ipsec_from_lxc_test.c
@@ -1,21 +1,20 @@
 // SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 /* Copyright Authors of Cilium */
 
-#include "common.h"
-#include <bpf/ctx/skb.h>
-#include "pktgen.h"
-#define ROUTER_IP
-#include "config_replacement.h"
-#undef ROUTER_IP
-
 #define NODE_ID 2333
 #define ENCRYPT_KEY 3
 #define ENABLE_IPV4
 #define ENABLE_IPV6
 #define ENABLE_IPSEC
 #define TUNNEL_MODE
-#define HAVE_ENCAP
 #define ENCAP_IFINDEX 4
+
+#include "common.h"
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+#define ROUTER_IP
+#include "config_replacement.h"
+#undef ROUTER_IP
 
 #include "bpf_lxc.c"
 

--- a/bpf/tests/ipsec_from_overlay_test.c
+++ b/bpf/tests/ipsec_from_overlay_test.c
@@ -1,6 +1,16 @@
 // SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 /* Copyright Authors of Cilium */
 
+#define NODE_ID 2333
+#define ENCRYPT_KEY 3
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_IPSEC
+#define TUNNEL_MODE
+#define ENCAP_IFINDEX 4
+#define DEST_IFINDEX 5
+#define DEST_LXC_ID 200
+
 #include "common.h"
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
@@ -9,17 +19,6 @@
 #include "config_replacement.h"
 #undef ROUTER_IP
 #undef SECLABEL
-
-#define NODE_ID 2333
-#define ENCRYPT_KEY 3
-#define ENABLE_IPV4
-#define ENABLE_IPV6
-#define ENABLE_IPSEC
-#define TUNNEL_MODE
-#define HAVE_ENCAP
-#define ENCAP_IFINDEX 4
-#define DEST_IFINDEX 5
-#define DEST_LXC_ID 200
 
 #define skb_change_type mock_skb_change_type
 int mock_skb_change_type(__maybe_unused struct __sk_buff *skb, __u32 type)

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1407,6 +1407,7 @@ func (m *IptablesManager) installHostTrafficMarkRule(prog iptablesInterface) err
 	// originated from the host.
 	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
 	matchFromIPSecDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
+	matchOverlay := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkOverlay, linux_defaults.MagicMarkHostMask)
 	matchFromProxy := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxy, linux_defaults.MagicMarkProxyMask)
 	matchFromProxyEPID := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxyEPID, linux_defaults.MagicMarkProxyMask)
 	matchFromDNSProxy := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIdentity, linux_defaults.MagicMarkHostMask)
@@ -1417,6 +1418,7 @@ func (m *IptablesManager) installHostTrafficMarkRule(prog iptablesInterface) err
 		"-A", ciliumOutputChain,
 		"-m", "mark", "!", "--mark", matchFromIPSecDecrypt, // Don't match ipsec traffic
 		"-m", "mark", "!", "--mark", matchFromIPSecEncrypt, // Don't match ipsec traffic
+		"-m", "mark", "!", "--mark", matchOverlay, // Don't match Cilium's overlay traffic
 		"-m", "mark", "!", "--mark", matchFromProxy, // Don't match proxy traffic
 		"-m", "mark", "!", "--mark", matchFromProxyEPID, // Don't match proxy traffic
 		"-m", "mark", "!", "--mark", matchFromDNSProxy, // Don't match DNS proxy egress traffic

--- a/pkg/datapath/linux/linux_defaults/mark.go
+++ b/pkg/datapath/linux/linux_defaults/mark.go
@@ -52,6 +52,12 @@ const (
 	// to a proxy.
 	MagicMarkIsToProxy uint32 = 0x0200
 
+	MagicMarkSNATDone int = 0x0300
+
+	// MagicMarkOverlay is set by the to-overlay program, and can be used
+	// to identify cilium-managed overlay traffic.
+	MagicMarkOverlay int = 0x0400
+
 	// MagicMarkProxyEgressEPID determines that the traffic is sourced from
 	// the proxy which is capturing traffic before it is subject to egress
 	// policy enforcement that must be done after the proxy. The identity


### PR DESCRIPTION
Manual backport of 

* [ ] #31737 (adjustments as the tests were structured differently)
* [ ] #31082 (resolved a bunch of contextual conflicts, and dropped the last two patches as they don't apply to `v1.14`)
* [ ] #31818
* [ ] #32116

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 31737 31082 31818 32116
```
