### PR TITLE
bpf: use node map spi field in set_ipsec_encrypt

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -397,7 +397,7 @@ skip_tunnel:
 	/* See IPv4 comment. */
 	if (from_proxy && info->tunnel_endpoint && encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
-					 info->sec_identity, true);
+					 info->sec_identity, true, false);
 #endif
 
 	return CTX_ACT_OK;
@@ -853,7 +853,7 @@ skip_tunnel:
 	/* We encrypt host to remote pod packets only if they are from proxy. */
 	if (from_proxy && info->tunnel_endpoint && encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
-					 info->sec_identity, true);
+					 info->sec_identity, true, false);
 #endif
 
 	return CTX_ACT_OK;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -706,7 +706,8 @@ pass_to_stack:
 #ifndef TUNNEL_MODE
 # ifdef ENABLE_IPSEC
 	if (encrypt_key && tunnel_endpoint) {
-		ret = set_ipsec_encrypt(ctx, encrypt_key, tunnel_endpoint, SECLABEL_IPV6, false);
+		ret = set_ipsec_encrypt(ctx, encrypt_key, tunnel_endpoint,
+					SECLABEL_IPV6, false, false);
 		if (unlikely(ret != CTX_ACT_OK))
 			return ret;
 	} else
@@ -1286,7 +1287,8 @@ pass_to_stack:
 #ifndef TUNNEL_MODE
 # ifdef ENABLE_IPSEC
 	if (encrypt_key && tunnel_endpoint) {
-		ret = set_ipsec_encrypt(ctx, encrypt_key, tunnel_endpoint, SECLABEL_IPV4, false);
+		ret = set_ipsec_encrypt(ctx, encrypt_key, tunnel_endpoint,
+					SECLABEL_IPV4, false, false);
 		if (unlikely(ret != CTX_ACT_OK))
 			return ret;
 	} else

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -75,7 +75,7 @@ encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 #ifdef ENABLE_IPSEC
 	if (encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, tunnel_endpoint,
-					 seclabel, true);
+					 seclabel, true, false);
 #endif
 
 	return __encap_and_redirect_with_nodeid(ctx, 0, tunnel_endpoint,
@@ -97,7 +97,7 @@ __encap_and_redirect_lxc(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 #ifdef ENABLE_IPSEC
 	if (encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, tunnel_endpoint,
-					 seclabel, false);
+					 seclabel, false, false);
 #endif
 
 	return encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, 0, seclabel,
@@ -147,7 +147,7 @@ encap_and_redirect_lxc(struct __ctx_buff *ctx,
 		__u8 min_encrypt_key = get_min_encrypt_key(tunnel->key);
 
 		return set_ipsec_encrypt(ctx, min_encrypt_key, tunnel->ip4,
-					 seclabel, false);
+					 seclabel, false, false);
 	}
 # endif
 	return encap_and_redirect_with_nodeid(ctx, tunnel->ip4, 0, seclabel, dstid,
@@ -169,7 +169,7 @@ encap_and_redirect_netdev(struct __ctx_buff *ctx, struct tunnel_key *k,
 #ifdef ENABLE_IPSEC
 	if (encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, tunnel->ip4,
-					 seclabel, true);
+					 seclabel, true, false);
 #endif
 
 	return encap_and_redirect_with_nodeid(ctx, tunnel->ip4, 0, seclabel, 0,


### PR DESCRIPTION
Updates `set_ipsec_encrypt` to allow an SPI to be retrieved from the node map when creating an encryption mark.

This is especially useful when Encrypted Overlay is enabled, allowing us to obtain the SPI via the VXLAN tunnel endpoint IP.

```release-note
bpf: update `set_ipsec_encrypt` to optionally fill SPI with node map value
```
