### PR TITLE
cni: Improve logging with common fields

### DIFF
--- a/plugins/cilium-cni/cmd/endpoint.go
+++ b/plugins/cilium-cni/cmd/endpoint.go
@@ -20,7 +20,7 @@ type EndpointConfigurator interface {
 }
 
 // EndpointConfiguration determines the configuration of an endpoint to be
-// created duing a CNI ADD invocation.
+// created during a CNI ADD invocation.
 type EndpointConfiguration interface {
 	// IfName specifies the container interface name to be used for this endpoint
 	IfName() string

--- a/plugins/cilium-cni/cmd/interface.go
+++ b/plugins/cilium-cni/cmd/interface.go
@@ -37,7 +37,7 @@ func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, 
 	}
 	// Coalesce CIDRs into minimum set needed for route rules
 	// The routes set up here will be cleaned up by linuxrouting.Delete.
-	// Therefore the code here should be kept in sync with the deletion code.
+	// Therefor the code here should be kept in sync with the deletion code.
 	ipv4CIDRs, _ := ip.CoalesceCIDRs(allCIDRs)
 	cidrs := make([]string, 0, len(ipv4CIDRs))
 	for _, cidr := range ipv4CIDRs {

--- a/plugins/cilium-cni/lib/deletion_queue.go
+++ b/plugins/cilium-cni/lib/deletion_queue.go
@@ -151,7 +151,7 @@ func (dc *DeletionFallbackClient) enqueueDeletionRequestLocked(contents string) 
 	// sanity check: if there are too many queued deletes, just return error
 	// back up to the kubelet. If we get here, it's either because something
 	// has gone wrong with the kubelet, or the agent has been down for a very
-	// long time. To guard aganst long agent startup times (when it empties the
+	// long time. To guard against long agent startup times (when it empties the
 	// queue), limit us to 256 queued deletions. If this does, indeed, overflow,
 	// then the kubelet will get the failure and eventually retry deletion.
 	files, err := os.ReadDir(defaults.DeleteQueueDir)


### PR DESCRIPTION
The main change is to add common fields to logger:

- containerID
- netns
- ifName
- k8sNamespace
- k8sPodName

These fields are propagated to all code paths, which will help to trace and troubleshoot issues.

