### PR TITLE
envoy: Bump envoy version to v1.27.4

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -7,7 +7,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:a83a56dbedd41d0b53415122e
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.27.3-8a7ce41ee14873387d7149c84f7f776f6b07a869@sha256:eaca067426d117fae8ec4532cc4ccab01875e166169748e64a8970060b790d3f as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.27.4-21905253931655328edaacf3cd16aeda73bbea2f@sha256:d52f476c29a97c8b250fdbfbb8472191a268916f6a8503671d0da61e323b02cc as cilium-envoy
 
 #
 # Hubble CLI


### PR DESCRIPTION
This is mainly to resolve CVE-2024-30255.

Related: https://github.com/envoyproxy/envoy/security/advisories/GHSA-j654-3ccm-vfmm
Related build: https://github.com/cilium/proxy/actions/runs/8579381142/job/23514301386
Related release: https://github.com/envoyproxy/envoy/releases/tag/v1.27.4