### PR TITLE
Add existingAgent value to ensure hubble agent resources are created.

### DIFF
--- a/install/kubernetes/cilium/templates/hubble/peer-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/peer-service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agent .Values.hubble.enabled }}
+{{- if and (or .Values.agent .Values.hubble.existingAgent) .Values.hubble.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/server-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agent .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "helm") }}
+{{- if and (or .Values.agent .Values.hubble.existingAgent) .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "helm") }}
 {{- $_ := include "hubble-generate-certs.helm.setup-ca" . -}}
 {{- $cn := list "*" (.Values.cluster.name | replace "." "-") "hubble-grpc.cilium.io" | join "." }}
 {{- $ip := .Values.hubble.tls.server.extraIpAddresses }}

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/server-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agent .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) }}
+{{- if and (or .Values.agent .Values.hubble.existingAgent) .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -986,6 +986,8 @@ certgen:
 hubble:
   # -- Enable Hubble (true by default).
   enabled: true
+  # -- Installs cilium agent integration resources even if cilium agent is not part of the release e.g. .Values.agent: false.
+  existingAgent: false
   # -- Annotations to be added to all top-level hubble objects (resources under templates/hubble)
   annotations: {}
   # -- Buffer size of the channel Hubble uses to receive monitor events. If this


### PR DESCRIPTION
Some hubble resources are coupled to the cilium agent (`.Values.agent: true`). This change allows hubble to integrate with an existing cilium deployment.

<!-- Description of change -->
I am installing cilium in stages. Cilium agent will be deployed initially and hubble afterwards (when KMS is available).
There are a few resources coupled to `.Values.agent` being `true` so I have added an extra value to allow this. 
