### PR TITLE
Fix node throughput

### DIFF
--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '39 0 * * *'
 
+# For testing uncomment following lines:
+#  push:
+#    branches:
+#      - your_branch_name
+
 permissions:
   # To be able to access the repository with actions/checkout
   contents: read
@@ -173,6 +178,7 @@ jobs:
         run: |
           mkdir ./report
           echo POD_STARTUP_LATENCY_THRESHOLD: 60s >> ./testoverrides.yaml
+          echo POD_COUNT: 98 >> ./testoverrides.yaml
           go run ./cmd/clusterloader.go \
             -v=4 \
             --testconfig=./testing/node-throughput/config.yaml \


### PR DESCRIPTION
ci: fix node throughput test by lowering the number of pods

We reached 110 pods per node limit, which caused the failure of the test.
This was due to cilium-envoy enabled by default.

Successful run: https://github.com/cilium/cilium/actions/runs/8597205233
