### PR TITLE
CI: Remove unsupported k8s version

### DIFF
--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,16 +1,13 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.24"
-    zone: us-west2-a
-    vmIndex: 1
   - version: "1.25"
     zone: us-west1-b
-    vmIndex: 2
+    vmIndex: 1
   - version: "1.26"
     zone: us-west2-c
-    vmIndex: 3
+    vmIndex: 2
   - version: "1.27"
     zone: us-west3-a
-    vmIndex: 4
+    vmIndex: 3
     default: true


### PR DESCRIPTION
K8S version 1.24 is no longer supported in the GKE Regular channel
This PR removes this version from tested K8S versions

Successful run: https://github.com/cilium/cilium/actions/runs/8598999265