### PR TITLE
CI: Remove no longer supported k8s v1.24

### DIFF
--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,13 +1,10 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.24"
-    zone: us-west2-a
-    vmIndex: 1
   - version: "1.25"
     zone: us-west1-b
-    vmIndex: 2
+    vmIndex: 1
   - version: "1.26"
     zone: us-west2-c
-    vmIndex: 3
+    vmIndex: 2
     default: true


### PR DESCRIPTION
K8S version 1.24 is no longer supported in the GKE Regular channel
This PR removes this version from tested k8s versions

Successful run: https://github.com/cilium/cilium/actions/runs/8598870510