### PR TITLE
Fix sysctl reconciler unit tests

### DIFF
--- a/pkg/datapath/linux/sysctl/sysctl_test.go
+++ b/pkg/datapath/linux/sysctl/sysctl_test.go
@@ -158,7 +158,6 @@ func TestSysctl(t *testing.T) {
 				newReconcilerConfig,
 				newOps,
 			),
-			cell.Invoke(reconciler.Register[*tables.Sysctl]),
 		),
 
 		cell.Invoke(func(s Sysctl) {
@@ -262,7 +261,6 @@ func TestSysctlIgnoreErr(t *testing.T) {
 				newReconcilerConfig,
 				newOps,
 			),
-			cell.Invoke(reconciler.Register[*tables.Sysctl]),
 		),
 
 		cell.Invoke(func(s Sysctl) {

--- a/pkg/datapath/linux/sysctl/sysctl_test.go
+++ b/pkg/datapath/linux/sysctl/sysctl_test.go
@@ -227,7 +227,7 @@ func TestSysctl(t *testing.T) {
 	for _, s := range batch {
 		val, err := sysctl.Read(s.Name)
 		assert.NoError(t, err)
-		assert.Equal(t, s.Val, val, "unexpected value for parameter %q", s)
+		assert.Equal(t, s.Val, val, "unexpected value %q for parameter %q", val, s.Name)
 	}
 
 	assert.NoError(t, hive.Stop(context.Background()))


### PR DESCRIPTION
Previous implementation of the tests relied on a forceful registration of the sysctl reconciler. This is incorrect, since it leads to two instances of the reconciler being registered and competing to update the same sysctl parameters, ultimately leading to flakiness: https://github.com/cilium/cilium/issues/31789#issuecomment-2041528911

Fixes: https://github.com/cilium/cilium/issues/31789