### PR TITLE
Fix ipset reconciler unit tests

### DIFF
--- a/pkg/datapath/iptables/ipset/ipset_test.go
+++ b/pkg/datapath/iptables/ipset/ipset_test.go
@@ -130,7 +130,6 @@ func TestManager(t *testing.T) {
 					log: logger,
 				}
 			}),
-			cell.Invoke(reconciler.Register[*tables.IPSet]),
 		),
 
 		cell.Invoke(func(m Manager) {
@@ -317,7 +316,6 @@ func TestManagerNodeIpsetNotNeeded(t *testing.T) {
 					log: logger,
 				}
 			}),
-			cell.Invoke(reconciler.Register[*tables.IPSet]),
 
 			// force manager instantiation
 			cell.Invoke(func(_ Manager) {}),


### PR DESCRIPTION
The tests incorrectly register the ipset reconciler twice: first forcefully with reconciler.Register and then at hive build time requesting the reconciler as a parameter in newIPSetManager signature.

The two reconcilers are appended to the hive lifecycle and compete to update the simulated ipsets, possibly leading to flakyness.

The commit removes the useless initial cell.Invoke.

Related: https://github.com/cilium/cilium/issues/31789
