### PR TITLE
Pass zone to backends

### DIFF
--- a/api/v1/models/backend_address.go
+++ b/api/v1/models/backend_address.go
@@ -43,6 +43,9 @@ type BackendAddress struct {
 
 	// Backend weight
 	Weight *uint16 `json:"weight,omitempty"`
+
+	// Optional name of the zone in which this backend runs
+	Zone string `json:"zone,omitempty"`
 }
 
 // Validate validates this backend address

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -3042,6 +3042,9 @@ definitions:
         type: integer
         format: uint16
         x-nullable: true
+      zone:
+        description: Optional name of the zone in which this backend runs
+        type: string
   LRPBackend:
     description: Pod backend of an LRP
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1987,6 +1987,10 @@ func init() {
           "type": "integer",
           "format": "uint16",
           "x-nullable": true
+        },
+        "zone": {
+          "description": "Optional name of the zone in which this backend runs",
+          "type": "string"
         }
       }
     },
@@ -7751,6 +7755,10 @@ func init() {
           "type": "integer",
           "format": "uint16",
           "x-nullable": true
+        },
+        "zone": {
+          "description": "Optional name of the zone in which this backend runs",
+          "type": "string"
         }
       }
     },

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -1025,7 +1025,8 @@ struct lb6_backend {
 				 * backends that have the same IP address,
 				 * but belong to the different cluster.
 				 */
-	__u8 pad[2];
+	__u8 zone;
+	__u8 pad;
 };
 
 struct lb6_health {
@@ -1084,7 +1085,8 @@ struct lb4_backend {
 				 * backends that have the same IP address,
 				 * but belong to the different cluster.
 				 */
-	__u8 pad[2];
+	__u8 zone;
+	__u8 pad;
 };
 
 struct lb4_health {

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -253,7 +253,7 @@ func ParseEndpointSliceV1Beta1(ep *slim_discovery_v1beta1.EndpointSlice) *Endpoi
 			if !ok {
 				backend = &Backend{Ports: serviceStore.PortConfiguration{}}
 				endpoints.Backends[addrCluster] = backend
-				if nodeName, ok := sub.Topology["kubernetes.io/hostname"]; ok {
+				if nodeName, ok := sub.Topology[corev1.LabelHostname]; ok {
 					backend.NodeName = nodeName
 				}
 				if sub.Hostname != nil {
@@ -371,7 +371,7 @@ func ParseEndpointSliceV1(ep *slim_discovery_v1.EndpointSlice) *Endpoints {
 				if sub.NodeName != nil {
 					backend.NodeName = *sub.NodeName
 				} else {
-					if nodeName, ok := sub.DeprecatedTopology["kubernetes.io/hostname"]; ok {
+					if nodeName, ok := sub.DeprecatedTopology[corev1.LabelHostname]; ok {
 						backend.NodeName = nodeName
 					}
 				}

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -685,6 +685,7 @@ func genCartesianProduct(
 				besValues = append(besValues, &loadbalancer.Backend{
 					FEPortName: string(fePortName),
 					NodeName:   backend.NodeName,
+					ZoneID:     option.Config.GetZoneID(backend.Zone),
 					L3n4Addr: loadbalancer.L3n4Addr{
 						AddrCluster: addrCluster,
 						L4Addr:      *backendPort,

--- a/pkg/k8s/zz_generated.deepequal.go
+++ b/pkg/k8s/zz_generated.deepequal.go
@@ -51,6 +51,9 @@ func (in *Backend) DeepEqual(other *Backend) bool {
 	if in.Preferred != other.Preferred {
 		return false
 	}
+	if in.Zone != other.Zone {
+		return false
+	}
 
 	return true
 }

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -435,7 +435,8 @@ type Backend4ValueV3 struct {
 	Proto     u8proto.U8proto `align:"proto"`
 	Flags     uint8           `align:"flags"`
 	ClusterID uint16          `align:"cluster_id"`
-	Pad       pad2uint8       `align:"pad"`
+	Zone      uint8           `align:"zone"`
+	Pad       uint8           `align:"pad"`
 }
 
 func NewBackend4ValueV3(addrCluster cmtypes.AddrCluster, port uint16, proto u8proto.U8proto, state loadbalancer.BackendState) (*Backend4ValueV3, error) {

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -331,7 +331,8 @@ type Backend6ValueV3 struct {
 	Proto     u8proto.U8proto `align:"proto"`
 	Flags     uint8           `align:"flags"`
 	ClusterID uint16          `align:"cluster_id"`
-	Pad       pad2uint8       `align:"pad"`
+	Zone      uint8           `align:"zone"`
+	Pad       uint8           `align:"pad"`
 }
 
 func NewBackend6ValueV3(addrCluster cmtypes.AddrCluster, port uint16, proto u8proto.U8proto, state loadbalancer.BackendState) (*Backend6ValueV3, error) {

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -548,7 +548,8 @@ func (*LBBPFMap) DumpBackendMaps() ([]*loadbalancer.Backend, error) {
 		port := backendVal.GetPort()
 		proto := loadbalancer.NONE
 		state := loadbalancer.GetBackendStateFromFlags(backendVal.GetFlags())
-		lbBackend := loadbalancer.NewBackendWithState(backendID, proto, addrCluster, port, state)
+		zone := backendVal.GetZone()
+		lbBackend := loadbalancer.NewBackendWithState(backendID, proto, addrCluster, port, zone, state)
 		lbBackends = append(lbBackends, lbBackend)
 	}
 
@@ -613,10 +614,10 @@ func getBackend(backend *loadbalancer.Backend, ipv6 bool) (Backend, error) {
 
 	if ipv6 {
 		lbBackend, err = NewBackend6V3(backend.ID, backend.AddrCluster, backend.Port, u8proto.ANY,
-			backend.State)
+			backend.State, backend.ZoneID)
 	} else {
 		lbBackend, err = NewBackend4V3(backend.ID, backend.AddrCluster, backend.Port, u8proto.ANY,
-			backend.State)
+			backend.State, backend.ZoneID)
 	}
 	if err != nil {
 		return lbBackend, fmt.Errorf("unable to create lbBackend (%d, %s, %d, %t): %w",

--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -129,6 +129,9 @@ type BackendValue interface {
 	// Get backend flags
 	GetFlags() uint8
 
+	// Get zone
+	GetZone() uint8
+
 	// Convert fields to network byte order.
 	ToNetwork() BackendValue
 
@@ -191,6 +194,7 @@ func svcBackend(backendID loadbalancer.BackendID, backend BackendValue) *loadbal
 	bePort := backend.GetPort()
 	beProto := loadbalancer.NONE
 	beState := loadbalancer.GetBackendStateFromFlags(backend.GetFlags())
-	beBackend := loadbalancer.NewBackendWithState(backendID, beProto, beAddrCluster, bePort, beState)
+	beZone := backend.GetZone()
+	beBackend := loadbalancer.NewBackendWithState(backendID, beProto, beAddrCluster, bePort, beZone, beState)
 	return beBackend
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -501,6 +501,7 @@ func (s *Service) populateBackendMapV3FromV2(ipv4, ipv6 bool) error {
 					v1BackendVal.Port,
 					v1BackendVal.Proto,
 					lb.GetBackendStateFromFlags(v1BackendVal.Flags),
+					0,
 				)
 				if err != nil {
 					log.WithError(err).WithField(logfields.BPFMapName, v3Map.Name()).Debug("Error creating map value")
@@ -515,6 +516,7 @@ func (s *Service) populateBackendMapV3FromV2(ipv4, ipv6 bool) error {
 					v1BackendVal.Port,
 					v1BackendVal.Proto,
 					lb.GetBackendStateFromFlags(v1BackendVal.Flags),
+					0,
 				)
 				if err != nil {
 					log.WithError(err).WithField(logfields.BPFMapName, v3Map.Name()).Debug("Error creating map value")

--- a/pkg/testutils/mockmaps/lbmap.go
+++ b/pkg/testutils/mockmaps/lbmap.go
@@ -128,7 +128,7 @@ func (m *LBMockMap) AddBackend(b *lb.Backend, ipv6 bool) error {
 		return fmt.Errorf("Backend %d already exists", id)
 	}
 
-	be := lb.NewBackendWithState(id, b.Protocol, b.AddrCluster, port, b.State)
+	be := lb.NewBackendWithState(id, b.Protocol, b.AddrCluster, port, b.ZoneID, b.State)
 	m.BackendByID[id] = be
 
 	return nil


### PR DESCRIPTION
As described in https://github.com/cilium/design-cfps/pull/31, this is part of https://github.com/cilium/cilium/issues/31752

`Zone` string is taken from `EndpointSlice`, then copied to `Backend` which is later reflected in BPF map as uint8 id in `lb{4,6}_backend`. uint8<->string mapping is based on configuration passed in `fixed-zone-mapping`. It follows the same pattern as `fixed-identity-mapping`.

Example configuration (in `cilium-config`) for KIND cluster:
```
  fixed-zone-mapping: zone-a=123,zone-b=129
```
where topology labels were set on the nodes:
```
kubectl label node kind-worker topology.kubernetes.io/zone=zone-a
kubectl label node kind-worker topology.kubernetes.io/zone=zone-b
```

Can be verified with `cilium map get cilium_lb4_backends_v3`:
```
Key   Value                        State   Error
17    ANY://10.244.0.151[zone-b]   sync
13    ANY://192.168.11.2[zone-a]   sync
18    ANY://10.244.1.64[zone-a]    sync
19    ANY://10.244.1.64[zone-a]    sync
14    ANY://10.244.1.70[zone-a]    sync
15    ANY://10.244.1.70[zone-a]    sync
16    ANY://10.244.0.151[zone-b]   sync
```

```release-note
Store zone information alongside lb{4,6}_backend entries (based on mapping from fixed-zone-mapping and values from EndpointSlices)
```
