### PR TITLE
docs: Remove Hubble-OTel from roadmap

### DIFF
--- a/Documentation/community/roadmap.rst
+++ b/Documentation/community/roadmap.rst
@@ -145,7 +145,6 @@ Hubble provides visibility into network flows through the :ref:`Hubble CLI<hubbl
 and :ref:`UI<hubble_ui>` (beta), with support for Prometheus and OpenTelemetry metrics. Areas of
 focus currently include:
 
-* Graduating the `Hubble OpenTelemetry collector`_ to stable
 * Hubble UI additional features
 
 CI Test Improvements
@@ -226,7 +225,6 @@ anything other than trivial fixes.
 .. _point releases: https://cilium.io/blog/categories/release/
 .. _Get Involved: https://cilium.io/get-involved
 .. _CNCF Graduation: https://github.com/cncf/toc/pull/952
-.. _Hubble OpenTelemetry collector: https://github.com/cilium/hubble-otel
 .. _CI improvements: https://github.com/cilium/cilium/issues?q=is%3Aopen+is%3Aissue+label%3Aarea%2FCI-improvement
 .. _good-first-issue: https://github.com/cilium/cilium/labels/good-first-issue
 .. _enterprise: https://cilium.io/enterprise


### PR DESCRIPTION
The Hubble OTel repo is going to be archived so it should be removed from the roadmap


```release-note
Remove Hubble-OTel from the roadmap
```
