### PR TITLE
cmd, watchers: Populate ipcache in case of high-scale ipcache

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -113,7 +113,6 @@ include:
   # K8sDatapathConfig Check BPF masquerading with ip-masq-agent DirectRouting, IPv4 only
   # K8sDatapathConfig Check BPF masquerading with ip-masq-agent VXLAN
   # K8sDatapathConfig High-scale IPcache Test ingress policy enforcement with GENEVE and endpoint routes
-  # K8sDatapathConfig High-scale IPcache Test ingress policy enforcement with VXLAN and no endpoint routes
   # K8sDatapathConfig Iptables Skip conntrack for pod traffic
   # K8sDatapathConfig IPv4Only Check connectivity with IPv6 disabled
   # K8sDatapathConfig IPv6 masquerading across K8s nodes, skipped due to native routing CIDR

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/endpoint"
@@ -32,7 +31,6 @@ import (
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
-	slimclientset "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
@@ -203,22 +201,6 @@ func (cemf *cachedEndpointMetadataFetcher) Fetch(nsName, podName string) (*slim_
 		return nil, nil, err
 	}
 	ns, err := cemf.k8sWatcher.GetCachedNamespace(nsName)
-	if err != nil {
-		return nil, nil, err
-	}
-	return ns, p, err
-}
-
-type uncachedEndpointMetadataFetcher struct {
-	slimcli slimclientset.Interface
-}
-
-func (uemf *uncachedEndpointMetadataFetcher) Fetch(nsName, podName string) (*slim_corev1.Namespace, *slim_corev1.Pod, error) {
-	p, err := uemf.slimcli.CoreV1().Pods(nsName).Get(context.TODO(), podName, metav1.GetOptions{})
-	if err != nil {
-		return nil, nil, err
-	}
-	ns, err := uemf.slimcli.CoreV1().Namespaces().Get(context.TODO(), nsName, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -165,13 +165,6 @@ func (k *K8sWatcher) podsInit(slimClient slimclientset.Interface, asyncControlle
 		return cancel
 	}
 
-	// Disable watching pods if we are in high-scale mode. We don't need to
-	// insert pod IPs into the ipcache.
-	if option.Config.EnableHighScaleIPcache {
-		asyncControllers.Done()
-		return
-	}
-
 	// We will watch for pods on th entire cluster to keep existing
 	// functionality untouched. If we are running with CiliumEndpoint CRD
 	// enabled then it means that we can simply watch for pods that are created

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -657,9 +657,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 		})
 	})
 
-	SkipContextIf(func() bool {
-		return helpers.SkipQuarantined() || helpers.DoesNotRunOnNetNextKernel()
-	}, "High-scale IPcache", func() {
+	SkipContextIf(helpers.DoesNotRunOnNetNextKernel, "High-scale IPcache", func() {
 		const hsIPcacheFile = "high-scale-ipcache.yaml"
 
 		AfterEach(func() {

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -682,6 +682,9 @@ var _ = Describe("K8sDatapathConfig", func() {
 			}
 			if helpers.RunsWithKubeProxy() {
 				options["kubeProxyReplacement"] = "false"
+			} else if helpers.RunsWithKubeProxyReplacement() {
+				options["loadBalancer.mode"] = "dsr"
+				options["loadBalancer.dsrDispatch"] = "geneve"
 			}
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 
@@ -696,10 +699,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l type=client", 2*helpers.HelperTimeout)
 			Expect(err).ToNot(HaveOccurred(), "Client pods not ready after timeout")
 		}
-
-		It("Test ingress policy enforcement with VXLAN and no endpoint routes", func() {
-			testHighScaleIPcache("vxlan", "false")
-		})
 
 		It("Test ingress policy enforcement with GENEVE and endpoint routes", func() {
 			testHighScaleIPcache("geneve", "true")


### PR DESCRIPTION
The first commit contains the main changes (description below). Second commit fixes our end-to-end test and third reenables it.

> The high-scale ipcache feature aims to enable policy enforcement across very large Kubernetes environments comprised of many clusters which are not using Cilium Clustermesh.
>
> The main issue of Cilium Clustermesh at that scale is that ipcache on each node would need to be populated with all remote pods, and they would be to be constantly updated. It doesn't scale. Instead the high-scale ipcache feature removes all pods from the ipcache and relies on other mecanisms to enforce policies.
>
> This comes with a significant drawback. Ipcache being such a central component of Cilium, without ipcache entries for pods, many features (egress gateway, IPsec, etc.) cannot work anymore. For that reason, high-scale ipcache is today incompatible with those features.
>
> This commit implements an intermediate solution found by Hemanth. Since the scalability concern comes from the very large number of remote clusters, we only need to keep pods from those clusters out of the ipcache. Hence, the ipcache can keep all pod entries for the local cluster's pods; since we are not using Cilium Clustermesh, entries for other clusters will never be added.
>
> As a consequence, all advanced features will keep working for the local cluster. Features that rely on the ipcache will of course not work for remote clusters, but that was never the goal of high-scale ipcache anyway.