### PR TITLE
bitlpm: Document and Fix Descendants Bug

### DIFF
--- a/pkg/container/bitlpm/unsigned_test.go
+++ b/pkg/container/bitlpm/unsigned_test.go
@@ -407,6 +407,17 @@ func TestUnsignedDescendants(t *testing.T) {
 			if !reflect.DeepEqual(expectedRes, gotRes) {
 				t.Fatalf("Descendants range %s, expected to get %v, but got: %v", entry, expectedRes, gotRes)
 			}
+			// It should still work even if the entry is not present
+			tu.Delete(i, rng)
+			expectedRes = expectedRes[1:]
+			gotRes = make([]string, 0, 16-i-1)
+			tu.Descendants(i, rng, func(prefix uint, key uint16, v string) bool {
+				gotRes = append(gotRes, v)
+				return true
+			})
+			if !reflect.DeepEqual(expectedRes, gotRes) {
+				t.Fatalf("Descendants range %s, expected to get %v, but got: %v", entry, expectedRes, gotRes)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Descendants and Ancestors cannot share the same
traversal method, because Descendants needs to be
able to select at least one in-trie key-prefix match that may not be a full match for the argument key-prefix. The old traversal method worked for the Descendants method if there happened to be an exact match of the argument key-prefix in the trie. These new tests ensure that Descendants will still return a proper list of Descendants even if there is no exact match in the trie.

Note: This does not need a release note because nothing was (yet) relying on this code.
