### PR TITLE
labelsfilter: silence log messages

### DIFF
--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
@@ -116,10 +118,10 @@ func ParseLabelPrefixCfg(prefixes, nodePrefixes []string, file string) error {
 
 	// Use default label prefix if configuration file not provided
 	if file == "" {
-		log.Info("Parsing base label prefixes from default label list")
+		log.Debug("Parsing base label prefixes from default label list")
 		cfg = defaultLabelPrefixCfg()
 	} else {
-		log.Infof("Parsing base label prefixes from file %s", file)
+		log.WithField(logfields.Path, file).Debug("Parsing base label prefixes from file")
 		cfg, err = readLabelPrefixCfgFrom(file)
 		if err != nil {
 			return fmt.Errorf("unable to read label prefix file: %w", err)
@@ -146,7 +148,7 @@ func ParseLabelPrefixCfg(prefixes, nodePrefixes []string, file string) error {
 		nodeCfg.LabelPrefixes = append(nodeCfg.LabelPrefixes, p)
 	}
 
-	log.Infof("Parsing additional label prefixes from user inputs: %v", prefixes)
+	log.WithField("label-prefixes", prefixes).Debugf("Parsing additional label prefixes from user inputs")
 	for _, label := range prefixes {
 		if len(label) == 0 {
 			continue
@@ -181,9 +183,11 @@ func ParseLabelPrefixCfg(prefixes, nodePrefixes []string, file string) error {
 	validLabelPrefixes = cfg
 	validNodeLabelPrefixes = nodeCfg
 
-	log.Info("Final label prefixes to be used for identity evaluation:")
-	for _, l := range validLabelPrefixes.LabelPrefixes {
-		log.Infof(" - %s", l)
+	if logging.CanLogAt(log.Logger, logrus.DebugLevel) {
+		log.Debug("Final label prefixes to be used for identity evaluation:")
+		for _, l := range validLabelPrefixes.LabelPrefixes {
+			log.Debugf(" - %s", l)
+		}
 	}
 
 	log.Info("Final node label prefixes to be used for identity evaluation:")


### PR DESCRIPTION
Currently, the labelsfilter package logs at info level leading to verbose logs like the following emitted on Cilium agent startup:

```
2023-12-07T19:13:21.139800870Z level=info msg="Parsing base label prefixes from default label list" subsys=labels-filter
2023-12-07T19:13:21.140137125Z level=info msg="Parsing additional label prefixes from user inputs: []" subsys=labels-filter
2023-12-07T19:13:21.140146893Z level=info msg="Final label prefixes to be used for identity evaluation:" subsys=labels-filter
2023-12-07T19:13:21.140151281Z level=info msg=" - reserved:.*" subsys=labels-filter
2023-12-07T19:13:21.140154918Z level=info msg=" - :io\\.kubernetes\\.pod\\.namespace" subsys=labels-filter
2023-12-07T19:13:21.140158124Z level=info msg=" - :io\\.cilium\\.k8s\\.namespace\\.labels" subsys=labels-filter
2023-12-07T19:13:21.140198309Z level=info msg=" - :app\\.kubernetes\\.io" subsys=labels-filter
2023-12-07T19:13:21.140203168Z level=info msg=" - !:io\\.kubernetes" subsys=labels-filter
2023-12-07T19:13:21.140206344Z level=info msg=" - !:kubernetes\\.io" subsys=labels-filter
2023-12-07T19:13:21.140210231Z level=info msg=" - !:statefulset\\.kubernetes\\.io/pod-name" subsys=labels-filter
2023-12-07T19:13:21.140214199Z level=info msg=" - !:apps\\.kubernetes\\.io/pod-index" subsys=labels-filter
2023-12-07T19:13:21.140217535Z level=info msg=" - !:batch\\.kubernetes\\.io/job-completion-index" subsys=labels-filter
2023-12-07T19:13:21.140220360Z level=info msg=" - !:.*beta\\.kubernetes\\.io" subsys=labels-filter
2023-12-07T19:13:21.140223206Z level=info msg=" - !:k8s\\.io" subsys=labels-filter
2023-12-07T19:13:21.140225981Z level=info msg=" - !:pod-template-generation" subsys=labels-filter
2023-12-07T19:13:21.140228605Z level=info msg=" - !:pod-template-hash" subsys=labels-filter
2023-12-07T19:13:21.140231150Z level=info msg=" - !:controller-revision-hash" subsys=labels-filter
2023-12-07T19:13:21.140239075Z level=info msg=" - !:annotation.*" subsys=labels-filter
2023-12-07T19:13:21.140242001Z level=info msg=" - !:etcd_node" subsys=labels-filter
```

Convert these to debug logs so users interested in these settings can still see them in debug mode.

Also convert the log messages to use structured logging while at it.