### PR TITLE
CI: bump default FQDN datapath timeout from 100 to 250ms

### DIFF
--- a/.github/actions/helm-default/action.yaml
+++ b/.github/actions/helm-default/action.yaml
@@ -29,7 +29,8 @@ runs:
 
         CILIUM_INSTALL_DEFAULTS="--chart-directory=${{ inputs.chart-dir }} \
           --helm-set=debug.enabled=true \
-          --helm-set=bpf.monitorAggregation=none"
+          --helm-set=bpf.monitorAggregation=none \
+          --helm-set=dnsProxy.proxyResponseMaxDelay=250ms"
 
         # only add SHA to the image tags if it was set
         if [ -n "${SHA}" ]; then


### PR DESCRIPTION
This timeout can be CPU sensitive, and the CI environments can be CPU constrained.

Bumping this timeout ensures that performance regressions will still be caught, as those tend to cause delays of 1+ seconds. This will, however, cut down on CI flakes due to noise.

Ref: #29846