### PR TITLE
WireGuard: Deprecate userspace fallback

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -165,7 +165,6 @@ cilium-agent [flags]
       --enable-vtep                                               Enable  VXLAN Tunnel Endpoint (VTEP) Integration (beta)
       --enable-well-known-identities                              Enable well-known identities for known Kubernetes components (default true)
       --enable-wireguard                                          Enable WireGuard
-      --enable-wireguard-userspace-fallback                       Enable fallback to the WireGuard userspace implementation
       --enable-xdp-prefilter                                      Enable XDP prefiltering
       --enable-xt-socket-fallback                                 Enable fallback for missing xt_socket module (default true)
       --encrypt-interface string                                  Transparent encryption interface

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1049,7 +1049,7 @@
      - string
      - ``"0s"``
    * - :spelling:ignore:`encryption.wireguard.userspaceFallback`
-     - Enables the fallback to the user-space implementation.
+     - Enables the fallback to the user-space implementation (deprecated).
      - bool
      - ``false``
    * - :spelling:ignore:`endpointHealthChecking.enabled`

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -315,6 +315,9 @@ Annotations:
 * L7 network policy with terminatingTLS will not load the key ``ca.crt`` even if it is present in the
   secret. This prevents Envoy from incorrectly requiring client certificates from pods when using TLS
   termination. To retain old behaviour for bug compatibility, please set ``--use-full-tls-context=true``.
+* The built-in WireGuard userspace-mode fallback (Helm ``wireguard.userspaceFallback``) has been
+  deprecated and will be removed in a future version of Cilium. Users of WireGuard transparent
+  encryption are required to use a Linux kernel with WireGuard support going forward.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -394,6 +394,7 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	option.BindEnv(vp, option.L2AnnouncerRetryPeriod)
 
 	flags.Bool(option.EnableWireguardUserspaceFallback, false, "Enable fallback to the WireGuard userspace implementation")
+	flags.MarkDeprecated(option.EnableWireguardUserspaceFallback, "WireGuard userspace fallback is deprecated")
 	option.BindEnv(vp, option.EnableWireguardUserspaceFallback)
 
 	flags.Duration(option.WireguardPersistentKeepalive, 0, "The Wireguard keepalive interval as a Go duration string")

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -312,7 +312,7 @@ contributors across the globe, there is almost always someone available to help.
 | encryption.strictMode.enabled | bool | `false` | Enable WireGuard Pod2Pod strict mode. |
 | encryption.type | string | `"ipsec"` | Encryption method. Can be either ipsec or wireguard. |
 | encryption.wireguard.persistentKeepalive | string | `"0s"` | Controls Wireguard PersistentKeepalive option. Set 0s to disable. |
-| encryption.wireguard.userspaceFallback | bool | `false` | Enables the fallback to the user-space implementation. |
+| encryption.wireguard.userspaceFallback | bool | `false` | Enables the fallback to the user-space implementation (deprecated). |
 | endpointHealthChecking.enabled | bool | `true` | Enable connectivity health checking between virtual endpoints. |
 | endpointRoutes.enabled | bool | `false` | Enable use of per endpoint routes instead of routing via the cilium_host interface. |
 | eni.awsEnablePrefixDelegation | bool | `false` | Enable ENI prefix delegation |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -871,7 +871,7 @@ encryption:
     # -- Enable IPSec encrypted overlay
     encryptedOverlay: false
   wireguard:
-    # -- Enables the fallback to the user-space implementation.
+    # -- Enables the fallback to the user-space implementation (deprecated).
     userspaceFallback: false
     # -- Controls Wireguard PersistentKeepalive option. Set 0s to disable.
     persistentKeepalive: 0s

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -870,7 +870,7 @@ encryption:
     # -- Enable IPSec encrypted overlay
     encryptedOverlay: false
   wireguard:
-    # -- Enables the fallback to the user-space implementation.
+    # -- Enables the fallback to the user-space implementation (deprecated).
     userspaceFallback: false
     # -- Controls Wireguard PersistentKeepalive option. Set 0s to disable.
     persistentKeepalive: 0s

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -247,6 +247,7 @@ func (a *Agent) Init(ipcache *ipcache.IPCache, mtuConfig mtu.MTU) error {
 			return fmt.Errorf("failed to add WireGuard device: %w", err)
 		}
 
+		// TODO: Remove this userspace fallback in Cilum v1.17
 		if !option.Config.EnableWireguardUserspaceFallback {
 			return fmt.Errorf("WireGuard not supported by the Linux kernel (netlink: %w). "+
 				"Please upgrade your kernel, manually install the kernel module "+


### PR DESCRIPTION
Cilium's WireGuard transparent encryption has the ability to run the WireGuard encryption logic in userspace via the
`enable-wireguard-userspace-fallback` flag. When enabled, and the Linux kernel does not support WireGuard, Cilium will run wireguard-go's userspace implementation of WireGuard inside the `cilium-agent` to provide encryption.

However, because encryption is done inside the `cilium-agent` process in that mode, any downtime of `cilium-agent` (e.g. during upgrades or pod restarts) means that all pod-to-pod traffic is disrupted during that downtime. This means that `enable-wireguard-userspace-fallback` is unsuitable for production use in its current form. As many cloud providers now have WireGuard support in their kernel, there is less need to provide a userspace fallback. This change therefore deprecates the `enable-wireguard-userspace-fallback` flag, so it can be removed in a future Cilium release. This does not prevent any future re-implementation of the feature using an out-of-process implementation if the need arises.