### PR TITLE
[v1.13] fqdn: Fix Restore Check Logic

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -215,7 +215,7 @@ func (p *DNSProxy) checkRestored(endpointID uint64, destPortProto restore.PortPr
 
 	for i := range ipRules {
 		ipRule := ipRules[i]
-		if _, exists := ipRule.IPs[destIP]; exists || ipRule.IPs == nil {
+		if _, exists := ipRule.IPs[destIP]; exists || len(ipRule.IPs) == 0 {
 			if ipRule.regex != nil && ipRule.regex.MatchString(name) {
 				return true
 			}


### PR DESCRIPTION
[ upstream commit 79029db115743b9884a06e1acf0067140d8a33fe ]

Sometimes restored IPRules do not have the
default "nil" populating their IP maps, but instead have an empty map structure. We need to check for this
restore possibility.

```release-note
fqdn: Fix minor restore bug that causes false negative checks against a restored DNS IP map.
```
