### PR TITLE
WireGuard: remove cleanup for obsolete IP rules

### DIFF
--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -12,10 +12,6 @@ const (
 	// RouteTableIPSec is the default table ID to use for IPSec routing rules
 	RouteTableIPSec = 200
 
-	// RouteTableWireguard is the default table ID to use for WireGuard routing
-	// rules
-	RouteTableWireguard = 201
-
 	// RouteTableVtep is the default table ID to use for VTEP routing rules
 	RouteTableVtep = 202
 
@@ -69,9 +65,6 @@ const (
 	// rules (see networkd config directive ManageForeignRoutingPolicyRules, set
 	// to 'yes' by default).
 	RTProto = unix.RTPROT_KERNEL
-
-	// RulePriorityWireguard is the priority of the rule used for routing packets to WireGuard device for encryption
-	RulePriorityWireguard = 1
 
 	// RulePriorityToProxyIngress is the priority of the routing rule installed by
 	// the proxy package for redirecting inbound packets to the proxy.

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
-	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/lock"
@@ -293,11 +292,6 @@ func (a *Agent) Init(ipcache *ipcache.IPCache, mtuConfig mtu.MTU) error {
 	for _, peer := range dev.Peers {
 		a.restoredPubKeys[peer.PublicKey] = struct{}{}
 	}
-
-	// Delete IP rules and routes installed by the agent to steer a traffic from
-	// a pod into the WireGuard tunnel device. The rules were used in Cilium
-	// versions < 1.13.
-	deleteObsoleteIPRules()
 
 	// this is read by the defer statement above
 	addIPCacheListener = true
@@ -698,38 +692,4 @@ func (p *peerConfig) insertAllowedIP(ip net.IPNet) (updated bool) {
 
 	p.allowedIPs = append(p.allowedIPs, ip)
 	return true
-}
-
-// Removes < v1.13 IP rules and routes.
-func deleteObsoleteIPRules() {
-	rule := route.Rule{
-		Priority: linux_defaults.RulePriorityWireguard,
-		Mark:     linux_defaults.RouteMarkEncrypt,
-		Mask:     linux_defaults.RouteMarkMask,
-		Table:    linux_defaults.RouteTableWireguard,
-	}
-	rt := route.Route{
-		Device: types.IfaceName,
-		Table:  linux_defaults.RouteTableWireguard,
-	}
-	if option.Config.EnableIPv4 {
-		route.DeleteRule(netlink.FAMILY_V4, rule)
-
-		subnet := net.IPNet{
-			IP:   net.IPv4zero,
-			Mask: net.CIDRMask(0, 8*net.IPv4len),
-		}
-		rt.Prefix = subnet
-		route.Delete(rt)
-	}
-	if option.Config.EnableIPv6 {
-		route.DeleteRule(netlink.FAMILY_V6, rule)
-
-		subnet := net.IPNet{
-			IP:   net.IPv6zero,
-			Mask: net.CIDRMask(0, 8*net.IPv6len),
-		}
-		rt.Prefix = subnet
-		route.Delete(rt)
-	}
 }


### PR DESCRIPTION
Once users reach v1.16, they will have upgraded through a Cilium version that no longer uses the IP rules and applies the cleanup logic. So v1.16 doesn't need to bother with the cleanup, and we can remove the relevant code.