### PR TITLE
ci: Add matrix for bpf.tproxy and ingress-controller

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -236,6 +236,17 @@ jobs:
             egress-gateway: 'true'
             lb-acceleration: 'testing-only'
 
+          - name: '15'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: 'bpf-next-20240307.011705'
+            kube-proxy: 'none'
+            kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
+            tunnel: 'disabled'
+            ingress-controller: 'true'
+            misc: 'bpfClockProbe=false,cni.uninstall=false,bpf.tproxy=true'
+
           - name: '16'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: '5.15-20240305.092417'
@@ -290,6 +301,7 @@ jobs:
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
           mutual-auth: false
+          ingress-controller: ${{ matrix.ingress-controller }}
           misc: ${{ matrix.misc || 'bpfClockProbe=false,cni.uninstall=false' }}
 
       - name: Derive newest Cilium installation config

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -439,8 +439,8 @@ jobs:
               --flush-ct \
               --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
-              --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
-              --junit-property github_job_step="Run tests upgrade 2 (${{ join(matrix.*, ', ') }})" \
+              --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
+              --junit-property github_job_step="Run tests upgrade 2 (${{ matrix.name }})" \
               \$EXTRA
 
             # --flush-ct interrupts the flows, so we need to set up again.
@@ -480,8 +480,8 @@ jobs:
               --flush-ct \
               --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
-              --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
-              --junit-property github_job_step="Run tests upgrade 3 (${{ join(matrix.*, ', ') }})" \
+              --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
+              --junit-property github_job_step="Run tests upgrade 3 (${{ matrix.name }})" \
               \$EXTRA
 
       - name: Fetch artifacts

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -290,7 +290,7 @@ jobs:
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
           mutual-auth: false
-          misc: 'bpfClockProbe=false,cni.uninstall=false' # TODO(brb) maybe it's only needed for <1.14
+          misc: ${{ matrix.misc || 'bpfClockProbe=false,cni.uninstall=false' }}
 
       - name: Derive newest Cilium installation config
         id: cilium-newest-config
@@ -310,7 +310,8 @@ jobs:
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
           mutual-auth: false
-          misc: 'bpfClockProbe=false,cni.uninstall=false'
+          ingress-controller: ${{ matrix.ingress-controller }}
+          misc: ${{ matrix.misc || 'bpfClockProbe=false,cni.uninstall=false' }}
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@a9579d1afc528b085930c5237a69ee77b2c2be76 # v0.16.4


### PR DESCRIPTION
This is to sync up with conformance-e2e workflow.

Relates: https://github.com/cilium/cilium/pull/31272