### PR TITLE
alibabacloud/eni: avoid racing node mgr in test

### DIFF
--- a/pkg/alibabacloud/eni/node_test.go
+++ b/pkg/alibabacloud/eni/node_test.go
@@ -143,11 +143,12 @@ func (e *ENISuite) TestPrepareIPAllocation(c *check.C) {
 	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
+	mngr.SetInstancesAPIReadiness(false) // to avoid the manager background jobs starting and racing us.
 
 	mngr.Upsert(newCiliumNode("node1", "i-1", "ecs.g7ne.large", "cn-hangzhou-i", "vpc-1"))
 	a, err := mngr.Get("node1").Ops().PrepareIPAllocation(log)
 	c.Assert(err, check.IsNil)
-	c.Assert(a.EmptyInterfaceSlots+a.IPv4.InterfaceCandidates, check.Equals, 2)
+	c.Assert(a.EmptyInterfaceSlots+a.IPv4.InterfaceCandidates, check.Equals, 2, check.Commentf("empty: %v, candidates: %v", a.EmptyInterfaceSlots, a.IPv4.InterfaceCandidates))
 
 	// create one eni
 	toAlloc, _, err := mngr.Get("node1").Ops().CreateInterface(context.Background(), &ipam.AllocationAction{
@@ -162,7 +163,7 @@ func (e *ENISuite) TestPrepareIPAllocation(c *check.C) {
 	// one eni left
 	a, err = mngr.Get("node1").Ops().PrepareIPAllocation(log)
 	c.Assert(err, check.IsNil)
-	c.Assert(a.EmptyInterfaceSlots+a.IPv4.InterfaceCandidates, check.Equals, 1)
+	c.Assert(a.EmptyInterfaceSlots+a.IPv4.InterfaceCandidates, check.Equals, 1, check.Commentf("empty: %v, candidates: %v", a.EmptyInterfaceSlots, a.IPv4.InterfaceCandidates))
 }
 
 func (e *ENISuite) TestNode_allocENIIndex(c *check.C) {


### PR DESCRIPTION
TestPrepareIPAllocation attempts to check that PerpareIPAllocation produces the expected results. It avoids starting the ipam node manager it constructs, likely trying to avoid starting the background maintenance jobs.

However, manager.Upsert _does_ asynchronously trigger pool maintenance, which results in a automated creation of an ENI with different params than the test expects, and hence assertion failures.

This patch avoids the race condition by explicitly setting the instance API readiness to false, which causes background pool maintenance to be delayed and hence guarantees that the PrepareIPAllocation call runs in the environment expected.

The following was used to reproduce this flake:

  `go test -c -race ./pkg/alibabacloud/eni && stress -p 50 ./eni.test`

The likelihood of hitting this flake approximates 0.02%, hence reproducing requires a reasonably large number of runs, as well as high load on the system to increase the likelihood of the flake (since it does depend on the test being somewhat starved for CPU).

With the above fix, I was able to achieve 40k runs without flaking.

Fixes: #30935
