### PR TITLE
helm: Add automatic lookup option for k8s service info

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2289,7 +2289,7 @@
      - bool
      - ``true``
    * - :spelling:ignore:`k8sServiceHost`
-     - Kubernetes service host
+     - Kubernetes service host - use "auto" for automatic lookup from the cluster-info ConfigMap (kubeadm-based clusters only)
      - string
      - ``""``
    * - :spelling:ignore:`k8sServicePort`

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -622,7 +622,7 @@ contributors across the globe, there is almost always someone available to help.
 | k8sClientRateLimit.burst | int | 10 for k8s up to 1.26. 20 for k8s version 1.27+ | The burst request rate in requests per second. The rate limiter will allow short bursts with a higher rate. |
 | k8sClientRateLimit.qps | int | 5 for k8s up to 1.26. 10 for k8s version 1.27+ | The sustained request rate in requests per second. |
 | k8sNetworkPolicy.enabled | bool | `true` | Enable support for K8s NetworkPolicy |
-| k8sServiceHost | string | `""` | Kubernetes service host |
+| k8sServiceHost | string | `""` | Kubernetes service host - use "auto" for automatic lookup from the cluster-info ConfigMap (kubeadm-based clusters only) |
 | k8sServicePort | string | `""` | Kubernetes service port |
 | keepDeprecatedLabels | bool | `false` | Keep the deprecated selector labels when deploying Cilium DaemonSet. |
 | keepDeprecatedProbes | bool | `false` | Keep the deprecated probes when deploying Cilium DaemonSet |

--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -165,3 +165,34 @@ Convert a map to a comma-separated string: key1=value1,key2=value2
 {{- end -}}
 {{ join "," $list }}
 {{- end -}}
+
+{{/*
+Enable automatic lookup of k8sServiceHost from the cluster-info ConfigMap (kubeadm-based clusters only)
+*/}}
+{{- define "k8sServiceHost" }}
+  {{- if eq .Values.k8sServiceHost "auto" }}
+    {{- $configmap := (lookup "v1" "ConfigMap" "kube-public" "cluster-info") }}
+    {{- $kubeconfig := get $configmap.data "kubeconfig" }}
+    {{- $k8sServer := get ($kubeconfig | fromYaml) "clusters" | mustFirst | dig "cluster" "server" "" }}
+    {{- $uri := (split "https://" $k8sServer)._1 | trim }}
+    {{- (split ":" $uri)._0 | quote }}
+  {{- else }}
+    {{- .Values.k8sServiceHost | quote }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Enable automatic lookup of k8sServicePort from the cluster-info ConfigMap (kubeadm-based clusters only)
+*/}}
+{{- define "k8sServicePort" }}
+  {{- if eq .Values.k8sServiceHost "auto" }}
+    {{- $configmap := (lookup "v1" "ConfigMap" "kube-public" "cluster-info") }}
+    {{- $kubeconfig := get $configmap.data "kubeconfig" }}
+    {{- $k8sServer := get ($kubeconfig | fromYaml) "clusters" | mustFirst | dig "cluster" "server" "" }}
+    {{- $uri := (split "https://" $k8sServer)._1 | trim }}
+    {{- (split ":" $uri)._1 | quote }}
+  {{- else }}
+    {{- .Values.k8sServicePort | quote }}
+  {{- end }}
+{{- end }}
+

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -204,11 +204,9 @@ spec:
               divisor: '1'
         {{- if .Values.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
-          value: {{ .Values.k8sServiceHost | quote }}
-        {{- end }}
-        {{- if .Values.k8sServicePort }}
+          value: {{ include "k8sServiceHost" . }}
         - name: KUBERNETES_SERVICE_PORT
-          value: {{ .Values.k8sServicePort | quote }}
+          value: {{ include "k8sServicePort" . }}
         {{- end }}
         {{- with .Values.extraEnv }}
         {{- toYaml . | trim | nindent 8 }}
@@ -452,11 +450,9 @@ spec:
               fieldPath: metadata.namespace
         {{- if .Values.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
-          value: {{ .Values.k8sServiceHost | quote }}
-        {{- end }}
-        {{- if .Values.k8sServicePort }}
+          value: {{ include "k8sServiceHost" . }}
         - name: KUBERNETES_SERVICE_PORT
-          value: {{ .Values.k8sServicePort | quote }}
+          value: {{ include "k8sServicePort" . }}
         {{- end }}
         {{- with .Values.extraEnv }}
         {{- toYaml . | nindent 8 }}
@@ -637,11 +633,9 @@ spec:
               optional: true
         {{- if .Values.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
-          value: {{ .Values.k8sServiceHost | quote }}
-        {{- end }}
-        {{- if .Values.k8sServicePort }}
+          value: {{ include "k8sServiceHost" . }}
         - name: KUBERNETES_SERVICE_PORT
-          value: {{ .Values.k8sServicePort | quote }}
+          value: {{ include "k8sServicePort" . }}
         {{- end }}
         {{- with .Values.extraEnv }}
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -139,11 +139,9 @@ spec:
               fieldPath: metadata.namespace
         {{- if .Values.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
-          value: {{ .Values.k8sServiceHost | quote }}
-        {{- end }}
-        {{- if .Values.k8sServicePort }}
+          value: {{ include "k8sServiceHost" . }}
         - name: KUBERNETES_SERVICE_PORT
-          value: {{ .Values.k8sServicePort | quote }}
+          value: {{ include "k8sServicePort" . }}
         {{- end }}
         {{- with .Values.envoy.extraEnv }}
         {{- toYaml . | trim | nindent 8 }}

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -138,11 +138,9 @@ spec:
         {{- end }}
         {{- if .Values.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
-          value: {{ .Values.k8sServiceHost | quote }}
-        {{- end }}
-        {{- if .Values.k8sServicePort }}
+          value: {{ include "k8sServiceHost" . }}
         - name: KUBERNETES_SERVICE_PORT
-          value: {{ .Values.k8sServicePort | quote }}
+          value: {{ include "k8sServicePort" . }}
         {{- end }}
         {{- if .Values.azure.enabled }}
         {{- if .Values.azure.subscriptionID }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -132,11 +132,9 @@ spec:
           env:
           {{- if .Values.k8sServiceHost }}
           - name: KUBERNETES_SERVICE_HOST
-            value: {{ .Values.k8sServiceHost | quote }}
-          {{- end }}
-          {{- if .Values.k8sServicePort }}
+            value: {{ include "k8sServiceHost" . }}
           - name: KUBERNETES_SERVICE_PORT
-            value: {{ .Values.k8sServicePort | quote }}
+            value: {{ include "k8sServicePort" . }}
           {{- end }}
           volumeMounts:
           - name: cilium-run

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -60,11 +60,9 @@ spec:
           env:
           {{- if .Values.k8sServiceHost }}
           - name: KUBERNETES_SERVICE_HOST
-            value: {{ .Values.k8sServiceHost | quote }}
-          {{- end }}
-          {{- if .Values.k8sServicePort }}
+            value: {{ include "k8sServiceHost" . }}
           - name: KUBERNETES_SERVICE_PORT
-            value: {{ .Values.k8sServicePort | quote }}
+            value: {{ include "k8sServicePort" . }}
           {{- end }}
           {{- with .Values.preflight.extraEnv }}
           {{- toYaml . | trim | nindent 10 }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -39,7 +39,7 @@ imagePullSecrets: []
 # -- (string) Kubernetes config path
 # @default -- `"~/.kube/config"`
 kubeConfigPath: ""
-# -- (string) Kubernetes service host
+# -- (string) Kubernetes service host - use "auto" for automatic lookup from the cluster-info ConfigMap (kubeadm-based clusters only)
 k8sServiceHost: ""
 # @schema
 # type: [string, integer]

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -37,7 +37,7 @@ imagePullSecrets: []
 # -- (string) Kubernetes config path
 # @default -- `"~/.kube/config"`
 kubeConfigPath: ""
-# -- (string) Kubernetes service host
+# -- (string) Kubernetes service host - use "auto" for automatic lookup from the cluster-info ConfigMap (kubeadm-based clusters only)
 k8sServiceHost: ""
 # @schema
 # type: [string, integer]


### PR DESCRIPTION
This commit adds an option for kubeadm-based clusters to specify
```
k8sServiceHost: "auto"
```
and have a helper function automatically determine the Kubernetes host and port information from the `cluster-info` ConfigMap in the `kube-public` namespace, and use that to populate the `k8sServiceHost` and `k8sServicePort` values. This can significantly simplify the enabling of kubeproxy-less mode, especially for CAPI clusters where the value for `k8sServiceHost` cannot always be known ahead of time.

If any other value than "auto" is provided for `k8sServiceHost`, the behavior reverts to its original form.

```release-note
Add option to automatically discover k8sServiceHost and k8sServicePort info (kubeadm clusters only)
```