### PR TITLE
fix: deduplicate ConfigMap key if ENI mode and endpointRoutes are enabled

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -500,7 +500,9 @@ data:
 {{- end }}
 
 {{- if .Values.eni.enabled }}
+  {{- if not .Values.endpointRoutes.enabled }}
   enable-endpoint-routes: "true"
+  {{- end }}
   auto-create-cilium-node-resource: "true"
 {{- if .Values.eni.updateEC2AdapterLimitViaAPI }}
   update-ec2-adapter-limit-via-api: "true"


### PR DESCRIPTION
Currently, if the Helm values `eni.enabled` and `endpointRoutes.enabled` are both explicitly enabled, the `enable-endpoint-routes` key in the main `ConfigMap` will be duplicated and fail schema validation. This PR adds an explicit check for `endpointRoutes.enabled` when `eni.enabled` is true to avoid duplicating the key, as discussed in #31868.

Fixes: #31868 
