### PR TITLE
docs: Make ICMP rules for the Host Firewall easier to read/search

### DIFF
--- a/Documentation/security/host-firewall.rst
+++ b/Documentation/security/host-firewall.rst
@@ -84,7 +84,8 @@ Apply a Host Network Policy
 `HostPolicies` match on node labels using a :ref:`NodeSelector` to identify the
 nodes to which the policy applies. The following policy applies to all nodes.
 It allows communications from outside the cluster only for TCP/22 and for ICMP
-echo requests. All communications from the cluster to the hosts are allowed.
+(ping) echo requests. All communications from the cluster to the hosts are
+allowed.
 
 Host policies don't apply to communications between pods or between pods and
 the outside of the cluster, except if those pods are host-networking pods.

--- a/examples/policies/host/demo-host-policy.yaml
+++ b/examples/policies/host/demo-host-policy.yaml
@@ -16,5 +16,5 @@ spec:
         protocol: TCP
   - icmps:
     - fields:
-      - type: 8
+      - type: EchoRequest
         family: IPv4


### PR DESCRIPTION
Two trivial improvements to the Host Firewall guide:

- Use the explicit name for the EchoRequest in the example policy (instead of "type: 8"), for better readability.
- Mention "ping" next to ICMP, to make it easier to search for this term in the document.

Fixes: https://github.com/cilium/cilium/issues/21986