### PR TITLE
policy/k8s: Fix bug where policy synchronization event was lost

### DIFF
--- a/pkg/policy/k8s/cell.go
+++ b/pkg/policy/k8s/cell.go
@@ -5,6 +5,7 @@ package k8s
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/cilium/stream"
 	"github.com/sirupsen/logrus"
@@ -19,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -43,6 +45,7 @@ var Cell = cell.Module(
 	"Watches K8s policy related objects",
 
 	cell.Invoke(startK8sPolicyWatcher),
+	cell.ProvidePrivate(newK8sSyncRegister),
 )
 
 type PolicyManager interface {
@@ -63,8 +66,7 @@ type PolicyWatcherParams struct {
 	Config    *option.DaemonConfig
 	Logger    logrus.FieldLogger
 
-	K8sResourceSynced *synced.Resources
-	K8sAPIGroups      *synced.APIGroups
+	K8sSyncRegister *k8sSyncRegister
 
 	PolicyManager promise.Promise[PolicyManager]
 	ServiceCache  *k8s.ServiceCache
@@ -86,6 +88,9 @@ func startK8sPolicyWatcher(p PolicyWatcherParams) {
 	svcCacheNotifications := stream.ToChannel(ctx, p.ServiceCache.Notifications(),
 		stream.WithBufferSize(int(p.Config.K8sServiceCacheSize)))
 
+	// Registering of resources needs to happen before the lifecycle is started
+	p.K8sSyncRegister.registerResources(ctx)
+
 	p.Lifecycle.Append(cell.Hook{
 		OnStart: func(startCtx cell.HookContext) error {
 			policyManager, err := p.PolicyManager.Await(startCtx)
@@ -96,8 +101,7 @@ func startK8sPolicyWatcher(p PolicyWatcherParams) {
 			w := &PolicyWatcher{
 				log:                              p.Logger,
 				config:                           p.Config,
-				k8sResourceSynced:                p.K8sResourceSynced,
-				k8sAPIGroups:                     p.K8sAPIGroups,
+				k8sSyncRegister:                  p.K8sSyncRegister,
 				svcCache:                         p.ServiceCache,
 				svcCacheNotifications:            svcCacheNotifications,
 				policyManager:                    policyManager,
@@ -114,7 +118,7 @@ func startK8sPolicyWatcher(p PolicyWatcherParams) {
 				cnpByServiceID:     make(map[k8s.ServiceID]map[resource.Key]struct{}),
 			}
 
-			w.watchResources(ctx)
+			go w.watchResources(ctx)
 
 			return nil
 		},
@@ -125,4 +129,93 @@ func startK8sPolicyWatcher(p PolicyWatcherParams) {
 			return nil
 		},
 	})
+}
+
+type k8sSyncRegister struct {
+	k8sResourceSynced *synced.Resources
+	k8sAPIGroups      *synced.APIGroups
+
+	k8sSyncResourceFlags map[string]*atomic.Bool
+
+	config *option.DaemonConfig
+	log    logrus.FieldLogger
+}
+
+type k8sSyncRegisterParams struct {
+	cell.In
+
+	Config *option.DaemonConfig
+	Logger logrus.FieldLogger
+
+	K8sResourceSynced *synced.Resources
+	K8sAPIGroups      *synced.APIGroups
+}
+
+// newK8sSyncRegister creates a new sync register where we track which K8s
+// resources have been synced
+func newK8sSyncRegister(p k8sSyncRegisterParams) *k8sSyncRegister {
+	k8sSyncResourceFlags := map[string]*atomic.Bool{
+		k8sAPIGroupCiliumNetworkPolicyV2:            new(atomic.Bool),
+		k8sAPIGroupCiliumClusterwideNetworkPolicyV2: new(atomic.Bool),
+		k8sAPIGroupCiliumCIDRGroupV2Alpha1:          new(atomic.Bool),
+	}
+	if p.Config.EnableK8sNetworkPolicy {
+		k8sSyncResourceFlags[k8sAPIGroupNetworkingV1Core] = new(atomic.Bool)
+	}
+
+	return &k8sSyncRegister{
+		k8sResourceSynced:    p.K8sResourceSynced,
+		k8sAPIGroups:         p.K8sAPIGroups,
+		k8sSyncResourceFlags: k8sSyncResourceFlags,
+
+		config: p.Config,
+		log:    p.Logger,
+	}
+}
+
+// registerResources registers all resources synced by this cell. This ensures that endpoint
+// regeneration does not happen before we have synced all network policies.
+// For CNPs and CCNPs, we only consider them synced if both the (C)CNP and CIDRGroup
+// resource has been synced. This needs to happen before the hive lifecylce is started.
+func (k *k8sSyncRegister) registerResources(ctx context.Context) {
+	f := k.k8sSyncResourceFlags
+
+	k.k8sResourceSynced.BlockWaitGroupToSyncResources(ctx.Done(), nil, func() bool {
+		return f[k8sAPIGroupCiliumNetworkPolicyV2].Load() && f[k8sAPIGroupCiliumCIDRGroupV2Alpha1].Load()
+	}, k8sAPIGroupCiliumNetworkPolicyV2)
+
+	k.k8sResourceSynced.BlockWaitGroupToSyncResources(ctx.Done(), nil, func() bool {
+		return f[k8sAPIGroupCiliumClusterwideNetworkPolicyV2].Load() && f[k8sAPIGroupCiliumCIDRGroupV2Alpha1].Load()
+	}, k8sAPIGroupCiliumClusterwideNetworkPolicyV2)
+
+	k.k8sResourceSynced.BlockWaitGroupToSyncResources(ctx.Done(), nil, func() bool {
+		return f[k8sAPIGroupCiliumCIDRGroupV2Alpha1].Load()
+	}, k8sAPIGroupCiliumCIDRGroupV2Alpha1)
+
+	if k.config.EnableK8sNetworkPolicy {
+		k.k8sResourceSynced.BlockWaitGroupToSyncResources(ctx.Done(), nil, func() bool {
+			return f[k8sAPIGroupNetworkingV1Core].Load()
+		}, k8sAPIGroupNetworkingV1Core)
+	}
+
+	// APIs handled by this cell
+	for resource := range k.k8sSyncResourceFlags {
+		k.k8sAPIGroups.AddAPI(resource)
+	}
+}
+
+// notifySynced forwards a sync event synced.K8sResources, thereby notifying any
+// subsystem waiting on a resource to be synced
+func (k *k8sSyncRegister) notifySynced(resource string) {
+	flag, ok := k.k8sSyncResourceFlags[resource]
+	if !ok {
+		k.log.WithField(logfields.Resource, resource).Error("BUG: Unregistered resource synced. Please report this bug to Cilium developers.")
+		return
+	}
+
+	flag.Store(true)
+}
+
+func (k *k8sSyncRegister) setEventTimestamp(resource string) {
+	k.k8sResourceSynced.SetEventTimestamp(resource)
 }

--- a/pkg/policy/k8s/cilium_cidr_group.go
+++ b/pkg/policy/k8s/cilium_cidr_group.go
@@ -22,7 +22,7 @@ func (p *PolicyWatcher) onUpsertCIDRGroup(
 ) error {
 
 	defer func() {
-		p.k8sResourceSynced.SetEventTimestamp(apiGroup)
+		p.k8sSyncRegister.setEventTimestamp(apiGroup)
 	}()
 
 	oldCidrGroup, ok := p.cidrGroupCache[cidrGroup.Name]
@@ -46,7 +46,7 @@ func (p *PolicyWatcher) onDeleteCIDRGroup(
 
 	err := p.updateCIDRGroupRefPolicies(cidrGroupName)
 
-	p.k8sResourceSynced.SetEventTimestamp(apiGroup)
+	p.k8sSyncRegister.setEventTimestamp(apiGroup)
 
 	return err
 }

--- a/pkg/policy/k8s/cilium_network_policy.go
+++ b/pkg/policy/k8s/cilium_network_policy.go
@@ -4,8 +4,6 @@
 package k8s
 
 import (
-	"context"
-
 	"github.com/sirupsen/logrus"
 
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
@@ -27,7 +25,7 @@ func (p *PolicyWatcher) onUpsert(
 	initialRecvTime := time.Now()
 
 	defer func() {
-		p.k8sResourceSynced.SetEventTimestamp(apiGroup)
+		p.k8sSyncRegister.setEventTimestamp(apiGroup)
 	}()
 
 	oldCNP, ok := p.cnpCache[key]
@@ -89,7 +87,7 @@ func (p *PolicyWatcher) onDelete(
 	}
 	delete(p.toServicesPolicies, key)
 
-	p.k8sResourceSynced.SetEventTimestamp(apiGroup)
+	p.k8sSyncRegister.setEventTimestamp(apiGroup)
 
 	return err
 }
@@ -173,11 +171,6 @@ func (p *PolicyWatcher) deleteCiliumNetworkPolicyV2(cnp *types.SlimCNP, resource
 		scopedLog.WithError(err).Warn("Unable to delete CiliumNetworkPolicy")
 	}
 	return err
-}
-
-func (p *PolicyWatcher) registerResourceWithSyncFn(ctx context.Context, resource string, syncFn func() bool) {
-	p.k8sResourceSynced.BlockWaitGroupToSyncResources(ctx.Done(), nil, syncFn, resource)
-	p.k8sAPIGroups.AddAPI(resource)
 }
 
 // reportCNPChangeMetrics generates metrics for changes (Add, Update, Delete) to

--- a/pkg/policy/k8s/network_policy.go
+++ b/pkg/policy/k8s/network_policy.go
@@ -17,7 +17,7 @@ import (
 
 func (p *PolicyWatcher) addK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPolicy, apiGroup string) error {
 	defer func() {
-		p.k8sResourceSynced.SetEventTimestamp(apiGroup)
+		p.k8sSyncRegister.setEventTimestamp(apiGroup)
 	}()
 
 	scopedLog := p.log.WithField(logfields.K8sAPIVersion, k8sNP.TypeMeta.APIVersion)
@@ -59,7 +59,7 @@ func (p *PolicyWatcher) addK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPo
 
 func (p *PolicyWatcher) deleteK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPolicy, apiGroup string) error {
 	defer func() {
-		p.k8sResourceSynced.SetEventTimestamp(apiGroup)
+		p.k8sSyncRegister.setEventTimestamp(apiGroup)
 	}()
 
 	labels := k8s.GetPolicyLabelsv1(k8sNP)

--- a/pkg/policy/k8s/service_test.go
+++ b/pkg/policy/k8s/service_test.go
@@ -250,10 +250,12 @@ func TestPolicyWatcher_updateToServicesPolicies(t *testing.T) {
 
 	svcCache := fakeServiceCache{}
 	p := &PolicyWatcher{
-		log:                logrus.NewEntry(logger),
-		config:             &option.DaemonConfig{},
-		k8sResourceSynced:  &k8sSynced.Resources{},
-		k8sAPIGroups:       &k8sSynced.APIGroups{},
+		log:    logrus.NewEntry(logger),
+		config: &option.DaemonConfig{},
+		k8sSyncRegister: &k8sSyncRegister{
+			k8sResourceSynced: &k8sSynced.Resources{},
+			k8sAPIGroups:      &k8sSynced.APIGroups{},
+		},
 		policyManager:      policyManager,
 		svcCache:           svcCache,
 		cnpCache:           map[resource.Key]*types.SlimCNP{},


### PR DESCRIPTION
This commit fixes an issue with the K8s policy ingestor where `InitK8sSubsystem` unblocked the daemon startup before all initial policies were processed by the ingestor.

This meant that we created unnecessary endpoint regenerations at startup, due to the initial endpoint regeneration being disrupted by the discovery of additional policies (and thus re-triggering endpoint regeneration).

The root cause of that bug was a race where sometimes we failed to register the policy resources with `BlockWaitGroupToSyncResources` before the other side (the K8s watcher in `InitK8sSubsystem`) called `WaitForCacheSyncWithTimeout`: If the call to `WaitForCacheSyncWithTimeout` happens before `BlockWaitGroupToSyncResources`, then `WaitForCacheSyncWithTimeout` assumes there is nothing to wait on and unblocks immediately. This commit fixes that issue by ensuring we register our resources via `BlockWaitGroupToSyncResources` in the cell constructor, thereby making sure they are registered before the Hive lifecycle starts.

Fixes: #31865