### PR TITLE
xds: Only pass relevant TLS config for originating/terminating TLS

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -343,6 +343,7 @@ cilium-agent [flags]
       --trace-sock                                                Enable tracing for socket-based LB (default true)
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")
+      --use-full-tls-context                                      If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.
       --version                                                   Print version information
       --vlan-bpf-bypass strings                                   List of explicitly allowed VLAN IDs, '0' id will allow all VLAN IDs
       --vtep-cidr strings                                         List of VTEP CIDRs that will be routed towards VTEPs for traffic cluster egress

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -99,6 +99,7 @@ cilium-agent hive [flags]
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")
+      --use-full-tls-context                                      If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.
       --write-cni-conf-when-ready string                          Write the CNI configuration to the specified path when agent is ready
 ```
 

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -104,6 +104,7 @@ cilium-agent hive dot-graph [flags]
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")
+      --use-full-tls-context                                      If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.
       --write-cni-conf-when-ready string                          Write the CNI configuration to the specified path when agent is ready
 ```
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -312,6 +312,9 @@ Annotations:
 * The ``cilium-dbg status --verbose`` command health data may now show health reported on a non-leaf
   component under a leaf named ``reporter``. Health data tree branches will now also be sorted by
   the fully qualified health status identifier.
+* L7 network policy with terminatingTLS will not load the key ``ca.crt`` even if it is present in the
+  secret. This prevents Envoy from incorrectly requiring client certificates from pods when using TLS
+  termination. To retain old behaviour for bug compatibility, please set ``--use-full-tls-context=true``.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -58,6 +58,7 @@ type envoyProxyConfig struct {
 	HTTPMaxGRPCTimeout                uint
 	HTTPRetryCount                    uint
 	HTTPRetryTimeout                  uint
+	UseFullTLSContext                 bool
 }
 
 func (r envoyProxyConfig) Flags(flags *pflag.FlagSet) {
@@ -77,6 +78,8 @@ func (r envoyProxyConfig) Flags(flags *pflag.FlagSet) {
 	flags.Uint("http-max-grpc-timeout", 0, "Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A \"grpc-timeout\" header may override this with a shorter value; defaults to 0 (unlimited)")
 	flags.Uint("http-retry-count", 3, "Number of retries performed after a forwarded request attempt fails")
 	flags.Uint("http-retry-timeout", 0, "Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)")
+	// This should default to false in 1.16+ (i.e., we don't implement buggy behaviour) and true in 1.15 and earlier (i.e., we keep compatibility with an existing bug).
+	flags.Bool("use-full-tls-context", false, "If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.")
 }
 
 type secretSyncConfig struct {
@@ -129,6 +132,7 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 			httpRetryCount:     int(params.EnvoyProxyConfig.HTTPRetryCount),
 			httpRetryTimeout:   int(params.EnvoyProxyConfig.HTTPRetryTimeout),
 			httpNormalizePath:  params.EnvoyProxyConfig.HTTPNormalizePath,
+			useFullTLSContext:  params.EnvoyProxyConfig.UseFullTLSContext,
 		})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Envoy xDS server: %w", err)

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1323,7 +1323,9 @@ var CiliumXDSConfigSource = &envoy_config_core.ConfigSource{
 	},
 }
 
-func getCiliumTLSContext(tls *policy.TLSContext) *cilium.TLSContext {
+// toEnvoyFullTLSContext converts a "policy" TLS context (i.e., from a CiliumNetworkPolicy or
+// CiliumClusterwideNetworkPolicy) into a "cilium envoy" TLS context (i.e., for the Cilium proxy plugin for Envoy).
+func toEnvoyFullTLSContext(tls *policy.TLSContext) *cilium.TLSContext {
 	return &cilium.TLSContext{
 		TrustedCa:        tls.TrustedCA,
 		CertificateChain: tls.CertificateChain,
@@ -1382,10 +1384,10 @@ func getPortNetworkPolicyRule(sel policy.CachedSelector, wildcard bool, l7Parser
 	}
 
 	if l7Rules.TerminatingTLS != nil {
-		r.DownstreamTlsContext = getCiliumTLSContext(l7Rules.TerminatingTLS)
+		r.DownstreamTlsContext = toEnvoyFullTLSContext(l7Rules.TerminatingTLS)
 	}
 	if l7Rules.OriginatingTLS != nil {
-		r.UpstreamTlsContext = getCiliumTLSContext(l7Rules.OriginatingTLS)
+		r.UpstreamTlsContext = toEnvoyFullTLSContext(l7Rules.OriginatingTLS)
 	}
 	if len(l7Rules.ServerNames) > 0 {
 		r.ServerNames = make([]string, 0, len(l7Rules.ServerNames))

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -486,47 +486,47 @@ func (s *ServerSuite) Test_getWildcardNetworkPolicyRule(c *C) {
 }
 
 func (s *ServerSuite) TestGetPortNetworkPolicyRule(c *C) {
-	obtained, canShortCircuit := getPortNetworkPolicyRule(cachedSelector1, cachedSelector1.IsWildcard(), policy.ParserTypeHTTP, L7Rules12)
+	obtained, canShortCircuit := getPortNetworkPolicyRule(cachedSelector1, cachedSelector1.IsWildcard(), policy.ParserTypeHTTP, L7Rules12, false)
 	c.Assert(obtained, checker.ExportedEquals, ExpectedPortNetworkPolicyRule12)
 	c.Assert(canShortCircuit, Equals, true)
 
-	obtained, canShortCircuit = getPortNetworkPolicyRule(cachedSelector1, cachedSelector1.IsWildcard(), policy.ParserTypeHTTP, L7Rules12HeaderMatch)
+	obtained, canShortCircuit = getPortNetworkPolicyRule(cachedSelector1, cachedSelector1.IsWildcard(), policy.ParserTypeHTTP, L7Rules12HeaderMatch, false)
 	c.Assert(obtained, checker.ExportedEquals, ExpectedPortNetworkPolicyRule122HeaderMatch)
 	c.Assert(canShortCircuit, Equals, false)
 
-	obtained, canShortCircuit = getPortNetworkPolicyRule(cachedSelector2, cachedSelector2.IsWildcard(), policy.ParserTypeHTTP, L7Rules1)
+	obtained, canShortCircuit = getPortNetworkPolicyRule(cachedSelector2, cachedSelector2.IsWildcard(), policy.ParserTypeHTTP, L7Rules1, false)
 	c.Assert(obtained, checker.ExportedEquals, ExpectedPortNetworkPolicyRule1)
 	c.Assert(canShortCircuit, Equals, true)
 }
 
 func (s *ServerSuite) TestGetDirectionNetworkPolicy(c *C) {
 	// L4+L7
-	obtained := getDirectionNetworkPolicy(ep, L4PolicyMap1, true, nil, "ingress")
+	obtained := getDirectionNetworkPolicy(ep, L4PolicyMap1, true, false, nil, "ingress")
 	c.Assert(obtained, checker.ExportedEquals, ExpectedPerPortPolicies12Wildcard)
 
 	// L4+L7 with header mods
-	obtained = getDirectionNetworkPolicy(ep, L4PolicyMap1HeaderMatch, true, nil, "ingress")
+	obtained = getDirectionNetworkPolicy(ep, L4PolicyMap1HeaderMatch, true, false, nil, "ingress")
 	c.Assert(obtained, checker.ExportedEquals, ExpectedPerPortPolicies122HeaderMatchWildcard)
 
 	// L4+L7
-	obtained = getDirectionNetworkPolicy(ep, L4PolicyMap2, true, nil, "ingress")
+	obtained = getDirectionNetworkPolicy(ep, L4PolicyMap2, true, false, nil, "ingress")
 	c.Assert(obtained, checker.ExportedEquals, ExpectedPerPortPolicies1Wildcard)
 
 	// L4-only
-	obtained = getDirectionNetworkPolicy(ep, L4PolicyMap4, true, nil, "ingress")
+	obtained = getDirectionNetworkPolicy(ep, L4PolicyMap4, true, false, nil, "ingress")
 	c.Assert(obtained, checker.ExportedEquals, ExpectedPerPortPoliciesWildcard)
 
 	// L4-only
-	obtained = getDirectionNetworkPolicy(ep, L4PolicyMap5, true, nil, "ingress")
+	obtained = getDirectionNetworkPolicy(ep, L4PolicyMap5, true, false, nil, "ingress")
 	c.Assert(obtained, checker.ExportedEquals, ExpectedPerPortPoliciesWildcard)
 
 	// L4-only with SNI
-	obtained = getDirectionNetworkPolicy(ep, L4PolicyMapSNI, true, nil, "ingress")
+	obtained = getDirectionNetworkPolicy(ep, L4PolicyMapSNI, true, false, nil, "ingress")
 	c.Assert(obtained, checker.ExportedEquals, ExpectedPerPortPoliciesSNI)
 }
 
 func (s *ServerSuite) TestGetNetworkPolicy(c *C) {
-	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4Policy1, true, true)
+	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4Policy1, true, true, false)
 	expected := &cilium.NetworkPolicy{
 		EndpointIps:            []string{IPv4Addr},
 		EndpointId:             uint64(ep.GetID()),
@@ -538,7 +538,7 @@ func (s *ServerSuite) TestGetNetworkPolicy(c *C) {
 }
 
 func (s *ServerSuite) TestGetNetworkPolicyWildcard(c *C) {
-	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4Policy2, true, true)
+	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4Policy2, true, true, false)
 	expected := &cilium.NetworkPolicy{
 		EndpointIps:            []string{IPv4Addr},
 		EndpointId:             uint64(ep.GetID()),
@@ -550,7 +550,7 @@ func (s *ServerSuite) TestGetNetworkPolicyWildcard(c *C) {
 }
 
 func (s *ServerSuite) TestGetNetworkPolicyDeny(c *C) {
-	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4Policy1RequiresV2, true, true)
+	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4Policy1RequiresV2, true, true, false)
 	expected := &cilium.NetworkPolicy{
 		EndpointIps:            []string{IPv4Addr},
 		EndpointId:             uint64(ep.GetID()),
@@ -562,7 +562,7 @@ func (s *ServerSuite) TestGetNetworkPolicyDeny(c *C) {
 }
 
 func (s *ServerSuite) TestGetNetworkPolicyWildcardDeny(c *C) {
-	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4Policy1RequiresV2, true, true)
+	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4Policy1RequiresV2, true, true, false)
 	expected := &cilium.NetworkPolicy{
 		EndpointIps:            []string{IPv4Addr},
 		EndpointId:             uint64(ep.GetID()),
@@ -574,7 +574,7 @@ func (s *ServerSuite) TestGetNetworkPolicyWildcardDeny(c *C) {
 }
 
 func (s *ServerSuite) TestGetNetworkPolicyNil(c *C) {
-	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, nil, true, true)
+	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, nil, true, true, false)
 	expected := &cilium.NetworkPolicy{
 		EndpointIps:            []string{IPv4Addr},
 		EndpointId:             uint64(ep.GetID()),
@@ -586,7 +586,7 @@ func (s *ServerSuite) TestGetNetworkPolicyNil(c *C) {
 }
 
 func (s *ServerSuite) TestGetNetworkPolicyIngressNotEnforced(c *C) {
-	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4Policy2, false, true)
+	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4Policy2, false, true, false)
 	expected := &cilium.NetworkPolicy{
 		EndpointIps:            []string{IPv4Addr},
 		EndpointId:             uint64(ep.GetID()),
@@ -598,7 +598,7 @@ func (s *ServerSuite) TestGetNetworkPolicyIngressNotEnforced(c *C) {
 }
 
 func (s *ServerSuite) TestGetNetworkPolicyEgressNotEnforced(c *C) {
-	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4Policy1RequiresV2, true, false)
+	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4Policy1RequiresV2, true, false, false)
 	expected := &cilium.NetworkPolicy{
 		EndpointIps:            []string{IPv4Addr},
 		EndpointId:             uint64(ep.GetID()),
@@ -662,7 +662,7 @@ var ExpectedPerPortPoliciesL7 = []*cilium.PortNetworkPolicy{
 }
 
 func (s *ServerSuite) TestGetNetworkPolicyL7(c *C) {
-	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4PolicyL7, true, true)
+	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4PolicyL7, true, true, false)
 	expected := &cilium.NetworkPolicy{
 		EndpointIps:            []string{IPv4Addr},
 		EndpointId:             uint64(ep.GetID()),
@@ -721,7 +721,7 @@ var ExpectedPerPortPoliciesKafka = []*cilium.PortNetworkPolicy{
 }
 
 func (s *ServerSuite) TestGetNetworkPolicyKafka(c *C) {
-	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4PolicyKafka, true, true)
+	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4PolicyKafka, true, true, false)
 	expected := &cilium.NetworkPolicy{
 		EndpointIps:            []string{IPv4Addr},
 		EndpointId:             uint64(ep.GetID()),
@@ -795,7 +795,7 @@ var ExpectedPerPortPoliciesMySQL = []*cilium.PortNetworkPolicy{
 }
 
 func (s *ServerSuite) TestGetNetworkPolicyMySQL(c *C) {
-	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4PolicyMySQL, true, true)
+	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4PolicyMySQL, true, true, false)
 	expected := &cilium.NetworkPolicy{
 		EndpointIps:           []string{IPv4Addr},
 		EndpointId:            uint64(ep.GetID()),
@@ -820,7 +820,7 @@ var kafkaIngressVisibilityPolicy = &policy.VisibilityPolicy{
 func (s *ServerSuite) TestGetNetworkPolicyProxylibVisibility(c *C) {
 	// No visibility gets allow-all policies
 	// Allow-all policies are generated also when l4 filter is nil when policy is not enforced.
-	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, nil, false, false)
+	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, nil, false, false, false)
 
 	expected := &cilium.NetworkPolicy{
 		EndpointIps:            []string{IPv4Addr},
@@ -832,7 +832,7 @@ func (s *ServerSuite) TestGetNetworkPolicyProxylibVisibility(c *C) {
 
 	c.Assert(obtained, checker.ExportedEquals, expected)
 
-	obtained = getNetworkPolicy(ep, kafkaIngressVisibilityPolicy, []string{IPv4Addr}, nil, false, false)
+	obtained = getNetworkPolicy(ep, kafkaIngressVisibilityPolicy, []string{IPv4Addr}, nil, false, false, false)
 
 	// Visibility policies still contain the allow-all policies, when policy is not enforced
 	expected = &cilium.NetworkPolicy{
@@ -886,7 +886,7 @@ var ExpectedPerPortPoliciesTLSEgress = []*cilium.PortNetworkPolicy{
 }
 
 func (s *ServerSuite) TestGetNetworkPolicyTLSEgress(c *C) {
-	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4PolicyTLSEgress, true, true)
+	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4PolicyTLSEgress, true, true, false)
 	expected := &cilium.NetworkPolicy{
 		EndpointIps:           []string{IPv4Addr},
 		EndpointId:            uint64(ep.GetID()),
@@ -928,11 +928,104 @@ var ExpectedPerPortPoliciesTLSIngress = []*cilium.PortNetworkPolicy{
 }
 
 func (s *ServerSuite) TestGetNetworkPolicyTLSIngress(c *C) {
-	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4PolicyTLSIngress, true, true)
+	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4PolicyTLSIngress, true, true, false)
 	expected := &cilium.NetworkPolicy{
 		EndpointIps:            []string{IPv4Addr},
 		EndpointId:             uint64(ep.GetID()),
 		IngressPerPortPolicies: ExpectedPerPortPoliciesTLSIngress,
+		ConntrackMapName:       "global",
+	}
+	c.Assert(obtained, checker.ExportedEquals, expected)
+}
+
+var L4PolicyTLSFullContext = &policy.L4Policy{
+	Ingress: policy.L4DirectionPolicy{PortRules: map[string]*policy.L4Filter{
+		"443/TCP": {
+			Port: 443, Protocol: api.ProtoTCP,
+			L7Parser: "tls",
+			PerSelectorPolicies: policy.L7DataMap{
+				cachedSelector1: &policy.PerSelectorPolicy{
+					TerminatingTLS: &policy.TLSContext{
+						CertificateChain: "terminatingCertchain",
+						PrivateKey:       "terminatingKey",
+						TrustedCA:        "terminatingCA",
+					},
+					OriginatingTLS: &policy.TLSContext{
+						CertificateChain: "originatingCertchain",
+						PrivateKey:       "originatingKey",
+						TrustedCA:        "originatingCA",
+					},
+				},
+			},
+			Ingress: true,
+		},
+	}},
+}
+
+var ExpectedPerPortPoliciesTLSFullContext = []*cilium.PortNetworkPolicy{
+	{
+		Port:     443,
+		Protocol: envoy_config_core.SocketAddress_TCP,
+		Rules: []*cilium.PortNetworkPolicyRule{{
+			DownstreamTlsContext: &cilium.TLSContext{
+				CertificateChain: "terminatingCertchain",
+				PrivateKey:       "terminatingKey",
+				TrustedCa:        "terminatingCA",
+			},
+			UpstreamTlsContext: &cilium.TLSContext{
+				CertificateChain: "originatingCertchain",
+				PrivateKey:       "originatingKey",
+				TrustedCa:        "originatingCA",
+			},
+		}},
+	},
+}
+
+// TestGetNetworkPolicyFullTLSContextEnabled tests that when the useFullTLSContext flag is passed we propagate all keys
+// from the secret to the Envoy config, including a CA on terminatingTLS/downstreamTls and a cert/key on originatingTLS/
+// upstreamTls. This is likely *not* correct, but is supported as an option for backwards bug compatabality. See
+// https://github.com/cilium/cilium/issues/31761 for full context.
+func (s *ServerSuite) TestGetNetworkPolicyFullTLSContextEnabled(c *C) {
+	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4PolicyTLSFullContext, true, true, true)
+	expected := &cilium.NetworkPolicy{
+		EndpointIps:            []string{IPv4Addr},
+		EndpointId:             uint64(ep.GetID()),
+		IngressPerPortPolicies: ExpectedPerPortPoliciesTLSFullContext,
+		ConntrackMapName:       "global",
+	}
+	c.Assert(obtained, checker.ExportedEquals, expected)
+}
+
+var ExpectedPerPortPoliciesTLSNotFullContext = []*cilium.PortNetworkPolicy{
+	{
+		Port:     443,
+		Protocol: envoy_config_core.SocketAddress_TCP,
+		Rules: []*cilium.PortNetworkPolicyRule{{
+			DownstreamTlsContext: &cilium.TLSContext{
+				CertificateChain: "terminatingCertchain",
+				PrivateKey:       "terminatingKey",
+			},
+			UpstreamTlsContext: &cilium.TLSContext{
+				TrustedCa: "originatingCA",
+			},
+		}},
+	},
+}
+
+// TestGetNetworkPolicyStripUnusedKeys is the counterpart to TestGetNetworkPolicyFullTLSContextEnabled, in that
+// it tests that when useFullTLSContext is false (i.e., don't implement buggy behaviour) we correctly strip out the CA
+// for a terminatingTLS/downstreamTls and the cert/key on originatingTLS/upstreamTls. Leaving them in can result in
+// incorrect behaviour from Envoy when using Cilium L7 policy, see https://github.com/cilium/cilium/issues/31761 for
+// full details.
+//
+// Even when the useFullTLSContext flag is removed in a future release, this test (or a variant of it) must remain to
+// verify that we correctly do not copy over the CA on terminatingTLS or the cert/key on originatingTLS.
+func (s *ServerSuite) TestGetNetworkPolicyStripUnusedKeys(c *C) {
+	obtained := getNetworkPolicy(ep, nil, []string{IPv4Addr}, L4PolicyTLSFullContext, true, true, false)
+	expected := &cilium.NetworkPolicy{
+		EndpointIps:            []string{IPv4Addr},
+		EndpointId:             uint64(ep.GetID()),
+		IngressPerPortPolicies: ExpectedPerPortPoliciesTLSNotFullContext,
 		ConntrackMapName:       "global",
 	}
 	c.Assert(obtained, checker.ExportedEquals, expected)

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -903,7 +903,7 @@ var L4PolicyTLSIngress = &policy.L4Policy{
 			L7Parser: "tls",
 			PerSelectorPolicies: policy.L7DataMap{
 				cachedSelector1: &policy.PerSelectorPolicy{
-					OriginatingTLS: &policy.TLSContext{
+					TerminatingTLS: &policy.TLSContext{
 						CertificateChain: "certchain",
 						PrivateKey:       "key",
 					},
@@ -919,7 +919,7 @@ var ExpectedPerPortPoliciesTLSIngress = []*cilium.PortNetworkPolicy{
 		Port:     443,
 		Protocol: envoy_config_core.SocketAddress_TCP,
 		Rules: []*cilium.PortNetworkPolicyRule{{
-			UpstreamTlsContext: &cilium.TLSContext{
+			DownstreamTlsContext: &cilium.TLSContext{
 				CertificateChain: "certchain",
 				PrivateKey:       "key",
 			},


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

See the release note for a summary of the change, and #31761 for discussion of the bug this fixes. A flag is provided for backwards compatibility, set to false for future versions of Cilium. The intent is to set this to true in backports, so as not to change behavior unexpectedly in a patch release.

Fixes: #31761 

```release-note
Only read the relevant parts of secrets for originatingTLS (ca.crt) and terminatingTLS (tls.crt, tls.key) blocks in Cilium L7 policies. Fixes a bug where a ca.crt key in a secret passed to terminatingTLS incorrectly configures Envoy to require a client certificate on TLS connections from pods. Previous behavior can be restored with the --use-full-tls-context=true agent flag.
```
