### PR TITLE
[v1.15] cilium-dbg: remove section with unknown health status.

### DIFF
--- a/pkg/health/client/modules.go
+++ b/pkg/health/client/modules.go
@@ -62,15 +62,13 @@ func GetAndFormatModulesHealth(w io.Writer, clt ModulesHealth, verbose bool) {
 	for _, m := range resp.Payload.Modules {
 		tally[cell.Level(m.Level)] += 1
 	}
-	fmt.Fprintf(w, "\t%s(%d) %s(%d) %s(%d) %s(%d)\n",
+	fmt.Fprintf(w, "\t%s(%d) %s(%d) %s(%d)\n",
 		cell.StatusStopped,
 		tally[cell.StatusStopped],
 		cell.StatusDegraded,
 		tally[cell.StatusDegraded],
 		cell.StatusOK,
 		tally[cell.StatusOK],
-		cell.StatusUnknown,
-		tally[cell.StatusUnknown],
 	)
 }
 

--- a/pkg/health/client/modules_test.go
+++ b/pkg/health/client/modules_test.go
@@ -31,7 +31,7 @@ func TestGetAndFormatModulesHealth(t *testing.T) {
 		},
 		"happy": {
 			h: newTestMHappy(),
-			e: "Modules Health:\tStopped(0) Degraded(1) OK(1) Unknown(0)",
+			e: "Modules Health:\tStopped(0) Degraded(1) OK(1)",
 		},
 		"happy-verbose": {
 			h: newTestMHappy(),


### PR DESCRIPTION
**This is not a backport**

Current changes in main branch already fixed [this](https://github.com/tommyp1ckles/cilium/commit/2434bf2a13df026989e5402bd84b4968624811aa#diff-491a0257dce068f8a03a32eae4f968424b041c587b76b73d11266b5c5d965d1bR54-R60).  This was initially planned to be[ fixed in main first ](https://github.com/cilium/cilium/pull/30541)and backported, however these [commits](https://github.com/cilium/cilium/pull/30925) cannot be backported to v1.15.

This mirrors the original fix PR by removing the Unknown status in v1.15, other version branches are unaffected. 

The "unknown" status simply refers to components that accept a health reporter scope, but have not declared their state as being either "ok" or degraded.

This is a bit confusing, as this does not necessarily mean any problems with Cilium.

In the future we may want to rework this state to distinguish between unreported states and components that are "timing-out" reconciling a desired state.

This PR simply removes displaying this information in `cilium-dbg status`
