### PR TITLE
v1.14 backports 2024-04-11

### DIFF
--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -16,6 +16,7 @@ import (
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 )
 
 var (
@@ -222,6 +223,9 @@ func registerMetrics() []prometheus.Collector {
 	collectors = append(collectors, CiliumEndpointSliceQueueDelay)
 
 	Registry.MustRegister(collectors...)
+	metrics.InitOperatorMetrics()
+	Registry.MustRegister(metrics.ErrorsWarnings)
+	metrics.FlushLoggingMetrics()
 
 	return collectors
 }

--- a/pkg/metrics/cell.go
+++ b/pkg/metrics/cell.go
@@ -14,9 +14,6 @@ var Cell = cell.Module("metrics", "Metrics",
 	cell.Invoke(func() {
 		// This is a hack to ensure that errors/warnings collected in the pre hive initialization
 		// phase are emitted as metrics.
-		if metricsInitialized != nil {
-			close(metricsInitialized)
-			metricsInitialized = nil
-		}
+		FlushLoggingMetrics()
 	}),
 )

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -911,12 +911,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Help:       "Number of services events labeled by action type",
 		}, []string{LabelAction}),
 
-		ErrorsWarnings: metric.NewCounterVec(metric.CounterOpts{
-			ConfigName: Namespace + "_errors_warnings_total",
-			Namespace:  Namespace,
-			Name:       "errors_warnings_total",
-			Help:       "Number of total errors in cilium-agent instances",
-		}, []string{"level", "subsystem"}),
+		ErrorsWarnings: newErrorsWarningsMetric(),
 
 		ControllerRuns: metric.NewCounterVec(metric.CounterOpts{
 			ConfigName: Namespace + "_controllers_runs_total",
@@ -1346,6 +1341,20 @@ func NewLegacyMetrics() *LegacyMetrics {
 	APILimiterProcessedRequests = lm.APILimiterProcessedRequests
 
 	return lm
+}
+
+// InitOperatorMetrics is used to init legacy metrics necessary during operator init.
+func InitOperatorMetrics() {
+	ErrorsWarnings = newErrorsWarningsMetric()
+}
+
+func newErrorsWarningsMetric() metric.Vec[metric.Counter] {
+	return metric.NewCounterVec(metric.CounterOpts{
+		ConfigName: Namespace + "_errors_warnings_total",
+		Namespace:  Namespace,
+		Name:       "errors_warnings_total",
+		Help:       "Number of total errors in cilium-agent instances",
+	}, []string{"level", "subsystem"})
 }
 
 // GaugeWithThreshold is a prometheus gauge that registers itself with


### PR DESCRIPTION
- https://github.com/cilium/cilium/pull/31214

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 31214
```