### PR TITLE
ci-e2e-upgrade: Disable ingress-controller and bpf.tproxy=true

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -162,7 +162,7 @@ jobs:
             lb-acceleration: 'testing-only'
             # Disable until https://github.com/cilium/cilium/issues/30717
             # has been resolved.
-            ingress-controller: 'true'
+            # ingress-controller: 'true'
 
           - name: '8'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -214,7 +214,7 @@ jobs:
             egress-gateway: 'true'
             # Disable until https://github.com/cilium/cilium/issues/30717
             # has been resolved.
-            ingress-controller: 'true'
+            # ingress-controller: 'true'
 
           # Disable until https://github.com/cilium/cilium/pull/31622
           # has been released. Otherwise, the health-ep is failing quite
@@ -259,7 +259,7 @@ jobs:
             tunnel: 'disabled'
             # Disable until https://github.com/cilium/cilium/issues/30717
             # has been resolved.
-            ingress-controller: 'true'
+            # ingress-controller: 'true'
             misc: 'bpfClockProbe=false,cni.uninstall=false,bpf.tproxy=true'
 
           - name: '16'

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -260,7 +260,9 @@ jobs:
             # Disable until https://github.com/cilium/cilium/issues/30717
             # has been resolved.
             # ingress-controller: 'true'
-            misc: 'bpfClockProbe=false,cni.uninstall=false,bpf.tproxy=true'
+            # Disable bpf.tproxy=true until https://github.com/cilium/cilium/issues/31918
+            # has been resolved.
+            misc: 'bpfClockProbe=false,cni.uninstall=false'
 
           - name: '16'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind


### PR DESCRIPTION
This time for real.

Fixes: dc3a2bed6d8 ("ci-e2e-upgrade: Disable ingress-controller")