### PR TITLE
Introduce fromEgressProxyRule

### DIFF
--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -70,9 +70,9 @@ const (
 	// the proxy package for redirecting inbound packets to the proxy.
 	RulePriorityToProxyIngress = 9
 
-	// RulePriorityFromProxyIngress is the priority of the routing rule installed by
-	// the proxy package for redirecting inbound packets from the proxy.
-	RulePriorityFromProxyIngress = 10
+	// RulePriorityFromProxy is the priority of the routing rule installed by
+	// the proxy package for redirecting packets from the proxy.
+	RulePriorityFromProxy = 10
 
 	// RulePriorityIngress is the priority of the rule used for ingress routing
 	// of endpoints. This priority is after encryption and proxy rules, and

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -411,7 +411,7 @@ func (p *Proxy) ReinstallRoutingRules() error {
 		}
 
 		if !option.Config.EnableIPSec || option.Config.TunnelingEnabled() {
-			if err := removeFromProxyRoutesIPv4(); err != nil {
+			if err := removeFromIngressProxyRoutesIPv4(); err != nil {
 				return err
 			}
 		} else {
@@ -423,7 +423,7 @@ func (p *Proxy) ReinstallRoutingRules() error {
 		if err := removeToProxyRoutesIPv4(); err != nil {
 			return err
 		}
-		if err := removeFromProxyRoutesIPv4(); err != nil {
+		if err := removeFromIngressProxyRoutesIPv4(); err != nil {
 			return err
 		}
 	}
@@ -434,7 +434,7 @@ func (p *Proxy) ReinstallRoutingRules() error {
 		}
 
 		if !option.Config.EnableIPSec || option.Config.TunnelingEnabled() {
-			if err := removeFromProxyRoutesIPv6(); err != nil {
+			if err := removeFromIngressProxyRoutesIPv6(); err != nil {
 				return err
 			}
 		} else {
@@ -450,7 +450,7 @@ func (p *Proxy) ReinstallRoutingRules() error {
 		if err := removeToProxyRoutesIPv6(); err != nil {
 			return err
 		}
-		if err := removeFromProxyRoutesIPv6(); err != nil {
+		if err := removeFromIngressProxyRoutesIPv6(); err != nil {
 			return err
 		}
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -410,6 +410,9 @@ func (p *Proxy) ReinstallRoutingRules() error {
 			return err
 		}
 
+		if err := removeFromEgressProxyRoutesIPv4(); err != nil {
+			return err
+		}
 		if !option.Config.EnableIPSec || option.Config.TunnelingEnabled() {
 			if err := removeFromIngressProxyRoutesIPv4(); err != nil {
 				return err
@@ -433,6 +436,9 @@ func (p *Proxy) ReinstallRoutingRules() error {
 			return err
 		}
 
+		if err := removeFromEgressProxyRoutesIPv6(); err != nil {
+			return err
+		}
 		if !option.Config.EnableIPSec || option.Config.TunnelingEnabled() {
 			if err := removeFromIngressProxyRoutesIPv6(); err != nil {
 				return err

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -100,10 +100,10 @@ func removeToProxyRoutesIPv6() error {
 }
 
 var (
-	// Routing rule for traffic from proxy.
-	fromProxyRule = route.Rule{
+	// Routing rule for traffic from ingress proxy.
+	fromIngressProxyRule = route.Rule{
 		Priority: linux_defaults.RulePriorityFromProxyIngress,
-		Mark:     linux_defaults.MagicMarkIsProxy,
+		Mark:     linux_defaults.MagicMarkIngress,
 		Mask:     linux_defaults.MagicMarkHostMask,
 		Table:    linux_defaults.RouteTableFromProxy,
 		Protocol: linux_defaults.RTProto,
@@ -130,8 +130,8 @@ func installFromProxyRoutesIPv4(ipv4 net.IP, device string) error {
 		Proto:   linux_defaults.RTProto,
 	}
 
-	if err := route.ReplaceRule(fromProxyRule); err != nil {
-		return fmt.Errorf("inserting ipv4 from proxy routing rule %v: %w", fromProxyRule, err)
+	if err := route.ReplaceRule(fromIngressProxyRule); err != nil {
+		return fmt.Errorf("inserting ipv4 from ingress proxy routing rule %v: %w", fromIngressProxyRule, err)
 	}
 	if err := route.Upsert(fromProxyToCiliumHostRoute4); err != nil {
 		return fmt.Errorf("inserting ipv4 from proxy to cilium_host route %v: %w", fromProxyToCiliumHostRoute4, err)
@@ -143,10 +143,10 @@ func installFromProxyRoutesIPv4(ipv4 net.IP, device string) error {
 	return nil
 }
 
-// removeFromProxyRoutesIPv4 ensures routes and rules for traffic from the proxy are removed.
-func removeFromProxyRoutesIPv4() error {
-	if err := route.DeleteRule(netlink.FAMILY_V4, fromProxyRule); err != nil && !errors.Is(err, syscall.ENOENT) {
-		return fmt.Errorf("removing ipv4 from proxy routing rule: %w", err)
+// removeFromIngressProxyRoutesIPv4 ensures routes and rules for traffic from the proxy are removed.
+func removeFromIngressProxyRoutesIPv4() error {
+	if err := route.DeleteRule(netlink.FAMILY_V4, fromIngressProxyRule); err != nil && !errors.Is(err, syscall.ENOENT) {
+		return fmt.Errorf("removing ipv4 from ingress proxy routing rule: %w", err)
 	}
 	if err := route.DeleteRouteTable(linux_defaults.RouteTableFromProxy, netlink.FAMILY_V4); err != nil {
 		return fmt.Errorf("removing ipv4 from proxy route table: %w", err)
@@ -175,8 +175,8 @@ func installFromProxyRoutesIPv6(ipv6 net.IP, device string) error {
 		Proto:   linux_defaults.RTProto,
 	}
 
-	if err := route.ReplaceRuleIPv6(fromProxyRule); err != nil {
-		return fmt.Errorf("inserting ipv6 from proxy routing rule %v: %w", fromProxyRule, err)
+	if err := route.ReplaceRuleIPv6(fromIngressProxyRule); err != nil {
+		return fmt.Errorf("inserting ipv6 from ingress proxy routing rule %v: %w", fromIngressProxyRule, err)
 	}
 	if err := route.Upsert(fromProxyToCiliumHostRoute6); err != nil {
 		return fmt.Errorf("inserting ipv6 from proxy to cilium_host route %v: %w", fromProxyToCiliumHostRoute6, err)
@@ -188,11 +188,11 @@ func installFromProxyRoutesIPv6(ipv6 net.IP, device string) error {
 	return nil
 }
 
-// removeFromProxyRoutesIPv6 ensures routes and rules for traffic from the proxy are removed.
-func removeFromProxyRoutesIPv6() error {
-	if err := route.DeleteRule(netlink.FAMILY_V6, fromProxyRule); err != nil {
+// removeFromIngressProxyRoutesIPv6 ensures routes and rules for traffic from the proxy are removed.
+func removeFromIngressProxyRoutesIPv6() error {
+	if err := route.DeleteRule(netlink.FAMILY_V6, fromIngressProxyRule); err != nil {
 		if !errors.Is(err, syscall.ENOENT) && !errors.Is(err, syscall.EAFNOSUPPORT) {
-			return fmt.Errorf("removing ipv6 from proxy routing rule: %w", err)
+			return fmt.Errorf("removing ipv6 from ingress proxy routing rule: %w", err)
 		}
 	}
 	if err := route.DeleteRouteTable(linux_defaults.RouteTableFromProxy, netlink.FAMILY_V6); err != nil {

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -108,6 +108,15 @@ var (
 		Table:    linux_defaults.RouteTableFromProxy,
 		Protocol: linux_defaults.RTProto,
 	}
+
+	//nolint:unused // Routing rule for traffic from egress proxy.
+	fromEgressProxyRule = route.Rule{
+		Priority: linux_defaults.RulePriorityFromProxy,
+		Mark:     linux_defaults.MagicMarkEgress,
+		Mask:     linux_defaults.MagicMarkHostMask,
+		Table:    linux_defaults.RouteTableFromProxy,
+		Protocol: linux_defaults.RTProto,
+	}
 )
 
 // installFromProxyRoutesIPv4 configures routes and rules needed to redirect ingress

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -109,7 +109,7 @@ var (
 		Protocol: linux_defaults.RTProto,
 	}
 
-	//nolint:unused // Routing rule for traffic from egress proxy.
+	// Routing rule for traffic from egress proxy.
 	fromEgressProxyRule = route.Rule{
 		Priority: linux_defaults.RulePriorityFromProxy,
 		Mark:     linux_defaults.MagicMarkEgress,
@@ -164,6 +164,13 @@ func removeFromIngressProxyRoutesIPv4() error {
 	return nil
 }
 
+func removeFromEgressProxyRoutesIPv4() error {
+	if err := route.DeleteRule(netlink.FAMILY_V4, fromEgressProxyRule); err != nil && !errors.Is(err, syscall.ENOENT) {
+		return fmt.Errorf("removing ipv4 from egress proxy routing rule: %w", err)
+	}
+	return nil
+}
+
 // installFromProxyRoutesIPv6 configures routes and rules needed to redirect ingress
 // packets from the proxy.
 func installFromProxyRoutesIPv6(ipv6 net.IP, device string) error {
@@ -208,5 +215,14 @@ func removeFromIngressProxyRoutesIPv6() error {
 		return fmt.Errorf("removing ipv6 from proxy route table: %w", err)
 	}
 
+	return nil
+}
+
+func removeFromEgressProxyRoutesIPv6() error {
+	if err := route.DeleteRule(netlink.FAMILY_V6, fromEgressProxyRule); err != nil {
+		if !errors.Is(err, syscall.ENOENT) && !errors.Is(err, syscall.EAFNOSUPPORT) {
+			return fmt.Errorf("removing ipv6 from egress proxy routing rule: %w", err)
+		}
+	}
 	return nil
 }

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -102,7 +102,7 @@ func removeToProxyRoutesIPv6() error {
 var (
 	// Routing rule for traffic from ingress proxy.
 	fromIngressProxyRule = route.Rule{
-		Priority: linux_defaults.RulePriorityFromProxyIngress,
+		Priority: linux_defaults.RulePriorityFromProxy,
 		Mark:     linux_defaults.MagicMarkIngress,
 		Mask:     linux_defaults.MagicMarkHostMask,
 		Table:    linux_defaults.RouteTableFromProxy,

--- a/pkg/proxy/routes_test.go
+++ b/pkg/proxy/routes_test.go
@@ -74,7 +74,7 @@ func TestRoutes(t *testing.T) {
 				// Install routes and rules the first time.
 				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName))
 
-				rules, err := route.ListRules(netlink.FAMILY_V4, &fromProxyRule)
+				rules, err := route.ListRules(netlink.FAMILY_V4, &fromIngressProxyRule)
 				assert.NoError(t, err)
 				assert.NotEmpty(t, rules)
 
@@ -88,9 +88,9 @@ func TestRoutes(t *testing.T) {
 				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName))
 
 				// Remove routes installed before.
-				assert.NoError(t, removeFromProxyRoutesIPv4())
+				assert.NoError(t, removeFromIngressProxyRoutesIPv4())
 
-				rules, err = route.ListRules(netlink.FAMILY_V4, &fromProxyRule)
+				rules, err = route.ListRules(netlink.FAMILY_V4, &fromIngressProxyRule)
 				assert.NoError(t, err)
 				assert.Empty(t, rules)
 
@@ -161,7 +161,7 @@ func TestRoutes(t *testing.T) {
 				// Install routes and rules the first time.
 				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName))
 
-				rules, err := route.ListRules(netlink.FAMILY_V6, &fromProxyRule)
+				rules, err := route.ListRules(netlink.FAMILY_V6, &fromIngressProxyRule)
 				assert.NoError(t, err)
 				assert.NotEmpty(t, rules)
 
@@ -175,9 +175,9 @@ func TestRoutes(t *testing.T) {
 				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName))
 
 				// Remove routes installed before.
-				assert.NoError(t, removeFromProxyRoutesIPv6())
+				assert.NoError(t, removeFromIngressProxyRoutesIPv6())
 
-				rules, err = route.ListRules(netlink.FAMILY_V6, &fromProxyRule)
+				rules, err = route.ListRules(netlink.FAMILY_V6, &fromIngressProxyRule)
 				assert.NoError(t, err)
 				assert.Empty(t, rules)
 


### PR DESCRIPTION
This simple PR introduces a new ip rule without installing it, mainly meant to take care of cilium downgrade for the new ip rule. Please see the commit messages for details.

This PR (along with its backport PRs) is the stage one of #31984 to address the remaining IPsec leak issues. Please see that issue for the the context.

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>