### PR TITLE
policy: skip client side validation of policies that can't be validated

### DIFF
--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -19,6 +19,10 @@ const (
 	maxICMPFields = 40
 )
 
+var (
+	ErrFromToNodesRequiresNodeSelectorOption = fmt.Errorf("FromNodes/ToNodes rules can only be applied when the %q flag is set", option.EnableNodeSelectorLabels)
+)
+
 // Sanitize validates and sanitizes a policy rule. Minor edits such as
 // capitalization of the protocol name are automatically fixed up. More
 // fundamental violations will cause an error to be returned.
@@ -95,6 +99,8 @@ func countL7Rules(ports []PortRule) map[string]int {
 }
 
 func (i *IngressRule) sanitize() error {
+	var retErr error
+
 	l3Members := map[string]int{
 		"FromEndpoints": len(i.FromEndpoints),
 		"FromCIDR":      len(i.FromCIDR),
@@ -136,7 +142,7 @@ func (i *IngressRule) sanitize() error {
 	}
 
 	if len(i.FromNodes) > 0 && !option.Config.EnableNodeSelectorLabels {
-		return fmt.Errorf("FromNodes rules can only be applied when the %q flag is set", option.EnableNodeSelectorLabels)
+		retErr = ErrFromToNodesRequiresNodeSelectorOption
 	}
 
 	for _, es := range i.FromEndpoints {
@@ -190,7 +196,7 @@ func (i *IngressRule) sanitize() error {
 
 	i.SetAggregatedSelectors()
 
-	return nil
+	return retErr
 }
 
 // countNonGeneratedRules counts the number of CIDRRule items which are not
@@ -211,6 +217,8 @@ func countNonGeneratedCIDRRules(s CIDRRuleSlice) int {
 }
 
 func (e *EgressRule) sanitize() error {
+	var retErr error
+
 	l3Members := map[string]int{
 		"ToCIDR":      len(e.ToCIDR),
 		"ToCIDRSet":   countNonGeneratedCIDRRules(e.ToCIDRSet),
@@ -269,7 +277,7 @@ func (e *EgressRule) sanitize() error {
 	}
 
 	if len(e.ToNodes) > 0 && !option.Config.EnableNodeSelectorLabels {
-		return fmt.Errorf("ToNodes rules can only be applied when the %q flag is set", option.EnableNodeSelectorLabels)
+		retErr = ErrFromToNodesRequiresNodeSelectorOption
 	}
 
 	for _, es := range e.ToEndpoints {
@@ -329,7 +337,7 @@ func (e *EgressRule) sanitize() error {
 
 	e.SetAggregatedSelectors()
 
-	return nil
+	return retErr
 }
 
 func (pr *L7Rules) sanitize(ports []PortProtocol) error {


### PR DESCRIPTION
Both `cilium policy import` and `cilium policy validate` command not
only use server side validation of policies but both also use client
side validation of policies - meaning they both run `r.Sanitize()`
without being able to properly check cilium-agent's configuration
flags. This can result in being unable to validate/import policy that
uses a field (like fromNodes, toNodes) which is not available by default
and it's configuration is false by default.

In existing examples this "only" runs `r.Sanitize()` twice. The problem
is in a situation where some of the features is not enabled by default.
In that case client side validation fails even though server side
validation would run properly.
This can also be a problem when we do `./check-examples.sh` in
documentation which runs only client side validation.

Let's skip client side validation of rules that are validatable only on
the server side.

```release-note
policy: fix client side validation of policies in policy import/validate command
```

I ran into this problem when in this PR https://github.com/cilium/cilium/pull/31188. 
Related slack thread: https://cilium.slack.com/archives/C2B917YHE/p1709720825271219
