### PR TITLE
[v1.13-backport] Introduce fromEgressProxyRule

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -111,6 +111,7 @@ function move_local_rules()
 function setup_proxy_rules()
 {
 	from_ingress_rulespec="fwmark 0xA00/0xF00 pref 10 lookup $PROXY_RT_TABLE"
+	from_egress_rulespec="fwmark 0xB00/0xF00 pref 10 lookup $PROXY_RT_TABLE"
 	use_from_ingress_proxy_rules_v4=0
 	use_from_ingress_proxy_rules_v6=0
 

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -145,6 +145,9 @@ function setup_proxy_rules()
 					ip -4 rule delete $from_ingress_rulespec || true
 				fi
 			fi
+                        if [ ! -z "$(ip -4 rule list $from_egress_rulespec)" ]; then
+                                ip -4 rule delete $from_egress_rulespec 2> /dev/null || true
+                        fi
 		fi
 
 		# Traffic to the host proxy is local
@@ -178,6 +181,9 @@ function setup_proxy_rules()
 					ip -6 rule delete $from_ingress_rulespec
 				fi
 			fi
+                        if [ ! -z "$(ip -6 rule list $from_egress_rulespec)" ]; then
+                                ip -6 rule delete $from_egress_rulespec 2> /dev/null || true
+                        fi
 		fi
 
 		IP6_LLADDR=$(ip -6 addr show dev $HOST_DEV2 | grep inet6 | head -1 | awk '{print $2}' | awk -F'/' '{print $1}')


### PR DESCRIPTION

- [x] https://github.com/cilium/cilium/pull/31923

This introduces fromEgressProxyRule on 1.14 but doesn't install the rule. It just tries to remove it to guarantee no stale fromEgressProxyRule installed by higher version during ci-ipsec-downgrade.