### PR TITLE
docs: Correct name of "cert-manager" in tab groups

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/https.rst
+++ b/Documentation/network/servicemesh/gateway-api/https.rst
@@ -33,7 +33,7 @@ The Gateway configuration for this demo provides the similar routing to the
 
             $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/gateway/basic-https.yaml
 
-    .. group-tab:: Cert Manager
+    .. group-tab:: cert-manager
 
         .. parsed-literal::
 
@@ -100,7 +100,7 @@ Make HTTPS Requests
         Specifying -v on the curl request, you can see that the TLS handshake took
         place successfully.
 
-    .. group-tab:: Cert Manager
+    .. group-tab:: cert-manager
 
         .. code-block:: shell-session
 

--- a/Documentation/network/servicemesh/tls-cert.rst
+++ b/Documentation/network/servicemesh/tls-cert.rst
@@ -25,7 +25,7 @@ Create TLS Certificate and Private Key
 
             $ kubectl create secret tls demo-cert --key=_.cilium.rocks/key.pem --cert=_.cilium.rocks/cert.pem
 
-    .. group-tab:: Cert Manager
+    .. group-tab:: cert-manager
 
         Let us install cert-manager:
 

--- a/Documentation/network/servicemesh/tls-termination.rst
+++ b/Documentation/network/servicemesh/tls-termination.rst
@@ -32,7 +32,7 @@ but with the addition of TLS termination.
 
             $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/servicemesh/tls-ingress.yaml
 
-    .. group-tab:: Cert Manager
+    .. group-tab:: cert-manager
 
         .. parsed-literal::
 
@@ -107,7 +107,7 @@ Make HTTPS Requests
             $ curl -o demo.proto https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/main/protos/demo.proto
             $ grpcurl -proto ./demo.proto -cacert minica.pem hipstershop.cilium.rocks:443 hipstershop.ProductCatalogService/ListProducts
 
-    .. group-tab:: Cert Manager
+    .. group-tab:: cert-manager
 
         .. code-block:: shell-session
 


### PR DESCRIPTION

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

cert-manager exclusively uses the lowercase hyphenated form of its name, even as the first word in a sentence. No release note needed as this is a docs-only change.