### PR TITLE
ipsec: Fix unencrypted traffic when IPsec is used with L7 egress proxy

### DIFF
--- a/.github/actions/bpftrace/check/action.yaml
+++ b/.github/actions/bpftrace/check/action.yaml
@@ -1,0 +1,35 @@
+name: Assert bpftrace script output
+description: Stops the background bpftrace process, asserts that it completed successfully and did not write anything to stdout
+
+inputs:
+  output-path:
+    description: "Directory where the output files are stored to"
+    default: "."
+
+runs:
+  using: composite
+  steps:
+    - name: Assert that bpftrace completed successfully
+      uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
+      with:
+        provision: 'false'
+        cmd: |
+          cd /host/
+
+          if [[ "\$(wc -l < ${{ inputs.output-path }}/bpftrace.err)" -ne 0 ]];
+          then
+            echo "Unexpected error reported by bpftrace"
+            cat ${{ inputs.output-path }}/bpftrace.err
+            exit 1
+          fi
+
+          pkill -F ${{ inputs.output-path }}/bpftrace.pid || { echo "Failed to stop bpftrace"; exit 1; }
+          # Wait until bpftrace terminates, so that the output is complete
+          while pgrep -F ${{ inputs.output-path }}/bpftrace.pid > /dev/null; do sleep 1; done
+
+          if [[ "\$(grep -cvE '(^\s*$)' ${{ inputs.output-path }}/bpftrace.out)" -ne 0 ]];
+          then
+            echo "Error: bpftrace output is not empty"
+            cat ${{ inputs.output-path }}/bpftrace.out
+            exit 1
+          fi

--- a/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
@@ -1,0 +1,223 @@
+// Six parameters expected:
+// $1: IPv4 CiliumInternalIP - Node1
+// $2: IPv6 CiliumInternalIP - Node1
+// $3: IPv4 CiliumInternalIP - Node2
+// $4: IPv6 CiliumInternalIP - Node2
+// $5: IPv4 CiliumInternalIP - Node3
+// $6: IPv6 CiliumInternalIP - Node3
+
+#define CIDR4 (uint32)0x0A000000 // 10.0.0.0/8
+#define MASK4 (uint32)0xFF000000
+#define CIDR6 (uint32)0xfd00
+
+#define PROTO_IPV4 0x0800
+#define PROTO_IPV6 0x86DD
+#define PROTO_TCP 6
+#define PROTO_UDP 17
+#define PROTO_ESP 50
+
+#define AF_INET	2
+#define AF_INET6 10
+
+#define PORT_DNS 53
+
+#define TYPE_PROXY_L7_IP4 1
+#define TYPE_PROXY_L7_IP6 2
+#define TYPE_PROXY_DNS_IP4 3
+#define TYPE_PROXY_DNS_IP6 4
+
+kprobe:br_forward
+{
+  $skb = ((struct sk_buff *) arg1);
+
+  $proto = bswap($skb->protocol);
+  $ip4h = ((struct iphdr *) ($skb->head + $skb->network_header));
+  $ip6h = ((struct ipv6hdr *) ($skb->head + $skb->network_header));
+  $udph = ((struct udphdr*) ($skb->head + $skb->transport_header));
+
+  if ($skb->encapsulation) {
+    // $skb->inner_protocol does not appear to be correctly initialized
+    $proto = bswap(*((uint16*) ($skb->head + $skb->inner_mac_header + 12)));
+    $ip4h = ((struct iphdr*) ($skb->head + $skb->inner_network_header));
+    $ip6h = ((struct ipv6hdr*) ($skb->head + $skb->inner_network_header));
+    $udph = ((struct udphdr*) ($skb->head + $skb->inner_transport_header));
+
+    if ($proto == PROTO_IPV4) {
+      $trace_override =
+        @trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] ||
+        @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol];
+
+      // Skip CiliumInternalIP addresses, as they belong to the PodCIDR,
+      // unless the given flow is explicitly marked as traced (i.e., from proxy).
+      if (!$trace_override &&
+           ($ip4h->saddr == (uint32)pton(str($1)) || $ip4h->daddr == (uint32)pton(str($1)) ||
+            $ip4h->saddr == (uint32)pton(str($3)) || $ip4h->daddr == (uint32)pton(str($3)) ||
+            $ip4h->saddr == (uint32)pton(str($5)) || $ip4h->daddr == (uint32)pton(str($5)))) {
+        return;
+      }
+    }
+
+    if ($proto == PROTO_IPV6) {
+      $trace_override =
+        @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] ||
+        @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr];
+
+      // Skip CiliumInternalIP addresses, as they belong to the PodCIDR
+      // unless the given flow is explicitly marked as traced (i.e., from proxy).
+      if (!$trace_override &&
+           ($ip6h->saddr.in6_u.u6_addr8 == pton(str($2)) || $ip6h->daddr.in6_u.u6_addr8 == pton(str($2)) ||
+            $ip6h->saddr.in6_u.u6_addr8 == pton(str($4)) || $ip6h->daddr.in6_u.u6_addr8 == pton(str($4)) ||
+            $ip6h->saddr.in6_u.u6_addr8 == pton(str($6)) || $ip6h->daddr.in6_u.u6_addr8 == pton(str($6)))) {
+        return;
+      }
+    }
+  }
+
+  if ($proto == PROTO_IPV4 && $ip4h->protocol != PROTO_ESP) {
+    $src_is_pod = (bswap($ip4h->saddr) & MASK4) == CIDR4;
+    $dst_is_pod = (bswap($ip4h->daddr) & MASK4) == CIDR4;
+
+    $trace_override =
+        @trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] ||
+        @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol];
+
+    if (($src_is_pod && $dst_is_pod) || ($trace_override && ($src_is_pod || $dst_is_pod))) {
+      printf("[%s] %s:%d -> %s:%d (proto: %d, ifindex: %d, netns: %x)\n",
+        strftime("%H:%M:%S:%f", nsecs),
+        ntop($ip4h->saddr), bswap($udph->source),
+        ntop($ip4h->daddr), bswap($udph->dest),
+        $ip4h->protocol,
+        $skb->dev->ifindex,
+        $skb->dev->nd_net.net->ns.inum);
+    }
+  }
+
+  if ($proto == PROTO_IPV6 && $ip6h->nexthdr != PROTO_ESP) {
+    $src_is_pod = bswap($ip6h->saddr.in6_u.u6_addr16[0]) == CIDR6;
+    $dst_is_pod = bswap($ip6h->daddr.in6_u.u6_addr16[0]) == CIDR6;
+
+    $trace_override =
+        @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] ||
+        @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr];
+
+    if (($src_is_pod && $dst_is_pod) || ($trace_override && ($src_is_pod || $dst_is_pod))) {
+      printf("[%s] %s:%d -> %s:%d (proto: %d, ifindex: %d, netns: %x)\n",
+        strftime("%H:%M:%S:%f", nsecs),
+        ntop($ip6h->saddr.in6_u.u6_addr8), bswap($udph->source),
+        ntop($ip6h->daddr.in6_u.u6_addr8), bswap($udph->dest),
+        $ip6h->nexthdr,
+        $skb->dev->ifindex,
+        $skb->dev->nd_net.net->ns.inum);
+    }
+  }
+}
+
+// Trace TCP connections established by the L7 proxy, even if the source address belongs to the host.
+kprobe:tcp_connect
+{
+  if (strncmp(comm, "wrk:", 4) != 0) {
+    return;
+  }
+
+  $sk = ((struct sock *) arg0);
+  $inet_family = $sk->__sk_common.skc_family;
+
+  if ($inet_family == AF_INET) {
+    @trace_ip4[$sk->__sk_common.skc_rcv_saddr, bswap($sk->__sk_common.skc_num), PROTO_TCP] = true;
+    @trace_sk[$sk] = true;
+    @sanity[TYPE_PROXY_L7_IP4] = true;
+  }
+
+  if ($inet_family == AF_INET6) {
+    @trace_ip6[$sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8, bswap($sk->__sk_common.skc_num), PROTO_TCP] = true;
+    @trace_sk[$sk] = true;
+    @sanity[TYPE_PROXY_L7_IP6] = true;
+  }
+}
+
+kprobe:tcp_close
+{
+  $sk = ((struct sock *) arg0);
+  $inet_family = $sk->__sk_common.skc_family;
+
+  if ($inet_family == AF_INET) {
+    delete(@trace_ip4[$sk->__sk_common.skc_rcv_saddr, bswap($sk->__sk_common.skc_num), PROTO_TCP]);
+  }
+
+  if ($inet_family == AF_INET6) {
+    delete(@trace_ip6[$sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8, bswap($sk->__sk_common.skc_num), PROTO_TCP]);
+  }
+}
+
+// Trace UDP messages sent by the DNS proxy, even if the source address belongs to the host.
+kprobe:udp_sendmsg /comm == "cilium-agent" || comm == "dnsproxy"/
+{
+  $sk = ((struct sock *) arg0);
+  if (bswap($sk->__sk_common.skc_dport) == PORT_DNS) {
+    @trace_ip4[$sk->__sk_common.skc_rcv_saddr, bswap($sk->__sk_common.skc_num), PROTO_UDP] = true;
+    @trace_sk[$sk] = true;
+    @sanity[TYPE_PROXY_DNS_IP4] = true;
+  }
+}
+
+// Trace UDP6 messages sent by the DNS proxy, even if the source address belongs to the host.
+kprobe:udpv6_sendmsg /comm == "cilium-agent" || comm == "dnsproxy"/
+{
+  $sk = ((struct sock *) arg0);
+  if ($sk->__sk_common.skc_num == PORT_DNS) {
+    @trace_ip6[$sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8, bswap($sk->__sk_common.skc_num), PROTO_UDP] = true;
+    @trace_sk[$sk] = true;
+    @sanity[TYPE_PROXY_DNS_IP6] = true;
+  }
+}
+
+// Additionally trace traffic flows in which the source got masquerated.
+kprobe:__dev_queue_xmit
+{
+  $skb = ((struct sk_buff *) arg0);
+  $sk = $skb->sk;
+
+  if ($sk == 0 || !@trace_sk[$sk]) {
+    return;
+  }
+
+  $proto = bswap($skb->protocol);
+  $ip4h = ((struct iphdr *) ($skb->head + $skb->network_header));
+  $ip6h = ((struct ipv6hdr *) ($skb->head + $skb->network_header));
+  $udph = ((struct udphdr*) ($skb->head + $skb->transport_header));
+  $l4proto = $proto == PROTO_IPV4 ? $ip4h->protocol : $ip6h->nexthdr;
+
+  if ($l4proto == PROTO_TCP) {
+    @sanity[$proto == PROTO_IPV4 ? TYPE_PROXY_L7_IP4 : TYPE_PROXY_L7_IP6] = true;
+  } else {
+    @sanity[$proto == PROTO_IPV4 ? TYPE_PROXY_DNS_IP4 : TYPE_PROXY_DNS_IP6] = true;
+  }
+
+  if ($proto == PROTO_IPV4) {
+    @trace_ip4[$ip4h->saddr, $udph->source, $l4proto] = true;
+  } else {
+    @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $l4proto] = true;
+  }
+
+  delete(@trace_sk[$sk])
+}
+
+END
+{
+  if (!@sanity[TYPE_PROXY_L7_IP4]) {
+    printf("Sanity check failed: detected no IPv4 connections from the L7 proxy. Is the filter correct?\n")
+  }
+
+  if (!@sanity[TYPE_PROXY_L7_IP6] && str($2) != "::1") {
+    printf("Sanity check failed: detected no IPv6 connections from the L7 proxy. Is the filter correct?\n")
+  }
+
+  if (!(@sanity[TYPE_PROXY_DNS_IP4] || @sanity[TYPE_PROXY_DNS_IP6])) {
+    printf("Sanity check failed: detected no messages sent by the DNS proxy. Is the filter correct?\n")
+  }
+
+  clear(@trace_ip4);
+  clear(@trace_ip6);
+  clear(@trace_sk);
+  clear(@sanity);
+}

--- a/.github/actions/bpftrace/start/action.yaml
+++ b/.github/actions/bpftrace/start/action.yaml
@@ -1,0 +1,49 @@
+name: Start bpftrace script in background
+description: Starts the given bpftrace script in background
+
+inputs:
+  script:
+    description: "The path of the bpftrace program to execute"
+    required: true
+  args:
+    description: "The arguments propagated to the bpftrace script"
+    default: ""
+  output-path:
+    description: "Directory where the output files are stored to"
+    default: "."
+
+runs:
+  using: composite
+  steps:
+    - name: Install bpftrace if not already present
+      uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
+      with:
+        provision: 'false'
+        cmd: |
+          if ! command -v bpftrace &> /dev/null; then
+            # bpftrace v0.20.1 doesn't seem to play well with Linux 4.19
+            # https://github.com/bpftrace/bpftrace/issues/3011
+            # Let's buy us some time, and keep installing v0.19.1 for the moment.
+            echo 'deb http://deb.debian.org/debian trixie main' >> /etc/apt/sources.list
+            apt update && apt install -y bpftrace -t trixie
+          fi
+
+    - name: Start bpftrace in background
+      id: run
+      uses: cilium/little-vm-helper@8410a93e544b7e180a2365e5fdab0724a39bc02a # v0.0.13
+      with:
+        provision: 'false'
+        cmd: |
+          cd /host/
+
+          if [[ -f "/boot/btf-\$(uname -r)" ]]; then
+            export BPFTRACE_BTF="/boot/btf-\$(uname -r)"
+          fi
+
+          bpftrace ${{ inputs.script }} -q \
+            ${{ inputs.args }} \
+            > ${{ inputs.output-path }}/bpftrace.out \
+            2> ${{ inputs.output-path }}/bpftrace.err \
+            < /dev/null &
+
+          echo \$! > ${{ inputs.output-path }}/bpftrace.pid

--- a/.github/actions/bpftrace/start/action.yaml
+++ b/.github/actions/bpftrace/start/action.yaml
@@ -24,8 +24,11 @@ runs:
             # bpftrace v0.20.1 doesn't seem to play well with Linux 4.19
             # https://github.com/bpftrace/bpftrace/issues/3011
             # Let's buy us some time, and keep installing v0.19.1 for the moment.
-            echo 'deb http://deb.debian.org/debian trixie main' >> /etc/apt/sources.list
-            apt update && apt install -y bpftrace -t trixie
+
+            curl -L https://github.com/bpftrace/bpftrace/releases/download/v0.19.1/bpftrace -o bpftrace
+            install -m 755 bpftrace /usr/local/bin/bpftrace
+
+            # apt update && apt install -y bpftrace
           fi
 
     - name: Start bpftrace in background

--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -55,6 +55,9 @@ inputs:
   ciliumendpointslice:
     description: 'Enable CiliumEndpointSlice'
     default: 'false'
+  bpf-masquerade:
+    description: 'Enable BPF masquerade'
+    default: ''
 outputs:
   config:
     description: 'Cilium installation config'
@@ -121,7 +124,11 @@ runs:
           MASQ=""
           if [ "${{ inputs.kpr }}" == "true" ]; then
             # BPF-masq requires KPR=true.
-            MASQ="--helm-set=bpf.masquerade=true"
+            if [ "${{ inputs.bpf-masquerade }}" != "" ]; then
+              MASQ="--helm-set=bpf.masquerade=${{ inputs.bpf-masquerade }}"
+            else
+              MASQ="--helm-set=bpf.masquerade=true"
+            fi
             if [ "${{ inputs.host-fw }}" == "true" ]; then
               # BPF IPv6 masquerade not currently supported with host firewall - GH-26074
               MASQ="${MASQ} --helm-set=enableIPv6Masquerade=false"
@@ -164,6 +171,6 @@ runs:
           if [ "${{ inputs.ciliumendpointslice }}" == "true" ]; then
             CILIUMENDPOINTSLICE="--helm-set=enableCiliumEndpointSlice=true"
           fi
-        
+
           CONFIG="${DEFAULTS} ${IMAGE} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION} ${INGRESS_CONTROLLER} ${CILIUMENDPOINTSLICE}"
           echo "config=${CONFIG}" >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -145,6 +145,7 @@ jobs:
             kernel: '5.4-20240417.104652'
             kube-proxy: 'none'
             kpr: 'true'
+            bpf-masquerade: 'false'
             tunnel: 'disabled'
             encryption: 'ipsec'
             encryption-node: 'false'
@@ -158,6 +159,7 @@ jobs:
             kernel: '5.10-20240417.104652'
             kube-proxy: 'none'
             kpr: 'true'
+            bpf-masquerade: 'false'
             tunnel: 'disabled'
             encryption: 'ipsec'
             encryption-node: 'false'
@@ -231,6 +233,7 @@ jobs:
           endpoint-routes: ${{ matrix.endpoint-routes }}
           ipv6: ${{ matrix.ipv6 }}
           kpr: ${{ matrix.kpr }}
+          bpf-masquerade: ${{ matrix.bpf-masquerade }}
           lb-mode: ${{ matrix.lb-mode }}
           lb-acceleration: ${{ matrix.lb-acceleration }}
           encryption: ${{ matrix.encryption }}

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -290,7 +290,7 @@ jobs:
             until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
-      - name: Run tests (${{ join(matrix.*, ', ') }})
+      - name: Install Cilium
         shell: bash
         run: |
           kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
@@ -313,6 +313,25 @@ jobs:
           kubectl get pods --all-namespaces -o wide
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 
+      - name: Prepare the bpftrace parameters
+        id: bpftrace-params
+        run: |
+          CILIUM_INTERNAL_IPS=$(kubectl get ciliumnode -o jsonpath='{.items[*].spec.addresses[?(@.type=="CiliumInternalIP")].ip}')
+          if [[ "${{ matrix.ipv6 }}" == "false" ]]; then
+            CILIUM_INTERNAL_IPS="${CILIUM_INTERNAL_IPS// / ::1 } ::1"
+          fi
+
+          echo "params=$CILIUM_INTERNAL_IPS" >> $GITHUB_OUTPUT
+
+      - name: Start unencrypted packets check
+        uses: ./.github/actions/bpftrace/start
+        with:
+          script: ./.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
+          args: ${{ steps.bpftrace-params.outputs.params }}
+
+      - name: Run tests (${{ join(matrix.*, ', ') }})
+        shell: bash
+        run: |
           mkdir -p cilium-junits
 
           ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
@@ -328,6 +347,9 @@ jobs:
           key-algo: ${{ matrix.key-two }}
           key-type-one: ${{ matrix.key-type-one }}
           key-type-two: ${{ matrix.key-type-two }}
+
+      - name: Assert that no unencrypted packets are leaked
+        uses: ./.github/actions/bpftrace/check
 
       - name: Fetch artifacts
         if: ${{ !success() }}

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -341,6 +341,15 @@ jobs:
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
             --flush-ct
 
+      - name: Assert that no unencrypted packets are leaked
+        uses: ./.github/actions/bpftrace/check
+
+      - name: Start unencrypted packets check
+        uses: ./.github/actions/bpftrace/start
+        with:
+          script: ./.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
+          args: ${{ steps.bpftrace-params.outputs.params }}
+
       - name: Rotate IPsec Key & Test (${{ join(matrix.*, ', ') }})
         uses: ./.github/actions/ipsec-key-rotate
         with:

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/versioncheck"
 )
@@ -545,6 +546,8 @@ func (m *Manager) installStaticProxyRules() error {
 	matchToProxy := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsToProxy, linux_defaults.MagicMarkHostMask)
 	// proxy return traffic has 0 ID in the mask
 	matchProxyReply := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxy, linux_defaults.MagicMarkProxyNoIDMask)
+	// proxy forward traffic
+	matchProxyForward := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkEgress, linux_defaults.MagicMarkHostMask)
 	// L7 proxy upstream return traffic has Endpoint ID in the mask
 	matchL7ProxyUpstream := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxyEPID, linux_defaults.MagicMarkProxyMask)
 	// match traffic from a proxy (either in forward or in return direction)
@@ -592,6 +595,19 @@ func (m *Manager) installStaticProxyRules() error {
 			"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
 			"-j", "CT", "--notrack"}); err != nil {
 			return err
+		}
+
+		// No conntrack for proxy forward traffic that is heading to cilium_host
+		if option.Config.EnableIPSec {
+			if err := ip4tables.runProg([]string{
+				"-t", "raw",
+				"-A", ciliumOutputRawChain,
+				"-o", defaults.HostDevice,
+				"-m", "mark", "--mark", matchProxyForward,
+				"-m", "comment", "--comment", "cilium: NOTRACK for proxy forward traffic",
+				"-j", "CT", "--notrack"}); err != nil {
+				return err
+			}
 		}
 
 		// No conntrack for proxy upstream traffic that is heading to lxc+

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -403,20 +403,19 @@ func (p *Proxy) SetProxyPort(name string, proxyType types.ProxyType, port uint16
 // ReinstallRoutingRules ensures the presence of routing rules and tables needed
 // to route packets to and from the L7 proxy.
 func (p *Proxy) ReinstallRoutingRules() error {
+	fromIngressProxy, fromEgressProxy := requireFromProxyRoutes()
+
 	if option.Config.EnableIPv4 {
 		if err := installToProxyRoutesIPv4(); err != nil {
 			return err
 		}
 
-		if err := removeFromEgressProxyRoutesIPv4(); err != nil {
-			return err
-		}
-		if requireFromProxyRoutes() {
-			if err := installFromProxyRoutesIPv4(node.GetInternalIPv4Router(), defaults.HostDevice); err != nil {
+		if fromIngressProxy || fromEgressProxy {
+			if err := installFromProxyRoutesIPv4(node.GetInternalIPv4Router(), defaults.HostDevice, fromIngressProxy, fromEgressProxy); err != nil {
 				return err
 			}
 		} else {
-			if err := removeFromIngressProxyRoutesIPv4(); err != nil {
+			if err := removeFromProxyRoutesIPv4(); err != nil {
 				return err
 			}
 		}
@@ -424,7 +423,7 @@ func (p *Proxy) ReinstallRoutingRules() error {
 		if err := removeToProxyRoutesIPv4(); err != nil {
 			return err
 		}
-		if err := removeFromIngressProxyRoutesIPv4(); err != nil {
+		if err := removeFromProxyRoutesIPv4(); err != nil {
 			return err
 		}
 	}
@@ -434,19 +433,16 @@ func (p *Proxy) ReinstallRoutingRules() error {
 			return err
 		}
 
-		if err := removeFromEgressProxyRoutesIPv6(); err != nil {
-			return err
-		}
-		if requireFromProxyRoutes() {
+		if fromIngressProxy || fromEgressProxy {
 			ipv6, err := getCiliumNetIPv6()
 			if err != nil {
 				return err
 			}
-			if err := installFromProxyRoutesIPv6(ipv6, defaults.HostDevice); err != nil {
+			if err := installFromProxyRoutesIPv6(ipv6, defaults.HostDevice, fromIngressProxy, fromEgressProxy); err != nil {
 				return err
 			}
 		} else {
-			if err := removeFromIngressProxyRoutesIPv6(); err != nil {
+			if err := removeFromProxyRoutesIPv6(); err != nil {
 				return err
 			}
 		}
@@ -454,7 +450,7 @@ func (p *Proxy) ReinstallRoutingRules() error {
 		if err := removeToProxyRoutesIPv6(); err != nil {
 			return err
 		}
-		if err := removeFromIngressProxyRoutesIPv6(); err != nil {
+		if err := removeFromProxyRoutesIPv6(); err != nil {
 			return err
 		}
 	}
@@ -462,8 +458,10 @@ func (p *Proxy) ReinstallRoutingRules() error {
 	return nil
 }
 
-func requireFromProxyRoutes() bool {
-	return (option.Config.EnableEnvoyConfig || option.Config.EnableIPSec) && !option.Config.TunnelingEnabled()
+func requireFromProxyRoutes() (fromIngressProxy, fromEgressProxy bool) {
+	fromIngressProxy = (option.Config.EnableEnvoyConfig || option.Config.EnableIPSec) && !option.Config.TunnelingEnabled()
+	fromEgressProxy = option.Config.EnableIPSec && !option.Config.TunnelingEnabled()
+	return
 }
 
 // getCiliumNetIPv6 retrieves the first IPv6 address from the cilium_net device.

--- a/pkg/proxy/routes_test.go
+++ b/pkg/proxy/routes_test.go
@@ -72,7 +72,7 @@ func TestRoutes(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Install routes and rules the first time.
-				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName))
+				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName, true, true))
 
 				rules, err := route.ListRules(netlink.FAMILY_V4, &fromIngressProxyRule)
 				assert.NoError(t, err)
@@ -85,10 +85,10 @@ func TestRoutes(t *testing.T) {
 				assert.Len(t, rt, 2)
 
 				// Ensure idempotence.
-				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName))
+				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName, true, true))
 
 				// Remove routes installed before.
-				assert.NoError(t, removeFromIngressProxyRoutesIPv4())
+				assert.NoError(t, removeFromProxyRoutesIPv4())
 
 				rules, err = route.ListRules(netlink.FAMILY_V4, &fromIngressProxyRule)
 				assert.NoError(t, err)
@@ -159,7 +159,7 @@ func TestRoutes(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Install routes and rules the first time.
-				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName))
+				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName, true, true))
 
 				rules, err := route.ListRules(netlink.FAMILY_V6, &fromIngressProxyRule)
 				assert.NoError(t, err)
@@ -172,10 +172,10 @@ func TestRoutes(t *testing.T) {
 				assert.Len(t, rt, 2)
 
 				// Ensure idempotence.
-				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName))
+				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName, true, true))
 
 				// Remove routes installed before.
-				assert.NoError(t, removeFromIngressProxyRoutesIPv6())
+				assert.NoError(t, removeFromProxyRoutesIPv6())
 
 				rules, err = route.ListRules(netlink.FAMILY_V6, &fromIngressProxyRule)
 				assert.NoError(t, err)


### PR DESCRIPTION
This PR fixes unencrypted traffic among nodes when IPsec is used with L7 egress proxy.

Fixes: #31984

```release-note
Fixes unencrypted traffic among nodes when IPsec is used with L7 egress proxy.
```
