### PR TITLE
fqdn: Fix goroutine leak in transparent-mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/cilium/checkmate v1.0.3
 	github.com/cilium/coverbee v0.3.2
 	github.com/cilium/deepequal-gen v0.0.0-20231116094812-0d6c075c335f
-	github.com/cilium/dns v1.1.51-0.20231120140355-729345173dc3
+	github.com/cilium/dns v1.1.51-0.20240411200813-4e6b438d9e05
 	github.com/cilium/ebpf v0.14.0
 	github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b
 	github.com/cilium/fake v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/cilium/coverbee v0.3.2 h1:RaJN5OaHf/M8tmeLemHmdO0H5bFUhvtTAoYbStDIX14
 github.com/cilium/coverbee v0.3.2/go.mod h1:p9Q2SRC/sPA0qATNfY19GXBUPdcQP6UVV2LKgOHRIzQ=
 github.com/cilium/deepequal-gen v0.0.0-20231116094812-0d6c075c335f h1:t1A8nGkbZcjLACtNGIkfhfnKgG7V83+Tzr1pMeoPuA8=
 github.com/cilium/deepequal-gen v0.0.0-20231116094812-0d6c075c335f/go.mod h1:O4ERd4TTIfE/EKtiqESR2OQEiLwkDwBTW3zrbcQ4S3M=
-github.com/cilium/dns v1.1.51-0.20231120140355-729345173dc3 h1:3PErIjIq4DlOwNsQNPcILFzbGnxPuKuqJsHEFpiwstM=
-github.com/cilium/dns v1.1.51-0.20231120140355-729345173dc3/go.mod h1:/7LC2GOgyXJ7maupZlaVIumYQiGPIgllSf6mA9sg6RU=
+github.com/cilium/dns v1.1.51-0.20240411200813-4e6b438d9e05 h1:lEzR/g0snQppy8yvaMSV7ZN5lcl54Ja4C6MpGqYz2PA=
+github.com/cilium/dns v1.1.51-0.20240411200813-4e6b438d9e05/go.mod h1:/7LC2GOgyXJ7maupZlaVIumYQiGPIgllSf6mA9sg6RU=
 github.com/cilium/ebpf v0.14.0 h1:0PsxAjO6EjI1rcT+rkp6WcCnE0ZvfkXBYiMedJtrSUs=
 github.com/cilium/ebpf v0.14.0/go.mod h1:DHp1WyrLeiBh19Cf/tfiSMhqheEiK8fXFZ4No0P1Hso=
 github.com/cilium/endpointslice v0.29.4-0.20240409195643-982ad68ab7ba h1:Ddc5e+pz0/nY0XiAEW/UcIlvnaHACSuF77ePyMNX510=

--- a/vendor/github.com/cilium/dns/shared_client.go
+++ b/vendor/github.com/cilium/dns/shared_client.go
@@ -227,6 +227,17 @@ func handler(wg *sync.WaitGroup, client *Client, conn *Conn, requests chan reque
 				return
 			}
 			start := time.Now()
+
+			// Check if we already have a request with the same id
+			// Due to birthday paradox and the fact that ID is uint16
+			// it's likely to happen with small number (~200) of concurrent requests
+			// which would result in goroutine leak as we would never close req.ch
+			if _, ok := waitingResponses[req.msg.Id]; ok {
+				req.ch <- sharedClientResponse{nil, 0, fmt.Errorf("duplicate request id %d", req.msg.Id)}
+				close(req.ch)
+				continue
+			}
+
 			err := client.SendContext(req.ctx, req.msg, conn, start)
 			if err != nil {
 				req.ch <- sharedClientResponse{nil, 0, err}
@@ -291,8 +302,13 @@ func (c *SharedClient) ExchangeSharedContext(ctx context.Context, m *Msg) (r *Ms
 	}
 
 	// Since c.requests is unbuffered, the handler is guaranteed to eventually close 'respCh'
-	resp := <-respCh
-	return resp.msg, resp.rtt, resp.err
+	select {
+	case resp := <-respCh:
+		return resp.msg, resp.rtt, resp.err
+	// This is just fail-safe mechanism in case there is another similar issue
+	case <-time.After(time.Minute):
+		return nil, 0, fmt.Errorf("timeout waiting for response")
+	}
 }
 
 // close closes and waits for the close to finish.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -200,7 +200,7 @@ github.com/cilium/coverbee/pkg/verifierlog
 ## explicit; go 1.20
 github.com/cilium/deepequal-gen
 github.com/cilium/deepequal-gen/generators
-# github.com/cilium/dns v1.1.51-0.20231120140355-729345173dc3
+# github.com/cilium/dns v1.1.51-0.20240411200813-4e6b438d9e05
 ## explicit; go 1.18
 github.com/cilium/dns
 # github.com/cilium/ebpf v0.14.0


### PR DESCRIPTION
When number of concurrent dns requests was moderately high, there was a chance that some of the gorutines would get stuck waiting for a response. Contains fix from https://github.com/cilium/dns/pull/10

```release-note
fqdn: fix memory leak in transparent mode when there was a moderately high number of parallel DNS requests (>100).
```
