### PR TITLE
bgpv2: introducing service reconciler in BGPv2 reconcilers

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/reconcilers.go
+++ b/pkg/bgpv1/manager/reconcilerv2/reconcilers.go
@@ -36,6 +36,7 @@ var ConfigReconcilers = cell.ProvidePrivate(
 	NewNeighborReconciler,
 	NewPodCIDRReconciler,
 	NewPodIPPoolReconciler,
+	NewServiceReconciler,
 )
 
 // GetActiveReconcilers returns a list of reconcilers in order of priority that should be used to reconcile the BGP config.

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -1,0 +1,535 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconcilerv2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"net/netip"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
+	"github.com/cilium/cilium/pkg/bgpv1/manager/store"
+	"github.com/cilium/cilium/pkg/bgpv1/types"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	ciliumslices "github.com/cilium/cilium/pkg/slices"
+)
+
+type ServiceReconcilerOut struct {
+	cell.Out
+
+	Reconciler ConfigReconciler `group:"bgp-config-reconciler-v2"`
+}
+
+type ServiceReconcilerIn struct {
+	cell.In
+
+	Logger       logrus.FieldLogger
+	PeerAdvert   *CiliumPeerAdvertisement
+	SvcDiffStore store.DiffStore[*slim_corev1.Service]
+	EPDiffStore  store.DiffStore[*k8s.Endpoints]
+}
+
+type ServiceReconciler struct {
+	logger       logrus.FieldLogger
+	peerAdvert   *CiliumPeerAdvertisement
+	svcDiffStore store.DiffStore[*slim_corev1.Service]
+	epDiffStore  store.DiffStore[*k8s.Endpoints]
+}
+
+func NewServiceReconciler(in ServiceReconcilerIn) ServiceReconcilerOut {
+	if in.SvcDiffStore == nil || in.EPDiffStore == nil {
+		in.Logger.Warn("ServiceReconciler: DiffStore is nil, skipping ServiceReconciler")
+		return ServiceReconcilerOut{}
+	}
+
+	return ServiceReconcilerOut{
+		Reconciler: &ServiceReconciler{
+			logger:       in.Logger,
+			peerAdvert:   in.PeerAdvert,
+			svcDiffStore: in.SvcDiffStore,
+			epDiffStore:  in.EPDiffStore,
+		},
+	}
+}
+
+// ServiceAFPathsMap holds the service prefixes per address family.
+type ServiceAFPathsMap map[resource.Key]AFPathsMap
+
+// ServiceReconcilerMetadata holds any announced service CIDRs per address family.
+type ServiceReconcilerMetadata struct {
+	ServicePaths          ServiceAFPathsMap
+	ServiceAdvertisements PeerAdvertisements
+}
+
+func (r *ServiceReconciler) getMetadata(i *instance.BGPInstance) ServiceReconcilerMetadata {
+	if _, found := i.Metadata[r.Name()]; !found {
+		i.Metadata[r.Name()] = ServiceReconcilerMetadata{
+			ServicePaths:          make(ServiceAFPathsMap),
+			ServiceAdvertisements: make(PeerAdvertisements),
+		}
+	}
+	return i.Metadata[r.Name()].(ServiceReconcilerMetadata)
+}
+
+func (r *ServiceReconciler) setMetadata(i *instance.BGPInstance, metadata ServiceReconcilerMetadata) {
+	i.Metadata[r.Name()] = metadata
+}
+
+func (r *ServiceReconciler) Name() string {
+	return "Service"
+}
+
+func (r *ServiceReconciler) Priority() int {
+	return 40
+}
+
+func (r *ServiceReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
+	if p.DesiredConfig == nil {
+		return fmt.Errorf("BUG: attempted service reconciliation with nil CiliumBGPNodeConfig")
+	}
+
+	if p.CiliumNode == nil {
+		return fmt.Errorf("BUG: attempted service reconciliation with nil local CiliumNode")
+	}
+
+	desiredPeerAdverts, err := r.peerAdvert.GetConfiguredAdvertisements(p.DesiredConfig, v2alpha1.BGPServiceAdvert)
+	if err != nil {
+		return err
+	}
+
+	ls, err := r.populateLocalServices(p.CiliumNode.Name)
+	if err != nil {
+		return fmt.Errorf("failed to populate local services: %w", err)
+	}
+
+	var desiredSvcPaths ServiceAFPathsMap
+	if r.modifiedServiceAdvertisements(p, desiredPeerAdverts) {
+		// BGP configuration for service advertisement changed, we should reconcile all services.
+		desiredSvcPaths, err = r.fullReconciliation(p, ls)
+		if err != nil {
+			return err
+		}
+	} else {
+		// BGP configuration is unchanged, only reconcile modified services.
+		desiredSvcPaths, err = r.svcDiffReconciliation(p, ls)
+		if err != nil {
+			return err
+		}
+	}
+
+	var allErr error
+	for svc, desiredAFPaths := range desiredSvcPaths {
+		metadata := r.getMetadata(p.BGPInstance)
+
+		// check if service exists
+		currentAFPaths, exists := metadata.ServicePaths[svc]
+		if !exists && len(desiredAFPaths) == 0 {
+			// service does not exist in our local state, and there is nothing to advertise
+			continue
+		}
+
+		// reconcile service paths
+		updatedAFPaths, err := ReconcileAFPaths(&ReconcileAFPathsParams{
+			Logger:       r.logger.WithField(types.InstanceLogField, p.DesiredConfig.Name),
+			Ctx:          ctx,
+			Instance:     p.BGPInstance,
+			DesiredPaths: desiredAFPaths,
+			CurrentPaths: currentAFPaths,
+		})
+
+		if err == nil && len(desiredAFPaths) == 0 {
+			// no error is reported and desiredAFPaths is empty, we should delete the service
+			delete(metadata.ServicePaths, svc)
+		} else {
+			// update service paths with returned updatedAFPaths even if there was an error.
+			metadata.ServicePaths[svc] = updatedAFPaths
+		}
+
+		r.setMetadata(p.BGPInstance, metadata)
+		allErr = errors.Join(allErr, err)
+	}
+
+	return allErr
+}
+
+// modifiedServiceAdvertisements compares local advertisement state with desiredPeerAdverts, if they differ, it updates the local state and returns true
+// for full reconciliation.
+func (r *ServiceReconciler) modifiedServiceAdvertisements(p ReconcileParams, desiredPeerAdverts PeerAdvertisements) bool {
+	// current metadata
+	serviceMetadata := r.getMetadata(p.BGPInstance)
+
+	// check if BGP advertisement configuration modified
+	modified := !PeerAdvertisementsEqual(serviceMetadata.ServiceAdvertisements, desiredPeerAdverts)
+
+	// update local state, if modified
+	if modified {
+		r.setMetadata(p.BGPInstance, ServiceReconcilerMetadata{
+			ServicePaths:          serviceMetadata.ServicePaths,
+			ServiceAdvertisements: desiredPeerAdverts,
+		})
+	}
+
+	return modified
+}
+
+// Populate locally available services used for externalTrafficPolicy=local handling
+func (r *ServiceReconciler) populateLocalServices(localNodeName string) (sets.Set[resource.Key], error) {
+	ls := sets.New[resource.Key]()
+
+	epList, err := r.epDiffStore.List()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list EPs from diffstore: %w", err)
+	}
+
+endpointsLoop:
+	for _, eps := range epList {
+		_, exists, err := r.resolveSvcFromEndpoints(eps)
+		if err != nil {
+			// Cannot resolve service from EPs. We have nothing to do here.
+			continue
+		}
+
+		if !exists {
+			// No service associated with this endpoint. We're not interested in this.
+			continue
+		}
+
+		svcKey := resource.Key{
+			Name:      eps.ServiceID.Name,
+			Namespace: eps.ServiceID.Namespace,
+		}
+
+		for _, be := range eps.Backends {
+			if be.NodeName == localNodeName {
+				// At least one endpoint is available on this node. We
+				// can add service to the local services set.
+				ls.Insert(svcKey)
+				continue endpointsLoop
+			}
+		}
+	}
+
+	return ls, nil
+}
+
+func hasLocalEndpoints(svc *slim_corev1.Service, ls sets.Set[resource.Key]) bool {
+	return ls.Has(resource.Key{Name: svc.GetName(), Namespace: svc.GetNamespace()})
+}
+
+func (r *ServiceReconciler) resolveSvcFromEndpoints(eps *k8s.Endpoints) (*slim_corev1.Service, bool, error) {
+	k := resource.Key{
+		Name:      eps.ServiceID.Name,
+		Namespace: eps.ServiceID.Namespace,
+	}
+	return r.svcDiffStore.GetByKey(k)
+}
+
+// fullReconciliation reconciles all services, this is a heavy operation due to the potential amount of services and
+// thus should be avoided if partial reconciliation is an option.
+func (r *ServiceReconciler) fullReconciliation(p ReconcileParams, ls sets.Set[resource.Key]) (ServiceAFPathsMap, error) {
+	r.logger.Debug("performing all services reconciliation")
+
+	desiredServiceAFPaths := make(ServiceAFPathsMap)
+
+	// check for services which are no longer present
+	serviceAFPaths := r.getMetadata(p.BGPInstance).ServicePaths
+	for svcKey := range serviceAFPaths {
+		_, exists, err := r.svcDiffStore.GetByKey(svcKey)
+		if err != nil {
+			return nil, fmt.Errorf("svcDiffStore.GetByKey(): %w", err)
+		}
+
+		// if the service no longer exists, withdraw it
+		if !exists {
+			desiredServiceAFPaths[svcKey] = nil
+		}
+	}
+
+	// check all services for advertisement
+	svcList, err := r.svcDiffStore.List()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list services from svcDiffstore: %w", err)
+	}
+
+	for _, svc := range svcList {
+		svcKey := resource.Key{
+			Name:      svc.GetName(),
+			Namespace: svc.GetNamespace(),
+		}
+
+		afPaths, err := r.getServiceDesiredAFPaths(p, svc, ls)
+		if err != nil {
+			return nil, err
+		}
+
+		desiredServiceAFPaths[svcKey] = afPaths
+	}
+
+	return desiredServiceAFPaths, nil
+}
+
+// svcDiffReconciliation performs reconciliation, only on services which have been created, updated or deleted since
+// the last diff reconciliation. This is a lighter operation compared to full reconciliation.
+func (r *ServiceReconciler) svcDiffReconciliation(p ReconcileParams, ls sets.Set[resource.Key]) (ServiceAFPathsMap, error) {
+	r.logger.Debug("performing modified services reconciliation")
+
+	desiredServiceAFPaths := make(ServiceAFPathsMap)
+	toReconcile, toWithdraw, err := r.diffReconciliationServiceList()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, svc := range toReconcile {
+		svcKey := resource.Key{
+			Name:      svc.GetName(),
+			Namespace: svc.GetNamespace(),
+		}
+
+		afPaths, err := r.getServiceDesiredAFPaths(p, svc, ls)
+		if err != nil {
+			return nil, err
+		}
+
+		desiredServiceAFPaths[svcKey] = afPaths
+	}
+
+	for _, svcKey := range toWithdraw {
+		// for withdrawn services, we need to set paths to nil.
+		desiredServiceAFPaths[svcKey] = nil
+	}
+
+	return desiredServiceAFPaths, nil
+}
+
+// diffReconciliationServiceList returns a list of services to reconcile and to withdraw when
+// performing partial (diff) service reconciliation.
+func (r *ServiceReconciler) diffReconciliationServiceList() (toReconcile []*slim_corev1.Service, toWithdraw []resource.Key, err error) {
+	upserted, deleted, err := r.svcDiffStore.Diff()
+	if err != nil {
+		return nil, nil, fmt.Errorf("svc store diff: %w", err)
+	}
+
+	// For externalTrafficPolicy=local, we need to take care of
+	// the endpoint changes in addition to the service changes.
+	// Take a diff of the EPs and get affected services.
+	// We don't handle service deletion here since we only see
+	// the key, we cannot resolve associated service, so we have
+	// nothing to do.
+	epsUpserted, _, err := r.epDiffStore.Diff()
+	if err != nil {
+		return nil, nil, fmt.Errorf("EPs store diff: %w", err)
+	}
+
+	for _, eps := range epsUpserted {
+		svc, exists, err := r.resolveSvcFromEndpoints(eps)
+		if err != nil {
+			// Cannot resolve service from EPs. We have nothing to do here.
+			continue
+		}
+
+		if !exists {
+			// No service associated with this endpoint. We're not interested in this.
+			continue
+		}
+
+		// We only need Endpoints tracking for externalTrafficPolicy=Local or internalTrafficPolicy=Local services.
+		if svc.Spec.ExternalTrafficPolicy == slim_corev1.ServiceExternalTrafficPolicyLocal ||
+			(svc.Spec.InternalTrafficPolicy != nil && *svc.Spec.InternalTrafficPolicy == slim_corev1.ServiceInternalTrafficPolicyLocal) {
+			upserted = append(upserted, svc)
+		}
+	}
+
+	// We may have duplicated services that changes happened for both of
+	// service and associated EPs.
+	deduped := ciliumslices.UniqueFunc(
+		upserted,
+		func(i int) resource.Key {
+			return resource.Key{
+				Name:      upserted[i].GetName(),
+				Namespace: upserted[i].GetNamespace(),
+			}
+		},
+	)
+
+	return deduped, deleted, nil
+}
+
+func (r *ServiceReconciler) getServiceDesiredAFPaths(p ReconcileParams, svc *slim_corev1.Service, ls sets.Set[resource.Key]) (AFPathsMap, error) {
+	desiredFamilyAdverts := make(AFPathsMap)
+	metadata := r.getMetadata(p.BGPInstance)
+
+	for _, peerFamilyAdverts := range metadata.ServiceAdvertisements {
+		for family, familyAdverts := range peerFamilyAdverts {
+			agentFamily := types.ToAgentFamily(family)
+
+			for _, advert := range familyAdverts {
+				// get prefixes for the service
+				desiredPrefixes, err := r.getServicePrefixes(svc, advert, ls)
+				if err != nil {
+					return nil, err
+				}
+
+				for _, prefix := range desiredPrefixes {
+					path := types.NewPathForPrefix(prefix)
+					path.Family = agentFamily
+
+					// we only add path corresponding to the family of the prefix.
+					if agentFamily.Afi == types.AfiIPv4 && prefix.Addr().Is4() {
+						addPathToAFPathsMap(desiredFamilyAdverts, agentFamily, path)
+					}
+					if agentFamily.Afi == types.AfiIPv6 && prefix.Addr().Is6() {
+						addPathToAFPathsMap(desiredFamilyAdverts, agentFamily, path)
+					}
+				}
+			}
+		}
+	}
+	return desiredFamilyAdverts, nil
+}
+
+func addPathToAFPathsMap(m AFPathsMap, fam types.Family, path *types.Path) {
+	pathsPerFamily, exists := m[fam]
+	if !exists {
+		pathsPerFamily = make(PathMap)
+		m[fam] = pathsPerFamily
+	}
+	pathsPerFamily[path.NLRI.String()] = path
+}
+
+func (r *ServiceReconciler) getServicePrefixes(svc *slim_corev1.Service, advert v2alpha1.BGPAdvertisement, ls sets.Set[resource.Key]) ([]netip.Prefix, error) {
+	if advert.AdvertisementType != v2alpha1.BGPServiceAdvert {
+		return nil, fmt.Errorf("unexpected advertisement type: %s", advert.AdvertisementType)
+	}
+
+	if advert.Selector == nil || advert.Service == nil {
+		// advertisement has no selector or no service options, default behavior is not to match any service.
+		return nil, nil
+	}
+
+	// The vRouter has a service selector, so determine the desired routes.
+	svcSelector, err := slim_metav1.LabelSelectorAsSelector(advert.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("labelSelectorAsSelector: %w", err)
+	}
+
+	// Ignore non matching services.
+	if !svcSelector.Matches(serviceLabelSet(svc)) {
+		return nil, nil
+	}
+
+	var desiredRoutes []netip.Prefix
+	// Loop over the service upsertAdverts and determine the desired routes.
+	for _, svcAdv := range advert.Service.Addresses {
+		switch svcAdv {
+		case v2alpha1.BGPLoadBalancerIPAddr:
+			desiredRoutes = append(desiredRoutes, r.lbSvcDesiredRoutes(svc, ls)...)
+		case v2alpha1.BGPClusterIPAddr:
+			desiredRoutes = append(desiredRoutes, r.clusterIPDesiredRoutes(svc, ls)...)
+		case v2alpha1.BGPExternalIPAddr:
+			desiredRoutes = append(desiredRoutes, r.externalIPDesiredRoutes(svc, ls)...)
+		}
+	}
+
+	return desiredRoutes, nil
+}
+
+func (r *ServiceReconciler) externalIPDesiredRoutes(svc *slim_corev1.Service, ls sets.Set[resource.Key]) []netip.Prefix {
+	var desiredRoutes []netip.Prefix
+	// Ignore externalTrafficPolicy == Local && no local EPs.
+	if svc.Spec.ExternalTrafficPolicy == slim_corev1.ServiceExternalTrafficPolicyLocal &&
+		!hasLocalEndpoints(svc, ls) {
+		return desiredRoutes
+	}
+	for _, extIP := range svc.Spec.ExternalIPs {
+		if extIP == "" {
+			continue
+		}
+		addr, err := netip.ParseAddr(extIP)
+		if err != nil {
+			continue
+		}
+		desiredRoutes = append(desiredRoutes, netip.PrefixFrom(addr, addr.BitLen()))
+	}
+	return desiredRoutes
+}
+
+func (r *ServiceReconciler) clusterIPDesiredRoutes(svc *slim_corev1.Service, ls sets.Set[resource.Key]) []netip.Prefix {
+	var desiredRoutes []netip.Prefix
+	// Ignore internalTrafficPolicy == Local && no local EPs.
+	if svc.Spec.InternalTrafficPolicy != nil && *svc.Spec.InternalTrafficPolicy == slim_corev1.ServiceInternalTrafficPolicyLocal &&
+		!hasLocalEndpoints(svc, ls) {
+		return desiredRoutes
+	}
+	if svc.Spec.ClusterIP == "" || len(svc.Spec.ClusterIPs) == 0 || svc.Spec.ClusterIP == corev1.ClusterIPNone {
+		return desiredRoutes
+	}
+	ips := sets.New[string]()
+	if svc.Spec.ClusterIP != "" {
+		ips.Insert(svc.Spec.ClusterIP)
+	}
+	for _, clusterIP := range svc.Spec.ClusterIPs {
+		if clusterIP == "" || clusterIP == corev1.ClusterIPNone {
+			continue
+		}
+		ips.Insert(clusterIP)
+	}
+	for _, ip := range sets.List(ips) {
+		addr, err := netip.ParseAddr(ip)
+		if err != nil {
+			continue
+		}
+		desiredRoutes = append(desiredRoutes, netip.PrefixFrom(addr, addr.BitLen()))
+	}
+	return desiredRoutes
+}
+
+func (r *ServiceReconciler) lbSvcDesiredRoutes(svc *slim_corev1.Service, ls sets.Set[resource.Key]) []netip.Prefix {
+	var desiredRoutes []netip.Prefix
+	if svc.Spec.Type != slim_corev1.ServiceTypeLoadBalancer {
+		return desiredRoutes
+	}
+	// Ignore externalTrafficPolicy == Local && no local EPs.
+	if svc.Spec.ExternalTrafficPolicy == slim_corev1.ServiceExternalTrafficPolicyLocal &&
+		!hasLocalEndpoints(svc, ls) {
+		return desiredRoutes
+	}
+	// Ignore service managed by an unsupported LB class.
+	if svc.Spec.LoadBalancerClass != nil && *svc.Spec.LoadBalancerClass != v2alpha1.BGPLoadBalancerClass {
+		// The service is managed by a different LB class.
+		return desiredRoutes
+	}
+	for _, ingress := range svc.Status.LoadBalancer.Ingress {
+		if ingress.IP == "" {
+			continue
+		}
+		addr, err := netip.ParseAddr(ingress.IP)
+		if err != nil {
+			continue
+		}
+		desiredRoutes = append(desiredRoutes, netip.PrefixFrom(addr, addr.BitLen()))
+	}
+	return desiredRoutes
+}
+
+func serviceLabelSet(svc *slim_corev1.Service) labels.Labels {
+	svcLabels := maps.Clone(svc.Labels)
+	if svcLabels == nil {
+		svcLabels = make(map[string]string)
+	}
+	svcLabels["io.kubernetes.service.name"] = svc.Name
+	svcLabels["io.kubernetes.service.namespace"] = svc.Namespace
+	return labels.Set(svcLabels)
+}

--- a/pkg/bgpv1/manager/reconcilerv2/service_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service_test.go
@@ -1,0 +1,1198 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconcilerv2
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
+	"github.com/cilium/cilium/pkg/bgpv1/manager/store"
+	"github.com/cilium/cilium/pkg/bgpv1/types"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/k8s"
+	v2api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+var (
+	serviceIPPoolTestLogger = logrus.WithField("unit_test", "reconcilerv2_service")
+)
+
+var (
+	redSvcKey           = resource.Key{Name: "red-svc", Namespace: "non-default"}
+	redSvcSelector      = &slim_metav1.LabelSelector{MatchLabels: map[string]string{"color": "red"}}
+	mismatchSvcSelector = &slim_metav1.LabelSelector{MatchLabels: map[string]string{"color": "blue"}}
+	ingressV4           = "192.168.0.1"
+	ingressV4Prefix     = "192.168.0.1/32"
+	externalV4          = "192.168.0.2"
+	externalV4Prefix    = "192.168.0.2/32"
+	clusterV4           = "192.168.0.3"
+	clusterV4Prefix     = "192.168.0.3/32"
+	ingressV6           = "2001:db8::1"
+	ingressV6Prefix     = "2001:db8::1/128"
+	externalV6          = "2001:db8::2"
+	externalV6Prefix    = "2001:db8::2/128"
+	clusterV6           = "2001:db8::3"
+	clusterV6Prefix     = "2001:db8::3/128"
+
+	redLBSvc = &slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      redSvcKey.Name,
+			Namespace: redSvcKey.Namespace,
+			Labels:    redSvcSelector.MatchLabels,
+		},
+		Spec: slim_corev1.ServiceSpec{
+			Type: slim_corev1.ServiceTypeLoadBalancer,
+		},
+		Status: slim_corev1.ServiceStatus{
+			LoadBalancer: slim_corev1.LoadBalancerStatus{
+				Ingress: []slim_corev1.LoadBalancerIngress{
+					{
+						IP: ingressV4,
+					},
+					{
+						IP: ingressV6,
+					},
+				},
+			},
+		},
+	}
+	redLBSvcWithETP = func(eTP slim_corev1.ServiceExternalTrafficPolicy) *slim_corev1.Service {
+		cp := redLBSvc.DeepCopy()
+		cp.Spec.ExternalTrafficPolicy = eTP
+		return cp
+	}
+
+	redExternalSvc = &slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      redSvcKey.Name,
+			Namespace: redSvcKey.Namespace,
+			Labels:    redSvcSelector.MatchLabels,
+		},
+		Spec: slim_corev1.ServiceSpec{
+			Type: slim_corev1.ServiceTypeClusterIP,
+			ExternalIPs: []string{
+				externalV4,
+				externalV6,
+			},
+		},
+	}
+
+	redExternalSvcWithETP = func(eTP slim_corev1.ServiceExternalTrafficPolicy) *slim_corev1.Service {
+		cp := redExternalSvc.DeepCopy()
+		cp.Spec.ExternalTrafficPolicy = eTP
+		return cp
+	}
+
+	redClusterSvc = &slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      redSvcKey.Name,
+			Namespace: redSvcKey.Namespace,
+			Labels:    redSvcSelector.MatchLabels,
+		},
+		Spec: slim_corev1.ServiceSpec{
+			Type:      slim_corev1.ServiceTypeClusterIP,
+			ClusterIP: clusterV4,
+			ClusterIPs: []string{
+				clusterV4,
+				clusterV6,
+			},
+		},
+	}
+
+	redClusterSvcWithITP = func(iTP slim_corev1.ServiceInternalTrafficPolicy) *slim_corev1.Service {
+		cp := redClusterSvc.DeepCopy()
+		cp.Spec.InternalTrafficPolicy = &iTP
+		return cp
+	}
+
+	redExternalAndClusterSvc = &slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      redSvcKey.Name,
+			Namespace: redSvcKey.Namespace,
+			Labels:    redSvcSelector.MatchLabels,
+		},
+		Spec: slim_corev1.ServiceSpec{
+			Type:      slim_corev1.ServiceTypeClusterIP,
+			ClusterIP: clusterV4,
+			ClusterIPs: []string{
+				clusterV4,
+				clusterV6,
+			},
+			ExternalIPs: []string{
+				externalV4,
+				externalV6,
+			},
+		},
+	}
+
+	redExternalAndClusterSvcWithITP = func(svc *slim_corev1.Service, iTP slim_corev1.ServiceInternalTrafficPolicy) *slim_corev1.Service {
+		cp := svc.DeepCopy()
+		cp.Spec.InternalTrafficPolicy = &iTP
+		return cp
+	}
+
+	redExternalAndClusterSvcWithETP = func(svc *slim_corev1.Service, eTP slim_corev1.ServiceExternalTrafficPolicy) *slim_corev1.Service {
+		cp := svc.DeepCopy()
+		cp.Spec.ExternalTrafficPolicy = eTP
+		return cp
+	}
+
+	redSvcAdvert = &v2alpha1.CiliumBGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "red-podCIDR-advertisement",
+			Labels: map[string]string{
+				"advertise": "red_bgp",
+			},
+		},
+	}
+
+	redSvcAdvertWithAdvertisements = func(adverts ...v2alpha1.BGPAdvertisement) *v2alpha1.CiliumBGPAdvertisement {
+		cp := redSvcAdvert.DeepCopy()
+		cp.Spec.Advertisements = adverts
+		return cp
+	}
+
+	lbSvcAdvert = v2alpha1.BGPAdvertisement{
+		AdvertisementType: v2alpha1.BGPServiceAdvert,
+		Service: &v2alpha1.BGPServiceOptions{
+			Addresses: []v2alpha1.BGPServiceAddressType{v2alpha1.BGPLoadBalancerIPAddr},
+		},
+	}
+	lbSvcAdvertWithSelector = func(selector *slim_metav1.LabelSelector) v2alpha1.BGPAdvertisement {
+		cp := lbSvcAdvert.DeepCopy()
+		cp.Selector = selector
+		return *cp
+	}
+
+	externalSvcAdvert = v2alpha1.BGPAdvertisement{
+		AdvertisementType: v2alpha1.BGPServiceAdvert,
+		Service: &v2alpha1.BGPServiceOptions{
+			Addresses: []v2alpha1.BGPServiceAddressType{v2alpha1.BGPExternalIPAddr},
+		},
+	}
+
+	externalSvcAdvertWithSelector = func(selector *slim_metav1.LabelSelector) v2alpha1.BGPAdvertisement {
+		cp := externalSvcAdvert.DeepCopy()
+		cp.Selector = selector
+		return *cp
+	}
+
+	clusterIPSvcAdvert = v2alpha1.BGPAdvertisement{
+		AdvertisementType: v2alpha1.BGPServiceAdvert,
+		Service: &v2alpha1.BGPServiceOptions{
+			Addresses: []v2alpha1.BGPServiceAddressType{v2alpha1.BGPClusterIPAddr},
+		},
+	}
+
+	clusterIPSvcAdvertWithSelector = func(selector *slim_metav1.LabelSelector) v2alpha1.BGPAdvertisement {
+		cp := clusterIPSvcAdvert.DeepCopy()
+		cp.Selector = selector
+		return *cp
+	}
+
+	testBGPInstanceConfig = &v2alpha1.CiliumBGPNodeInstance{
+		Name:     "bgp-65001",
+		LocalASN: ptr.To[int64](65001),
+		Peers: []v2alpha1.CiliumBGPNodePeer{
+			{
+				Name: "red-peer-65001",
+				PeerConfigRef: &v2alpha1.PeerConfigReference{
+					Group: "cilium.io",
+					Kind:  "CiliumBGPPeerConfig",
+					Name:  "peer-config-red",
+				},
+			},
+		},
+	}
+
+	testCiliumNodeConfig = &v2api.CiliumNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+		},
+	}
+
+	eps1Local = &k8s.Endpoints{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "svc-1",
+			Namespace: "non-default",
+		},
+		EndpointSliceID: k8s.EndpointSliceID{
+			ServiceID: k8s.ServiceID{
+				Name:      redSvcKey.Name,
+				Namespace: redSvcKey.Namespace,
+			},
+			EndpointSliceName: "svc-1",
+		},
+		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
+			cmtypes.MustParseAddrCluster("10.0.0.1"): {
+				NodeName: "node1",
+			},
+			cmtypes.MustParseAddrCluster("2001:db8:1000::1"): {
+				NodeName: "node1",
+			},
+		},
+	}
+
+	eps1Remote = &k8s.Endpoints{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "svc-1",
+			Namespace: "default",
+		},
+		EndpointSliceID: k8s.EndpointSliceID{
+			ServiceID: k8s.ServiceID{
+				Name:      redSvcKey.Name,
+				Namespace: redSvcKey.Namespace,
+			},
+			EndpointSliceName: "svc-1",
+		},
+		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
+			cmtypes.MustParseAddrCluster("10.0.0.2"): {
+				NodeName: "node2",
+			},
+			cmtypes.MustParseAddrCluster("2001:db8:1000::2"): {
+				NodeName: "node2",
+			},
+		},
+	}
+
+	eps1Mixed = &k8s.Endpoints{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "svc-1",
+			Namespace: "default",
+		},
+		EndpointSliceID: k8s.EndpointSliceID{
+			ServiceID: k8s.ServiceID{
+				Name:      redSvcKey.Name,
+				Namespace: redSvcKey.Namespace,
+			},
+			EndpointSliceName: "svc-1",
+		},
+		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
+			cmtypes.MustParseAddrCluster("10.0.0.1"): {
+				NodeName: "node1",
+			},
+			cmtypes.MustParseAddrCluster("10.0.0.2"): {
+				NodeName: "node2",
+			},
+			cmtypes.MustParseAddrCluster("2001:db8:1000::1"): {
+				NodeName: "node1",
+			},
+			cmtypes.MustParseAddrCluster("2001:db8:1000::2"): {
+				NodeName: "node2",
+			},
+		},
+	}
+)
+
+// Test_ServiceLBReconciler tests reconciliation of service of type load-balancer
+func Test_ServiceLBReconciler(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+
+	tests := []struct {
+		name             string
+		peerConfig       []*v2alpha1.CiliumBGPPeerConfig
+		advertisements   []*v2alpha1.CiliumBGPAdvertisement
+		services         []*slim_corev1.Service
+		endpoints        []*k8s.Endpoints
+		expectedMetadata ServiceReconcilerMetadata
+	}{
+		{
+			name:           "Service (LB) with advertisement( empty )",
+			peerConfig:     []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:       []*slim_corev1.Service{redLBSvc},
+			advertisements: nil,
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: nil,
+						{Afi: "ipv6", Safi: "unicast"}: nil,
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (LB) with advertisement(LB) - mismatch labels",
+			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{redLBSvc},
+			advertisements: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(lbSvcAdvertWithSelector(mismatchSvcSelector)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							lbSvcAdvertWithSelector(mismatchSvcSelector),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							lbSvcAdvertWithSelector(mismatchSvcSelector),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (LB) with advertisement(LB) - matching labels (eTP=cluster)",
+			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{redLBSvcWithETP(slim_corev1.ServiceExternalTrafficPolicyCluster)},
+			advertisements: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(lbSvcAdvertWithSelector(redSvcSelector)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+						},
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							lbSvcAdvertWithSelector(redSvcSelector),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							lbSvcAdvertWithSelector(redSvcSelector),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (LB) with advertisement(LB) - matching labels (eTP=local, ep on node)",
+			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{redLBSvcWithETP(slim_corev1.ServiceExternalTrafficPolicyLocal)},
+			endpoints:  []*k8s.Endpoints{eps1Local},
+			advertisements: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(lbSvcAdvertWithSelector(redSvcSelector)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+						},
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							lbSvcAdvertWithSelector(redSvcSelector),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							lbSvcAdvertWithSelector(redSvcSelector),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (LB) with advertisement(LB) - matching labels (eTP=local, mixed ep)",
+			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{redLBSvcWithETP(slim_corev1.ServiceExternalTrafficPolicyLocal)},
+			endpoints:  []*k8s.Endpoints{eps1Mixed},
+			advertisements: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(lbSvcAdvertWithSelector(redSvcSelector)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+						},
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							lbSvcAdvertWithSelector(redSvcSelector),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							lbSvcAdvertWithSelector(redSvcSelector),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (LB) with advertisement(LB) - matching labels (eTP=local, ep on remote)",
+			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{redLBSvcWithETP(slim_corev1.ServiceExternalTrafficPolicyLocal)},
+			endpoints:  []*k8s.Endpoints{eps1Remote},
+			advertisements: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(lbSvcAdvertWithSelector(redSvcSelector)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							lbSvcAdvertWithSelector(redSvcSelector),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							lbSvcAdvertWithSelector(redSvcSelector),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			params := ServiceReconcilerIn{
+				Logger: serviceIPPoolTestLogger,
+				PeerAdvert: NewCiliumPeerAdvertisement(
+					PeerAdvertisementIn{
+						Logger:          podCIDRTestLogger,
+						PeerConfigStore: store.InitMockStore[*v2alpha1.CiliumBGPPeerConfig](tt.peerConfig),
+						AdvertStore:     store.InitMockStore[*v2alpha1.CiliumBGPAdvertisement](tt.advertisements),
+					}),
+				SvcDiffStore: store.InitFakeDiffStore[*slim_corev1.Service](tt.services),
+				EPDiffStore:  store.InitFakeDiffStore[*k8s.Endpoints](tt.endpoints),
+			}
+
+			svcReconciler := NewServiceReconciler(params).Reconciler.(*ServiceReconciler)
+			testBGPInstance := instance.NewFakeBGPInstance()
+
+			// reconcile twice to validate idempotency
+			for i := 0; i < 2; i++ {
+				err := svcReconciler.Reconcile(context.Background(), ReconcileParams{
+					BGPInstance:   testBGPInstance,
+					DesiredConfig: testBGPInstanceConfig,
+					CiliumNode:    testCiliumNodeConfig,
+				})
+				req.NoError(err)
+			}
+
+			// validate new metadata
+			serviceMetadataEqual(req, tt.expectedMetadata, svcReconciler.getMetadata(testBGPInstance))
+		})
+	}
+}
+
+// Test_ServiceExternalIPReconciler tests reconciliation of cluster service with external IP
+func Test_ServiceExternalIPReconciler(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+
+	tests := []struct {
+		name             string
+		peerConfig       []*v2alpha1.CiliumBGPPeerConfig
+		advertisements   []*v2alpha1.CiliumBGPAdvertisement
+		services         []*slim_corev1.Service
+		endpoints        []*k8s.Endpoints
+		expectedMetadata ServiceReconcilerMetadata
+	}{
+		{
+			name:           "Service (External) with advertisement( empty )",
+			peerConfig:     []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:       []*slim_corev1.Service{redExternalSvc},
+			advertisements: nil,
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: nil,
+						{Afi: "ipv6", Safi: "unicast"}: nil,
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (External) with advertisement(External) - mismatch labels",
+			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{redExternalSvc},
+			advertisements: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(externalSvcAdvertWithSelector(mismatchSvcSelector)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							externalSvcAdvertWithSelector(mismatchSvcSelector),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							externalSvcAdvertWithSelector(mismatchSvcSelector),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (External) with advertisement(External) - matching labels (eTP=cluster)",
+			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{redExternalSvcWithETP(slim_corev1.ServiceExternalTrafficPolicyCluster)},
+			advertisements: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(externalSvcAdvertWithSelector(redSvcSelector)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							externalV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							externalV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
+						},
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							externalSvcAdvertWithSelector(redSvcSelector),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							externalSvcAdvertWithSelector(redSvcSelector),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (External) with advertisement(External) - matching labels (eTP=local, ep on node)",
+			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{redExternalSvcWithETP(slim_corev1.ServiceExternalTrafficPolicyLocal)},
+			endpoints:  []*k8s.Endpoints{eps1Local},
+			advertisements: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(externalSvcAdvertWithSelector(redSvcSelector)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							externalV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							externalV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
+						},
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							externalSvcAdvertWithSelector(redSvcSelector),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							externalSvcAdvertWithSelector(redSvcSelector),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (External) with advertisement(External) - matching labels (eTP=local, mixed ep)",
+			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{redExternalSvcWithETP(slim_corev1.ServiceExternalTrafficPolicyLocal)},
+			endpoints:  []*k8s.Endpoints{eps1Mixed},
+			advertisements: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(externalSvcAdvertWithSelector(redSvcSelector)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							externalV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							externalV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
+						},
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							externalSvcAdvertWithSelector(redSvcSelector),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							externalSvcAdvertWithSelector(redSvcSelector),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (External) with advertisement(External) - matching labels (eTP=local, ep on remote)",
+			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{redExternalSvcWithETP(slim_corev1.ServiceExternalTrafficPolicyLocal)},
+			endpoints:  []*k8s.Endpoints{eps1Remote},
+			advertisements: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(externalSvcAdvertWithSelector(redSvcSelector)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							externalSvcAdvertWithSelector(redSvcSelector),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							externalSvcAdvertWithSelector(redSvcSelector),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			params := ServiceReconcilerIn{
+				Logger: serviceIPPoolTestLogger,
+				PeerAdvert: NewCiliumPeerAdvertisement(
+					PeerAdvertisementIn{
+						Logger:          podCIDRTestLogger,
+						PeerConfigStore: store.InitMockStore[*v2alpha1.CiliumBGPPeerConfig](tt.peerConfig),
+						AdvertStore:     store.InitMockStore[*v2alpha1.CiliumBGPAdvertisement](tt.advertisements),
+					}),
+				SvcDiffStore: store.InitFakeDiffStore[*slim_corev1.Service](tt.services),
+				EPDiffStore:  store.InitFakeDiffStore[*k8s.Endpoints](tt.endpoints),
+			}
+
+			svcReconciler := NewServiceReconciler(params).Reconciler.(*ServiceReconciler)
+			testBGPInstance := instance.NewFakeBGPInstance()
+
+			// reconcile twice to validate idempotency
+			for i := 0; i < 2; i++ {
+				err := svcReconciler.Reconcile(context.Background(), ReconcileParams{
+					BGPInstance:   testBGPInstance,
+					DesiredConfig: testBGPInstanceConfig,
+					CiliumNode:    testCiliumNodeConfig,
+				})
+				req.NoError(err)
+			}
+
+			// validate new metadata
+			serviceMetadataEqual(req, tt.expectedMetadata, svcReconciler.getMetadata(testBGPInstance))
+		})
+	}
+}
+
+// Test_ServiceClusterIPReconciler tests reconciliation of cluster service
+func Test_ServiceClusterIPReconciler(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+
+	tests := []struct {
+		name             string
+		peerConfig       []*v2alpha1.CiliumBGPPeerConfig
+		advertisements   []*v2alpha1.CiliumBGPAdvertisement
+		services         []*slim_corev1.Service
+		endpoints        []*k8s.Endpoints
+		expectedMetadata ServiceReconcilerMetadata
+	}{
+		{
+			name:           "Service (Cluster) with advertisement( empty )",
+			peerConfig:     []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:       []*slim_corev1.Service{redClusterSvc},
+			advertisements: nil,
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: nil,
+						{Afi: "ipv6", Safi: "unicast"}: nil,
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (Cluster) with advertisement(Cluster) - mismatch labels",
+			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{redClusterSvc},
+			advertisements: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(clusterIPSvcAdvertWithSelector(mismatchSvcSelector)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							clusterIPSvcAdvertWithSelector(mismatchSvcSelector),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							clusterIPSvcAdvertWithSelector(mismatchSvcSelector),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (Cluster) with advertisement(Cluster) - matching labels (iTP=cluster)",
+			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{redClusterSvcWithITP(slim_corev1.ServiceInternalTrafficPolicyCluster)},
+			advertisements: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(clusterIPSvcAdvertWithSelector(redSvcSelector)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							clusterV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							clusterV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
+						},
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							clusterIPSvcAdvertWithSelector(redSvcSelector),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							clusterIPSvcAdvertWithSelector(redSvcSelector),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (Cluster) with advertisement(Cluster) - matching labels (eTP=local, ep on node)",
+			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{redClusterSvcWithITP(slim_corev1.ServiceInternalTrafficPolicyLocal)},
+			endpoints:  []*k8s.Endpoints{eps1Local},
+			advertisements: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(clusterIPSvcAdvertWithSelector(redSvcSelector)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							clusterV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							clusterV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
+						},
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							clusterIPSvcAdvertWithSelector(redSvcSelector),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							clusterIPSvcAdvertWithSelector(redSvcSelector),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (Cluster) with advertisement(Cluster) - matching labels (eTP=local, mixed ep)",
+			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{redClusterSvcWithITP(slim_corev1.ServiceInternalTrafficPolicyLocal)},
+			endpoints:  []*k8s.Endpoints{eps1Mixed},
+			advertisements: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(clusterIPSvcAdvertWithSelector(redSvcSelector)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							clusterV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							clusterV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
+						},
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							clusterIPSvcAdvertWithSelector(redSvcSelector),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							clusterIPSvcAdvertWithSelector(redSvcSelector),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (Cluster) with advertisement(Cluster) - matching labels (eTP=local, ep on remote)",
+			peerConfig: []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{redClusterSvcWithITP(slim_corev1.ServiceInternalTrafficPolicyLocal)},
+			endpoints:  []*k8s.Endpoints{eps1Remote},
+			advertisements: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(clusterIPSvcAdvertWithSelector(redSvcSelector)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							clusterIPSvcAdvertWithSelector(redSvcSelector),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							clusterIPSvcAdvertWithSelector(redSvcSelector),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			params := ServiceReconcilerIn{
+				Logger: serviceIPPoolTestLogger,
+				PeerAdvert: NewCiliumPeerAdvertisement(
+					PeerAdvertisementIn{
+						Logger:          podCIDRTestLogger,
+						PeerConfigStore: store.InitMockStore[*v2alpha1.CiliumBGPPeerConfig](tt.peerConfig),
+						AdvertStore:     store.InitMockStore[*v2alpha1.CiliumBGPAdvertisement](tt.advertisements),
+					}),
+				SvcDiffStore: store.InitFakeDiffStore[*slim_corev1.Service](tt.services),
+				EPDiffStore:  store.InitFakeDiffStore[*k8s.Endpoints](tt.endpoints),
+			}
+
+			svcReconciler := NewServiceReconciler(params).Reconciler.(*ServiceReconciler)
+			testBGPInstance := instance.NewFakeBGPInstance()
+
+			// reconcile twice to validate idempotency
+			for i := 0; i < 2; i++ {
+				err := svcReconciler.Reconcile(context.Background(), ReconcileParams{
+					BGPInstance:   testBGPInstance,
+					DesiredConfig: testBGPInstanceConfig,
+					CiliumNode:    testCiliumNodeConfig,
+				})
+				req.NoError(err)
+			}
+
+			// validate new metadata
+			serviceMetadataEqual(req, tt.expectedMetadata, svcReconciler.getMetadata(testBGPInstance))
+		})
+	}
+}
+
+// Test_ServiceAndAdvertisementModifications is a step test, in which each step modifies the advertisement or service parameters.
+func Test_ServiceAndAdvertisementModifications(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+
+	peerConfigs := []*v2alpha1.CiliumBGPPeerConfig{redPeerConfig}
+
+	steps := []struct {
+		name             string
+		upsertAdverts    []*v2alpha1.CiliumBGPAdvertisement
+		upsertServices   []*slim_corev1.Service
+		upsertEPs        []*k8s.Endpoints
+		expectedMetadata ServiceReconcilerMetadata
+	}{
+		{
+			name:           "Initial setup - Service (nil) with advertisement( empty )",
+			upsertAdverts:  nil,
+			upsertServices: nil,
+			upsertEPs:      nil,
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ServiceAFPathsMap{},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: nil,
+						{Afi: "ipv6", Safi: "unicast"}: nil,
+					},
+				},
+			},
+		},
+		{
+			name: "Add service (Cluster, External) with advertisement(Cluster) - matching labels",
+			upsertAdverts: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(v2alpha1.BGPAdvertisement{
+					AdvertisementType: v2alpha1.BGPServiceAdvert,
+					Service: &v2alpha1.BGPServiceOptions{
+						Addresses: []v2alpha1.BGPServiceAddressType{v2alpha1.BGPClusterIPAddr},
+					},
+					Selector: redSvcSelector,
+				}),
+			},
+			upsertServices: []*slim_corev1.Service{redExternalAndClusterSvc},
+			expectedMetadata: ServiceReconcilerMetadata{
+				// Only cluster IPs are advertised
+				ServicePaths: ServiceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							clusterV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							clusterV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
+						},
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							{
+								AdvertisementType: v2alpha1.BGPServiceAdvert,
+								Service: &v2alpha1.BGPServiceOptions{
+									Addresses: []v2alpha1.BGPServiceAddressType{v2alpha1.BGPClusterIPAddr},
+								},
+								Selector: redSvcSelector,
+							},
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							{
+								AdvertisementType: v2alpha1.BGPServiceAdvert,
+								Service: &v2alpha1.BGPServiceOptions{
+									Addresses: []v2alpha1.BGPServiceAddressType{v2alpha1.BGPClusterIPAddr},
+								},
+								Selector: redSvcSelector,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Update advertisement(Cluster, External) - matching labels",
+			upsertAdverts: []*v2alpha1.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(v2alpha1.BGPAdvertisement{
+					AdvertisementType: v2alpha1.BGPServiceAdvert,
+					Service: &v2alpha1.BGPServiceOptions{
+						Addresses: []v2alpha1.BGPServiceAddressType{
+							v2alpha1.BGPClusterIPAddr,
+							v2alpha1.BGPExternalIPAddr,
+						},
+					},
+					Selector: redSvcSelector,
+				}),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				// Both cluster and external IPs are advertised
+				ServicePaths: ServiceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							clusterV4Prefix:  types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
+							externalV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							clusterV6Prefix:  types.NewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
+							externalV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
+						},
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							{
+								AdvertisementType: v2alpha1.BGPServiceAdvert,
+								Service: &v2alpha1.BGPServiceOptions{
+									Addresses: []v2alpha1.BGPServiceAddressType{
+										v2alpha1.BGPClusterIPAddr,
+										v2alpha1.BGPExternalIPAddr,
+									},
+								},
+								Selector: redSvcSelector,
+							},
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							{
+								AdvertisementType: v2alpha1.BGPServiceAdvert,
+								Service: &v2alpha1.BGPServiceOptions{
+									Addresses: []v2alpha1.BGPServiceAddressType{
+										v2alpha1.BGPClusterIPAddr,
+										v2alpha1.BGPExternalIPAddr,
+									},
+								},
+								Selector: redSvcSelector,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Update service (Cluster, External) traffic policy local",
+			upsertServices: []*slim_corev1.Service{
+				redExternalAndClusterSvcWithITP(
+					redExternalAndClusterSvcWithETP(redExternalAndClusterSvc, slim_corev1.ServiceExternalTrafficPolicyLocal),
+					slim_corev1.ServiceInternalTrafficPolicyLocal),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				// Both cluster and external IPs are withdrawn, since traffic policy is local and there are no endpoints.
+				ServicePaths: ServiceAFPathsMap{},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							{
+								AdvertisementType: v2alpha1.BGPServiceAdvert,
+								Service: &v2alpha1.BGPServiceOptions{
+									Addresses: []v2alpha1.BGPServiceAddressType{
+										v2alpha1.BGPClusterIPAddr,
+										v2alpha1.BGPExternalIPAddr,
+									},
+								},
+								Selector: redSvcSelector,
+							},
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							{
+								AdvertisementType: v2alpha1.BGPServiceAdvert,
+								Service: &v2alpha1.BGPServiceOptions{
+									Addresses: []v2alpha1.BGPServiceAddressType{
+										v2alpha1.BGPClusterIPAddr,
+										v2alpha1.BGPExternalIPAddr,
+									},
+								},
+								Selector: redSvcSelector,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "Update local endpoints (Cluster, External)",
+			upsertEPs: []*k8s.Endpoints{eps1Mixed},
+			expectedMetadata: ServiceReconcilerMetadata{
+				// Both cluster and external IPs are advertised since there is local endpoint.
+				ServicePaths: ServiceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							clusterV4Prefix:  types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
+							externalV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							clusterV6Prefix:  types.NewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
+							externalV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
+						},
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					"red-peer-65001": PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							{
+								AdvertisementType: v2alpha1.BGPServiceAdvert,
+								Service: &v2alpha1.BGPServiceOptions{
+									Addresses: []v2alpha1.BGPServiceAddressType{
+										v2alpha1.BGPClusterIPAddr,
+										v2alpha1.BGPExternalIPAddr,
+									},
+								},
+								Selector: redSvcSelector,
+							},
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2alpha1.BGPAdvertisement{
+							{
+								AdvertisementType: v2alpha1.BGPServiceAdvert,
+								Service: &v2alpha1.BGPServiceOptions{
+									Addresses: []v2alpha1.BGPServiceAddressType{
+										v2alpha1.BGPClusterIPAddr,
+										v2alpha1.BGPExternalIPAddr,
+									},
+								},
+								Selector: redSvcSelector,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	req := require.New(t)
+	advertStore := store.NewMockBGPCPResourceStore[*v2alpha1.CiliumBGPAdvertisement]()
+	serviceStore := store.NewFakeDiffStore[*slim_corev1.Service]()
+	epStore := store.NewFakeDiffStore[*k8s.Endpoints]()
+
+	params := ServiceReconcilerIn{
+		Logger: serviceIPPoolTestLogger,
+		PeerAdvert: NewCiliumPeerAdvertisement(
+			PeerAdvertisementIn{
+				Logger:          podCIDRTestLogger,
+				PeerConfigStore: store.InitMockStore[*v2alpha1.CiliumBGPPeerConfig](peerConfigs),
+				AdvertStore:     advertStore,
+			}),
+		SvcDiffStore: serviceStore,
+		EPDiffStore:  epStore,
+	}
+
+	svcReconciler := NewServiceReconciler(params).Reconciler.(*ServiceReconciler)
+	testBGPInstance := instance.NewFakeBGPInstance()
+
+	for _, tt := range steps {
+		t.Logf("Running step - %s", tt.name)
+		for _, advert := range tt.upsertAdverts {
+			advertStore.Upsert(advert)
+		}
+
+		for _, svc := range tt.upsertServices {
+			serviceStore.Upsert(svc)
+		}
+
+		for _, ep := range tt.upsertEPs {
+			epStore.Upsert(ep)
+		}
+
+		err := svcReconciler.Reconcile(context.Background(), ReconcileParams{
+			BGPInstance:   testBGPInstance,
+			DesiredConfig: testBGPInstanceConfig,
+			CiliumNode:    testCiliumNodeConfig,
+		})
+		req.NoError(err)
+
+		// validate new metadata
+		serviceMetadataEqual(req, tt.expectedMetadata, svcReconciler.getMetadata(testBGPInstance))
+	}
+}
+
+func serviceMetadataEqual(req *require.Assertions, expectedMetadata, runningMetadata ServiceReconcilerMetadata) {
+	req.Truef(PeerAdvertisementsEqual(expectedMetadata.ServiceAdvertisements, runningMetadata.ServiceAdvertisements),
+		"ServiceAdvertisements mismatch, expected: %v, got: %v", expectedMetadata.ServiceAdvertisements, runningMetadata.ServiceAdvertisements)
+
+	req.Equalf(len(expectedMetadata.ServicePaths), len(runningMetadata.ServicePaths),
+		"ServicePaths length mismatch, expected: %v, got: %v", expectedMetadata.ServicePaths, runningMetadata.ServicePaths)
+
+	for svc, expectedSvcPaths := range expectedMetadata.ServicePaths {
+		runningSvcPaths, exists := runningMetadata.ServicePaths[svc]
+		req.Truef(exists, "Service not found in running: %v", svc)
+
+		runningFamilyPaths := make(map[types.Family]map[string]struct{})
+		for family, paths := range runningSvcPaths {
+			pathSet := make(map[string]struct{})
+
+			for pathKey := range paths {
+				pathSet[pathKey] = struct{}{}
+			}
+			runningFamilyPaths[family] = pathSet
+		}
+
+		expectedFamilyPaths := make(map[types.Family]map[string]struct{})
+		for family, paths := range expectedSvcPaths {
+			pathSet := make(map[string]struct{})
+
+			for pathKey := range paths {
+				pathSet[pathKey] = struct{}{}
+			}
+			expectedFamilyPaths[family] = pathSet
+		}
+
+		req.Equal(expectedFamilyPaths, runningFamilyPaths)
+	}
+}

--- a/pkg/bgpv1/manager/store/diffstore_fake.go
+++ b/pkg/bgpv1/manager/store/diffstore_fake.go
@@ -28,6 +28,14 @@ func NewFakeDiffStore[T runtime.Object]() *fakeDiffStore[T] {
 	}
 }
 
+func InitFakeDiffStore[T runtime.Object](objs []T) *fakeDiffStore[T] {
+	mds := NewFakeDiffStore[T]()
+	for _, obj := range objs {
+		mds.Upsert(obj)
+	}
+	return mds
+}
+
 func (mds *fakeDiffStore[T]) Diff() (upserted []T, deleted []resource.Key, err error) {
 	mds.changedMu.Lock()
 	defer mds.changedMu.Unlock()


### PR DESCRIPTION
Adding service reconcilers in BGPv2 implementation. This change also includes unit tests.

BGPv2 service reconcilers will support services of type LB, cluster IP and external IP for BGP advertisement. As well as external and internal traffic policy constructs.

This is continuation of BGPv2 implementation.