### PR TITLE
labels: Add controller-uid into default ignore list

### DIFF
--- a/Documentation/operations/performance/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/performance/scalability/identity-relevant-labels.rst
@@ -29,12 +29,14 @@ Label                                               Description
 ``any:!statefulset\.kubernetes\.io/pod-name``       Ignore ``statefulset.kubernetes.io/pod-name`` label
 ``any:!apps\.kubernetes\.io/pod-index``             Ignore ``apps.kubernetes.io/pod-index`` label
 ``any:!batch\.kubernetes\.io/job-completion-index`` Ignore ``batch.kubernetes.io/job-completion-index`` label
+``any:!batch\.kubernetes\.io/controller-uid``       Ignore ``batch.kubernetes.io/controller-uid`` label
 ``any:!beta\.kubernetes\.io``                       Ignore all ``beta.kubernetes.io`` labels
 ``any:!k8s\.io``                                    Ignore all ``k8s.io`` labels
 ``any:!pod-template-generation``                    Ignore all ``pod-template-generation`` labels
 ``any:!pod-template-hash``                          Ignore all ``pod-template-hash`` labels
 ``any:!controller-revision-hash``                   Ignore all ``controller-revision-hash`` labels
 ``any:!annotation.*``                               Ignore all ``annotation`` labels
+``any:!controller-uid``                             Ignore all ``controller-uid`` labels
 ``any:!etcd_node``                                  Ignore all ``etcd_node`` labels
 =================================================== =========================================================
 

--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -70,6 +70,10 @@ const (
 	// completion index.
 	IndexedJobCompletionIndexLabel = "batch.kubernetes.io/job-completion-index"
 
+	// BatchJobControllerUID is one of the labels that is available on a Job
+	// https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-labels
+	BatchJobControllerUID = "batch.kubernetes.io/controller-uid"
+
 	// CiliumIdentityAnnotationDeprecated is the previous annotation key used to map to an endpoint's security identity.
 	CiliumIdentityAnnotationDeprecated = "cilium-identity"
 )

--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -224,11 +224,13 @@ func defaultLabelPrefixCfg() *labelPrefixCfg {
 		"!" + regexp.QuoteMeta(k8sConst.StatefulSetPodNameLabel),        // ignore statefulset.kubernetes.io/pod-name label
 		"!" + regexp.QuoteMeta(k8sConst.StatefulSetPodIndexLabel),       // ignore apps.kubernetes.io/pod-index label
 		"!" + regexp.QuoteMeta(k8sConst.IndexedJobCompletionIndexLabel), // ignore batch.kubernetes.io/job-completion-index label
+		"!" + regexp.QuoteMeta(k8sConst.BatchJobControllerUID),          // ignore batch.kubernetes.io/controller-uid
 		`!.*beta\.kubernetes\.io`,                                       // ignore all beta.kubernetes.io labels
 		`!k8s\.io`,                                                      // ignore all k8s.io labels
 		`!pod-template-generation`,                                      // ignore pod-template-generation
 		`!pod-template-hash`,                                            // ignore pod-template-hash
 		`!controller-revision-hash`,                                     // ignore controller-revision-hash
+		`!controller-uid`,                                               // ignore controller-uid
 		`!annotation.*`,                                                 // ignore all annotation labels
 		`!etcd_node`,                                                    // ignore etcd_node label
 	}


### PR DESCRIPTION
### Description

Having uid in security labels will significantly increase the number of
identities, not to mention about high cardinality in metrics. This
commit is to add *controller-uid related labels into default exclusion
list.

### Testing

Sample job pod created by CronJob

```yaml
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2024-04-17T03:15:00Z"
  generateName: hello-28555395-
  labels:
    app: hello
    batch.kubernetes.io/controller-uid: 249b1dfa-3414-4052-9abc-612c99cf0c79
    batch.kubernetes.io/job-name: hello-28555395
    controller-uid: 249b1dfa-3414-4052-9abc-612c99cf0c79
    job-name: hello-28555395
  name: hello-28555395-pp5rm
  namespace: default
  ownerReferences:
  - apiVersion: batch/v1
    blockOwnerDeletion: true
    controller: true
    kind: Job
    name: hello-28555395
    uid: 249b1dfa-3414-4052-9abc-612c99cf0c79
  resourceVersion: "240215"
  uid: 1aae749d-a72a-4bcf-984f-b54a76f7dc92
...
```

Cilium Identity **before** the changes

```yaml
apiVersion: cilium.io/v2
kind: CiliumIdentity
metadata:
  creationTimestamp: "2024-04-17T03:31:01Z"
  generation: 1
  labels:
    app: hello
    batch.kubernetes.io/controller-uid: dd2af12a-d9f3-4725-aba1-2e5430a38bd7
    batch.kubernetes.io/job-name: hello-28555411
    controller-uid: dd2af12a-d9f3-4725-aba1-2e5430a38bd7
    io.cilium.k8s.policy.cluster: default
    io.cilium.k8s.policy.serviceaccount: default
    io.kubernetes.pod.namespace: default
    job-name: hello-28555411
  name: "13968"
  resourceVersion: "247636"
  uid: a041bdbd-4117-4a75-81db-614f7dfc7969
security-labels:
  k8s:app: hello
  k8s:batch.kubernetes.io/controller-uid: dd2af12a-d9f3-4725-aba1-2e5430a38bd7
  k8s:batch.kubernetes.io/job-name: hello-28555411
  k8s:controller-uid: dd2af12a-d9f3-4725-aba1-2e5430a38bd7
  k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name: default
  k8s:io.cilium.k8s.policy.cluster: default
  k8s:io.cilium.k8s.policy.serviceaccount: default
  k8s:io.kubernetes.pod.namespace: default
  k8s:job-name: hello-28555411
```

Cilium Identity **after** the changes

```yaml
apiVersion: cilium.io/v2
kind: CiliumIdentity
metadata:
  creationTimestamp: "2024-04-17T03:33:01Z"
  generation: 1
  labels:
    app: hello
    batch.kubernetes.io/job-name: hello-28555413
    io.cilium.k8s.policy.cluster: default
    io.cilium.k8s.policy.serviceaccount: default
    io.kubernetes.pod.namespace: default
    job-name: hello-28555413
  name: "22956"
  resourceVersion: "248251"
  uid: 61f591b4-a777-4fc8-b64a-5c2b05199aac
security-labels:
  k8s:app: hello
  k8s:batch.kubernetes.io/job-name: hello-28555413
  k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name: default
  k8s:io.cilium.k8s.policy.cluster: default
  k8s:io.cilium.k8s.policy.serviceaccount: default
  k8s:io.kubernetes.pod.namespace: default
  k8s:job-name: hello-28555413
```