### PR TITLE
fix k8s versions tested in CI

### DIFF
--- a/.github/actions/aws/k8s-versions.yaml
+++ b/.github/actions/aws/k8s-versions.yaml
@@ -1,16 +1,10 @@
 # List of k8s version for EKS tests
 ---
 include:
-  - version: "1.24"
-    region: ca-west-1
-  - version: "1.25"
-    region: us-west-2
   - version: "1.26"
     region: us-west-1
-    default: true
   - version: "1.27"
     region: us-east-2
-    default: true
     ipsec: true
   - version: "1.28"
     region: ca-central-1
@@ -18,3 +12,4 @@ include:
   - version: "1.29"
     region: us-east-1
     ipsec: true
+    default: true

--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -10,7 +10,7 @@ include:
   - version: "1.28"
     location: eastus2
     index: 3
-    default: true
   - version: "1.29"
     location: eastus
     index: 4
+    default: true

--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,19 +1,16 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.25"
-    zone: us-west1-b
-    vmIndex: 1
   - version: "1.26"
     zone: us-west2-c
-    vmIndex: 2
+    vmIndex: 1
   - version: "1.27"
     zone: us-west3-a
-    vmIndex: 3
-    default: true
+    vmIndex: 2
   - version: "1.28"
     zone: us-east4-b
-    vmIndex: 4
+    vmIndex: 3
   - version: "1.29"
     zone: us-east1-c
-    vmIndex: 5
+    vmIndex: 4
+    default: true


### PR DESCRIPTION
- Remove older versions we do not officially support anymore on v1.15.
- Make K8s 1.29 the default version on all platforms.