### PR TITLE
fix k8s versions tested in CI

### DIFF
--- a/.github/actions/aws/k8s-versions.yaml
+++ b/.github/actions/aws/k8s-versions.yaml
@@ -7,7 +7,6 @@ include:
     region: us-west-2
   - version: "1.26"
     region: us-west-1
-    default: true
   - version: "1.27"
     region: us-east-2
     default: true

--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -1,14 +1,10 @@
 # List of k8s version for AKS tests
 ---
 include:
-  - version: "1.25"
-    location: westus3
-    index: 1
-    disabled: true
   - version: "1.26"
     location: westus2
-    index: 2
+    index: 1
   - version: "1.27"
     location: eastus2
-    index: 3
+    index: 2
     default: true


### PR DESCRIPTION
- Remove older versions not available on platforms anymore.
- Make K8s 1.27 the default version on all platforms.