### PR TITLE
docs: Add Pod eviction warning in upgrade notes for Envoy DS

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -308,7 +308,9 @@ Annotations:
 
 * Cilium Envoy DaemonSet is now enabled by default, and existing in-container installs
   will be changed to DaemonSet mode unless specifically opted out of. This can be done by
-  disabling it manually by setting ``envoy.enabled=false`` accordingly.
+  disabling it manually by setting ``envoy.enabled=false`` accordingly. This change adds
+  one additional Pod per Node, therefore Nodes at maximum Pod capacity will face an
+  eviction of a single non-system critical Pod after upgrading.
 * The ``cilium-dbg status --verbose`` command health data may now show health reported on a non-leaf
   component under a leaf named ``reporter``. Health data tree branches will now also be sorted by
   the fully qualified health status identifier.


### PR DESCRIPTION
This commit expands on the upgrade warning in the documentation for the Envoy DaemonSet, describing a potential case in which pod evictions could occur during upgrade.

Related: https://github.com/cilium/cilium/pull/31825

```release-note
Add Pod eviction warning in upgrade notes for Envoy DS
```
