### PR TITLE
[1.14-backport] ipsec: Fix unencrypted traffic when IPsec is used with L7 egress proxy

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -399,7 +399,11 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	if (from_proxy && info->tunnel_endpoint && encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
 					 info->sec_identity, true);
-#endif
+
+	if (from_proxy &&
+	    (!info || !identity_is_cluster(info->sec_identity)))
+		ctx->mark = MARK_MAGIC_PROXY_TO_WORLD;
+#endif /* ENABLE_IPSEC && !TUNNEL_MODE */
 
 	return CTX_ACT_OK;
 }
@@ -853,7 +857,11 @@ skip_vtep:
 	if (from_proxy && info->tunnel_endpoint && encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
 					 info->sec_identity, true);
-#endif
+
+	if (from_proxy &&
+	    (!info || !identity_is_cluster(info->sec_identity)))
+		ctx->mark = MARK_MAGIC_PROXY_TO_WORLD;
+#endif /* ENABLE_IPSEC && !TUNNEL_MODE */
 
 	return CTX_ACT_OK;
 }

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -110,9 +110,13 @@ function setup_proxy_rules()
 	from_ingress_rulespec="fwmark 0xA00/0xF00 pref 10 lookup $PROXY_RT_TABLE proto $DEFAULT_RTPROTO"
         from_egress_rulespec="fwmark 0xB00/0xF00 pref 10 lookup $PROXY_RT_TABLE proto $DEFAULT_RTPROTO"
 	use_from_ingress_proxy_rules=0
+	use_from_egress_proxy_rules=0
 
 	if [[ ("$IPSEC_ENCRYPTION" = "true" || "$CILIUM_ENVOY_CONFIG" = "true") ]] && [ "$MODE" != "tunnel" ]; then
 		use_from_ingress_proxy_rules=1
+	fi
+	if [[ "$IPSEC_ENCRYPTION" = "true" ]] && [ "$MODE" != "tunnel" ]; then
+		use_from_egress_proxy_rules=1
 	fi
 
 	# Any packet to an ingress or egress proxy uses a separate routing table
@@ -136,8 +140,14 @@ function setup_proxy_rules()
 					ip -4 rule delete $from_ingress_rulespec 2> /dev/null || true
 				fi
 			fi
-                        if [ ! -z "$(ip -4 rule list $from_egress_rulespec)" ]; then
-                                ip -4 rule delete $from_egress_rulespec 2> /dev/null || true
+                        if [ $use_from_egress_proxy_rules -eq 1 ]; then
+                                if [ -z "$(ip -4 rule list $from_egress_rulespec)" ]; then
+                                        ip -4 rule add $from_egress_rulespec
+                                fi
+                        else
+                                if [ ! -z "$(ip -4 rule list $from_egress_rulespec)" ]; then
+                                        ip -4 rule delete $from_egress_rulespec 2> /dev/null || true
+                                fi
                         fi
 		fi
 
@@ -172,8 +182,14 @@ function setup_proxy_rules()
 					ip -6 rule delete $from_ingress_rulespec 2> /dev/null || true
 				fi
 			fi
-                        if [ ! -z "$(ip -6 rule list $from_egress_rulespec)" ]; then
-                                ip -6 rule delete $from_egress_rulespec 2> /dev/null || true
+                        if [ $use_from_egress_proxy_rules -eq 1 ]; then
+                                if [ -z "$(ip -6 rule list $from_egress_rulespec)" ]; then
+                                        ip -6 rule add $from_egress_rulespec
+                                fi
+                        else
+                                if [ ! -z "$(ip -6 rule list $from_egress_rulespec)" ]; then
+                                        ip -6 rule delete $from_egress_rulespec 2> /dev/null || true
+                                fi
                         fi
 		fi
 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -666,6 +666,7 @@ enum metric_dir {
  *    In the IPsec case this becomes the SPI on the wire.
  */
 #define MARK_MAGIC_HOST_MASK		0x0F00
+#define MARK_MAGIC_PROXY_TO_WORLD	0x0800
 #define MARK_MAGIC_PROXY_EGRESS_EPID	0x0900 /* mark carries source endpoint ID */
 #define MARK_MAGIC_PROXY_INGRESS	0x0A00
 #define MARK_MAGIC_PROXY_EGRESS		0x0B00

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -451,11 +451,13 @@ func (m *IptablesManager) inboundProxyRedirectRule(cmd string) []string {
 	//    by ip_early_demux
 	toProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
 	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
+	matchProxyToWorld := fmt.Sprintf("%#08x/%#08x", linux_defaults.MarkProxyToWorld, linux_defaults.RouteMarkMask)
 	return []string{
 		"-t", "mangle",
 		cmd, ciliumPreMangleChain,
 		"-m", "socket", "--transparent",
 		"-m", "mark", "!", "--mark", matchFromIPSecEncrypt,
+		"-m", "mark", "!", "--mark", matchProxyToWorld,
 		"-m", "comment", "--comment", "cilium: any->pod redirect proxied traffic to host proxy",
 		"-j", "MARK",
 		"--set-mark", toProxyMark}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -516,6 +516,8 @@ func (m *IptablesManager) installStaticProxyRules() error {
 	matchToProxy := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsToProxy, linux_defaults.MagicMarkHostMask)
 	// proxy return traffic has 0 ID in the mask
 	matchProxyReply := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxy, linux_defaults.MagicMarkProxyNoIDMask)
+	// proxy forward traffic
+	matchProxyForward := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkEgress, linux_defaults.MagicMarkHostMask)
 	// L7 proxy upstream return traffic has Endpoint ID in the mask
 	matchL7ProxyUpstream := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxyEPID, linux_defaults.MagicMarkProxyMask)
 	// match traffic from a proxy (either in forward or in return direction)
@@ -563,6 +565,19 @@ func (m *IptablesManager) installStaticProxyRules() error {
 			"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
 			"-j", "CT", "--notrack"}); err != nil {
 			return err
+		}
+
+		// No conntrack for proxy forward traffic that is heading to cilium_host
+		if option.Config.EnableIPSec {
+			if err := ip4tables.runProg([]string{
+				"-t", "raw",
+				"-A", ciliumOutputRawChain,
+				"-o", defaults.HostDevice,
+				"-m", "mark", "--mark", matchProxyForward,
+				"-m", "comment", "--comment", "cilium: NOTRACK for proxy forward traffic",
+				"-j", "CT", "--notrack"}); err != nil {
+				return err
+			}
 		}
 
 		// No conntrack for proxy upstream traffic that is heading to lxc+

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -32,6 +32,10 @@ const (
 	// table which is between 253-255. See ip-route(8).
 	RouteTableInterfacesOffset = 10
 
+	// MarkProxyToWorld is the default mark to use to indicate that a packet
+	// from proxy needs to be sent to the world.
+	MarkProxyToWorld = 0x800
+
 	// RouteMarkDecrypt is the default route mark to use to indicate datapath
 	// needs to decrypt a packet.
 	RouteMarkDecrypt = 0x0D00


### PR DESCRIPTION
- [x] https://github.com/cilium/cilium/pull/32683 @jschwinger233 