### PR TITLE
[1.13-backport] ipsec: Fix unencrypted traffic when IPsec is used with L7 egress proxy

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -393,6 +393,13 @@ jobs:
             kubectl get pods --all-namespaces -o wide
             kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium status
 
+            # 1.12 is EOL, we have to run commands manually to clean up stale routing rules
+            cilium_pods=$(kubectl -nkube-system get po -l k8s-app=cilium --no-headers -o custom-columns=":metadata.name")
+            for cilium_pod in $cilium_pods; do
+              kubectl -nkube-system exec $cilium_pod -- ip -4 rule delete fwmark 0xB00/0xF00 lookup 2005 2>/dev/null || true
+              kubectl -nkube-system exec $cilium_pod -- ip -6 rule delete fwmark 0xB00/0xF00 lookup 2005 2>/dev/null || true
+            done
+
       - name: Fetch artifacts
         if: ${{ steps.vars.outputs.downgrade_version != '' && !success() }}
         shell: bash

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -314,10 +314,6 @@ To disable the encryption, regenerate the YAML with the option
 Limitations
 ===========
 
-    * For clusters running in native routing mode, IPsec encryption is not applied to
-      connections which are selected by an L7 Egress Network Policy or a DNS Policy.
-      For more information see `GHSA-j89h-qrvr-xc36
-      <https://github.com/cilium/cilium/security/advisories/GHSA-j89h-qrvr-xc36>`__.
     * Transparent encryption is not currently supported when chaining Cilium on
       top of other CNI plugins. For more information, see :gh-issue:`15596`.
     * :ref:`HostPolicies` are not currently supported with IPsec encryption.

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -333,7 +333,11 @@ skip_host_firewall:
 	if (from_proxy && info->tunnel_endpoint && encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
 					 info->sec_label, true);
-#endif
+
+	if (from_proxy &&
+	    (!info || !identity_is_cluster(info->sec_label)))
+		ctx->mark = MARK_MAGIC_PROXY_TO_WORLD;
+#endif /* ENABLE_IPSEC && !TUNNEL_MODE */
 
 	return CTX_ACT_OK;
 }
@@ -646,7 +650,11 @@ skip_vtep:
 	if (from_proxy && info->tunnel_endpoint && encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
 					 info->sec_label, true);
-#endif
+
+	if (from_proxy &&
+	    (!info || !identity_is_cluster(info->sec_label)))
+		ctx->mark = MARK_MAGIC_PROXY_TO_WORLD;
+#endif /* ENABLE_IPSEC && !TUNNEL_MODE */
 
 	return CTX_ACT_OK;
 }

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -590,6 +590,7 @@ enum metric_dir {
  *    In the IPsec case this becomes the SPI on the wire.
  */
 #define MARK_MAGIC_HOST_MASK		0x0F00
+#define MARK_MAGIC_PROXY_TO_WORLD	0x0800
 #define MARK_MAGIC_PROXY_EGRESS_EPID	0x0900 /* mark carries source endpoint ID */
 #define MARK_MAGIC_PROXY_INGRESS	0x0A00
 #define MARK_MAGIC_PROXY_EGRESS		0x0B00

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -445,11 +445,13 @@ func (m *IptablesManager) inboundProxyRedirectRule(cmd string) []string {
 	//    by ip_early_demux
 	toProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
 	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
+	matchProxyToWorld := fmt.Sprintf("%#08x/%#08x", linux_defaults.MarkProxyToWorld, linux_defaults.RouteMarkMask)
 	return []string{
 		"-t", "mangle",
 		cmd, ciliumPreMangleChain,
 		"-m", "socket", "--transparent",
 		"-m", "mark", "!", "--mark", matchFromIPSecEncrypt,
+		"-m", "mark", "!", "--mark", matchProxyToWorld,
 		"-m", "comment", "--comment", "cilium: any->pod redirect proxied traffic to host proxy",
 		"-j", "MARK",
 		"--set-mark", toProxyMark}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -506,6 +506,8 @@ func (m *IptablesManager) installStaticProxyRules() error {
 	matchToProxy := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsToProxy, linux_defaults.MagicMarkHostMask)
 	// proxy return traffic has 0 ID in the mask
 	matchProxyReply := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxy, linux_defaults.MagicMarkProxyNoIDMask)
+	// proxy forward traffic
+	matchProxyForward := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkEgress, linux_defaults.MagicMarkHostMask)
 	// L7 proxy upstream return traffic has Endpoint ID in the mask
 	matchL7ProxyUpstream := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxyEPID, linux_defaults.MagicMarkProxyMask)
 	// match traffic from a proxy (either in forward or in return direction)
@@ -553,6 +555,19 @@ func (m *IptablesManager) installStaticProxyRules() error {
 			"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
 			"-j", "CT", "--notrack"}); err != nil {
 			return err
+		}
+
+		// No conntrack for proxy forward traffic that is heading to cilium_host
+		if option.Config.EnableIPSec {
+			if err := ip4tables.runProg([]string{
+				"-t", "raw",
+				"-A", ciliumOutputRawChain,
+				"-o", defaults.HostDevice,
+				"-m", "mark", "--mark", matchProxyForward,
+				"-m", "comment", "--comment", "cilium: NOTRACK for proxy forward traffic",
+				"-j", "CT", "--notrack"}); err != nil {
+				return err
+			}
 		}
 
 		// No conntrack for proxy upstream traffic that is heading to lxc+

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -32,6 +32,10 @@ const (
 	// table which is between 253-255. See ip-route(8).
 	RouteTableInterfacesOffset = 10
 
+	// MarkProxyToWorld is the default mark to use to indicate that a packet
+	// from proxy needs to be sent to the world.
+	MarkProxyToWorld = 0x800
+
 	// RouteMarkDecrypt is the default route mark to use to indicate datapath
 	// needs to decrypt a packet.
 	RouteMarkDecrypt = 0x0D00


### PR DESCRIPTION
- [x] https://github.com/cilium/cilium/pull/32683 @jschwinger233 
- [x] https://github.com/cilium/cilium/pull/32906 @julianwiedmann 

```upstream-prs
 32683 32906
```