### PR TITLE
bpf: minor tail-call cleanups

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1783,8 +1783,8 @@ int handle_lxc_traffic(struct __ctx_buff *ctx)
 
 		lxc_id = ctx_load_meta(ctx, CB_DST_ENDPOINT_ID);
 		ctx_store_meta(ctx, CB_SRC_LABEL, HOST_ID);
-		tail_call_dynamic(ctx, &POLICY_CALL_MAP, lxc_id);
-		return send_drop_notify_error(ctx, HOST_ID, DROP_MISSED_TAIL_CALL,
+		ret = tail_call_policy_dynamic(ctx, (__u16)lxc_id);
+		return send_drop_notify_error(ctx, HOST_ID, ret,
 					      CTX_ACT_DROP, METRIC_EGRESS);
 	}
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -599,7 +599,9 @@ ct_recreate6:
 	 */
 	if (*dst_sec_identity == HOST_ID) {
 		ctx_store_meta(ctx, CB_FROM_HOST, 0);
-		tail_call_static(ctx, POLICY_CALL_MAP, HOST_EP_ID);
+		ret = tail_call_policy_static(ctx, HOST_EP_ID);
+
+		/* return fine-grained error: */
 		return DROP_HOST_NOT_READY;
 	}
 #endif /* ENABLE_HOST_FIREWALL && !ENABLE_ROUTING */
@@ -1077,7 +1079,9 @@ ct_recreate4:
 	 */
 	if (*dst_sec_identity == HOST_ID) {
 		ctx_store_meta(ctx, CB_FROM_HOST, 0);
-		tail_call_static(ctx, POLICY_CALL_MAP, HOST_EP_ID);
+		ret = tail_call_policy_static(ctx, HOST_EP_ID);
+
+		/* report fine-grained error: */
 		return DROP_HOST_NOT_READY;
 	}
 #endif /* ENABLE_HOST_FIREWALL && !ENABLE_ROUTING */
@@ -2427,7 +2431,8 @@ int cil_to_container(struct __ctx_buff *ctx)
 	if (identity == HOST_ID) {
 		ctx_store_meta(ctx, CB_FROM_HOST, 1);
 		ctx_store_meta(ctx, CB_DST_ENDPOINT_ID, LXC_ID);
-		tail_call_static(ctx, POLICY_CALL_MAP, HOST_EP_ID);
+
+		ret = tail_call_policy_static(ctx, HOST_EP_ID);
 		return send_drop_notify(ctx, identity, sec_label, LXC_ID,
 					DROP_HOST_NOT_READY, CTX_ACT_DROP,
 					METRIC_INGRESS);

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1374,10 +1374,10 @@ static __always_inline int __tail_handle_ipv4(struct __ctx_buff *ctx,
 	}
 
 	if (IN_MULTICAST(bpf_ntohl(ip4->daddr))) {
-		if (mcast_lookup_subscriber_map(&ip4->daddr)) {
-			ep_tail_call(ctx, CILIUM_CALL_MULTICAST_EP_DELIVERY);
-			return DROP_MISSED_TAIL_CALL;
-		}
+		if (mcast_lookup_subscriber_map(&ip4->daddr))
+			return tail_call_internal(ctx,
+						  CILIUM_CALL_MULTICAST_EP_DELIVERY,
+						  ext_err);
 	}
 #endif /* ENABLE_MULTICAST */
 

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -300,9 +300,10 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 
 #ifdef ENABLE_MULTICAST
 	if (IN_MULTICAST(bpf_ntohl(ip4->daddr))) {
-		if (mcast_lookup_subscriber_map(&ip4->daddr)) {
-			ep_tail_call(ctx, CILIUM_CALL_MULTICAST_EP_DELIVERY);
-			return DROP_MISSED_TAIL_CALL;
+		if (mcast_lookup_subscriber_map(&ip4->daddr))
+			return tail_call_internal(ctx,
+						  CILIUM_CALL_MULTICAST_EP_DELIVERY,
+						  ext_err);
 		}
 	}
 #endif /* ENABLE_MULTICAST */

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -124,8 +124,7 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 	ctx_store_meta(ctx, CB_FROM_TUNNEL, from_tunnel ? 1 : 0);
 	ctx_store_meta(ctx, CB_CLUSTER_ID_INGRESS, cluster_id);
 
-	tail_call_dynamic(ctx, &POLICY_CALL_MAP, ep->lxc_id);
-	return DROP_MISSED_TAIL_CALL;
+	return tail_call_policy_dynamic(ctx, ep->lxc_id);
 #endif
 }
 

--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -39,6 +39,20 @@ struct bpf_elf_map __section_maps POLICY_CALL_MAP = {
 	.pinning	= PIN_GLOBAL_NS,
 	.max_elem	= POLICY_PROG_MAP_SIZE,
 };
+
+static __always_inline __must_check int
+tail_call_policy_dynamic(struct __ctx_buff *ctx, __u16 endpoint_id)
+{
+	tail_call_dynamic(ctx, &POLICY_CALL_MAP, endpoint_id);
+	return DROP_MISSED_TAIL_CALL;
+}
+
+static __always_inline __must_check int
+tail_call_policy_static(struct __ctx_buff *ctx, __u16 endpoint_id)
+{
+	tail_call_static(ctx, POLICY_CALL_MAP, endpoint_id);
+	return DROP_MISSED_TAIL_CALL;
+}
 #endif /* SKIP_POLICY_MAP */
 
 #ifdef ENABLE_L7_LB

--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -314,13 +314,6 @@ struct {
 #endif /* ENABLE_HIGH_SCALE_IPCACHE */
 
 #ifndef SKIP_CALLS_MAP
-/* Deprecated, use tail_call_internal() instead. */
-static __always_inline void ep_tail_call(struct __ctx_buff *ctx __maybe_unused,
-					 const __u32 index __maybe_unused)
-{
-	tail_call_static(ctx, CALLS_MAP, index);
-}
-
 static __always_inline __must_check int
 tail_call_internal(struct __ctx_buff *ctx, const __u32 index, __s8 *ext_err)
 {


### PR DESCRIPTION
Continue the migration from https://github.com/cilium/cilium/pull/30001, to improved wrappers with `__must_check` annotation and `ext_err` reporting.
