### PR TITLE
workflows: Bump the timeout for Ginkgo tests

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -234,7 +234,7 @@ jobs:
     needs: [setup-vars, build-ginkgo-binary, generate-matrix, wait-for-images]
     runs-on:
       group: ginkgo-runners
-    timeout-minutes: 35
+    timeout-minutes: 45
     name: "E2E Test (${{ matrix.k8s-version }}, ${{matrix.focus}})"
     env:
       job_name: "E2E Test (${{ matrix.k8s-version }}, ${{matrix.focus}})"


### PR DESCRIPTION
We've recently reenabled some quarantined tests and the workflow is therefore hitting the 35min timeout [once in a while](https://github.com/cilium/cilium/actions/runs/8701368687). That timeout didn't make a lot of sense anyway since a substep has a timeout of 40min. Let's bump it to 45min.