### PR TITLE
dnsproxy: Fix bug where DNS request timed out too soon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/cilium/checkmate v1.0.3
 	github.com/cilium/coverbee v0.3.2
 	github.com/cilium/deepequal-gen v0.0.0-20231116094812-0d6c075c335f
-	github.com/cilium/dns v1.1.51-0.20240411200813-4e6b438d9e05
+	github.com/cilium/dns v1.1.51-0.20240416134107-d47d0dd702a1
 	github.com/cilium/ebpf v0.14.0
 	github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b
 	github.com/cilium/fake v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/cilium/coverbee v0.3.2 h1:RaJN5OaHf/M8tmeLemHmdO0H5bFUhvtTAoYbStDIX14
 github.com/cilium/coverbee v0.3.2/go.mod h1:p9Q2SRC/sPA0qATNfY19GXBUPdcQP6UVV2LKgOHRIzQ=
 github.com/cilium/deepequal-gen v0.0.0-20231116094812-0d6c075c335f h1:t1A8nGkbZcjLACtNGIkfhfnKgG7V83+Tzr1pMeoPuA8=
 github.com/cilium/deepequal-gen v0.0.0-20231116094812-0d6c075c335f/go.mod h1:O4ERd4TTIfE/EKtiqESR2OQEiLwkDwBTW3zrbcQ4S3M=
-github.com/cilium/dns v1.1.51-0.20240411200813-4e6b438d9e05 h1:lEzR/g0snQppy8yvaMSV7ZN5lcl54Ja4C6MpGqYz2PA=
-github.com/cilium/dns v1.1.51-0.20240411200813-4e6b438d9e05/go.mod h1:/7LC2GOgyXJ7maupZlaVIumYQiGPIgllSf6mA9sg6RU=
+github.com/cilium/dns v1.1.51-0.20240416134107-d47d0dd702a1 h1:IR2iQhLyEVDJ52rPpqYAdRZMwlOSDl1XJqkD5PQJAfs=
+github.com/cilium/dns v1.1.51-0.20240416134107-d47d0dd702a1/go.mod h1:/7LC2GOgyXJ7maupZlaVIumYQiGPIgllSf6mA9sg6RU=
 github.com/cilium/ebpf v0.14.0 h1:0PsxAjO6EjI1rcT+rkp6WcCnE0ZvfkXBYiMedJtrSUs=
 github.com/cilium/ebpf v0.14.0/go.mod h1:DHp1WyrLeiBh19Cf/tfiSMhqheEiK8fXFZ4No0P1Hso=
 github.com/cilium/endpointslice v0.29.4-0.20240409195643-982ad68ab7ba h1:Ddc5e+pz0/nY0XiAEW/UcIlvnaHACSuF77ePyMNX510=

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -1013,7 +1013,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	}
 
 	dialer := net.Dialer{
-		Timeout: 2 * time.Second,
+		Timeout: ProxyForwardTimeout,
 		Control: func(network, address string, c syscall.RawConn) error {
 			var soerr error
 			if err := c.Control(func(su uintptr) {

--- a/vendor/github.com/cilium/dns/shared_client.go
+++ b/vendor/github.com/cilium/dns/shared_client.go
@@ -291,7 +291,7 @@ func (c *SharedClient) ExchangeSharedContext(ctx context.Context, m *Msg) (r *Ms
 
 	// This request keeps 'c.requests' open; sending a request may hang indefinitely if
 	// the handler happens to quit at the same time. Use ctx.Done to avoid this.
-	timeout := c.Client.writeTimeout()
+	timeout := c.getTimeoutForRequest(c.Client.writeTimeout())
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	respCh := make(chan sharedClientResponse)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -200,7 +200,7 @@ github.com/cilium/coverbee/pkg/verifierlog
 ## explicit; go 1.20
 github.com/cilium/deepequal-gen
 github.com/cilium/deepequal-gen/generators
-# github.com/cilium/dns v1.1.51-0.20240411200813-4e6b438d9e05
+# github.com/cilium/dns v1.1.51-0.20240416134107-d47d0dd702a1
 ## explicit; go 1.18
 github.com/cilium/dns
 # github.com/cilium/ebpf v0.14.0


### PR DESCRIPTION
This fixes a bug where DNS requests would timeout after 2 seconds, instead of the intended 10 seconds. This resulted in a `Timeout waiting for response to forwarded proxied DNS lookup` log message whenver the response took longer than 2 seconds.

The `dns.Client` used by the proxy is [already configured][1] to use `ProxyForwardTimeout` value of 10 seconds, which would apply also to the `dns.Client.DialTimeout`, if it was not for the custom `net.Dialer` we use in Cilium. The logic in [dns.Client.getTimeoutForRequest][2] overwrites the request timeout with the timeout from the custom `Dialer`. Therefore, the intended `ProxyForwardTimeout` 10 second timeout value was overwritten with the much shorter `net.Dialer.Timeout` value of two seconds. This commit fixes that issue by using `ProxyForwardTimeout` for the `net.Dialer` too.

Fixes: cf3cc16289b7 ("fqdn: dnsproxy: fix forwarding of the original security identity for TCP")

[1]: https://github.com/cilium/cilium/blob/50943dbc02496c42a4375947a988fc233417e163/pkg/fqdn/dnsproxy/proxy.go#L1042
[2]: https://github.com/cilium/cilium/blob/94f6553f5b79383b561e8630bdf40bd824769ede/vendor/github.com/cilium/dns/client.go#L405

Reported-by: @ayuspin

Backporting because the above commit was backported all the way to v1.11.
