### PR TITLE
operator/bgpv2: Fix CiliumBGPNodeConfig OwnerReference & job health reporting

### DIFF
--- a/operator/pkg/bgpv2/cluster.go
+++ b/operator/pkg/bgpv2/cluster.go
@@ -16,7 +16,6 @@ import (
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
-	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_labels "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 )
@@ -78,7 +77,7 @@ func (b *BGPResourceManager) upsertNodeConfig(ctx context.Context, config *v2alp
 			Name: nodeName,
 			OwnerReferences: []meta_v1.OwnerReference{
 				{
-					APIVersion: slim_core_v1.SchemeGroupVersion.String(),
+					APIVersion: v2alpha1.SchemeGroupVersion.String(),
 					Kind:       v2alpha1.BGPCCKindDefinition,
 					Name:       config.GetName(),
 					UID:        config.GetUID(),

--- a/operator/pkg/bgpv2/manager.go
+++ b/operator/pkg/bgpv2/manager.go
@@ -155,15 +155,6 @@ func (b *BGPResourceManager) initializeJobs() {
 }
 
 func (b *BGPResourceManager) initializeStores(ctx context.Context) (err error) {
-	defer func() {
-		hr := b.health.NewScope("bgpv2-store-initialization")
-		if err != nil {
-			hr.Stopped("store initialization failed")
-		} else {
-			hr.OK("store initialization successful")
-		}
-	}()
-
 	b.clusterConfigStore, err = b.clusterConfig.Store(ctx)
 	if err != nil {
 		return


### PR DESCRIPTION
Fixes incorrect `APIVersion` in `CiliumBGPNodeConfig`'s `OwnerReference`, which makes k8s garbage collection work, and we can get rid of explicit cleanup code handling deletion of stale `CiliumBGPNodeConfigs`.

Also removes unnecessary health report from `initializeStores` This is not necessary as the jobs are automatically hooked into
health reporter ([here](https://github.com/cilium/cilium/blob/main/pkg/hive/job/job.go#L311-L312)).

Example of working k8s garbage collection with this change:
```
$ k get cbgpnode -o yaml  
apiVersion: v1
items:
- apiVersion: cilium.io/v2alpha1
  kind: CiliumBGPNodeConfig
  metadata:
    creationTimestamp: "2024-04-16T11:49:51Z"
    generation: 1
    name: clab-bgp-cplane-devel-control-plane
    ownerReferences:
    - apiVersion: cilium.io/v2alpha1
      kind: CiliumBGPClusterConfig
      name: tor
      uid: 80bdb609-f0ed-4050-9795-8beb68a4e91a
    resourceVersion: "2021"
    uid: e785877b-3c1e-4e89-bdd3-ef61404305af
  spec:
    bgpInstances:
    - localASN: 65001
      name: test-instance
      peers:
      - name: test-peer
        peerASN: 65000
        peerAddress: 172.0.0.1
  status: {}
kind: List
metadata:
  resourceVersion: ""
```

```
$ k delete CiliumBGPClusterConfig tor 
ciliumbgpclusterconfig.cilium.io "tor" deleted
```

```
$ k get cbgpnode -o yaml     
apiVersion: v1
items: []
kind: List
metadata:
  resourceVersion: ""

```