### PR TITLE
test: De-flake xds server_e2e_test

### DIFF
--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -262,7 +262,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 		switch chosen {
 		case doneChIndex: // Context got canceled, most likely by the client terminating.
 			streamLog.WithError(ctx.Err()).Debug("xDS stream context canceled")
-			return ctx.Err()
+			return nil
 
 		case reqChIndex: // Request received from the stream.
 			if !recvOK {

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -725,18 +725,7 @@ func (s *ServerSuite) TestRequestStaleNonce(c *C) {
 	err = stream.SendRequest(req)
 	c.Assert(err, IsNil)
 
-	// Expecting no response from the server.
-
-	// Resend the request with the correct nonce.
-	req = &envoy_service_discovery.DiscoveryRequest{
-		TypeUrl:       typeURL,
-		VersionInfo:   resp.VersionInfo, // ACK the received version.
-		Node:          nodes[node0],
-		ResourceNames: nil,
-		ResponseNonce: resp.Nonce,
-	}
-	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	// Server correctly detects 0 nonce and resets it to the correct value.
 
 	// Expecting a response with both resources.
 	resp, err = stream.RecvResponse()

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -35,9 +35,8 @@ type ServerSuite struct{}
 var _ = Suite(&ServerSuite{})
 
 const (
-	TestTimeout      = 10 * time.Second
-	StreamTimeout    = 2 * time.Second
-	CacheUpdateDelay = 250 * time.Millisecond
+	TestTimeout   = 10 * time.Second
+	StreamTimeout = 2 * time.Second
 )
 
 var (
@@ -185,7 +184,6 @@ func (s *ServerSuite) TestRequestAllResources(c *C) {
 	c.Assert(err, IsNil)
 
 	// Create version 2 with resource 0.
-	time.Sleep(CacheUpdateDelay)
 	v, mod, _ = cache.Upsert(typeURL, resources[0].Name, resources[0])
 	c.Assert(v, Equals, uint64(2))
 	c.Assert(mod, Equals, true)
@@ -231,7 +229,6 @@ func (s *ServerSuite) TestRequestAllResources(c *C) {
 	c.Assert(err, IsNil)
 
 	// Create version 4 with resource 1.
-	time.Sleep(CacheUpdateDelay)
 	v, mod, _ = cache.Delete(typeURL, resources[0].Name)
 	c.Assert(v, Equals, uint64(4))
 	c.Assert(mod, Equals, true)
@@ -310,7 +307,6 @@ func (s *ServerSuite) TestAck(c *C) {
 	c.Assert(err, IsNil)
 
 	// Create version 2 with resource 0.
-	time.Sleep(CacheUpdateDelay)
 	callback1, comp1 := newCompCallback()
 	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
 	c.Assert(comp1, Not(IsCompleted))
@@ -359,12 +355,8 @@ func (s *ServerSuite) TestAck(c *C) {
 	err = stream.SendRequest(req)
 	c.Assert(err, IsNil)
 
-	// Expecting no response.
-
-	time.Sleep(CacheUpdateDelay)
-
 	// Version 3 was ACKed by the last request.
-	c.Assert(comp2, IsCompleted)
+	c.Assert(comp2, IsCompletedInTime)
 
 	// Close the stream.
 	closeStream()
@@ -435,7 +427,6 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 	c.Assert(err, IsNil)
 
 	// Create version 2 with resource 0.
-	time.Sleep(CacheUpdateDelay)
 	v, mod, _ = cache.Upsert(typeURL, resources[0].Name, resources[0])
 	c.Assert(v, Equals, uint64(2))
 	c.Assert(mod, Equals, true)
@@ -481,7 +472,6 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 	c.Assert(err, IsNil)
 
 	// Create version 4 with resources 0, 1 and 2.
-	time.Sleep(CacheUpdateDelay)
 	v, mod, _ = cache.Upsert(typeURL, resources[2].Name, resources[2])
 	c.Assert(v, Equals, uint64(4))
 	c.Assert(mod, Equals, true)
@@ -504,7 +494,6 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 	c.Assert(err, IsNil)
 
 	// Create version 5 with resources 1 and 2.
-	time.Sleep(CacheUpdateDelay)
 	v, mod, _ = cache.Delete(typeURL, resources[0].Name)
 	c.Assert(v, Equals, uint64(5))
 	c.Assert(mod, Equals, true)
@@ -580,7 +569,6 @@ func (s *ServerSuite) TestUpdateRequestResources(c *C) {
 	}()
 
 	// Create version 2 with resources 0 and 1.
-	time.Sleep(CacheUpdateDelay)
 	v, mod, _ = cache.tx(typeURL, map[string]proto.Message{
 		resources[0].Name: resources[0],
 		resources[1].Name: resources[1],
@@ -617,7 +605,6 @@ func (s *ServerSuite) TestUpdateRequestResources(c *C) {
 	c.Assert(err, IsNil)
 
 	// Create version 3 with resource 0, 1 and 2.
-	time.Sleep(CacheUpdateDelay)
 	v, mod, _ = cache.Upsert(typeURL, resources[2].Name, resources[2])
 	c.Assert(v, Equals, uint64(3))
 	c.Assert(mod, Equals, true)
@@ -710,7 +697,6 @@ func (s *ServerSuite) TestRequestStaleNonce(c *C) {
 	c.Assert(err, IsNil)
 
 	// Create version 2 with resource 0.
-	time.Sleep(CacheUpdateDelay)
 	v, mod, _ = cache.Upsert(typeURL, resources[0].Name, resources[0])
 	c.Assert(v, Equals, uint64(2))
 	c.Assert(mod, Equals, true)
@@ -770,7 +756,6 @@ func (s *ServerSuite) TestRequestStaleNonce(c *C) {
 	c.Assert(err, IsNil)
 
 	// Create version 4 with resource 1.
-	time.Sleep(CacheUpdateDelay)
 	v, mod, _ = cache.Delete(typeURL, resources[0].Name)
 	c.Assert(v, Equals, uint64(4))
 	c.Assert(mod, Equals, true)
@@ -850,7 +835,6 @@ func (s *ServerSuite) TestNAck(c *C) {
 	c.Assert(err, IsNil)
 
 	// Create version 2 with resource 0.
-	time.Sleep(CacheUpdateDelay)
 	callback1, comp1 := newCompCallback()
 	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
 	c.Assert(comp1, Not(IsCompleted))
@@ -868,14 +852,12 @@ func (s *ServerSuite) TestNAck(c *C) {
 		Node:          nodes[node0],
 		ResourceNames: nil,
 		ResponseNonce: resp.Nonce,
-		ErrorDetail:   &status.Status{Message: "FAILFAIL"},
+		ErrorDetail:   &status.Status{Message: "NACKNACK"},
 	}
 	err = stream.SendRequest(req)
 	c.Assert(err, IsNil)
 
 	// Create version 3 with resources 0 and 1.
-	time.Sleep(CacheUpdateDelay)
-
 	// NACK cancelled the wg, create a new one
 	wg = completion.NewWaitGroup(ctx)
 	callback2, comp2 := newCompCallback()
@@ -883,8 +865,8 @@ func (s *ServerSuite) TestNAck(c *C) {
 	c.Assert(comp2, Not(IsCompleted))
 
 	// Version 2 was NACKed by the last request, so comp1 must NOT be completed ever.
-	c.Assert(comp1, Not(IsCompleted))
-	c.Assert(comp1.Err(), checker.DeepEquals, &ProxyError{Err: ErrNackReceived, Detail: "FAILFAIL"})
+	c.Assert(comp1, Not(IsCompletedInTime))
+	c.Assert(comp1.Err(), checker.DeepEquals, &ProxyError{Err: ErrNackReceived, Detail: "NACKNACK"})
 
 	// Expecting a response with both resources.
 	// Note that the stream should not have a message that repeats the previous one!
@@ -907,13 +889,8 @@ func (s *ServerSuite) TestNAck(c *C) {
 	err = stream.SendRequest(req)
 	c.Assert(err, IsNil)
 
-	// Expecting no response.
-
-	time.Sleep(CacheUpdateDelay)
-
-	// comp2 was ACKed by the last request.
 	c.Assert(comp1, Not(IsCompleted))
-	c.Assert(comp2, IsCompleted)
+	c.Assert(comp2, IsCompletedInTime)
 
 	// Close the stream.
 	closeStream()
@@ -972,7 +949,6 @@ func (s *ServerSuite) TestNAckFromTheStart(c *C) {
 	c.Assert(resp, ResponseMatches, "1", nil, false, typeURL)
 
 	// Create version 2 with resource 0.
-	time.Sleep(CacheUpdateDelay)
 	callback1, comp1 := newCompCallback()
 	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
 	c.Assert(comp1, Not(IsCompleted))
@@ -1005,10 +981,8 @@ func (s *ServerSuite) TestNAckFromTheStart(c *C) {
 	err = stream.SendRequest(req)
 	c.Assert(err, IsNil)
 
-	time.Sleep(CacheUpdateDelay)
-
 	// Version 2 was NACKed by the last request, so it must NOT be completed successfully.
-	c.Assert(comp1, Not(IsCompleted))
+	c.Assert(comp1, Not(IsCompletedInTime))
 	// Version 2 did not have a callback, so the completion was completed with an error
 	c.Assert(comp1.Err(), Not(IsNil))
 	c.Assert(comp1.Err(), checker.DeepEquals, &ProxyError{Err: ErrNackReceived})
@@ -1041,12 +1015,8 @@ func (s *ServerSuite) TestNAckFromTheStart(c *C) {
 	err = stream.SendRequest(req)
 	c.Assert(err, IsNil)
 
-	// Expecting no response.
-
-	time.Sleep(CacheUpdateDelay)
-
 	// Version 3 was ACKed by the last request.
-	c.Assert(comp2, IsCompleted)
+	c.Assert(comp2, IsCompletedInTime)
 
 	// Close the stream.
 	closeStream()
@@ -1088,7 +1058,6 @@ func (s *ServerSuite) TestRequestHighVersionFromTheStart(c *C) {
 	}()
 
 	// Create version 2 with resource 0.
-	time.Sleep(CacheUpdateDelay)
 	callback1, comp1 := newCompCallback()
 	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
 	c.Assert(comp1, Not(IsCompleted))

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -36,7 +36,7 @@ var _ = Suite(&ServerSuite{})
 
 const (
 	TestTimeout   = 10 * time.Second
-	StreamTimeout = 2 * time.Second
+	StreamTimeout = 4 * time.Second
 )
 
 var (

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -151,8 +151,8 @@ func (s *ServerSuite) TestRequestAllResources(c *C) {
 
 	// Run the server's stream handler concurrently.
 	go func() {
+		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		close(streamDone)
 		c.Check(err, IsNil)
 	}()
 
@@ -276,8 +276,8 @@ func (s *ServerSuite) TestAck(c *C) {
 
 	// Run the server's stream handler concurrently.
 	go func() {
+		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		close(streamDone)
 		c.Check(err, IsNil)
 	}()
 
@@ -401,8 +401,8 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 
 	// Run the server's stream handler concurrently.
 	go func() {
+		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		close(streamDone)
 		c.Check(err, IsNil)
 	}()
 
@@ -574,8 +574,8 @@ func (s *ServerSuite) TestUpdateRequestResources(c *C) {
 
 	// Run the server's stream handler concurrently.
 	go func() {
+		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		close(streamDone)
 		c.Check(err, IsNil)
 	}()
 
@@ -676,8 +676,8 @@ func (s *ServerSuite) TestRequestStaleNonce(c *C) {
 
 	// Run the server's stream handler concurrently.
 	go func() {
+		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		close(streamDone)
 		c.Check(err, IsNil)
 	}()
 
@@ -815,8 +815,8 @@ func (s *ServerSuite) TestNAck(c *C) {
 
 	// Run the server's stream handler concurrently.
 	go func() {
+		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		close(streamDone)
 		c.Check(err, IsNil)
 	}()
 
@@ -949,8 +949,8 @@ func (s *ServerSuite) TestNAckFromTheStart(c *C) {
 
 	// Run the server's stream handler concurrently.
 	go func() {
+		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		close(streamDone)
 		c.Check(err, IsNil)
 	}()
 
@@ -1082,8 +1082,8 @@ func (s *ServerSuite) TestRequestHighVersionFromTheStart(c *C) {
 
 	// Run the server's stream handler concurrently.
 	go func() {
+		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		close(streamDone)
 		c.Check(err, IsNil)
 	}()
 

--- a/pkg/envoy/xds/stream_test.go
+++ b/pkg/envoy/xds/stream_test.go
@@ -59,6 +59,9 @@ func (s *MockStream) Recv() (*envoy_service_discovery.DiscoveryRequest, error) {
 		return nil, subCtx.Err()
 	case req := <-s.recv:
 		cancel()
+		if req == nil {
+			return nil, io.EOF
+		}
 		return req, nil
 	}
 }


### PR DESCRIPTION
De-flake xds server_e2e_test by:
- return `nil` error from xDS server after context cancel
- wait for stream server error check to be done before completing test
- return io.EOF upon channel close from stream_test mock
- eliminate xDS CacheUpdateDelay
- eliminate duplicate SendRequest in TestRequestStaleNonce
- increase xDS test stream timeout

See commit messages for rationale for each step.

Fixes: #31855
