### PR TITLE
daemon: Run conntrack GC after Endpoint Restore

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1704,11 +1704,6 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 		return fmt.Errorf("postinit failed: %w", err)
 	}
 
-	bootstrapStats.enableConntrack.Start()
-	log.Info("Starting connection tracking garbage collector")
-	params.CTNATMapGC.Enable()
-	bootstrapStats.enableConntrack.End(true)
-
 	bootstrapStats.k8sInit.Start()
 	if params.Clientset.IsEnabled() {
 		// Wait only for certain caches, but not all!
@@ -1717,6 +1712,11 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 	}
 	bootstrapStats.k8sInit.End(true)
 	d.initRestore(restoredEndpoints, params.EndpointRegenerator)
+
+	bootstrapStats.enableConntrack.Start()
+	log.Info("Starting connection tracking garbage collector")
+	params.CTNATMapGC.Enable()
+	bootstrapStats.enableConntrack.End(true)
 
 	if params.WGAgent != nil {
 		go func() {


### PR DESCRIPTION
Relies on https://github.com/cilium/cilium/pull/32068 to debug test failures.

The reverse call tree for RestoreEndpoint, which exposes all restored
endpoints in the EndpointManager, is as follows:

```
INCOMING CALLS
- f RestoreEndpoint github.com/cilium/cilium/pkg/endpointmanager
  - f regenerateRestoredEndpoints github.com/cilium/cilium/pkg/endpointmanager
    - f initRestore github.com/cilium/cilium/daemon/cmd
      + f startDaemon github.com/cilium/cilium/daemon/cmd
```

Previously, the `CTNATMapGC.Enable()` call, which invokes
`gc.endpointsManager.GetEndpoints()`, would be called prior to exposing
these endpoints in the EndpointManager. As a result, the step where the
initial scan attempts to update each Endpoint's DNSHistory with the
latest CT GC timers would fail, leaving the timestamps empty.

The potential impact of this is that DNS entries that should expire soon
after a cilium-agent restart may not time out for an extra entire
conntrack garbage collection interval several minutes later.