### PR TITLE
Report estimated expiry timers for connection-based FQDN entries

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -203,8 +203,18 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 
 // getEndpointsDNSInfo is used by the NameManager to iterate through endpoints
 // without having to have access to the EndpointManager.
-func (d *Daemon) getEndpointsDNSInfo() []fqdn.EndpointDNSInfo {
+//
+// Optional parameter endpointID will cause this function to only return the
+// endpoint with the ID matching the parameter.
+func (d *Daemon) getEndpointsDNSInfo(endpointID string) []fqdn.EndpointDNSInfo {
 	eps := d.endpointManager.GetEndpoints()
+	if endpointID != "" {
+		ep, err := d.endpointManager.Lookup(endpointID)
+		if ep == nil || err != nil {
+			return nil
+		}
+		eps = []*endpoint.Endpoint{ep}
+	}
 	out := make([]fqdn.EndpointDNSInfo, 0, len(eps))
 	for _, ep := range eps {
 		out = append(out, fqdn.EndpointDNSInfo{

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -109,7 +109,9 @@ func BenchmarkFqdnCache(b *testing.B) {
 	}
 	b.ResetTimer()
 
-	extractDNSLookups(endpoints, "0.0.0.0/0", "*", "")
+	prefixMatcher := func(_ netip.Addr) bool { return true }
+	nameMatcher := func(_ string) bool { return true }
+	extractDNSLookups(endpoints, prefixMatcher, nameMatcher, "")
 }
 
 // BenchmarkNotifyOnDNSMsg stresses the main callback function for the DNS

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -93,14 +93,13 @@ func BenchmarkFqdnCacheEtcd(b *testing.B) {
 // BenchmarkFqdnCache tests how slow a full dump of DNSHistory from a number of
 // endpoints is. Each endpoints has 1000 DNS lookups, each with 10 IPs. The
 // dump iterates over all endpoints, lookups, and IPs.
-func (ds *DaemonSuite) benchmarkFqdnCache(b *testing.B) {
-	b.StopTimer()
-
+func BenchmarkFqdnCache(b *testing.B) {
 	endpoints := make([]*endpoint.Endpoint, 0, b.N)
 	for i := 0; i < b.N; i++ {
 		lookupTime := time.Now()
 		ep := &endpoint.Endpoint{} // only works because we only touch .DNSHistory
 		ep.DNSHistory = fqdn.NewDNSCache(0)
+		ep.DNSZombies = &fqdn.DNSZombieMappings{}
 
 		for i := 0; i < 1000; i++ {
 			ep.DNSHistory.Update(lookupTime, fmt.Sprintf("domain-%d.com.", i), makeIPs(10), 1000)
@@ -108,7 +107,7 @@ func (ds *DaemonSuite) benchmarkFqdnCache(b *testing.B) {
 
 		endpoints = append(endpoints, ep)
 	}
-	b.StartTimer()
+	b.ResetTimer()
 
 	extractDNSLookups(endpoints, "0.0.0.0/0", "*", "")
 }

--- a/pkg/endpoint/fqdn.go
+++ b/pkg/endpoint/fqdn.go
@@ -39,6 +39,6 @@ func (e *Endpoint) MarkDNSCTEntry(dstIP netip.Addr, now time.Time) {
 // deleted.
 // The DNS garbage collector is in daemon/fqdn.go and the CT GC is in
 // pkg/maps/ctmap/gc/gc.go
-func (e *Endpoint) MarkCTGCTime(now time.Time) {
-	e.DNSZombies.SetCTGCTime(now)
+func (e *Endpoint) MarkCTGCTime(prev, next time.Time) {
+	e.DNSZombies.SetCTGCTime(prev, next)
 }

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -1154,6 +1154,7 @@ func (zombies *DNSZombieMappings) ForceExpireByNameIP(expireLookupsBefore time.T
 // PrefixMatcherFunc is a function passed to (*DNSZombieMappings).DumpAlive,
 // called on each zombie to determine whether it should be returned.
 type PrefixMatcherFunc func(ip netip.Addr) bool
+type NameMatcherFunc func(name string) bool
 
 // DumpAlive returns copies of still-alive zombies matching prefixMatcher.
 func (zombies *DNSZombieMappings) DumpAlive(prefixMatcher PrefixMatcherFunc) (alive []*DNSZombieMapping) {

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -1151,12 +1151,12 @@ func (zombies *DNSZombieMappings) ForceExpireByNameIP(expireLookupsBefore time.T
 	return nil
 }
 
-// CIDRMatcherFunc is a function passed to (*DNSZombieMappings).DumpAlive,
+// PrefixMatcherFunc is a function passed to (*DNSZombieMappings).DumpAlive,
 // called on each zombie to determine whether it should be returned.
-type CIDRMatcherFunc func(ip net.IP) bool
+type PrefixMatcherFunc func(ip netip.Addr) bool
 
-// DumpAlive returns copies of still-alive zombies matching cidrMatcher.
-func (zombies *DNSZombieMappings) DumpAlive(cidrMatcher CIDRMatcherFunc) (alive []*DNSZombieMapping) {
+// DumpAlive returns copies of still-alive zombies matching prefixMatcher.
+func (zombies *DNSZombieMappings) DumpAlive(prefixMatcher PrefixMatcherFunc) (alive []*DNSZombieMapping) {
 	zombies.Lock()
 	defer zombies.Unlock()
 
@@ -1166,7 +1166,7 @@ func (zombies *DNSZombieMappings) DumpAlive(cidrMatcher CIDRMatcherFunc) (alive 
 			continue
 		}
 		// only proceed if zombie is alive and the IP matches the CIDR selector
-		if cidrMatcher != nil && !cidrMatcher(zombie.IP.AsSlice()) {
+		if prefixMatcher != nil && !prefixMatcher(zombie.IP) {
 			continue
 		}
 

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -791,6 +791,7 @@ type DNSZombieMappings struct {
 	lock.Mutex
 	deletes        map[netip.Addr]*DNSZombieMapping
 	lastCTGCUpdate time.Time
+	nextCTGCUpdate time.Time // estimated
 	// ctGCRevision is a serial number tracking the number of conntrack
 	// garbage collection runs. It is used to ensure that entries
 	// are not reaped until CT GC has run at least twice.
@@ -1059,9 +1060,10 @@ func (zombies *DNSZombieMappings) MarkAlive(now time.Time, ip netip.Addr) {
 // When 'ctGCStart' is later than an alive timestamp, set with MarkAlive, the zombie is
 // no longer alive. Thus, this call acts as a gating function for what data is
 // returned by GC.
-func (zombies *DNSZombieMappings) SetCTGCTime(ctGCStart time.Time) {
+func (zombies *DNSZombieMappings) SetCTGCTime(ctGCStart, estNext time.Time) {
 	zombies.Lock()
 	zombies.lastCTGCUpdate = ctGCStart
+	zombies.nextCTGCUpdate = estNext
 	zombies.ctGCRevision++
 	zombies.Unlock()
 }

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -1024,20 +1024,19 @@ func TestZombiesDumpAlive(t *testing.T) {
 		"2.2.2.2": {"example.com"},
 	})
 
-	cidrMatcher := func(ip net.IP) bool { return false }
+	cidrMatcher := func(addr netip.Addr) bool { return false }
 	alive = zombies.DumpAlive(cidrMatcher)
 	require.Len(t, alive, 0)
 
-	cidrMatcher = func(ip net.IP) bool { return true }
+	cidrMatcher = func(_ netip.Addr) bool { return true }
 	alive = zombies.DumpAlive(cidrMatcher)
 	assertZombiesContain(t, alive, map[string][]string{
 		"1.1.1.1": {"test.com"},
 		"2.2.2.2": {"example.com"},
 	})
 
-	_, cidr, err := net.ParseCIDR("1.1.1.0/24")
-	require.Nil(t, err)
-	cidrMatcher = func(ip net.IP) bool { return cidr.Contains(ip) }
+	prefix := netip.MustParsePrefix("1.1.1.0/24")
+	cidrMatcher = func(a netip.Addr) bool { return prefix.Contains(a) }
 	alive = zombies.DumpAlive(cidrMatcher)
 	assertZombiesContain(t, alive, map[string][]string{
 		"1.1.1.1": {"test.com"},
@@ -1051,9 +1050,8 @@ func TestZombiesDumpAlive(t *testing.T) {
 		"1.1.1.2": {"test2.com"},
 	})
 
-	_, cidr, err = net.ParseCIDR("4.4.0.0/16")
-	require.Nil(t, err)
-	cidrMatcher = func(ip net.IP) bool { return cidr.Contains(ip) }
+	prefix = netip.MustParsePrefix("4.4.0.0/16")
+	cidrMatcher = func(a netip.Addr) bool { return prefix.Contains(a) }
 	alive = zombies.DumpAlive(cidrMatcher)
 	require.Len(t, alive, 0)
 }

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -38,6 +38,7 @@ type Config struct {
 
 type EndpointDNSInfo struct {
 	ID         string
+	ID64       int64
 	DNSHistory *DNSCache
 	DNSZombies *DNSZombieMappings
 }

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -29,7 +29,9 @@ type Config struct {
 
 	// GetEndpointsDNSInfo is a function that returns a list of fqdn-relevant fields from all Endpoints known to the agent.
 	// The endpoint's DNSHistory and DNSZombies are used as part of the garbage collection and restoration processes.
-	GetEndpointsDNSInfo func() []EndpointDNSInfo
+	//
+	// Optional parameter endpointID will cause this function to only return the endpoint with the specified ID.
+	GetEndpointsDNSInfo func(endpointID string) []EndpointDNSInfo
 
 	IPCache IPCache
 }

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -145,7 +145,7 @@ func (n *NameManager) GetDNSHistoryModel(endpointID string, prefixMatcher Prefix
 					Ips:            []string{delete.IP.String()},
 					LookupTime:     strfmt.DateTime(delete.AliveAt),
 					TTL:            0,
-					ExpirationTime: strfmt.DateTime(delete.AliveAt),
+					ExpirationTime: strfmt.DateTime(ep.DNSZombies.nextCTGCUpdate),
 					EndpointID:     int64(ep.ID64),
 					Source:         DNSSourceConnection,
 				})

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -145,7 +145,7 @@ func NewNameManager(config Config) *NameManager {
 		}
 	}
 	if config.GetEndpointsDNSInfo == nil {
-		config.GetEndpointsDNSInfo = func() []EndpointDNSInfo {
+		config.GetEndpointsDNSInfo = func(_ string) []EndpointDNSInfo {
 			return nil
 		}
 	}

--- a/pkg/fqdn/name_manager_bench_test.go
+++ b/pkg/fqdn/name_manager_bench_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"strconv"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/defaults"
@@ -77,4 +78,44 @@ func BenchmarkUpdateGenerateDNS(b *testing.B) {
 				IPs: []net.IP{ip.AsSlice()},
 			}})
 	}
+}
+
+// BenchmarkFqdnCache tests how slow a full dump of DNSHistory from a number of
+// endpoints is. Each endpoints has 1000 DNS lookups, each with 10 IPs. The
+// dump iterates over all endpoints, lookups, and IPs.
+func BenchmarkFqdnCache(b *testing.B) {
+	caches := make([]*DNSCache, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		lookupTime := time.Now()
+		dnsHistory := NewDNSCache(0)
+
+		for i := 0; i < 1000; i++ {
+			dnsHistory.Update(lookupTime, fmt.Sprintf("domain-%d.com.", i), makeIPs(10), 1000)
+		}
+
+		caches = append(caches, dnsHistory)
+	}
+
+	nameManager := NewNameManager(Config{
+		MinTTL:  1,
+		Cache:   NewDNSCache(0),
+		IPCache: testipcache.NewMockIPCache(),
+		GetEndpointsDNSInfo: func(endpointID string) []EndpointDNSInfo {
+			out := make([]EndpointDNSInfo, 0, len(caches))
+			for i, c := range caches {
+				out = append(out, EndpointDNSInfo{
+					ID:         strconv.Itoa(i),
+					ID64:       int64(i),
+					DNSHistory: c,
+					DNSZombies: NewDNSZombieMappings(1000, 1000),
+				})
+			}
+			return out
+		},
+	})
+	b.ResetTimer()
+
+	prefixMatcher := func(_ netip.Addr) bool { return true }
+	nameMatcher := func(_ string) bool { return true }
+	nameManager.GetDNSHistoryModel("", prefixMatcher, nameMatcher, "")
 }

--- a/pkg/fqdn/name_manager_gc.go
+++ b/pkg/fqdn/name_manager_gc.go
@@ -60,7 +60,7 @@ func (n *NameManager) GC(ctx context.Context) error {
 	maybeStaleIPs := n.cache.GetIPs()
 
 	// Cleanup each endpoint cache, deferring deletions via DNSZombies.
-	endpoints := n.config.GetEndpointsDNSInfo()
+	endpoints := n.config.GetEndpointsDNSInfo("")
 	for _, ep := range endpoints {
 		epID := ep.ID
 		if metrics.FQDNActiveNames.IsEnabled() || metrics.FQDNActiveIPs.IsEnabled() {
@@ -175,7 +175,7 @@ func (n *NameManager) DeleteDNSLookups(expireLookupsBefore time.Time, matchPatte
 	// insert any entries that now should be in the global cache (because they
 	// provide an IP at the latest expiration time).
 	namesToRegen := n.cache.ForceExpire(expireLookupsBefore, nameMatcher)
-	for _, ep := range n.config.GetEndpointsDNSInfo() {
+	for _, ep := range n.config.GetEndpointsDNSInfo("") {
 		namesToRegen = namesToRegen.Union(ep.DNSHistory.ForceExpire(expireLookupsBefore, nameMatcher))
 		n.cache.UpdateFromCache(ep.DNSHistory, nil)
 

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -163,9 +163,10 @@ func (gc *GC) Enable() {
 			}
 
 			// Mark the CT GC as over in each EP DNSZombies instance, if we did a *full* GC run
+			interval := ctmap.GetInterval(gcInterval, maxDeleteRatio)
 			if success && ipv4 == gc.ipv4 && ipv6 == gc.ipv6 {
 				for _, e := range eps {
-					e.MarkCTGCTime(gcStart)
+					e.MarkCTGCTime(gcStart, time.Now().Add(interval))
 				}
 			}
 
@@ -198,7 +199,7 @@ func (gc *GC) Enable() {
 						ipv6 = true
 					}
 				}
-			case <-ctTimer.After(ctmap.GetInterval(gcInterval, maxDeleteRatio)):
+			case <-ctTimer.After(interval):
 				gc.signalHandler.MuteSignals()
 				ipv4 = gc.ipv4
 				ipv6 = gc.ipv6


### PR DESCRIPTION
Based on #32012

Report the expiry time for entries kept alive based on connection state
as the next time that connection tracking garbage collection will run.
This way, the expiration time should be closer to the actual expiry time
rather than simply reporting the zero timestamp.

Commits 1-5 do some refactoring and cleanups in preparation for the target
feature in this PR. The final commit has the functional changes.
- **daemon: Fix BenchmarkFqdnCache**
- **daemon: Use netip library in fqdn logic**
- **daemon: Tidy up fqdn dump parsing logic**
- **fqdn: Add EndpointID filter to endpoint getter**
- **daemon: Move DNS model code to pkg/fqdn**
- **fqdn: Report zombie expiry time by CT GC**

Related: https://github.com/cilium/cilium/issues/24246
Fixes: #21540
