### PR TITLE
docs: clean up example yaml for L4 Deny Policy

### DIFF
--- a/examples/policies/host/lock-down-ingress.yaml
+++ b/examples/policies/host/lock-down-ingress.yaml
@@ -13,9 +13,9 @@ spec:
     - health
   - toPorts:
     - ports:
-      - port: "6443"
-        protocol: TCP
       - port: "22"
+        protocol: TCP
+      - port: "6443"
         protocol: TCP
       - port: "2379"
         protocol: TCP
@@ -23,5 +23,3 @@ spec:
         protocol: TCP
       - port: "8472"
         protocol: UDP
-      - port: "REMOVE_ME_AFTER_DOUBLE_CHECKING_PORTS"
-        protocol: TCP


### PR DESCRIPTION
Fixes an example L4 Deny Policy in the [documentation](https://docs.cilium.io/en/latest/security/policy/language/#host-policies), removing a developer's note in the yaml referenced by https://github.com/cilium/cilium/blob/main/Documentation/security/policy/language.rst

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!