### PR TITLE
Add OVERWRITE_LOOPBACK + OVERWRITE_CILIUM env var to install-plugins.sh

### DIFF
--- a/plugins/cilium-cni/install-plugin.sh
+++ b/plugins/cilium-cni/install-plugin.sh
@@ -26,10 +26,13 @@ install_cni() {
 	echo "Wrote $dst"
 }
 
-# Install the CNI loopback driver if not installed already
-if [ ! -f "${CNI_DIR}/bin/loopback" ]; then
+# Install the CNI loopback driver if not installed already or instructed to overwrite
+if [ "${OVERWRITE_LOOPBACK:-false}" = "true" ] || [ ! -f "${CNI_DIR}/bin/loopback" ]; then
 	# Don't fail hard if this fails as it is usually not required
 	install_cni /cni/loopback || true
 fi
 
-install_cni "/opt/cni/bin/${BIN_NAME}"
+# Install the Cilium CNI binary unless installed already and instructed not to overwrite
+if [ "${OVERWRITE_CILIUM:-true}" = "true" ] || [ ! -f "${CNI_DIR}/bin/${BIN_NAME}" ]; then
+	install_cni "/opt/cni/bin/${BIN_NAME}"
+fi


### PR DESCRIPTION
To specify the overwriting behavior when the destination already exists.

The default values match the original behavior (overwriting for cilium-cni, not overwriting for loopback).

This allows reusing existing cilium-cni binary on node if it exists, similar to loopback. The [Compatibility Guarantees](https://docs.cilium.io/en/stable/api/#compatibility-guarantees) ensures the interoperability if the versions are not matching.

OVERWRITE_LOOPBACK is to achieve parity with OVERWRITE_CILIUM.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

```release-note
Make the overwriting behavior of install-plugins.sh configurable.
```