### PR TITLE
Helm: possibility to install operator as standalone app

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2556,6 +2556,10 @@
      - Additional cilium-operator volumes.
      - list
      - ``[]``
+   * - :spelling:ignore:`operator.hostNetwork`
+     - HostNetwork setting
+     - bool
+     - ``true``
    * - :spelling:ignore:`operator.identityGCInterval`
      - Interval for identity garbage collection.
      - string

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -689,6 +689,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.extraHostPathMounts | list | `[]` | Additional cilium-operator hostPath mounts. |
 | operator.extraVolumeMounts | list | `[]` | Additional cilium-operator volumeMounts. |
 | operator.extraVolumes | list | `[]` | Additional cilium-operator volumes. |
+| operator.hostNetwork | bool | `true` | HostNetwork setting |
 | operator.identityGCInterval | string | `"15m0s"` | Interval for identity garbage collection. |
 | operator.identityHeartbeatTimeout | string | `"30m0s"` | Timeout for identity heartbeats. |
 | operator.image | object | `{"alibabacloudDigest":"","awsDigest":"","azureDigest":"","genericDigest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/operator","suffix":"-ci","tag":"latest","useDigest":false}` | cilium-operator image. |

--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agent (not .Values.preflight.enabled) }}
+{{- if and .Values.agent (not .Values.preflight.enabled) .Values.rbac.create }}
 {{- /*
 Keep file in sync with cilium-preflight/clusterrole.yaml
 */ -}}

--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agent (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create }}
+{{- if and .Values.agent (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.agent) (not .Values.preflight.enabled) }}
+{{- if and ( or (.Values.agent) (.Values.operator.enabled) .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) (not .Values.preflight.enabled) }}
 {{- /*  Default values with backwards compatibility */ -}}
 {{- $defaultBpfMapDynamicSizeRatio := 0.0 -}}
 {{- $defaultBpfMasquerade := "false" -}}

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create }}
+{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create }}
+{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -178,7 +178,9 @@ spec:
         {{- end }}
         livenessProbe:
           httpGet:
+        {{- if .Values.operator.hostNetwork }}
             host: {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }}
+        {{- end }}
             path: /healthz
             port: 9234
             scheme: HTTP
@@ -187,7 +189,9 @@ spec:
           timeoutSeconds: 3
         readinessProbe:
           httpGet:
+        {{- if .Values.operator.hostNetwork }}
             host: {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }}
+        {{- end }}
             path: /healthz
             port: 9234
             scheme: HTTP
@@ -249,7 +253,7 @@ spec:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
-      hostNetwork: true
+      hostNetwork: {{ .Values.operator.hostNetwork }}
       {{- if and .Values.etcd.managed (not .Values.etcd.k8sService) }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
       # the etcd service

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.preflight.enabled }}
+{{- if and .Values.preflight.enabled .Values.rbac.create }}
 {{- /*
 Keep file in sync with cilium-agent/clusterrole.yaml
 */ -}}

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.preflight.enabled .Values.serviceAccounts.preflight.create }}
+{{- if and .Values.preflight.enabled .Values.serviceAccounts.preflight.create .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.etcd.managed .Values.serviceAccounts.etcd.create }}
+{{- if and .Values.etcd.managed .Values.serviceAccounts.etcd.create .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/install/kubernetes/cilium/templates/etcd-operator/etcd-operator-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/etcd-operator-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.etcd.managed }}
+{{- if and .Values.etcd.managed .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/install/kubernetes/cilium/templates/etcd-operator/etcd-operator-clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/etcd-operator-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.etcd.managed }}
+{{- if and .Values.etcd.managed .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/install/kubernetes/cilium/templates/hubble-ui/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.hubble.enabled .Values.hubble.ui.standalone.enabled) .Values.hubble.ui.enabled .Values.serviceAccounts.ui.create }}
+{{- if and (or .Values.hubble.enabled .Values.hubble.ui.standalone.enabled) .Values.hubble.ui.enabled .Values.serviceAccounts.ui.create .Values.rbac.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/install/kubernetes/cilium/templates/hubble-ui/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.hubble.enabled .Values.hubble.ui.standalone.enabled) .Values.hubble.ui.enabled .Values.serviceAccounts.ui.create }}
+{{- if and (or .Values.hubble.enabled .Values.hubble.ui.standalone.enabled) .Values.hubble.ui.enabled .Values.serviceAccounts.ui.create .Values.rbac.create }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") .Values.serviceAccounts.hubblecertgen.create }}
+{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") .Values.serviceAccounts.hubblecertgen.create .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") .Values.serviceAccounts.hubblecertgen.create }}
+{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") .Values.serviceAccounts.hubblecertgen.create .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/install/kubernetes/cilium/templates/spire/agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.authentication.mutual.spire.enabled .Values.authentication.mutual.spire.install.enabled .Values.authentication.mutual.spire.install.agent.serviceAccount.create -}}
+{{- if and .Values.authentication.mutual.spire.enabled .Values.authentication.mutual.spire.install.enabled .Values.authentication.mutual.spire.install.agent.serviceAccount.create .Values.rbac.create -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/install/kubernetes/cilium/templates/spire/agent/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.authentication.mutual.spire.enabled .Values.authentication.mutual.spire.install.enabled .Values.authentication.mutual.spire.install.agent.serviceAccount.create -}}
+{{- if and .Values.authentication.mutual.spire.enabled .Values.authentication.mutual.spire.install.enabled .Values.authentication.mutual.spire.install.agent.serviceAccount.create .Values.rbac.create -}}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/kubernetes/cilium/templates/spire/server/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.authentication.mutual.spire.enabled .Values.authentication.mutual.spire.install.enabled .Values.authentication.mutual.spire.install.server.serviceAccount.create -}}
+{{- if and .Values.authentication.mutual.spire.enabled .Values.authentication.mutual.spire.install.enabled .Values.authentication.mutual.spire.install.server.serviceAccount.create .Values.rbac.create -}}
 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/kubernetes/cilium/templates/spire/server/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.authentication.mutual.spire.enabled .Values.authentication.mutual.spire.install.enabled .Values.authentication.mutual.spire.install.server.serviceAccount.create -}}
+{{- if and .Values.authentication.mutual.spire.enabled .Values.authentication.mutual.spire.install.enabled .Values.authentication.mutual.spire.install.server.serviceAccount.create .Values.rbac.create -}}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4090,6 +4090,9 @@
           "items": {},
           "type": "array"
         },
+        "hostNetwork": {
+          "type": "boolean"
+        },
         "identityGCInterval": {
           "type": "string"
         },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2508,6 +2508,8 @@ operator:
   extraVolumeMounts: []
   # -- Annotations to be added to all top-level cilium-operator objects (resources under templates/cilium-operator)
   annotations: {}
+  # -- HostNetwork setting
+  hostNetwork: true
   # -- Security context to be added to cilium-operator pods
   podSecurityContext: {}
   # -- Annotations to be added to cilium-operator pods

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2512,6 +2512,8 @@ operator:
   extraVolumeMounts: []
   # -- Annotations to be added to all top-level cilium-operator objects (resources under templates/cilium-operator)
   annotations: {}
+  # -- HostNetwork setting
+  hostNetwork: true
   # -- Security context to be added to cilium-operator pods
   podSecurityContext: {}
   # -- Annotations to be added to cilium-operator pods


### PR DESCRIPTION
This PR fixes problems encountered when installing multiple instances of operator into a single kubernetes cluster. We use Cilium in Openstack clusters and external LoadBalancer connected to clustermesh. Agents are installed on LB and OS hosts, operator is run in a common kubernetes clusters. Each OS and LB cluster has its its own operator instance.

Problems needed to be fixed in helm chart:

- logic around installing cluster-wide RBAC was added - `rbac.create` setting was already present in chart `values.yaml` but was not used anywhere. Now it is used to control ClusterRoles and ClusterRoleBindings installation throughout the chart.
- hostNetwork for operator was made configurable so that operator pods won't collide on open ports
- fine tuned logic around `cilium-config` config map installation - it is mounted as volume by agent, operator and clustermesh apiserver so it has to be installed if either of the three is enabled, not just agent.