### PR TITLE
clustermesh: enable endpointslice sync by default on headless services

### DIFF
--- a/Documentation/network/clustermesh/services.rst
+++ b/Documentation/network/clustermesh/services.rst
@@ -67,10 +67,14 @@ Synchronizing Kubernetes EndpointSlice (Beta)
 
 .. include:: ../../beta.rst
 
-By default Kubernetes EndpointSlice synchronization is disabled on Global services.
+By default Kubernetes EndpointSlice synchronization is disabled on non Headless Global services.
 To have Cilium discover remote clusters endpoints of a Global Service
 from DNS or any third party controllers, enable synchronization by adding
 the annotation ``service.cilium.io/global-sync-endpoint-slices: "true"``.
+This will allow Cilium to create Kubernetes EndpointSlices belonging to a
+remote cluster for services that have that annotation.
+Regarding Global Headless services this option is enabled by default unless
+explicitly opted-out by adding the annotation ``service.cilium.io/global-sync-endpoint-slices: "false"``.
 
 Note that this feature does not complement/is not required by any other Cilium features
 and is only required if you need to discover EndpointSlice from remote cluster on

--- a/pkg/clustermesh/endpointslicesync/service_informer.go
+++ b/pkg/clustermesh/endpointslicesync/service_informer.go
@@ -72,11 +72,11 @@ func doesServiceSyncEndpointSlice(svc *slim_corev1.Service) bool {
 	}
 
 	value, ok = annotation.Get(svc, annotation.GlobalServiceSyncEndpointSlices)
-	if !ok || strings.ToLower(value) != "true" {
-		return false
+	if !ok {
+		// If the service is headless we sync the EndpointSlice by default
+		return svc.Spec.ClusterIP == v1.ClusterIPNone
 	}
-
-	return true
+	return strings.ToLower(value) == "true"
 }
 
 func (i *meshServiceInformer) refreshAllCluster(svc *slim_corev1.Service) error {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

As it's highly likely that for an Headless Service the user wants to sync EndpointSlices we should set it by default in this case and make the behavior opt-out instead of opt-in.

It's highly unlikely that this change anything for existing setup as before endpoint slice synchronization were a thing Headless services were ignored. Also EndpointSlice sync is still guarded by a feature flag set in helm/in the configmap.

```release-note
Make endpointslice clustermesh syncing opt-out for headless services 
```
