### PR TITLE
ci: deduplicate image build matrix definition

### DIFF
--- a/.github/actions/set-env-variables/action.yml
+++ b/.github/actions/set-env-variables/action.yml
@@ -29,3 +29,6 @@ runs:
         echo "KIND_VERSION=$KIND_VERSION" >> $GITHUB_ENV
         echo "KIND_K8S_IMAGE=$KIND_K8S_IMAGE" >> $GITHUB_ENV
         echo "KIND_K8S_VERSION=$KIND_K8S_VERSION" >> $GITHUB_ENV
+
+        BUILD_AND_PUSH_IMAGES=$(cat .github/images.json)
+        echo "BUILD_AND_PUSH_IMAGES=$BUILD_AND_PUSH_IMAGES" >> $GITHUB_ENV

--- a/.github/images.json
+++ b/.github/images.json
@@ -1,0 +1,34 @@
+[
+  {
+    'name': 'cilium',
+    'dockerfile': './images/cilium/Dockerfile'
+  },
+  {
+    'name': 'operator-aws',
+    'dockerfile': './images/operator/Dockerfile'
+  },
+  {
+    'name': 'operator-azure',
+    'dockerfile': './images/operator/Dockerfile'
+  },
+  {
+    'name': 'operator-alibabacloud',
+    'dockerfile': './images/operator/Dockerfile'
+  },
+  {
+    'name': 'operator-generic',
+    'dockerfile': './images/operator/Dockerfile'
+  },
+  {
+    'name': 'hubble-relay',
+    'dockerfile': './images/hubble-relay/Dockerfile'
+  },
+  {
+    'name': 'clustermesh-apiserver',
+    'dockerfile': './images/clustermesh-apiserver/Dockerfile'
+  },
+  {
+    'name': 'docker-plugin',
+    'dockerfile': './images/cilium-docker-plugin/Dockerfile'
+  }
+]

--- a/.github/workflows/build-images-beta.yaml
+++ b/.github/workflows/build-images-beta.yaml
@@ -27,7 +27,28 @@ jobs:
         run: |
           echo '${{ tojson(inputs) }}'
 
+  setup-vars:
+    name: Setup Variables
+    runs-on: ubuntu-latest
+    outputs:
+      build-and-push-images: ${{ steps.vars.outputs.build-and-push-images }}
+    steps:
+      - name: Checkout main branch to access local actions
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up job variables
+        id: vars
+        run: |
+          echo build-and-push-images=${BUILD_AND_PUSH_IMAGES} >> $GITHUB_OUTPUT
+
   build-and-push:
+    needs: [ setup-vars ]
     timeout-minutes: 45
     name: Build and Push Images
     environment: release-beta-images
@@ -35,32 +56,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: cilium
-            dockerfile: ./images/cilium/Dockerfile
-
-          - name: operator
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: operator-aws
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: operator-azure
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: operator-alibabacloud
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: operator-generic
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: hubble-relay
-            dockerfile: ./images/hubble-relay/Dockerfile
-
-          - name: clustermesh-apiserver
-            dockerfile: ./images/clustermesh-apiserver/Dockerfile
-
-          - name: docker-plugin
-            dockerfile: ./images/cilium-docker-plugin/Dockerfile
+          ${{ fromJSON(needs.setup-vars.outputs.build-and-push-images) }}
 
     steps:
       - name: Checkout main branch to access local actions

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -2,7 +2,7 @@ name: Image CI Build
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
@@ -139,7 +139,7 @@ jobs:
 
       # main branch pushes
       - name: CI Build ${{ matrix.name }}
-        if: ${{ github.event_name != 'pull_request_target' && !startsWith(github.ref_name, 'ft/') }}
+        if: ${{ github.event_name != 'pull_request' && !startsWith(github.ref_name, 'ft/') }}
         uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # v6.5.0
         id: docker_build_ci
         with:
@@ -159,7 +159,7 @@ jobs:
             OPERATOR_VARIANT=${{ matrix.name }}
 
       - name: CI race detection Build ${{ matrix.name }}
-        if: ${{ github.event_name != 'pull_request_target' && !startsWith(github.ref_name, 'ft/') }}
+        if: ${{ github.event_name != 'pull_request' && !startsWith(github.ref_name, 'ft/') }}
         uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # v6.5.0
         id: docker_build_ci_detect_race_condition
         with:
@@ -181,7 +181,7 @@ jobs:
             OPERATOR_VARIANT=${{ matrix.name }}
 
       - name: CI Unstripped Binaries Build ${{ matrix.name }}
-        if: ${{ github.event_name != 'pull_request_target' && !startsWith(github.ref_name, 'ft/') }}
+        if: ${{ github.event_name != 'pull_request' && !startsWith(github.ref_name, 'ft/') }}
         uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # v6.5.0
         id: docker_build_ci_unstripped
         with:
@@ -269,7 +269,7 @@ jobs:
 
       # PR or feature branch updates
       - name: CI Build ${{ matrix.name }}
-        if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
+        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
         uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # v6.5.0
         id: docker_build_ci_pr
         with:
@@ -285,7 +285,7 @@ jobs:
             OPERATOR_VARIANT=${{ matrix.name }}
 
       - name: CI race detection Build ${{ matrix.name }}
-        if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
+        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
         uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # v6.5.0
         id: docker_build_ci_pr_detect_race_condition
         with:
@@ -303,7 +303,7 @@ jobs:
             OPERATOR_VARIANT=${{ matrix.name }}
 
       - name: CI Unstripped Binaries Build ${{ matrix.name }}
-        if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
+        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
         uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # v6.5.0
         id: docker_build_ci_pr_unstripped
         with:
@@ -320,14 +320,14 @@ jobs:
             OPERATOR_VARIANT=${{ matrix.name }}
 
       - name: Sign Container Images
-        if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
+        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
         run: |
           cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_pr.outputs.digest }}
           cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_pr_detect_race_condition.outputs.digest }}
           cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_pr_unstripped.outputs.digest }}
 
       - name: Generate SBOM
-        if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
+        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
         uses: anchore/sbom-action@d94f46e13c6c62f59525ac9a1e147a99dc0b9bf5 # v0.17.0
         with:
           artifact-name: sbom_ci_pr_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
@@ -335,7 +335,7 @@ jobs:
           image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
 
       - name: Generate SBOM (race)
-        if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
+        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
         uses: anchore/sbom-action@d94f46e13c6c62f59525ac9a1e147a99dc0b9bf5 # v0.17.0
         with:
           artifact-name: sbom_ci_pr_race_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
@@ -343,7 +343,7 @@ jobs:
           image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race
 
       - name: Generate SBOM (unstripped)
-        if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
+        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
         uses: anchore/sbom-action@d94f46e13c6c62f59525ac9a1e147a99dc0b9bf5 # v0.17.0
         with:
           artifact-name: sbom_ci_pr_unstripped_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
@@ -351,14 +351,14 @@ jobs:
           image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-unstripped
 
       - name: Attach SBOM attestation to container image
-        if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
+        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
         run: |
           cosign attest -r -y --predicate sbom_ci_pr_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_pr.outputs.digest }}
           cosign attest -r -y --predicate sbom_ci_pr_race_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_pr_detect_race_condition.outputs.digest }}
           cosign attest -r -y --predicate sbom_ci_pr_unstripped_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_pr_unstripped.outputs.digest }}
 
       - name: CI Image Releases digests
-        if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
+        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref_name, 'ft/')) }}
         shell: bash
         run: |
           mkdir -p image-digest/
@@ -376,7 +376,7 @@ jobs:
 
       # Store docker's golang's cache build locally only on the main branch
       - name: Store ${{ matrix.name }} Golang cache build locally
-        if: ${{ github.event_name != 'pull_request_target' && steps.cache.outputs.cache-hit != 'true' && github.ref_name == github.event.repository.default_branch }}
+        if: ${{ github.event_name != 'pull_request' && steps.cache.outputs.cache-hit != 'true' && github.ref_name == github.event.repository.default_branch }}
         uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # v6.5.0
         with:
           provenance: false
@@ -389,7 +389,7 @@ jobs:
 
       # Store docker's golang's cache build locally only on the main branch
       - name: Store ${{ matrix.name }} Golang cache in GitHub cache path
-        if: ${{ github.event_name != 'pull_request_target' && steps.cache.outputs.cache-hit != 'true' && github.ref_name == github.event.repository.default_branch }}
+        if: ${{ github.event_name != 'pull_request' && steps.cache.outputs.cache-hit != 'true' && github.ref_name == github.event.repository.default_branch }}
         shell: bash
         run: |
           mkdir -p /tmp/.cache/${{ matrix.name }}/

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -33,36 +33,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup-vars:
+    name: Setup Variables
+    runs-on: ubuntu-latest
+    outputs:
+      build-and-push-images: ${{ steps.vars.outputs.build-and-push-images }}
+    steps:
+      - name: Checkout default branch (trusted)
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up job variables
+        id: vars
+        run: |
+          echo build-and-push-images=${BUILD_AND_PUSH_IMAGES} >> $GITHUB_OUTPUT
+
   build-and-push-prs:
+    needs: [ setup-vars ]
     timeout-minutes: 45
     name: Build and Push Images
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER }}
     strategy:
       matrix:
         include:
-          - name: cilium
-            dockerfile: ./images/cilium/Dockerfile
-
-          - name: operator-aws
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: operator-azure
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: operator-alibabacloud
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: operator-generic
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: hubble-relay
-            dockerfile: ./images/hubble-relay/Dockerfile
-
-          - name: clustermesh-apiserver
-            dockerfile: ./images/clustermesh-apiserver/Dockerfile
-
-          - name: docker-plugin
-            dockerfile: ./images/cilium-docker-plugin/Dockerfile
+          ${{ fromJSON(needs.setup-vars.outputs.build-and-push-images) }}
 
     steps:
       - name: Checkout default branch (trusted)

--- a/.github/workflows/build-images-hotfixes.yaml
+++ b/.github/workflows/build-images-hotfixes.yaml
@@ -12,7 +12,28 @@ permissions:
   id-token: write
 
 jobs:
+  setup-vars:
+    name: Setup Variables
+    runs-on: ubuntu-latest
+    outputs:
+      build-and-push-images: ${{ steps.vars.outputs.build-and-push-images }}
+    steps:
+      - name: Checkout main branch to access local actions
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up job variables
+        id: vars
+        run: |
+          echo build-and-push-images=${BUILD_AND_PUSH_IMAGES} >> $GITHUB_OUTPUT
+
   build-and-push:
+    needs: [ setup-vars ]
     timeout-minutes: 45
     name: Build and Push Images
     environment: release-developer-images
@@ -20,32 +41,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: cilium
-            dockerfile: ./images/cilium/Dockerfile
-
-          - name: operator
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: operator-aws
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: operator-azure
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: operator-alibabacloud
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: operator-generic
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: hubble-relay
-            dockerfile: ./images/hubble-relay/Dockerfile
-
-          - name: clustermesh-apiserver
-            dockerfile: ./images/clustermesh-apiserver/Dockerfile
-
-          - name: docker-plugin
-            dockerfile: ./images/cilium-docker-plugin/Dockerfile
+          ${{ fromJSON(env.BUILD_AND_PUSH_IMAGES) }}
 
     steps:
       - name: Checkout main branch to access local actions

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -13,7 +13,28 @@ permissions:
   id-token: write
 
 jobs:
+  setup-vars:
+    name: Setup Variables
+    runs-on: ubuntu-latest
+    outputs:
+      build-and-push-images: ${{ steps.vars.outputs.build-and-push-images }}
+    steps:
+      - name: Checkout main branch to access local actions
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up job variables
+        id: vars
+        run: |
+          echo build-and-push-images=${BUILD_AND_PUSH_IMAGES} >> $GITHUB_OUTPUT
+
   build-and-push:
+    needs: [ setup-vars ]
     timeout-minutes: 45
     name: Build and Push Images
     environment: release
@@ -21,32 +42,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: cilium
-            dockerfile: ./images/cilium/Dockerfile
-
-          - name: operator
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: operator-aws
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: operator-azure
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: operator-alibabacloud
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: operator-generic
-            dockerfile: ./images/operator/Dockerfile
-
-          - name: hubble-relay
-            dockerfile: ./images/hubble-relay/Dockerfile
-
-          - name: clustermesh-apiserver
-            dockerfile: ./images/clustermesh-apiserver/Dockerfile
-
-          - name: docker-plugin
-            dockerfile: ./images/cilium-docker-plugin/Dockerfile
+          ${{ fromJSON(needs.setup-vars.outputs.build-and-push-images) }}
 
     steps:
       - name: Checkout main branch to access local actions

--- a/.github/workflows/ci-images-cache-cleaner.yaml
+++ b/.github/workflows/ci-images-cache-cleaner.yaml
@@ -14,29 +14,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup-vars:
+    name: Setup Variables
+    runs-on: ubuntu-latest
+    outputs:
+      build-and-push-images: ${{ steps.vars.outputs.build-and-push-images }}
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up job variables
+        id: vars
+        run: |
+          echo build-and-push-images=${BUILD_AND_PUSH_IMAGES} >> $GITHUB_OUTPUT
+
   cache-cleaner:
     name: Clean Image Cache
+    needs: [ setup-vars ]
     runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:
-          - name: cilium
-
-          - name: operator-aws
-
-          - name: operator-azure
-
-          - name: operator-alibabacloud
-
-          - name: operator-generic
-
-          - name: hubble-relay
-
-          - name: clustermesh-apiserver
-
-          - name: kvstoremesh
-
-          - name: docker-plugin
+          ${{ fromJSON(needs.setup-vars.outputs.build-and-push-images) }}
 
     steps:
       # Fetch the source code so that we can get the right cache key


### PR DESCRIPTION
Currently, the image build matrix is defined in 4 different workflows and needs to be update in all of them whenever an image changes or a new one is added. Deduplicate the matrix definition in an environment variable.
