### PR TITLE
policy/k8s: Fix bug where policy synchronization event was lost

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -45,7 +45,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	policyK8s "github.com/cilium/cilium/pkg/policy/k8s"
 	"github.com/cilium/cilium/pkg/pprof"
-	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 	"github.com/cilium/cilium/pkg/service"
@@ -223,13 +222,7 @@ var (
 		// ServiceCache holds the list of known services correlated with the matching endpoints.
 		k8s.ServiceCacheCell,
 
-		// K8s policy resource watcher cell. It depends on the daemon which we cast into
-		// the interface type here to avoid a circular package import
-		cell.Provide(func(p promise.Promise[*Daemon]) promise.Promise[policyK8s.PolicyManager] {
-			return promise.Map(p, func(d *Daemon) policyK8s.PolicyManager {
-				return d
-			})
-		}),
+		// K8s policy resource watcher cell.
 		policyK8s.Cell,
 
 		// ClusterMesh is the Cilium's multicluster implementation.

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -807,6 +807,11 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	if params.Clientset.IsEnabled() {
 		bootstrapStats.k8sInit.Start()
 
+		// Launch the policy K8s watcher
+		if params.PolicyK8sWatcher != nil {
+			params.PolicyK8sWatcher.WatchK8sPolicyResources(d.ctx, &d)
+		}
+
 		// Launch the K8s watchers in parallel as we continue to process other
 		// daemon options.
 		resources, cacheOnly := d.k8sWatcher.ResourceGroups()

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -92,6 +92,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pidfile"
 	"github.com/cilium/cilium/pkg/policy"
+	policyK8s "github.com/cilium/cilium/pkg/policy/k8s"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/rate"
@@ -1606,6 +1607,7 @@ type daemonParams struct {
 	Policy               *policy.Repository
 	PolicyUpdater        *policy.Updater
 	IPCache              *ipcache.IPCache
+	PolicyK8sWatcher     *policyK8s.PolicyResourcesWatcher
 	EgressGatewayManager *egressgateway.Manager
 	IPAMMetadataManager  *ipamMetadata.Manager
 	CNIConfigManager     cni.CNIConfigManager

--- a/pkg/policy/k8s/cell.go
+++ b/pkg/policy/k8s/cell.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/promise"
 )
 
 const (
@@ -32,7 +31,7 @@ const (
 	k8sAPIGroupCiliumCIDRGroupV2Alpha1          = "cilium/v2alpha1::CiliumCIDRGroup"
 )
 
-// Cell starts the K8s policy watcher. The K8s policy watcher watches all
+// Cell provides the K8s policy watcher. The K8s policy watcher watches all
 // policy related K8s resources (Kubernetes NetworkPolicy (KNP),
 // CiliumNetworkPolicy (CNP), ClusterwideCiliumNetworkPolicy (CCNP),
 // and CiliumCIDRGroup (CCG)), translates them to Cilium's own
@@ -42,7 +41,7 @@ var Cell = cell.Module(
 	"policy-k8s-watcher",
 	"Watches K8s policy related objects",
 
-	cell.Invoke(startK8sPolicyWatcher),
+	cell.Provide(newPolicyResourcesWatcher),
 )
 
 type PolicyManager interface {
@@ -66,8 +65,7 @@ type PolicyWatcherParams struct {
 	K8sResourceSynced *synced.Resources
 	K8sAPIGroups      *synced.APIGroups
 
-	PolicyManager promise.Promise[PolicyManager]
-	ServiceCache  *k8s.ServiceCache
+	ServiceCache *k8s.ServiceCache
 
 	CiliumNetworkPolicies            resource.Resource[*cilium_v2.CiliumNetworkPolicy]
 	CiliumClusterwideNetworkPolicies resource.Resource[*cilium_v2.CiliumClusterwideNetworkPolicy]
@@ -75,54 +73,61 @@ type PolicyWatcherParams struct {
 	NetworkPolicies                  resource.Resource[*slim_networking_v1.NetworkPolicy]
 }
 
-func startK8sPolicyWatcher(p PolicyWatcherParams) {
+type PolicyResourcesWatcher struct {
+	params PolicyWatcherParams
+}
+
+func newPolicyResourcesWatcher(p PolicyWatcherParams) *PolicyResourcesWatcher {
 	if !p.ClientSet.IsEnabled() {
-		return // skip watcher if K8s is not enabled
+		return nil // skip watcher if K8s is not enabled
 	}
 
-	// We want to subscribe before the start hook is invoked in order to not miss
-	// any events
-	ctx, cancel := context.WithCancel(context.Background())
-	svcCacheNotifications := stream.ToChannel(ctx, p.ServiceCache.Notifications(),
-		stream.WithBufferSize(int(p.Config.K8sServiceCacheSize)))
+	return &PolicyResourcesWatcher{
+		params: p,
+	}
+}
 
-	p.Lifecycle.Append(cell.Hook{
-		OnStart: func(startCtx cell.HookContext) error {
-			policyManager, err := p.PolicyManager.Await(startCtx)
-			if err != nil {
-				return err
-			}
+// WatchK8sPolicyResources starts watching Kubernetes policy resources.
+// Needs to be called before K8sWatcher.InitK8sSubsystem.
+func (p *PolicyResourcesWatcher) WatchK8sPolicyResources(ctx context.Context, policyManager PolicyManager) {
+	w := newPolicyWatcher(ctx, policyManager, p)
+	w.watchResources(ctx)
+}
 
-			w := &policyWatcher{
-				log:                              p.Logger,
-				config:                           p.Config,
-				k8sResourceSynced:                p.K8sResourceSynced,
-				k8sAPIGroups:                     p.K8sAPIGroups,
-				svcCache:                         p.ServiceCache,
-				svcCacheNotifications:            svcCacheNotifications,
-				policyManager:                    policyManager,
-				ciliumNetworkPolicies:            p.CiliumNetworkPolicies,
-				ciliumClusterwideNetworkPolicies: p.CiliumClusterwideNetworkPolicies,
-				ciliumCIDRGroups:                 p.CiliumCIDRGroups,
-				networkPolicies:                  p.NetworkPolicies,
+// newPolicyWatcher constructs a new policy watcher. Needs to be constructed
+// before K8sWatcher.InitK8sSubsystem is executed.
+// This constructor unfortunately cannot be started via the Hive lifecycle as
+// there exists a circular dependency between this watcher and the Daemon:
+// The constructor newDaemon cannot complete before all pre-existing
+// K8s policy resources have been added via the PolicyManager
+// (i.e. watchResources has observed the Sync event for CNP/CCNP/KNP).
+// Because the PolicyManager interface itself is implemented by the Daemon
+// struct, we have a circular dependency.
+func newPolicyWatcher(ctx context.Context, policyManager PolicyManager, p *PolicyResourcesWatcher) *policyWatcher {
+	// In order to not miss any service events, we register a subscriber here,
+	// before the call to K8sWatcher.InitK8sSubsystem.
+	svcCacheNotifications := stream.ToChannel(ctx, p.params.ServiceCache.Notifications(),
+		stream.WithBufferSize(int(p.params.Config.K8sServiceCacheSize)))
 
-				cnpCache:          make(map[resource.Key]*types.SlimCNP),
-				cidrGroupCache:    make(map[string]*cilium_v2_alpha1.CiliumCIDRGroup),
-				cidrGroupPolicies: make(map[resource.Key]struct{}),
+	w := &policyWatcher{
+		log:                              p.params.Logger,
+		config:                           p.params.Config,
+		k8sResourceSynced:                p.params.K8sResourceSynced,
+		k8sAPIGroups:                     p.params.K8sAPIGroups,
+		svcCache:                         p.params.ServiceCache,
+		svcCacheNotifications:            svcCacheNotifications,
+		policyManager:                    policyManager,
+		ciliumNetworkPolicies:            p.params.CiliumNetworkPolicies,
+		ciliumClusterwideNetworkPolicies: p.params.CiliumClusterwideNetworkPolicies,
+		ciliumCIDRGroups:                 p.params.CiliumCIDRGroups,
+		networkPolicies:                  p.params.NetworkPolicies,
 
-				toServicesPolicies: make(map[resource.Key]struct{}),
-				cnpByServiceID:     make(map[k8s.ServiceID]map[resource.Key]struct{}),
-			}
+		cnpCache:          make(map[resource.Key]*types.SlimCNP),
+		cidrGroupCache:    make(map[string]*cilium_v2_alpha1.CiliumCIDRGroup),
+		cidrGroupPolicies: make(map[resource.Key]struct{}),
 
-			w.watchResources(ctx)
-
-			return nil
-		},
-		OnStop: func(cell.HookContext) error {
-			if cancel != nil {
-				cancel()
-			}
-			return nil
-		},
-	})
+		toServicesPolicies: make(map[resource.Key]struct{}),
+		cnpByServiceID:     make(map[k8s.ServiceID]map[resource.Key]struct{}),
+	}
+	return w
 }

--- a/pkg/policy/k8s/cell.go
+++ b/pkg/policy/k8s/cell.go
@@ -93,7 +93,7 @@ func startK8sPolicyWatcher(p PolicyWatcherParams) {
 				return err
 			}
 
-			w := &PolicyWatcher{
+			w := &policyWatcher{
 				log:                              p.Logger,
 				config:                           p.Config,
 				k8sResourceSynced:                p.K8sResourceSynced,
@@ -101,10 +101,10 @@ func startK8sPolicyWatcher(p PolicyWatcherParams) {
 				svcCache:                         p.ServiceCache,
 				svcCacheNotifications:            svcCacheNotifications,
 				policyManager:                    policyManager,
-				CiliumNetworkPolicies:            p.CiliumNetworkPolicies,
-				CiliumClusterwideNetworkPolicies: p.CiliumClusterwideNetworkPolicies,
-				CiliumCIDRGroups:                 p.CiliumCIDRGroups,
-				NetworkPolicies:                  p.NetworkPolicies,
+				ciliumNetworkPolicies:            p.CiliumNetworkPolicies,
+				ciliumClusterwideNetworkPolicies: p.CiliumClusterwideNetworkPolicies,
+				ciliumCIDRGroups:                 p.CiliumCIDRGroups,
+				networkPolicies:                  p.NetworkPolicies,
 
 				cnpCache:          make(map[resource.Key]*types.SlimCNP),
 				cidrGroupCache:    make(map[string]*cilium_v2_alpha1.CiliumCIDRGroup),

--- a/pkg/policy/k8s/cilium_cidr_group.go
+++ b/pkg/policy/k8s/cilium_cidr_group.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-func (p *PolicyWatcher) onUpsertCIDRGroup(
+func (p *policyWatcher) onUpsertCIDRGroup(
 	cidrGroup *cilium_v2_alpha1.CiliumCIDRGroup,
 	apiGroup string,
 ) error {
@@ -38,7 +38,7 @@ func (p *PolicyWatcher) onUpsertCIDRGroup(
 	return err
 }
 
-func (p *PolicyWatcher) onDeleteCIDRGroup(
+func (p *policyWatcher) onDeleteCIDRGroup(
 	cidrGroupName string,
 	apiGroup string,
 ) error {
@@ -51,7 +51,7 @@ func (p *PolicyWatcher) onDeleteCIDRGroup(
 	return err
 }
 
-func (p *PolicyWatcher) updateCIDRGroupRefPolicies(
+func (p *policyWatcher) updateCIDRGroupRefPolicies(
 	cidrGroup string,
 ) error {
 	var errs []error
@@ -76,7 +76,7 @@ func (p *PolicyWatcher) updateCIDRGroupRefPolicies(
 	return errors.Join(errs...)
 }
 
-func (p *PolicyWatcher) resolveCIDRGroupRef(cnp *types.SlimCNP) {
+func (p *policyWatcher) resolveCIDRGroupRef(cnp *types.SlimCNP) {
 	refs := getCIDRGroupRefs(cnp)
 	if len(refs) == 0 {
 		return
@@ -190,7 +190,7 @@ func getCIDRGroupRefs(cnp *types.SlimCNP) []string {
 	return cidrGroupRefs
 }
 
-func (p *PolicyWatcher) cidrGroupRefsToCIDRsSets(cidrGroupRefs []string) (map[string][]api.CIDR, error) {
+func (p *policyWatcher) cidrGroupRefsToCIDRsSets(cidrGroupRefs []string) (map[string][]api.CIDR, error) {
 	var errs []error
 	cidrsSet := make(map[string][]api.CIDR)
 	for _, cidrGroupRef := range cidrGroupRefs {

--- a/pkg/policy/k8s/cilium_cidr_group_test.go
+++ b/pkg/policy/k8s/cilium_cidr_group_test.go
@@ -1137,7 +1137,7 @@ func TestCIDRGroupRefsToCIDRsSets(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			p := &PolicyWatcher{cidrGroupCache: tc.cache}
+			p := &policyWatcher{cidrGroupCache: tc.cache}
 			got, err := p.cidrGroupRefsToCIDRsSets(tc.refs)
 			if err != nil {
 				t.Fatalf("unexpected error from cidrGroupRefsToCIDRsSets: %s", err)

--- a/pkg/policy/k8s/cilium_network_policy.go
+++ b/pkg/policy/k8s/cilium_network_policy.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-func (p *PolicyWatcher) onUpsert(
+func (p *policyWatcher) onUpsert(
 	cnp *types.SlimCNP,
 	key resource.Key,
 	apiGroup string,
@@ -70,7 +70,7 @@ func (p *PolicyWatcher) onUpsert(
 	return p.resolveCiliumNetworkPolicyRefs(cnp, key, initialRecvTime, resourceID)
 }
 
-func (p *PolicyWatcher) onDelete(
+func (p *policyWatcher) onDelete(
 	cnp *types.SlimCNP,
 	key resource.Key,
 	apiGroup string,
@@ -99,7 +99,7 @@ func (p *PolicyWatcher) onDelete(
 // and then adds the translated CNP to the policy repository.
 // If the CNP was successfully imported, the raw (i.e. untranslated) CNP/CCNP
 // is also added to p.cnpCache.
-func (p *PolicyWatcher) resolveCiliumNetworkPolicyRefs(
+func (p *policyWatcher) resolveCiliumNetworkPolicyRefs(
 	cnp *types.SlimCNP,
 	key resource.Key,
 	initialRecvTime time.Time,
@@ -126,7 +126,7 @@ func (p *PolicyWatcher) resolveCiliumNetworkPolicyRefs(
 	return err
 }
 
-func (p *PolicyWatcher) upsertCiliumNetworkPolicyV2(cnp *types.SlimCNP, initialRecvTime time.Time, resourceID ipcacheTypes.ResourceID) error {
+func (p *policyWatcher) upsertCiliumNetworkPolicyV2(cnp *types.SlimCNP, initialRecvTime time.Time, resourceID ipcacheTypes.ResourceID) error {
 	scopedLog := p.log.WithFields(logrus.Fields{
 		logfields.CiliumNetworkPolicyName: cnp.ObjectMeta.Name,
 		logfields.K8sAPIVersion:           cnp.TypeMeta.APIVersion,
@@ -154,7 +154,7 @@ func (p *PolicyWatcher) upsertCiliumNetworkPolicyV2(cnp *types.SlimCNP, initialR
 	return policyImportErr
 }
 
-func (p *PolicyWatcher) deleteCiliumNetworkPolicyV2(cnp *types.SlimCNP, resourceID ipcacheTypes.ResourceID) error {
+func (p *policyWatcher) deleteCiliumNetworkPolicyV2(cnp *types.SlimCNP, resourceID ipcacheTypes.ResourceID) error {
 	scopedLog := p.log.WithFields(logrus.Fields{
 		logfields.CiliumNetworkPolicyName: cnp.ObjectMeta.Name,
 		logfields.K8sAPIVersion:           cnp.TypeMeta.APIVersion,
@@ -175,7 +175,7 @@ func (p *PolicyWatcher) deleteCiliumNetworkPolicyV2(cnp *types.SlimCNP, resource
 	return err
 }
 
-func (p *PolicyWatcher) registerResourceWithSyncFn(ctx context.Context, resource string, syncFn func() bool) {
+func (p *policyWatcher) registerResourceWithSyncFn(ctx context.Context, resource string, syncFn func() bool) {
 	p.k8sResourceSynced.BlockWaitGroupToSyncResources(ctx.Done(), nil, syncFn, resource)
 	p.k8sAPIGroups.AddAPI(resource)
 }

--- a/pkg/policy/k8s/network_policy.go
+++ b/pkg/policy/k8s/network_policy.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/source"
 )
 
-func (p *PolicyWatcher) addK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPolicy, apiGroup string) error {
+func (p *policyWatcher) addK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPolicy, apiGroup string) error {
 	defer func() {
 		p.k8sResourceSynced.SetEventTimestamp(apiGroup)
 	}()
@@ -57,7 +57,7 @@ func (p *PolicyWatcher) addK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPo
 	return nil
 }
 
-func (p *PolicyWatcher) deleteK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPolicy, apiGroup string) error {
+func (p *policyWatcher) deleteK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPolicy, apiGroup string) error {
 	defer func() {
 		p.k8sResourceSynced.SetEventTimestamp(apiGroup)
 	}()

--- a/pkg/policy/k8s/service_test.go
+++ b/pkg/policy/k8s/service_test.go
@@ -249,7 +249,7 @@ func TestPolicyWatcher_updateToServicesPolicies(t *testing.T) {
 	logger.SetLevel(logrus.DebugLevel)
 
 	svcCache := fakeServiceCache{}
-	p := &PolicyWatcher{
+	p := &policyWatcher{
 		log:                logrus.NewEntry(logger),
 		config:             &option.DaemonConfig{},
 		k8sResourceSynced:  &k8sSynced.Resources{},


### PR DESCRIPTION
This PR fixes an issue with the K8s policy ingestor where `InitK8sSubsystem` unblocked the daemon startup before all initial policies were processed by the ingestor.

This meant that we created unnecessary endpoint regenerations at startup, due to the initial endpoint regeneration being disrupted by the discovery of additional policies (and thus re-triggering endpoint regeneration).

The cause for the race was that we started the K8s policy watcher in the Hive lifecycle start hook, which is too late: The `InitK8sSubsystem` function called from newDaemon constructor is supposed to block on policy resources being synced. But because we registered those resources (via `BlockWaitGroupToSyncResources`) only after the `newDaemon` constructor already ran (we depended on a fully constructed `Daemon` object), `InitK8sSubsystem` would continue without the policy resources being synced and thus causing unnecessary endpoint regenerations.

This PR fixes the issue by starting the policy resource watcher earlier, namely directly in `newDaemon`. This unfortunately means that we have to side-step the Hive infrastructure, as we currently require a partially initialized `Daemon` object to implement the `PolicyManager` interface for the time being. Hopefully, in the future we can move the `PolicyManager` logic out of the `Daemon` struct and thereby breaking this cyclic dependency.

I have manually tested this, both by checking the logs and by disabling the CNP sync manually (which then blocks the agent before it restores endpoints). Unfortunately, I didn't find a good way to assert this via unit tests.

Fixes: https://github.com/cilium/cilium/issues/31865