### PR TITLE
docs: Fix prometheus port regex

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -84,7 +84,7 @@ option is set in the ``scrape_configs`` section:
           regex: true
         - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
           action: replace
-          regex: (.+):(?:\d+);(\d+)
+          regex: ([^:]+)(?::\d+)?;(\d+)
           replacement: ${1}:${2}
           target_label: __address__
 

--- a/examples/kubernetes/addons/prometheus/files/prometheus/prometheus.yaml
+++ b/examples/kubernetes/addons/prometheus/files/prometheus/prometheus.yaml
@@ -27,7 +27,7 @@ scrape_configs:
       - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
         action: replace
         target_label: __address__
-        regex: (.+)(?::\d+);(\d+)
+        regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:$2
       - action: labelmap
         regex: __meta_kubernetes_service_label_(.+)
@@ -52,7 +52,7 @@ scrape_configs:
         regex: (.+)
       - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
         action: replace
-        regex: (.+):(?:\d+);(\d+)
+        regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: ${1}:${2}
         target_label: __address__
       - action: labelmap


### PR DESCRIPTION
The [example](https://github.com/prometheus/prometheus/blob/b938bbc11169dc224c103bec32a55daad0f3f34e/documentation/examples/prometheus-kubernetes.yml#L286-L292) documentation in prometheus has a different regex pattern compared cilium. In some instances, prometheus or the [opentelemetry collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32306#issuecomment-2061135204) is not picking up the correct port, because the relabel config is not applying since the regex doesn't match.