### PR TITLE
hive: Reduce hive trace logs to debug level

### DIFF
--- a/pkg/hive/cell/cell.go
+++ b/pkg/hive/cell/cell.go
@@ -4,11 +4,15 @@
 package cell
 
 import (
+	"time"
+
 	"go.uber.org/dig"
 
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
+
+const logThreshold = 100 * time.Millisecond
 
 var (
 	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "hive")

--- a/pkg/hive/cell/invoke.go
+++ b/pkg/hive/cell/invoke.go
@@ -37,7 +37,11 @@ func (inv *invoker) invoke(cont container) error {
 			return err
 		}
 		d := time.Since(t0)
-		log.WithField("duration", d).WithField("function", afn.name).Info("Invoked")
+		if d > logThreshold {
+			log.WithField("duration", d).WithField("function", afn.name).Info("Invoked")
+		} else {
+			log.WithField("duration", d).WithField("function", afn.name).Debug("Invoked")
+		}
 	}
 	return nil
 }

--- a/pkg/hive/cell/lifecycle.go
+++ b/pkg/hive/cell/lifecycle.go
@@ -110,7 +110,11 @@ func (lc *DefaultLifecycle) Start(ctx context.Context) error {
 			return err
 		}
 		d := time.Since(t0)
-		l.WithField("duration", d).Info("Start hook executed")
+		if d > logThreshold {
+			l.WithField("duration", d).Info("Start hook executed")
+		} else {
+			l.WithField("duration", d).Debug("Start hook executed")
+		}
 		lc.numStarted++
 	}
 	return nil
@@ -145,7 +149,11 @@ func (lc *DefaultLifecycle) Stop(ctx context.Context) error {
 			errs = errors.Join(errs, err)
 		} else {
 			d := time.Since(t0)
-			l.WithField("duration", d).Info("Stop hook executed")
+			if d > logThreshold {
+				l.WithField("duration", d).Info("Stop hook executed")
+			} else {
+				l.WithField("duration", d).Debug("Stop hook executed")
+			}
 		}
 	}
 	return errs


### PR DESCRIPTION
The cilium-agent logs get spammed with this information in standard
environments, but these logs are not generally useful for users to
understand what's going on. The vast majority of them take microseconds
to run so they don't have any meaningful impact on startup.

Create a threshold to only report long-running tasks at info level,
while leaving most such reporting at debug level.

See also corresponding Hive library PR https://github.com/cilium/hive/pull/2.