### PR TITLE
bpf: nodeport: avoid revalidation in nodeport_rev_dnat_ingress_ipv4()

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -995,9 +995,13 @@ encap_redirect:
 	if (ret == CTX_ACT_REDIRECT && ifindex)
 		return ctx_redirect(ctx, ifindex, 0);
 
+	fib_params.l.ipv4_src = IPV4_DIRECT_ROUTING;
+	fib_params.l.ipv4_dst = tunnel_endpoint;
+	fib_params.l.family = AF_INET;
+
 	/* neigh map doesn't contain DMACs for other nodes */
 	allow_neigh_map = false;
-	goto fib_ipv4;
+	goto fib_redirect;
 #endif
 
 fib_lookup:
@@ -1008,9 +1012,6 @@ fib_lookup:
 		if (ret < 0)
 			return ret;
 
-#ifdef TUNNEL_MODE
-fib_ipv4:
-#endif
 		if (!revalidate_data(ctx, &data, &data_end, &ip4))
 			return DROP_INVALID;
 
@@ -1023,6 +1024,10 @@ fib_ipv4:
 		ipv6_addr_copy((union v6addr *)&fib_params.l.ipv6_dst,
 			       (union v6addr *)&ip6->daddr);
 	}
+
+#ifdef TUNNEL_MODE
+fib_redirect:
+#endif
 	return fib_redirect(ctx, true, &fib_params, allow_neigh_map, ext_err, &ifindex);
 }
 
@@ -2497,6 +2502,9 @@ out:
 	return CTX_ACT_OK;
 
 redirect:
+	fib_params.l.ipv4_src = ip4->saddr;
+	fib_params.l.ipv4_dst = ip4->daddr;
+
 	ret = ipv4_l3(ctx, l3_off, NULL, NULL, ip4);
 	if (unlikely(ret != CTX_ACT_OK))
 		return ret;
@@ -2514,16 +2522,13 @@ redirect:
 		if (ret == CTX_ACT_REDIRECT && ifindex)
 			return ctx_redirect(ctx, ifindex, 0);
 
+		fib_params.l.ipv4_src = IPV4_DIRECT_ROUTING;
+		fib_params.l.ipv4_dst = tunnel_endpoint;
+
 		/* neigh map doesn't contain DMACs for other nodes */
 		allow_neigh_map = false;
 	}
 #endif
-
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
-		return DROP_INVALID;
-
-	fib_params.l.ipv4_src = ip4->saddr;
-	fib_params.l.ipv4_dst = ip4->daddr;
 
 	return fib_redirect(ctx, true, &fib_params, allow_neigh_map, ext_err, &ifindex);
 }


### PR DESCRIPTION
Set up saddr/daddr for the fib_params struct a bit earlier, so that we don't have to revalidate after the ipv4_l3() call. In case of XDP manually pushing tunnel headers, we can just set the selected outer IP addresses.

Apply the same logic to the IPv6 path for consistency, and to untangle the goto flow a tiny bit.