### PR TITLE
.github: Don't cache LLVM

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -146,19 +146,11 @@ jobs:
         id: set_clang_dir
         run: echo "clang_dir=$HOME/.clang" >> $GITHUB_OUTPUT
 
-      - name: Cache LLVM and Clang
-        id: cache-llvm
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        with:
-          path: ${{ steps.set_clang_dir.outputs.clang_dir }}
-          key: llvm-17.0.6-${{ matrix.arch }}
-
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@8b37482c5a2997a3ab5dbf6561f8109e2eaa7d3b # v2.0.2
         with:
           version: "17.0.6"
           directory: ${{ steps.set_clang_dir.outputs.clang_dir }}
-          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
 
       - name: Prepare environment
         timeout-minutes: 15

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -30,13 +30,6 @@ jobs:
         id: set_clang_dir
         run: echo "clang_dir=$HOME/.clang" >> $GITHUB_OUTPUT
 
-      - name: Cache LLVM and Clang
-        id: cache-llvm
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        with:
-          path: ${{ steps.set_clang_dir.outputs.clang_dir }}
-          key: llvm-17.0.6
-
       - name: Install LLVM and Clang prerequisites
         run: |
           sudo apt-get update
@@ -47,7 +40,6 @@ jobs:
         with:
           version: "17.0.6"
           directory: ${{ steps.set_clang_dir.outputs.clang_dir }}
-          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
 
       - name: Install ginkgo
         run: |


### PR DESCRIPTION
Upstream of install-llvm-action says that caching is not recommended, because it's faster to redownload [1]. Remove caching for LLVM, because we observe disk space issues in the CI.

[1]: https://github.com/KyleMayes/install-llvm-action/blob/8b37482c5a2997a3ab5dbf6561f8109e2eaa7d3b/README.md#cached

```release-note
Don't cache LLVM in the CI to resolve disk space issues.
```
