### PR TITLE
Remove hostPort dependency on BPF NodePort

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -456,7 +456,6 @@ func finishKubeProxyReplacementInit(sysctl sysctl.Sysctl, devices []*tables.Devi
 // the latter.
 func disableNodePort() {
 	option.Config.EnableNodePort = false
-	option.Config.EnableHostPort = false
 	option.Config.EnableExternalIPs = false
 	option.Config.EnableSVCSourceRangeCheck = false
 	option.Config.EnableHostLegacyRouting = true


### PR DESCRIPTION

Remove hostPort dependency on BPF NodePort

Fixes: #31532

```release-note
Remove hostPort dependency on BPF NodePort
```
