### PR TITLE
ci: remove build artifacts in integration tests to prevent space issues

### DIFF
--- a/.github/actions/unit-tests/build.sh
+++ b/.github/actions/unit-tests/build.sh
@@ -8,6 +8,10 @@ export CFLAGS="-Werror"
 # Set V=0 here to get GO/CHECK/CC lines, --quiet to hide long clang invocations.
 V=0 make precheck build -j 2 --quiet
 
+# Delete the artifacts created "make build", to prevent disk space issues in CI,
+# as not used by the subsequent steps.
+make clean
+
 # Run with default verbosity here since this builds all Go code by running
 # 'go vet' and all integration tests. At least one line of output is generated
 # after each Go package is built and tested.


### PR DESCRIPTION
We have recently started observing disk space issues in CI when running integration tests. Let's execute "make clean" to remove the build artifacts created by the "make build" step executed to verify that all binaries build successfully, as not used in the subsequent steps. On my machine, that allows to free ~1GB of disk space.
