### PR TITLE
v1.13 Backports 2024-04-18

### DIFF
--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -301,7 +301,7 @@ jobs:
         timeout-minutes: 10
         shell: bash
         run: |
-          for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
+          for image in cilium-ci operator-generic-ci clustermesh-apiserver-ci ; do
             until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
@@ -309,7 +309,7 @@ jobs:
         timeout-minutes: 10
         shell: bash
         run: |
-          for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
+          for image in cilium-ci operator-generic-ci clustermesh-apiserver-ci ; do
             until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.downgrade-vars.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -116,6 +116,9 @@ jobs:
           # * bpf.masquerade is disabled due to #23283
           # * Hubble is disabled to avoid the performance penalty in the testing
           #   environment due to the relatively high traffic load.
+          # * We configure the maximum number of unavailable agents to 1 to slow
+          #   down the rollout process and highlight possible connection disruption
+          #   occurring in the meanwhile.
           CILIUM_INSTALL_DEFAULTS=" \
             --set=debug.enabled=true \
             --set=bpf.masquerade=false \
@@ -124,6 +127,7 @@ jobs:
             --set=tunnel=vxlan \
             --set=ipv4.enabled=true \
             --set=ipv6.enabled=true \
+            --set=updateStrategy.rollingUpdate.maxUnavailable=1 \
             --set=clustermesh.useAPIServer=true \
             --set=clustermesh.config.enabled=true"
 

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -145,7 +145,7 @@ jobs:
             --test='allow-all-except-world/' \
             --test='client-ingress/' \
             --test='client-egress/' \
-            --test='cluster-entity-multicluster/' \
+            --test='cluster-entity-multi-cluster/' \
             --test='!/pod-to-world' \
             --test='!/pod-to-cidr' \
             --collect-sysdump-on-failure"

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -114,8 +114,8 @@ jobs:
           "
 
           # * bpf.masquerade is disabled due to #23283
-          # * Hubble is disabled to avoid the performance penalty in the testing
-          #   environment due to the relatively high traffic load.
+          # * Monitor aggregation is set to medium to avoid the performance penalty
+          #   in the testing environment due to the relatively high traffic load.
           # * We explicitly configure the IPAM mode to prevent it from being
           #   reset to the default value on upgrade/downgrade due to --reset-values.
           # * We configure the maximum number of unavailable agents to 1 to slow
@@ -124,8 +124,8 @@ jobs:
           CILIUM_INSTALL_DEFAULTS=" \
             --set=debug.enabled=true \
             --set=bpf.masquerade=false \
-            --set=bpf.monitorAggregation=none \
-            --set=hubble.enabled=false \
+            --set=bpf.monitorAggregation=medium \
+            --set=hubble.enabled=true \
             --set=tunnel=vxlan \
             --set=ipv4.enabled=true \
             --set=ipv6.enabled=true \

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -116,6 +116,8 @@ jobs:
           # * bpf.masquerade is disabled due to #23283
           # * Hubble is disabled to avoid the performance penalty in the testing
           #   environment due to the relatively high traffic load.
+          # * We explicitly configure the IPAM mode to prevent it from being
+          #   reset to the default value on upgrade/downgrade due to --reset-values.
           # * We configure the maximum number of unavailable agents to 1 to slow
           #   down the rollout process and highlight possible connection disruption
           #   occurring in the meanwhile.
@@ -127,6 +129,8 @@ jobs:
             --set=tunnel=vxlan \
             --set=ipv4.enabled=true \
             --set=ipv6.enabled=true \
+            --set=ipam.mode=kubernetes \
+            --set=operator.replicas=1 \
             --set=updateStrategy.rollingUpdate.maxUnavailable=1 \
             --set=clustermesh.useAPIServer=true \
             --set=clustermesh.config.enabled=true"

--- a/Documentation/community/roadmap.rst
+++ b/Documentation/community/roadmap.rst
@@ -33,7 +33,7 @@ Major Feature Status
 +-----------------------------+------------------------------------------------------------+
 | Service Mesh                | Stable (:ref:`Roadmap Details<rm-cilium-service-mesh>`)    |
 +-----------------------------+------------------------------------------------------------+
-| Tetragon Security           | Beta                                                       |
+| Tetragon Security           | Stable (:ref:`Roadmap Details<rm-tetragon>`)               |
 +-----------------------------+------------------------------------------------------------+
 
 "Stable" means that the feature is in use in production (though advanced
@@ -143,6 +143,8 @@ We have a comprehensive set of tests running in CI, but several contributors are
 currently working on `CI improvements`_ to make these more reliable and easier to
 maintain. This is a good area to get involved if you are interested in learning
 more about Cilium internals and development.
+
+.. _rm-tetragon:
 
 Tetragon Security
 ~~~~~~~~~~~~~~~~~

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -116,7 +116,7 @@ github_repo = 'https://github.com/cilium/cilium/'
 archive_filename = archive_name + '.tar.gz'
 archive_link = github_repo + 'archive/' + archive_filename
 archive_name = 'cilium-' + archive_name.strip('v')
-project_link = github_repo + 'projects?query=is:open+' + next_release
+project_link = github_repo + 'projects?type=classic&query=is:open+' + next_release
 backport_format = github_repo + \
     'pulls?q=is:open+is:pr+-label:backport/author+label:%s/' + current_release
 

--- a/Documentation/contributing/release/organization.rst
+++ b/Documentation/contributing/release/organization.rst
@@ -18,9 +18,9 @@ view the projects related to the \ |NEXT_RELEASE| release here:
 Release Cadence
 ---------------
 
-New versions of Cilium are released based on completion of feature work that
-has been scheduled for that release. Minor releases are typically designated by
-by incrementing the ``Y`` in the version format ``X.Y.Z``.
+New versions of Cilium are released on a cadence of around six months. Minor
+releases are typically designated by by incrementing the ``Y`` in the version
+format ``X.Y.Z``.
 
 Three stable branches are maintained at a time: One for the most recent minor
 release, and two for the prior two minor releases. For each minor release that

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/cilium/coverbee v0.2.2
 	github.com/cilium/customvet v0.0.0-20201209211516-9852765c1ac4
 	github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e
-	github.com/cilium/dns v1.1.51-0.20231120140355-729345173dc3
+	github.com/cilium/dns v1.1.51-0.20240411200813-4e6b438d9e05
 	github.com/cilium/ebpf v0.9.4-0.20221102092914-a9cf21df64c2
 	github.com/cilium/ipam v0.0.0-20220824141044-46ef3d556735
 	github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/cilium/customvet v0.0.0-20201209211516-9852765c1ac4 h1:aqrS+g/6xLKJjc
 github.com/cilium/customvet v0.0.0-20201209211516-9852765c1ac4/go.mod h1:MEn5V1CejgUNFP3Y1JKmBC6Mb9TuK53ecHG9lffctFg=
 github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e h1:VZolEtS7AlGDu3IH368iqkvfQQSGPgOnPjNaUx4dS7M=
 github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e/go.mod h1:c4R5wxGyXhbM6zyKeRKNIc9aab5EZi4z4oOSZvUMvZA=
-github.com/cilium/dns v1.1.51-0.20231120140355-729345173dc3 h1:3PErIjIq4DlOwNsQNPcILFzbGnxPuKuqJsHEFpiwstM=
-github.com/cilium/dns v1.1.51-0.20231120140355-729345173dc3/go.mod h1:/7LC2GOgyXJ7maupZlaVIumYQiGPIgllSf6mA9sg6RU=
+github.com/cilium/dns v1.1.51-0.20240411200813-4e6b438d9e05 h1:lEzR/g0snQppy8yvaMSV7ZN5lcl54Ja4C6MpGqYz2PA=
+github.com/cilium/dns v1.1.51-0.20240411200813-4e6b438d9e05/go.mod h1:/7LC2GOgyXJ7maupZlaVIumYQiGPIgllSf6mA9sg6RU=
 github.com/cilium/ebpf v0.5.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.9.4-0.20221102092914-a9cf21df64c2 h1:0uNZvKfSZS/iA3EnfrnhNu/ZwZIxs5KW3j6sCg2ENNU=
 github.com/cilium/ebpf v0.9.4-0.20221102092914-a9cf21df64c2/go.mod h1:w27N4UjpaQ9X/DGrSugxUG+H+NhgntDuPb5lCzxCn8A=

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -263,7 +263,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 		switch chosen {
 		case doneChIndex: // Context got canceled, most likely by the client terminating.
 			streamLog.WithError(ctx.Err()).Debug("xDS stream context canceled")
-			return ctx.Err()
+			return nil
 
 		case reqChIndex: // Request received from the stream.
 			if !recvOK {

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -329,6 +329,11 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			state := &typeStates[index]
 			watcher := s.watchers[typeURL]
 
+			if nonce == 0 && versionInfo > 0 {
+				requestLog.Debugf("xDS was restarted, setting nonce to %d", versionInfo)
+				nonce = versionInfo
+			}
+
 			// Response nonce is always the same as the response version.
 			// Request version indicates the last acked version. If the
 			// response nonce in the request is different (smaller) than

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -36,7 +36,7 @@ var _ = Suite(&ServerSuite{})
 
 const (
 	TestTimeout   = 10 * time.Second
-	StreamTimeout = 2 * time.Second
+	StreamTimeout = 4 * time.Second
 )
 
 var (

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -151,8 +151,8 @@ func (s *ServerSuite) TestRequestAllResources(c *C) {
 
 	// Run the server's stream handler concurrently.
 	go func() {
+		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		close(streamDone)
 		c.Check(err, IsNil)
 	}()
 
@@ -277,8 +277,8 @@ func (s *ServerSuite) TestAck(c *C) {
 
 	// Run the server's stream handler concurrently.
 	go func() {
+		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		close(streamDone)
 		c.Check(err, IsNil)
 	}()
 
@@ -403,8 +403,8 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 
 	// Run the server's stream handler concurrently.
 	go func() {
+		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		close(streamDone)
 		c.Check(err, IsNil)
 	}()
 
@@ -577,8 +577,8 @@ func (s *ServerSuite) TestUpdateRequestResources(c *C) {
 
 	// Run the server's stream handler concurrently.
 	go func() {
+		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		close(streamDone)
 		c.Check(err, IsNil)
 	}()
 
@@ -680,8 +680,8 @@ func (s *ServerSuite) TestRequestStaleNonce(c *C) {
 
 	// Run the server's stream handler concurrently.
 	go func() {
+		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		close(streamDone)
 		c.Check(err, IsNil)
 	}()
 
@@ -820,8 +820,8 @@ func (s *ServerSuite) TestNAck(c *C) {
 
 	// Run the server's stream handler concurrently.
 	go func() {
+		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		close(streamDone)
 		c.Check(err, IsNil)
 	}()
 
@@ -955,8 +955,8 @@ func (s *ServerSuite) TestNAckFromTheStart(c *C) {
 
 	// Run the server's stream handler concurrently.
 	go func() {
+		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		close(streamDone)
 		c.Check(err, IsNil)
 	}()
 
@@ -1089,8 +1089,8 @@ func (s *ServerSuite) TestRequestHighVersionFromTheStart(c *C) {
 
 	// Run the server's stream handler concurrently.
 	go func() {
+		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		close(streamDone)
 		c.Check(err, IsNil)
 	}()
 

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -729,18 +729,7 @@ func (s *ServerSuite) TestRequestStaleNonce(c *C) {
 	err = stream.SendRequest(req)
 	c.Assert(err, IsNil)
 
-	// Expecting no response from the server.
-
-	// Resend the request with the correct nonce.
-	req = &envoy_service_discovery.DiscoveryRequest{
-		TypeUrl:       typeURL,
-		VersionInfo:   resp.VersionInfo, // ACK the received version.
-		Node:          nodes[node0],
-		ResourceNames: nil,
-		ResponseNonce: resp.Nonce,
-	}
-	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	// Server correctly detects 0 nonce and resets it to the correct value.
 
 	// Expecting a response with both resources.
 	resp, err = stream.RecvResponse()

--- a/pkg/envoy/xds/stream.go
+++ b/pkg/envoy/xds/stream.go
@@ -70,6 +70,9 @@ func (s *MockStream) Recv() (*envoy_service_discovery.DiscoveryRequest, error) {
 		return nil, subCtx.Err()
 	case req := <-s.recv:
 		cancel()
+		if req == nil {
+			return nil, io.EOF
+		}
 		return req, nil
 	}
 }

--- a/vendor/github.com/cilium/dns/shared_client.go
+++ b/vendor/github.com/cilium/dns/shared_client.go
@@ -227,6 +227,17 @@ func handler(wg *sync.WaitGroup, client *Client, conn *Conn, requests chan reque
 				return
 			}
 			start := time.Now()
+
+			// Check if we already have a request with the same id
+			// Due to birthday paradox and the fact that ID is uint16
+			// it's likely to happen with small number (~200) of concurrent requests
+			// which would result in goroutine leak as we would never close req.ch
+			if _, ok := waitingResponses[req.msg.Id]; ok {
+				req.ch <- sharedClientResponse{nil, 0, fmt.Errorf("duplicate request id %d", req.msg.Id)}
+				close(req.ch)
+				continue
+			}
+
 			err := client.SendContext(req.ctx, req.msg, conn, start)
 			if err != nil {
 				req.ch <- sharedClientResponse{nil, 0, err}
@@ -291,8 +302,13 @@ func (c *SharedClient) ExchangeSharedContext(ctx context.Context, m *Msg) (r *Ms
 	}
 
 	// Since c.requests is unbuffered, the handler is guaranteed to eventually close 'respCh'
-	resp := <-respCh
-	return resp.msg, resp.rtt, resp.err
+	select {
+	case resp := <-respCh:
+		return resp.msg, resp.rtt, resp.err
+	// This is just fail-safe mechanism in case there is another similar issue
+	case <-time.After(time.Minute):
+		return nil, 0, fmt.Errorf("timeout waiting for response")
+	}
 }
 
 // close closes and waits for the close to finish.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -181,7 +181,7 @@ github.com/cilium/customvet/analysis/timeafter
 ## explicit; go 1.14
 github.com/cilium/deepequal-gen
 github.com/cilium/deepequal-gen/generators
-# github.com/cilium/dns v1.1.51-0.20231120140355-729345173dc3
+# github.com/cilium/dns v1.1.51-0.20240411200813-4e6b438d9e05
 ## explicit; go 1.18
 github.com/cilium/dns
 # github.com/cilium/ebpf v0.9.4-0.20221102092914-a9cf21df64c2


### PR DESCRIPTION
 * [x] #31886 (@sharlns) :warning: resolved conflicts
    * :information_source: Manually added the `rm-tetragon` target, and skipped the adopters hunk, as already not present.
 * [x] #31970 (@joestringer)
 * [x] #31959 (@marseel) :warning: resolved conflicts
   * :information_source: Trivial conflicts in `go.{mod,sum}`.
 * [x] #32004 (@jrajahalme) :warning: resolved conflicts
   * :information_source: Applied the same hunk to the `stream.go` file.
 * [x] #31958 (@giorio94) :warning: resolved conflicts
    * :information_source: Trivial conflicts due to different surrounding context, accepted combination.
 * [x] #31061 (@sayboras)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 31061 31886 31970 31959 32004 31958
```
