### PR TITLE
Adds metric for monitoring the service programming duration

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -291,6 +291,7 @@ Services
 Name                                       Labels                                             Default    Description
 ========================================== ================================================== ========== ========================================================
 ``services_events_total``                                                                     Enabled    Number of services events labeled by action type
+``service_implementation_delay``           ``action``                                         Enabled    Duration in seconds to propagate the data plane programming of a service, its network and endpoints from the time the service or the service pod was changed excluding the event queue latency
 ========================================== ================================================== ========== ========================================================
 
 Cluster health

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/redirectpolicy"
+	"github.com/cilium/cilium/pkg/safetime"
 	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
@@ -536,7 +537,10 @@ func (k *K8sWatcher) enableK8sWatchers(ctx context.Context, resourceNames []stri
 
 func (k *K8sWatcher) k8sServiceHandler() {
 	eventHandler := func(event k8s.ServiceEvent) {
-		defer event.SWG.Done()
+		defer func(startTime time.Time) {
+			event.SWG.Done()
+			k.K8sServiceEventProcessed(event.Action.String(), startTime)
+		}(time.Now())
 
 		svc := event.Service
 
@@ -890,6 +894,12 @@ func (k *K8sWatcher) K8sEventReceived(apiResourceName, scope, action string, val
 	metrics.KubernetesEventReceived.WithLabelValues(scope, action, validStr, equalStr).Inc()
 
 	k.k8sResourceSynced.SetEventTimestamp(apiResourceName)
+}
+
+// K8sServiceEventProcessed is called to do metrics accounting the duration to program the service.
+func (k *K8sWatcher) K8sServiceEventProcessed(action string, startTime time.Time) {
+	duration, _ := safetime.TimeSinceSafe(startTime, log)
+	metrics.ServiceImplementationDelay.WithLabelValues(action).Observe(duration.Seconds())
 }
 
 // initCiliumEndpointOrSlices intializes the ciliumEndpoints or ciliumEndpointSlice

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -412,6 +412,10 @@ var (
 	// ServicesEventsCount counts the number of services
 	ServicesEventsCount = NoOpCounterVec
 
+	// ServiceImplementationDelay the execution duration of the service handler in milliseconds.
+	// The metric reflects the time it took to program the service excluding the event queue latency.
+	ServiceImplementationDelay = NoOpObserverVec
+
 	// Errors and warnings
 
 	// ErrorsWarnings is the number of errors and warnings in cilium-agent instances
@@ -673,6 +677,7 @@ type LegacyMetrics struct {
 	ConntrackDumpResets              metric.Vec[metric.Counter]
 	SignalsHandled                   metric.Vec[metric.Counter]
 	ServicesEventsCount              metric.Vec[metric.Counter]
+	ServiceImplementationDelay       metric.Vec[metric.Observer]
 	ErrorsWarnings                   metric.Vec[metric.Counter]
 	ControllerRuns                   metric.Vec[metric.Counter]
 	ControllerRunsDuration           metric.Vec[metric.Observer]
@@ -979,6 +984,14 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Namespace:  Namespace,
 			Name:       "services_events_total",
 			Help:       "Number of services events labeled by action type",
+		}, []string{LabelAction}),
+
+		ServiceImplementationDelay: metric.NewHistogramVec(metric.HistogramOpts{
+			ConfigName: Namespace + "_service_implementation_delay",
+			Namespace:  Namespace,
+			Name:       "service_implementation_delay",
+			Help: "Duration in seconds to propagate the data plane programming of a service, its network and endpoints " +
+				"from the time the service or the service pod was changed excluding the event queue latency",
 		}, []string{LabelAction}),
 
 		ErrorsWarnings: newErrorsWarningsMetric(),
@@ -1367,6 +1380,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 	ConntrackDumpResets = lm.ConntrackDumpResets
 	SignalsHandled = lm.SignalsHandled
 	ServicesEventsCount = lm.ServicesEventsCount
+	ServiceImplementationDelay = lm.ServiceImplementationDelay
 	ErrorsWarnings = lm.ErrorsWarnings
 	ControllerRuns = lm.ControllerRuns
 	ControllerRunsDuration = lm.ControllerRunsDuration


### PR DESCRIPTION
Adds a new metric (`service_implementation_delay `) for monitoring the service programming duration. The metrics measures the execution time of the service event handler reflecting the time it took to program the service. From the time the service or pod was changed to the time the change was propagated.

The metric also take into consideration the duration to program the in-cluster network (Network programming latency SLIs) which is useful to monitor and understand network bottlenecks in large clusters. 

The metric should not impact the current performance of the handler allowing us to have it enabled by default.

```release-note
Adds `service_implementation_delay` metric accounting the duration in seconds to propagate the data plane programming of a service, its network and endpoints from the time the service or the service pod was changed excluding the event queue latency
```
