### PR TITLE
Add pprof collection to 100 node scale test

### DIFF
--- a/.github/actions/cl2-modules/cilium-agent-pprofs.yaml
+++ b/.github/actions/cl2-modules/cilium-agent-pprofs.yaml
@@ -1,0 +1,25 @@
+{{$action := .action}}
+
+steps:
+  - name: {{$action}} Cilium Agent PProfs
+    measurements:
+    - identifier: cilium-agent-PodPeriodicCommand
+      method: PodPeriodicCommand
+      params:
+        action: {{$action}}
+        labelSelector: k8s-app=cilium
+        interval: 60s
+        container: cilium-agent
+        limit: 5
+        failOnCommandError: true
+        failOnExecError: true
+        failOnTimeout: true
+        commands:
+        - name: Profiles
+          command:
+          - cilium-bugtool
+          - --get-pprof
+          - --pprof-trace-seconds=40
+          - -t=-
+          timeout: 55s
+

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -113,7 +113,12 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: kubernetes/perf-tests
-          ref: 82036a7e9bdb803b5b133c2d83cfec710819f9ab # master
+          # Avoid using renovate to update this dependency because: (1)
+          # perf-tests does not tag or release, so renovate will pull
+          # all updates to the default branch and (2) continually
+          # updating CL2 may impact the stability of the scale test
+          # results.
+          ref: 920c39ef245a81bd8fb39d7fecf39eb35820d9ef
           persist-credentials: false
           sparse-checkout: clusterloader2
           path: perf-tests

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -191,6 +191,13 @@ jobs:
           export CL2_ALLOWED_SLOW_API_CALLS=1
           export CL2_SCHEDULER_THROUGHPUT_THRESHOLD=0
 
+          # CL2 hardcodes module paths to live in ./testing/load, even
+          # if the path given is relative.
+          cp ../../.github/actions/cl2-modules/cilium-agent-pprofs.yaml ./testing/load/
+          echo \
+            '{"CL2_ADDITIONAL_MEASUREMENT_MODULES": ["./cilium-agent-pprofs.yaml"]}' \
+            > modules.yaml
+
           # CL2 needs ssh access to control plane nodes
           gcloud compute config-ssh
 
@@ -207,6 +214,7 @@ jobs:
             --testoverrides=./testing/overrides/load_throughput.yaml \
             --testoverrides=./testing/experiments/use_simple_latency_query.yaml \
             --testoverrides=./testing/prometheus/not-scrape-kube-proxy.yaml \
+            --testoverrides=./modules.yaml \
             2>&1 | tee cl2-output.txt
 
       - name: Get sysdump

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -65,6 +65,7 @@ jobs:
 
           # Setup Cilium install options
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
+            --set pprof.enabled=true \
             --wait=false"
 
           CLUSTER_NAME="${{ env.test_name }}-${{ env.cluster_base_name }}"

--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -119,7 +119,12 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: kubernetes/perf-tests
-          ref: 82036a7e9bdb803b5b133c2d83cfec710819f9ab # master
+          # Avoid using renovate to update this dependency because: (1)
+          # perf-tests does not tag or release, so renovate will pull
+          # all updates to the default branch and (2) continually
+          # updating CL2 may impact the stability of the scale test
+          # results.
+          ref: 920c39ef245a81bd8fb39d7fecf39eb35820d9ef
           persist-credentials: false
           sparse-checkout: clusterloader2
           path: perf-tests

--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -184,6 +184,7 @@ jobs:
           mkdir ./report
           echo POD_STARTUP_LATENCY_THRESHOLD: 60s >> ./testoverrides.yaml
           echo POD_COUNT: 98 >> ./testoverrides.yaml
+
           go run ./cmd/clusterloader.go \
             -v=4 \
             --testconfig=./testing/node-throughput/config.yaml \


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

This PR utilizes a recent change to ClusterLoader2 that allows for [injecting additional measurements](https://github.com/kubernetes/perf-tests/pull/2483) to collect pprofs throughout the duration of the 100 node scale test. These pprofs are saved as artifacts and can be used for debugging.

Pprofs are pulled using the PodPeriodicCommand measurement, which periodically executes `cilium-bugtool --get-pprof` inside a randomly selected cilium-agent. A tar archive containing the profiles is saved to stdout, which is saved by the PodPeriodicCommand measurement and can later be extracted.

```release-note
Scrape pprofs in 100 node scale test workflow for extra debugging information
```
