### PR TITLE
policy: Remove unused `allow-remotehost-ingress` derivedFrom label

### DIFF
--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -35,12 +35,11 @@ var (
 )
 
 const (
-	LabelKeyPolicyDerivedFrom   = "io.cilium.policy.derived-from"
-	LabelAllowLocalHostIngress  = "allow-localhost-ingress"
-	LabelAllowRemoteHostIngress = "allow-remotehost-ingress"
-	LabelAllowAnyIngress        = "allow-any-ingress"
-	LabelAllowAnyEgress         = "allow-any-egress"
-	LabelVisibilityAnnotation   = "visibility-annotation"
+	LabelKeyPolicyDerivedFrom  = "io.cilium.policy.derived-from"
+	LabelAllowLocalHostIngress = "allow-localhost-ingress"
+	LabelAllowAnyIngress       = "allow-any-ingress"
+	LabelAllowAnyEgress        = "allow-any-egress"
+	LabelVisibilityAnnotation  = "visibility-annotation"
 
 	// Using largest possible port value since it has the lowest priority
 	unrealizedRedirectPort = uint16(65535)


### PR DESCRIPTION
Now that the `enable-remote-node-identity` flag has been removed, we no longer create policy map entries to allow ingress from remote nodes.

Discovered while reviewing another PR

Fixes: 2f829958b714 ("daemon,test: remove enableRemoteNodeIdentity flag")