### PR TITLE
ci: Set hubble.relay.retryTimeout=5s 

### DIFF
--- a/.github/actions/helm-default/action.yaml
+++ b/.github/actions/helm-default/action.yaml
@@ -30,7 +30,8 @@ runs:
         CILIUM_INSTALL_DEFAULTS="--chart-directory=${{ inputs.chart-dir }} \
           --helm-set=debug.enabled=true \
           --helm-set=bpf.monitorAggregation=none \
-          --helm-set=dnsProxy.proxyResponseMaxDelay=250ms"
+          --helm-set=dnsProxy.proxyResponseMaxDelay=250ms \
+          --helm-set=hubble.relay.retryTimeout=5s"
 
         # only add SHA to the image tags if it was set
         if [ -n "${SHA}" ]; then


### PR DESCRIPTION
I noticed CI seemed to flake on hubble-relay being ready. Based on the logs it was due to it being unable to connect to its peers. 

Based on the sysdump the endpoints did eventually come up, so I think it just needs to retry more often, and the default is 30s so lower it to 5s in CI.

An example of such a CI run: https://github.com/cilium/cilium/actions/runs/8729875690/job/23952676116?pr=31973. 

I've added some temporary commits to test the changes, which I'll remove after I verify the correct options are being used.