### PR TITLE
.github: No need to install Docker in complexity-test manually anymore

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -141,7 +141,6 @@ jobs:
 
             # The LVH image ships with LLVM taken from a release Cilium version.
             # Replace it with the one extracted from the cilium-builder image.
-            /bootstrap/deb-docker.sh # Install docker first.
             /host/contrib/scripts/extract-llvm.sh /tmp/llvm
             mv /tmp/llvm/usr/local/bin/{clang,llc} /bin/
             rm -r /tmp/llvm


### PR DESCRIPTION
After [1] has been merged, Docker is part of complexity-test images, therefore it's no longer needed to install it manually.

[1]: https://github.com/cilium/little-vm-helper-images/pull/461

```release-note
Cleanups after LLVM upgrade.
```
