### PR TITLE
Simplify NAT46x64,recorder tests

### DIFF
--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -384,6 +384,24 @@ ${CILIUM_EXEC} \
     cilium-dbg recorder update --id 2 --caplen 100 \
         --filters="$(printf '%s,' "${RECORDER_FILTERS_IPV6[@]}" | sed 's/,*$//')"
 
+info "Checking the list of filters in IPv4 recorder ID:1"
+if [ $(${CILIUM_EXEC} cilium-dbg bpf recorder list | grep "ID:1" | wc -l) -ne ${#RECORDER_FILTERS_IPV4[@]} ]; then
+    echo "Expected filters:"
+    echo "${RECORDER_FILTERS_IPV4[@]}" | nl -bn
+    echo "Found filters:"
+    ${CILIUM_EXEC} cilium-dbg bpf recorder list | nl -bn
+    fatal "Recorder filters did not match expected list"
+fi
+
+info "Checking the list of filters in IPv6 recorder ID:2"
+if [ $(${CILIUM_EXEC} cilium-dbg bpf recorder list | grep "ID:2" | wc -l) -ne ${#RECORDER_FILTERS_IPV6[@]} ]; then
+    echo "Expected filters:"
+    echo "${RECORDER_FILTERS_IPV6[@]}" | nl -bn
+    echo "Found filters:"
+    ${CILIUM_EXEC} cilium-dbg bpf recorder list | nl -bn
+    fatal "Recorder filters did not match expected list"
+fi
+
 trace_exec ${CILIUM_EXEC} cilium-dbg recorder list
 trace_exec ${CILIUM_EXEC} cilium-dbg bpf recorder list
 ${CILIUM_EXEC} cilium-dbg recorder delete 1

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -279,6 +279,8 @@ for i in $(seq 1 10); do
     curl -s -o /dev/null "[${LB_VIP}]:80" || (echo "Failed $i"; exit 1)
 done
 
+wait_service_ready "${LB_ALT}:80"
+
 # Issue 10 requests to LB2
 for i in $(seq 1 10); do
     curl -s -o /dev/null "${LB_ALT}:80" || (echo "Failed $i"; exit 1)

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -135,11 +135,10 @@ function cleanup {
     if tty -s; then
         read -p "Hold the environment for debugging? [y/n]" -n 1 -r
         echo
-        if [[ $REPLY =~ ^[Yy]$ ]]; then
-            return
+        if [[ $REPLY =~ ^[Nn]$ ]]; then
+            force_cleanup
         fi
     fi
-    force_cleanup
 }
 
 # $1 - target service, for example "[fd00:dead:beef:15:bad::1]:80"
@@ -408,4 +407,5 @@ ${CILIUM_EXEC} cilium-dbg recorder delete 1
 ${CILIUM_EXEC} cilium-dbg recorder delete 2
 trace_exec ${CILIUM_EXEC} cilium-dbg recorder list
 
+force_cleanup
 echo "YAY!"

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -298,6 +298,76 @@ test_services "$LB_VIP" "$LB_VIP_SVC" "$LB_VIP_FAM" "128" "$BACKEND_SVC" \
 # NAT test suite & PCAP recorder
 ################################
 
+RECORDER_FILTERS_IPV4=("2.2.2.2/0 0 1.1.1.1/32 80 TCP" \
+                       "2.2.2.2/1 0 1.1.1.1/32 80 TCP" \
+                       "2.2.2.2/2 0 1.1.1.1/31 80 TCP" \
+                       "2.2.2.2/3 0 1.1.1.1/30 80 TCP" \
+                       "2.2.2.2/4 0 1.1.1.1/29 80 TCP" \
+                       "2.2.2.2/5 0 1.1.1.1/28 80 TCP" \
+                       "2.2.2.2/6 0 1.1.1.1/27 80 TCP" \
+                       "2.2.2.2/7 0 1.1.1.1/26 80 TCP" \
+                       "2.2.2.2/8 0 1.1.1.1/25 80 TCP" \
+                       "2.2.2.2/9 0 1.1.1.1/24 80 TCP" \
+                       "2.2.2.2/10 0 1.1.1.1/23 80 TCP" \
+                       "2.2.2.2/11 0 1.1.1.1/22 80 TCP" \
+                       "2.2.2.2/12 0 1.1.1.1/21 80 TCP" \
+                       "2.2.2.2/13 0 1.1.1.1/20 80 TCP" \
+                       "2.2.2.2/14 0 1.1.1.1/19 80 TCP" \
+                       "2.2.2.2/15 0 1.1.1.1/18 80 TCP" \
+                       "2.2.2.2/16 0 1.1.1.1/17 80 TCP" \
+                       "2.2.2.2/17 0 1.1.1.1/16 80 TCP" \
+                       "2.2.2.2/18 0 1.1.1.1/15 80 TCP" \
+                       "2.2.2.2/19 0 1.1.1.1/14 80 TCP" \
+                       "2.2.2.2/20 0 1.1.1.1/13 80 TCP" \
+                       "2.2.2.2/21 0 1.1.1.1/12 80 TCP" \
+                       "2.2.2.2/22 0 1.1.1.1/11 80 TCP" \
+                       "2.2.2.2/23 0 1.1.1.1/10 80 TCP" \
+                       "2.2.2.2/24 0 1.1.1.1/9 80 TCP" \
+                       "2.2.2.2/25 0 1.1.1.1/8 80 TCP" \
+                       "2.2.2.2/26 0 1.1.1.1/7 80 TCP" \
+                       "2.2.2.2/27 0 1.1.1.1/6 80 TCP" \
+                       "2.2.2.2/28 0 1.1.1.1/5 80 TCP" \
+                       "2.2.2.2/29 0 1.1.1.1/4 80 TCP" \
+                       "2.2.2.2/30 0 1.1.1.1/3 80 TCP" \
+                       "2.2.2.2/31 0 1.1.1.1/2 80 TCP" \
+                       "2.2.2.2/32 0 1.1.1.1/1 80 TCP" \
+                       "2.2.2.2/32 0 1.1.1.1/0 80 TCP")
+
+RECORDER_FILTERS_IPV6=("f00d::1/0 80 cafe::/128 0 UDP" \
+                       "f00d::1/1 80 cafe::/127 0 UDP" \
+                       "f00d::1/2 80 cafe::/126 0 UDP" \
+                       "f00d::1/3 80 cafe::/125 0 UDP" \
+                       "f00d::1/4 80 cafe::/124 0 UDP" \
+                       "f00d::1/5 80 cafe::/123 0 UDP" \
+                       "f00d::1/6 80 cafe::/122 0 UDP" \
+                       "f00d::1/7 80 cafe::/121 0 UDP" \
+                       "f00d::1/8 80 cafe::/120 0 UDP" \
+                       "f00d::1/9 80 cafe::/119 0 UDP" \
+                       "f00d::1/10 80 cafe::/118 0 UDP" \
+                       "f00d::1/11 80 cafe::/117 0 UDP" \
+                       "f00d::1/12 80 cafe::/116 0 UDP" \
+                       "f00d::1/13 80 cafe::/115 0 UDP" \
+                       "f00d::1/14 80 cafe::/114 0 UDP" \
+                       "f00d::1/15 80 cafe::/113 0 UDP" \
+                       "f00d::1/16 80 cafe::/112 0 UDP" \
+                       "f00d::1/17 80 cafe::/111 0 UDP" \
+                       "f00d::1/18 80 cafe::/110 0 UDP" \
+                       "f00d::1/19 80 cafe::/109 0 UDP" \
+                       "f00d::1/20 80 cafe::/108 0 UDP" \
+                       "f00d::1/21 80 cafe::/107 0 UDP" \
+                       "f00d::1/22 80 cafe::/106 0 UDP" \
+                       "f00d::1/23 80 cafe::/105 0 UDP" \
+                       "f00d::1/24 80 cafe::/104 0 UDP" \
+                       "f00d::1/25 80 cafe::/103 0 UDP" \
+                       "f00d::1/26 80 cafe::/102 0 UDP" \
+                       "f00d::1/27 80 cafe::/101 0 UDP" \
+                       "f00d::1/28 80 cafe::/100 0 UDP" \
+                       "f00d::1/29 80 cafe::/99 0 UDP" \
+                       "f00d::1/30 80 cafe::/98 0 UDP" \
+                       "f00d::1/31 80 cafe::/97 0 UDP" \
+                       "f00d::1/32 80 cafe::/96 0 UDP" \
+                       "f00d::1/32 80 cafe::/0 0 UDP")
+
 # Install Cilium as standalone L4LB: XDP/Maglev/SNAT/Recorder
 cilium_install "$TXT_XDP_MAGLEV_RECORDER" \
     --bpf-lb-algorithm=maglev \
@@ -307,83 +377,17 @@ cilium_install "$TXT_XDP_MAGLEV_RECORDER" \
 # Trigger recompilation with 32 IPv4 filter masks
 ${CILIUM_EXEC} \
     cilium-dbg recorder update --id 1 --caplen 100 \
-        --filters="2.2.2.2/0 0 1.1.1.1/32 80 TCP,\
-2.2.2.2/1 0 1.1.1.1/32 80 TCP,\
-2.2.2.2/2 0 1.1.1.1/31 80 TCP,\
-2.2.2.2/3 0 1.1.1.1/30 80 TCP,\
-2.2.2.2/4 0 1.1.1.1/29 80 TCP,\
-2.2.2.2/5 0 1.1.1.1/28 80 TCP,\
-2.2.2.2/6 0 1.1.1.1/27 80 TCP,\
-2.2.2.2/7 0 1.1.1.1/26 80 TCP,\
-2.2.2.2/8 0 1.1.1.1/25 80 TCP,\
-2.2.2.2/9 0 1.1.1.1/24 80 TCP,\
-2.2.2.2/10 0 1.1.1.1/23 80 TCP,\
-2.2.2.2/11 0 1.1.1.1/22 80 TCP,\
-2.2.2.2/12 0 1.1.1.1/21 80 TCP,\
-2.2.2.2/13 0 1.1.1.1/20 80 TCP,\
-2.2.2.2/14 0 1.1.1.1/19 80 TCP,\
-2.2.2.2/15 0 1.1.1.1/18 80 TCP,\
-2.2.2.2/16 0 1.1.1.1/17 80 TCP,\
-2.2.2.2/17 0 1.1.1.1/16 80 TCP,\
-2.2.2.2/18 0 1.1.1.1/15 80 TCP,\
-2.2.2.2/19 0 1.1.1.1/14 80 TCP,\
-2.2.2.2/20 0 1.1.1.1/13 80 TCP,\
-2.2.2.2/21 0 1.1.1.1/12 80 TCP,\
-2.2.2.2/22 0 1.1.1.1/11 80 TCP,\
-2.2.2.2/23 0 1.1.1.1/10 80 TCP,\
-2.2.2.2/24 0 1.1.1.1/9 80 TCP,\
-2.2.2.2/25 0 1.1.1.1/8 80 TCP,\
-2.2.2.2/26 0 1.1.1.1/7 80 TCP,\
-2.2.2.2/27 0 1.1.1.1/6 80 TCP,\
-2.2.2.2/28 0 1.1.1.1/5 80 TCP,\
-2.2.2.2/29 0 1.1.1.1/4 80 TCP,\
-2.2.2.2/30 0 1.1.1.1/3 80 TCP,\
-2.2.2.2/31 0 1.1.1.1/2 80 TCP,\
-2.2.2.2/32 0 1.1.1.1/1 80 TCP,\
-2.2.2.2/32 0 1.1.1.1/0 80 TCP"
+        --filters="$(printf '%s,' "${RECORDER_FILTERS_IPV4[@]}" | sed 's/,*$//')"
 
 # Trigger recompilation with 32 IPv6 filter masks
 ${CILIUM_EXEC} \
     cilium-dbg recorder update --id 2 --caplen 100 \
-        --filters="f00d::1/0 80 cafe::/128 0 UDP,\
-f00d::1/1 80 cafe::/127 0 UDP,\
-f00d::1/2 80 cafe::/126 0 UDP,\
-f00d::1/3 80 cafe::/125 0 UDP,\
-f00d::1/4 80 cafe::/124 0 UDP,\
-f00d::1/5 80 cafe::/123 0 UDP,\
-f00d::1/6 80 cafe::/122 0 UDP,\
-f00d::1/7 80 cafe::/121 0 UDP,\
-f00d::1/8 80 cafe::/120 0 UDP,\
-f00d::1/9 80 cafe::/119 0 UDP,\
-f00d::1/10 80 cafe::/118 0 UDP,\
-f00d::1/11 80 cafe::/117 0 UDP,\
-f00d::1/12 80 cafe::/116 0 UDP,\
-f00d::1/13 80 cafe::/115 0 UDP,\
-f00d::1/14 80 cafe::/114 0 UDP,\
-f00d::1/15 80 cafe::/113 0 UDP,\
-f00d::1/16 80 cafe::/112 0 UDP,\
-f00d::1/17 80 cafe::/111 0 UDP,\
-f00d::1/18 80 cafe::/110 0 UDP,\
-f00d::1/19 80 cafe::/109 0 UDP,\
-f00d::1/20 80 cafe::/108 0 UDP,\
-f00d::1/21 80 cafe::/107 0 UDP,\
-f00d::1/22 80 cafe::/106 0 UDP,\
-f00d::1/23 80 cafe::/105 0 UDP,\
-f00d::1/24 80 cafe::/104 0 UDP,\
-f00d::1/25 80 cafe::/103 0 UDP,\
-f00d::1/26 80 cafe::/102 0 UDP,\
-f00d::1/27 80 cafe::/101 0 UDP,\
-f00d::1/28 80 cafe::/100 0 UDP,\
-f00d::1/29 80 cafe::/99 0 UDP,\
-f00d::1/30 80 cafe::/98 0 UDP,\
-f00d::1/31 80 cafe::/97 0 UDP,\
-f00d::1/32 80 cafe::/96 0 UDP,\
-f00d::1/32 80 cafe::/0 0 UDP"
+        --filters="$(printf '%s,' "${RECORDER_FILTERS_IPV6[@]}" | sed 's/,*$//')"
 
-${CILIUM_EXEC} cilium-dbg recorder list
-${CILIUM_EXEC} cilium-dbg bpf recorder list
+trace_exec ${CILIUM_EXEC} cilium-dbg recorder list
+trace_exec ${CILIUM_EXEC} cilium-dbg bpf recorder list
 ${CILIUM_EXEC} cilium-dbg recorder delete 1
 ${CILIUM_EXEC} cilium-dbg recorder delete 2
-${CILIUM_EXEC} cilium-dbg recorder list
+trace_exec ${CILIUM_EXEC} cilium-dbg recorder list
 
 echo "YAY!"

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -9,7 +9,7 @@ CILIUM_EXEC="docker exec -t lb-node docker exec -t cilium-lb"
 
 CFG_COMMON=("--enable-ipv4=true" "--enable-ipv6=true" "--devices=eth0" \
             "--datapath-mode=lb-only" "--bpf-lb-dsr-dispatch=ipip" \
-            "--bpf-lb-mode=snat")
+            "--bpf-lb-mode=snat" "--enable-nat46x64-gateway=true")
 
 function cilium_install {
     docker exec -t lb-node docker rm -f cilium-lb || true
@@ -190,8 +190,7 @@ done
 # Install Cilium as standalone L4LB: tc/Maglev/SNAT/GW
 cilium_install \
     --bpf-lb-algorithm=maglev \
-    --bpf-lb-acceleration=disabled \
-    --enable-nat46x64-gateway=true
+    --bpf-lb-acceleration=disabled
 
 # Issue 10 requests to LB1
 for i in $(seq 1 10); do
@@ -292,8 +291,7 @@ done
 # Install Cilium as standalone L4LB: tc/Maglev/SNAT/GW
 cilium_install \
     --bpf-lb-algorithm=maglev \
-    --bpf-lb-acceleration=disabled \
-    --enable-nat46x64-gateway=true
+    --bpf-lb-acceleration=disabled
 
 # Issue 10 requests to LB1
 for i in $(seq 1 10); do
@@ -314,14 +312,12 @@ ${CILIUM_EXEC} cilium-dbg service delete 2
 # Install Cilium as standalone L4LB & NAT46/64 GW: tc
 cilium_install \
     --bpf-lb-algorithm=maglev \
-    --bpf-lb-acceleration=disabled \
-    --enable-nat46x64-gateway=true
+    --bpf-lb-acceleration=disabled
 
 # Install Cilium as standalone L4LB & NAT46/64 GW: XDP
 cilium_install \
     --bpf-lb-algorithm=maglev \
-    --bpf-lb-acceleration=native \
-    --enable-nat46x64-gateway=true
+    --bpf-lb-acceleration=native
 
 # Install Cilium as standalone L4LB & NAT46/64 GW: restore
 cilium_install \

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -306,24 +306,6 @@ done
 ${CILIUM_EXEC} cilium-dbg service delete 1
 ${CILIUM_EXEC} cilium-dbg service delete 2
 
-# Misc compilation tests
-########################
-
-# Install Cilium as standalone L4LB & NAT46/64 GW: tc
-cilium_install \
-    --bpf-lb-algorithm=maglev \
-    --bpf-lb-acceleration=disabled
-
-# Install Cilium as standalone L4LB & NAT46/64 GW: XDP
-cilium_install \
-    --bpf-lb-algorithm=maglev \
-    --bpf-lb-acceleration=native
-
-# Install Cilium as standalone L4LB & NAT46/64 GW: restore
-cilium_install \
-    --bpf-lb-algorithm=maglev \
-    --bpf-lb-acceleration=disabled
-
 # NAT test suite & PCAP recorder
 ################################
 


### PR DESCRIPTION
Requires https://github.com/cilium/cilium/pull/32070 to test.

Review commit-by-commit to reason through the changes over the course of the PR.

Previously, these tests would emit very verbose output which was hard to
interpret when it failed, for instance a test may fail and this is the output:

```
++[01:02:57] docker exec -t lb-node ip -o -4 a s eth0
++[01:02:57] awk '{print $4}'
++[01:02:57] head -n1
++[01:02:57] cut -d/ -f1
+[01:02:57] LB_NODE_IP=172.12.42.2
+[01:02:57] ip r a 10.0.0.8/32 via 172.12.42.2
++[01:02:57] seq 1 10
+[01:02:57] for i in $(seq 1 10)
+[01:02:57] curl -s -o /dev/null '[fd00:cafe::1]:80'
+[01:02:57] for i in $(seq 1 10)
+[01:02:57] curl -s -o /dev/null '[fd00:cafe::1]:80'
+[01:02:57] for i in $(seq 1 10)
+[01:02:57] curl -s -o /dev/null '[fd00:cafe::1]:80'
+[01:02:57] for i in $(seq 1 10)
+[01:02:57] curl -s -o /dev/null '[fd00:cafe::1]:80'
+[01:02:57] for i in $(seq 1 10)
+[01:02:57] curl -s -o /dev/null '[fd00:cafe::1]:80'
+[01:02:57] for i in $(seq 1 10)
+[01:02:57] curl -s -o /dev/null '[fd00:cafe::1]:80'
+[01:02:57] for i in $(seq 1 10)
+[01:02:57] curl -s -o /dev/null '[fd00:cafe::1]:80'
+[01:02:57] for i in $(seq 1 10)
+[01:02:57] curl -s -o /dev/null '[fd00:cafe::1]:80'
+[01:02:57] for i in $(seq 1 10)
+[01:02:57] curl -s -o /dev/null '[fd00:cafe::1]:80'
+[01:02:57] for i in $(seq 1 10)
+[01:02:57] curl -s -o /dev/null '[fd00:cafe::1]:80'
++[01:02:57] seq 1 10
+[01:02:57] for i in $(seq 1 10)
+[01:02:57] curl -s -o /dev/null 10.0.0.8:80
+[01:02:57] echo 'Failed 1'
Failed 1
+[01:02:57] exit -1
Error: Process completed with exit code 255.
```

If you understand what the test is trying to do and where in the test that
these commands were run, then you might be able to debug it. But for most
mortals, this output was not very easy to understand.

With this PR, the tests are reworked to only print verbose output when the
environment variable `V=1` is set, and by default it prints a much terser
set of output, such as:

```
[./test/nat46x64/test.sh:228]     Installing Cilium with Mode:TC  Algorithm:Maglev        Recorder:Disabled
cilium-lb
9c536a08a4bdb8751cdc2337503c5864e1fd1984619635b466cf4352d99d71b2
cilium: daemon unreachable
cilium: daemon unreachable
OK
[./test/nat46x64/test.sh:229]     Testing service [fd00:cafe::1]:80 -> 172.12.42.3:80 via TC + Maglev
[./test/nat46x64/test.sh:233]     Installing Cilium with Mode:TC  Algorithm:Random        Recorder:Disabled
cilium-lb
894298c1821b2b536f6744c78aa886bc8f3ab7f4a291b82d9ccb6677d253f26b
cilium: daemon unreachable
cilium: daemon unreachable
OK
[./test/nat46x64/test.sh:234]     Testing service [fd00:cafe::1]:80 -> 172.12.42.3:80 via TC + Random
[./test/nat46x64/test.sh:238]     Configuring service 10.0.0.8:80 -> 172.12.42.3:80
Deprecation warning: --id parameter will change from int to string in v1.14
Creating new service with id '2'
Added service with 1 backends
[./test/nat46x64/test.sh:244]     Installing route: 'ip -4 r a 10.0.0.8/32 via 172.12.42.2'
[./test/nat46x64/test.sh:246]     Checking connectivity via [fd00:cafe::1]:80 -> 172.12.42.3:80
[./test/nat46x64/test.sh:249]     Checking connectivity via 10.0.0.8:80 -> 172.12.42.3:80
[./test/nat46x64/test.sh:252]     Installing Cilium with Mode:TC  Algorithm:Maglev        Recorder:Disabled
cilium-lb
89f2ad155a0a5ae0922ba741baa8d6186d4f87ee4a3e019d5845a1847b6f5f1d
cilium: daemon unreachable
cilium: daemon unreachable
OK
[./test/nat46x64/test.sh:253]     Testing service [fd00:cafe::1]:80 -> 172.12.42.3:80 via TC + Maglev
Deprecation warning: --id parameter will change from int to string in v1.14
Service 1 deleted successfully
Deprecation warning: --id parameter will change from int to string in v1.14
Service 2 deleted successfully
```

Or, on failure:

```
$ sudo ./test/nat46x64/test.sh
[./test/nat46x64/test.sh:197]     Installing Cilium with Mode:TC  Algorithm:Maglev        Recorder:Disabled
cilium-lb
ccb3d8f50c6d15a016035eb81c12e62efa04ef79cad62a00a1c1b9bd529ca58c
cilium: daemon unreachable
OK
[./test/nat46x64/test.sh:199]     Configuring service 10.0.0.4:80 -> [2001:db8:1::3]:80
Deprecation warning: --id parameter will change from int to string in v1.14
Creating new service with id '1'
Added service with 1 backends
[./test/nat46x64/test.sh:209]     Testing service 10.0.0.4:80 -> [2001:db8:1::3]:80 via TC + Maglev
[./test/nat46x64/test.sh:210]     Installing route: 'ip -4 r a 10.0.0.4/32 via 172.12.42.2'
[./test/nat46x64/test.sh:211]     Failed connection from localhost to 10.0.0.4:80 (attempt 5/10)
```

The annotated lines in the square brackets also provide a test file and line number where the failure occurred to make it easier to track down the failure and attempt to reproduce.
