### PR TITLE
enable kube cache mutation detector

### DIFF
--- a/.github/actions/helm-default/ci-required-values.yaml
+++ b/.github/actions/helm-default/ci-required-values.yaml
@@ -1,0 +1,3 @@
+extraEnv:
+  - name: "KUBE_CACHE_MUTATION_DETECTOR"
+    value: "true"


### PR DESCRIPTION
  This file was accidentally removed while refactoring the commits before
  merging the PR.

Fixes: 8021e953e630 (".github/actions: enable k8s cache mutation detector in the CI")