### PR TITLE
ariane: Fix detection of changes to nat46x64 tests

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -113,7 +113,7 @@ workflows:
   tests-datapath-verifier.yaml:
     paths-regex: (bpf|test/verifier|vendor|images)/
   tests-l4lb.yaml:
-    paths-regex: (bpf|daemon|images|pkg|test/l4lb|vendor)/
+    paths-regex: (bpf|daemon|images|pkg|test/l4lb|test/nat46x64|vendor)/
   tests-e2e-upgrade.yaml:
     paths-ignore-regex: (test|Documentation)/
   tests-ipsec-upgrade.yaml:


### PR DESCRIPTION
`nat46x64` tests are included in the `tests-l4lb.yaml`, so that workflow needs to run when those files are changed.