### PR TITLE
ci-l4lb: Remove unnecessary untrusted checkout

### DIFF
--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -116,15 +116,6 @@ jobs:
           release-version: ${{ env.CILIUM_CLI_VERSION }}
           ci-version: ${{ env.cilium_cli_ci_version }}
 
-      # Warning: since this is a privileged workflow, subsequent workflow job
-      # steps must take care not to execute untrusted code.
-      - name: Checkout pull request branch (NOT TRUSTED)
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          ref: ${{ steps.vars.outputs.sha }}
-          persist-credentials: false
-          path: pull-request
-
       - name: Wait for image to be available
         timeout-minutes: 10
         shell: bash


### PR DESCRIPTION
We should be running the test code from a trusted branch which was
already checked out earlier, then we pass in the sha of the image
compiled from CI into the script so it can run the docker image in the
test environment. Since the pull request was checked out to another
branch that wasn't being used, it should be fine to just drop that step.
