### PR TITLE
LRP: Terminate connections to deleted LRP backends

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1559,11 +1559,7 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, isExtLocal, isIntLocal b
 				Debug("Removing obsolete backend")
 		}
 		s.lbmap.DeleteBackendByID(id)
-		// With socket-lb, existing client applications can continue to connect to
-		// deleted backends. Destroy any client sockets connected to the backend.
-		if option.Config.EnableSocketLB || option.Config.BPFSocketLBHostnsOnly {
-			s.destroyConnectionsToBackend(be)
-		}
+		s.TerminateUDPConnectionsToBackend(&be.L3n4Addr)
 	}
 
 	return nil

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -74,4 +74,8 @@ type ServiceManager interface {
 
 	// UpsertService inserts or updates the given service.
 	UpsertService(*lb.SVC) (bool, lb.ID, error)
+
+	// TerminateUDPConnectionsToBackend terminates UDP connections to the passed
+	// backend with address when socket-LB is enabled.
+	TerminateUDPConnectionsToBackend(l3n4Addr *lb.L3n4Addr)
 }

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
+var _ ServiceManager = &Service{}
+
 // ServiceManager provides an interface for service related operations.
 // It is implemented by service handler which main responsibility is to reflect
 // service-related changes into BPF maps used by datapath BPF programs.


### PR DESCRIPTION
When socket-lb is enabled, client applications can continue
to connect to deleted LRP backends. Handle these connections
so that applications can connect to active LRP backends.

Fixes: https://github.com/cilium/cilium/issues/31012

Reported-by: Andrey Pavlov <andrey.pavlov@flant.com>
Tested-by: Andrey Pavlov <andrey.pavlov@flant.com>
Signed-off-by: Aditi Ghag <aditi@cilium.io>

```release-note
Forcefully terminate stale sockets in the host netns connected to deleted LRP backends when socket-lb is enabled, and allow applications to re-connect to active LRP backends.
```
