### PR TITLE
egressgw: minor bpf refactors

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1170,13 +1170,9 @@ ct_recreate4:
 			goto skip_egress_gateway;
 
 		/* Send the packet to egress gateway node through a tunnel. */
-		ret = __encap_and_redirect_lxc(ctx, gateway_ip, 0,
-					       SECLABEL_IPV4,
-					       *dst_sec_identity, &trace);
-		if (ret == CTX_ACT_OK)
-			goto encrypt_to_stack;
-
-		return ret;
+		return __encap_and_redirect_lxc(ctx, gateway_ip, 0,
+						SECLABEL_IPV4,
+						*dst_sec_identity, &trace);
 	}
 skip_egress_gateway:
 #endif
@@ -1321,7 +1317,7 @@ pass_to_stack:
 #endif
 	}
 
-#if defined(TUNNEL_MODE) || defined(ENABLE_EGRESS_GATEWAY_COMMON) || defined(ENABLE_HIGH_SCALE_IPCACHE)
+#if defined(TUNNEL_MODE) || defined(ENABLE_HIGH_SCALE_IPCACHE)
 encrypt_to_stack:
 #endif
 	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL_IPV4, *dst_sec_identity, 0, 0,

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -69,52 +69,30 @@ struct egress_gw_policy_entry *lookup_ip4_egress_gw_policy(__be32 saddr, __be32 
 }
 #endif /* ENABLE_EGRESS_GATEWAY */
 
-static __always_inline
-bool egress_gw_request_needs_redirect(struct ipv4_ct_tuple *rtuple __maybe_unused,
-				      enum ct_status ct_status __maybe_unused,
-				      __u32 *tunnel_endpoint __maybe_unused)
+static __always_inline int
+egress_gw_request_needs_redirect(struct ipv4_ct_tuple *rtuple __maybe_unused,
+				 __be32 *gateway_ip __maybe_unused)
 {
 #if defined(ENABLE_EGRESS_GATEWAY)
 	struct egress_gw_policy_entry *egress_gw_policy;
-	struct endpoint_info *gateway_node_ep;
-
-	/* If the packet is a reply or is related, it means that outside
-	* has initiated the connection, and so we should skip egress
-	* gateway, since an egress policy is only matching connections
-	* originating from a pod.
-	*/
-	if (ct_status == CT_REPLY || ct_status == CT_RELATED)
-		return false;
 
 	egress_gw_policy = lookup_ip4_egress_gw_policy(ipv4_ct_reverse_tuple_saddr(rtuple),
 						       ipv4_ct_reverse_tuple_daddr(rtuple));
 	if (!egress_gw_policy)
-		return false;
+		return CTX_ACT_OK;
 
 	switch (egress_gw_policy->gateway_ip) {
 	case EGRESS_GATEWAY_NO_GATEWAY:
-		/* If no gateway is found we return that the connection is
-		 * "redirected" and the caller will handle this special case
-		 * and drop the traffic.
-		 */
-		*tunnel_endpoint = EGRESS_GATEWAY_NO_GATEWAY;
-		return true;
+		/* If no gateway is found, drop the packet. */
+		return DROP_NO_EGRESS_GATEWAY;
 	case EGRESS_GATEWAY_EXCLUDED_CIDR:
-		return false;
+		return CTX_ACT_OK;
 	}
 
-	/* If the gateway node is the local node, then just let the
-	 * packet go through, as it will be SNATed later on by
-	 * handle_nat_fwd().
-	 */
-	gateway_node_ep = __lookup_ip4_endpoint(egress_gw_policy->gateway_ip);
-	if (gateway_node_ep && (gateway_node_ep->flags & ENDPOINT_F_HOST))
-		return false;
-
-	*tunnel_endpoint = egress_gw_policy->gateway_ip;
-	return true;
+	*gateway_ip = egress_gw_policy->gateway_ip;
+	return CTX_ACT_REDIRECT;
 #else
-	return false;
+	return CTX_ACT_OK;
 #endif /* ENABLE_EGRESS_GATEWAY */
 }
 
@@ -162,12 +140,30 @@ bool egress_gw_reply_matches_policy(struct iphdr *ip4 __maybe_unused)
 #endif /* ENABLE_EGRESS_GATEWAY */
 }
 
-static __always_inline
-bool egress_gw_request_needs_redirect_hook(struct ipv4_ct_tuple *rtuple,
-					   enum ct_status ct_status,
-					   __u32 *tunnel_endpoint)
+/** Match a packet against EGW policy map, and return the gateway's IP.
+ * @arg rtuple		CT tuple for the packet
+ * @arg ct_status	CT result, to identify egressing connections
+ * @arg gateway_ip	returns the gateway node's IP
+ *
+ * Returns
+ * * CTX_ACT_REDIRECT if a matching policy entry was found,
+ * * CTX_ACT_OK if no EGW logic should be applied,
+ * * DROP_* for error conditions.
+ */
+static __always_inline int
+egress_gw_request_needs_redirect_hook(struct ipv4_ct_tuple *rtuple,
+				      enum ct_status ct_status,
+				      __be32 *gateway_ip)
 {
-	return egress_gw_request_needs_redirect(rtuple, ct_status, tunnel_endpoint);
+	/* If the packet is a reply or is related, it means that outside
+	 * has initiated the connection, and so we should skip egress
+	 * gateway, since an egress policy is only matching connections
+	 * originating from a pod.
+	 */
+	if (ct_status == CT_REPLY || ct_status == CT_RELATED)
+		return CTX_ACT_OK;
+
+	return egress_gw_request_needs_redirect(rtuple, gateway_ip);
 }
 
 static __always_inline


### PR DESCRIPTION
This slightly refactors some of the EGW bpf code, so that we have low-level EGW helpers that are only concerned about the map lookup & interpreting the result. High-level logic (ie. EGW only handles outbound connections) gets applied independently of what the policy mechanism looks like, and error propagation is more straight-forward.