### PR TITLE
ipam: retry netlink.LinkList call when setting up ENI devices

### DIFF
--- a/pkg/ipam/crd_eni.go
+++ b/pkg/ipam/crd_eni.go
@@ -136,19 +136,19 @@ func waitForNetlinkDevices(configByMac configMap) (linkByMac linkMap, err error)
 	for try := 0; try < waitForNetlinkDevicesMaxTries; try++ {
 		links, err := netlink.LinkList()
 		if err != nil {
-			return nil, fmt.Errorf("failed to obtain eni link list: %w", err)
-		}
-
-		linkByMac = linkMap{}
-		for _, link := range links {
-			mac := link.Attrs().HardwareAddr.String()
-			if _, ok := configByMac[mac]; ok {
-				linkByMac[mac] = link
+			log.WithError(err).Error("failed to obtain eni link list")
+		} else {
+			linkByMac = linkMap{}
+			for _, link := range links {
+				mac := link.Attrs().HardwareAddr.String()
+				if _, ok := configByMac[mac]; ok {
+					linkByMac[mac] = link
+				}
 			}
-		}
 
-		if len(linkByMac) == len(configByMac) {
-			return linkByMac, nil
+			if len(linkByMac) == len(configByMac) {
+				return linkByMac, nil
+			}
 		}
 
 		sleep := backoff.CalculateDuration(


### PR DESCRIPTION
LinkList is prone to interrupts which are surfaced by the netlink library.  This leads to stability issues when using the ENI datapath.  This change makes it part of the retry loop in waitForNetlinkDevices.

Fixes: #31974

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!



