### PR TITLE
egressgw: remove deprecated install-egress-gateway-routes option

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -936,10 +936,6 @@
      - Enables egress gateway to redirect and SNAT the traffic that leaves the cluster.
      - bool
      - ``false``
-   * - :spelling:ignore:`egressGateway.installRoutes`
-     - Deprecated without a replacement necessary.
-     - bool
-     - ``false``
    * - :spelling:ignore:`egressGateway.reconciliationTriggerInterval`
      - Time between triggers of egress gateway state reconciliations
      - string

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -330,6 +330,7 @@ Removed Options
   now always happens asynchronously, therefore making this timeout obsolete.
 * The deprecated flag ``enable-remote-node-identity`` has been removed.
   More information can be found in the following Helm upgrade notes.
+* The deprecated flag ``install-egress-gateway-routes`` has been removed.
 
 Helm Options
 ~~~~~~~~~~~~

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -284,7 +284,6 @@ contributors across the globe, there is almost always someone available to help.
 | dnsProxy.proxyPort | int | `0` | Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port. |
 | dnsProxy.proxyResponseMaxDelay | string | `"100ms"` | The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. |
 | egressGateway.enabled | bool | `false` | Enables egress gateway to redirect and SNAT the traffic that leaves the cluster. |
-| egressGateway.installRoutes | bool | `false` | Deprecated without a replacement necessary. |
 | egressGateway.reconciliationTriggerInterval | string | `"1s"` | Time between triggers of egress gateway state reconciliations |
 | enableCiliumEndpointSlice | bool | `false` | Enable CiliumEndpointSlice feature. |
 | enableCriticalPriorityClass | bool | `true` | Explicitly enable or disable priority class. .Capabilities.KubeVersion is unsettable in `helm template` calls, it depends on k8s libraries version that Helm was compiled against. This option allows to explicitly disable setting the priority class, which is useful for rendering charts for gke clusters in advance. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1031,9 +1031,6 @@ data:
 {{- if .Values.egressGateway.enabled }}
   enable-ipv4-egress-gateway: "true"
 {{- end }}
-{{- if .Values.egressGateway.installRoutes }}
-  install-egress-gateway-routes: "true"
-{{- end }}
 {{- if hasKey .Values.egressGateway "reconciliationTriggerInterval" }}
   egress-gateway-reconciliation-trigger-interval: {{ .Values.egressGateway.reconciliationTriggerInterval | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1466,9 +1466,6 @@
         "enabled": {
           "type": "boolean"
         },
-        "installRoutes": {
-          "type": "boolean"
-        },
         "reconciliationTriggerInterval": {
           "type": "string"
         }

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1808,8 +1808,6 @@ egressGateway:
   # -- Enables egress gateway to redirect and SNAT the traffic that leaves the
   # cluster.
   enabled: false
-  # -- Deprecated without a replacement necessary.
-  installRoutes: false
   # -- Time between triggers of egress gateway state reconciliations
   reconciliationTriggerInterval: 1s
   # -- Maximum number of entries in egress gateway policy map

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1809,8 +1809,6 @@ egressGateway:
   # -- Enables egress gateway to redirect and SNAT the traffic that leaves the
   # cluster.
   enabled: false
-  # -- Deprecated without a replacement necessary.
-  installRoutes: false
   # -- Time between triggers of egress gateway state reconciliations
   reconciliationTriggerInterval: 1s
   # -- Maximum number of entries in egress gateway policy map

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -68,23 +68,16 @@ const (
 )
 
 type Config struct {
-	// Install egress gateway IP rules and routes in order to properly steer
-	// egress gateway traffic to the correct ENI interface
-	InstallEgressGatewayRoutes bool
-
 	// Default amount of time between triggers of egress gateway state
 	// reconciliations are invoked
 	EgressGatewayReconciliationTriggerInterval time.Duration
 }
 
 var defaultConfig = Config{
-	InstallEgressGatewayRoutes:                 false,
 	EgressGatewayReconciliationTriggerInterval: 1 * time.Second,
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {
-	flags.Bool("install-egress-gateway-routes", def.InstallEgressGatewayRoutes, "Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface")
-	flags.MarkDeprecated("install-egress-gateway-routes", "This option is deprecated, has no effect, and will be removed in v1.16")
 	flags.Duration("egress-gateway-reconciliation-trigger-interval", def.EgressGatewayReconciliationTriggerInterval, "Time between triggers of egress gateway state reconciliations")
 }
 

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -124,7 +124,7 @@ func (k *EgressGatewayTestSuite) SetUpTest(c *C) {
 	var err error
 	k.manager, err = newEgressGatewayManager(Params{
 		Lifecycle:         lc,
-		Config:            Config{true, 1 * time.Millisecond},
+		Config:            Config{1 * time.Millisecond},
 		DaemonConfig:      &option.DaemonConfig{},
 		IdentityAllocator: identityAllocator,
 		PolicyMap:         policyMap,


### PR DESCRIPTION
This option is deprecated and scheduled for removal with v1.16. Make it happen.