### PR TITLE
Remove v1.12 from Container Vulnerability Scan

### DIFF
--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -22,7 +22,7 @@ jobs:
           {name: hubble-relay, dockerfile: ./images/hubble-relay/Dockerfile},
           {name: operator-generic, dockerfile: ./images/operator/Dockerfile},
         ]
-        branch: [v1.12, v1.13, v1.14, v1.15]
+        branch: [v1.13, v1.14, v1.15]
         include:
           - image: {name: kvstoremesh, dockerfile: ./images/kvstoremesh/Dockerfile}
             branch: v1.14


### PR DESCRIPTION
1.12 is EOL and Container Vulnerability Scan keeps failing:
https://github.com/cilium/cilium/actions/runs/8778305868/job/24084556188
https://github.com/cilium/cilium/actions/runs/8778305868/job/24084557591