### PR TITLE
bpf: nodeport: fix double-SNAT for LB'ed requests in from-overlay

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1202,8 +1202,7 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 	if (IS_ERR(ret))
 		goto drop_err;
 
-	if (is_defined(IS_BPF_HOST))
-		ctx_snat_done_set(ctx);
+	ctx_snat_done_set(ctx);
 
 #ifdef TUNNEL_MODE
 	if (tunnel_endpoint) {
@@ -2740,8 +2739,10 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 	if (IS_ERR(ret))
 		goto drop_err;
 
-	if (is_defined(IS_BPF_HOST))
-		ctx_snat_done_set(ctx);
+	/* This is also needed for from-overlay, to avoid a second SNAT by
+	 * to-overlay or to-netdev.
+	 */
+	ctx_snat_done_set(ctx);
 
 #ifdef TUNNEL_MODE
 	if (tunnel_endpoint) {


### PR DESCRIPTION
The blamed commit attempted to remove all usage of MARK_MAGIC_SNAT_DONE inside to-overlay, so that we can use MARK_MAGIC_OVERLAY instead.

But it accidentally also touched the LB's NAT-egress path (which is used by from-overlay to forward LB'ed requests to the egress path, on their way to a remote backend). Here we need to maintain the usage of MARK_MAGIC_SNAT_DONE, so that the egress program (either to-overlay or to-netdev) doesn't apply a second SNAT operation. Otherwise the LB node is unable to properly RevNAT the reply traffic.

Fix this by restoring the code that sets the MARK_MAGIC_SNAT_DONE flag for traffic in from-overlay. When such a request is forwarded to the overlay interface, then to-overlay will consume the mark, override it with MARK_MAGIC_OVERLAY and skip the additional SNAT step.

Fixes: 5b37dc9d6a4f ("bpf: nodeport: avoid setting SNAT-done mark for to-overlay")
Reported-by: Marco Iorio <marco.iorio@isovalent.com>

```release-note
Fix failing service connections, when the service requests are transported via cilium's overlay network.
```
