### PR TITLE
Add missing kvstore-max-consecutive-quorum-errors option to clustermesh-apiserver/kvstoremesh binaries

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -267,7 +267,7 @@ cilium-agent [flags]
       --kube-proxy-replacement-healthz-bind-address string        The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.
       --kvstore string                                            Key-value store type
       --kvstore-connectivity-timeout duration                     Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
-      --kvstore-max-consecutive-quorum-errors int                 Max acceptable kvstore consecutive quorum errors before the agent assumes permanent failure (default 2)
+      --kvstore-max-consecutive-quorum-errors uint                Max acceptable kvstore consecutive quorum errors before the agent assumes permanent failure (default 2)
       --kvstore-opt map                                           Key-value store options e.g. etcd.address=127.0.0.1:4001
       --kvstore-periodic-sync duration                            Periodic KVstore synchronization interval (default 5m0s)
       --l2-announcements-lease-duration duration                  Duration of inactivity after which a new leader is selected (default 15s)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -472,7 +472,7 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.KVstoreLeaseTTL)
 	option.BindEnv(vp, option.KVstoreLeaseTTL)
 
-	flags.Int(option.KVstoreMaxConsecutiveQuorumErrorsName, defaults.KVstoreMaxConsecutiveQuorumErrors, "Max acceptable kvstore consecutive quorum errors before the agent assumes permanent failure")
+	flags.Uint(option.KVstoreMaxConsecutiveQuorumErrorsName, defaults.KVstoreMaxConsecutiveQuorumErrors, "Max acceptable kvstore consecutive quorum errors before the agent assumes permanent failure")
 	option.BindEnv(vp, option.KVstoreMaxConsecutiveQuorumErrorsName)
 
 	flags.Duration(option.KVstorePeriodicSync, defaults.KVstorePeriodicSync, "Periodic KVstore synchronization interval")

--- a/pkg/kvstore/cell.go
+++ b/pkg/kvstore/cell.go
@@ -30,10 +30,11 @@ var Cell = func(defaultBackend string) cell.Cell {
 		"KVStore Client",
 
 		cell.Config(config{
-			KVStore:                    defaultBackend,
-			KVStoreConnectivityTimeout: defaults.KVstoreConnectivityTimeout,
-			KVStoreLeaseTTL:            defaults.KVstoreLeaseTTL,
-			KVStorePeriodicSync:        defaults.KVstorePeriodicSync,
+			KVStore:                           defaultBackend,
+			KVStoreConnectivityTimeout:        defaults.KVstoreConnectivityTimeout,
+			KVStoreLeaseTTL:                   defaults.KVstoreLeaseTTL,
+			KVStorePeriodicSync:               defaults.KVstorePeriodicSync,
+			KVstoreMaxConsecutiveQuorumErrors: defaults.KVstoreMaxConsecutiveQuorumErrors,
 		}),
 
 		cell.Provide(func(lc cell.Lifecycle, shutdowner hive.Shutdowner, cfg config, opts *ExtraOptions) promise.Promise[BackendOperations] {
@@ -50,6 +51,7 @@ var Cell = func(defaultBackend string) cell.Cell {
 			option.Config.KVstoreConnectivityTimeout = cfg.KVStoreConnectivityTimeout
 			option.Config.KVstoreLeaseTTL = cfg.KVStoreLeaseTTL
 			option.Config.KVstorePeriodicSync = cfg.KVStorePeriodicSync
+			option.Config.KVstoreMaxConsecutiveQuorumErrors = cfg.KVstoreMaxConsecutiveQuorumErrors
 
 			ctx, cancel := context.WithCancel(context.Background())
 			var wg sync.WaitGroup
@@ -94,11 +96,12 @@ var Cell = func(defaultBackend string) cell.Cell {
 }
 
 type config struct {
-	KVStore                    string
-	KVStoreOpt                 map[string]string
-	KVStoreConnectivityTimeout time.Duration
-	KVStoreLeaseTTL            time.Duration
-	KVStorePeriodicSync        time.Duration
+	KVStore                           string
+	KVStoreOpt                        map[string]string
+	KVStoreConnectivityTimeout        time.Duration
+	KVStoreLeaseTTL                   time.Duration
+	KVStorePeriodicSync               time.Duration
+	KVstoreMaxConsecutiveQuorumErrors uint
 }
 
 func (def config) Flags(flags *pflag.FlagSet) {
@@ -116,6 +119,9 @@ func (def config) Flags(flags *pflag.FlagSet) {
 
 	flags.Duration(option.KVstorePeriodicSync, def.KVStorePeriodicSync,
 		"Periodic KVstore synchronization interval")
+
+	flags.Uint(option.KVstoreMaxConsecutiveQuorumErrorsName, def.KVstoreMaxConsecutiveQuorumErrors,
+		"Max acceptable kvstore consecutive quorum errors before recreating the etcd connection")
 }
 
 // GlobalUserMgmtClientPromiseCell provides a promise returning the global kvstore client to perform users

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1025,7 +1025,7 @@ func (e *etcdClient) determineEndpointStatus(ctx context.Context, endpointAddres
 func (e *etcdClient) statusChecker() {
 	ctx := context.Background()
 
-	consecutiveQuorumErrors := 0
+	var consecutiveQuorumErrors uint
 
 	statusTimer, statusTimerDone := inctimer.New()
 	defer statusTimerDone()

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1778,7 +1778,7 @@ type DaemonConfig struct {
 
 	// KVstoreMaxConsecutiveQuorumErrors is the maximum number of acceptable
 	// kvstore consecutive quorum errors before the agent assumes permanent failure
-	KVstoreMaxConsecutiveQuorumErrors int
+	KVstoreMaxConsecutiveQuorumErrors uint
 
 	// KVstorePeriodicSync is the time interval in which periodic
 	// synchronization with the kvstore occurs
@@ -2958,7 +2958,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.KVstoreKeepAliveInterval = c.KVstoreLeaseTTL / defaults.KVstoreKeepAliveIntervalFactor
 	c.KVstorePeriodicSync = vp.GetDuration(KVstorePeriodicSync)
 	c.KVstoreConnectivityTimeout = vp.GetDuration(KVstoreConnectivityTimeout)
-	c.KVstoreMaxConsecutiveQuorumErrors = vp.GetInt(KVstoreMaxConsecutiveQuorumErrorsName)
+	c.KVstoreMaxConsecutiveQuorumErrors = vp.GetUint(KVstoreMaxConsecutiveQuorumErrorsName)
 	c.LabelPrefixFile = vp.GetString(LabelPrefixFile)
 	c.Labels = vp.GetStringSlice(Labels)
 	c.LibDir = vp.GetString(LibDir)


### PR DESCRIPTION
Extend the clustermesh-apiserver/kvstoremesh configurations by adding the previously missed kvstore-max-consecutive-quorum-errors option to match the one already provided by the Cilium agents, as well as configure the same default value. While being there, let's also convert the flag to be of Uint type, to reflect the fact that negative values are not expected to be provided.

Fixes: 2911b44ace7b ("kvstore: add a cell for the kvstore client")

<!-- Description of change -->

```release-note
Add missing kvstore-max-consecutive-quorum-errors option to clustermesh-apiserver/kvstoremesh binaries
```
