### PR TITLE
helm: no operator hostPorts when hostNetwork is disabled

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -173,7 +173,9 @@ spec:
         ports:
         - name: prometheus
           containerPort: {{ .Values.operator.prometheus.port }}
+        {{- if .Values.operator.hostNetwork }}
           hostPort: {{ .Values.operator.prometheus.port }}
+        {{- end }}
           protocol: TCP
         {{- end }}
         livenessProbe:


### PR DESCRIPTION
Fixes: fbe159f52ba6b3742db723f6350b45ef9a1659d6 ("helm: possibility to disable hostNetwork for operator")

My previous PR implementing configurable host network for operator missed `hostPort` parameter in `prometheus` port definition. Operator worked fine without this but cluster nodes we quickly depleted as, with this setting, just one operator pod per node is allowed. This PR omits `hostPort` parameter when host network is disabled.