### PR TITLE
endpoint: Skip build queue warning log is context is canceled

### DIFF
--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -4,6 +4,8 @@
 package endpoint
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -45,7 +47,9 @@ func (ev *EndpointRegenerationEvent) Handle(res chan interface{}) {
 	// being deleted at the same time. More info PR-1777.
 	doneFunc, err := e.owner.QueueEndpointBuild(regenContext.parentContext, uint64(e.ID))
 	if err != nil {
-		e.getLogger().WithError(err).Warning("unable to queue endpoint build")
+		if !errors.Is(err, context.Canceled) {
+			e.getLogger().WithError(err).Warning("unable to queue endpoint build")
+		}
 	} else if doneFunc != nil {
 		e.getLogger().Debug("Dequeued endpoint from build queue")
 


### PR DESCRIPTION
The warning log on failure to queue endpoint build is most likely not meaningful when the context is canceled, as this typically happends when the endpoint is deleted.

Skip the warning log if error is context.Canceled. This fixes CI flakes like this:

    Found 1 k8s-app=cilium logs matching list of errors that must be investigated:
    2024-04-22T07:48:47.779499679Z time="2024-04-22T07:48:47Z" level=warning msg="unable to queue endpoint build" ciliumEndpointName=kube-system/coredns-76f75df574-9k8sp containerID=3791acef13 containerInterface=eth0 datapathPolicyRevision=0 desiredPolicyRevision=0 endpointID=637 error="context canceled" identity=25283 ipv4=10.0.0.151 ipv6="fd02::82" k8sPodName=kube-system/coredns-76f75df574-9k8sp subsys=endpoint

Fixes: #31827
