### PR TITLE
Spread ariane-scheduled workflows over multiple hours

### DIFF
--- a/.github/workflows/ariane-scheduled.yaml
+++ b/.github/workflows/ariane-scheduled.yaml
@@ -1,9 +1,12 @@
 name: Ariane scheduled workflows
 
 on:
-  # Run every 6 hours
+  # Run every 1 hours
+  # Tests are only run when current hour % 6 corresponds
+  # to the branch hourModulo value in the matrix
   schedule:
-    - cron: '0 */6 * * *'
+    - cron: '0 */1 * * *'
+
 
 permissions:
   # To be able to access the repository with actions/checkout
@@ -17,10 +20,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch:
-          - "1.13"
-          - "1.14"
-          - "1.15"
+        include:
+        # DON'T USE hourModulo=0 to avoid running ariane scheduled-workflows
+        # at the same time as regular main scheduled workflows
+          - branch: '1.13'
+            hourModulo: 1
+          - branch: '1.14'
+            hourModulo: 2
+          - branch: '1.15'
+            hourModulo: 3
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
@@ -33,6 +41,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          HOUR=$(date -u +"%H")
+          if (( HOUR % 6 == ${{ matrix.hourModulo }} )); then
+            echo "Running scheduled workflows for branch ${{ matrix.branch }}"
+          else
+            echo "Skipping scheduled workflows for branch ${{ matrix.branch }}"
+            exit 0
+          fi
           BRANCH="${{ matrix.branch }}"
           REF="v${BRANCH}"
           SHA=$(git rev-parse ${REF})


### PR DESCRIPTION
Currently, we were triggering ariane-scheduled workflows all at the same time.
This causes few issues with cloud-providers:
- GKE - we were hitting quota issues: https://github.com/cilium/cilium/actions/runs/8746299915/job/24002950173
- AKS - we are hitting similar throttling on API in Azure, which is triggering https://github.com/cilium/cilium/issues/32038#issuecomment-2072248216
