### PR TITLE
egressgw: reject config with EnableIPv4Masquerade false

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -178,7 +178,7 @@ func NewEgressGatewayManager(p Params) (out struct {
 		return out, errors.New("egress gateway is not supported in combination with the CiliumEndpointSlice feature")
 	}
 
-	if !dcfg.MasqueradingEnabled() || !dcfg.EnableBPFMasquerade {
+	if !dcfg.EnableIPv4Masquerade || !dcfg.EnableBPFMasquerade {
 		return out, fmt.Errorf("egress gateway requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
 	}
 


### PR DESCRIPTION
Currently, the condition check in the egw cell code is not strict enough. EGW doesn't work with EnableIPv4Masquerade false, but it doesn't reject that config if EnableIPv6Masquerade is true.
This commit rejects that invalidated config.