### PR TITLE
daemon: Deprecate EnableRuntimeDeviceDetection

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -157,7 +157,6 @@ cilium-agent [flags]
       --enable-pmtu-discovery                                     Enable path MTU discovery to send ICMP fragmentation-needed replies to the client
       --enable-policy string                                      Enable policy enforcement (default "default")
       --enable-recorder                                           Enable BPF datapath pcap recorder
-      --enable-runtime-device-detection                           Enable runtime device detection and datapath reconfiguration (experimental)
       --enable-sctp                                               Enable SCTP support (beta)
       --enable-service-topology                                   Enable support for service topology aware hints
       --enable-session-affinity                                   Enable support for service session affinity

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -977,9 +977,9 @@
      - bool
      - ``false``
    * - :spelling:ignore:`enableRuntimeDeviceDetection`
-     - Enables experimental support for the detection of new and removed datapath devices. When devices change the eBPF datapath is reloaded and services updated. If "devices" is set then only those devices, or devices matching a wildcard will be considered.
+     - Enables experimental support for the detection of new and removed datapath devices. When devices change the eBPF datapath is reloaded and services updated. If "devices" is set then only those devices, or devices matching a wildcard will be considered.   This option has been deprecated and is a no-op.
      - bool
-     - ``false``
+     - ``true``
    * - :spelling:ignore:`enableXTSocketFallback`
      - Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: https://docs.cilium.io/en/stable/operations/system_requirements/#linux-kernel.
      - bool

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -329,6 +329,15 @@ Annotations:
   from policy-selected node-local backends destined to the policy's frontend, back to the
   node-local backends. To override this behavior, which is enabled by default, create
   local redirect policies with the ``skipRedirectFromBackend`` flag set to ``false``.
+* Detection and reconfiguration on changes to native network devices and their addresses is now
+  the default. Cilium will now load the native device BPF program onto devices that appear after
+  Cilium has started. NodePort services are now available on addresses assigned after Cilium has
+  started. The set of addresses to use for NodePort can be configured with the Helm option 
+  ``nodePort.addresses``.
+  The related Helm option ``enableRuntimeDeviceDetection`` has been deprecated and will be
+  removed in future release. The devices and the addresses Cilium considers the node's addresses
+  can be inspected with the ``cilium-dbg statedb devices`` and ``cilium-dbg statedb node-addresses``
+  commands.
 
 Removed Options
 ~~~~~~~~~~~~~~~
@@ -361,6 +370,9 @@ Helm Options
 * The clustermesh-apiserver ``podSecurityContext`` and ``securityContext`` settings now
   default to drop all capabilities and run as non-root user.
 * Deprecated Helm option ``containerRuntime.integration`` is removed. If you are using crio, please check :ref:`crio-instructions`.
+* Helm option ``enableRuntimeDeviceDetection`` is now deprecated and is a no-op.
+* The IP addresses on which to expose NodePort services can now be configured with ``nodePort.addresses``. Prior to this, Cilium only
+  exposed NodePort services on the first (preferably private) IPv4 and IPv6 address of each device.
 
 Added Metrics
 ~~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -229,8 +229,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(option.DirectRoutingDevice, "", "Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)")
 	option.BindEnv(vp, option.DirectRoutingDevice)
 
-	flags.Bool(option.EnableRuntimeDeviceDetection, false, "Enable runtime device detection and datapath reconfiguration (experimental)")
+	flags.Bool(option.EnableRuntimeDeviceDetection, true, "Enable runtime device detection and datapath reconfiguration (experimental)")
 	option.BindEnv(vp, option.EnableRuntimeDeviceDetection)
+	flags.MarkDeprecated(option.EnableRuntimeDeviceDetection, "Runtime device detection and datapath reconfiguration is now the default and only mode of operation")
 
 	flags.String(option.DatapathMode, defaults.DatapathMode, "Datapath mode name")
 	option.BindEnv(vp, option.DatapathMode)

--- a/daemon/cmd/device-reloader.go
+++ b/daemon/cmd/device-reloader.go
@@ -46,20 +46,11 @@ type deviceReloader struct {
 // changes have not yet propagated to the NodeAddress changes. Components which depend on both need
 // to live with this fact and come up with component-specific strategies to deal with it.
 func registerDeviceReloader(lc cell.Lifecycle, p deviceReloaderParams) {
-	if !p.Config.EnableRuntimeDeviceDetection {
-		return
-	}
-
 	lc.Append(&deviceReloader{params: p})
 }
 
 // Start listening to changed devices if requested.
 func (d *deviceReloader) Start(ctx cell.HookContext) error {
-	if !d.params.Config.AreDevicesRequired() {
-		log.Info("Runtime device detection requested, but no feature requires it. Disabling detection.")
-		return nil
-	}
-
 	// Force an initial reload by supplying a closed channel.
 	c := make(chan struct{})
 	close(c)

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -294,7 +294,7 @@ contributors across the globe, there is almost always someone available to help.
 | enableIPv6Masquerade | bool | `true` | Enables masquerading of IPv6 traffic leaving the node from endpoints. |
 | enableK8sTerminatingEndpoint | bool | `true` | Configure whether to enable auto detect of terminating state for endpoints in order to support graceful termination. |
 | enableMasqueradeRouteSource | bool | `false` | Enables masquerading to the source of the route for traffic leaving the node from endpoints. |
-| enableRuntimeDeviceDetection | bool | `false` | Enables experimental support for the detection of new and removed datapath devices. When devices change the eBPF datapath is reloaded and services updated. If "devices" is set then only those devices, or devices matching a wildcard will be considered. |
+| enableRuntimeDeviceDetection | bool | `true` | Enables experimental support for the detection of new and removed datapath devices. When devices change the eBPF datapath is reloaded and services updated. If "devices" is set then only those devices, or devices matching a wildcard will be considered.   This option has been deprecated and is a no-op. |
 | enableXTSocketFallback | bool | `true` | Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: https://docs.cilium.io/en/stable/operations/system_requirements/#linux-kernel. |
 | encryption.enabled | bool | `false` | Enable transparent network encryption. |
 | encryption.ipsec.encryptedOverlay | bool | `false` | Enable IPsec encrypted overlay |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -686,8 +686,10 @@ daemon:
 # -- Enables experimental support for the detection of new and removed datapath
 # devices. When devices change the eBPF datapath is reloaded and services updated.
 # If "devices" is set then only those devices, or devices matching a wildcard will
-# be considered.
-enableRuntimeDeviceDetection: false
+# be considered. 
+#
+# This option has been deprecated and is a no-op.
+enableRuntimeDeviceDetection: true
 # -- Chains to ignore when installing feeder rules.
 # disableIptablesFeederRules: ""
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -684,8 +684,11 @@ daemon:
 # -- Enables experimental support for the detection of new and removed datapath
 # devices. When devices change the eBPF datapath is reloaded and services updated.
 # If "devices" is set then only those devices, or devices matching a wildcard will
-# be considered.
-enableRuntimeDeviceDetection: false
+# be considered. 
+#
+# This option has been deprecated and is a no-op.
+enableRuntimeDeviceDetection: true
+
 # -- Chains to ignore when installing feeder rules.
 # disableIptablesFeederRules: ""
 

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -20,12 +20,9 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/inctimer"
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/time"
 )
 
 const qdiscClsact = "clsact"
@@ -378,88 +375,6 @@ func setupBaseDevice(sysctl sysctl.Sysctl, mtu int) (netlink.Link, netlink.Link,
 	}
 
 	return linkHost, linkNet, nil
-}
-
-// reloadIPSecOnLinkChanges subscribes to link changes to detect newly added devices
-// and reinitializes IPsec on changes. Only in effect for ENI mode in which we expect
-// new devices at runtime.
-func (l *loader) reloadIPSecOnLinkChanges() {
-	// settleDuration is the amount of time to wait for further link updates
-	// before proceeding with reinitialization. This avoids back-to-back
-	// reinitialization when multiple link changes are made at once.
-	const settleDuration = 1 * time.Second
-
-	if !option.Config.EnableIPSec || option.Config.IPAM != ipamOption.IPAMENI {
-		return
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	updates := make(chan netlink.LinkUpdate)
-
-	if err := netlink.LinkSubscribe(updates, ctx.Done()); err != nil {
-		log.WithError(err).Fatal("Failed to subscribe for link changes")
-	}
-
-	go func() {
-		defer cancel()
-
-		timer, stop := inctimer.New()
-		defer stop()
-
-		// If updates arrive during settle duration a single element
-		// is sent to this channel and we reinitialize right away
-		// without waiting for further updates.
-		trigger := make(chan struct{}, 1)
-
-		for {
-			// Wait for first update or trigger before reinitializing.
-		getUpdate:
-			select {
-			case u, ok := <-updates:
-				if !ok {
-					return
-				}
-				// Ignore veth devices
-				if u.Type() == "veth" {
-					goto getUpdate
-				}
-			case <-trigger:
-			}
-
-			log.Info("Reinitializing IPsec due to device changes")
-			err := l.reinitializeIPSec(ctx)
-			if err != nil {
-				// We may fail if links have been removed during the reload. In this case
-				// the updates channel will have queued updates which will retrigger the
-				// reinitialization.
-				log.WithError(err).Warn("Failed to reinitialize IPsec after device change")
-			}
-
-			// Avoid reinitializing repeatedly in short period of time
-			// by draining further updates for 'settleDuration'.
-			settled := timer.After(settleDuration)
-		settleLoop:
-			for {
-				select {
-				case <-settled:
-					break settleLoop
-				case u := <-updates:
-					// Ignore veth devices
-					if u.Type() == "veth" {
-						continue
-					}
-
-					// Trigger reinit immediately after
-					// settle duration has passed.
-					select {
-					case trigger <- struct{}{}:
-					default:
-					}
-				}
-
-			}
-		}
-	}()
 }
 
 // addHostDeviceAddr add internal ipv4 and ipv6 addresses to the cilium_host device.

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -731,8 +731,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				demoYAML = helpers.ManifestGet(kubectl.BasePath(), "demo_ds.yaml")
 
 				DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-					"enableRuntimeDeviceDetection": "true",
-					"devices":                      "",
+					"devices": "",
 				})
 
 				res := kubectl.ApplyDefault(demoYAML)


### PR DESCRIPTION
Mark the EnableRuntimeDeviceDetection flag deprecated and remove the check for it in device reloader to make runtime reconfiguration the default and only mode of operation.

```release-note
Runtime device detection and subsequent datapath reconfiguration is now the default and only mode of operation.
The enableRuntimeDeviceDetection option is now a no-op and will be removed in v1.17.
```
