### PR TITLE
bpf: lxc: don't take RevDNAT tailcall for service backend's ICMP messages

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -546,7 +546,7 @@ ct_recreate6:
 		} else
 # endif /* ENABLE_DSR */
 		/* See comment in handle_ipv4_from_lxc(). */
-		if (ct_state->node_port) {
+		if (ct_state->node_port && lb_is_svc_proto(tuple->nexthdr)) {
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV6,
 					  *dst_sec_identity, 0, 0,
 					  trace.reason, trace.monitor);
@@ -1009,8 +1009,11 @@ ct_recreate4:
 		/* This handles reply traffic for the case where the nodeport EP
 		 * is local to the node. We'll do the tail call to perform
 		 * the reverse DNAT.
+		 *
+		 * This codepath currently doesn't support revDNAT for ICMP,
+		 * so make sure that we only send TCP/UDP/SCTP down this way.
 		 */
-		if (ct_state->node_port) {
+		if (ct_state->node_port && lb_is_svc_proto(tuple->nexthdr)) {
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV4,
 					  *dst_sec_identity, 0, 0,
 					  trace.reason, trace.monitor);


### PR DESCRIPTION
When tail_nodeport_rev_dnat_ingress_ipv*() is called by from-container to apply RevDNAT for a local backend's reply traffic, it drops all unhandled packets. This would mostly be traffic where the pod-level CT entry was flagged as .node_port = 1, but there is no corresponding nodeport-level CT entry to provide a rev_nat_index for RevDNAT. Essentially an unexpected error situation.

But we didn't consider that from-container might also see ICMP error messages by a service backend, and the CT_RELATED entry for such traffic *also* has the .node_port flag set. As we don't have RevDNAT support for such traffic, there's no good reason to send it down the RevDNAT tailcall. Let it continue in the normal from-container flow instead. This avoids subsequent drops with DROP_NAT_NO_MAPPING.

Alternative solutions would be to tolerate ICMP traffic in tail_nodeport_rev_dnat_ingress_ipv*(), or not propagate the .node_port flag into CT_RELATED entries.

Fixes: 6936db59e3ee ("bpf: nodeport: drop reply by local backend if revDNAT is skipped")

```release-note
Avoids drops with "No mapping for NAT masquerade" for ICMP messages by local service backends.
```
