### PR TITLE
test: remove unused assertion helpers

### DIFF
--- a/test/k8s/assertion_helpers.go
+++ b/test/k8s/assertion_helpers.go
@@ -36,13 +36,6 @@ func ExpectCiliumReady(vm *helpers.Kubectl) {
 	ExpectWithOffset(1, err).Should(BeNil(), "cilium pre-flight checks failed")
 }
 
-func ExpectCiliumNotRunning(vm *helpers.Kubectl) {
-	err := vm.WaitTerminatingPodsInNsWithFilter(helpers.CiliumNamespace, "-l name=cilium-operator", helpers.HelperTimeout)
-	ExpectWithOffset(1, err).To(BeNil(), "terminating cilium-operator pod is not deleted after timeout")
-	err = vm.WaitTerminatingPodsInNsWithFilter(helpers.CiliumNamespace, "-l k8s-app=cilium", helpers.HelperTimeout)
-	ExpectWithOffset(1, err).To(BeNil(), "terminating cilium pods are not deleted after timeout")
-}
-
 // ExpectCiliumOperatorReady is a wrapper around helpers/WaitForPods. It asserts that
 // the error returned by that function is nil.
 func ExpectCiliumOperatorReady(vm *helpers.Kubectl) {

--- a/test/runtime/assertion_helpers.go
+++ b/test/runtime/assertion_helpers.go
@@ -20,15 +20,6 @@ func ExpectPolicyEnforcementUpdated(vm *helpers.SSHMeta, policyEnforcementType s
 	ExpectWithOffset(1, areEndpointsReady).Should(BeTrue(), "unable to set PolicyEnforcement=%s", policyEnforcementType)
 }
 
-// ExpectEndpointSummary asserts whether the amount of endpoints managed by
-// Cilium running on vm with PolicyEnforcement equal to policyEnforcementType
-// is equal to numWithPolicyEnforcementType.
-func ExpectEndpointSummary(vm *helpers.SSHMeta, policyEnforcementType string, numWithPolicyEnforcementType int) {
-	endpoints, err := vm.PolicyEndpointsSummary()
-	ExpectWithOffset(1, err).Should(BeNil(), "error getting endpoint summary")
-	ExpectWithOffset(1, endpoints[policyEnforcementType]).To(Equal(numWithPolicyEnforcementType), "number of endpoints with %s=%s does not match", helpers.PolicyEnforcement, policyEnforcementType)
-}
-
 // ExpectCiliumReady asserts that cilium status is ready
 func ExpectCiliumReady(vm *helpers.SSHMeta) {
 	err := vm.WaitUntilReady(helpers.CiliumStartTimeout)


### PR DESCRIPTION
ExpectEndpointSummary is unused since commit d0eff29b2534 ("test: remove RuntimePolicyEnforcement tests"). PolicyEndpointsSummary is only used by ExpectEndpointSummary and can thus be removed as well.

ExpectCiliumNotRunning is unused since commit 1827d2f12f7a ("ci: move 4.19 complexity tests to tests-datapath-verifier GHA workflow").
