### PR TITLE
Revert "Remove hostPort dependency on BPF NodePort"

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -456,6 +456,7 @@ func finishKubeProxyReplacementInit(sysctl sysctl.Sysctl, devices []*tables.Devi
 // the latter.
 func disableNodePort() {
 	option.Config.EnableNodePort = false
+	option.Config.EnableHostPort = false
 	option.Config.EnableExternalIPs = false
 	option.Config.EnableSVCSourceRangeCheck = false
 	option.Config.EnableHostLegacyRouting = true


### PR DESCRIPTION
Reverts cilium/cilium#32046

According to @borkmann, this PR is inaccurate.