### PR TITLE
ci: remove unsupported k8s version in GKE

### DIFF
--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,19 +1,16 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.25"
-    zone: us-west1-b
-    vmIndex: 1
   - version: "1.26"
     zone: us-west2-c
-    vmIndex: 2
+    vmIndex: 1
   - version: "1.27"
     zone: us-west3-a
-    vmIndex: 3
+    vmIndex: 2
     default: true
   - version: "1.28"
     zone: us-east4-b
-    vmIndex: 4
+    vmIndex: 3
   - version: "1.29"
     zone: us-east1-c
-    vmIndex: 5
+    vmIndex: 4


### PR DESCRIPTION
1.25 GKE version is no longer available: https://github.com/cilium/cilium/actions/runs/8809563049/job/24180562253

```
ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=No valid versions with the prefix "1.25" found.
```
