### PR TITLE
Expose clustermesh-apiserver version through a dedicated command, and as part of logs

### DIFF
--- a/clustermesh-apiserver/clustermesh/root.go
+++ b/clustermesh-apiserver/clustermesh/root.go
@@ -39,6 +39,7 @@ import (
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/version"
 )
 
 var (
@@ -62,6 +63,7 @@ func NewCmd(h *hive.Hive) *cobra.Command {
 				log.Logger.SetLevel(logrus.DebugLevel)
 			}
 			option.LogRegisteredOptions(h.Viper(), log)
+			log.Infof("Cilium ClusterMesh %s", version.Version)
 		},
 	}
 

--- a/clustermesh-apiserver/etcdinit/root.go
+++ b/clustermesh-apiserver/etcdinit/root.go
@@ -18,6 +18,8 @@ import (
 	kvstoreEtcdInit "github.com/cilium/cilium/pkg/kvstore/etcdinit"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/version"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -38,6 +40,10 @@ func NewCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "etcdinit",
 		Short: "Initialise an etcd data directory for use by the etcd sidecar of clustermesh-apiserver",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			option.LogRegisteredOptions(vp, log)
+			log.Infof("Cilium ClusterMesh etcd init %s", version.Version)
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			err := InitEtcdLocal()
 			// The error has already been handled and logged by InitEtcdLocal. We just use it to determine the exit code

--- a/clustermesh-apiserver/etcdinit/root.go
+++ b/clustermesh-apiserver/etcdinit/root.go
@@ -25,9 +25,9 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
-// etcdBinaryLocation is hardcoded because we expect this command to be run inside a Cilium container that places the
+// EtcdBinaryLocation is hardcoded because we expect this command to be run inside a Cilium container that places the
 // etcd binary in a specific location.
-const etcdBinaryLocation = "/usr/bin/etcd"
+const EtcdBinaryLocation = "/usr/bin/etcd"
 
 var (
 	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "etcdinit")
@@ -126,14 +126,14 @@ func InitEtcdLocal() (returnErr error) {
 	}).
 		Info("Starting localhost-only etcd process")
 	// Specify the full path to the etcd binary to avoid any PATH search binary replacement nonsense
-	etcdCmd := exec.CommandContext(ctx, etcdBinaryLocation,
+	etcdCmd := exec.CommandContext(ctx, EtcdBinaryLocation,
 		fmt.Sprintf("--data-dir=%s", etcdDataDir),
 		fmt.Sprintf("--name=%s", etcdClusterName),
 		fmt.Sprintf("--listen-client-urls=%s", loopbackEndpoint),
 		fmt.Sprintf("--advertise-client-urls=%s", loopbackEndpoint),
 		fmt.Sprintf("--initial-cluster-token=%s", etcdInitialClusterToken),
 		"--initial-cluster-state=new")
-	log.WithField("etcdBinary", etcdBinaryLocation).
+	log.WithField("etcdBinary", EtcdBinaryLocation).
 		WithField("etcdFlags", etcdCmd.Args).
 		Debug("Executing etcd")
 
@@ -141,7 +141,7 @@ func InitEtcdLocal() (returnErr error) {
 	// it'll never complete of course.
 	err = etcdCmd.Start()
 	if err != nil {
-		log.WithField("etcdBinary", etcdBinaryLocation).
+		log.WithField("etcdBinary", EtcdBinaryLocation).
 			WithField("etcdFlags", etcdCmd.Args).
 			WithError(err).
 			Error("Failed to launch etcd process")

--- a/clustermesh-apiserver/kvstoremesh/root.go
+++ b/clustermesh-apiserver/kvstoremesh/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/version"
 )
 
 var (
@@ -37,6 +38,7 @@ func NewCmd(h *hive.Hive) *cobra.Command {
 				log.Logger.SetLevel(logrus.DebugLevel)
 			}
 			option.LogRegisteredOptions(h.Viper(), log)
+			log.Infof("Cilium KVStoreMesh %s", version.Version)
 		},
 	}
 

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/clustermesh-apiserver/clustermesh"
 	"github.com/cilium/cilium/clustermesh-apiserver/etcdinit"
 	"github.com/cilium/cilium/clustermesh-apiserver/kvstoremesh"
+	"github.com/cilium/cilium/clustermesh-apiserver/version"
 	"github.com/cilium/cilium/pkg/hive"
 )
 
@@ -22,6 +23,7 @@ func main() {
 	}
 
 	cmd.AddCommand(
+		version.NewCmd(),
 		// etcd init does not use the Hive framework, because it's a "one and done" process that doesn't spawn a service
 		// or server, or perform any waiting for connections.
 		etcdinit.NewCmd(),

--- a/clustermesh-apiserver/version/version.go
+++ b/clustermesh-apiserver/version/version.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package version
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cilium/cilium/clustermesh-apiserver/etcdinit"
+	"github.com/cilium/cilium/pkg/version"
+)
+
+func NewCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print version information",
+		Run: func(_ *cobra.Command, _ []string) {
+			fmt.Printf("Cilium ClusterMesh: %s\n", version.Version)
+			fmt.Printf("etcd: %s\n", getEtcdVersion())
+		},
+	}
+}
+
+func getEtcdVersion() string {
+	out, err := exec.Command(etcdinit.EtcdBinaryLocation, "--version").Output()
+	if err != nil {
+		return fmt.Sprintf("unable to retrieve version: %s", err)
+	}
+
+	const pattern = `etcd Version: (?P<version>.*?)\nGit SHA: (?P<sha>.*?)\nGo Version: (?P<go>.*?)\nGo OS\/Arch: (?P<arch>.*?)\n`
+	re := regexp.MustCompile(pattern)
+	matches := re.FindAllStringSubmatch(string(out), 1)
+	if len(matches) != 1 {
+		return "unable to parse version"
+	}
+
+	return fmt.Sprintf("%s %s go version %s %s",
+		matches[0][re.SubexpIndex("version")],
+		matches[0][re.SubexpIndex("sha")],
+		matches[0][re.SubexpIndex("go")],
+		matches[0][re.SubexpIndex("arch")],
+	)
+}


### PR DESCRIPTION
Extend the clustermesh-apiserver by introducing a `version` sub-command, which outputs the binary version, as well as that of the etcd binary packaged as part of the same image. Additionally, make sure that all sub-commands output the parsed flags and binary version as part of their logs, as potentially useful for troubleshooting purposes.

<!-- Description of change -->

```release-note
Expose clustermesh-apiserver version through a dedicated command, and as part of logs
```
