### PR TITLE
datapath,endpoint: explicitly remove TC filters during endpoint teardown

### DIFF
--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -747,13 +747,29 @@ func (l *loader) Unload(ep datapath.Endpoint) {
 		}
 	}
 
+	log := log.WithField(logfields.EndpointID, ep.StringID())
+
+	// Remove legacy tc attachments.
+	if err := removeTCFilters(ep.InterfaceName(), netlink.HANDLE_MIN_INGRESS); err != nil {
+		log.WithError(err).Errorf("Removing ingress filter from interface %s", ep.InterfaceName())
+	}
+	if err := removeTCFilters(ep.InterfaceName(), netlink.HANDLE_MIN_EGRESS); err != nil {
+		log.WithError(err).Errorf("Removing egress filter from interface %s", ep.InterfaceName())
+	}
+
 	// If Cilium and the kernel support tcx to attach TC programs to the
 	// endpoint's veth device, its bpf_link object is pinned to a per-endpoint
-	// bpffs directory. When the endpoint gets deleted, removing the whole
-	// directory cleans up any pinned maps and links.
-	bpffsPath := bpffsEndpointDir(bpf.CiliumPath(), ep)
-	if err := bpf.Remove(bpffsPath); err != nil {
-		log.WithError(err).WithField(logfields.EndpointID, ep.StringID())
+	// bpffs directory. When the endpoint gets deleted, we can remove the whole
+	// directory to clean up any leftover pinned links and maps.
+
+	// Remove the links directory first to avoid removing program arrays before
+	// the entrypoints are detached.
+	if err := bpf.Remove(bpffsEndpointLinksDir(bpf.CiliumPath(), ep)); err != nil {
+		log.WithError(err)
+	}
+	// Finally, remove the endpoint's top-level directory.
+	if err := bpf.Remove(bpffsEndpointDir(bpf.CiliumPath(), ep)); err != nil {
+		log.WithError(err)
 	}
 }
 

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -333,6 +333,10 @@ func attachTCProgram(link netlink.Link, prog *ebpf.Program, progName, bpffsDir s
 // Direction is passed as netlink.HANDLE_MIN_{INGRESS,EGRESS} via tcDir.
 func removeTCFilters(ifName string, tcDir uint32) error {
 	link, err := netlink.LinkByName(ifName)
+	if errors.As(err, &netlink.LinkNotFoundError{}) {
+		// No interface, no filters to remove.
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/datapath/loader/netlink_test.go
+++ b/pkg/datapath/loader/netlink_test.go
@@ -393,6 +393,12 @@ func TestAttachRemoveTCProgram(t *testing.T) {
 	})
 }
 
+func TestRemoveTCFiltersError(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	require.NoError(t, removeTCFilters("missing", directionToParent(dirIngress)))
+}
+
 func TestSetupIPIPDevices(t *testing.T) {
 	testutils.PrivilegedTest(t)
 


### PR DESCRIPTION
Prior to this commit, we left it up to the kernel to clean up tc attachments when the CNI finally removes the veth when a Pod goes away. This leaves a window of time where an endpoint's tc programs can potentially be invoked after the endpoint's internal tail call maps have already been cleared and the endpoint has been removed from the endpoint map and ipcache, resulting in undefined behaviour.

This patch clearly defines the endpoint teardown sequence as follows:
- remove (endpoint) routes
- detach tc(x) hooks
- remove endpoint from endpoint map
- remove endpoint policy program(s)
- delete conntrack map pins
- remove policy prog array map pin
- remove internal tail call map pin
- remove custom calls map pin

This puts the agent more in control of the teardown sequence and will allow us to reason better about failures related to missed tail calls and other flakes.

```release-note
Accurately manage the teardown sequence of an Endpoint's BPF resources
```

cc @julianwiedmann 