### PR TITLE
daemon: don't go ready until CNI configuration has been written

### DIFF
--- a/daemon/cmd/cni/fake/fakecni.go
+++ b/daemon/cmd/cni/fake/fakecni.go
@@ -4,6 +4,7 @@
 package fake
 
 import (
+	"github.com/cilium/cilium/api/v1/models"
 	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 )
 
@@ -23,5 +24,9 @@ func (c *FakeCNIConfigManager) ExternalRoutingEnabled() bool {
 }
 
 func (f *FakeCNIConfigManager) GetCustomNetConf() *cnitypes.NetConf {
+	return nil
+}
+
+func (f *FakeCNIConfigManager) Status() *models.Status {
 	return nil
 }

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -1072,6 +1072,25 @@ func (d *Daemon) startStatusCollector(cleaner *daemonCleanup) {
 				}
 			},
 		},
+		{
+			Name: "cni-config",
+			Probe: func(ctx context.Context) (interface{}, error) {
+				if d.cniConfigManager == nil {
+					return nil, nil
+				}
+				return d.cniConfigManager.Status(), nil
+			},
+			OnStatusUpdate: func(status status.Status) {
+				d.statusCollectMutex.Lock()
+				defer d.statusCollectMutex.Unlock()
+
+				if status.Err == nil {
+					if s, ok := status.Data.(*models.Status); ok {
+						d.statusResponse.CniFile = s
+					}
+				}
+			},
+		},
 	}
 
 	d.statusResponse.Masquerading = d.getMasqueradingStatus()


### PR DESCRIPTION
If the daemon is configured to write a CNI configuration file, we should not go ready until that CNI configuration file has been written. This prevents a race condition where the controller removes the taint from a node too early, meaning pods may be created with a different CNI provider.

In #29405, Cilium was configured in chaining mode, but the "primary" CNI provider hadn't written its configuration yet. This caused the not-ready taint to be removed from the node too early, and pods were created in a bad state.

By hooking in the CNI cell's status in the daemon's Status type, we prevent the daemon's healthz endpoint from returning a successful response until the CNI cell has been successful.

Fixes: #29405

```release-note
Fixes a bug where Cilium in chained mode removed the `agent-not-ready` taint too early if the primary network is slow in deploying.
```
