### PR TITLE
bpf: fix same insn cannot be used with different pointers in proxy.h

### DIFF
--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -18,6 +18,7 @@ assign_socket_tcp(struct __ctx_buff *ctx,
 	int result = DROP_PROXY_LOOKUP_FAILED;
 	struct bpf_sock *sk;
 	__u32 dbg_ctx;
+	__u32 family;
 
 	sk = skc_lookup_tcp(ctx, tuple, len, BPF_F_CURRENT_NETNS, 0);
 	if (!sk)
@@ -28,7 +29,8 @@ assign_socket_tcp(struct __ctx_buff *ctx,
 	if (established && sk->state == BPF_TCP_LISTEN)
 		goto release;
 
-	dbg_ctx = sk->family << 16 | ctx->protocol;
+	family = sk->family;
+	dbg_ctx = family << 16 | ctx->protocol;
 	result = sk_assign(ctx, sk, 0);
 	cilium_dbg(ctx, DBG_SK_ASSIGN, -result, dbg_ctx);
 	if (result == 0)
@@ -49,12 +51,14 @@ assign_socket_udp(struct __ctx_buff *ctx,
 	int result = DROP_PROXY_LOOKUP_FAILED;
 	struct bpf_sock *sk;
 	__u32 dbg_ctx;
+	__u32 family;
 
 	sk = sk_lookup_udp(ctx, tuple, len, BPF_F_CURRENT_NETNS, 0);
 	if (!sk)
 		goto out;
 
-	dbg_ctx = sk->family << 16 | ctx->protocol;
+	family = sk->family;
+	dbg_ctx = family << 16 | ctx->protocol;
 	result = sk_assign(ctx, sk, 0);
 	cilium_dbg(ctx, DBG_SK_ASSIGN, -result, dbg_ctx);
 	if (result == 0)


### PR DESCRIPTION
With the following helm config enabled, Cilium Agent fails to load BPF programs on `main`.

The error only occurs if verbose datapath logging is enabled.

Tested on a local kind cluster

```
make kind
make kind-debug
```

helm values (in addition to default ones)

```
debug:
  enabled: true
  verbose: "datapath"
bpf:
  tproxy: true
```

error:

```
Verifier error: program cil_to_host: load program: invalid argument: same insn cannot be used with different pointers (356 line(s) omitted)
Verifier log: load program: invalid argument:
...
; sk = sk_lookup_udp(ctx, tuple, len, BPF_F_CURRENT_NETNS, 0);
829: (bf) r1 = r6
830: (b4) w3 = 36
831: (b7) r4 = -1
832: (b7) r5 = 0
833: (85) call bpf_sk_lookup_udp#85
last_idx 833 first_idx 827
regs=8 stack=0 before 832: (b7) r5 = 0
regs=8 stack=0 before 831: (b7) r4 = -1
regs=8 stack=0 before 830: (b4) w3 = 36
834: (b4) w7 = -178
; if (!sk)
835: (15) if r0 == 0x0 goto pc+38
 R0_w=sock(id=0,ref_obj_id=29,off=0,imm=0) R6=ctx(id=0,off=0,imm=0) R7_w=inv4294967118 R8=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R9=inv(id=22,umax_value=65535,var_off=(0x0; 0xffff)) R10=fp0 fp-16=???mmmmm fp-24=mmmmmmmm fp-32=mmmmmmmm fp-40=mmmmmmmm fp-48=mmmmmmmm fp-72=????mmmm fp-80=mmmmmmmm fp-88=mmmmmmmm refs=29
;
836: (61) r1 = *(u32 *)(r6 +16)
837: (63) *(u32 *)(r10 -104) = r1
838: (61) r7 = *(u32 *)(r0 +4)
same insn cannot be used with different pointers
processed 1261 insns (limit 1000000) max_states_per_insn 4 total_states 68 peak_states 67 mark_read 19
```

This breaks datapath connectivitiy in the cluster (e.g. coredns crash-loops and is unable to connect to k8s api server)

This commit fixes this issue by extracting a variable `family`.

Related to: https://github.com/cilium/cilium/pull/31418 (Bisected it down to this PR (`e4316b9d044ec2fe437ffc1b1094a4cb4c5a20d6` doesn't work - `af9bfba4e8fa4c80bd75e4d46f667ad757e6b073` works)

Note: I'm not sure whether this is THE right and only fix or whether the related PR introduced some other issues that might arise for other configs.