### PR TITLE
[v1.13] endpoint: Fix Endpoint Integration Tests

### DIFF
--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -533,32 +533,31 @@ func (s *EndpointSuite) TestWaitForPolicyRevision(c *C) {
 func (s *EndpointSuite) TestProxyID(c *C) {
 	e := &Endpoint{ID: 123, policyRevision: 0}
 
-	id, port, proto := e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true}, "")
+	id, port, proto := e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true})
 	c.Assert(id, Not(Equals), "")
 	c.Assert(port, Equals, uint16(8080))
 	c.Assert(proto, Equals, uint8(6))
 
-	endpointID, ingress, protocol, port, listener, err := policy.ParseProxyID(id)
+	endpointID, ingress, protocol, port, err := policy.ParseProxyID(id)
 	c.Assert(endpointID, Equals, uint16(123))
 	c.Assert(ingress, Equals, true)
 	c.Assert(protocol, Equals, "TCP")
 	c.Assert(port, Equals, uint16(8080))
 	c.Assert(err, IsNil)
 
-	id, port, proto = e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true, L7Parser: policy.ParserTypeCRD}, "test-listener")
+	id, port, proto = e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true, L7Parser: policy.ParserTypeCRD})
 	c.Assert(id, Not(Equals), "")
 	c.Assert(port, Equals, uint16(8080))
 	c.Assert(proto, Equals, uint8(6))
-	endpointID, ingress, protocol, port, listener, err = policy.ParseProxyID(id)
+	endpointID, ingress, protocol, port, err = policy.ParseProxyID(id)
 	c.Assert(endpointID, Equals, uint16(123))
 	c.Assert(ingress, Equals, true)
 	c.Assert(protocol, Equals, "TCP")
 	c.Assert(port, Equals, uint16(8080))
-	c.Assert(listener, Equals, "test-listener")
 	c.Assert(err, IsNil)
 
 	// Undefined named port
-	id, port, proto = e.proxyID(&policy.L4Filter{PortName: "foobar", Protocol: api.ProtoTCP, Ingress: true}, "")
+	id, port, proto = e.proxyID(&policy.L4Filter{PortName: "foobar", Protocol: api.ProtoTCP, Ingress: true})
 	c.Assert(id, Equals, "")
 	c.Assert(port, Equals, uint16(0))
 	c.Assert(proto, Equals, uint8(0))


### PR DESCRIPTION
This was introduced by https://github.com/cilium/cilium/pull/31713,
from a bad method signature hidden behind a build flag.

Fixes: #32163

