### PR TITLE
ci: Run cilium sysdump in conformance-ginkgo

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -432,6 +432,8 @@ jobs:
           cmd: |
             cd /host
             kubectl get pods --all-namespaces -o wide
+            cilium status
+            cilium sysdump --output-filename cilium-sysdump-final
             tar -zcf "test_results-${{ env.job_name }}.tar.gz" /host/test/test_results
 
       - name: Upload artifacts


### PR DESCRIPTION
To make it easier to debug test failures in ginkgo.