### PR TITLE
CODEOWNERS: Remove the catch-all rule

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -70,14 +70,11 @@
 #   Provide recommendations about the types, names and labels for metrics to
 #   follow best practices. This includes considering the cardinality impact of
 #   metrics being added or extended.
+# - @cilium/release-managers:
+#   Review files related to releases like AUTHORS and VERSION.
 # - @cilium/security:
 #   Provide feedback on changes that could have security implications for Cilium,
 #   and maintain security-related documentation.
-# - @cilium/tophat:
-#   Top Hat duties rotate between the committer group from week to week, and
-#   they may assist in maintenance, triage and backporting duties across
-#   different Cilium repositories. Catch-all for code not otherwise owned by a
-#   team.
 # - @cilium/vendor:
 #   Review vendor updates for software dependencies to check for any potential
 #   upstream breakages / incompatibilities. Discourage the use of unofficial
@@ -223,15 +220,14 @@
 # The following filepaths should be sorted so that more specific paths occur
 # after the less specific paths, otherwise the ownership for the specific paths
 # is not properly picked up in Github.
-* @cilium/tophat
-/AUTHORS @cilium/tophat
+/AUTHORS @cilium/release-managers
 /CODE_OF_CONDUCT.md @cilium/contributing
 /CODEOWNERS @cilium/contributing
 /CONTRIBUTING.md @cilium/contributing
-/.authors.aux @cilium/tophat
-/.clomonitor.yml @cilium/tophat
+/.authors.aux @cilium/contributing
+/.clomonitor.yml @cilium/contributing
 /.devcontainer @cilium/contributing
-/.gitattributes @cilium/tophat
+/.gitattributes @cilium/contributing
 /.github/ @cilium/contributing
 /.github/ariane-config.yaml @cilium/github-sec @cilium/ci-structure
 /.github/renovate.json5 @cilium/github-sec @cilium/ci-structure
@@ -247,9 +243,9 @@
 /.github/workflows/*ingress*.yaml @cilium/sig-servicemesh @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*scale*.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*perf*.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure
-/.gitignore @cilium/tophat
+/.gitignore @cilium/contributing
 /.golangci.yaml @cilium/ci-structure
-/.mailmap @cilium/tophat
+/.mailmap @cilium/release-managers
 /.nvim @cilium/contributing
 /.vscode @cilium/contributing
 /api/ @cilium/api
@@ -272,8 +268,7 @@ Makefile* @cilium/build
 /bpf/lib/wireguard.h @cilium/wireguard @cilium/sig-datapath
 /bpf/lib/ids.h @cilium/loader
 /bpf/include/bpf/tailcall.h @cilium/loader
-/bugtool/ @cilium/tophat
-/bugtool/cmd/ @cilium/cli
+/bugtool/ @cilium/cli
 /cilium-dbg/ @cilium/cli
 /cilium-dbg/cmd/encrypt* @cilium/ipsec @cilium/cli
 /cilium-dbg/cmd/preflight_k8s_valid_cnp.go @cilium/sig-k8s
@@ -375,7 +370,7 @@ Makefile* @cilium/build
 /examples/minikube/ @cilium/sig-k8s
 /examples/policies/kubernetes/clustermesh/ @cilium/sig-clustermesh
 /FURTHER_READINGS.rst @cilium/docs-structure
-/hack/ @cilium/tophat
+/hack/ @cilium/contributing
 /hubble/ @cilium/sig-hubble
 /hubble-relay/ @cilium/sig-hubble
 /images @cilium/build
@@ -389,7 +384,7 @@ Makefile* @cilium/build
 /install/kubernetes/cilium/**/spire @cilium/sig-k8s @cilium/helm @cilium/sig-servicemesh
 /install/kubernetes/cilium/templates/clustermesh* @cilium/sig-k8s @cilium/helm @cilium/sig-clustermesh
 /install/kubernetes/cilium/templates/hubble* @cilium/sig-k8s @cilium/helm @cilium/sig-hubble
-/LICENSE @cilium/tophat
+/LICENSE @cilium/contributing
 /MAINTAINERS.md @cilium/contributing
 /netlify.toml @cilium/ci-structure
 /operator/ @cilium/operator
@@ -402,7 +397,6 @@ Makefile* @cilium/build
 /operator/pkg/model @cilium/sig-servicemesh
 /operator/pkg/secretsync @cilium/sig-servicemesh
 /operator/watchers/bgp.go @cilium/sig-bgp
-/pkg/ @cilium/tophat
 /pkg/annotation @cilium/sig-k8s
 /pkg/alibabacloud/ @cilium/alibabacloud
 /pkg/alignchecker/ @cilium/sig-datapath @cilium/loader
@@ -419,12 +413,15 @@ Makefile* @cilium/build
 /pkg/byteorder/ @cilium/sig-datapath @cilium/api
 /pkg/cgroups/ @cilium/sig-datapath
 /pkg/checker/ @cilium/ci-structure
+/pkg/cidr/ @cilium/sig-agent
 /pkg/ciliumenvoyconfig/ @cilium/envoy @cilium/sig-servicemesh
 /pkg/cleanup/ @cilium/sig-agent
 /pkg/client @cilium/api
 /pkg/clustermesh @cilium/sig-clustermesh
 /pkg/command/ @cilium/cli
+/pkg/common/ @cilium/sig-agent
 /pkg/common/ipsec/ @cilium/ipsec
+/pkg/comparator/ @cilium/sig-agent
 /pkg/completion/ @cilium/proxy
 /pkg/components/ @cilium/sig-agent
 /pkg/container/ @cilium/sig-foundations
@@ -447,6 +444,7 @@ Makefile* @cilium/build
 /pkg/datapath/loader/ @cilium/loader
 /pkg/datapath/ipcache/ @cilium/ipcache
 /pkg/defaults @cilium/sig-agent
+/pkg/debug @cilium/sig-agent
 /pkg/ebpf @cilium/sig-datapath
 /pkg/egressgateway/ @cilium/egress-gateway
 /pkg/elf @cilium/loader
@@ -455,17 +453,21 @@ Makefile* @cilium/build
 /pkg/endpointmanager/ @cilium/endpoint
 /pkg/endpointstate/ @cilium/endpoint
 /pkg/envoy/ @cilium/envoy
+/pkg/eventqueue/ @cilium/sig-agent
 /pkg/flowdebug/ @cilium/proxy
 /pkg/fqdn/ @cilium/fqdn
 /pkg/fswatcher/ @cilium/sig-datapath @cilium/sig-hubble
+/pkg/gops/ @cilium/sig-agent
 /pkg/healthv2/ @cilium/sig-foundations
 /pkg/health/ @cilium/sig-agent
 /pkg/hive/ @cilium/sig-foundations
 /pkg/hive/job/metrics.go @cilium/sig-foundations @cilium/metrics
 /pkg/hubble/ @cilium/sig-hubble
 /pkg/hubble/metrics @cilium/sig-hubble @cilium/sig-hubble-api
+/pkg/iana/ @cilium/sig-agent
 /pkg/identity @cilium/sig-policy
 /pkg/idpool/ @cilium/kvstore
+/pkg/inctimer/ @cilium/sig-agent
 /pkg/ip/ @cilium/sig-agent
 /pkg/ipalloc/ @cilium/sig-ipam
 /pkg/ipam/ @cilium/sig-ipam
@@ -486,12 +488,14 @@ Makefile* @cilium/build
 /pkg/labelsfilter @cilium/sig-policy
 /pkg/launcher @cilium/sig-agent
 /pkg/loadbalancer @cilium/sig-lb
+/pkg/loadinfo/ @cilium/sig-agent
 /pkg/lock @cilium/sig-agent
 /pkg/logging/ @cilium/cli
 /pkg/mac @cilium/sig-datapath
 /pkg/maglev @cilium/sig-lb
 /pkg/maps/ @cilium/sig-datapath
 /pkg/maps/egressmap @cilium/egress-gateway
+/pkg/math/ @cilium/sig-agent
 /pkg/mcastmanager @cilium/sig-datapath
 /pkg/metrics @cilium/metrics
 /pkg/monitor @cilium/sig-datapath
@@ -501,6 +505,7 @@ Makefile* @cilium/build
 /pkg/mountinfo @cilium/sig-datapath
 /pkg/mtu @cilium/sig-datapath
 /pkg/multicast @cilium/sig-datapath
+/pkg/murmur3/ @cilium/sig-datapath
 /pkg/netns/ @cilium/sig-datapath @cilium/sig-k8s
 /pkg/node @cilium/sig-agent
 /pkg/nodediscovery/ @cilium/sig-agent
@@ -516,22 +521,29 @@ Makefile* @cilium/build
 /pkg/proxy/accesslog @cilium/proxy @cilium/api
 /pkg/proxy/dns.go @cilium/proxy @cilium/fqdn
 /pkg/proxy/envoyproxy.go @cilium/proxy @cilium/envoy
+/pkg/rand/ @cilium/sig-agent
+/pkg/rate/ @cilium/sig-agent
 /pkg/rate/metrics @cilium/metrics
 /pkg/recorder @cilium/sig-datapath
 /pkg/redirectpolicy @cilium/sig-lb
 /pkg/resiliency @cilium/sig-agent
+/pkg/revert/ @cilium/sig-agent
 /pkg/safeio @cilium/sig-agent
+/pkg/safetime/ @cilium/sig-agent
 /pkg/service @cilium/sig-lb
 /pkg/signal @cilium/sig-datapath
 /pkg/slices @cilium/sig-foundations
 /pkg/socketlb @cilium/loader
 /pkg/source @cilium/ipcache
+/pkg/spanstat/ @cilium/sig-agent
 /pkg/status/ @cilium/sig-agent
 /pkg/statedb @cilium/sig-foundations
 /pkg/testutils/ @cilium/ci-structure
 /pkg/time @cilium/sig-agent
+/pkg/trigger/ @cilium/sig-agent
 /pkg/tuple @cilium/sig-datapath
 /pkg/types/ @cilium/sig-datapath
+/pkg/u8proto/ @cilium/sig-agent
 /pkg/wireguard @cilium/wireguard
 /pkg/version/ @cilium/sig-agent
 /pkg/versioncheck/ @cilium/sig-agent
@@ -540,7 +552,7 @@ Makefile* @cilium/build
 /README.rst @cilium/docs-structure
 /SECURITY.md @cilium/contributing
 /SECURITY-INSIGHTS.yml @cilium/security
-/stable.txt @cilium/tophat
+/stable.txt @cilium/release-managers
 /test/ @cilium/ci-structure
 /test/Makefile* @cilium/ci-structure @cilium/build
 # Service handling tests
@@ -582,6 +594,6 @@ Vagrantfile @cilium/ci-structure
 /go.mod @cilium/vendor
 /vagrant_box_defaults.rb @cilium/ci-structure
 /vendor/ @cilium/vendor
-/VERSION @cilium/tophat
+/VERSION @cilium/release-managers
 /.clang-format @cilium/contributing
 /.openvex.json @cilium/security

--- a/Documentation/codeowners.rst
+++ b/Documentation/codeowners.rst
@@ -73,14 +73,11 @@ repository in the Cilium project:
   Provide recommendations about the types, names and labels for metrics to
   follow best practices. This includes considering the cardinality impact of
   metrics being added or extended.
+- `@cilium/release-managers <https://github.com/orgs/cilium/teams/release-managers>`__:
+  Review files related to releases like AUTHORS and VERSION.
 - `@cilium/security <https://github.com/orgs/cilium/teams/security>`__:
   Provide feedback on changes that could have security implications for Cilium,
   and maintain security-related documentation.
-- `@cilium/tophat <https://github.com/orgs/cilium/teams/tophat>`__:
-  Top Hat duties rotate between the committer group from week to week, and
-  they may assist in maintenance, triage and backporting duties across
-  different Cilium repositories. Catch-all for code not otherwise owned by a
-  team.
 - `@cilium/vendor <https://github.com/orgs/cilium/teams/vendor>`__:
   Review vendor updates for software dependencies to check for any potential
   upstream breakages / incompatibilities. Discourage the use of unofficial


### PR DESCRIPTION
Remove the catch-all rule to avoid pulling in tophat for review whenever new files get added. Pulling in tophat is unnecessary because:

- lint-codeowners.yaml [^1] validates CODEOWNERS has entries for new files.
- cilium/contributing team owns CODEOWNERS file. This team can ensure that new files get placed in appropriate locations.

[^1]: https://github.com/cilium/cilium/blob/main/.github/workflows/lint-codeowners.yaml

Suggested-by: Timo Beckers <timo@isovalent.com>