### PR TITLE
[v1.15] Author backport of #31646

### DIFF
--- a/operator/pkg/model/ingestion/ingress.go
+++ b/operator/pkg/model/ingestion/ingress.go
@@ -276,7 +276,11 @@ func IngressPassthrough(ing networkingv1.Ingress, defaultSecretNamespace, defaul
 				continue
 			}
 
-			route := model.TLSRoute{}
+			route := model.TLSRoute{
+				Hostnames: []string{
+					host,
+				},
+			}
 
 			backend := model.Backend{
 				Name:      path.Backend.Service.Name,

--- a/operator/pkg/model/ingestion/ingress_test.go
+++ b/operator/pkg/model/ingestion/ingress_test.go
@@ -1593,6 +1593,9 @@ var sslPassthruTLSListeners = []model.TLSListener{
 		Hostname: "sslpassthru.example.com",
 		Routes: []model.TLSRoute{
 			{
+				Hostnames: []string{
+					"sslpassthru.example.com",
+				},
 				Backends: []model.Backend{
 					{
 						Name:      "dummy-backend",
@@ -1748,6 +1751,9 @@ var sslPassthruTLSListenersNodePort = []model.TLSListener{
 		Hostname: "sslpassthru.example.com",
 		Routes: []model.TLSRoute{
 			{
+				Hostnames: []string{
+					"sslpassthru.example.com",
+				},
 				Backends: []model.Backend{
 					{
 						Name:      "dummy-backend",
@@ -1824,6 +1830,9 @@ var sslPassthruMultiplePathsTLSListeners = []model.TLSListener{
 		Hostname: "sslpassthru.example.com",
 		Routes: []model.TLSRoute{
 			{
+				Hostnames: []string{
+					"sslpassthru.example.com",
+				},
 				Backends: []model.Backend{
 					{
 						Name:      "dummy-backend",

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -102,8 +102,8 @@ func WithSocketOption(tcpKeepAlive, tcpKeepIdleInSeconds, tcpKeepAliveProbeInter
 	}
 }
 
-// NewHTTPListenerWithDefaults same as NewListener but with default mutators applied.
-func NewHTTPListenerWithDefaults(name string, ciliumSecretNamespace string, tlsSecretsToHostnames map[model.TLSSecret][]string, mutatorFunc ...ListenerMutator) (ciliumv2.XDSResource, error) {
+// newListenerWithDefaults same as newListener but with default mutators applied.
+func newListenerWithDefaults(name string, ciliumSecretNamespace string, includeHTTPFilterchain bool, tlsSecretsToHostnames map[model.TLSSecret][]string, ptBackendsToHostnames map[string][]string, mutatorFunc ...ListenerMutator) (ciliumv2.XDSResource, error) {
 	fns := append(mutatorFunc,
 		WithSocketOption(
 			defaultTCPKeepAlive,
@@ -111,7 +111,8 @@ func NewHTTPListenerWithDefaults(name string, ciliumSecretNamespace string, tlsS
 			defaultTCPKeepAliveProbeIntervalInSeconds,
 			defaultTCPKeepAliveMaxFailures),
 	)
-	return NewHTTPListener(name, ciliumSecretNamespace, tlsSecretsToHostnames, fns...)
+
+	return newListener(name, ciliumSecretNamespace, includeHTTPFilterchain, tlsSecretsToHostnames, ptBackendsToHostnames, fns...)
 }
 
 func httpFilterChain(name string) (*envoy_config_listener.FilterChain, error) {
@@ -149,11 +150,9 @@ func httpsFilterChains(name string, ciliumSecretNamespace string, tlsSecretsToHo
 
 	for _, secret := range orderedSecrets {
 		hostNames := tlsSecretsToHostnames[secret]
+
 		secureHttpConnectionManagerName := fmt.Sprintf("%s-secure", name)
-		secureHttpConnectionManager, err := NewHTTPConnectionManager(
-			secureHttpConnectionManagerName,
-			secureHttpConnectionManagerName,
-			WithXffNumTrustedHops())
+		secureHttpConnectionManager, err := NewHTTPConnectionManager(secureHttpConnectionManagerName, secureHttpConnectionManagerName)
 		if err != nil {
 			return nil, err
 		}
@@ -180,17 +179,20 @@ func httpsFilterChains(name string, ciliumSecretNamespace string, tlsSecretsToHo
 	return filterChains, nil
 }
 
-// NewHTTPListener creates a new Envoy listener with the given name.
+// newListener creates a new Envoy listener with the given name.
 // The listener will have both secure and insecure filters.
+//
 // Secret Discovery Service (SDS) is used to fetch the TLS certificates.
-func NewHTTPListener(name string, ciliumSecretNamespace string, tlsSecretsToHostnames map[model.TLSSecret][]string, mutatorFunc ...ListenerMutator) (ciliumv2.XDSResource, error) {
+func newListener(name string, ciliumSecretNamespace string, includeHTTPFilterchain bool, tlsSecretsToHostnames map[model.TLSSecret][]string, tlsPassthroughBackendsMap map[string][]string, mutatorFunc ...ListenerMutator) (ciliumv2.XDSResource, error) {
 	filterChains := []*envoy_config_listener.FilterChain{}
 
-	httpFilterChain, err := httpFilterChain(name)
-	if err != nil {
-		return ciliumv2.XDSResource{}, fmt.Errorf("failed to create http filterchain: %w", err)
+	if includeHTTPFilterchain {
+		httpFilterChain, err := httpFilterChain(name)
+		if err != nil {
+			return ciliumv2.XDSResource{}, err
+		}
+		filterChains = append(filterChains, httpFilterChain)
 	}
-	filterChains = append(filterChains, httpFilterChain)
 
 	httpsFilterChains, err := httpsFilterChains(name, ciliumSecretNamespace, tlsSecretsToHostnames)
 	if err != nil {
@@ -198,82 +200,7 @@ func NewHTTPListener(name string, ciliumSecretNamespace string, tlsSecretsToHost
 	}
 	filterChains = append(filterChains, httpsFilterChains...)
 
-	listener := &envoy_config_listener.Listener{
-		Name:         name,
-		FilterChains: filterChains,
-		ListenerFilters: []*envoy_config_listener.ListenerFilter{
-			{
-				Name: tlsInspectorType,
-				ConfigType: &envoy_config_listener.ListenerFilter_TypedConfig{
-					TypedConfig: toAny(&envoy_extensions_listener_tls_inspector_v3.TlsInspector{}),
-				},
-			},
-		},
-	}
-
-	for _, fn := range mutatorFunc {
-		listener = fn(listener)
-	}
-
-	listenerBytes, err := proto.Marshal(listener)
-	if err != nil {
-		return ciliumv2.XDSResource{}, err
-	}
-	return ciliumv2.XDSResource{
-		Any: &anypb.Any{
-			TypeUrl: envoy.ListenerTypeURL,
-			Value:   listenerBytes,
-		},
-	}, nil
-}
-
-// NewSNIListenerWithDefaults same as NewSNIListener but with default mutators applied.
-func NewSNIListenerWithDefaults(name string, ptBackendsToHostnames map[string][]string, mutatorFunc ...ListenerMutator) (ciliumv2.XDSResource, error) {
-	fns := append(mutatorFunc,
-		WithSocketOption(
-			defaultTCPKeepAlive,
-			defaultTCPKeepAliveIdleTimeInSeconds,
-			defaultTCPKeepAliveProbeIntervalInSeconds,
-			defaultTCPKeepAliveMaxFailures),
-	)
-	return NewSNIListener(name, ptBackendsToHostnames, fns...)
-}
-
-func tlsPassthroughFilterChains(ptBackendsToHostnames map[string][]string) ([]*envoy_config_listener.FilterChain, error) {
-	var filterChains []*envoy_config_listener.FilterChain
-
-	orderedBackends := maps.Keys(ptBackendsToHostnames)
-	goslices.Sort(orderedBackends)
-
-	for _, backend := range orderedBackends {
-		hostNames := ptBackendsToHostnames[backend]
-		filterChains = append(filterChains, &envoy_config_listener.FilterChain{
-			FilterChainMatch: toFilterChainMatch(hostNames),
-			Filters: []*envoy_config_listener.Filter{
-				{
-					Name: tcpProxyType,
-					ConfigType: &envoy_config_listener.Filter_TypedConfig{
-						TypedConfig: toAny(&envoy_extensions_filters_network_tcp_v3.TcpProxy{
-							StatPrefix: backend,
-							ClusterSpecifier: &envoy_extensions_filters_network_tcp_v3.TcpProxy_Cluster{
-								Cluster: backend,
-							},
-						}),
-					},
-				},
-			},
-		})
-	}
-
-	return filterChains, nil
-}
-
-// NewSNIListener creates a new Envoy listener with the given name.
-// The listener will be configured to use SNI to determine thhe backend
-func NewSNIListener(name string, ptBackendsToHostnames map[string][]string, mutatorFunc ...ListenerMutator) (ciliumv2.XDSResource, error) {
-	filterChains := []*envoy_config_listener.FilterChain{}
-
-	tlsPassthroughFilterChains, err := tlsPassthroughFilterChains(ptBackendsToHostnames)
+	tlsPassthroughFilterChains, err := tlsPassthroughFilterChains(tlsPassthroughBackendsMap)
 	if err != nil {
 		return ciliumv2.XDSResource{}, fmt.Errorf("failed to create tls passthrough filterchains: %w", err)
 	}
@@ -306,6 +233,39 @@ func NewSNIListener(name string, ptBackendsToHostnames map[string][]string, muta
 			Value:   listenerBytes,
 		},
 	}, nil
+}
+
+func tlsPassthroughFilterChains(ptBackendsToHostnames map[string][]string) ([]*envoy_config_listener.FilterChain, error) {
+	if len(ptBackendsToHostnames) == 0 {
+		return nil, nil
+	}
+
+	var filterChains []*envoy_config_listener.FilterChain
+
+	orderedBackends := maps.Keys(ptBackendsToHostnames)
+	goslices.Sort(orderedBackends)
+
+	for _, backend := range orderedBackends {
+		hostNames := ptBackendsToHostnames[backend]
+		filterChains = append(filterChains, &envoy_config_listener.FilterChain{
+			FilterChainMatch: toFilterChainMatch(hostNames),
+			Filters: []*envoy_config_listener.Filter{
+				{
+					Name: tcpProxyType,
+					ConfigType: &envoy_config_listener.Filter_TypedConfig{
+						TypedConfig: toAny(&envoy_extensions_filters_network_tcp_v3.TcpProxy{
+							StatPrefix: backend,
+							ClusterSpecifier: &envoy_extensions_filters_network_tcp_v3.TcpProxy_Cluster{
+								Cluster: backend,
+							},
+						}),
+					},
+				},
+			},
+		})
+	}
+
+	return filterChains, nil
 }
 
 func newTransportSocket(ciliumSecretNamespace string, tls []model.TLSSecret) (*envoy_config_core_v3.TransportSocket, error) {

--- a/operator/pkg/model/translation/envoy_listener_test.go
+++ b/operator/pkg/model/translation/envoy_listener_test.go
@@ -20,9 +20,22 @@ import (
 	"github.com/cilium/cilium/operator/pkg/model"
 )
 
-func TestNewHTTPListener(t *testing.T) {
+func TestNewListener(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		res, err := newListener("dummy-name", "dummy-secret-namespace", false, nil, nil)
+		require.Nil(t, err)
+
+		listener := &envoy_config_listener.Listener{}
+		err = proto.Unmarshal(res.Value, listener)
+		require.Nil(t, err)
+
+		require.Equal(t, "dummy-name", listener.Name)
+		require.Len(t, listener.GetListenerFilters(), 1)
+		require.Empty(t, listener.GetFilterChains())
+	})
+
 	t.Run("without TLS", func(t *testing.T) {
-		res, err := NewHTTPListener("dummy-name", "dummy-secret-namespace", nil)
+		res, err := newListener("dummy-name", "dummy-secret-namespace", true, nil, nil)
 		require.Nil(t, err)
 
 		listener := &envoy_config_listener.Listener{}
@@ -35,7 +48,7 @@ func TestNewHTTPListener(t *testing.T) {
 	})
 
 	t.Run("with default XffNumTrustedHops", func(t *testing.T) {
-		res, err := NewHTTPListener("dummy-name", "dummy-secret-namespace", nil)
+		res, err := newListener("dummy-name", "dummy-secret-namespace", true, nil, nil)
 		require.Nil(t, err)
 
 		listener := &envoy_config_listener.Listener{}
@@ -52,7 +65,7 @@ func TestNewHTTPListener(t *testing.T) {
 	})
 
 	t.Run("without TLS with Proxy Protocol", func(t *testing.T) {
-		res, err := NewHTTPListener("dummy-name", "dummy-secret-namespace", nil, WithProxyProtocol())
+		res, err := newListener("dummy-name", "dummy-secret-namespace", true, nil, nil, WithProxyProtocol())
 		require.Nil(t, err)
 
 		listener := &envoy_config_listener.Listener{}
@@ -70,15 +83,15 @@ func TestNewHTTPListener(t *testing.T) {
 		require.Len(t, listener.GetFilterChains(), 1)
 	})
 
-	t.Run("TLS filterchain order", func(t *testing.T) {
-		res1, err1 := NewHTTPListener("dummy-name", "dummy-secret-namespace", map[model.TLSSecret][]string{
+	t.Run("stable filterchain sort-order with TLS", func(t *testing.T) {
+		res1, err1 := newListener("dummy-name", "dummy-secret-namespace", true, map[model.TLSSecret][]string{
 			{Name: "dummy-secret-1", Namespace: "dummy-namespace"}: {"dummy.server.com"},
 			{Name: "dummy-secret-2", Namespace: "dummy-namespace"}: {"dummy.anotherserver.com"},
-		})
-		res2, err2 := NewHTTPListener("dummy-name", "dummy-secret-namespace", map[model.TLSSecret][]string{
+		}, nil)
+		res2, err2 := newListener("dummy-name", "dummy-secret-namespace", true, map[model.TLSSecret][]string{
 			{Name: "dummy-secret-2", Namespace: "dummy-namespace"}: {"dummy.anotherserver.com"},
 			{Name: "dummy-secret-1", Namespace: "dummy-namespace"}: {"dummy.server.com"},
-		})
+		}, nil)
 
 		require.NoError(t, err1)
 		require.NoError(t, err2)
@@ -89,11 +102,11 @@ func TestNewHTTPListener(t *testing.T) {
 		}
 	})
 
-	t.Run("TLS", func(t *testing.T) {
-		res, err := NewHTTPListener("dummy-name", "dummy-secret-namespace", map[model.TLSSecret][]string{
+	t.Run("with TLS (termination)", func(t *testing.T) {
+		res, err := newListener("dummy-name", "dummy-secret-namespace", true, map[model.TLSSecret][]string{
 			{Name: "dummy-secret-1", Namespace: "dummy-namespace"}: {"dummy.server.com"},
 			{Name: "dummy-secret-2", Namespace: "dummy-namespace"}: {"dummy.anotherserver.com"},
-		})
+		}, nil)
 		require.Nil(t, err)
 
 		listener := &envoy_config_listener.Listener{}
@@ -135,11 +148,12 @@ func TestNewHTTPListener(t *testing.T) {
 		require.Equal(t, "dummy-secret-namespace/dummy-namespace-dummy-secret-2", secretNames[1])
 
 	})
-}
 
-func TestNewSNIListener(t *testing.T) {
-	t.Run("normal SNI listener", func(t *testing.T) {
-		res, err := NewSNIListener("dummy-name",
+	t.Run("with TLS (passthrough)", func(t *testing.T) {
+		res, err := newListener("dummy-name",
+			"",
+			false,
+			nil,
 			map[string][]string{
 				"foo-namespace/dummy-service:443": {
 					"foo.bar",
@@ -163,8 +177,11 @@ func TestNewSNIListener(t *testing.T) {
 		require.Equal(t, []string{"foo.bar"}, listener.GetFilterChains()[1].FilterChainMatch.ServerNames)
 	})
 
-	t.Run("SNI listener with stable filterchain sort-order", func(t *testing.T) {
-		res1, err1 := NewSNIListener("dummy-name",
+	t.Run("stable filterchain sort-order for TLS passthrough", func(t *testing.T) {
+		res1, err1 := newListener("dummy-name",
+			"",
+			false,
+			nil,
 			map[string][]string{
 				"dummy-namespace/dummy-service:443": {
 					"example.org",
@@ -175,7 +192,10 @@ func TestNewSNIListener(t *testing.T) {
 				},
 			},
 		)
-		res2, err2 := NewSNIListener("dummy-name",
+		res2, err2 := newListener("dummy-name",
+			"",
+			false,
+			nil,
 			map[string][]string{
 				"foo-namespace/dummy-service:443": {
 					"foo.bar",
@@ -195,8 +215,8 @@ func TestNewSNIListener(t *testing.T) {
 		}
 	})
 
-	t.Run("normal SNI listener with Proxy Protocol", func(t *testing.T) {
-		res, err := NewSNIListener("dummy-name", map[string][]string{"dummy-namespace/dummy-service:443": {"example.org", "example.com"}}, WithProxyProtocol())
+	t.Run("TLS passthrough with Proxy Protocol", func(t *testing.T) {
+		res, err := newListener("dummy-name", "", false, nil, map[string][]string{"dummy-namespace/dummy-service:443": {"example.org", "example.com"}}, WithProxyProtocol())
 		require.Nil(t, err)
 
 		listener := &envoy_config_listener.Listener{}
@@ -212,5 +232,47 @@ func TestNewSNIListener(t *testing.T) {
 		require.Equal(t, []string{proxyProtocolType, tlsInspectorType}, listenerNames)
 		require.Len(t, listener.GetFilterChains(), 1)
 		require.Len(t, listener.GetFilterChains()[0].FilterChainMatch.ServerNames, 2)
+	})
+
+	t.Run("Combined (non-TLS, TLS & TLS passthrough)", func(t *testing.T) {
+		res, err := newListener("dummy-name",
+			"dummy-namespace",
+			true,
+			map[model.TLSSecret][]string{
+				{Name: "dummy-secret-1", Namespace: "dummy-namespace"}: {"dummy.server.com"},
+				{Name: "dummy-secret-2", Namespace: "dummy-namespace"}: {"dummy.anotherserver.com"},
+				{Name: "dummy-secret-3", Namespace: "dummy-namespace"}: {"foo.acme.com", "bar.acme.com"},
+			},
+			map[string][]string{
+				"foo-namespace/dummy-service:443": {
+					"foo.bar",
+				},
+				"dummy-namespace/dummy-service:443": {
+					"example.org",
+					"example.com",
+				},
+			},
+		)
+		require.Nil(t, err)
+
+		listener := &envoy_config_listener.Listener{}
+		err = proto.Unmarshal(res.Value, listener)
+		require.Nil(t, err)
+
+		require.Equal(t, "dummy-name", listener.Name)
+		require.Len(t, listener.GetListenerFilters(), 1)
+		require.Len(t, listener.GetFilterChains(), 6)
+		require.Equal(t, "raw_buffer", listener.GetFilterChains()[0].FilterChainMatch.TransportProtocol)
+		require.Equal(t, "tls", listener.GetFilterChains()[1].FilterChainMatch.TransportProtocol)
+		require.Equal(t, "tls", listener.GetFilterChains()[2].FilterChainMatch.TransportProtocol)
+		require.Equal(t, "tls", listener.GetFilterChains()[3].FilterChainMatch.TransportProtocol)
+		require.Equal(t, "tls", listener.GetFilterChains()[4].FilterChainMatch.TransportProtocol)
+		require.Equal(t, "tls", listener.GetFilterChains()[5].FilterChainMatch.TransportProtocol)
+		require.Empty(t, listener.GetFilterChains()[0].FilterChainMatch.ServerNames)
+		require.Equal(t, []string{"dummy.server.com"}, listener.GetFilterChains()[1].FilterChainMatch.ServerNames)
+		require.Equal(t, []string{"dummy.anotherserver.com"}, listener.GetFilterChains()[2].FilterChainMatch.ServerNames)
+		require.Equal(t, []string{"bar.acme.com", "foo.acme.com"}, listener.GetFilterChains()[3].FilterChainMatch.ServerNames)
+		require.Equal(t, []string{"example.com", "example.org"}, listener.GetFilterChains()[4].FilterChainMatch.ServerNames)
+		require.Equal(t, []string{"foo.bar"}, listener.GetFilterChains()[5].FilterChainMatch.ServerNames)
 	})
 }

--- a/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
@@ -270,25 +270,27 @@ var basicTLSListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Any: toAny(&envoy_config_listener.Listener{
 					Name: "listener",
-					FilterChains: []*envoy_config_listener.FilterChain{{
-						FilterChainMatch: &envoy_config_listener.FilterChainMatch{
-							ServerNames:       []string{"foo.com"},
-							TransportProtocol: "tls",
-						},
-						Filters: []*envoy_config_listener.Filter{
-							{
-								Name: "envoy.filters.network.tcp_proxy",
-								ConfigType: &envoy_config_listener.Filter_TypedConfig{
-									TypedConfig: toAny(&envoy_extensions_filters_network_tcp_v3.TcpProxy{
-										StatPrefix: "default:my-service:8080",
-										ClusterSpecifier: &envoy_extensions_filters_network_tcp_v3.TcpProxy_Cluster{
-											Cluster: "default:my-service:8080",
-										},
-									}),
+					FilterChains: []*envoy_config_listener.FilterChain{
+						{
+							FilterChainMatch: &envoy_config_listener.FilterChainMatch{
+								ServerNames:       []string{"foo.com"},
+								TransportProtocol: "tls",
+							},
+							Filters: []*envoy_config_listener.Filter{
+								{
+									Name: "envoy.filters.network.tcp_proxy",
+									ConfigType: &envoy_config_listener.Filter_TypedConfig{
+										TypedConfig: toAny(&envoy_extensions_filters_network_tcp_v3.TcpProxy{
+											StatPrefix: "default:my-service:8080",
+											ClusterSpecifier: &envoy_extensions_filters_network_tcp_v3.TcpProxy_Cluster{
+												Cluster: "default:my-service:8080",
+											},
+										}),
+									},
 								},
 							},
 						},
-					}},
+					},
 					ListenerFilters: []*envoy_config_listener.ListenerFilter{
 						{
 							Name: "envoy.filters.listener.tls_inspector",
@@ -3937,6 +3939,7 @@ var requestRedirectWithMultiHTTPListeners = []model.HTTPListener{
 		},
 	},
 }
+
 var requestRedirectWithMultiHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "cilium-gateway-same-namespace",

--- a/operator/pkg/model/translation/translator.go
+++ b/operator/pkg/model/translation/translator.go
@@ -156,17 +156,17 @@ func (i *defaultTranslator) getTLSRouteListener(m *model.Model) []ciliumv2.XDSRe
 	if len(m.TLS) == 0 {
 		return nil
 	}
-	backendsMap := make(map[string][]string)
+	ptBackendsToHostnames := make(map[string][]string)
 	for _, h := range m.TLS {
 		for _, route := range h.Routes {
 			for _, backend := range route.Backends {
 				key := fmt.Sprintf("%s:%s:%s", backend.Namespace, backend.Name, backend.Port.GetPort())
-				backendsMap[key] = append(backendsMap[key], route.Hostnames...)
+				ptBackendsToHostnames[key] = append(ptBackendsToHostnames[key], route.Hostnames...)
 			}
 		}
 	}
 
-	if len(backendsMap) == 0 {
+	if len(ptBackendsToHostnames) == 0 {
 		return nil
 	}
 
@@ -174,7 +174,7 @@ func (i *defaultTranslator) getTLSRouteListener(m *model.Model) []ciliumv2.XDSRe
 	if i.useProxyProtocol {
 		mutatorFuncs = append(mutatorFuncs, WithProxyProtocol())
 	}
-	l, _ := NewSNIListenerWithDefaults("listener", backendsMap, mutatorFuncs...)
+	l, _ := NewSNIListenerWithDefaults("listener", ptBackendsToHostnames, mutatorFuncs...)
 	return []ciliumv2.XDSResource{l}
 }
 

--- a/operator/pkg/model/translation/translator.go
+++ b/operator/pkg/model/translation/translator.go
@@ -135,10 +135,10 @@ func (i *defaultTranslator) getHTTPRouteListener(m *model.Model) []ciliumv2.XDSR
 	if len(m.HTTP) == 0 {
 		return nil
 	}
-	tlsMap := make(map[model.TLSSecret][]string)
+	tlsSecretsToHostnames := make(map[model.TLSSecret][]string)
 	for _, h := range m.HTTP {
 		for _, s := range h.TLS {
-			tlsMap[s] = append(tlsMap[s], h.Hostname)
+			tlsSecretsToHostnames[s] = append(tlsSecretsToHostnames[s], h.Hostname)
 		}
 	}
 
@@ -146,7 +146,7 @@ func (i *defaultTranslator) getHTTPRouteListener(m *model.Model) []ciliumv2.XDSR
 	if i.useProxyProtocol {
 		mutatorFuncs = append(mutatorFuncs, WithProxyProtocol())
 	}
-	l, _ := NewHTTPListenerWithDefaults("listener", i.secretsNamespace, tlsMap, mutatorFuncs...)
+	l, _ := NewHTTPListenerWithDefaults("listener", i.secretsNamespace, tlsSecretsToHostnames, mutatorFuncs...)
 	return []ciliumv2.XDSResource{l}
 }
 

--- a/operator/pkg/model/translation/translator_test.go
+++ b/operator/pkg/model/translation/translator_test.go
@@ -193,14 +193,14 @@ func TestSharedIngressTranslator_getServices(t *testing.T) {
 	}
 }
 
-func TestSharedIngressTranslator_getHTTPRouteListenerProxy(t *testing.T) {
+func TestSharedIngressTranslator_getListenerProxy(t *testing.T) {
 	i := &defaultTranslator{
 		name:             "cilium-ingress",
 		namespace:        "kube-system",
 		secretsNamespace: "cilium-secrets",
 		useProxyProtocol: true,
 	}
-	res := i.getHTTPRouteListener(&model.Model{
+	res := i.getListener(&model.Model{
 		HTTP: []model.HTTPListener{
 			{
 				TLS: []model.TLSSecret{
@@ -225,14 +225,14 @@ func TestSharedIngressTranslator_getHTTPRouteListenerProxy(t *testing.T) {
 	require.Equal(t, []string{proxyProtocolType, tlsInspectorType}, listenerNames)
 }
 
-func TestSharedIngressTranslator_getHTTPRouteListener(t *testing.T) {
+func TestSharedIngressTranslator_getListener(t *testing.T) {
 	i := &defaultTranslator{
 		name:             "cilium-ingress",
 		namespace:        "kube-system",
 		secretsNamespace: "cilium-secrets",
 	}
 
-	res := i.getHTTPRouteListener(&model.Model{
+	res := i.getListener(&model.Model{
 		HTTP: []model.HTTPListener{
 			{
 				TLS: []model.TLSSecret{


### PR DESCRIPTION
Currently, the translation from Ingress controller & Gateway API resources into the corresponding `CiliumEnvoyConfig` creates two Envoy listeners for TLS passthrough (Ingress annotation or GW-API `TLSRoute`) and HTTP(S) related functionality.

- TLS Passthrough implemented with Envoy [TCPProxy](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/tcp_proxy_filter) network filter
- HTTP(S) implemented with Envoy [HCM](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/http_conn_man#config-http-conn-man) network filter

This works fine for Gateway API and Dedicated Ingresses where the two use-cases are never combined into the same `CiliumEnvoyConfig` - but leads to problems with Shared Ingresses.

Problem 1: Listener name clash

The two listeners have the same name listener - hence only one of them ends up in the configuration (in most of the cases the TLS Passthrough one which appears later in the configuration).

Problem 2: TPROXY redirection to different listeners with same frontend service port

After solving the name clash, there's still an issue with TLS Passthrough and HTTPS using the same "frontend" port 443 (or the corresponding NodePort) on the Ingress Service that is handled by different Envoy listeners. The current implementation (based on TPROXY) is not able to conditionally (HTTPS or TLS Passthrough) forward traffic to one of these two Listeners.

Therefore, this PR merges the two functionalities within the same Envoy listener by using different filterchains and filterchain-matches based on the servernames (SNI).

Fixes: https://github.com/cilium/cilium/issues/31242

Backport of #31646 (HostNetwork support isn't available on v1.15, other smaller conflicts due to refactorings not being backported) 

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 31646
```

```release-note
Ingress/Gateway API: merge Envoy listeners for HTTP(S) and TLS passthrough
```