### PR TITLE
ci: no longer suppported v1.25 in GKE

### DIFF
--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,13 +1,10 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.25"
-    zone: us-west1-b
-    vmIndex: 1
   - version: "1.26"
     zone: us-west2-c
-    vmIndex: 2
+    vmIndex: 1
   - version: "1.27"
     zone: us-west3-a
-    vmIndex: 3
+    vmIndex: 2
     default: true


### PR DESCRIPTION
K8S version 1.25 is no longer supported in the GKE Regular channel
