### PR TITLE
Dns proxy port test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/cilium/checkmate v1.0.3
 	github.com/cilium/coverbee v0.3.2
 	github.com/cilium/deepequal-gen v0.0.0-20231116094812-0d6c075c335f
-	github.com/cilium/dns v1.1.51-0.20240416134107-d47d0dd702a1
+	github.com/cilium/dns v1.1.51-0.20240425101412-2469d2c08d78
 	github.com/cilium/ebpf v0.14.0
 	github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b
 	github.com/cilium/fake v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/cilium/coverbee v0.3.2 h1:RaJN5OaHf/M8tmeLemHmdO0H5bFUhvtTAoYbStDIX14
 github.com/cilium/coverbee v0.3.2/go.mod h1:p9Q2SRC/sPA0qATNfY19GXBUPdcQP6UVV2LKgOHRIzQ=
 github.com/cilium/deepequal-gen v0.0.0-20231116094812-0d6c075c335f h1:t1A8nGkbZcjLACtNGIkfhfnKgG7V83+Tzr1pMeoPuA8=
 github.com/cilium/deepequal-gen v0.0.0-20231116094812-0d6c075c335f/go.mod h1:O4ERd4TTIfE/EKtiqESR2OQEiLwkDwBTW3zrbcQ4S3M=
-github.com/cilium/dns v1.1.51-0.20240416134107-d47d0dd702a1 h1:IR2iQhLyEVDJ52rPpqYAdRZMwlOSDl1XJqkD5PQJAfs=
-github.com/cilium/dns v1.1.51-0.20240416134107-d47d0dd702a1/go.mod h1:/7LC2GOgyXJ7maupZlaVIumYQiGPIgllSf6mA9sg6RU=
+github.com/cilium/dns v1.1.51-0.20240425101412-2469d2c08d78 h1:aQGIJGYqSFuTW24sMAsjAwOwpIMV3V+4KQmPb11ApnQ=
+github.com/cilium/dns v1.1.51-0.20240425101412-2469d2c08d78/go.mod h1:/7LC2GOgyXJ7maupZlaVIumYQiGPIgllSf6mA9sg6RU=
 github.com/cilium/ebpf v0.14.0 h1:0PsxAjO6EjI1rcT+rkp6WcCnE0ZvfkXBYiMedJtrSUs=
 github.com/cilium/ebpf v0.14.0/go.mod h1:DHp1WyrLeiBh19Cf/tfiSMhqheEiK8fXFZ4No0P1Hso=
 github.com/cilium/endpointslice v0.29.4-0.20240409195643-982ad68ab7ba h1:Ddc5e+pz0/nY0XiAEW/UcIlvnaHACSuF77ePyMNX510=

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -720,6 +720,15 @@ func (e *Endpoint) GetNodeMAC() mac.MAC {
 	return e.nodeMAC
 }
 
+// ConntrackName returns the name suffix for the endpoint-specific bpf
+// conntrack map, which is a 5-digit endpoint ID, or "global" when the
+// global map should be used.
+func (e *Endpoint) ConntrackName() string {
+	e.unconditionalRLock()
+	defer e.runlock()
+	return e.ConntrackNameLocked()
+}
+
 // ConntrackNameLocked returns the name suffix for the endpoint-specific bpf
 // conntrack map, which is a 5-digit endpoint ID, or "global" when the
 // global map should be used.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -206,7 +206,7 @@ github.com/cilium/coverbee/pkg/verifierlog
 ## explicit; go 1.20
 github.com/cilium/deepequal-gen
 github.com/cilium/deepequal-gen/generators
-# github.com/cilium/dns v1.1.51-0.20240416134107-d47d0dd702a1
+# github.com/cilium/dns v1.1.51-0.20240425101412-2469d2c08d78
 ## explicit; go 1.18
 github.com/cilium/dns
 # github.com/cilium/ebpf v0.14.0


### PR DESCRIPTION
Test DNS proxy always setting the source port to a fixed value (1109).

cilium/dns is updated to make it look for an unused request id value if there is a conflict with a pending request.

Cilium dns proxy now needs to make sure a conntrack entry with the proxy redirect flag exists so that DNS responses get back to the proxy.