### PR TITLE
ingress: move flag `ingress-default-xff-num-trusted-hops` to cell config

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -53,6 +53,7 @@ cilium-operator-alibabacloud hive [flags]
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
       --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -58,6 +58,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
       --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -53,6 +53,7 @@ cilium-operator-aws hive [flags]
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
       --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -58,6 +58,7 @@ cilium-operator-aws hive dot-graph [flags]
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
       --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -53,6 +53,7 @@ cilium-operator-azure hive [flags]
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
       --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -58,6 +58,7 @@ cilium-operator-azure hive dot-graph [flags]
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
       --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -53,6 +53,7 @@ cilium-operator-generic hive [flags]
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
       --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -58,6 +58,7 @@ cilium-operator-generic hive dot-graph [flags]
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
       --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -53,6 +53,7 @@ cilium-operator hive [flags]
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
       --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -58,6 +58,7 @@ cilium-operator hive dot-graph [flags]
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-secret-name string                   Default secret name for Ingress.
       --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
       --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -271,9 +271,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(operatorOption.SetCiliumIsUpCondition, true, "Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node")
 	option.BindEnv(vp, operatorOption.SetCiliumIsUpCondition)
 
-	flags.Uint32(operatorOption.IngressDefaultXffNumTrustedHops, 0, "The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.")
-	option.BindEnv(vp, operatorOption.IngressDefaultXffNumTrustedHops)
-
 	flags.String(operatorOption.PodRestartSelector, "k8s-app=kube-dns", "cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted")
 	option.BindEnv(vp, operatorOption.PodRestartSelector)
 

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -246,9 +246,6 @@ const (
 	// nodes.
 	SetCiliumIsUpCondition = "set-cilium-is-up-condition"
 
-	// IngressDefaultXffNumTrustedHops is the default XffNumTrustedHops value for Ingress.
-	IngressDefaultXffNumTrustedHops = "ingress-default-xff-num-trusted-hops"
-
 	// PodRestartSelector specify the labels contained in the pod that needs to be restarted before the node can be de-stained
 	// default values: k8s-app=kube-dns
 	PodRestartSelector = "pod-restart-selector"
@@ -445,11 +442,6 @@ type OperatorConfig struct {
 	// nodes.
 	SetCiliumIsUpCondition bool
 
-	// IngressProxyXffNumTrustedHops The number of additional ingress proxy hops from the right side of the
-	// HTTP header to trust when determining the origin client's IP address.
-	// The default is zero if this option is not specified.
-	IngressProxyXffNumTrustedHops uint32
-
 	// PodRestartSelector specify the labels contained in the pod that needs to be restarted before the node can be de-stained
 	PodRestartSelector string
 }
@@ -483,7 +475,6 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.RemoveCiliumNodeTaints = vp.GetBool(RemoveCiliumNodeTaints)
 	c.SetCiliumNodeTaints = vp.GetBool(SetCiliumNodeTaints)
 	c.SetCiliumIsUpCondition = vp.GetBool(SetCiliumIsUpCondition)
-	c.IngressProxyXffNumTrustedHops = vp.GetUint32(IngressDefaultXffNumTrustedHops)
 	c.PodRestartSelector = vp.GetString(PodRestartSelector)
 
 	c.CiliumK8sNamespace = vp.GetString(CiliumK8sNamespace)

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -60,6 +60,7 @@ type ingressConfig struct {
 	IngressHostnetworkEnabled            bool
 	IngressHostnetworkSharedListenerPort uint32
 	IngressHostnetworkNodelabelselector  string
+	IngressDefaultXffNumTrustedHops      uint32
 }
 
 func (r ingressConfig) Flags(flags *pflag.FlagSet) {
@@ -78,6 +79,7 @@ func (r ingressConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool("ingress-hostnetwork-enabled", r.IngressHostnetworkEnabled, "Exposes ingress listeners on the host network.")
 	flags.Uint32("ingress-hostnetwork-shared-listener-port", r.IngressHostnetworkSharedListenerPort, "Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)")
 	flags.String("ingress-hostnetwork-nodelabelselector", r.IngressHostnetworkNodelabelselector, "Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'")
+	flags.Uint32("ingress-default-xff-num-trusted-hops", r.IngressDefaultXffNumTrustedHops, "The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.")
 }
 
 type ingressParams struct {
@@ -110,7 +112,7 @@ func registerReconciler(params ingressParams) error {
 		translation.ParseNodeLabelSelector(params.IngressConfig.IngressHostnetworkNodelabelselector),
 		params.AgentConfig.EnableIPv4,
 		params.AgentConfig.EnableIPv6,
-		operatorOption.Config.IngressProxyXffNumTrustedHops,
+		params.IngressConfig.IngressDefaultXffNumTrustedHops,
 	)
 
 	dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, params.IngressConfig.IngressHostnetworkEnabled)


### PR DESCRIPTION
This commit moves the Cilium Operator flag `ingress-default-xff-num-trusted-hops` from the global Operator Config struct into the config struct of the corresponding Ingress hive cell.
