### PR TITLE
build: golangci-lint: update go version configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -49,8 +49,6 @@ linters-settings:
       - nilness
   goimports:
     local-prefixes: github.com/cilium/cilium/
-  staticcheck:
-    go: "1.20"
   unused:
     go: "1.20"
   goheader:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -49,8 +49,6 @@ linters-settings:
       - nilness
   goimports:
     local-prefixes: github.com/cilium/cilium/
-  unused:
-    go: "1.20"
   goheader:
     values:
       regexp:


### PR DESCRIPTION
**linters-settings.staticcheck.go**

Currently, the Go version for the staticcheck linter is configured via the property `linters-settings.staticcheck.go`. This has been deprecated in favor of the global config property `run.go` and results in the following warning.

```
❯ make lint
golangci-lint run
WARN [config_reader] The configuration option `linters.staticcheck.go` is deprecated, please use global `run.go`.
```

(or CI: https://github.com/cilium/cilium/actions/runs/8832188630/job/24249007710)

In addition, the new property `run.go` defaults to the Go version defined in the `go.mod` file.

Therefore, this commit removes the deprecated property in the golangci-lint config completely and depends on the fallback mechanism (`go.mod`).

**linters-settings.unused.go**

According to the golangci-lint documentation, the cofig property
`linters-settings.unused.go` doesn't exist (and AFAIU never has - according to some investigation)

https://golangci-lint.run/usage/linters/#unused

Hence, let's remove it.