### PR TITLE
bgpv2: fix pod ip pool cleanup

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/paths.go
+++ b/pkg/bgpv1/manager/reconcilerv2/paths.go
@@ -176,3 +176,12 @@ func reconcilePaths(params *reconcilePathsParams) (PathMap, error) {
 
 	return runningAdverts, nil
 }
+
+func addPathToAFPathsMap(m AFPathsMap, fam types.Family, path *types.Path) {
+	pathsPerFamily, exists := m[fam]
+	if !exists {
+		pathsPerFamily = make(PathMap)
+		m[fam] = pathsPerFamily
+	}
+	pathsPerFamily[path.NLRI.String()] = path
+}

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -400,15 +400,6 @@ func (r *ServiceReconciler) getServiceDesiredAFPaths(p ReconcileParams, svc *sli
 	return desiredFamilyAdverts, nil
 }
 
-func addPathToAFPathsMap(m AFPathsMap, fam types.Family, path *types.Path) {
-	pathsPerFamily, exists := m[fam]
-	if !exists {
-		pathsPerFamily = make(PathMap)
-		m[fam] = pathsPerFamily
-	}
-	pathsPerFamily[path.NLRI.String()] = path
-}
-
 func (r *ServiceReconciler) getServicePrefixes(svc *slim_corev1.Service, advert v2alpha1.BGPAdvertisement, ls sets.Set[resource.Key]) ([]netip.Prefix, error) {
 	if advert.AdvertisementType != v2alpha1.BGPServiceAdvert {
 		return nil, fmt.Errorf("unexpected advertisement type: %s", advert.AdvertisementType)

--- a/pkg/bgpv1/types/log.go
+++ b/pkg/bgpv1/types/log.go
@@ -36,4 +36,7 @@ const (
 
 	// AdvertTypeLogField is used as key for BGP advertisement type in the log field.
 	AdvertTypeLogField = "advertisement_type"
+
+	// PodIPPoolLogField is used as key for Pod IP pool in the log field.
+	PodIPPoolLogField = "pod_ip_pool"
 )


### PR DESCRIPTION
Modifying the reconciler logic in pod IP pool reconciler. Metadata to be maintained per pool, which is used to remove paths for pools which are deleted. Fixed the tests to match new metadata data structure.

