### PR TITLE
[v.13] test: Fix Endpoint Test

### DIFF
--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -532,6 +532,7 @@ func (s *EndpointSuite) TestWaitForPolicyRevision(c *C) {
 
 func (s *EndpointSuite) TestProxyID(c *C) {
 	e := &Endpoint{ID: 123, policyRevision: 0}
+	e.UpdateLogger(nil)
 
 	id, port, proto := e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true})
 	c.Assert(id, Not(Equals), "")


### PR DESCRIPTION
We need to set up an Endpoint logger
for the integration tests, otherwise
we will get a nil pointer dereferences
when we look up an invalid named port.

Fixes: #32163

