### PR TITLE
l7 policy: add possibility to configure Envoy proxy xff-num-trusted-hops

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -323,6 +323,8 @@ cilium-agent [flags]
       --proxy-portrange-max uint16                                End of port range that is used to allocate ports for L7 proxies. (default 20000)
       --proxy-portrange-min uint16                                Start of port range that is used to allocate ports for L7 proxies. (default 10000)
       --proxy-prometheus-port int                                 Port to serve Envoy metrics on. Default 0 (disabled).
+      --proxy-xff-num-trusted-hops-egress uint32                  Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
+      --proxy-xff-num-trusted-hops-ingress uint32                 Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --restore                                                   Restores state, if possible, from previous daemon (default true)
       --route-metric int                                          Overwrite the metric used by cilium when adding routes to its 'cilium_host' device

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -97,6 +97,8 @@ cilium-agent hive [flags]
       --proxy-portrange-max uint16                                End of port range that is used to allocate ports for L7 proxies. (default 20000)
       --proxy-portrange-min uint16                                Start of port range that is used to allocate ports for L7 proxies. (default 10000)
       --proxy-prometheus-port int                                 Port to serve Envoy metrics on. Default 0 (disabled).
+      --proxy-xff-num-trusted-hops-egress uint32                  Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
+      --proxy-xff-num-trusted-hops-ingress uint32                 Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -102,6 +102,8 @@ cilium-agent hive dot-graph [flags]
       --proxy-portrange-max uint16                                End of port range that is used to allocate ports for L7 proxies. (default 20000)
       --proxy-portrange-min uint16                                Start of port range that is used to allocate ports for L7 proxies. (default 10000)
       --proxy-prometheus-port int                                 Port to serve Envoy metrics on. Default 0 (disabled).
+      --proxy-xff-num-trusted-hops-egress uint32                  Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
+      --proxy-xff-num-trusted-hops-ingress uint32                 Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1296,6 +1296,14 @@
      - cilium-envoy update strategy ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#updating-a-daemonset
      - object
      - ``{"rollingUpdate":{"maxUnavailable":2},"type":"RollingUpdate"}``
+   * - :spelling:ignore:`envoy.xffNumTrustedHopsL7PolicyEgress`
+     - Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
+     - int
+     - ``0``
+   * - :spelling:ignore:`envoy.xffNumTrustedHopsL7PolicyIngress`
+     - Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
+     - int
+     - ``0``
    * - :spelling:ignore:`envoyConfig.enabled`
      - Enable CiliumEnvoyConfig CRD CiliumEnvoyConfig CRD can also be implicitly enabled by other options.
      - bool

--- a/Documentation/network/servicemesh/envoy-traffic-management.rst
+++ b/Documentation/network/servicemesh/envoy-traffic-management.rst
@@ -111,6 +111,22 @@ Adding a Layer 7 policy enables Layer 7 visibility. Notice that the Hubble outpu
 now includes flows ``to-proxy``, and also shows the HTTP protocol information at
 level 7 (for example ``HTTP/1.1 GET http://echo-service-1:8080/``)
 
+.. Note::
+
+    Note that Envoy may `sanitize some headers <https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/header_sanitizing#http-header-sanitizing>`_.
+
+    Instead, you can make Envoy trust previous hops and prevent Envoy from rewriting
+    some of these HTTP headers. Trust previous hops by setting Helm values
+    ``envoy.xffNumTrustedHopsL7PolicyIngress`` and ``envoy.xffNumTrustedHopsL7PolicyEgress``
+    to the number of hops to trust.
+
+    For an egress policy the previous hop is the source pod, whereas for an ingress policy
+    it can be either the source pod, the "egress policy transparent proxy", Cilium Ingress Controller,
+    Cilium Gateway API, or any other Ingress proxy or infrastructure.
+
+    Depending on your environment, you should consider the security implications of trusting
+    previous hops.
+
 Test Layer 7 Policy Enforcement
 ===============================
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -374,6 +374,8 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.terminationGracePeriodSeconds | int | `1` | Configure termination grace period for cilium-envoy DaemonSet. |
 | envoy.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for envoy scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | envoy.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":2},"type":"RollingUpdate"}` | cilium-envoy update strategy ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#updating-a-daemonset |
+| envoy.xffNumTrustedHopsL7PolicyEgress | int | `0` | Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners. |
+| envoy.xffNumTrustedHopsL7PolicyIngress | int | `0` | Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners. |
 | envoyConfig.enabled | bool | `false` | Enable CiliumEnvoyConfig CRD CiliumEnvoyConfig CRD can also be implicitly enabled by other options. |
 | envoyConfig.retryInterval | string | `"15s"` | Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated. |
 | envoyConfig.secretsNamespace | object | `{"create":true,"name":"cilium-secrets"}` | SecretsNamespace is the namespace in which envoy SDS will retrieve secrets from. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1242,6 +1242,8 @@ data:
   mesh-auth-spiffe-trust-domain: {{ .Values.authentication.mutual.spire.trustDomain | quote }}
 {{- end }}
 
+  proxy-xff-num-trusted-hops-ingress: {{ .Values.envoy.xffNumTrustedHopsL7PolicyIngress | quote }}
+  proxy-xff-num-trusted-hops-egress: {{ .Values.envoy.xffNumTrustedHopsL7PolicyEgress | quote }}
   proxy-connect-timeout: {{ .Values.envoy.connectTimeoutSeconds | quote }}
   proxy-max-requests-per-connection: {{ .Values.envoy.maxRequestsPerConnection | quote }}
   proxy-max-connection-duration-seconds: {{ .Values.envoy.maxConnectionDurationSeconds | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2051,6 +2051,12 @@
             }
           },
           "type": "object"
+        },
+        "xffNumTrustedHopsL7PolicyEgress": {
+          "type": "integer"
+        },
+        "xffNumTrustedHopsL7PolicyIngress": {
+          "type": "integer"
         }
       },
       "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2024,6 +2024,10 @@ envoy:
   # -- Set Envoy upstream HTTP idle connection timeout seconds.
   # Does not apply to connections with pending requests. Default 60s
   idleTimeoutDurationSeconds: 60
+  # -- Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
+  xffNumTrustedHopsL7PolicyIngress: 0
+  # -- Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
+  xffNumTrustedHopsL7PolicyEgress: 0
   # -- Envoy container image.
   image:
     # @schema

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2026,6 +2026,10 @@ envoy:
   # -- Set Envoy upstream HTTP idle connection timeout seconds.
   # Does not apply to connections with pending requests. Default 60s
   idleTimeoutDurationSeconds: 60
+  # -- Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
+  xffNumTrustedHopsL7PolicyIngress: 0
+  # -- Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
+  xffNumTrustedHopsL7PolicyEgress: 0
   # -- Envoy container image.
   image:
     # @schema

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -59,6 +59,8 @@ type envoyProxyConfig struct {
 	HTTPRetryCount                    uint
 	HTTPRetryTimeout                  uint
 	UseFullTLSContext                 bool
+	ProxyXffNumTrustedHopsIngress     uint32
+	ProxyXffNumTrustedHopsEgress      uint32
 }
 
 func (r envoyProxyConfig) Flags(flags *pflag.FlagSet) {
@@ -80,6 +82,8 @@ func (r envoyProxyConfig) Flags(flags *pflag.FlagSet) {
 	flags.Uint("http-retry-timeout", 0, "Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)")
 	// This should default to false in 1.16+ (i.e., we don't implement buggy behaviour) and true in 1.15 and earlier (i.e., we keep compatibility with an existing bug).
 	flags.Bool("use-full-tls-context", false, "If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.")
+	flags.Uint32("proxy-xff-num-trusted-hops-ingress", 0, "Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.")
+	flags.Uint32("proxy-xff-num-trusted-hops-egress", 0, "Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.")
 }
 
 type secretSyncConfig struct {
@@ -124,15 +128,17 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 		params.IPCache,
 		params.LocalEndpointStore,
 		xdsServerConfig{
-			envoySocketDir:     GetSocketDir(option.Config.RunDir),
-			proxyGID:           int(params.EnvoyProxyConfig.ProxyGID),
-			httpRequestTimeout: int(params.EnvoyProxyConfig.HTTPRequestTimeout),
-			httpIdleTimeout:    params.EnvoyProxyConfig.ProxyIdleTimeoutSeconds,
-			httpMaxGRPCTimeout: int(params.EnvoyProxyConfig.HTTPMaxGRPCTimeout),
-			httpRetryCount:     int(params.EnvoyProxyConfig.HTTPRetryCount),
-			httpRetryTimeout:   int(params.EnvoyProxyConfig.HTTPRetryTimeout),
-			httpNormalizePath:  params.EnvoyProxyConfig.HTTPNormalizePath,
-			useFullTLSContext:  params.EnvoyProxyConfig.UseFullTLSContext,
+			envoySocketDir:                GetSocketDir(option.Config.RunDir),
+			proxyGID:                      int(params.EnvoyProxyConfig.ProxyGID),
+			httpRequestTimeout:            int(params.EnvoyProxyConfig.HTTPRequestTimeout),
+			httpIdleTimeout:               params.EnvoyProxyConfig.ProxyIdleTimeoutSeconds,
+			httpMaxGRPCTimeout:            int(params.EnvoyProxyConfig.HTTPMaxGRPCTimeout),
+			httpRetryCount:                int(params.EnvoyProxyConfig.HTTPRetryCount),
+			httpRetryTimeout:              int(params.EnvoyProxyConfig.HTTPRetryTimeout),
+			httpNormalizePath:             params.EnvoyProxyConfig.HTTPNormalizePath,
+			useFullTLSContext:             params.EnvoyProxyConfig.UseFullTLSContext,
+			proxyXffNumTrustedHopsIngress: params.EnvoyProxyConfig.ProxyXffNumTrustedHopsIngress,
+			proxyXffNumTrustedHopsEgress:  params.EnvoyProxyConfig.ProxyXffNumTrustedHopsEgress,
 		})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Envoy xDS server: %w", err)


### PR DESCRIPTION
Currently, when L7 policies (egress or ingress) are enforced for traffic
between Pods, Envoy might change x-forwarded-for related headers because the corresponding
Envoy listeners don't trust the downstream headers because `XffNumTrustedHops`
is set to `0`.

e.g. `x-forwarded-proto` header:

> Downstream x-forwarded-proto headers will only be trusted if xff_num_trusted_hops is non-zero. If xff_num_trusted_hops is zero, downstream x-forwarded-proto headers and :scheme headers will be set to http or https based on if the downstream connection is TLS or not.

https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-proto

This might be problematic if L7 policies are used for egress traffic for Pods from
a non-Cilium ingress controller (e.g. nginx). If the Ingress Controller is terminating TLS
traffic and forwards the protocol via `x-forwarded-proto=https`, Cilium Envoy Proxy changes
this header to `x-forwarded-proto=http` (if no tls termination itself is used in the policy configuration).

This breaks applications that depend on the forwarded protocol.

Therefore, this commit introduces two new config flags `proxy-xff-num-trusted-hops-ingress` and
`proxy-xff-num-trusted-hops-egresss` that configures the property `XffNumTrustedHops` on the respective
L7 policy Envoy listeners.

For backwards compabitility and security reasons, the values still default to `0`.

Note: It's also possible to configure these values via Helm (`envoy.xffNumTrustedHopsL7PolicyIngress` &
`envoy.xffNumTrustedHopsL7PolicyEgress`).