### PR TITLE
loader: infrastructure for attaching SKB programs using the tcx API

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -161,6 +161,7 @@ cilium-agent [flags]
       --enable-service-topology                                   Enable support for service topology aware hints
       --enable-session-affinity                                   Enable support for service session affinity
       --enable-svc-source-range-check                             Enable check of service source ranges (currently, only for LoadBalancer) (default true)
+      --enable-tcx                                                Attach endpoint programs using tcx if supported by the kernel
       --enable-tracing                                            Enable tracing while determining policy (debugging)
       --enable-unreachable-routes                                 Add unreachable routes on pod deletion
       --enable-vtep                                               Enable  VXLAN Tunnel Endpoint (VTEP) Integration (beta)

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -19,6 +19,9 @@ bpf_clear_meta(struct __sk_buff *ctx)
 	WRITE_ONCE(ctx->cb[2], zero);
 	WRITE_ONCE(ctx->cb[3], zero);
 	WRITE_ONCE(ctx->cb[4], zero);
+
+	/* This needs to be cleared mainly for tcx. */
+	WRITE_ONCE(ctx->tc_classid, zero);
 }
 
 /**

--- a/cilium-dbg/cmd/post_uninstall_cleanup.go
+++ b/cilium-dbg/cmd/post_uninstall_cleanup.go
@@ -255,6 +255,7 @@ func (c ciliumCleanup) cleanupFuncs() []cleanupFunc {
 		cleanupTCFilters,
 		cleanupXDPs,
 		removeSocketLBPrograms,
+		removeCiliumBPFFS,
 	}
 	if !c.bpfOnly {
 		funcs = append(funcs, cleanupRoutesAndLinks)
@@ -594,4 +595,15 @@ func isCiliumXDP(progId uint32) (bool, error) {
 
 	return false, nil
 
+}
+
+func removeCiliumBPFFS() error {
+	path := bpf.CiliumPath()
+
+	if err := bpf.Remove(path); err != nil {
+		return err
+	}
+
+	fmt.Printf("removed all cilium bpffs objects under %s\n", path)
+	return nil
 }

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -705,6 +705,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableXDPPrefilter, false, "Enable XDP prefiltering")
 	option.BindEnv(vp, option.EnableXDPPrefilter)
 
+	flags.Bool(option.EnableTCX, false, "Attach endpoint programs using tcx if supported by the kernel")
+	option.BindEnv(vp, option.EnableTCX)
+
 	flags.Bool(option.PreAllocateMapsName, defaults.PreAllocateMaps, "Enable BPF map pre-allocation")
 	option.BindEnv(vp, option.PreAllocateMapsName)
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -294,6 +294,7 @@ contributors across the globe, there is almost always someone available to help.
 | enableK8sTerminatingEndpoint | bool | `true` | Configure whether to enable auto detect of terminating state for endpoints in order to support graceful termination. |
 | enableMasqueradeRouteSource | bool | `false` | Enables masquerading to the source of the route for traffic leaving the node from endpoints. |
 | enableRuntimeDeviceDetection | bool | `false` | Enables experimental support for the detection of new and removed datapath devices. When devices change the eBPF datapath is reloaded and services updated. If "devices" is set then only those devices, or devices matching a wildcard will be considered. |
+| enableTCX | bool | `true` | Attach endpoint programs using tcx instead of legacy tc hooks on supported kernels. |
 | enableXTSocketFallback | bool | `true` | Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: https://docs.cilium.io/en/stable/operations/system_requirements/#linux-kernel. |
 | encryption.enabled | bool | `false` | Enable transparent network encryption. |
 | encryption.ipsec.encryptedOverlay | bool | `false` | Enable IPsec encrypted overlay |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -579,6 +579,12 @@ data:
   enable-ipv6-big-tcp: {{ .Values.enableIPv6BIGTCP | quote }}
   enable-ipv6-masquerade: {{ .Values.enableIPv6Masquerade | quote }}
 
+{{- if hasKey .Values "enableTCX" }}
+  enable-tcx: {{ .Values.enableTCX | quote }}
+{{- else }}
+  enable-tcx: "true"
+{{- end }}
+
 {{- if (not (kindIs "invalid" .Values.bpf.masquerade)) }}
   enable-bpf-masquerade: {{ .Values.bpf.masquerade | quote }}
 {{- else if eq $defaultBpfMasquerade "true" }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1499,6 +1499,9 @@
     "enableRuntimeDeviceDetection": {
       "type": "boolean"
     },
+    "enableTCX": {
+      "type": "boolean"
+    },
     "enableXTSocketFallback": {
       "type": "boolean"
     },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1801,6 +1801,8 @@ enableMasqueradeRouteSource: false
 enableIPv4BIGTCP: false
 # -- Enables IPv6 BIG TCP support which increases maximum IPv6 GSO/GRO limits for nodes and pods
 enableIPv6BIGTCP: false
+# -- Attach endpoint programs using tcx instead of legacy tc hooks on supported kernels.
+enableTCX: true
 egressGateway:
   # -- Enables egress gateway to redirect and SNAT the traffic that leaves the
   # cluster.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1802,6 +1802,8 @@ enableMasqueradeRouteSource: false
 enableIPv4BIGTCP: false
 # -- Enables IPv6 BIG TCP support which increases maximum IPv6 GSO/GRO limits for nodes and pods
 enableIPv6BIGTCP: false
+# -- Attach endpoint programs using tcx instead of legacy tc hooks on supported kernels.
+enableTCX: true
 egressGateway:
   # -- Enables egress gateway to redirect and SNAT the traffic that leaves the
   # cluster.

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -223,6 +223,7 @@ func (l *loader) reinitializeIPSec(ctx context.Context) error {
 				elf:      networkObj,
 				programs: progs,
 				linkDir:  bpffsDeviceLinksDir(bpf.CiliumPath(), device),
+				tcx:      option.Config.EnableTCX,
 			},
 		)
 		if err != nil {

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -412,6 +412,7 @@ func (l *loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 			elf:      objPath,
 			programs: progs,
 			linkDir:  bpffsDeviceLinksDir(bpf.CiliumPath(), host),
+			tcx:      option.Config.EnableTCX,
 		},
 	)
 	if err != nil {
@@ -452,6 +453,7 @@ func (l *loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 			elf:      secondDevObjPath,
 			programs: progs,
 			linkDir:  bpffsDeviceLinksDir(bpf.CiliumPath(), net),
+			tcx:      option.Config.EnableTCX,
 		},
 	)
 	if err != nil {
@@ -506,6 +508,7 @@ func (l *loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 				elf:      netdevObjPath,
 				programs: progs,
 				linkDir:  linkDir,
+				tcx:      option.Config.EnableTCX,
 			},
 		)
 		if err != nil {
@@ -575,6 +578,7 @@ func (l *loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 				elf:      objPath,
 				programs: progs,
 				linkDir:  linkDir,
+				tcx:      option.Config.EnableTCX,
 			},
 		)
 		if err != nil {
@@ -633,6 +637,7 @@ func (l *loader) replaceOverlayDatapath(ctx context.Context, cArgs []string, ifa
 			elf:      overlayObj,
 			programs: progs,
 			linkDir:  bpffsDeviceLinksDir(bpf.CiliumPath(), device),
+			tcx:      option.Config.EnableTCX,
 		},
 	)
 	if err != nil {

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -141,6 +141,7 @@ func TestReload(t *testing.T) {
 		elf:      objPath,
 		programs: progs,
 		linkDir:  testutils.TempBPFFS(t),
+		tcx:      true,
 	}
 	finalize, err := replaceDatapath(ctx, opts)
 	require.NoError(t, err)
@@ -289,6 +290,7 @@ func BenchmarkReplaceDatapath(b *testing.B) {
 				elf:      objPath,
 				programs: progs,
 				linkDir:  linkDir,
+				tcx:      true,
 			},
 		)
 		if err != nil {

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -52,6 +52,7 @@ type replaceDatapathOptions struct {
 	programs []progDefinition // programs that we want to attach/replace
 	xdpMode  string           // XDP driver mode, only applies when attaching XDP programs
 	linkDir  string           // path to bpffs dir holding bpf_links for the device/endpoint
+	tcx      bool             // attempt attaching skb programs using tcx
 }
 
 // replaceDatapath replaces the qdisc and BPF program for an endpoint or XDP program.
@@ -230,7 +231,7 @@ func replaceDatapath(ctx context.Context, opts replaceDatapathOptions) (_ func()
 			err = attachXDPProgram(link, coll.Programs[prog.progName], prog.progName, opts.linkDir, xdpConfigModeToFlag(opts.xdpMode))
 		} else {
 			scopedLog.Debug("Attaching SKB program to interface")
-			err = attachSKBProgram(link, coll.Programs[prog.progName], prog.progName, opts.linkDir, directionToParent(prog.direction))
+			err = attachSKBProgram(link, coll.Programs[prog.progName], prog.progName, opts.linkDir, directionToParent(prog.direction), opts.tcx)
 		}
 
 		if err != nil {

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/vishvananda/netlink"
@@ -40,21 +39,6 @@ func directionToParent(dir string) uint32 {
 		return netlink.HANDLE_MIN_EGRESS
 	}
 	return 0
-}
-
-func replaceQdisc(link netlink.Link) error {
-	attrs := netlink.QdiscAttrs{
-		LinkIndex: link.Attrs().Index,
-		Handle:    netlink.MakeHandle(0xffff, 0),
-		Parent:    netlink.HANDLE_CLSACT,
-	}
-
-	qdisc := &netlink.GenericQdisc{
-		QdiscAttrs: attrs,
-		QdiscType:  qdiscClsact,
-	}
-
-	return netlink.QdiscReplace(qdisc)
 }
 
 type progDefinition struct {
@@ -245,8 +229,8 @@ func replaceDatapath(ctx context.Context, opts replaceDatapathOptions) (_ func()
 			scopedLog.Debug("Attaching XDP program to interface")
 			err = attachXDPProgram(link, coll.Programs[prog.progName], prog.progName, opts.linkDir, xdpConfigModeToFlag(opts.xdpMode))
 		} else {
-			scopedLog.Debug("Attaching TC program to interface")
-			err = attachTCProgram(link, coll.Programs[prog.progName], prog.progName, opts.linkDir, directionToParent(prog.direction))
+			scopedLog.Debug("Attaching SKB program to interface")
+			err = attachSKBProgram(link, coll.Programs[prog.progName], prog.progName, opts.linkDir, directionToParent(prog.direction))
 		}
 
 		if err != nil {
@@ -283,71 +267,6 @@ func resolveAndInsertCalls(coll *ebpf.Collection, mapName string, calls []ebpf.M
 		}
 
 		log.Debugf("Inserted program %s into %s slot %d", name, mapName, slot)
-	}
-
-	return nil
-}
-
-// attachTCProgram attaches the TC program 'prog' to link.
-func attachTCProgram(link netlink.Link, prog *ebpf.Program, progName, bpffsDir string, qdiscParent uint32) error {
-	if prog == nil {
-		return errors.New("cannot attach a nil program")
-	}
-
-	// Remove tcx bpf_links created by newer versions of Cilium. They cannot be
-	// overwritten by netlink-based tc attachments, as tcx is a separate hook
-	// altogether. Remove the tcx link first to avoid tc programs being run twice
-	// for every packet. This cannot be done seamlessly and will cause a small
-	// window of connection interruption.
-	pin := filepath.Join(bpffsDir, progName)
-	if err := os.Remove(pin); err == nil {
-		log.WithField("device", link.Attrs().Name).WithField("pinPath", pin).
-			Info("Removed tcx link before legacy tc downgrade, possible connectivity interruption")
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("unpinning defunct link %s: %w", pin, err)
-	}
-
-	if err := replaceQdisc(link); err != nil {
-		return fmt.Errorf("replacing clsact qdisc for interface %s: %w", link.Attrs().Name, err)
-	}
-
-	filter := &netlink.BpfFilter{
-		FilterAttrs: netlink.FilterAttrs{
-			LinkIndex: link.Attrs().Index,
-			Parent:    qdiscParent,
-			Handle:    1,
-			Protocol:  unix.ETH_P_ALL,
-			Priority:  option.Config.TCFilterPriority,
-		},
-		Fd:           prog.FD(),
-		Name:         fmt.Sprintf("%s-%s", progName, link.Attrs().Name),
-		DirectAction: true,
-	}
-
-	if err := netlink.FilterReplace(filter); err != nil {
-		return fmt.Errorf("replacing tc filter for interface %s: %w", link.Attrs().Name, err)
-	}
-
-	return nil
-}
-
-// removeTCFilters removes all tc filters from the given interface.
-// Direction is passed as netlink.HANDLE_MIN_{INGRESS,EGRESS} via tcDir.
-func removeTCFilters(ifName string, tcDir uint32) error {
-	link, err := netlink.LinkByName(ifName)
-	if err != nil {
-		return err
-	}
-
-	filters, err := netlink.FilterList(link, tcDir)
-	if err != nil {
-		return err
-	}
-
-	for _, f := range filters {
-		if err := netlink.FilterDel(f); err != nil {
-			return err
-		}
 	}
 
 	return nil
@@ -829,60 +748,43 @@ func renameDevice(from, to string) error {
 	return nil
 }
 
-// DeviceHasTCProgramLoaded checks whether a given device has tc filter/qdisc progs attached.
-func (l *loader) DeviceHasTCProgramLoaded(hostInterface string, checkEgress bool) (bool, error) {
-	const bpfProgPrefix = "cil_"
-
-	link, err := netlink.LinkByName(hostInterface)
+// DeviceHasTCProgramLoaded returns true if the given device has a tc(x) program
+// attached.
+//
+// If checkEgress is true, returns true if there's both an ingress and
+// egress program attached.
+func (l *loader) DeviceHasTCProgramLoaded(device string, checkEgress bool) (bool, error) {
+	link, err := netlink.LinkByName(device)
 	if err != nil {
-		return false, fmt.Errorf("unable to find endpoint link by name: %w", err)
+		return false, fmt.Errorf("retrieving device %s: %w", device, err)
 	}
 
-	dd, err := netlink.QdiscList(link)
+	itcx, err := hasCiliumTCXLinks(link, ebpf.AttachTCXIngress)
 	if err != nil {
-		return false, fmt.Errorf("unable to fetch qdisc list for endpoint: %w", err)
+		return false, err
 	}
-	var found bool
-	for _, d := range dd {
-		if d.Type() == qdiscClsact {
-			found = true
-			break
-		}
+	itc, err := hasCiliumTCFilters(link, netlink.HANDLE_MIN_INGRESS)
+	if err != nil {
+		return false, err
 	}
-	if !found {
+
+	// Need ingress programs at minimum, bail out if these are already missing.
+	if !itc && !itcx {
 		return false, nil
 	}
 
-	ff, err := netlink.FilterList(link, netlink.HANDLE_MIN_INGRESS)
-	if err != nil {
-		return false, fmt.Errorf("unable to fetch ingress filter list: %w", err)
-	}
-	var filtersCount int
-	for _, f := range ff {
-		if filter, ok := f.(*netlink.BpfFilter); ok {
-			if strings.HasPrefix(filter.Name, bpfProgPrefix) {
-				filtersCount++
-			}
-		}
-	}
-	if filtersCount == 0 {
-		return false, nil
-	}
 	if !checkEgress {
 		return true, nil
 	}
 
-	ff, err = netlink.FilterList(link, netlink.HANDLE_MIN_EGRESS)
+	etcx, err := hasCiliumTCXLinks(link, ebpf.AttachTCXEgress)
 	if err != nil {
-		return false, fmt.Errorf("unable to fetch egress filter list: %w", err)
+		return false, err
 	}
-	filtersCount = 0
-	for _, f := range ff {
-		if filter, ok := f.(*netlink.BpfFilter); ok {
-			if strings.HasPrefix(filter.Name, bpfProgPrefix) {
-				filtersCount++
-			}
-		}
+	etc, err := hasCiliumTCFilters(link, netlink.HANDLE_MIN_EGRESS)
+	if err != nil {
+		return false, err
 	}
-	return len(ff) > 0 && filtersCount > 0, nil
+
+	return etc || etcx, nil
 }

--- a/pkg/datapath/loader/tc.go
+++ b/pkg/datapath/loader/tc.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package loader
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// attachSKBProgram attaches prog to device using legacy tc.
+func attachSKBProgram(device netlink.Link, prog *ebpf.Program, progName, bpffsDir string, parent uint32) error {
+	// tcx not available or disabled, fall back to legacy tc.
+	if err := attachTCProgram(device, prog, progName, parent); err != nil {
+		return fmt.Errorf("attaching legacy tc program %s: %w", progName, err)
+	}
+
+	// Legacy tc attached, make sure tcx is detached in case of downgrade.
+	if err := detachTCX(bpffsDir, progName); err != nil {
+		return fmt.Errorf("tcx cleanup after attaching legacy tc program %s: %w", progName, err)
+	}
+
+	return nil
+}
+
+// detachSKBProgram attempts to remove an existing tcx and legacy tc link with
+// the given properties. Always attempts to remove both tcx and tc attachments.
+func detachSKBProgram(device netlink.Link, progName, bpffsDir string, parent uint32) error {
+	if err := detachTCX(bpffsDir, progName); err != nil {
+		return err
+	}
+
+	return removeTCFilters(device, parent)
+}
+
+// attachTCProgram attaches prog to device using a legacy tc bpf filter.
+func attachTCProgram(device netlink.Link, prog *ebpf.Program, progName string, parent uint32) error {
+	if err := replaceQdisc(device); err != nil {
+		return fmt.Errorf("replacing clsact qdisc for interface %s: %w", device.Attrs().Name, err)
+	}
+
+	filter := &netlink.BpfFilter{
+		FilterAttrs: netlink.FilterAttrs{
+			LinkIndex: device.Attrs().Index,
+			Parent:    parent,
+			Handle:    1,
+			Protocol:  unix.ETH_P_ALL,
+			Priority:  option.Config.TCFilterPriority,
+		},
+		Fd:           prog.FD(),
+		Name:         fmt.Sprintf("%s-%s", progName, device.Attrs().Name),
+		DirectAction: true,
+	}
+
+	if err := netlink.FilterReplace(filter); err != nil {
+		return fmt.Errorf("replacing tc filter for interface %s: %w", device.Attrs().Name, err)
+	}
+
+	log.Infof("Program %s attached to device %s using legacy tc", progName, device.Attrs().Name)
+
+	return nil
+}
+
+// removeTCFilters removes all tc filters from the given interface.
+// Direction is passed as netlink.HANDLE_MIN_{INGRESS,EGRESS} via parent.
+func removeTCFilters(device netlink.Link, parent uint32) error {
+	filters, err := netlink.FilterList(device, parent)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range filters {
+		if err := netlink.FilterDel(f); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// hasCiliumTCFilters returns true if device has Cilium-managed bpf filters
+// for the given direction (parent).
+func hasCiliumTCFilters(device netlink.Link, parent uint32) (bool, error) {
+	filters, err := netlink.FilterList(device, parent)
+	if err != nil {
+		return false, fmt.Errorf("listing tc filters for device %s, direction %d: %w", device.Attrs().Name, parent, err)
+	}
+
+	for _, f := range filters {
+		if bpfFilter, ok := f.(*netlink.BpfFilter); ok {
+			// If any filter contains the cil_ prefix in the name we know Cilium
+			// previously attached its programs to this netlink device.
+			if strings.HasPrefix(bpfFilter.Name, "cil_") {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func replaceQdisc(link netlink.Link) error {
+	attrs := netlink.QdiscAttrs{
+		LinkIndex: link.Attrs().Index,
+		Handle:    netlink.MakeHandle(0xffff, 0),
+		Parent:    netlink.HANDLE_CLSACT,
+	}
+
+	qdisc := &netlink.GenericQdisc{
+		QdiscAttrs: attrs,
+		QdiscType:  qdiscClsact,
+	}
+
+	return netlink.QdiscReplace(qdisc)
+}

--- a/pkg/datapath/loader/tc_test.go
+++ b/pkg/datapath/loader/tc_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package loader
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/testutils/netns"
+)
+
+func newTCProgram() (*ebpf.Program, error) {
+	return ebpf.NewProgram(&ebpf.ProgramSpec{
+		Type: ebpf.SchedCLS,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		License: "Apache-2.0",
+	})
+}
+
+func mustTCProgram(tb testing.TB) *ebpf.Program {
+	p, err := newTCProgram()
+	if err != nil {
+		tb.Skipf("tc programs not supported: %s", err)
+	}
+	tb.Cleanup(func() {
+		p.Close()
+	})
+	return p
+}
+
+func mustTCProgramWithName(t *testing.T, name string) *ebpf.Program {
+	p, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name: name,
+		Type: ebpf.SchedCLS,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		License: "Apache-2.0",
+	})
+	if err != nil {
+		t.Skipf("tc programs not supported: %s", err)
+	}
+	t.Cleanup(func() {
+		p.Close()
+	})
+	return p
+}
+
+func TestAttachDetachSKBProgram(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		prog := mustTCProgram(t)
+		linkDir := testutils.TempBPFFS(t)
+
+		require.NoError(t, attachSKBProgram(lo, prog, "test", linkDir, directionToParent(dirEgress)))
+		require.NoError(t, detachSKBProgram(lo, "test", linkDir, directionToParent(dirEgress)))
+
+		return nil
+	})
+}
+
+// Downgrade a tcx program to legacy tc.
+func TestAttachSKBDowngrade(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		prog := mustTCProgramWithName(t, "cil_test")
+		linkDir := testutils.TempBPFFS(t)
+
+		require.NoError(t, upsertTCXProgram(lo, prog, "cil_test", linkDir, directionToParent(dirEgress)))
+
+		require.NoError(t, attachSKBProgram(lo, prog, "cil_test", linkDir, directionToParent(dirEgress)))
+
+		hasFilters, err := hasCiliumTCFilters(lo, directionToParent(dirEgress))
+		require.NoError(t, err)
+		require.True(t, hasFilters)
+
+		require.NoError(t, testutils.WaitUntil(func() bool {
+			hasLinks, err := hasCiliumTCXLinks(lo, ebpf.AttachTCXEgress)
+			require.NoError(t, err)
+			return !hasLinks
+		}, time.Second))
+
+		return nil
+	})
+}
+
+func TestHasCiliumTCFilters(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		// Test if function succeeds and returns false if no filters are attached
+		hasFilters, err := hasCiliumTCFilters(lo, directionToParent(dirEgress))
+		require.NoError(t, err)
+		require.False(t, hasFilters)
+
+		prog := mustTCProgram(t)
+
+		err = attachTCProgram(lo, prog, "no_prefix_test", directionToParent(dirEgress))
+		require.NoError(t, err)
+
+		// Test if function succeeds and return false if no filter with 'cil' prefix is attached
+		hasFilters, err = hasCiliumTCFilters(lo, directionToParent(dirEgress))
+		require.NoError(t, err)
+		require.False(t, hasFilters)
+
+		err = attachTCProgram(lo, prog, "cil_test", directionToParent(dirEgress))
+		require.NoError(t, err)
+
+		// Test if function succeeds and return true if filter with 'cil' prefix is attached
+		hasFilters, err = hasCiliumTCFilters(lo, directionToParent(dirEgress))
+		require.NoError(t, err)
+		require.True(t, hasFilters)
+
+		return nil
+	})
+}

--- a/pkg/datapath/loader/tcx.go
+++ b/pkg/datapath/loader/tcx.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package loader
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+
+	"github.com/cilium/cilium/pkg/bpf"
+)
+
+func parentToAttachType(parent uint32) ebpf.AttachType {
+	switch parent {
+	case netlink.HANDLE_MIN_INGRESS:
+		return ebpf.AttachTCXIngress
+	case netlink.HANDLE_MIN_EGRESS:
+		return ebpf.AttachTCXEgress
+	}
+	panic(fmt.Sprintf("invalid tc direction: %d", parent))
+}
+
+// upsertTCXProgram updates or creates a new tcx attachment for prog to device.
+// Returns [link.ErrNotSupported] if tcx is not supported on the node.
+func upsertTCXProgram(device netlink.Link, prog *ebpf.Program, progName, bpffsDir string, parent uint32) error {
+	err := updateTCX(prog, progName, bpffsDir)
+	if err == nil {
+		// Link was updated, nothing left to do.
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		// Unrecoverable error, surface to the caller.
+		return fmt.Errorf("updating tcx program: %w", err)
+	}
+
+	return attachTCX(device, prog, progName, bpffsDir, parentToAttachType(parent))
+}
+
+// attachTCX creates a new tcx attachment for prog to device at the given attach
+// type. It pins the resulting link object to progName in bpffsDir.
+//
+// progName is typically the Program's key in CollectionSpec.Programs.
+func attachTCX(device netlink.Link, prog *ebpf.Program, progName, bpffsDir string, attach ebpf.AttachType) error {
+	l, err := link.AttachTCX(link.TCXOptions{
+		Program:   prog,
+		Attach:    attach,
+		Interface: device.Attrs().Index,
+		Anchor:    link.Tail(),
+	})
+	if err != nil {
+		return fmt.Errorf("attaching tcx: %w", err)
+	}
+
+	defer func() {
+		// The program was successfully attached using tcx. Closing a link does not
+		// detach the program if the link is pinned.
+		if err := l.Close(); err != nil {
+			log.Warnf("Failed to close tcx link for program %s", progName)
+		}
+	}()
+
+	pin := filepath.Join(bpffsDir, progName)
+	if err := l.Pin(pin); err != nil {
+		return fmt.Errorf("pinning link at %s for program %s : %w", pin, progName, err)
+	}
+
+	log.Infof("Program %s attached to device %s using tcx", progName, device.Attrs().Name)
+
+	return nil
+}
+
+// updateTCX attempts to update an existing tcx link called progName in
+// bpffsDir. If the link is defunct, the pin is removed.
+//
+// Returns nil if the update was successful. Returns an error wrapping
+// [os.ErrNotExist] if the link is defunct or missing.
+func updateTCX(prog *ebpf.Program, progName, bpffsDir string) error {
+	// Attempt to open and update an existing link.
+	pin := filepath.Join(bpffsDir, progName)
+	err := bpf.UpdateLink(pin, prog)
+	switch {
+	// Update successful, nothing left to do.
+	case err == nil:
+		log.Infof("Updated link %s for program %s", pin, progName)
+		return nil
+
+	// Link exists, but is defunct, and needs to be recreated. The program
+	// no longer gets triggered at this point and the link needs to be removed
+	// to proceed.
+	case errors.Is(err, unix.ENOLINK):
+		if err := os.Remove(pin); err != nil {
+			return fmt.Errorf("unpinning defunct link %s: %w", pin, err)
+		}
+
+		log.Infof("Unpinned defunct link %s for program %s", pin, progName)
+
+		// Wrap in os.ErrNotExist so the caller needs to look for one error.
+		err = fmt.Errorf("unpinned defunct link: %w", os.ErrNotExist)
+
+	// No existing link found, continue trying to create one.
+	case errors.Is(err, os.ErrNotExist):
+		log.Debugf("No existing link found at %s for program %s", pin, progName)
+
+	default:
+		return fmt.Errorf("updating link %s for program %s: %w", pin, progName, err)
+	}
+
+	return err
+}
+
+// detachTCX attempts to open the link at progName in bpffsDir and unpins it.
+// Only returns unrecoverable errors. Returns nil if the link doesn't exist or
+// if removal was successful.
+func detachTCX(bpffsDir, progName string) error {
+	pin := filepath.Join(bpffsDir, progName)
+	err := bpf.UnpinLink(pin)
+	if err == nil {
+		log.Infof("Removed tcx link at %s", pin)
+		return nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+
+	// The pinned link exists, something went wrong unpinning it.
+	return fmt.Errorf("unpinning tcx link: %w", err)
+}
+
+// hasCiliumTCXLinks returns true if device has a Cilium-managed tcx program
+// with the given attach type.
+func hasCiliumTCXLinks(device netlink.Link, attach ebpf.AttachType) (bool, error) {
+	result, err := link.QueryPrograms(link.QueryOptions{
+		Target: int(device.Attrs().Index),
+		Attach: attach,
+	})
+	if errors.Is(err, unix.EINVAL) {
+		// Attach type likely not supported, kernel doesn't support tcx.
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("querying %s tcx programs for device %s: %w", attach, device.Attrs().Name, err)
+	}
+	if result == nil || len(result.Programs) == 0 {
+		return false, nil
+	}
+
+	for _, p := range result.Programs {
+		prog, err := ebpf.NewProgramFromID(p.ID)
+		if err != nil {
+			return false, fmt.Errorf("opening program with id %d: %w", p.ID, err)
+		}
+		defer prog.Close()
+
+		pi, err := prog.Info()
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(pi.Name, "cil_") {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/datapath/loader/tcx_test.go
+++ b/pkg/datapath/loader/tcx_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build linux
+
+package loader
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/testutils/netns"
+)
+
+func TestAttachDetachTCX(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	skipTCXUnsupported(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		prog := mustTCProgramWithName(t, "cil_test")
+		linkDir := testutils.TempBPFFS(t)
+
+		// Attaching the same program twice should result in a link create and update.
+		require.NoError(t, upsertTCXProgram(lo, prog, "cil_test", linkDir, directionToParent(dirEgress)))
+		require.NoError(t, upsertTCXProgram(lo, prog, "cil_test", linkDir, directionToParent(dirEgress)))
+
+		// Query tcx programs.
+		hasPrograms, err := hasCiliumTCXLinks(lo, ebpf.AttachTCXEgress)
+		require.NoError(t, err)
+		require.True(t, hasPrograms)
+
+		// Detach the program.
+		err = detachSKBProgram(lo, "cil_test", linkDir, directionToParent(dirEgress))
+		require.NoError(t, err)
+
+		// bpf_prog_query is eventually-consistent, retries may be necessary.
+		require.NoError(t, testutils.WaitUntil(func() bool {
+			hasPrograms, err := hasCiliumTCXLinks(lo, ebpf.AttachTCXIngress)
+			require.NoError(t, err)
+			return !hasPrograms
+		}, time.Second))
+
+		return nil
+	})
+}
+
+func TestHasCiliumTCXLinks(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	skipTCXUnsupported(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		// No tcx progs attached, expect false.
+		hasPrograms, err := hasCiliumTCXLinks(lo, ebpf.AttachTCXEgress)
+		require.NoError(t, err)
+		require.False(t, hasPrograms)
+
+		l1, err := link.AttachTCX(link.TCXOptions{
+			Program:   mustTCProgram(t),
+			Attach:    ebpf.AttachTCXEgress,
+			Interface: lo.Attrs().Index,
+			Anchor:    link.Tail(),
+		})
+		require.NoError(t, err)
+
+		// tcx program without cil_ prefix is attached, expect false.
+		hasPrograms, err = hasCiliumTCXLinks(lo, ebpf.AttachTCXEgress)
+		require.NoError(t, err)
+		require.False(t, hasPrograms)
+
+		l2, err := link.AttachTCX(link.TCXOptions{
+			Program:   mustTCProgramWithName(t, "cil_test"),
+			Attach:    ebpf.AttachTCXEgress,
+			Interface: lo.Attrs().Index,
+			Anchor:    link.Tail(),
+		})
+		require.NoError(t, err)
+
+		// tcx program with cil_ prefix is attached, expect true.
+		hasPrograms, err = hasCiliumTCXLinks(lo, ebpf.AttachTCXEgress)
+		require.NoError(t, err)
+		require.True(t, hasPrograms)
+
+		require.NoError(t, l1.Close())
+		require.NoError(t, l2.Close())
+
+		return nil
+	})
+}
+
+func skipTCXUnsupported(tb testing.TB) {
+	tb.Helper()
+
+	err := onceTCX()
+	if errors.Is(err, ebpf.ErrNotSupported) {
+		tb.Skip("tcx is not supported")
+	}
+	if err != nil {
+		tb.Fatalf("probing tcx support: %s", err)
+	}
+}
+
+var onceTCX = sync.OnceValue(func() error {
+	prog, err := newTCProgram()
+	if err != nil {
+		return err
+	}
+	defer prog.Close()
+
+	l, err := link.AttachTCX(link.TCXOptions{
+		Program:   prog,
+		Attach:    ebpf.AttachTCXEgress,
+		Interface: lo.Attrs().Index,
+		Anchor:    link.Tail(),
+	})
+	if err != nil {
+		return fmt.Errorf("creating link: %w", err)
+	}
+	if err := l.Close(); err != nil {
+		return fmt.Errorf("closing link: %w", err)
+	}
+
+	return nil
+})

--- a/pkg/datapath/loader/xdp_test.go
+++ b/pkg/datapath/loader/xdp_test.go
@@ -26,9 +26,6 @@ func TestMaybeUnloadObsoleteXDPPrograms(t *testing.T) {
 	ns := netns.NewNetNS(t)
 
 	ns.Do(func() error {
-		// create netlink handle in the test netns to ensure subsequent netlink
-		// calls request data from the correct netns, even if called in a separate
-		// goroutine (require.Eventually)
 		h, err := netlink.NewHandle()
 		require.NoError(t, err)
 
@@ -63,14 +60,14 @@ func TestMaybeUnloadObsoleteXDPPrograms(t *testing.T) {
 			[]string{"veth0"}, option.XDPModeLinkDriver, basePath,
 		)
 
-		require.Eventually(t, func() bool {
+		require.NoError(t, testutils.WaitUntil(func() bool {
 			v1, err := h.LinkByName("veth1")
 			require.NoError(t, err)
 			if v1.Attrs().Xdp != nil {
 				return v1.Attrs().Xdp.Attached == false
 			}
 			return true
-		}, 150*time.Millisecond, 15*time.Millisecond)
+		}, time.Second))
 
 		v0, err := h.LinkByName("veth0")
 		require.NoError(t, err)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -391,6 +391,9 @@ const (
 	// EnableXDPPrefilter enables XDP-based prefiltering
 	EnableXDPPrefilter = "enable-xdp-prefilter"
 
+	// EnableTCX enables attaching endpoint programs using tcx
+	EnableTCX = "enable-tcx"
+
 	ProcFs = "procfs"
 
 	// PrometheusServeAddr IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
@@ -1350,6 +1353,7 @@ type DaemonConfig struct {
 	LBDevInheritIPAddr  string   // Device which IP addr used by bpf_host devices
 	EnableXDPPrefilter  bool     // Enable XDP-based prefiltering
 	XDPMode             string   // XDP mode, values: { xdpdrv | xdpgeneric | none }
+	EnableTCX           bool     // Enable attaching endpoint programs using tcx
 	HostV4Addr          net.IP   // Host v4 address of the snooping device
 	HostV6Addr          net.IP   // Host v6 address of the snooping device
 	EncryptInterface    []string // Set of network facing interface to encrypt over
@@ -2896,6 +2900,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.WireguardPersistentKeepalive = vp.GetDuration(WireguardPersistentKeepalive)
 	c.EnableWellKnownIdentities = vp.GetBool(EnableWellKnownIdentities)
 	c.EnableXDPPrefilter = vp.GetBool(EnableXDPPrefilter)
+	c.EnableTCX = vp.GetBool(EnableTCX)
 	c.DisableCiliumEndpointCRD = vp.GetBool(DisableCiliumEndpointCRDName)
 	c.MasqueradeInterfaces = vp.GetStringSlice(MasqueradeInterfaces)
 	c.EgressMasqueradeInterfaces = strings.Join(c.MasqueradeInterfaces, ",")


### PR DESCRIPTION
Split off from https://github.com/cilium/cilium/pull/30103, this pulls out the tcx infrastructure so it can be merged without enabling the feature.

@rgo3 