### PR TITLE
envoy: pass idle timeout configuration option to cilium configmap

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1245,6 +1245,7 @@ data:
   proxy-connect-timeout: {{ .Values.envoy.connectTimeoutSeconds | quote }}
   proxy-max-requests-per-connection: {{ .Values.envoy.maxRequestsPerConnection | quote }}
   proxy-max-connection-duration-seconds: {{ .Values.envoy.maxConnectionDurationSeconds | quote }}
+  proxy-idle-timeout-seconds: {{ .Values.envoy.idleTimeoutDurationSeconds | quote }}
 
   external-envoy-proxy: {{ .Values.envoy.enabled | quote }}
   envoy-base-id: {{ .Values.envoy.baseID | quote }}


### PR DESCRIPTION
Currently, Envoys idle timeout configuration option can be configured in Helm `envoy.idleTimeoutDurationSeconds` and the agent/operator Go flag `proxy-idle-timeout-seconds`.

Unfortunately, changing the value in the Helm values doesn't have an effect when running in embedded mode, because the helm value isn't passed to the Cilium ConfigMap.

This commit fixes this, by setting the value in the configmap.

Fixes: #25214