### PR TITLE
Fixes redundant space on the introduction page (intro.rst)

### DIFF
--- a/Documentation/network/kubernetes/intro.rst
+++ b/Documentation/network/kubernetes/intro.rst
@@ -78,6 +78,5 @@ The Kubernetes documentation contains more background on the `Kubernetes
 Networking Model
 <https://kubernetes.io/docs/concepts/cluster-administration/networking/>`_ and
 `Kubernetes Network Plugins
-<https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/>`_
-.
+<https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/>`_.
 


### PR DESCRIPTION
I removed the redundant space in the sentence; words before a period don't include a space.

Signed-off-by: Charles Uneze <charlesniklaus@gmail.com>