### PR TITLE
k8s: Replace gocheck with built-in go test

### DIFF
--- a/plugins/cilium-cni/chaining/api/api_test.go
+++ b/plugins/cilium-cni/chaining/api/api_test.go
@@ -7,20 +7,12 @@ import (
 	"context"
 	"testing"
 
-	check "github.com/cilium/checkmate"
 	cniTypesVer "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/plugins/cilium-cni/lib"
 )
-
-func Test(t *testing.T) {
-	check.TestingT(t)
-}
-
-type APISuite struct{}
-
-var _ = check.Suite(&APISuite{})
 
 type pluginTest struct{}
 
@@ -36,17 +28,17 @@ func (p *pluginTest) Check(ctx context.Context, pluginContext PluginContext, cli
 	return nil
 }
 
-func (a *APISuite) TestRegistration(c *check.C) {
+func TestRegistration(t *testing.T) {
 	err := Register("foo", &pluginTest{})
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	err = Register("foo", &pluginTest{})
-	c.Assert(err, check.Not(check.IsNil))
+	require.Error(t, err)
 
 	err = Register(DefaultConfigName, &pluginTest{})
-	c.Assert(err, check.Not(check.IsNil))
+	require.Error(t, err)
 }
 
-func (a *APISuite) TestNonChaining(c *check.C) {
-	c.Assert(Lookup("cilium"), check.IsNil)
+func TestNonChaining(t *testing.T) {
+	require.Nil(t, Lookup("cilium"))
 }

--- a/plugins/cilium-cni/types/types_test.go
+++ b/plugins/cilium-cni/types/types_test.go
@@ -8,39 +8,30 @@ import (
 	"path"
 	"testing"
 
-	check "github.com/cilium/checkmate"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/stretchr/testify/require"
 
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	azureTypes "github.com/cilium/cilium/pkg/azure/types"
-	"github.com/cilium/cilium/pkg/checker"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 )
 
-func Test(t *testing.T) {
-	check.TestingT(t)
-}
-
-type CNITypesSuite struct{}
-
-var _ = check.Suite(&CNITypesSuite{})
-
-func testConfRead(c *check.C, confContent string, netconf *NetConf) {
+func testConfRead(t *testing.T, confContent string, netconf *NetConf) {
 	dir, err := os.MkdirTemp("", "cilium-cnitype-testsuite")
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
 	p := path.Join(dir, "conf1")
 	err = os.WriteFile(p, []byte(confContent), 0644)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	netConf, err := ReadNetConf(p)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
-	c.Assert(netConf, checker.DeepEquals, netconf)
+	require.EqualValues(t, netConf, netconf)
 }
 
-func (t *CNITypesSuite) TestReadCNIConf(c *check.C) {
+func TestReadCNIConf(t *testing.T) {
 	confFile1 := `
 {
   "name": "cilium",
@@ -54,7 +45,7 @@ func (t *CNITypesSuite) TestReadCNIConf(c *check.C) {
 			Type: "cilium-cni",
 		},
 	}
-	testConfRead(c, confFile1, &netConf1)
+	testConfRead(t, confFile1, &netConf1)
 
 	confFile2 := `
 {
@@ -71,10 +62,10 @@ func (t *CNITypesSuite) TestReadCNIConf(c *check.C) {
 		},
 		MTU: 9000,
 	}
-	testConfRead(c, confFile2, &netConf2)
+	testConfRead(t, confFile2, &netConf2)
 }
 
-func (t *CNITypesSuite) TestReadCNIConfENIWithPlugins(c *check.C) {
+func TestReadCNIConfENIWithPlugins(t *testing.T) {
 	confFile1 := `
 {
   "cniVersion":"0.3.1",
@@ -120,10 +111,10 @@ func (t *CNITypesSuite) TestReadCNIConfENIWithPlugins(c *check.C) {
 			},
 		},
 	}
-	testConfRead(c, confFile1, &netConf1)
+	testConfRead(t, confFile1, &netConf1)
 }
 
-func (t *CNITypesSuite) TestReadCNIConfENI(c *check.C) {
+func TestReadCNIConfENI(t *testing.T) {
 	confFile1 := `
 {
   "name": "cilium",
@@ -172,10 +163,10 @@ func (t *CNITypesSuite) TestReadCNIConfENI(c *check.C) {
 			AvailabilityZone: "us-west1",
 		},
 	}
-	testConfRead(c, confFile1, &netConf1)
+	testConfRead(t, confFile1, &netConf1)
 }
 
-func (t *CNITypesSuite) TestReadCNIConfENIv2WithPlugins(c *check.C) {
+func TestReadCNIConfENIv2WithPlugins(t *testing.T) {
 	confFile1 := `
 {
   "cniVersion":"0.3.1",
@@ -229,10 +220,10 @@ func (t *CNITypesSuite) TestReadCNIConfENIv2WithPlugins(c *check.C) {
 			},
 		},
 	}
-	testConfRead(c, confFile1, &netConf1)
+	testConfRead(t, confFile1, &netConf1)
 }
 
-func (t *CNITypesSuite) TestReadCNIConfAzurev2WithPlugins(c *check.C) {
+func TestReadCNIConfAzurev2WithPlugins(t *testing.T) {
 	confFile1 := `
 {
   "cniVersion":"0.3.1",
@@ -265,10 +256,10 @@ func (t *CNITypesSuite) TestReadCNIConfAzurev2WithPlugins(c *check.C) {
 			},
 		},
 	}
-	testConfRead(c, confFile1, &netConf1)
+	testConfRead(t, confFile1, &netConf1)
 }
 
-func (t *CNITypesSuite) TestReadCNIConfIPAMType(c *check.C) {
+func TestReadCNIConfIPAMType(t *testing.T) {
 	confFile := `
 {
   "cniVersion":"0.3.1",
@@ -295,10 +286,10 @@ func (t *CNITypesSuite) TestReadCNIConfIPAMType(c *check.C) {
 			},
 		},
 	}
-	testConfRead(c, confFile, &netConf)
+	testConfRead(t, confFile, &netConf)
 }
 
-func (t *CNITypesSuite) TestReadCNIConfError(c *check.C) {
+func TestReadCNIConfError(t *testing.T) {
 	// Try to read errorneous CNI configuration file with MTU provided as
 	// string instead of int
 	errorConf := `
@@ -310,13 +301,13 @@ func (t *CNITypesSuite) TestReadCNIConfError(c *check.C) {
 `
 
 	dir, err := os.MkdirTemp("", "cilium-cnitype-testsuite")
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
 	p := path.Join(dir, "errorconf")
 	err = os.WriteFile(p, []byte(errorConf), 0644)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	_, err = ReadNetConf(p)
-	c.Assert(err, check.Not(check.IsNil))
+	require.Error(t, err)
 }


### PR DESCRIPTION
Please refer to individual commits for more details, this PR is focusing on files owned by sig-k8s team

Relates: https://github.com/cilium/cilium/issues/28596
