### PR TITLE
operator: Replace gocheck with built-in go test

### DIFF
--- a/operator/identitygc/heartbeat_test.go
+++ b/operator/identitygc/heartbeat_test.go
@@ -7,39 +7,31 @@ import (
 	"testing"
 	"time"
 
-	check "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/require"
 )
 
-func Test(t *testing.T) {
-	check.TestingT(t)
-}
-
-type OperatorTestSuite struct{}
-
-var _ = check.Suite(&OperatorTestSuite{})
-
-func (s *OperatorTestSuite) TestIdentityHeartbeatStore(c *check.C) {
+func TestIdentityHeartbeatStore(t *testing.T) {
 	store := newHeartbeatStore(time.Second)
 
 	// mark lifesign to now, identity must be alive, run GC, identity
 	// should still exist
 	store.markAlive("foo", time.Now())
-	c.Assert(store.isAlive("foo"), check.Equals, true)
+	require.Equal(t, true, store.isAlive("foo"))
 	store.gc()
-	c.Assert(store.isAlive("foo"), check.Equals, true)
+	require.Equal(t, true, store.isAlive("foo"))
 
 	// mark lifesign in the past, identity should not be alive anymore
 	store.markAlive("foo", time.Now().Add(-time.Minute))
-	c.Assert(store.isAlive("foo"), check.Equals, false)
+	require.Equal(t, false, store.isAlive("foo"))
 
 	// mark lifesign way in the past, run GC, validate that identity is no
 	// longer tracked
 	store.markAlive("foo", time.Now().Add(-24*time.Hour))
-	c.Assert(store.isAlive("foo"), check.Equals, false)
+	require.Equal(t, false, store.isAlive("foo"))
 	store.gc()
 	store.mutex.RLock()
 	_, ok := store.lastLifesign["foo"]
-	c.Assert(ok, check.Equals, false)
+	require.Equal(t, false, ok)
 	store.mutex.RUnlock()
 
 	// mark lifesign to now and validate deletion
@@ -47,15 +39,15 @@ func (s *OperatorTestSuite) TestIdentityHeartbeatStore(c *check.C) {
 	store.mutex.RLock()
 	_, ok = store.lastLifesign["foo"]
 	store.mutex.RUnlock()
-	c.Assert(ok, check.Equals, true)
+	require.Equal(t, true, ok)
 	store.delete("foo")
 	store.mutex.RLock()
 	_, ok = store.lastLifesign["foo"]
 	store.mutex.RUnlock()
-	c.Assert(ok, check.Equals, false)
+	require.Equal(t, false, ok)
 
-	// identtity foo now doesn't exist, simulate start time of operator way
-	// in the past to check if an old, stale identity will be deleeted
+	// identity foo now doesn't exist, simulate start time of operator way
+	// in the past to check if an old, stale identity will be deleted
 	store.firstRun = time.Now().Add(-24 * time.Hour)
-	c.Assert(store.isAlive("foo"), check.Equals, false)
+	require.Equal(t, false, store.isAlive("foo"))
 }


### PR DESCRIPTION
Please refer to individual commits for more details, this PR is focusing on files owned by cilium/operator team.

Relates: https://github.com/cilium/cilium/issues/28596