### PR TITLE
Move init phase of KPR configuration outside of Hive Runtime 

### DIFF
--- a/daemon/cmd/cells_test.go
+++ b/daemon/cmd/cells_test.go
@@ -37,10 +37,16 @@ func TestAgentCell(t *testing.T) {
 
 	logging.SetLogLevelToDebug()
 
+	h := hive.New(Agent)
+
+	NewAgentCmd(h)
+	option.Config.Populate(h.Viper())
+
 	// Populate config with default values normally set by Viper flag defaults
 	option.Config.IPv4ServiceRange = AutoCIDR
 	option.Config.IPv6ServiceRange = AutoCIDR
 
-	err := hive.New(Agent).Populate(hivetest.Logger(t))
+	err := h.Populate(hivetest.Logger(t))
+
 	assert.NoError(t, err, "Populate()")
 }

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -358,15 +358,19 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		}
 	}
 
-	// Do the partial kube-proxy replacement initialization before creating BPF
+	// Do the partial kube-proxy replacement probing before creating BPF
 	// maps. Otherwise, some maps might not be created (e.g. session affinity).
+	//
+	// During the populate phase, initKubeProxyReplacementOptions is run to finalize
+	// some of the options prior to runtime.
+	//
 	// finishKubeProxyReplacementInit(), which is called later after the device
 	// detection, might disable BPF NodePort and friends. But this is fine, as
 	// the feature does not influence the decision which BPF maps should be
 	// created.
-	if err := initKubeProxyReplacementOptions(params.Sysctl, params.TunnelConfig); err != nil {
-		log.WithError(err).Error("unable to initialize kube-proxy replacement options")
-		return nil, nil, fmt.Errorf("unable to initialize kube-proxy replacement options: %w", err)
+	if err := probeKubeProxyReplacementOptions(params.Sysctl); err != nil {
+		log.WithError(err).Error("unable to probe kube-proxy replacement options")
+		return nil, nil, fmt.Errorf("unable to probe kube-proxy replacement options: %w", err)
 	}
 
 	ctmap.InitMapInfo(option.Config.EnableIPv4, option.Config.EnableIPv6, option.Config.EnableNodePort)

--- a/daemon/cmd/kube_proxy_replacement_test.go
+++ b/daemon/cmd/kube_proxy_replacement_test.go
@@ -7,10 +7,8 @@ import (
 	"strings"
 
 	. "github.com/cilium/checkmate"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
-	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/option"
@@ -65,7 +63,7 @@ func (cfg *kprConfig) set() {
 }
 
 func (cfg *kprConfig) verify(c *C, tc tunnel.Config) {
-	err := initKubeProxyReplacementOptions(sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"), tc)
+	err := initKubeProxyReplacementOptions(tc)
 	if err != nil || cfg.expectedErrorRegex != "" {
 		c.Assert(err, ErrorMatches, cfg.expectedErrorRegex)
 		if strings.Contains(cfg.expectedErrorRegex, "Invalid") {

--- a/pkg/mtu/cell.go
+++ b/pkg/mtu/cell.go
@@ -33,6 +33,7 @@ type mtuParams struct {
 	IPsec        types.IPsecKeyCustodian
 	CNI          cni.CNIConfigManager
 	TunnelConfig tunnel.Config
+	Config       *option.FinalDaemonConfig
 }
 
 func newForCell(lc cell.Lifecycle, p mtuParams) MTU {
@@ -57,7 +58,7 @@ func newForCell(lc cell.Lifecycle, p mtuParams) MTU {
 				option.Config.EnableIPSec,
 				p.TunnelConfig.ShouldAdaptMTU(),
 				option.Config.EnableWireguard,
-				option.Config.EnableHighScaleIPcache && option.Config.EnableNodePort,
+				option.Config.EnableHighScaleIPcache && p.Config.NodePortEnabled(),
 				configuredMTU,
 				externalIP,
 			)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1356,6 +1356,14 @@ func LogRegisteredOptions(vp *viper.Viper, entry *logrus.Entry) {
 	}
 }
 
+// FinalDaemonConfig is a alias for DaemonConfig used to differentiate what stage of daemon option init
+// the config is when it is provided.
+type FinalDaemonConfig DaemonConfig
+
+func (c *FinalDaemonConfig) NodePortEnabled() bool {
+	return c.EnableNodePort
+}
+
 // DaemonConfig is the configuration used by Daemon.
 type DaemonConfig struct {
 	CreationTime        time.Time


### PR DESCRIPTION
Please see commit message for detailed explanation.

```release-note
move part of kube-proxy-replacement configuration init logic to daemon initialization phase to prevent incorrect node-port-enabled usage.
```
