### PR TITLE
loader: Replace gocheck with built-in go test

### DIFF
--- a/pkg/bpf/bpf_test.go
+++ b/pkg/bpf/bpf_test.go
@@ -6,23 +6,21 @@ package bpf
 import (
 	"testing"
 
-	. "github.com/cilium/checkmate"
 	"github.com/cilium/ebpf"
+	"github.com/stretchr/testify/require"
 )
 
-func Test(t *testing.T) { TestingT(t) }
+func TestDefaultMapFlags(t *testing.T) {
+	require.Equal(t, uint32(BPF_F_NO_PREALLOC), GetPreAllocateMapFlags(ebpf.LPMTrie))
+	require.Equal(t, uint32(0), GetPreAllocateMapFlags(ebpf.Array))
+	require.Equal(t, uint32(0), GetPreAllocateMapFlags(ebpf.LRUHash))
 
-func (s *BPFTestSuite) TestDefaultMapFlags(c *C) {
-	c.Assert(GetPreAllocateMapFlags(ebpf.LPMTrie), Equals, uint32(BPF_F_NO_PREALLOC))
-	c.Assert(GetPreAllocateMapFlags(ebpf.Array), Equals, uint32(0))
-	c.Assert(GetPreAllocateMapFlags(ebpf.LRUHash), Equals, uint32(0))
-
-	c.Assert(GetPreAllocateMapFlags(ebpf.Hash), Equals, uint32(BPF_F_NO_PREALLOC))
+	require.Equal(t, uint32(BPF_F_NO_PREALLOC), GetPreAllocateMapFlags(ebpf.Hash))
 	EnableMapPreAllocation()
-	c.Assert(GetPreAllocateMapFlags(ebpf.Hash), Equals, uint32(0))
+	require.Equal(t, uint32(0), GetPreAllocateMapFlags(ebpf.Hash))
 
-	c.Assert(GetPreAllocateMapFlags(ebpf.LPMTrie), Equals, uint32(BPF_F_NO_PREALLOC))
-	c.Assert(GetPreAllocateMapFlags(ebpf.Array), Equals, uint32(0))
-	c.Assert(GetPreAllocateMapFlags(ebpf.LRUHash), Equals, uint32(0))
+	require.Equal(t, uint32(BPF_F_NO_PREALLOC), GetPreAllocateMapFlags(ebpf.LPMTrie))
+	require.Equal(t, uint32(0), GetPreAllocateMapFlags(ebpf.Array))
+	require.Equal(t, uint32(0), GetPreAllocateMapFlags(ebpf.LRUHash))
 	DisableMapPreAllocation()
 }

--- a/pkg/bpf/endpoint_test.go
+++ b/pkg/bpf/endpoint_test.go
@@ -5,16 +5,12 @@ package bpf
 
 import (
 	"net"
+	"testing"
 
-	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/require"
 )
 
-// Hook up gocheck into the "go test" runner.
-type BPFTestSuite struct{}
-
-var _ = Suite(&BPFTestSuite{})
-
-func (s *BPFTestSuite) TestEndpointKeyToString(c *C) {
+func TestEndpointKeyToString(t *testing.T) {
 	tests := []struct {
 		ip string
 	}{
@@ -27,6 +23,6 @@ func (s *BPFTestSuite) TestEndpointKeyToString(c *C) {
 	for _, tt := range tests {
 		ip := net.ParseIP(tt.ip)
 		k := NewEndpointKey(ip, 0)
-		c.Assert(k.ToIP().String(), Equals, tt.ip)
+		require.Equal(t, tt.ip, k.ToIP().String())
 	}
 }

--- a/pkg/bpf/map_test.go
+++ b/pkg/bpf/map_test.go
@@ -4,25 +4,27 @@
 package bpf
 
 import (
-	. "github.com/cilium/checkmate"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func (s *BPFTestSuite) TestExtractCommonName(c *C) {
-	c.Assert(extractCommonName("cilium_calls_1157"), Equals, "calls")
-	c.Assert(extractCommonName("cilium_calls_netdev_ns_1"), Equals, "calls")
-	c.Assert(extractCommonName("cilium_calls_overlay_2"), Equals, "calls")
-	c.Assert(extractCommonName("cilium_ct4_global"), Equals, "ct4_global")
-	c.Assert(extractCommonName("cilium_ct_any4_global"), Equals, "ct_any4_global")
-	c.Assert(extractCommonName("cilium_events"), Equals, "events")
-	c.Assert(extractCommonName("cilium_ipcache"), Equals, "ipcache")
-	c.Assert(extractCommonName("cilium_lb4_reverse_nat"), Equals, "lb4_reverse_nat")
-	c.Assert(extractCommonName("cilium_lb4_rr_seq"), Equals, "lb4_rr_seq")
-	c.Assert(extractCommonName("cilium_lb4_services"), Equals, "lb4_services")
-	c.Assert(extractCommonName("cilium_lxc"), Equals, "lxc")
-	c.Assert(extractCommonName("cilium_metrics"), Equals, "metrics")
-	c.Assert(extractCommonName("cilium_policy"), Equals, "policy")
-	c.Assert(extractCommonName("cilium_policy_1157"), Equals, "policy")
-	c.Assert(extractCommonName("cilium_policy_reserved_1"), Equals, "policy")
-	c.Assert(extractCommonName("cilium_proxy4"), Equals, "proxy4")
-	c.Assert(extractCommonName("cilium_tunnel_map"), Equals, "tunnel_map")
+func TestExtractCommonName(t *testing.T) {
+	assert.Equal(t, "calls", extractCommonName("cilium_calls_1157"))
+	assert.Equal(t, "calls", extractCommonName("cilium_calls_netdev_ns_1"))
+	assert.Equal(t, "calls", extractCommonName("cilium_calls_overlay_2"))
+	assert.Equal(t, "ct4_global", extractCommonName("cilium_ct4_global"))
+	assert.Equal(t, "ct_any4_global", extractCommonName("cilium_ct_any4_global"))
+	assert.Equal(t, "events", extractCommonName("cilium_events"))
+	assert.Equal(t, "ipcache", extractCommonName("cilium_ipcache"))
+	assert.Equal(t, "lb4_reverse_nat", extractCommonName("cilium_lb4_reverse_nat"))
+	assert.Equal(t, "lb4_rr_seq", extractCommonName("cilium_lb4_rr_seq"))
+	assert.Equal(t, "lb4_services", extractCommonName("cilium_lb4_services"))
+	assert.Equal(t, "lxc", extractCommonName("cilium_lxc"))
+	assert.Equal(t, "metrics", extractCommonName("cilium_metrics"))
+	assert.Equal(t, "policy", extractCommonName("cilium_policy"))
+	assert.Equal(t, "policy", extractCommonName("cilium_policy_1157"))
+	assert.Equal(t, "policy", extractCommonName("cilium_policy_reserved_1"))
+	assert.Equal(t, "proxy4", extractCommonName("cilium_proxy4"))
+	assert.Equal(t, "tunnel_map", extractCommonName("cilium_tunnel_map"))
 }

--- a/pkg/datapath/linux/config/utils_test.go
+++ b/pkg/datapath/linux/config/utils_test.go
@@ -4,7 +4,9 @@
 package config
 
 import (
-	. "github.com/cilium/checkmate"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type formatTestCase struct {
@@ -12,7 +14,7 @@ type formatTestCase struct {
 	output string
 }
 
-func (s *ConfigSuite) TestdefineIPv6(c *C) {
+func TestDefineIPv6(t *testing.T) {
 	tests := []formatTestCase{
 		{
 			input:  nil,
@@ -34,11 +36,11 @@ func (s *ConfigSuite) TestdefineIPv6(c *C) {
 	}
 
 	for _, test := range tests {
-		c.Assert(defineIPv6("foo", test.input), Equals, test.output)
+		require.Equal(t, test.output, defineIPv6("foo", test.input))
 	}
 }
 
-func (s *ConfigSuite) TestdefineMAC(c *C) {
+func TestDefineMAC(t *testing.T) {
 	tests := []formatTestCase{
 		{
 			input:  nil,
@@ -59,6 +61,6 @@ func (s *ConfigSuite) TestdefineMAC(c *C) {
 		},
 	}
 	for _, test := range tests {
-		c.Assert(defineMAC("foo", test.input), Equals, test.output)
+		require.Equal(t, test.output, defineMAC("foo", test.input))
 	}
 }


### PR DESCRIPTION
Please refer to individual commits for more details, this PR is focusing on files owned by cilium/loader team.

Relates: https://github.com/cilium/cilium/issues/28596