### PR TITLE
pkg/clustermesh: Replace gocheck with built-in go test

### DIFF
--- a/pkg/clustermesh/common/config_test.go
+++ b/pkg/clustermesh/common/config_test.go
@@ -11,12 +11,13 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/cilium/checkmate"
 	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
 
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/kvstore"
-	"github.com/cilium/cilium/pkg/testutils"
 )
 
 const (
@@ -24,13 +25,11 @@ const (
 	content2 = "endpoints:\n- https://cluster1.cilium-etcd.cilium.svc:2380\n"
 )
 
-func Test(t *testing.T) {
-	TestingT(t)
-}
-
-type ClusterMeshTestSuite struct{}
-
-var _ = Suite(&ClusterMeshTestSuite{})
+// Configure a generous timeout to prevent flakes when running in a noisy CI environment.
+var (
+	tick    = 10 * time.Millisecond
+	timeout = 5 * time.Second
+)
 
 type fakeRemoteCluster struct{}
 
@@ -41,58 +40,50 @@ func (*fakeRemoteCluster) ClusterConfigRequired() bool { return false }
 func (*fakeRemoteCluster) Stop()                       {}
 func (*fakeRemoteCluster) Remove()                     {}
 
-func writeFile(c *C, name, content string) {
+func writeFile(t *testing.T, name, content string) {
+	t.Helper()
+
 	err := os.WriteFile(name, []byte(content), 0644)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 }
 
-func expectExists(c *C, cm *clusterMesh, name string) {
-	cm.mutex.RLock()
-	defer cm.mutex.RUnlock()
-	c.Assert(cm.clusters[name], Not(IsNil))
-}
+func expectChange(t *testing.T, cm *clusterMesh, name string) {
+	t.Helper()
 
-func expectChange(c *C, cm *clusterMesh, name string) {
 	cm.mutex.RLock()
+	require.Contains(t, cm.clusters, name)
 	cluster := cm.clusters[name]
 	cm.mutex.RUnlock()
-	c.Assert(cluster, Not(IsNil))
 
 	select {
 	case <-cluster.changed:
 	case <-time.After(time.Second):
-		c.Fatal("timeout while waiting for changed event")
+		t.Fatal("timeout while waiting for changed event")
 	}
 }
 
-func expectNoChange(c *C, cm *clusterMesh, name string) {
+func expectNoChange(t *testing.T, cm *clusterMesh, name string) {
+	t.Helper()
+
 	cm.mutex.RLock()
 	cluster := cm.clusters[name]
 	cm.mutex.RUnlock()
-	c.Assert(cluster, Not(IsNil))
+	require.NotNil(t, cluster)
 
 	select {
 	case <-cluster.changed:
-		c.Fatal("unexpected changed event detected")
+		t.Fatal("unexpected changed event detected")
 	case <-time.After(100 * time.Millisecond):
 	}
 }
 
-func expectNotExist(c *C, cm *clusterMesh, name string) {
-	cm.mutex.RLock()
-	defer cm.mutex.RUnlock()
-	c.Assert(cm.clusters[name], IsNil)
-}
-
-func (s *ClusterMeshTestSuite) TestWatchConfigDirectory(c *C) {
+func TestWatchConfigDirectory(t *testing.T) {
 	skipKvstoreConnection = true
 	defer func() {
 		skipKvstoreConnection = false
 	}()
 
-	baseDir, err := os.MkdirTemp("", "multicluster")
-	c.Assert(err, IsNil)
-	defer os.RemoveAll(baseDir)
+	baseDir := t.TempDir()
 
 	dataDir := path.Join(baseDir, "..data")
 	dataDirTmp := path.Join(baseDir, "..data_tmp")
@@ -100,22 +91,22 @@ func (s *ClusterMeshTestSuite) TestWatchConfigDirectory(c *C) {
 	dataDir2 := path.Join(baseDir, "..data-2")
 	dataDir3 := path.Join(baseDir, "..data-3")
 
-	c.Assert(os.Symlink(dataDir1, dataDir), IsNil)
-	c.Assert(os.Mkdir(dataDir1, 0755), IsNil)
-	c.Assert(os.Mkdir(dataDir2, 0755), IsNil)
-	c.Assert(os.Mkdir(dataDir3, 0755), IsNil)
+	require.NoError(t, os.Symlink(dataDir1, dataDir))
+	require.NoError(t, os.Mkdir(dataDir1, 0755))
+	require.NoError(t, os.Mkdir(dataDir2, 0755))
+	require.NoError(t, os.Mkdir(dataDir3, 0755))
 
 	file1 := path.Join(baseDir, "cluster1")
 	file2 := path.Join(baseDir, "cluster2")
 	file3 := path.Join(baseDir, "cluster3")
 
-	writeFile(c, file1, content1)
-	writeFile(c, path.Join(dataDir1, "cluster2"), content1)
-	writeFile(c, path.Join(dataDir2, "cluster2"), content2)
-	writeFile(c, path.Join(dataDir3, "cluster2"), content1)
+	writeFile(t, file1, content1)
+	writeFile(t, path.Join(dataDir1, "cluster2"), content1)
+	writeFile(t, path.Join(dataDir2, "cluster2"), content2)
+	writeFile(t, path.Join(dataDir3, "cluster2"), content1)
 
 	// Create an indirect link, as in case of Kubernetes COnfigMaps/Secret mounted inside pods.
-	c.Assert(os.Symlink(path.Join(dataDir, "cluster2"), file2), IsNil)
+	require.NoError(t, os.Symlink(path.Join(dataDir, "cluster2"), file2))
 
 	gcm := NewClusterMesh(Configuration{
 		Config:           Config{ClusterMeshConfig: baseDir},
@@ -124,114 +115,96 @@ func (s *ClusterMeshTestSuite) TestWatchConfigDirectory(c *C) {
 		Metrics:          MetricsProvider("clustermesh")(),
 	})
 	cm := gcm.(*clusterMesh)
-	hivetest.Lifecycle(c).Append(cm)
+	hivetest.Lifecycle(t).Append(cm)
 
 	// wait for cluster1 and cluster2 to appear
-	c.Assert(testutils.WaitUntil(func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		cm.mutex.RLock()
 		defer cm.mutex.RUnlock()
-		return len(cm.clusters) == 2
-	}, time.Second), IsNil)
-	expectExists(c, cm, "cluster1")
-	expectExists(c, cm, "cluster2")
-	expectNotExist(c, cm, "cluster3")
+		assert.ElementsMatch(c, maps.Keys(cm.clusters), []string{"cluster1", "cluster2"})
+	}, timeout, tick)
 
-	err = os.RemoveAll(file1)
-	c.Assert(err, IsNil)
+	require.NoError(t, os.RemoveAll(file1))
 
 	// wait for cluster1 to disappear
-	c.Assert(testutils.WaitUntil(func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		cm.mutex.RLock()
 		defer cm.mutex.RUnlock()
-		return len(cm.clusters) == 1
-	}, time.Second), IsNil)
+		assert.ElementsMatch(c, maps.Keys(cm.clusters), []string{"cluster2"})
+	}, timeout, tick)
 
-	writeFile(c, file3, content1)
+	writeFile(t, file3, content1)
 
 	// wait for cluster3 to appear
-	c.Assert(testutils.WaitUntil(func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		cm.mutex.RLock()
 		defer cm.mutex.RUnlock()
-		return len(cm.clusters) == 2
-	}, time.Second), IsNil)
-	expectNotExist(c, cm, "cluster1")
-	expectExists(c, cm, "cluster2")
-	expectExists(c, cm, "cluster3")
+		assert.ElementsMatch(c, maps.Keys(cm.clusters), []string{"cluster2", "cluster3"})
+	}, timeout, tick)
 
 	// Test renaming of file from cluster3 to cluster1
-	err = os.Rename(file3, file1)
-	c.Assert(err, IsNil)
+	require.NoError(t, os.Rename(file3, file1))
 
 	// wait for cluster1 to appear
-	c.Assert(testutils.WaitUntil(func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		cm.mutex.RLock()
 		defer cm.mutex.RUnlock()
-		return cm.clusters["cluster1"] != nil
-	}, time.Second), IsNil)
-	expectExists(c, cm, "cluster2")
-	expectNotExist(c, cm, "cluster3")
+		assert.ElementsMatch(c, maps.Keys(cm.clusters), []string{"cluster1", "cluster2"})
+	}, timeout, tick)
 
 	// touch file
-	c.Assert(os.Chtimes(file1, time.Now(), time.Now()), IsNil)
-	expectNoChange(c, cm, "cluster1")
+	require.NoError(t, os.Chtimes(file1, time.Now(), time.Now()))
+	expectNoChange(t, cm, "cluster1")
 
 	// update file content changing the symlink target, adopting
 	// the same approach of the kubelet on ConfigMap/Secret update
-	c.Assert(os.Symlink(dataDir2, dataDirTmp), IsNil)
-	c.Assert(os.Rename(dataDirTmp, dataDir), IsNil)
-	c.Assert(os.RemoveAll(dataDir1), IsNil)
-	expectChange(c, cm, "cluster2")
+	require.NoError(t, os.Symlink(dataDir2, dataDirTmp))
+	require.NoError(t, os.Rename(dataDirTmp, dataDir))
+	require.NoError(t, os.RemoveAll(dataDir1))
+	expectChange(t, cm, "cluster2")
 
 	// update file content once more
-	c.Assert(os.Symlink(dataDir3, dataDirTmp), IsNil)
-	c.Assert(os.Rename(dataDirTmp, dataDir), IsNil)
-	c.Assert(os.RemoveAll(dataDir2), IsNil)
-	expectChange(c, cm, "cluster2")
+	require.NoError(t, os.Symlink(dataDir3, dataDirTmp))
+	require.NoError(t, os.Rename(dataDirTmp, dataDir))
+	require.NoError(t, os.RemoveAll(dataDir2))
+	expectChange(t, cm, "cluster2")
 
-	err = os.RemoveAll(file1)
-	c.Assert(err, IsNil)
-	err = os.RemoveAll(file2)
-	c.Assert(err, IsNil)
+	require.NoError(t, os.RemoveAll(file1))
+	require.NoError(t, os.RemoveAll(file2))
 
 	// wait for all clusters to disappear
-	c.Assert(testutils.WaitUntil(func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		cm.mutex.RLock()
 		defer cm.mutex.RUnlock()
-		return len(cm.clusters) == 0
-	}, time.Second), IsNil)
-	expectNotExist(c, cm, "cluster1")
-	expectNotExist(c, cm, "cluster2")
-	expectNotExist(c, cm, "cluster3")
+		assert.Empty(c, cm.clusters)
+	}, timeout, tick)
 
 	// Ensure that per-config watches are removed properly
 	wl := cm.configWatcher.watcher.WatchList()
-	c.Assert(wl, HasLen, 1)
-	c.Assert(wl[0], Equals, baseDir)
+	require.ElementsMatch(t, wl, []string{baseDir})
 }
 
-func (s *ClusterMeshTestSuite) TestIsEtcdConfigFile(c *C) {
-	dir, err := os.MkdirTemp("", "etcdconfig")
-	c.Assert(err, IsNil)
-	defer os.RemoveAll(dir)
+func TestIsEtcdConfigFile(t *testing.T) {
+	dir := t.TempDir()
 
 	validPath := path.Join(dir, "valid")
 	content := []byte("endpoints:\n- https://cluster1.cilium-etcd.cilium.svc:2379\n")
-	err = os.WriteFile(validPath, content, 0644)
-	c.Assert(err, IsNil)
+	err := os.WriteFile(validPath, content, 0644)
+	require.NoError(t, err)
 
 	isConfig, hash := isEtcdConfigFile(validPath)
-	c.Assert(isConfig, Equals, true)
-	c.Assert(hash, Equals, fhash(sha256.Sum256(content)))
+	require.True(t, isConfig)
+	require.Equal(t, fhash(sha256.Sum256(content)), hash)
 
 	invalidPath := path.Join(dir, "valid")
 	err = os.WriteFile(invalidPath, []byte("sf324kj234lkjsdvl\nwl34kj23l4k\nendpoints"), 0644)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	isConfig, hash = isEtcdConfigFile(validPath)
-	c.Assert(isConfig, Equals, false)
-	c.Assert(hash, Equals, fhash{})
+	require.False(t, isConfig)
+	require.Equal(t, fhash{}, hash)
 
 	isConfig, hash = isEtcdConfigFile(dir)
-	c.Assert(isConfig, Equals, false)
-	c.Assert(hash, Equals, fhash{})
+	require.False(t, isConfig)
+	require.Equal(t, fhash{}, hash)
 }

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/cilium/checkmate"
 	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
@@ -36,10 +36,6 @@ import (
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
 
-func Test(t *testing.T) {
-	TestingT(t)
-}
-
 var etcdConfig = []byte(fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
 
 func (s *ClusterMeshServicesTestSuite) prepareServiceUpdate(clusterSuffix, backendIP, portName, port string) (string, string) {
@@ -50,36 +46,30 @@ func (s *ClusterMeshServicesTestSuite) prepareServiceUpdate(clusterSuffix, backe
 
 type ClusterMeshServicesTestSuite struct {
 	svcCache   *k8s.ServiceCache
-	testDir    string
 	mesh       *ClusterMesh
 	randomName string
 }
 
-var _ = Suite(&ClusterMeshServicesTestSuite{})
+func setup(tb testing.TB) *ClusterMeshServicesTestSuite {
+	testutils.IntegrationTest(tb)
 
-func (s *ClusterMeshServicesTestSuite) SetUpSuite(c *C) {
-	testutils.IntegrationTest(c)
-}
-
-func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	kvstore.SetupDummy(c, "etcd")
+	kvstore.SetupDummy(tb, "etcd")
 
+	s := &ClusterMeshServicesTestSuite{}
 	s.randomName = rand.String(12)
 	clusterName1 := s.randomName + "1"
 	clusterName2 := s.randomName + "2"
 
-	kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName)
+	require.NoError(tb, kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName))
 	s.svcCache = k8s.NewServiceCache(fakeTypes.NewNodeAddressing())
 
 	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	<-mgr.InitIdentityAllocator(nil)
-	dir, err := os.MkdirTemp("", "multicluster")
-	s.testDir = dir
-	c.Assert(err, IsNil)
+	dir := tb.TempDir()
 
 	for i, cluster := range []string{clusterName1, clusterName2} {
 		config := cmtypes.CiliumClusterConfig{
@@ -89,23 +79,23 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 			},
 		}
 		err := cmutils.SetClusterConfig(ctx, cluster, &config, kvstore.Client())
-		c.Assert(err, IsNil)
+		require.NoError(tb, err)
 	}
 
 	config1 := path.Join(dir, clusterName1)
-	err = os.WriteFile(config1, etcdConfig, 0644)
-	c.Assert(err, IsNil)
+	err := os.WriteFile(config1, etcdConfig, 0644)
+	require.NoError(tb, err)
 
 	config2 := path.Join(dir, clusterName2)
 	err = os.WriteFile(config2, etcdConfig, 0644)
-	c.Assert(err, IsNil)
+	require.NoError(tb, err)
 
 	ipc := ipcache.NewIPCache(&ipcache.Configuration{
 		Context: ctx,
 	})
 	defer ipc.Shutdown()
 	store := store.NewFactory(store.MetricsProvider())
-	s.mesh = NewClusterMesh(hivetest.Lifecycle(c), Configuration{
+	s.mesh = NewClusterMesh(hivetest.Lifecycle(tb), Configuration{
 		Config:                common.Config{ClusterMeshConfig: dir},
 		ClusterInfo:           cmtypes.ClusterInfo{ID: 255, Name: "test2", MaxConnectedClusters: 255},
 		NodeKeyCreator:        testNodeCreator,
@@ -118,45 +108,44 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 		CommonMetrics:         common.MetricsProvider(subsystem)(),
 		StoreFactory:          store,
 	})
-	c.Assert(s.mesh, Not(IsNil))
+	require.NotNil(tb, s.mesh)
 
 	// wait for both clusters to appear in the list of cm clusters
-	c.Assert(testutils.WaitUntil(func() bool {
-		return s.mesh.NumReadyClusters() == 2
-	}, 10*time.Second), IsNil)
+	require.EventuallyWithT(tb, func(c *assert.CollectT) {
+		assert.EqualValues(c, s.mesh.NumReadyClusters(), 2)
+	}, timeout, tick)
+
+	return s
 }
 
-func (s *ClusterMeshServicesTestSuite) TearDownTest(c *C) {
-	os.RemoveAll(s.testDir)
-}
+func (s *ClusterMeshServicesTestSuite) expectEvent(t *testing.T, action k8s.CacheAction, id k8s.ServiceID, fn func(c *assert.CollectT, event k8s.ServiceEvent)) {
+	t.Helper()
 
-func (s *ClusterMeshServicesTestSuite) expectEvent(c *C, action k8s.CacheAction, id k8s.ServiceID, fn func(event k8s.ServiceEvent) bool) {
-	c.Assert(testutils.WaitUntil(func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		var event k8s.ServiceEvent
 		select {
 		case event = <-s.svcCache.Events:
-		case <-time.After(defaults.NodeDeleteDelay + time.Second*10):
+		case <-time.After(defaults.NodeDeleteDelay + timeout):
 			c.Errorf("Timeout while waiting for event to be received")
-			return false
 		}
 		defer event.SWG.Done()
 
-		c.Assert(event.Action, Equals, action)
-		c.Assert(event.ID, Equals, id)
+		require.Equal(t, action, event.Action)
+		require.Equal(t, id, event.ID)
 
 		if fn != nil {
-			return fn(event)
+			fn(c, event)
 		}
-
-		return true
-	}, 2*time.Second), IsNil)
+	}, timeout, tick)
 }
 
-func (s *ClusterMeshServicesTestSuite) TestClusterMeshServicesGlobal(c *C) {
+func TestClusterMeshServicesGlobal(t *testing.T) {
+	s := setup(t)
+
 	k, v := s.prepareServiceUpdate("1", "10.0.185.196", "http", "80")
-	kvstore.Client().Update(context.TODO(), k, []byte(v), false)
+	require.NoError(t, kvstore.Client().Update(context.TODO(), k, []byte(v), false))
 	k, v = s.prepareServiceUpdate("2", "20.0.185.196", "http2", "90")
-	kvstore.Client().Update(context.TODO(), k, []byte(v), false)
+	require.NoError(t, kvstore.Client().Update(context.TODO(), k, []byte(v), false))
 
 	swgSvcs := lock.NewStoppableWaitGroup()
 	k8sSvc := &slim_corev1.Service{
@@ -175,9 +164,9 @@ func (s *ClusterMeshServicesTestSuite) TestClusterMeshServicesGlobal(c *C) {
 
 	svcID := s.svcCache.UpdateService(k8sSvc, swgSvcs)
 
-	s.expectEvent(c, k8s.UpdateService, svcID, func(event k8s.ServiceEvent) bool {
-		return event.Endpoints.Backends[cmtypes.MustParseAddrCluster("10.0.185.196")] != nil &&
-			event.Endpoints.Backends[cmtypes.MustParseAddrCluster("20.0.185.196")] != nil
+	s.expectEvent(t, k8s.UpdateService, svcID, func(c *assert.CollectT, event k8s.ServiceEvent) {
+		assert.Contains(c, event.Endpoints.Backends, cmtypes.MustParseAddrCluster("10.0.185.196"))
+		assert.Contains(c, event.Endpoints.Backends, cmtypes.MustParseAddrCluster("20.0.185.196"))
 	})
 
 	k8sEndpoints := k8s.ParseEndpoints(&slim_corev1.Endpoints{
@@ -201,39 +190,35 @@ func (s *ClusterMeshServicesTestSuite) TestClusterMeshServicesGlobal(c *C) {
 
 	swgEps := lock.NewStoppableWaitGroup()
 	s.svcCache.UpdateEndpoints(k8sEndpoints, swgEps)
-	s.expectEvent(c, k8s.UpdateService, svcID, func(event k8s.ServiceEvent) bool {
-		return event.Endpoints.Backends[cmtypes.MustParseAddrCluster("30.0.185.196")] != nil
+	s.expectEvent(t, k8s.UpdateService, svcID, func(c *assert.CollectT, event k8s.ServiceEvent) {
+		assert.Contains(c, event.Endpoints.Backends, cmtypes.MustParseAddrCluster("30.0.185.196"))
 	})
 
 	s.svcCache.DeleteEndpoints(k8sEndpoints.EndpointSliceID, swgEps)
-	s.expectEvent(c, k8s.UpdateService, svcID, func(event k8s.ServiceEvent) bool {
-		return event.Endpoints.Backends[cmtypes.MustParseAddrCluster("30.0.185.196")] == nil
+	s.expectEvent(t, k8s.UpdateService, svcID, func(c *assert.CollectT, event k8s.ServiceEvent) {
+		assert.NotContains(c, event.Endpoints.Backends, cmtypes.MustParseAddrCluster("30.0.185.196"))
 	})
 
-	kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName+"1")
-	s.expectEvent(c, k8s.UpdateService, svcID, nil)
+	require.NoError(t, kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName+"1"))
+	s.expectEvent(t, k8s.UpdateService, svcID, nil)
 
-	kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName+"2")
-	s.expectEvent(c, k8s.DeleteService, svcID, nil)
+	require.NoError(t, kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName+"2"))
+	s.expectEvent(t, k8s.DeleteService, svcID, nil)
 
 	swgSvcs.Stop()
-	c.Assert(testutils.WaitUntil(func() bool {
-		swgSvcs.Wait()
-		return true
-	}, 2*time.Second), IsNil)
+	swgSvcs.Wait()
 
 	swgEps.Stop()
-	c.Assert(testutils.WaitUntil(func() bool {
-		swgEps.Wait()
-		return true
-	}, 2*time.Second), IsNil)
+	swgEps.Wait()
 }
 
-func (s *ClusterMeshServicesTestSuite) TestClusterMeshServicesUpdate(c *C) {
+func TestClusterMeshServicesUpdate(t *testing.T) {
+	s := setup(t)
+
 	k, v := s.prepareServiceUpdate("1", "10.0.185.196", "http", "80")
-	kvstore.Client().Update(context.TODO(), k, []byte(v), false)
+	require.NoError(t, kvstore.Client().Update(context.TODO(), k, []byte(v), false))
 	k, v = s.prepareServiceUpdate("2", "20.0.185.196", "http2", "90")
-	kvstore.Client().Update(context.TODO(), k, []byte(v), false)
+	require.NoError(t, kvstore.Client().Update(context.TODO(), k, []byte(v), false))
 
 	k8sSvc := &slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -252,61 +237,67 @@ func (s *ClusterMeshServicesTestSuite) TestClusterMeshServicesUpdate(c *C) {
 	swgSvcs := lock.NewStoppableWaitGroup()
 	svcID := s.svcCache.UpdateService(k8sSvc, swgSvcs)
 
-	s.expectEvent(c, k8s.UpdateService, svcID, func(event k8s.ServiceEvent) bool {
-		return event.Endpoints.Backends[cmtypes.MustParseAddrCluster("10.0.185.196")] != nil &&
-			event.Endpoints.Backends[cmtypes.MustParseAddrCluster("10.0.185.196")].Ports["http"].DeepEqual(
-				loadbalancer.NewL4Addr(loadbalancer.TCP, 80)) &&
-			event.Endpoints.Backends[cmtypes.MustParseAddrCluster("20.0.185.196")] != nil &&
-			event.Endpoints.Backends[cmtypes.MustParseAddrCluster("20.0.185.196")].Ports["http2"].DeepEqual(
-				loadbalancer.NewL4Addr(loadbalancer.TCP, 90))
+	s.expectEvent(t, k8s.UpdateService, svcID, func(c *assert.CollectT, event k8s.ServiceEvent) {
+		if assert.Contains(c, event.Endpoints.Backends, cmtypes.MustParseAddrCluster("10.0.185.196")) {
+			assert.Equal(c, loadbalancer.NewL4Addr(loadbalancer.TCP, 80),
+				event.Endpoints.Backends[cmtypes.MustParseAddrCluster("10.0.185.196")].Ports["http"])
+		}
+		if assert.Contains(c, event.Endpoints.Backends, cmtypes.MustParseAddrCluster("20.0.185.196")) {
+			assert.Equal(c, loadbalancer.NewL4Addr(loadbalancer.TCP, 90),
+				event.Endpoints.Backends[cmtypes.MustParseAddrCluster("20.0.185.196")].Ports["http2"])
+		}
 	})
 
 	k, v = s.prepareServiceUpdate("1", "80.0.185.196", "http", "8080")
-	kvstore.Client().Update(context.TODO(), k, []byte(v), false)
-	s.expectEvent(c, k8s.UpdateService, svcID, func(event k8s.ServiceEvent) bool {
-		return event.Endpoints.Backends[cmtypes.MustParseAddrCluster("80.0.185.196")] != nil &&
-			event.Endpoints.Backends[cmtypes.MustParseAddrCluster("80.0.185.196")].Ports["http"].DeepEqual(
-				loadbalancer.NewL4Addr(loadbalancer.TCP, 8080)) &&
-			event.Endpoints.Backends[cmtypes.MustParseAddrCluster("20.0.185.196")] != nil &&
-			event.Endpoints.Backends[cmtypes.MustParseAddrCluster("20.0.185.196")].Ports["http2"].DeepEqual(
-				loadbalancer.NewL4Addr(loadbalancer.TCP, 90))
+	require.NoError(t, kvstore.Client().Update(context.TODO(), k, []byte(v), false))
+	s.expectEvent(t, k8s.UpdateService, svcID, func(c *assert.CollectT, event k8s.ServiceEvent) {
+		if assert.Contains(c, event.Endpoints.Backends, cmtypes.MustParseAddrCluster("80.0.185.196")) {
+			assert.Equal(c, loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+				event.Endpoints.Backends[cmtypes.MustParseAddrCluster("80.0.185.196")].Ports["http"])
+		}
+		if assert.Contains(c, event.Endpoints.Backends, cmtypes.MustParseAddrCluster("20.0.185.196")) {
+			assert.Equal(c, loadbalancer.NewL4Addr(loadbalancer.TCP, 90),
+				event.Endpoints.Backends[cmtypes.MustParseAddrCluster("20.0.185.196")].Ports["http2"])
+		}
 	})
 
 	k, v = s.prepareServiceUpdate("2", "90.0.185.196", "http", "8080")
-	kvstore.Client().Update(context.TODO(), k, []byte(v), false)
-	s.expectEvent(c, k8s.UpdateService, svcID, func(event k8s.ServiceEvent) bool {
-		return event.Endpoints.Backends[cmtypes.MustParseAddrCluster("80.0.185.196")] != nil &&
-			event.Endpoints.Backends[cmtypes.MustParseAddrCluster("80.0.185.196")].Ports["http"].DeepEqual(
-				loadbalancer.NewL4Addr(loadbalancer.TCP, 8080)) &&
-			event.Endpoints.Backends[cmtypes.MustParseAddrCluster("90.0.185.196")] != nil &&
-			event.Endpoints.Backends[cmtypes.MustParseAddrCluster("90.0.185.196")].Ports["http"].DeepEqual(
-				loadbalancer.NewL4Addr(loadbalancer.TCP, 8080))
+	require.NoError(t, kvstore.Client().Update(context.TODO(), k, []byte(v), false))
+	s.expectEvent(t, k8s.UpdateService, svcID, func(c *assert.CollectT, event k8s.ServiceEvent) {
+		if assert.Contains(c, event.Endpoints.Backends, cmtypes.MustParseAddrCluster("80.0.185.196")) {
+			assert.Equal(c, loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+				event.Endpoints.Backends[cmtypes.MustParseAddrCluster("80.0.185.196")].Ports["http"])
+		}
+		if assert.Contains(c, event.Endpoints.Backends, cmtypes.MustParseAddrCluster("90.0.185.196")) {
+			assert.Equal(c, loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+				event.Endpoints.Backends[cmtypes.MustParseAddrCluster("90.0.185.196")].Ports["http"])
+		}
 	})
 
-	kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName+"1")
-	s.expectEvent(c, k8s.UpdateService, svcID, func(event k8s.ServiceEvent) bool {
-		return event.Endpoints.Backends[cmtypes.MustParseAddrCluster("90.0.185.196")] != nil &&
-			event.Endpoints.Backends[cmtypes.MustParseAddrCluster("90.0.185.196")].Ports["http"].DeepEqual(
-				loadbalancer.NewL4Addr(loadbalancer.TCP, 8080))
+	require.NoError(t, kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName+"1"))
+	s.expectEvent(t, k8s.UpdateService, svcID, func(c *assert.CollectT, event k8s.ServiceEvent) {
+		if assert.Contains(c, event.Endpoints.Backends, cmtypes.MustParseAddrCluster("90.0.185.196")) {
+			assert.Equal(c, loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+				event.Endpoints.Backends[cmtypes.MustParseAddrCluster("90.0.185.196")].Ports["http"])
+		}
 	})
 
-	kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName+"2")
-	s.expectEvent(c, k8s.DeleteService, svcID, func(event k8s.ServiceEvent) bool {
-		return len(event.Endpoints.Backends) == 0
+	require.NoError(t, kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName+"2"))
+	s.expectEvent(t, k8s.DeleteService, svcID, func(c *assert.CollectT, event k8s.ServiceEvent) {
+		assert.Len(c, event.Endpoints.Backends, 0)
 	})
 
 	swgSvcs.Stop()
-	c.Assert(testutils.WaitUntil(func() bool {
-		swgSvcs.Wait()
-		return true
-	}, 2*time.Second), IsNil)
+	swgSvcs.Wait()
 }
 
-func (s *ClusterMeshServicesTestSuite) TestClusterMeshServicesNonGlobal(c *C) {
+func TestClusterMeshServicesNonGlobal(t *testing.T) {
+	s := setup(t)
+
 	k, v := s.prepareServiceUpdate("1", "10.0.185.196", "http", "80")
-	kvstore.Client().Update(context.TODO(), k, []byte(v), false)
+	require.NoError(t, kvstore.Client().Update(context.TODO(), k, []byte(v), false))
 	k, v = s.prepareServiceUpdate("2", "20.0.185.196", "http2", "90")
-	kvstore.Client().Update(context.TODO(), k, []byte(v), false)
+	require.NoError(t, kvstore.Client().Update(context.TODO(), k, []byte(v), false))
 
 	k8sSvc := &slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -326,15 +317,12 @@ func (s *ClusterMeshServicesTestSuite) TestClusterMeshServicesNonGlobal(c *C) {
 	time.Sleep(100 * time.Millisecond)
 	select {
 	case event := <-s.svcCache.Events:
-		c.Errorf("Unexpected service event received: %+v", event)
+		t.Errorf("Unexpected service event received: %+v", event)
 	default:
 	}
 
 	swgSvcs.Stop()
-	c.Assert(testutils.WaitUntil(func() bool {
-		swgSvcs.Wait()
-		return true
-	}, 2*time.Second), IsNil)
+	swgSvcs.Wait()
 }
 
 type fakeServiceMerger struct {
@@ -355,7 +343,7 @@ func (f *fakeServiceMerger) MergeExternalServiceDelete(service *serviceStore.Clu
 	f.deleted[service.String()]++
 }
 
-func (s *ClusterMeshServicesTestSuite) TestRemoteServiceObserver(c *C) {
+func TestRemoteServiceObserver(t *testing.T) {
 	svc1 := serviceStore.ClusterService{Cluster: "remote", Namespace: "namespace", Name: "name", IncludeExternal: false, Shared: true}
 	svc2 := serviceStore.ClusterService{Cluster: "remote", Namespace: "namespace", Name: "name"}
 	cache := common.NewGlobalServiceCache(metrics.NoOpGauge)
@@ -375,30 +363,30 @@ func (s *ClusterMeshServicesTestSuite) TestRemoteServiceObserver(c *C) {
 	merger.init()
 	observer.OnUpdate(&svc2)
 
-	c.Assert(merger.updated[svc1.String()], Equals, 0)
-	c.Assert(cache.Size(), Equals, 0)
+	require.Equal(t, 0, merger.updated[svc1.String()])
+	require.Equal(t, 0, cache.Size())
 
 	// Observe a new service update (for a shared service), and assert it is correctly added to the cache
 	merger.init()
 	observer.OnUpdate(&svc1)
 
-	c.Assert(merger.updated[svc1.String()], Equals, 1)
-	c.Assert(merger.deleted[svc1.String()], Equals, 0)
+	require.Equal(t, 1, merger.updated[svc1.String()])
+	require.Equal(t, 0, merger.deleted[svc1.String()])
+	require.Equal(t, 1, cache.Size())
 
-	c.Assert(cache.Size(), Equals, 1)
 	gs := cache.GetGlobalService(svc1.NamespaceServiceName())
-	c.Assert(gs.ClusterServices, HasLen, 1)
+	require.Equal(t, 1, len(gs.ClusterServices))
 	found, ok := gs.ClusterServices[svc1.Cluster]
-	c.Assert(ok, Equals, true)
-	c.Assert(found, checker.DeepEquals, &svc1)
+	require.True(t, ok)
+	require.Equal(t, &svc1, found)
 
 	// Observe a new service deletion, and assert it is correctly removed from the cache
 	merger.init()
 	observer.OnDelete(&svc1)
 
-	c.Assert(merger.updated[svc1.String()], Equals, 0)
-	c.Assert(merger.deleted[svc1.String()], Equals, 1)
-	c.Assert(cache.Size(), Equals, 0)
+	require.Equal(t, 0, merger.updated[svc1.String()])
+	require.Equal(t, 1, merger.deleted[svc1.String()])
+	require.Equal(t, 0, cache.Size())
 
 	// Observe two service updates in sequence (first shared, then non-shared),
 	// and assert that at the end it is not present in the cache (equivalent to update, then delete).
@@ -406,7 +394,7 @@ func (s *ClusterMeshServicesTestSuite) TestRemoteServiceObserver(c *C) {
 	observer.OnUpdate(&svc1)
 	observer.OnUpdate(&svc2)
 
-	c.Assert(merger.updated[svc1.String()], Equals, 1)
-	c.Assert(merger.deleted[svc1.String()], Equals, 1)
-	c.Assert(cache.Size(), Equals, 0)
+	require.Equal(t, 1, merger.updated[svc1.String()])
+	require.Equal(t, 1, merger.deleted[svc1.String()])
+	require.Equal(t, 0, cache.Size())
 }


### PR DESCRIPTION
Please refer to individual commits for more details, this PR is focusing on files owned by cilium/sig-clustermesh team.

Relates: https://github.com/cilium/cilium/issues/28596