### PR TITLE
pkg/policy: Replace gocheck with built-in go test

### DIFF
--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -8,80 +8,70 @@ import (
 	"net/netip"
 	"testing"
 
-	. "github.com/cilium/checkmate"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 )
 
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) {
-	TestingT(t)
-}
-
-type IdentityTestSuite struct{}
-
-var _ = Suite(&IdentityTestSuite{})
-
-func (s *IdentityTestSuite) TestReservedID(c *C) {
+func TestReservedID(t *testing.T) {
 	i := GetReservedID("host")
-	c.Assert(i, Equals, NumericIdentity(1))
-	c.Assert(i.String(), Equals, "host")
+	require.Equal(t, NumericIdentity(1), i)
+	require.Equal(t, "host", i.String())
 
 	i = GetReservedID("world")
-	c.Assert(i, Equals, NumericIdentity(2))
-	c.Assert(i.String(), Equals, "world")
+	require.Equal(t, NumericIdentity(2), i)
+	require.Equal(t, "world", i.String())
 
 	// This is an obsoleted identity, we verify that it returns 0
 	i = GetReservedID("cluster")
-	c.Assert(i, Equals, NumericIdentity(0))
-	c.Assert(i.String(), Equals, "unknown")
+	require.Equal(t, NumericIdentity(0), i)
+	require.Equal(t, "unknown", i.String())
 
 	i = GetReservedID("health")
-	c.Assert(i, Equals, NumericIdentity(4))
-	c.Assert(i.String(), Equals, "health")
+	require.Equal(t, NumericIdentity(4), i)
+	require.Equal(t, "health", i.String())
 
 	i = GetReservedID("init")
-	c.Assert(i, Equals, NumericIdentity(5))
-	c.Assert(i.String(), Equals, "init")
+	require.Equal(t, NumericIdentity(5), i)
+	require.Equal(t, "init", i.String())
 
 	i = GetReservedID("unmanaged")
-	c.Assert(i, Equals, NumericIdentity(3))
-	c.Assert(i.String(), Equals, "unmanaged")
+	require.Equal(t, NumericIdentity(3), i)
+	require.Equal(t, "unmanaged", i.String())
 
 	i = GetReservedID("kube-apiserver")
-	c.Assert(i, Equals, NumericIdentity(7))
-	c.Assert(i.String(), Equals, "kube-apiserver")
+	require.Equal(t, NumericIdentity(7), i)
+	require.Equal(t, "kube-apiserver", i.String())
 
-	c.Assert(GetReservedID("unknown"), Equals, IdentityUnknown)
+	require.Equal(t, IdentityUnknown, GetReservedID("unknown"))
 	unknown := NumericIdentity(700)
-	c.Assert(unknown.String(), Equals, "700")
+	require.Equal(t, "700", unknown.String())
 }
 
-func (s *IdentityTestSuite) TestIsReservedIdentity(c *C) {
-	c.Assert(ReservedIdentityKubeAPIServer.IsReservedIdentity(), Equals, true)
-	c.Assert(ReservedIdentityHealth.IsReservedIdentity(), Equals, true)
-	c.Assert(ReservedIdentityHost.IsReservedIdentity(), Equals, true)
-	c.Assert(ReservedIdentityWorld.IsReservedIdentity(), Equals, true)
-	c.Assert(ReservedIdentityInit.IsReservedIdentity(), Equals, true)
-	c.Assert(ReservedIdentityUnmanaged.IsReservedIdentity(), Equals, true)
+func TestIsReservedIdentity(t *testing.T) {
+	require.True(t, ReservedIdentityKubeAPIServer.IsReservedIdentity())
+	require.True(t, ReservedIdentityHealth.IsReservedIdentity())
+	require.True(t, ReservedIdentityHost.IsReservedIdentity())
+	require.True(t, ReservedIdentityWorld.IsReservedIdentity())
+	require.True(t, ReservedIdentityInit.IsReservedIdentity())
+	require.True(t, ReservedIdentityUnmanaged.IsReservedIdentity())
 
-	c.Assert(NumericIdentity(123456).IsReservedIdentity(), Equals, false)
+	require.Equal(t, false, NumericIdentity(123456).IsReservedIdentity())
 }
 
-func (s *IdentityTestSuite) TestRequiresGlobalIdentity(c *C) {
+func TestRequiresGlobalIdentity(t *testing.T) {
 	prefix := netip.MustParsePrefix("0.0.0.0/0")
-	c.Assert(RequiresGlobalIdentity(labels.GetCIDRLabels(prefix)), Equals, false)
+	require.Equal(t, false, RequiresGlobalIdentity(labels.GetCIDRLabels(prefix)))
 
 	prefix = netip.MustParsePrefix("192.168.23.0/24")
-	c.Assert(RequiresGlobalIdentity(labels.GetCIDRLabels(prefix)), Equals, false)
+	require.Equal(t, false, RequiresGlobalIdentity(labels.GetCIDRLabels(prefix)))
 
-	c.Assert(RequiresGlobalIdentity(labels.NewLabelsFromModel([]string{"k8s:foo=bar"})), Equals, true)
+	require.True(t, RequiresGlobalIdentity(labels.NewLabelsFromModel([]string{"k8s:foo=bar"})))
 }
 
-func (s *IdentityTestSuite) TestScopeForLabels(c *C) {
+func TestScopeForLabels(t *testing.T) {
 	tests := []struct {
 		lbls  labels.Labels
 		scope NumericIdentity
@@ -135,11 +125,11 @@ func (s *IdentityTestSuite) TestScopeForLabels(c *C) {
 			continue
 		}
 		scope := ScopeForLabels(test.lbls)
-		c.Assert(scope, Equals, test.scope, Commentf("%d / labels %s", i, test.lbls.String()))
+		require.Equal(t, test.scope, scope, "%d / labels %s", i, test.lbls.String())
 	}
 }
 
-func (s *IdentityTestSuite) TestNewIdentityFromLabelArray(c *C) {
+func TestNewIdentityFromLabelArray(t *testing.T) {
 	id := NewIdentityFromLabelArray(NumericIdentity(1001),
 		labels.NewLabelArrayFromSortedList("unspec:a=;unspec:b;unspec:c=d"))
 
@@ -148,9 +138,9 @@ func (s *IdentityTestSuite) TestNewIdentityFromLabelArray(c *C) {
 		"c": labels.ParseLabel("c=d"),
 		"b": labels.ParseLabel("b"),
 	}
-	c.Assert(id.ID, Equals, NumericIdentity(1001))
-	c.Assert(id.Labels, checker.DeepEquals, lbls)
-	c.Assert(id.LabelArray, checker.DeepEquals, lbls.LabelArray())
+	require.Equal(t, NumericIdentity(1001), id.ID)
+	require.EqualValues(t, lbls, id.Labels)
+	require.EqualValues(t, lbls.LabelArray(), id.LabelArray)
 }
 
 func TestLookupReservedIdentityByLabels(t *testing.T) {

--- a/pkg/identity/numericidentity_test.go
+++ b/pkg/identity/numericidentity_test.go
@@ -7,24 +7,23 @@ import (
 	"sync"
 	"testing"
 
-	. "github.com/cilium/checkmate"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 )
 
-func (s *IdentityTestSuite) TestLocalIdentity(c *C) {
+func TestLocalIdentity(t *testing.T) {
 	localID := NumericIdentity(IdentityScopeLocal | 1)
-	c.Assert(localID.HasLocalScope(), Equals, true)
+	require.True(t, localID.HasLocalScope())
 
 	maxClusterID := NumericIdentity(cmtypes.ClusterIDMax | 1)
-	c.Assert(maxClusterID.HasLocalScope(), Equals, false)
+	require.Equal(t, false, maxClusterID.HasLocalScope())
 
-	c.Assert(ReservedIdentityWorld.HasLocalScope(), Equals, false)
+	require.Equal(t, false, ReservedIdentityWorld.HasLocalScope())
 }
 
-func (s *IdentityTestSuite) TestClusterID(c *C) {
+func TestClusterID(t *testing.T) {
 	tbl := []struct {
 		identity  uint32
 		clusterID uint32
@@ -56,7 +55,7 @@ func (s *IdentityTestSuite) TestClusterID(c *C) {
 	}
 
 	for _, item := range tbl {
-		c.Assert(NumericIdentity(item.identity).ClusterID(), Equals, item.clusterID)
+		require.Equal(t, item.clusterID, NumericIdentity(item.identity).ClusterID())
 	}
 }
 

--- a/pkg/policy/cidr_test.go
+++ b/pkg/policy/cidr_test.go
@@ -5,15 +5,15 @@ package policy
 
 import (
 	"net/netip"
+	"testing"
 
-	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
 
-func (ds *PolicyTestSuite) TestgetPrefixesFromCIDR(c *C) {
+func TestGetPrefixesFromCIDR(t *testing.T) {
 	inputToCIDRString := map[string]string{
 		"0.0.0.0/0":    "0.0.0.0/0",
 		"192.0.2.3":    "192.0.2.3/32",
@@ -31,10 +31,10 @@ func (ds *PolicyTestSuite) TestgetPrefixesFromCIDR(c *C) {
 		inputs = append(inputs, api.CIDR(ruleStr))
 	}
 	result := getPrefixesFromCIDR(inputs)
-	c.Assert(result, checker.DeepEquals, expected)
+	require.EqualValues(t, expected, result)
 }
 
-func (ds *PolicyTestSuite) TestGetCIDRPrefixes(c *C) {
+func TestGetCIDRPrefixes(t *testing.T) {
 	rules := api.Rules{
 		&api.Rule{
 			EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
@@ -71,7 +71,7 @@ func (ds *PolicyTestSuite) TestGetCIDRPrefixes(c *C) {
 		cidr := netip.MustParsePrefix(ipStr)
 		expectedCIDRs = append(expectedCIDRs, cidr)
 	}
-	c.Assert(GetCIDRPrefixes(rules), checker.DeepEquals, expectedCIDRs)
+	require.EqualValues(t, expectedCIDRs, GetCIDRPrefixes(rules))
 
 	// Now, test with CIDRSets.
 	rules = api.Rules{
@@ -123,5 +123,5 @@ func (ds *PolicyTestSuite) TestGetCIDRPrefixes(c *C) {
 		cidr := netip.MustParsePrefix(ipStr)
 		expectedCIDRs = append(expectedCIDRs, cidr)
 	}
-	c.Assert(GetCIDRPrefixes(rules), checker.DeepEquals, expectedCIDRs)
+	require.EqualValues(t, expectedCIDRs, GetCIDRPrefixes(rules))
 }

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -6,22 +6,13 @@ package policy
 import (
 	"testing"
 
-	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/labels"
 )
 
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) {
-	TestingT(t)
-}
-
-type PolicyTestSuite struct{}
-
-var _ = Suite(&PolicyTestSuite{})
-
-func (ds *PolicyTestSuite) TestSearchContextString(c *C) {
+func TestSearchContextString(t *testing.T) {
 	for expected, sc := range map[string]SearchContext{
 		"From: [unspec:a, unspec:b, unspec:c] => To: [unspec:d, unspec:e, unspec:f] Ports: [HTTP/TCP, HTTPs/TCP]": {
 			Trace: 1,
@@ -68,7 +59,7 @@ func (ds *PolicyTestSuite) TestSearchContextString(c *C) {
 		},
 	} {
 		str := sc.String()
-		c.Assert(str, Equals, expected)
+		require.Equal(t, expected, str)
 	}
 }
 
@@ -80,7 +71,7 @@ func BenchmarkSearchContextString(b *testing.B) {
 			{
 				Trace: 1,
 				Depth: 0,
-				From:  labels.ParseLabelArray("a", "c", "b"),
+				From:  labels.ParseLabelArray("a", "t", "b"),
 				To:    labels.ParseLabelArray("d", "e", "f"),
 				DPorts: []*models.Port{
 					{
@@ -99,7 +90,7 @@ func BenchmarkSearchContextString(b *testing.B) {
 			{
 				Trace: 1,
 				Depth: 0,
-				From:  labels.ParseLabelArray("a", "c", "b"),
+				From:  labels.ParseLabelArray("a", "t", "b"),
 				To:    labels.ParseLabelArray("d", "e", "f"),
 				DPorts: []*models.Port{
 					{

--- a/pkg/policy/proxyid_test.go
+++ b/pkg/policy/proxyid_test.go
@@ -8,29 +8,29 @@ import (
 	"strconv"
 	"testing"
 
-	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/require"
 )
 
-func (s *PolicyTestSuite) TestProxyID(c *C) {
+func TestProxyID(t *testing.T) {
 	id := ProxyID(123, true, "TCP", uint16(8080), "")
-	c.Assert("123:ingress:TCP:8080:", Equals, id)
+	require.Equal(t, id, "123:ingress:TCP:8080:")
 	endpointID, ingress, protocol, port, listener, err := ParseProxyID(id)
-	c.Assert(endpointID, Equals, uint16(123))
-	c.Assert(ingress, Equals, true)
-	c.Assert(protocol, Equals, "TCP")
-	c.Assert(port, Equals, uint16(8080))
-	c.Assert(listener, Equals, "")
-	c.Assert(err, IsNil)
+	require.Equal(t, uint16(123), endpointID)
+	require.True(t, ingress)
+	require.Equal(t, "TCP", protocol)
+	require.Equal(t, uint16(8080), port)
+	require.Equal(t, "", listener)
+	require.NoError(t, err)
 
 	id = ProxyID(321, false, "TCP", uint16(80), "myListener")
-	c.Assert("321:egress:TCP:80:myListener", Equals, id)
+	require.Equal(t, id, "321:egress:TCP:80:myListener")
 	endpointID, ingress, protocol, port, listener, err = ParseProxyID(id)
-	c.Assert(endpointID, Equals, uint16(321))
-	c.Assert(ingress, Equals, false)
-	c.Assert(protocol, Equals, "TCP")
-	c.Assert(port, Equals, uint16(80))
-	c.Assert(listener, Equals, "myListener")
-	c.Assert(err, IsNil)
+	require.Equal(t, uint16(321), endpointID)
+	require.Equal(t, false, ingress)
+	require.Equal(t, "TCP", protocol)
+	require.Equal(t, uint16(80), port)
+	require.Equal(t, "myListener", listener)
+	require.NoError(t, err)
 }
 
 func BenchmarkProxyID(b *testing.B) {

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -5,12 +5,14 @@ package policy
 
 import (
 	"bytes"
+	"fmt"
 	stdlog "log"
+	"testing"
 
-	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -19,7 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 )
 
-func (ds *PolicyTestSuite) TestComputePolicyDenyEnforcementAndRules(c *C) {
+func TestComputePolicyDenyEnforcementAndRules(t *testing.T) {
 	// Cache policy enforcement value from when test was ran to avoid pollution
 	// across tests.
 	oldPolicyEnable := GetPolicyEnabled()
@@ -134,7 +136,7 @@ func (ds *PolicyTestSuite) TestComputePolicyDenyEnforcementAndRules(c *C) {
 	}
 	combinedRule.Sanitize()
 
-	genCommentf := func(ingress, accept bool) CommentInterface {
+	genCommentf := func(ingress, accept bool) string {
 		direction := "egress"
 		if ingress {
 			direction = "ingress"
@@ -145,88 +147,88 @@ func (ds *PolicyTestSuite) TestComputePolicyDenyEnforcementAndRules(c *C) {
 			acceptStr = " not"
 			acceptStr2 = " no"
 		}
-		return Commentf(
+		return fmt.Sprintf(
 			"%s policy enforcement should%s be applied since%s %s rule selects it in the repository",
 			direction, acceptStr, acceptStr2, direction)
 	}
 
 	ing, egr, matchingRules := repo.computePolicyEnforcementAndRules(fooIdentity)
-	c.Assert(ing, Equals, false, genCommentf(true, false))
-	c.Assert(egr, Equals, false, genCommentf(false, false))
-	c.Assert(matchingRules, checker.DeepEquals, ruleSlice{}, Commentf("returned matching rules did not match"))
+	require.Equal(t, false, ing, genCommentf(true, false))
+	require.Equal(t, false, egr, genCommentf(false, false))
+	require.EqualValues(t, ruleSlice{}, matchingRules, "returned matching rules did not match")
 
 	_, _, err := repo.Add(fooIngressDenyRule1)
-	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
+	require.NoError(t, err, "unable to add rule to policy repository")
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
-	c.Assert(ing, Equals, true, genCommentf(true, true))
-	c.Assert(egr, Equals, false, genCommentf(false, false))
-	c.Assert(matchingRules[0].Rule, checker.DeepEquals, fooIngressDenyRule1, Commentf("returned matching rules did not match"))
+	require.Equal(t, true, ing, genCommentf(true, true))
+	require.Equal(t, false, egr, genCommentf(false, false))
+	require.EqualValues(t, fooIngressDenyRule1, matchingRules[0].Rule, "returned matching rules did not match")
 
 	_, _, err = repo.Add(fooIngressDenyRule2)
-	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
+	require.NoError(t, err, "unable to add rule to policy repository")
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
-	c.Assert(ing, Equals, true, genCommentf(true, true))
-	c.Assert(egr, Equals, false, genCommentf(false, false))
-	c.Assert(matchingRules[0].Rule, checker.DeepEquals, fooIngressDenyRule1, Commentf("returned matching rules did not match"))
-	c.Assert(matchingRules[1].Rule, checker.DeepEquals, fooIngressDenyRule2, Commentf("returned matching rules did not match"))
+	require.Equal(t, true, ing, genCommentf(true, true))
+	require.Equal(t, false, egr, genCommentf(false, false))
+	require.EqualValues(t, fooIngressDenyRule1, matchingRules[0].Rule, "returned matching rules did not match")
+	require.EqualValues(t, fooIngressDenyRule2, matchingRules[1].Rule, "returned matching rules did not match")
 
 	_, _, numDeleted := repo.DeleteByLabelsLocked(labels.LabelArray{fooIngressDenyRule1Label})
-	c.Assert(numDeleted, Equals, 1)
-	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
+	require.Equal(t, 1, numDeleted)
+	require.NoError(t, err, "unable to add rule to policy repository")
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
-	c.Assert(ing, Equals, true, genCommentf(true, true))
-	c.Assert(egr, Equals, false, genCommentf(false, false))
-	c.Assert(matchingRules[0].Rule, checker.DeepEquals, fooIngressDenyRule2, Commentf("returned matching rules did not match"))
+	require.Equal(t, true, ing, genCommentf(true, true))
+	require.Equal(t, false, egr, genCommentf(false, false))
+	require.EqualValues(t, fooIngressDenyRule2, matchingRules[0].Rule, "returned matching rules did not match")
 
 	_, _, numDeleted = repo.DeleteByLabelsLocked(labels.LabelArray{fooIngressDenyRule2Label})
-	c.Assert(numDeleted, Equals, 1)
+	require.Equal(t, 1, numDeleted)
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
-	c.Assert(ing, Equals, false, genCommentf(true, false))
-	c.Assert(egr, Equals, false, genCommentf(false, false))
-	c.Assert(matchingRules, checker.DeepEquals, ruleSlice{}, Commentf("returned matching rules did not match"))
+	require.Equal(t, false, ing, genCommentf(true, false))
+	require.Equal(t, false, egr, genCommentf(false, false))
+	require.EqualValues(t, ruleSlice{}, matchingRules, "returned matching rules did not match")
 
 	_, _, err = repo.Add(fooEgressDenyRule1)
-	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
+	require.NoError(t, err, "unable to add rule to policy repository")
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
-	c.Assert(ing, Equals, false, genCommentf(true, false))
-	c.Assert(egr, Equals, true, genCommentf(false, true))
-	c.Assert(matchingRules[0].Rule, checker.DeepEquals, fooEgressDenyRule1, Commentf("returned matching rules did not match"))
+	require.Equal(t, false, ing, genCommentf(true, false))
+	require.Equal(t, true, egr, genCommentf(false, true))
+	require.EqualValues(t, fooEgressDenyRule1, matchingRules[0].Rule, "returned matching rules did not match")
 	_, _, numDeleted = repo.DeleteByLabelsLocked(labels.LabelArray{fooEgressDenyRule1Label})
-	c.Assert(numDeleted, Equals, 1)
+	require.Equal(t, 1, numDeleted)
 
 	_, _, err = repo.Add(fooEgressDenyRule2)
-	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
+	require.NoError(t, err, "unable to add rule to policy repository")
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
-	c.Assert(ing, Equals, false, genCommentf(true, false))
-	c.Assert(egr, Equals, true, genCommentf(false, true))
-	c.Assert(matchingRules[0].Rule, checker.DeepEquals, fooEgressDenyRule2, Commentf("returned matching rules did not match"))
+	require.Equal(t, false, ing, genCommentf(true, false))
+	require.Equal(t, true, egr, genCommentf(false, true))
+	require.EqualValues(t, fooEgressDenyRule2, matchingRules[0].Rule, "returned matching rules did not match")
 
 	_, _, numDeleted = repo.DeleteByLabelsLocked(labels.LabelArray{fooEgressDenyRule2Label})
-	c.Assert(numDeleted, Equals, 1)
+	require.Equal(t, 1, numDeleted)
 
 	_, _, err = repo.Add(combinedRule)
-	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
+	require.NoError(t, err, "unable to add rule to policy repository")
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
-	c.Assert(ing, Equals, true, genCommentf(true, true))
-	c.Assert(egr, Equals, true, genCommentf(false, true))
-	c.Assert(matchingRules[0].Rule, checker.DeepEquals, combinedRule, Commentf("returned matching rules did not match"))
+	require.Equal(t, true, ing, genCommentf(true, true))
+	require.Equal(t, true, egr, genCommentf(false, true))
+	require.EqualValues(t, combinedRule, matchingRules[0].Rule, "returned matching rules did not match")
 	_, _, numDeleted = repo.DeleteByLabelsLocked(labels.LabelArray{combinedLabel})
-	c.Assert(numDeleted, Equals, 1)
+	require.Equal(t, 1, numDeleted)
 
 	SetPolicyEnabled(option.AlwaysEnforce)
-	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
+	require.NoError(t, err, "unable to add rule to policy repository")
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
-	c.Assert(ing, Equals, true, genCommentf(true, true))
-	c.Assert(egr, Equals, true, genCommentf(false, true))
-	c.Assert(matchingRules, checker.DeepEquals, ruleSlice{}, Commentf("returned matching rules did not match"))
+	require.Equal(t, true, ing, genCommentf(true, true))
+	require.Equal(t, true, egr, genCommentf(false, true))
+	require.EqualValues(t, ruleSlice{}, matchingRules, "returned matching rules did not match")
 
 	SetPolicyEnabled(option.NeverEnforce)
 	_, _, err = repo.Add(combinedRule)
-	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
+	require.NoError(t, err, "unable to add rule to policy repository")
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
-	c.Assert(ing, Equals, false, genCommentf(true, false))
-	c.Assert(egr, Equals, false, genCommentf(false, false))
-	c.Assert(matchingRules, IsNil, Commentf("no rules should be returned since policy enforcement is disabled"))
+	require.Equal(t, false, ing, genCommentf(true, false))
+	require.Equal(t, false, egr, genCommentf(false, false))
+	require.Nil(t, matchingRules, "no rules should be returned since policy enforcement is disabled")
 
 	// Test init identity.
 
@@ -235,24 +237,24 @@ func (ds *PolicyTestSuite) TestComputePolicyDenyEnforcementAndRules(c *C) {
 	// endpoints with the reserved:init label. If no policy rules match
 	// reserved:init, this drops all ingress and egress traffic.
 	ingress, egress, matchingRules := repo.computePolicyEnforcementAndRules(initIdentity)
-	c.Assert(ingress, Equals, true)
-	c.Assert(egress, Equals, true)
-	c.Assert(matchingRules, checker.DeepEquals, ruleSlice{}, Commentf("no rules should be returned since policy enforcement is disabled"))
+	require.Equal(t, true, ingress)
+	require.Equal(t, true, egress)
+	require.EqualValues(t, ruleSlice{}, matchingRules, "no rules should be returned since policy enforcement is disabled")
 
 	// Check that the "always" and "never" modes are not affected.
 	SetPolicyEnabled(option.AlwaysEnforce)
 	ingress, egress, _ = repo.computePolicyEnforcementAndRules(initIdentity)
-	c.Assert(ingress, Equals, true)
-	c.Assert(egress, Equals, true)
+	require.Equal(t, true, ingress)
+	require.Equal(t, true, egress)
 
 	SetPolicyEnabled(option.NeverEnforce)
 	ingress, egress, _ = repo.computePolicyEnforcementAndRules(initIdentity)
-	c.Assert(ingress, Equals, false)
-	c.Assert(egress, Equals, false)
+	require.Equal(t, false, ingress)
+	require.Equal(t, false, egress)
 
 }
 
-func (ds *PolicyTestSuite) TestGetRulesMatching(c *C) {
+func TestGetRulesMatching(t *testing.T) {
 	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
@@ -263,7 +265,7 @@ func (ds *PolicyTestSuite) TestGetRulesMatching(c *C) {
 
 	repo.Mutex.RLock()
 	// no rules loaded: Allows() => denied
-	c.Assert(repo.AllowsIngressRLocked(fooToBar), Equals, api.Denied)
+	require.Equal(t, api.Denied, repo.AllowsIngressRLocked(fooToBar))
 	repo.Mutex.RUnlock()
 
 	bar := labels.ParseSelectLabel("bar")
@@ -299,28 +301,28 @@ func (ds *PolicyTestSuite) TestGetRulesMatching(c *C) {
 
 	// When no policy is applied.
 	ingressMatch, egressMatch := repo.GetRulesMatching(labels.LabelArray{bar, foo})
-	c.Assert(ingressMatch, Equals, false)
-	c.Assert(egressMatch, Equals, false)
+	require.Equal(t, false, ingressMatch)
+	require.Equal(t, false, egressMatch)
 
 	// When ingress deny policy is applied.
 	_, _, err := repo.Add(ingressDenyRule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	ingressMatch, egressMatch = repo.GetRulesMatching(labels.LabelArray{bar, foo})
-	c.Assert(ingressMatch, Equals, true)
-	c.Assert(egressMatch, Equals, false)
+	require.Equal(t, true, ingressMatch)
+	require.Equal(t, false, egressMatch)
 
 	// Delete igress deny policy.
 	repo.DeleteByLabels(tag)
 
 	// When egress deny policy is applied.
 	_, _, err = repo.Add(egressDenyRule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	ingressMatch, egressMatch = repo.GetRulesMatching(labels.LabelArray{bar, foo})
-	c.Assert(ingressMatch, Equals, false)
-	c.Assert(egressMatch, Equals, true)
+	require.Equal(t, false, ingressMatch)
+	require.Equal(t, true, egressMatch)
 }
 
-func (ds *PolicyTestSuite) TestDeniesIngress(c *C) {
+func TestDeniesIngress(t *testing.T) {
 	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
@@ -331,7 +333,7 @@ func (ds *PolicyTestSuite) TestDeniesIngress(c *C) {
 
 	repo.Mutex.RLock()
 	// no rules loaded: Allows() => denied
-	c.Assert(repo.AllowsIngressRLocked(fooToBar), Equals, api.Denied)
+	require.Equal(t, api.Denied, repo.AllowsIngressRLocked(fooToBar))
 	repo.Mutex.RUnlock()
 
 	tag1 := labels.LabelArray{labels.ParseLabel("tag1")}
@@ -379,47 +381,47 @@ func (ds *PolicyTestSuite) TestDeniesIngress(c *C) {
 	}
 
 	_, _, err := repo.Add(rule1)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	_, _, err = repo.Add(rule2)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	_, _, err = repo.Add(rule3)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// foo=>bar is not OK
-	c.Assert(repo.AllowsIngressRLocked(fooToBar), Equals, api.Denied)
+	require.Equal(t, api.Denied, repo.AllowsIngressRLocked(fooToBar))
 
 	// foo=>bar2 is not OK
-	c.Assert(repo.AllowsIngressRLocked(&SearchContext{
+	require.Equal(t, api.Denied, repo.AllowsIngressRLocked(&SearchContext{
 		From: labels.ParseSelectLabelArray("foo"),
 		To:   labels.ParseSelectLabelArray("bar2"),
-	}), Equals, api.Denied)
+	}))
 
 	// foo=>bar inside groupA is not OK
-	c.Assert(repo.AllowsIngressRLocked(&SearchContext{
+	require.Equal(t, api.Denied, repo.AllowsIngressRLocked(&SearchContext{
 		From: labels.ParseSelectLabelArray("foo", "groupA"),
 		To:   labels.ParseSelectLabelArray("bar", "groupA"),
-	}), Equals, api.Denied)
+	}))
 
 	// groupB can't talk to groupA => Denied
-	c.Assert(repo.AllowsIngressRLocked(&SearchContext{
+	require.Equal(t, api.Denied, repo.AllowsIngressRLocked(&SearchContext{
 		From: labels.ParseSelectLabelArray("foo", "groupB"),
 		To:   labels.ParseSelectLabelArray("bar", "groupA"),
-	}), Equals, api.Denied)
+	}))
 
 	//  restriction on groupB, unused label => not OK
-	c.Assert(repo.AllowsIngressRLocked(&SearchContext{
+	require.Equal(t, api.Denied, repo.AllowsIngressRLocked(&SearchContext{
 		From: labels.ParseSelectLabelArray("foo", "groupB"),
 		To:   labels.ParseSelectLabelArray("bar", "groupB"),
-	}), Equals, api.Denied)
+	}))
 
 	// foo=>bar3, no rule => Denied
-	c.Assert(repo.AllowsIngressRLocked(&SearchContext{
+	require.Equal(t, api.Denied, repo.AllowsIngressRLocked(&SearchContext{
 		From: labels.ParseSelectLabelArray("foo"),
 		To:   labels.ParseSelectLabelArray("bar3"),
-	}), Equals, api.Denied)
+	}))
 }
 
-func (ds *PolicyTestSuite) TestDeniesEgress(c *C) {
+func TestDeniesEgress(t *testing.T) {
 	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
@@ -430,7 +432,7 @@ func (ds *PolicyTestSuite) TestDeniesEgress(c *C) {
 
 	repo.Mutex.RLock()
 	// no rules loaded: Allows() => denied
-	c.Assert(repo.AllowsEgressRLocked(fooToBar), Equals, api.Denied)
+	require.Equal(t, api.Denied, repo.AllowsEgressRLocked(fooToBar))
 	repo.Mutex.RUnlock()
 
 	tag1 := labels.LabelArray{labels.ParseLabel("tag1")}
@@ -477,31 +479,31 @@ func (ds *PolicyTestSuite) TestDeniesEgress(c *C) {
 		Labels: tag1,
 	}
 	_, _, err := repo.Add(rule1)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	_, _, err = repo.Add(rule2)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	_, _, err = repo.Add(rule3)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// foo=>bar is not OK
 	logBuffer := new(bytes.Buffer)
 	result := repo.AllowsEgressRLocked(fooToBar.WithLogger(logBuffer))
-	if equal, err := checker.DeepEqual(result, api.Denied); !equal {
-		c.Logf("%s", logBuffer.String())
-		c.Errorf("Resolved policy did not match expected: \n%s", err)
+	if !assert.EqualValues(t, api.Denied, result) {
+		t.Logf("%s", logBuffer.String())
+		t.Errorf("Resolved policy did not match expected")
 	}
 
 	// foo=>bar2 is not OK
-	c.Assert(repo.AllowsEgressRLocked(&SearchContext{
+	require.Equal(t, api.Denied, repo.AllowsEgressRLocked(&SearchContext{
 		From: labels.ParseSelectLabelArray("foo"),
 		To:   labels.ParseSelectLabelArray("bar2"),
-	}), Equals, api.Denied)
+	}))
 
 	// foo=>bar inside groupA is not OK
-	c.Assert(repo.AllowsEgressRLocked(&SearchContext{
+	require.Equal(t, api.Denied, repo.AllowsEgressRLocked(&SearchContext{
 		From: labels.ParseSelectLabelArray("foo", "groupA"),
 		To:   labels.ParseSelectLabelArray("bar", "groupA"),
-	}), Equals, api.Denied)
+	}))
 
 	buffer := new(bytes.Buffer)
 	// groupB can't talk to groupA => Denied
@@ -512,22 +514,22 @@ func (ds *PolicyTestSuite) TestDeniesEgress(c *C) {
 		Trace:   TRACE_VERBOSE,
 	}
 	verdict := repo.AllowsEgressRLocked(ctx)
-	c.Assert(verdict, Equals, api.Denied)
+	require.Equal(t, api.Denied, verdict)
 
 	// no restriction on groupB, unused label => not OK
-	c.Assert(repo.AllowsEgressRLocked(&SearchContext{
+	require.Equal(t, api.Denied, repo.AllowsEgressRLocked(&SearchContext{
 		From: labels.ParseSelectLabelArray("foo", "groupB"),
 		To:   labels.ParseSelectLabelArray("bar", "groupB"),
-	}), Equals, api.Denied)
+	}))
 
 	// foo=>bar3, no rule => Denied
-	c.Assert(repo.AllowsEgressRLocked(&SearchContext{
+	require.Equal(t, api.Denied, repo.AllowsEgressRLocked(&SearchContext{
 		From: labels.ParseSelectLabelArray("foo"),
 		To:   labels.ParseSelectLabelArray("bar3"),
-	}), Equals, api.Denied)
+	}))
 }
 
-func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDeny(c *C) {
+func TestWildcardL3RulesIngressDeny(t *testing.T) {
 	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
@@ -546,7 +548,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDeny(c *C) {
 	}
 	l3Rule.Sanitize()
 	_, _, err := repo.Add(l3Rule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	ctx := &SearchContext{
 		To: labels.ParseSelectLabelArray("id=foo"),
@@ -556,7 +558,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDeny(c *C) {
 	defer repo.Mutex.RUnlock()
 
 	policyDeny, err := repo.ResolveL4IngressPolicy(ctx)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	expectedPolicy := L4PolicyMap{
 		"0/ANY": {
@@ -570,11 +572,11 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDeny(c *C) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectorBar1: {labelsL3}},
 		},
 	}
-	c.Assert(policyDeny, checker.DeepEquals, expectedPolicy)
+	require.EqualValues(t, expectedPolicy, policyDeny)
 	policyDeny.Detach(repo.GetSelectorCache())
 }
 
-func (ds *PolicyTestSuite) TestWildcardL4RulesIngressDeny(c *C) {
+func TestWildcardL4RulesIngressDeny(t *testing.T) {
 	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
@@ -602,7 +604,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngressDeny(c *C) {
 	}
 	l49092Rule.Sanitize()
 	_, _, err := repo.Add(l49092Rule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	l480Rule := api.Rule{
 		EndpointSelector: selFoo,
@@ -622,7 +624,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngressDeny(c *C) {
 	}
 	l480Rule.Sanitize()
 	_, _, err = repo.Add(l480Rule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	ctx := &SearchContext{
 		To: labels.ParseSelectLabelArray("id=foo"),
@@ -632,7 +634,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngressDeny(c *C) {
 	defer repo.Mutex.RUnlock()
 
 	policyDeny, err := repo.ResolveL4IngressPolicy(ctx)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	expectedDenyPolicy := L4PolicyMap{
 		"80/TCP": {
@@ -658,11 +660,11 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngressDeny(c *C) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectorBar1: {labelsL4Kafka}},
 		},
 	}
-	c.Assert(policyDeny, checker.DeepEquals, expectedDenyPolicy)
+	require.EqualValues(t, expectedDenyPolicy, policyDeny)
 	policyDeny.Detach(repo.GetSelectorCache())
 }
 
-func (ds *PolicyTestSuite) TestL3DependentL4IngressDenyFromRequires(c *C) {
+func TestL3DependentL4IngressDenyFromRequires(t *testing.T) {
 	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
@@ -694,7 +696,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4IngressDenyFromRequires(c *C) {
 	}
 	l480Rule.Sanitize()
 	_, _, err := repo.Add(l480Rule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	ctx := &SearchContext{
 		To: labels.ParseSelectLabelArray("id=foo"),
@@ -704,7 +706,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4IngressDenyFromRequires(c *C) {
 	defer repo.Mutex.RUnlock()
 
 	policyDeny, err := repo.ResolveL4IngressPolicy(ctx)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	expectedSelector := api.NewESFromMatchRequirements(map[string]string{"any.id": "bar1"}, []slim_metav1.LabelSelectorRequirement{
 		{
@@ -727,11 +729,11 @@ func (ds *PolicyTestSuite) TestL3DependentL4IngressDenyFromRequires(c *C) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{expectedCachedSelector: {nil}},
 		},
 	}
-	c.Assert(policyDeny, checker.DeepEquals, expectedDenyPolicy)
+	require.EqualValues(t, expectedDenyPolicy, policyDeny)
 	policyDeny.Detach(repo.GetSelectorCache())
 }
 
-func (ds *PolicyTestSuite) TestL3DependentL4EgressDenyFromRequires(c *C) {
+func TestL3DependentL4EgressDenyFromRequires(t *testing.T) {
 	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
@@ -766,7 +768,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressDenyFromRequires(c *C) {
 	}
 	l480Rule.Sanitize()
 	_, _, err := repo.Add(l480Rule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	ctx := &SearchContext{
 		From: labels.ParseSelectLabelArray("id=foo"),
@@ -777,7 +779,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressDenyFromRequires(c *C) {
 
 	logBuffer := new(bytes.Buffer)
 	policyDeny, err := repo.ResolveL4EgressPolicy(ctx.WithLogger(logBuffer))
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	expectedSelector := api.NewESFromMatchRequirements(map[string]string{"any.id": "bar1"}, []slim_metav1.LabelSelectorRequirement{
 		{
@@ -816,13 +818,13 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressDenyFromRequires(c *C) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{expectedCachedSelector: {nil}},
 		},
 	}
-	if !c.Check(policyDeny, checker.DeepEquals, expectedDenyPolicy) {
-		c.Errorf("Policy doesn't match expected:\n%s", logBuffer.String())
+	if !assert.EqualValues(t, expectedDenyPolicy, policyDeny) {
+		t.Errorf("Policy doesn't match expected:\n%s", logBuffer.String())
 	}
 	policyDeny.Detach(repo.GetSelectorCache())
 }
 
-func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDeny(c *C) {
+func TestWildcardL3RulesEgressDeny(t *testing.T) {
 	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
@@ -846,7 +848,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDeny(c *C) {
 	}
 	l3Rule.Sanitize()
 	_, _, err := repo.Add(l3Rule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	icmpV4Type := intstr.FromInt(8)
 	icmpRule := api.Rule{
@@ -866,10 +868,10 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDeny(c *C) {
 		Labels: labelsICMP,
 	}
 	err = icmpRule.Sanitize()
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	_, _, err = repo.Add(icmpRule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	icmpV6Type := intstr.FromInt(128)
 	icmpV6Rule := api.Rule{
@@ -890,10 +892,10 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDeny(c *C) {
 		Labels: labelsICMPv6,
 	}
 	err = icmpV6Rule.Sanitize()
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	_, _, err = repo.Add(icmpV6Rule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	ctx := &SearchContext{
 		From: labels.ParseSelectLabelArray("id=foo"),
@@ -904,7 +906,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDeny(c *C) {
 
 	logBuffer := new(bytes.Buffer)
 	policyDeny, err := repo.ResolveL4EgressPolicy(ctx.WithLogger(logBuffer))
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Traffic to bar1 should not be forwarded to the DNS or HTTP
 	// proxy at all, but if it is (e.g., for visibility, the
@@ -944,11 +946,11 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDeny(c *C) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectorBar1: {labelsICMPv6}},
 		},
 	}
-	c.Assert(policyDeny, checker.DeepEquals, expectedDenyPolicy, Commentf("Resolved policy did not match expected:\n%s", logBuffer.String()))
+	require.EqualValuesf(t, expectedDenyPolicy, policyDeny, "Resolved policy did not match expected:\n%s", logBuffer.String())
 	policyDeny.Detach(repo.GetSelectorCache())
 }
 
-func (ds *PolicyTestSuite) TestWildcardL4RulesEgressDeny(c *C) {
+func TestWildcardL4RulesEgressDeny(t *testing.T) {
 	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
@@ -976,7 +978,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgressDeny(c *C) {
 	}
 	l453Rule.Sanitize()
 	_, _, err := repo.Add(l453Rule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	l480Rule := api.Rule{
 		EndpointSelector: selFoo,
@@ -996,7 +998,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgressDeny(c *C) {
 	}
 	l480Rule.Sanitize()
 	_, _, err = repo.Add(l480Rule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	ctx := &SearchContext{
 		From: labels.ParseSelectLabelArray("id=foo"),
@@ -1007,7 +1009,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgressDeny(c *C) {
 
 	logBuffer := new(bytes.Buffer)
 	policyDeny, err := repo.ResolveL4EgressPolicy(ctx.WithLogger(logBuffer))
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Bar1 should not be forwarded to the proxy, but if it is (e.g., for visibility),
 	// the L3/L4 deny should pass it without an explicit L7 wildcard.
@@ -1035,14 +1037,14 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgressDeny(c *C) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectorBar1: {labelsL3DNS}},
 		},
 	}
-	if equal, err := checker.DeepEqual(policyDeny, expectedDenyPolicy); !equal {
-		c.Logf("%s", logBuffer.String())
-		c.Errorf("Resolved policy did not match expected: \n%s", err)
+	if !assert.EqualValues(t, expectedDenyPolicy, policyDeny) {
+		t.Logf("%s", logBuffer.String())
+		t.Errorf("Resolved policy did not match expected")
 	}
 	policyDeny.Detach(repo.GetSelectorCache())
 }
 
-func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgressDeny(c *C) {
+func TestWildcardCIDRRulesEgressDeny(t *testing.T) {
 	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
@@ -1080,7 +1082,7 @@ func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgressDeny(c *C) {
 	}
 	l480Get.Sanitize()
 	_, _, err := repo.Add(l480Get)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	l3Rule := api.Rule{
 		EndpointSelector: selFoo,
@@ -1095,7 +1097,7 @@ func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgressDeny(c *C) {
 	}
 	l3Rule.Sanitize()
 	_, _, err = repo.Add(l3Rule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	ctx := &SearchContext{
 		From: labels.ParseSelectLabelArray("id=foo"),
@@ -1106,7 +1108,7 @@ func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgressDeny(c *C) {
 
 	logBuffer := new(bytes.Buffer)
 	policyDeny, err := repo.ResolveL4EgressPolicy(ctx.WithLogger(logBuffer))
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Port 80 policy does not need the wildcard, as the "0" port policy will deny the traffic.
 	expectedDenyPolicy := L4PolicyMap{
@@ -1133,14 +1135,14 @@ func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgressDeny(c *C) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectors[0]: {labelsL3}},
 		},
 	}
-	if equal, err := checker.DeepEqual(policyDeny, expectedDenyPolicy); !equal {
-		c.Logf("%s", logBuffer.String())
-		c.Errorf("Resolved policy did not match expected: \n%s", err)
+	if !assert.EqualValues(t, expectedDenyPolicy, policyDeny) {
+		t.Logf("%s", logBuffer.String())
+		t.Errorf("Resolved policy did not match expected: \n%s", err)
 	}
 	policyDeny.Detach(repo.GetSelectorCache())
 }
 
-func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDenyFromEntities(c *C) {
+func TestWildcardL3RulesIngressDenyFromEntities(t *testing.T) {
 	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
@@ -1161,7 +1163,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDenyFromEntities(c *C) {
 	}
 	l3Rule.Sanitize()
 	_, _, err := repo.Add(l3Rule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	ctx := &SearchContext{
 		To: labels.ParseSelectLabelArray("id=foo"),
@@ -1171,17 +1173,17 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDenyFromEntities(c *C) {
 	defer repo.Mutex.RUnlock()
 
 	policyDeny, err := repo.ResolveL4IngressPolicy(ctx)
-	c.Assert(err, IsNil)
-	c.Assert(len(policyDeny), Equals, 1)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(policyDeny))
 	selWorld := api.EntitySelectorMapping[api.EntityWorld][0]
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(selWorld)
-	c.Assert(cachedSelectorWorld, Not(IsNil))
+	require.NotNil(t, cachedSelectorWorld)
 
 	cachedSelectorWorldV4 := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv4])
-	c.Assert(cachedSelectorWorldV4, Not(IsNil))
+	require.NotNil(t, cachedSelectorWorldV4)
 
 	cachedSelectorWorldV6 := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv6])
-	c.Assert(cachedSelectorWorldV6, Not(IsNil))
+	require.NotNil(t, cachedSelectorWorldV6)
 
 	expectedPolicy := L4PolicyMap{
 		"0/ANY": {
@@ -1203,11 +1205,11 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDenyFromEntities(c *C) {
 		},
 	}
 
-	c.Assert(policyDeny, checker.DeepEquals, expectedPolicy)
+	require.EqualValues(t, expectedPolicy, policyDeny)
 	policyDeny.Detach(repo.GetSelectorCache())
 }
 
-func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDenyToEntities(c *C) {
+func TestWildcardL3RulesEgressDenyToEntities(t *testing.T) {
 	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
@@ -1228,7 +1230,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDenyToEntities(c *C) {
 	}
 	l3Rule.Sanitize()
 	_, _, err := repo.Add(l3Rule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	ctx := &SearchContext{
 		From: labels.ParseSelectLabelArray("id=foo"),
@@ -1238,17 +1240,17 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDenyToEntities(c *C) {
 	defer repo.Mutex.RUnlock()
 
 	policyDeny, err := repo.ResolveL4EgressPolicy(ctx)
-	c.Assert(err, IsNil)
-	c.Assert(len(policyDeny), Equals, 1)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(policyDeny))
 	selWorld := api.EntitySelectorMapping[api.EntityWorld][0]
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(selWorld)
-	c.Assert(cachedSelectorWorld, Not(IsNil))
+	require.NotNil(t, cachedSelectorWorld)
 
 	cachedSelectorWorldV4 := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv4])
-	c.Assert(cachedSelectorWorldV4, Not(IsNil))
+	require.NotNil(t, cachedSelectorWorldV4)
 
 	cachedSelectorWorldV6 := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv6])
-	c.Assert(cachedSelectorWorldV6, Not(IsNil))
+	require.NotNil(t, cachedSelectorWorldV6)
 
 	// We should expect an empty deny policy because the policy does not
 	// contain any rules with the label 'id=foo'.
@@ -1272,11 +1274,11 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDenyToEntities(c *C) {
 		},
 	}
 
-	c.Assert(policyDeny, checker.DeepEquals, expectedDenyPolicy)
+	require.EqualValues(t, expectedDenyPolicy, policyDeny)
 	policyDeny.Detach(repo.GetSelectorCache())
 }
 
-func (ds *PolicyTestSuite) TestMinikubeGettingStartedDeny(c *C) {
+func TestMinikubeGettingStartedDeny(t *testing.T) {
 	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
@@ -1295,8 +1297,8 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStartedDeny(c *C) {
 
 	repo.Mutex.RLock()
 	// no rules loaded: Allows() => denied
-	c.Assert(repo.AllowsIngressRLocked(fromApp2), Equals, api.Denied)
-	c.Assert(repo.AllowsIngressRLocked(fromApp3), Equals, api.Denied)
+	require.Equal(t, api.Denied, repo.AllowsIngressRLocked(fromApp2))
+	require.Equal(t, api.Denied, repo.AllowsIngressRLocked(fromApp3))
 	repo.Mutex.RUnlock()
 
 	selFromApp2 := api.NewESFromLabels(
@@ -1322,7 +1324,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStartedDeny(c *C) {
 			},
 		},
 	})
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	_, _, err = repo.Add(api.Rule{
 		EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("id=app1")),
@@ -1339,7 +1341,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStartedDeny(c *C) {
 			},
 		},
 	})
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	repo.Mutex.RLock()
 	defer repo.Mutex.RUnlock()
@@ -1347,10 +1349,10 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStartedDeny(c *C) {
 	// L4 from app2 is restricted
 	logBuffer := new(bytes.Buffer)
 	l4IngressDenyPolicy, err := repo.ResolveL4IngressPolicy(fromApp2.WithLogger(logBuffer))
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	cachedSelectorApp2 := testSelectorCache.FindCachedIdentitySelector(selFromApp2)
-	c.Assert(cachedSelectorApp2, Not(IsNil))
+	require.NotNil(t, cachedSelectorApp2)
 
 	expectedDeny := NewL4Policy(repo.GetRevision())
 	expectedDeny.Ingress.PortRules["80/TCP"] = &L4Filter{
@@ -1363,9 +1365,9 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStartedDeny(c *C) {
 		RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectorApp2: {nil}},
 	}
 
-	if equal, err := checker.DeepEqual(l4IngressDenyPolicy, expectedDeny.Ingress.PortRules); !equal {
-		c.Logf("%s", logBuffer.String())
-		c.Errorf("Resolved policy did not match expected: \n%s", err)
+	if !assert.EqualValues(t, expectedDeny.Ingress.PortRules, l4IngressDenyPolicy) {
+		t.Logf("%s", logBuffer.String())
+		t.Errorf("Resolved policy did not match expected")
 	}
 	l4IngressDenyPolicy.Detach(testSelectorCache)
 	expectedDeny.Detach(testSelectorCache)
@@ -1373,9 +1375,9 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStartedDeny(c *C) {
 	// L4 from app3 has no rules
 	expectedDeny = NewL4Policy(repo.GetRevision())
 	l4IngressDenyPolicy, err = repo.ResolveL4IngressPolicy(fromApp3)
-	c.Assert(err, IsNil)
-	c.Assert(len(l4IngressDenyPolicy), Equals, 0)
-	c.Assert(l4IngressDenyPolicy, checker.Equals, expectedDeny.Ingress.PortRules)
+	require.Nil(t, err)
+	require.Equal(t, 0, len(l4IngressDenyPolicy))
+	require.Equal(t, expectedDeny.Ingress.PortRules, l4IngressDenyPolicy)
 	l4IngressDenyPolicy.Detach(testSelectorCache)
 	expectedDeny.Detach(testSelectorCache)
 }
@@ -1407,7 +1409,7 @@ func buildDenyRule(from, to, port string) api.Rule {
 	}
 }
 
-func (ds *PolicyTestSuite) TestPolicyDenyTrace(c *C) {
+func TestPolicyDenyTrace(t *testing.T) {
 	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
@@ -1429,11 +1431,11 @@ Found deny rule
 Ingress verdict: denied
 `
 	ctx := buildSearchCtx("foo", "bar", 0)
-	repo.checkTrace(c, ctx, expectedOut, api.Denied)
+	repo.checkTrace(t, ctx, expectedOut, api.Denied)
 
 	// foo=>bar:80 is OK
 	ctx = buildSearchCtx("foo", "bar", 80)
-	repo.checkTrace(c, ctx, expectedOut, api.Denied)
+	repo.checkTrace(t, ctx, expectedOut, api.Denied)
 
 	// bar=>foo is Denied
 	ctx = buildSearchCtx("bar", "foo", 0)
@@ -1444,16 +1446,16 @@ Found no allow rule
 Found no deny rule
 Ingress verdict: denied
 `
-	repo.checkTrace(c, ctx, expectedOut, api.Denied)
+	repo.checkTrace(t, ctx, expectedOut, api.Denied)
 
 	// bar=>foo:80 is also Denied by the same logic
 	ctx = buildSearchCtx("bar", "foo", 80)
-	repo.checkTrace(c, ctx, expectedOut, api.Denied)
+	repo.checkTrace(t, ctx, expectedOut, api.Denied)
 
 	// Now, add extra rules to allow specifically baz=>bar on port 80
 	l4rule := buildDenyRule("baz", "bar", "80")
 	_, _, err := repo.Add(l4rule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// baz=>bar:80 is OK
 	ctx = buildSearchCtx("baz", "bar", 80)
@@ -1473,7 +1475,7 @@ Found no allow rule
 Found deny rule
 Ingress verdict: denied
 `
-	repo.checkTrace(c, ctx, expectedOut, api.Denied)
+	repo.checkTrace(t, ctx, expectedOut, api.Denied)
 
 	// bar=>bar:80 is Denied
 	ctx = buildSearchCtx("bar", "bar", 80)
@@ -1492,7 +1494,7 @@ Found no allow rule
 Found no deny rule
 Ingress verdict: denied
 `
-	repo.checkTrace(c, ctx, expectedOut, api.Denied)
+	repo.checkTrace(t, ctx, expectedOut, api.Denied)
 
 	// Test that FromRequires "baz" drops "foo" traffic
 	l3rule = api.Rule{
@@ -1506,7 +1508,7 @@ Ingress verdict: denied
 		}},
 	}
 	_, _, err = repo.Add(l3rule)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// foo=>bar is now denied due to the FromRequires
 	ctx = buildSearchCtx("foo", "bar", 0)
@@ -1528,7 +1530,7 @@ Found no allow rule
 Found no deny rule
 Ingress verdict: denied
 `
-	repo.checkTrace(c, ctx, expectedOut, api.Denied)
+	repo.checkTrace(t, ctx, expectedOut, api.Denied)
 
 	// baz=>bar is only denied because of the L4 policy
 	ctx = buildSearchCtx("baz", "bar", 0)
@@ -1552,19 +1554,19 @@ Found no allow rule
 Found no deny rule
 Ingress verdict: denied
 `
-	repo.checkTrace(c, ctx, expectedOut, api.Denied)
+	repo.checkTrace(t, ctx, expectedOut, api.Denied)
 
 	// Should still be allowed with the new FromRequires constraint
 	ctx = buildSearchCtx("baz", "bar", 80)
 	repo.Mutex.RLock()
 	verdict := repo.AllowsIngressRLocked(ctx)
 	repo.Mutex.RUnlock()
-	c.Assert(verdict, Equals, api.Denied)
+	require.Equal(t, api.Denied, verdict)
 }
 
-func (ds *PolicyTestSuite) TestRemoveIdentityFromRuleDenyCaches(c *C) {
+func TestRemoveIdentityFromRuleDenyCaches(t *testing.T) {
 
-	testRepo := parseAndAddRules(c, api.Rules{&api.Rule{
+	testRepo := parseAndAddRules(t, api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
 		IngressDeny: []api.IngressDenyRule{
 			{
@@ -1585,19 +1587,19 @@ func (ds *PolicyTestSuite) TestRemoveIdentityFromRuleDenyCaches(c *C) {
 
 	// selectedEndpoint is selected by rule, so we it should be added to
 	// EndpointsSelected.
-	c.Assert(addedRule.matches(selectedIdentity), Equals, true)
-	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[identity.NumericIdentity]bool{selectedIdentity.ID: true})
+	require.Equal(t, true, addedRule.matches(selectedIdentity))
+	require.EqualValues(t, map[identity.NumericIdentity]bool{selectedIdentity.ID: true}, addedRule.metadata.IdentitySelected)
 
 	wg := testRepo.removeIdentityFromRuleCaches(selectedIdentity)
 	wg.Wait()
 
-	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[identity.NumericIdentity]bool{})
+	require.EqualValues(t, map[identity.NumericIdentity]bool{}, addedRule.metadata.IdentitySelected)
 
-	c.Assert(addedRule.matches(notSelectedIdentity), Equals, false)
-	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[identity.NumericIdentity]bool{notSelectedIdentity.ID: false})
+	require.Equal(t, false, addedRule.matches(notSelectedIdentity))
+	require.EqualValues(t, map[identity.NumericIdentity]bool{notSelectedIdentity.ID: false}, addedRule.metadata.IdentitySelected)
 
 	wg = testRepo.removeIdentityFromRuleCaches(notSelectedIdentity)
 	wg.Wait()
 
-	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[identity.NumericIdentity]bool{})
+	require.EqualValues(t, map[identity.NumericIdentity]bool{}, addedRule.metadata.IdentitySelected)
 }

--- a/pkg/policy/utils_test.go
+++ b/pkg/policy/utils_test.go
@@ -4,10 +4,12 @@
 package policy
 
 import (
-	. "github.com/cilium/checkmate"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func (s *PolicyTestSuite) TestJoinPath(c *C) {
+func TestJoinPath(t *testing.T) {
 	var joinPathTests = []struct {
 		input1   string // input 1
 		input2   string // input 2
@@ -21,6 +23,6 @@ func (s *PolicyTestSuite) TestJoinPath(c *C) {
 	}
 	for _, tt := range joinPathTests {
 		actual := JoinPath(tt.input1, tt.input2)
-		c.Assert(actual, Equals, tt.expected)
+		require.Equal(t, tt.expected, actual)
 	}
 }

--- a/pkg/policy/visibility_test.go
+++ b/pkg/policy/visibility_test.go
@@ -4,167 +4,168 @@
 package policy
 
 import (
-	. "github.com/cilium/checkmate"
+	"testing"
 
-	"github.com/cilium/cilium/pkg/checker"
+	"github.com/stretchr/testify/require"
+
 	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
-func (ds *PolicyTestSuite) TestGenerateL7RulesByParser(c *C) {
+func TestGenerateL7RulesByParser(t *testing.T) {
 	m := generateL7AllowAllRules(ParserTypeHTTP, "", "")
-	c.Assert(m, IsNil)
+	require.Nil(t, m)
 
 	m = generateL7AllowAllRules(ParserTypeKafka, "", "")
-	c.Assert(m, IsNil)
+	require.Nil(t, m)
 
 	m = generateL7AllowAllRules(ParserTypeDNS, "ns-name", "pod-name")
-	c.Assert(m, Not(IsNil))
-	c.Assert(len(m), Equals, 1)
+	require.NotNil(t, m)
+	require.Equal(t, 1, len(m))
 
 	for k, v := range m {
 		// Check that we allow all at L7 for DNS for the one rule we should have
 		// generated.
-		c.Assert(v, checker.DeepEquals, &PerSelectorPolicy{L7Rules: api.L7Rules{DNS: []api.PortRuleDNS{{MatchPattern: "*"}}}})
+		require.EqualValues(t, &PerSelectorPolicy{L7Rules: api.L7Rules{DNS: []api.PortRuleDNS{{MatchPattern: "*"}}}}, v)
 
-		c.Assert(k.GetMetadataLabels(), checker.DeepEquals, labels.LabelArray{
+		require.EqualValues(t, labels.LabelArray{
 			labels.NewLabel(ciliumio.PolicyLabelDerivedFrom, "PodVisibilityAnnotation", labels.LabelSourceK8s),
 			labels.NewLabel(ciliumio.PodNamespaceLabel, "ns-name", labels.LabelSourceK8s),
 			labels.NewLabel(ciliumio.PodNameLabel, "pod-name", labels.LabelSourceK8s),
-		})
+		}, k.GetMetadataLabels())
 	}
 
 	// test that we are not setting empty metadata labels when provided pod or namespace name is empty
 	m = generateL7AllowAllRules(ParserTypeDNS, "ns-name", "")
 
 	for k := range m {
-		c.Assert(k.GetMetadataLabels(), checker.DeepEquals, labels.LabelArray{
+		require.EqualValues(t, labels.LabelArray{
 			labels.NewLabel(ciliumio.PolicyLabelDerivedFrom, "PodVisibilityAnnotation", labels.LabelSourceK8s),
 			labels.NewLabel(ciliumio.PodNamespaceLabel, "ns-name", labels.LabelSourceK8s),
-		})
+		}, k.GetMetadataLabels())
 	}
 
 	m = generateL7AllowAllRules(ParserTypeDNS, "", "pod-name")
 
 	for k := range m {
-		c.Assert(k.GetMetadataLabels(), checker.DeepEquals, labels.LabelArray{
+		require.EqualValues(t, labels.LabelArray{
 			labels.NewLabel(ciliumio.PolicyLabelDerivedFrom, "PodVisibilityAnnotation", labels.LabelSourceK8s),
 			labels.NewLabel(ciliumio.PodNameLabel, "pod-name", labels.LabelSourceK8s),
-		})
+		}, k.GetMetadataLabels())
 	}
 
 	m = generateL7AllowAllRules(ParserTypeDNS, "", "")
 
 	for k := range m {
-		c.Assert(k.GetMetadataLabels(), checker.DeepEquals, labels.LabelArray{
+		require.EqualValues(t, labels.LabelArray{
 			labels.NewLabel(ciliumio.PolicyLabelDerivedFrom, "PodVisibilityAnnotation", labels.LabelSourceK8s),
-		})
+		}, k.GetMetadataLabels())
 	}
 }
 
-func (ds *PolicyTestSuite) TestVisibilityPolicyCreation(c *C) {
+func TestVisibilityPolicyCreation(t *testing.T) {
 
 	anno := "<Ingress/80/TCP/HTTP>"
 	vp, err := NewVisibilityPolicy(anno, "", "")
-	c.Assert(vp, Not(IsNil))
-	c.Assert(err, IsNil)
+	require.NotNil(t, vp)
+	require.NoError(t, err)
 
-	c.Assert(len(vp.Ingress), Equals, 1)
-	c.Assert(vp.Ingress["80/TCP"], checker.DeepEquals, &VisibilityMetadata{
+	require.Equal(t, 1, len(vp.Ingress))
+	require.Equal(t, &VisibilityMetadata{
 		Proto:   u8proto.TCP,
 		Port:    uint16(80),
 		Parser:  ParserTypeHTTP,
 		Ingress: true,
-	})
+	}, vp.Ingress["80/TCP"])
 
 	anno = "<Ingress/80/TCP/HTTP>,<Ingress/8080/TCP/HTTP>"
 	vp, err = NewVisibilityPolicy(anno, "", "")
-	c.Assert(vp, Not(IsNil))
-	c.Assert(err, IsNil)
+	require.NotNil(t, vp)
+	require.NoError(t, err)
 
-	c.Assert(len(vp.Ingress), Equals, 2)
-	c.Assert(vp.Ingress["80/TCP"], checker.DeepEquals, &VisibilityMetadata{
+	require.Equal(t, 2, len(vp.Ingress))
+	require.Equal(t, &VisibilityMetadata{
 		Proto:   u8proto.TCP,
 		Port:    uint16(80),
 		Parser:  ParserTypeHTTP,
 		Ingress: true,
-	})
-	c.Assert(vp.Ingress["8080/TCP"], checker.DeepEquals, &VisibilityMetadata{
+	}, vp.Ingress["80/TCP"])
+	require.Equal(t, &VisibilityMetadata{
 		Proto:   u8proto.TCP,
 		Port:    uint16(8080),
 		Parser:  ParserTypeHTTP,
 		Ingress: true,
-	})
+	}, vp.Ingress["8080/TCP"])
 
 	anno = "<Ingress/80/TCP/HTTP>,<Ingress/80/TCP/HTTP>"
 	vp, err = NewVisibilityPolicy(anno, "", "")
-	c.Assert(vp, Not(IsNil))
-	c.Assert(err, IsNil)
+	require.NotNil(t, vp)
+	require.NoError(t, err)
 
-	c.Assert(len(vp.Ingress), Equals, 1)
-	c.Assert(vp.Ingress["80/TCP"], checker.DeepEquals, &VisibilityMetadata{
+	require.Equal(t, 1, len(vp.Ingress))
+	require.Equal(t, &VisibilityMetadata{
 		Proto:   u8proto.TCP,
 		Port:    uint16(80),
 		Parser:  ParserTypeHTTP,
 		Ingress: true,
-	})
+	}, vp.Ingress["80/TCP"])
 
 	anno = "<Ingress/80/TCP/HTTP>,<Ingress/80/TCP/Kafka>"
 	vp, err = NewVisibilityPolicy(anno, "", "")
-	c.Assert(vp, IsNil)
-	c.Assert(err, Not(IsNil))
+	require.Nil(t, vp)
+	require.NotNil(t, err)
 
 	anno = "asdf"
 	vp, err = NewVisibilityPolicy(anno, "", "")
-	c.Assert(vp, IsNil)
-	c.Assert(err, Not(IsNil))
+	require.Nil(t, vp)
+	require.NotNil(t, err)
 
 	anno = "<Ingress/65536/TCP/HTTP>"
 	vp, err = NewVisibilityPolicy(anno, "", "")
-	c.Assert(vp, IsNil)
-	c.Assert(err, Not(IsNil))
+	require.Nil(t, vp)
+	require.NotNil(t, err)
 
 	anno = "<Ingress/65535/TCP/HTTP>"
 	vp, err = NewVisibilityPolicy(anno, "", "")
-	c.Assert(vp, Not(IsNil))
-	c.Assert(err, IsNil)
+	require.NotNil(t, vp)
+	require.NoError(t, err)
 
 	anno = "<Ingress/99999/TCP/HTTP>"
 	vp, err = NewVisibilityPolicy(anno, "", "")
-	c.Assert(vp, IsNil)
-	c.Assert(err, Not(IsNil))
+	require.Nil(t, vp)
+	require.NotNil(t, err)
 
 	anno = "<Ingress/0/TCP/HTTP>"
 	vp, err = NewVisibilityPolicy(anno, "", "")
-	c.Assert(vp, IsNil)
-	c.Assert(err, Not(IsNil))
+	require.Nil(t, vp)
+	require.NotNil(t, err)
 
 	// Do not allow > 5 digits.
 	anno = "<Ingress/123456/TCP/HTTP"
 	vp, err = NewVisibilityPolicy(anno, "", "")
-	c.Assert(vp, IsNil)
-	c.Assert(err, Not(IsNil))
+	require.Nil(t, vp)
+	require.NotNil(t, err)
 
 	// Do not allow leading zeroes.
 	anno = "<Ingress/02345/TCP/HTTP"
 	vp, err = NewVisibilityPolicy(anno, "", "")
-	c.Assert(vp, IsNil)
-	c.Assert(err, Not(IsNil))
+	require.Nil(t, vp)
+	require.NotNil(t, err)
 
 	anno = "<Egress/53/ANY/DNS>"
 	vp, err = NewVisibilityPolicy(anno, "", "")
-	c.Assert(err, IsNil)
-	c.Assert(vp.Egress, HasLen, 3)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(vp.Egress))
 	udp, ok := vp.Egress["53/UDP"]
-	c.Assert(ok, Equals, true)
-	c.Assert(udp.Proto, Equals, u8proto.UDP)
+	require.True(t, ok)
+	require.Equal(t, u8proto.UDP, udp.Proto)
 	tcp, ok := vp.Egress["53/TCP"]
-	c.Assert(tcp.Proto, Equals, u8proto.TCP)
-	c.Assert(ok, Equals, true)
+	require.Equal(t, u8proto.TCP, tcp.Proto)
+	require.True(t, ok)
 	sctp, ok := vp.Egress["53/SCTP"]
-	c.Assert(sctp.Proto, Equals, u8proto.SCTP)
-	c.Assert(ok, Equals, true)
+	require.Equal(t, u8proto.SCTP, sctp.Proto)
+	require.True(t, ok)
 
 }


### PR DESCRIPTION
Please refer to individual commits for more details, this PR is focusing on files owned by cilium/sig-policy team.

Relates: https://github.com/cilium/cilium/issues/28596