### PR TITLE
pkg/metrics: Replace gocheck with built-in go test

### DIFF
--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -4,12 +4,14 @@
 package metrics
 
 import (
-	. "github.com/cilium/checkmate"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/option"
 )
 
-func (s *MetricsSuite) TestGaugeWithThreshold(c *C) {
+func TestGaugeWithThreshold(t *testing.T) {
 	threshold := 1.0
 	underThreshold := threshold - 0.5
 	overThreshold := threshold + 0.5
@@ -28,36 +30,36 @@ func (s *MetricsSuite) TestGaugeWithThreshold(c *C) {
 	})
 
 	metrics, err := reg.inner.Gather()
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	initMetricLen := len(metrics)
 
 	gauge.Set(underThreshold)
 	metrics, err = reg.inner.Gather()
-	c.Assert(err, IsNil)
-	c.Assert(metrics, HasLen, initMetricLen)
-	c.Assert(GetGaugeValue(gauge.gauge), Equals, underThreshold)
+	require.Nil(t, err)
+	require.Len(t, metrics, initMetricLen)
+	require.Equal(t, underThreshold, GetGaugeValue(gauge.gauge))
 
 	gauge.Set(overThreshold)
 	metrics, err = reg.inner.Gather()
-	c.Assert(err, IsNil)
-	c.Assert(metrics, HasLen, initMetricLen+1)
-	c.Assert(GetGaugeValue(gauge.gauge), Equals, overThreshold)
+	require.Nil(t, err)
+	require.Len(t, metrics, initMetricLen+1)
+	require.Equal(t, overThreshold, GetGaugeValue(gauge.gauge))
 
 	gauge.Set(threshold)
 	metrics, err = reg.inner.Gather()
-	c.Assert(err, IsNil)
-	c.Assert(metrics, HasLen, initMetricLen)
-	c.Assert(GetGaugeValue(gauge.gauge), Equals, threshold)
+	require.Nil(t, err)
+	require.Len(t, metrics, initMetricLen)
+	require.Equal(t, threshold, GetGaugeValue(gauge.gauge))
 
 	gauge.Set(overThreshold)
 	metrics, err = reg.inner.Gather()
-	c.Assert(err, IsNil)
-	c.Assert(metrics, HasLen, initMetricLen+1)
-	c.Assert(GetGaugeValue(gauge.gauge), Equals, overThreshold)
+	require.Nil(t, err)
+	require.Len(t, metrics, initMetricLen+1)
+	require.Equal(t, overThreshold, GetGaugeValue(gauge.gauge))
 
 	gauge.Set(underThreshold)
 	metrics, err = reg.inner.Gather()
-	c.Assert(err, IsNil)
-	c.Assert(metrics, HasLen, initMetricLen)
-	c.Assert(GetGaugeValue(gauge.gauge), Equals, underThreshold)
+	require.Nil(t, err)
+	require.Len(t, metrics, initMetricLen)
+	require.Equal(t, underThreshold, GetGaugeValue(gauge.gauge))
 }

--- a/pkg/metrics/middleware_test.go
+++ b/pkg/metrics/middleware_test.go
@@ -9,22 +9,13 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/cilium/checkmate"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/metrics/metric"
 )
 
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) {
-	TestingT(t)
-}
-
-type MetricsSuite struct{}
-
-var _ = Suite(&MetricsSuite{})
-
-func (s *MetricsSuite) TestAPIEventsTSHelperMiddleware(c *C) {
+func TestAPIEventsTSHelperMiddleware(t *testing.T) {
 	for _, test := range []struct {
 		url         string
 		statusCode  int
@@ -35,7 +26,7 @@ func (s *MetricsSuite) TestAPIEventsTSHelperMiddleware(c *C) {
 		{url: "", statusCode: http.StatusNotFound, expectEvent: false}, // invalid urls should not be emitted.
 	} {
 		req, err := http.NewRequest(http.MethodGet, test.url, nil)
-		c.Assert(err, Equals, nil)
+		require.Equal(t, nil, err)
 		gauge := metric.NewGaugeVec(metric.GaugeOpts{}, []string{LabelEventSource, LabelScope, LabelAction})
 		hist := metric.NewHistogramVec(metric.HistogramOpts{Name: "test_api_hist"}, []string{LabelEventSource, LabelScope, LabelAction})
 		middleware := &APIEventTSHelper{
@@ -45,12 +36,12 @@ func (s *MetricsSuite) TestAPIEventsTSHelperMiddleware(c *C) {
 		}
 		middleware.ServeHTTP(httptest.NewRecorder(), req)
 		v := testutil.ToFloat64(gauge.WithLabelValues(LabelEventSourceAPI, "/v1/endpoint", http.MethodGet))
-		c.Assert(v >= float64(time.Now().Unix()), Equals, test.expectEvent)
-		c.Assert(testutil.CollectAndCount(hist, "test_api_hist") == 1, Equals, test.expectEvent)
+		require.Equal(t, test.expectEvent, v >= float64(time.Now().Unix()))
+		require.Equal(t, test.expectEvent, testutil.CollectAndCount(hist, "test_api_hist") == 1)
 	}
 }
 
-func (s *MetricsSuite) Test_getShortPath(c *C) {
+func Test_getShortPath(t *testing.T) {
 	tests := []struct {
 		args string
 		want string
@@ -158,6 +149,6 @@ func (s *MetricsSuite) Test_getShortPath(c *C) {
 	}
 	for _, tt := range tests {
 		got := getShortPath(tt.args)
-		c.Assert(got, Equals, tt.want)
+		require.Equal(t, tt.want, got)
 	}
 }


### PR DESCRIPTION
Please refer to individual commits for more details, this PR is focusing on files owned by cilium/metrics team.

Relates: https://github.com/cilium/cilium/issues/28596