### PR TITLE
pkg/ipam: Replace gocheck with built-in go test

### DIFF
--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"errors"
 	"net"
+	"testing"
 	"time"
 
-	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/require"
 
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -41,24 +42,24 @@ func (rm *resourceMock) Store(context.Context) (resource.Store[*ciliumv2.CiliumN
 
 var mtuMock = mtu.NewConfiguration(0, false, false, false, false, 1500, nil)
 
-func (s *IPAMSuite) TestAllocatedIPDump(c *C) {
+func TestAllocatedIPDump(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
 	allocv4, allocv6, status := ipam.Dump()
-	c.Assert(status, Not(Equals), "")
+	require.NotEqual(t, "", status)
 
 	// Test the format of the dumped ip addresses
 	for ip := range allocv4 {
-		c.Assert(net.ParseIP(ip), NotNil)
+		require.NotNil(t, net.ParseIP(ip))
 	}
 	for ip := range allocv6 {
-		c.Assert(net.ParseIP(ip), NotNil)
+		require.NotNil(t, net.ParseIP(ip))
 	}
 }
 
-func (s *IPAMSuite) TestExpirationTimer(c *C) {
+func TestExpirationTimer(t *testing.T) {
 	ip := net.ParseIP("1.1.1.1")
 	timeout := 50 * time.Millisecond
 
@@ -67,65 +68,65 @@ func (s *IPAMSuite) TestExpirationTimer(c *C) {
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
 	err := ipam.AllocateIP(ip, "foo", PoolDefault())
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	uuid, err := ipam.StartExpirationTimer(ip, PoolDefault(), timeout)
-	c.Assert(err, IsNil)
-	c.Assert(uuid, Not(Equals), "")
+	require.Nil(t, err)
+	require.NotEqual(t, "", uuid)
 	// must fail, already registered
 	uuid, err = ipam.StartExpirationTimer(ip, PoolDefault(), timeout)
-	c.Assert(err, Not(IsNil))
-	c.Assert(uuid, Equals, "")
+	require.NotNil(t, err)
+	require.Equal(t, "", uuid)
 	// must fail, already in use
 	err = ipam.AllocateIP(ip, "foo", PoolDefault())
-	c.Assert(err, Not(IsNil))
+	require.NotNil(t, err)
 	// Let expiration timer expire
 	time.Sleep(2 * timeout)
 	// Must succeed, IP must be released again
 	err = ipam.AllocateIP(ip, "foo", PoolDefault())
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	// register new expiration timer
 	uuid, err = ipam.StartExpirationTimer(ip, PoolDefault(), timeout)
-	c.Assert(err, IsNil)
-	c.Assert(uuid, Not(Equals), "")
+	require.Nil(t, err)
+	require.NotEqual(t, "", uuid)
 	// attempt to stop with an invalid uuid, must fail
 	err = ipam.StopExpirationTimer(ip, PoolDefault(), "unknown-uuid")
-	c.Assert(err, Not(IsNil))
+	require.NotNil(t, err)
 	// stop expiration with valid uuid
 	err = ipam.StopExpirationTimer(ip, PoolDefault(), uuid)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	// Let expiration timer expire
 	time.Sleep(2 * timeout)
 	// must fail as IP is properly in use now
 	err = ipam.AllocateIP(ip, "foo", PoolDefault())
-	c.Assert(err, Not(IsNil))
+	require.NotNil(t, err)
 	// release IP for real
 	err = ipam.ReleaseIP(ip, PoolDefault())
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// allocate IP again
 	err = ipam.AllocateIP(ip, "foo", PoolDefault())
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	// register expiration timer
 	uuid, err = ipam.StartExpirationTimer(ip, PoolDefault(), timeout)
-	c.Assert(err, IsNil)
-	c.Assert(uuid, Not(Equals), "")
+	require.Nil(t, err)
+	require.NotEqual(t, "", uuid)
 	// release IP, must also stop expiration timer
 	err = ipam.ReleaseIP(ip, PoolDefault())
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	// allocate same IP again
 	err = ipam.AllocateIP(ip, "foo", PoolDefault())
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	// register expiration timer must succeed even though stop was never called
 	uuid, err = ipam.StartExpirationTimer(ip, PoolDefault(), timeout)
-	c.Assert(err, IsNil)
-	c.Assert(uuid, Not(Equals), "")
+	require.Nil(t, err)
+	require.NotEqual(t, "", uuid)
 	// release IP
 	err = ipam.ReleaseIP(ip, PoolDefault())
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 }
 
-func (s *IPAMSuite) TestAllocateNextWithExpiration(c *C) {
+func TestAllocateNextWithExpiration(t *testing.T) {
 	timeout := 50 * time.Millisecond
 
 	fakeAddressing := fakeTypes.NewNodeAddressing()
@@ -135,46 +136,46 @@ func (s *IPAMSuite) TestAllocateNextWithExpiration(c *C) {
 	// Allocate IPs and test expiration timer. 'pool' is empty in order to test
 	// that the allocated pool is passed to StartExpirationTimer
 	ipv4, ipv6, err := ipam.AllocateNextWithExpiration("", "foo", "", timeout)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// IPv4 address must be in use
 	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault())
-	c.Assert(err, Not(IsNil))
+	require.NotNil(t, err)
 	// IPv6 address must be in use
 	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault())
-	c.Assert(err, Not(IsNil))
+	require.NotNil(t, err)
 
 	// Let expiration timer expire
 	time.Sleep(time.Second)
 	// IPv4 address must be available again
 	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault())
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	// IPv6 address must be available again
 	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault())
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	// Release IPs
 	err = ipam.ReleaseIP(ipv4.IP, PoolDefault())
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	err = ipam.ReleaseIP(ipv6.IP, PoolDefault())
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Allocate IPs again and test stopping the expiration timer
 	ipv4, ipv6, err = ipam.AllocateNextWithExpiration("", "foo", PoolDefault(), timeout)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Stop expiration timer for IPv4 address
 	err = ipam.StopExpirationTimer(ipv4.IP, PoolDefault(), ipv4.ExpirationUUID)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Let expiration timer expire
 	time.Sleep(time.Second)
 	// IPv4 address must be in use
 	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault())
-	c.Assert(err, Not(IsNil))
+	require.NotNil(t, err)
 	// IPv6 address must be available again
 	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault())
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	// Release IPv4 address
 	err = ipam.ReleaseIP(ipv4.IP, PoolDefault())
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 }

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -11,10 +11,9 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/cilium/checkmate"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/checker"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
@@ -67,8 +66,8 @@ var testConfigurationCRD = &option.DaemonConfig{
 	IPAM:                    ipamOption.IPAMCRD,
 }
 
-func newFakeNodeStore(conf *option.DaemonConfig, c *C) *nodeStore {
-	t, err := trigger.NewTrigger(trigger.Parameters{
+func newFakeNodeStore(conf *option.DaemonConfig, t *testing.T) *nodeStore {
+	tr, err := trigger.NewTrigger(trigger.Parameters{
 		Name:        "fake-crd-allocator-node-refresher",
 		MinInterval: 3 * time.Second,
 		TriggerFunc: func(reasons []string) {},
@@ -80,12 +79,12 @@ func newFakeNodeStore(conf *option.DaemonConfig, c *C) *nodeStore {
 		allocators:         []*crdAllocator{},
 		allocationPoolSize: map[Family]int{},
 		conf:               conf,
-		refreshTrigger:     t,
+		refreshTrigger:     tr,
 	}
 	return store
 }
 
-func (s *IPAMSuite) TestMarkForReleaseNoAllocate(c *C) {
+func TestMarkForReleaseNoAllocate(t *testing.T) {
 	cn := newCiliumNode("node1", 4, 4, 0)
 	dummyResource := ipamTypes.AllocationIP{Resource: "foo"}
 	for i := 1; i <= 4; i++ {
@@ -95,7 +94,7 @@ func (s *IPAMSuite) TestMarkForReleaseNoAllocate(c *C) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	conf := testConfigurationCRD
 	initNodeStore.Do(func() {
-		sharedNodeStore = newFakeNodeStore(conf, c)
+		sharedNodeStore = newFakeNodeStore(conf, t)
 		sharedNodeStore.ownNode = cn
 	})
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
@@ -106,7 +105,7 @@ func (s *IPAMSuite) TestMarkForReleaseNoAllocate(c *C) {
 	for i := 1; i <= 3; i++ {
 		epipv4 := netip.MustParseAddr(fmt.Sprintf("1.1.1.%d", i))
 		_, err := ipam.IPv4Allocator.Allocate(epipv4.AsSlice(), fmt.Sprintf("test%d", i), PoolDefault())
-		c.Assert(err, IsNil)
+		require.Nil(t, err)
 	}
 
 	// Update 1.1.1.4 as marked for release like operator would.
@@ -114,13 +113,13 @@ func (s *IPAMSuite) TestMarkForReleaseNoAllocate(c *C) {
 	// Attempts to allocate 1.1.1.4 should fail, since it's already marked for release
 	epipv4 := netip.MustParseAddr("1.1.1.4")
 	_, err := ipam.IPv4Allocator.Allocate(epipv4.AsSlice(), "test", PoolDefault())
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 	// Call agent's CRD update function. status for 1.1.1.4 should change from marked for release to ready for release
 	sharedNodeStore.updateLocalNodeResource(cn)
-	c.Assert(string(cn.Status.IPAM.ReleaseIPs["1.1.1.4"]), checker.Equals, ipamOption.IPAMReadyForRelease)
+	require.Equal(t, ipamOption.IPAMReadyForRelease, string(cn.Status.IPAM.ReleaseIPs["1.1.1.4"]))
 
 	// Verify that 1.1.1.3 is denied for release, since it's already in use
 	cn.Status.IPAM.ReleaseIPs["1.1.1.3"] = ipamOption.IPAMMarkForRelease
 	sharedNodeStore.updateLocalNodeResource(cn)
-	c.Assert(string(cn.Status.IPAM.ReleaseIPs["1.1.1.3"]), checker.Equals, ipamOption.IPAMDoNotRelease)
+	require.Equal(t, ipamOption.IPAMDoNotRelease, string(cn.Status.IPAM.ReleaseIPs["1.1.1.3"]))
 }

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -10,23 +10,14 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/checker"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 )
-
-func Test(t *testing.T) {
-	TestingT(t)
-}
-
-type IPAMSuite struct{}
-
-var _ = Suite(&IPAMSuite{})
 
 func fakeIPv4AllocCIDRIP(fakeAddressing types.NodeAddressing) netip.Addr {
 	return netip.MustParseAddr(fakeAddressing.IPv4().AllocationCIDR().IP.String())
@@ -128,7 +119,7 @@ func (f fakePoolAllocator) Capacity() uint64 {
 
 func (f fakePoolAllocator) RestoreFinished() {}
 
-func (s *IPAMSuite) TestLock(c *C) {
+func TestLock(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
@@ -147,11 +138,11 @@ func (s *IPAMSuite) TestLock(c *C) {
 
 	// Let's allocate the IP first so we can see the tests failing
 	result, err := ipam.IPv4Allocator.Allocate(ipv4.AsSlice(), "test", PoolDefault())
-	c.Assert(err, IsNil)
-	c.Assert(result.IP, checker.DeepEquals, net.IP(ipv4.AsSlice()))
+	require.Nil(t, err)
+	require.EqualValues(t, net.IP(ipv4.AsSlice()), result.IP)
 }
 
-func (s *IPAMSuite) TestExcludeIP(c *C) {
+func TestExcludeIP(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
@@ -161,29 +152,29 @@ func (s *IPAMSuite) TestExcludeIP(c *C) {
 
 	ipam.ExcludeIP(ipv4.AsSlice(), "test-foo", PoolDefault())
 	err := ipam.AllocateIP(ipv4.AsSlice(), "test-bar", PoolDefault())
-	c.Assert(err, Not(IsNil))
-	c.Assert(err, ErrorMatches, ".* owned by test-foo")
+	require.NotNil(t, err)
+	require.ErrorContains(t, err, "owned by test-foo")
 	err = ipam.ReleaseIP(ipv4.AsSlice(), PoolDefault())
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	ipv6 := fakeIPv6AllocCIDRIP(fakeAddressing)
 	ipv6 = ipv6.Next()
 
 	ipam.ExcludeIP(ipv6.AsSlice(), "test-foo", PoolDefault())
 	err = ipam.AllocateIP(ipv6.AsSlice(), "test-bar", PoolDefault())
-	c.Assert(err, Not(IsNil))
-	c.Assert(err, ErrorMatches, ".* owned by test-foo")
+	require.NotNil(t, err)
+	require.ErrorContains(t, err, "owned by test-foo")
 	ipam.ReleaseIP(ipv6.AsSlice(), PoolDefault())
 	err = ipam.ReleaseIP(ipv4.AsSlice(), PoolDefault())
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 }
 
-func (s *IPAMSuite) TestDeriveFamily(c *C) {
-	c.Assert(DeriveFamily(net.ParseIP("1.1.1.1")), Equals, IPv4)
-	c.Assert(DeriveFamily(net.ParseIP("f00d::1")), Equals, IPv6)
+func TestDeriveFamily(t *testing.T) {
+	require.Equal(t, IPv4, DeriveFamily(net.ParseIP("1.1.1.1")))
+	require.Equal(t, IPv6, DeriveFamily(net.ParseIP("f00d::1")))
 }
 
-func (s *IPAMSuite) TestIPAMMetadata(c *C) {
+func TestIPAMMetadata(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
@@ -200,9 +191,9 @@ func (s *IPAMSuite) TestIPAMMetadata(c *C) {
 
 	// Without metadata, should always return PoolDefault()
 	resIPv4, resIPv6, err := ipam.AllocateNext("", "test/some-pod", "")
-	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault())
-	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault())
+	require.Nil(t, err)
+	require.Equal(t, PoolDefault(), resIPv4.IPPoolName)
+	require.Equal(t, PoolDefault(), resIPv6.IPPoolName)
 
 	ipam.WithMetadata(fakeMetadataFunc(func(owner string, family Family) (pool string, err error) {
 		// use namespace to determine pool name
@@ -222,42 +213,42 @@ func (s *IPAMSuite) TestIPAMMetadata(c *C) {
 	// Checks AllocateIP
 	specialIP := net.ParseIP("172.18.19.20")
 	_, err = ipam.AllocateIPWithoutSyncUpstream(specialIP, "special/wants-special-ip", "")
-	c.Assert(err, Not(IsNil)) // pool required
+	require.NotNil(t, err) // pool required
 	resIPv4, err = ipam.AllocateIPWithoutSyncUpstream(specialIP, "special/wants-special-ip", "special")
-	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, Pool("special"))
-	c.Assert(resIPv4.IP.Equal(specialIP), Equals, true)
+	require.Nil(t, err)
+	require.Equal(t, Pool("special"), resIPv4.IPPoolName)
+	require.Equal(t, true, resIPv4.IP.Equal(specialIP))
 
 	// Checks ReleaseIP
 	err = ipam.ReleaseIP(specialIP, "")
-	c.Assert(err, Not(IsNil)) // pool required
+	require.NotNil(t, err) // pool required
 	err = ipam.ReleaseIP(specialIP, "special")
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Checks if pool metadata is used if pool is empty
 	resIPv4, resIPv6, err = ipam.AllocateNext("", "test/some-other-pod", "")
-	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, Pool("test"))
-	c.Assert(resIPv6.IPPoolName, Equals, Pool("test"))
+	require.Nil(t, err)
+	require.Equal(t, Pool("test"), resIPv4.IPPoolName)
+	require.Equal(t, Pool("test"), resIPv6.IPPoolName)
 
 	// Checks if pool can be overwritten
 	resIPv4, resIPv6, err = ipam.AllocateNext("", "test/special-pod", "special")
-	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, Pool("special"))
-	c.Assert(resIPv6.IPPoolName, Equals, Pool("special"))
+	require.Nil(t, err)
+	require.Equal(t, Pool("special"), resIPv4.IPPoolName)
+	require.Equal(t, Pool("special"), resIPv6.IPPoolName)
 
 	// Checks if fallback to default works
 	resIPv4, resIPv6, err = ipam.AllocateNext("", "other/special-pod", "")
-	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault())
-	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault())
+	require.Nil(t, err)
+	require.Equal(t, PoolDefault(), resIPv4.IPPoolName)
+	require.Equal(t, PoolDefault(), resIPv6.IPPoolName)
 
 	// Checks if metadata errors are propagated
 	_, _, err = ipam.AllocateNext("", "error/special-value", "")
-	c.Assert(err, Not(IsNil))
+	require.NotNil(t, err)
 }
 
-func (s *IPAMSuite) TestLegacyAllocatorIPAMMetadata(c *C) {
+func TestLegacyAllocatorIPAMMetadata(t *testing.T) {
 	// This test uses a regular hostScope allocator which does not support
 	// IPAM pools. We assert that in this scenario, the pool returned in the
 	// AllocationResult is always set to PoolDefault(), regardless of the requested
@@ -273,35 +264,35 @@ func (s *IPAMSuite) TestLegacyAllocatorIPAMMetadata(c *C) {
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
 	ipv4 = ipv4.Next()
 	_, err := ipam.AllocateIPWithoutSyncUpstream(ipv4.AsSlice(), "default/specific-ip", "")
-	c.Assert(err, Not(IsNil))
+	require.NotNil(t, err)
 
 	// AllocateIP with specific pool
 	ipv4 = ipv4.Next()
 	resIPv4, err := ipam.AllocateIPWithoutSyncUpstream(ipv4.AsSlice(), "default/specific-ip", "override")
-	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault())
+	require.Nil(t, err)
+	require.Equal(t, PoolDefault(), resIPv4.IPPoolName)
 
 	// AllocateIP with default pool
 	ipv4 = ipv4.Next()
 	resIPv4, err = ipam.AllocateIPWithoutSyncUpstream(ipv4.AsSlice(), "default/specific-ip", "default")
-	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault())
+	require.Nil(t, err)
+	require.Equal(t, PoolDefault(), resIPv4.IPPoolName)
 
 	// AllocateNext with empty pool
 	resIPv4, resIPv6, err := ipam.AllocateNext("", "test/some-pod", "")
-	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault())
-	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault())
+	require.Nil(t, err)
+	require.Equal(t, PoolDefault(), resIPv4.IPPoolName)
+	require.Equal(t, PoolDefault(), resIPv6.IPPoolName)
 
 	// AllocateNext with specific pool
 	resIPv4, resIPv6, err = ipam.AllocateNext("", "test/some-other-pod", "override")
-	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault())
-	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault())
+	require.Nil(t, err)
+	require.Equal(t, PoolDefault(), resIPv4.IPPoolName)
+	require.Equal(t, PoolDefault(), resIPv6.IPPoolName)
 
 	// AllocateNext with default pool
 	resIPv4, resIPv6, err = ipam.AllocateNext("", "test/some-other-pod", "default")
-	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault())
-	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault())
+	require.Nil(t, err)
+	require.Equal(t, PoolDefault(), resIPv4.IPPoolName)
+	require.Equal(t, PoolDefault(), resIPv6.IPPoolName)
 }

--- a/pkg/ipam/node_test.go
+++ b/pkg/ipam/node_test.go
@@ -3,7 +3,11 @@
 
 package ipam
 
-import check "github.com/cilium/checkmate"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 type testNeededDef struct {
 	available   int
@@ -49,16 +53,16 @@ var excessDef = []testExcessDef{
 	{20, 4, 8, 0, 8, 0},
 }
 
-func (e *IPAMSuite) TestCalculateNeededIPs(c *check.C) {
+func TestCalculateNeededIPs(t *testing.T) {
 	for _, d := range neededDef {
 		result := calculateNeededIPs(d.available, d.used, d.preallocate, d.minallocate, d.maxallocate)
-		c.Assert(result, check.Equals, d.result)
+		require.Equal(t, d.result, result)
 	}
 }
 
-func (e *IPAMSuite) TestCalculateExcessIPs(c *check.C) {
+func TestCalculateExcessIPs(t *testing.T) {
 	for _, d := range excessDef {
 		result := calculateExcessIPs(d.available, d.used, d.preallocate, d.minallocate, d.maxabovewatermark)
-		c.Assert(result, check.Equals, d.result)
+		require.Equal(t, d.result, result)
 	}
 }


### PR DESCRIPTION
Please refer to individual commits for more details, this PR is focusing on files owned by cilium/sig-ipam team.

Relates: https://github.com/cilium/cilium/issues/28596