### PR TITLE
ingress: Correct FromGroups rule Parsing

### DIFF
--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -140,6 +140,11 @@ func parseToCiliumIngressCommonRule(namespace string, es api.EndpointSelector, i
 		copy(retRule.FromEntities, ing.FromEntities)
 	}
 
+	if ing.FromGroups != nil {
+		retRule.FromGroups = make([]api.Groups, len(ing.FromGroups))
+		copy(retRule.FromGroups, ing.FromGroups)
+	}
+
 	return retRule
 }
 

--- a/pkg/policy/api/egress_test.go
+++ b/pkg/policy/api/egress_test.go
@@ -23,7 +23,7 @@ func TestRequiresDerivativeRuleWithoutToGroups(t *testing.T) {
 func TestRequiresDerivativeRuleWithToGroups(t *testing.T) {
 	eg := EgressRule{}
 	eg.ToGroups = []Groups{
-		GetToGroupsRule(),
+		GetGroupsRule(),
 	}
 	require.Equal(t, true, eg.RequiresDerivative())
 }
@@ -55,7 +55,7 @@ func TestCreateDerivativeRuleWithToGroupsWitInvalidRegisterCallback(t *testing.T
 	eg := &EgressRule{
 		EgressCommonRule: EgressCommonRule{
 			ToGroups: []Groups{
-				GetToGroupsRule(),
+				GetGroupsRule(),
 			},
 		},
 	}
@@ -70,7 +70,7 @@ func TestCreateDerivativeRuleWithToGroupsAndToPorts(t *testing.T) {
 	eg := &EgressRule{
 		EgressCommonRule: EgressCommonRule{
 			ToGroups: []Groups{
-				GetToGroupsRule(),
+				GetGroupsRule(),
 			},
 		},
 	}
@@ -93,7 +93,7 @@ func TestCreateDerivativeWithoutErrorAndNoIPs(t *testing.T) {
 	eg := &EgressRule{
 		EgressCommonRule: EgressCommonRule{
 			ToGroups: []Groups{
-				GetToGroupsRule(),
+				GetGroupsRule(),
 			},
 		},
 	}

--- a/pkg/policy/api/groups_test.go
+++ b/pkg/policy/api/groups_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func GetToGroupsRule() Groups {
+func GetGroupsRule() Groups {
 	return Groups{
 		AWS: &AWSGroup{
 			Labels: map[string]string{
@@ -46,7 +46,7 @@ func TestGetCIDRSetWithValidValue(t *testing.T) {
 
 	expectedCidrRule := []CIDRRule{
 		{Cidr: "192.168.1.1/32", ExceptCIDRs: []CIDR{}, Generated: true}}
-	group := GetToGroupsRule()
+	group := GetGroupsRule()
 	cidr, err := group.GetCidrSet(context.TODO())
 	require.EqualValues(t, expectedCidrRule, cidr)
 	require.Nil(t, err)
@@ -59,7 +59,7 @@ func TestGetCIDRSetWithMultipleSorted(t *testing.T) {
 		{Cidr: "192.168.1.1/32", ExceptCIDRs: []CIDR{}, Generated: true},
 		{Cidr: "192.168.10.3/32", ExceptCIDRs: []CIDR{}, Generated: true},
 		{Cidr: "192.168.10.10/32", ExceptCIDRs: []CIDR{}, Generated: true}}
-	group := GetToGroupsRule()
+	group := GetGroupsRule()
 	cidr, err := group.GetCidrSet(context.TODO())
 	require.EqualValues(t, expectedCidrRule, cidr)
 	require.Nil(t, err)
@@ -73,7 +73,7 @@ func TestGetCIDRSetWithUniqueCIDRRule(t *testing.T) {
 		{Cidr: "192.168.1.1/32", ExceptCIDRs: []CIDR{}, Generated: true},
 		{Cidr: "192.168.10.10/32", ExceptCIDRs: []CIDR{}, Generated: true}}
 
-	group := GetToGroupsRule()
+	group := GetGroupsRule()
 	cidr, err := group.GetCidrSet(context.TODO())
 	require.EqualValues(t, cidrRule, cidr)
 	require.Nil(t, err)
@@ -86,7 +86,7 @@ func TestGetCIDRSetWithError(t *testing.T) {
 		return []netip.Addr{}, fmt.Errorf("Invalid credentials")
 	}
 	RegisterToGroupsProvider(AWSProvider, cb)
-	group := GetToGroupsRule()
+	group := GetGroupsRule()
 	cidr, err := group.GetCidrSet(context.TODO())
 	require.Nil(t, cidr)
 	require.Error(t, err)
@@ -96,7 +96,7 @@ func TestWithoutProviderRegister(t *testing.T) {
 	setUpSuite(t)
 
 	providers.Delete(AWSProvider)
-	group := GetToGroupsRule()
+	group := GetGroupsRule()
 	cidr, err := group.GetCidrSet(context.TODO())
 	require.Nil(t, cidr)
 	require.Error(t, err)
@@ -105,7 +105,7 @@ func TestWithoutProviderRegister(t *testing.T) {
 func BenchmarkGetCIDRSet(b *testing.B) {
 	cb := GetCallBackWithRule("192.168.1.1", "192.168.10.10", "192.168.10.3")
 	RegisterToGroupsProvider(AWSProvider, cb)
-	group := GetToGroupsRule()
+	group := GetGroupsRule()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -252,6 +252,16 @@ func (r *Rule) RequiresDerivative() bool {
 			return true
 		}
 	}
+	for _, rule := range r.Ingress {
+		if rule.RequiresDerivative() {
+			return true
+		}
+	}
+	for _, rule := range r.IngressDeny {
+		if rule.RequiresDerivative() {
+			return true
+		}
+	}
 	return false
 }
 
@@ -261,6 +271,8 @@ func (r *Rule) CreateDerivative(ctx context.Context) (*Rule, error) {
 	newRule := r.DeepCopy()
 	newRule.Egress = []EgressRule{}
 	newRule.EgressDeny = []EgressDenyRule{}
+	newRule.Ingress = []IngressRule{}
+	newRule.IngressDeny = []IngressDenyRule{}
 
 	for _, egressRule := range r.Egress {
 		derivativeEgressRule, err := egressRule.CreateDerivative(ctx)

--- a/pkg/policy/api/rule_test.go
+++ b/pkg/policy/api/rule_test.go
@@ -45,7 +45,7 @@ func getEgressRuleWithToGroups() *Rule {
 			{
 				EgressCommonRule: EgressCommonRule{
 					ToGroups: []Groups{
-						GetToGroupsRule(),
+						GetGroupsRule(),
 					},
 				},
 			},
@@ -59,7 +59,35 @@ func getEgressDenyRuleWithToGroups() *Rule {
 			{
 				EgressCommonRule: EgressCommonRule{
 					ToGroups: []Groups{
-						GetToGroupsRule(),
+						GetGroupsRule(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func getIngressRuleWithFromGroups() *Rule {
+	return &Rule{
+		Ingress: []IngressRule{
+			{
+				IngressCommonRule: IngressCommonRule{
+					FromGroups: []Groups{
+						GetGroupsRule(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func getIngressDenyRuleWithFromGroups() *Rule {
+	return &Rule{
+		IngressDeny: []IngressDenyRule{
+			{
+				IngressCommonRule: IngressCommonRule{
+					FromGroups: []Groups{
+						GetGroupsRule(),
 					},
 				},
 			},
@@ -78,6 +106,12 @@ func TestRequiresDerivative(t *testing.T) {
 
 	egressDenyRuleWithToGroups := getEgressDenyRuleWithToGroups()
 	require.Equal(t, true, egressDenyRuleWithToGroups.RequiresDerivative())
+
+	ingressRuleWithToGroups := getIngressRuleWithFromGroups()
+	require.Equal(t, true, ingressRuleWithToGroups.RequiresDerivative())
+
+	ingressDenyRuleWithToGroups := getIngressDenyRuleWithFromGroups()
+	require.Equal(t, true, ingressDenyRuleWithToGroups.RequiresDerivative())
 }
 
 func TestCreateDerivative(t *testing.T) {
@@ -104,4 +138,18 @@ func TestCreateDerivative(t *testing.T) {
 	require.Equal(t, 0, len(newRule.Egress))
 	require.Equal(t, 1, len(newRule.EgressDeny))
 	require.Equal(t, 1, len(newRule.EgressDeny[0].ToCIDRSet))
+
+	ingressRuleWithToGroups := getIngressRuleWithFromGroups()
+	newRule, err = ingressRuleWithToGroups.CreateDerivative(context.TODO())
+	require.Nil(t, err)
+	require.Equal(t, 0, len(newRule.IngressDeny))
+	require.Equal(t, 1, len(newRule.Ingress))
+	require.Equal(t, 1, len(newRule.Ingress[0].FromCIDRSet))
+
+	ingressDenyRuleWithToGroups := getIngressDenyRuleWithFromGroups()
+	newRule, err = ingressDenyRuleWithToGroups.CreateDerivative(context.TODO())
+	require.Nil(t, err)
+	require.Equal(t, 0, len(newRule.Ingress))
+	require.Equal(t, 1, len(newRule.IngressDeny))
+	require.Equal(t, 1, len(newRule.IngressDeny[0].FromCIDRSet))
 }

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -101,6 +101,7 @@ func (i *IngressRule) sanitize() error {
 		"FromCIDRSet":   len(i.FromCIDRSet),
 		"FromEntities":  len(i.FromEntities),
 		"FromNodes":     len(i.FromNodes),
+		"FromGroups":    len(i.FromGroups),
 	}
 	l7Members := countL7Rules(i.ToPorts)
 	l7IngressSupport := map[string]bool{


### PR DESCRIPTION
<!-- Description of change -->

In https://github.com/cilium/cilium/pull/30708 I created a resource that translates to a K8s resource but not to an actual resource. This PR corrects that behaviour by adding in some tests and fixing when they break. You could argue I should have done this initially, you're right.

This should be backported to 1.16 so it goes out with the original PR.