### PR TITLE
operator: fix CES sync in identity-based batching

### DIFF
--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 )
 
-func TestSyncCESsInLocalCache(t *testing.T) {
+func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 	var r *reconciler
 	var fakeClient k8sClient.FakeClientset
 	m := newCESManagerFcfs(2, log).(*cesManagerFcfs)
@@ -78,20 +78,81 @@ func TestSyncCESsInLocalCache(t *testing.T) {
 
 	mapping := m.mapping
 
-	cesN, _ := mapping.getCESName(NewCEPName("cep1", "ns"))
-	assert.Equal(t, cesN, NewCESName("ces1"))
-	cesN, _ = mapping.getCESName(NewCEPName("cep2", "ns"))
-	assert.Equal(t, cesN, NewCESName("ces1"))
-	cesN, _ = mapping.getCESName(NewCEPName("cep3", "ns"))
-	assert.Equal(t, cesN, NewCESName("ces1"))
-	cesN, _ = mapping.getCESName(NewCEPName("cep4", "ns"))
-	assert.Equal(t, cesN, NewCESName("ces1"))
-	cesN, _ = mapping.getCESName(NewCEPName("cep5", "ns"))
-	assert.Equal(t, cesN, NewCESName("ces2"))
-	cesN, _ = mapping.getCESName(NewCEPName("cep6", "ns"))
-	assert.Equal(t, cesN, NewCESName("ces2"))
-	cesN, _ = mapping.getCESName(NewCEPName("cep7", "ns"))
-	assert.Equal(t, cesN, NewCESName("ces2"))
+	for _, ces := range []*cilium_v2a1.CiliumEndpointSlice{ces1, ces2} {
+		for _, cep := range ces.Endpoints {
+			cesN, _ := mapping.getCESName(NewCEPName(cep.Name, "ns"))
+			// ensure that the CEP is mapped to the correct CES
+			assert.Equal(t, cesN, NewCESName(ces.Name))
+		}
+	}
+
+	cesController.queue.ShutDown()
+	hive.Stop(tlog, context.Background())
+}
+
+func TestIdentityModeSyncCESsInLocalCache(t *testing.T) {
+	var r *reconciler
+	var fakeClient k8sClient.FakeClientset
+	m := newCESManagerIdentity(2, log).(*cesManagerIdentity)
+	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	var cesMetrics *Metrics
+	hive := hive.New(
+		k8sClient.FakeClientCell,
+		k8s.ResourcesCell,
+		metrics.Metric(NewMetrics),
+		cell.Invoke(func(
+			c *k8sClient.FakeClientset,
+			cep resource.Resource[*cilium_v2.CiliumEndpoint],
+			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
+			metrics *Metrics,
+		) error {
+			fakeClient = *c
+			ciliumEndpoint = cep
+			ciliumEndpointSlice = ces
+			cesMetrics = metrics
+			return nil
+		}),
+	)
+	tlog := hivetest.Logger(t)
+	hive.Start(tlog, context.Background())
+	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
+	cesController := &Controller{
+		logger:              log,
+		clientset:           fakeClient.Clientset,
+		ciliumEndpoint:      ciliumEndpoint,
+		ciliumEndpointSlice: ciliumEndpointSlice,
+		reconciler:          r,
+		manager:             m,
+		rateLimit:           getRateLimitConfig(params{Cfg: Config{CESWriteQPSLimit: 2, CESWriteQPSBurst: 1}}),
+		enqueuedAt:          make(map[CESName]time.Time),
+	}
+	cesController.initializeQueue()
+
+	cep1 := tu.CreateManagerEndpoint("cep1", 1)
+	cep2 := tu.CreateManagerEndpoint("cep2", 1)
+	cep3 := tu.CreateManagerEndpoint("cep3", 2)
+	cep4 := tu.CreateManagerEndpoint("cep4", 2)
+	ces1 := tu.CreateStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep1, cep2})
+	ces2 := tu.CreateStoreEndpointSlice("ces2", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep3, cep4})
+	cesStore.CacheStore().Add(ces1)
+	cesStore.CacheStore().Add(ces2)
+
+	cesController.syncCESsInLocalCache(context.Background())
+
+	mapping := m.mapping
+
+	for _, ces := range []*cilium_v2a1.CiliumEndpointSlice{ces1, ces2} {
+		for _, cep := range ces.Endpoints {
+			cesN, _ := mapping.getCESName(NewCEPName(cep.Name, "ns"))
+			// ensure that the CEP is mapped to the correct CES
+			assert.Equal(t, cesN, NewCESName(ces.Name))
+			// ensure that the CES to identity mappings are correct
+			assert.Equal(t, m.cesToIdentity[cesN], cep.IdentityID)
+			assert.Contains(t, m.identityToCES[cep.IdentityID], cesN)
+		}
+	}
 
 	cesController.queue.ShutDown()
 	hive.Stop(tlog, context.Background())


### PR DESCRIPTION
When CiliumEndpointSlice is enabled, any existing
CiliumEndpointSlices need to be added to the Cilium Operator's cache on start up.

The 'cesManagerIdentity' used for the identity-based slicing mode has 2 additional maps to track which CES map to which identity, and vice-versa. Currently these maps are not populated on the initial sync, causing the operator to believe the identity of a CiliumEndpoint has changed and removing it from the CES on first update. This causes all CiliumEndpointSlices to be recreated whenever the operator restarts.

This commit adds an override method to 'cesManagerIdentity' to populate the identity mapping on initial sync, allowing the operator to properly sync the existing CiliumEndpointSlices and avoid recreating them.

Fixes: #31564

```release-note
Fix synchronization of CiliumEndpointSlices when running the Cilium Operator in identity-based slicing mode.
```
