### PR TITLE
ipsec: Debug info for transient IPsec upgrade drops

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	"github.com/fsnotify/fsnotify"
+	"github.com/prometheus/procfs"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
@@ -402,6 +403,18 @@ func xfrmStateReplace(new *netlink.XfrmState, remoteRebooted bool) error {
 // conflicting XFRM state. This function removes the conflicting state and
 // prepares a defer callback to re-add it with proper logging.
 func xfrmTemporarilyRemoveState(scopedLog *logrus.Entry, state netlink.XfrmState, dir string) (error, func()) {
+	stats, err := procfs.NewXfrmStat()
+	errorCnt := 0
+	if err != nil {
+		log.WithError(err).Error("Error while getting XFRM stats before state removal")
+	} else {
+		if dir == "IN" {
+			errorCnt = stats.XfrmInNoStates
+		} else {
+			errorCnt = stats.XfrmOutNoStates
+		}
+	}
+
 	start := time.Now()
 	if err := netlink.XfrmStateDel(&state); err != nil {
 		return err, nil
@@ -411,7 +424,19 @@ func xfrmTemporarilyRemoveState(scopedLog *logrus.Entry, state netlink.XfrmState
 			scopedLog.WithError(err).Errorf("Failed to re-add old XFRM %s state", dir)
 		}
 		elapsed := time.Since(start)
-		scopedLog.WithField(logfields.Duration, elapsed).Infof("Temporarily removed old XFRM %s state", dir)
+
+		stats, err := procfs.NewXfrmStat()
+		if err != nil {
+			log.WithError(err).Error("Error while getting XFRM stats after state removal")
+			errorCnt = 0
+		} else {
+			if dir == "IN" {
+				errorCnt = stats.XfrmInNoStates - errorCnt
+			} else {
+				errorCnt = stats.XfrmOutNoStates - errorCnt
+			}
+		}
+		scopedLog.WithField(logfields.Duration, elapsed).Infof("Temporarily removed old XFRM %s state (%d packets dropped)", dir, errorCnt)
 	}
 }
 


### PR DESCRIPTION
During IPsec upgrades, we may have to temporarily remove some XFRM states due to conflicts with the new states and because the Linux API doesn't enable us to perform this atomically as we do for XFRM policies.

This temporary removal should be very short but can still cause drops under heavy throughput. This pull request logs the duration of the removal and the number of drops that happened.

I validated the behavior on v1.13. The removal lasts 200-900µs for every remote node.

