### PR TITLE
cni: Use correct route MTU for various cloud cidrs

### DIFF
--- a/plugins/cilium-cni/cmd/interface.go
+++ b/plugins/cilium-cni/cmd/interface.go
@@ -58,7 +58,7 @@ func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, 
 
 	if err := routingInfo.Configure(
 		ipConfig.Address.IP,
-		int(conf.DeviceMTU),
+		int(conf.RouteMTU),
 		conf.EgressMultiHomeIPRuleCompat,
 		false,
 	); err != nil {


### PR DESCRIPTION
This commit corrects the MTU that is used by the cilium-cni plugin when creating routes for CIDRs received from ENI, Azure or Alibaba Cloud.

The cilium-agent daemon returns two MTUs to the cilium-cni plugin: a "device" MTU, which is used to set the MTU on a Pod's interface in its network namespace, and a "route" MTU, which is used to set the MTU on the routes created inside the Pod's network namespace that handle traffic leaving the Pod. The "route" MTU is adjusted based on the Cilium configuration to account for any configured encapsulation protocols, such as VXLAN or WireGuard. Before this commit, when ENI, Azure or Alibaba Cloud IPAM was enabled, the routes created in a Pod's network namespace were using the "device" MTU, rather than the "route" MTU, leading to fragmentation issues.

```release-note
cni: Use correct route MTU when ENI, Azure or Alibaba Cloud IPAM is enabled
```
