### PR TITLE
install/kubernetes: add extraInitContainers

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1456,6 +1456,10 @@
      - Additional agent hostPath mounts.
      - list
      - ``[]``
+   * - :spelling:ignore:`extraInitContainers`
+     - Additional initContainers added to the cilium Daemonset.
+     - list
+     - ``[]``
    * - :spelling:ignore:`extraVolumeMounts`
      - Additional agent volumeMounts.
      - list

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -384,6 +384,7 @@ impactful
 ingressing
 init
 initContainer
+initContainers
 initialDelaySeconds
 inlined
 inlines
@@ -609,6 +610,7 @@ qede
 qemu
 queryable
 queueing
+rST
 rc
 reStructuredText
 reachability
@@ -636,7 +638,6 @@ roadmap
 rollout
 routable
 routingMode
-rST
 runnable
 runtimes
 sandboxing

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -414,6 +414,7 @@ contributors across the globe, there is almost always someone available to help.
 | extraContainers | list | `[]` | Additional containers added to the cilium DaemonSet. |
 | extraEnv | list | `[]` | Additional agent container environment variables. |
 | extraHostPathMounts | list | `[]` | Additional agent hostPath mounts. |
+| extraInitContainers | list | `[]` | Additional initContainers added to the cilium Daemonset. |
 | extraVolumeMounts | list | `[]` | Additional agent volumeMounts. |
 | extraVolumes | list | `[]` | Additional agent volumes. |
 | gatewayAPI.enableAppProtocol | bool | `false` | Enable Backend Protocol selection support (GEP-1911) for Gateway API via appProtocol. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -745,6 +745,9 @@ spec:
           - name: cni-path
             mountPath: /host/opt/cni/bin
       {{- end }} # .Values.cni.install
+      {{- if .Values.extraInitContainers }}
+      {{- toYaml .Values.extraInitContainers | nindent 6 }}
+      {{- end }}
       restartPolicy: Always
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.priorityClassName "system-node-critical") }}
       serviceAccountName: {{ .Values.serviceAccounts.cilium.name | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2290,6 +2290,10 @@
       "items": {},
       "type": "array"
     },
+    "extraInitContainers": {
+      "items": {},
+      "type": "array"
+    },
     "extraVolumeMounts": {
       "items": {},
       "type": "array"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -184,6 +184,8 @@ priorityClassName: ""
 dnsPolicy: ""
 # -- Additional containers added to the cilium DaemonSet.
 extraContainers: []
+# -- Additional initContainers added to the cilium Daemonset.
+extraInitContainers: []
 # -- Additional agent container arguments.
 extraArgs: []
 # -- Additional agent container environment variables.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -182,6 +182,8 @@ priorityClassName: ""
 dnsPolicy: ""
 # -- Additional containers added to the cilium DaemonSet.
 extraContainers: []
+# -- Additional initContainers added to the cilium Daemonset.
+extraInitContainers: []
 # -- Additional agent container arguments.
 extraArgs: []
 # -- Additional agent container environment variables.


### PR DESCRIPTION
allow additional initContainers to be added to cilium-agent Daemonset via helm values.