### PR TITLE
policy: Add L7 HTTP rule in CNP CRD

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -920,6 +920,12 @@ spec:
                             - secret
                             type: object
                         type: object
+                        x-kubernetes-validations:
+                        - message: If a non-TCP protocol is used in any of the ports,
+                            then there should not be any HTTP rules set
+                          rule: '!has(self.rules) || !has(self.rules.http) || !self.ports.exists_one(p,
+                            !has(p.protocol) || p.protocol != ''TCP'')'
+                      maxItems: 32
                       type: array
                     toRequires:
                       description: "ToRequires is a list of additional constraints
@@ -1076,6 +1082,7 @@ spec:
                         type: object
                       type: array
                   type: object
+                maxItems: 32
                 type: array
               egressDeny:
                 description: EgressDeny is a list of EgressDenyRule which are enforced
@@ -2558,8 +2565,15 @@ spec:
                             - secret
                             type: object
                         type: object
+                        x-kubernetes-validations:
+                        - message: If a non-TCP protocol is used in any of the ports,
+                            then there should not be any HTTP rules set
+                          rule: '!has(self.rules) || !has(self.rules.http) || !self.ports.exists_one(p,
+                            !has(p.protocol) || p.protocol != ''TCP'')'
+                      maxItems: 32
                       type: array
                   type: object
+                maxItems: 32
                 type: array
               ingressDeny:
                 description: IngressDeny is a list of IngressDenyRule which are enforced
@@ -3979,6 +3993,12 @@ spec:
                               - secret
                               type: object
                           type: object
+                          x-kubernetes-validations:
+                          - message: If a non-TCP protocol is used in any of the ports,
+                              then there should not be any HTTP rules set
+                            rule: '!has(self.rules) || !has(self.rules.http) || !self.ports.exists_one(p,
+                              !has(p.protocol) || p.protocol != ''TCP'')'
+                        maxItems: 32
                         type: array
                       toRequires:
                         description: "ToRequires is a list of additional constraints
@@ -4139,6 +4159,7 @@ spec:
                           type: object
                         type: array
                     type: object
+                  maxItems: 32
                   type: array
                 egressDeny:
                   description: EgressDeny is a list of EgressDenyRule which are enforced
@@ -5640,8 +5661,15 @@ spec:
                               - secret
                               type: object
                           type: object
+                          x-kubernetes-validations:
+                          - message: If a non-TCP protocol is used in any of the ports,
+                              then there should not be any HTTP rules set
+                            rule: '!has(self.rules) || !has(self.rules.http) || !self.ports.exists_one(p,
+                              !has(p.protocol) || p.protocol != ''TCP'')'
+                        maxItems: 32
                         type: array
                     type: object
+                  maxItems: 32
                   type: array
                 ingressDeny:
                   description: IngressDeny is a list of IngressDenyRule which are
@@ -6164,6 +6192,7 @@ spec:
                       type: object
                   type: object
               type: object
+            maxItems: 32
             type: array
           status:
             description: "Status is the status of the Cilium policy rule. \n The reason

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -924,6 +924,12 @@ spec:
                             - secret
                             type: object
                         type: object
+                        x-kubernetes-validations:
+                        - message: If a non-TCP protocol is used in any of the ports,
+                            then there should not be any HTTP rules set
+                          rule: '!has(self.rules) || !has(self.rules.http) || !self.ports.exists_one(p,
+                            !has(p.protocol) || p.protocol != ''TCP'')'
+                      maxItems: 32
                       type: array
                     toRequires:
                       description: "ToRequires is a list of additional constraints
@@ -1080,6 +1086,7 @@ spec:
                         type: object
                       type: array
                   type: object
+                maxItems: 32
                 type: array
               egressDeny:
                 description: EgressDeny is a list of EgressDenyRule which are enforced
@@ -2562,8 +2569,15 @@ spec:
                             - secret
                             type: object
                         type: object
+                        x-kubernetes-validations:
+                        - message: If a non-TCP protocol is used in any of the ports,
+                            then there should not be any HTTP rules set
+                          rule: '!has(self.rules) || !has(self.rules.http) || !self.ports.exists_one(p,
+                            !has(p.protocol) || p.protocol != ''TCP'')'
+                      maxItems: 32
                       type: array
                   type: object
+                maxItems: 32
                 type: array
               ingressDeny:
                 description: IngressDeny is a list of IngressDenyRule which are enforced
@@ -3983,6 +3997,12 @@ spec:
                               - secret
                               type: object
                           type: object
+                          x-kubernetes-validations:
+                          - message: If a non-TCP protocol is used in any of the ports,
+                              then there should not be any HTTP rules set
+                            rule: '!has(self.rules) || !has(self.rules.http) || !self.ports.exists_one(p,
+                              !has(p.protocol) || p.protocol != ''TCP'')'
+                        maxItems: 32
                         type: array
                       toRequires:
                         description: "ToRequires is a list of additional constraints
@@ -4143,6 +4163,7 @@ spec:
                           type: object
                         type: array
                     type: object
+                  maxItems: 32
                   type: array
                 egressDeny:
                   description: EgressDeny is a list of EgressDenyRule which are enforced
@@ -5644,8 +5665,15 @@ spec:
                               - secret
                               type: object
                           type: object
+                          x-kubernetes-validations:
+                          - message: If a non-TCP protocol is used in any of the ports,
+                              then there should not be any HTTP rules set
+                            rule: '!has(self.rules) || !has(self.rules.http) || !self.ports.exists_one(p,
+                              !has(p.protocol) || p.protocol != ''TCP'')'
+                        maxItems: 32
                         type: array
                     type: object
+                  maxItems: 32
                   type: array
                 ingressDeny:
                   description: IngressDeny is a list of IngressDenyRule which are
@@ -6168,6 +6196,7 @@ spec:
                       type: object
                   type: object
               type: object
+            maxItems: 32
             type: array
           status:
             description: Status is the status of the Cilium policy rule

--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -165,6 +165,7 @@ type Listener struct {
 
 // PortRule is a list of ports/protocol combinations with optional Layer 7
 // rules which must be met.
+// +kubebuilder:validation:XValidation:message="If a non-TCP protocol is used in any of the ports, then there should not be any HTTP rules set",rule="!has(self.rules) || !has(self.rules.http) || !self.ports.exists_one(p, !has(p.protocol) || p.protocol != 'TCP')"
 type PortRule struct {
 	// Ports is a list of L4 port/protocol
 	//
@@ -292,6 +293,7 @@ func (rules *L7Rules) IsEmpty() bool {
 }
 
 // PortRules is a slice of PortRule.
+// +kubebuilder:validation:MaxItems=32
 type PortRules []PortRule
 
 // Iterate iterates over all elements of PortRules.

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -77,6 +77,7 @@ type Rule struct {
 	// If omitted or empty, this rule does not apply at ingress.
 	//
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxItems=32
 	Ingress []IngressRule `json:"ingress,omitempty"`
 
 	// IngressDeny is a list of IngressDenyRule which are enforced at ingress.
@@ -91,6 +92,7 @@ type Rule struct {
 	// If omitted or empty, this rule does not apply at egress.
 	//
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxItems=32
 	Egress []EgressRule `json:"egress,omitempty"`
 
 	// EgressDeny is a list of EgressDenyRule which are enforced at egress.

--- a/pkg/policy/api/rules.go
+++ b/pkg/policy/api/rules.go
@@ -14,6 +14,7 @@ import (
 // it is sufficient to have a single fromEndpoints rule match, none of
 // the fromRequires may be violated at the same time.
 // +deepequal-gen:private-method=true
+// +kubebuilder:validation:MaxItems=32
 type Rules []*Rule
 
 func (rs Rules) String() string {


### PR DESCRIPTION
This commit is to add one simple rule to avoid the common mistake when configuring L7 HTTP rule. One point worth noting is that mixItems and maxItems are added to reduce the cost constraint in k8s.

```
* spec.validation.openAPIV3Schema.properties[specs].items.properties[egress].items.properties[toPorts].items.x-kubernetes-validations[0].rule: Forbidden: estimated rule cost exceeds budget by factor of 13.6x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared)
```

Relates: #23152

