### PR TITLE
Bugtool commands list generation improvements

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -126,73 +126,72 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"tc qdisc show",
 	}
 
-	if bpffsMountpoint := bpffsMountpoint(); bpffsMountpoint != "" {
-		commands = append(commands, []string{
-			// LB and CT map for debugging services; using bpftool for a reliable dump
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_auth_map", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_call_policy", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_calls_overlay_2", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_calls_xdp", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_capture_cache", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_runtime_config", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lxc", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_metrics", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_tunnel_map", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ktime_cache", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ipcache", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_events", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_signals", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_capture4_rules", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_capture6_rules", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_nodeport_neigh4", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_nodeport_neigh6", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_node_map", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_node_map_v2", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_source_range", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb6_source_range", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_maglev", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb6_maglev", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb6_health", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb6_reverse_sk", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_health", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_reverse_sk", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ipmasq_v4", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ipmasq_v6", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ipv4_frag_datagrams", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_throttle", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_encrypt_state", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_egress_gw_policy_v4", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_srv6_vrf_v4", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_srv6_vrf_v6", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_srv6_policy_v4", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_srv6_policy_v6", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_srv6_state_v4", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_srv6_state_v6", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_srv6_sid", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_services_v2", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_backends_v2", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_backends_v3", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_backends", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_reverse_nat", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ct4_global", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ct_any4_global", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_affinity", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb6_affinity", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb_affinity_match", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb6_services_v2", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb6_backends_v2", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb6_backends_v3", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb6_backends", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb6_reverse_nat", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ct6_global", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ct_any6_global", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_snat_v4_external", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_snat_v6_external", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_vtep_map", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_l2_responder_v4", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ratelimit", bpffsMountpoint),
-		}...)
+	// LB and CT map for debugging services; using bpftool for a reliable dump
+	bpfMapsPath := []string{
+		"tc/globals/cilium_auth_map",
+		"tc/globals/cilium_call_policy",
+		"tc/globals/cilium_calls_overlay_2",
+		"tc/globals/cilium_calls_xdp",
+		"tc/globals/cilium_capture_cache",
+		"tc/globals/cilium_runtime_config",
+		"tc/globals/cilium_lxc",
+		"tc/globals/cilium_metrics",
+		"tc/globals/cilium_tunnel_map",
+		"tc/globals/cilium_ktime_cache",
+		"tc/globals/cilium_ipcache",
+		"tc/globals/cilium_events",
+		"tc/globals/cilium_signals",
+		"tc/globals/cilium_capture4_rules",
+		"tc/globals/cilium_capture6_rules",
+		"tc/globals/cilium_nodeport_neigh4",
+		"tc/globals/cilium_nodeport_neigh6",
+		"tc/globals/cilium_node_map",
+		"tc/globals/cilium_node_map_v2",
+		"tc/globals/cilium_lb4_source_range",
+		"tc/globals/cilium_lb6_source_range",
+		"tc/globals/cilium_lb4_maglev",
+		"tc/globals/cilium_lb6_maglev",
+		"tc/globals/cilium_lb6_health",
+		"tc/globals/cilium_lb6_reverse_sk",
+		"tc/globals/cilium_lb4_health",
+		"tc/globals/cilium_lb4_reverse_sk",
+		"tc/globals/cilium_ipmasq_v4",
+		"tc/globals/cilium_ipmasq_v6",
+		"tc/globals/cilium_ipv4_frag_datagrams",
+		"tc/globals/cilium_throttle",
+		"tc/globals/cilium_encrypt_state",
+		"tc/globals/cilium_egress_gw_policy_v4",
+		"tc/globals/cilium_srv6_vrf_v4",
+		"tc/globals/cilium_srv6_vrf_v6",
+		"tc/globals/cilium_srv6_policy_v4",
+		"tc/globals/cilium_srv6_policy_v6",
+		"tc/globals/cilium_srv6_state_v4",
+		"tc/globals/cilium_srv6_state_v6",
+		"tc/globals/cilium_srv6_sid",
+		"tc/globals/cilium_lb4_services_v2",
+		"tc/globals/cilium_lb4_backends_v2",
+		"tc/globals/cilium_lb4_backends_v3",
+		"tc/globals/cilium_lb4_backends",
+		"tc/globals/cilium_lb4_reverse_nat",
+		"tc/globals/cilium_ct4_global",
+		"tc/globals/cilium_ct_any4_global",
+		"tc/globals/cilium_lb4_affinity",
+		"tc/globals/cilium_lb6_affinity",
+		"tc/globals/cilium_lb_affinity_match",
+		"tc/globals/cilium_lb6_services_v2",
+		"tc/globals/cilium_lb6_backends_v2",
+		"tc/globals/cilium_lb6_backends_v3",
+		"tc/globals/cilium_lb6_backends",
+		"tc/globals/cilium_lb6_reverse_nat",
+		"tc/globals/cilium_ct6_global",
+		"tc/globals/cilium_ct_any6_global",
+		"tc/globals/cilium_snat_v4_external",
+		"tc/globals/cilium_snat_v6_external",
+		"tc/globals/cilium_vtep_map",
+		"tc/globals/cilium_l2_responder_v4",
+		"tc/globals/cilium_ratelimit",
 	}
+	commands = append(commands, bpfMapDumpCommands(bpfMapsPath)...)
 
 	cgroup2fsMounts := cgroup2fsMounts()
 	for i := range cgroup2fsMounts {
@@ -226,6 +225,20 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 	commands = append(commands, "cat -u /proc/net/xfrm_stat")
 
 	return k8sCommands(commands, k8sPods)
+}
+
+func bpfMapDumpCommands(mapPaths []string) []string {
+	bpffsMountpoint := bpffsMountpoint()
+	if bpffsMountpoint == "" {
+		return nil
+	}
+
+	commands := make([]string, 0, len(mapPaths))
+	for _, mapPath := range mapPaths {
+		commands = append(commands, "bpftool map dump pinned "+filepath.Join(bpffsMountpoint, mapPath))
+	}
+
+	return commands
 }
 
 func save(c *BugtoolConfiguration, path string) error {

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -25,11 +25,6 @@ type BugtoolConfiguration struct {
 	Commands []string `json:"commands"`
 }
 
-func setupDefaultConfig(path string, k8sPods []string, confDir, cmdDir string) (*BugtoolConfiguration, error) {
-	c := BugtoolConfiguration{defaultCommands(confDir, cmdDir, k8sPods)}
-	return &c, save(&c, path)
-}
-
 func bpffsMountpoint() string {
 	mountInfos, err := mountinfo.GetMountInfo()
 	if err != nil {

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -199,11 +199,18 @@ func runTool() {
 
 	k8sPods := getVerifyCiliumPods()
 
-	var commands []string
+	commands := defaultCommands(confDir, cmdDir, k8sPods)
+
 	if dryRunMode {
-		dryRun(configPath, k8sPods, confDir, cmdDir)
+		dryRun(configPath, commands)
 		fmt.Fprintf(os.Stderr, "Configuration file at %s\n", configPath)
 		return
+	}
+
+	// Check if there is a non-empty user supplied configuration
+	if config, _ := loadConfigFile(configPath); config != nil && len(config.Commands) > 0 {
+		// All of of the commands run are from the configuration file
+		commands = config.Commands
 	}
 
 	if getPProf {
@@ -231,17 +238,7 @@ func runTool() {
 			}
 		}
 
-		// Check if there is a user supplied configuration
-		if config, _ := loadConfigFile(configPath); config != nil {
-			// All of of the commands run are from the configuration file
-			commands = config.Commands
-		}
-		if len(commands) == 0 {
-			// Found no configuration file or empty so fall back to default commands.
-			commands = defaultCommands(confDir, cmdDir, k8sPods)
-		}
 		defer printDisclaimer()
-
 		runAll(commands, cmdDir, k8sPods)
 
 		if excludeObjectFiles {
@@ -276,9 +273,8 @@ func runTool() {
 
 // dryRun creates the configuration file to show the user what would have been run.
 // The same file can be used to modify what will be run by the bugtool.
-func dryRun(configPath string, k8sPods []string, confDir, cmdDir string) {
-	_, err := setupDefaultConfig(configPath, k8sPods, confDir, cmdDir)
-	if err != nil {
+func dryRun(configPath string, commands []string) {
+	if err := save(&BugtoolConfiguration{commands}, configPath); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Miscellaneous improvements to increase modularity and reusability of the bugtool helpers to generate the list of commands to be run.

This should ease the extensibility of bugtool itself in case we want to add some environment-specific command on top of the default ones.

Notes to the reviewers: better reviewed commit by commit.