### PR TITLE
Scrape cilium metrics and add custom prometheus queries

### DIFF
--- a/.github/actions/cl2-modules/cilium-metrics.yaml
+++ b/.github/actions/cl2-modules/cilium-metrics.yaml
@@ -1,0 +1,19 @@
+{{$action := .action}}
+
+steps:
+  - name: {{$action}} Cilium Agent Policy implementation delay
+    measurements:
+    - Identifier: PolicyImplementationDelay
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: Policy Implementation Delay
+        metricVersion: v1
+        unit: s
+        queries:
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(rate(cilium_policy_implementation_delay_bucket[%v])) by (le))
+        - name: Perc90
+          query: histogram_quantile(0.90, sum(rate(cilium_policy_implementation_delay_bucket[%v])) by (le))
+        - name: Perc50
+          query: histogram_quantile(0.50, sum(rate(cilium_policy_implementation_delay_bucket[%v])) by (le))

--- a/.github/actions/cl2-modules/cilium-metrics.yaml
+++ b/.github/actions/cl2-modules/cilium-metrics.yaml
@@ -17,3 +17,16 @@ steps:
           query: histogram_quantile(0.90, sum(rate(cilium_policy_implementation_delay_bucket[%v])) by (le))
         - name: Perc50
           query: histogram_quantile(0.50, sum(rate(cilium_policy_implementation_delay_bucket[%v])) by (le))
+    # For debugging cardinality of metrics, fetch prometheus snapshot and use
+    # following query to get the cardinality of metrics:
+    # topk(10, count by (__name__)({__name__=~"cilium_.+"}))
+    - Identifier: CiliumMetricsCardinality
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: Metrics Cardinality
+        metricVersion: v1
+        unit: count
+        queries:
+        - name: Max
+          query: max_over_time(count({__name__=~"cilium_.+"})[%v:])

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -57,22 +57,37 @@ jobs:
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 
-      - name: Get Cilium's default values
-        id: default_vars
-        uses: ./.github/actions/helm-default
-        with:
-          image-tag: ${{ github.sha }}
-
       - name: Set up job variables
         id: vars
         run: |
-          SHA="${{ github.sha }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] ; then
+            SHA="${{ inputs.image-tag }}"
+          else
+            SHA="${{ github.sha }}"
+          fi
 
-          # Setup Cilium install options
-          CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
+          CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
             --set pprof.enabled=true \
             --helm-set=prometheus.enabled=true \
             --wait=false"
+
+          # only add SHA to the image tags if it was set
+          if [ -n "${SHA}" ]; then
+            echo sha=${SHA} >> $GITHUB_OUTPUT
+            CILIUM_INSTALL_DEFAULTS+=" --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
+            --helm-set=image.useDigest=false \
+            --helm-set=image.tag=${SHA} \
+            --helm-set=operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
+            --helm-set=operator.image.suffix=-ci \
+            --helm-set=operator.image.tag=${SHA} \
+            --helm-set=operator.image.useDigest=false \
+            --helm-set=clustermesh.apiserver.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci \
+            --helm-set=clustermesh.apiserver.image.tag=${SHA} \
+            --helm-set=clustermesh.apiserver.image.useDigest=false \
+            --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
+            --helm-set=hubble.relay.image.tag=${SHA} \
+            --helm-set=hubble.relay.image.useDigest=false"
+          fi
 
           CLUSTER_NAME="${{ env.test_name }}-${{ env.cluster_base_name }}"
 
@@ -171,6 +186,7 @@ jobs:
 
       - name: Install Cilium
         run: |
+          cilium install --dry-run-helm-values ${{ steps.vars.outputs.cilium_install_defaults }}
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
       - name: Wait for cluster to be ready

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -214,6 +214,7 @@ jobs:
           export CL2_SCHEDULER_THROUGHPUT_THRESHOLD=0
           export CL2_PROMETHEUS_SCRAPE_CILIUM_OPERATOR=true
           export CL2_PROMETHEUS_SCRAPE_CILIUM_AGENT=true
+          export CL2_PROMETHEUS_MEMORY_SCALE_FACTOR=2.0
 
           # CL2 hardcodes module paths to live in ./testing/load, even
           # if the path given is relative.

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '39 0 * * 1-5'
 
+# For testing uncomment following lines:
+#  push:
+#    branches:
+#      - your_branch_name
+
 permissions:
   # To be able to access the repository with actions/checkout
   contents: read
@@ -66,6 +71,7 @@ jobs:
           # Setup Cilium install options
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --set pprof.enabled=true \
+            --helm-set=prometheus.enabled=true \
             --wait=false"
 
           CLUSTER_NAME="${{ env.test_name }}-${{ env.cluster_base_name }}"
@@ -119,7 +125,7 @@ jobs:
           # all updates to the default branch and (2) continually
           # updating CL2 may impact the stability of the scale test
           # results.
-          ref: 920c39ef245a81bd8fb39d7fecf39eb35820d9ef
+          ref: 6eb52ac89d5de15a0ad13cfeb2b2026e57ce4f64
           persist-credentials: false
           sparse-checkout: clusterloader2
           path: perf-tests
@@ -182,7 +188,7 @@ jobs:
         id: run-cl2
         working-directory: ./perf-tests/clusterloader2
         shell: bash
-        timeout-minutes: 30
+        timeout-minutes: 40
         run: |
           mkdir ./report
           export CL2_PROMETHEUS_PVC_ENABLED=false
@@ -190,12 +196,15 @@ jobs:
           export CL2_ENABLE_NETWORKPOLICIES=true
           export CL2_ALLOWED_SLOW_API_CALLS=1
           export CL2_SCHEDULER_THROUGHPUT_THRESHOLD=0
+          export CL2_PROMETHEUS_SCRAPE_CILIUM_OPERATOR=true
+          export CL2_PROMETHEUS_SCRAPE_CILIUM_AGENT=true
 
           # CL2 hardcodes module paths to live in ./testing/load, even
           # if the path given is relative.
           cp ../../.github/actions/cl2-modules/cilium-agent-pprofs.yaml ./testing/load/
+          cp ../../.github/actions/cl2-modules/cilium-metrics.yaml ./testing/load/
           echo \
-            '{"CL2_ADDITIONAL_MEASUREMENT_MODULES": ["./cilium-agent-pprofs.yaml"]}' \
+            '{"CL2_ADDITIONAL_MEASUREMENT_MODULES": ["./cilium-agent-pprofs.yaml", "./cilium-metrics.yaml"]}' \
             > modules.yaml
 
           # CL2 needs ssh access to control plane nodes


### PR DESCRIPTION
Summary:
- start scraping cilium metrics
- Stop using default helm values - essentially turn of debug logs and switch monitoringAggregation to default
- Keep track of policy implementation delay
- Keep track of cardinality of metrics
