### PR TITLE
[v1.15] Run removeStaleProxyRules only when IP family is enabled

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -437,6 +437,9 @@ func (p *Proxy) ReinstallRoutingRules() error {
 				return err
 			}
 		}
+		if err := removeStaleProxyRulesIPv4(); err != nil {
+			return err
+		}
 	} else {
 		if err := removeToProxyRoutesIPv4(); err != nil {
 			return err
@@ -444,9 +447,6 @@ func (p *Proxy) ReinstallRoutingRules() error {
 		if err := removeFromIngressProxyRoutesIPv4(); err != nil {
 			return err
 		}
-	}
-	if err := removeStaleProxyRulesIPv4(); err != nil {
-		return err
 	}
 
 	if option.Config.EnableIPv6 {
@@ -470,6 +470,9 @@ func (p *Proxy) ReinstallRoutingRules() error {
 				return err
 			}
 		}
+		if err := removeStaleProxyRulesIPv6(); err != nil {
+			return err
+		}
 	} else {
 		if err := removeToProxyRoutesIPv6(); err != nil {
 			return err
@@ -477,9 +480,6 @@ func (p *Proxy) ReinstallRoutingRules() error {
 		if err := removeFromIngressProxyRoutesIPv6(); err != nil {
 			return err
 		}
-	}
-	if err := removeStaleProxyRulesIPv6(); err != nil {
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
Hello,

Cilium shouldn't try to remove stale proxy rules if the corresponding IP family isn't enabled. Doing this can prevent the cilium agent from starting on IPv4 or IPv6 only nodes as it will fail with "address family not supported by protocol".

As I understand the consequence of this change would be to keep stale rules only if someone choose to disable an IP family at the same time as he upgrade from Cilium 1.14 to 1.15, which seem unlikely.

```release-note
Fix: stale proxy rules cleanup preventing agent startup on IPv4 or IPv6 only nodes
```

Best Regards.