### PR TITLE
kvstore: Replace gocheck with built-in go test

### DIFF
--- a/pkg/idpool/idpool_norace_test.go
+++ b/pkg/idpool/idpool_norace_test.go
@@ -6,9 +6,9 @@
 package idpool
 
 import (
-	. "github.com/cilium/checkmate"
+	"testing"
 )
 
-func (s *IDPoolTestSuite) TestAllocateID(c *C) {
-	s.testAllocatedID(c, 256)
+func TestAllocateID(t *testing.T) {
+	testAllocatedID(t, 256)
 }

--- a/pkg/idpool/idpool_race_test.go
+++ b/pkg/idpool/idpool_race_test.go
@@ -6,7 +6,7 @@
 package idpool
 
 import (
-	. "github.com/cilium/checkmate"
+	"testing"
 )
 
 // TestAllocateID without the race detection enabled is too slow to run with
@@ -14,6 +14,6 @@ import (
 // tests don't time out while running with race detector by having a lower
 // number of parallel goroutines than it would have been if we ran it without
 // the race detector.
-func (s *IDPoolTestSuite) TestAllocateID(c *C) {
-	s.testAllocatedID(c, 5)
+func TestAllocateID(t *testing.T) {
+	testAllocatedID(t, 5)
 }

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -12,7 +12,8 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/cilium/cilium/pkg/allocator"
@@ -26,47 +27,11 @@ const (
 	testPrefix = "test-prefix"
 )
 
-func Test(t *testing.T) {
-	TestingT(t)
-}
-
-type AllocatorSuite struct {
-	backend string
-}
-
-func (s *AllocatorSuite) SetUpSuite(c *C) {
-	testutils.IntegrationTest(c)
-}
-
-type AllocatorEtcdSuite struct {
-	AllocatorSuite
-}
-
-var _ = Suite(&AllocatorEtcdSuite{})
-
-func (e *AllocatorEtcdSuite) SetUpSuite(c *C) {
-	testutils.IntegrationTest(c)
-}
-
-func (e *AllocatorEtcdSuite) SetUpTest(c *C) {
-	e.backend = "etcd"
-	kvstore.SetupDummy(c, "etcd")
-}
-
-type AllocatorConsulSuite struct {
-	AllocatorSuite
-}
-
-var _ = Suite(&AllocatorConsulSuite{})
-
-func (e *AllocatorConsulSuite) SetUpSuite(c *C) {
-	testutils.IntegrationTest(c)
-}
-
-func (e *AllocatorConsulSuite) SetUpTest(c *C) {
-	e.backend = "consul"
-	kvstore.SetupDummy(c, "consul")
-}
+// Configure a generous timeout to prevent flakes when running in a noisy CI environment.
+var (
+	tick    = 10 * time.Millisecond
+	timeout = 5 * time.Second
+)
 
 // FIXME: this should be named better, it implements pkg/allocator.Backend
 type TestAllocatorKey string
@@ -99,40 +64,58 @@ func randomTestName() string {
 	return fmt.Sprintf("%s%s", testPrefix, rand.String(12))
 }
 
-func (s *AllocatorSuite) BenchmarkAllocate(c *C) {
-	allocatorName := randomTestName()
-	maxID := idpool.ID(256 + c.N)
-	backend, err := NewKVStoreBackend(allocatorName, "a", TestAllocatorKey(""), kvstore.Client())
-	c.Assert(err, IsNil)
-	a, err := allocator.NewAllocator(TestAllocatorKey(""), backend, allocator.WithMax(maxID))
-	c.Assert(err, IsNil)
-	c.Assert(a, Not(IsNil))
-	defer a.DeleteAllKeys()
-
-	c.ResetTimer()
-	for i := 0; i < c.N; i++ {
-		_, _, _, err := a.Allocate(context.Background(), TestAllocatorKey(fmt.Sprintf("key%04d", i)))
-		c.Assert(err, IsNil)
+func BenchmarkAllocate(b *testing.B) {
+	testutils.IntegrationTest(b)
+	for _, backendName := range []string{"etcd", "consul"} {
+		b.Run(backendName, func(b *testing.B) {
+			kvstore.SetupDummyWithConfigOpts(b, backendName, opts(backendName))
+			benchmarkAllocate(b)
+		})
 	}
-	c.StopTimer()
-
 }
 
-func (s *AllocatorSuite) TestRunLocksGC(c *C) {
+func benchmarkAllocate(b *testing.B) {
 	allocatorName := randomTestName()
-	maxID := idpool.ID(256 + c.N)
-	// FIXME: Did this previousy use allocatorName := randomTestName() ? so TestAllocatorKey(randomeTestName())
+	maxID := idpool.ID(256 + b.N)
+	backend, err := NewKVStoreBackend(allocatorName, "a", TestAllocatorKey(""), kvstore.Client())
+	require.NoError(b, err)
+	a, err := allocator.NewAllocator(TestAllocatorKey(""), backend, allocator.WithMax(maxID))
+	require.NoError(b, err)
+	require.NotNil(b, a)
+	defer a.DeleteAllKeys()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _, err := a.Allocate(context.Background(), TestAllocatorKey(fmt.Sprintf("key%04d", i)))
+		require.NoError(b, err)
+	}
+	b.StopTimer()
+}
+
+func BenchmarkRunLocksGC(b *testing.B) {
+	testutils.IntegrationTest(b)
+	for _, backendName := range []string{"etcd", "consul"} {
+		b.Run(backendName, func(b *testing.B) {
+			kvstore.SetupDummyWithConfigOpts(b, backendName, opts(backendName))
+			benchmarkRunLocksGC(b, backendName)
+		})
+	}
+}
+
+func benchmarkRunLocksGC(b *testing.B, backendName string) {
+	allocatorName := randomTestName()
+	maxID := idpool.ID(256 + b.N)
+	// FIXME: Did this previously use allocatorName := randomTestName() ? so TestAllocatorKey(randomeTestName())
 	backend1, err := NewKVStoreBackend(allocatorName, "a", TestAllocatorKey(""), kvstore.Client())
-	c.Assert(err, IsNil)
-	c.Assert(err, IsNil)
+	require.NoError(b, err)
 	allocator, err := allocator.NewAllocator(TestAllocatorKey(""), backend1, allocator.WithMax(maxID), allocator.WithoutGC())
-	c.Assert(err, IsNil)
+	require.NoError(b, err)
 	shortKey := TestAllocatorKey("1;")
 
 	staleLocks := map[string]kvstore.Value{}
 	staleLocks, err = allocator.RunLocksGC(context.Background(), staleLocks)
-	c.Assert(err, IsNil)
-	c.Assert(len(staleLocks), Equals, 0)
+	require.NoError(b, err)
+	require.Empty(b, staleLocks)
 
 	var (
 		lock1, lock2 kvstore.KVLocker
@@ -144,13 +127,13 @@ func (s *AllocatorSuite) TestRunLocksGC(c *C) {
 			err error
 		)
 		lock1, err = backend1.Lock(context.Background(), shortKey)
-		c.Assert(err, IsNil)
+		require.NoError(b, err)
 		close(gotLock1)
 		var client kvstore.BackendOperations
-		switch s.backend {
+		switch backendName {
 		case "etcd":
 			client, _ = kvstore.NewClient(context.Background(),
-				s.backend,
+				backendName,
 				map[string]string{
 					kvstore.EtcdAddrOption: kvstore.EtcdDummyAddress(),
 				},
@@ -158,7 +141,7 @@ func (s *AllocatorSuite) TestRunLocksGC(c *C) {
 			)
 		case "consul":
 			client, _ = kvstore.NewClient(context.Background(),
-				s.backend,
+				backendName,
 				map[string]string{
 					kvstore.ConsulAddrOption:   kvstore.ConsulDummyAddress(),
 					kvstore.ConsulOptionConfig: kvstore.ConsulDummyConfigFile(),
@@ -167,19 +150,16 @@ func (s *AllocatorSuite) TestRunLocksGC(c *C) {
 			)
 		}
 		lock2, err = client.LockPath(context.Background(), allocatorName+"/locks/"+kvstore.Client().Encode([]byte(shortKey.GetKey())))
-		c.Assert(err, IsNil)
+		require.NoError(b, err)
 		close(gotLock2)
 	}()
 
 	// Wait until lock1 is gotten.
-	c.Assert(testutils.WaitUntil(func() bool {
-		select {
-		case <-gotLock1:
-			return true
-		default:
-			return false
-		}
-	}, 5*time.Second), IsNil)
+	select {
+	case <-gotLock1:
+	case <-time.After(timeout):
+		b.Error("Lock1 not obtained on time")
+	}
 
 	// wait until client2, in line 160, tries to grab the lock.
 	// We can't detect when that actually happen so we have to assume it will
@@ -188,14 +168,14 @@ func (s *AllocatorSuite) TestRunLocksGC(c *C) {
 
 	// Check which locks are stale, it should be lock1 and lock2
 	staleLocks, err = allocator.RunLocksGC(context.Background(), staleLocks)
-	c.Assert(err, IsNil)
-	switch s.backend {
+	require.NoError(b, err)
+	switch backendName {
 	case "consul":
 		// Contrary to etcd, consul does not create a lock in the kvstore
 		// if a lock is already being held.
-		c.Assert(len(staleLocks), Equals, 1)
+		require.Len(b, staleLocks, 1)
 	case "etcd":
-		c.Assert(len(staleLocks), Equals, 2)
+		require.Len(b, staleLocks, 2)
 	}
 
 	var (
@@ -226,46 +206,53 @@ func (s *AllocatorSuite) TestRunLocksGC(c *C) {
 
 	// GC lock1 because it's the oldest lock being held.
 	staleLocks, err = allocator.RunLocksGC(context.Background(), staleLocks)
-	c.Assert(err, IsNil)
-	switch s.backend {
+	require.NoError(b, err)
+	switch backendName {
 	case "consul":
 		// Contrary to etcd, consul does not create a lock in the kvstore
 		// if a lock is already being held. So we have GCed the only lock
 		// available.
-		c.Assert(len(staleLocks), Equals, 0)
+		require.Len(b, staleLocks, 0)
 	case "etcd":
 		// There are 2 clients trying to get the lock, we have GC one of them
 		// so that is way we have 1 staleLock in the map.
-		c.Assert(len(staleLocks), Equals, 1)
+		require.Len(b, staleLocks, 1)
 	}
 
 	// Wait until lock2 is gotten as it should have happen since we have
 	// GC lock1.
-	c.Assert(testutils.WaitUntil(func() bool {
-		select {
-		case <-gotLock2:
-			return true
-		default:
-			return false
-		}
-	}, 10*time.Second), IsNil)
+	select {
+	case <-gotLock2:
+	case <-time.After(timeout):
+		b.Error("Lock2 not obtained on time")
+	}
 
 	// Unlock lock1 because we still hold the local locks.
 	err = lock1.Unlock(context.Background())
-	c.Assert(err, IsNil)
+	require.NoError(b, err)
 	err = lock2.Unlock(context.Background())
-	c.Assert(err, IsNil)
+	require.NoError(b, err)
 }
 
-func (s *AllocatorSuite) TestGC(c *C) {
+func BenchmarkGC(b *testing.B) {
+	testutils.IntegrationTest(b)
+	for _, backendName := range []string{"etcd", "consul"} {
+		b.Run(backendName, func(b *testing.B) {
+			kvstore.SetupDummyWithConfigOpts(b, backendName, opts(backendName))
+			benchmarkGC(b)
+		})
+	}
+}
+
+func benchmarkGC(b *testing.B) {
 	allocatorName := randomTestName()
-	maxID := idpool.ID(256 + c.N)
-	// FIXME: Did this previousy use allocatorName := randomTestName() ? so TestAllocatorKey(randomeTestName())
+	maxID := idpool.ID(256 + b.N)
+	// FIXME: Did this previously use allocatorName := randomTestName() ? so TestAllocatorKey(randomeTestName())
 	backend, err := NewKVStoreBackend(allocatorName, "a", TestAllocatorKey(""), kvstore.Client())
-	c.Assert(err, IsNil)
+	require.NoError(b, err)
 	allocator, err := allocator.NewAllocator(TestAllocatorKey(""), backend, allocator.WithMax(maxID), allocator.WithoutGC())
-	c.Assert(err, IsNil)
-	c.Assert(allocator, Not(IsNil))
+	require.NoError(b, err)
+	require.NotNil(b, allocator)
 	defer allocator.DeleteAllKeys()
 	defer allocator.Delete()
 
@@ -273,51 +260,58 @@ func (s *AllocatorSuite) TestGC(c *C) {
 
 	shortKey := TestAllocatorKey("1;")
 	shortID, _, _, err := allocator.Allocate(context.Background(), shortKey)
-	c.Assert(err, IsNil)
-	c.Assert(shortID, Not(Equals), 0)
+	require.NoError(b, err)
+	require.NotEqual(b, 0, shortID)
 
 	longKey := TestAllocatorKey("1;2;")
 	longID, _, _, err := allocator.Allocate(context.Background(), longKey)
-	c.Assert(err, IsNil)
-	c.Assert(longID, Not(Equals), 0)
+	require.NoError(b, err)
+	require.NotEqual(b, 0, longID)
 
-	allocator.Release(context.Background(), shortKey)
+	_, err = allocator.Release(context.Background(), shortKey)
+	require.NoError(b, err)
 
 	rateLimiter := rate.NewLimiter(10*time.Second, 100)
 
 	keysToDelete := map[string]uint64{}
 	keysToDelete, _, err = allocator.RunGC(rateLimiter, keysToDelete)
-	c.Assert(err, IsNil)
-	c.Assert(len(keysToDelete), Equals, 1)
+	require.NoError(b, err)
+	require.Len(b, keysToDelete, 1)
 	keysToDelete, _, err = allocator.RunGC(rateLimiter, keysToDelete)
-	c.Assert(err, IsNil)
-	c.Assert(len(keysToDelete), Equals, 0)
+	require.NoError(b, err)
+	require.Len(b, keysToDelete, 0)
 
 	// wait for cache to be updated via delete notification
-	c.Assert(testutils.WaitUntil(func() bool {
+	require.EventuallyWithT(b, func(c *assert.CollectT) {
 		key, err := allocator.GetByID(context.TODO(), shortID)
-		if err != nil {
-			c.Error(err)
-			return false
-		}
-		return key == nil
-	}, 5*time.Second), IsNil)
+		assert.NoError(c, err)
+		assert.Nil(c, key)
+	}, timeout, tick)
 
 	key, err := allocator.GetByID(context.TODO(), shortID)
-	c.Assert(err, IsNil)
-	c.Assert(key, IsNil)
+	require.NoError(b, err)
+	require.Nil(b, key)
 }
 
-func (s *AllocatorSuite) TestGC_ShouldSkipOutOfRangeIdentites(c *C) {
+func BenchmarkGCShouldSkipOutOfRangeIdentities(b *testing.B) {
+	testutils.IntegrationTest(b)
+	for _, backendName := range []string{"etcd", "consul"} {
+		b.Run(backendName, func(b *testing.B) {
+			kvstore.SetupDummyWithConfigOpts(b, backendName, opts(backendName))
+			benchmarkGCShouldSkipOutOfRangeIdentities(b)
+		})
+	}
+}
 
+func benchmarkGCShouldSkipOutOfRangeIdentities(b *testing.B) {
 	// Allocator1: allocator under test
 	backend, err := NewKVStoreBackend(randomTestName(), "a", TestAllocatorKey(""), kvstore.Client())
-	c.Assert(err, IsNil)
+	require.NoError(b, err)
 
-	maxID1 := idpool.ID(4 + c.N)
+	maxID1 := idpool.ID(4 + b.N)
 	allocator1, err := allocator.NewAllocator(TestAllocatorKey(""), backend, allocator.WithMax(maxID1), allocator.WithoutGC())
-	c.Assert(err, IsNil)
-	c.Assert(allocator1, Not(IsNil))
+	require.NoError(b, err)
+	require.NotNil(b, allocator1)
 
 	defer allocator1.DeleteAllKeys()
 	defer allocator1.Delete()
@@ -326,25 +320,26 @@ func (s *AllocatorSuite) TestGC_ShouldSkipOutOfRangeIdentites(c *C) {
 
 	shortKey1 := TestAllocatorKey("1;")
 	shortID1, _, _, err := allocator1.Allocate(context.Background(), shortKey1)
-	c.Assert(err, IsNil)
-	c.Assert(shortID1, Not(Equals), 0)
+	require.NoError(b, err)
+	require.NotEqual(b, 0, shortID1)
 
-	allocator1.Release(context.Background(), shortKey1)
+	_, err = allocator1.Release(context.Background(), shortKey1)
+	require.NoError(b, err)
 
 	// Alloctor2: with a non-overlapping range compared with allocator1
 	backend2, err := NewKVStoreBackend(randomTestName(), "a", TestAllocatorKey(""), kvstore.Client())
-	c.Assert(err, IsNil)
+	require.NoError(b, err)
 
 	minID2 := maxID1 + 1
 	maxID2 := minID2 + 4
 	allocator2, err := allocator.NewAllocator(TestAllocatorKey(""), backend2, allocator.WithMin(minID2), allocator.WithMax(maxID2), allocator.WithoutGC())
-	c.Assert(err, IsNil)
-	c.Assert(allocator2, Not(IsNil))
+	require.NoError(b, err)
+	require.NotNil(b, allocator2)
 
 	shortKey2 := TestAllocatorKey("2;")
 	shortID2, _, _, err := allocator2.Allocate(context.Background(), shortKey2)
-	c.Assert(err, IsNil)
-	c.Assert(shortID2, Not(Equals), 0)
+	require.NoError(b, err)
+	require.NotEqual(b, 0, shortID2)
 
 	defer allocator2.DeleteAllKeys()
 	defer allocator2.Delete()
@@ -356,41 +351,48 @@ func (s *AllocatorSuite) TestGC_ShouldSkipOutOfRangeIdentites(c *C) {
 
 	keysToDelete := map[string]uint64{}
 	keysToDelete, _, err = allocator1.RunGC(rateLimiter, keysToDelete)
-	c.Assert(err, IsNil)
+	require.NoError(b, err)
 	// But, only one will be filtered out and GC'ed
-	c.Assert(len(keysToDelete), Equals, 1)
+	require.Len(b, keysToDelete, 1)
 	keysToDelete, _, err = allocator1.RunGC(rateLimiter, keysToDelete)
-	c.Assert(err, IsNil)
-	c.Assert(len(keysToDelete), Equals, 0)
+	require.NoError(b, err)
+	require.Len(b, keysToDelete, 0)
 
 	// Wait for cache to be updated via delete notification
-	c.Assert(testutils.WaitUntil(func() bool {
+	require.EventuallyWithT(b, func(c *assert.CollectT) {
 		key, err := allocator1.GetByID(context.TODO(), shortID1)
-		if err != nil {
-			c.Error(err)
-			return false
-		}
-		return key == nil
-	}, 5*time.Second), IsNil)
+		assert.NoError(c, err)
+		assert.Nil(c, key)
+	}, timeout, tick)
 
 	// The key created with allocator1 should be GC'd
 	key, err := allocator1.GetByID(context.TODO(), shortID1)
-	c.Assert(err, IsNil)
-	c.Assert(key, IsNil)
+	require.NoError(b, err)
+	require.Nil(b, key)
 
 	// The key created with allocator2 should NOT be GC'd
 	key2, err := allocator2.GetByID(context.TODO(), shortID2)
-	c.Assert(err, IsNil)
-	c.Assert(key2, Not(IsNil))
+	require.NoError(b, err)
+	require.NotNil(b, key2)
 }
 
-func testAllocator(c *C, maxID idpool.ID, allocatorName string, suffix string) {
+func TestAllocateCached(t *testing.T) {
+	testutils.IntegrationTest(t)
+	for _, backendName := range []string{"etcd", "consul"} {
+		t.Run(backendName, func(t *testing.T) {
+			kvstore.SetupDummyWithConfigOpts(t, backendName, opts(backendName))
+			testAllocatorCached(t, idpool.ID(32), randomTestName()) // enable use of local cache
+		})
+	}
+}
+
+func testAllocatorCached(t *testing.T, maxID idpool.ID, allocatorName string) {
 	backend, err := NewKVStoreBackend(allocatorName, "a", TestAllocatorKey(""), kvstore.Client())
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	a, err := allocator.NewAllocator(TestAllocatorKey(""), backend,
 		allocator.WithMax(maxID), allocator.WithoutGC())
-	c.Assert(err, IsNil)
-	c.Assert(a, Not(IsNil))
+	require.NoError(t, err)
+	require.NotNil(t, a)
 
 	// remove any keys which might be leftover
 	a.DeleteAllKeys()
@@ -399,113 +401,131 @@ func testAllocator(c *C, maxID idpool.ID, allocatorName string, suffix string) {
 	for i := idpool.ID(1); i <= maxID; i++ {
 		key := TestAllocatorKey(fmt.Sprintf("key%04d", i))
 		id, new, newLocally, err := a.Allocate(context.Background(), key)
-		c.Assert(err, IsNil)
-		c.Assert(id, Not(Equals), 0)
-		c.Assert(new, Equals, true)
-		c.Assert(newLocally, Equals, true)
+		require.NoError(t, err)
+		require.NotEqual(t, 0, id)
+		require.True(t, new)
+		require.True(t, newLocally)
 	}
 
 	// allocate all IDs again using the same set of keys, refcnt should go to 2
 	for i := idpool.ID(1); i <= maxID; i++ {
 		key := TestAllocatorKey(fmt.Sprintf("key%04d", i))
 		id, new, newLocally, err := a.Allocate(context.Background(), key)
-		c.Assert(err, IsNil)
-		c.Assert(id, Not(Equals), 0)
-		c.Assert(new, Equals, false)
-		c.Assert(newLocally, Equals, false)
+		require.NoError(t, err)
+		require.NotEqual(t, 0, id)
+		require.False(t, new)
+		require.False(t, newLocally)
 	}
 
 	// Create a 2nd allocator, refill it
 	backend2, err := NewKVStoreBackend(allocatorName, "r", TestAllocatorKey(""), kvstore.Client())
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	a2, err := allocator.NewAllocator(TestAllocatorKey(""), backend2,
 		allocator.WithMax(maxID), allocator.WithoutGC())
-	c.Assert(err, IsNil)
-	c.Assert(a2, Not(IsNil))
+	require.NoError(t, err)
+	require.NotNil(t, a2)
 
 	// allocate all IDs again using the same set of keys, refcnt should go to 2
 	for i := idpool.ID(1); i <= maxID; i++ {
 		key := TestAllocatorKey(fmt.Sprintf("key%04d", i))
 		id, new, newLocally, err := a2.Allocate(context.Background(), key)
-		c.Assert(err, IsNil)
-		c.Assert(id, Not(Equals), 0)
-		c.Assert(new, Equals, false)
-		c.Assert(newLocally, Equals, true)
+		require.NoError(t, err)
+		require.NotEqual(t, 0, id)
+		require.False(t, new)
+		require.True(t, newLocally)
 
 		a2.Release(context.Background(), key)
 	}
 
 	// release 2nd reference of all IDs
 	for i := idpool.ID(1); i <= maxID; i++ {
-		a.Release(context.Background(), TestAllocatorKey(fmt.Sprintf("key%04d", i)))
+		_, err := a.Release(context.Background(), TestAllocatorKey(fmt.Sprintf("key%04d", i)))
+		require.NoError(t, err)
 	}
 
 	staleKeysPreviousRound := map[string]uint64{}
 	rateLimiter := rate.NewLimiter(10*time.Second, 100)
 	// running the GC should not evict any entries
 	staleKeysPreviousRound, _, err = a.RunGC(rateLimiter, staleKeysPreviousRound)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	v, err := kvstore.Client().ListPrefix(context.TODO(), path.Join(allocatorName, "id"))
-	c.Assert(err, IsNil)
-	c.Assert(len(v), Equals, int(maxID))
+	require.NoError(t, err)
+	require.Len(t, v, int(maxID))
 
 	// release final reference of all IDs
 	for i := idpool.ID(1); i <= maxID; i++ {
-		a.Release(context.Background(), TestAllocatorKey(fmt.Sprintf("key%04d", i)))
+		_, err := a.Release(context.Background(), TestAllocatorKey(fmt.Sprintf("key%04d", i)))
+		require.NoError(t, err)
 	}
 
 	// running the GC should evict all entries
 	staleKeysPreviousRound, _, err = a.RunGC(rateLimiter, staleKeysPreviousRound)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	_, _, err = a.RunGC(rateLimiter, staleKeysPreviousRound)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	v, err = kvstore.Client().ListPrefix(context.TODO(), path.Join(allocatorName, "id"))
-	c.Assert(err, IsNil)
-	c.Assert(len(v), Equals, 0)
+	require.NoError(t, err)
+	require.Len(t, v, 0)
 
 	a.DeleteAllKeys()
 	a.Delete()
 	a2.Delete()
 }
 
-func (s *AllocatorSuite) TestAllocateCached(c *C) {
-	testAllocator(c, idpool.ID(32), randomTestName(), "a") // enable use of local cache
+func TestKeyToID(t *testing.T) {
+	testutils.IntegrationTest(t)
+	for _, backendName := range []string{"etcd", "consul"} {
+		t.Run(backendName, func(t *testing.T) {
+			kvstore.SetupDummyWithConfigOpts(t, backendName, opts(backendName))
+			testKeyToID(t)
+		})
+	}
 }
 
-func (s *AllocatorSuite) TestKeyToID(c *C) {
+func testKeyToID(t *testing.T) {
 	allocatorName := randomTestName()
 	backend, err := NewKVStoreBackend(allocatorName, "a", TestAllocatorKey(""), kvstore.Client())
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	a, err := allocator.NewAllocator(TestAllocatorKey(""), backend)
-	c.Assert(err, IsNil)
-	c.Assert(a, Not(IsNil))
+	require.NoError(t, err)
+	require.NotNil(t, a)
 
 	// An error is returned because the path is outside the prefix (allocatorName/id)
 	id, err := backend.keyToID(path.Join(allocatorName, "invalid"))
-	c.Assert(err, Not(IsNil))
-	c.Assert(id, Equals, idpool.NoID)
+	require.NotNil(t, err)
+	require.Equal(t, idpool.NoID, id)
 
 	// An error is returned because the path contains the prefix
 	// (allocatorName/id) but cannot be parsed ("invalid")
 	id, err = backend.keyToID(path.Join(allocatorName, "id", "invalid"))
-	c.Assert(err, Not(IsNil))
-	c.Assert(id, Equals, idpool.NoID)
+	require.NotNil(t, err)
+	require.Equal(t, idpool.NoID, id)
 
 	// A valid lookup that finds an ID
 	id, err = backend.keyToID(path.Join(allocatorName, "id", "10"))
-	c.Assert(err, IsNil)
-	c.Assert(id, Equals, idpool.ID(10))
+	require.NoError(t, err)
+	require.Equal(t, idpool.ID(10), id)
 }
 
-func testGetNoCache(c *C, maxID idpool.ID, suffix string) {
+func TestGetNoCache(t *testing.T) {
+	testutils.IntegrationTest(t)
+	for _, backendName := range []string{"etcd", "consul"} {
+		t.Run(backendName, func(t *testing.T) {
+			kvstore.SetupDummyWithConfigOpts(t, backendName, opts(backendName))
+			testGetNoCache(t, idpool.ID(256))
+		})
+	}
+}
+
+func testGetNoCache(t *testing.T, maxID idpool.ID) {
 	allocatorName := randomTestName()
 	backend, err := NewKVStoreBackend(allocatorName, "a", TestAllocatorKey(""), kvstore.Client())
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	allocator, err := allocator.NewAllocator(TestAllocatorKey(""), backend, allocator.WithMax(maxID), allocator.WithoutGC())
-	c.Assert(err, IsNil)
-	c.Assert(allocator, Not(IsNil))
+	require.NoError(t, err)
+	require.NotNil(t, allocator)
 
 	// remove any keys which might be leftover
 	allocator.DeleteAllKeys()
@@ -514,33 +534,33 @@ func testGetNoCache(c *C, maxID idpool.ID, suffix string) {
 	labelsLong := "foo;/;bar;"
 	key := TestAllocatorKey(fmt.Sprintf("%s%010d", labelsLong, 0))
 	longID, new, newLocally, err := allocator.Allocate(context.Background(), key)
-	c.Assert(err, IsNil)
-	c.Assert(longID, Not(Equals), 0)
-	c.Assert(new, Equals, true)
-	c.Assert(newLocally, Equals, true)
+	require.NoError(t, err)
+	require.NotEqual(t, 0, longID)
+	require.True(t, new)
+	require.True(t, newLocally)
 
 	observedID, err := allocator.GetNoCache(context.Background(), key)
-	c.Assert(err, IsNil)
-	c.Assert(observedID, Not(Equals), 0)
+	require.NoError(t, err)
+	require.NotEqual(t, 0, observedID)
 
 	labelsShort := "foo;/;"
 	shortKey := TestAllocatorKey(labelsShort)
 	observedID, err = allocator.GetNoCache(context.Background(), shortKey)
-	c.Assert(err, IsNil)
-	c.Assert(observedID, Equals, idpool.NoID)
+	require.NoError(t, err)
+	require.Equal(t, idpool.NoID, observedID)
 
 	shortID, new, newLocally, err := allocator.Allocate(context.Background(), shortKey)
-	c.Assert(err, IsNil)
-	c.Assert(shortID, Not(Equals), 0)
-	c.Assert(new, Equals, true)
-	c.Assert(newLocally, Equals, true)
+	require.NoError(t, err)
+	require.NotEqual(t, 0, shortID)
+	require.True(t, new)
+	require.True(t, newLocally)
 
 	observedID, err = allocator.GetNoCache(context.Background(), shortKey)
-	c.Assert(err, IsNil)
-	c.Assert(observedID, Equals, shortID)
+	require.NoError(t, err)
+	require.Equal(t, shortID, observedID)
 }
 
-func (s *AllocatorSuite) TestprefixMatchesKey(c *C) {
+func TestPrefixMatchesKey(t *testing.T) {
 	// cilium/state/identities/v1/value/label;foo;bar;/172.0.124.60
 
 	tests := []struct {
@@ -571,23 +591,29 @@ func (s *AllocatorSuite) TestprefixMatchesKey(c *C) {
 	}
 
 	for _, tt := range tests {
-		c.Logf("prefixMatchesKey(%q, %q) expected to be %t", tt.prefix, tt.key, tt.expected)
+		t.Logf("prefixMatchesKey(%q, %q) expected to be %t", tt.prefix, tt.key, tt.expected)
 		result := prefixMatchesKey(tt.prefix, tt.key)
-		c.Assert(result, Equals, tt.expected)
+		require.Equal(t, tt.expected, result)
 	}
 }
 
-func (s *AllocatorSuite) TestGetNoCache(c *C) {
-	testGetNoCache(c, idpool.ID(256), "a") // enable use of local cache
+func TestRemoteCache(t *testing.T) {
+	testutils.IntegrationTest(t)
+	for _, backendName := range []string{"etcd", "consul"} {
+		t.Run(backendName, func(t *testing.T) {
+			kvstore.SetupDummyWithConfigOpts(t, backendName, opts(backendName))
+			testRemoteCache(t)
+		})
+	}
 }
 
-func (s *AllocatorSuite) TestRemoteCache(c *C) {
+func testRemoteCache(t *testing.T) {
 	testName := randomTestName()
 	backend, err := NewKVStoreBackend(testName, "a", TestAllocatorKey(""), kvstore.Client())
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	a, err := allocator.NewAllocator(TestAllocatorKey(""), backend, allocator.WithMax(idpool.ID(256)))
-	c.Assert(err, IsNil)
-	c.Assert(a, Not(IsNil))
+	require.NoError(t, err)
+	require.NotNil(t, a)
 
 	// remove any keys which might be leftover
 	a.DeleteAllKeys()
@@ -601,17 +627,17 @@ func (s *AllocatorSuite) TestRemoteCache(c *C) {
 	for i := idpool.ID(1); i <= idpool.ID(4); i++ {
 		key := TestAllocatorKey(fmt.Sprintf("key%04d", i))
 		_, _, _, err := a.Allocate(context.Background(), key)
-		c.Assert(err, IsNil)
+		require.NoError(t, err)
 	}
 
 	// wait for main cache to be populated
-	c.Assert(testutils.WaitUntil(func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		cacheLen := 0
 		a.ForeachCache(func(id idpool.ID, val allocator.AllocatorKey) {
 			cacheLen++
 		})
-		return cacheLen == 4
-	}, 5*time.Second), IsNil)
+		assert.EqualValues(c, 4, cacheLen)
+	}, timeout, tick)
 
 	// count identical allocations returned
 	cache := map[idpool.ID]int{}
@@ -620,20 +646,20 @@ func (s *AllocatorSuite) TestRemoteCache(c *C) {
 	})
 
 	// ForeachCache must have returned 4 allocations all unique
-	c.Assert(len(cache), Equals, 4)
+	require.Len(t, cache, 4)
 	for i := range cache {
-		c.Assert(cache[i], Equals, 1)
+		require.Equal(t, 1, cache[i])
 	}
 
 	// watch the prefix in the same kvstore via a 2nd watcher
 	backend2, err := NewKVStoreBackend(testName, "a", TestAllocatorKey(""), kvstore.Client())
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	a2, err := allocator.NewAllocator(TestAllocatorKey(""), backend2, allocator.WithMax(idpool.ID(256)),
 		allocator.WithoutAutostart(), allocator.WithoutGC())
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	rc := a.NewRemoteCache("remote", a2)
-	c.Assert(rc, Not(IsNil))
+	require.NotNil(t, rc)
 
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
@@ -650,14 +676,14 @@ func (s *AllocatorSuite) TestRemoteCache(c *C) {
 	}()
 
 	// wait for remote cache to be populated
-	c.Assert(testutils.WaitUntil(func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		cacheLen := 0
 		a.ForeachCache(func(id idpool.ID, val allocator.AllocatorKey) {
 			cacheLen++
 		})
 		// 4 local + 4 remote
-		return cacheLen == 8
-	}, 5*time.Second), IsNil)
+		assert.EqualValues(c, 8, cacheLen)
+	}, timeout, tick)
 
 	// count the allocations in the main cache *AND* the remote cache
 	cache = map[idpool.ID]int{}
@@ -667,8 +693,17 @@ func (s *AllocatorSuite) TestRemoteCache(c *C) {
 
 	// Foreach must have returned 4 allocations each duplicated, once in
 	// the main cache, once in the remote cache
-	c.Assert(len(cache), Equals, 4)
+	require.Len(t, cache, 4)
 	for i := range cache {
-		c.Assert(cache[i], Equals, 2)
+		require.Equal(t, 2, cache[i])
 	}
+}
+
+func opts(backendName string) map[string]string {
+	if backendName == "etcd" {
+		// Explicitly set higher QPS than the default to speedup the test
+		return map[string]string{kvstore.EtcdRateLimitOption: "100"}
+	}
+
+	return nil
 }

--- a/pkg/kvstore/consul_test.go
+++ b/pkg/kvstore/consul_test.go
@@ -11,25 +11,10 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/cilium/checkmate"
 	consulAPI "github.com/hashicorp/consul/api"
 
 	"github.com/cilium/cilium/pkg/testutils"
 )
-
-type ConsulSuite struct {
-	BaseTests
-}
-
-var _ = Suite(&ConsulSuite{})
-
-func (e *ConsulSuite) SetUpSuite(c *C) {
-	testutils.IntegrationTest(c)
-}
-
-func (e *ConsulSuite) SetUpTest(c *C) {
-	SetupDummy(c, "consul")
-}
 
 var handler http.HandlerFunc
 
@@ -69,7 +54,7 @@ func TestConsulClientOk(t *testing.T) {
 	maxRetries = 3
 	doneC := make(chan struct{})
 
-	handler = func(w http.ResponseWriter, r *http.Request) {
+	handler = func(w http.ResponseWriter, _ *http.Request) {
 		io.WriteString(w, "\"nanananananananananleaaderrrr\"")
 		close(doneC)
 	}

--- a/pkg/kvstore/kvstore_test.go
+++ b/pkg/kvstore/kvstore_test.go
@@ -6,31 +6,20 @@ package kvstore
 import (
 	"testing"
 
-	. "github.com/cilium/checkmate"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-func Test(t *testing.T) {
-	TestingT(t)
-}
+func TestGetLockPath(t *testing.T) {
+	testutils.IntegrationTest(t)
 
-// independentSuite tests are tests which can run without creating a backend
-type independentSuite struct{}
-
-var _ = Suite(&independentSuite{})
-
-func (s *independentSuite) SetUpSuite(c *C) {
-	testutils.IntegrationTest(c)
-}
-
-func (s *independentSuite) TestGetLockPath(c *C) {
 	const path = "foo/path"
-	c.Assert(getLockPath(path), Equals, path+".lock")
+	require.Equal(t, path+".lock", getLockPath(path))
 }
 
-func (s *independentSuite) TestValidateScopesFromKey(c *C) {
+func TestValidateScopesFromKey(t *testing.T) {
 	mockData := map[string]string{
 		"cilium/state/identities/v1/id": "identities/v1",
 		"cilium/state/identities/v1/value/Y29udGFpbmVyOmlkPWFwcDE7Y29udGFpbmVyOmlkLnNlcnZpY2UxPTs=": "identities/v1",
@@ -41,7 +30,7 @@ func (s *independentSuite) TestValidateScopesFromKey(c *C) {
 	}
 
 	for key, val := range mockData {
-		c.Assert(GetScopeFromKey(key), Equals, val)
+		require.Equal(t, val, GetScopeFromKey(key))
 	}
 }
 

--- a/pkg/kvstore/lock_test.go
+++ b/pkg/kvstore/lock_test.go
@@ -5,12 +5,13 @@ package kvstore
 
 import (
 	"context"
+	"testing"
 	"time"
 
-	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/require"
 )
 
-func (s *independentSuite) TestLocalLock(c *C) {
+func TestLocalLock(t *testing.T) {
 	prefix := "locktest/"
 	path := prefix + "foo"
 
@@ -22,7 +23,7 @@ func (s *independentSuite) TestLocalLock(c *C) {
 
 	// Acquie lock1
 	id1, err := locks.lock(context.Background(), path)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Ensure that staleLockTimeout has passed
 	time.Sleep(staleLockTimeout * 2)
@@ -30,29 +31,29 @@ func (s *independentSuite) TestLocalLock(c *C) {
 
 	// Acquire lock on same path, must unlock local use
 	id2, err := locks.lock(context.Background(), path)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Unlock lock1, this should be a no-op
 	locks.unlock(path, id1)
 
 	owner, ok := locks.lockPaths[path]
-	c.Assert(ok, Equals, true)
-	c.Assert(owner.id, Equals, id2)
+	require.Equal(t, true, ok)
+	require.Equal(t, id2, owner.id)
 
 	// Unlock lock2, this should be a no-op
 	locks.unlock(path, id2)
 }
 
-func (s *independentSuite) TestLocalLockCancel(c *C) {
+func TestLocalLockCancel(t *testing.T) {
 	path := "locktest/foo"
 	locks := pathLocks{lockPaths: map[string]lockOwner{}}
 	// grab lock to ensure that 2nd lock attempt needs to retry and can be
 	// cancelled
 	id1, err := locks.lock(context.Background(), path)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	defer locks.unlock(path, id1)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	_, err = locks.lock(ctx, path)
-	c.Assert(err, Not(IsNil))
+	require.NotNil(t, err)
 }


### PR DESCRIPTION
Please refer to individual commits for more details, this PR is focusing on files owned by cilium/kvstore team.

Relates: https://github.com/cilium/cilium/issues/28596