### PR TITLE
pkg/endpoint: Replace gocheck with built-in go test

### DIFF
--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
@@ -18,12 +18,12 @@ import (
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
 
-func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
-	e := NewTestEndpointWithState(c, s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
+func (s *EndpointSuite) TestWriteInformationalComments(t *testing.T) {
+	e := NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
 
 	var f bytes.Buffer
 	err := e.writeInformationalComments(&f)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 }
 
 type writeFunc func(io.Writer) error
@@ -31,7 +31,9 @@ type writeFunc func(io.Writer) error
 func BenchmarkWriteHeaderfile(b *testing.B) {
 	testutils.IntegrationTest(b)
 
-	e := NewTestEndpointWithState(b, &suite, &suite, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
+	s := setupEndpointSuite(b)
+
+	e := NewTestEndpointWithState(b, s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
 	dp := linux.NewDatapath(linux.DatapathParams{
 		RuleManager:    nil,
 		NodeAddressing: nil,

--- a/pkg/endpoint/directory_test.go
+++ b/pkg/endpoint/directory_test.go
@@ -10,36 +10,34 @@ import (
 	"path/filepath"
 	"testing"
 
-	check "github.com/cilium/checkmate"
-
-	"github.com/cilium/cilium/pkg/checker"
+	"github.com/stretchr/testify/require"
 )
 
-func (s *EndpointSuite) TestMoveNewFilesTo(c *check.C) {
-	oldDir := c.MkDir()
-	newDir := c.MkDir()
+func (s *EndpointSuite) TestMoveNewFilesTo(t *testing.T) {
+	oldDir := t.TempDir()
+	newDir := t.TempDir()
 	f1, err := os.CreateTemp(oldDir, "")
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	f2, err := os.CreateTemp(oldDir, "")
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	f3, err := os.CreateTemp(newDir, "")
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	// Copy the same file in both directories to make sure the same files
 	// are not moved from the old directory into the new directory.
 	err = os.WriteFile(filepath.Join(oldDir, "foo"), []byte(""), os.FileMode(0644))
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	err = os.WriteFile(filepath.Join(newDir, "foo"), []byte(""), os.FileMode(0644))
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	compareDir := func(dir string, wantedFiles []string) {
 		files, err := os.ReadDir(dir)
-		c.Assert(err, check.IsNil)
+		require.Nil(t, err)
 		filesNames := make([]string, 0, len(wantedFiles))
 		for _, file := range files {
 			filesNames = append(filesNames, file.Name())
 		}
-		c.Assert(wantedFiles, checker.DeepEquals, filesNames)
+		require.EqualValues(t, filesNames, wantedFiles)
 	}
 
 	type args struct {
@@ -73,7 +71,7 @@ func (s *EndpointSuite) TestMoveNewFilesTo(c *check.C) {
 	}
 	for _, tt := range tests {
 		if err := moveNewFilesTo(tt.args.oldDir, tt.args.newDir); (err != nil) != tt.wantErr {
-			c.Assert(err != nil, check.Equals, tt.wantErr)
+			require.Equal(t, tt.wantErr, err != nil)
 			compareDir(tt.args.oldDir, tt.wantOldDir)
 			compareDir(tt.args.newDir, tt.wantNewDir)
 		}

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -5,8 +5,8 @@ package endpoint
 
 import (
 	"context"
+	"testing"
 
-	. "github.com/cilium/checkmate"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -14,7 +14,7 @@ import (
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
 
-func (s *EndpointSuite) TestGetCiliumEndpointStatus(c *C) {
+func (s *EndpointSuite) TestGetCiliumEndpointStatus(t *testing.T) {
 	e, err := NewEndpointFromChangeModel(context.TODO(), s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, s.mgr, &models.EndpointChangeRequest{
 		Addressing: &models.AddressPair{
 			IPV4: "192.168.1.100",
@@ -33,14 +33,14 @@ func (s *EndpointSuite) TestGetCiliumEndpointStatus(c *C) {
 		},
 		State: models.EndpointStateWaitingDashForDashIdentity.Pointer(),
 	})
-	require.Nil(c, err)
+	require.Nil(t, err)
 
 	status := e.GetCiliumEndpointStatus()
 
-	require.Equal(c, int64(200), status.ID)
-	require.Equal(c, string(models.EndpointStateWaitingDashForDashIdentity), status.State)
-	require.Nil(c, status.Log)
-	require.Equal(c, &models.EndpointIdentifiers{
+	require.Equal(t, int64(200), status.ID)
+	require.Equal(t, string(models.EndpointStateWaitingDashForDashIdentity), status.State)
+	require.Nil(t, status.Log)
+	require.Equal(t, &models.EndpointIdentifiers{
 		ContainerID:     "ContainerID",
 		CniAttachmentID: "ContainerID",
 		ContainerName:   "ContainerName",
@@ -48,8 +48,8 @@ func (s *EndpointSuite) TestGetCiliumEndpointStatus(c *C) {
 		K8sPodName:      "PodName",
 		PodName:         "Namespace/PodName",
 	}, status.ExternalIdentifiers)
-	require.Nil(c, status.Identity)
-	require.Equal(c, &v2.EndpointNetworking{Addressing: []*v2.AddressPair{{IPV4: "192.168.1.100", IPV6: "f00d::a10:0:0:abcd"}}, NodeIP: "<nil>"}, status.Networking)
-	require.Equal(c, v2.EncryptionSpec{Key: 0}, status.Encryption)
-	require.Equal(c, models.NamedPorts{}, status.NamedPorts)
+	require.Nil(t, status.Identity)
+	require.Equal(t, &v2.EndpointNetworking{Addressing: []*v2.AddressPair{{IPV4: "192.168.1.100", IPV6: "f00d::a10:0:0:abcd"}}, NodeIP: "<nil>"}, status.Networking)
+	require.Equal(t, v2.EncryptionSpec{Key: 0}, status.Encryption)
+	require.Equal(t, models.NamedPorts{}, status.NamedPorts)
 }

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -5,8 +5,9 @@ package endpoint
 
 import (
 	"context"
+	"testing"
 
-	check "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/completion"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -36,12 +37,50 @@ type RedirectSuite struct {
 	rsp             *RedirectSuiteProxy
 }
 
-// suite can be used by testing.T benchmarks or tests as a mock regeneration.Owner
-var redirectSuite = RedirectSuite{}
-var _ = check.Suite(&redirectSuite)
+func setupRedirectSuite(tb testing.TB) *RedirectSuite {
+	testutils.IntegrationTest(tb)
 
-func (s *RedirectSuite) SetUpSuite(c *check.C) {
-	testutils.IntegrationTest(c)
+	s := &RedirectSuite{}
+	s.oldPolicyEnable = policy.GetPolicyEnabled()
+	policy.SetPolicyEnabled(option.DefaultEnforcement)
+
+	// Setup dependencies for endpoint.
+	kvstore.SetupDummy(tb, "etcd")
+
+	idAllocatorOwner := &DummyIdentityAllocatorOwner{}
+
+	s.mgr = cache.NewCachingIdentityAllocator(idAllocatorOwner)
+	<-s.mgr.InitIdentityAllocator(nil)
+
+	identityCache := cache.IdentityCache{
+		identity.NumericIdentity(identityFoo): labelsFoo,
+		identity.NumericIdentity(identityBar): labelsBar,
+	}
+
+	s.do = &DummyOwner{
+		repo: policy.NewPolicyRepository(s.mgr, identityCache, nil, nil),
+	}
+	s.do.repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
+	identitymanager.Subscribe(s.do.repo)
+
+	s.rsp = &RedirectSuiteProxy{
+		parserProxyPortMap: map[string]uint16{
+			policy.ParserTypeHTTP.String():  httpPort,
+			policy.ParserTypeDNS.String():   dnsPort,
+			policy.ParserTypeKafka.String(): kafkaPort,
+			"crd/cec1/listener1":            crd1Port,
+			"crd/cec2/listener2":            crd2Port,
+		},
+		redirectPortUserMap: make(map[uint16][]string),
+	}
+
+	tb.Cleanup(func() {
+		identitymanager.RemoveAll()
+		s.mgr.Close()
+		policy.SetPolicyEnabled(s.oldPolicyEnable)
+	})
+
+	return s
 }
 
 // RedirectSuiteProxy implements EndpointProxy. It is used for testing the
@@ -142,47 +181,12 @@ const (
 	crd2Port  = uint16(19005)
 )
 
-func (s *RedirectSuite) SetUpTest(c *check.C) {
-	s.oldPolicyEnable = policy.GetPolicyEnabled()
-	policy.SetPolicyEnabled(option.DefaultEnforcement)
-
-	// Setup dependencies for endpoint.
-	kvstore.SetupDummy(c, "etcd")
-
-	idAllocatorOwner := &DummyIdentityAllocatorOwner{}
-
-	s.mgr = cache.NewCachingIdentityAllocator(idAllocatorOwner)
-	<-s.mgr.InitIdentityAllocator(nil)
-
-	identityCache := cache.IdentityCache{
-		identity.NumericIdentity(identityFoo): labelsFoo,
-		identity.NumericIdentity(identityBar): labelsBar,
-	}
-
-	s.do = &DummyOwner{
-		repo: policy.NewPolicyRepository(s.mgr, identityCache, nil, nil),
-	}
-	s.do.repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
-	identitymanager.Subscribe(s.do.repo)
-
-	s.rsp = &RedirectSuiteProxy{
-		parserProxyPortMap: map[string]uint16{
-			policy.ParserTypeHTTP.String():  httpPort,
-			policy.ParserTypeDNS.String():   dnsPort,
-			policy.ParserTypeKafka.String(): kafkaPort,
-			"crd/cec1/listener1":            crd1Port,
-			"crd/cec2/listener2":            crd2Port,
-		},
-		redirectPortUserMap: make(map[uint16][]string),
-	}
-}
-
-func (s *RedirectSuite) NewTestEndpoint(c *check.C) *Endpoint {
-	ep := NewTestEndpointWithState(c, s.do, s.do, testipcache.NewMockIPCache(), s.rsp, s.mgr, 12345, StateRegenerating)
+func (s *RedirectSuite) NewTestEndpoint(t *testing.T) *Endpoint {
+	ep := NewTestEndpointWithState(t, s.do, s.do, testipcache.NewMockIPCache(), s.rsp, s.mgr, 12345, StateRegenerating)
 	ep.SetPropertyValue(PropertyFakeEndpoint, false)
 
 	epIdentity, _, err := s.mgr.AllocateIdentity(context.Background(), labelsBar.Labels(), true, identity.NumericIdentity(identityBar))
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	ep.SetIdentity(epIdentity, true)
 
 	return ep
@@ -192,38 +196,38 @@ func (s *RedirectSuite) AddRules(rules api.Rules) {
 	s.do.repo.AddList(rules)
 }
 
-func (s *RedirectSuite) TearDownTest(c *check.C) {
+func (s *RedirectSuite) TearDownTest(t *testing.T) {
 	identitymanager.RemoveAll()
 	s.mgr.Close()
 	policy.SetPolicyEnabled(s.oldPolicyEnable)
 }
 
-func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
-	ep := s.NewTestEndpoint(c)
+func (s *RedirectSuite) TestAddVisibilityRedirects(t *testing.T) {
+	ep := s.NewTestEndpoint(t)
 
 	firstAnno := "<Ingress/80/TCP/HTTP>"
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return firstAnno, nil
 	})
 	res, err := ep.regeneratePolicy()
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	err = ep.setDesiredPolicy(res)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cmp := completion.NewWaitGroup(ctx)
 
 	_, err, _, _ = ep.addNewRedirects(cmp)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	v, ok := ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	})
-	c.Assert(ok, check.Equals, true)
-	c.Assert(v.ProxyPort, check.Equals, httpPort)
+	require.Equal(t, true, ok)
+	require.Equal(t, httpPort, v.ProxyPort)
 
 	secondAnno := "<Ingress/80/TCP/Kafka>"
 
@@ -231,21 +235,21 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 		return secondAnno, nil
 	})
 	res, err = ep.regeneratePolicy()
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	err = ep.setDesiredPolicy(res)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	d, err, _, _ := ep.addNewRedirects(cmp)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	})
-	c.Assert(ok, check.Equals, true)
+	require.Equal(t, true, ok)
 	// Check that proxyport was updated accordingly.
-	c.Assert(v.ProxyPort, check.Equals, kafkaPort)
+	require.Equal(t, kafkaPort, v.ProxyPort)
 
 	thirdAnno := "<Ingress/80/TCP/Kafka>,<Egress/80/TCP/HTTP>"
 
@@ -254,21 +258,21 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 		return thirdAnno, nil
 	})
 	res, err = ep.regeneratePolicy()
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	err = ep.setDesiredPolicy(res)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	realizedRedirects := ep.GetRealizedRedirects()
 	d2, err, _, _ := ep.addNewRedirects(cmp)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	})
-	c.Assert(ok, check.Equals, true)
-	c.Assert(v.ProxyPort, check.Equals, kafkaPort)
+	require.Equal(t, true, ok)
+	require.Equal(t, kafkaPort, v.ProxyPort)
 
 	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
@@ -276,8 +280,8 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	})
-	c.Assert(ok, check.Equals, true)
-	c.Assert(v.ProxyPort, check.Equals, kafkaPort)
+	require.Equal(t, true, ok)
+	require.Equal(t, kafkaPort, v.ProxyPort)
 
 	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
@@ -285,19 +289,19 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Egress.Uint8(),
 	})
-	c.Assert(ok, check.Equals, true)
-	c.Assert(v.ProxyPort, check.Equals, httpPort)
+	require.Equal(t, true, ok)
+	require.Equal(t, httpPort, v.ProxyPort)
 	pID := policy.ProxyID(ep.ID, false, u8proto.TCP.String(), uint16(80), "")
 	p, ok := d2[pID]
-	c.Assert(ok, check.Equals, true)
-	c.Assert(p, check.Equals, httpPort)
+	require.Equal(t, true, ok)
+	require.Equal(t, httpPort, p)
 
 	// Check that the egress redirect is removed when the redirects have been
 	// updated.
 	ep.removeOldRedirects(d, realizedRedirects, cmp)
 	// Egress redirect should not exist in desired redirects
 	_, ok = d[pID]
-	c.Assert(ok, check.Equals, false)
+	require.Equal(t, false, ok)
 
 	// Check that all redirects are removed when no visibility policy applies.
 	noAnno := ""
@@ -305,15 +309,15 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 		return noAnno, nil
 	})
 	res, err = ep.regeneratePolicy()
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	err = ep.setDesiredPolicy(res)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	realizedRedirects = ep.GetRealizedRedirects()
 	d, err, _, _ = ep.addNewRedirects(cmp)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	ep.removeOldRedirects(d, realizedRedirects, cmp)
-	c.Assert(len(d), check.Equals, 0)
+	require.Equal(t, 0, len(d))
 }
 
 var (
@@ -385,8 +389,9 @@ func combineL4L7(l4 []api.PortRule, l7 *api.L7Rules) []api.PortRule {
 	return result
 }
 
-func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
-	ep := s.NewTestEndpoint(c)
+func TestRedirectWithDeny(t *testing.T) {
+	s := setupRedirectSuite(t)
+	ep := s.NewTestEndpoint(t)
 
 	// Policy denies anything to "foo"
 	s.AddRules(api.Rules{
@@ -395,9 +400,9 @@ func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
 	})
 
 	res, err := ep.regeneratePolicy()
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	err = ep.setDesiredPolicy(res)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	expected := policy.NewMapState(map[policy.Key]policy.MapStateEntry{
 		mapKeyAllowAllE: {
@@ -409,8 +414,8 @@ func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
 		},
 	})
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
-		c.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(c.T, expected))
+		t.Fatal("desired policy map does not equal expected map:\n",
+			ep.desiredPolicy.GetPolicyMap().Diff(t, expected))
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -419,14 +424,14 @@ func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
 
 	realizedRedirects := ep.GetRealizedRedirects()
 	desiredRedirects, err, finalizeFunc, revertFunc := ep.addNewRedirects(cmp)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	finalizeFunc()
 
 	// Redirect is still created, even if all MapState entries may have been overridden by a
 	// deny entry.  A new FQDN redirect may have no MapState entries as the associated CIDR
 	// identities may match no numeric IDs yet, so we can not count the number of added MapState
 	// entries and make any conclusions from it.
-	c.Assert(len(desiredRedirects), check.Equals, 1)
+	require.Equal(t, 1, len(desiredRedirects))
 
 	expected2 := policy.NewMapState(map[policy.Key]policy.MapStateEntry{
 		mapKeyAllowAllE: {
@@ -450,26 +455,26 @@ func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
 	// Redirect for the HTTP port should have been added, but there should be a deny for Foo on
 	// that port, as it is shadowed by the deny rule
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected2) {
-		c.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(c.T, expected2))
+		t.Fatal("desired policy map does not equal expected map:\n",
+			ep.desiredPolicy.GetPolicyMap().Diff(t, expected2))
 	}
 
 	// Keep only desired redirects
 	ep.removeOldRedirects(desiredRedirects, realizedRedirects, cmp)
 
 	// Check that the redirect is still realized
-	c.Assert(len(desiredRedirects), check.Equals, 1)
-	c.Assert(ep.desiredPolicy.GetPolicyMap().Len(), check.Equals, 4)
+	require.Equal(t, 1, len(desiredRedirects))
+	require.Equal(t, 4, ep.desiredPolicy.GetPolicyMap().Len())
 
 	// Pretend that something failed and revert the changes
 	revertFunc()
 
 	// Check that the state before addRedirects is restored
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
-		c.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(c.T, expected))
+		t.Fatal("desired policy map does not equal expected map:\n",
+			ep.desiredPolicy.GetPolicyMap().Diff(t, expected))
 	}
-	c.Assert(ep.desiredPolicy.GetPolicyMap().Len(), check.Equals, 2)
+	require.Equal(t, 2, ep.desiredPolicy.GetPolicyMap().Len())
 }
 
 var (
@@ -544,8 +549,10 @@ var (
 		}})
 )
 
-func (s *RedirectSuite) TestRedirectWithPriority(c *check.C) {
-	ep := s.NewTestEndpoint(c)
+func TestRedirectWithPriority(t *testing.T) {
+	s := setupRedirectSuite(t)
+
+	ep := s.NewTestEndpoint(t)
 
 	s.AddRules(api.Rules{
 		ruleL4AllowListener1.WithEndpointSelector(selectBar_),
@@ -554,9 +561,9 @@ func (s *RedirectSuite) TestRedirectWithPriority(c *check.C) {
 	})
 
 	res, err := ep.regeneratePolicy()
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	err = ep.setDesiredPolicy(res)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	expected := policy.NewMapState(map[policy.Key]policy.MapStateEntry{
 		mapKeyAllowAllE: {
@@ -567,8 +574,8 @@ func (s *RedirectSuite) TestRedirectWithPriority(c *check.C) {
 		},
 	})
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
-		c.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(c.T, expected))
+		t.Fatal("desired policy map does not equal expected map:\n",
+			ep.desiredPolicy.GetPolicyMap().Diff(t, expected))
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -577,13 +584,13 @@ func (s *RedirectSuite) TestRedirectWithPriority(c *check.C) {
 
 	realizedRedirects := ep.GetRealizedRedirects()
 	desiredRedirects, err, finalizeFunc, revertFunc := ep.addNewRedirects(cmp)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	finalizeFunc()
 
 	// Check that all redirects have been created.
-	c.Assert(desiredRedirects["12345:ingress:TCP:80:/cec2/listener2"], check.Equals, crd2Port)
-	c.Assert(desiredRedirects["12345:ingress:TCP:80:/cec1/listener1"], check.Equals, crd1Port)
-	c.Assert(len(desiredRedirects), check.Equals, 2)
+	require.Equal(t, crd2Port, desiredRedirects["12345:ingress:TCP:80:/cec2/listener2"])
+	require.Equal(t, crd1Port, desiredRedirects["12345:ingress:TCP:80:/cec1/listener1"])
+	require.Equal(t, 2, len(desiredRedirects))
 
 	expected2 := policy.NewMapState(map[policy.Key]policy.MapStateEntry{
 		mapKeyAllowAllE: {
@@ -599,30 +606,32 @@ func (s *RedirectSuite) TestRedirectWithPriority(c *check.C) {
 		},
 	})
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected2) {
-		c.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(c.T, expected2))
+		t.Fatal("desired policy map does not equal expected map:\n",
+			ep.desiredPolicy.GetPolicyMap().Diff(t, expected2))
 	}
 
 	// Keep only desired redirects
 	ep.removeOldRedirects(desiredRedirects, realizedRedirects, cmp)
 
 	// Check that the redirect is still realized
-	c.Assert(len(desiredRedirects), check.Equals, 2)
-	c.Assert(ep.desiredPolicy.GetPolicyMap().Len(), check.Equals, 3)
+	require.Equal(t, 2, len(desiredRedirects))
+	require.Equal(t, 3, ep.desiredPolicy.GetPolicyMap().Len())
 
 	// Pretend that something failed and revert the changes
 	revertFunc()
 
 	// Check that the state before addRedirects is restored
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
-		c.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(c.T, expected))
+		t.Fatal("desired policy map does not equal expected map:\n",
+			ep.desiredPolicy.GetPolicyMap().Diff(t, expected))
 	}
-	c.Assert(ep.desiredPolicy.GetPolicyMap().Len(), check.Equals, 2)
+	require.Equal(t, 2, ep.desiredPolicy.GetPolicyMap().Len())
 }
 
-func (s *RedirectSuite) TestRedirectWithEqualPriority(c *check.C) {
-	ep := s.NewTestEndpoint(c)
+func TestRedirectWithEqualPriority(t *testing.T) {
+	s := setupRedirectSuite(t)
+
+	ep := s.NewTestEndpoint(t)
 
 	s.AddRules(api.Rules{
 		ruleL4L7AllowListener1Priority1.WithEndpointSelector(selectBar_),
@@ -631,9 +640,9 @@ func (s *RedirectSuite) TestRedirectWithEqualPriority(c *check.C) {
 	})
 
 	res, err := ep.regeneratePolicy()
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	err = ep.setDesiredPolicy(res)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	expected := policy.NewMapState(map[policy.Key]policy.MapStateEntry{
 		mapKeyAllowAllE: {
@@ -644,8 +653,8 @@ func (s *RedirectSuite) TestRedirectWithEqualPriority(c *check.C) {
 		},
 	})
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
-		c.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(c.T, expected))
+		t.Fatal("desired policy map does not equal expected map:\n",
+			ep.desiredPolicy.GetPolicyMap().Diff(t, expected))
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -654,13 +663,13 @@ func (s *RedirectSuite) TestRedirectWithEqualPriority(c *check.C) {
 
 	realizedRedirects := ep.GetRealizedRedirects()
 	desiredRedirects, err, finalizeFunc, revertFunc := ep.addNewRedirects(cmp)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	finalizeFunc()
 
 	// Check that all redirects have been created.
-	c.Assert(desiredRedirects["12345:ingress:TCP:80:/cec2/listener2"], check.Equals, crd2Port)
-	c.Assert(desiredRedirects["12345:ingress:TCP:80:/cec1/listener1"], check.Equals, crd1Port)
-	c.Assert(len(desiredRedirects), check.Equals, 2)
+	require.Equal(t, crd2Port, desiredRedirects["12345:ingress:TCP:80:/cec2/listener2"])
+	require.Equal(t, crd1Port, desiredRedirects["12345:ingress:TCP:80:/cec1/listener1"])
+	require.Equal(t, 2, len(desiredRedirects))
 
 	expected2 := policy.NewMapState(map[policy.Key]policy.MapStateEntry{
 		mapKeyAllowAllE: {
@@ -676,24 +685,24 @@ func (s *RedirectSuite) TestRedirectWithEqualPriority(c *check.C) {
 		},
 	})
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected2) {
-		c.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(c.T, expected2))
+		t.Fatal("desired policy map does not equal expected map:\n",
+			ep.desiredPolicy.GetPolicyMap().Diff(t, expected2))
 	}
 
 	// Keep only desired redirects
 	ep.removeOldRedirects(desiredRedirects, realizedRedirects, cmp)
 
 	// Check that the redirect is still realized
-	c.Assert(len(desiredRedirects), check.Equals, 2)
-	c.Assert(ep.desiredPolicy.GetPolicyMap().Len(), check.Equals, 3)
+	require.Equal(t, 2, len(desiredRedirects))
+	require.Equal(t, 3, ep.desiredPolicy.GetPolicyMap().Len())
 
 	// Pretend that something failed and revert the changes
 	revertFunc()
 
 	// Check that the state before addRedirects is restored
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
-		c.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(c.T, expected))
+		t.Fatal("desired policy map does not equal expected map:\n",
+			ep.desiredPolicy.GetPolicyMap().Diff(t, expected))
 	}
-	c.Assert(ep.desiredPolicy.GetPolicyMap().Len(), check.Equals, 2)
+	require.Equal(t, 2, ep.desiredPolicy.GetPolicyMap().Len())
 }


### PR DESCRIPTION
Please refer to individual commits for more details, this PR is focusing on files owned by cilium/endpoint team.

Relates: https://github.com/cilium/cilium/issues/28596