### PR TITLE
clustermesh: add initial support for MCS-API

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -36,6 +36,7 @@ cilium-operator-alibabacloud [flags]
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --cnp-status-cleanup-burst int                         Maximum burst of requests to clean up status nodes updates in CNPs (default 20)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -25,6 +25,7 @@ cilium-operator-alibabacloud hive [flags]
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -31,6 +31,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -39,6 +39,7 @@ cilium-operator-aws [flags]
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --cnp-status-cleanup-burst int                         Maximum burst of requests to clean up status nodes updates in CNPs (default 20)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -25,6 +25,7 @@ cilium-operator-aws hive [flags]
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -31,6 +31,7 @@ cilium-operator-aws hive dot-graph [flags]
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -39,6 +39,7 @@ cilium-operator-azure [flags]
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --cnp-status-cleanup-burst int                         Maximum burst of requests to clean up status nodes updates in CNPs (default 20)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -25,6 +25,7 @@ cilium-operator-azure hive [flags]
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -31,6 +31,7 @@ cilium-operator-azure hive dot-graph [flags]
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -35,6 +35,7 @@ cilium-operator-generic [flags]
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --cnp-status-cleanup-burst int                         Maximum burst of requests to clean up status nodes updates in CNPs (default 20)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -25,6 +25,7 @@ cilium-operator-generic hive [flags]
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -31,6 +31,7 @@ cilium-operator-generic hive dot-graph [flags]
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -44,6 +44,7 @@ cilium-operator [flags]
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --cnp-status-cleanup-burst int                         Maximum burst of requests to clean up status nodes updates in CNPs (default 20)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -25,6 +25,7 @@ cilium-operator hive [flags]
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -31,6 +31,7 @@ cilium-operator hive dot-graph [flags]
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -784,6 +784,10 @@
      - Enable the synchronization of Kubernetes EndpointSlices corresponding to the remote endpoints of appropriately-annotated global services through ClusterMesh
      - bool
      - ``false``
+   * - :spelling:ignore:`clustermesh.enableMCSAPISupport`
+     - Enable Multi-Cluster Services API support
+     - bool
+     - ``false``
    * - :spelling:ignore:`clustermesh.maxConnectedClusters`
      - The maximum number of clusters to support in a ClusterMesh. This value cannot be changed on running clusters, and all clusters in a ClusterMesh must be configured with the same value. Values > 255 will decrease the maximum allocatable cluster-local identities. Supported values are 255 and 511.
      - int

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -246,6 +246,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.config.domain | string | `"mesh.cilium.io"` | Default dns domain for the Clustermesh API servers This is used in the case cluster addresses are not provided and IPs are used. |
 | clustermesh.config.enabled | bool | `false` | Enable the Clustermesh explicit configuration. |
 | clustermesh.enableEndpointSliceSynchronization | bool | `false` | Enable the synchronization of Kubernetes EndpointSlices corresponding to the remote endpoints of appropriately-annotated global services through ClusterMesh |
+| clustermesh.enableMCSAPISupport | bool | `false` | Enable Multi-Cluster Services API support |
 | clustermesh.maxConnectedClusters | int | `255` | The maximum number of clusters to support in a ClusterMesh. This value cannot be changed on running clusters, and all clusters in a ClusterMesh must be configured with the same value. Values > 255 will decrease the maximum allocatable cluster-local identities. Supported values are 255 and 511. |
 | clustermesh.useAPIServer | bool | `false` | Deploy clustermesh-apiserver for clustermesh |
 | cni.binPath | string | `"/opt/cni/bin"` | Configure the path to the CNI binary directory on the host. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1275,6 +1275,7 @@ data:
   max-connected-clusters: {{ .Values.clustermesh.maxConnectedClusters | quote }}
 {{- end }}
   clustermesh-enable-endpoint-sync: {{ .Values.clustermesh.enableEndpointSliceSynchronization | quote }}
+  clustermesh-enable-mcs-api: {{ .Values.clustermesh.enableMCSAPISupport | quote }}
 
 # Extra config allows adding arbitrary properties to the cilium config.
 # By putting it at the end of the ConfigMap, it's also possible to override existing properties.

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -306,6 +306,8 @@ rules:
   verbs:
   - update
   - patch
+{{- end }}
+{{- if or .Values.gatewayAPI.enabled .Values.clustermesh.enableMCSAPISupport }}
 - apiGroups:
   - multicluster.x-k8s.io
   resources:
@@ -314,5 +316,30 @@ rules:
   - get
   - list
   - watch
+{{- if .Values.clustermesh.enableMCSAPISupport }}
+  - create
+  - update
+  - patch
+  - delete
+{{- end }}
+{{- end }}
+{{- if .Values.clustermesh.enableMCSAPISupport }}
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceexports
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
 {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1274,6 +1274,9 @@
         "enableEndpointSliceSynchronization": {
           "type": "boolean"
         },
+        "enableMCSAPISupport": {
+          "type": "boolean"
+        },
         "maxConnectedClusters": {
           "type": "integer"
         },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2890,6 +2890,8 @@ clustermesh:
   # -- Enable the synchronization of Kubernetes EndpointSlices corresponding to
   # the remote endpoints of appropriately-annotated global services through ClusterMesh
   enableEndpointSliceSynchronization: false
+  # -- Enable Multi-Cluster Services API support
+  enableMCSAPISupport: false
   # -- Annotations to be added to all top-level clustermesh objects (resources under templates/clustermesh-apiserver and templates/clustermesh-config)
   annotations: {}
   # -- Clustermesh explicit configuration.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2895,6 +2895,8 @@ clustermesh:
   # -- Enable the synchronization of Kubernetes EndpointSlices corresponding to
   # the remote endpoints of appropriately-annotated global services through ClusterMesh
   enableEndpointSliceSynchronization: false
+  # -- Enable Multi-Cluster Services API support
+  enableMCSAPISupport: false
 
   # -- Annotations to be added to all top-level clustermesh objects (resources under templates/clustermesh-apiserver and templates/clustermesh-config)
   annotations: {}

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/secretsync"
 	operatorWatchers "github.com/cilium/cilium/operator/watchers"
 	"github.com/cilium/cilium/pkg/clustermesh/endpointslicesync"
+	"github.com/cilium/cilium/pkg/clustermesh/mcsapi"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -185,6 +186,7 @@ var (
 			auth.Cell,
 			store.Cell,
 			endpointslicesync.Cell,
+			mcsapi.Cell,
 			legacyCell,
 
 			// When running in kvstore mode, the start hook of the identity GC

--- a/pkg/clustermesh/mcsapi/cell.go
+++ b/pkg/clustermesh/mcsapi/cell.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mcsapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cilium/hive/cell"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrlRuntime "sigs.k8s.io/controller-runtime"
+	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+	mcsapicontrollers "sigs.k8s.io/mcs-api/pkg/controllers"
+
+	"github.com/cilium/cilium/pkg/clustermesh/common"
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+)
+
+var Cell = cell.Module(
+	"mcsapi",
+	"Multi-Cluster Services API",
+	cell.Config(MCSAPIConfig{}),
+	cell.Invoke(initMCSAPIController),
+)
+
+type mcsAPIParams struct {
+	cell.In
+
+	common.Config
+	Cfg MCSAPIConfig
+
+	// ClusterInfo is the id/name of the local cluster.
+	ClusterInfo types.ClusterInfo
+
+	Clientset          k8sClient.Clientset
+	CtrlRuntimeManager ctrlRuntime.Manager
+	Scheme             *runtime.Scheme
+
+	Logger logrus.FieldLogger
+}
+
+type MCSAPIConfig struct {
+	// ClusterMeshEnableEndpointSync enables the MCS API support
+	ClusterMeshEnableMCSAPI bool `mapstructure:"clustermesh-enable-mcs-api"`
+}
+
+// Flags adds the flags used by ClientConfig.
+func (cfg MCSAPIConfig) Flags(flags *pflag.FlagSet) {
+	flags.BoolVar(&cfg.ClusterMeshEnableMCSAPI,
+		"clustermesh-enable-mcs-api",
+		false,
+		"Whether or not the MCS API support is enabled.",
+	)
+}
+
+var requiredGVK = []schema.GroupVersionKind{
+	mcsapiv1alpha1.SchemeGroupVersion.WithKind("serviceimports"),
+	mcsapiv1alpha1.SchemeGroupVersion.WithKind("serviceexports"),
+}
+
+func checkCRD(ctx context.Context, clientset k8sClient.Clientset, gvk schema.GroupVersionKind) error {
+	if !clientset.IsEnabled() {
+		return nil
+	}
+
+	crd, err := clientset.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, gvk.GroupKind().String(), metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	found := false
+	for _, v := range crd.Spec.Versions {
+		if v.Name == gvk.Version {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("CRD %q does not have version %q", gvk.GroupKind().String(), gvk.Version)
+	}
+
+	return nil
+}
+
+func checkRequiredCRDs(ctx context.Context, clientset k8sClient.Clientset) error {
+	var res error
+	for _, gvk := range requiredGVK {
+		if err := checkCRD(ctx, clientset, gvk); err != nil {
+			res = errors.Join(res, err)
+		}
+	}
+	return res
+}
+
+func initMCSAPIController(params mcsAPIParams) error {
+	if !params.Clientset.IsEnabled() || params.ClusterMeshConfig == "" || !params.Cfg.ClusterMeshEnableMCSAPI {
+		return nil
+	}
+
+	params.Logger.WithField("requiredGVK", requiredGVK).Info("Checking for required MCS-API resources")
+	if err := checkRequiredCRDs(context.Background(), params.Clientset); err != nil {
+		params.Logger.WithError(err).Error("Required MCS-API resources are not found, please refer to docs for installation instructions")
+		return err
+	}
+	if err := mcsapiv1alpha1.AddToScheme(params.Scheme); err != nil {
+		return err
+	}
+
+	if err := newMCSAPIServiceReconciler(params.CtrlRuntimeManager, params.Logger, params.ClusterInfo.Name).SetupWithManager(params.CtrlRuntimeManager); err != nil {
+		return fmt.Errorf("Failed to register MCSAPIServiceReconciler: %w", err)
+	}
+
+	svcImportReconciler := mcsapicontrollers.ServiceImportReconciler{
+		Client: params.CtrlRuntimeManager.GetClient(),
+		Log:    params.CtrlRuntimeManager.GetLogger(),
+	}
+	if err := svcImportReconciler.SetupWithManager(params.CtrlRuntimeManager); err != nil {
+		return fmt.Errorf("Failed to register svcImportReconciler: %w", err)
+	}
+
+	params.Logger.Info("Multi-Cluster Services API support enabled")
+	return nil
+}

--- a/pkg/clustermesh/mcsapi/service_controller.go
+++ b/pkg/clustermesh/mcsapi/service_controller.go
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mcsapi
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base32"
+	"maps"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	k8sApiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+	mcsapicontrollers "sigs.k8s.io/mcs-api/pkg/controllers"
+
+	controllerruntime "github.com/cilium/cilium/operator/pkg/controller-runtime"
+	"github.com/cilium/cilium/pkg/annotation"
+)
+
+const (
+	kindServiceImport = "ServiceImport"
+	kindServiceExport = "ServiceExport"
+)
+
+// mcsAPIServiceReconciler is a controller that creates a derived service from
+// a ServiceImport and ServiceExport objects. The derived Service is created
+// with the Cilium annotations to mark it as a global Service so that we can
+// take advantage of the existing clustermesh features for the MCS API Support.
+type mcsAPIServiceReconciler struct {
+	client.Client
+	Logger logrus.FieldLogger
+
+	clusterName string
+}
+
+func newMCSAPIServiceReconciler(mgr ctrl.Manager, logger logrus.FieldLogger, clusterName string) *mcsAPIServiceReconciler {
+	return &mcsAPIServiceReconciler{
+		Client:      mgr.GetClient(),
+		Logger:      logger,
+		clusterName: clusterName,
+	}
+}
+
+func getOwnerReferenceName(refs []metav1.OwnerReference, apiVersion string, kind string) string {
+	for _, ref := range refs {
+		if ref.APIVersion != apiVersion {
+			continue
+		}
+		if ref.Kind == kind {
+			return ref.Name
+		}
+	}
+	return ""
+}
+
+func getMCSAPIOwner(refs []metav1.OwnerReference) string {
+	if ref := getOwnerReferenceName(refs, mcsapiv1alpha1.GroupVersion.String(), kindServiceImport); ref != "" {
+		return ref
+	}
+	if ref := getOwnerReferenceName(refs, mcsapiv1alpha1.GroupVersion.String(), kindServiceExport); ref != "" {
+		return ref
+	}
+	return ""
+}
+
+// derivedName derive the original name in the format "derived-$hash".
+// This function was taken from the mcs-api repo: https://github.com/kubernetes-sigs/mcs-api/blob/4231f56e5ff985676b8ac99034b05609cf4a9e0d/pkg/controllers/common.go#L39
+func derivedName(name types.NamespacedName) string {
+	hash := sha256.New()
+	hash.Write([]byte(name.String()))
+	return "derived-" + strings.ToLower(base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString(hash.Sum(nil)))[:10]
+}
+
+func servicePorts(svcImport *mcsapiv1alpha1.ServiceImport) []corev1.ServicePort {
+	ports := make([]corev1.ServicePort, 0, len(svcImport.Spec.Ports))
+	for _, port := range svcImport.Spec.Ports {
+		ports = append(ports, corev1.ServicePort{
+			Name:        port.Name,
+			Protocol:    port.Protocol,
+			AppProtocol: port.AppProtocol,
+			Port:        port.Port,
+		})
+	}
+	return ports
+}
+
+func addOwnerReference(svc *corev1.Service, objOwner client.Object) {
+	apiVersion := objOwner.GetObjectKind().GroupVersionKind().GroupVersion().String()
+	kind := objOwner.GetObjectKind().GroupVersionKind().Kind
+
+	svc.OwnerReferences = append(svc.OwnerReferences,
+		metav1.OwnerReference{
+			Name:       objOwner.GetName(),
+			Kind:       kind,
+			APIVersion: apiVersion,
+			UID:        objOwner.GetUID(),
+		})
+}
+
+func (r *mcsAPIServiceReconciler) addServiceImportDerivedAnnotation(ctx context.Context, svcImport *mcsapiv1alpha1.ServiceImport, derivedServiceName string) error {
+	if svcImport == nil {
+		return nil
+	}
+	if svcImport.Annotations == nil {
+		svcImport.Annotations = map[string]string{}
+	}
+	if svcImport.Annotations[mcsapicontrollers.DerivedServiceAnnotation] != derivedServiceName {
+		svcImport.Annotations[mcsapicontrollers.DerivedServiceAnnotation] = derivedServiceName
+		if err := r.Client.Update(ctx, svcImport); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// getDerivedService get the derived service if it exist or else a minimally constructed
+// service. If the base service has the wrong headlessness it will be auto deleted as well.
+func (r *mcsAPIServiceReconciler) getBaseDerivedService(
+	ctx context.Context,
+	req ctrl.Request,
+	derivedServiceName string,
+	svcImport *mcsapiv1alpha1.ServiceImport,
+) (*corev1.Service, bool, error) {
+	isHeadless := false
+	if svcImport != nil {
+		isHeadless = svcImport.Spec.Type == mcsapiv1alpha1.Headless
+	}
+
+	svcBase := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: req.Namespace,
+			Name:      derivedServiceName,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+	if isHeadless {
+		svcBase.Spec.ClusterIP = corev1.ClusterIPNone
+	}
+
+	var svc corev1.Service
+	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: derivedServiceName}, &svc); err != nil {
+		if !k8sApiErrors.IsNotFound(err) {
+			return nil, false, err
+		}
+		return svcBase, false, nil
+	}
+
+	if isHeadless != (svc.Spec.ClusterIP == corev1.ClusterIPNone) {
+		// We need to delete the derived service first if we need to switch
+		// to/from headless on a Service that already exists.
+		if err := r.Client.Delete(ctx, &svc); err != nil {
+			return nil, false, err
+		}
+		return svcBase, false, nil
+	}
+	return &svc, true, nil
+}
+
+func (r *mcsAPIServiceReconciler) getLocalService(ctx context.Context, req ctrl.Request) (*corev1.Service, error) {
+	var svc corev1.Service
+	if err := r.Client.Get(ctx, req.NamespacedName, &svc); err != nil {
+		return nil, err
+	}
+	return &svc, nil
+}
+
+func (r *mcsAPIServiceReconciler) getSvcExport(ctx context.Context, req ctrl.Request) (*mcsapiv1alpha1.ServiceExport, error) {
+	var svcExport mcsapiv1alpha1.ServiceExport
+	if err := r.Client.Get(ctx, req.NamespacedName, &svcExport); err != nil {
+		if k8sApiErrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &svcExport, nil
+}
+
+func (r *mcsAPIServiceReconciler) getSvcImport(ctx context.Context, req ctrl.Request) (*mcsapiv1alpha1.ServiceImport, error) {
+	var svcImport mcsapiv1alpha1.ServiceImport
+	if err := r.Client.Get(ctx, req.NamespacedName, &svcImport); err != nil {
+		if k8sApiErrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &svcImport, nil
+}
+
+func (r *mcsAPIServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	svcImport, err := r.getSvcImport(ctx, req)
+	if err != nil {
+		return controllerruntime.Fail(err)
+	}
+	svcExport, err := r.getSvcExport(ctx, req)
+	if err != nil {
+		return controllerruntime.Fail(err)
+	}
+
+	if svcExport == nil && svcImport == nil {
+		return controllerruntime.Success()
+	}
+
+	derivedServiceName := derivedName(req.NamespacedName)
+	svc, svcExists, err := r.getBaseDerivedService(ctx, req, derivedServiceName, svcImport)
+	if err != nil {
+		return controllerruntime.Fail(err)
+	}
+
+	svc.Spec.Ports = []corev1.ServicePort{}
+	svc.Spec.Selector = map[string]string{}
+	svc.OwnerReferences = []metav1.OwnerReference{}
+	svc.Annotations = map[string]string{}
+	svc.Labels = map[string]string{}
+
+	localSvc, err := r.getLocalService(ctx, req)
+	if err != nil && (!k8sApiErrors.IsNotFound(err) || svcExport != nil) {
+		return controllerruntime.Fail(err)
+	}
+
+	// Copy the local Service selector to let kube-controller-manager do
+	// the actual syncing of the endpoints.
+	// This has the drawback that this implementation doesn't
+	// support the endpoints created with the `kubernetes.io/service-name`
+	// label without any pod backing them (i.e.: endpoints created manually
+	// or by some third party tooling).
+	if localSvc != nil {
+		svc.Spec.Selector = localSvc.Spec.Selector
+		svc.Spec.Ports = localSvc.Spec.Ports
+	}
+
+	if svcImport != nil {
+		addOwnerReference(svc, svcImport)
+		svc.Spec.Ports = servicePorts(svcImport)
+		maps.Copy(svc.Annotations, svcImport.Annotations)
+		maps.Copy(svc.Labels, svcImport.Labels)
+	}
+
+	svc.Annotations[annotation.GlobalService] = "true"
+	svc.Annotations[annotation.SharedService] = "false"
+
+	svc.Labels[mcsapiv1alpha1.LabelServiceName] = req.NamespacedName.Name
+	// We set the source cluster label on the service as well so that the
+	// EndpointSlices created by kube-controller-manager will also mirror that label.
+	svc.Labels[mcsapiv1alpha1.LabelSourceCluster] = r.clusterName
+
+	if svcExport != nil {
+		addOwnerReference(svc, svcExport)
+		svc.Annotations[annotation.SharedService] = "true"
+	}
+
+	if !svcExists {
+		if err := r.Client.Create(ctx, svc); err != nil {
+			return controllerruntime.Fail(err)
+		}
+	} else {
+		if err := r.Client.Update(ctx, svc); err != nil {
+			return controllerruntime.Fail(err)
+		}
+	}
+
+	// Update the derived Service annotation on the ServiceImport object
+	// only after that the derived Service has been created for higher consistency.
+	return controllerruntime.Fail(r.addServiceImportDerivedAnnotation(ctx, svcImport, derivedServiceName))
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *mcsAPIServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		// Technically this controller owns the derived Services rather than the ServiceImports.
+		// However we operate on the ServiceImport (and ServiceExport) name rather than
+		// the derived service name so we say that we own ServiceImport here
+		// and always derive the name in the Reconcile function anyway.
+		For(&mcsapiv1alpha1.ServiceImport{}).
+		// Watch for changes to ServiceExport
+		Watches(&mcsapiv1alpha1.ServiceExport{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+			svcExport, ok := obj.(*mcsapiv1alpha1.ServiceExport)
+			if !ok {
+				return []ctrl.Request{}
+			}
+			name := types.NamespacedName{Name: svcExport.Name, Namespace: svcExport.Namespace}
+			return []ctrl.Request{{NamespacedName: name}}
+		})).
+		// Watch for changes to Services supported that have a MCS API object as owner reference
+		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+			svc, ok := obj.(*corev1.Service)
+			if !ok {
+				return []ctrl.Request{}
+			}
+			mcsAPIOwner := getMCSAPIOwner(svc.OwnerReferences)
+			if mcsAPIOwner == "" {
+				return []ctrl.Request{}
+			}
+			name := types.NamespacedName{Name: mcsAPIOwner, Namespace: svc.Namespace}
+			return []ctrl.Request{{NamespacedName: name}}
+		})).
+		Complete(r)
+}

--- a/pkg/clustermesh/mcsapi/service_controller_test.go
+++ b/pkg/clustermesh/mcsapi/service_controller_test.go
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mcsapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8sApiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+	mcsapicontrollers "sigs.k8s.io/mcs-api/pkg/controllers"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/logging"
+)
+
+var (
+	typeMetaSvcImport = metav1.TypeMeta{
+		Kind:       "ServiceImport",
+		APIVersion: mcsapiv1alpha1.GroupVersion.String(),
+	}
+	typeMetaSvcExport = metav1.TypeMeta{
+		Kind:       "ServiceExport",
+		APIVersion: mcsapiv1alpha1.GroupVersion.String(),
+	}
+
+	mcsFixtures = []client.Object{
+		&mcsapiv1alpha1.ServiceExport{
+			TypeMeta: typeMetaSvcExport,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full",
+				Namespace: "default",
+			},
+		},
+		&mcsapiv1alpha1.ServiceImport{
+			TypeMeta: typeMetaSvcImport,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full",
+				Namespace: "default",
+				Annotations: map[string]string{
+					annotation.SharedService: "not-used",
+					annotation.GlobalService: "not-used",
+					"test-annotation":        "copied",
+				},
+				Labels: map[string]string{
+					mcsapiv1alpha1.LabelSourceCluster: "not-used",
+					mcsapiv1alpha1.LabelServiceName:   "not-used",
+					"test-label":                      "copied",
+				},
+			},
+			Spec: mcsapiv1alpha1.ServiceImportSpec{
+				Ports: []mcsapiv1alpha1.ServicePort{{
+					Name: "my-port-1",
+				}},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full",
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"selector": "value",
+				},
+				Ports: []corev1.ServicePort{{
+					Name: "not-used",
+				}},
+			},
+		},
+
+		&mcsapiv1alpha1.ServiceExport{
+			TypeMeta: typeMetaSvcExport,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full-update",
+				Namespace: "default",
+			},
+		},
+		&mcsapiv1alpha1.ServiceImport{
+			TypeMeta: typeMetaSvcImport,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full-update",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"test-annotation": "copied",
+				},
+				Labels: map[string]string{
+					"test-label": "copied",
+				},
+			},
+			Spec: mcsapiv1alpha1.ServiceImportSpec{
+				Ports: []mcsapiv1alpha1.ServicePort{{
+					Name: "my-port-1",
+				}},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full-update",
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"selector": "value",
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      derivedName(types.NamespacedName{Name: "full-update", Namespace: "default"}),
+				Namespace: "default",
+			},
+		},
+
+		&mcsapiv1alpha1.ServiceImport{
+			TypeMeta: typeMetaSvcImport,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "import-only",
+				Namespace: "default",
+				Annotations: map[string]string{
+					annotation.SharedService: "not-used",
+					annotation.GlobalService: "not-used",
+				},
+				Labels: map[string]string{
+					mcsapiv1alpha1.LabelSourceCluster: "not-used",
+				},
+			},
+			Spec: mcsapiv1alpha1.ServiceImportSpec{
+				Ports: []mcsapiv1alpha1.ServicePort{{
+					Name: "my-port-2",
+				}},
+			},
+		},
+
+		&mcsapiv1alpha1.ServiceImport{
+			TypeMeta: typeMetaSvcImport,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "import-and-local",
+				Namespace: "default",
+			},
+			Spec: mcsapiv1alpha1.ServiceImportSpec{
+				Ports: []mcsapiv1alpha1.ServicePort{{
+					Name: "my-port-2",
+				}},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "import-and-local",
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"selector": "value",
+				},
+			},
+		},
+
+		&mcsapiv1alpha1.ServiceExport{
+			TypeMeta: typeMetaSvcExport,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "export-only",
+				Namespace: "default",
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "export-only",
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{
+					Name: "my-port-3",
+				}},
+			},
+		},
+
+		&mcsapiv1alpha1.ServiceExport{
+			TypeMeta: typeMetaSvcExport,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "export-no-svc",
+				Namespace: "default",
+			},
+		},
+
+		&mcsapiv1alpha1.ServiceImport{
+			TypeMeta: typeMetaSvcImport,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "switch-to-headless",
+				Namespace: "default",
+			},
+			Spec: mcsapiv1alpha1.ServiceImportSpec{
+				Type: mcsapiv1alpha1.Headless,
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      derivedName(types.NamespacedName{Name: "switch-to-headless", Namespace: "default"}),
+				Namespace: "default",
+			},
+		},
+	}
+)
+
+func testScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(mcsapiv1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+func Test_httpRouteReconciler_Reconcile(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithObjects(mcsFixtures...).
+		WithScheme(testScheme()).
+		Build()
+	r := &mcsAPIServiceReconciler{
+		Client:      c,
+		Logger:      logging.DefaultLogger,
+		clusterName: "cluster1",
+	}
+
+	t.Run("Test service creation/update with export and import", func(t *testing.T) {
+		for _, name := range []string{"full", "full-update"} {
+			key := types.NamespacedName{
+				Name:      name,
+				Namespace: "default",
+			}
+			result, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: key,
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+			keyDerived := types.NamespacedName{
+				Name:      derivedName(key),
+				Namespace: key.Namespace,
+			}
+			svc := &corev1.Service{}
+			err = c.Get(context.Background(), keyDerived, svc)
+			require.NoError(t, err)
+
+			require.Len(t, svc.OwnerReferences, 2)
+
+			require.Equal(t, "cluster1", svc.Labels[mcsapiv1alpha1.LabelSourceCluster])
+			require.Equal(t, key.Name, svc.Labels[mcsapiv1alpha1.LabelServiceName])
+			require.Equal(t, "copied", svc.Labels["test-label"])
+
+			require.Equal(t, "true", svc.Annotations[annotation.GlobalService])
+			require.Equal(t, "true", svc.Annotations[annotation.SharedService])
+			require.Equal(t, "copied", svc.Annotations["test-annotation"])
+
+			require.Len(t, svc.Spec.Ports, 1)
+			require.Equal(t, "my-port-1", svc.Spec.Ports[0].Name)
+
+			require.Equal(t, "value", svc.Spec.Selector["selector"])
+
+			svcImport := &mcsapiv1alpha1.ServiceImport{}
+			err = c.Get(context.Background(), key, svcImport)
+			require.NoError(t, err)
+			require.Equal(t, keyDerived.Name, svcImport.Annotations[mcsapicontrollers.DerivedServiceAnnotation])
+		}
+	})
+
+	t.Run("Test service creation with only import", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "import-only",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		keyDerived := types.NamespacedName{
+			Name:      derivedName(key),
+			Namespace: key.Namespace,
+		}
+		svc := &corev1.Service{}
+		err = c.Get(context.Background(), keyDerived, svc)
+		require.NoError(t, err)
+
+		require.Len(t, svc.OwnerReferences, 1)
+		require.Equal(t, "ServiceImport", svc.OwnerReferences[0].Kind)
+
+		require.Nil(t, svc.Spec.Selector)
+
+		require.Equal(t, "cluster1", svc.Labels[mcsapiv1alpha1.LabelSourceCluster])
+
+		require.Equal(t, "true", svc.Annotations[annotation.GlobalService])
+		require.Equal(t, "false", svc.Annotations[annotation.SharedService])
+
+		require.Len(t, svc.Spec.Ports, 1)
+		require.Equal(t, "my-port-2", svc.Spec.Ports[0].Name)
+	})
+
+	t.Run("Test service creation with import and local svc", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "import-and-local",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		keyDerived := types.NamespacedName{
+			Name:      derivedName(key),
+			Namespace: key.Namespace,
+		}
+		svc := &corev1.Service{}
+		err = c.Get(context.Background(), keyDerived, svc)
+		require.NoError(t, err)
+
+		require.Equal(t, "value", svc.Spec.Selector["selector"])
+	})
+
+	t.Run("Test service creation with only export", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "export-only",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		keyDerived := types.NamespacedName{
+			Name:      derivedName(key),
+			Namespace: key.Namespace,
+		}
+		svc := &corev1.Service{}
+		err = c.Get(context.Background(), keyDerived, svc)
+		require.NoError(t, err)
+
+		require.Len(t, svc.OwnerReferences, 1)
+		require.Equal(t, "ServiceExport", svc.OwnerReferences[0].Kind)
+
+		require.Equal(t, "true", svc.Annotations[annotation.GlobalService])
+		require.Equal(t, "true", svc.Annotations[annotation.SharedService])
+
+		require.Len(t, svc.Spec.Ports, 1)
+		require.Equal(t, "my-port-3", svc.Spec.Ports[0].Name)
+	})
+
+	t.Run("Test service creation with export but no exported service", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "export-no-svc",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.True(t, k8sApiErrors.IsNotFound(err), "Should return not found error")
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+	})
+
+	t.Run("Test service recreation to headless service", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "switch-to-headless",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		keyDerived := types.NamespacedName{
+			Name:      derivedName(key),
+			Namespace: key.Namespace,
+		}
+		svc := &corev1.Service{}
+		err = c.Get(context.Background(), keyDerived, svc)
+		require.NoError(t, err)
+
+		require.Equal(t, corev1.ClusterIPNone, svc.Spec.ClusterIP)
+	})
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

This adds initial support for MCS API (ServiceImport/Export) for Cilium clustermesh. It adds the controller to deals with ServiceImport/Export and create a derived services with the right Cilium clustermesh annotation so that the underlying service is correctly shared.

However this is not fully compliant with the MCS-API KEP as it does not handle automatic creation of ServiceImport yet. This is a first step that is not intended to be fully utilized by actual users yet.

Future work should include automatic creation of ServiceImport (that would be tied to the endpointslicesync package as the mcsapi support is running in the operator) and an associated documentation explaining how to get started with MCS API in Cilium when this would be in a more complete shape.

Related to #27902

```release-note
Add initial support for Multi-Cluster Services API in Cilium clustermesh
```
