### PR TITLE
docs: Clean-up Host Firewall documentation, list known issues

### DIFF
--- a/Documentation/gettingstarted/terminology.rst
+++ b/Documentation/gettingstarted/terminology.rst
@@ -281,6 +281,8 @@ of labels and then query the key-value store to derive the identity. Depending
 on whether the set of labels has been queried before, either a new identity
 will be created, or the identity of the initial query will be returned.
 
+.. _node:
+
 Node
 ====
 

--- a/Documentation/security/host-firewall.rst
+++ b/Documentation/security/host-firewall.rst
@@ -71,10 +71,11 @@ recommended for production deployment*.
 
     $ CILIUM_NAMESPACE=kube-system
     $ CILIUM_POD_NAME=$(kubectl -n $CILIUM_NAMESPACE get pods -l "k8s-app=cilium" -o jsonpath="{.items[?(@.spec.nodeName=='$NODE_NAME')].metadata.name}")
-    $ HOST_EP_ID=$(kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium-dbg endpoint list -o jsonpath='{[?(@.status.identity.id==1)].id}')
-    $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium-dbg endpoint config $HOST_EP_ID PolicyAuditMode=Enabled
+    $ alias kexec="kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME --"
+    $ HOST_EP_ID=$(kexec cilium-dbg endpoint list -o jsonpath='{[?(@.status.identity.id==1)].id}')
+    $ kexec cilium-dbg endpoint config $HOST_EP_ID PolicyAuditMode=Enabled
     Endpoint 3353 configuration updated successfully
-    $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium-dbg endpoint config $HOST_EP_ID | grep PolicyAuditMode
+    $ kexec cilium-dbg endpoint config $HOST_EP_ID | grep PolicyAuditMode
     PolicyAuditMode          Enabled
 
 
@@ -105,7 +106,7 @@ status of the policy using that command.
 
 .. code-block:: shell-session
 
-    $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium-dbg endpoint list
+    $ kexec cilium-dbg endpoint list
     ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                       IPv6                 IPv4           STATUS
                ENFORCEMENT        ENFORCEMENT
     266        Disabled           Disabled          104        k8s:io.cilium.k8s.policy.cluster=default          f00d::a0b:0:0:ef4e   10.16.172.63   ready
@@ -128,7 +129,7 @@ breakages.
 
 .. code-block:: shell-session
 
-    $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium-dbg monitor -t policy-verdict --related-to $HOST_EP_ID
+    $ kexec cilium-dbg monitor -t policy-verdict --related-to $HOST_EP_ID
     Policy verdict log: flow 0x0 local EP ID 1687, remote ID 6, proto 1, ingress, action allow, match L3-Only, 192.168.60.12 -> 192.168.60.11 EchoRequest
     Policy verdict log: flow 0x0 local EP ID 1687, remote ID 6, proto 6, ingress, action allow, match L3-Only, 192.168.60.12:37278 -> 192.168.60.11:2379 tcp SYN
     Policy verdict log: flow 0x0 local EP ID 1687, remote ID 2, proto 6, ingress, action audit, match none, 10.0.2.2:47500 -> 10.0.2.15:6443 tcp SYN
@@ -158,14 +159,14 @@ policy.
 
 .. code-block:: shell-session
 
-    $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium-dbg endpoint config $HOST_EP_ID PolicyAuditMode=Disabled
+    $ kexec cilium-dbg endpoint config $HOST_EP_ID PolicyAuditMode=Disabled
     Endpoint 3353 configuration updated successfully
 
 Ingress host policies should now appear as enforced:
 
 .. code-block:: shell-session
 
-    $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium-dbg endpoint list
+    $ kexec cilium-dbg endpoint list
     ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                       IPv6                 IPv4           STATUS
                ENFORCEMENT        ENFORCEMENT
     266        Disabled           Disabled          104        k8s:io.cilium.k8s.policy.cluster=default          f00d::a0b:0:0:ef4e   10.16.172.63   ready
@@ -181,7 +182,7 @@ Communications not explicitly allowed by the host policy will now be dropped:
 
 .. code-block:: shell-session
 
-    $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium-dbg monitor -t policy-verdict --related-to $HOST_EP_ID
+    $ kexec cilium-dbg monitor -t policy-verdict --related-to $HOST_EP_ID
     Policy verdict log: flow 0x0 local EP ID 1687, remote ID 2, proto 6, ingress, action deny, match none, 10.0.2.2:49038 -> 10.0.2.15:21 tcp SYN
 
 

--- a/Documentation/security/host-firewall.rst
+++ b/Documentation/security/host-firewall.rst
@@ -15,7 +15,7 @@ security policies for Kubernetes nodes.
 
 .. admonition:: Video
   :class: attention
-  
+
   You can also watch a video of Cilium's host firewall in action on
   `eCHO Episode 40: Cilium Host Firewall <https://www.youtube.com/watch?v=GLLLcz398K0&t=288s>`__.
 
@@ -33,8 +33,8 @@ Deploy Cilium release via Helm:
       --set hostFirewall.enabled=true          \\
       --set devices='{ethX,ethY}'
 
-The ``devices`` flag refers to the network devices Cilium is configured on such
-as ``eth0``. Omitting this option leads Cilium to auto-detect what interfaces
+The ``devices`` flag refers to the network devices Cilium is configured on,
+such as ``eth0``. If you omit this option, Cilium auto-detects what interfaces
 the host firewall applies to.
 
 At this point, the Cilium-managed nodes are ready to enforce network policies.
@@ -43,9 +43,9 @@ At this point, the Cilium-managed nodes are ready to enforce network policies.
 Attach a Label to the Node
 ==========================
 
-In this guide, we will apply host policies only to nodes with the label
-``node-access=ssh``. We thus first need to attach that label to a node in the
-cluster.
+In this guide, host policies only apply to nodes with the label
+``node-access=ssh``. Therefore, you first need to attach this label to a node
+in the cluster:
 
 .. code-block:: shell-session
 
@@ -62,10 +62,16 @@ Particular care must be taken to ensure that when host policies are imported,
 Cilium does not block access to the nodes or break the cluster's normal
 behavior (for example by blocking communication with ``kube-apiserver``).
 
-To avoid such issues, we can switch the host firewall in audit mode, to
-validate the impact of host policies before enforcing them. When Policy Audit
-Mode is enabled, no network policy is enforced so this setting is *not
-recommended for production deployment*.
+To avoid such issues, switch the host firewall in audit mode and validate the
+impact of host policies before enforcing them.
+
+.. warning::
+
+   When Policy Audit Mode is enabled, no network policy is enforced so this
+   setting is not recommended for production deployment.
+
+Enable and check status for the Policy Audit Mode on the host endpoint for a
+given node with the following commands:
 
 .. code-block:: shell-session
 
@@ -76,20 +82,22 @@ recommended for production deployment*.
     $ kexec cilium-dbg endpoint config $HOST_EP_ID PolicyAuditMode=Enabled
     Endpoint 3353 configuration updated successfully
     $ kexec cilium-dbg endpoint config $HOST_EP_ID | grep PolicyAuditMode
-    PolicyAuditMode          Enabled
+    PolicyAuditMode        : Enabled
 
 
 Apply a Host Network Policy
 ===========================
 
-`HostPolicies` match on node labels using a :ref:`NodeSelector` to identify the
-nodes to which the policy applies. The following policy applies to all nodes.
+:ref:`HostPolicies` match on node labels using a :ref:`NodeSelector` to
+identify the nodes to which the policies applies. They apply only to the host
+namespace, including host-networking pods. They don't apply to communications
+between pods or between pods and the outside of the cluster, except if those
+pods are host-networking pods.
+
+The following policy applies to all nodes with the ``node-access=ssh`` label.
 It allows communications from outside the cluster only for TCP/22 and for ICMP
 (ping) echo requests. All communications from the cluster to the hosts are
 allowed.
-
-Host policies don't apply to communications between pods or between pods and
-the outside of the cluster, except if those pods are host-networking pods.
 
 .. literalinclude:: ../../examples/policies/host/demo-host-policy.yaml
 
@@ -101,8 +109,8 @@ To apply this policy, run:
     ciliumclusterwidenetworkpolicy.cilium.io/demo-host-policy created
 
 The host is represented as a special endpoint, with label ``reserved:host``, in
-the output of command ``cilium-dbg endpoint list``. You can therefore inspect the
-status of the policy using that command.
+the output of command ``cilium-dbg endpoint list``. Use this command to inspect
+the status of host policies:
 
 .. code-block:: shell-session
 
@@ -117,15 +125,18 @@ status of the policy using that command.
                                                                reserved:host
     3362       Disabled           Disabled          4          reserved:health                                   f00d::a0b:0:0:49cf   10.16.87.66    ready
 
+In this example, one can observe that policy enforcement on the host endpoint
+is in audit mode for ingress traffic, and disabled for egress traffic.
+
 
 Adjust the Host Policy to Your Environment
 ==========================================
 
-As long as the host endpoint is running in audit mode, communications
-disallowed by the policy won't be dropped. They will however be reported by
-``cilium-dbg monitor`` as ``action audit``. The audit mode thus allows you to
-adjust the host policy to your environment, to avoid unexpected connection
-breakages.
+As long as the host endpoint runs in audit mode, communications disallowed by
+the policy are not dropped. Nevertheless, they are reported by ``cilium-dbg
+monitor``, as ``action audit``. With these reports, the audit mode allows you
+to adjust the host policy to your environment in order to avoid unexpected
+connection breakages.
 
 .. code-block:: shell-session
 
@@ -134,28 +145,28 @@ breakages.
     Policy verdict log: flow 0x0 local EP ID 1687, remote ID 6, proto 6, ingress, action allow, match L3-Only, 192.168.60.12:37278 -> 192.168.60.11:2379 tcp SYN
     Policy verdict log: flow 0x0 local EP ID 1687, remote ID 2, proto 6, ingress, action audit, match none, 10.0.2.2:47500 -> 10.0.2.15:6443 tcp SYN
 
-For details on how to derive the network policies from the output of ``cilium
-monitor``, please refer to `observe_policy_verdicts` and
-`create_network_policy` in the `policy_verdicts` guide.
+For details on deriving the network policies from the output of ``cilium
+monitor``, refer to `observe_policy_verdicts` and `create_network_policy` in
+the `policy_verdicts` guide.
 
-In particular, `Entities based` rules are convenient for example to allow
-communication to entire classes of destinations, such as all remotes nodes
-(``remote-node``) or the entire cluster (``cluster``).
+Note that `Entities based` rules are convenient when combined with host
+policies, for example to allow communication to entire classes of destinations,
+such as all remotes nodes (``remote-node``) or the entire cluster
+(``cluster``).
 
 .. warning::
 
     Make sure that none of the communications required to access the cluster or
-    for the cluster to work properly are denied. They should appear as ``action
-    allow``.
+    for the cluster to work properly are denied. Ensure they all appear as
+    ``action allow`` before disabling the audit mode.
 
-
+.. _disable_policy_audit_mode:
 
 Disable Policy Audit Mode
 =========================
 
-Once you are confident all required communication to the host from outside the
-cluster are allowed, you can disable policy audit mode to enforce the host
-policy.
+Once you are confident all required communications to the host from outside the
+cluster are allowed, disable the policy audit mode to enforce the host policy:
 
 .. code-block:: shell-session
 
@@ -178,7 +189,8 @@ Ingress host policies should now appear as enforced:
     3362       Disabled           Disabled          4          reserved:health                                   f00d::a0b:0:0:49cf   10.16.87.66    ready
 
 
-Communications not explicitly allowed by the host policy will now be dropped:
+Communications that are not explicitly allowed by the host policy are now
+dropped:
 
 .. code-block:: shell-session
 
@@ -186,7 +198,7 @@ Communications not explicitly allowed by the host policy will now be dropped:
     Policy verdict log: flow 0x0 local EP ID 1687, remote ID 2, proto 6, ingress, action deny, match none, 10.0.2.2:49038 -> 10.0.2.15:21 tcp SYN
 
 
-Clean Up
+Clean up
 ========
 
 .. code-block:: shell-session

--- a/Documentation/security/host-firewall.rst
+++ b/Documentation/security/host-firewall.rst
@@ -205,3 +205,13 @@ Clean up
 
    $ kubectl delete ccnp demo-host-policy
    $ kubectl label node $NODE_NAME node-access-
+
+Further Reading
+===============
+
+Read the documentation on :ref:`HostPolicies` for additional details on how to
+use the policies. In particular, refer to the :ref:`Troubleshooting Host
+Policies <troubleshooting_host_policies>` subsection to understand how to debug
+issues with Host Policies, or to the section on :ref:`Host Policies known
+issues <host_policies_known_issues>` to understand the current limitations of
+the feature.

--- a/Documentation/security/policy/intro.rst
+++ b/Documentation/security/policy/intro.rst
@@ -168,8 +168,8 @@ provided. If both ingress and egress are omitted, the rule has no effect.
 endpointSelector / nodeSelector
   Selects the endpoints or nodes which the policy rules apply to. The policy
   rules will be applied to all endpoints which match the labels specified in
-  the selector. See the `LabelSelector` and :ref:`NodeSelector` sections for
-  additional details.
+  the selector. For additional details, see the :ref:`EndpointSelector` and
+  :ref:`NodeSelector` sections.
 
 ingress
   List of rules which must apply at ingress of the endpoint, i.e. to all
@@ -190,26 +190,27 @@ description
   Description is a string which is not interpreted by Cilium. It can be used to
   describe the intent and scope of the rule in a human readable form.
 
-.. _label_selector:
-.. _LabelSelector:
 .. _EndpointSelector:
 
 Endpoint Selector
 -----------------
 
-The Endpoint Selector is based on the `Kubernetes LabelSelector
-<https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors>`_.
-It is called Endpoint Selector because it only applies to labels associated
-with an `endpoints`.
+The Endpoint Selector is based on the `Kubernetes LabelSelector`_. It is called
+Endpoint Selector because it only applies to labels associated with an
+:ref:`Endpoint <endpoint>`.
 
 .. _NodeSelector:
 
 Node Selector
 -------------
 
-The Node Selector is also based on the `LabelSelector`, although rather than
-matching on labels associated with an `endpoints`, it instead applies to labels
-associated with a node in the cluster.
+Like the :ref:`Endpoint Selector <EndpointSelector>`, the Node Selector is
+based on the `Kubernetes LabelSelector`_, although rather than
+matching on labels associated with Endpoints, it applies to labels associated
+with :ref:`Nodes <node>` in the cluster.
 
-Node Selectors can only be used in `CiliumClusterwideNetworkPolicy`. See
-`HostPolicies` for details on the scope of node-level policies.
+Node Selectors can only be used in :ref:`CiliumClusterwideNetworkPolicies
+<CiliumClusterwideNetworkPolicy>`. For details on the scope of node-level
+policies, see :ref:`HostPolicies`.
+
+.. _Kubernetes LabelSelector: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -1353,3 +1353,37 @@ endpoint get -l reserved:host -o jsonpath='{[0].id}'``. Use this ID to replace
 
 - Use ``cilium-dbg monitor`` with ``--related-to $HOST_EP_ID`` to examine
   traffic for the host endpoint.
+
+Host Policies known issues
+--------------------------
+
+- The first time Cilium enforces Host Policies in the cluster, it may drop
+  reply traffic for legitimate connections that should be allowed by the
+  policies in place. Connections should stabilize again after a few seconds.
+  One workaround is to enable, disable, then re-enable Host Policies
+  enforcement. For details, see :gh-issue:`25448`.
+
+- In the context of ClusterMesh, the following combination of options is not
+  supported:
+
+  - Cilium operating in CRD mode (as opposed to KVstore mode),
+  - Host Policies enabled,
+  - tunneling enabled,
+  - kube-proxy-replacement enabled, and
+  - WireGuard enabled.
+
+  This combination results in a failure to connect to the
+  clustermesh-apiserver. For details, refer to :gh-issue:`31209`.
+
+- Host Policies do not work on host WireGuard interfaces. For details, see
+  :gh-issue:`17636`.
+
+- When Host Policies are enabled, hosts drop traffic from layer-2 protocols
+  that they consider as unknown, even if no Host Policies are loaded. For
+  example, this affects LLC traffic (see :gh-issue:`17877`) or VRRP traffic
+  (see :gh-issue:`18347`).
+
+- When kube-proxy-replacement is disabled, or configured not to implement
+  services for the native device (such as NodePort), hosts will enforce Host
+  Policies on service addresses rather than the service endpoints. For details,
+  refer to :gh-issue:`12545`.

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -1309,6 +1309,8 @@ the label ``type=ingress-worker`` on TCP ports 22, 6443 (kube-apiserver), 2379
 To reuse this policy, replace the ``port:`` values with ports used in your
 environment.
 
+.. _troubleshooting_host_policies:
+
 Troubleshooting Host Policies
 -----------------------------
 
@@ -1353,6 +1355,8 @@ endpoint get -l reserved:host -o jsonpath='{[0].id}'``. Use this ID to replace
 
 - Use ``cilium-dbg monitor`` with ``--related-to $HOST_EP_ID`` to examine
   traffic for the host endpoint.
+
+.. _host_policies_known_issues:
 
 Host Policies known issues
 --------------------------

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -1273,29 +1273,27 @@ external traffic to your cluster.
 Host Policies
 =============
 
-Host policies take the form of a `CiliumClusterwideNetworkPolicy` with a
-:ref:`NodeSelector` instead of an `EndpointSelector`. Host policies can have
-layer 3 and layer 4 rules on both ingress and egress. They cannot have layer
-7 rules.
+Host policies take the form of a :ref:`CiliumClusterwideNetworkPolicy` with a
+:ref:`NodeSelector` instead of an :ref:`EndpointSelector`. Host policies can
+have layer 3 and layer 4 rules on both ingress and egress. They cannot have
+layer 7 rules.
 
 Host policies apply to all the nodes selected by their :ref:`NodeSelector`. In
 each selected node, they apply only to the host namespace, including
-host-networking pods. They therefore don't apply to communications between
+host-networking pods. They don't apply to communications between
 non-host-networking pods and locations outside of the cluster.
 
 Installation of Host Policies requires the addition of the following ``helm``
 flags when installing Cilium:
 
-* ``--set devices='{interface}'`` where ``interface`` refers to the
-  network device Cilium is configured on such as ``eth0``. Omitting this option
-  leads Cilium to auto-detect what interface the host firewall applies to.
+* ``--set devices='{interface}'`` where ``interface`` refers to the network
+  device Cilium is configured on, for example ``eth0``. If you omit this
+  option, Cilium auto-detects what interface the host firewall applies to.
 * ``--set hostFirewall.enabled=true``
 
-The following policy will allow ingress traffic for any node with the label
-``type=ingress-worker`` on TCP ports 22, 6443 (kube-apiserver), 2379 (etcd) and 4240
-(health checks), as well as UDP port 8472 (VXLAN).
-
-Replace the ``port:`` value with ports used in your environment.
+As an example, the following policy allows ingress traffic for any node with
+the label ``type=ingress-worker`` on TCP ports 22, 6443 (kube-apiserver), 2379
+(etcd), and 4240 (health checks), as well as UDP port 8472 (VXLAN).
 
 .. only:: html
 
@@ -1308,23 +1306,50 @@ Replace the ``port:`` value with ports used in your environment.
 
         .. literalinclude:: ../../../examples/policies/host/lock-down-ingress.yaml
 
+To reuse this policy, replace the ``port:`` values with ports used in your
+environment.
+
 Troubleshooting Host Policies
 -----------------------------
 
-If you're having troubles with Host Policies please ensure the ``helm`` options
-listed above were applied during installation. To verify that your policy has
-been applied, you can run ``kubectl get CiliumClusterwideNetworkPolicy -o yaml``
-to validate the policy was accepted.
+If you have troubles with Host Policies, try the following steps:
 
-If policies don't seem to be applied to your nodes, verify the ``nodeSelector``
-is labeled correctly in your environment. In the example configuration, you can
-run ``kubectl get nodes -o wide|grep type=ingress-worker`` to verify labels
-match the policy.
+- Ensure the ``helm`` options listed in :ref:`the Host Policies description
+  <HostPolicies>` were applied during installation.
 
-You can verify the policy was applied by running ``kubectl exec -n $CILIUM_NAMESPACE cilium-xxxx -- cilium-dbg policy get``
-for the Cilium agent pod. Verify that the host is selected by the policy using
-``cilium-dbg endpoint list`` and look for the endpoint with ``reserved:host`` as the
-label and ensure that policy is enabled in the selected direction. Ensure the
-traffic is arriving on the device visible on the ``NodePort`` field of the
-``cilium-dbg status list`` output. Use ``cilium-dbg monitor`` with ``--related-to`` and
-the endpoint ID of the ``reserved:host`` endpoint to view traffic.
+- To verify that your policy has been accepted and applied by the Cilium agent,
+  run ``kubectl get CiliumClusterwideNetworkPolicy -o yaml`` and make sure the
+  policy is listed.
+
+- If policies don't seem to be applied to your nodes, verify the
+  ``nodeSelector`` is labeled correctly in your environment. In the example
+  configuration, you can run ``kubectl get nodes -o
+  custom-columns=NAME:.metadata.name,LABELS:.metadata.labels | grep
+  type:ingress-worker`` to verify labels match the policy.
+
+To troubleshoot policies for a given node, try the following steps. For all
+steps, run ``cilium-dbg`` in the relevant namespace, on the Cilium agent pod
+for the node, for example with:
+
+.. code-block:: shell-session
+
+   $ kubectl exec -n $CILIUM_NAMESPACE $CILIUM_POD_NAME -- cilium-dbg ...
+
+Retrieve the endpoint ID for the host endpoint on the node with ``cilium-dbg
+endpoint get -l reserved:host -o jsonpath='{[0].id}'``. Use this ID to replace
+``$HOST_EP_ID`` in the next steps:
+
+- If policies are applied, but not enforced for the node, check the status of
+  the policy audit mode with ``cilium-dbg endpoint config $HOST_EP_ID | grep
+  PolicyAuditMode``. If necessary, :ref:`disable the audit mode
+  <disable_policy_audit_mode>`.
+
+- Run ``cilium-dbg endpoint list``, and look for the host endpoint, with
+  ``$HOST_EP_ID`` and the ``reserved:host`` label. Ensure that policy is
+  enabled in the selected direction.
+
+- Run ``cilium-dbg status list`` and check the devices listed in the ``Host
+  firewall`` field. Verify that traffic actually reaches the listed devices.
+
+- Use ``cilium-dbg monitor`` with ``--related-to $HOST_EP_ID`` to examine
+  traffic for the host endpoint.


### PR DESCRIPTION
- docs: Alias "kubectl exec" command in Host Firewall guide
- docs: Clean up Host Firewall documentation
- docs: Document Host Policies known issues
  Refers to:
  - https://github.com/cilium/cilium/issues/25448
  - https://github.com/cilium/cilium/issues/31209
  - https://github.com/cilium/cilium/issues/17636
  - https://github.com/cilium/cilium/issues/17877
  - https://github.com/cilium/cilium/issues/18347
  - https://github.com/cilium/cilium/issues/12545
- docs: Link Host Policies "troubleshooting"/"known issues" from HFW tuto
