### PR TITLE
gh/actions: Bump CLI to v0.16.6

### DIFF
--- a/.github/actions/set-env-variables/action.yml
+++ b/.github/actions/set-env-variables/action.yml
@@ -12,7 +12,7 @@ runs:
         echo "EGRESS_GATEWAY_HELM_VALUES=--helm-set=egressGateway.enabled=true" >> $GITHUB_ENV
         echo "CILIUM_CLI_RELEASE_REPO=cilium/cilium-cli" >> $GITHUB_ENV
         # renovate: datasource=github-releases depName=cilium/cilium-cli
-        CILIUM_CLI_VERSION="v0.16.4"
+        CILIUM_CLI_VERSION="v0.16.6"
         echo "CILIUM_CLI_VERSION=$CILIUM_CLI_VERSION" >> $GITHUB_ENV
         echo "PUSH_TO_DOCKER_HUB=true" >> $GITHUB_ENV
         echo "GCP_PERF_RESULTS_BUCKET=gs://cilium-scale-results" >> $GITHUB_ENV


### PR DESCRIPTION
CPU for the CI upgrade jobs before and after :sunglasses: 
![image](https://github.com/cilium/cilium/assets/122571/57016458-a3ad-43df-b89d-9f75d2c11d1d)

![image](https://github.com/cilium/cilium/assets/122571/fe674414-8b24-4917-aed1-7272353cfd6e)
