### PR TITLE
fqdn: Fix benchmarking for fqdn cache test

### DIFF
--- a/pkg/fqdn/name_manager_bench_test.go
+++ b/pkg/fqdn/name_manager_bench_test.go
@@ -84,7 +84,9 @@ func BenchmarkUpdateGenerateDNS(b *testing.B) {
 // endpoints is. Each endpoints has 1000 DNS lookups, each with 10 IPs. The
 // dump iterates over all endpoints, lookups, and IPs.
 func BenchmarkFqdnCache(b *testing.B) {
-	caches := make([]*DNSCache, 0, b.N)
+	const endpoints = 8
+
+	caches := make([]*DNSCache, 0, endpoints)
 	for i := 0; i < b.N; i++ {
 		lookupTime := time.Now()
 		dnsHistory := NewDNSCache(0)
@@ -113,9 +115,11 @@ func BenchmarkFqdnCache(b *testing.B) {
 			return out
 		},
 	})
-	b.ResetTimer()
-
 	prefixMatcher := func(_ netip.Addr) bool { return true }
 	nameMatcher := func(_ string) bool { return true }
-	nameManager.GetDNSHistoryModel("", prefixMatcher, nameMatcher, "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		nameManager.GetDNSHistoryModel("", prefixMatcher, nameMatcher, "")
+	}
 }


### PR DESCRIPTION
Requires: https://github.com/cilium/cilium/pull/32013

Rather than testing a number of iterations of the core update function
here, the test was varying the data input size. This was violating the
recommendations from the Go docs, which state:

    The benchmark function must run the target code b.N times. During
    benchmark execution, b.N is adjusted until the benchmark function
    lasts long enough to be timed reliably.

This could lead to unreliable benchmarking numbers. Fix it.

Example run:

    $ go test ./pkg/fqdn -bench BenchmarkFqdnCache
    ...
    goos: linux
    goarch: amd64
    pkg: github.com/cilium/cilium/pkg/fqdn
    cpu: 13th Gen Intel(R) Core(TM) i7-1365U
    BenchmarkFqdnCache-12                100         110924076 ns/op
    PASS
    ok      github.com/cilium/cilium/pkg/fqdn       11.505s
