### PR TITLE
l2announcer: Fix delete entry if no origins left

### DIFF
--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -897,7 +897,15 @@ func (l2a *L2Announcer) recalculateL2EntriesTableEntries(ss *selectedService) er
 				e.Origins = slices.Delete(e.Origins, idx, idx+1)
 			}
 
-			_, _, err := tbl.Delete(txn, e)
+			if len(e.Origins) == 0 {
+				_, _, err := tbl.Delete(txn, e)
+				if err != nil {
+					return fmt.Errorf("delete in table: %w", err)
+				}
+				return nil
+			}
+
+			_, _, err := tbl.Insert(txn, e)
 			if err != nil {
 				return fmt.Errorf("update in table: %w", err)
 			}


### PR DESCRIPTION
When enabling L2Announcer and using the sharedingkeys feature, deleting a service that uses the same requestIP will unexpectedly delete the allocated LB IP in the Cilium agent.

Fixes: #32115
