### PR TITLE
pkg/envoy: Replace gocheck with built-in go test

### DIFF
--- a/pkg/envoy/accesslog_server_test.go
+++ b/pkg/envoy/accesslog_server_test.go
@@ -5,19 +5,16 @@ package envoy
 
 import (
 	"encoding/json"
+	"testing"
 
-	. "github.com/cilium/checkmate"
 	cilium "github.com/cilium/proxy/go/cilium/api"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/proxy/logger"
 )
 
-type AccessLogServerSuite struct{}
-
-var _ = Suite(&AccessLogServerSuite{})
-
-func (k *AccessLogServerSuite) TestParseURL(c *C) {
+func TestParseURL(t *testing.T) {
 	logs := []*cilium.HttpLogEntry{
 		{Scheme: "http", Host: "foo", Path: "/foo?blah=131"},
 		{Scheme: "http", Host: "foo", Path: "foo?blah=131"},
@@ -26,9 +23,9 @@ func (k *AccessLogServerSuite) TestParseURL(c *C) {
 
 	for _, l := range logs {
 		u := ParseURL(l.Scheme, l.Host, l.Path)
-		c.Assert(u.Scheme, Equals, "http")
-		c.Assert(u.Host, Equals, "foo")
-		c.Assert(u.Path, Equals, "/foo")
+		require.Equal(t, "http", u.Scheme)
+		require.Equal(t, "foo", u.Host)
+		require.Equal(t, "/foo", u.Path)
 	}
 }
 
@@ -54,7 +51,7 @@ func (n *testNotifier) NewProxyLogRecord(l *logger.LogRecord) error {
 	return nil
 }
 
-func (k *AccessLogServerSuite) TestKafkaLogNoTopic(c *C) {
+func TestKafkaLogNoTopic(t *testing.T) {
 	node.WithTestLocalNodeStore(func() {
 		notifier := &testNotifier{}
 		logger.SetNotifier(notifier)
@@ -67,12 +64,12 @@ func (k *AccessLogServerSuite) TestKafkaLogNoTopic(c *C) {
 			}},
 		})
 
-		c.Assert(notifier.kafka, HasLen, 1)
-		c.Assert(notifier.kafka[0], Equals, `{"ErrorCode":42,"APIVersion":3,"APIKey":"fetch","CorrelationID":76541,"Topic":{}}`)
+		require.Len(t, notifier.kafka, 1)
+		require.Equal(t, `{"ErrorCode":42,"APIVersion":3,"APIKey":"fetch","CorrelationID":76541,"Topic":{}}`, notifier.kafka[0])
 	})
 }
 
-func (k *AccessLogServerSuite) TestKafkaLogSingleTopic(c *C) {
+func TestKafkaLogSingleTopic(t *testing.T) {
 	node.WithTestLocalNodeStore(func() {
 		notifier := &testNotifier{}
 		logger.SetNotifier(notifier)
@@ -86,14 +83,14 @@ func (k *AccessLogServerSuite) TestKafkaLogSingleTopic(c *C) {
 			}},
 		})
 
-		c.Assert(notifier.kafka, HasLen, 1)
-		c.Assert(notifier.kafka[0], Equals, `{"ErrorCode":42,"APIVersion":3,"APIKey":"fetch","CorrelationID":76541,"Topic":{"Topic":"topic 1"}}`)
+		require.Len(t, notifier.kafka, 1)
+		require.Equal(t, `{"ErrorCode":42,"APIVersion":3,"APIKey":"fetch","CorrelationID":76541,"Topic":{"Topic":"topic 1"}}`, notifier.kafka[0])
 	})
 }
 
 // TestKafkaLogMultipleTopics checks that a cilium.KafkaLogEntry with
 // multiple topics is split into multiple log messages, one per topic
-func (k *AccessLogServerSuite) TestKafkaLogMultipleTopics(c *C) {
+func TestKafkaLogMultipleTopics(t *testing.T) {
 	node.WithTestLocalNodeStore(func() {
 		notifier := &testNotifier{}
 		logger.SetNotifier(notifier)
@@ -107,8 +104,8 @@ func (k *AccessLogServerSuite) TestKafkaLogMultipleTopics(c *C) {
 			}},
 		})
 
-		c.Assert(notifier.kafka, HasLen, 2)
-		c.Assert(notifier.kafka[0], Equals, `{"ErrorCode":42,"APIVersion":3,"APIKey":"fetch","CorrelationID":76541,"Topic":{"Topic":"topic 1"}}`)
-		c.Assert(notifier.kafka[1], Equals, `{"ErrorCode":42,"APIVersion":3,"APIKey":"fetch","CorrelationID":76541,"Topic":{"Topic":"topic 2"}}`)
+		require.Len(t, notifier.kafka, 2)
+		require.Equal(t, `{"ErrorCode":42,"APIVersion":3,"APIKey":"fetch","CorrelationID":76541,"Topic":{"Topic":"topic 1"}}`, notifier.kafka[0])
+		require.Equal(t, `{"ErrorCode":42,"APIVersion":3,"APIKey":"fetch","CorrelationID":76541,"Topic":{"Topic":"topic 2"}}`, notifier.kafka[1])
 	})
 }

--- a/pkg/envoy/resources_test.go
+++ b/pkg/envoy/resources_test.go
@@ -4,58 +4,56 @@
 package envoy
 
 import (
-	. "github.com/cilium/checkmate"
+	"testing"
+
 	envoyAPI "github.com/cilium/proxy/go/cilium/api"
+	"github.com/stretchr/testify/require"
 )
 
-type ResourcesSuite struct{}
-
-var _ = Suite(&ResourcesSuite{})
-
-func (s *SortSuite) TestHandleIPUpsert(c *C) {
+func TestHandleIPUpsert(t *testing.T) {
 	cache := newNPHDSCache(nil)
 
 	msg, err := cache.Lookup(NetworkPolicyHostsTypeURL, "123")
-	c.Assert(err, IsNil)
-	c.Assert(msg, IsNil)
+	require.NoError(t, err)
+	require.Nil(t, msg)
 
 	err = cache.handleIPUpsert(nil, "123", "1.2.3.0/32", 123)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	msg, err = cache.Lookup(NetworkPolicyHostsTypeURL, "123")
-	c.Assert(err, IsNil)
-	c.Assert(msg, Not(IsNil))
+	require.NoError(t, err)
+	require.NotNil(t, msg)
 	npHost := msg.(*envoyAPI.NetworkPolicyHosts)
-	c.Assert(npHost, Not(IsNil))
-	c.Assert(npHost.Policy, Equals, uint64(123))
-	c.Assert(len(npHost.HostAddresses), Equals, 1)
-	c.Assert(npHost.HostAddresses[0], Equals, "1.2.3.0/32")
+	require.NotNil(t, npHost)
+	require.Equal(t, uint64(123), npHost.Policy)
+	require.Equal(t, 1, len(npHost.HostAddresses))
+	require.Equal(t, "1.2.3.0/32", npHost.HostAddresses[0])
 
 	// Another address
 	err = cache.handleIPUpsert(npHost, "123", "::1/128", 123)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	msg, err = cache.Lookup(NetworkPolicyHostsTypeURL, "123")
-	c.Assert(err, IsNil)
-	c.Assert(msg, Not(IsNil))
+	require.NoError(t, err)
+	require.NotNil(t, msg)
 	npHost = msg.(*envoyAPI.NetworkPolicyHosts)
-	c.Assert(npHost, Not(IsNil))
-	c.Assert(npHost.Policy, Equals, uint64(123))
-	c.Assert(len(npHost.HostAddresses), Equals, 2)
-	c.Assert(npHost.HostAddresses[0], Equals, "1.2.3.0/32")
-	c.Assert(npHost.HostAddresses[1], Equals, "::1/128")
+	require.NotNil(t, npHost)
+	require.Equal(t, uint64(123), npHost.Policy)
+	require.Equal(t, 2, len(npHost.HostAddresses))
+	require.Equal(t, "1.2.3.0/32", npHost.HostAddresses[0])
+	require.Equal(t, "::1/128", npHost.HostAddresses[1])
 
 	// Check that duplicates are not added, and not erroring out
 	err = cache.handleIPUpsert(npHost, "123", "1.2.3.0/32", 123)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	msg, err = cache.Lookup(NetworkPolicyHostsTypeURL, "123")
-	c.Assert(err, IsNil)
-	c.Assert(msg, Not(IsNil))
+	require.NoError(t, err)
+	require.NotNil(t, msg)
 	npHost = msg.(*envoyAPI.NetworkPolicyHosts)
-	c.Assert(npHost, Not(IsNil))
-	c.Assert(npHost.Policy, Equals, uint64(123))
-	c.Assert(len(npHost.HostAddresses), Equals, 2)
-	c.Assert(npHost.HostAddresses[0], Equals, "1.2.3.0/32")
-	c.Assert(npHost.HostAddresses[1], Equals, "::1/128")
+	require.NotNil(t, npHost)
+	require.Equal(t, uint64(123), npHost.Policy)
+	require.Equal(t, 2, len(npHost.HostAddresses))
+	require.Equal(t, "1.2.3.0/32", npHost.HostAddresses[0])
+	require.Equal(t, "::1/128", npHost.HostAddresses[1])
 }

--- a/pkg/envoy/sort_test.go
+++ b/pkg/envoy/sort_test.go
@@ -4,18 +4,14 @@
 package envoy
 
 import (
-	. "github.com/cilium/checkmate"
+	"testing"
+
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_config_core "github.com/cilium/proxy/go/envoy/config/core/v3"
 	envoy_config_route "github.com/cilium/proxy/go/envoy/config/route/v3"
 	envoy_type_matcher "github.com/cilium/proxy/go/envoy/type/matcher/v3"
-
-	"github.com/cilium/cilium/pkg/checker"
+	"github.com/stretchr/testify/require"
 )
-
-type SortSuite struct{}
-
-var _ = Suite(&SortSuite{})
 
 var HeaderMatcher1 = &envoy_config_route.HeaderMatcher{
 	Name: "aaa",
@@ -69,7 +65,7 @@ var HeaderMatcher4 = &envoy_config_route.HeaderMatcher{
 	},
 }
 
-func (s *SortSuite) TestSortHeaderMatchers(c *C) {
+func TestSortHeaderMatchers(t *testing.T) {
 	var slice, expected []*envoy_config_route.HeaderMatcher
 
 	slice = []*envoy_config_route.HeaderMatcher{
@@ -85,7 +81,7 @@ func (s *SortSuite) TestSortHeaderMatchers(c *C) {
 		HeaderMatcher4,
 	}
 	SortHeaderMatchers(slice)
-	c.Assert(slice, checker.DeepEquals, expected)
+	require.EqualValues(t, expected, slice)
 }
 
 var HTTPNetworkPolicyRule1 = &cilium.HttpNetworkPolicyRule{}
@@ -102,7 +98,7 @@ var HTTPNetworkPolicyRule4 = &cilium.HttpNetworkPolicyRule{
 	Headers: []*envoy_config_route.HeaderMatcher{HeaderMatcher1, HeaderMatcher3},
 }
 
-func (s *SortSuite) TestSortHttpNetworkPolicyRules(c *C) {
+func TestSortHttpNetworkPolicyRules(t *testing.T) {
 	var slice, expected []*cilium.HttpNetworkPolicyRule
 
 	slice = []*cilium.HttpNetworkPolicyRule{
@@ -118,7 +114,7 @@ func (s *SortSuite) TestSortHttpNetworkPolicyRules(c *C) {
 		HTTPNetworkPolicyRule4,
 	}
 	SortHTTPNetworkPolicyRules(slice)
-	c.Assert(slice, checker.DeepEquals, expected)
+	require.EqualValues(t, expected, slice)
 }
 
 var PortNetworkPolicyRule1 = &cilium.PortNetworkPolicyRule{
@@ -184,7 +180,7 @@ var PortNetworkPolicyRule7 = &cilium.PortNetworkPolicyRule{
 
 // TODO: Test sorting Kafka rules.
 
-func (s *SortSuite) TestSortPortNetworkPolicyRules(c *C) {
+func TestSortPortNetworkPolicyRules(t *testing.T) {
 	var slice, expected []*cilium.PortNetworkPolicyRule
 
 	slice = []*cilium.PortNetworkPolicyRule{
@@ -206,7 +202,7 @@ func (s *SortSuite) TestSortPortNetworkPolicyRules(c *C) {
 		PortNetworkPolicyRule7,
 	}
 	SortPortNetworkPolicyRules(slice)
-	c.Assert(slice, checker.DeepEquals, expected)
+	require.EqualValues(t, expected, slice)
 }
 
 var PortNetworkPolicy1 = &cilium.PortNetworkPolicy{
@@ -253,7 +249,7 @@ var PortNetworkPolicy6 = &cilium.PortNetworkPolicy{
 	},
 }
 
-func (s *SortSuite) TestSortPortNetworkPolicies(c *C) {
+func TestSortPortNetworkPolicies(t *testing.T) {
 	var slice, expected []*cilium.PortNetworkPolicy
 
 	slice = []*cilium.PortNetworkPolicy{
@@ -273,5 +269,5 @@ func (s *SortSuite) TestSortPortNetworkPolicies(c *C) {
 		PortNetworkPolicy6,
 	}
 	SortPortNetworkPolicies(slice)
-	c.Assert(slice, checker.DeepEquals, expected)
+	require.EqualValues(t, expected, slice)
 }

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -336,7 +336,7 @@ func (m *AckingResourceMutatorWrapper) HandleResourceVersionAck(ackVersion uint6
 						delete(pending.remainingNodesResources, nodeIP)
 					}
 					if len(pending.remainingNodesResources) == 0 {
-						// Completed. Notify and remove from pending list.
+						// completedComparision. Notify and remove from pending list.
 						if pending.version <= ackVersion {
 							ackLog.Debugf("completing ACK: %v", pending)
 							comp.Complete(nil)

--- a/pkg/envoy/xds/node_test.go
+++ b/pkg/envoy/xds/node_test.go
@@ -4,24 +4,22 @@
 package xds
 
 import (
-	. "github.com/cilium/checkmate"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-type NodeSuite struct{}
-
-var _ = Suite(&NodeSuite{})
-
-func (s *NodeSuite) TestEnvoyNodeToIP(c *C) {
+func TestEnvoyNodeToIP(t *testing.T) {
 	var ip string
 	var err error
 
 	ip, err = EnvoyNodeIdToIP("host~127.0.0.1~no-id~localdomain")
-	c.Assert(err, IsNil)
-	c.Check(ip, Equals, "127.0.0.1")
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1", ip)
 
 	_, err = EnvoyNodeIdToIP("host~127.0.0.1~localdomain")
-	c.Assert(err, Not(IsNil))
+	require.Error(t, err)
 
 	_, err = EnvoyNodeIdToIP("host~not-an-ip~v0.default~default.svc.cluster.local")
-	c.Assert(err, Not(IsNil))
+	require.Error(t, err)
 }

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -5,34 +5,22 @@ package xds
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"reflect"
 	"sort"
 	"testing"
 	"time"
 
-	. "github.com/cilium/checkmate"
 	envoy_config_core "github.com/cilium/proxy/go/envoy/config/core/v3"
 	envoy_config_route "github.com/cilium/proxy/go/envoy/config/route/v3"
 	envoy_service_discovery "github.com/cilium/proxy/go/envoy/service/discovery/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
-	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/completion"
 )
-
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) {
-	// logging.ToggleDebugLogs(true)
-	TestingT(t)
-}
-
-type ServerSuite struct{}
-
-var _ = Suite(&ServerSuite{})
 
 const (
 	TestTimeout   = 10 * time.Second
@@ -40,84 +28,12 @@ const (
 )
 
 var (
-	DeferredCompletion = errors.New("Deferred completion")
-	nodes              = map[string]*envoy_config_core.Node{
+	nodes = map[string]*envoy_config_core.Node{
 		node0: {Id: "node0~10.0.0.0~node0~bar"},
 		node1: {Id: "node1~10.0.0.1~node1~bar"},
 		node2: {Id: "node2~10.0.0.2~node2~bar"},
 	}
 )
-
-// ResponseMatchesChecker checks that a DiscoveryResponse's fields match the given
-// parameters.
-type ResponseMatchesChecker struct {
-	*CheckerInfo
-}
-
-func (c *ResponseMatchesChecker) Check(params []interface{}, names []string) (result bool, error string) {
-	response, ok := params[0].(*envoy_service_discovery.DiscoveryResponse)
-	if !ok {
-		return false, "response must be an *envoy_service_discovery.DiscoveryResponse"
-	}
-	if response == nil {
-		return false, "response is nil"
-	}
-
-	versionInfo, ok := params[1].(string)
-	if !ok {
-		return false, "VersionInfo must be a string"
-	}
-	resources, ok := params[2].([]proto.Message)
-	if params[2] != nil && !ok {
-		return false, "Resources must be a []proto.Message"
-	}
-	canary, ok := params[3].(bool)
-	if !ok {
-		return false, "Canary must be a bool"
-	}
-	typeURL, ok := params[4].(string)
-	if !ok {
-		return false, "TypeURL must be a string"
-	}
-
-	error = ""
-
-	result = response.VersionInfo == versionInfo &&
-		len(response.Resources) == len(resources) &&
-		response.Canary == canary &&
-		response.TypeUrl == typeURL
-
-	if result && len(resources) > 0 {
-		// Convert the resources into Any protocol buffer messages, which is
-		// the type of Resources in the response, so that we can compare them.
-		resourcesAny := make([]*anypb.Any, 0, len(resources))
-		for _, res := range resources {
-			any, err := anypb.New(res)
-			if err != nil {
-				return false, fmt.Sprintf("error marshalling protocol buffer %v", res)
-			}
-			resourcesAny = append(resourcesAny, any)
-		}
-		// Sort both lists.
-		sort.Slice(response.Resources, func(i, j int) bool {
-			return response.Resources[i].String() < response.Resources[j].String()
-		})
-		sort.Slice(resourcesAny, func(i, j int) bool {
-			return resourcesAny[i].String() < resourcesAny[j].String()
-		})
-		result = reflect.DeepEqual(response.Resources, resourcesAny)
-	}
-
-	return
-}
-
-// ResponseMatches checks that a DiscoveryResponse's fields match the given
-// parameters.
-var ResponseMatches Checker = &ResponseMatchesChecker{
-	&CheckerInfo{Name: "ResponseMatches", Params: []string{
-		"response", "VersionInfo", "Resources", "Canary", "TypeUrl",
-	}},
-}
 
 var resources = []*envoy_config_route.RouteConfiguration{
 	{Name: "resource0"},
@@ -125,7 +41,40 @@ var resources = []*envoy_config_route.RouteConfiguration{
 	{Name: "resource2"},
 }
 
-func (s *ServerSuite) TestRequestAllResources(c *C) {
+func responseCheck(response *envoy_service_discovery.DiscoveryResponse,
+	versionInfo string, resources []proto.Message, canary bool, typeURL string) assert.Comparison {
+	return func() bool {
+		result := response.VersionInfo == versionInfo &&
+			len(response.Resources) == len(resources) &&
+			response.Canary == canary &&
+			response.TypeUrl == typeURL
+
+		if result && len(resources) > 0 {
+			// Convert the resources into Any protocol buffer messages, which is
+			// the type of Resources in the response, so that we can compare them.
+			resourcesAny := make([]*anypb.Any, 0, len(resources))
+			for _, res := range resources {
+				a, err := anypb.New(res)
+				if err != nil {
+					return false
+				}
+				resourcesAny = append(resourcesAny, a)
+			}
+			// Sort both lists.
+			sort.Slice(response.Resources, func(i, j int) bool {
+				return response.Resources[i].String() < response.Resources[j].String()
+			})
+			sort.Slice(resourcesAny, func(i, j int) bool {
+				return resourcesAny[i].String() < resourcesAny[j].String()
+			})
+			result = reflect.DeepEqual(response.Resources, resourcesAny)
+		}
+
+		return result
+	}
+}
+
+func TestRequestAllResources(t *testing.T) {
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
 
 	var err error
@@ -152,7 +101,7 @@ func (s *ServerSuite) TestRequestAllResources(c *C) {
 	go func() {
 		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		c.Check(err, IsNil)
+		require.NoError(t, err)
 	}()
 
 	// Request all resources.
@@ -164,13 +113,13 @@ func (s *ServerSuite) TestRequestAllResources(c *C) {
 		ResponseNonce: "",
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Expecting an empty response.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp, ResponseMatches, "1", nil, false, typeURL)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
+	require.NoError(t, err)
+	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -181,24 +130,24 @@ func (s *ServerSuite) TestRequestAllResources(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Create version 2 with resource 0.
 	v, mod, _ = cache.Upsert(typeURL, resources[0].Name, resources[0])
-	c.Assert(v, Equals, uint64(2))
-	c.Assert(mod, Equals, true)
+	require.Equal(t, uint64(2), v)
+	require.Equal(t, true, mod)
 
 	// Expecting a response with that resource.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "2", []proto.Message{resources[0]}, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
 
 	// Create version 3 with resources 0 and 1.
 	// This time, update the cache before sending the request.
 	v, mod, _ = cache.Upsert(typeURL, resources[1].Name, resources[1])
-	c.Assert(v, Equals, uint64(3))
-	c.Assert(mod, Equals, true)
+	require.Equal(t, uint64(3), v)
+	require.Equal(t, true, mod)
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -209,13 +158,13 @@ func (s *ServerSuite) TestRequestAllResources(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Expecting a response with both resources.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "3", []proto.Message{resources[0], resources[1]}, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0], resources[1]}, false, typeURL))
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -226,30 +175,30 @@ func (s *ServerSuite) TestRequestAllResources(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Create version 4 with resource 1.
 	v, mod, _ = cache.Delete(typeURL, resources[0].Name)
-	c.Assert(v, Equals, uint64(4))
-	c.Assert(mod, Equals, true)
+	require.Equal(t, uint64(4), v)
+	require.Equal(t, true, mod)
 
 	// Expecting a response with that resource.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "4", []proto.Message{resources[1]}, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "4", []proto.Message{resources[1]}, false, typeURL))
 
 	// Close the stream.
 	closeStream()
 
 	select {
 	case <-ctx.Done():
-		c.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
+		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
 	case <-streamDone:
 	}
 }
 
-func (s *ServerSuite) TestAck(c *C) {
+func TestAck(t *testing.T) {
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
 
 	var err error
@@ -275,7 +224,7 @@ func (s *ServerSuite) TestAck(c *C) {
 	go func() {
 		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		c.Check(err, IsNil)
+		require.NoError(t, err)
 	}()
 
 	// Request all resources.
@@ -287,13 +236,14 @@ func (s *ServerSuite) TestAck(c *C) {
 		ResponseNonce: "",
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Expecting an empty response.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "1", nil, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
+	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -304,24 +254,24 @@ func (s *ServerSuite) TestAck(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Create version 2 with resource 0.
 	callback1, comp1 := newCompCallback()
 	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
-	c.Assert(comp1, Not(IsCompleted))
+	require.Condition(t, isNotCompletedComparison(comp1))
 
 	// Expecting a response with that resource.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "2", []proto.Message{resources[0]}, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
 
 	// Create version 3 with resources 0 and 1.
 	// This time, update the cache before sending the request.
 	callback2, comp2 := newCompCallback()
 	mutator.Upsert(typeURL, resources[1].Name, resources[1], []string{node0}, wg, callback2)
-	c.Assert(comp2, Not(IsCompleted))
+	require.Condition(t, isNotCompletedComparison(comp2))
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -332,17 +282,17 @@ func (s *ServerSuite) TestAck(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Expecting a response with both resources.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "3", []proto.Message{resources[0], resources[1]}, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0], resources[1]}, false, typeURL))
 
 	// Version 2 was ACKed by the last request.
-	c.Assert(comp1, IsCompleted)
-	c.Assert(comp2, Not(IsCompleted))
+	require.Condition(t, completedComparison(comp1))
+	require.Condition(t, isNotCompletedComparison(comp2))
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -353,22 +303,22 @@ func (s *ServerSuite) TestAck(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Version 3 was ACKed by the last request.
-	c.Assert(comp2, IsCompletedInTime)
+	require.Condition(t, completedComparison(comp2))
 
 	// Close the stream.
 	closeStream()
 
 	select {
 	case <-ctx.Done():
-		c.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
+		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
 	case <-streamDone:
 	}
 }
 
-func (s *ServerSuite) TestRequestSomeResources(c *C) {
+func TestRequestSomeResources(t *testing.T) {
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
 
 	var err error
@@ -395,7 +345,7 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 	go func() {
 		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		c.Check(err, IsNil)
+		require.NoError(t, err)
 	}()
 
 	// Request resources 1 and 2 (not 0).
@@ -407,13 +357,13 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 		ResponseNonce: "",
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Expecting an empty response.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "1", nil, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -424,24 +374,24 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Create version 2 with resource 0.
 	v, mod, _ = cache.Upsert(typeURL, resources[0].Name, resources[0])
-	c.Assert(v, Equals, uint64(2))
-	c.Assert(mod, Equals, true)
+	require.Equal(t, uint64(2), v)
+	require.Equal(t, true, mod)
 
 	// There should be a response with no resources.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "2", nil, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "2", nil, false, typeURL))
 
 	// Create version 3 with resource 0 and 1.
 	// This time, update the cache before sending the request.
 	v, mod, _ = cache.Upsert(typeURL, resources[1].Name, resources[1])
-	c.Assert(v, Equals, uint64(3))
-	c.Assert(mod, Equals, true)
+	require.Equal(t, uint64(3), v)
+	require.Equal(t, true, mod)
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -452,13 +402,13 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Expecting a response with one resource.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "3", []proto.Message{resources[1]}, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[1]}, false, typeURL))
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -469,18 +419,18 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Create version 4 with resources 0, 1 and 2.
 	v, mod, _ = cache.Upsert(typeURL, resources[2].Name, resources[2])
-	c.Assert(v, Equals, uint64(4))
-	c.Assert(mod, Equals, true)
+	require.Equal(t, uint64(4), v)
+	require.Equal(t, true, mod)
 
 	// Expecting a response with resources 1 and 2.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "4", []proto.Message{resources[1], resources[2]}, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "4", []proto.Message{resources[1], resources[2]}, false, typeURL))
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -491,12 +441,12 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Create version 5 with resources 1 and 2.
 	v, mod, _ = cache.Delete(typeURL, resources[0].Name)
-	c.Assert(v, Equals, uint64(5))
-	c.Assert(mod, Equals, true)
+	require.Equal(t, uint64(5), v)
+	require.Equal(t, true, mod)
 
 	// Expecting no response for version 5, since neither resources 1 and 2
 	// have changed.
@@ -504,41 +454,41 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 	// Updating resource 2 with the exact same value won't increase the version
 	// number. Remain at version 5.
 	v, mod, _ = cache.Upsert(typeURL, resources[2].Name, resources[2])
-	c.Assert(v, Equals, uint64(5))
-	c.Assert(mod, Equals, false)
+	require.Equal(t, uint64(5), v)
+	require.Equal(t, false, mod)
 
 	// Create version 6 with resource 1.
 	v, mod, _ = cache.Delete(typeURL, resources[1].Name)
-	c.Assert(v, Equals, uint64(6))
-	c.Assert(mod, Equals, true)
+	require.Equal(t, uint64(6), v)
+	require.Equal(t, true, mod)
 
 	// Expecting a response with resource 2.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "6", []proto.Message{resources[2]}, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "6", []proto.Message{resources[2]}, false, typeURL))
 
 	// Resource 1 has been deleted; Resource 2 exists. Confirm using Lookup().
 	rsrc, err := cache.Lookup(typeURL, resources[1].Name)
-	c.Assert(err, IsNil)
-	c.Assert(rsrc, IsNil)
+	require.NoError(t, err)
+	require.Nil(t, rsrc)
 
 	rsrc, err = cache.Lookup(typeURL, resources[2].Name)
-	c.Assert(err, IsNil)
-	c.Assert(rsrc, Not(IsNil))
-	c.Assert(rsrc.(*envoy_config_route.RouteConfiguration), checker.DeepEquals, resources[2])
+	require.NoError(t, err)
+	require.NotNil(t, rsrc)
+	require.EqualValues(t, resources[2], rsrc.(*envoy_config_route.RouteConfiguration))
 
 	// Close the stream.
 	closeStream()
 
 	select {
 	case <-ctx.Done():
-		c.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
+		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
 	case <-streamDone:
 	}
 }
 
-func (s *ServerSuite) TestUpdateRequestResources(c *C) {
+func TestUpdateRequestResources(t *testing.T) {
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
 
 	var err error
@@ -565,7 +515,7 @@ func (s *ServerSuite) TestUpdateRequestResources(c *C) {
 	go func() {
 		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		c.Check(err, IsNil)
+		require.NoError(t, err)
 	}()
 
 	// Create version 2 with resources 0 and 1.
@@ -573,8 +523,8 @@ func (s *ServerSuite) TestUpdateRequestResources(c *C) {
 		resources[0].Name: resources[0],
 		resources[1].Name: resources[1],
 	}, nil)
-	c.Assert(v, Equals, uint64(2))
-	c.Assert(mod, Equals, true)
+	require.Equal(t, uint64(2), v)
+	require.Equal(t, true, mod)
 
 	// Request resource 1.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -585,13 +535,13 @@ func (s *ServerSuite) TestUpdateRequestResources(c *C) {
 		ResponseNonce: "",
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Expecting a response with resource 1.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "2", []proto.Message{resources[1]}, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[1]}, false, typeURL))
 
 	// Request the next version of resource 1.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -602,12 +552,12 @@ func (s *ServerSuite) TestUpdateRequestResources(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Create version 3 with resource 0, 1 and 2.
 	v, mod, _ = cache.Upsert(typeURL, resources[2].Name, resources[2])
-	c.Assert(v, Equals, uint64(3))
-	c.Assert(mod, Equals, true)
+	require.Equal(t, uint64(3), v)
+	require.Equal(t, true, mod)
 
 	// Not expecting any response since resource 1 didn't change in version 3.
 
@@ -620,25 +570,25 @@ func (s *ServerSuite) TestUpdateRequestResources(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Expecting a response with resources 1 and 2.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "3", []proto.Message{resources[1], resources[2]}, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[1], resources[2]}, false, typeURL))
 
 	// Close the stream.
 	closeStream()
 
 	select {
 	case <-ctx.Done():
-		c.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
+		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
 	case <-streamDone:
 	}
 }
 
-func (s *ServerSuite) TestRequestStaleNonce(c *C) {
+func TestRequestStaleNonce(t *testing.T) {
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
 
 	var err error
@@ -665,7 +615,7 @@ func (s *ServerSuite) TestRequestStaleNonce(c *C) {
 	go func() {
 		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		c.Check(err, IsNil)
+		require.NoError(t, err)
 	}()
 
 	// Request all resources.
@@ -677,13 +627,13 @@ func (s *ServerSuite) TestRequestStaleNonce(c *C) {
 		ResponseNonce: "",
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Expecting an empty response.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "1", nil, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -694,24 +644,24 @@ func (s *ServerSuite) TestRequestStaleNonce(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Create version 2 with resource 0.
 	v, mod, _ = cache.Upsert(typeURL, resources[0].Name, resources[0])
-	c.Assert(v, Equals, uint64(2))
-	c.Assert(mod, Equals, true)
+	require.Equal(t, uint64(2), v)
+	require.Equal(t, true, mod)
 
 	// Expecting a response with that resource.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "2", []proto.Message{resources[0]}, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
 
 	// Create version 3 with resources 0 and 1.
 	// This time, update the cache before sending the request.
 	v, mod, _ = cache.Upsert(typeURL, resources[1].Name, resources[1])
-	c.Assert(v, Equals, uint64(3))
-	c.Assert(mod, Equals, true)
+	require.Equal(t, uint64(3), v)
+	require.Equal(t, true, mod)
 
 	// Request the next version of resources, with a stale nonce.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -723,15 +673,15 @@ func (s *ServerSuite) TestRequestStaleNonce(c *C) {
 	}
 	// Do not update the nonce.
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Server correctly detects 0 nonce and resets it to the correct value.
 
 	// Expecting a response with both resources.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "3", []proto.Message{resources[0], resources[1]}, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0], resources[1]}, false, typeURL))
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -742,30 +692,30 @@ func (s *ServerSuite) TestRequestStaleNonce(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Create version 4 with resource 1.
 	v, mod, _ = cache.Delete(typeURL, resources[0].Name)
-	c.Assert(v, Equals, uint64(4))
-	c.Assert(mod, Equals, true)
+	require.Equal(t, uint64(4), v)
+	require.Equal(t, true, mod)
 
 	// Expecting a response with that resource.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "4", []proto.Message{resources[1]}, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "4", []proto.Message{resources[1]}, false, typeURL))
 
 	// Close the stream.
 	closeStream()
 
 	select {
 	case <-ctx.Done():
-		c.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
+		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
 	case <-streamDone:
 	}
 }
 
-func (s *ServerSuite) TestNAck(c *C) {
+func TestNAck(t *testing.T) {
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
 
 	var err error
@@ -791,7 +741,7 @@ func (s *ServerSuite) TestNAck(c *C) {
 	go func() {
 		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		c.Check(err, IsNil)
+		require.NoError(t, err)
 	}()
 
 	// Request all resources.
@@ -803,13 +753,13 @@ func (s *ServerSuite) TestNAck(c *C) {
 		ResponseNonce: "",
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Expecting an empty response.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "1", nil, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -821,18 +771,18 @@ func (s *ServerSuite) TestNAck(c *C) {
 	}
 	ackedVersion := resp.VersionInfo
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Create version 2 with resource 0.
 	callback1, comp1 := newCompCallback()
 	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
-	c.Assert(comp1, Not(IsCompleted))
+	require.Condition(t, isNotCompletedComparison(comp1))
 
 	// Expecting a response with that resource.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "2", []proto.Message{resources[0]}, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
 
 	// NACK the received version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -844,28 +794,28 @@ func (s *ServerSuite) TestNAck(c *C) {
 		ErrorDetail:   &status.Status{Message: "NACKNACK"},
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Create version 3 with resources 0 and 1.
 	// NACK cancelled the wg, create a new one
 	wg = completion.NewWaitGroup(ctx)
 	callback2, comp2 := newCompCallback()
 	mutator.Upsert(typeURL, resources[1].Name, resources[1], []string{node0}, wg, callback2)
-	c.Assert(comp2, Not(IsCompleted))
+	require.Condition(t, isNotCompletedComparison(comp2))
 
-	// Version 2 was NACKed by the last request, so comp1 must NOT be completed ever.
-	c.Assert(comp1, Not(IsCompletedInTime))
-	c.Assert(comp1.Err(), checker.DeepEquals, &ProxyError{Err: ErrNackReceived, Detail: "NACKNACK"})
+	// Version 2 was NACKed by the last request, so comp1 must NOT be completedInTime ever.
+	require.Condition(t, isNotCompletedComparison(comp1))
+	require.EqualValues(t, &ProxyError{Err: ErrNackReceived, Detail: "NACKNACK"}, comp1.Err())
 
 	// Expecting a response with both resources.
 	// Note that the stream should not have a message that repeats the previous one!
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "3", []proto.Message{resources[0], resources[1]}, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0], resources[1]}, false, typeURL))
 
-	c.Assert(comp1, Not(IsCompleted))
-	c.Assert(comp2, Not(IsCompleted))
+	require.Condition(t, isNotCompletedComparison(comp1))
+	require.Condition(t, isNotCompletedComparison(comp2))
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -876,22 +826,22 @@ func (s *ServerSuite) TestNAck(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
-	c.Assert(comp1, Not(IsCompleted))
-	c.Assert(comp2, IsCompletedInTime)
+	require.Condition(t, isNotCompletedComparison(comp1))
+	require.Condition(t, completedComparison(comp2))
 
 	// Close the stream.
 	closeStream()
 
 	select {
 	case <-ctx.Done():
-		c.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
+		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
 	case <-streamDone:
 	}
 }
 
-func (s *ServerSuite) TestNAckFromTheStart(c *C) {
+func TestNAckFromTheStart(t *testing.T) {
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
 
 	var err error
@@ -917,7 +867,7 @@ func (s *ServerSuite) TestNAckFromTheStart(c *C) {
 	go func() {
 		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		c.Check(err, IsNil)
+		require.NoError(t, err)
 	}()
 
 	// Request all resources.
@@ -929,18 +879,18 @@ func (s *ServerSuite) TestNAckFromTheStart(c *C) {
 		ResponseNonce: "",
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Expecting an empty response.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "1", nil, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
 
 	// Create version 2 with resource 0.
 	callback1, comp1 := newCompCallback()
 	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
-	c.Assert(comp1, Not(IsCompleted))
+	require.Condition(t, isNotCompletedComparison(comp1))
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -951,13 +901,13 @@ func (s *ServerSuite) TestNAckFromTheStart(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Expecting a response with that resource.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp.Nonce, Equals, resp.VersionInfo)
-	c.Assert(resp, ResponseMatches, "2", []proto.Message{resources[0]}, false, typeURL)
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
 
 	// NACK the received version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -968,13 +918,14 @@ func (s *ServerSuite) TestNAckFromTheStart(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
-	// Version 2 was NACKed by the last request, so it must NOT be completed successfully.
-	c.Assert(comp1, Not(IsCompletedInTime))
-	// Version 2 did not have a callback, so the completion was completed with an error
-	c.Assert(comp1.Err(), Not(IsNil))
-	c.Assert(comp1.Err(), checker.DeepEquals, &ProxyError{Err: ErrNackReceived})
+	// Version 2 was NACKed by the last request, so it must NOT be completedInTime successfully.
+	require.Condition(t, isNotCompletedComparison(comp1))
+
+	// Version 2 did not have a callback, so the completion was completedInTime with an error
+	require.NotNil(t, comp1.Err())
+	require.EqualValues(t, &ProxyError{Err: ErrNackReceived}, comp1.Err())
 
 	// NACK canceled the WaitGroup, create new one
 	wg = completion.NewWaitGroup(ctx)
@@ -982,16 +933,16 @@ func (s *ServerSuite) TestNAckFromTheStart(c *C) {
 	// Create version 3 with resources 0 and 1.
 	callback2, comp2 := newCompCallback()
 	mutator.Upsert(typeURL, resources[1].Name, resources[1], []string{node0}, wg, callback2)
-	c.Assert(comp2, Not(IsCompleted))
+	require.Condition(t, isNotCompletedComparison(comp2))
 
 	// Expecting a response with both resources.
 	// Note that the stream should not have a message that repeats the previous one!
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp, ResponseMatches, "3", []proto.Message{resources[0], resources[1]}, false, typeURL)
-	c.Assert(resp.Nonce, Not(Equals), "")
+	require.NoError(t, err)
+	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0], resources[1]}, false, typeURL))
+	require.NotEqual(t, "", resp.Nonce)
 
-	c.Assert(comp2, Not(IsCompleted))
+	require.Condition(t, isNotCompletedComparison(comp2))
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -1002,22 +953,22 @@ func (s *ServerSuite) TestNAckFromTheStart(c *C) {
 		ResponseNonce: resp.Nonce,
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Version 3 was ACKed by the last request.
-	c.Assert(comp2, IsCompletedInTime)
+	require.Condition(t, completedComparison(comp2))
 
 	// Close the stream.
 	closeStream()
 
 	select {
 	case <-ctx.Done():
-		c.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
+		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
 	case <-streamDone:
 	}
 }
 
-func (s *ServerSuite) TestRequestHighVersionFromTheStart(c *C) {
+func TestRequestHighVersionFromTheStart(t *testing.T) {
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
 
 	var err error
@@ -1043,13 +994,13 @@ func (s *ServerSuite) TestRequestHighVersionFromTheStart(c *C) {
 	go func() {
 		defer close(streamDone)
 		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
-		c.Check(err, IsNil)
+		require.NoError(t, err)
 	}()
 
 	// Create version 2 with resource 0.
 	callback1, comp1 := newCompCallback()
 	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
-	c.Assert(comp1, Not(IsCompleted))
+	require.Condition(t, isNotCompletedComparison(comp1))
 
 	// Request all resources, with a version higher than the version currently
 	// in Cilium's cache. This happens after the server restarts but the
@@ -1062,20 +1013,20 @@ func (s *ServerSuite) TestRequestHighVersionFromTheStart(c *C) {
 		ResponseNonce: "64",
 	}
 	err = stream.SendRequest(req)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Expecting a response with that resource, and an updated version.
 	resp, err = stream.RecvResponse()
-	c.Assert(err, IsNil)
-	c.Assert(resp, ResponseMatches, "65", []proto.Message{resources[0]}, false, typeURL)
-	c.Assert(resp.Nonce, Not(Equals), "")
+	require.NoError(t, err)
+	require.Condition(t, responseCheck(resp, "65", []proto.Message{resources[0]}, false, typeURL))
+	require.NotEqual(t, "", resp.Nonce)
 
 	// Close the stream.
 	closeStream()
 
 	select {
 	case <-ctx.Done():
-		c.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
+		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
 	case <-streamDone:
 	}
 }


### PR DESCRIPTION
One point worth noting is the custom checker is migrated to assert.AssertComparision interface.

Relates: https://github.com/cilium/cilium/issues/28596
