### PR TITLE
lb: Replace gocheck with built-in go test 

### DIFF
--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -6,19 +6,8 @@ package loadbalancer
 import (
 	"testing"
 
-	check "github.com/cilium/checkmate"
-
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 )
-
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) {
-	check.TestingT(t)
-}
-
-type TypesSuite struct{}
-
-var _ = check.Suite(&TypesSuite{})
 
 func TestL4Addr_Equals(t *testing.T) {
 	type args struct {

--- a/pkg/service/id_test.go
+++ b/pkg/service/id_test.go
@@ -6,31 +6,11 @@ package service
 import (
 	"testing"
 
-	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/checker"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 )
-
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) {
-	TestingT(t)
-}
-
-type IDAllocTestSuite struct{}
-
-var _ = Suite(&IDAllocTestSuite{})
-
-func (e *IDAllocTestSuite) SetUpTest(c *C) {
-	serviceIDAlloc.resetLocalID()
-	backendIDAlloc.resetLocalID()
-}
-
-func (e *IDAllocTestSuite) TearDownTest(c *C) {
-	serviceIDAlloc.resetLocalID()
-	backendIDAlloc.resetLocalID()
-}
 
 var (
 	l3n4Addr1 = loadbalancer.L3n4Addr{
@@ -63,150 +43,150 @@ var (
 	}
 )
 
-func (s *IDAllocTestSuite) TestServices(c *C) {
+func TestServices(t *testing.T) {
 	var nilL3n4AddrID *loadbalancer.L3n4AddrID
 	// Set up last free ID with zero
 	id, err := getMaxServiceID()
-	c.Assert(err, Equals, nil)
-	c.Assert(id, Equals, FirstFreeServiceID)
+	require.Equal(t, nil, err)
+	require.Equal(t, FirstFreeServiceID, id)
 
 	ffsIDu16 := loadbalancer.ServiceID(uint16(FirstFreeServiceID))
 
 	l3n4AddrID, err := AcquireID(l3n4Addr1, 0)
-	c.Assert(err, Equals, nil)
-	c.Assert(l3n4AddrID.ID, Equals, loadbalancer.ID(ffsIDu16))
+	require.Equal(t, nil, err)
+	require.Equal(t, loadbalancer.ID(ffsIDu16), l3n4AddrID.ID)
 
 	l3n4AddrID, err = AcquireID(l3n4Addr1, 0)
-	c.Assert(err, Equals, nil)
-	c.Assert(l3n4AddrID.ID, Equals, loadbalancer.ID(ffsIDu16))
+	require.Equal(t, nil, err)
+	require.Equal(t, loadbalancer.ID(ffsIDu16), l3n4AddrID.ID)
 
 	l3n4AddrID, err = AcquireID(l3n4Addr2, 0)
-	c.Assert(err, Equals, nil)
-	c.Assert(l3n4AddrID.ID, Equals, loadbalancer.ID(ffsIDu16+1))
+	require.Equal(t, nil, err)
+	require.Equal(t, loadbalancer.ID(ffsIDu16+1), l3n4AddrID.ID)
 
 	// l3n4Addr3 should have the same ID as l3n4Addr2 since we are omitting the
 	// protocol type.
 	l3n4AddrID, err = AcquireID(l3n4Addr3, 0)
-	c.Assert(err, Equals, nil)
-	c.Assert(l3n4AddrID.ID, Equals, loadbalancer.ID(ffsIDu16+1))
+	require.Equal(t, nil, err)
+	require.Equal(t, loadbalancer.ID(ffsIDu16+1), l3n4AddrID.ID)
 
 	gotL3n4AddrID, err := GetID(FirstFreeServiceID)
-	c.Assert(err, Equals, nil)
+	require.Equal(t, nil, err)
 	wantL3n4AddrID.ID = loadbalancer.ID(ffsIDu16)
 	wantL3n4AddrID.L3n4Addr = l3n4Addr1
-	c.Assert(gotL3n4AddrID, checker.DeepEquals, wantL3n4AddrID)
+	require.EqualValues(t, wantL3n4AddrID, gotL3n4AddrID)
 
 	err = DeleteID(FirstFreeServiceID)
-	c.Assert(err, Equals, nil)
+	require.Equal(t, nil, err)
 	gotL3n4AddrID, err = GetID(FirstFreeServiceID)
-	c.Assert(err, Equals, nil)
-	c.Assert(gotL3n4AddrID, Equals, nilL3n4AddrID)
+	require.Equal(t, nil, err)
+	require.Equal(t, nilL3n4AddrID, gotL3n4AddrID)
 
 	gotL3n4AddrID, err = GetID(FirstFreeServiceID + 1)
-	c.Assert(err, Equals, nil)
+	require.Equal(t, nil, err)
 	wantL3n4AddrID.ID = loadbalancer.ID(FirstFreeServiceID + 1)
 	wantL3n4AddrID.L3n4Addr = l3n4Addr2
-	c.Assert(gotL3n4AddrID, checker.DeepEquals, wantL3n4AddrID)
+	require.EqualValues(t, wantL3n4AddrID, gotL3n4AddrID)
 
 	err = DeleteID(FirstFreeServiceID)
-	c.Assert(err, Equals, nil)
+	require.Equal(t, nil, err)
 
 	err = setIDSpace(FirstFreeServiceID, FirstFreeServiceID)
-	c.Assert(err, Equals, nil)
+	require.Equal(t, nil, err)
 
 	err = DeleteID(FirstFreeServiceID)
-	c.Assert(err, Equals, nil)
+	require.Equal(t, nil, err)
 	gotL3n4AddrID, err = GetID(FirstFreeServiceID)
-	c.Assert(err, Equals, nil)
-	c.Assert(gotL3n4AddrID, Equals, nilL3n4AddrID)
+	require.Equal(t, nil, err)
+	require.Equal(t, nilL3n4AddrID, gotL3n4AddrID)
 
 	gotL3n4AddrID, err = AcquireID(l3n4Addr2, 0)
-	c.Assert(err, Equals, nil)
-	c.Assert(gotL3n4AddrID.ID, Equals, loadbalancer.ID(FirstFreeServiceID+1))
+	require.Equal(t, nil, err)
+	require.Equal(t, loadbalancer.ID(FirstFreeServiceID+1), gotL3n4AddrID.ID)
 
 	err = DeleteID(uint32(gotL3n4AddrID.ID))
-	c.Assert(err, Equals, nil)
+	require.Equal(t, nil, err)
 	err = DeleteID(FirstFreeServiceID + 1)
-	c.Assert(err, Equals, nil)
+	require.Equal(t, nil, err)
 	err = DeleteID(FirstFreeServiceID + 1)
-	c.Assert(err, Equals, nil)
+	require.Equal(t, nil, err)
 
 	gotL3n4AddrID, err = AcquireID(l3n4Addr2, 0)
-	c.Assert(err, Equals, nil)
-	c.Assert(gotL3n4AddrID.ID, Equals, loadbalancer.ID(ffsIDu16))
+	require.Equal(t, nil, err)
+	require.Equal(t, loadbalancer.ID(ffsIDu16), gotL3n4AddrID.ID)
 
 	gotL3n4AddrID, err = AcquireID(l3n4Addr1, 0)
-	c.Assert(err, Equals, nil)
-	c.Assert(gotL3n4AddrID.ID, Equals, loadbalancer.ID(FirstFreeServiceID+1))
+	require.Equal(t, nil, err)
+	require.Equal(t, loadbalancer.ID(FirstFreeServiceID+1), gotL3n4AddrID.ID)
 
 	gotL3n4AddrID, err = AcquireID(l3n4Addr1, 99)
-	c.Assert(err, Equals, nil)
-	c.Assert(gotL3n4AddrID.ID, Equals, loadbalancer.ID(FirstFreeServiceID+1))
+	require.Equal(t, nil, err)
+	require.Equal(t, loadbalancer.ID(FirstFreeServiceID+1), gotL3n4AddrID.ID)
 
 	err = DeleteID(uint32(FirstFreeServiceID + 1))
-	c.Assert(err, Equals, nil)
+	require.Equal(t, nil, err)
 
 	gotL3n4AddrID, err = AcquireID(l3n4Addr1, 99)
-	c.Assert(err, Equals, nil)
-	c.Assert(gotL3n4AddrID.ID, Equals, loadbalancer.ID(99))
+	require.Equal(t, nil, err)
+	require.Equal(t, loadbalancer.ID(99), gotL3n4AddrID.ID)
 
 	// ID "99" has been already allocated to l3n4Addr1
 	gotL3n4AddrID, err = AcquireID(l3n4Addr4, 99)
-	c.Assert(err, NotNil)
-	c.Assert(gotL3n4AddrID, IsNil)
+	require.Error(t, err)
+	require.Nil(t, gotL3n4AddrID)
 }
 
-func (s *IDAllocTestSuite) TestGetMaxServiceID(c *C) {
+func TestGetMaxServiceID(t *testing.T) {
 	lastID := uint32(MaxSetOfServiceID - 1)
 
 	err := setIDSpace(lastID, MaxSetOfServiceID)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	id, err := getMaxServiceID()
-	c.Assert(err, Equals, nil)
-	c.Assert(id, Equals, (MaxSetOfServiceID - 1))
+	require.Equal(t, nil, err)
+	require.Equal(t, (MaxSetOfServiceID - 1), id)
 }
 
-func (s *IDAllocTestSuite) TestBackendID(c *C) {
+func TestBackendID(t *testing.T) {
 	firstBackendID := loadbalancer.BackendID(FirstFreeBackendID)
 
 	id1, err := AcquireBackendID(l3n4Addr1)
-	c.Assert(err, Equals, nil)
-	c.Assert(id1, Equals, firstBackendID)
+	require.Equal(t, nil, err)
+	require.Equal(t, firstBackendID, id1)
 
 	id1, err = AcquireBackendID(l3n4Addr1)
-	c.Assert(err, Equals, nil)
-	c.Assert(id1, Equals, firstBackendID)
+	require.Equal(t, nil, err)
+	require.Equal(t, firstBackendID, id1)
 
 	id2, err := AcquireBackendID(l3n4Addr2)
-	c.Assert(err, Equals, nil)
-	c.Assert(id2, Equals, firstBackendID+1)
+	require.Equal(t, nil, err)
+	require.Equal(t, firstBackendID+1, id2)
 
 	existingID1, err := LookupBackendID(l3n4Addr1)
-	c.Assert(err, Equals, nil)
-	c.Assert(existingID1, Equals, id1)
+	require.Equal(t, nil, err)
+	require.Equal(t, id1, existingID1)
 
 	// Check that the backend ID restoration advances the nextID
 	err = RestoreBackendID(l3n4Addr5, firstBackendID+10)
-	c.Assert(err, Equals, nil)
+	require.Equal(t, nil, err)
 	id3, err := AcquireBackendID(l3n4Addr6)
-	c.Assert(err, Equals, nil)
-	c.Assert(id3, Equals, firstBackendID+11)
+	require.Equal(t, nil, err)
+	require.Equal(t, firstBackendID+11, id3)
 
 }
 
-func (s *IDAllocTestSuite) BenchmarkAllocation(c *C) {
+func BenchmarkAllocation(b *testing.B) {
 	addr := loadbalancer.L3n4Addr{
 		AddrCluster: cmtypes.MustParseAddrCluster("::1"),
 		L4Addr:      loadbalancer.L4Addr{Port: 0, Protocol: "UDP"},
 	}
 
-	c.ResetTimer()
-	for i := 0; i < c.N; i++ {
-		addr.L4Addr.Port = uint16(c.N)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		addr.L4Addr.Port = uint16(b.N)
 		_, err := AcquireID(addr, 0)
-		c.Assert(err, IsNil)
+		require.Nil(b, err)
 	}
-	c.StopTimer()
+	b.StopTimer()
 
 }

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -18,7 +18,6 @@ import (
 	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/cidr"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	datapathOpt "github.com/cilium/cilium/pkg/datapath/option"
@@ -156,7 +155,8 @@ var (
 	backends1, backends2, backends3, backends4, backends5, backends6 []*lb.Backend
 )
 
-func (m *ManagerTestSuite) SetUpTest(c *C) {
+func setupManagerTestSuite(tb testing.TB) *ManagerTestSuite {
+	m := &ManagerTestSuite{}
 	serviceIDAlloc.resetLocalID()
 	backendIDAlloc.resetLocalID()
 
@@ -199,17 +199,19 @@ func (m *ManagerTestSuite) SetUpTest(c *C) {
 	backends6 = []*lb.Backend{
 		lb.NewBackend(0, lb.TCP, cmtypes.MustParseAddrCluster("10.0.0.7"), 8080),
 	}
-}
 
-func (m *ManagerTestSuite) TearDownTest(c *C) {
-	serviceIDAlloc.resetLocalID()
-	backendIDAlloc.resetLocalID()
-	option.Config.EnableSessionAffinity = m.prevOptionSessionAffinity
-	option.Config.EnableSVCSourceRangeCheck = m.prevOptionLBSourceRanges
-	option.Config.NodePortAlg = m.prevOptionNPAlgo
-	option.Config.DatapathMode = m.prevOptionDPMode
-	option.Config.ExternalClusterIP = m.prevOptionExternalClusterIP
-	option.Config.EnableIPv6 = m.ipv6
+	tb.Cleanup(func() {
+		serviceIDAlloc.resetLocalID()
+		backendIDAlloc.resetLocalID()
+		option.Config.EnableSessionAffinity = m.prevOptionSessionAffinity
+		option.Config.EnableSVCSourceRangeCheck = m.prevOptionLBSourceRanges
+		option.Config.NodePortAlg = m.prevOptionNPAlgo
+		option.Config.DatapathMode = m.prevOptionDPMode
+		option.Config.ExternalClusterIP = m.prevOptionExternalClusterIP
+		option.Config.EnableIPv6 = m.ipv6
+	})
+
+	return m
 }
 
 func (m *ManagerTestSuite) newServiceMock(lbmap datapathTypes.LBMap) {
@@ -217,30 +219,37 @@ func (m *ManagerTestSuite) newServiceMock(lbmap datapathTypes.LBMap) {
 	m.svc.backendConnectionHandler = testsockets.NewMockSockets(make([]*testsockets.MockSocket, 0))
 }
 
-func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
-	m.testUpsertAndDeleteService(c)
+func TestUpsertAndDeleteService(t *testing.T) {
+	m := setupManagerTestSuite(t)
+	m.testUpsertAndDeleteService(t)
 }
 
-func (m *ManagerTestSuite) TestUpsertAndDeleteServiceWithoutIPv6(c *C) {
+func TestUpsertAndDeleteServiceWithoutIPv6(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	option.Config.EnableIPv6 = false
-	m.testUpsertAndDeleteService(c)
+	m.testUpsertAndDeleteService(t)
 }
 
-func (m *ManagerTestSuite) TestUpsertAndDeleteServiceNat46(c *C) {
+func TestUpsertAndDeleteServiceNat46(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	option.Config.EnableIPv4 = true
 	option.Config.EnableIPv6 = true
 	option.Config.NodePortNat46X64 = true
-	m.testUpsertAndDeleteService46(c)
+	m.testUpsertAndDeleteService46(t)
 }
 
-func (m *ManagerTestSuite) TestUpsertAndDeleteServiceNat64(c *C) {
+func TestUpsertAndDeleteServiceNat64(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	option.Config.EnableIPv4 = true
 	option.Config.EnableIPv6 = true
 	option.Config.NodePortNat46X64 = true
-	m.testUpsertAndDeleteService64(c)
+	m.testUpsertAndDeleteService64(t)
 }
 
-func (m *ManagerTestSuite) testUpsertAndDeleteService46(c *C) {
+func (m *ManagerTestSuite) testUpsertAndDeleteService46(t *testing.T) {
 	// Should create a new v4 service with two v6 backends
 	p := &lb.SVC{
 		Frontend:         frontend1,
@@ -251,36 +260,36 @@ func (m *ManagerTestSuite) testUpsertAndDeleteService46(c *C) {
 		Name:             lb.ServiceName{Name: "svc1", Namespace: "ns1"},
 	}
 	created, id1, err := m.svc.UpsertService(p)
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 2)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
-	c.Assert(m.svc.svcByID[id1].svcName.Name, Equals, "svc1")
-	c.Assert(m.svc.svcByID[id1].svcName.Namespace, Equals, "ns1")
-	c.Assert(m.svc.svcByID[id1].svcNatPolicy, Equals, lb.SVCNatPolicyNat46)
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, 2, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 2, len(m.lbmap.BackendByID))
+	require.Equal(t, "svc1", m.svc.svcByID[id1].svcName.Name)
+	require.Equal(t, "ns1", m.svc.svcByID[id1].svcName.Namespace)
+	require.Equal(t, lb.SVCNatPolicyNat46, m.svc.svcByID[id1].svcNatPolicy)
 
 	// Should delete both backends of service
 	p.Backends = nil
 	created, id2, err := m.svc.UpsertService(p)
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, false)
-	c.Assert(id2, Equals, id1)
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id2)].Backends), Equals, 0)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 0)
-	c.Assert(m.svc.svcByID[id2].svcName.Name, Equals, "svc1")
-	c.Assert(m.svc.svcByID[id2].svcName.Namespace, Equals, "ns1")
-	c.Assert(m.svc.svcByID[id2].svcNatPolicy, Equals, lb.SVCNatPolicyNone)
+	require.Nil(t, err)
+	require.Equal(t, false, created)
+	require.Equal(t, id1, id2)
+	require.Equal(t, 0, len(m.lbmap.ServiceByID[uint16(id2)].Backends))
+	require.Equal(t, 0, len(m.lbmap.BackendByID))
+	require.Equal(t, "svc1", m.svc.svcByID[id2].svcName.Name)
+	require.Equal(t, "ns1", m.svc.svcByID[id2].svcName.Namespace)
+	require.Equal(t, lb.SVCNatPolicyNone, m.svc.svcByID[id2].svcNatPolicy)
 
 	// Should delete the remaining service
 	found, err := m.svc.DeleteServiceByID(lb.ServiceID(id1))
-	c.Assert(err, IsNil)
-	c.Assert(found, Equals, true)
-	c.Assert(len(m.lbmap.ServiceByID), Equals, 0)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 0)
+	require.Nil(t, err)
+	require.Equal(t, true, found)
+	require.Equal(t, 0, len(m.lbmap.ServiceByID))
+	require.Equal(t, 0, len(m.lbmap.BackendByID))
 }
 
-func (m *ManagerTestSuite) testUpsertAndDeleteService64(c *C) {
+func (m *ManagerTestSuite) testUpsertAndDeleteService64(t *testing.T) {
 	// Should create a new v6 service with two v4 backends
 	p := &lb.SVC{
 		Frontend:         frontend3,
@@ -291,36 +300,36 @@ func (m *ManagerTestSuite) testUpsertAndDeleteService64(c *C) {
 		Name:             lb.ServiceName{Name: "svc1", Namespace: "ns1"},
 	}
 	created, id1, err := m.svc.UpsertService(p)
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 2)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
-	c.Assert(m.svc.svcByID[id1].svcName.Name, Equals, "svc1")
-	c.Assert(m.svc.svcByID[id1].svcName.Namespace, Equals, "ns1")
-	c.Assert(m.svc.svcByID[id1].svcNatPolicy, Equals, lb.SVCNatPolicyNat64)
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, 2, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 2, len(m.lbmap.BackendByID))
+	require.Equal(t, "svc1", m.svc.svcByID[id1].svcName.Name)
+	require.Equal(t, "ns1", m.svc.svcByID[id1].svcName.Namespace)
+	require.Equal(t, lb.SVCNatPolicyNat64, m.svc.svcByID[id1].svcNatPolicy)
 
 	// Should delete both backends of service
 	p.Backends = nil
 	created, id2, err := m.svc.UpsertService(p)
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, false)
-	c.Assert(id2, Equals, id1)
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id2)].Backends), Equals, 0)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 0)
-	c.Assert(m.svc.svcByID[id2].svcName.Name, Equals, "svc1")
-	c.Assert(m.svc.svcByID[id2].svcName.Namespace, Equals, "ns1")
-	c.Assert(m.svc.svcByID[id2].svcNatPolicy, Equals, lb.SVCNatPolicyNone)
+	require.Nil(t, err)
+	require.Equal(t, false, created)
+	require.Equal(t, id1, id2)
+	require.Equal(t, 0, len(m.lbmap.ServiceByID[uint16(id2)].Backends))
+	require.Equal(t, 0, len(m.lbmap.BackendByID))
+	require.Equal(t, "svc1", m.svc.svcByID[id2].svcName.Name)
+	require.Equal(t, "ns1", m.svc.svcByID[id2].svcName.Namespace)
+	require.Equal(t, lb.SVCNatPolicyNone, m.svc.svcByID[id2].svcNatPolicy)
 
 	// Should delete the remaining service
 	found, err := m.svc.DeleteServiceByID(lb.ServiceID(id1))
-	c.Assert(err, IsNil)
-	c.Assert(found, Equals, true)
-	c.Assert(len(m.lbmap.ServiceByID), Equals, 0)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 0)
+	require.Nil(t, err)
+	require.Equal(t, true, found)
+	require.Equal(t, 0, len(m.lbmap.ServiceByID))
+	require.Equal(t, 0, len(m.lbmap.BackendByID))
 }
 
-func (m *ManagerTestSuite) testUpsertAndDeleteService(c *C) {
+func (m *ManagerTestSuite) testUpsertAndDeleteService(t *testing.T) {
 	// Should create a new service with two backends and session affinity
 	p := &lb.SVC{
 		Frontend:                  frontend1,
@@ -333,35 +342,35 @@ func (m *ManagerTestSuite) testUpsertAndDeleteService(c *C) {
 		Name:                      lb.ServiceName{Name: "svc1", Namespace: "ns1"},
 	}
 	created, id1, err := m.svc.UpsertService(p)
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 2)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
-	c.Assert(m.svc.svcByID[id1].svcName.Name, Equals, "svc1")
-	c.Assert(m.svc.svcByID[id1].svcName.Namespace, Equals, "ns1")
-	c.Assert(m.svc.svcByID[id1].sessionAffinity, Equals, true)
-	c.Assert(m.svc.svcByID[id1].sessionAffinityTimeoutSec, Equals, uint32(100))
-	c.Assert(m.lbmap.ServiceByID[uint16(id1)].SessionAffinity, Equals, true)
-	c.Assert(m.lbmap.ServiceByID[uint16(id1)].SessionAffinityTimeoutSec, Equals, uint32(100))
-	c.Assert(len(m.lbmap.AffinityMatch[uint16(id1)]), Equals, 2)
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, 2, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 2, len(m.lbmap.BackendByID))
+	require.Equal(t, "svc1", m.svc.svcByID[id1].svcName.Name)
+	require.Equal(t, "ns1", m.svc.svcByID[id1].svcName.Namespace)
+	require.Equal(t, true, m.svc.svcByID[id1].sessionAffinity)
+	require.Equal(t, uint32(100), m.svc.svcByID[id1].sessionAffinityTimeoutSec)
+	require.Equal(t, true, m.lbmap.ServiceByID[uint16(id1)].SessionAffinity)
+	require.Equal(t, uint32(100), m.lbmap.ServiceByID[uint16(id1)].SessionAffinityTimeoutSec)
+	require.Equal(t, 2, len(m.lbmap.AffinityMatch[uint16(id1)]))
 	for bID := range m.lbmap.BackendByID {
-		c.Assert(m.lbmap.AffinityMatch[uint16(id1)][bID], Equals, struct{}{})
+		require.Equal(t, struct{}{}, m.lbmap.AffinityMatch[uint16(id1)][bID])
 	}
 
 	// Should remove session affinity
 	p.SessionAffinity = false
 	created, id1, err = m.svc.UpsertService(p)
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, false)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 2)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
-	c.Assert(m.svc.svcByID[id1].svcName.Name, Equals, "svc1")
-	c.Assert(m.svc.svcByID[id1].svcName.Namespace, Equals, "ns1")
-	c.Assert(len(m.lbmap.AffinityMatch[uint16(id1)]), Equals, 0)
-	c.Assert(m.svc.svcByID[id1].sessionAffinity, Equals, false)
-	c.Assert(m.lbmap.ServiceByID[uint16(id1)].SessionAffinity, Equals, false)
+	require.Nil(t, err)
+	require.Equal(t, false, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, 2, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 2, len(m.lbmap.BackendByID))
+	require.Equal(t, "svc1", m.svc.svcByID[id1].svcName.Name)
+	require.Equal(t, "ns1", m.svc.svcByID[id1].svcName.Namespace)
+	require.Equal(t, 0, len(m.lbmap.AffinityMatch[uint16(id1)]))
+	require.Equal(t, false, m.svc.svcByID[id1].sessionAffinity)
+	require.Equal(t, false, m.lbmap.ServiceByID[uint16(id1)].SessionAffinity)
 	// TODO(brb) test that backends are the same
 	// TODO(brb) check that .backends =~ .backendsByHash
 
@@ -370,26 +379,26 @@ func (m *ManagerTestSuite) testUpsertAndDeleteService(c *C) {
 	p.SessionAffinity = true
 	p.SessionAffinityTimeoutSec = 200
 	created, id1, err = m.svc.UpsertService(p)
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, false)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 1)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 1)
-	c.Assert(m.svc.svcByID[id1].svcName.Name, Equals, "svc1")
-	c.Assert(m.svc.svcByID[id1].svcName.Namespace, Equals, "ns1")
-	c.Assert(m.svc.svcByID[id1].sessionAffinity, Equals, true)
-	c.Assert(m.svc.svcByID[id1].sessionAffinityTimeoutSec, Equals, uint32(200))
-	c.Assert(len(m.lbmap.AffinityMatch[uint16(id1)]), Equals, 1)
+	require.Nil(t, err)
+	require.Equal(t, false, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, 1, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 1, len(m.lbmap.BackendByID))
+	require.Equal(t, "svc1", m.svc.svcByID[id1].svcName.Name)
+	require.Equal(t, "ns1", m.svc.svcByID[id1].svcName.Namespace)
+	require.Equal(t, true, m.svc.svcByID[id1].sessionAffinity)
+	require.Equal(t, uint32(200), m.svc.svcByID[id1].sessionAffinityTimeoutSec)
+	require.Equal(t, 1, len(m.lbmap.AffinityMatch[uint16(id1)]))
 	for bID := range m.lbmap.BackendByID {
-		c.Assert(m.lbmap.AffinityMatch[uint16(id1)][bID], Equals, struct{}{})
+		require.Equal(t, struct{}{}, m.lbmap.AffinityMatch[uint16(id1)][bID])
 	}
 
 	// Should add another service
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	cidr1, err := cidr.ParseCIDR("10.0.0.0/8")
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	cidr2, err := cidr.ParseCIDR("192.168.1.0/24")
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	p2 := &lb.SVC{
 		Frontend:                  frontend2,
 		Backends:                  backends1,
@@ -402,20 +411,20 @@ func (m *ManagerTestSuite) testUpsertAndDeleteService(c *C) {
 		LoadBalancerSourceRanges:  []*cidr.CIDR{cidr1, cidr2},
 	}
 	created, id2, err := m.svc.UpsertService(p2)
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id2, Equals, lb.ID(2))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id2)].Backends), Equals, 2)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
-	c.Assert(m.svc.svcByID[id2].svcName.Name, Equals, "svc2")
-	c.Assert(m.svc.svcByID[id2].svcName.Namespace, Equals, "ns2")
-	c.Assert(len(m.lbmap.AffinityMatch[uint16(id2)]), Equals, 2)
-	c.Assert(len(m.lbmap.SourceRanges[uint16(id2)]), Equals, 2)
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.Equal(t, lb.ID(2), id2)
+	require.Equal(t, 2, len(m.lbmap.ServiceByID[uint16(id2)].Backends))
+	require.Equal(t, 2, len(m.lbmap.BackendByID))
+	require.Equal(t, "svc2", m.svc.svcByID[id2].svcName.Name)
+	require.Equal(t, "ns2", m.svc.svcByID[id2].svcName.Namespace)
+	require.Equal(t, 2, len(m.lbmap.AffinityMatch[uint16(id2)]))
+	require.Equal(t, 2, len(m.lbmap.SourceRanges[uint16(id2)]))
 
 	// Should add IPv6 service only if IPv6 is enabled
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	cidr1, err = cidr.ParseCIDR("fd00::/8")
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	p3 := &lb.SVC{
 		Frontend:                  frontend3,
 		Backends:                  backends3,
@@ -429,62 +438,63 @@ func (m *ManagerTestSuite) testUpsertAndDeleteService(c *C) {
 	}
 	created, id3, err := m.svc.UpsertService(p3)
 	if option.Config.EnableIPv6 {
-		c.Assert(err, IsNil)
-		c.Assert(created, Equals, true)
-		c.Assert(id3, Equals, lb.ID(3))
-		c.Assert(len(m.lbmap.ServiceByID[uint16(id3)].Backends), Equals, 2)
-		c.Assert(len(m.lbmap.BackendByID), Equals, 4)
-		c.Assert(m.svc.svcByID[id3].svcName.Name, Equals, "svc3")
-		c.Assert(m.svc.svcByID[id3].svcName.Namespace, Equals, "ns3")
-		c.Assert(len(m.lbmap.AffinityMatch[uint16(id3)]), Equals, 2)
-		c.Assert(len(m.lbmap.SourceRanges[uint16(id3)]), Equals, 1)
+		require.Nil(t, err)
+		require.Equal(t, true, created)
+		require.Equal(t, lb.ID(3), id3)
+		require.Equal(t, 2, len(m.lbmap.ServiceByID[uint16(id3)].Backends))
+		require.Equal(t, 4, len(m.lbmap.BackendByID))
+		require.Equal(t, "svc3", m.svc.svcByID[id3].svcName.Name)
+		require.Equal(t, "ns3", m.svc.svcByID[id3].svcName.Namespace)
+		require.Equal(t, 2, len(m.lbmap.AffinityMatch[uint16(id3)]))
+		require.Equal(t, 1, len(m.lbmap.SourceRanges[uint16(id3)]))
 
 		// Should remove the IPv6 service
 		found, err := m.svc.DeleteServiceByID(lb.ServiceID(id3))
-		c.Assert(err, IsNil)
-		c.Assert(found, Equals, true)
+		require.Nil(t, err)
+		require.Equal(t, true, found)
 	} else {
-		c.Assert(err, ErrorMatches, "Unable to upsert service .+ as IPv6 is disabled")
-		c.Assert(created, Equals, false)
+		require.ErrorContains(t, err, "Unable to upsert service")
+		require.ErrorContains(t, err, "as IPv6 is disabled")
+		require.Equal(t, false, created)
 	}
-	c.Assert(len(m.lbmap.ServiceByID), Equals, 2)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
+	require.Equal(t, 2, len(m.lbmap.ServiceByID))
+	require.Equal(t, 2, len(m.lbmap.BackendByID))
 
 	// Should remove the service and the backend, but keep another service and
 	// its backends. Also, should remove the affinity match.
 	found, err := m.svc.DeleteServiceByID(lb.ServiceID(id1))
-	c.Assert(err, IsNil)
-	c.Assert(found, Equals, true)
-	c.Assert(len(m.lbmap.ServiceByID), Equals, 1)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
-	c.Assert(len(m.lbmap.AffinityMatch[uint16(id1)]), Equals, 0)
+	require.Nil(t, err)
+	require.Equal(t, true, found)
+	require.Equal(t, 1, len(m.lbmap.ServiceByID))
+	require.Equal(t, 2, len(m.lbmap.BackendByID))
+	require.Equal(t, 0, len(m.lbmap.AffinityMatch[uint16(id1)]))
 
 	// Should delete both backends of service
 	p2.Backends = nil
 	p2.LoadBalancerSourceRanges = []*cidr.CIDR{cidr2}
 	created, id2, err = m.svc.UpsertService(p2)
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, false)
-	c.Assert(id2, Equals, lb.ID(2))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id2)].Backends), Equals, 0)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 0)
-	c.Assert(m.svc.svcByID[id2].svcName.Name, Equals, "svc2")
-	c.Assert(m.svc.svcByID[id2].svcName.Namespace, Equals, "ns2")
-	c.Assert(len(m.lbmap.AffinityMatch[uint16(id2)]), Equals, 0)
-	c.Assert(len(m.lbmap.SourceRanges[uint16(id2)]), Equals, 1)
+	require.Nil(t, err)
+	require.Equal(t, false, created)
+	require.Equal(t, lb.ID(2), id2)
+	require.Equal(t, 0, len(m.lbmap.ServiceByID[uint16(id2)].Backends))
+	require.Equal(t, 0, len(m.lbmap.BackendByID))
+	require.Equal(t, "svc2", m.svc.svcByID[id2].svcName.Name)
+	require.Equal(t, "ns2", m.svc.svcByID[id2].svcName.Namespace)
+	require.Equal(t, 0, len(m.lbmap.AffinityMatch[uint16(id2)]))
+	require.Equal(t, 1, len(m.lbmap.SourceRanges[uint16(id2)]))
 
 	// Should delete the remaining service
 	found, err = m.svc.DeleteServiceByID(lb.ServiceID(id2))
-	c.Assert(err, IsNil)
-	c.Assert(found, Equals, true)
-	c.Assert(len(m.lbmap.ServiceByID), Equals, 0)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 0)
+	require.Nil(t, err)
+	require.Equal(t, true, found)
+	require.Equal(t, 0, len(m.lbmap.ServiceByID))
+	require.Equal(t, 0, len(m.lbmap.BackendByID))
 
 	// Should ignore the source range if it does not match FE's ip family
 	cidr1, err = cidr.ParseCIDR("fd00::/8")
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	cidr2, err = cidr.ParseCIDR("192.168.1.0/24")
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	p4 := &lb.SVC{
 		Frontend:                  frontend1,
@@ -498,12 +508,14 @@ func (m *ManagerTestSuite) testUpsertAndDeleteService(c *C) {
 		LoadBalancerSourceRanges:  []*cidr.CIDR{cidr1, cidr2},
 	}
 	created, id4, err := m.svc.UpsertService(p4)
-	c.Assert(created, Equals, true)
-	c.Assert(err, IsNil)
-	c.Assert(len(m.lbmap.SourceRanges[uint16(id4)]), Equals, 1)
+	require.Equal(t, true, created)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(m.lbmap.SourceRanges[uint16(id4)]))
 }
 
-func (m *ManagerTestSuite) TestRestoreServices(c *C) {
+func TestRestoreServices(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	p1 := &lb.SVC{
 		Frontend:         frontend1,
 		Backends:         backends1,
@@ -512,11 +524,11 @@ func (m *ManagerTestSuite) TestRestoreServices(c *C) {
 		IntTrafficPolicy: lb.SVCTrafficPolicyCluster,
 	}
 	_, id1, err := m.svc.UpsertService(p1)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	cidr1, err := cidr.ParseCIDR("10.0.0.0/8")
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	cidr2, err := cidr.ParseCIDR("192.168.1.0/24")
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	p2 := &lb.SVC{
 		Frontend:                  frontend2,
 		Backends:                  backends2,
@@ -528,7 +540,7 @@ func (m *ManagerTestSuite) TestRestoreServices(c *C) {
 		LoadBalancerSourceRanges:  []*cidr.CIDR{cidr1, cidr2},
 	}
 	_, id2, err := m.svc.UpsertService(p2)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Restart service, but keep the lbmap to restore services from
 	option.Config.NodePortAlg = option.NodePortAlgMaglev
@@ -538,30 +550,30 @@ func (m *ManagerTestSuite) TestRestoreServices(c *C) {
 
 	// Restore services from lbmap
 	err = m.svc.RestoreServices()
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Backends have been restored
-	c.Assert(len(m.svc.backendByHash), Equals, 3)
+	require.Equal(t, 3, len(m.svc.backendByHash))
 	backends := append(backends1, backends2...)
 	for _, b := range backends {
 		_, found := m.svc.backendByHash[b.Hash()]
-		c.Assert(found, Equals, true)
+		require.Equal(t, true, found)
 	}
 
 	// Services have been restored too
-	c.Assert(len(m.svc.svcByID), Equals, 2)
-	c.Assert(m.svc.svcByID[id1].frontend, checker.DeepEquals, lbmap.ServiceByID[uint16(id1)].Frontend)
-	c.Assert(m.svc.svcByID[id1].backends, checker.DeepEquals, lbmap.ServiceByID[uint16(id1)].Backends)
-	c.Assert(m.svc.svcByID[id2].frontend, checker.DeepEquals, lbmap.ServiceByID[uint16(id2)].Frontend)
-	c.Assert(m.svc.svcByID[id2].backends, checker.DeepEquals, lbmap.ServiceByID[uint16(id2)].Backends)
+	require.Equal(t, 2, len(m.svc.svcByID))
+	require.EqualValues(t, lbmap.ServiceByID[uint16(id1)].Frontend, m.svc.svcByID[id1].frontend)
+	require.EqualValues(t, lbmap.ServiceByID[uint16(id1)].Backends, m.svc.svcByID[id1].backends)
+	require.EqualValues(t, lbmap.ServiceByID[uint16(id2)].Frontend, m.svc.svcByID[id2].frontend)
+	require.EqualValues(t, lbmap.ServiceByID[uint16(id2)].Backends, m.svc.svcByID[id2].backends)
 
 	// Session affinity too
-	c.Assert(m.svc.svcByID[id1].sessionAffinity, Equals, false)
-	c.Assert(m.svc.svcByID[id2].sessionAffinity, Equals, true)
-	c.Assert(m.svc.svcByID[id2].sessionAffinityTimeoutSec, Equals, uint32(200))
+	require.Equal(t, false, m.svc.svcByID[id1].sessionAffinity)
+	require.Equal(t, true, m.svc.svcByID[id2].sessionAffinity)
+	require.Equal(t, uint32(200), m.svc.svcByID[id2].sessionAffinityTimeoutSec)
 
 	// LoadBalancer source ranges too
-	c.Assert(len(m.svc.svcByID[id2].loadBalancerSourceRanges), Equals, 2)
+	require.Equal(t, 2, len(m.svc.svcByID[id2].loadBalancerSourceRanges))
 	for _, cidr := range []*cidr.CIDR{cidr1, cidr2} {
 		found := false
 		for _, c := range m.svc.svcByID[id2].loadBalancerSourceRanges {
@@ -570,15 +582,17 @@ func (m *ManagerTestSuite) TestRestoreServices(c *C) {
 				break
 			}
 		}
-		c.Assert(found, Equals, true)
+		require.Equal(t, true, found)
 	}
 
 	// Maglev lookup table too
-	c.Assert(m.lbmap.DummyMaglevTable[uint16(id1)], Equals, len(backends1))
-	c.Assert(m.lbmap.DummyMaglevTable[uint16(id2)], Equals, len(backends2))
+	require.Equal(t, len(backends1), m.lbmap.DummyMaglevTable[uint16(id1)])
+	require.Equal(t, len(backends2), m.lbmap.DummyMaglevTable[uint16(id2)])
 }
 
-func (m *ManagerTestSuite) TestSyncWithK8sFinished(c *C) {
+func TestSyncWithK8sFinished(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	p1 := &lb.SVC{
 		Frontend:                  frontend1,
 		Backends:                  backends1,
@@ -589,7 +603,7 @@ func (m *ManagerTestSuite) TestSyncWithK8sFinished(c *C) {
 		SessionAffinityTimeoutSec: 300,
 	}
 	_, id1, err := m.svc.UpsertService(p1)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	p2 := &lb.SVC{
 		Frontend:         frontend2,
 		Backends:         backends2,
@@ -599,16 +613,16 @@ func (m *ManagerTestSuite) TestSyncWithK8sFinished(c *C) {
 		Name:             lb.ServiceName{Name: "svc2", Namespace: "ns2"},
 	}
 	_, _, err = m.svc.UpsertService(p2)
-	c.Assert(err, IsNil)
-	c.Assert(len(m.svc.svcByID), Equals, 2)
-	c.Assert(len(m.lbmap.AffinityMatch[uint16(id1)]), Equals, 2)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(m.svc.svcByID))
+	require.Equal(t, 2, len(m.lbmap.AffinityMatch[uint16(id1)]))
 
 	// Restart service, but keep the lbmap to restore services from
 	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
 	m.newServiceMock(lbmap)
 	err = m.svc.RestoreServices()
-	c.Assert(err, IsNil)
-	c.Assert(len(m.svc.svcByID), Equals, 2)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(m.svc.svcByID))
 
 	// Imitate a situation where svc1 was deleted while we were down.
 	// In real life, the following upsert is called by k8s_watcher during
@@ -617,7 +631,7 @@ func (m *ManagerTestSuite) TestSyncWithK8sFinished(c *C) {
 	p2.SessionAffinity = true
 	p2.SessionAffinityTimeoutSec = 100
 	_, id2, err := m.svc.UpsertService(p2)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Add non-existing affinity matches
 	lbmap.AddAffinityMatch(20, 300)
@@ -628,24 +642,24 @@ func (m *ManagerTestSuite) TestSyncWithK8sFinished(c *C) {
 	// cilium-agent finished the initialization, and thus SyncWithK8sFinished
 	// is called
 	stale, err := m.svc.SyncWithK8sFinished(false, nil)
-	c.Assert(stale, IsNil)
-	c.Assert(err, IsNil)
+	require.Nil(t, stale)
+	require.Nil(t, err)
 
 	// svc1 should be removed from cilium while svc2 is synced
-	c.Assert(len(m.svc.svcByID), Equals, 1)
+	require.Equal(t, 1, len(m.svc.svcByID))
 	_, found := m.svc.svcByID[id2]
-	c.Assert(found, Equals, true)
+	require.Equal(t, true, found)
 	_, found = m.svc.svcByID[id1]
-	c.Assert(found, Equals, false)
-	c.Assert(m.svc.svcByID[id2].svcName.Name, Equals, "svc2")
-	c.Assert(m.svc.svcByID[id2].svcName.Namespace, Equals, "ns2")
-	c.Assert(len(m.lbmap.AffinityMatch), Equals, 1)
+	require.Equal(t, false, found)
+	require.Equal(t, "svc2", m.svc.svcByID[id2].svcName.Name)
+	require.Equal(t, "ns2", m.svc.svcByID[id2].svcName.Namespace)
+	require.Equal(t, 1, len(m.lbmap.AffinityMatch))
 	// Check that the non-existing affinity matches were removed
 	matches, _ := lbmap.DumpAffinityMatches()
-	c.Assert(len(matches), Equals, 1) // id2 svc has updated session affinity
-	c.Assert(len(matches[uint16(id2)]), Equals, 2)
+	require.Equal(t, 1, len(matches)) // id2 svc has updated session affinity
+	require.Equal(t, 2, len(matches[uint16(id2)]))
 	for _, b := range lbmap.ServiceByID[uint16(id2)].Backends {
-		c.Assert(m.lbmap.AffinityMatch[uint16(id2)][b.ID], Equals, struct{}{})
+		require.Equal(t, struct{}{}, m.lbmap.AffinityMatch[uint16(id2)][b.ID])
 	}
 }
 
@@ -776,7 +790,9 @@ func TestRestoreServiceWithStaleBackends(t *testing.T) {
 	}
 }
 
-func (m *ManagerTestSuite) TestHealthCheckNodePort(c *C) {
+func TestHealthCheckNodePort(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	// Create two frontends, one for LoadBalaner and one for ClusterIP.
 	// This is used to emulate how we get K8s services from the K8s watcher,
 	// i.e. one service per frontend (even if it is logically the same service)
@@ -814,13 +830,13 @@ func (m *ManagerTestSuite) TestHealthCheckNodePort(c *C) {
 		Name:                lb.ServiceName{Name: "svc1", Namespace: "ns1"},
 	}
 	_, id1, err := m.svc.UpsertService(p1)
-	c.Assert(err, IsNil)
-	c.Assert(m.svcHealth.ServiceByPort(32001).Service.Name, Equals, "svc1")
-	c.Assert(m.svcHealth.ServiceByPort(32001).Service.Namespace, Equals, "ns1")
+	require.Nil(t, err)
+	require.Equal(t, "svc1", m.svcHealth.ServiceByPort(32001).Service.Name)
+	require.Equal(t, "ns1", m.svcHealth.ServiceByPort(32001).Service.Namespace)
 
 	p1.Backends[2].State = lb.BackendStateTerminating
 	_, _, _ = m.svc.UpsertService(p1)
-	c.Assert(m.svcHealth.ServiceByPort(32001).LocalEndpoints, Equals, len(localActiveBackends))
+	require.Equal(t, len(localActiveBackends), m.svcHealth.ServiceByPort(32001).LocalEndpoints)
 
 	// Insert the ClusterIP frontend of svc1
 	p2 := &lb.SVC{
@@ -833,69 +849,69 @@ func (m *ManagerTestSuite) TestHealthCheckNodePort(c *C) {
 		Name:                lb.ServiceName{Name: "svc1", Namespace: "ns1"},
 	}
 	_, id2, err := m.svc.UpsertService(p2)
-	c.Assert(err, IsNil)
-	c.Assert(m.svcHealth.ServiceByPort(32001).Service.Name, Equals, "svc1")
-	c.Assert(m.svcHealth.ServiceByPort(32001).Service.Namespace, Equals, "ns1")
-	c.Assert(m.svcHealth.ServiceByPort(32001).LocalEndpoints, Equals, len(localActiveBackends))
+	require.Nil(t, err)
+	require.Equal(t, "svc1", m.svcHealth.ServiceByPort(32001).Service.Name)
+	require.Equal(t, "ns1", m.svcHealth.ServiceByPort(32001).Service.Namespace)
+	require.Equal(t, len(localActiveBackends), m.svcHealth.ServiceByPort(32001).LocalEndpoints)
 
 	// Update the HealthCheckNodePort for svc1
 	p1.HealthCheckNodePort = 32000
 	new, _, err := m.svc.UpsertService(p1)
-	c.Assert(err, IsNil)
-	c.Assert(new, Equals, false)
-	c.Assert(m.svcHealth.ServiceByPort(32000).Service.Name, Equals, "svc1")
-	c.Assert(m.svcHealth.ServiceByPort(32000).Service.Namespace, Equals, "ns1")
-	c.Assert(m.svcHealth.ServiceByPort(32000).LocalEndpoints, Equals, len(localActiveBackends))
-	c.Assert(m.svcHealth.ServiceByPort(32001), IsNil)
+	require.Nil(t, err)
+	require.Equal(t, false, new)
+	require.Equal(t, "svc1", m.svcHealth.ServiceByPort(32000).Service.Name)
+	require.Equal(t, "ns1", m.svcHealth.ServiceByPort(32000).Service.Namespace)
+	require.Equal(t, len(localActiveBackends), m.svcHealth.ServiceByPort(32000).LocalEndpoints)
+	require.Nil(t, m.svcHealth.ServiceByPort(32001))
 
 	// Update the externalTrafficPolicy for svc1
 	p1.ExtTrafficPolicy = lb.SVCTrafficPolicyCluster
 	p1.HealthCheckNodePort = 0
 	new, _, err = m.svc.UpsertService(p1)
-	c.Assert(err, IsNil)
-	c.Assert(new, Equals, false)
-	c.Assert(m.svcHealth.ServiceByPort(32000), IsNil)
-	c.Assert(m.svcHealth.ServiceByPort(32001), IsNil)
+	require.Nil(t, err)
+	require.Equal(t, false, new)
+	require.Nil(t, m.svcHealth.ServiceByPort(32000))
+	require.Nil(t, m.svcHealth.ServiceByPort(32001))
 
 	// Restore the original version of svc1
 	p1.ExtTrafficPolicy = lb.SVCTrafficPolicyLocal
 	p1.HealthCheckNodePort = 32001
 	new, _, err = m.svc.UpsertService(p1)
-	c.Assert(err, IsNil)
-	c.Assert(new, Equals, false)
-	c.Assert(m.svcHealth.ServiceByPort(32001).Service.Name, Equals, "svc1")
-	c.Assert(m.svcHealth.ServiceByPort(32001).Service.Namespace, Equals, "ns1")
-	c.Assert(m.svcHealth.ServiceByPort(32001).LocalEndpoints, Equals, len(localActiveBackends))
+	require.Nil(t, err)
+	require.Equal(t, false, new)
+	require.Equal(t, "svc1", m.svcHealth.ServiceByPort(32001).Service.Name)
+	require.Equal(t, "ns1", m.svcHealth.ServiceByPort(32001).Service.Namespace)
+	require.Equal(t, len(localActiveBackends), m.svcHealth.ServiceByPort(32001).LocalEndpoints)
 
 	// Upsert svc1 of type LoadBalancer with only remote backends
 	p1.Backends = remoteBackends
 	new, _, err = m.svc.UpsertService(p1)
-	c.Assert(err, IsNil)
-	c.Assert(new, Equals, false)
-	c.Assert(m.svcHealth.ServiceByPort(32001).Service.Name, Equals, "svc1")
-	c.Assert(m.svcHealth.ServiceByPort(32001).Service.Namespace, Equals, "ns1")
-	c.Assert(m.svcHealth.ServiceByPort(32001).LocalEndpoints, Equals, 0)
+	require.Nil(t, err)
+	require.Equal(t, false, new)
+	require.Equal(t, "svc1", m.svcHealth.ServiceByPort(32001).Service.Name)
+	require.Equal(t, "ns1", m.svcHealth.ServiceByPort(32001).Service.Namespace)
+	require.Equal(t, 0, m.svcHealth.ServiceByPort(32001).LocalEndpoints)
 
 	// Upsert svc1 of type ClusterIP with only remote backends
 	p2.Backends = remoteBackends
 	new, _, err = m.svc.UpsertService(p2)
-	c.Assert(err, IsNil)
-	c.Assert(new, Equals, false)
-	c.Assert(m.svcHealth.ServiceByPort(32001).Service.Name, Equals, "svc1")
-	c.Assert(m.svcHealth.ServiceByPort(32001).Service.Namespace, Equals, "ns1")
-	c.Assert(m.svcHealth.ServiceByPort(32001).LocalEndpoints, Equals, 0)
+	require.Nil(t, err)
+	require.Equal(t, false, new)
+	require.Equal(t, "svc1", m.svcHealth.ServiceByPort(32001).Service.Name)
+	require.Equal(t, "ns1", m.svcHealth.ServiceByPort(32001).Service.Namespace)
+	require.Equal(t, 0, m.svcHealth.ServiceByPort(32001).LocalEndpoints)
 
 	// Delete svc1 of type LoadBalancer
 	found, err := m.svc.DeleteServiceByID(lb.ServiceID(id1))
-	c.Assert(err, IsNil)
-	c.Assert(found, Equals, true)
-	c.Assert(m.svcHealth.ServiceByPort(32001), IsNil)
+	require.Nil(t, err)
+	require.Equal(t, true, found)
+	require.Nil(t, m.svcHealth.ServiceByPort(32001))
 
 	// Delete svc1 of type ClusterIP
 	found, err = m.svc.DeleteServiceByID(lb.ServiceID(id2))
-	c.Assert(err, IsNil)
-	c.Assert(found, Equals, true)
-	c.Assert(m.svcHealth.ServiceByPort(32001), IsNil)
+	require.Nil(t, err)
+	require.Equal(t, true, found)
+	require.Nil(t, m.svcHealth.ServiceByPort(32001))
 }
 
 // Define a mock implementation of the NodeMetaCollector interface for testing
@@ -912,7 +928,9 @@ func (m *mockNodeMetaCollector) GetIPv6() net.IP {
 	return m.ipv6
 }
 
-func (m *ManagerTestSuite) TestHealthCheckLoadBalancerIP(c *C) {
+func TestHealthCheckLoadBalancerIP(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	option.Config.EnableHealthCheckLoadBalancerIP = true
 
 	mockCollector := &mockNodeMetaCollector{
@@ -941,53 +959,55 @@ func (m *ManagerTestSuite) TestHealthCheckLoadBalancerIP(c *C) {
 	svc, _, _, _, _ := m.svc.createSVCInfoIfNotExist(p1)
 	err := m.svc.upsertNodePortHealthService(svc, mockCollector)
 
-	c.Assert(err, IsNil)
-	c.Assert(svc.healthcheckFrontendHash, Not(Equals), "")
-	c.Assert(m.svc.svcByHash[svc.healthcheckFrontendHash].svcName.Name, Equals, "svc1-healthCheck")
-	c.Assert(m.svc.svcByHash[svc.healthcheckFrontendHash].svcName.Namespace, Equals, "ns1")
-	c.Assert(m.svc.svcByHash[svc.healthcheckFrontendHash].frontend.Port, Equals, svc.svcHealthCheckNodePort)
-	c.Assert(m.svc.svcByHash[svc.healthcheckFrontendHash].frontend.AddrCluster.Addr(), Equals, netip.MustParseAddr("1.1.1.1"))
-	c.Assert(m.svc.svcByHash[svc.healthcheckFrontendHash].backends[0].AddrCluster, Equals, cmtypes.AddrClusterFrom(netip.MustParseAddr("192.0.2.0"), option.Config.ClusterID))
+	require.Nil(t, err)
+	require.NotEqual(t, "", svc.healthcheckFrontendHash)
+	require.Equal(t, "svc1-healthCheck", m.svc.svcByHash[svc.healthcheckFrontendHash].svcName.Name)
+	require.Equal(t, "ns1", m.svc.svcByHash[svc.healthcheckFrontendHash].svcName.Namespace)
+	require.Equal(t, svc.svcHealthCheckNodePort, m.svc.svcByHash[svc.healthcheckFrontendHash].frontend.Port)
+	require.Equal(t, netip.MustParseAddr("1.1.1.1"), m.svc.svcByHash[svc.healthcheckFrontendHash].frontend.AddrCluster.Addr())
+	require.Equal(t, cmtypes.AddrClusterFrom(netip.MustParseAddr("192.0.2.0"), option.Config.ClusterID), m.svc.svcByHash[svc.healthcheckFrontendHash].backends[0].AddrCluster)
 
 	// Update the externalTrafficPolicy for svc1
 	svc.frontend.Scope = lb.ScopeExternal
 	svc.svcHealthCheckNodePort = 0
 	oldHealthHash := svc.healthcheckFrontendHash
 	err = m.svc.upsertNodePortHealthService(svc, mockCollector)
-	c.Assert(err, IsNil)
-	c.Assert(svc.healthcheckFrontendHash, Equals, "")
-	c.Assert(m.svc.svcByHash[oldHealthHash], IsNil)
+	require.Nil(t, err)
+	require.Equal(t, "", svc.healthcheckFrontendHash)
+	require.Nil(t, m.svc.svcByHash[oldHealthHash])
 
 	// Restore the original version of svc1
 	svc.frontend.Scope = lb.ScopeInternal
 	svc.svcHealthCheckNodePort = 32001
 	err = m.svc.upsertNodePortHealthService(svc, mockCollector)
-	c.Assert(err, IsNil)
-	c.Assert(svc.healthcheckFrontendHash, Not(Equals), "")
-	c.Assert(m.svc.svcByHash[svc.healthcheckFrontendHash].svcName.Name, Equals, "svc1-healthCheck")
-	c.Assert(m.svc.svcByHash[svc.healthcheckFrontendHash].svcName.Namespace, Equals, "ns1")
-	c.Assert(m.svc.svcByHash[svc.healthcheckFrontendHash].frontend.Port, Equals, svc.svcHealthCheckNodePort)
-	c.Assert(m.svc.svcByHash[svc.healthcheckFrontendHash].frontend.AddrCluster.Addr(), Equals, netip.MustParseAddr("1.1.1.1"))
-	c.Assert(m.svc.svcByHash[svc.healthcheckFrontendHash].backends[0].AddrCluster, Equals, cmtypes.AddrClusterFrom(netip.MustParseAddr("192.0.2.0"), option.Config.ClusterID))
+	require.Nil(t, err)
+	require.NotEqual(t, "", svc.healthcheckFrontendHash)
+	require.Equal(t, "svc1-healthCheck", m.svc.svcByHash[svc.healthcheckFrontendHash].svcName.Name)
+	require.Equal(t, "ns1", m.svc.svcByHash[svc.healthcheckFrontendHash].svcName.Namespace)
+	require.Equal(t, svc.svcHealthCheckNodePort, m.svc.svcByHash[svc.healthcheckFrontendHash].frontend.Port)
+	require.Equal(t, netip.MustParseAddr("1.1.1.1"), m.svc.svcByHash[svc.healthcheckFrontendHash].frontend.AddrCluster.Addr())
+	require.Equal(t, cmtypes.AddrClusterFrom(netip.MustParseAddr("192.0.2.0"), option.Config.ClusterID), m.svc.svcByHash[svc.healthcheckFrontendHash].backends[0].AddrCluster)
 
 	// IPv6 NodePort Backend
 	oldHealthHash = svc.healthcheckFrontendHash
 	svc.frontend = *lb.NewL3n4AddrID(lb.TCP, cmtypes.MustParseAddrCluster("2001:db8:1::1"), 80, lb.ScopeExternal, 0)
 	err = m.svc.upsertNodePortHealthService(svc, mockCollector)
-	c.Assert(err, IsNil)
-	c.Assert(m.svc.svcByHash[svc.healthcheckFrontendHash].backends[0].AddrCluster, Equals, cmtypes.AddrClusterFrom(netip.MustParseAddr("2001:db8::1"), option.Config.ClusterID))
-	c.Assert(m.svc.svcByHash[oldHealthHash], IsNil)
+	require.Nil(t, err)
+	require.Equal(t, cmtypes.AddrClusterFrom(netip.MustParseAddr("2001:db8::1"), option.Config.ClusterID), m.svc.svcByHash[svc.healthcheckFrontendHash].backends[0].AddrCluster)
+	require.Nil(t, m.svc.svcByHash[oldHealthHash])
 
 	var ok bool
 	// Delete
 	ok, err = m.svc.DeleteService(m.svc.svcByHash[svc.healthcheckFrontendHash].frontend.L3n4Addr)
-	c.Assert(ok, Equals, true)
-	c.Assert(err, IsNil)
+	require.Equal(t, true, ok)
+	require.Nil(t, err)
 
 	option.Config.EnableHealthCheckLoadBalancerIP = false
 }
 
-func (m *ManagerTestSuite) TestHealthCheckNodePortDisabled(c *C) {
+func TestHealthCheckNodePortDisabled(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	// NewService sets healthServer to nil if EnableHealthCheckNodePort is
 	// false at start time. We emulate this here by temporarily setting it nil.
 	enableHealthCheckNodePort := option.Config.EnableHealthCheckNodePort
@@ -1008,27 +1028,29 @@ func (m *ManagerTestSuite) TestHealthCheckNodePortDisabled(c *C) {
 		HealthCheckNodePort: 32000,
 	}
 	_, id1, err := m.svc.UpsertService(p1)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Unset HealthCheckNodePort for that service
 	p1.HealthCheckNodePort = 0
 	p1.ExtTrafficPolicy = lb.SVCTrafficPolicyCluster
 	_, _, err = m.svc.UpsertService(p1)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Set HealthCheckNodePort for that service
 	p1.HealthCheckNodePort = 32000
 	p1.ExtTrafficPolicy = lb.SVCTrafficPolicyLocal
 	_, _, err = m.svc.UpsertService(p1)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Delete service with active HealthCheckNodePort
 	found, err := m.svc.DeleteServiceByID(lb.ServiceID(id1))
-	c.Assert(err, IsNil)
-	c.Assert(found, Equals, true)
+	require.Nil(t, err)
+	require.Equal(t, true, found)
 }
 
-func (m *ManagerTestSuite) TestGetServiceNameByAddr(c *C) {
+func TestGetServiceNameByAddr(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	fe := frontend1.DeepCopy()
 	name := "svc1"
 	namespace := "ns1"
@@ -1043,19 +1065,21 @@ func (m *ManagerTestSuite) TestGetServiceNameByAddr(c *C) {
 		Name:                lb.ServiceName{Name: name, Namespace: namespace},
 	}
 	created, id1, err := m.svc.UpsertService(p)
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id1, Equals, lb.ID(1))
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.Equal(t, lb.ID(1), id1)
 	fe.ID = id1
 	gotNamespace, gotName, ok := m.svc.GetServiceNameByAddr(frontend1.L3n4Addr)
-	c.Assert(gotNamespace, Equals, namespace)
-	c.Assert(gotName, Equals, name)
-	c.Assert(ok, Equals, true)
+	require.Equal(t, namespace, gotNamespace)
+	require.Equal(t, name, gotName)
+	require.Equal(t, true, ok)
 	_, _, ok = m.svc.GetServiceNameByAddr(frontend2.L3n4Addr)
-	c.Assert(ok, Equals, false)
+	require.Equal(t, false, ok)
 }
 
-func (m *ManagerTestSuite) TestLocalRedirectLocalBackendSelection(c *C) {
+func TestLocalRedirectLocalBackendSelection(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	// Create a node-local backend.
 	localBackend := backends1[0]
 	localBackend.NodeName = nodeTypes.GetName()
@@ -1081,26 +1105,28 @@ func (m *ManagerTestSuite) TestLocalRedirectLocalBackendSelection(c *C) {
 	}
 	// Insert the service entry of type Local Redirect.
 	created, id, err := m.svc.UpsertService(p1)
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id, Not(Equals), lb.ID(0))
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.NotEqual(t, lb.ID(0), id)
 
 	svc, ok := m.svc.svcByID[id]
-	c.Assert(ok, Equals, true)
-	c.Assert(svc.svcName.Namespace, Equals, "ns1")
-	c.Assert(svc.svcName.Name, Equals, "svc1")
+	require.Equal(t, true, ok)
+	require.Equal(t, "ns1", svc.svcName.Namespace)
+	require.Equal(t, "svc1", svc.svcName.Name)
 	// Only node-local backends are selected
-	c.Assert(len(svc.backends), Equals, len(localBackends))
+	require.Equal(t, len(localBackends), len(svc.backends))
 
 	svcFromLbMap, ok := m.lbmap.ServiceByID[uint16(id)]
-	c.Assert(ok, Equals, true)
-	c.Assert(len(svcFromLbMap.Backends), Equals, len(svc.backends))
+	require.Equal(t, true, ok)
+	require.Equal(t, len(svc.backends), len(svcFromLbMap.Backends))
 }
 
 // Local redirect service should be able to override a ClusterIP service with same
 // frontend, but reverse should produce an error. Also, it should not override
 // any other type besides itself or clusterIP type.
-func (m *ManagerTestSuite) TestLocalRedirectServiceOverride(c *C) {
+func TestLocalRedirectServiceOverride(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	// Create a node-local backend.
 	localBackend := backends1[0]
 	localBackend.NodeName = nodeTypes.GetName()
@@ -1126,32 +1152,32 @@ func (m *ManagerTestSuite) TestLocalRedirectServiceOverride(c *C) {
 
 	// Insert the service entry of type ClusterIP.
 	created, id, err := m.svc.UpsertService(p1)
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id, Not(Equals), lb.ID(0))
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.NotEqual(t, lb.ID(0), id)
 
 	svc, ok := m.svc.svcByID[id]
-	c.Assert(len(svc.backends), Equals, len(allBackends))
-	c.Assert(ok, Equals, true)
+	require.Equal(t, len(allBackends), len(svc.backends))
+	require.Equal(t, true, ok)
 
 	// Insert the service entry of type Local Redirect.
 	p1.Type = lb.SVCTypeLocalRedirect
 	created, id, err = m.svc.UpsertService(p1)
 
 	// Local redirect service should override the ClusterIP service with node-local backends.
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, false)
-	c.Assert(id, Not(Equals), lb.ID(0))
+	require.Nil(t, err)
+	require.Equal(t, false, created)
+	require.NotEqual(t, lb.ID(0), id)
 	svc = m.svc.svcByID[id]
 	// Only node-local backends are selected.
-	c.Assert(len(svc.backends), Equals, len(localBackends))
+	require.Equal(t, len(localBackends), len(svc.backends))
 
 	// Insert the service entry of type ClusterIP.
 	p1.Type = lb.SVCTypeClusterIP
 	created, _, err = m.svc.UpsertService(p1)
 
-	c.Assert(err, NotNil)
-	c.Assert(created, Equals, false)
+	require.Error(t, err)
+	require.Equal(t, false, created)
 
 	p2 := &lb.SVC{
 		Frontend:         frontend2,
@@ -1164,27 +1190,29 @@ func (m *ManagerTestSuite) TestLocalRedirectServiceOverride(c *C) {
 
 	// Insert the service entry of type NodePort.
 	created, id, err = m.svc.UpsertService(p2)
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id, Not(Equals), lb.ID(0))
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.NotEqual(t, lb.ID(0), id)
 
 	svc, ok = m.svc.svcByID[id]
-	c.Assert(len(svc.backends), Equals, len(allBackends))
-	c.Assert(ok, Equals, true)
+	require.Equal(t, len(allBackends), len(svc.backends))
+	require.Equal(t, true, ok)
 
 	// Insert the service entry of type Local Redirect.
 	p2.Type = lb.SVCTypeLocalRedirect
 	created, _, err = m.svc.UpsertService(p2)
 
 	// Local redirect service should not override the NodePort service.
-	c.Assert(err, NotNil)
-	c.Assert(created, Equals, false)
+	require.Error(t, err)
+	require.Equal(t, false, created)
 }
 
 // Tests whether upsert service handles terminating backends, whereby terminating
 // backends are not added to the service map, but are added to the backends and
 // affinity maps.
-func (m *ManagerTestSuite) TestUpsertServiceWithTerminatingBackends(c *C) {
+func TestUpsertServiceWithTerminatingBackends(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	option.Config.NodePortAlg = option.NodePortAlgMaglev
 	backends := append(backends4, backends1...)
 	p := &lb.SVC{
@@ -1200,50 +1228,52 @@ func (m *ManagerTestSuite) TestUpsertServiceWithTerminatingBackends(c *C) {
 
 	created, id1, err := m.svc.UpsertService(p)
 
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, len(backends))
-	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id1)], Equals, len(backends))
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, len(backends), len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, len(backends), m.lbmap.SvcActiveBackendsCount[uint16(id1)])
 
 	p.Backends[0].State = lb.BackendStateTerminating
 
 	_, _, err = m.svc.UpsertService(p)
 
-	c.Assert(err, IsNil)
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, len(backends))
-	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id1)], Equals, len(backends1))
+	require.Nil(t, err)
+	require.Equal(t, len(backends), len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, len(backends1), m.lbmap.SvcActiveBackendsCount[uint16(id1)])
 	// Sorted active backends by ID first followed by non-active
-	c.Assert(m.lbmap.ServiceByID[uint16(id1)].Backends[0].ID, Equals, lb.BackendID(2))
-	c.Assert(m.lbmap.ServiceByID[uint16(id1)].Backends[1].ID, Equals, lb.BackendID(3))
-	c.Assert(m.lbmap.ServiceByID[uint16(id1)].Backends[2].ID, Equals, lb.BackendID(1))
-	c.Assert(len(m.lbmap.BackendByID), Equals, 3)
-	c.Assert(m.svc.svcByID[id1].svcName.Name, Equals, "svc1")
-	c.Assert(m.svc.svcByID[id1].svcName.Namespace, Equals, "ns1")
-	c.Assert(len(m.lbmap.AffinityMatch[uint16(id1)]), Equals, 3)
+	require.Equal(t, lb.BackendID(2), m.lbmap.ServiceByID[uint16(id1)].Backends[0].ID)
+	require.Equal(t, lb.BackendID(3), m.lbmap.ServiceByID[uint16(id1)].Backends[1].ID)
+	require.Equal(t, lb.BackendID(1), m.lbmap.ServiceByID[uint16(id1)].Backends[2].ID)
+	require.Equal(t, 3, len(m.lbmap.BackendByID))
+	require.Equal(t, "svc1", m.svc.svcByID[id1].svcName.Name)
+	require.Equal(t, "ns1", m.svc.svcByID[id1].svcName.Namespace)
+	require.Equal(t, 3, len(m.lbmap.AffinityMatch[uint16(id1)]))
 	for bID := range m.lbmap.BackendByID {
-		c.Assert(m.lbmap.AffinityMatch[uint16(id1)][bID], Equals, struct{}{})
+		require.Equal(t, struct{}{}, m.lbmap.AffinityMatch[uint16(id1)][bID])
 	}
-	c.Assert(m.lbmap.DummyMaglevTable[uint16(id1)], Equals, len(backends1))
+	require.Equal(t, len(backends1), m.lbmap.DummyMaglevTable[uint16(id1)])
 
 	// Delete terminating backends.
 	p.Backends = []*lb.Backend{}
 
 	created, id1, err = m.svc.UpsertService(p)
 
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, false)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 0)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 0)
-	c.Assert(m.svc.svcByID[id1].svcName.Name, Equals, "svc1")
-	c.Assert(m.svc.svcByID[id1].svcName.Namespace, Equals, "ns1")
-	c.Assert(len(m.lbmap.AffinityMatch[uint16(id1)]), Equals, 0)
+	require.Nil(t, err)
+	require.Equal(t, false, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, 0, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 0, len(m.lbmap.BackendByID))
+	require.Equal(t, "svc1", m.svc.svcByID[id1].svcName.Name)
+	require.Equal(t, "ns1", m.svc.svcByID[id1].svcName.Namespace)
+	require.Equal(t, 0, len(m.lbmap.AffinityMatch[uint16(id1)]))
 }
 
 // TestUpsertServiceWithOnlyTerminatingBackends tests that a terminating backend is still
 // used if there are not active backends.
-func (m *ManagerTestSuite) TestUpsertServiceWithOnlyTerminatingBackends(c *C) {
+func TestUpsertServiceWithOnlyTerminatingBackends(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	option.Config.NodePortAlg = option.NodePortAlgMaglev
 	backends := backends1 // There are 2 backends
 	p := &lb.SVC{
@@ -1259,68 +1289,70 @@ func (m *ManagerTestSuite) TestUpsertServiceWithOnlyTerminatingBackends(c *C) {
 
 	created, id1, err := m.svc.UpsertService(p)
 
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 2)
-	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id1)], Equals, 2)
-	c.Assert(m.svc.svcByID[id1].svcName.Name, Equals, "svc1")
-	c.Assert(m.svc.svcByID[id1].svcName.Namespace, Equals, "ns1")
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, 2, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 2, m.lbmap.SvcActiveBackendsCount[uint16(id1)])
+	require.Equal(t, "svc1", m.svc.svcByID[id1].svcName.Name)
+	require.Equal(t, "ns1", m.svc.svcByID[id1].svcName.Namespace)
 
 	// The terminating backend should not be considered
 	p.Backends[1].State = lb.BackendStateTerminating
 
 	created, id1, err = m.svc.UpsertService(p)
 
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, false)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 2)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
-	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id1)], Equals, 1)
+	require.Nil(t, err)
+	require.Equal(t, false, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, 2, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 2, len(m.lbmap.BackendByID))
+	require.Equal(t, 1, m.lbmap.SvcActiveBackendsCount[uint16(id1)])
 
 	// Delete terminating backends.
 	p.Backends = p.Backends[:1]
 
 	created, id1, err = m.svc.UpsertService(p)
 
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, false)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 1)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 1)
-	c.Assert(len(m.lbmap.AffinityMatch[uint16(id1)]), Equals, 1)
+	require.Nil(t, err)
+	require.Equal(t, false, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, 1, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 1, len(m.lbmap.BackendByID))
+	require.Equal(t, 1, len(m.lbmap.AffinityMatch[uint16(id1)]))
 
 	// The terminating backend should be considered since there are no more active
 	p.Backends[0].State = lb.BackendStateTerminating
 
 	created, id1, err = m.svc.UpsertService(p)
 
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, false)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 1)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 1)
-	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id1)], Equals, 0)
+	require.Nil(t, err)
+	require.Equal(t, false, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, 1, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 1, len(m.lbmap.BackendByID))
+	require.Equal(t, 0, m.lbmap.SvcActiveBackendsCount[uint16(id1)])
 
 	// Delete terminating backends.
 	p.Backends = []*lb.Backend{}
 
 	created, id1, err = m.svc.UpsertService(p)
 
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, false)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 0)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 0)
-	c.Assert(m.svc.svcByID[id1].svcName.Name, Equals, "svc1")
-	c.Assert(m.svc.svcByID[id1].svcName.Namespace, Equals, "ns1")
-	c.Assert(len(m.lbmap.AffinityMatch[uint16(id1)]), Equals, 0)
+	require.Nil(t, err)
+	require.Equal(t, false, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, 0, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 0, len(m.lbmap.BackendByID))
+	require.Equal(t, "svc1", m.svc.svcByID[id1].svcName.Name)
+	require.Equal(t, "ns1", m.svc.svcByID[id1].svcName.Namespace)
+	require.Equal(t, 0, len(m.lbmap.AffinityMatch[uint16(id1)]))
 }
 
 // Tests whether upsert service provisions the Maglev LUT for ClusterIP,
 // if ExternalClusterIP is true
-func (m *ManagerTestSuite) TestUpsertServiceWithExternalClusterIP(c *C) {
+func TestUpsertServiceWithExternalClusterIP(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	option.Config.NodePortAlg = option.NodePortAlgMaglev
 	option.Config.ExternalClusterIP = true
 	backends := make([]*lb.Backend, 0, len(backends1))
@@ -1340,19 +1372,21 @@ func (m *ManagerTestSuite) TestUpsertServiceWithExternalClusterIP(c *C) {
 
 	created, id1, err := m.svc.UpsertService(p)
 
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 2)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
-	c.Assert(m.svc.svcByID[id1].svcName.Name, Equals, "svc1")
-	c.Assert(m.svc.svcByID[id1].svcName.Namespace, Equals, "ns1")
-	c.Assert(m.lbmap.DummyMaglevTable[uint16(id1)], Equals, len(backends))
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, 2, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 2, len(m.lbmap.BackendByID))
+	require.Equal(t, "svc1", m.svc.svcByID[id1].svcName.Name)
+	require.Equal(t, "ns1", m.svc.svcByID[id1].svcName.Namespace)
+	require.Equal(t, len(backends), m.lbmap.DummyMaglevTable[uint16(id1)])
 }
 
 // Tests whether upsert service doesn't provision the Maglev LUT for ClusterIP,
 // if ExternalClusterIP is false
-func (m *ManagerTestSuite) TestUpsertServiceWithOutExternalClusterIP(c *C) {
+func TestUpsertServiceWithOutExternalClusterIP(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	option.Config.NodePortAlg = option.NodePortAlgMaglev
 	p := &lb.SVC{
 		Frontend:         frontend1,
@@ -1365,18 +1399,20 @@ func (m *ManagerTestSuite) TestUpsertServiceWithOutExternalClusterIP(c *C) {
 
 	created, id1, err := m.svc.UpsertService(p)
 
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 2)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
-	c.Assert(m.svc.svcByID[id1].svcName.Name, Equals, "svc1")
-	c.Assert(m.svc.svcByID[id1].svcName.Namespace, Equals, "ns1")
-	c.Assert(m.lbmap.DummyMaglevTable[uint16(id1)], Equals, 0)
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, 2, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 2, len(m.lbmap.BackendByID))
+	require.Equal(t, "svc1", m.svc.svcByID[id1].svcName.Name)
+	require.Equal(t, "ns1", m.svc.svcByID[id1].svcName.Namespace)
+	require.Equal(t, 0, m.lbmap.DummyMaglevTable[uint16(id1)])
 }
 
 // Tests terminating backend entries are not removed after service restore.
-func (m *ManagerTestSuite) TestRestoreServiceWithTerminatingBackends(c *C) {
+func TestRestoreServiceWithTerminatingBackends(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	option.Config.NodePortAlg = option.NodePortAlgMaglev
 	backends := append(backends4, backends1...)
 	p := &lb.SVC{
@@ -1392,18 +1428,18 @@ func (m *ManagerTestSuite) TestRestoreServiceWithTerminatingBackends(c *C) {
 
 	created, id1, err := m.svc.UpsertService(p)
 
-	c.Log(m.lbmap.ServiceByID[0])
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, len(backends))
-	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id1)], Equals, len(backends))
+	t.Log(m.lbmap.ServiceByID[0])
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, len(backends), len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, len(backends), m.lbmap.SvcActiveBackendsCount[uint16(id1)])
 
 	p.Backends[0].State = lb.BackendStateTerminating
 
 	_, _, err = m.svc.UpsertService(p)
 
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Simulate agent restart.
 	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
@@ -1411,28 +1447,30 @@ func (m *ManagerTestSuite) TestRestoreServiceWithTerminatingBackends(c *C) {
 
 	// Restore services from lbmap
 	err = m.svc.RestoreServices()
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Backends including terminating ones have been restored
-	c.Assert(len(m.svc.backendByHash), Equals, 3)
+	require.Equal(t, 3, len(m.svc.backendByHash))
 	for _, b := range backends1 {
 		_, found := m.svc.backendByHash[b.Hash()]
-		c.Assert(found, Equals, true)
+		require.Equal(t, true, found)
 	}
 
 	// Affinity matches including terminating ones were restored
 	matches, _ := m.lbmap.DumpAffinityMatches()
-	c.Assert(len(matches), Equals, 1)
-	c.Assert(len(matches[uint16(id1)]), Equals, 3)
+	require.Equal(t, 1, len(matches))
+	require.Equal(t, 3, len(matches[uint16(id1)]))
 	for _, b := range m.lbmap.ServiceByID[uint16(id1)].Backends {
-		c.Assert(m.lbmap.AffinityMatch[uint16(id1)][b.ID], Equals, struct{}{})
+		require.Equal(t, struct{}{}, m.lbmap.AffinityMatch[uint16(id1)][b.ID])
 	}
-	c.Assert(m.lbmap.DummyMaglevTable[uint16(id1)], Equals, len(backends1))
+	require.Equal(t, len(backends1), m.lbmap.DummyMaglevTable[uint16(id1)])
 }
 
 // l7 load balancer service should be able to override any service type
 // (Cluster IP, NodePort, etc.) with same frontend.
-func (m *ManagerTestSuite) TestL7LoadBalancerServiceOverride(c *C) {
+func TestL7LoadBalancerServiceOverride(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	// Create a node-local backend.
 	localBackend := backends1[0]
 	localBackend.NodeName = nodeTypes.GetName()
@@ -1457,73 +1495,75 @@ func (m *ManagerTestSuite) TestL7LoadBalancerServiceOverride(c *C) {
 
 	// Insert the service entry of type ClusterIP.
 	created, id, err := m.svc.UpsertService(p1)
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id, Not(Equals), lb.ID(0))
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.NotEqual(t, lb.ID(0), id)
 
 	svc, ok := m.svc.svcByID[id]
-	c.Assert(len(svc.backends), Equals, len(allBackends))
-	c.Assert(ok, Equals, true)
-	c.Assert(svc.l7LBProxyPort, Equals, uint16(0))
+	require.Equal(t, len(allBackends), len(svc.backends))
+	require.Equal(t, true, ok)
+	require.Equal(t, uint16(0), svc.l7LBProxyPort)
 
 	// registering redirection with proxy port 0 should result in an error
 	echoOtherNode := lb.ServiceName{Name: "echo-other-node", Namespace: "cilium-test"}
 	resource1 := L7LBResourceName{Name: "testOwner1", Namespace: "cilium-test"}
 	err = m.svc.RegisterL7LBServiceRedirect(echoOtherNode, resource1, 0)
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 
 	svc, ok = m.svc.svcByID[id]
-	c.Assert(len(svc.backends), Equals, len(allBackends))
-	c.Assert(ok, Equals, true)
-	c.Assert(svc.l7LBProxyPort, Equals, uint16(0))
+	require.Equal(t, len(allBackends), len(svc.backends))
+	require.Equal(t, true, ok)
+	require.Equal(t, uint16(0), svc.l7LBProxyPort)
 
 	// Registering with redirection stores the proxy port.
 	resource2 := L7LBResourceName{Name: "testOwner2", Namespace: "cilium-test"}
 	err = m.svc.RegisterL7LBServiceRedirect(echoOtherNode, resource2, 9090)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	svc, ok = m.svc.svcByID[id]
-	c.Assert(len(svc.backends), Equals, len(allBackends))
-	c.Assert(ok, Equals, true)
-	c.Assert(svc.l7LBProxyPort, Equals, uint16(9090))
+	require.Equal(t, len(allBackends), len(svc.backends))
+	require.Equal(t, true, ok)
+	require.Equal(t, uint16(9090), svc.l7LBProxyPort)
 
 	// registering redirection for a Service that already has a redirect registration
 	// should result in an error.
 	resource3 := L7LBResourceName{Name: "testOwner3", Namespace: "cilium-test"}
 	err = m.svc.RegisterL7LBServiceRedirect(echoOtherNode, resource3, 10000)
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 
 	// Remove with an unregistered owner name does not remove
 	resource4 := L7LBResourceName{Name: "testOwner4", Namespace: "cilium-test"}
 	err = m.svc.DeregisterL7LBServiceRedirect(echoOtherNode, resource4)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	svc, ok = m.svc.svcByID[id]
-	c.Assert(len(svc.backends), Equals, len(allBackends))
-	c.Assert(ok, Equals, true)
-	c.Assert(svc.l7LBProxyPort, Equals, uint16(9090))
+	require.Equal(t, len(allBackends), len(svc.backends))
+	require.Equal(t, true, ok)
+	require.Equal(t, uint16(9090), svc.l7LBProxyPort)
 
 	// Removing registration without redirection does not remove the proxy port
 	err = m.svc.DeregisterL7LBServiceRedirect(echoOtherNode, resource1)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	svc, ok = m.svc.svcByID[id]
-	c.Assert(len(svc.backends), Equals, len(allBackends))
-	c.Assert(ok, Equals, true)
-	c.Assert(svc.l7LBProxyPort, Equals, uint16(9090))
+	require.Equal(t, len(allBackends), len(svc.backends))
+	require.Equal(t, true, ok)
+	require.Equal(t, uint16(9090), svc.l7LBProxyPort)
 
 	// removing the registration with redirection removes the proxy port
 	err = m.svc.DeregisterL7LBServiceRedirect(echoOtherNode, resource2)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	svc, ok = m.svc.svcByID[id]
-	c.Assert(len(svc.backends), Equals, len(allBackends))
-	c.Assert(ok, Equals, true)
-	c.Assert(svc.l7LBProxyPort, Equals, uint16(0))
+	require.Equal(t, len(allBackends), len(svc.backends))
+	require.Equal(t, true, ok)
+	require.Equal(t, uint16(0), svc.l7LBProxyPort)
 }
 
 // L7 LB proxies should be able to register callback based backend sync registration
-func (m *ManagerTestSuite) TestL7LoadBalancerServiceBackendSyncRegistration(c *C) {
+func TestL7LoadBalancerServiceBackendSyncRegistration(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	// Create a node-local backend.
 	localBackend := backends1[0]
 	localBackend.NodeName = nodeTypes.GetName()
@@ -1548,55 +1588,57 @@ func (m *ManagerTestSuite) TestL7LoadBalancerServiceBackendSyncRegistration(c *C
 
 	// Insert the service entry of type ClusterIP.
 	created, id, err := m.svc.UpsertService(p1)
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id, Not(Equals), lb.ID(0))
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.NotEqual(t, lb.ID(0), id)
 
 	// Registering L7LB backend sync should register backend sync and trigger an initial synchronization
 	service := lb.ServiceName{Name: "echo-other-node", Namespace: "cilium-test"}
 	backendSyncer := &FakeBackendSyncer{}
 	err = m.svc.RegisterL7LBServiceBackendSync(service, backendSyncer)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
-	c.Assert(len(m.svc.l7lbSvcs), Equals, 1)
-	c.Assert(len(m.svc.l7lbSvcs[service].backendSyncRegistrations), Equals, 1)
-	c.Assert(backendSyncer.nrOfBackends, Equals, len(allBackends))
-	c.Assert(backendSyncer.nrOfSyncs, Equals, 1)
+	require.Equal(t, 1, len(m.svc.l7lbSvcs))
+	require.Equal(t, 1, len(m.svc.l7lbSvcs[service].backendSyncRegistrations))
+	require.Equal(t, len(allBackends), backendSyncer.nrOfBackends)
+	require.Equal(t, 1, backendSyncer.nrOfSyncs)
 
 	// Re-Registering L7LB backend sync should keep the existing registration and trigger an implicit re-synchronization
 	err = m.svc.RegisterL7LBServiceBackendSync(service, backendSyncer)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
-	c.Assert(len(m.svc.l7lbSvcs), Equals, 1)
-	c.Assert(len(m.svc.l7lbSvcs[service].backendSyncRegistrations), Equals, 1)
-	c.Assert(backendSyncer.nrOfBackends, Equals, len(allBackends))
-	c.Assert(backendSyncer.nrOfSyncs, Equals, 2)
+	require.Equal(t, 1, len(m.svc.l7lbSvcs))
+	require.Equal(t, 1, len(m.svc.l7lbSvcs[service].backendSyncRegistrations))
+	require.Equal(t, len(allBackends), backendSyncer.nrOfBackends)
+	require.Equal(t, 2, backendSyncer.nrOfSyncs)
 
 	// Upserting a service should trigger a sync for the registered backend sync registrations
 	allBackends = append(allBackends, backends4...)
 	p1.Backends = allBackends
 	created, id, err = m.svc.UpsertService(p1)
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, false)
-	c.Assert(id, Not(Equals), lb.ID(0))
+	require.Nil(t, err)
+	require.Equal(t, false, created)
+	require.NotEqual(t, lb.ID(0), id)
 
-	c.Assert(len(m.svc.l7lbSvcs), Equals, 1)
-	c.Assert(len(m.svc.l7lbSvcs[service].backendSyncRegistrations), Equals, 1)
-	c.Assert(backendSyncer.nrOfBackends, Equals, len(allBackends))
-	c.Assert(backendSyncer.nrOfSyncs, Equals, 3)
+	require.Equal(t, 1, len(m.svc.l7lbSvcs))
+	require.Equal(t, 1, len(m.svc.l7lbSvcs[service].backendSyncRegistrations))
+	require.Equal(t, len(allBackends), backendSyncer.nrOfBackends)
+	require.Equal(t, 3, backendSyncer.nrOfSyncs)
 
 	// De-registering a backend sync should delete the backend sync registration
 	err = m.svc.DeregisterL7LBServiceBackendSync(service, backendSyncer)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
-	c.Assert(len(m.svc.l7lbSvcs), Equals, 0)
-	c.Assert(backendSyncer.nrOfBackends, Equals, len(allBackends))
-	c.Assert(backendSyncer.nrOfSyncs, Equals, 3)
+	require.Equal(t, 0, len(m.svc.l7lbSvcs))
+	require.Equal(t, len(allBackends), backendSyncer.nrOfBackends)
+	require.Equal(t, 3, backendSyncer.nrOfSyncs)
 }
 
 // Tests that services with the given backends are updated with the new backend
 // state.
-func (m *ManagerTestSuite) TestUpdateBackendsState(c *C) {
+func TestUpdateBackendsState(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	backends := make([]*lb.Backend, 0, len(backends1))
 	for _, b := range backends1 {
 		backends = append(backends, b.DeepCopy())
@@ -1619,22 +1661,22 @@ func (m *ManagerTestSuite) TestUpdateBackendsState(c *C) {
 	_, id1, err1 := m.svc.UpsertService(p1)
 	_, id2, err2 := m.svc.UpsertService(p2)
 
-	c.Assert(err1, IsNil)
-	c.Assert(err2, IsNil)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(id2, Equals, lb.ID(2))
-	c.Assert(m.svc.svcByID[id1].backends[0].State, Equals, lb.BackendStateActive)
-	c.Assert(m.svc.svcByID[id1].backends[1].State, Equals, lb.BackendStateActive)
-	c.Assert(m.svc.svcByID[id2].backends[0].State, Equals, lb.BackendStateActive)
-	c.Assert(m.svc.svcByID[id2].backends[1].State, Equals, lb.BackendStateActive)
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, len(backends))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id2)].Backends), Equals, len(backends))
-	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id1)], Equals, len(backends))
-	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id2)], Equals, len(backends))
-	c.Assert(len(m.lbmap.BackendByID), Equals, len(backends))
+	require.Nil(t, err1)
+	require.Nil(t, err2)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, lb.ID(2), id2)
+	require.Equal(t, lb.BackendStateActive, m.svc.svcByID[id1].backends[0].State)
+	require.Equal(t, lb.BackendStateActive, m.svc.svcByID[id1].backends[1].State)
+	require.Equal(t, lb.BackendStateActive, m.svc.svcByID[id2].backends[0].State)
+	require.Equal(t, lb.BackendStateActive, m.svc.svcByID[id2].backends[1].State)
+	require.Equal(t, len(backends), len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, len(backends), len(m.lbmap.ServiceByID[uint16(id2)].Backends))
+	require.Equal(t, len(backends), m.lbmap.SvcActiveBackendsCount[uint16(id1)])
+	require.Equal(t, len(backends), m.lbmap.SvcActiveBackendsCount[uint16(id2)])
+	require.Equal(t, len(backends), len(m.lbmap.BackendByID))
 	// Backend states are persisted in the map.
-	c.Assert(m.lbmap.BackendByID[1].State, Equals, lb.BackendStateActive)
-	c.Assert(m.lbmap.BackendByID[2].State, Equals, lb.BackendStateActive)
+	require.Equal(t, lb.BackendStateActive, m.lbmap.BackendByID[1].State)
+	require.Equal(t, lb.BackendStateActive, m.lbmap.BackendByID[2].State)
 
 	// Update the state for one of the backends.
 	updated := []*lb.Backend{backends[0]}
@@ -1642,20 +1684,20 @@ func (m *ManagerTestSuite) TestUpdateBackendsState(c *C) {
 
 	err := m.svc.UpdateBackendsState(updated)
 
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	// Both the services are updated with the update backend state.
-	c.Assert(m.svc.svcByID[id1].backends[0].State, Equals, lb.BackendStateQuarantined)
-	c.Assert(m.svc.svcByID[id1].backends[1].State, Equals, lb.BackendStateActive)
-	c.Assert(m.svc.svcByID[id2].backends[0].State, Equals, lb.BackendStateQuarantined)
-	c.Assert(m.svc.svcByID[id2].backends[1].State, Equals, lb.BackendStateActive)
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, len(backends))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id2)].Backends), Equals, len(backends))
-	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id1)], Equals, 1)
-	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id2)], Equals, 1)
-	c.Assert(len(m.lbmap.BackendByID), Equals, len(backends))
+	require.Equal(t, lb.BackendStateQuarantined, m.svc.svcByID[id1].backends[0].State)
+	require.Equal(t, lb.BackendStateActive, m.svc.svcByID[id1].backends[1].State)
+	require.Equal(t, lb.BackendStateQuarantined, m.svc.svcByID[id2].backends[0].State)
+	require.Equal(t, lb.BackendStateActive, m.svc.svcByID[id2].backends[1].State)
+	require.Equal(t, len(backends), len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, len(backends), len(m.lbmap.ServiceByID[uint16(id2)].Backends))
+	require.Equal(t, 1, m.lbmap.SvcActiveBackendsCount[uint16(id1)])
+	require.Equal(t, 1, m.lbmap.SvcActiveBackendsCount[uint16(id2)])
+	require.Equal(t, len(backends), len(m.lbmap.BackendByID))
 	// Updated backend states are persisted in the map.
-	c.Assert(m.lbmap.BackendByID[1].State, Equals, lb.BackendStateQuarantined)
-	c.Assert(m.lbmap.BackendByID[2].State, Equals, lb.BackendStateActive)
+	require.Equal(t, lb.BackendStateQuarantined, m.lbmap.BackendByID[1].State)
+	require.Equal(t, lb.BackendStateActive, m.lbmap.BackendByID[2].State)
 
 	// Update the state again.
 	updated = []*lb.Backend{backends[0]}
@@ -1663,24 +1705,26 @@ func (m *ManagerTestSuite) TestUpdateBackendsState(c *C) {
 
 	err = m.svc.UpdateBackendsState(updated)
 
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	// Both the services are updated with the update backend state.
-	c.Assert(m.svc.svcByID[id1].backends[0].State, Equals, lb.BackendStateActive)
-	c.Assert(m.svc.svcByID[id1].backends[1].State, Equals, lb.BackendStateActive)
-	c.Assert(m.svc.svcByID[id2].backends[0].State, Equals, lb.BackendStateActive)
-	c.Assert(m.svc.svcByID[id2].backends[1].State, Equals, lb.BackendStateActive)
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, len(backends))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id2)].Backends), Equals, len(backends))
-	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id1)], Equals, len(backends))
-	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id2)], Equals, len(backends))
-	c.Assert(len(m.lbmap.BackendByID), Equals, len(backends))
+	require.Equal(t, lb.BackendStateActive, m.svc.svcByID[id1].backends[0].State)
+	require.Equal(t, lb.BackendStateActive, m.svc.svcByID[id1].backends[1].State)
+	require.Equal(t, lb.BackendStateActive, m.svc.svcByID[id2].backends[0].State)
+	require.Equal(t, lb.BackendStateActive, m.svc.svcByID[id2].backends[1].State)
+	require.Equal(t, len(backends), len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, len(backends), len(m.lbmap.ServiceByID[uint16(id2)].Backends))
+	require.Equal(t, len(backends), m.lbmap.SvcActiveBackendsCount[uint16(id1)])
+	require.Equal(t, len(backends), m.lbmap.SvcActiveBackendsCount[uint16(id2)])
+	require.Equal(t, len(backends), len(m.lbmap.BackendByID))
 	// Updated backend states are persisted in the map.
-	c.Assert(m.lbmap.BackendByID[1].State, Equals, lb.BackendStateActive)
-	c.Assert(m.lbmap.BackendByID[2].State, Equals, lb.BackendStateActive)
+	require.Equal(t, lb.BackendStateActive, m.lbmap.BackendByID[1].State)
+	require.Equal(t, lb.BackendStateActive, m.lbmap.BackendByID[2].State)
 }
 
 // Tests that backend states are restored.
-func (m *ManagerTestSuite) TestRestoreServiceWithBackendStates(c *C) {
+func TestRestoreServiceWithBackendStates(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	option.Config.NodePortAlg = option.NodePortAlgMaglev
 	bs := append(backends1, backends4...)
 	backends := make([]*lb.Backend, 0, len(bs))
@@ -1702,11 +1746,11 @@ func (m *ManagerTestSuite) TestRestoreServiceWithBackendStates(c *C) {
 	}
 	created, id1, err := m.svc.UpsertService(p1)
 
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, len(backends))
-	c.Assert(len(m.svc.backendByHash), Equals, len(backends))
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, len(backends), len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, len(backends), len(m.svc.backendByHash))
 
 	// Update backend states.
 	var updates []*lb.Backend
@@ -1715,7 +1759,7 @@ func (m *ManagerTestSuite) TestRestoreServiceWithBackendStates(c *C) {
 	updates = append(updates, backends[0], backends[1])
 	err = m.svc.UpdateBackendsState(updates)
 
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Simulate agent restart.
 	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
@@ -1723,24 +1767,26 @@ func (m *ManagerTestSuite) TestRestoreServiceWithBackendStates(c *C) {
 
 	// Restore services from lbmap
 	err = m.svc.RestoreServices()
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	// Check that backends along with their states have been restored
-	c.Assert(len(m.svc.backendByHash), Equals, len(backends))
+	require.Equal(t, len(backends), len(m.svc.backendByHash))
 	statesMatched := 0
 	for _, b := range backends {
 		be, found := m.svc.backendByHash[b.Hash()]
-		c.Assert(found, Equals, true)
+		require.Equal(t, true, found)
 		if be.String() == b.String() {
-			c.Assert(be.State, Equals, b.State, Commentf("before %+v restored %+v", b, be))
+			require.Equal(t, b.State, be.State, "before %+v restored %+v", b, be)
 			statesMatched++
 		}
 	}
-	c.Assert(statesMatched, Equals, len(backends))
-	c.Assert(m.lbmap.DummyMaglevTable[uint16(id1)], Equals, 1)
+	require.Equal(t, len(backends), statesMatched)
+	require.Equal(t, 1, m.lbmap.DummyMaglevTable[uint16(id1)])
 }
 
-func (m *ManagerTestSuite) TestUpsertServiceWithZeroWeightBackends(c *C) {
+func TestUpsertServiceWithZeroWeightBackends(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	option.Config.NodePortAlg = option.NodePortAlgMaglev
 	backends := append(backends1, backends4...)
 	backends[1].Weight = 0
@@ -1763,17 +1809,17 @@ func (m *ManagerTestSuite) TestUpsertServiceWithZeroWeightBackends(c *C) {
 
 	created, id1, err := m.svc.UpsertService(p)
 
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 3)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 3)
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.Equal(t, 3, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 3, len(m.lbmap.BackendByID))
 	hash := backends[1].L3n4Addr.Hash()
-	c.Assert(m.svc.backendByHash[hash].State, Equals, lb.BackendStateMaintenance)
-	c.Assert(m.svc.svcByID[id1].backendByHash[hash].State, Equals, lb.BackendStateMaintenance)
+	require.Equal(t, lb.BackendStateMaintenance, m.svc.backendByHash[hash].State)
+	require.Equal(t, lb.BackendStateMaintenance, m.svc.svcByID[id1].backendByHash[hash].State)
 	hash2 := backends[2].L3n4Addr.Hash()
-	c.Assert(m.svc.backendByHash[hash2].State, Equals, lb.BackendStateActive)
-	c.Assert(m.svc.svcByID[id1].backendByHash[hash2].State, Equals, lb.BackendStateActive)
-	c.Assert(m.lbmap.DummyMaglevTable[uint16(id1)], Equals, 2)
+	require.Equal(t, lb.BackendStateActive, m.svc.backendByHash[hash2].State)
+	require.Equal(t, lb.BackendStateActive, m.svc.svcByID[id1].backendByHash[hash2].State)
+	require.Equal(t, 2, m.lbmap.DummyMaglevTable[uint16(id1)])
 
 	// Update existing backend weight
 	p.Backends[2].Weight = 0
@@ -1781,26 +1827,28 @@ func (m *ManagerTestSuite) TestUpsertServiceWithZeroWeightBackends(c *C) {
 
 	created, id1, err = m.svc.UpsertService(p)
 
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, false)
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 3)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 3)
-	c.Assert(m.svc.svcByID[id1].backendByHash[hash2].State, Equals, lb.BackendStateMaintenance)
-	c.Assert(m.lbmap.DummyMaglevTable[uint16(id1)], Equals, 1)
+	require.Nil(t, err)
+	require.Equal(t, false, created)
+	require.Equal(t, 3, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 3, len(m.lbmap.BackendByID))
+	require.Equal(t, lb.BackendStateMaintenance, m.svc.svcByID[id1].backendByHash[hash2].State)
+	require.Equal(t, 1, m.lbmap.DummyMaglevTable[uint16(id1)])
 
 	// Delete backends with weight 0
 	p.Backends = backends[:1]
 
 	created, id1, err = m.svc.UpsertService(p)
 
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, false)
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 1)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 1)
-	c.Assert(m.lbmap.DummyMaglevTable[uint16(id1)], Equals, 1)
+	require.Nil(t, err)
+	require.Equal(t, false, created)
+	require.Equal(t, 1, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 1, len(m.lbmap.BackendByID))
+	require.Equal(t, 1, m.lbmap.DummyMaglevTable[uint16(id1)])
 }
 
-func (m *ManagerTestSuite) TestUpdateBackendsStateWithBackendSharedAcrossServices(c *C) {
+func TestUpdateBackendsStateWithBackendSharedAcrossServices(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	option.Config.NodePortAlg = option.NodePortAlgMaglev
 	be := append(backends1, backends4...)
 	backends := make([]*lb.Backend, 0, len(be))
@@ -1843,29 +1891,31 @@ func (m *ManagerTestSuite) TestUpdateBackendsStateWithBackendSharedAcrossService
 	svcHash2 := r.Frontend.Hash()
 
 	_, _, err := m.svc.UpsertService(p)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	_, _, err = m.svc.UpsertService(r)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	_, id1, err := m.svc.UpsertService(r)
 
 	// Assert expected backend states after consecutive upsert service calls that share the backends.
-	c.Assert(err, IsNil)
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 3)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 3)
-	c.Assert(m.svc.backendByHash[hash0].State, Equals, lb.BackendStateActive)
-	c.Assert(m.svc.backendByHash[hash1].State, Equals, lb.BackendStateActive)
-	c.Assert(m.svc.backendByHash[hash2].State, Equals, lb.BackendStateMaintenance)
+	require.Nil(t, err)
+	require.Equal(t, 3, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 3, len(m.lbmap.BackendByID))
+	require.Equal(t, lb.BackendStateActive, m.svc.backendByHash[hash0].State)
+	require.Equal(t, lb.BackendStateActive, m.svc.backendByHash[hash1].State)
+	require.Equal(t, lb.BackendStateMaintenance, m.svc.backendByHash[hash2].State)
 
 	backends[1].State = lb.BackendStateMaintenance
 	err = m.svc.UpdateBackendsState(backends)
 
-	c.Assert(err, IsNil)
-	c.Assert(m.svc.backendByHash[hash1].State, Equals, lb.BackendStateMaintenance)
-	c.Assert(m.svc.svcByHash[svcHash2].backends[1].State, Equals, lb.BackendStateMaintenance)
-	c.Assert(m.svc.svcByHash[svcHash2].backendByHash[hash1].State, Equals, lb.BackendStateMaintenance)
+	require.Nil(t, err)
+	require.Equal(t, lb.BackendStateMaintenance, m.svc.backendByHash[hash1].State)
+	require.Equal(t, lb.BackendStateMaintenance, m.svc.svcByHash[svcHash2].backends[1].State)
+	require.Equal(t, lb.BackendStateMaintenance, m.svc.svcByHash[svcHash2].backendByHash[hash1].State)
 }
 
-func (m *ManagerTestSuite) TestSyncNodePortFrontends(c *C) {
+func TestSyncNodePortFrontends(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	// Add a IPv4 surrogate frontend
 	surrogate := &lb.SVC{
 		Frontend: surrogateFE,
@@ -1873,23 +1923,23 @@ func (m *ManagerTestSuite) TestSyncNodePortFrontends(c *C) {
 		Type:     lb.SVCTypeNodePort,
 	}
 	_, surrID, err := m.svc.UpsertService(surrogate)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 	p1 := &lb.SVC{
 		Frontend: frontend1,
 		Backends: backends1,
 		Type:     lb.SVCTypeNodePort,
 	}
 	_, _, err = m.svc.UpsertService(p1)
-	c.Assert(err, IsNil)
-	c.Assert(len(m.svc.svcByID), Equals, 2)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(m.svc.svcByID))
 
 	// With no addresses all frontends (except surrogates) should be removed.
 	err = m.svc.SyncNodePortFrontends(sets.New[netip.Addr]())
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
-	c.Assert(len(m.svc.svcByID), Equals, 1)
+	require.Equal(t, 1, len(m.svc.svcByID))
 	_, ok := m.svc.svcByID[surrID]
-	c.Assert(ok, Equals, true)
+	require.Equal(t, true, ok)
 
 	// With a new frontend addresses services should be re-created.
 	nodeAddrs := sets.New[netip.Addr](
@@ -1899,12 +1949,12 @@ func (m *ManagerTestSuite) TestSyncNodePortFrontends(c *C) {
 		frontend3.AddrCluster.Addr(),
 	)
 	m.svc.SyncNodePortFrontends(nodeAddrs)
-	c.Assert(len(m.svc.svcByID), Equals, 2+1 /* surrogate */)
+	require.Equal(t, 2+1 /* surrogate */, len(m.svc.svcByID))
 
 	_, _, found := m.svc.GetServiceNameByAddr(frontend1.L3n4Addr)
-	c.Assert(found, Equals, true)
+	require.Equal(t, true, found)
 	_, _, found = m.svc.GetServiceNameByAddr(frontend2.L3n4Addr)
-	c.Assert(found, Equals, true)
+	require.Equal(t, true, found)
 
 	// Add an IPv6 surrogate
 	surrogate = &lb.SVC{
@@ -1913,14 +1963,16 @@ func (m *ManagerTestSuite) TestSyncNodePortFrontends(c *C) {
 		Type:     lb.SVCTypeNodePort,
 	}
 	_, _, err = m.svc.UpsertService(surrogate)
-	c.Assert(err, IsNil)
+	require.Nil(t, err)
 
 	err = m.svc.SyncNodePortFrontends(nodeAddrs)
-	c.Assert(err, IsNil)
-	c.Assert(len(m.svc.svcByID), Equals, 3+2 /* surrogates */)
+	require.Nil(t, err)
+	require.Equal(t, 3+2 /* surrogates */, len(m.svc.svcByID))
 }
 
-func (m *ManagerTestSuite) TestTrafficPolicy(c *C) {
+func TestTrafficPolicy(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	internalIP := *lb.NewL3n4AddrID(lb.TCP, cmtypes.MustParseAddrCluster("1.1.1.1"), 80, lb.ScopeInternal, 0)
 	externalIP := *lb.NewL3n4AddrID(lb.TCP, cmtypes.MustParseAddrCluster("1.1.1.1"), 80, lb.ScopeExternal, 0)
 
@@ -1951,8 +2003,8 @@ func (m *ManagerTestSuite) TestTrafficPolicy(c *C) {
 		Name:             lb.ServiceName{Name: "svc1", Namespace: "ns1"},
 	}
 	created, id1, err := m.svc.UpsertService(p1)
-	c.Assert(created, Equals, true)
-	c.Assert(err, IsNil)
+	require.Equal(t, true, created)
+	require.Nil(t, err)
 
 	p2 := &lb.SVC{
 		Frontend:         externalIP,
@@ -1963,49 +2015,51 @@ func (m *ManagerTestSuite) TestTrafficPolicy(c *C) {
 		Name:             lb.ServiceName{Name: "svc1", Namespace: "ns1"},
 	}
 	created, id2, err := m.svc.UpsertService(p2)
-	c.Assert(created, Equals, true)
-	c.Assert(err, IsNil)
+	require.Equal(t, true, created)
+	require.Nil(t, err)
 
 	svcFromLbMap1, ok := m.lbmap.ServiceByID[uint16(id1)]
-	c.Assert(ok, Equals, true)
-	c.Assert(len(svcFromLbMap1.Backends), Equals, len(localBackends))
+	require.Equal(t, true, ok)
+	require.Equal(t, len(localBackends), len(svcFromLbMap1.Backends))
 
 	svcFromLbMap2, ok := m.lbmap.ServiceByID[uint16(id2)]
-	c.Assert(ok, Equals, true)
-	c.Assert(len(svcFromLbMap2.Backends), Equals, len(allBackends))
+	require.Equal(t, true, ok)
+	require.Equal(t, len(allBackends), len(svcFromLbMap2.Backends))
 
 	p1.ExtTrafficPolicy = lb.SVCTrafficPolicyLocal
 	p1.IntTrafficPolicy = lb.SVCTrafficPolicyCluster
 	created, id3, err := m.svc.UpsertService(p1)
-	c.Assert(created, Equals, false)
-	c.Assert(err, IsNil)
-	c.Assert(id3, Equals, id1)
+	require.Equal(t, false, created)
+	require.Nil(t, err)
+	require.Equal(t, id1, id3)
 
 	svcFromLbMap3, ok := m.lbmap.ServiceByID[uint16(id1)]
-	c.Assert(ok, Equals, true)
-	c.Assert(len(svcFromLbMap3.Backends), Equals, len(allBackends))
+	require.Equal(t, true, ok)
+	require.Equal(t, len(allBackends), len(svcFromLbMap3.Backends))
 
 	p2.ExtTrafficPolicy = lb.SVCTrafficPolicyLocal
 	p2.IntTrafficPolicy = lb.SVCTrafficPolicyCluster
 	created, id4, err := m.svc.UpsertService(p2)
-	c.Assert(created, Equals, false)
-	c.Assert(err, IsNil)
-	c.Assert(id4, Equals, id2)
+	require.Equal(t, false, created)
+	require.Nil(t, err)
+	require.Equal(t, id2, id4)
 
 	svcFromLbMap4, ok := m.lbmap.ServiceByID[uint16(id2)]
-	c.Assert(ok, Equals, true)
-	c.Assert(len(svcFromLbMap4.Backends), Equals, len(localBackends))
+	require.Equal(t, true, ok)
+	require.Equal(t, len(localBackends), len(svcFromLbMap4.Backends))
 
 	found, err := m.svc.DeleteServiceByID(lb.ServiceID(id1))
-	c.Assert(err, IsNil)
-	c.Assert(found, Equals, true)
+	require.Nil(t, err)
+	require.Equal(t, true, found)
 	found, err = m.svc.DeleteServiceByID(lb.ServiceID(id2))
-	c.Assert(err, IsNil)
-	c.Assert(found, Equals, true)
+	require.Nil(t, err)
+	require.Equal(t, true, found)
 }
 
 // Tests whether delete service handles non-active backends.
-func (m *ManagerTestSuite) TestDeleteServiceWithTerminatingBackends(c *C) {
+func TestDeleteServiceWithTerminatingBackends(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	backends := backends5
 	backends[0].State = lb.BackendStateTerminating
 	p := &lb.SVC{
@@ -2016,23 +2070,25 @@ func (m *ManagerTestSuite) TestDeleteServiceWithTerminatingBackends(c *C) {
 
 	created, id1, err := m.svc.UpsertService(p)
 
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 2)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
-	c.Assert(m.svc.svcByID[id1].svcName, Equals, lb.ServiceName{Name: "svc1", Namespace: "ns1"})
+	require.Nil(t, err)
+	require.Equal(t, true, created)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, 2, len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, 2, len(m.lbmap.BackendByID))
+	require.Equal(t, lb.ServiceName{Name: "svc1", Namespace: "ns1"}, m.svc.svcByID[id1].svcName)
 
 	// Delete service.
 	found, err := m.svc.DeleteServiceByID(lb.ServiceID(id1))
 
-	c.Assert(err, IsNil)
-	c.Assert(found, Equals, true)
-	c.Assert(len(m.lbmap.ServiceByID), Equals, 0)
-	c.Assert(len(m.lbmap.BackendByID), Equals, 0)
+	require.Nil(t, err)
+	require.Equal(t, true, found)
+	require.Equal(t, 0, len(m.lbmap.ServiceByID))
+	require.Equal(t, 0, len(m.lbmap.BackendByID))
 }
 
-func (m *ManagerTestSuite) TestRestoreServicesWithLeakedBackends(c *C) {
+func TestRestoreServicesWithLeakedBackends(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	backends := make([]*lb.Backend, len(backends1))
 	backends[0] = backends1[0].DeepCopy()
 	backends[1] = backends1[1].DeepCopy()
@@ -2045,10 +2101,10 @@ func (m *ManagerTestSuite) TestRestoreServicesWithLeakedBackends(c *C) {
 
 	_, id1, err1 := m.svc.UpsertService(p1)
 
-	c.Assert(err1, IsNil)
-	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, len(backends))
-	c.Assert(len(m.lbmap.BackendByID), Equals, len(backends))
+	require.Nil(t, err1)
+	require.Equal(t, lb.ID(1), id1)
+	require.Equal(t, len(backends), len(m.lbmap.ServiceByID[uint16(id1)].Backends))
+	require.Equal(t, len(backends), len(m.lbmap.BackendByID))
 
 	// Simulate leaked backends with various leaked scenarios.
 	// Backend2 is a duplicate leaked backend with the same L3nL4Addr as backends[0]
@@ -2066,20 +2122,22 @@ func (m *ManagerTestSuite) TestRestoreServicesWithLeakedBackends(c *C) {
 	m.svc.lbmap.AddBackend(backend3, backend3.L3n4Addr.IsIPv6())
 	m.svc.lbmap.AddBackend(backend4, backend4.L3n4Addr.IsIPv6())
 	m.svc.lbmap.AddBackend(backend5, backend5.L3n4Addr.IsIPv6())
-	c.Assert(len(m.lbmap.BackendByID), Equals, len(backends)+4)
+	require.Equal(t, len(backends)+4, len(m.lbmap.BackendByID))
 	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
 	m.svc = NewService(nil, lbmap, nil)
 
 	// Restore services from lbmap
 	err := m.svc.RestoreServices()
-	c.Assert(err, IsNil)
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, len(backends))
+	require.Nil(t, err)
+	require.Equal(t, len(backends), len(m.lbmap.ServiceByID[uint16(id1)].Backends))
 	// Leaked backends should be deleted.
-	c.Assert(len(m.lbmap.BackendByID), Equals, len(backends))
+	require.Equal(t, len(backends), len(m.lbmap.BackendByID))
 }
 
 // Tests backend connections getting destroyed.
-func (m *ManagerTestSuite) TestUpsertServiceWithDeletedBackends(c *C) {
+func TestUpsertServiceWithDeletedBackends(t *testing.T) {
+	m := setupManagerTestSuite(t)
+
 	option.Config.EnableSocketLB = true
 	backends := []*lb.Backend{
 		lb.NewBackend(0, lb.UDP, cmtypes.MustParseAddrCluster("10.0.0.1"), 8080),
@@ -2119,8 +2177,8 @@ func (m *ManagerTestSuite) TestUpsertServiceWithDeletedBackends(c *C) {
 
 	created, _, err := m.svc.UpsertService(svc)
 
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, true)
+	require.Nil(t, err)
+	require.Equal(t, true, created)
 
 	// Delete one of the backends.
 	svc = &lb.SVC{
@@ -2131,15 +2189,15 @@ func (m *ManagerTestSuite) TestUpsertServiceWithDeletedBackends(c *C) {
 
 	created, _, err = m.svc.UpsertService(svc)
 
-	c.Assert(err, IsNil)
-	c.Assert(created, Equals, false)
+	require.Nil(t, err)
+	require.Equal(t, false, created)
 
 	// Only the sockets connected to the deleted backend are destroyed.
 	for _, socket := range sockets {
 		if socket.Equal(sockets[0]) {
-			c.Assert(socket.Destroyed, Equals, true)
+			require.Equal(t, true, socket.Destroyed)
 		} else {
-			c.Assert(socket.Destroyed, Equals, false)
+			require.Equal(t, false, socket.Destroyed)
 		}
 	}
 }

--- a/pkg/service/store/store_test.go
+++ b/pkg/service/store/store_test.go
@@ -6,41 +6,33 @@ package store
 import (
 	"testing"
 
-	check "github.com/cilium/checkmate"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 )
 
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) { check.TestingT(t) }
-
-type ServiceGenericSuite struct{}
-
-var _ = check.Suite(&ServiceGenericSuite{})
-
-func (s *ServiceGenericSuite) TestClusterService(c *check.C) {
+func TestClusterService(t *testing.T) {
 	svc := NewClusterService("foo", "bar")
 	svc.Cluster = "default"
 
-	c.Assert(svc.Name, check.Equals, "foo")
-	c.Assert(svc.Namespace, check.Equals, "bar")
+	require.Equal(t, "foo", svc.Name)
+	require.Equal(t, "bar", svc.Namespace)
 
-	c.Assert(svc.String(), check.Equals, "default/bar/foo")
+	require.Equal(t, "default/bar/foo", svc.String())
 
 	b, err := svc.Marshal()
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	unmarshal := ClusterService{}
 	err = unmarshal.Unmarshal("", b)
-	c.Assert(err, check.IsNil)
-	c.Assert(svc, checker.DeepEquals, unmarshal)
+	require.Nil(t, err)
+	require.EqualValues(t, unmarshal, svc)
 
-	c.Assert(svc.GetKeyName(), check.Equals, "default/bar/foo")
+	require.Equal(t, "default/bar/foo", svc.GetKeyName())
 }
 
-func (s *ServiceGenericSuite) TestPortConfigurationDeepEqual(c *check.C) {
+func TestPortConfigurationDeepEqual(t *testing.T) {
 	tests := []struct {
 		a    PortConfiguration
 		b    PortConfiguration
@@ -96,9 +88,8 @@ func (s *ServiceGenericSuite) TestPortConfigurationDeepEqual(c *check.C) {
 		},
 	}
 	for _, tt := range tests {
-		if got := tt.a.DeepEqual(&tt.b); got != tt.want {
-			c.Errorf("PortConfiguration.DeepEqual() = %v, want %v", got, tt.want)
-		}
+		got := tt.a.DeepEqual(&tt.b)
+		require.Equalf(t, tt.want, got, "PortConfiguration.DeepEqual() = %v, want %v", got, tt.want)
 	}
 }
 


### PR DESCRIPTION
Please refer to individual commits for more details, this PR is focusing on files owned by cilium/sig-lb team.

Relates: https://github.com/cilium/cilium/issues/28596