### PR TITLE
clustermesh: expose service cache and hooks from endpointslicesync

### DIFF
--- a/pkg/clustermesh/endpointslicesync/cell.go
+++ b/pkg/clustermesh/endpointslicesync/cell.go
@@ -30,8 +30,8 @@ var Cell = cell.Module(
 	"EndpointSlice clustermesh synchronization in the Cilium operator",
 	cell.Config(ClusterMeshConfig{}),
 	cell.Provide(newClusterMesh),
-	// Invoke an empty function which takes a clusterMesh to force its construction.
-	cell.Invoke(func(*clusterMesh) {}),
+	// Invoke an empty function which takes a ClusterMesh to force its construction.
+	cell.Invoke(func(ClusterMesh) {}),
 
 	cell.Config(common.Config{}),
 

--- a/pkg/clustermesh/endpointslicesync/clustermesh.go
+++ b/pkg/clustermesh/endpointslicesync/clustermesh.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync/atomic"
 
 	"github.com/cilium/endpointslice-controller/endpointslice"
 	"github.com/cilium/hive/cell"
@@ -47,9 +48,34 @@ type clusterMesh struct {
 
 	endpointSliceMeshController  *endpointslice.Controller
 	endpointSliceInformerFactory informers.SharedInformerFactory
+
+	started                   atomic.Bool
+	clusterAddHooks           []func(string)
+	clusterDeleteHooks        []func(string)
+	clusterServiceUpdateHooks []func(*serviceStore.ClusterService)
+	clusterServiceDeleteHooks []func(*serviceStore.ClusterService)
 }
 
-func newClusterMesh(lc cell.Lifecycle, params clusterMeshParams) *clusterMesh {
+// ClusterMesh is the interface corresponding to the clusterMesh struct to expose
+// its public methods to other Cilium packages.
+type ClusterMesh interface {
+	// RegisterClusterAddHook register a hook when a cluster is added to the mesh.
+	// This should NOT be called after the Start hook.
+	RegisterClusterAddHook(clusterAddHook func(string))
+	// RegisterClusterDeleteHook register a hook when a cluster is removed from the mesh.
+	// This should NOT be called after the Start hook.
+	RegisterClusterDeleteHook(clusterDeleteHook func(string))
+	// RegisterClusterServiceUpdateHook register a hook when a service in the mesh is updated.
+	// This should NOT be called after the Start hook.
+	RegisterClusterServiceUpdateHook(clusterServiceUpdateHook func(*serviceStore.ClusterService))
+	// RegisterClusterServiceDeleteHook register a hook when a service in the mesh is deleted.
+	// This should NOT be called after the Start hook.
+	RegisterClusterServiceDeleteHook(clusterServiceDeleteHook func(*serviceStore.ClusterService))
+
+	GlobalServices() *common.GlobalServiceCache
+}
+
+func newClusterMesh(lc cell.Lifecycle, params clusterMeshParams) ClusterMesh {
 	if !params.Clientset.IsEnabled() || params.ClusterMeshConfig == "" || !params.Cfg.ClusterMeshEnableEndpointSync {
 		return nil
 	}
@@ -66,7 +92,11 @@ func newClusterMesh(lc cell.Lifecycle, params clusterMeshParams) *clusterMesh {
 	}
 	cm.context, cm.contextCancel = context.WithCancel(context.Background())
 	cm.meshPodInformer = newMeshPodInformer(cm.globalServices)
+	cm.RegisterClusterServiceUpdateHook(cm.meshPodInformer.onClusterServiceUpdate)
+	cm.RegisterClusterServiceDeleteHook(cm.meshPodInformer.onClusterServiceDelete)
 	cm.meshNodeInformer = newMeshNodeInformer()
+	cm.RegisterClusterAddHook(cm.meshNodeInformer.onClusterAdd)
+	cm.RegisterClusterDeleteHook(cm.meshNodeInformer.onClusterDelete)
 	cm.endpointSliceMeshController, cm.meshServiceInformer, cm.endpointSliceInformerFactory = newEndpointSliceMeshController(
 		cm.context, params.Cfg, cm.meshPodInformer,
 		cm.meshNodeInformer, params.Clientset,
@@ -124,19 +154,64 @@ func (cm *clusterMeshServiceGetter) GetServiceIP(svcID k8s.ServiceID) *loadbalan
 	return nil
 }
 
+// RegisterClusterAddHook register a hook when a cluster is added to the mesh.
+// This should NOT be called after the Start hook.
+func (cm *clusterMesh) RegisterClusterAddHook(clusterAddHook func(string)) {
+	if cm.started.Load() {
+		panic(fmt.Errorf("can't call RegisterClusterAddHook after the Start hook"))
+	}
+	cm.clusterAddHooks = append(cm.clusterAddHooks, clusterAddHook)
+}
+
+// RegisterClusterDeleteHook register a hook when a cluster is removed from the mesh.
+// This should NOT be called after the Start hook.
+func (cm *clusterMesh) RegisterClusterDeleteHook(clusterDeleteHook func(string)) {
+	if cm.started.Load() {
+		panic(fmt.Errorf("can't call RegisterClusterDeleteHook after the Start hook"))
+	}
+	cm.clusterDeleteHooks = append(cm.clusterDeleteHooks, clusterDeleteHook)
+}
+
+// RegisterClusterServiceUpdateHook register a hook when a service in the mesh is updated.
+// This should NOT be called after the Start hook.
+func (cm *clusterMesh) RegisterClusterServiceUpdateHook(clusterServiceUpdateHook func(*serviceStore.ClusterService)) {
+	if cm.started.Load() {
+		panic(fmt.Errorf("can't call RegisterClusterServiceUpdateHook after the Start hook"))
+	}
+	cm.clusterServiceUpdateHooks = append(cm.clusterServiceUpdateHooks, clusterServiceUpdateHook)
+}
+
+// RegisterClusterServiceDeleteHook register a hook when a service in the mesh is deleted.
+// This should NOT be called after the Start hook.
+func (cm *clusterMesh) RegisterClusterServiceDeleteHook(clusterServiceDeleteHook func(*serviceStore.ClusterService)) {
+	if cm.started.Load() {
+		panic(fmt.Errorf("can't call RegisterClusterServiceDeleteHook after the Start hook"))
+	}
+	cm.clusterServiceDeleteHooks = append(cm.clusterServiceDeleteHooks, clusterServiceDeleteHook)
+}
+
+func (cm *clusterMesh) GlobalServices() *common.GlobalServiceCache {
+	return cm.globalServices
+}
+
 func (cm *clusterMesh) newRemoteCluster(name string, status common.StatusFunc) common.RemoteCluster {
 	rc := &remoteCluster{
-		name:             name,
-		meshNodeInformer: cm.meshNodeInformer,
-		globalServices:   cm.globalServices,
-		storeFactory:     cm.storeFactory,
-		synced:           newSynced(),
+		name:               name,
+		globalServices:     cm.globalServices,
+		storeFactory:       cm.storeFactory,
+		synced:             newSynced(),
+		clusterAddHooks:    cm.clusterAddHooks,
+		clusterDeleteHooks: cm.clusterDeleteHooks,
 	}
 
 	rc.remoteServices = cm.storeFactory.NewWatchStore(
 		name,
 		func() store.Key { return new(serviceStore.ClusterService) },
-		&remoteServiceObserver{globalServices: cm.globalServices, meshPodInformer: cm.meshPodInformer},
+		&remoteServiceObserver{
+			globalServices:            cm.globalServices,
+			clusterServiceUpdateHooks: cm.clusterServiceUpdateHooks,
+			clusterServiceDeleteHooks: cm.clusterServiceDeleteHooks,
+		},
 		store.RWSWithOnSyncCallback(func(ctx context.Context) { rc.synced.services.Stop() }),
 	)
 
@@ -145,6 +220,7 @@ func (cm *clusterMesh) newRemoteCluster(name string, status common.StatusFunc) c
 
 func (cm *clusterMesh) Start(startCtx cell.HookContext) error {
 	log.Info("Bootstrap clustermesh EndpointSlice controller")
+	cm.started.Store(true)
 
 	cm.endpointSliceInformerFactory.Start(cm.context.Done())
 	if err := cm.meshServiceInformer.Start(cm.context); err != nil {

--- a/pkg/clustermesh/endpointslicesync/endpointslice_test.go
+++ b/pkg/clustermesh/endpointslicesync/endpointslice_test.go
@@ -142,7 +142,7 @@ func Test_meshEndpointSlice_Reconcile(t *testing.T) {
 	cache.WaitForCacheSync(context.Background().Done(), serviceInformer.HasSynced)
 
 	go controller.Run(context.Background(), 1)
-	nodeInformer.onAddCluster(remoteClusterName)
+	nodeInformer.onClusterAdd(remoteClusterName)
 
 	svcStore, _ := services.Store(context.Background())
 

--- a/pkg/clustermesh/endpointslicesync/node_informer.go
+++ b/pkg/clustermesh/endpointslicesync/node_informer.go
@@ -75,7 +75,7 @@ func (i *meshNodeInformer) Get(name string) (*v1.Node, error) {
 	return nil, newNotFoundError(fmt.Sprintf("node '%s' not found", name))
 }
 
-func (i *meshNodeInformer) onAddCluster(cluster string) {
+func (i *meshNodeInformer) onClusterAdd(cluster string) {
 	i.mutex.Lock()
 	node := createDummyNode(cluster)
 	i.nodes[cluster] = node
@@ -87,7 +87,7 @@ func (i *meshNodeInformer) onAddCluster(cluster string) {
 	i.handler.OnAdd(node, false)
 }
 
-func (i *meshNodeInformer) onDeleteCluster(cluster string) {
+func (i *meshNodeInformer) onClusterDelete(cluster string) {
 	i.mutex.Lock()
 	delete(i.nodes, cluster)
 	i.mutex.Unlock()


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

Expose Global Service cache and various hooks registration from the endpointslicesync package. This will allow to collocate other controllers in different go packages in the operator that need to use the global service cache and register hooks.

The first use case for this would be for the Multi-Cluster Services API support.

Related to #27902
This is needed for a future followup to #32264 to have the last bits needed for full MCS-API support (ServiceImport object auto creation)

```release-note
Expose clustermesh global service cache and hooks in the operator to prepare for MCS-API support
```
