### PR TITLE
install/kubernetes: allow extra helm resources

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1460,6 +1460,10 @@
      - Additional initContainers added to the cilium Daemonset.
      - list
      - ``[]``
+   * - :spelling:ignore:`extraResources`
+     - extraResources allows you to add additional resources to the install
+     - list
+     - ``[]``
    * - :spelling:ignore:`extraVolumeMounts`
      - Additional agent volumeMounts.
      - list

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -315,6 +315,7 @@ extern
 externalIPs
 externalTrafficPolicy
 extraConfig
+extraResources
 facto
 failover
 fec

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -415,6 +415,7 @@ contributors across the globe, there is almost always someone available to help.
 | extraEnv | list | `[]` | Additional agent container environment variables. |
 | extraHostPathMounts | list | `[]` | Additional agent hostPath mounts. |
 | extraInitContainers | list | `[]` | Additional initContainers added to the cilium Daemonset. |
+| extraResources | list | `[]` | extraResources allows you to add additional resources to the install |
 | extraVolumeMounts | list | `[]` | Additional agent volumeMounts. |
 | extraVolumes | list | `[]` | Additional agent volumes. |
 | gatewayAPI.enableAppProtocol | bool | `false` | Enable Backend Protocol selection support (GEP-1911) for Gateway API via appProtocol. |

--- a/install/kubernetes/cilium/templates/cilium-extra.yaml
+++ b/install/kubernetes/cilium/templates/cilium-extra.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraResources }}
+---
+{{ . }}
+{{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2294,6 +2294,10 @@
       "items": {},
       "type": "array"
     },
+    "extraResources": {
+      "items": {},
+      "type": "array"
+    },
     "extraVolumeMounts": {
       "items": {},
       "type": "array"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -211,7 +211,8 @@ extraConfig: {}
 #    test 1
 #    test 2
 #    test 3
-
+# -- extraResources allows you to add additional resources to the install
+extraResources: []
 # -- Annotations to be added to all top-level cilium-agent objects (resources under templates/cilium-agent)
 annotations: {}
 # -- Security Context for cilium-agent pods.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -209,7 +209,8 @@ extraConfig: {}
 #    test 1
 #    test 2
 #    test 3
-
+# -- extraResources allows you to add additional resources to the install
+extraResources: []
 # -- Annotations to be added to all top-level cilium-agent objects (resources under templates/cilium-agent)
 annotations: {}
 # -- Security Context for cilium-agent pods.


### PR DESCRIPTION
Allow additional aribitrary k8s resources to be added to the helm chart via the values file.  This allows extension of the existing chart in a way that allows for the extension to be tracked via helm installation history, making rollbacks to earlier state easier than the current case, which involves performing a helm install and then adding/editing additional resources manually.

As an example use-case, you may wish to add additional ClusterRoles and ClusterRoleBindings to the cilium daemonset's service account to let an initContainer or sidecar container watch for LLDP traffic indicating a router, and configure CiliumBgpPeeringPolicies based on that data.

```yaml
extraResources:
- |
  apiversion: rbac.authorization.k8s.io/v1
  kind: ClusterRole
  metadata:
    name: cilium-bgppeers
  rules:
  - apiGroups:
    - cilium.io
    resources:
    - ciliumbgppeerpolicies
    verbs:
    - get
    - list
    - create
    - patch
- |
  apiVersion: rbac.authorization.k8s.io/v1
  kind: ClusterRoleBinding
  metadata:
    name: cilium-bgppeers
  roleRef:
    apiGroup: rbac.authorization.k8s.io
    kind: ClusterRole
    name: cilium-bgppeers
  subjects:
  - kind: ServiceAccount
    name: cilium
    namespace: kube-system
```
