### PR TITLE
fqdn: updating the variable name in fqdn

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -129,9 +129,9 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 	// locally running endpoints.
 	cfg.Cache.DisableCleanupTrack()
 
-	rg := fqdn.NewNameManager(cfg)
-	d.policy.GetSelectorCache().SetLocalIdentityNotifier(rg)
-	d.dnsNameManager = rg
+	nameManager := fqdn.NewNameManager(cfg)
+	d.policy.GetSelectorCache().SetLocalIdentityNotifier(nameManager)
+	d.dnsNameManager = nameManager
 
 	// Controller to cleanup TTL expired entries from the DNS policies.
 	d.dnsNameManager.StartGC(d.ctx)


### PR DESCRIPTION
While going through the fqdn code I see the variable `rg`(RuleGen) is no longer correspond to the component `nameManager` as it got renamed: https://github.com/cilium/cilium/commit/f1f3d2c1d10866cd85309dee782a58a488907cbd 
