### PR TITLE
bpf: hide dynamic/static variant for policy tail-call

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1782,7 +1782,7 @@ int handle_lxc_traffic(struct __ctx_buff *ctx)
 
 		lxc_id = ctx_load_meta(ctx, CB_DST_ENDPOINT_ID);
 		ctx_store_meta(ctx, CB_SRC_LABEL, HOST_ID);
-		ret = tail_call_policy_dynamic(ctx, (__u16)lxc_id);
+		ret = tail_call_policy(ctx, (__u16)lxc_id);
 		return send_drop_notify_error(ctx, HOST_ID, ret,
 					      CTX_ACT_DROP, METRIC_EGRESS);
 	}

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -599,7 +599,7 @@ ct_recreate6:
 	 */
 	if (*dst_sec_identity == HOST_ID) {
 		ctx_store_meta(ctx, CB_FROM_HOST, 0);
-		ret = tail_call_policy_static(ctx, HOST_EP_ID);
+		ret = tail_call_policy(ctx, HOST_EP_ID);
 
 		/* return fine-grained error: */
 		return DROP_HOST_NOT_READY;
@@ -1079,7 +1079,7 @@ ct_recreate4:
 	 */
 	if (*dst_sec_identity == HOST_ID) {
 		ctx_store_meta(ctx, CB_FROM_HOST, 0);
-		ret = tail_call_policy_static(ctx, HOST_EP_ID);
+		ret = tail_call_policy(ctx, HOST_EP_ID);
 
 		/* report fine-grained error: */
 		return DROP_HOST_NOT_READY;
@@ -2439,7 +2439,7 @@ int cil_to_container(struct __ctx_buff *ctx)
 		ctx_store_meta(ctx, CB_FROM_HOST, 1);
 		ctx_store_meta(ctx, CB_DST_ENDPOINT_ID, LXC_ID);
 
-		ret = tail_call_policy_static(ctx, HOST_EP_ID);
+		ret = tail_call_policy(ctx, HOST_EP_ID);
 		return send_drop_notify(ctx, identity, sec_label, LXC_ID,
 					DROP_HOST_NOT_READY, CTX_ACT_DROP,
 					METRIC_INGRESS);

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -124,7 +124,7 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 	ctx_store_meta(ctx, CB_FROM_TUNNEL, from_tunnel ? 1 : 0);
 	ctx_store_meta(ctx, CB_CLUSTER_ID_INGRESS, cluster_id);
 
-	return tail_call_policy_dynamic(ctx, ep->lxc_id);
+	return tail_call_policy(ctx, ep->lxc_id);
 #endif
 }
 

--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -41,22 +41,19 @@ struct bpf_elf_map __section_maps POLICY_CALL_MAP = {
 };
 
 static __always_inline __must_check int
-tail_call_policy_dynamic(struct __ctx_buff *ctx, __u16 endpoint_id)
+tail_call_policy(struct __ctx_buff *ctx, __u16 endpoint_id)
 {
-	tail_call_dynamic(ctx, &POLICY_CALL_MAP, endpoint_id);
+	if (__builtin_constant_p(endpoint_id)) {
+		tail_call_static(ctx, POLICY_CALL_MAP, endpoint_id);
+	} else {
+		tail_call_dynamic(ctx, &POLICY_CALL_MAP, endpoint_id);
+	}
+
 	/* When forwarding from a BPF program to some endpoint,
 	 * there are inherent races that can result in the endpoint's
 	 * policy program being unavailable (eg. if the endpoint is
 	 * terminating).
 	 */
-	return DROP_EP_NOT_READY;
-}
-
-static __always_inline __must_check int
-tail_call_policy_static(struct __ctx_buff *ctx, __u16 endpoint_id)
-{
-	tail_call_static(ctx, POLICY_CALL_MAP, endpoint_id);
-	/* see above */
 	return DROP_EP_NOT_READY;
 }
 #endif /* SKIP_POLICY_MAP */


### PR DESCRIPTION
Whether the tail-call is executed as dynamic or static is an implementation detail. Hide it in a generic tail_call_policy() helper.

Suggested-by: Timo Beckers <timo@isovalent.com>