### PR TITLE
ci: Filter supported versions of GKE

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -128,7 +128,7 @@ jobs:
             if grep -q -F $VERSION /tmp/output; then
               echo "Version $VERSION is valid for location $LOCATION"
             else
-              echo "Removing version $VERSION as it's not valid for location $LOCATION"
+              echo "::notice::Removing version $VERSION as it's not valid for location $LOCATION"
               jq 'del(.include[] | select(.version == "'$VERSION'"))' /tmp/result.json > /tmp/result.json.tmp
               mv /tmp/result.json.tmp /tmp/result.json
             fi

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -58,6 +58,8 @@ env:
   vmStartupScript: .github/gcp-vm-startup.sh
   cilium_cli_ci_version:
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
+  # renovate: datasource=docker depName=google/cloud-sdk
+  gcloud_version: 405.0.0
 
 jobs:
   echo-inputs:
@@ -127,7 +129,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
-          version: "405.0.0"
+          version: ${{ env.gcloud_version }}
 
       - name: Filter Matrix
         id: set-matrix
@@ -235,7 +237,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
-          version: "405.0.0"
+          version: ${{ env.gcloud_version }}
 
       - name: Install gke-gcloud-auth-plugin
         run: |

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -144,7 +144,7 @@ jobs:
             if grep -q -F $VERSION /tmp/output; then
               echo "Version $VERSION is valid for zone $ZONE"
             else
-              echo "Removing version $VERSION as it's not valid for zone $ZONE"
+              echo "::notice::Removing version $VERSION as it's not valid for zone $ZONE"
               jq 'del(.include[] | select(.version == "'$VERSION'"))' /tmp/result.json > /tmp/result.json.tmp
               mv /tmp/result.json.tmp /tmp/result.json
             fi

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -99,7 +99,6 @@ jobs:
           yq -o=json ${work_dir}/k8s-versions.yaml | jq . > "${destination_directory}/gke.json"
 
       - name: Generate Matrix
-        id: set-matrix
         run: |
           cd /tmp/generated/gke
 
@@ -114,7 +113,44 @@ jobs:
 
           echo "Generated matrix:"
           cat /tmp/matrix.json
-          echo "matrix=$(jq -c . < /tmp/matrix.json)" >> $GITHUB_OUTPUT
+
+      - name: Set up gcloud credentials
+        id: 'auth'
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_PR_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_PR_SA }}
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          version: "405.0.0"
+
+      - name: Filter Matrix
+        id: set-matrix
+        run: |
+          cp /tmp/matrix.json /tmp/result.json
+          jq -c '.include[]' /tmp/matrix.json | while read i; do
+            VERSION=$(echo $i | jq -r '.version')
+            ZONE=$(echo $i | jq -r '.zone')
+            gcloud --quiet container get-server-config \
+              --flatten="channels" --filter="channels.channel=REGULAR"   \
+              --format="yaml(channels.validVersions)" --zone $ZONE > /tmp/output
+            if grep -q -F $VERSION /tmp/output; then
+              echo "Version $VERSION is valid for zone $ZONE"
+            else
+              echo "Removing version $VERSION as it's not valid for zone $ZONE"
+              jq 'del(.include[] | select(.version == "'$VERSION'"))' /tmp/result.json > /tmp/result.json.tmp
+              mv /tmp/result.json.tmp /tmp/result.json
+            fi
+          done
+          echo "Filtered matrix:"
+          cat /tmp/result.json
+
+          echo "matrix=$(jq -c . < /tmp/result.json)" >> $GITHUB_OUTPUT
 
   installation-and-connectivity:
     name: Installation and Connectivity Test

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -99,12 +99,11 @@ jobs:
             new_filename="${filename%.yaml}.json"
             yq -o=json "${file}" | jq . > "${destination_directory}/${new_filename}"
           done
-          
+
           # Merge 2 files into one
           jq -s "add" ${destination_directory}/*.json > "${destination_directory}/gke.json"
 
       - name: Generate Matrix
-        id: set-matrix
         run: |
           cd /tmp/generated/gke
 
@@ -119,7 +118,44 @@ jobs:
 
           echo "Generated matrix:"
           cat /tmp/matrix.json
-          echo "matrix=$(jq -c . < /tmp/matrix.json)" >> $GITHUB_OUTPUT
+
+      - name: Set up gcloud credentials
+        id: 'auth'
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_PR_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_PR_SA }}
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          version: "405.0.0"
+
+      - name: Filter Matrix
+        id: set-matrix
+        run: |
+          cp /tmp/matrix.json /tmp/result.json
+          jq -c '.k8s[]' /tmp/matrix.json | while read i; do
+            VERSION=$(echo $i | jq -r '.version')
+            ZONE=$(echo $i | jq -r '.zone')
+            gcloud --quiet container get-server-config \
+              --flatten="channels" --filter="channels.channel=REGULAR"   \
+              --format="yaml(channels.validVersions)" --zone $ZONE > /tmp/output
+            if grep -q -F $VERSION /tmp/output; then
+              echo "Version $VERSION is valid for zone $ZONE"
+            else
+              echo "Removing version $VERSION as it's not valid for zone $ZONE"
+              jq 'del(.k8s[] | select(.version == "'$VERSION'"))' /tmp/result.json > /tmp/result.json.tmp
+              mv /tmp/result.json.tmp /tmp/result.json
+            fi
+          done
+          echo "Filtered matrix:"
+          cat /tmp/result.json
+
+          echo "matrix=$(jq -c . < /tmp/result.json)" >> $GITHUB_OUTPUT
 
   installation-and-connectivity:
     name: Installation and Connectivity Test

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -149,7 +149,7 @@ jobs:
             if grep -q -F $VERSION /tmp/output; then
               echo "Version $VERSION is valid for zone $ZONE"
             else
-              echo "Removing version $VERSION as it's not valid for zone $ZONE"
+              echo "::notice::Removing version $VERSION as it's not valid for zone $ZONE"
               jq 'del(.k8s[] | select(.version == "'$VERSION'"))' /tmp/result.json > /tmp/result.json.tmp
               mv /tmp/result.json.tmp /tmp/result.json
             fi

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -56,6 +56,8 @@ env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cilium_cli_ci_version:
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
+  # renovate: datasource=docker depName=google/cloud-sdk
+  gcloud_version: 405.0.0
 
 jobs:
   echo-inputs:
@@ -132,7 +134,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
-          version: "405.0.0"
+          version: ${{ env.gcloud_version }}
 
       - name: Filter Matrix
         id: set-matrix
@@ -237,7 +239,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
-          version: "405.0.0"
+          version: ${{ env.gcloud_version }}
 
       - name: Install gke-gcloud-auth-plugin
         run: |

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -43,6 +43,8 @@ env:
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
   gcp_zone: us-east5-a
   k8s_version: 1.28
+  # renovate: datasource=docker depName=google/cloud-sdk
+  gcloud_version: 405.0.0
 
 jobs:
   installation-and-perf:
@@ -185,7 +187,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
         with:
           project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
-          version: "405.0.0"
+          version: ${{ env.gcloud_version }}
 
       - name: Install gke-gcloud-auth-plugin
         run: |

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -36,6 +36,8 @@ env:
   # has stricter DNS naming requirements.
   test_name: scale-100
   cluster_base_name: ${{ github.run_id }}-${{ github.run_attempt }}.k8s.local
+  # renovate: datasource=docker depName=google/cloud-sdk
+  gcloud_version: 405.0.0
 
 jobs:
   install-and-scaletest:
@@ -108,7 +110,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
         with:
           project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
-          version: "405.0.0"
+          version: ${{ env.gcloud_version }}
 
       - name: Clone ClusterLoader2
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -42,6 +42,8 @@ env:
   test_name: node-throughput
   cluster_base_name: ${{ github.run_id }}-${{ github.run_attempt }}.k8s.local
   GCP_PERF_RESULTS_BUCKET: gs://cilium-scale-results
+  # renovate: datasource=docker depName=google/cloud-sdk
+  gcloud_version: 405.0.0
 
 jobs:
   install-and-scaletest:
@@ -113,7 +115,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
         with:
           project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
-          version: "405.0.0"
+          version: ${{ env.gcloud_version }}
       
       - name: Clone ClusterLoader2
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4


### PR DESCRIPTION
Whenever GKE stopped supporting a particular version of GKE, we had to
manually remove it from all stable branches. Now instead of that, we
will dynamically check if it's supported and only then run the test.

I will follow-up with the same approach for other cloud-providers.
