### PR TITLE
restoration: checkpoint local allocator state, utilize on restoration

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -228,7 +228,7 @@ cilium-agent [flags]
       --hubble-tls-key-file string                                Path to the private key file for the Hubble server. The file must contain PEM encoded data.
       --identity-allocation-mode string                           Method to use for identity allocation (default "kvstore")
       --identity-change-grace-period duration                     Time to wait before using new identity on endpoint identity change (default 5s)
-      --identity-restore-grace-period duration                    Time to wait before releasing unused restored CIDR identities during agent restart (default 10m0s)
+      --identity-restore-grace-period duration                    Time to wait before releasing unused restored CIDR identities during agent restart (default 30s)
       --ingress-secrets-namespace string                          IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller
       --install-no-conntrack-iptables-rules                       Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.
       --ip-masq-agent-config-path string                          ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -466,7 +466,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	if option.Config.RestoreState && !option.Config.DryMode {
 		// this *must* be called before initMaps(), which will "hide"
 		// the "old" ipcache.
-		err := d.restoreIPCache()
+		err := d.restoreLocalIdentities()
 		if err != nil {
 			log.WithError(err).Warn("Failed to restore existing identities from the previous ipcache. This may cause policy interruptions during restart.")
 		}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1812,7 +1812,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 		// Sleep for the --identity-restore-grace-period (default 10 minutes), allowing
 		// the normal allocation processes to finish, before releasing restored resources.
 		time.Sleep(option.Config.IdentityRestoreGracePeriod)
-		d.releaseRestoredCIDRs()
+		d.releaseRestoredIdentities()
 	}()
 	d.endpointManager.Subscribe(d)
 	// Add the endpoint manager unsubscribe as the last step in cleanup

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -439,7 +439,7 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Duration(option.IdentityChangeGracePeriod, defaults.IdentityChangeGracePeriod, "Time to wait before using new identity on endpoint identity change")
 	option.BindEnv(vp, option.IdentityChangeGracePeriod)
 
-	flags.Duration(option.IdentityRestoreGracePeriod, defaults.IdentityRestoreGracePeriod, "Time to wait before releasing unused restored CIDR identities during agent restart")
+	flags.Duration(option.IdentityRestoreGracePeriod, defaults.IdentityRestoreGracePeriodK8s, "Time to wait before releasing unused restored CIDR identities during agent restart")
 	option.BindEnv(vp, option.IdentityRestoreGracePeriod)
 
 	flags.String(option.IdentityAllocationMode, option.IdentityAllocationModeKVstore, "Method to use for identity allocation")
@@ -1809,7 +1809,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 		ms.CollectStaleMapGarbage()
 		ms.RemoveDisabledMaps()
 
-		// Sleep for the --identity-restore-grace-period (default 10 minutes), allowing
+		// Sleep for the --identity-restore-grace-period (default: 30 seconds k8s, 10 minutes kvstore), allowing
 		// the normal allocation processes to finish, before releasing restored resources.
 		time.Sleep(option.Config.IdentityRestoreGracePeriod)
 		d.releaseRestoredIdentities()

--- a/daemon/cmd/identity.go
+++ b/daemon/cmd/identity.go
@@ -72,5 +72,17 @@ type CachingIdentityAllocator interface {
 	clustermesh.RemoteIdentityWatcher
 
 	InitIdentityAllocator(versioned.Interface) <-chan struct{}
+
+	// RestoreLocalIdentities reads in the checkpointed local allocator state
+	// from disk and allocates a reference to every previously existing identity.
+	//
+	// Once all identity-allocating objects are synchronized (e.g. network policies,
+	// remote nodes), call ReleaseRestoredIdentities to release the held references.
+	RestoreLocalIdentities() (map[identity.NumericIdentity]*identity.Identity, error)
+
+	// ReleaseRestoredIdentities releases any identities that were restored, reducing their reference
+	// count and cleaning up as necessary.
+	ReleaseRestoredIdentities()
+
 	Close()
 }

--- a/daemon/cmd/ipcache.go
+++ b/daemon/cmd/ipcache.go
@@ -308,8 +308,8 @@ func (d *Daemon) restoreIPCache(localPrefixes map[netip.Prefix]identity.NumericI
 //
 // Any identities and prefixes actually in use will still exist after this.
 //
-// This should be called after a grace period (default 10 minutes, set
-// by --identity-restore-grace-period).
+// This should be called after a grace period (default 30 seconds,
+// 10 minutes for kvstore, set by --identity-restore-grace-period).
 // This grace period is needed when running on an external workload
 // where policy synchronization is not done via k8s. Also in k8s
 // case it is prudent to allow concurrent endpoint regenerations to

--- a/daemon/cmd/ipcache.go
+++ b/daemon/cmd/ipcache.go
@@ -5,12 +5,12 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"io/fs"
 	"net"
 	"net/netip"
 
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/policy"
@@ -24,7 +24,6 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
 	"github.com/cilium/cilium/pkg/node"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 )
 
@@ -102,30 +101,52 @@ func containsSubnet(outer, inner net.IPNet) bool {
 	return outerBits == innerBits && outerOnes <= innerOnes && outer.Contains(inner.IP)
 }
 
-// restoreIPCache dumps the existing (old) bpf ipcache, adding relevant information
-// back in to the ipcache / identity allocator.
+// restoreLocalIdentities restores the local identity state in the
+// allocator and IPCache.
 //
-// The goal of this logic is to ensure, as much as possible, that local identities (i.e. CIDR)
-// get the same numeric identity upon agent restart.
+// First, the local identity allocator checkpoint is loaded.
+// This will ensure that the same set of labels is assigned the same numeric
+// identity once the agent has restored all state.
 //
-// For all local (cidr / remote-node) identities found, this adds a placeholder entry in the
-// ipcache metadata layer requesting the previous numeric identity. When the agent initializes
-// and the ipcache finally recreates the bpf map, this placeholder entry ensures the prefixes
-// exist and have the same identity as before.
+// Next, the outgoing ipcache bpf map is read. For any prefixes that
+// mapped to a CIDR-specific identity, the ipcache metadata is re-created
+// and inserted in to the ipcache.
 //
-// After a grace period, the placeholder metadata is removed and any prefixes not referenced
-// by other subsystems will be deallocated, see releaseRestoredCIDRs().
-// (Aside: prefix references mostly come from network policies, either directly through CIDR
-// selectors or via ToFQDN rules.)
+// The purpose of this is to preserve stable local identities on agent
+// restart as much as possible. This helps prevent spurious policy drops
+// on agent restart.
 //
-// For ingress IPs, it will add those to the ipcache and configure the local node
-// accordingly.
+// After a grace period, the restored identity references and placeholder ipcache
+// metadata entries are removed, assuming that the agent has synchronized
+// with other state (i.e. kvstore, k8s) and that all necessary entries
+// are present in ipcache & the identity allocator.
 //
 // This *must* be called before initMaps(), which will hide the "old" ipcache.
-func (d *Daemon) restoreIPCache() error {
-	ingressIPs := make([]netip.Prefix, 0, 2)
-	// need to preserve this so we can remove it later.
-	d.restoredCIDRs = map[netip.Prefix]identity.NumericIdentity{}
+func (d *Daemon) restoreLocalIdentities() error {
+	// Restore the local identity allocator from its checkpoint.
+	// This returns the set of identities created. We will use this set
+	// to regenerate the set of labels for prefixes in the ipcache.
+	restoredIdentities, err := d.identityAllocator.RestoreLocalIdentities()
+
+	// Dump the existing BPF ipcache map
+	localPrefixes, err2 := d.dumpOldIPCache()
+	if err2 != nil {
+		log.WithError(err2).Warn("Failed to restore existing identities from the previous ipcache. This may cause policy interruptions during restart.")
+		err = errors.Join(err, err2)
+		// continue; we may have a partial dump
+	}
+
+	// create placeholder CIDR labels in the ipcache.
+	// This only adds an ipcache metadata entry for prefixes with a `cidr:`
+	// label and ingress IPs. All other entries will have to be created anew.
+	d.restoreIPCache(localPrefixes, restoredIdentities)
+	return err
+}
+
+// dumpOldIPache reads the soon-to-be-overwritten ipcache BPF map, noting any prefixes
+// with a locally-scoped or ingress identity.
+func (d *Daemon) dumpOldIPCache() (map[netip.Prefix]identity.NumericIdentity, error) {
+	localPrefixes := map[netip.Prefix]identity.NumericIdentity{}
 
 	// Dump the bpf ipcache, recording any prefixes with local or ingress
 	// numeric identities.
@@ -134,10 +155,8 @@ func (d *Daemon) restoreIPCache() error {
 		v := value.(*ipcachemap.RemoteEndpointInfo)
 		nid := identity.NumericIdentity(v.SecurityIdentity)
 
-		if isLocalIdentity(nid) {
-			d.restoredCIDRs[k.Prefix()] = nid
-		} else if nid == identity.ReservedIdentityIngress && v.TunnelEndpoint.IsZero() {
-			ingressIPs = append(ingressIPs, k.Prefix())
+		if nid.Scope() == identity.IdentityScopeLocal || (nid == identity.ReservedIdentityIngress && v.TunnelEndpoint.IsZero()) {
+			localPrefixes[k.Prefix()] = nid
 		}
 	})
 	// dumpwithcallback() leaves the ipcache map open, must close before opened for
@@ -145,48 +164,133 @@ func (d *Daemon) restoreIPCache() error {
 	ipcachemap.IPCacheMap().Close()
 
 	if err != nil {
+		// ignore non-existent cache
 		if errors.Is(err, fs.ErrNotExist) {
-			return nil
+			err = nil
 		}
-		return fmt.Errorf("error dumping ipcache: %w", err)
+	}
+	log.Debugf("dumping ipache found %d local identities", len(localPrefixes))
+	return localPrefixes, err
+}
+
+// restoreIPCache recreated ipcache metadata entries from the dumped allocator and
+// bpf map state.
+//
+// The goal of this logic is to ensure, as much as possible, that local identities (i.e. CIDR)
+// get the same numeric identity upon agent restart.
+//
+// This reconstructs the ipcache state from the previous BPF map and the restored local
+// identities. Specifically, if a prefix in the ipcache has a CIDR label, this re-creates
+// that metadata entry.
+//
+// For ingress IPs, it will add those to the ipcache and configure the local node
+// accordingly.
+func (d *Daemon) restoreIPCache(localPrefixes map[netip.Prefix]identity.NumericIdentity, restoredIdentities map[identity.NumericIdentity]*identity.Identity) {
+	if len(localPrefixes) == 0 {
+		return
 	}
 
-	// Now that the map is dumped,
-	// - upsert relevant metadata in to the ipcache
-	// - withhold all existing CIDR identities
-	// - add Ingress IPs to local Node.
-	metaUpdates := make([]ipcache.MU, 0, len(ingressIPs)+len(d.restoredCIDRs))
-	nidsToWithhold := make([]identity.NumericIdentity, 0, len(d.restoredCIDRs))
+	metaUpdates := make([]ipcache.MU, 0, len(localPrefixes))
+	d.restoredCIDRs = make(map[netip.Prefix]identity.NumericIdentity, len(localPrefixes))
+	nidsToWithhold := []identity.NumericIdentity{}
 
-	for prefix, nid := range d.restoredCIDRs {
-		nidsToWithhold = append(nidsToWithhold, nid)
-		metaUpdates = append(metaUpdates, ipcache.MU{
-			Prefix:   prefix,
-			Source:   source.Restored,
-			Resource: restoredCIDRResource,
-			Metadata: []ipcache.IPMetadata{ipcachetypes.RequestedIdentity(nid)},
-		})
+	// Determine which numeric identities are not shared.
+	// This is used for identity recreation.
+	uniqueIDs := map[identity.NumericIdentity]struct{}{}
+	sharedIDs := map[identity.NumericIdentity]struct{}{}
+	for _, nid := range localPrefixes {
+		if _, ok := sharedIDs[nid]; ok {
+			continue
+		} else if _, ok := uniqueIDs[nid]; ok {
+			delete(uniqueIDs, nid)
+			sharedIDs[nid] = struct{}{}
+			continue
+		} else {
+			uniqueIDs[nid] = struct{}{}
+		}
 	}
-	for _, prefix := range ingressIPs {
-		metaUpdates = append(metaUpdates, ipcache.MU{
-			Prefix:   prefix,
-			Source:   source.Restored,
-			Resource: ingressResource,
-			Metadata: []ipcache.IPMetadata{labels.LabelIngress},
-		})
 
-		// Set any restored ingress IPs back on the LocalNode object
-		d.nodeLocalStore.Update(func(n *node.LocalNode) {
-			addr := prefix.Addr()
-			if addr.Is4() {
-				n.IPv4IngressIP = addr.AsSlice()
-			} else {
-				n.IPv6IngressIP = addr.AsSlice()
+	// Loop through prefixes recovered from the ipcache, using a few different
+	// heuristics to recreate the metadata in the ipcache.
+	for prefix, nid := range localPrefixes {
+		// Restore Ingress IPs as necessary
+		if nid == identity.ReservedIdentityIngress {
+			metaUpdates = append(metaUpdates, ipcache.MU{
+				Prefix:   prefix,
+				Source:   source.Restored,
+				Resource: ingressResource,
+				Metadata: []ipcache.IPMetadata{labels.LabelIngress},
+			})
+
+			// Set any restored ingress IPs back on the LocalNode object
+			d.nodeLocalStore.Update(func(n *node.LocalNode) {
+				addr := prefix.Addr()
+				if addr.Is4() {
+					n.IPv4IngressIP = addr.AsSlice()
+				} else {
+					n.IPv6IngressIP = addr.AsSlice()
+				}
+			})
+			log.WithField(logfields.Ingress, prefix).Info("Restored ingress IP")
+			continue
+		}
+
+		// For every prefix -> nid pair, look to see if there is a restored identity for this nid.
+		// If not, then request the same numeric identity *and* possibly insert CIDR labels
+		// If yes, **and** the identity contains the prefix `cidr:` label,
+		//   then upsert that exact set of labels in the ipcache.
+		id := restoredIdentities[nid]
+		if id == nil {
+			// Always request the previous numeric ID for this prefix.
+			metadata := []ipcache.IPMetadata{ipcachetypes.RequestedIdentity(nid)}
+
+			// If this numeric ID is not shared by any other prefixes, add CIDR labels
+			// as well.
+			if _, unique := uniqueIDs[nid]; unique {
+				metadata = append(metadata, labels.GetCIDRLabels(prefix))
 			}
-		})
-	}
-	if len(ingressIPs) > 0 {
-		log.WithField(logfields.Ingress, ingressIPs).Info("Restored ingress IPs")
+
+			// Commit to ipcache.
+			metaUpdates = append(metaUpdates, ipcache.MU{
+				Prefix:   prefix,
+				Source:   source.Restored,
+				Resource: restoredCIDRResource,
+				Metadata: metadata,
+			})
+			d.restoredCIDRs[prefix] = nid
+			nidsToWithhold = append(nidsToWithhold, nid)
+			log.WithField(logfields.Prefix, prefix).Debug("ipache prefix not found in allocator cache, requesting identity")
+
+		} else {
+			// The prefix's labels *have* been restored from the checkpoint.
+			//
+			// If the restored identity contains an exact CIDR match
+			// for this prefix, then insert its labels in to the ipcache.
+			//
+			// Otherwise, do nothing. The set of labels for this prefix will
+			// be recreated from other sources on startup, such as reading the FQDN
+			// checkpoint.
+			//
+			// Note that the set of labels may be more than just reserved:world
+			// and the cidr:xxx/32. For example, the CIDR may also have the apiserver
+			// or reserved:remote-node label.
+			wantLbl, _ := labels.IPStringToLabel(prefix.String())
+			if _, exists := id.Labels[wantLbl.Key]; exists {
+
+				metaUpdates = append(metaUpdates, ipcache.MU{
+					Prefix:   prefix,
+					Source:   source.Restored,
+					Resource: restoredCIDRResource,
+					Metadata: []ipcache.IPMetadata{id.Labels},
+				})
+				log.WithFields(logrus.Fields{
+					logfields.Labels: id.Labels,
+					logfields.Prefix: prefix,
+				}).Debug("restoring local ipcache entry")
+
+				d.restoredCIDRs[prefix] = nid
+			}
+		}
 	}
 
 	// Insert the batched changes in to the ipcache.
@@ -196,12 +300,13 @@ func (d *Daemon) restoreIPCache() error {
 	d.ipcache.IdentityAllocator.WithholdLocalIdentities(nidsToWithhold)
 	d.ipcache.UpsertMetadataBatch(metaUpdates...)
 
-	return nil
+	log.Infof("restored %d out of %d possible prefixes in the ipcache", len(d.restoredCIDRs), len(localPrefixes))
 }
 
-// releaseRestoredCIDRS removes the placeholder metadata that was inserted
-// in to the ipcache when local identities were restored.
-// Any identities actually in use will still exist after this.
+// releaseRestoredIdentities removes the placeholder state that was inserted
+// in to the ipcache and local identity allocators on restoration
+//
+// Any identities and prefixes actually in use will still exist after this.
 //
 // This should be called after a grace period (default 10 minutes, set
 // by --identity-restore-grace-period).
@@ -212,12 +317,17 @@ func (d *Daemon) restoreIPCache() error {
 //
 // Any CIDRs still in use after the grace period will have other sources
 // of metadata in the ipcache, and thus will remain. CIDRs for which
-// restoration was the only source of metadata will be deallocated.
-func (d *Daemon) releaseRestoredCIDRs() {
+// restoration was the only source of metadata will be deallocated. Identities
+// with no references after restoration will be deallocated.
+func (d *Daemon) releaseRestoredIdentities() {
 	defer func() {
 		// release the memory held by restored CIDRs
 		d.restoredCIDRs = nil
 	}()
+
+	// Remove any references to restored identities in the local allocators
+	d.identityAllocator.ReleaseRestoredIdentities()
+
 	if len(d.restoredCIDRs) == 0 {
 		return
 	}
@@ -230,16 +340,13 @@ func (d *Daemon) releaseRestoredCIDRs() {
 		updates = append(updates, ipcache.MU{
 			Prefix:   prefix,
 			Resource: restoredCIDRResource,
-			Metadata: []ipcache.IPMetadata{ipcachetypes.RequestedIdentity(0)},
+			Metadata: []ipcache.IPMetadata{
+				ipcachetypes.RequestedIdentity(0), // remove requsted ID, if present
+				labels.Labels{},                   // remove labels, if present
+			},
 		})
 	}
 
 	d.ipcache.RemoveMetadataBatch(updates...)
 	d.ipcache.IdentityAllocator.UnwithholdLocalIdentities(nids)
-}
-
-func isLocalIdentity(nid identity.NumericIdentity) bool {
-	scope := nid.Scope()
-	return scope == identity.IdentityScopeLocal ||
-		(scope == identity.IdentityScopeRemoteNode && option.Config.PolicyCIDRMatchesNodes())
 }

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -101,6 +101,7 @@ func newPolicyTrifecta(params policyParams) (policyOut, error) {
 	}
 	iao := &identityAllocatorOwner{}
 	idAlloc := cache.NewCachingIdentityAllocator(iao)
+	idAlloc.EnableCheckpointing()
 
 	iao.policy = policy.NewStoppedPolicyRepository(
 		idAlloc,

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jeremywohl/flatten v1.0.1
+	github.com/json-iterator/go v1.1.12
 	github.com/kevinburke/ssh_config v1.2.0
 	github.com/kr/pretty v0.3.1
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
@@ -213,7 +214,6 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/josharian/native v1.1.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/k-sone/critbitgo v1.4.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -193,9 +193,13 @@ const (
 	// option.IdentityChangeGracePeriod
 	IdentityChangeGracePeriod = 5 * time.Second
 
-	// IdentityRestoreGracePeriod is the default value for
-	// option.IdentityRestoreGracePeriod
-	IdentityRestoreGracePeriod = 10 * time.Minute
+	// IdentityRestoreGracePeriodKvstore is the default value for
+	// option.IdentityRestoreGracePeriod when kvstore is enabled.
+	IdentityRestoreGracePeriodKvstore = 10 * time.Minute
+
+	// IdentityRestoreGracePeriodKvstore is the default value for
+	// option.IdentityRestoreGracePeriod when only k8s is in use
+	IdentityRestoreGracePeriodK8s = 30 * time.Second
 
 	// ExecTimeout is a timeout for executing commands.
 	ExecTimeout = 300 * time.Second

--- a/pkg/identity/cache/local.go
+++ b/pkg/identity/cache/local.go
@@ -256,6 +256,21 @@ func (l *localIdentityCache) GetIdentities() map[identity.NumericIdentity]*ident
 	return cache
 }
 
+func (l *localIdentityCache) checkpoint(dst []*identity.Identity) []*identity.Identity {
+	l.mutex.RLock()
+	defer l.mutex.RUnlock()
+	for _, id := range l.identitiesByID {
+		dst = append(dst, id)
+	}
+	return dst
+}
+
+func (l *localIdentityCache) size() int {
+	l.mutex.RLock()
+	defer l.mutex.RUnlock()
+	return len(l.identitiesByID)
+}
+
 // close removes the events channel.
 func (l *localIdentityCache) close() {
 	l.mutex.Lock()

--- a/pkg/identity/model/identity.go
+++ b/pkg/identity/model/identity.go
@@ -37,7 +37,7 @@ func CreateModel(id *identity.Identity) *models.Identity {
 		Labels: make([]string, 0, len(id.Labels)),
 	}
 
-	for _, v := range id.Labels {
+	for _, v := range id.LabelArray {
 		ret.Labels = append(ret.Labels, v.String())
 	}
 	return ret

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -564,14 +564,6 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 		}
 	}
 
-	// If we are restoring a host identity and policy-cidr-match-mode includes "nodes"
-	// then merge the CIDR-label.
-	if lbls.Has(labels.LabelHost[labels.IDNameHost]) &&
-		option.Config.PolicyCIDRMatchesNodes() {
-		cidrLabels := labels.GetCIDRLabels(prefix)
-		lbls.MergeLabels(cidrLabels)
-	}
-
 	// If the prefix is associated with the host or remote-node, then
 	// force-remove the world label.
 	if lbls.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode]) ||

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1832,6 +1832,8 @@ type DaemonConfig struct {
 	// unused after this time, they will be removed from the IP cache. Any of the restored
 	// identities that are used in network policies will remain in the IP cache until all such
 	// policies are removed.
+	//
+	// The default is 30 seconds for k8s clusters, and 10 minutes for kvstore clusters
 	IdentityRestoreGracePeriod time.Duration
 
 	// PolicyQueueSize is the size of the queues for the policy repository.
@@ -2404,7 +2406,7 @@ var (
 		KVstorePeriodicSync:             defaults.KVstorePeriodicSync,
 		KVstoreConnectivityTimeout:      defaults.KVstoreConnectivityTimeout,
 		IdentityChangeGracePeriod:       defaults.IdentityChangeGracePeriod,
-		IdentityRestoreGracePeriod:      defaults.IdentityRestoreGracePeriod,
+		IdentityRestoreGracePeriod:      defaults.IdentityRestoreGracePeriodK8s,
 		FixedIdentityMapping:            make(map[string]string),
 		KVStoreOpt:                      make(map[string]string),
 		LogOpt:                          make(map[string]string),
@@ -3504,6 +3506,10 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 			continue
 		}
 		c.ExcludeNodeLabelPatterns = append(c.ExcludeNodeLabelPatterns, r)
+	}
+
+	if c.KVStore != "" {
+		c.IdentityRestoreGracePeriod = defaults.IdentityRestoreGracePeriodKvstore
 	}
 }
 


### PR DESCRIPTION
This is a stepping stone for the broader [fqdn refactor](https://github.com/cilium/design-cfps/pull/17).

There are 3 changes:
1. Checkpoint local allocator state
2. Use this to generate *all* labels for a prefix upon restart
3. Reduce identity restoration grace period to 30 seconds.

Right now, selector / identity stability is ensured by the ipcache restoration mechanism, which dumps the outgoing ipcache, then requests the same numeric identity for any new prefixes. This is to prevent policy drops as endpoints are regenerated for the first time, as they may select "old" identities until regeneration is complete. Therefore, the goal is that a selector has a consistent set of identities across restarts, and prefixes have a consistent identity.

The current mechanism is simplistic: we dump the outgoing ipcache, list all prefixes, which request their previous numeric identity upon restoration, and we *hope* that their set of labels after restart is the same. This will not work, however, once a single local identity can have multiple prefixes.

#### Example

Imagine a future where we have 3 identities and 3 IPs, all with ID3:
- ID1: `(fqdn:a.com)`
- ID2: `(fqdn:b.com)`
- ID3: `(fqdn:a.com, fqdn:b.com)`

Some endpoints will select (ID1, ID3) and some will select (ID2, ID3). As such, their bpf policy maps will contain these two identities.

The problem comes when we restart the agent. If we do not restore FQDN state exactly (which happens commonly enough), and an IP changes from (a.com, b.com) to (a.com), it could be the case that ID3 now has the set of labels `(fqdn:a.com)`. This could cause policy drops during restoration.

So, a better approach is to restore identities directly, and only fall back to requesting old numeric identities as a fallback.
