### PR TITLE
Revert "test: Disable hostfw in monitor aggregation test"

### DIFF
--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -63,9 +63,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"bpf.monitorAggregation": "medium",
 				"bpf.monitorInterval":    "60s",
 				"bpf.monitorFlags":       "syn",
-				// Need to disable the host firewall for now due to complexity issue.
-				// See #14552 for details.
-				"hostFirewall.enabled": "false",
 			}, DeployCiliumOptionsAndDNS)
 
 			monitorRes, monitorCancel, targetIP := monitorConnectivityAcrossNodes(kubectl)


### PR DESCRIPTION
This reverts commit 7a1a76e3cbda75ed42d874f1127007aedc651bb6.

The complexity issue occurred on kernel 4.19, which is no longer supported. We closed https://github.com/cilium/cilium/issues/14552 and we can now have the Host Firewall, `monitorAggregation=medium` and `monitorFlags=syn` together.
