### PR TITLE
ci: Fix typo on "Ginkgo"

### DIFF
--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   ginkgo-workflow-comments:
-    name: Lint Ginko Workflows Comments
+    name: Lint Ginkgo Workflows Comments
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -138,7 +138,7 @@ jobs:
           fi
 
   ginkgo-schema-validation:
-    name: Validate Ginko Schema
+    name: Validate Ginkgo Schema
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Let's fix a typo: "Ginko" -> "Ginkgo". Given that the strings appear in the list of jobs on GitHub Pull Requests, it's easier to search for the specific job without the typo.
