### PR TITLE
egressgw: remove gwc.ifaceName

### DIFF
--- a/pkg/datapath/linux/netdevice/netdevice.go
+++ b/pkg/datapath/linux/netdevice/netdevice.go
@@ -35,16 +35,16 @@ func GetIfaceFirstIPv4Address(ifaceName string) (netip.Addr, error) {
 	return netip.Addr{}, fmt.Errorf("no IPv4 address assigned to interface")
 }
 
-func GetIfaceWithIPv4Address(ip netip.Addr) (string, error) {
+func TestForIfaceWithIPv4Address(ip netip.Addr) error {
 	links, err := netlink.LinkList()
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	for _, l := range links {
 		addrs, err := netlink.AddrList(l, netlink.FAMILY_V4)
 		if err != nil {
-			return "", err
+			return err
 		}
 
 		for _, addr := range addrs {
@@ -53,10 +53,10 @@ func GetIfaceWithIPv4Address(ip netip.Addr) (string, error) {
 				continue
 			}
 			if a == ip {
-				return l.Attrs().Name, nil
+				return nil
 			}
 		}
 	}
 
-	return "", fmt.Errorf("no interface with %s IPv4 assigned to", ip)
+	return fmt.Errorf("no interface with %s IPv4 assigned to", ip)
 }

--- a/pkg/datapath/linux/netdevice/netdevice.go
+++ b/pkg/datapath/linux/netdevice/netdevice.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package egressgateway
+package netdevice
 
 import (
 	"fmt"
@@ -11,7 +11,7 @@ import (
 	"go4.org/netipx"
 )
 
-func getIfaceFirstIPv4Address(ifaceName string) (netip.Addr, error) {
+func GetIfaceFirstIPv4Address(ifaceName string) (netip.Addr, error) {
 	dev, err := netlink.LinkByName(ifaceName)
 	if err != nil {
 		return netip.Addr{}, err
@@ -35,7 +35,7 @@ func getIfaceFirstIPv4Address(ifaceName string) (netip.Addr, error) {
 	return netip.Addr{}, fmt.Errorf("no IPv4 address assigned to interface")
 }
 
-func getIfaceWithIPv4Address(ip netip.Addr) (string, error) {
+func GetIfaceWithIPv4Address(ip netip.Addr) (string, error) {
 	links, err := netlink.LinkList()
 	if err != nil {
 		return "", err

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -11,6 +11,7 @@ import (
 	"go4.org/netipx"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/netdevice"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -137,7 +138,7 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(gc *policyGatewayConfig)
 		// If the gateway config specifies an interface, use the first IPv4 assigned to that
 		// interface as egress IP
 		gwc.ifaceName = gc.iface
-		gwc.egressIP, err = getIfaceFirstIPv4Address(gc.iface)
+		gwc.egressIP, err = netdevice.GetIfaceFirstIPv4Address(gc.iface)
 		if err != nil {
 			return fmt.Errorf("failed to retrieve IPv4 address for egress interface: %w", err)
 		}
@@ -145,7 +146,7 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(gc *policyGatewayConfig)
 		// If the gateway config specifies an egress IP, use the interface with that IP as egress
 		// interface
 		gwc.egressIP = gc.egressIP
-		gwc.ifaceName, err = getIfaceWithIPv4Address(gc.egressIP)
+		gwc.ifaceName, err = netdevice.GetIfaceWithIPv4Address(gc.egressIP)
 		if err != nil {
 			return fmt.Errorf("failed to retrieve interface with egress IP: %w", err)
 		}
@@ -158,7 +159,7 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(gc *policyGatewayConfig)
 		}
 
 		gwc.ifaceName = iface.Attrs().Name
-		gwc.egressIP, err = getIfaceFirstIPv4Address(gwc.ifaceName)
+		gwc.egressIP, err = netdevice.GetIfaceFirstIPv4Address(gwc.ifaceName)
 		if err != nil {
 			return fmt.Errorf("failed to retrieve IPv4 address for egress interface: %w", err)
 		}


### PR DESCRIPTION
Remove an unused field in the EGW policy parsing code. While at it also move the netdevice-related helpers in their own package.