### PR TITLE
Use ebpf.PossibleCPU to determine number of possible CPUs

### DIFF
--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -13,7 +13,4 @@ const (
 	// EndpointStateFileName is used as the file name for the JSON representation
 	// of endpoint state.
 	EndpointStateFileName = "ep_config.json"
-
-	// PossibleCPUSysfsPath is used to retrieve the number of CPUs for per-CPU maps.
-	PossibleCPUSysfsPath = "/sys/devices/system/cpu/possible"
 )

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -5,14 +5,9 @@ package common
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"strconv"
 	"strings"
-
-	"github.com/sirupsen/logrus"
-
-	"github.com/cilium/cilium/pkg/safeio"
 )
 
 // C2GoArray transforms an hexadecimal string representation into a byte slice.
@@ -88,50 +83,4 @@ func MapStringStructToSlice(m map[string]struct{}) []string {
 		s = append(s, k)
 	}
 	return s
-}
-
-// GetNumPossibleCPUs returns a total number of possible CPUS, i.e. CPUs that
-// have been allocated resources and can be brought online if they are present.
-// The number is retrieved by parsing /sys/devices/system/cpu/possible.
-//
-// See https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/cpumask.h?h=v4.19#n50
-// for more details.
-func GetNumPossibleCPUs(log logrus.FieldLogger) int {
-	f, err := os.Open(PossibleCPUSysfsPath)
-	if err != nil {
-		log.WithError(err).Errorf("unable to open %q", PossibleCPUSysfsPath)
-		return 0
-	}
-	defer f.Close()
-
-	return getNumPossibleCPUsFromReader(log, f)
-}
-
-func getNumPossibleCPUsFromReader(log logrus.FieldLogger, r io.Reader) int {
-	out, err := safeio.ReadAllLimit(r, safeio.KB)
-	if err != nil {
-		log.WithError(err).Errorf("unable to read %q to get CPU count", PossibleCPUSysfsPath)
-		return 0
-	}
-
-	var start, end int
-	count := 0
-	for _, s := range strings.Split(string(out), ",") {
-		// Go's scanf will return an error if a format cannot be fully matched.
-		// So, just ignore it, as a partial match (e.g. when there is only one
-		// CPU) is expected.
-		n, err := fmt.Sscanf(s, "%d-%d", &start, &end)
-
-		switch n {
-		case 0:
-			log.WithError(err).Errorf("failed to scan %q to retrieve number of possible CPUs!", s)
-			return 0
-		case 1:
-			count++
-		default:
-			count += (end - start + 1)
-		}
-	}
-
-	return count
 }

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -4,13 +4,9 @@
 package common
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 func TestC2GoArray(t *testing.T) {
@@ -51,24 +47,4 @@ func TestGoArray2C(t *testing.T) {
 	for _, test := range tests {
 		require.Equal(t, test.output, GoArray2C(test.input))
 	}
-}
-
-func TestGetNumPossibleCPUsFromReader(t *testing.T) {
-	log := logging.DefaultLogger.WithField(logfields.LogSubsys, "utils-test")
-	tests := []struct {
-		in       string
-		expected int
-	}{
-		{"0", 1},
-		{"0-7", 8},
-		{"0,2-3", 3},
-		{"", 0},
-		{"foobar", 0},
-	}
-
-	for _, tt := range tests {
-		possibleCpus := getNumPossibleCPUsFromReader(log, strings.NewReader(tt.in))
-		require.Equal(t, tt.expected, possibleCpus)
-	}
-
 }


### PR DESCRIPTION
Use the existing functionality provided by the cilium/ebpf library. This also makes sure that errors parsing the sysfs file are checked and will lead to cell startup failing, rather than just logging an error. Moreover, the underlying sysfs will only be parsed once and the result is cached using `sync.OnceValues`.