### PR TITLE
contrib: Switch from 'hub' to 'gh'

### DIFF
--- a/contrib/backporting/Dockerfile
+++ b/contrib/backporting/Dockerfile
@@ -14,13 +14,14 @@ RUN apt-get install -y \
   curl \
   vim
 
+ARG GH_VERSION=2.49.0
 RUN set -ex \
   && mkdir -p /hub \
   && cd /hub \
   && HUB_ARCH=amd64; if [ "$(uname -m)" = "aarch64" ]; then HUB_ARCH=arm64; fi \
-  && curl -L -o hub.tgz https://github.com/github/hub/releases/download/v2.14.0/hub-linux-${HUB_ARCH}-2.14.0.tgz \
-  && tar xfz hub.tgz \
-  && $(tar tfz hub.tgz | head -n1 | cut -f1 -d"/")/install \
+  && curl -L -o gh.tar.gz https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${HUB_ARCH}.tar.gz \
+  && tar xfz gh.tar.gz \
+  && cp $(tar tfz gh.tar.gz | tail -n1 | cut -f1 -d"/")/bin/gh /usr/sbin/ \
   && rm -rf /hub
 RUN useradd -m user
 USER user

--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -22,7 +22,7 @@ get_remote () {
 }
 
 get_user() {
-  gh_username=$(hub api user --flat | awk '/.login/ {print $2}')
+  gh_username=$(gh api user | jq -r '.login')
   if [ "$gh_username" = "" ]; then
     echo "Error: could not get user info from hub" 1>&2
     exit 1
@@ -50,7 +50,7 @@ is_collaborator() {
       exit 1
   fi
   local path="repos/$org/$repo/collaborators/$username"
-  if hub api "$path" &> /dev/null; then
+  if gh api "$path" &> /dev/null; then
     echo "yes"
   else
     echo "no"

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -8,8 +8,8 @@ source $DIR/common.sh
 
 require_linux
 
-if ! hub help | grep -q "api"; then
-    echo "This tool relies on a recent version of 'hub' from https://github.com/github/hub." 1>&2
+if ! gh help | grep -q "api"; then
+    echo "This tool relies on 'gh' from https://cli.github.com/." 1>&2
     echo "Please install this tool first." 1>&2
     exit 1
 fi
@@ -54,9 +54,9 @@ PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git config --local "branch.${PR_BRANCH}.remote" "$USER_REMOTE"
 git push -q "$USER_REMOTE" "$PR_BRANCH"
 if [ -z "$REVIEWERS" ]; then
-  hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
+  gh pr create -B "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 else
-  hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY -r $REVIEWERS
+  gh pr create -B "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY -r $REVIEWERS
 fi
 
 prs=$(sed -En "/upstream-prs/ { n; p }" < "$SUMMARY")

--- a/contrib/release/post-release.sh
+++ b/contrib/release/post-release.sh
@@ -71,6 +71,10 @@ main() {
     tail -n+4 CHANGELOG.md | sed '/^## v.*$/q' > $version-release-summary.txt
     tail -n+2 digest-$version.txt >> $version-release-summary.txt
     logecho "Creating Github draft release"
+    prerelease=""
+    if echo $ersion | grep -q 'pre\|rc'; then
+        prerelease="-p"
+    fi
     logrun gh release create -d $prerelease -F $version-release-summary.txt $version --title "$ersion"
     logecho "Browse to $RELEASES_URL to see the draft release"
 

--- a/contrib/release/post-release.sh
+++ b/contrib/release/post-release.sh
@@ -28,8 +28,8 @@ handle_args() {
         common::exit 0
     fi
 
-    if ! hub help | grep -q "pull-request"; then
-        echo "This tool relies on 'hub' from https://github.com/github/hub." 1>&2
+    if ! gh help > /dev/null; then
+        echo "This tool relies on 'gh' from https://cli.github.com/." 1>&2
         echo "Please install this tool first." 1>&2
         common::exit 1
     fi
@@ -66,13 +66,12 @@ main() {
     git checkout -b pr/$version-digests $version
     ${DIR}/pull-docker-manifests.sh "$@"
 
-    echo -e "$ersion\n" > $version-release-summary.txt
     # Grab the release notes for the current release, stop before the next
     # release. The start of line `## vX.Y.Z` lines will match in command.
-    tail -n+4 CHANGELOG.md | sed '/^## v.*$/q' >> $version-release-summary.txt
+    tail -n+4 CHANGELOG.md | sed '/^## v.*$/q' > $version-release-summary.txt
     tail -n+2 digest-$version.txt >> $version-release-summary.txt
     logecho "Creating Github draft release"
-    logrun hub release create -d -F $version-release-summary.txt $version
+    logrun gh release create -d $prerelease -F $version-release-summary.txt $version --title "$ersion"
     logecho "Browse to $RELEASES_URL to see the draft release"
 
     if version_is_prerelease "$version" && ! version_is_rc "$version"; then
@@ -95,7 +94,7 @@ main() {
     logecho "Sending pull request for branch v$branch..."
     PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
     git push $user_remote "$PR_BRANCH"
-    hub pull-request -b "v$branch" -l backport/$branch
+    gh pr create -B "v$branch" -l backport/$branch
 }
 
 main "$@"

--- a/contrib/release/post-release.sh
+++ b/contrib/release/post-release.sh
@@ -49,9 +49,8 @@ handle_args() {
         common::exit 1 "Invalid VERSION ARG \"$2\"; $RELEASE_FORMAT_MSG"
     fi
 
-    if [ -z "${GITHUB_TOKEN}" ]; then
-        usage 2>&1
-        common::exit 1 "GITHUB_TOKEN not set!"
+    if ! gh auth status >/dev/null; then
+        common::exit 1 "Failed to authenticate with GitHub"
     fi
 }
 

--- a/contrib/release/post-release.sh
+++ b/contrib/release/post-release.sh
@@ -6,6 +6,8 @@ DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source "${DIR}/lib/common.sh"
 source "${DIR}/../backporting/common.sh"
 
+RELEASES_URL="https://github.com/cilium/cilium/releases"
+
 usage() {
     logecho "usage: $0 <RUN-URL> [VERSION] [GH-USERNAME]"
     logecho "RUN-URL      GitHub URL with the RUN for the release images"

--- a/contrib/release/prep-changelog.sh
+++ b/contrib/release/prep-changelog.sh
@@ -59,6 +59,7 @@ main() {
     local version="v$ersion"
     local old_branch="$(echo $3 | sed 's/^v//')"
     local GITHUB_TOKEN=${GITHUB_TOKEN:-"$(gh auth token)"}
+    export GITHUB_TOKEN
 
     logecho "Generating CHANGELOG.md"
     rm -f $RELNOTESCACHE

--- a/contrib/release/pull-docker-manifests.sh
+++ b/contrib/release/pull-docker-manifests.sh
@@ -37,14 +37,14 @@ handle_args() {
         common::exit 1 "Invalid VERSION ARG \"$2\"; Expected X.Y.Z"
     fi
 
-    if [ -z "${GITHUB_TOKEN}" ]; then
-        usage 2>&1
-        common::exit 1 "GITHUB_TOKEN not set!"
+    if ! gh auth status >/dev/null; then
+        common::exit 1 "Failed to authenticate with GitHub"
     fi
 }
 
 get_digest_output() {
     local username run_id file tmp_dir archive_download_url archive_download_url_zip
+    local GITHUB_TOKEN=${GITHUB_TOKEN:-$(gh auth token)}
 
     username="${1}"
     run_id="${2}"

--- a/contrib/release/submit-release.sh
+++ b/contrib/release/submit-release.sh
@@ -29,8 +29,8 @@ if ! git branch -a | grep -q "$REMOTE/$BRANCH$" || [ ! -e $SUMMARY ]; then
     exit 1
 fi
 
-if ! hub help | grep -q "pull-request"; then
-    echo "This tool relies on 'hub' from https://github.com/github/hub." 1>&2
+if ! gh help | grep -q "pr"; then
+    echo "This tool relies on 'gh' from https://cli.github.com/." 1>&2
     echo "Please install this tool first." 1>&2
     exit 1
 fi
@@ -67,4 +67,4 @@ LABELS="kind/release"
 if [ "$BRANCH" != "main" ]; then
     LABELS="$LABELS,backport/$(echo $BRANCH | sed 's/^v//')"
 fi
-hub pull-request -b "$BRANCH" -l "$LABELS" -F $SUMMARY
+gh pr create -b "$BRANCH" -l "$LABELS" -F $SUMMARY -t "$(head -n 1 $SUMMARY)"

--- a/contrib/release/tag-release.sh
+++ b/contrib/release/tag-release.sh
@@ -27,8 +27,8 @@ handle_args() {
         common::exit 1 "VERSION file not found. Is this directory a Cilium repository?"
     fi
 
-    if ! which hub >/dev/null; then
-        echo "This tool relies on 'hub' from https://github.com/github/hub ." 1>&2
+    if ! which gh >/dev/null; then
+        echo "This tool relies on 'gh' from https://cli.github.com/ ." 1>&2
         common::exit 1 "Please install this tool first."
     fi
 

--- a/tools/dev-doctor/rootcmd.go
+++ b/tools/dev-doctor/rootcmd.go
@@ -232,12 +232,12 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 				hint:             `Run "pip3 install --user PyGithub".`,
 			},
 			&binaryCheck{
-				name:          "hub",
+				name:          "gh",
 				ifNotFound:    checkError,
 				versionArgs:   []string{"--version"},
-				versionRegexp: regexp.MustCompile(`hub\s+version\s+` + versionRegex),
+				versionRegexp: regexp.MustCompile(`gh\s+version\s+` + versionRegex),
 				minVersion:    &semver.Version{Major: 2, Minor: 14, Patch: 0},
-				hint:          `Download the latest version from https://github.com/github/hub/releases.`,
+				hint:          `Download the latest version from https://cli.github.com`,
 			},
 			&envVarCheck{
 				name:            "GITHUB_TOKEN",


### PR DESCRIPTION
GitHub hasn't been maintaining https://github.com/github/hub for some time.
This PR switches the tree over to using the newer tool https://cli.github.com .

Tested while preparing the v1.16.0-pre.2 release.