### PR TITLE
contrib: Remove CHARTS_PATH dependency

### DIFF
--- a/contrib/release/tag-release.sh
+++ b/contrib/release/tag-release.sh
@@ -7,8 +7,6 @@ source $DIR/lib/common.sh
 source $DIR/../backporting/common.sh
 
 REMOTE="$(get_remote)"
-CHARTS_PATH="${CHARTS_PATH:-$GOPATH/src/github.com/cilium/charts}"
-CHARTS_TOOL="prepare_artifacts.sh"
 RELEASES_URL="https://github.com/cilium/cilium/releases"
 VERSION=""
 
@@ -27,11 +25,6 @@ handle_args() {
 
     if [[ ! -e VERSION ]]; then
         common::exit 1 "VERSION file not found. Is this directory a Cilium repository?"
-    fi
-
-    if [[ ! -e "$CHARTS_PATH/$CHARTS_TOOL" ]]; then
-        usage
-        common::exit 1 "CHARTS_PATH='$CHARTS_PATH' invalid. Clone from github.com/cilium/charts"
     fi
 
     if ! which hub >/dev/null; then


### PR DESCRIPTION
This script would check for CHARTS_PATH and CHARTS_TOOL, but it never
actually invoked them. We've renamed the script now so it's out of date.
Remove the check altogether, we can automate running the Helm bits later.

Related: https://github.com/cilium/charts/pull/114
