### PR TITLE
[v1.13] envoy: Update to use source port in connection pool hash

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -7,7 +7,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:af8e10f638d5b651812d4d464
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.27.5-4fd4e4cca980b620e318f89bf257cbda75178199@sha256:a161bc0ab3d7832eeb4d7ab8ce13d151a5baf1adf62fc23980a35580df8c22c0 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.27.5-c369b503a1029442ababa1f0f3cae8b6ad2d9791@sha256:03f77ffe88ba76677482710acfd41899e24be3c6ccd22d504eb1fc30045c235d as cilium-envoy
 
 #
 # Hubble CLI


### PR DESCRIPTION
Author backport of 

* [ ] #32270

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
32270
```
