### PR TITLE
gha: Enable Envoy debug in default Cilium options

### DIFF
--- a/.github/actions/helm-default/action.yaml
+++ b/.github/actions/helm-default/action.yaml
@@ -29,6 +29,7 @@ runs:
 
         CILIUM_INSTALL_DEFAULTS="--chart-directory=${{ inputs.chart-dir }} \
           --helm-set=debug.enabled=true \
+          --helm-set=debug.verbose=envoy \
           --helm-set=bpf.monitorAggregation=none \
           --helm-set=dnsProxy.proxyResponseMaxDelay=250ms \
           --helm-set=hubble.relay.retryTimeout=5s"

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -135,7 +135,6 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
-            --helm-set=debug.verbose=envoy \
             --helm-set=kubeProxyReplacement=true \
             --helm-set=gatewayAPI.enabled=true \
             --helm-set=l2announcements.enabled=true"

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -153,7 +153,6 @@ jobs:
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
 
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
-            --helm-set=debug.verbose=envoy \
             --helm-set kubeProxyReplacement=${{ matrix.kube-proxy-replacement }} \
             --helm-set nodePort.enabled=${{ matrix.enable-node-port }} \
             --helm-set=ingressController.enabled=true \


### PR DESCRIPTION
Enable Envoy debug in the default Cilium options so that all workflows using the defaults have Envoy debug enabled.

