### PR TITLE
Add auto labeler for hubble-cli

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,5 @@
+# Add 'hubble-cli' label to any file changes in 'hubble/'
+hubble-cli:
+- changed-files:
+  - any-glob-to-any-file:
+    - hubble/**

--- a/.github/workflows/auto-labeler.yaml
+++ b/.github/workflows/auto-labeler.yaml
@@ -74,3 +74,13 @@ jobs:
               repo: context.repo.repo,
               labels: ["kind/community-contribution"]
             })
+
+  auto-labeler:
+    name: Auto Labeler
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Label The PR
+      uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0

--- a/.github/workflows/auto-labeler.yaml
+++ b/.github/workflows/auto-labeler.yaml
@@ -1,4 +1,4 @@
-name: PR from External Contribution Detector
+name: PR and Issues Auto Labeler
 
 on:
   pull_request_target:
@@ -7,7 +7,7 @@ on:
       - reopened
 
 jobs:
-  labeler:
+  external-contributions:
     if: |
       (
         (github.event.pull_request.author_association != 'OWNER') &&
@@ -15,7 +15,7 @@ jobs:
         (github.event.pull_request.author_association != 'MEMBER')
       )
     runs-on: ubuntu-latest
-    name: Label PRs
+    name: External Contributions
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
This will allow us to generate a dedicated CHANGELOG for any PR that
affects hubble-cli.