### PR TITLE
common: remove unused MapStringStructToSlice

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -74,13 +74,3 @@ func RequireRootPrivilege(cmd string) {
 		os.Exit(1)
 	}
 }
-
-// MapStringStructToSlice returns a slice with all keys of the given
-// map[string]struct{}
-func MapStringStructToSlice(m map[string]struct{}) []string {
-	s := make([]string, 0, len(m))
-	for k := range m {
-		s = append(s, k)
-	}
-	return s
-}


### PR DESCRIPTION
It's unused since commit c49ef45399fc ("metrics: Modularize daemon metrics registry").

In case similar functionality is needed in the future, the generic functions in the standard library `maps` package or in `golang.org/x/exp/maps` should be used.