### PR TITLE
gha: bump post-upgrade timeout in clustermesh upgrade/downgrade tests

### DIFF
--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -462,8 +462,8 @@ jobs:
 
       - name: Wait for cluster mesh status to be ready
         run: |
-          cilium --context ${{ env.contextName1 }} status --wait
-          cilium --context ${{ env.contextName2 }} status --wait
+          cilium --context ${{ env.contextName1 }} status --wait --wait-duration=10m
+          cilium --context ${{ env.contextName2 }} status --wait --wait-duration=10m
           cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
           cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
 


### PR DESCRIPTION
The KPR matrix entry recently started failing quite frequently due to cilium status --wait failing to complete within the timeout after the upgrading Cilium to the tip of main. Part of the cause seems to be cilium/test-connection-disruption@619be5ab79a6, which made the connection disruption test more aggressive. In turn, causing more CPU contention during endpoint regeneration, which now requires longer. Hence, let's bump the timeout, to avoid failing too early due to the endpoint regeneration not having terminated yet.