### PR TITLE
ci/ipsec-upgrade: complete the switch to cilium-dbg

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -367,8 +367,7 @@ jobs:
 
           ./cilium-cli status --wait
           kubectl get pods --all-namespaces -o wide
-          # TODO: After Cilium 1.15 release, update to cilium-dbg
-          kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium status
+          kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 
       - name: Start conn-disrupt-test
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
@@ -404,8 +403,7 @@ jobs:
 
             ./cilium-cli status --wait
             kubectl get pods --all-namespaces -o wide
-            # TODO: After Cilium 1.15 release, update to cilium-dbg
-            kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium status
+            kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 
       - name: Fetch artifacts
         if: ${{ steps.vars.outputs.downgrade_version != '' && !success() }}


### PR DESCRIPTION
We're now downgrading to v1.15, which provides the cilium-dbg command.