### PR TITLE
Add a `--masquerade-exclusion-cidrs` setting

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -284,6 +284,7 @@ cilium-agent [flags]
       --log-driver strings                                        Logging endpoints to use for example syslog
       --log-opt map                                               Log driver options for cilium-agent, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"}
       --log-system-load                                           Enable periodic logging of system load
+      --masquerade-exclusion-cidrs                                A set of CIDRs that will be excluded from Masquarading
       --max-connected-clusters uint32                             Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
       --mesh-auth-enabled                                         Enable authentication processing & garbage collection (beta) (default true)
       --mesh-auth-gc-interval duration                            Interval in which auth entries are attempted to be garbage collected (default 5m0s)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -636,6 +636,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableIPv6Masquerade, true, "Masquerade IPv6 traffic from endpoints leaving the host")
 	option.BindEnv(vp, option.EnableIPv6Masquerade)
 
+	flags.StringSlice(option.MasqueradeExclusionCIDRs, nil, "A set of CIDRs that will be excluded from Masquarading")
+	option.BindEnv(vp, option.MasqueradeExclusionCIDRs)
+
 	flags.Bool(option.EnableBPFMasquerade, false, "Masquerade packets from endpoints leaving the host with BPF instead of iptables")
 	option.BindEnv(vp, option.EnableBPFMasquerade)
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -579,6 +579,7 @@ data:
   enable-ipv4-big-tcp: {{ .Values.enableIPv4BIGTCP | quote }}
   enable-ipv6-big-tcp: {{ .Values.enableIPv6BIGTCP | quote }}
   enable-ipv6-masquerade: {{ .Values.enableIPv6Masquerade | quote }}
+  masquerade-exclusion-cidrs: {{ .Values.masqueradeExclusionCIDRs | quote }}
 
 {{- if hasKey .Values.bpf "enableTCX" }}
   enable-tcx: {{ .Values.bpf.enableTCX | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1838,6 +1838,8 @@ enableIPv4Masquerade: true
 enableIPv6Masquerade: true
 # -- Enables masquerading to the source of the route for traffic leaving the node from endpoints.
 enableMasqueradeRouteSource: false
+# -- A comma-separated list of CIDRs that will be excluded from masquarading.
+masquerade-exclusion-cidrs: ""
 # -- Enables IPv4 BIG TCP support which increases maximum IPv4 GSO/GRO limits for nodes and pods
 enableIPv4BIGTCP: false
 # -- Enables IPv6 BIG TCP support which increases maximum IPv6 GSO/GRO limits for nodes and pods

--- a/pkg/datapath/iptables/cell.go
+++ b/pkg/datapath/iptables/cell.go
@@ -43,6 +43,7 @@ var Cell = cell.Module(
 			EnableMasqueradeRouteSource: cfg.EnableMasqueradeRouteSource,
 			EnableL7Proxy:               cfg.EnableL7Proxy,
 			InstallIptRules:             cfg.InstallIptRules,
+			SnatDstExclusionCIDRs:       cfg.SnatDstExclusionCIDRs,
 		}
 	}),
 	cell.Provide(newIptablesManager),
@@ -95,4 +96,5 @@ type SharedConfig struct {
 	EnableMasqueradeRouteSource bool
 	EnableL7Proxy               bool
 	InstallIptRules             bool
+	SnatDstExclusionCIDRs       []string
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -333,6 +333,9 @@ const (
 	// EnableIPv6Masquerade masquerades IPv6 packets from endpoints leaving the host.
 	EnableIPv6Masquerade = "enable-ipv6-masquerade"
 
+	// MasqueradeExclusionCIDRs is a list of CIDRs that are excluded from masquarding
+	MasqueradeExclusionCIDRs = "masquerade-exclusion-cidrs"
+
 	// EnableBPFClockProbe selects a more efficient source clock (jiffies vs ktime)
 	EnableBPFClockProbe = "enable-bpf-clock-probe"
 
@@ -1674,6 +1677,7 @@ type DaemonConfig struct {
 	EnableMasqueradeRouteSource bool
 	EnableIPMasqAgent           bool
 	IPMasqAgentConfigPath       string
+	SnatDstExclusionCIDRs       []string
 
 	EnableBPFClockProbe     bool
 	EnableIPv4EgressGateway bool
@@ -3057,6 +3061,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableNat46X64Gateway = vp.GetBool(EnableNat46X64Gateway)
 	c.EnableHighScaleIPcache = vp.GetBool(EnableHighScaleIPcache)
 	c.EnableIPv4Masquerade = vp.GetBool(EnableIPv4Masquerade) && c.EnableIPv4
+	c.SnatDstExclusionCIDRs = vp.GetStringSlice(MasqueradeExclusionCIDRs)
 	c.EnableIPv6Masquerade = vp.GetBool(EnableIPv6Masquerade) && c.EnableIPv6
 	c.EnableBPFMasquerade = vp.GetBool(EnableBPFMasquerade)
 	c.EnableMasqueradeRouteSource = vp.GetBool(EnableMasqueradeRouteSource)


### PR DESCRIPTION
This change adds a new `--masquerade-exclusion-cidrs` setting in order to allow an arbitrary set of CIDRs to be configured to not get masqueraded. This is primarily to deal with
https://github.com/cilium/cilium/issues/20554 by allowing to configure Cilium to exclude all RFC 1918 ranges from masquerading.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
A new --masquerade-exclusion-cidrs setting was added to allow configuring an arbitrary set of CIDRs to not get masqueraded
```
