### PR TITLE
IPAM: Adds AWS ENI IPv6 Prefix Delegation Support

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1060,8 +1060,12 @@
      - Enable use of per endpoint routes instead of routing via the cilium_host interface.
      - bool
      - ``false``
+   * - :spelling:ignore:`eni.awsEnableIPv6PrefixDelegation`
+     - Enable ENI IPv6 prefix delegation
+     - bool
+     - ``false``
    * - :spelling:ignore:`eni.awsEnablePrefixDelegation`
-     - Enable ENI prefix delegation
+     - Enable ENI IPv4 prefix delegation
      - bool
      - ``false``
    * - :spelling:ignore:`eni.awsReleaseExcessIPs`

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -341,7 +341,6 @@ func LaunchAsEndpoint(baseCtx context.Context,
 	}
 
 	if option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAlibabaCloud {
-		// ENI mode does not support IPv6.
 		if err := routingConfig.Configure(
 			healthIP,
 			mtuConfig.GetDeviceMTU(),

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1386,6 +1386,22 @@ func initEnv(vp *viper.Viper) {
 		log.Warn("IPSec encrypted overlay is enabled but IPSec is not. Ignoring option.")
 	}
 
+	// AWS does not support dualstack: https://docs.aws.amazon.com/eks/latest/userguide/cni-ipv6.html
+	if option.Config.IPAM == ipamOption.IPAMENI && option.Config.IsDualStack() {
+		log.Fatalf("Both %s and %s options cannot be set since AWS does not support dualstack",
+			option.EnableIPv4Name, option.EnableIPv6Name)
+	}
+
+	// IPv6 is not supported for the Alibaba IPAM plugin.
+	if option.Config.IPAM == ipamOption.IPAMAlibabaCloud && option.Config.IPv6Enabled() {
+		log.Fatalf("%s ENI IPAM plugin does not support IPv6", ipamOption.IPAMAlibabaCloud)
+	}
+
+	// IPv6 is not supported for the Azure IPAM plugin.
+	if option.Config.IPAM == ipamOption.IPAMAzure && option.Config.IPv6Enabled() {
+		log.Fatalf("%s ENI IPAM plugin does not support IPv6", ipamOption.IPAMAzure)
+	}
+
 	// IPAMENI IPSec is configured from Reinitialize() to pull in devices
 	// that may be added or removed at runtime.
 	if option.Config.EnableIPSec &&

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -315,7 +315,8 @@ contributors across the globe, there is almost always someone available to help.
 | encryption.wireguard.userspaceFallback | bool | `false` | Enables the fallback to the user-space implementation (deprecated). |
 | endpointHealthChecking.enabled | bool | `true` | Enable connectivity health checking between virtual endpoints. |
 | endpointRoutes.enabled | bool | `false` | Enable use of per endpoint routes instead of routing via the cilium_host interface. |
-| eni.awsEnablePrefixDelegation | bool | `false` | Enable ENI prefix delegation |
+| eni.awsEnableIPv6PrefixDelegation | bool | `false` | Enable ENI IPv6 prefix delegation |
+| eni.awsEnablePrefixDelegation | bool | `false` | Enable ENI IPv4 prefix delegation |
 | eni.awsReleaseExcessIPs | bool | `false` | Release IPs not used from the ENI |
 | eni.ec2APIEndpoint | string | `""` | EC2 API endpoint to use |
 | eni.enabled | bool | `false` | Enable Elastic Network Interface (ENI) integration. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -513,6 +513,9 @@ data:
 {{- if .Values.eni.awsEnablePrefixDelegation }}
   aws-enable-prefix-delegation: "true"
 {{- end }}
+{{- if .Values.eni.awsEnableIPv6PrefixDelegation }}
+  aws-enable-ipv6-prefix-delegation: "true"
+{{- end }}
   ec2-api-endpoint: {{ .Values.eni.ec2APIEndpoint | quote }}
   eni-tags: {{ .Values.eni.eniTags | toRawJson | quote }}
 {{- if .Values.eni.subnetIDsFilter }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1594,6 +1594,9 @@
     },
     "eni": {
       "properties": {
+        "awsEnableIPv6PrefixDelegation": {
+          "type": "boolean"
+        },
         "awsEnablePrefixDelegation": {
           "type": "boolean"
         },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -900,8 +900,10 @@ eni:
   updateEC2AdapterLimitViaAPI: true
   # -- Release IPs not used from the ENI
   awsReleaseExcessIPs: false
-  # -- Enable ENI prefix delegation
+  # -- Enable ENI IPv4 prefix delegation
   awsEnablePrefixDelegation: false
+  # -- Enable ENI IPv6 prefix delegation
+  awsEnableIPv6PrefixDelegation: false
   # -- EC2 API endpoint to use
   ec2APIEndpoint: ""
   # -- Tags to apply to the newly created ENIs

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -900,8 +900,10 @@ eni:
   updateEC2AdapterLimitViaAPI: true
   # -- Release IPs not used from the ENI
   awsReleaseExcessIPs: false
-  # -- Enable ENI prefix delegation
+  # -- Enable ENI IPv4 prefix delegation
   awsEnablePrefixDelegation: false
+  # -- Enable ENI IPv6 prefix delegation
+  awsEnableIPv6PrefixDelegation: false
   # -- EC2 API endpoint to use
   ec2APIEndpoint: ""
   # -- Tags to apply to the newly created ENIs

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -531,6 +531,10 @@ func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 			log.Fatalf("%s allocator is not supported by this version of %s", ipamMode, binaryName)
 		}
 
+		if (ipamMode == ipamOption.IPAMAlibabaCloud || ipamMode == ipamOption.IPAMAzure) && option.Config.IPv6Enabled() {
+			log.Fatalf("%s allocator does not support IPv6", ipamMode)
+		}
+
 		if err := alloc.Init(legacy.ctx); err != nil {
 			log.WithError(err).Fatalf("Unable to init %s allocator", ipamMode)
 		}

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -147,9 +147,12 @@ const (
 	// Defaults to 180 secs
 	ExcessIPReleaseDelay = "excess-ip-release-delay"
 
-	// AWSEnablePrefixDelegation allows operator to allocate prefixes to ENIs on nitro instances instead of individual
+	// AWSEnablePrefixDelegation allows operator to allocate IPv4 prefixes to ENIs on nitro instances instead of individual
 	// IP addresses. Allows for increased pod density on nodes.
 	AWSEnablePrefixDelegation = "aws-enable-prefix-delegation"
+
+	// AWSEnableIPv6PrefixDelegation allows operator to allocate IPv6 prefixes to ENIs on nitro instances.
+	AWSEnableIPv6PrefixDelegation = "aws-enable-ipv6-prefix-delegation"
 
 	// ENITags are the tags that will be added to every ENI created by the
 	// AWS ENI IPAM.
@@ -368,9 +371,12 @@ type OperatorConfig struct {
 	// the number of API calls to AWS EC2 service.
 	AWSReleaseExcessIPs bool
 
-	// AWSEnablePrefixDelegation allows operator to allocate prefixes to ENIs on nitro instances instead of individual
+	// AWSEnablePrefixDelegation allows operator to allocate IPv4 prefixes to ENIs on nitro instances instead of individual
 	// IP addresses. Allows for increased pod density on nodes.
 	AWSEnablePrefixDelegation bool
+
+	// AWSEnablePrefixDelegation allows operator to allocate IPv6 prefixes to ENIs on nitro instances.
+	AWSEnableIPv6PrefixDelegation bool
 
 	// AWSUsePrimaryAddress specifies whether an interface's primary address should be available for allocations on
 	// node
@@ -503,6 +509,7 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 
 	c.AWSReleaseExcessIPs = vp.GetBool(AWSReleaseExcessIPs)
 	c.AWSEnablePrefixDelegation = vp.GetBool(AWSEnablePrefixDelegation)
+	c.AWSEnableIPv6PrefixDelegation = vp.GetBool(AWSEnableIPv6PrefixDelegation)
 	c.AWSUsePrimaryAddress = vp.GetBool(AWSUsePrimaryAddress)
 	c.UpdateEC2AdapterLimitViaAPI = vp.GetBool(UpdateEC2AdapterLimitViaAPI)
 	c.EC2APIEndpoint = vp.GetString(EC2APIEndpoint)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -516,6 +516,12 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.ExcessIPReleaseDelay = vp.GetInt(ExcessIPReleaseDelay)
 	c.ENIGarbageCollectionInterval = vp.GetDuration(ENIGarbageCollectionInterval)
 
+	// AWS does not support dual stack: https://docs.aws.amazon.com/eks/latest/userguide/cni-ipv6.html
+	if c.AWSEnablePrefixDelegation && c.AWSEnableIPv6PrefixDelegation {
+		log.Fatalf("both %s and %s cannot be set since AWS does not support dualstack",
+			AWSEnablePrefixDelegation, AWSEnableIPv6PrefixDelegation)
+	}
+
 	// Azure options
 
 	c.AzureSubscriptionID = vp.GetString(AzureSubscriptionID)

--- a/pkg/alibabacloud/eni/node_stat_test.go
+++ b/pkg/alibabacloud/eni/node_stat_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/alibabacloud/eni/limits"
 	eniTypes "github.com/cilium/cilium/pkg/alibabacloud/eni/types"
+	"github.com/cilium/cilium/pkg/ipam"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
@@ -49,7 +50,7 @@ func TestENIIPAMCapacityAccounting(t *testing.T) {
 			},
 		},
 	}
-	_, stats, err := n.ResyncInterfacesAndIPs(context.Background(), log)
+	_, stats, err := n.ResyncInterfacesAndIPs(context.Background(), log, ipam.IPv4)
 	assert.NoError(err)
 	// 3 ENIs, 10 IPs per ENI, 1 primary IP and one ENI is primary.
 	assert.Equal(19, stats.NodeCapacity)

--- a/pkg/alibabacloud/eni/node_test.go
+++ b/pkg/alibabacloud/eni/node_test.go
@@ -66,7 +66,7 @@ func TestCreateInterface(t *testing.T) {
 	alibabaAPI.UpdateENIs(primaryENIs)
 	instances.Resync(context.TODO())
 
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -119,7 +119,7 @@ func TestCandidateAndEmptyInterfaces(t *testing.T) {
 	alibabaAPI.UpdateENIs(primaryENIs)
 	instances.Resync(context.TODO())
 
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 	// Set PreAllocate as 1
@@ -150,7 +150,7 @@ func TestPrepareIPAllocation(t *testing.T) {
 	alibabaAPI.UpdateENIs(primaryENIs)
 	instances.Resync(context.TODO())
 
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 	mngr.SetInstancesAPIReadiness(false) // to avoid the manager background jobs starting and racing us.

--- a/pkg/aws/ec2/ec2_test.go
+++ b/pkg/aws/ec2/ec2_test.go
@@ -147,3 +147,142 @@ func TestNewTagsFilters(t *testing.T) {
 		})
 	}
 }
+
+func TestParseEniIpAddresses(t *testing.T) {
+	testCases := map[string]struct {
+		iface             ec2_types.NetworkInterface
+		usePrimary        bool
+		wantIPv4Addresses []string
+		wantIPv6Addresses []string
+		wantErr           bool
+	}{
+		"IPv4 only ENI": {
+			iface: ec2_types.NetworkInterface{
+				NetworkInterfaceId: aws.String("eni-ipv4only"),
+				PrivateIpAddress:   aws.String("192.0.2.1"),
+				PrivateIpAddresses: []ec2_types.NetworkInterfacePrivateIpAddress{
+					{
+						Primary:          aws.Bool(true),
+						PrivateIpAddress: aws.String("192.0.2.1"),
+					},
+					{
+						Primary:          aws.Bool(false),
+						PrivateIpAddress: aws.String("192.0.2.2"),
+					},
+					{
+						Primary:          aws.Bool(false),
+						PrivateIpAddress: aws.String("192.0.2.3"),
+					},
+				},
+				Ipv6Address: nil,
+				MacAddress:  aws.String("01:23:45:67:89:ab"),
+			},
+			usePrimary:        false,
+			wantIPv4Addresses: []string{"192.0.2.2", "192.0.2.3"},
+			wantErr:           false,
+		},
+		"IPv6 only ENI": {
+			iface: ec2_types.NetworkInterface{
+				NetworkInterfaceId: aws.String("eni-ipv6only"),
+				PrivateIpAddress:   nil,
+				Ipv6Address:        aws.String("2001:db8::1"),
+				MacAddress:         aws.String("01:23:45:67:89:cd"),
+				Ipv6Prefixes: []ec2_types.Ipv6PrefixSpecification{
+					{
+						Ipv6Prefix: aws.String("2001:db9::/80"),
+					},
+				},
+			},
+			usePrimary: false,
+			wantIPv6Addresses: []string{"2001:db9::", "2001:db9::1", "2001:db9::2", "2001:db9::3", "2001:db9::4",
+				"2001:db9::5", "2001:db9::6", "2001:db9::7", "2001:db9::8", "2001:db9::9", "2001:db9::a", "2001:db9::b",
+				"2001:db9::c", "2001:db9::d", "2001:db9::e", "2001:db9::f", "2001:db9::10", "2001:db9::11", "2001:db9::12",
+				"2001:db9::13", "2001:db9::14", "2001:db9::15", "2001:db9::16", "2001:db9::17", "2001:db9::18", "2001:db9::19",
+				"2001:db9::1a", "2001:db9::1b", "2001:db9::1c", "2001:db9::1d", "2001:db9::1e", "2001:db9::1f", "2001:db9::20",
+				"2001:db9::21", "2001:db9::22", "2001:db9::23", "2001:db9::24", "2001:db9::25", "2001:db9::26", "2001:db9::27",
+				"2001:db9::28", "2001:db9::29", "2001:db9::2a", "2001:db9::2b", "2001:db9::2c", "2001:db9::2d", "2001:db9::2e",
+				"2001:db9::2f", "2001:db9::30", "2001:db9::31", "2001:db9::32", "2001:db9::33", "2001:db9::34", "2001:db9::35",
+				"2001:db9::36", "2001:db9::37", "2001:db9::38", "2001:db9::39", "2001:db9::3a", "2001:db9::3b", "2001:db9::3c",
+				"2001:db9::3d", "2001:db9::3e", "2001:db9::3f"},
+			wantErr: false,
+		},
+		"Dual-Stack ENI": {
+			iface: ec2_types.NetworkInterface{
+				NetworkInterfaceId: aws.String("eni-dualstack"),
+				PrivateIpAddress:   aws.String("192.0.2.2"),
+				PrivateIpAddresses: []ec2_types.NetworkInterfacePrivateIpAddress{
+					{
+						Primary:          aws.Bool(true),
+						PrivateIpAddress: aws.String("192.0.2.1"),
+					},
+					{
+						Primary:          aws.Bool(false),
+						PrivateIpAddress: aws.String("192.0.2.2"),
+					},
+					{
+						Primary:          aws.Bool(false),
+						PrivateIpAddress: aws.String("192.0.2.3"),
+					},
+				},
+				Ipv6Address: aws.String("2001:db8::2"),
+				Ipv6Prefixes: []ec2_types.Ipv6PrefixSpecification{
+					{
+						Ipv6Prefix: aws.String("2001:db9::/80"),
+					},
+				},
+				MacAddress: aws.String("01:23:45:67:89:ef"),
+			},
+			usePrimary:        false,
+			wantIPv4Addresses: []string{"192.0.2.2", "192.0.2.3"},
+			wantIPv6Addresses: []string{"2001:db9::", "2001:db9::1", "2001:db9::2", "2001:db9::3", "2001:db9::4",
+				"2001:db9::5", "2001:db9::6", "2001:db9::7", "2001:db9::8", "2001:db9::9", "2001:db9::a", "2001:db9::b",
+				"2001:db9::c", "2001:db9::d", "2001:db9::e", "2001:db9::f", "2001:db9::10", "2001:db9::11", "2001:db9::12",
+				"2001:db9::13", "2001:db9::14", "2001:db9::15", "2001:db9::16", "2001:db9::17", "2001:db9::18", "2001:db9::19",
+				"2001:db9::1a", "2001:db9::1b", "2001:db9::1c", "2001:db9::1d", "2001:db9::1e", "2001:db9::1f", "2001:db9::20",
+				"2001:db9::21", "2001:db9::22", "2001:db9::23", "2001:db9::24", "2001:db9::25", "2001:db9::26", "2001:db9::27",
+				"2001:db9::28", "2001:db9::29", "2001:db9::2a", "2001:db9::2b", "2001:db9::2c", "2001:db9::2d", "2001:db9::2e",
+				"2001:db9::2f", "2001:db9::30", "2001:db9::31", "2001:db9::32", "2001:db9::33", "2001:db9::34", "2001:db9::35",
+				"2001:db9::36", "2001:db9::37", "2001:db9::38", "2001:db9::39", "2001:db9::3a", "2001:db9::3b", "2001:db9::3c",
+				"2001:db9::3d", "2001:db9::3e", "2001:db9::3f"},
+			wantErr: false,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, eni, err := parseENI(&tc.iface, nil, nil, tc.usePrimary)
+
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("parseENI() error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			if !slicesEqual(eni.Addresses, tc.wantIPv4Addresses) {
+				t.Errorf("IPv4 addresses mismatch: got %v, want %v", eni.Addresses, tc.wantIPv4Addresses)
+			}
+
+			if !slicesEqual(eni.IPv6Addresses, tc.wantIPv6Addresses) {
+				t.Errorf("IPv6 addresses mismatch: got %v, want %v", eni.IPv6Addresses, tc.wantIPv6Addresses)
+			}
+		})
+	}
+}
+
+// slicesEqual checks if two slices of strings are equal (order does not matter).
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aMap := make(map[string]int)
+	for _, item := range a {
+		aMap[item]++
+	}
+	for _, item := range b {
+		if _, ok := aMap[item]; !ok {
+			return false
+		}
+		aMap[item]--
+		if aMap[item] == 0 {
+			delete(aMap, item)
+		}
+	}
+	return len(aMap) == 0
+}

--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -19,6 +19,7 @@ import (
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/aws/types"
 	"github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipam/cidrset"
 	"github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipam/service/ipallocator"
@@ -40,6 +41,7 @@ const (
 	AttachNetworkInterface
 	ModifyNetworkInterface
 	AssignPrivateIpAddresses
+	AssignIPv6Prefixes
 	UnassignPrivateIpAddresses
 	TagENI
 	MaxOperation
@@ -47,19 +49,21 @@ const (
 
 // API represents a mocked EC2 API
 type API struct {
-	mutex          lock.RWMutex
-	unattached     map[string]*eniTypes.ENI
-	enis           map[string]ENIMap
-	subnets        map[string]*ipamTypes.Subnet
-	vpcs           map[string]*ipamTypes.VirtualNetwork
-	securityGroups map[string]*types.SecurityGroup
-	instanceTypes  []ec2_types.InstanceTypeInfo
-	errors         map[Operation]error
-	allocator      *ipallocator.Range
-	pdAllocator    *cidrset.CidrSet
-	limiter        *rate.Limiter
-	delaySim       *helpers.DelaySimulator
-	pdSubnet       *net.IPNet
+	mutex             lock.RWMutex
+	unattached        map[string]*eniTypes.ENI
+	enis              map[string]ENIMap
+	subnets           map[string]*ipamTypes.Subnet
+	vpcs              map[string]*ipamTypes.VirtualNetwork
+	securityGroups    map[string]*types.SecurityGroup
+	instanceTypes     []ec2_types.InstanceTypeInfo
+	errors            map[Operation]error
+	ipAllocator       *ipallocator.Range
+	v4PrefixAllocator *cidrset.CidrSet
+	v6PrefixAllocator *cidrset.CidrSet
+	limiter           *rate.Limiter
+	delaySim          *helpers.DelaySimulator
+	pdSubnet          *net.IPNet
+	ipv6PDSubnet      *net.IPNet
 }
 
 // NewAPI returns a new mocked EC2 API
@@ -80,18 +84,33 @@ func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, secur
 		panic(err)
 	}
 
+	// Start with a base IPv6 2001:db8::/56 CIDR for the VPC.
+	_, vpcV6Cidr, _ := net.ParseCIDR("2001:db8::/56")
+
+	// Use /64 for the VPC subnet allocation.
+	v6SubnetCidrSet, _ := cidrset.NewCIDRSet(vpcV6Cidr, 64)
+	v6SubnetCidr, _ := v6SubnetCidrSet.AllocateNext()
+
+	// Use /80 for IPv6 prefix allocations.
+	v6PdCidrRange, err := cidrset.NewCIDRSet(v6SubnetCidr, 80)
+	if err != nil {
+		panic(err)
+	}
+
 	api := &API{
-		unattached:     map[string]*eniTypes.ENI{},
-		enis:           map[string]ENIMap{},
-		subnets:        map[string]*ipamTypes.Subnet{},
-		vpcs:           map[string]*ipamTypes.VirtualNetwork{},
-		securityGroups: map[string]*types.SecurityGroup{},
-		instanceTypes:  []ec2_types.InstanceTypeInfo{},
-		allocator:      podCidrRange,
-		pdAllocator:    pdCidrRange,
-		errors:         map[Operation]error{},
-		delaySim:       helpers.NewDelaySimulator(),
-		pdSubnet:       pdCidr,
+		unattached:        map[string]*eniTypes.ENI{},
+		enis:              map[string]ENIMap{},
+		subnets:           map[string]*ipamTypes.Subnet{},
+		vpcs:              map[string]*ipamTypes.VirtualNetwork{},
+		securityGroups:    map[string]*types.SecurityGroup{},
+		instanceTypes:     []ec2_types.InstanceTypeInfo{},
+		ipAllocator:       podCidrRange,
+		v4PrefixAllocator: pdCidrRange,
+		v6PrefixAllocator: v6PdCidrRange,
+		errors:            map[Operation]error{},
+		delaySim:          helpers.NewDelaySimulator(),
+		pdSubnet:          pdCidr,
+		ipv6PDSubnet:      v6SubnetCidr,
 	}
 
 	api.UpdateSubnets(subnets)
@@ -184,10 +203,10 @@ func (e *API) rateLimit() {
 	}
 }
 
-// CreateNetworkInterface mocks the interface creation. As with the upstream
-// EC2 API, the number of IP addresses in toAllocate are the number of
-// secondary IPs, a primary IP is always allocated.
-func (e *API) CreateNetworkInterface(ctx context.Context, toAllocate int32, subnetID, desc string, groups []string, allocatePrefixes bool) (string, *eniTypes.ENI, error) {
+// CreateNetworkInterface mocks the interface creation based on the provided IP family.
+// When the IP family is "IPv4", the number of IP addresses in toAllocate are the number
+// of secondary IPs, a primary IP is always allocated.
+func (e *API) CreateNetworkInterface(ctx context.Context, toAllocate int32, subnetID, desc string, groups []string, allocatePrefixes bool, family ipam.Family) (string, *eniTypes.ENI, error) {
 	e.rateLimit()
 	e.delaySim.Delay(CreateNetworkInterface)
 
@@ -203,9 +222,12 @@ func (e *API) CreateNetworkInterface(ctx context.Context, toAllocate int32, subn
 		return "", nil, fmt.Errorf("subnet %s not found", subnetID)
 	}
 
-	numAddresses := int(toAllocate) + 1 // include primary IP
-	if numAddresses > subnet.AvailableAddresses {
-		return "", nil, fmt.Errorf("subnet %s has not enough addresses available", subnetID)
+	numAddresses := int(toAllocate)
+	if family == ipam.IPv4 {
+		numAddresses += 1 // include primary IP
+		if numAddresses > subnet.AvailableAddresses {
+			return "", nil, fmt.Errorf("subnet %s has not enough IPv4 addresses available", subnetID)
+		}
 	}
 
 	eniID := uuid.New().String()
@@ -218,28 +240,44 @@ func (e *API) CreateNetworkInterface(ctx context.Context, toAllocate int32, subn
 		SecurityGroups: groups,
 	}
 
-	primaryIP, err := e.allocator.AllocateNext()
-	if err != nil {
-		panic("Unable to allocate primary IP from allocator")
-	}
-	eni.IP = primaryIP.String()
-
-	if allocatePrefixes {
+	switch {
+	case family == ipam.IPv4 && allocatePrefixes:
 		err := assignPrefixToENI(e, eni, int32(1))
 		if err != nil {
 			return "", nil, err
 		}
-	} else {
+	case family == ipam.IPv6 && allocatePrefixes:
+		pfx, err := e.v6PrefixAllocator.AllocateNext()
+		if err != nil {
+			panic("Unable to allocate IPv6 prefix from allocator")
+		}
+		eni.IPv6 = pfx.IP.String()
+
+		err = assignIPv6PrefixToENI(e, eni, int32(1))
+		if err != nil {
+			return "", nil, err
+		}
+	default:
+		primaryIP, err := e.ipAllocator.AllocateNext()
+		if err != nil {
+			panic("Unable to allocate primary IP from allocator")
+		}
+		eni.IPv6 = primaryIP.String()
+
 		for i := int32(0); i < toAllocate; i++ {
-			ip, err := e.allocator.AllocateNext()
+			ip, err := e.ipAllocator.AllocateNext()
 			if err != nil {
-				panic("Unable to allocate IP from allocator")
+				panic("Unable to allocate IPv4 address from allocator")
 			}
 			eni.Addresses = append(eni.Addresses, ip.String())
 		}
 	}
 
-	subnet.AvailableAddresses -= numAddresses
+	if family == ipam.IPv4 {
+		subnet.AvailableAddresses -= numAddresses
+	} else {
+		subnet.AvailableIPv6Addresses -= numAddresses
+	}
 
 	e.unattached[eniID] = eni
 	log.Debugf(" ENI after initial creation %v", eni)
@@ -366,7 +404,7 @@ func (e *API) AssignPrivateIpAddresses(ctx context.Context, eniID string, addres
 			}
 
 			for i := int32(0); i < addresses; i++ {
-				ip, err := e.allocator.AllocateNext()
+				ip, err := e.ipAllocator.AllocateNext()
 				if err != nil {
 					panic("Unable to allocate IP from allocator")
 				}
@@ -418,7 +456,7 @@ func (e *API) UnassignPrivateIpAddresses(ctx context.Context, eniID string, addr
 				addressesAfterRelease = append(addressesAfterRelease, address)
 			} else {
 				ip := net.ParseIP(address)
-				e.allocator.Release(ip)
+				e.ipAllocator.Release(ip)
 				subnet.AvailableAddresses++
 			}
 		}
@@ -443,7 +481,7 @@ func assignPrefixToENI(e *API, eni *eniTypes.ENI, prefixes int32) error {
 
 	for i := int32(0); i < prefixes; i++ {
 		// Get a new /28 prefix
-		pfx, err := e.pdAllocator.AllocateNext()
+		pfx, err := e.v4PrefixAllocator.AllocateNext()
 		if err != nil {
 			return err
 		}
@@ -452,11 +490,36 @@ func assignPrefixToENI(e *API, eni *eniTypes.ENI, prefixes int32) error {
 		eni.Prefixes = append(eni.Prefixes, prefixStr)
 		prefixIPs, err := ip.PrefixToIps(prefixStr, 0)
 		if err != nil {
-			return fmt.Errorf("unable to convert prefix %s to ips", prefixStr)
+			return fmt.Errorf("unable to convert prefix %s to ipv4 addresses", prefixStr)
 		}
 		eni.Addresses = append(eni.Addresses, prefixIPs...)
 	}
 	subnet.AvailableAddresses -= int(prefixes * option.ENIPDBlockSizeIPv4)
+	return nil
+}
+
+func assignIPv6PrefixToENI(e *API, eni *eniTypes.ENI, prefixes int32) error {
+	subnet, ok := e.subnets[eni.Subnet.ID]
+	if !ok {
+		return fmt.Errorf("subnet %s not found", eni.Subnet.ID)
+	}
+
+	for i := int32(0); i < prefixes; i++ {
+		// Get a new /80 prefix
+		pfx, err := e.v6PrefixAllocator.AllocateNext()
+		if err != nil {
+			return err
+		}
+
+		prefixStr := pfx.String()
+		eni.IPv6Prefixes = append(eni.IPv6Prefixes, prefixStr)
+		prefixIPs, err := ip.PrefixToIps(prefixStr, option.ENIPDBlockSizeIPv6)
+		if err != nil {
+			return fmt.Errorf("unable to convert prefix %s to ipv6 addresses", prefixStr)
+		}
+		eni.IPv6Addresses = append(eni.IPv6Addresses, prefixIPs...)
+	}
+	subnet.AvailableIPv6Addresses -= int(prefixes * option.ENIPDBlockSizeIPv6)
 	return nil
 }
 
@@ -474,6 +537,25 @@ func (e *API) AssignENIPrefixes(ctx context.Context, eniID string, prefixes int3
 	for _, enis := range e.enis {
 		if eni, ok := enis[eniID]; ok {
 			return assignPrefixToENI(e, eni, prefixes)
+		}
+	}
+	return fmt.Errorf("Unable to find ENI with ID %s", eniID)
+}
+
+func (e *API) AssignENIIPv6Prefixes(ctx context.Context, eniID string, prefixes int32) error {
+	e.rateLimit()
+	e.delaySim.Delay(AssignIPv6Prefixes)
+
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	if err, ok := e.errors[AssignIPv6Prefixes]; ok {
+		return err
+	}
+
+	for _, enis := range e.enis {
+		if eni, ok := enis[eniID]; ok {
+			return assignIPv6PrefixToENI(e, eni, prefixes)
 		}
 	}
 	return fmt.Errorf("Unable to find ENI with ID %s", eniID)
@@ -497,7 +579,7 @@ func (e *API) UnassignENIPrefixes(ctx context.Context, eniID string, prefixes []
 		if err != nil {
 			return fmt.Errorf("Invalid CIDR block %s", prefix)
 		}
-		e.pdAllocator.Release(ipNet)
+		e.v4PrefixAllocator.Release(ipNet)
 		ips, _ := ip.PrefixToIps(prefix, 0)
 		addresses = append(addresses, ips...)
 	}

--- a/pkg/aws/eni/eni_gc_test.go
+++ b/pkg/aws/eni/eni_gc_test.go
@@ -13,6 +13,7 @@ import (
 	ec2mock "github.com/cilium/cilium/pkg/aws/ec2/mock"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/inctimer"
+	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/logging"
 )
 
@@ -52,13 +53,13 @@ func TestStartENIGarbageCollector(t *testing.T) {
 
 	untaggedENIs := map[string]bool{}
 	for i := 0; i < 8; i++ {
-		eniID, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "subnet-1", "desc", []string{"sg-1", "sg-2"}, false)
+		eniID, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "subnet-1", "desc", []string{"sg-1", "sg-2"}, false, ipam.IPv4)
 		require.NoError(t, err)
 		untaggedENIs[eniID] = true
 	}
 
 	createTaggedENI := func() string {
-		eniID, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "subnet-2", "desc", []string{"sg-1", "sg-2"}, false)
+		eniID, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "subnet-2", "desc", []string{"sg-1", "sg-2"}, false, ipam.IPv4)
 		require.NoError(t, err)
 		err = ec2api.TagENI(context.TODO(), eniID, tags)
 		require.NoError(t, err)

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -30,13 +30,14 @@ type EC2API interface {
 	GetVpcs(ctx context.Context) (ipamTypes.VirtualNetworkMap, error)
 	GetSecurityGroups(ctx context.Context) (types.SecurityGroupMap, error)
 	GetDetachedNetworkInterfaces(ctx context.Context, tags ipamTypes.Tags, maxResults int32) ([]string, error)
-	CreateNetworkInterface(ctx context.Context, toAllocate int32, subnetID, desc string, groups []string, allocatePrefixes bool) (string, *eniTypes.ENI, error)
+	CreateNetworkInterface(ctx context.Context, toAllocate int32, subnetID, desc string, groups []string, allocatePrefixes bool, family ipam.Family) (string, *eniTypes.ENI, error)
 	AttachNetworkInterface(ctx context.Context, index int32, instanceID, eniID string) (string, error)
 	DeleteNetworkInterface(ctx context.Context, eniID string) error
 	ModifyNetworkInterface(ctx context.Context, eniID, attachmentID string, deleteOnTermination bool) error
 	AssignPrivateIpAddresses(ctx context.Context, eniID string, addresses int32) error
 	UnassignPrivateIpAddresses(ctx context.Context, eniID string, addresses []string) error
 	AssignENIPrefixes(ctx context.Context, eniID string, prefixes int32) error
+	AssignENIIPv6Prefixes(ctx context.Context, eniID string, prefixes int32) error
 	UnassignENIPrefixes(ctx context.Context, eniID string, prefixes []string) error
 	GetInstanceTypes(context.Context) ([]ec2_types.InstanceTypeInfo, error)
 }

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -67,7 +67,7 @@ func TestGetNodeNames(t *testing.T) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
 	require.NotNil(t, instances)
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -96,7 +96,7 @@ func TestNodeManagerGet(t *testing.T) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
 	require.NotNil(t, instances)
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -131,7 +131,7 @@ func TestNodeManagerDefaultAllocation(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -176,7 +176,7 @@ func TestNodeManagerPrefixDelegation(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, true)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, true, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -245,7 +245,7 @@ func TestNodeManagerENIWithSGTags(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -305,7 +305,7 @@ func TestNodeManagerMinAllocate20(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -361,7 +361,7 @@ func TestNodeManagerMinAllocateAndPreallocate(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -426,7 +426,7 @@ func TestNodeManagerReleaseAddress(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, true, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, true, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -533,7 +533,7 @@ func TestNodeManagerENIExcludeInterfaceTags(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -596,7 +596,7 @@ func TestNodeManagerExceedENICapacity(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -654,7 +654,7 @@ func TestInterfaceCreatedInInitialSubnet(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -712,7 +712,7 @@ func TestNodeManagerManyNodes(t *testing.T) {
 
 	ec2api := ec2mock.NewAPI(subnets, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instancesManager := NewInstancesManager(ec2api)
-	mngr, err := ipam.NewNodeManager(instancesManager, k8sapi, metricsapi, 10, false, false)
+	mngr, err := ipam.NewNodeManager(instancesManager, k8sapi, metricsapi, 10, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -787,7 +787,7 @@ func TestNodeManagerInstanceNotRunning(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
 	ec2api.SetMockError(ec2mock.AttachNetworkInterface, errors.New("foo is not 'running' foo"))
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -836,7 +836,7 @@ func TestInstanceBeenDeleted(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 1, instanceID, eniID2)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -881,7 +881,7 @@ func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rate
 	ec2api.SetLimiter(rateLimit, burst)
 	instances := NewInstancesManager(ec2api)
 	require.NotNil(b, instances)
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
 	require.NoError(b, err)
 	require.NotNil(b, mngr)
 

--- a/pkg/aws/eni/node_test.go
+++ b/pkg/aws/eni/node_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/aws/eni/types"
+	"github.com/cilium/cilium/pkg/ipam"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 )
 
@@ -16,23 +17,48 @@ func TestGetMaximumAllocatableIPv4(t *testing.T) {
 	n := &Node{}
 
 	// With no k8sObj defined, it should return 0
-	require.Equal(t, 0, n.GetMaximumAllocatableIPv4())
+	require.Equal(t, 0, n.GetMaximumAllocatableIP(ipam.IPv4))
 
 	// With instance-type = m5.large and first-interface-index = 0, we should be able to allocate up to 3x10-3 addresses
 	n.k8sObj = newCiliumNode("node", withInstanceType("m5.large"), withFirstInterfaceIndex(0))
-	require.Equal(t, 27, n.GetMaximumAllocatableIPv4())
+	require.Equal(t, 27, n.GetMaximumAllocatableIP(ipam.IPv4))
 
 	// With instance-type = m5.large and first-interface-index = 1, we should be able to allocate up to 2x10-2 addresses
 	n.k8sObj = newCiliumNode("node", withInstanceType("m5.large"), withFirstInterfaceIndex(1))
-	require.Equal(t, 18, n.GetMaximumAllocatableIPv4())
+	require.Equal(t, 18, n.GetMaximumAllocatableIP(ipam.IPv4))
 
 	// With instance-type = m5.large and first-interface-index = 4, we should return 0 as there is only 3 interfaces
 	n.k8sObj = newCiliumNode("node", withInstanceType("m5.large"), withFirstInterfaceIndex(4))
-	require.Equal(t, 0, n.GetMaximumAllocatableIPv4())
+	require.Equal(t, 0, n.GetMaximumAllocatableIP(ipam.IPv4))
 
 	// With instance-type = foo we should return 0
 	n.k8sObj = newCiliumNode("node", withInstanceType("foo"))
-	require.Equal(t, 0, n.GetMaximumAllocatableIPv4())
+	require.Equal(t, 0, n.GetMaximumAllocatableIP(ipam.IPv4))
+}
+
+func TestGetMaximumAllocatableIPv6(t *testing.T) {
+	n := &Node{}
+
+	// With no k8sObj defined, it should return 64
+	require.Equal(t, 0, n.GetMaximumAllocatableIP(ipam.IPv6))
+
+	// With instance-type = m5.large and first-interface-index = 0, we should be able to allocate up to
+	// ((10-1 prefix allocations) * 64 ENIPDBlockSizeIPv6) * 3 ENIs.
+	n.k8sObj = newCiliumNode("node", withInstanceType("m5.large"), withFirstInterfaceIndex(0))
+	require.Equal(t, 1728, n.GetMaximumAllocatableIP(ipam.IPv6))
+
+	// With instance-type = m5.large and first-interface-index = 1, we should be able to allocate up to
+	// ((10-1 prefix allocations) * 64 ENIPDBlockSizeIPv6) * 2 ENIs.
+	n.k8sObj = newCiliumNode("node", withInstanceType("m5.large"), withFirstInterfaceIndex(1))
+	require.Equal(t, 1152, n.GetMaximumAllocatableIP(ipam.IPv6))
+
+	// With instance-type = m5.large and first-interface-index = 4, we should return 0 as there is only 3 interfaces
+	n.k8sObj = newCiliumNode("node", withInstanceType("m5.large"), withFirstInterfaceIndex(4))
+	require.Equal(t, 0, n.GetMaximumAllocatableIP(ipam.IPv6))
+
+	// With instance-type = foo we should return 0
+	n.k8sObj = newCiliumNode("node", withInstanceType("foo"))
+	require.Equal(t, 0, n.GetMaximumAllocatableIP(ipam.IPv6))
 }
 
 // TestGetUsedIPWithPrefixes tests the logic computing used IPs on a node when prefix delegation is enabled.
@@ -49,5 +75,23 @@ func TestGetUsedIPWithPrefixes(t *testing.T) {
 	allocationMap["10.10.128.2"] = ipamTypes.AllocationIP{Resource: eniName}
 	allocationMap["10.10.128.18"] = ipamTypes.AllocationIP{Resource: eniName}
 	n.k8sObj.Status.IPAM.Used = allocationMap
-	require.Equal(t, 32, n.GetUsedIPWithPrefixes())
+	require.Equal(t, 32, n.GetUsedIPWithPrefixes(ipam.IPv4))
+}
+
+// TestGetUsedIPWithPrefixes tests the logic computing used IPv6 addresses
+// on a node when prefix delegation is enabled.
+func TestGetUsedIPv6WithPrefixes(t *testing.T) {
+	cn := newCiliumNode("node1", withInstanceType("m5a.large"))
+	n := &Node{k8sObj: cn}
+	eniName := "eni-1"
+	prefixes := []string{"2001:db8::/80", "2001:db8:1::/80"}
+	eniMap := make(map[string]types.ENI)
+	eniMap[eniName] = types.ENI{IPv6Prefixes: prefixes}
+	cn.Status.ENI.ENIs = eniMap
+
+	allocationMap := make(ipamTypes.AllocationMap)
+	allocationMap["2001:db8::1"] = ipamTypes.AllocationIP{Resource: eniName}
+	allocationMap["2001:db8:1::1"] = ipamTypes.AllocationIP{Resource: eniName}
+	n.k8sObj.Status.IPAM.IPv6Used = allocationMap
+	require.Equal(t, 128, n.GetUsedIPWithPrefixes(ipam.IPv6)) // 64 IPs per prefix
 }

--- a/pkg/aws/eni/types/types.go
+++ b/pkg/aws/eni/types/types.go
@@ -152,7 +152,7 @@ type ENI struct {
 	// +optional
 	ID string `json:"id,omitempty"`
 
-	// IP is the primary IP of the ENI
+	// IP is the primary IPv4 address of the ENI
 	//
 	// +optional
 	IP string `json:"ip,omitempty"`
@@ -188,15 +188,30 @@ type ENI struct {
 	// +optional
 	VPC AwsVPC `json:"vpc,omitempty"`
 
-	// Addresses is the list of all secondary IPs associated with the ENI
+	// Addresses is the list of all secondary IPv4 addresses associated with the ENI
 	//
 	// +optional
 	Addresses []string `json:"addresses,omitempty"`
 
-	// Prefixes is the list of all /28 prefixes associated with the ENI
+	// Prefixes is the list of all /28 IPv4 prefixes associated with the ENI
 	//
 	// +optional
 	Prefixes []string `json:"prefixes,omitempty"`
+
+	// The IPv6 globally unique address associated with the ENI.
+	//
+	// +optional
+	IPv6 string `json:"ipv6,omitempty"`
+
+	// IPv6Addresses is the IPv6 addresses associated with the ENI.
+	//
+	// +optional
+	IPv6Addresses []string `json:"ipv6-addresses,omitempty"`
+
+	// IPv6Prefixes is the list of /80 IPv6 prefixes assigned to the ENI.
+	//
+	// +optional
+	IPv6Prefixes []string `json:"ipv6-prefixes,omitempty"`
 
 	// SecurityGroups are the security groups associated with the ENI
 	SecurityGroups []string `json:"security-groups,omitempty"`
@@ -259,6 +274,9 @@ type AwsSubnet struct {
 
 	// CIDR is the CIDR range associated with the subnet
 	CIDR string `json:"cidr,omitempty"`
+
+	// IPv6CIDR is the IPv6 CIDR range associated with the subnet
+	IPv6CIDR string `json:"ipv6-cidr,omitempty"`
 }
 
 // AwsVPC stores information regarding an AWS VPC
@@ -271,4 +289,7 @@ type AwsVPC struct {
 
 	// CIDRs is the list of CIDR ranges associated with the VPC
 	CIDRs []string `json:"cidrs,omitempty"`
+
+	// IPv6CIDRs is the list of IPv6 CIDR ranges associated with the VPC
+	IPv6CIDRs []string `json:"ipv6-cidrs,omitempty"`
 }

--- a/pkg/aws/eni/types/zz_generated.deepcopy.go
+++ b/pkg/aws/eni/types/zz_generated.deepcopy.go
@@ -32,6 +32,11 @@ func (in *AwsVPC) DeepCopyInto(out *AwsVPC) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.IPv6CIDRs != nil {
+		in, out := &in.IPv6CIDRs, &out.IPv6CIDRs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -57,6 +62,16 @@ func (in *ENI) DeepCopyInto(out *ENI) {
 	}
 	if in.Prefixes != nil {
 		in, out := &in.Prefixes, &out.Prefixes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.IPv6Addresses != nil {
+		in, out := &in.IPv6Addresses, &out.IPv6Addresses
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.IPv6Prefixes != nil {
+		in, out := &in.IPv6Prefixes, &out.IPv6Prefixes
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/aws/eni/types/zz_generated.deepequal.go
+++ b/pkg/aws/eni/types/zz_generated.deepequal.go
@@ -21,6 +21,9 @@ func (in *AwsSubnet) DeepEqual(other *AwsSubnet) bool {
 	if in.CIDR != other.CIDR {
 		return false
 	}
+	if in.IPv6CIDR != other.IPv6CIDR {
+		return false
+	}
 
 	return true
 }
@@ -40,6 +43,23 @@ func (in *AwsVPC) DeepEqual(other *AwsVPC) bool {
 	}
 	if ((in.CIDRs != nil) && (other.CIDRs != nil)) || ((in.CIDRs == nil) != (other.CIDRs == nil)) {
 		in, other := &in.CIDRs, &other.CIDRs
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if inElement != (*other)[i] {
+					return false
+				}
+			}
+		}
+	}
+
+	if ((in.IPv6CIDRs != nil) && (other.IPv6CIDRs != nil)) || ((in.IPv6CIDRs == nil) != (other.IPv6CIDRs == nil)) {
+		in, other := &in.IPv6CIDRs, &other.IPv6CIDRs
 		if other == nil {
 			return false
 		}
@@ -110,6 +130,43 @@ func (in *ENI) DeepEqual(other *ENI) bool {
 
 	if ((in.Prefixes != nil) && (other.Prefixes != nil)) || ((in.Prefixes == nil) != (other.Prefixes == nil)) {
 		in, other := &in.Prefixes, &other.Prefixes
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if inElement != (*other)[i] {
+					return false
+				}
+			}
+		}
+	}
+
+	if in.IPv6 != other.IPv6 {
+		return false
+	}
+	if ((in.IPv6Addresses != nil) && (other.IPv6Addresses != nil)) || ((in.IPv6Addresses == nil) != (other.IPv6Addresses == nil)) {
+		in, other := &in.IPv6Addresses, &other.IPv6Addresses
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if inElement != (*other)[i] {
+					return false
+				}
+			}
+		}
+	}
+
+	if ((in.IPv6Prefixes != nil) && (other.IPv6Prefixes != nil)) || ((in.IPv6Prefixes == nil) != (other.IPv6Prefixes == nil)) {
+		in, other := &in.IPv6Prefixes, &other.IPv6Prefixes
 		if other == nil {
 			return false
 		}

--- a/pkg/azure/ipam/ipam_test.go
+++ b/pkg/azure/ipam/ipam_test.go
@@ -171,7 +171,7 @@ func TestIpamPreAllocate8(t *testing.T) {
 	instances.Resync(context.TODO())
 
 	k8sapi := newK8sMock()
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsmock.NewMockMetrics(), 10, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -233,7 +233,7 @@ func TestIpamMinAllocate10(t *testing.T) {
 	instances.Resync(context.TODO())
 
 	k8sapi := newK8sMock()
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsmock.NewMockMetrics(), 10, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -296,7 +296,7 @@ func TestIpamManyNodes(t *testing.T) {
 
 			k8sapi := newK8sMock()
 			metrics := metricsmock.NewMockMetrics()
-			mngr, err := ipam.NewNodeManager(instances, k8sapi, metrics, int64(test.concurrency), false, false)
+			mngr, err := ipam.NewNodeManager(instances, k8sapi, metrics, int64(test.concurrency), false, false, false)
 			require.NoError(t, err)
 			require.NotNil(t, mngr)
 
@@ -371,7 +371,7 @@ func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rate
 
 	k8sapi := newK8sMock()
 	metrics := metricsmock.NewMockMetrics()
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metrics, workers, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metrics, workers, false, false, false)
 	require.NoError(b, err)
 	require.NotNil(b, mngr)
 

--- a/pkg/azure/ipam/node_stats_test.go
+++ b/pkg/azure/ipam/node_stats_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/pkg/azure/types"
+	"github.com/cilium/cilium/pkg/ipam"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
@@ -47,7 +48,7 @@ func TestENIIPAMCapacityAccounting(t *testing.T) {
 			},
 		},
 	}
-	_, stats, err := n.ResyncInterfacesAndIPs(context.Background(), log)
+	_, stats, err := n.ResyncInterfacesAndIPs(context.Background(), log, ipam.IPv4)
 	assert.NoError(err)
 	assert.Equal(255, stats.NodeCapacity)
 }

--- a/pkg/azure/ipam/node_test.go
+++ b/pkg/azure/ipam/node_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/azure/types"
+	"github.com/cilium/cilium/pkg/ipam"
 )
 
 func TestGetMaximumAllocatableIPv4(t *testing.T) {
 	n := &Node{}
-	require.Equal(t, n.GetMaximumAllocatableIPv4(), types.InterfaceAddressLimit)
+	require.Equal(t, n.GetMaximumAllocatableIP(ipam.IPv4), types.InterfaceAddressLimit)
 }

--- a/pkg/cidr/cidr.go
+++ b/pkg/cidr/cidr.go
@@ -165,6 +165,21 @@ func ParseCIDR(str string) (*CIDR, error) {
 	return NewCIDR(ipnet), nil
 }
 
+// ParseIPv6CIDR parses the provided CIDR string and ensures it represents an IPv6 CIDR.
+func ParseIPv6CIDR(str string) (*CIDR, error) {
+	_, ipnet, err := net.ParseCIDR(str)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if the IP is an IPv6 address; if IP.To4() is nil, it's an IPv6 address
+	if ipnet.IP.To4() == nil {
+		return NewCIDR(ipnet), nil
+	}
+
+	return nil, fmt.Errorf("the provided CIDR is not a valid IPv6 CIDR")
+}
+
 // MustParseCIDR parses the CIDR string using net.ParseCIDR and panics if the
 // CIDR cannot be parsed
 func MustParseCIDR(str string) *CIDR {

--- a/pkg/cidr/cidr_test.go
+++ b/pkg/cidr/cidr_test.go
@@ -284,3 +284,28 @@ func TestRemoveAll(t *testing.T) {
 		require.EqualValuesf(t, tt.want, result, "Test Name: %s", tt.name)
 	}
 }
+
+func TestParseIPv6CIDR(t *testing.T) {
+	testCases := []struct {
+		name    string
+		cidrStr string
+		valid   bool
+	}{
+		{"Valid IPv6 CIDR", "2001:db8::/32", true},
+		{"Invalid IPv6 CIDR", "2001:db8::/129", false}, // Invalid mask
+		{"IPv4 CIDR", "192.168.1.0/24", false},
+		{"Invalid CIDR Format", "invalid", false},
+		{"Empty String", "", false},
+	}
+
+	for _, tc := range testCases {
+		cidr, err := ParseIPv6CIDR(tc.cidrStr)
+		if tc.valid {
+			require.Nilf(t, err, "Test failed for: %s", tc.name)
+			require.NotNilf(t, cidr, "Expected a non-nil CIDR for: %s", tc.name)
+			require.Nilf(t, cidr.IPNet.IP.To4(), "Expected an IPv6 address for: %s", tc.name)
+		} else {
+			require.NotNilf(t, err, "Expected an error for: %s", tc.name)
+		}
+	}
+}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -387,8 +387,12 @@ const (
 	KVstoreLeaseMaxTTL = 86400 * time.Second
 
 	// IPAMPreAllocation is the default value for
-	// CiliumNode.Spec.IPAM.PreAllocate if no value is set
+	// CiliumNode.Spec.IPAM.IPv4.PreAllocate if no value is set
 	IPAMPreAllocation = 8
+
+	// IPAMIPv6PreAllocation is the default value for
+	// CiliumNode.Spec.IPAM.IPv6.PreAllocate if no value is set
+	IPAMIPv6PreAllocation = 32
 
 	// IPAMDefaultIPPool is the default value for the multi-pool default pool name.
 	IPAMDefaultIPPool = "default"

--- a/pkg/ipam/allocator/alibabacloud/alibabacloud.go
+++ b/pkg/ipam/allocator/alibabacloud/alibabacloud.go
@@ -101,7 +101,7 @@ func (a *AllocatorAlibabaCloud) Start(ctx context.Context, getterUpdater ipam.Ci
 	}
 	instances := eni.NewInstancesManager(a.client)
 	nodeManager, err := ipam.NewNodeManager(instances, getterUpdater, iMetrics,
-		operatorOption.Config.ParallelAllocWorkers, operatorOption.Config.AlibabaCloudReleaseExcessIPs, false)
+		operatorOption.Config.ParallelAllocWorkers, operatorOption.Config.AlibabaCloudReleaseExcessIPs, false, false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize AlibabaCloud node manager: %w", err)
 	}

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -123,7 +123,7 @@ func (a *AllocatorAWS) Start(ctx context.Context, getterUpdater ipam.CiliumNodeG
 	instances := eni.NewInstancesManager(a.client)
 	nodeManager, err := ipam.NewNodeManager(instances, getterUpdater, iMetrics,
 		operatorOption.Config.ParallelAllocWorkers, operatorOption.Config.AWSReleaseExcessIPs,
-		operatorOption.Config.AWSEnablePrefixDelegation)
+		operatorOption.Config.AWSEnablePrefixDelegation, operatorOption.Config.AWSEnableIPv6PrefixDelegation)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize ENI node manager: %w", err)
 	}

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -79,7 +79,7 @@ func (*AllocatorAzure) Start(ctx context.Context, getterUpdater ipam.CiliumNodeG
 		return nil, fmt.Errorf("unable to create Azure client: %w", err)
 	}
 	instances := azureIPAM.NewInstancesManager(azureClient)
-	nodeManager, err := ipam.NewNodeManager(instances, getterUpdater, iMetrics, operatorOption.Config.ParallelAllocWorkers, false, false)
+	nodeManager, err := ipam.NewNodeManager(instances, getterUpdater, iMetrics, operatorOption.Config.ParallelAllocWorkers, false, false, false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize Azure node manager: %w", err)
 	}

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -86,7 +86,8 @@ type Node struct {
 	// ipv4Alloc represents IPv4-specific allocation attributes for this node
 	ipv4Alloc ipAllocAttrs
 
-	// TODO: Add support for IPv6 allocation: https://github.com/cilium/cilium/issues/19251
+	// ipv6Alloc represents IPv6-specific allocation attributes for this node
+	ipv6Alloc ipAllocAttrs
 
 	// resyncNeeded is set to the current time when a resync with the EC2
 	// API is required. The timestamp is required to ensure that this is

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -181,7 +181,7 @@ func (n *nodeOperationsMock) IsPrefixDelegated() bool {
 func TestGetNodeNames(t *testing.T) {
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
-	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -207,7 +207,7 @@ func TestGetNodeNames(t *testing.T) {
 func TestNodeManagerGet(t *testing.T) {
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
-	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -226,7 +226,7 @@ func TestNodeManagerDelete(t *testing.T) {
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
 	metrics := metricsmock.NewMockMetrics()
-	mngr, err := NewNodeManager(am, k8sapi, metrics, 10, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metrics, 10, false, false, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -325,7 +325,7 @@ func reachedAddressesNeeded(mngr *NodeManager, nodeName string, needed int) (suc
 func TestNodeManagerDefaultAllocation(t *testing.T) {
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
-	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -356,7 +356,7 @@ func TestNodeManagerDefaultAllocation(t *testing.T) {
 func TestNodeManagerMinAllocate20(t *testing.T) {
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
-	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -396,7 +396,7 @@ func TestNodeManagerMinAllocate20(t *testing.T) {
 func TestNodeManagerMinAllocateAndPreallocate(t *testing.T) {
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
-	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -445,7 +445,7 @@ func TestNodeManagerReleaseAddress(t *testing.T) {
 	operatorOption.Config.ExcessIPReleaseDelay = 2
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
-	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, true, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, true, false, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -516,7 +516,7 @@ func TestNodeManagerAbortRelease(t *testing.T) {
 	operatorOption.Config.ExcessIPReleaseDelay = 2
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
-	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, true, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, true, false, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -603,7 +603,7 @@ func TestNodeManagerManyNodes(t *testing.T) {
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
 	metricsapi := metricsmock.NewMockMetrics()
-	mngr, err := NewNodeManager(am, k8sapi, metricsapi, 10, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsapi, 10, false, false, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -647,7 +647,7 @@ func TestNodeManagerManyNodes(t *testing.T) {
 func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rateLimit float64, burst int) {
 	am := newAllocationImplementationMock()
 	require.NotNil(b, am)
-	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false, false)
 	require.Nil(b, err)
 	require.NotNil(b, mngr)
 

--- a/pkg/ipam/option/option.go
+++ b/pkg/ipam/option/option.go
@@ -46,3 +46,8 @@ const (
 // prefixes. Every /28 prefix contains 16 IP addresses.
 // See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-prefix-eni.html#ec2-prefix-basics for more details
 const ENIPDBlockSizeIPv4 = 16
+
+// ENIPDBlockSizeIPv6 is the number of IPs available on an ENI IPv6 prefix. AWS assigns a /80 prefixto an IPv6 ENI
+// which contains 2^(128-80) IP addresses, so the number of IPv6 addresses is scaled down to this value.
+// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-prefix-eni.html#ec2-prefix-basics for more details
+const ENIPDBlockSizeIPv6 = 64

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -144,7 +144,7 @@ type IPAMSpec struct {
 	// +optional
 	PodCIDRs []string `json:"podCIDRs,omitempty"`
 
-	// MinAllocate is the minimum number of IPs that must be allocated when
+	// MinAllocate is the minimum number of IPv4 addresses that must be allocated when
 	// the node is first bootstrapped. It defines the minimum base socket
 	// of addresses that must be available. After reaching this watermark,
 	// the PreAllocate and MaxAboveWatermark logic takes over to continue
@@ -153,7 +153,7 @@ type IPAMSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	MinAllocate int `json:"min-allocate,omitempty"`
 
-	// MaxAllocate is the maximum number of IPs that can be allocated to the
+	// MaxAllocate is the maximum number of IPv4 addresses that can be allocated to the
 	// node. When the current amount of allocated IPs will approach this value,
 	// the considered value for PreAllocate will decrease down to 0 in order to
 	// not attempt to allocate more addresses than defined.
@@ -161,7 +161,7 @@ type IPAMSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	MaxAllocate int `json:"max-allocate,omitempty"`
 
-	// PreAllocate defines the number of IP addresses that must be
+	// PreAllocate defines the number of IPv4 addresses that must be
 	// available for allocation in the IPAMspec. It defines the buffer of
 	// addresses available immediately without requiring cilium-operator to
 	// get involved.
@@ -169,7 +169,7 @@ type IPAMSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	PreAllocate int `json:"pre-allocate,omitempty"`
 
-	// MaxAboveWatermark is the maximum number of addresses to allocate
+	// MaxAboveWatermark is the maximum number of IPv4 addresses to allocate
 	// beyond the addresses needed to reach the PreAllocate watermark.
 	// Going above the watermark can help reduce the number of API calls to
 	// allocate IPs, e.g. when a new ENI is allocated, as many secondary
@@ -178,6 +178,41 @@ type IPAMSpec struct {
 	//
 	// +kubebuilder:validation:Minimum=0
 	MaxAboveWatermark int `json:"max-above-watermark,omitempty"`
+
+	// IPv6MinAllocate is the minimum number of IPv6 addresses that must be allocated when
+	// the node is first bootstrapped. It defines the minimum base socket
+	// of IPv6 addresses that must be available. After reaching this watermark,
+	// the IPv6PreAllocate and IPv6MaxAboveWatermark logic takes over to continue
+	// allocating IPv6 addresses.
+	//
+	// +kubebuilder:validation:Minimum=0
+	IPv6MinAllocate int `json:"ipv6-min-allocate,omitempty"`
+
+	// IPv6MaxAllocate is the maximum number of IPv6 addresses that can be allocated
+	// to the node. When the current amount of allocated IPv6 addresses will approach
+	// this value, the considered value for IPv6PreAllocate will decrease down to 0 in
+	// order to not attempt to allocate more IPv6 addresses than defined.
+	//
+	// +kubebuilder:validation:Minimum=0
+	IPv6MaxAllocate int `json:"ipv6-max-allocate,omitempty"`
+
+	// IPv6PreAllocate defines the number of IPv6 addresses that must be
+	// available for allocation in the IPAMspec. It defines the buffer of IPv6
+	// addresses available immediately without requiring cilium-operator to
+	// get involved.
+	//
+	// +kubebuilder:validation:Minimum=0
+	IPv6PreAllocate int `json:"ipv6-pre-allocate,omitempty"`
+
+	// IPv6MaxAboveWatermark is the maximum number of IPv6 addresses to allocate
+	// beyond the addresses needed to reach the IPv6PreAllocate watermark.
+	// Going above the watermark can help reduce the number of API calls to
+	// allocate IPs, e.g. when a new ENI is allocated, as many secondary
+	// IPv6 adresses as possible are allocated. Limiting the amount can help reduce
+	// waste of IPs.
+	//
+	// +kubebuilder:validation:Minimum=0
+	IPv6MaxAboveWatermark int `json:"ipv6-max-above-watermark,omitempty"`
 }
 
 // IPReleaseStatus defines the valid states in IP release handshake

--- a/pkg/ipam/types/zz_generated.deepequal.go
+++ b/pkg/ipam/types/zz_generated.deepequal.go
@@ -211,6 +211,18 @@ func (in *IPAMSpec) DeepEqual(other *IPAMSpec) bool {
 	if in.MaxAboveWatermark != other.MaxAboveWatermark {
 		return false
 	}
+	if in.IPv6MinAllocate != other.IPv6MinAllocate {
+		return false
+	}
+	if in.IPv6MaxAllocate != other.IPv6MaxAllocate {
+		return false
+	}
+	if in.IPv6PreAllocate != other.IPv6PreAllocate {
+		return false
+	}
+	if in.IPv6MaxAboveWatermark != other.IPv6MaxAboveWatermark {
+		return false
+	}
 
 	return true
 }

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -263,6 +263,33 @@ spec:
                   can be populated by a user or it can be automatically populated
                   by an IPAM operator.
                 properties:
+                  ipv6-max-above-watermark:
+                    description: IPv6MaxAboveWatermark is the maximum number of IPv6
+                      addresses to allocate beyond the addresses needed to reach the
+                      IPv6PreAllocate watermark. Going above the watermark can help
+                      reduce the number of API calls to allocate IPs, e.g. when a
+                      new ENI is allocated, as many secondary IPv6 adresses as possible
+                      are allocated. Limiting the amount can help reduce waste of
+                      IPs.
+                    minimum: 0
+                    type: integer
+                  ipv6-max-allocate:
+                    description: IPv6MaxAllocate is the maximum number of IPv6 addresses
+                      that can be allocated to the node. When the current amount of
+                      allocated IPv6 addresses will approach this value, the considered
+                      value for IPv6PreAllocate will decrease down to 0 in order to
+                      not attempt to allocate more IPv6 addresses than defined.
+                    minimum: 0
+                    type: integer
+                  ipv6-min-allocate:
+                    description: IPv6MinAllocate is the minimum number of IPv6 addresses
+                      that must be allocated when the node is first bootstrapped.
+                      It defines the minimum base socket of IPv6 addresses that must
+                      be available. After reaching this watermark, the IPv6PreAllocate
+                      and IPv6MaxAboveWatermark logic takes over to continue allocating
+                      IPv6 addresses.
+                    minimum: 0
+                    type: integer
                   ipv6-pool:
                     additionalProperties:
                       description: AllocationIP is an IP which is available for allocation,
@@ -287,8 +314,15 @@ spec:
                       to the node for allocation. When an IPv6 address is used, it
                       will remain on this list but will be added to Status.IPAM.IPv6Used
                     type: object
+                  ipv6-pre-allocate:
+                    description: IPv6PreAllocate defines the number of IPv6 addresses
+                      that must be available for allocation in the IPAMspec. It defines
+                      the buffer of IPv6 addresses available immediately without requiring
+                      cilium-operator to get involved.
+                    minimum: 0
+                    type: integer
                   max-above-watermark:
-                    description: MaxAboveWatermark is the maximum number of addresses
+                    description: MaxAboveWatermark is the maximum number of IPv4 addresses
                       to allocate beyond the addresses needed to reach the PreAllocate
                       watermark. Going above the watermark can help reduce the number
                       of API calls to allocate IPs, e.g. when a new ENI is allocated,
@@ -297,19 +331,19 @@ spec:
                     minimum: 0
                     type: integer
                   max-allocate:
-                    description: MaxAllocate is the maximum number of IPs that can
-                      be allocated to the node. When the current amount of allocated
-                      IPs will approach this value, the considered value for PreAllocate
-                      will decrease down to 0 in order to not attempt to allocate
-                      more addresses than defined.
+                    description: MaxAllocate is the maximum number of IPv4 addresses
+                      that can be allocated to the node. When the current amount of
+                      allocated IPs will approach this value, the considered value
+                      for PreAllocate will decrease down to 0 in order to not attempt
+                      to allocate more addresses than defined.
                     minimum: 0
                     type: integer
                   min-allocate:
-                    description: MinAllocate is the minimum number of IPs that must
-                      be allocated when the node is first bootstrapped. It defines
-                      the minimum base socket of addresses that must be available.
-                      After reaching this watermark, the PreAllocate and MaxAboveWatermark
-                      logic takes over to continue allocating IPs.
+                    description: MinAllocate is the minimum number of IPv4 addresses
+                      that must be allocated when the node is first bootstrapped.
+                      It defines the minimum base socket of addresses that must be
+                      available. After reaching this watermark, the PreAllocate and
+                      MaxAboveWatermark logic takes over to continue allocating IPs.
                     minimum: 0
                     type: integer
                   podCIDRs:
@@ -407,8 +441,8 @@ spec:
                         type: array
                     type: object
                   pre-allocate:
-                    description: PreAllocate defines the number of IP addresses that
-                      must be available for allocation in the IPAMspec. It defines
+                    description: PreAllocate defines the number of IPv4 addresses
+                      that must be available for allocation in the IPAMspec. It defines
                       the buffer of addresses available immediately without requiring
                       cilium-operator to get involved.
                     minimum: 0
@@ -580,8 +614,8 @@ spec:
                         \n More details: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html"
                       properties:
                         addresses:
-                          description: Addresses is the list of all secondary IPs
-                            associated with the ENI
+                          description: Addresses is the list of all secondary IPv4
+                            addresses associated with the ENI
                           items:
                             type: string
                           type: array
@@ -597,8 +631,24 @@ spec:
                           description: ID is the ENI ID
                           type: string
                         ip:
-                          description: IP is the primary IP of the ENI
+                          description: IP is the primary IPv4 address of the ENI
                           type: string
+                        ipv6:
+                          description: The IPv6 globally unique address associated
+                            with the ENI.
+                          type: string
+                        ipv6-addresses:
+                          description: IPv6Addresses is the IPv6 addresses associated
+                            with the ENI.
+                          items:
+                            type: string
+                          type: array
+                        ipv6-prefixes:
+                          description: IPv6Prefixes is the list of /80 IPv6 prefixes
+                            assigned to the ENI.
+                          items:
+                            type: string
+                          type: array
                         mac:
                           description: MAC is the mac address of the ENI
                           type: string
@@ -607,8 +657,8 @@ spec:
                             with FirstInterfaceIndex
                           type: integer
                         prefixes:
-                          description: Prefixes is the list of all /28 prefixes associated
-                            with the ENI
+                          description: Prefixes is the list of all /28 IPv4 prefixes
+                            associated with the ENI
                           items:
                             type: string
                           type: array
@@ -628,6 +678,10 @@ spec:
                               type: string
                             id:
                               description: ID is the ID of the subnet
+                              type: string
+                            ipv6-cidr:
+                              description: IPv6CIDR is the IPv6 CIDR range associated
+                                with the subnet
                               type: string
                           type: object
                         tags:
@@ -649,6 +703,12 @@ spec:
                             id:
                               description: / ID is the ID of a VPC
                               type: string
+                            ipv6-cidrs:
+                              description: IPv6CIDRs is the list of IPv6 CIDR ranges
+                                associated with the VPC
+                              items:
+                                type: string
+                              type: array
                             primary-cidr:
                               description: PrimaryCIDR is the primary CIDR of the
                                 VPC

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -61,6 +61,7 @@ type addresses struct {
 
 type RouterInfo interface {
 	GetIPv4CIDRs() []net.IPNet
+	GetIPv6CIDRs() []net.IPNet
 }
 
 func makeIPv6HostIP() net.IP {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2766,10 +2766,6 @@ func (c *DaemonConfig) Validate(vp *viper.Viper) error {
 		return fmt.Errorf("RouteMetric '%d' cannot be negative", c.RouteMetric)
 	}
 
-	if c.IPAM == ipamOption.IPAMENI && c.EnableIPv6 {
-		return fmt.Errorf("IPv6 cannot be enabled in ENI IPAM mode")
-	}
-
 	if c.EnableIPv6NDP {
 		if !c.EnableIPv6 {
 			return fmt.Errorf("IPv6NDP cannot be enabled when IPv6 is not enabled")

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -617,7 +617,16 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 		}
 
 		switch conf.IpamMode {
-		case ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
+		case ipamOption.IPAMENI:
+			resp := ipam.IPV6
+			if ipConfig.Address.IP.To4() != nil {
+				resp = ipam.IPV4
+			}
+			err = interfaceAdd(ipConfig, resp, conf)
+			if err != nil {
+				return fmt.Errorf("unable to setup interface datapath: %w", err)
+			}
+		case ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
 			err = interfaceAdd(ipConfig, ipam.IPV4, conf)
 			if err != nil {
 				return fmt.Errorf("unable to setup interface datapath: %w", err)

--- a/plugins/cilium-cni/cmd/interface.go
+++ b/plugins/cilium-cni/cmd/interface.go
@@ -38,10 +38,16 @@ func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, 
 	// Coalesce CIDRs into minimum set needed for route rules
 	// The routes set up here will be cleaned up by linuxrouting.Delete.
 	// Therefor the code here should be kept in sync with the deletion code.
-	ipv4CIDRs, _ := ip.CoalesceCIDRs(allCIDRs)
-	cidrs := make([]string, 0, len(ipv4CIDRs))
-	for _, cidr := range ipv4CIDRs {
-		cidrs = append(cidrs, cidr.String())
+	ipv4CIDRs, ipv6CIDRs := ip.CoalesceCIDRs(allCIDRs)
+	var cidrs []string
+	if ipConfig.Address.IP.To4() != nil {
+		for _, cidr := range ipv4CIDRs {
+			cidrs = append(cidrs, cidr.String())
+		}
+	} else {
+		for _, cidr := range ipv6CIDRs {
+			cidrs = append(cidrs, cidr.String())
+		}
 	}
 
 	routingInfo, err := linuxrouting.NewRoutingInfo(


### PR DESCRIPTION
Previously, ENI prefix delegation support was limited to IPv4.
This PR updates existing structs, methods, etc. to support IPv6
prefix delegation. The overall implementation follows the [existing
approach](https://github.com/cilium/cilium/issues/16987) taken for IPv4 prefix delegation.

Although AWS assigns a /80 prefix to an ENI, 64 addresses are the
maximum number of allocatable addresses. This restriction can be user
configurable in the future if needed.

Fixes: #19251
Fixes: #18405

```release-note
Adds "aws-enable-ipv6-prefix-delegation" configuration flag to enable IPv6 prefix delegation support for ENI IPAM mode in AWS.
```

Includes commit 3b20d9cd3a91fc7232ccf2812343bc028054b252 from #31145. When #31145 is merged, I will rebase to remove this commit so ignore this commit from your review.
