### PR TITLE
Decouple CiliumEndpointSlice controller from operator Clientset

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -101,6 +101,9 @@ var (
 		// Provides Clientset, API for accessing Kubernetes objects.
 		k8sClient.Cell,
 
+		// Provides a ClientBuilderFunc that can be used by other cells to create a client.
+		k8sClient.ClientBuilderCell,
+
 		// Provides the modular metrics registry, metric HTTP server and legacy metrics cell.
 		operatorMetrics.Cell,
 		cell.Provide(func(

--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -27,7 +27,7 @@ type params struct {
 	Logger    logrus.FieldLogger
 	Lifecycle cell.Lifecycle
 
-	Clientset           k8sClient.Clientset
+	NewClient           k8sClient.ClientBuilderFunc
 	CiliumEndpoint      resource.Resource[*v2.CiliumEndpoint]
 	CiliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice]
 	CiliumNodes         resource.Resource[*v2.CiliumNode]
@@ -76,13 +76,14 @@ type Controller struct {
 
 // registerController creates and initializes the CES controller
 func registerController(p params) {
-	if !p.Clientset.IsEnabled() || !p.SharedCfg.EnableCiliumEndpointSlice {
+	clientset, err := p.NewClient("ciliumendpointslice-controller")
+	if err != nil || !clientset.IsEnabled() || !p.SharedCfg.EnableCiliumEndpointSlice {
 		return
 	}
 
 	cesController := &Controller{
 		logger:              p.Logger,
-		clientset:           p.Clientset,
+		clientset:           clientset,
 		ciliumEndpoint:      p.CiliumEndpoint,
 		ciliumEndpointSlice: p.CiliumEndpointSlice,
 		ciliumNodes:         p.CiliumNodes,

--- a/pkg/k8s/client/config.go
+++ b/pkg/k8s/client/config.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 )
 
+const OptUserAgent = "user-agent"
+
 type Config struct {
 	// EnableK8s is a flag that, when set to false, forcibly disables the clientset, to let cilium
 	// operates with CNI-compatible orchestrators other than Kubernetes. Default to true.

--- a/test/controlplane/suite/operator.go
+++ b/test/controlplane/suite/operator.go
@@ -39,6 +39,7 @@ func setupCiliumOperatorHive(clients *k8sClient.FakeClientset) *hive.Hive {
 		cell.Provide(func() k8sClient.Clientset {
 			return clients
 		}),
+		k8sClient.FakeClientBuilderCell,
 		cmd.ControlPlane,
 	)
 }


### PR DESCRIPTION
Decouple the CiliumEndpointSlice controller from the main operator Clientset to prevent it from saturating the rate limit and affecting other controllers.

The 1st commit introduces a new Hive Cell to provide a `ClientBuilderFunc`, which can be executed by a controller to retrieve a new Clientset. The 2nd commit utilizes the `ClientBuilderFunc` in the CiliumEndpointSlice controller to create a new Clientset

```release-note
Grant the CiliumEndpointSlice controller a new Clientset to decouple it from the other Cilium Operator controllers.
```