### PR TITLE
proxy: Re-enable proxy rule installation in native-routing mode for CEC

### DIFF
--- a/.github/actions/gke/test-config-helm.yaml
+++ b/.github/actions/gke/test-config-helm.yaml
@@ -12,3 +12,7 @@ config:
   - type: "tunnel-ipsec"
     index: 4
     cilium-install-opts: "--helm-set=encryption.enabled=true --helm-set=encryption.type=ipsec --datapath-mode=tunnel"
+  - type: "tunnel-ingress-controller"
+    index: 5
+    cilium-install-opts: "--helm-set=kubeProxyReplacement=true --helm-set=ingressController.enabled=true"
+    nodes: 1

--- a/.github/actions/gke/test-config-schema.yaml
+++ b/.github/actions/gke/test-config-schema.yaml
@@ -4,3 +4,4 @@ testConfigItem:
   type: str()
   index: int()
   cilium-install-opts: str()
+  nodes: int(required=False)

--- a/.github/actions/set-env-variables/action.yml
+++ b/.github/actions/set-env-variables/action.yml
@@ -12,7 +12,7 @@ runs:
         echo "EGRESS_GATEWAY_HELM_VALUES=--helm-set=egressGateway.enabled=true" >> $GITHUB_ENV
         echo "CILIUM_CLI_RELEASE_REPO=cilium/cilium-cli" >> $GITHUB_ENV
         # renovate: datasource=github-releases depName=cilium/cilium-cli
-        CILIUM_CLI_VERSION="v0.16.6"
+        CILIUM_CLI_VERSION="v0.16.7"
         echo "CILIUM_CLI_VERSION=$CILIUM_CLI_VERSION" >> $GITHUB_ENV
         echo "PUSH_TO_DOCKER_HUB=true" >> $GITHUB_ENV
         echo "GCP_PERF_RESULTS_BUCKET=gs://cilium-scale-results" >> $GITHUB_ENV

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -273,9 +273,12 @@ jobs:
 
           CILIUM_INSTALL_INGRESS=""
           if [ "${{ matrix.kube-proxy }}" == "none" ]; then
-            # The ingress controller requires KPR to be enabled.
-            CILIUM_INSTALL_INGRESS="--helm-set=ingressController.enabled=true \
-              --helm-set-string=kubeProxyReplacement=true"
+            CILIUM_INSTALL_INGRESS="--helm-set=ingressController.enabled=true"
+            # Once https://github.com/cilium/cilium/issues/31653 is fixed, we can remove tunnel check
+            # Use the legacy host routing in case of tunnel disabled
+            if [ "${{ matrix.tunnel }}" == "disabled" ]; then
+              CILIUM_INSTALL_INGRESS+=" --helm-set=bpf.hostLegacyRouting=true"
+            fi
           fi
 
           CONNECTIVITY_TEST_DEFAULTS="--hubble=false \

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -222,7 +222,7 @@ jobs:
             --cluster-ipv4-cidr="/21" \
             --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
-            --num-nodes 2 \
+            --num-nodes ${{ matrix.config.nodes || 2 }} \
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 20GB \

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -567,6 +567,9 @@ const (
 
 	// BPFEventsTraceEnabled controls whether the Cilium datapath exposes "trace" events to Cilium monitor and Hubble.
 	BPFEventsTraceEnabled = true
+
+	// EnableEnvoyConfig is the default value for option.EnableEnvoyConfig
+	EnableEnvoyConfig = false
 )
 
 var (

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2424,6 +2424,7 @@ var (
 		BPFEventsDropEnabled:          defaults.BPFEventsDropEnabled,
 		BPFEventsPolicyVerdictEnabled: defaults.BPFEventsPolicyVerdictEnabled,
 		BPFEventsTraceEnabled:         defaults.BPFEventsTraceEnabled,
+		EnableEnvoyConfig:             defaults.EnableEnvoyConfig,
 	}
 )
 


### PR DESCRIPTION
This commit is to re-enable proxy rule installation in native-routing mode if
cilium envoy config or ipsec is enabled. The reason is to handle the
reply packet of hair-pinning traffic in Ingress L7 proxy (i.e. backend
is in the same node).

Relates: 0ebe5162373c00f85e7ae43d0bc5d474fa08c485
Relates: #29530, #29864

Signed-off-by: Tam Mach <tam.mach@cilium.io>