### PR TITLE
bgpv2:  Route policies for various reconcilers

### DIFF
--- a/pkg/bgpv1/manager/reconciler/route_policy.go
+++ b/pkg/bgpv1/manager/reconciler/route_policy.go
@@ -120,7 +120,10 @@ func (r *RoutePolicyReconciler) Reconcile(ctx context.Context, params ReconcileP
 	// add missing policies
 	for _, p := range toAdd {
 		l.Infof("Adding route policy %s to vrouter %d", p.Name, params.DesiredConfig.LocalASN)
-		err := params.CurrentServer.Server.AddRoutePolicy(ctx, types.RoutePolicyRequest{Policy: p})
+		err := params.CurrentServer.Server.AddRoutePolicy(ctx, types.RoutePolicyRequest{
+			DefaultExportAction: types.RoutePolicyActionNone, // no change to the default action
+			Policy:              p,
+		})
 		if err != nil {
 			return fmt.Errorf("failed adding route policy %v to vrouter %d: %w", p.Name, params.DesiredConfig.LocalASN, err)
 		}
@@ -136,7 +139,10 @@ func (r *RoutePolicyReconciler) Reconcile(ctx context.Context, params ReconcileP
 		if err != nil {
 			return fmt.Errorf("failed removing route policy %v from vrouter %d: %w", existing.Name, params.DesiredConfig.LocalASN, err)
 		}
-		err = params.CurrentServer.Server.AddRoutePolicy(ctx, types.RoutePolicyRequest{Policy: p})
+		err = params.CurrentServer.Server.AddRoutePolicy(ctx, types.RoutePolicyRequest{
+			DefaultExportAction: types.RoutePolicyActionNone, // no change to the default action
+			Policy:              p,
+		})
 		if err != nil {
 			return fmt.Errorf("failed adding route policy %v to vrouter %d: %w", p.Name, params.DesiredConfig.LocalASN, err)
 		}

--- a/pkg/bgpv1/manager/reconcilerv2/neighbor.go
+++ b/pkg/bgpv1/manager/reconcilerv2/neighbor.go
@@ -6,6 +6,7 @@ package reconcilerv2
 import (
 	"context"
 	"fmt"
+	"net/netip"
 
 	"github.com/cilium/hive/cell"
 	"github.com/sirupsen/logrus"
@@ -356,4 +357,21 @@ func (r *NeighborReconciler) fetchSecret(name string) (map[string][]byte, bool, 
 		result[k] = []byte(v)
 	}
 	return result, true, nil
+}
+
+func GetPeerAddressFromConfig(conf *v2alpha1.CiliumBGPNodeInstance, peerName string) (netip.Addr, error) {
+	if conf == nil {
+		return netip.Addr{}, fmt.Errorf("passed instance is nil")
+	}
+
+	for _, peer := range conf.Peers {
+		if peer.Name == peerName {
+			if peer.PeerAddress != nil {
+				return netip.ParseAddr(*peer.PeerAddress)
+			} else {
+				return netip.Addr{}, fmt.Errorf("peer %s does not have a PeerAddress", peerName)
+			}
+		}
+	}
+	return netip.Addr{}, fmt.Errorf("peer %s not found in instance %s", peerName, conf.Name)
 }

--- a/pkg/bgpv1/manager/reconcilerv2/paths.go
+++ b/pkg/bgpv1/manager/reconcilerv2/paths.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
+	"github.com/cilium/cilium/pkg/k8s/resource"
 )
 
 // PathMap is a map of paths indexed by the NLRI string
@@ -18,6 +19,9 @@ type PathMap map[string]*types.Path
 
 // AFPathsMap is a map of paths per address family, indexed by the family
 type AFPathsMap map[types.Family]PathMap
+
+// ResourceAFPathsMap holds the AF paths keyed by the resource name.
+type ResourceAFPathsMap map[resource.Key]AFPathsMap
 
 type ReconcileAFPathsParams struct {
 	Logger       logrus.FieldLogger

--- a/pkg/bgpv1/manager/reconcilerv2/peer_advertisements_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/peer_advertisements_test.go
@@ -90,7 +90,7 @@ var (
 		Attributes: &v2alpha1.BGPAttributes{
 			Communities: &v2alpha1.BGPCommunities{
 				Standard: []v2alpha1.BGPStandardCommunity{
-					"65555:100",
+					"65355:100",
 				},
 			},
 		},
@@ -101,7 +101,7 @@ var (
 		Attributes: &v2alpha1.BGPAttributes{
 			Communities: &v2alpha1.BGPCommunities{
 				Standard: []v2alpha1.BGPStandardCommunity{
-					"65555:200",
+					"65355:200",
 				},
 			},
 		},
@@ -116,7 +116,7 @@ var (
 		Attributes: &v2alpha1.BGPAttributes{
 			Communities: &v2alpha1.BGPCommunities{
 				Standard: []v2alpha1.BGPStandardCommunity{
-					"65555:300",
+					"65355:300",
 				},
 			},
 		},
@@ -231,6 +231,27 @@ var (
 					},
 				},
 			},
+		},
+	}
+
+	// peer configuration
+	redPeer65001 = v2alpha1.CiliumBGPNodePeer{
+		Name:        "red-peer-65001",
+		PeerAddress: ptr.To[string]("10.10.10.1"),
+		PeerConfigRef: &v2alpha1.PeerConfigReference{
+			Group: "cilium.io",
+			Kind:  "CiliumBGPPeerConfig",
+			Name:  "peer-config-red",
+		},
+	}
+
+	bluePeer65001 = v2alpha1.CiliumBGPNodePeer{
+		Name:        "blue-peer-65001",
+		PeerAddress: ptr.To[string]("10.10.10.2"),
+		PeerConfigRef: &v2alpha1.PeerConfigReference{
+			Group: "cilium.io",
+			Kind:  "CiliumBGPPeerConfig",
+			Name:  "peer-config-blue",
 		},
 	}
 )

--- a/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
@@ -14,6 +14,8 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -38,7 +40,8 @@ type PodCIDRReconciler struct {
 
 // PodCIDRReconcilerMetadata is a map of advertisements per family, key is family type
 type PodCIDRReconcilerMetadata struct {
-	AFPaths AFPathsMap
+	AFPaths       AFPathsMap
+	RoutePolicies RoutePolicyMap
 }
 
 func NewPodCIDRReconciler(params PodCIDRReconcilerIn) PodCIDRReconcilerOut {
@@ -82,8 +85,25 @@ func (r *PodCIDRReconciler) Reconcile(ctx context.Context, p ReconcileParams) er
 		podCIDRPrefixes = append(podCIDRPrefixes, prefix)
 	}
 
+	// get per peer per family pod cidr advertisements
+	desiredPeerAdverts, err := r.peerAdvert.GetConfiguredAdvertisements(p.DesiredConfig, v2alpha1.BGPPodCIDRAdvert)
+	if err != nil {
+		return err
+	}
+
+	err = r.reconcileRoutePolicies(ctx, p, desiredPeerAdverts, podCIDRPrefixes)
+	if err != nil {
+		return err
+	}
+
+	return r.reconcilePaths(ctx, p, desiredPeerAdverts, podCIDRPrefixes)
+}
+
+func (r *PodCIDRReconciler) reconcilePaths(ctx context.Context, p ReconcileParams, desiredPeerAdverts PeerAdvertisements, podPrefixes []netip.Prefix) error {
+	metadata := r.getMetadata(p.BGPInstance)
+
 	// get desired paths per address family
-	desiredFamilyAdverts, err := r.getDesiredPathsPerFamily(p, podCIDRPrefixes)
+	desiredFamilyAdverts, err := r.getDesiredPathsPerFamily(desiredPeerAdverts, podPrefixes)
 	if err != nil {
 		return err
 	}
@@ -94,24 +114,41 @@ func (r *PodCIDRReconciler) Reconcile(ctx context.Context, p ReconcileParams) er
 		Ctx:          ctx,
 		Instance:     p.BGPInstance,
 		DesiredPaths: desiredFamilyAdverts,
-		CurrentPaths: r.getMetadata(p.BGPInstance).AFPaths,
+		CurrentPaths: metadata.AFPaths,
 	})
 
-	// We set the metadata even if there is an error to make sure metadata state matches underlying BGP instance state.
-	r.setMetadata(p.BGPInstance, PodCIDRReconcilerMetadata{AFPaths: updatedAFPaths})
+	metadata.AFPaths = updatedAFPaths
+	r.setMetadata(p.BGPInstance, metadata)
+	return err
+}
+
+func (r *PodCIDRReconciler) reconcileRoutePolicies(ctx context.Context, p ReconcileParams, desiredPeerAdverts PeerAdvertisements, podPrefixes []netip.Prefix) error {
+	metadata := r.getMetadata(p.BGPInstance)
+
+	// get desired policies
+	desiredRoutePolicies, err := r.getDesiredRoutePolicies(p, desiredPeerAdverts, podPrefixes)
+	if err != nil {
+		return err
+	}
+
+	// reconcile route policies
+	updatedPolicies, err := ReconcileRoutePolicies(&ReconcileRoutePoliciesParams{
+		Logger:          r.logger.WithField(types.InstanceLogField, p.DesiredConfig.Name),
+		Ctx:             ctx,
+		Instance:        p.BGPInstance,
+		DesiredPolicies: desiredRoutePolicies,
+		CurrentPolicies: r.getMetadata(p.BGPInstance).RoutePolicies,
+	})
+
+	metadata.RoutePolicies = updatedPolicies
+	r.setMetadata(p.BGPInstance, metadata)
 	return err
 }
 
 // getDesiredPathsPerFamily returns a map of desired paths per address family.
 // Note: This returns prefixes per address family. Global routing table will contain prefix per family not per neighbor.
 // Per neighbor advertisement will be controlled by BGP Policy.
-func (r *PodCIDRReconciler) getDesiredPathsPerFamily(p ReconcileParams, desiredPrefixes []netip.Prefix) (AFPathsMap, error) {
-	// get per peer per family pod cidr advertisements
-	desiredPeerAdverts, err := r.peerAdvert.GetConfiguredAdvertisements(p.DesiredConfig, v2alpha1.BGPPodCIDRAdvert)
-	if err != nil {
-		return nil, err
-	}
-
+func (r *PodCIDRReconciler) getDesiredPathsPerFamily(desiredPeerAdverts PeerAdvertisements, desiredPrefixes []netip.Prefix) (AFPathsMap, error) {
 	// Calculate desired paths per address family, collapsing per-peer advertisements into per-family advertisements.
 	desiredFamilyAdverts := make(AFPathsMap)
 	for _, peerFamilyAdverts := range desiredPeerAdverts {
@@ -144,10 +181,63 @@ func (r *PodCIDRReconciler) getDesiredPathsPerFamily(p ReconcileParams, desiredP
 	return desiredFamilyAdverts, nil
 }
 
+func (r *PodCIDRReconciler) getDesiredRoutePolicies(p ReconcileParams, desiredPeerAdverts PeerAdvertisements, desiredPrefixes []netip.Prefix) (RoutePolicyMap, error) {
+	desiredPolicies := make(RoutePolicyMap)
+
+	for peer, afAdverts := range desiredPeerAdverts {
+		peerAddr, err := GetPeerAddressFromConfig(p.DesiredConfig, peer)
+		if err != nil {
+			return nil, err
+		}
+
+		for family, adverts := range afAdverts {
+			fam := types.ToAgentFamily(family)
+
+			for _, advert := range adverts {
+				labelSelector, err := slim_metav1.LabelSelectorAsSelector(advert.Selector)
+				if err != nil {
+					return nil, fmt.Errorf("failed constructing LabelSelector: %w", err)
+				}
+
+				// if there is a label selector in advertisement, check if it matches cilium node label.
+				// No selector means it matches the node.
+				if advert.Selector != nil && !labelSelector.Matches(labels.Set(p.CiliumNode.Labels)) {
+					continue
+				}
+
+				var v4Prefixes, v6Prefixes types.PolicyPrefixMatchList
+				for _, prefix := range desiredPrefixes {
+					match := &types.RoutePolicyPrefixMatch{CIDR: prefix, PrefixLenMin: prefix.Bits(), PrefixLenMax: prefix.Bits()}
+
+					if fam.Afi == types.AfiIPv4 && prefix.Addr().Is4() {
+						v4Prefixes = append(v4Prefixes, match)
+					}
+
+					if fam.Afi == types.AfiIPv6 && prefix.Addr().Is6() {
+						v6Prefixes = append(v6Prefixes, match)
+					}
+				}
+
+				if len(v6Prefixes) > 0 || len(v4Prefixes) > 0 {
+					name := PolicyName(peer, fam.Afi.String(), string(advert.AdvertisementType))
+					policy, err := CreatePolicy(name, peerAddr, v4Prefixes, v6Prefixes, advert)
+					if err != nil {
+						return nil, err
+					}
+					desiredPolicies[name] = policy
+				}
+			}
+		}
+	}
+
+	return desiredPolicies, nil
+}
+
 func (r *PodCIDRReconciler) getMetadata(i *instance.BGPInstance) PodCIDRReconcilerMetadata {
 	if _, found := i.Metadata[r.Name()]; !found {
 		i.Metadata[r.Name()] = PodCIDRReconcilerMetadata{
-			AFPaths: make(AFPathsMap),
+			AFPaths:       make(AFPathsMap),
+			RoutePolicies: make(RoutePolicyMap),
 		}
 	}
 	return i.Metadata[r.Name()].(PodCIDRReconcilerMetadata)

--- a/pkg/bgpv1/manager/reconcilerv2/pod_cidr_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_cidr_test.go
@@ -34,6 +34,118 @@ var (
 	podCIDR2v6 = "2001:db8:2::/96"
 	podCIDR3v4 = "10.10.3.0/24"
 	podCIDR3v6 = "2001:db8:3::/96"
+
+	redPeer65001v4PodCIDRRoutePolicy = &types.RoutePolicy{
+		Name: "red-peer-65001-ipv4-PodCIDR",
+		Type: types.RoutePolicyTypeExport,
+		Statements: []*types.RoutePolicyStatement{
+			{
+				Conditions: types.RoutePolicyConditions{
+					MatchNeighbors: []string{"10.10.10.1/32"},
+					MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+						{
+							CIDR:         netip.MustParsePrefix(podCIDR1v4),
+							PrefixLenMin: netip.MustParsePrefix(podCIDR1v4).Bits(),
+							PrefixLenMax: netip.MustParsePrefix(podCIDR1v4).Bits(),
+						},
+						{
+							CIDR:         netip.MustParsePrefix(podCIDR2v4),
+							PrefixLenMin: netip.MustParsePrefix(podCIDR2v4).Bits(),
+							PrefixLenMax: netip.MustParsePrefix(podCIDR2v4).Bits(),
+						},
+					},
+				},
+				Actions: types.RoutePolicyActions{
+					RouteAction:    types.RoutePolicyActionAccept,
+					AddCommunities: []string{"65000:100"},
+				},
+			},
+		},
+	}
+
+	redPeer65001v6PodCIDRRoutePolicy = &types.RoutePolicy{
+		Name: "red-peer-65001-ipv6-PodCIDR",
+		Type: types.RoutePolicyTypeExport,
+		Statements: []*types.RoutePolicyStatement{
+			{
+				Conditions: types.RoutePolicyConditions{
+					MatchNeighbors: []string{"10.10.10.1/32"},
+					MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+						{
+							CIDR:         netip.MustParsePrefix(podCIDR1v6),
+							PrefixLenMin: netip.MustParsePrefix(podCIDR1v6).Bits(),
+							PrefixLenMax: netip.MustParsePrefix(podCIDR1v6).Bits(),
+						},
+						{
+							CIDR:         netip.MustParsePrefix(podCIDR2v6),
+							PrefixLenMin: netip.MustParsePrefix(podCIDR2v6).Bits(),
+							PrefixLenMax: netip.MustParsePrefix(podCIDR2v6).Bits(),
+						},
+					},
+				},
+				Actions: types.RoutePolicyActions{
+					RouteAction:    types.RoutePolicyActionAccept,
+					AddCommunities: []string{"65000:100"},
+				},
+			},
+		},
+	}
+
+	bluePeer65001v4PodCIDRRoutePolicy = &types.RoutePolicy{
+		Name: "blue-peer-65001-ipv4-PodCIDR",
+		Type: types.RoutePolicyTypeExport,
+		Statements: []*types.RoutePolicyStatement{
+			{
+				Conditions: types.RoutePolicyConditions{
+					MatchNeighbors: []string{"10.10.10.2/32"},
+					MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+						{
+							CIDR:         netip.MustParsePrefix(podCIDR1v4),
+							PrefixLenMin: netip.MustParsePrefix(podCIDR1v4).Bits(),
+							PrefixLenMax: netip.MustParsePrefix(podCIDR1v4).Bits(),
+						},
+						{
+							CIDR:         netip.MustParsePrefix(podCIDR2v4),
+							PrefixLenMin: netip.MustParsePrefix(podCIDR2v4).Bits(),
+							PrefixLenMax: netip.MustParsePrefix(podCIDR2v4).Bits(),
+						},
+					},
+				},
+				Actions: types.RoutePolicyActions{
+					RouteAction:    types.RoutePolicyActionAccept,
+					AddCommunities: []string{"65355:100"},
+				},
+			},
+		},
+	}
+
+	bluePeer65001v6PodCIDRRoutePolicy = &types.RoutePolicy{
+		Name: "blue-peer-65001-ipv6-PodCIDR",
+		Type: types.RoutePolicyTypeExport,
+		Statements: []*types.RoutePolicyStatement{
+			{
+				Conditions: types.RoutePolicyConditions{
+					MatchNeighbors: []string{"10.10.10.2/32"},
+					MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+						{
+							CIDR:         netip.MustParsePrefix(podCIDR1v6),
+							PrefixLenMin: netip.MustParsePrefix(podCIDR1v6).Bits(),
+							PrefixLenMax: netip.MustParsePrefix(podCIDR1v6).Bits(),
+						},
+						{
+							CIDR:         netip.MustParsePrefix(podCIDR2v6),
+							PrefixLenMin: netip.MustParsePrefix(podCIDR2v6).Bits(),
+							PrefixLenMax: netip.MustParsePrefix(podCIDR2v6).Bits(),
+						},
+					},
+				},
+				Actions: types.RoutePolicyActions{
+					RouteAction:    types.RoutePolicyActionAccept,
+					AddCommunities: []string{"65355:100"},
+				},
+			},
+		},
+	}
 )
 
 func Test_PodCIDRAdvertisement(t *testing.T) {
@@ -43,10 +155,12 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 		name                  string
 		peerConfig            []*v2alpha1.CiliumBGPPeerConfig
 		advertisements        []*v2alpha1.CiliumBGPAdvertisement
-		preconfiguredAdverts  map[types.Family]map[string]struct{}
+		preconfiguredPaths    map[types.Family]map[string]struct{}
+		preconfiguredRPs      RoutePolicyMap
 		testCiliumNode        *v2api.CiliumNode
 		testBGPInstanceConfig *v2alpha1.CiliumBGPNodeInstance
-		expectedAdverts       map[types.Family]map[string]struct{}
+		expectedPaths         map[types.Family]map[string]struct{}
+		expectedRPs           RoutePolicyMap
 	}{
 		{
 			name: "pod cidr advertisement with no preconfigured advertisements",
@@ -58,7 +172,8 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				redAdvert,
 				blueAdvert,
 			},
-			preconfiguredAdverts: map[types.Family]map[string]struct{}{},
+			preconfiguredPaths: map[types.Family]map[string]struct{}{},
+			preconfiguredRPs:   map[string]*types.RoutePolicy{},
 			testCiliumNode: &v2api.CiliumNode{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "Test Node",
@@ -78,17 +193,10 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				Name:     "bgp-65001",
 				LocalASN: ptr.To[int64](65001),
 				Peers: []v2alpha1.CiliumBGPNodePeer{
-					{
-						Name: "red-peer-65001",
-						PeerConfigRef: &v2alpha1.PeerConfigReference{
-							Group: "cilium.io",
-							Kind:  "CiliumBGPPeerConfig",
-							Name:  "peer-config-red",
-						},
-					},
+					redPeer65001,
 				},
 			},
-			expectedAdverts: map[types.Family]map[string]struct{}{
+			expectedPaths: map[types.Family]map[string]struct{}{
 				{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 					podCIDR1v4: struct{}{},
 					podCIDR2v4: struct{}{},
@@ -97,6 +205,10 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 					podCIDR1v6: struct{}{},
 					podCIDR2v6: struct{}{},
 				},
+			},
+			expectedRPs: map[string]*types.RoutePolicy{
+				redPeer65001v4PodCIDRRoutePolicy.Name: redPeer65001v4PodCIDRRoutePolicy,
+				redPeer65001v6PodCIDRRoutePolicy.Name: redPeer65001v6PodCIDRRoutePolicy,
 			},
 		},
 		{
@@ -109,7 +221,7 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				redAdvert,
 				blueAdvert,
 			},
-			preconfiguredAdverts: map[types.Family]map[string]struct{}{},
+			preconfiguredPaths: map[types.Family]map[string]struct{}{},
 			testCiliumNode: &v2api.CiliumNode{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "Test Node",
@@ -129,25 +241,11 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				Name:     "bgp-65001",
 				LocalASN: ptr.To[int64](65001),
 				Peers: []v2alpha1.CiliumBGPNodePeer{
-					{
-						Name: "red-peer-65001",
-						PeerConfigRef: &v2alpha1.PeerConfigReference{
-							Group: "cilium.io",
-							Kind:  "CiliumBGPPeerConfig",
-							Name:  "peer-config-red",
-						},
-					},
-					{
-						Name: "blue-peer-65001",
-						PeerConfigRef: &v2alpha1.PeerConfigReference{
-							Group: "cilium.io",
-							Kind:  "CiliumBGPPeerConfig",
-							Name:  "peer-config-blue",
-						},
-					},
+					redPeer65001,
+					bluePeer65001,
 				},
 			},
-			expectedAdverts: map[types.Family]map[string]struct{}{
+			expectedPaths: map[types.Family]map[string]struct{}{
 				{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 					podCIDR1v4: struct{}{},
 					podCIDR2v4: struct{}{},
@@ -156,6 +254,12 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 					podCIDR1v6: struct{}{},
 					podCIDR2v6: struct{}{},
 				},
+			},
+			expectedRPs: map[string]*types.RoutePolicy{
+				redPeer65001v4PodCIDRRoutePolicy.Name:  redPeer65001v4PodCIDRRoutePolicy,
+				redPeer65001v6PodCIDRRoutePolicy.Name:  redPeer65001v6PodCIDRRoutePolicy,
+				bluePeer65001v4PodCIDRRoutePolicy.Name: bluePeer65001v4PodCIDRRoutePolicy,
+				bluePeer65001v6PodCIDRRoutePolicy.Name: bluePeer65001v6PodCIDRRoutePolicy,
 			},
 		},
 		{
@@ -168,12 +272,15 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				redAdvert,
 				blueAdvert,
 			},
-			preconfiguredAdverts: map[types.Family]map[string]struct{}{
+			preconfiguredPaths: map[types.Family]map[string]struct{}{
 				// pod cidr 3 is extra advertisement, reconcile should clean this.
 				{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 					podCIDR3v4: struct{}{},
 					podCIDR3v6: struct{}{},
 				},
+			},
+			preconfiguredRPs: map[string]*types.RoutePolicy{
+				bluePeer65001v4PodCIDRRoutePolicy.Name: bluePeer65001v4PodCIDRRoutePolicy,
 			},
 			testCiliumNode: &v2api.CiliumNode{
 				ObjectMeta: meta_v1.ObjectMeta{
@@ -189,22 +296,18 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				Name:     "bgp-65001",
 				LocalASN: ptr.To[int64](65001),
 				Peers: []v2alpha1.CiliumBGPNodePeer{
-					{
-						Name: "red-peer-65001",
-						PeerConfigRef: &v2alpha1.PeerConfigReference{
-							Group: "cilium.io",
-							Kind:  "CiliumBGPPeerConfig",
-							Name:  "peer-config-red",
-						},
-					},
+					redPeer65001,
 				},
 			},
-			expectedAdverts: map[types.Family]map[string]struct{}{
+			expectedPaths: map[types.Family]map[string]struct{}{
 				{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 					podCIDR1v4: struct{}{},
 					podCIDR2v4: struct{}{},
 				},
 				{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {},
+			},
+			expectedRPs: map[string]*types.RoutePolicy{
+				redPeer65001v4PodCIDRRoutePolicy.Name: redPeer65001v4PodCIDRRoutePolicy,
 			},
 		},
 		{
@@ -218,12 +321,18 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				//redPodCIDRAdvert,
 				//bluePodCIDRAdvert,
 			},
-			preconfiguredAdverts: map[types.Family]map[string]struct{}{
+			preconfiguredPaths: map[types.Family]map[string]struct{}{
 				// pod cidr 1,2 already advertised, reconcile should clean this as there is no matching pod cidr advertisement.
 				{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 					podCIDR1v4: struct{}{},
 					podCIDR2v4: struct{}{},
 				},
+			},
+			preconfiguredRPs: map[string]*types.RoutePolicy{
+				redPeer65001v4PodCIDRRoutePolicy.Name:  redPeer65001v4PodCIDRRoutePolicy,
+				redPeer65001v6PodCIDRRoutePolicy.Name:  redPeer65001v6PodCIDRRoutePolicy,
+				bluePeer65001v4PodCIDRRoutePolicy.Name: bluePeer65001v4PodCIDRRoutePolicy,
+				bluePeer65001v6PodCIDRRoutePolicy.Name: bluePeer65001v6PodCIDRRoutePolicy,
 			},
 			testCiliumNode: &v2api.CiliumNode{
 				ObjectMeta: meta_v1.ObjectMeta{
@@ -239,20 +348,14 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				Name:     "bgp-65001",
 				LocalASN: ptr.To[int64](65001),
 				Peers: []v2alpha1.CiliumBGPNodePeer{
-					{
-						Name: "red-peer-65001",
-						PeerConfigRef: &v2alpha1.PeerConfigReference{
-							Group: "cilium.io",
-							Kind:  "CiliumBGPPeerConfig",
-							Name:  "peer-config-red",
-						},
-					},
+					redPeer65001,
 				},
 			},
-			expectedAdverts: map[types.Family]map[string]struct{}{
+			expectedPaths: map[types.Family]map[string]struct{}{
 				{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {},
 				{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {},
 			},
+			expectedRPs: map[string]*types.RoutePolicy{},
 		},
 		{
 			name: "pod cidr advertisement - v4 only",
@@ -263,7 +366,7 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				redAdvert,
 				//bluePodCIDRAdvert,
 			},
-			preconfiguredAdverts: map[types.Family]map[string]struct{}{
+			preconfiguredPaths: map[types.Family]map[string]struct{}{
 				{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 					podCIDR1v4: struct{}{},
 					podCIDR2v4: struct{}{},
@@ -272,6 +375,10 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 					podCIDR1v6: struct{}{},
 					podCIDR2v6: struct{}{},
 				},
+			},
+			preconfiguredRPs: map[string]*types.RoutePolicy{
+				redPeer65001v4PodCIDRRoutePolicy.Name: redPeer65001v4PodCIDRRoutePolicy,
+				redPeer65001v6PodCIDRRoutePolicy.Name: redPeer65001v6PodCIDRRoutePolicy,
 			},
 			testCiliumNode: &v2api.CiliumNode{
 				ObjectMeta: meta_v1.ObjectMeta{
@@ -288,7 +395,8 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				LocalASN: ptr.To[int64](65001),
 				Peers: []v2alpha1.CiliumBGPNodePeer{
 					{
-						Name: "red-peer-65001",
+						Name:        "red-peer-65001",
+						PeerAddress: ptr.To[string]("10.10.10.1"),
 						PeerConfigRef: &v2alpha1.PeerConfigReference{
 							Group: "cilium.io",
 							Kind:  "CiliumBGPPeerConfig",
@@ -297,11 +405,14 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 					},
 				},
 			},
-			expectedAdverts: map[types.Family]map[string]struct{}{
+			expectedPaths: map[types.Family]map[string]struct{}{
 				{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 					podCIDR1v4: struct{}{},
 					podCIDR2v4: struct{}{},
 				},
+			},
+			expectedRPs: map[string]*types.RoutePolicy{
+				redPeer65001v4PodCIDRRoutePolicy.Name: redPeer65001v4PodCIDRRoutePolicy,
 			},
 		},
 	}
@@ -327,7 +438,7 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 			testBGPInstance := instance.NewFakeBGPInstance()
 
 			presetAdverts := make(AFPathsMap)
-			for preAdvertFam, preAdverts := range tt.preconfiguredAdverts {
+			for preAdvertFam, preAdverts := range tt.preconfiguredPaths {
 				pathSet := make(map[string]*types.Path)
 				for preAdvert := range preAdverts {
 					path := types.NewPathForPrefix(netip.MustParsePrefix(preAdvert))
@@ -336,7 +447,10 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				}
 				presetAdverts[preAdvertFam] = pathSet
 			}
-			podCIDRReconciler.setMetadata(testBGPInstance, PodCIDRReconcilerMetadata{presetAdverts})
+			podCIDRReconciler.setMetadata(testBGPInstance, PodCIDRReconcilerMetadata{
+				AFPaths:       presetAdverts,
+				RoutePolicies: tt.preconfiguredRPs,
+			})
 
 			// reconcile pod cidr
 			// run reconciler twice to ensure idempotency
@@ -359,7 +473,11 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				runningFamilyPaths[family] = pathSet
 			}
 
-			req.Equal(tt.expectedAdverts, runningFamilyPaths)
+			req.Equal(tt.expectedPaths, runningFamilyPaths)
+
+			// check if the route policies are as expected
+			runningRPs := podCIDRReconciler.getMetadata(testBGPInstance).RoutePolicies
+			req.Equal(tt.expectedRPs, runningRPs)
 		})
 	}
 }

--- a/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool.go
@@ -48,12 +48,9 @@ type PodIPPoolReconciler struct {
 	poolStore  store.BGPCPResourceStore[*v2alpha1.CiliumPodIPPool]
 }
 
-// PoolAFPathsMap holds the desired paths per address family keyed by the pool name of the backing CiliumPodIPPool.
-type PoolAFPathsMap map[resource.Key]AFPathsMap
-
 // PodIPPoolReconcilerMetadata holds any announced pod ip pool CIDRs keyed by pool name of the backing CiliumPodIPPool.
 type PodIPPoolReconcilerMetadata struct {
-	PoolAFPaths       PoolAFPathsMap
+	PoolAFPaths       ResourceAFPathsMap
 	PoolRoutePolicies ResourceRoutePolicyMap
 }
 
@@ -141,8 +138,8 @@ func (r *PodIPPoolReconciler) reconcilePaths(ctx context.Context, p ReconcilePar
 	return err
 }
 
-func (r *PodIPPoolReconciler) getDesiredPoolAFPaths(p ReconcileParams, desiredFamilyAdverts PeerAdvertisements, lp map[string][]netip.Prefix) (PoolAFPathsMap, error) {
-	desiredPoolAFPaths := make(PoolAFPathsMap)
+func (r *PodIPPoolReconciler) getDesiredPoolAFPaths(p ReconcileParams, desiredFamilyAdverts PeerAdvertisements, lp map[string][]netip.Prefix) (ResourceAFPathsMap, error) {
+	desiredPoolAFPaths := make(ResourceAFPathsMap)
 
 	metadata := r.getMetadata(p.BGPInstance)
 
@@ -419,7 +416,7 @@ func podIPPoolLabelSet(pool *v2alpha1.CiliumPodIPPool) labels.Labels {
 func (r *PodIPPoolReconciler) getMetadata(i *instance.BGPInstance) PodIPPoolReconcilerMetadata {
 	if _, found := i.Metadata[r.Name()]; !found {
 		i.Metadata[r.Name()] = PodIPPoolReconcilerMetadata{
-			PoolAFPaths:       make(PoolAFPathsMap),
+			PoolAFPaths:       make(ResourceAFPathsMap),
 			PoolRoutePolicies: make(ResourceRoutePolicyMap),
 		}
 	}

--- a/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool_test.go
@@ -606,7 +606,7 @@ func Test_PodIPPoolAdvertisements(t *testing.T) {
 			testBGPInstance := instance.NewFakeBGPInstance()
 
 			// set the preconfigured advertisements
-			presetPoolAFPaths := make(PoolAFPathsMap)
+			presetPoolAFPaths := make(ResourceAFPathsMap)
 			for pool, prePoolAFPaths := range tt.preconfiguredPoolAFPaths {
 				presetPoolAFPaths[pool] = make(AFPathsMap)
 				for fam, afPaths := range prePoolAFPaths {

--- a/pkg/bgpv1/manager/reconcilerv2/policies.go
+++ b/pkg/bgpv1/manager/reconcilerv2/policies.go
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconcilerv2
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"net/netip"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
+	"github.com/cilium/cilium/pkg/bgpv1/types"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+)
+
+const (
+	MaxPrefixLenIPv4 = 32
+	MaxPrefixLenIPv6 = 128
+)
+
+// ResourceRoutePolicyMap holds the route policies per resource.
+type ResourceRoutePolicyMap map[resource.Key]RoutePolicyMap
+
+// RoutePolicyMap holds routing policies configured by the policy reconciler keyed by policy name.
+type RoutePolicyMap map[string]*types.RoutePolicy
+
+type ReconcileRoutePoliciesParams struct {
+	Logger          logrus.FieldLogger
+	Ctx             context.Context
+	Instance        *instance.BGPInstance
+	DesiredPolicies RoutePolicyMap
+	CurrentPolicies RoutePolicyMap
+}
+
+// ReconcileRoutePolicies reconciles routing policies between the desired and the current state.
+// It returns the updated routing policies and an error if the reconciliation fails.
+func ReconcileRoutePolicies(rp *ReconcileRoutePoliciesParams) (RoutePolicyMap, error) {
+	runningPolicies := make(RoutePolicyMap)
+	maps.Copy(runningPolicies, rp.CurrentPolicies)
+
+	var toAdd, toRemove, toUpdate []*types.RoutePolicy
+
+	for _, p := range rp.DesiredPolicies {
+		if existing, found := rp.CurrentPolicies[p.Name]; found {
+			if !existing.DeepEqual(p) {
+				toUpdate = append(toUpdate, p)
+			}
+		} else {
+			toAdd = append(toAdd, p)
+		}
+	}
+	for _, p := range rp.CurrentPolicies {
+		if _, found := rp.DesiredPolicies[p.Name]; !found {
+			toRemove = append(toRemove, p)
+		}
+	}
+
+	// tracks which peers have to be reset because of policy change
+	resetPeers := sets.New[string]()
+
+	// add missing policies
+	for _, p := range toAdd {
+		rp.Logger.WithFields(logrus.Fields{
+			types.PolicyLogField: p.Name,
+		}).Debug("Adding route policy")
+
+		err := rp.Instance.Router.AddRoutePolicy(rp.Ctx, types.RoutePolicyRequest{
+			DefaultExportAction: types.RoutePolicyActionReject, // do not advertise routes by default
+			Policy:              p,
+		})
+		if err != nil {
+			return runningPolicies, err
+		}
+
+		runningPolicies[p.Name] = p
+		resetPeers.Insert(peerAddressFromPolicy(p))
+	}
+
+	// update modified policies
+	for _, p := range toUpdate {
+		// As proper implementation of an update operation for complex policies would be quite involved,
+		// we resort to recreating the policies that need an update here.
+		rp.Logger.WithFields(logrus.Fields{
+			types.PolicyLogField: p.Name,
+		}).Debug("Updating (re-creating) route policy")
+
+		existing := rp.CurrentPolicies[p.Name]
+		err := rp.Instance.Router.RemoveRoutePolicy(rp.Ctx, types.RoutePolicyRequest{Policy: existing})
+		if err != nil {
+			return runningPolicies, err
+		}
+		delete(runningPolicies, existing.Name)
+
+		err = rp.Instance.Router.AddRoutePolicy(rp.Ctx, types.RoutePolicyRequest{
+			DefaultExportAction: types.RoutePolicyActionReject, // do not advertise routes by default
+			Policy:              p,
+		})
+		if err != nil {
+			return runningPolicies, err
+		}
+
+		runningPolicies[p.Name] = p
+		resetPeers.Insert(peerAddressFromPolicy(p))
+	}
+
+	// remove old policies
+	for _, p := range toRemove {
+		rp.Logger.WithFields(logrus.Fields{
+			types.PolicyLogField: p.Name,
+		}).Debug("Removing route policy")
+
+		err := rp.Instance.Router.RemoveRoutePolicy(rp.Ctx, types.RoutePolicyRequest{Policy: p})
+		if err != nil {
+			return runningPolicies, err
+		}
+		delete(runningPolicies, p.Name)
+		resetPeers.Insert(peerAddressFromPolicy(p))
+	}
+
+	// soft-reset affected BGP peers to apply the changes on already advertised routes
+	for peer := range resetPeers {
+		_, err := netip.ParsePrefix(peer)
+		if err != nil {
+			continue
+		}
+
+		rp.Logger.WithFields(logrus.Fields{
+			types.PeerLogField: peer,
+		}).Debug("Resetting peer due to a routing policy change")
+
+		req := types.ResetNeighborRequest{
+			PeerAddress:        peer,
+			Soft:               true,
+			SoftResetDirection: types.SoftResetDirectionOut, // we are using only export policies
+		}
+
+		err = rp.Instance.Router.ResetNeighbor(rp.Ctx, req)
+		if err != nil {
+			// non-fatal error (may happen if the neighbor is not up), just log it
+			rp.Logger.WithFields(logrus.Fields{
+				types.PeerLogField: peer,
+			}).WithError(err).Debug("resetting peer failed after a routing policy change")
+		}
+	}
+
+	return runningPolicies, nil
+}
+
+func PolicyName(peer, family, advertType string) string {
+	return fmt.Sprintf("%s-%s-%s", peer, family, advertType)
+}
+
+func CreatePolicy(name string, peerAddr netip.Addr, v4Prefixes, v6Prefixes types.PolicyPrefixMatchList, advert v2alpha1.BGPAdvertisement) (*types.RoutePolicy, error) {
+	policy := &types.RoutePolicy{
+		Name: name,
+		Type: types.RoutePolicyTypeExport,
+	}
+
+	// sort prefixes to have consistent order for DeepEqual
+	sort.Slice(v4Prefixes, v4Prefixes.Less)
+	sort.Slice(v6Prefixes, v6Prefixes.Less)
+
+	// get communities
+	communities, largeCommunities, err := getCommunities(advert)
+	if err != nil {
+		return nil, err
+	}
+
+	// get local preference
+	var localPref *int64
+	if advert.Attributes != nil {
+		localPref = advert.Attributes.LocalPreference
+	}
+
+	// Due to a GoBGP limitation, we need to generate a separate statement for v4 and v6 prefixes, as families
+	// can not be mixed in a single statement. Nevertheless, they can be both part of the same Policy.
+	if len(v4Prefixes) > 0 {
+		policy.Statements = append(policy.Statements, policyStatement(peerAddr, v4Prefixes, localPref, communities, largeCommunities))
+	}
+	if len(v6Prefixes) > 0 {
+		policy.Statements = append(policy.Statements, policyStatement(peerAddr, v6Prefixes, localPref, communities, largeCommunities))
+	}
+
+	return policy, nil
+}
+
+func getCommunities(advert v2alpha1.BGPAdvertisement) (standard, large []string, err error) {
+	standard, err = mergeAndDedupCommunities(advert)
+	if err != nil {
+		return nil, nil, err
+	}
+	large = dedupLargeCommunities(advert)
+
+	return standard, large, nil
+}
+
+// mergeAndDedupCommunities merges numeric standard community and well-known community strings,
+// deduplicated by their actual community values.
+func mergeAndDedupCommunities(advert v2alpha1.BGPAdvertisement) ([]string, error) {
+	var res []string
+
+	if advert.Attributes == nil || advert.Attributes.Communities == nil {
+		return res, nil
+	}
+
+	standard := advert.Attributes.Communities.Standard
+	wellKnown := advert.Attributes.Communities.WellKnown
+
+	existing := sets.New[uint32]()
+	for _, c := range standard {
+		val, err := parseCommunity(string(c))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse standard BGP community: %w", err)
+		}
+		if existing.Has(val) {
+			continue
+		}
+		existing.Insert(val)
+		res = append(res, string(c))
+	}
+
+	for _, c := range wellKnown {
+		val, ok := bgp.WellKnownCommunityValueMap[string(c)]
+		if !ok {
+			return nil, fmt.Errorf("invalid well-known community value '%s'", c)
+		}
+		if existing.Has(uint32(val)) {
+			continue
+		}
+		existing.Insert(uint32(val))
+		res = append(res, string(c))
+	}
+	return res, nil
+}
+
+func parseCommunity(communityStr string) (uint32, error) {
+	// parse as <0-65535>:<0-65535>
+	if elems := strings.Split(communityStr, ":"); len(elems) == 2 {
+		fst, err := strconv.ParseUint(elems[0], 10, 16)
+		if err != nil {
+			return 0, err
+		}
+		snd, err := strconv.ParseUint(elems[1], 10, 16)
+		if err != nil {
+			return 0, err
+		}
+		return uint32(fst<<16 | snd), nil
+	}
+	// parse as a single decimal number
+	c, err := strconv.ParseUint(communityStr, 10, 32)
+	return uint32(c), err
+}
+
+// dedupLargeCommunities returns deduplicated large communities as a string slice.
+func dedupLargeCommunities(advert v2alpha1.BGPAdvertisement) []string {
+	var res []string
+
+	if advert.Attributes == nil || advert.Attributes.Communities == nil {
+		return res
+	}
+
+	communities := advert.Attributes.Communities.Large
+
+	existing := sets.New[string]()
+	for _, c := range communities {
+		if existing.Has(string(c)) {
+			continue
+		}
+		existing.Insert(string(c))
+		res = append(res, string(c))
+	}
+	return res
+}
+
+func policyStatement(neighborAddr netip.Addr, prefixes []*types.RoutePolicyPrefixMatch, localPref *int64, communities, largeCommunities []string) *types.RoutePolicyStatement {
+	// create /32 or /128 neighbor prefix match
+	neighborPrefix := netip.PrefixFrom(neighborAddr, neighborAddr.BitLen())
+
+	return &types.RoutePolicyStatement{
+		Conditions: types.RoutePolicyConditions{
+			MatchNeighbors: []string{neighborPrefix.String()},
+			MatchPrefixes:  prefixes,
+		},
+		Actions: types.RoutePolicyActions{
+			RouteAction:         types.RoutePolicyActionAccept,
+			SetLocalPreference:  localPref,
+			AddCommunities:      communities,
+			AddLargeCommunities: largeCommunities,
+		},
+	}
+}
+
+// peerAddressFromPolicy returns the first neighbor address found in a routing policy.
+func peerAddressFromPolicy(p *types.RoutePolicy) string {
+	if p == nil {
+		return ""
+	}
+	for _, s := range p.Statements {
+		for _, m := range s.Conditions.MatchNeighbors {
+			return m
+		}
+	}
+	return ""
+}

--- a/pkg/bgpv1/manager/reconcilerv2/service_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service_test.go
@@ -501,7 +501,7 @@ func Test_ServiceLBReconciler(t *testing.T) {
 			lbIPPools:      []*v2alpha1.CiliumLoadBalancerIPPool{redLBPool},
 			advertisements: nil,
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths:         ServiceAFPathsMap{},
+				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
 					"red-peer-65001": PeerFamilyAdvertisements{
@@ -521,7 +521,7 @@ func Test_ServiceLBReconciler(t *testing.T) {
 				redSvcAdvertWithAdvertisements(lbSvcAdvertWithSelector(mismatchSvcSelector)),
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths:         ServiceAFPathsMap{},
+				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
 					"red-peer-65001": PeerFamilyAdvertisements{
@@ -545,7 +545,7 @@ func Test_ServiceLBReconciler(t *testing.T) {
 				redSvcAdvertWithAdvertisements(lbSvcAdvertWithSelector(redSvcSelector)),
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths: ServiceAFPathsMap{
+				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
@@ -584,7 +584,7 @@ func Test_ServiceLBReconciler(t *testing.T) {
 				redSvcAdvertWithAdvertisements(lbSvcAdvertWithSelector(redSvcSelector)),
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths: ServiceAFPathsMap{
+				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
@@ -623,7 +623,7 @@ func Test_ServiceLBReconciler(t *testing.T) {
 				redSvcAdvertWithAdvertisements(lbSvcAdvertWithSelector(redSvcSelector)),
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths: ServiceAFPathsMap{
+				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
@@ -662,7 +662,7 @@ func Test_ServiceLBReconciler(t *testing.T) {
 				redSvcAdvertWithAdvertisements(lbSvcAdvertWithSelector(redSvcSelector)),
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths:         ServiceAFPathsMap{},
+				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
 					"red-peer-65001": PeerFamilyAdvertisements{
@@ -739,7 +739,7 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 			services:       []*slim_corev1.Service{redExternalSvc},
 			advertisements: nil,
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths:         ServiceAFPathsMap{},
+				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				LBPoolRoutePolicies:  ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
@@ -758,7 +758,7 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 				redSvcAdvertWithAdvertisements(externalSvcAdvertWithSelector(mismatchSvcSelector)),
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths:         ServiceAFPathsMap{},
+				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				LBPoolRoutePolicies:  ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
@@ -781,7 +781,7 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 				redSvcAdvertWithAdvertisements(externalSvcAdvertWithSelector(redSvcSelector)),
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths: ServiceAFPathsMap{
+				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 							externalV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
@@ -819,7 +819,7 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 				redSvcAdvertWithAdvertisements(externalSvcAdvertWithSelector(redSvcSelector)),
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths: ServiceAFPathsMap{
+				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 							externalV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
@@ -857,7 +857,7 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 				redSvcAdvertWithAdvertisements(externalSvcAdvertWithSelector(redSvcSelector)),
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths: ServiceAFPathsMap{
+				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 							externalV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
@@ -895,7 +895,7 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 				redSvcAdvertWithAdvertisements(externalSvcAdvertWithSelector(redSvcSelector)),
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths:         ServiceAFPathsMap{},
+				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				LBPoolRoutePolicies:  ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
@@ -967,7 +967,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 			services:       []*slim_corev1.Service{redClusterSvc},
 			advertisements: nil,
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths:         ServiceAFPathsMap{},
+				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				LBPoolRoutePolicies:  ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
@@ -986,7 +986,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 				redSvcAdvertWithAdvertisements(clusterIPSvcAdvertWithSelector(mismatchSvcSelector)),
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths:         ServiceAFPathsMap{},
+				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				LBPoolRoutePolicies:  ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
@@ -1009,7 +1009,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 				redSvcAdvertWithAdvertisements(clusterIPSvcAdvertWithSelector(redSvcSelector)),
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths: ServiceAFPathsMap{
+				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 							clusterV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
@@ -1047,7 +1047,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 				redSvcAdvertWithAdvertisements(clusterIPSvcAdvertWithSelector(redSvcSelector)),
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths: ServiceAFPathsMap{
+				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 							clusterV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
@@ -1085,7 +1085,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 				redSvcAdvertWithAdvertisements(clusterIPSvcAdvertWithSelector(redSvcSelector)),
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths: ServiceAFPathsMap{
+				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 							clusterV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
@@ -1123,7 +1123,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 				redSvcAdvertWithAdvertisements(clusterIPSvcAdvertWithSelector(redSvcSelector)),
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths:         ServiceAFPathsMap{},
+				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				LBPoolRoutePolicies:  ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
@@ -1195,7 +1195,7 @@ func Test_ServiceAndAdvertisementModifications(t *testing.T) {
 			upsertServices: nil,
 			upsertEPs:      nil,
 			expectedMetadata: ServiceReconcilerMetadata{
-				ServicePaths:         ServiceAFPathsMap{},
+				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				LBPoolRoutePolicies:  ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
@@ -1226,7 +1226,7 @@ func Test_ServiceAndAdvertisementModifications(t *testing.T) {
 			upsertServices: []*slim_corev1.Service{redExternalAndClusterSvc},
 			expectedMetadata: ServiceReconcilerMetadata{
 				// Only cluster IPs are advertised
-				ServicePaths: ServiceAFPathsMap{
+				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 							clusterV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
@@ -1301,7 +1301,7 @@ func Test_ServiceAndAdvertisementModifications(t *testing.T) {
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
 				// Both cluster and external IPs are advertised
-				ServicePaths: ServiceAFPathsMap{
+				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 							clusterV4Prefix:  types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
@@ -1373,7 +1373,7 @@ func Test_ServiceAndAdvertisementModifications(t *testing.T) {
 			},
 			expectedMetadata: ServiceReconcilerMetadata{
 				// Both cluster and external IPs are withdrawn, since traffic policy is local and there are no endpoints.
-				ServicePaths:         ServiceAFPathsMap{},
+				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				LBPoolRoutePolicies:  ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
@@ -1423,7 +1423,7 @@ func Test_ServiceAndAdvertisementModifications(t *testing.T) {
 			upsertEPs: []*k8s.Endpoints{eps1Mixed},
 			expectedMetadata: ServiceReconcilerMetadata{
 				// Both cluster and external IPs are advertised since there is local endpoint.
-				ServicePaths: ServiceAFPathsMap{
+				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
 							clusterV4Prefix:  types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),

--- a/pkg/bgpv1/types/bgp.go
+++ b/pkg/bgpv1/types/bgp.go
@@ -180,7 +180,8 @@ type RoutePolicy struct {
 
 // RoutePolicyRequest contains parameters for adding or removing a routing policy.
 type RoutePolicyRequest struct {
-	Policy *RoutePolicy
+	DefaultExportAction RoutePolicyAction
+	Policy              *RoutePolicy
 }
 
 // GetPeerStateResponse contains state of peers configured in given instance

--- a/pkg/bgpv1/types/log.go
+++ b/pkg/bgpv1/types/log.go
@@ -39,4 +39,7 @@ const (
 
 	// PodIPPoolLogField is used as key for Pod IP pool in the log field.
 	PodIPPoolLogField = "pod_ip_pool"
+
+	// PolicyLogField is used as key for BGP policy in the log field.
+	PolicyLogField = "policy"
 )


### PR DESCRIPTION
This change introduces generic route policy reconciler which can be used by other advertisement reconcilers

Please check each commit for route policy integration 
- Pod CIDR
- Pod IP Pool
- Service 
  - LB Pool
  - Cluster IP / External IP 
 