### PR TITLE
v1.15 Backports 2024-05-06

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -89,7 +89,6 @@ jobs:
           yq -o=json "${work_dir}/k8s-versions.yaml" | jq . > "${destination_directory}/azure.json"
 
       - name: Generate Matrix
-        id: set-matrix
         run: |
           cd /tmp/generated/azure
 
@@ -104,7 +103,31 @@ jobs:
 
           echo "Generated matrix:"
           cat /tmp/matrix.json
-          echo "matrix=$(jq -c . < /tmp/matrix.json)" >> $GITHUB_OUTPUT
+
+      - name: Login to Azure
+        uses: azure/login@6b2456866fc08b011acb422a92a4aa20e2c4de32 # v2.1.0
+        with:
+          creds: ${{ secrets.AZURE_PR_SP_CREDS }}
+
+      - name: Filter Matrix
+        id: set-matrix
+        run: |
+          cp /tmp/matrix.json /tmp/result.json
+          jq -c '.include[]' /tmp/matrix.json | while read i; do
+            VERSION=$(echo $i | jq -r '.version')
+            LOCATION=$(echo $i | jq -r '.location')
+            az aks get-versions --location $LOCATION > /tmp/output
+            if grep -q -F $VERSION /tmp/output; then
+              echo "Version $VERSION is valid for location $LOCATION"
+            else
+              echo "Removing version $VERSION as it's not valid for location $LOCATION"
+              jq 'del(.include[] | select(.version == "'$VERSION'"))' /tmp/result.json > /tmp/result.json.tmp
+              mv /tmp/result.json.tmp /tmp/result.json
+            fi
+          done
+          echo "Filtered matrix:"
+          cat /tmp/result.json
+          echo "matrix=$(jq -c . < /tmp/result.json)" >> $GITHUB_OUTPUT
 
   installation-and-connectivity:
     name: Installation and Connectivity Test

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -453,8 +453,8 @@ jobs:
 
       - name: Wait for cluster mesh status to be ready
         run: |
-          cilium --context ${{ env.contextName1 }} status --wait
-          cilium --context ${{ env.contextName2 }} status --wait
+          cilium --context ${{ env.contextName1 }} status --wait --wait-duration=10m
+          cilium --context ${{ env.contextName2 }} status --wait --wait-duration=10m
           cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
           cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
 

--- a/Documentation/community/community.rst
+++ b/Documentation/community/community.rst
@@ -106,16 +106,16 @@ The following is a list of special interest groups (SIG) that are meeting on a
 regular interval. See the respective slack channel for exact meeting cadence
 and meeting links.
 
-====================== ===================================== ================= ============================================================================
-SIG                    Meeting                               Slack             Description
-====================== ===================================== ================= ============================================================================
-Datapath               On demand                             ``#sig-datapath`` Development discussions for Linux and eBPF code used in Cilium.
-Documentation          None                                  ``#sig-docs``     Documentation, Helm references, and translations.
-Envoy                  On demand                             ``#sig-envoy``    Envoy, Istio and maintenance of all L7 protocol parsers.
-Hubble                 During community meeting              ``#sig-hubble``   All Hubble-related code: Server, UI, CLI and Relay.
-Policy                 None                                  ``#sig-policy``   Network policy and enforcement.
-Release Management     None                                  ``#launchpad``    Release management and backport coordination.
-====================== ===================================== ================= ============================================================================
+====================== ============================================== ================= ============================================================================
+SIG                    Meeting                                        Slack             Description
+====================== ============================================== ================= ============================================================================
+Datapath               On demand                                      ``#sig-datapath`` Development discussions for Linux and eBPF code used in Cilium.
+Documentation          None                                           ``#sig-docs``     Documentation, Helm references, and translations.
+Envoy                  On demand                                      ``#sig-envoy``    Envoy, Istio and maintenance of all L7 protocol parsers.
+Hubble                 During community meeting                       ``#sig-hubble``   All Hubble-related code: Server, UI, CLI and Relay.
+Policy                 `First Tuesday <https://isogo.to/sig-policy>`_ ``#sig-policy``   Network policy and enforcement.
+Release Management     None                                           ``#launchpad``    Release management and backport coordination.
+====================== ============================================== ================= ============================================================================
 
 How to create a SIG
 -------------------

--- a/Documentation/gettingstarted/terminology.rst
+++ b/Documentation/gettingstarted/terminology.rst
@@ -288,6 +288,8 @@ of labels and then query the key-value store to derive the identity. Depending
 on whether the set of labels has been queried before, either a new identity
 will be created, or the identity of the initial query will be returned.
 
+.. _node:
+
 Node
 ====
 

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1179,7 +1179,11 @@
    * - :spelling:ignore:`envoy.podSecurityContext`
      - Security Context for cilium-envoy pods.
      - object
-     - ``{}``
+     - ``{"appArmorProfile":{"type":"Unconfined"}}``
+   * - :spelling:ignore:`envoy.podSecurityContext.appArmorProfile`
+     - AppArmorProfile options for the ``cilium-agent`` and init containers
+     - object
+     - ``{"type":"Unconfined"}``
    * - :spelling:ignore:`envoy.priorityClassName`
      - The priority class to use for cilium-envoy.
      - string
@@ -2396,6 +2400,14 @@
      - Labels to be added to node-init pods.
      - object
      - ``{}``
+   * - :spelling:ignore:`nodeinit.podSecurityContext`
+     - Security Context for cilium-node-init pods.
+     - object
+     - ``{"appArmorProfile":{"type":"Unconfined"}}``
+   * - :spelling:ignore:`nodeinit.podSecurityContext.appArmorProfile`
+     - AppArmorProfile options for the ``cilium-node-init`` and init containers
+     - object
+     - ``{"type":"Unconfined"}``
    * - :spelling:ignore:`nodeinit.prestop`
      - prestop offers way to customize prestop nodeinit script (pre and post position)
      - object
@@ -2631,7 +2643,11 @@
    * - :spelling:ignore:`podSecurityContext`
      - Security Context for cilium-agent pods.
      - object
-     - ``{}``
+     - ``{"appArmorProfile":{"type":"Unconfined"}}``
+   * - :spelling:ignore:`podSecurityContext.appArmorProfile`
+     - AppArmorProfile options for the ``cilium-agent`` and init containers
+     - object
+     - ``{"type":"Unconfined"}``
    * - :spelling:ignore:`policyCIDRMatchMode`
      - policyCIDRMatchMode is a list of entities that may be selected by CIDR selector. The possible value is "nodes".
      - string

--- a/Documentation/network/concepts/ipam/kubernetes.rst
+++ b/Documentation/network/concepts/ipam/kubernetes.rst
@@ -46,6 +46,8 @@ Annotation                             Description
 ``network.cilium.io/ipv6-cilium-host`` IPv6 address of the cilium host interface
 ``network.cilium.io/ipv4-health-ip``   IPv4 address of the cilium-health endpoint
 ``network.cilium.io/ipv6-health-ip``   IPv6 address of the cilium-health endpoint
+``network.cilium.io/ipv4-Ingress-ip``  IPv4 address of the cilium-ingress endpoint
+``network.cilium.io/ipv6-Ingress-ip``  IPv6 address of the cilium-ingress endpoint
 ====================================== ==========================================================
 
 .. note:: The annotation-based mechanism is primarily useful in combination with

--- a/Documentation/security/host-firewall.rst
+++ b/Documentation/security/host-firewall.rst
@@ -71,10 +71,11 @@ recommended for production deployment*.
 
     $ CILIUM_NAMESPACE=kube-system
     $ CILIUM_POD_NAME=$(kubectl -n $CILIUM_NAMESPACE get pods -l "k8s-app=cilium" -o jsonpath="{.items[?(@.spec.nodeName=='$NODE_NAME')].metadata.name}")
-    $ HOST_EP_ID=$(kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium-dbg endpoint list -o jsonpath='{[?(@.status.identity.id==1)].id}')
-    $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium-dbg endpoint config $HOST_EP_ID PolicyAuditMode=Enabled
+    $ alias kexec="kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME --"
+    $ HOST_EP_ID=$(kexec cilium-dbg endpoint list -o jsonpath='{[?(@.status.identity.id==1)].id}')
+    $ kexec cilium-dbg endpoint config $HOST_EP_ID PolicyAuditMode=Enabled
     Endpoint 3353 configuration updated successfully
-    $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium-dbg endpoint config $HOST_EP_ID | grep PolicyAuditMode
+    $ kexec cilium-dbg endpoint config $HOST_EP_ID | grep PolicyAuditMode
     PolicyAuditMode          Enabled
 
 
@@ -104,7 +105,7 @@ status of the policy using that command.
 
 .. code-block:: shell-session
 
-    $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium-dbg endpoint list
+    $ kexec cilium-dbg endpoint list
     ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                       IPv6                 IPv4           STATUS
                ENFORCEMENT        ENFORCEMENT
     266        Disabled           Disabled          104        k8s:io.cilium.k8s.policy.cluster=default          f00d::a0b:0:0:ef4e   10.16.172.63   ready
@@ -127,7 +128,7 @@ breakages.
 
 .. code-block:: shell-session
 
-    $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium-dbg monitor -t policy-verdict --related-to $HOST_EP_ID
+    $ kexec cilium-dbg monitor -t policy-verdict --related-to $HOST_EP_ID
     Policy verdict log: flow 0x0 local EP ID 1687, remote ID 6, proto 1, ingress, action allow, match L3-Only, 192.168.60.12 -> 192.168.60.11 EchoRequest
     Policy verdict log: flow 0x0 local EP ID 1687, remote ID 6, proto 6, ingress, action allow, match L3-Only, 192.168.60.12:37278 -> 192.168.60.11:2379 tcp SYN
     Policy verdict log: flow 0x0 local EP ID 1687, remote ID 2, proto 6, ingress, action audit, match none, 10.0.2.2:47500 -> 10.0.2.15:6443 tcp SYN
@@ -157,14 +158,14 @@ policy.
 
 .. code-block:: shell-session
 
-    $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium-dbg endpoint config $HOST_EP_ID PolicyAuditMode=Disabled
+    $ kexec cilium-dbg endpoint config $HOST_EP_ID PolicyAuditMode=Disabled
     Endpoint 3353 configuration updated successfully
 
 Ingress host policies should now appear as enforced:
 
 .. code-block:: shell-session
 
-    $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium-dbg endpoint list
+    $ kexec cilium-dbg endpoint list
     ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                       IPv6                 IPv4           STATUS
                ENFORCEMENT        ENFORCEMENT
     266        Disabled           Disabled          104        k8s:io.cilium.k8s.policy.cluster=default          f00d::a0b:0:0:ef4e   10.16.172.63   ready
@@ -180,7 +181,7 @@ Communications not explicitly allowed by the host policy will now be dropped:
 
 .. code-block:: shell-session
 
-    $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium-dbg monitor -t policy-verdict --related-to $HOST_EP_ID
+    $ kexec cilium-dbg monitor -t policy-verdict --related-to $HOST_EP_ID
     Policy verdict log: flow 0x0 local EP ID 1687, remote ID 2, proto 6, ingress, action deny, match none, 10.0.2.2:49038 -> 10.0.2.15:21 tcp SYN
 
 

--- a/Documentation/security/host-firewall.rst
+++ b/Documentation/security/host-firewall.rst
@@ -204,3 +204,13 @@ Clean up
 
    $ kubectl delete ccnp demo-host-policy
    $ kubectl label node $NODE_NAME node-access-
+
+Further Reading
+===============
+
+Read the documentation on :ref:`HostPolicies` for additional details on how to
+use the policies. In particular, refer to the :ref:`Troubleshooting Host
+Policies <troubleshooting_host_policies>` subsection to understand how to debug
+issues with Host Policies, or to the section on :ref:`Host Policies known
+issues <host_policies_known_issues>` to understand the current limitations of
+the feature.

--- a/Documentation/security/policy/intro.rst
+++ b/Documentation/security/policy/intro.rst
@@ -133,8 +133,8 @@ provided. If both ingress and egress are omitted, the rule has no effect.
 endpointSelector / nodeSelector
   Selects the endpoints or nodes which the policy rules apply to. The policy
   rules will be applied to all endpoints which match the labels specified in
-  the selector. See the `LabelSelector` and :ref:`NodeSelector` sections for
-  additional details.
+  the selector. For additional details, see the :ref:`EndpointSelector` and
+  :ref:`NodeSelector` sections.
 
 ingress
   List of rules which must apply at ingress of the endpoint, i.e. to all
@@ -155,26 +155,27 @@ description
   Description is a string which is not interpreted by Cilium. It can be used to
   describe the intent and scope of the rule in a human readable form.
 
-.. _label_selector:
-.. _LabelSelector:
 .. _EndpointSelector:
 
 Endpoint Selector
 -----------------
 
-The Endpoint Selector is based on the `Kubernetes LabelSelector
-<https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors>`_.
-It is called Endpoint Selector because it only applies to labels associated
-with an `endpoints`.
+The Endpoint Selector is based on the `Kubernetes LabelSelector`_. It is called
+Endpoint Selector because it only applies to labels associated with an
+:ref:`Endpoint <endpoint>`.
 
 .. _NodeSelector:
 
 Node Selector
 -------------
 
-The Node Selector is also based on the `LabelSelector`, although rather than
-matching on labels associated with an `endpoints`, it instead applies to labels
-associated with a node in the cluster.
+Like the :ref:`Endpoint Selector <EndpointSelector>`, the Node Selector is
+based on the `Kubernetes LabelSelector`_, although rather than
+matching on labels associated with Endpoints, it applies to labels associated
+with :ref:`Nodes <node>` in the cluster.
 
-Node Selectors can only be used in `CiliumClusterwideNetworkPolicy`. See
-`HostPolicies` for details on the scope of node-level policies.
+Node Selectors can only be used in :ref:`CiliumClusterwideNetworkPolicies
+<CiliumClusterwideNetworkPolicy>`. For details on the scope of node-level
+policies, see :ref:`HostPolicies`.
+
+.. _Kubernetes LabelSelector: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -1289,6 +1289,8 @@ the label ``type=ingress-worker`` on TCP ports 22, 6443 (kube-apiserver), 2379
 To reuse this policy, replace the ``port:`` values with ports used in your
 environment.
 
+.. _troubleshooting_host_policies:
+
 Troubleshooting Host Policies
 -----------------------------
 
@@ -1333,6 +1335,8 @@ endpoint get -l reserved:host -o jsonpath='{[0].id}'``. Use this ID to replace
 
 - Use ``cilium-dbg monitor`` with ``--related-to $HOST_EP_ID`` to examine
   traffic for the host endpoint.
+
+.. _host_policies_known_issues:
 
 Host Policies known issues
 --------------------------

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -1333,3 +1333,37 @@ endpoint get -l reserved:host -o jsonpath='{[0].id}'``. Use this ID to replace
 
 - Use ``cilium-dbg monitor`` with ``--related-to $HOST_EP_ID`` to examine
   traffic for the host endpoint.
+
+Host Policies known issues
+--------------------------
+
+- The first time Cilium enforces Host Policies in the cluster, it may drop
+  reply traffic for legitimate connections that should be allowed by the
+  policies in place. Connections should stabilize again after a few seconds.
+  One workaround is to enable, disable, then re-enable Host Policies
+  enforcement. For details, see :gh-issue:`25448`.
+
+- In the context of ClusterMesh, the following combination of options is not
+  supported:
+
+  - Cilium operating in CRD mode (as opposed to KVstore mode),
+  - Host Policies enabled,
+  - tunneling enabled,
+  - kube-proxy-replacement enabled, and
+  - WireGuard enabled.
+
+  This combination results in a failure to connect to the
+  clustermesh-apiserver. For details, refer to :gh-issue:`31209`.
+
+- Host Policies do not work on host WireGuard interfaces. For details, see
+  :gh-issue:`17636`.
+
+- When Host Policies are enabled, hosts drop traffic from layer-2 protocols
+  that they consider as unknown, even if no Host Policies are loaded. For
+  example, this affects LLC traffic (see :gh-issue:`17877`) or VRRP traffic
+  (see :gh-issue:`18347`).
+
+- When kube-proxy-replacement is disabled, or configured not to implement
+  services for the native device (such as NodePort), hosts will enforce Host
+  Policies on service addresses rather than the service endpoints. For details,
+  refer to :gh-issue:`12545`.

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1049,6 +1049,8 @@ static __always_inline int handle_l2_announcement(struct __ctx_buff *ctx)
 static __always_inline int
 do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 {
+	enum trace_point trace = from_host ? TRACE_FROM_HOST :
+					     TRACE_FROM_NETWORK;
 	__u32 __maybe_unused identity = 0;
 	__u32 __maybe_unused ipcache_srcid = 0;
 	void __maybe_unused *data, *data_end;
@@ -1063,7 +1065,6 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 
 	if (from_host) {
 		__u32 magic;
-		enum trace_point trace = TRACE_FROM_HOST;
 
 		magic = inherit_identity_from_host(ctx, &identity);
 		if (magic == MARK_MAGIC_PROXY_INGRESS ||  magic == MARK_MAGIC_PROXY_EGRESS)
@@ -1092,15 +1093,10 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 			return ret;
 		}
 #endif /* ENABLE_IPSEC */
-
-		send_trace_notify(ctx, trace, identity, 0, 0,
-				  ctx->ingress_ifindex,
-				  TRACE_REASON_UNKNOWN, TRACE_PAYLOAD_LEN);
-	} else {
-		send_trace_notify(ctx, TRACE_FROM_NETWORK, 0, 0, 0,
-				  ctx->ingress_ifindex,
-				  TRACE_REASON_UNKNOWN, TRACE_PAYLOAD_LEN);
 	}
+
+	send_trace_notify(ctx, trace, identity, 0, 0, ctx->ingress_ifindex,
+			  TRACE_REASON_UNKNOWN, TRACE_PAYLOAD_LEN);
 
 	bpf_clear_meta(ctx);
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1056,21 +1056,6 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 	struct iphdr __maybe_unused *ip4;
 	int ret;
 
-#if defined(ENABLE_L7_LB)
-	if (from_host) {
-		__u32 magic = ctx->mark & MARK_MAGIC_HOST_MASK;
-
-		if (magic == MARK_MAGIC_PROXY_EGRESS_EPID) {
-			__u32 lxc_id = get_epid(ctx);
-
-			ctx->mark = 0;
-			tail_call_dynamic(ctx, &POLICY_EGRESSCALL_MAP, lxc_id);
-			return send_drop_notify_error(ctx, identity, DROP_MISSED_TAIL_CALL,
-						      CTX_ACT_DROP, METRIC_EGRESS);
-		}
-	}
-#endif
-
 #ifdef ENABLE_IPSEC
 	if (!from_host && !do_decrypt(ctx, proto))
 		return CTX_ACT_OK;
@@ -1083,6 +1068,15 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 		magic = inherit_identity_from_host(ctx, &identity);
 		if (magic == MARK_MAGIC_PROXY_INGRESS ||  magic == MARK_MAGIC_PROXY_EGRESS)
 			trace = TRACE_FROM_PROXY;
+
+#if defined(ENABLE_L7_LB)
+		if (magic == MARK_MAGIC_PROXY_EGRESS_EPID) {
+			/* extracted identity is actually the endpoint ID */
+			tail_call_dynamic(ctx, &POLICY_EGRESSCALL_MAP, identity);
+			return send_drop_notify_error(ctx, 0, DROP_MISSED_TAIL_CALL,
+						      CTX_ACT_DROP, METRIC_EGRESS);
+		}
+#endif
 
 #ifdef ENABLE_IPSEC
 		if (magic == MARK_MAGIC_ENCRYPT) {

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -542,7 +542,7 @@ ct_recreate6:
 		} else
 # endif /* ENABLE_DSR */
 		/* See comment in handle_ipv4_from_lxc(). */
-		if (ct_state->node_port) {
+		if (ct_state->node_port && lb_is_svc_proto(tuple->nexthdr)) {
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV6,
 					  *dst_sec_identity, 0, 0,
 					  trace.reason, trace.monitor);
@@ -999,8 +999,11 @@ ct_recreate4:
 		/* This handles reply traffic for the case where the nodeport EP
 		 * is local to the node. We'll do the tail call to perform
 		 * the reverse DNAT.
+		 *
+		 * This codepath currently doesn't support revDNAT for ICMP,
+		 * so make sure that we only send TCP/UDP/SCTP down this way.
 		 */
-		if (ct_state->node_port) {
+		if (ct_state->node_port && lb_is_svc_proto(tuple->nexthdr)) {
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV4,
 					  *dst_sec_identity, 0, 0,
 					  trace.reason, trace.monitor);

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -442,7 +442,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 
 		select {
 		case <-updateCtx.Done():
-			log.Error("Timed out waiting for datapath updates of FQDN IP information; returning response")
+			log.Warning("Timed out waiting for datapath updates of FQDN IP information; returning response. Consider increasing --tofqdns-proxy-response-max-delay if this keeps happening.")
 			metrics.ProxyDatapathUpdateTimeout.Inc()
 		case <-updateComplete:
 		}

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -344,7 +344,8 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for cilium-envoy. |
 | envoy.podAnnotations | object | `{}` | Annotations to be added to envoy pods |
 | envoy.podLabels | object | `{}` | Labels to be added to envoy pods |
-| envoy.podSecurityContext | object | `{}` | Security Context for cilium-envoy pods. |
+| envoy.podSecurityContext | object | `{"appArmorProfile":{"type":"Unconfined"}}` | Security Context for cilium-envoy pods. |
+| envoy.podSecurityContext.appArmorProfile | object | `{"type":"Unconfined"}` | AppArmorProfile options for the `cilium-agent` and init containers |
 | envoy.priorityClassName | string | `nil` | The priority class to use for cilium-envoy. |
 | envoy.prometheus | object | `{"enabled":true,"port":"9964","serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]}}` | Configure Cilium Envoy Prometheus options. Note that some of these apply to either cilium-agent or cilium-envoy. |
 | envoy.prometheus.enabled | bool | `true` | Enable prometheus metrics for cilium-envoy |
@@ -649,6 +650,8 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | nodeinit.podAnnotations | object | `{}` | Annotations to be added to node-init pods. |
 | nodeinit.podLabels | object | `{}` | Labels to be added to node-init pods. |
+| nodeinit.podSecurityContext | object | `{"appArmorProfile":{"type":"Unconfined"}}` | Security Context for cilium-node-init pods. |
+| nodeinit.podSecurityContext.appArmorProfile | object | `{"type":"Unconfined"}` | AppArmorProfile options for the `cilium-node-init` and init containers |
 | nodeinit.prestop | object | `{"postScript":"","preScript":""}` | prestop offers way to customize prestop nodeinit script (pre and post position) |
 | nodeinit.priorityClassName | string | `""` | The priority class to use for the nodeinit pod. |
 | nodeinit.resources | object | `{"requests":{"cpu":"100m","memory":"100Mi"}}` | nodeinit resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
@@ -707,7 +710,8 @@ contributors across the globe, there is almost always someone available to help.
 | pmtuDiscovery.enabled | bool | `false` | Enable path MTU discovery to send ICMP fragmentation-needed replies to the client. |
 | podAnnotations | object | `{}` | Annotations to be added to agent pods |
 | podLabels | object | `{}` | Labels to be added to agent pods |
-| podSecurityContext | object | `{}` | Security Context for cilium-agent pods. |
+| podSecurityContext | object | `{"appArmorProfile":{"type":"Unconfined"}}` | Security Context for cilium-agent pods. |
+| podSecurityContext.appArmorProfile | object | `{"type":"Unconfined"}` | AppArmorProfile options for the `cilium-agent` and init containers |
 | policyCIDRMatchMode | string | `nil` | policyCIDRMatchMode is a list of entities that may be selected by CIDR selector. The possible value is "nodes". |
 | policyEnforcementMode | string | `"default"` | The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/security/policy/intro/#policy-enforcement-modes |
 | pprof.address | string | `"localhost"` | Configure pprof listen address for cilium-agent |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -53,6 +53,7 @@ spec:
         cilium.io/cilium-configmap-checksum: {{ include (print $.Template.BasePath "/cilium-configmap.yaml") . | sha256sum | quote }}
         {{- end }}
         {{- if not .Values.securityContext.privileged }}
+        {{- if semverCompare "<1.30.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
         # Set app AppArmor's profile to "unconfined". The value of this annotation
         # can be modified as long users know which profiles they have available
         # in AppArmor.
@@ -61,6 +62,7 @@ spec:
         {{- if .Values.cgroup.autoMount.enabled }}
         container.apparmor.security.beta.kubernetes.io/mount-cgroup: "unconfined"
         container.apparmor.security.beta.kubernetes.io/apply-sysctl-overwrites: "unconfined"
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- with .Values.podAnnotations }}
@@ -80,6 +82,11 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- /* K8s version lower than 1.30.0 don't support the "appArmorProfile" field, */}}
+      {{- /* thus we have to remove it. */}}
+      {{- if semverCompare "<1.30.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
+        {{- $_ := unset .Values.podSecurityContext "appArmorProfile" }}
       {{- end }}
       {{- with .Values.podSecurityContext }}
       securityContext:

--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -35,10 +35,12 @@ spec:
         cilium.io/cilium-envoy-configmap-checksum: {{ include (print $.Template.BasePath "/cilium-envoy/configmap.yaml") . | sha256sum | quote }}
         {{- end }}
         {{- if not .Values.envoy.securityContext.privileged }}
+        {{- if semverCompare "<1.30.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
         # Set app AppArmor's profile to "unconfined". The value of this annotation
         # can be modified as long users know which profiles they have available
         # in AppArmor.
         container.apparmor.security.beta.kubernetes.io/cilium-envoy: "unconfined"
+        {{- end }}
         {{- end }}
         {{- with .Values.envoy.podAnnotations }}
         {{- toYaml . | nindent 8 }}
@@ -55,6 +57,11 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- /* K8s version lower than 1.30.0 don't support the "appArmorProfile" field, */}}
+      {{- /* thus we have to remove it. */}}
+      {{- if semverCompare "<1.30.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
+        {{- $_ := unset .Values.envoy.podSecurityContext "appArmorProfile" }}
       {{- end }}
       {{- with .Values.envoy.podSecurityContext }}
       securityContext:

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -28,10 +28,12 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- if not .Values.securityContext.privileged }}
+        {{- if semverCompare "<1.30.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
         # Set app AppArmor's profile to "unconfined". The value of this annotation
         # can be modified as long users know which profiles they have available
         # in AppArmor.
         container.apparmor.security.beta.kubernetes.io/node-init: "unconfined"
+        {{- end }}
         {{- end }}
       labels:
         app: cilium-node-init
@@ -43,6 +45,15 @@ spec:
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- /* K8s version lower than 1.30.0 don't support the "appArmorProfile" field, */}}
+      {{- /* thus we have to remove it. */}}
+      {{- if semverCompare "<1.30.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
+        {{- $_ := unset .Values.nodeinit.podSecurityContext "appArmorProfile" }}
+      {{- end }}
+      {{- with .Values.nodeinit.podSecurityContext }}
+      securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -218,8 +218,10 @@ extraConfig: {}
 annotations: {}
 
 # -- Security Context for cilium-agent pods.
-podSecurityContext: {}
-
+podSecurityContext:
+  # -- AppArmorProfile options for the `cilium-agent` and init containers
+  appArmorProfile:
+    type: "Unconfined"
 # -- Annotations to be added to agent pods
 podAnnotations: {}
 
@@ -2126,8 +2128,10 @@ envoy:
   annotations: {}
 
   # -- Security Context for cilium-envoy pods.
-  podSecurityContext: {}
-
+  podSecurityContext:
+    # -- AppArmorProfile options for the `cilium-agent` and init containers
+    appArmorProfile:
+      type: "Unconfined"
   # -- Annotations to be added to envoy pods
   podAnnotations: {}
 
@@ -2748,7 +2752,11 @@ nodeinit:
 
   # -- Labels to be added to node-init pods.
   podLabels: {}
-
+  # -- Security Context for cilium-node-init pods.
+  podSecurityContext:
+    # -- AppArmorProfile options for the `cilium-node-init` and init containers
+    appArmorProfile:
+      type: "Unconfined"
   # -- nodeinit resource limits & requests
   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -215,8 +215,10 @@ extraConfig: {}
 annotations: {}
 
 # -- Security Context for cilium-agent pods.
-podSecurityContext: {}
-
+podSecurityContext:
+  # -- AppArmorProfile options for the `cilium-agent` and init containers
+  appArmorProfile:
+    type: "Unconfined"
 # -- Annotations to be added to agent pods
 podAnnotations: {}
 
@@ -2123,8 +2125,10 @@ envoy:
   annotations: {}
 
   # -- Security Context for cilium-envoy pods.
-  podSecurityContext: {}
-
+  podSecurityContext:
+    # -- AppArmorProfile options for the `cilium-agent` and init containers
+    appArmorProfile:
+      type: "Unconfined"
   # -- Annotations to be added to envoy pods
   podAnnotations: {}
 
@@ -2745,7 +2749,11 @@ nodeinit:
 
   # -- Labels to be added to node-init pods.
   podLabels: {}
-
+  # -- Security Context for cilium-node-init pods.
+  podSecurityContext:
+    # -- AppArmorProfile options for the `cilium-node-init` and init containers
+    appArmorProfile:
+      type: "Unconfined"
   # -- nodeinit resource limits & requests
   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:

--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -147,6 +147,29 @@ func (rc *remoteCluster) restartRemoteConnection() {
 				backend, errChan := kvstore.NewClient(ctx, kvstore.EtcdBackendName,
 					rc.makeEtcdOpts(), &extraOpts)
 
+				// Block until either an error is returned or
+				// the channel is closed due to success of the
+				// connection
+				rc.logger.Debugf("Waiting for connection to be established")
+
+				var err error
+				select {
+				case err = <-errChan:
+				case err = <-clusterLock.errors:
+				}
+
+				if err != nil {
+					if backend != nil {
+						backend.Close(ctx)
+					}
+					rc.logger.WithError(err).Warning("Unable to establish etcd connection to remote cluster")
+					return err
+				}
+
+				rc.mutex.Lock()
+				rc.backend = backend
+				rc.mutex.Unlock()
+
 				ctx, cancel := context.WithCancel(ctx)
 				rc.wg.Add(1)
 				go func() {
@@ -154,24 +177,6 @@ func (rc *remoteCluster) restartRemoteConnection() {
 					cancel()
 					rc.wg.Done()
 				}()
-
-				// Block until either an error is returned or
-				// the channel is closed due to success of the
-				// connection
-				rc.logger.Debugf("Waiting for connection to be established")
-				err, isErr := <-errChan
-				if isErr {
-					if backend != nil {
-						backend.Close(ctx)
-					}
-					rc.logger.WithError(err).Warning("Unable to establish etcd connection to remote cluster")
-					cancel()
-					return err
-				}
-
-				rc.mutex.Lock()
-				rc.backend = backend
-				rc.mutex.Unlock()
 
 				rc.logger.WithField(logfields.EtcdClusterID, clusterLock.etcdClusterID.Load()).Info("Connection to remote cluster established")
 

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/prometheus/procfs"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
@@ -402,6 +403,18 @@ func xfrmStateReplace(new *netlink.XfrmState, remoteRebooted bool) error {
 // conflicting XFRM state. This function removes the conflicting state and
 // prepares a defer callback to re-add it with proper logging.
 func xfrmTemporarilyRemoveState(scopedLog *logrus.Entry, state netlink.XfrmState, dir string) (error, func()) {
+	stats, err := procfs.NewXfrmStat()
+	errorCnt := 0
+	if err != nil {
+		log.WithError(err).Error("Error while getting XFRM stats before state removal")
+	} else {
+		if dir == "IN" {
+			errorCnt = stats.XfrmInNoStates
+		} else {
+			errorCnt = stats.XfrmOutNoStates
+		}
+	}
+
 	start := time.Now()
 	if err := netlink.XfrmStateDel(&state); err != nil {
 		return err, nil
@@ -411,7 +424,19 @@ func xfrmTemporarilyRemoveState(scopedLog *logrus.Entry, state netlink.XfrmState
 			scopedLog.WithError(err).Errorf("Failed to re-add old XFRM %s state", dir)
 		}
 		elapsed := time.Since(start)
-		scopedLog.WithField(logfields.Duration, elapsed).Infof("Temporarily removed old XFRM %s state", dir)
+
+		stats, err := procfs.NewXfrmStat()
+		if err != nil {
+			log.WithError(err).Error("Error while getting XFRM stats after state removal")
+			errorCnt = 0
+		} else {
+			if dir == "IN" {
+				errorCnt = stats.XfrmInNoStates - errorCnt
+			} else {
+				errorCnt = stats.XfrmOutNoStates - errorCnt
+			}
+		}
+		scopedLog.WithField(logfields.Duration, elapsed).Infof("Temporarily removed old XFRM %s state (%d packets dropped)", dir, errorCnt)
 	}
 }
 

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -205,6 +205,11 @@ func (p *DNSProxy) checkRestored(endpointID uint64, destPortProto restore.PortPr
 	if !exists && destPortProto.IsPortV2() {
 		// Check if there is a Version 1 restore.
 		ipRules, exists = p.restored[endpointID][destPortProto.ToV1()]
+		log.WithFields(logrus.Fields{
+			logfields.EndpointID: endpointID,
+			logfields.Port:       destPortProto.Port(),
+			logfields.Protocol:   destPortProto.Protocol(),
+		}).Debugf("Checking if restored V1 IP rules (exists: %t) for endpoint: %+v", exists, ipRules)
 		if !exists {
 			return false
 		}
@@ -514,6 +519,14 @@ func (allow perEPAllow) setPortRulesForIDFromUnifiedFormat(cache regexCache, end
 // passed-in endpointID and destPort with setPortRulesForID
 func (allow perEPAllow) getPortRulesForID(endpointID uint64, destPortProto restore.PortProto) (rules CachedSelectorREEntry, exists bool) {
 	rules, exists = allow[endpointID][destPortProto]
+	if !exists && destPortProto.Protocol() != 0 {
+		rules, exists = allow[endpointID][destPortProto.ToV1()]
+		log.WithFields(logrus.Fields{
+			logfields.EndpointID: endpointID,
+			logfields.Port:       destPortProto.Port(),
+			logfields.Protocol:   destPortProto.Protocol(),
+		}).Debugf("Checking for V1 port rule (exists: %t) for endpoint: %+v", exists, rules)
+	}
 	return
 }
 

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -571,22 +571,26 @@ func (r *rule) resolveIngressPolicy(
 func (r *rule) matches(securityIdentity *identity.Identity) bool {
 	r.metadata.Mutex.Lock()
 	defer r.metadata.Mutex.Unlock()
-	var ruleMatches bool
+	isNode := securityIdentity.ID == identity.ReservedIdentityHost
 
 	if ruleMatches, cached := r.metadata.IdentitySelected[securityIdentity.ID]; cached {
 		return ruleMatches
 	}
-	isNode := securityIdentity.ID == identity.ReservedIdentityHost
+
+	// Short-circuit if the rule's selector type (node vs. endpoint) does not match the
+	// identity's type
 	if (r.NodeSelector.LabelSelector != nil) != isNode {
 		r.metadata.IdentitySelected[securityIdentity.ID] = false
-		return ruleMatches
+		return false
 	}
+
 	// Fall back to costly matching.
-	if ruleMatches = r.getSelector().Matches(securityIdentity.LabelArray); ruleMatches {
-		// Update cache so we don't have to do costly matching again.
-		r.metadata.IdentitySelected[securityIdentity.ID] = true
-	} else {
-		r.metadata.IdentitySelected[securityIdentity.ID] = false
+	ruleMatches := r.getSelector().Matches(securityIdentity.LabelArray)
+
+	// Update cache so we don't have to do costly matching again.
+	// the local Host identity has mutable labels, so we cannot use the cache
+	if !isNode {
+		r.metadata.IdentitySelected[securityIdentity.ID] = ruleMatches
 	}
 
 	return ruleMatches

--- a/plugins/cilium-cni/cmd/interface.go
+++ b/plugins/cilium-cni/cmd/interface.go
@@ -58,7 +58,7 @@ func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, 
 
 	if err := routingInfo.Configure(
 		ipConfig.Address.IP,
-		int(conf.DeviceMTU),
+		int(conf.RouteMTU),
 		conf.EgressMultiHomeIPRuleCompat,
 		false,
 	); err != nil {


### PR DESCRIPTION
 * [x] #29803 (@julianwiedmann)
 * [x] #32225 (@giorio94)
 * [x] #32199 (@aanm) :warning: resolved conflicts by ignoring the changes to `values.schema.json` not present in v1.15
 * [x] #32284 (@sayboras)
 * [x] #30548 (@squeed)
 * [x] #32240 (@pchaigno)
 * [x] #32303 (@marseel)
 * [x] #32244 (@learnitall)
 * [x] #32333 (@jrajahalme)
 * [x] #32155 (@julianwiedmann)
 * [x] #32340 (@squeed)
 * [x] #32347 (@giorio94) :warning: resolved conflicts moving the wait duration bump up to step `Wait for cluster mesh status to be ready` after the first Cilium rollout in cluster2
 * [x] #32325 (@nathanjsweet)
 * [x] #32267 (@qmonnet)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 29803 32225 32199 32284 30548 32240 32303 32244 32333 32155 32340 32347 32325 32267
```
