### PR TITLE
policy: Add Port Range Support for Policies

### DIFF
--- a/cilium-dbg/cmd/helpers.go
+++ b/cilium-dbg/cmd/helpers.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
+	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -346,15 +347,15 @@ func updatePolicyKey(pa *PolicyUpdateArgs, add bool) {
 				err       error
 			)
 			if pa.isDeny {
-				err = policyMap.Deny(pa.label, pa.port, u8p, pa.trafficDirection)
+				err = policyMap.Deny(pa.label, pa.port, policyapi.FullPortMask, u8p, pa.trafficDirection)
 			} else {
-				err = policyMap.Allow(pa.label, pa.port, u8p, pa.trafficDirection, authType, proxyPort)
+				err = policyMap.Allow(pa.label, pa.port, policyapi.FullPortMask, u8p, pa.trafficDirection, authType, proxyPort)
 			}
 			if err != nil {
 				Fatalf("Cannot add policy key '%s': %s\n", entry, err)
 			}
 		} else {
-			if err := policyMap.Delete(pa.label, pa.port, u8p, pa.trafficDirection); err != nil {
+			if err := policyMap.Delete(pa.label, pa.port, policyapi.FullPortMask, u8p, pa.trafficDirection); err != nil {
 				Fatalf("Cannot delete policy key '%s': %s\n", entry, err)
 			}
 		}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/version"
@@ -1115,7 +1116,7 @@ func (e *Endpoint) updatePolicyMapPressureMetric() {
 
 func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool) bool {
 	// Convert from policy.Key to policymap.Key
-	policymapKey := policymap.NewKey(keyToDelete.Identity, keyToDelete.DestPort,
+	policymapKey := policymap.NewKey(keyToDelete.Identity, keyToDelete.DestPort, keyToDelete.PortMask,
 		keyToDelete.Nexthdr, keyToDelete.TrafficDirection)
 
 	// Do not error out if the map entry was already deleted from the bpf map.
@@ -1149,7 +1150,7 @@ func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool) boo
 
 func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry, incremental bool) bool {
 	// Convert from policy.Key to policymap.Key
-	policymapKey := policymap.NewKey(keyToAdd.Identity, keyToAdd.DestPort,
+	policymapKey := policymap.NewKey(keyToAdd.Identity, keyToAdd.DestPort, keyToAdd.PortMask,
 		keyToAdd.Nexthdr, keyToAdd.TrafficDirection)
 
 	var err error
@@ -1367,6 +1368,7 @@ func (e *Endpoint) dumpPolicyMapToMapState() (policy.MapState, error) {
 		policyKey := policy.Key{
 			Identity:         policymapKey.Identity,
 			DestPort:         policymapKey.GetDestPort(),
+			PortMask:         policyapi.FullPortMask,
 			Nexthdr:          policymapKey.Nexthdr,
 			TrafficDirection: policymapKey.TrafficDirection,
 		}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/time"
@@ -772,6 +773,7 @@ func (e *Endpoint) Allows(id identity.NumericIdentity) bool {
 
 	keyToLookup := policy.Key{
 		Identity:         uint32(id),
+		PortMask:         policyapi.FullPortMask,
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	}
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -92,7 +92,7 @@ func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string
 // and the resolved destination port and protocol numbers, if any.
 // Must be called with e.mutex held.
 func (e *Endpoint) proxyID(l4 *policy.L4Filter, listener string) (string, uint16, uint8) {
-	port := uint16(l4.Port)
+	port := l4.Port
 	protocol := uint8(l4.U8Proto)
 	// Calculate protocol if it is 0 (default) and
 	// is not "ANY" (that is, it was not calculated).

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -89,7 +89,9 @@ func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string
 }
 
 // proxyID returns a unique string to identify a proxy mapping,
-// and the resolved destination port and protocol numbers, if any.
+// and the resolved destination port number, if any.
+// For port ranges the proxy is identified by the first port in
+// the range, as overlapping proxy port ranges are not supported.
 // Must be called with e.mutex held.
 func (e *Endpoint) proxyID(l4 *policy.L4Filter, listener string) (string, uint16, uint8) {
 	port := l4.Port

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -223,6 +223,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(t *testing.T) {
 	v, ok := ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
+		PortMask:         api.FullPortMask,
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	})
@@ -244,6 +245,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(t *testing.T) {
 	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
+		PortMask:         api.FullPortMask,
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	})
@@ -268,6 +270,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(t *testing.T) {
 	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
+		PortMask:         api.FullPortMask,
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	})
@@ -277,6 +280,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(t *testing.T) {
 	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
+		PortMask:         api.FullPortMask,
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	})
@@ -286,6 +290,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(t *testing.T) {
 	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
+		PortMask:         api.FullPortMask,
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Egress.Uint8(),
 	})
@@ -370,10 +375,10 @@ var (
 
 	dirIngress      = trafficdirection.Ingress.Uint8()
 	dirEgress       = trafficdirection.Egress.Uint8()
-	mapKeyAllL7     = policy.Key{Identity: 0, DestPort: 80, Nexthdr: 6, TrafficDirection: dirIngress}
-	mapKeyFoo       = policy.Key{Identity: identityFoo, DestPort: 0, Nexthdr: 0, TrafficDirection: dirIngress}
-	mapKeyFooL7     = policy.Key{Identity: identityFoo, DestPort: 80, Nexthdr: 6, TrafficDirection: dirIngress}
-	mapKeyAllowAllE = policy.Key{Identity: 0, DestPort: 0, Nexthdr: 0, TrafficDirection: dirEgress}
+	mapKeyAllL7     = policy.Key{Identity: 0, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6, TrafficDirection: dirIngress}
+	mapKeyFoo       = policy.Key{Identity: identityFoo, DestPort: 0, PortMask: api.FullPortMask, Nexthdr: 0, TrafficDirection: dirIngress}
+	mapKeyFooL7     = policy.Key{Identity: identityFoo, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6, TrafficDirection: dirIngress}
+	mapKeyAllowAllE = policy.Key{Identity: 0, DestPort: 0, PortMask: api.FullPortMask, Nexthdr: 0, TrafficDirection: dirEgress}
 )
 
 // combineL4L7 returns a new PortRule that refers to the specified l4 ports and

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1596,7 +1596,7 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 			continue
 		}
 
-		port := uint16(l4.Port)
+		port := l4.Port
 		if port == 0 && l4.PortName != "" {
 			port = ep.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
 			if port == 0 {

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1600,7 +1600,7 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 		if port == 0 && l4.PortName != "" {
 			port = ep.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
 			if port == 0 {
-				continue
+				continue // Skip if a named port can not be resolved (yet)
 			}
 		}
 
@@ -1677,8 +1677,11 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 			continue
 		}
 
+		// NPDS supports port ranges, but range overlaps in the policy are NOT allowed.
+		// Envoy will reject a policy if any overlaps exist.
 		PerPortPolicies = append(PerPortPolicies, &cilium.PortNetworkPolicy{
 			Port:     uint32(port),
+			EndPort:  uint32(l4.EndPort),
 			Protocol: protocol,
 			Rules:    SortPortNetworkPolicyRules(rules),
 		})

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/policy"
+	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -388,6 +389,7 @@ func TestDecodePolicyVerdictNotify(t *testing.T) {
 	policyKey := policy.Key{
 		Identity:         uint32(remoteIdentity),
 		DestPort:         uint16(dstPort),
+		PortMask:         policyapi.FullPortMask,
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Egress.Uint8(),
 	}
@@ -658,6 +660,7 @@ func TestDecodeTrafficDirection(t *testing.T) {
 	policyKey := policy.Key{
 		Identity:         remoteID,
 		DestPort:         0,
+		PortMask:         policyapi.FullPortMask,
 		Nexthdr:          0,
 		TrafficDirection: trafficdirection.Egress.Uint8(),
 	}
@@ -841,6 +844,7 @@ func TestDecodeTrafficDirection(t *testing.T) {
 	assert.Equal(t, true, ok)
 	lbls, rev, ok := ep.GetRealizedPolicyRuleLabelsForKey(policy.Key{
 		Identity:         f.GetDestination().GetIdentity(),
+		PortMask:         policyapi.FullPortMask,
 		TrafficDirection: directionFromProto(f.GetTrafficDirection()).Uint8(),
 	})
 	assert.Equal(t, true, ok)

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -548,15 +548,15 @@ spec:
                               description: PortProtocol specifies an L4 port with
                                 an optional transport protocol
                               properties:
+                                endPort:
+                                  description: EndPort can be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
+                                  description: Port can be an L4 port number, or a
+                                    name in the form of "http" or "http-8080".
                                   pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
@@ -1377,15 +1377,15 @@ spec:
                               description: PortProtocol specifies an L4 port with
                                 an optional transport protocol
                               properties:
+                                endPort:
+                                  description: EndPort can be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
+                                  description: Port can be an L4 port number, or a
+                                    name in the form of "http" or "http-8080".
                                   pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
@@ -2156,15 +2156,15 @@ spec:
                               description: PortProtocol specifies an L4 port with
                                 an optional transport protocol
                               properties:
+                                endPort:
+                                  description: EndPort can be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
+                                  description: Port can be an L4 port number, or a
+                                    name in the form of "http" or "http-8080".
                                   pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
@@ -2897,15 +2897,15 @@ spec:
                               description: PortProtocol specifies an L4 port with
                                 an optional transport protocol
                               properties:
+                                endPort:
+                                  description: EndPort can be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
+                                  description: Port can be an L4 port number, or a
+                                    name in the form of "http" or "http-8080".
                                   pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
@@ -3531,15 +3531,15 @@ spec:
                                 description: PortProtocol specifies an L4 port with
                                   an optional transport protocol
                                 properties:
+                                  endPort:
+                                    description: EndPort can be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
+                                    description: Port can be an L4 port number, or
+                                      a name in the form of "http" or "http-8080".
                                     pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
@@ -4373,15 +4373,15 @@ spec:
                                 description: PortProtocol specifies an L4 port with
                                   an optional transport protocol
                                 properties:
+                                  endPort:
+                                    description: EndPort can be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
+                                    description: Port can be an L4 port number, or
+                                      a name in the form of "http" or "http-8080".
                                     pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
@@ -5162,15 +5162,15 @@ spec:
                                 description: PortProtocol specifies an L4 port with
                                   an optional transport protocol
                                 properties:
+                                  endPort:
+                                    description: EndPort can be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
+                                    description: Port can be an L4 port number, or
+                                      a name in the form of "http" or "http-8080".
                                     pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
@@ -5914,15 +5914,15 @@ spec:
                                 description: PortProtocol specifies an L4 port with
                                   an optional transport protocol
                                 properties:
+                                  endPort:
+                                    description: EndPort can be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
+                                    description: Port can be an L4 port number, or
+                                      a name in the form of "http" or "http-8080".
                                     pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -552,15 +552,15 @@ spec:
                               description: PortProtocol specifies an L4 port with
                                 an optional transport protocol
                               properties:
+                                endPort:
+                                  description: EndPort can be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
+                                  description: Port can be an L4 port number, or a
+                                    name in the form of "http" or "http-8080".
                                   pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
@@ -1381,15 +1381,15 @@ spec:
                               description: PortProtocol specifies an L4 port with
                                 an optional transport protocol
                               properties:
+                                endPort:
+                                  description: EndPort can be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
+                                  description: Port can be an L4 port number, or a
+                                    name in the form of "http" or "http-8080".
                                   pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
@@ -2160,15 +2160,15 @@ spec:
                               description: PortProtocol specifies an L4 port with
                                 an optional transport protocol
                               properties:
+                                endPort:
+                                  description: EndPort can be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
+                                  description: Port can be an L4 port number, or a
+                                    name in the form of "http" or "http-8080".
                                   pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
@@ -2901,15 +2901,15 @@ spec:
                               description: PortProtocol specifies an L4 port with
                                 an optional transport protocol
                               properties:
+                                endPort:
+                                  description: EndPort can be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
+                                  description: Port can be an L4 port number, or a
+                                    name in the form of "http" or "http-8080".
                                   pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
@@ -3535,15 +3535,15 @@ spec:
                                 description: PortProtocol specifies an L4 port with
                                   an optional transport protocol
                                 properties:
+                                  endPort:
+                                    description: EndPort can be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
+                                    description: Port can be an L4 port number, or
+                                      a name in the form of "http" or "http-8080".
                                     pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
@@ -4377,15 +4377,15 @@ spec:
                                 description: PortProtocol specifies an L4 port with
                                   an optional transport protocol
                                 properties:
+                                  endPort:
+                                    description: EndPort can be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
+                                    description: Port can be an L4 port number, or
+                                      a name in the form of "http" or "http-8080".
                                     pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
@@ -5166,15 +5166,15 @@ spec:
                                 description: PortProtocol specifies an L4 port with
                                   an optional transport protocol
                                 properties:
+                                  endPort:
+                                    description: EndPort can be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
+                                    description: Port can be an L4 port number, or
+                                      a name in the form of "http" or "http-8080".
                                     pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
@@ -5918,15 +5918,15 @@ spec:
                                 description: PortProtocol specifies an L4 port with
                                   an optional transport protocol
                                 properties:
+                                  endPort:
+                                    description: EndPort can be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
+                                    description: Port can be an L4 port number, or
+                                      a name in the form of "http" or "http-8080".
                                     pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:

--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -251,26 +251,6 @@ func ParseNetworkPolicy(np *slim_networkingv1.NetworkPolicy) (api.Rules, error) 
 	return api.Rules{rule}, nil
 }
 
-// NetworkPolicyHasEndPort returns true if the network policy has an
-// EndPort.
-func NetworkPolicyHasEndPort(np *slim_networkingv1.NetworkPolicy) bool {
-	for _, iRule := range np.Spec.Ingress {
-		for _, port := range iRule.Ports {
-			if port.EndPort != nil && *port.EndPort > 0 {
-				return true
-			}
-		}
-	}
-	for _, eRule := range np.Spec.Egress {
-		for _, port := range eRule.Ports {
-			if port.EndPort != nil && *port.EndPort > 0 {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 func parsePodSelector(podSelectorIn *slim_metav1.LabelSelector, namespace string) *slim_metav1.LabelSelector {
 	podSelector := &slim_metav1.LabelSelector{
 		MatchLabels: make(map[string]slim_metav1.MatchLabelsValue, len(podSelectorIn.MatchLabels)),
@@ -317,13 +297,17 @@ func parsePorts(ports []slim_networkingv1.NetworkPolicyPort) []api.PortRule {
 		}
 
 		portStr := "0"
+		var endPort int32
 		if port.Port != nil {
 			portStr = port.Port.String()
+		}
+		if port.EndPort != nil {
+			endPort = *port.EndPort
 		}
 
 		portRule := api.PortRule{
 			Ports: []api.PortProtocol{
-				{Port: portStr, Protocol: protocol},
+				{Port: portStr, EndPort: endPort, Protocol: protocol},
 			},
 		}
 

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -13,6 +13,8 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
+
+	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -44,7 +46,7 @@ func setupPolicyMapPrivilegedTestSuite(tb testing.TB) *PolicyMap {
 func TestPolicyMapDumpToSlice(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 
-	fooEntry := newKey(1, 1, 1, 1)
+	fooEntry := newKey(1, 1, policyapi.FullPortMask, 1, 1)
 	err := testMap.AllowKey(fooEntry, 0, 0)
 	require.Nil(t, err)
 
@@ -55,7 +57,7 @@ func TestPolicyMapDumpToSlice(t *testing.T) {
 	require.EqualValues(t, fooEntry, dump[0].Key)
 
 	// Special case: allow-all entry
-	barEntry := newKey(0, 0, 0, 0)
+	barEntry := newKey(0, 0, policyapi.FullPortMask, 0, 0)
 	err = testMap.AllowKey(barEntry, 0, 0)
 	require.Nil(t, err)
 
@@ -66,8 +68,7 @@ func TestPolicyMapDumpToSlice(t *testing.T) {
 
 func TestDeleteNonexistentKey(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
-
-	key := newKey(27, 80, u8proto.TCP, trafficdirection.Ingress)
+	key := newKey(27, 80, policyapi.FullPortMask, u8proto.TCP, trafficdirection.Ingress)
 	err := testMap.Map.Delete(&key)
 	require.NotNil(t, err)
 	var errno unix.Errno
@@ -78,7 +79,7 @@ func TestDeleteNonexistentKey(t *testing.T) {
 func TestDenyPolicyMapDumpToSlice(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 
-	fooKey := newKey(1, 1, 1, 1)
+	fooKey := newKey(1, 1, policyapi.FullPortMask, 1, 1)
 	fooEntry := newDenyEntry(fooKey)
 	err := testMap.DenyKey(fooKey)
 	require.Nil(t, err)
@@ -91,7 +92,7 @@ func TestDenyPolicyMapDumpToSlice(t *testing.T) {
 	require.EqualValues(t, fooEntry, dump[0].PolicyEntry)
 
 	// Special case: deny-all entry
-	barKey := newKey(0, 0, 0, 0)
+	barKey := newKey(0, 0, policyapi.FullPortMask, 0, 0)
 	err = testMap.DenyKey(barKey)
 	require.Nil(t, err)
 

--- a/pkg/maps/policymap/policymap_test.go
+++ b/pkg/maps/policymap/policymap_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/byteorder"
+	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -263,7 +264,7 @@ func TestPolicyMapWildcarding(t *testing.T) {
 		}
 
 		// Get key
-		key := newKey(uint32(tt.args.id), uint16(tt.args.dport), u8proto.U8proto(tt.args.proto),
+		key := newKey(uint32(tt.args.id), uint16(tt.args.dport), policyapi.FullPortMask, u8proto.U8proto(tt.args.proto),
 			trafficdirection.TrafficDirection(tt.args.trafficDirection))
 
 		// Compure entry & validate key and entry

--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -21,6 +21,9 @@ const (
 	ProtoAny    L4Proto = "ANY"
 
 	PortProtocolAny = "0/ANY"
+
+	// FullPortMask is the mask to select only one port.
+	FullPortMask uint16 = 0xffff
 )
 
 // IsAny returns true if an L4Proto represents ANY protocol
@@ -30,15 +33,18 @@ func (l4 L4Proto) IsAny() bool {
 
 // PortProtocol specifies an L4 port with an optional transport protocol
 type PortProtocol struct {
-	// Port is an L4 port number. For now the string will be strictly
-	// parsed as a single uint16. In the future, this field may support
-	// ranges in the form "1024-2048
-	// Port can also be a port name, which must contain at least one [a-z],
-	// and may also contain [0-9] and '-' anywhere except adjacent to another
-	// '-' or in the beginning or the end.
+	// Port can be an L4 port number, or a name in the form of "http"
+	// or "http-8080".
 	//
 	// +kubebuilder:validation:Pattern=`^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$`
 	Port string `json:"port"`
+
+	// EndPort can be an L4 port number.
+	//
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
+	// +kubebuilder:validation:Optional
+	EndPort int32 `json:"endPort,omitempty"`
 
 	// Protocol is the L4 protocol. If omitted or empty, any protocol
 	// matches. Accepted values: "TCP", "UDP", "SCTP", "ANY"

--- a/pkg/policy/api/zz_generated.deepequal.go
+++ b/pkg/policy/api/zz_generated.deepequal.go
@@ -987,6 +987,9 @@ func (in *PortProtocol) DeepEqual(other *PortProtocol) bool {
 	if in.Port != other.Port {
 		return false
 	}
+	if in.EndPort != other.EndPort {
+		return false
+	}
 	if in.Protocol != other.Protocol {
 		return false
 	}

--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -59,6 +60,7 @@ func CorrelatePolicy(endpointGetter getters.EndpointGetter, f *flowpb.Flow) {
 	derivedFrom, rev, ok := lookupPolicyForKey(epInfo, policy.Key{
 		Identity:         uint32(remoteIdentity),
 		DestPort:         dport,
+		PortMask:         api.FullPortMask,
 		Nexthdr:          uint8(proto),
 		TrafficDirection: uint8(direction),
 	}, f.GetPolicyMatchType())
@@ -141,6 +143,7 @@ func lookupPolicyForKey(ep v1.EndpointInfo, key policy.Key, matchType uint32) (d
 		derivedFrom, rev, ok = ep.GetRealizedPolicyRuleLabelsForKey(policy.Key{
 			Identity:         key.Identity,
 			DestPort:         0,
+			PortMask:         api.FullPortMask,
 			Nexthdr:          0,
 			TrafficDirection: key.TrafficDirection,
 		})
@@ -149,6 +152,7 @@ func lookupPolicyForKey(ep v1.EndpointInfo, key policy.Key, matchType uint32) (d
 		derivedFrom, rev, ok = ep.GetRealizedPolicyRuleLabelsForKey(policy.Key{
 			Identity:         0,
 			DestPort:         0,
+			PortMask:         api.FullPortMask,
 			Nexthdr:          0,
 			TrafficDirection: key.TrafficDirection,
 		})

--- a/pkg/policy/correlation/correlation_test.go
+++ b/pkg/policy/correlation/correlation_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -64,6 +65,7 @@ func TestCorrelatePolicy(t *testing.T) {
 	policyKey := policy.Key{
 		Identity:         uint32(remoteIdentity),
 		DestPort:         uint16(dstPort),
+		PortMask:         api.FullPortMask,
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Egress.Uint8(),
 	}

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -344,16 +344,16 @@ var (
 	dirIngress = trafficdirection.Ingress.Uint8()
 	dirEgress  = trafficdirection.Egress.Uint8()
 	// Desired map keys for L3, L3-dependent L4, L4
-	mapKeyAllowFoo__ = Key{identityFoo, 0, 0, dirIngress}
-	mapKeyAllowBar__ = Key{identityBar, 0, 0, dirIngress}
-	mapKeyAllowBarL4 = Key{identityBar, 80, 6, dirIngress}
-	mapKeyAllowFooL4 = Key{identityFoo, 80, 6, dirIngress}
+	mapKeyAllowFoo__ = Key{identityFoo, 0, api.FullPortMask, 0, dirIngress}
+	mapKeyAllowBar__ = Key{identityBar, 0, api.FullPortMask, 0, dirIngress}
+	mapKeyAllowBarL4 = Key{identityBar, 80, api.FullPortMask, 6, dirIngress}
+	mapKeyAllowFooL4 = Key{identityFoo, 80, api.FullPortMask, 6, dirIngress}
 	mapKeyDeny_Foo__ = mapKeyAllowFoo__
 	mapKeyDeny_FooL4 = mapKeyAllowFooL4
-	mapKeyAllow___L4 = Key{0, 80, 6, dirIngress}
+	mapKeyAllow___L4 = Key{0, 80, api.FullPortMask, 6, dirIngress}
 	mapKeyDeny____L4 = mapKeyAllow___L4
-	mapKeyAllowAll__ = Key{0, 0, 0, dirIngress}
-	mapKeyAllowAllE_ = Key{0, 0, 0, dirEgress}
+	mapKeyAllowAll__ = Key{0, 0, api.FullPortMask, 0, dirIngress}
+	mapKeyAllowAllE_ = Key{0, 0, api.FullPortMask, 0, dirEgress}
 	// Desired map entries for no L7 redirect / redirect to Proxy
 	mapEntryL7None_ = func(lbls ...labels.LabelArray) MapStateEntry {
 		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), 0, "", 0, false, DefaultAuthType, AuthTypeDisabled).WithOwners()
@@ -1366,8 +1366,8 @@ var (
 	worldReservedID           = identity.ReservedIdentityWorld.Uint32()
 	worldReservedIPv4ID       = identity.ReservedIdentityWorldIPv4.Uint32()
 	worldReservedIPv6ID       = identity.ReservedIdentityWorldIPv6.Uint32()
-	mapKeyL3WorldIngress      = Key{worldReservedID, 0, 0, trafficdirection.Ingress.Uint8()}
-	mapKeyL3WorldEgress       = Key{worldReservedID, 0, 0, trafficdirection.Egress.Uint8()}
+	mapKeyL3WorldIngress      = Key{worldReservedID, 0, api.FullPortMask, 0, trafficdirection.Ingress.Uint8()}
+	mapKeyL3WorldEgress       = Key{worldReservedID, 0, api.FullPortMask, 0, trafficdirection.Egress.Uint8()}
 	mapEntryDeny              = MapStateEntry{
 		ProxyPort:        0,
 		DerivedFromRules: labels.LabelArrayList{nil},
@@ -1420,8 +1420,8 @@ var (
 			ToCIDRSet: api.CIDRRuleSlice{worldSubnetRule},
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
-	mapKeyL3SubnetIngress = Key{worldSubnetIdentity.Uint32(), 0, 0, trafficdirection.Ingress.Uint8()}
-	mapKeyL3SubnetEgress  = Key{worldSubnetIdentity.Uint32(), 0, 0, trafficdirection.Egress.Uint8()}
+	mapKeyL3SubnetIngress = Key{worldSubnetIdentity.Uint32(), 0, api.FullPortMask, 0, trafficdirection.Ingress.Uint8()}
+	mapKeyL3SubnetEgress  = Key{worldSubnetIdentity.Uint32(), 0, api.FullPortMask, 0, trafficdirection.Egress.Uint8()}
 
 	ruleL3DenySmallerSubnet = api.NewRule().WithIngressDenyRules([]api.IngressDenyRule{{
 		IngressCommonRule: api.IngressCommonRule{
@@ -1443,8 +1443,8 @@ var (
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
 
-	mapKeyL3SmallerSubnetIngress = Key{worldIPIdentity.Uint32(), 0, 0, trafficdirection.Ingress.Uint8()}
-	mapKeyL3SmallerSubnetEgress  = Key{worldIPIdentity.Uint32(), 0, 0, trafficdirection.Egress.Uint8()}
+	mapKeyL3SmallerSubnetIngress = Key{worldIPIdentity.Uint32(), 0, api.FullPortMask, 0, trafficdirection.Ingress.Uint8()}
+	mapKeyL3SmallerSubnetEgress  = Key{worldIPIdentity.Uint32(), 0, api.FullPortMask, 0, trafficdirection.Egress.Uint8()}
 
 	ruleL3AllowHostEgress = api.NewRule().WithEgressRules([]api.EgressRule{{
 		EgressCommonRule: api.EgressCommonRule{
@@ -1452,14 +1452,14 @@ var (
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
 
-	mapKeyL3UnknownIngress = Key{identity.IdentityUnknown.Uint32(), 0, 0, trafficdirection.Ingress.Uint8()}
+	mapKeyL3UnknownIngress = Key{identity.IdentityUnknown.Uint32(), 0, api.FullPortMask, 0, trafficdirection.Ingress.Uint8()}
 	derivedFrom            = labels.LabelArrayList{
 		labels.LabelArray{
 			labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowAnyIngress, labels.LabelSourceReserved),
 		},
 	}
 	mapEntryL3UnknownIngress = NewMapStateEntry(nil, derivedFrom, 0, "", 0, false, ExplicitAuthType, AuthTypeDisabled)
-	mapKeyL3HostEgress       = Key{identity.ReservedIdentityHost.Uint32(), 0, 0, trafficdirection.Egress.Uint8()}
+	mapKeyL3HostEgress       = Key{identity.ReservedIdentityHost.Uint32(), 0, api.FullPortMask, 0, trafficdirection.Egress.Uint8()}
 
 	ruleL3L4Port8080ProtoAnyDenyWorld = api.NewRule().WithIngressDenyRules([]api.IngressDenyRule{
 		{
@@ -1494,31 +1494,31 @@ var (
 			},
 		},
 	}).WithEndpointSelector(api.WildcardEndpointSelector)
-	mapKeyL3L4Port8080ProtoTCPWorldIngress      = Key{worldReservedID, 8080, 6, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoTCPWorldEgress       = Key{worldReservedID, 8080, 6, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoTCPWorldIPv4Ingress  = Key{worldReservedIPv4ID, 8080, 6, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoTCPWorldIPv4Egress   = Key{worldReservedIPv4ID, 8080, 6, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoTCPWorldIPv6Ingress  = Key{worldReservedIPv6ID, 8080, 6, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoTCPWorldIPv6Egress   = Key{worldReservedIPv6ID, 8080, 6, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoUDPWorldIngress      = Key{worldReservedID, 8080, 17, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoUDPWorldEgress       = Key{worldReservedID, 8080, 17, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoUDPWorldIPv4Ingress  = Key{worldReservedIPv4ID, 8080, 17, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoUDPWorldIPv4Egress   = Key{worldReservedIPv4ID, 8080, 17, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoUDPWorldIPv6Ingress  = Key{worldReservedIPv6ID, 8080, 17, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoUDPWorldIPv6Egress   = Key{worldReservedIPv6ID, 8080, 17, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoSCTPWorldIngress     = Key{worldReservedID, 8080, 132, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoSCTPWorldEgress      = Key{worldReservedID, 8080, 132, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoSCTPWorldIPv4Ingress = Key{worldReservedIPv4ID, 8080, 132, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoSCTPWorldIPv4Egress  = Key{worldReservedIPv4ID, 8080, 132, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoSCTPWorldIPv6Ingress = Key{worldReservedIPv6ID, 8080, 132, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoSCTPWorldIPv6Egress  = Key{worldReservedIPv6ID, 8080, 132, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoTCPWorldIngress      = Key{worldReservedID, 8080, api.FullPortMask, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoTCPWorldEgress       = Key{worldReservedID, 8080, api.FullPortMask, 6, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoTCPWorldIPv4Ingress  = Key{worldReservedIPv4ID, 8080, api.FullPortMask, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoTCPWorldIPv4Egress   = Key{worldReservedIPv4ID, 8080, api.FullPortMask, 6, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoTCPWorldIPv6Ingress  = Key{worldReservedIPv6ID, 8080, api.FullPortMask, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoTCPWorldIPv6Egress   = Key{worldReservedIPv6ID, 8080, api.FullPortMask, 6, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoUDPWorldIngress      = Key{worldReservedID, 8080, api.FullPortMask, 17, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoUDPWorldEgress       = Key{worldReservedID, 8080, api.FullPortMask, 17, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoUDPWorldIPv4Ingress  = Key{worldReservedIPv4ID, 8080, api.FullPortMask, 17, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoUDPWorldIPv4Egress   = Key{worldReservedIPv4ID, 8080, api.FullPortMask, 17, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoUDPWorldIPv6Ingress  = Key{worldReservedIPv6ID, 8080, api.FullPortMask, 17, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoUDPWorldIPv6Egress   = Key{worldReservedIPv6ID, 8080, api.FullPortMask, 17, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoSCTPWorldIngress     = Key{worldReservedID, 8080, api.FullPortMask, 132, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoSCTPWorldEgress      = Key{worldReservedID, 8080, api.FullPortMask, 132, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoSCTPWorldIPv4Ingress = Key{worldReservedIPv4ID, 8080, api.FullPortMask, 132, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoSCTPWorldIPv4Egress  = Key{worldReservedIPv4ID, 8080, api.FullPortMask, 132, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoSCTPWorldIPv6Ingress = Key{worldReservedIPv6ID, 8080, api.FullPortMask, 132, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoSCTPWorldIPv6Egress  = Key{worldReservedIPv6ID, 8080, api.FullPortMask, 132, trafficdirection.Egress.Uint8()}
 
-	mapKeyL3L4Port8080ProtoTCPWorldSNIngress  = Key{worldSubnetIdentity.Uint32(), 8080, 6, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoTCPWorldSNEgress   = Key{worldSubnetIdentity.Uint32(), 8080, 6, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoUDPWorldSNIngress  = Key{worldSubnetIdentity.Uint32(), 8080, 17, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoUDPWorldSNEgress   = Key{worldSubnetIdentity.Uint32(), 8080, 17, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoSCTPWorldSNIngress = Key{worldSubnetIdentity.Uint32(), 8080, 132, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoSCTPWorldSNEgress  = Key{worldSubnetIdentity.Uint32(), 8080, 132, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoTCPWorldSNIngress  = Key{worldSubnetIdentity.Uint32(), 8080, api.FullPortMask, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoTCPWorldSNEgress   = Key{worldSubnetIdentity.Uint32(), 8080, api.FullPortMask, 6, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoUDPWorldSNIngress  = Key{worldSubnetIdentity.Uint32(), 8080, api.FullPortMask, 17, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoUDPWorldSNEgress   = Key{worldSubnetIdentity.Uint32(), 8080, api.FullPortMask, 17, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoSCTPWorldSNIngress = Key{worldSubnetIdentity.Uint32(), 8080, api.FullPortMask, 132, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoSCTPWorldSNEgress  = Key{worldSubnetIdentity.Uint32(), 8080, api.FullPortMask, 132, trafficdirection.Egress.Uint8()}
 
 	ruleL3AllowWorldSubnet = api.NewRule().WithIngressRules([]api.IngressRule{{
 		ToPorts: api.PortRules{
@@ -1559,14 +1559,14 @@ var (
 			ToCIDR: api.CIDRSlice{worldCIDR},
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
-	mapKeyL4Port8080ProtoAnyWorldIPIngress       = Key{worldIPIdentity.Uint32(), 0, 0, trafficdirection.Ingress.Uint8()}
-	mapKeyL4Port8080ProtoAnyWorldIPEgress        = Key{worldIPIdentity.Uint32(), 0, 0, trafficdirection.Egress.Uint8()}
-	mapKeyL4Port8080ProtoTCPWorldIPIngress       = Key{worldIPIdentity.Uint32(), 8080, 6, trafficdirection.Ingress.Uint8()}
-	mapKeyL4Port8080ProtoTCPWorldIPEgress        = Key{worldIPIdentity.Uint32(), 8080, 6, trafficdirection.Egress.Uint8()}
-	mapKeyL4Port8080ProtoUDPWorldIPIngress       = Key{worldIPIdentity.Uint32(), 8080, 17, trafficdirection.Ingress.Uint8()}
-	mapKeyL4Port8080ProtoUDPWorldIPEgress        = Key{worldIPIdentity.Uint32(), 8080, 17, trafficdirection.Egress.Uint8()}
-	mapKeyL4Port8080ProtoSCTPWorldIPIngress      = Key{worldIPIdentity.Uint32(), 8080, 132, trafficdirection.Ingress.Uint8()}
-	mapKeyL4Port8080ProtoSCTPWorldIPEgress       = Key{worldIPIdentity.Uint32(), 8080, 132, trafficdirection.Egress.Uint8()}
+	mapKeyL4Port8080ProtoAnyWorldIPIngress       = Key{worldIPIdentity.Uint32(), 0, api.FullPortMask, 0, trafficdirection.Ingress.Uint8()}
+	mapKeyL4Port8080ProtoAnyWorldIPEgress        = Key{worldIPIdentity.Uint32(), 0, api.FullPortMask, 0, trafficdirection.Egress.Uint8()}
+	mapKeyL4Port8080ProtoTCPWorldIPIngress       = Key{worldIPIdentity.Uint32(), 8080, api.FullPortMask, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL4Port8080ProtoTCPWorldIPEgress        = Key{worldIPIdentity.Uint32(), 8080, api.FullPortMask, 6, trafficdirection.Egress.Uint8()}
+	mapKeyL4Port8080ProtoUDPWorldIPIngress       = Key{worldIPIdentity.Uint32(), 8080, api.FullPortMask, 17, trafficdirection.Ingress.Uint8()}
+	mapKeyL4Port8080ProtoUDPWorldIPEgress        = Key{worldIPIdentity.Uint32(), 8080, api.FullPortMask, 17, trafficdirection.Egress.Uint8()}
+	mapKeyL4Port8080ProtoSCTPWorldIPIngress      = Key{worldIPIdentity.Uint32(), 8080, api.FullPortMask, 132, trafficdirection.Ingress.Uint8()}
+	mapKeyL4Port8080ProtoSCTPWorldIPEgress       = Key{worldIPIdentity.Uint32(), 8080, api.FullPortMask, 132, trafficdirection.Egress.Uint8()}
 	mapEntryL4SubnetPort8080ProtoAnyIngressAllow = MapStateEntry{
 		ProxyPort:        0,
 		IsDeny:           true,
@@ -1589,6 +1589,48 @@ var (
 			mapKeyL4Port8080ProtoSCTPWorldIPEgress: struct{}{},
 		},
 	}
+
+	ruleL3AllowWorldSubnetNamedPort = api.NewRule().WithIngressRules([]api.IngressRule{{
+		ToPorts: api.PortRules{
+			api.PortRule{
+				Ports: []api.PortProtocol{
+					{
+						Port:     "http-8080",
+						Protocol: api.ProtoTCP,
+					},
+				},
+			},
+		},
+		IngressCommonRule: api.IngressCommonRule{
+			FromCIDR: api.CIDRSlice{worldSubnet},
+		},
+	}})
+	mapKeyL3L4NamedPort8080ProtoTCPWorldSubNetIngress = Key{worldSubnetIdentity.Uint32(), 8080, api.FullPortMask, 6, trafficdirection.Ingress.Uint8()}
+
+	ruleL3AllowWorldSubnetPortRange = api.NewRule().WithIngressRules([]api.IngressRule{{
+		ToPorts: api.PortRules{
+			api.PortRule{
+				Ports: []api.PortProtocol{
+					{
+						Port:     "64-127",
+						Protocol: api.ProtoAny,
+					},
+					{
+						Port:     "5-10",
+						Protocol: api.ProtoAny,
+					},
+				},
+			},
+		},
+		IngressCommonRule: api.IngressCommonRule{
+			FromCIDR: api.CIDRSlice{worldSubnet},
+		},
+	}})
+	mapKeyL3L4Port64To127ProtoTCPWorldSubNetIngress = Key{worldSubnetIdentity.Uint32(), 64, 0xffc0, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port5ProtoTCPWorldSubNetIngress       = Key{worldSubnetIdentity.Uint32(), 5, api.FullPortMask, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port6To7ProtoTCPWorldSubNetIngress    = Key{worldSubnetIdentity.Uint32(), 6, 0xfffe, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8To9ProtoTCPWorldSubNetIngress    = Key{worldSubnetIdentity.Uint32(), 8, 0xfffe, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port10ProtoTCPWorldSubNetIngress      = Key{worldSubnetIdentity.Uint32(), 10, api.FullPortMask, 6, trafficdirection.Ingress.Uint8()}
 )
 
 func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
@@ -1664,6 +1706,14 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 			mapKeyL4Port8080ProtoUDPWorldIPEgress:   mapEntryDeny,
 			mapKeyL4Port8080ProtoSCTPWorldIPIngress: mapEntryDeny,
 			mapKeyL4Port8080ProtoSCTPWorldIPEgress:  mapEntryDeny,
+		})}, {"named_port_world_subnet", api.Rules{ruleL3AllowWorldSubnetNamedPort}, newMapState(map[Key]MapStateEntry{
+			mapKeyL3L4NamedPort8080ProtoTCPWorldSubNetIngress: mapEntryAllow,
+		})}, {"port_range_world_subnet", api.Rules{ruleL3AllowWorldSubnetPortRange}, newMapState(map[Key]MapStateEntry{
+			mapKeyL3L4Port64To127ProtoTCPWorldSubNetIngress: mapEntryAllow,
+			mapKeyL3L4Port5ProtoTCPWorldSubNetIngress:       mapEntryAllow,
+			mapKeyL3L4Port6To7ProtoTCPWorldSubNetIngress:    mapEntryAllow,
+			mapKeyL3L4Port8To9ProtoTCPWorldSubNetIngress:    mapEntryAllow,
+			mapKeyL3L4Port10ProtoTCPWorldSubNetIngress:      mapEntryAllow,
 		})},
 	}
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -745,11 +745,11 @@ func testCaseToMapState(t generatedBPFKey) MapState {
 
 	if t.L3Key.L3 != nil {
 		if t.L3Key.Deny != nil && *t.L3Key.Deny {
-			m.denies[mapKeyDeny_Foo__] = mapEntryL7Deny_()
+			m.denies.Upsert(mapKeyDeny_Foo__, mapEntryL7Deny_())
 		} else {
 			// If L7 is not set or if it explicitly set but it's false
 			if t.L3Key.L7 == nil || !*t.L3Key.L7 {
-				m.allows[mapKeyAllowFoo__] = mapEntryL7None_()
+				m.allows.Upsert(mapKeyAllowFoo__, mapEntryL7None_())
 			}
 			// there's no "else" because we don't support L3L7 policies, i.e.,
 			// a L4 port needs to be specified.
@@ -757,40 +757,40 @@ func testCaseToMapState(t generatedBPFKey) MapState {
 	}
 	if t.L4Key.L3 != nil {
 		if t.L4Key.Deny != nil && *t.L4Key.Deny {
-			m.denies[mapKeyDeny____L4] = mapEntryL7Deny_()
+			m.denies.Upsert(mapKeyDeny____L4, mapEntryL7Deny_())
 		} else {
 			// If L7 is not set or if it explicitly set but it's false
 			if t.L4Key.L7 == nil || !*t.L4Key.L7 {
-				m.allows[mapKeyAllow___L4] = mapEntryL7None_()
+				m.allows.Upsert(mapKeyAllow___L4, mapEntryL7None_())
 			} else {
 				// L7 is set and it's true then we should expected a mapEntry
 				// with L7 redirection.
-				m.allows[mapKeyAllow___L4] = mapEntryL7Proxy()
+				m.allows.Upsert(mapKeyAllow___L4, mapEntryL7Proxy())
 			}
 		}
 	}
 	if t.L3L4Key.L3 != nil {
 		if t.L3L4Key.Deny != nil && *t.L3L4Key.Deny {
-			m.denies[mapKeyDeny_FooL4] = mapEntryL7Deny_()
+			m.denies.Upsert(mapKeyDeny_FooL4, mapEntryL7Deny_())
 		} else {
 			// If L7 is not set or if it explicitly set but it's false
 			if t.L3L4Key.L7 == nil || !*t.L3L4Key.L7 {
-				m.allows[mapKeyAllowFooL4] = mapEntryL7None_()
+				m.allows.Upsert(mapKeyAllowFooL4, mapEntryL7None_())
 			} else {
 				// L7 is set and it's true then we should expected a mapEntry
 				// with L7 redirection only if we haven't set it already
 				// for an existing L4-only.
 				if t.L4Key.L7 == nil || !*t.L4Key.L7 {
-					m.allows[mapKeyAllowFooL4] = mapEntryL7Proxy()
+					m.allows.Upsert(mapKeyAllowFooL4, mapEntryL7Proxy())
 				}
 			}
 		}
 	}
 
 	// Add dependency deny-L3->deny-L3L4 if allow-L4 exists
-	denyL3, denyL3exists := m.denies[mapKeyDeny_Foo__]
-	denyL3L4, denyL3L4exists := m.denies[mapKeyDeny_FooL4]
-	allowL4, allowL4exists := m.allows[mapKeyAllow___L4]
+	denyL3, denyL3exists := m.denies.Lookup(mapKeyDeny_Foo__)
+	denyL3L4, denyL3L4exists := m.denies.Lookup(mapKeyDeny_FooL4)
+	allowL4, allowL4exists := m.allows.Lookup(mapKeyAllow___L4)
 	if allowL4exists && !allowL4.IsDeny && denyL3exists && denyL3.IsDeny && denyL3L4exists && denyL3L4.IsDeny {
 		m.AddDependent(mapKeyDeny_Foo__, mapKeyDeny_FooL4, ChangeState{})
 	}

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -41,7 +41,7 @@ func FuzzResolveEgressPolicy(f *testing.F) {
 func FuzzDenyPreferredInsert(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		keys := newMapState(nil)
-		key := Key{}
+		key := Key{PortMask: api.FullPortMask}
 		entry := MapStateEntry{}
 		ff := fuzz.NewConsumer(data)
 		ff.GenerateStruct(&keys)
@@ -80,9 +80,9 @@ func FuzzAccumulateMapChange(f *testing.F) {
 		if redirect {
 			proxyPort = 1
 		}
-		key := Key{DestPort: port, Nexthdr: proto, TrafficDirection: dir.Uint8()}
+		key := Key{DestPort: port, PortMask: api.FullPortMask, Nexthdr: proto, TrafficDirection: dir.Uint8()}
 		value := NewMapStateEntry(csFoo, nil, proxyPort, "", 0, deny, DefaultAuthType, AuthTypeDisabled)
 		policyMaps := MapChanges{}
-		policyMaps.AccumulateMapChanges(csFoo, adds, deletes, key, value)
+		policyMaps.AccumulateMapChanges(csFoo, adds, deletes, []Key{key}, value)
 	})
 }

--- a/pkg/policy/k8s/network_policy.go
+++ b/pkg/policy/k8s/network_policy.go
@@ -31,10 +31,6 @@ func (p *policyWatcher) addK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPo
 	}
 	scopedLog = scopedLog.WithField(logfields.K8sNetworkPolicyName, k8sNP.ObjectMeta.Name)
 
-	if k8s.NetworkPolicyHasEndPort(k8sNP) {
-		scopedLog.Warning("EndPort in kubernetes NetworkPolicy is not supported")
-	}
-
 	opts := policy.AddOptions{
 		Replace: true,
 		Source:  source.Kubernetes,

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -431,7 +431,9 @@ func (a L7ParserType) Merge(b L7ParserType) (L7ParserType, error) {
 type L4Filter struct {
 	// Port is the destination port to allow. Port 0 indicates that all traffic
 	// is allowed at L4.
-	Port     uint16 `json:"port"`
+	Port uint16 `json:"port"`
+	// EndPort is zero for a singular port
+	EndPort  uint16 `json:"endPort,omitempty"`
 	PortName string `json:"port-name,omitempty"`
 	// Protocol is the L4 protocol to allow or NONE
 	Protocol api.L4Proto `json:"protocol"`
@@ -538,11 +540,15 @@ func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redir
 		}
 	}
 
-	keyToAdd := Key{
-		Identity:         0,    // Set in the loop below (if not wildcard)
-		DestPort:         port, // NOTE: Port is in host byte-order!
-		Nexthdr:          proto,
-		TrafficDirection: direction.Uint8(),
+	var keysToAdd []Key
+	for _, mp := range PortRangeToMaskedPorts(port, l4.EndPort) {
+		keysToAdd = append(keysToAdd, Key{
+			Identity:         0,       // Set in the loop below (if not wildcard)
+			DestPort:         mp.port, // NOTE: Port is in host byte-order!
+			PortMask:         mp.mask,
+			Nexthdr:          proto,
+			TrafficDirection: direction.Uint8(),
+		})
 	}
 
 	// find the L7 rules for the wildcard entry, if any
@@ -589,15 +595,17 @@ func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redir
 		entry := NewMapStateEntry(cs, l4.RuleOrigin[cs], proxyPort, currentRule.GetListener(), currentRule.GetPriority(), isDenyRule, hasAuth, authType)
 
 		if cs.IsWildcard() {
-			keyToAdd.Identity = 0
-			p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
+			for _, keyToAdd := range keysToAdd {
+				keyToAdd.Identity = 0
+				p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
 
-			if port == 0 {
-				// Allow-all
-				logger.WithField(logfields.EndpointSelector, cs).Debug("ToMapState: allow all")
-			} else {
-				// L4 allow
-				logger.WithField(logfields.EndpointSelector, cs).Debug("ToMapState: L4 allow all")
+				if port == 0 {
+					// Allow-all
+					logger.WithField(logfields.EndpointSelector, cs).Debug("ToMapState: allow all")
+				} else {
+					// L4 allow
+					logger.WithField(logfields.EndpointSelector, cs).Debug("ToMapState: L4 allow all")
+				}
 			}
 			continue
 		}
@@ -617,16 +625,18 @@ func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redir
 			}
 		}
 		for _, id := range idents {
-			keyToAdd.Identity = id.Uint32()
-			p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
-			// If Cilium is in dual-stack mode then the "World" identity
-			// needs to be split into two identities to represent World
-			// IPv6 and IPv4 traffic distinctly from one another.
-			if id == identity.ReservedIdentityWorld && option.Config.IsDualStack() {
-				keyToAdd.Identity = identity.ReservedIdentityWorldIPv4.Uint32()
+			for _, keyToAdd := range keysToAdd {
+				keyToAdd.Identity = id.Uint32()
 				p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
-				keyToAdd.Identity = identity.ReservedIdentityWorldIPv6.Uint32()
-				p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
+				// If Cilium is in dual-stack mode then the "World" identity
+				// needs to be split into two identities to represent World
+				// IPv6 and IPv4 traffic distinctly from one another.
+				if id == identity.ReservedIdentityWorld && option.Config.IsDualStack() {
+					keyToAdd.Identity = identity.ReservedIdentityWorldIPv4.Uint32()
+					p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
+					keyToAdd.Identity = identity.ReservedIdentityWorldIPv6.Uint32()
+					p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
+				}
 			}
 		}
 	}
@@ -776,8 +786,9 @@ func createL4Filter(policyCtx PolicyContext, peerEndpoints api.EndpointSelectorS
 	u8p, _ := u8proto.ParseProtocol(string(protocol))
 
 	l4 := &L4Filter{
-		Port:                uint16(p), // 0 for L3-only rules and named ports
-		PortName:            portName,  // non-"" for named ports
+		Port:                uint16(p),            // 0 for L3-only rules and named ports
+		EndPort:             uint16(port.EndPort), // 0 for a single port, >= 'Port' for a range
+		PortName:            portName,             // non-"" for named ports
 		Protocol:            protocol,
 		U8Proto:             u8p,
 		PerSelectorPolicies: make(L7DataMap),
@@ -1337,7 +1348,15 @@ func (l4Policy *L4Policy) AccumulateMapChanges(l4 *L4Filter, cs CachedSelector, 
 				proxyPort = unrealizedRedirectPort
 			}
 		}
-		key := Key{DestPort: port, Nexthdr: proto, TrafficDirection: direction.Uint8()}
+		var keysToAdd []Key
+		for _, mp := range PortRangeToMaskedPorts(port, l4.EndPort) {
+			keysToAdd = append(keysToAdd, Key{
+				DestPort:         mp.port, // NOTE: Port is in host byte-order!
+				PortMask:         mp.mask,
+				Nexthdr:          proto,
+				TrafficDirection: direction.Uint8(),
+			})
+		}
 		value := NewMapStateEntry(cs, derivedFrom, proxyPort, listener, priority, isDeny, hasAuth, authType)
 
 		if option.Config.Debug {
@@ -1358,7 +1377,7 @@ func (l4Policy *L4Policy) AccumulateMapChanges(l4 *L4Filter, cs CachedSelector, 
 				logfields.ListenerPriority: priority,
 			}).Debug("AccumulateMapChanges")
 		}
-		epPolicy.policyMapChanges.AccumulateMapChanges(cs, adds, deletes, key, value)
+		epPolicy.policyMapChanges.AccumulateMapChanges(cs, adds, deletes, keysToAdd, value)
 	}
 }
 

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -431,7 +431,7 @@ func (a L7ParserType) Merge(b L7ParserType) (L7ParserType, error) {
 type L4Filter struct {
 	// Port is the destination port to allow. Port 0 indicates that all traffic
 	// is allowed at L4.
-	Port     int    `json:"port"`
+	Port     uint16 `json:"port"`
 	PortName string `json:"port-name,omitempty"`
 	// Protocol is the L4 protocol to allow or NONE
 	Protocol api.L4Proto `json:"protocol"`
@@ -493,7 +493,7 @@ func (l4 *L4Filter) GetIngress() bool {
 
 // GetPort returns the port at which the L4Filter applies as a uint16.
 func (l4 *L4Filter) GetPort() uint16 {
-	return uint16(l4.Port)
+	return l4.Port
 }
 
 // ChangeState allows caller to revert changes made by (multiple) toMapState call(s)
@@ -512,7 +512,7 @@ type ChangeState struct {
 // 'redirects' is the map of currently realized redirects, it is used to find the proxy port for any redirects.
 // SelectorCache is also in read-locked state during this call.
 func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redirects map[string]uint16, changes ChangeState) {
-	port := uint16(l4.Port)
+	port := l4.Port
 	proto := uint8(l4.U8Proto)
 
 	direction := trafficdirection.Egress
@@ -776,8 +776,8 @@ func createL4Filter(policyCtx PolicyContext, peerEndpoints api.EndpointSelectorS
 	u8p, _ := u8proto.ParseProtocol(string(protocol))
 
 	l4 := &L4Filter{
-		Port:                int(p),   // 0 for L3-only rules and named ports
-		PortName:            portName, // non-"" for named ports
+		Port:                uint16(p), // 0 for L3-only rules and named ports
+		PortName:            portName,  // non-"" for named ports
 		Protocol:            protocol,
 		U8Proto:             u8p,
 		PerSelectorPolicies: make(L7DataMap),

--- a/pkg/policy/l4_filter_deny_test.go
+++ b/pkg/policy/l4_filter_deny_test.go
@@ -94,7 +94,7 @@ func TestMergeDenyAllL3(t *testing.T) {
 
 	filter, ok := l4IngressDenyPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.True(t, filter.SelectsAllEndpoints())

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -168,7 +168,7 @@ func TestMergeAllowAllL3AndAllowAllL7(t *testing.T) {
 
 	filter, ok := l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.True(t, filter.SelectsAllEndpoints())
@@ -335,7 +335,7 @@ func TestMergeAllowAllL3AndShadowedL7(t *testing.T) {
 
 	filter, ok := l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.True(t, filter.SelectsAllEndpoints())

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -232,8 +232,10 @@ func (k Key) EndPort() uint16 {
 // that covers the argument Key's port-protocol and is larger.
 // An equal port-protocol will return false.
 func (k Key) PortProtoIsBroader(c Key) bool {
-	return k.Nexthdr == 0 && c.Nexthdr != 0 ||
-		k.Nexthdr == c.Nexthdr && k.PortIsBroader(c)
+	if k.Nexthdr == 0 && c.Nexthdr != 0 {
+		return k.PortIsEqual(c) || k.PortIsBroader(c)
+	}
+	return k.Nexthdr == c.Nexthdr && k.PortIsBroader(c)
 }
 
 // PortProtoIsEqual returns true if the port-protocols of the
@@ -256,11 +258,9 @@ func (k Key) PortIsBroader(c Key) bool {
 	}
 	kEP := k.EndPort()
 	cEP := c.EndPort()
-	if k.DestPort <= c.DestPort && kEP >= cEP {
+	return k.DestPort <= c.DestPort && kEP >= cEP &&
 		// The port ranges cannot be exactly equal.
-		return k.DestPort != c.DestPort || kEP != cEP
-	}
-	return false
+		(k.DestPort != c.DestPort || kEP != cEP)
 }
 
 // PortIsEqual returns true if the port ranges
@@ -414,6 +414,29 @@ func (e *MapStateEntry) HasDependent(key Key) bool {
 	return ok
 }
 
+// HasSameOwners returns true if both MapStateEntries
+// have the same owners as one another (which means that
+// one of the entries is redundant).
+func (e *MapStateEntry) HasSameOwners(bEntry *MapStateEntry) bool {
+	if e == nil && bEntry == nil {
+		return true
+	}
+	if e == nil || bEntry == nil {
+		return false
+	}
+	for _, owner := range e.owners {
+		if _, ok := bEntry.owners[owner]; !ok {
+			return false
+		}
+	}
+	for _, owner := range bEntry.owners {
+		if _, ok := e.owners[owner]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 var worldNets = map[identity.NumericIdentity][]*net.IPNet{
 	identity.ReservedIdentityWorld: {
 		{IP: net.IPv4zero, Mask: net.CIDRMask(0, net.IPv4len*8)},
@@ -530,6 +553,7 @@ func (msA *mapState) Equals(msB MapState) bool {
 // '+ ' or '- ' for obtaining something unexpected, or not obtaining the expected, respectively.
 // For use in debugging.
 func (obtained *mapState) Diff(_ *testing.T, expected MapState) (res string) {
+	res += "Missing (-), Unexpected (+):\n"
 	expected.ForEach(func(kE Key, vE MapStateEntry) bool {
 		if vO, ok := obtained.Get(kE); ok {
 			if !(&vO).DatapathEqual(&vE) {
@@ -1004,12 +1028,13 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 				return true
 			}
 
-			if (newKey.Identity == k.Identity ||
-				identityIsSupersetOf(k.Identity, newKey.Identity, identities)) &&
-				k.DestPort == 0 && k.Nexthdr == 0 &&
-				!v.HasDependent(newKey) {
+			if !v.HasDependent(newKey) && v.HasSameOwners(&newEntry) &&
+				(k.PortProtoIsEqual(newKey) || k.PortProtoIsBroader(newKey)) &&
+				(newKey.Identity == k.Identity ||
+					identityIsSupersetOf(k.Identity, newKey.Identity, identities)) {
 				// If this iterated-deny-entry is a supserset (or equal) of the new-entry and
-				// the iterated-deny-entry is an L3-only policy then we
+				// the iterated-deny-entry has a broader (or equal) port-protocol and
+				// the ownership between the entries is the same then we
 				// should not insert the new entry (as long as it is not one
 				// of the special L4-only denies we created to cover the special
 				// case of a superset-allow with a more specific port-protocol).
@@ -1018,12 +1043,13 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 				// but there *may* be performance tradeoffs.
 				bailed = true
 				return false
-			} else if (newKey.Identity == k.Identity ||
-				identityIsSupersetOf(newKey.Identity, k.Identity, identities)) &&
-				newKey.DestPort == 0 && newKey.Nexthdr == 0 &&
-				!newEntry.HasDependent(k) {
+			} else if !newEntry.HasDependent(k) && newEntry.HasSameOwners(&v) &&
+				(newKey.PortProtoIsEqual(k) || newKey.PortProtoIsBroader(k)) &&
+				(newKey.Identity == k.Identity ||
+					identityIsSupersetOf(newKey.Identity, k.Identity, identities)) {
 				// If this iterated-deny-entry is a subset (or equal) of the new-entry and
-				// the new-entry is an L3-only policy then we
+				// the new-entry has a broader (or equal) port-protocol and
+				// the ownership between the entries is the same then we
 				// should delete the iterated-deny-entry (as long as it is not one
 				// of the special L4-only denies we created to cover the special
 				// case of a superset-allow with a more specific port-protocol).

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1176,16 +1176,14 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 
 		ms.denyPreferredInsertWithChanges(tt.args.key, tt.args.entry, nil, denyRules, changes)
 		ms.validatePortProto(t)
-		require.EqualValuesf(t, tt.want.allows, ms.allows, "%s: MapState mismatch allows", tt.name)
-		require.EqualValuesf(t, tt.want.denies, ms.denies, "%s: MapState mismatch denies", tt.name)
+		require.Truef(t, ms.Equals(tt.want), "%s: MapState mismatch:\n%s", tt.name, ms.Diff(nil, tt.want))
 		require.EqualValuesf(t, tt.wantAdds, changes.Adds, "%s: Adds mismatch", tt.name)
 		require.EqualValuesf(t, tt.wantDeletes, changes.Deletes, "%s: Deletes mismatch", tt.name)
 		require.EqualValuesf(t, tt.wantOld, changes.Old, "%s: OldValues mismatch allows", tt.name)
 
 		// Revert changes and check that we get the original mapstate
 		ms.RevertChanges(changes)
-		require.EqualValuesf(t, tt.ms.allows, ms.allows, "%s: Revert mismatch allows", tt.name)
-		require.EqualValuesf(t, tt.ms.denies, ms.denies, "%s: Revert mismatch denies", tt.name)
+		require.Truef(t, ms.Equals(tt.ms), "%s: MapState mismatch:\n%s", tt.name, ms.Diff(nil, tt.ms))
 	}
 }
 
@@ -1603,7 +1601,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		}
 		adds, deletes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, denyRules, nil)
 		policyMapState.validatePortProto(t)
-		require.EqualValues(t, tt.state, policyMapState, tt.name+" (MapState)")
+		require.True(t, policyMapState.Equals(tt.state), "%s (MapState):\n%s", tt.name, policyMapState.Diff(nil, tt.state))
 		require.EqualValues(t, tt.adds, adds, tt.name+" (adds)")
 		require.EqualValues(t, tt.deletes, deletes, tt.name+" (deletes)")
 	}
@@ -1824,7 +1822,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		}
 		adds, deletes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, policyFeatures(0), nil)
 		policyMapState.validatePortProto(t)
-		require.EqualValues(t, tt.state, policyMapState, tt.name+" (MapState)")
+		require.True(t, policyMapState.Equals(tt.state), tt.name+"%s (MapState):\n%s", policyMapState.Diff(nil, tt.state))
 		require.EqualValues(t, tt.adds, adds, tt.name+" (adds)")
 		require.EqualValues(t, tt.deletes, deletes, tt.name+" (deletes)")
 	}
@@ -2000,8 +1998,7 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 		}
 		tt.ms.AddVisibilityKeys(DummyOwner{}, tt.args.redirectPort, &tt.args.visMeta, changes)
 		tt.ms.validatePortProto(t)
-		require.EqualValues(t, tt.want.allows, tt.ms.allows, tt.name)
-		require.EqualValues(t, tt.want.denies, tt.ms.denies, tt.name)
+		require.True(t, tt.ms.Equals(tt.want), "%s:\n%s", tt.name, tt.ms.Diff(nil, tt.want))
 		// Find new and updated entries
 		wantAdds := make(Keys)
 		wantOld := make(map[Key]MapStateEntry)
@@ -2405,7 +2402,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			changes.Deletes[k] = struct{}{}
 		}
 		policyMapState.validatePortProto(t)
-		require.EqualValues(t, tt.state, policyMapState, tt.name+" (MapState)")
+		require.True(t, tt.state.Equals(policyMapState), "%s (MapState):\n%s", tt.name, policyMapState.Diff(nil, tt.state))
 		require.EqualValues(t, tt.adds, changes.Adds, tt.name+" (adds)")
 		require.EqualValues(t, tt.deletes, changes.Deletes, tt.name+" (deletes)")
 	}
@@ -2496,16 +2493,16 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		expectedKeys := newMapState(nil)
 		if tt.outcome&insertA > 0 {
 			if tt.aIsDeny {
-				expectedKeys.denies[aKey] = aEntry
+				expectedKeys.denies.Upsert(aKey, aEntry)
 			} else {
-				expectedKeys.allows[aKey] = aEntry
+				expectedKeys.allows.Upsert(aKey, aEntry)
 			}
 		}
 		if tt.outcome&insertB > 0 {
 			if tt.bIsDeny {
-				expectedKeys.denies[bKey] = bEntry
+				expectedKeys.denies.Upsert(bKey, bEntry)
 			} else {
-				expectedKeys.allows[bKey] = bEntry
+				expectedKeys.allows.Upsert(bKey, bEntry)
 			}
 		}
 		if tt.outcome&insertAWithBProto > 0 {
@@ -2514,11 +2511,11 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 			aEntryCpy.owners = map[MapStateOwner]struct{}{aKey: {}}
 			aEntry.AddDependent(aKeyWithBProto)
 			if tt.aIsDeny {
-				expectedKeys.denies[aKey] = aEntry
-				expectedKeys.denies[aKeyWithBProto] = aEntryCpy
+				expectedKeys.denies.Upsert(aKey, aEntry)
+				expectedKeys.denies.Upsert(aKeyWithBProto, aEntryCpy)
 			} else {
-				expectedKeys.allows[aKey] = aEntry
-				expectedKeys.allows[aKeyWithBProto] = aEntryCpy
+				expectedKeys.allows.Upsert(aKey, aEntry)
+				expectedKeys.allows.Upsert(aKeyWithBProto, aEntryCpy)
 			}
 		}
 		if tt.outcome&insertBWithAProto > 0 {
@@ -2527,11 +2524,11 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 			bEntryCpy.owners = map[MapStateOwner]struct{}{bKey: {}}
 			bEntry.AddDependent(bKeyWithBProto)
 			if tt.bIsDeny {
-				expectedKeys.denies[bKey] = bEntry
-				expectedKeys.denies[bKeyWithBProto] = bEntryCpy
+				expectedKeys.denies.Upsert(bKey, bEntry)
+				expectedKeys.denies.Upsert(bKeyWithBProto, bEntryCpy)
 			} else {
-				expectedKeys.allows[bKey] = bEntry
-				expectedKeys.allows[bKeyWithBProto] = bEntryCpy
+				expectedKeys.allows.Upsert(bKey, bEntry)
+				expectedKeys.allows.Upsert(bKeyWithBProto, bEntryCpy)
 			}
 		}
 		outcomeKeys := newMapState(nil)
@@ -2550,14 +2547,14 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		bEntry := MapStateEntry{IsDeny: tt.bIsDeny}
 		expectedKeys := newMapState(nil)
 		if tt.aIsDeny {
-			expectedKeys.denies[aKey] = aEntry
+			expectedKeys.denies.Upsert(aKey, aEntry)
 		} else {
-			expectedKeys.allows[aKey] = aEntry
+			expectedKeys.allows.Upsert(aKey, aEntry)
 		}
 		if tt.bIsDeny {
-			expectedKeys.denies[bKey] = bEntry
+			expectedKeys.denies.Upsert(bKey, bEntry)
 		} else {
-			expectedKeys.allows[bKey] = bEntry
+			expectedKeys.allows.Upsert(bKey, bEntry)
 		}
 		outcomeKeys := newMapState(nil)
 		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -2513,9 +2513,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		{"deny-allow: a superset a L3L4, b L3L4", reservedWorldID, worldSubnetID, true, false, 80, 6, 80, 6, insertA},
 		{"deny-allow: b superset a L3L4, b L3L4", worldIPID, worldSubnetID, true, false, 80, 6, 80, 6, insertBoth},
 
-		// deny-deny insertions: Note: We do not delete all redundant deny-deny insertions that we could.
-		// We only delete entries redundant to L3-only port protocols, all other port-protocol supersets
-		// *do not* have this effect.
+		// deny-deny insertions: Note: We do delete all redundant deny-deny insertions.
 		{"deny-deny: a superset a|b L3-only", worldSubnetID, worldIPID, true, true, 0, 0, 0, 0, insertA},
 		{"deny-deny: b superset a|b L3-only", worldSubnetID, reservedWorldID, true, true, 0, 0, 0, 0, insertB},
 		{"deny-deny: a superset a L3-only, b L4", worldSubnetID, worldIPID, true, true, 0, 0, 0, 6, insertA},
@@ -2524,17 +2522,17 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		{"deny-deny: b superset a L3-only, b L3L4", worldSubnetID, reservedWorldID, true, true, 0, 0, 80, 6, insertBoth},
 		{"deny-deny: a superset a L4, b L3-only", worldSubnetID, worldIPID, true, true, 0, 6, 0, 0, insertBoth},
 		{"deny-deny: b superset a L4, b L3-only", worldSubnetID, reservedWorldID, true, true, 0, 6, 0, 0, insertB},
-		{"deny-deny: a superset a L4, b L4", worldSubnetID, worldIPID, true, true, 0, 6, 0, 6, canDeleteBInsertsBoth},
-		{"deny-deny: b superset a L4, b L4", worldSubnetID, reservedWorldID, true, true, 0, 6, 0, 6, canDeleteAInsertsBoth},
-		{"deny-deny: a superset a L4, b L3L4", worldSubnetID, worldIPID, true, true, 0, 6, 80, 6, canDeleteBInsertsBoth},
+		{"deny-deny: a superset a L4, b L4", worldSubnetID, worldIPID, true, true, 0, 6, 0, 6, insertA},
+		{"deny-deny: b superset a L4, b L4", worldSubnetID, reservedWorldID, true, true, 0, 6, 0, 6, insertB},
+		{"deny-deny: a superset a L4, b L3L4", worldSubnetID, worldIPID, true, true, 0, 6, 80, 6, insertA},
 		{"deny-deny: b superset a L4, b L3L4", worldSubnetID, reservedWorldID, true, true, 0, 6, 80, 6, insertBoth},
 		{"deny-deny: a superset a L3L4, b L3-only", worldSubnetID, worldIPID, true, true, 80, 6, 0, 0, insertBoth},
 		{"deny-deny: b superset a L3L4, b L3-only", worldSubnetID, reservedWorldID, true, true, 80, 6, 0, 0, insertB},
 		{"deny-deny: a superset a L3L4, b L4", worldSubnetID, worldIPID, true, true, 80, 6, 0, 6, insertBoth},
-		{"deny-deny: b superset a L3L4, b L4", worldSubnetID, reservedWorldID, true, true, 80, 6, 0, 6, canDeleteAInsertsBoth},
-		{"deny-deny: a superset a L3L4, b L3L4", worldSubnetID, worldIPID, true, true, 80, 6, 80, 6, canDeleteBInsertsBoth},
-		{"deny-deny: b superset a L3L4, b L3L4", worldSubnetID, reservedWorldID, true, true, 80, 6, 80, 6, canDeleteAInsertsBoth},
-		// allow-allow insertions do not need to be tests as they will all be inserted
+		{"deny-deny: b superset a L3L4, b L4", worldSubnetID, reservedWorldID, true, true, 80, 6, 0, 6, insertB},
+		{"deny-deny: a superset a L3L4, b L3L4", worldSubnetID, worldIPID, true, true, 80, 6, 80, 6, insertA},
+		{"deny-deny: b superset a L3L4, b L3L4", worldSubnetID, reservedWorldID, true, true, 80, 6, 80, 6, insertB},
+		// allow-allow insertions do not need tests as their affect on one another does not matter.
 	}
 	for _, tt := range tests {
 		aKey := Key{Identity: tt.aIdentity, DestPort: tt.aPort, Nexthdr: tt.aProto}
@@ -2586,7 +2584,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
 		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
 		outcomeKeys.validatePortProto(t)
-		require.True(t, expectedKeys.Equals(outcomeKeys), "%s (MapState):\n%s", tt.name, expectedKeys.Diff(nil, outcomeKeys))
+		require.True(t, expectedKeys.Equals(outcomeKeys), "%s (MapState):\n%s", tt.name, outcomeKeys.Diff(nil, expectedKeys))
 	}
 	// Now test all cases with different traffic directions.
 	// This should result in both entries being inserted with

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -25,67 +26,67 @@ func Test_IsSuperSetOf(t *testing.T) {
 		res      int
 	}{
 		{Key{}, Key{}, 0},
-		{Key{0, 0, 0, 0}, Key{42, 0, 6, 0}, 1},
-		{Key{0, 0, 0, 0}, Key{42, 80, 6, 0}, 1},
-		{Key{0, 0, 0, 0}, Key{42, 0, 0, 0}, 1},
-		{Key{0, 0, 6, 0}, Key{42, 0, 6, 0}, 2},
-		{Key{0, 0, 6, 0}, Key{42, 80, 6, 0}, 2},
-		{Key{0, 80, 6, 0}, Key{42, 80, 6, 0}, 3},
-		{Key{0, 80, 6, 0}, Key{42, 80, 17, 0}, 0},  // proto is different
-		{Key{2, 80, 6, 0}, Key{42, 80, 6, 0}, 0},   // id is different
-		{Key{0, 8080, 6, 0}, Key{42, 80, 6, 0}, 0}, // port is different
-		{Key{42, 0, 0, 0}, Key{42, 0, 0, 0}, 0},    // same key
-		{Key{42, 0, 0, 0}, Key{42, 0, 6, 0}, 4},
-		{Key{42, 0, 0, 0}, Key{42, 80, 6, 0}, 4},
-		{Key{42, 0, 0, 0}, Key{42, 0, 17, 0}, 4},
-		{Key{42, 0, 0, 0}, Key{42, 80, 17, 0}, 4},
-		{Key{42, 0, 6, 0}, Key{42, 0, 6, 0}, 0}, // same key
-		{Key{42, 0, 6, 0}, Key{42, 80, 6, 0}, 5},
-		{Key{42, 0, 6, 0}, Key{42, 8080, 6, 0}, 5},
-		{Key{42, 80, 6, 0}, Key{42, 80, 6, 0}, 0},    // same key
-		{Key{42, 80, 6, 0}, Key{42, 8080, 6, 0}, 0},  // different port
-		{Key{42, 80, 6, 0}, Key{42, 80, 17, 0}, 0},   // different proto
-		{Key{42, 80, 6, 0}, Key{42, 8080, 17, 0}, 0}, // different port and proto
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 3},
+		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 2},
+		{Key{0, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 3},
+		{Key{0, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 17, 0}, 0},  // proto is different
+		{Key{2, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 0},   // id is different
+		{Key{0, 8080, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 0}, // port is different
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},    // same key
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 4},
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 4},
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 17, 0}, 4},
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 80, api.FullPortMask, 17, 0}, 4},
+		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 0}, // same key
+		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 5},
+		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 8080, api.FullPortMask, 6, 0}, 5},
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 0},    // same key
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 8080, api.FullPortMask, 6, 0}, 0},  // different port
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 17, 0}, 0},   // different proto
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 8080, api.FullPortMask, 17, 0}, 0}, // different port and proto
 
 		// increasing specificity for a L3/L4 key
-		{Key{0, 0, 0, 0}, Key{42, 80, 6, 0}, 1},
-		{Key{0, 0, 6, 0}, Key{42, 80, 6, 0}, 2},
-		{Key{0, 80, 6, 0}, Key{42, 80, 6, 0}, 3},
-		{Key{42, 0, 0, 0}, Key{42, 80, 6, 0}, 4},
-		{Key{42, 0, 6, 0}, Key{42, 80, 6, 0}, 5},
-		{Key{42, 80, 6, 0}, Key{42, 80, 6, 0}, 0}, // same key
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 2},
+		{Key{0, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 3},
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 4},
+		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 5},
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 0}, // same key
 
 		// increasing specificity for a L3-only key
-		{Key{0, 0, 0, 0}, Key{42, 0, 0, 0}, 1},
-		{Key{0, 0, 6, 0}, Key{42, 0, 0, 0}, 0},   // not a superset
-		{Key{0, 80, 6, 0}, Key{42, 0, 0, 0}, 0},  // not a superset
-		{Key{42, 0, 0, 0}, Key{42, 0, 0, 0}, 0},  // same key
-		{Key{42, 0, 6, 0}, Key{42, 0, 0, 0}, 0},  // not a superset
-		{Key{42, 80, 6, 0}, Key{42, 0, 0, 0}, 0}, // not a superset
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},   // not a superset
+		{Key{0, 80, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},  // not a superset
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},  // same key
+		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},  // not a superset
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0}, // not a superset
 
 		// increasing specificity for a L3/proto key
-		{Key{0, 0, 0, 0}, Key{42, 0, 6, 0}, 1},
-		{Key{0, 0, 6, 0}, Key{42, 0, 6, 0}, 2},
-		{Key{0, 80, 6, 0}, Key{42, 0, 6, 0}, 0}, // not a superset
-		{Key{42, 0, 0, 0}, Key{42, 0, 6, 0}, 4},
-		{Key{42, 0, 6, 0}, Key{42, 0, 6, 0}, 0},  // same key
-		{Key{42, 80, 6, 0}, Key{42, 0, 6, 0}, 0}, // not a superset
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 3},
+		{Key{0, 80, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 0}, // not a superset
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 4},
+		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 0},  // same key
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 0}, // not a superset
 
 		// increasing specificity for a proto-only key
-		{Key{0, 0, 0, 0}, Key{0, 0, 6, 0}, 1},
-		{Key{0, 0, 6, 0}, Key{0, 0, 6, 0}, 0},   // same key
-		{Key{0, 80, 6, 0}, Key{0, 0, 6, 0}, 0},  // not a superset
-		{Key{42, 0, 0, 0}, Key{0, 0, 6, 0}, 0},  // not a superset
-		{Key{42, 0, 6, 0}, Key{0, 0, 6, 0}, 0},  // not a superset
-		{Key{42, 80, 6, 0}, Key{0, 0, 6, 0}, 0}, // not a superset
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 6, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 0},   // same key
+		{Key{0, 80, api.FullPortMask, 6, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 0},  // not a superset
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 0},  // not a superset
+		{Key{42, 0, api.FullPortMask, 6, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 0},  // not a superset
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 0}, // not a superset
 
 		// increasing specificity for a L4-only key
-		{Key{0, 0, 0, 0}, Key{0, 80, 6, 0}, 1},
-		{Key{0, 0, 6, 0}, Key{0, 80, 6, 0}, 2},
-		{Key{0, 80, 6, 0}, Key{0, 80, 6, 0}, 0},  // same key
-		{Key{42, 0, 0, 0}, Key{0, 80, 6, 0}, 0},  // not a superset
-		{Key{42, 0, 6, 0}, Key{0, 80, 6, 0}, 0},  // not a superset
-		{Key{42, 80, 6, 0}, Key{0, 80, 6, 0}, 0}, // not a superset
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 6, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 2},
+		{Key{0, 80, api.FullPortMask, 6, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 0},  // same key
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 0},  // not a superset
+		{Key{42, 0, api.FullPortMask, 6, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 0},  // not a superset
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 0}, // not a superset
 
 	}
 	for i, tt := range tests {
@@ -204,6 +205,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -239,6 +241,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -264,6 +267,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -276,6 +280,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				},
@@ -289,6 +294,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -307,6 +313,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -319,6 +326,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				},
@@ -332,6 +340,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -344,6 +353,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				Key{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
@@ -353,6 +363,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -368,6 +379,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -388,6 +400,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         2,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -433,6 +446,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         2,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -463,6 +477,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				Key{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
@@ -481,6 +496,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -496,6 +512,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -516,6 +533,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         2,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -551,6 +569,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -581,6 +600,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         2,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -628,6 +648,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				},
@@ -671,6 +692,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				},
@@ -703,6 +725,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -749,6 +772,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				Key{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
@@ -757,6 +781,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -773,6 +798,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -784,6 +810,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -829,12 +856,14 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				Key{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
 				Key{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
@@ -843,6 +872,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -854,6 +884,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -869,6 +900,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Egress.Uint8(),
 				}: {
@@ -905,6 +937,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Egress.Uint8(),
 				}: {
@@ -933,6 +966,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -944,6 +978,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         5,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -955,6 +990,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         100,
 					DestPort:         5,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Egress.Uint8(),
 				}: {
@@ -991,6 +1027,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         100,
 					DestPort:         5,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Egress.Uint8(),
 				}: {
@@ -1012,12 +1049,14 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				Key{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
 				Key{
 					Identity:         1,
 					DestPort:         5,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
@@ -1026,6 +1065,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1037,6 +1077,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         5,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1052,6 +1093,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1064,6 +1106,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				},
@@ -1077,6 +1120,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1089,6 +1133,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				Key{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
@@ -1098,6 +1143,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1112,6 +1158,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1124,6 +1171,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				},
@@ -1137,6 +1185,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1151,6 +1200,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					PortMask:         api.FullPortMask,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1192,6 +1242,7 @@ func testKey(id int, port uint16, proto uint8, direction trafficdirection.Traffi
 		Identity:         uint32(id),
 		DestPort:         port,
 		Nexthdr:          proto,
+		PortMask:         api.FullPortMask,
 		TrafficDirection: direction.Uint8(),
 	}
 }
@@ -1591,13 +1642,13 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 			if x.cs != nil {
 				cs = x.cs
 			}
-			key := Key{DestPort: x.port, Nexthdr: x.proto, TrafficDirection: dir.Uint8()}
+			key := Key{DestPort: x.port, PortMask: api.FullPortMask, Nexthdr: x.proto, TrafficDirection: dir.Uint8()}
 			var proxyPort uint16
 			if x.redirect {
 				proxyPort = 1
 			}
 			value := NewMapStateEntry(cs, nil, proxyPort, "", 0, x.deny, DefaultAuthType, AuthTypeDisabled)
-			policyMaps.AccumulateMapChanges(cs, adds, deletes, key, value)
+			policyMaps.AccumulateMapChanges(cs, adds, deletes, []Key{key}, value)
 		}
 		adds, deletes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, denyRules, nil)
 		policyMapState.validatePortProto(t)
@@ -1812,13 +1863,13 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			if x.cs != nil {
 				cs = x.cs
 			}
-			key := Key{DestPort: x.port, Nexthdr: x.proto, TrafficDirection: dir.Uint8()}
+			key := Key{DestPort: x.port, PortMask: api.FullPortMask, Nexthdr: x.proto, TrafficDirection: dir.Uint8()}
 			var proxyPort uint16
 			if x.redirect {
 				proxyPort = 1
 			}
 			value := NewMapStateEntry(cs, nil, proxyPort, "", 0, x.deny, x.hasAuth, x.authType)
-			policyMaps.AccumulateMapChanges(cs, adds, deletes, key, value)
+			policyMaps.AccumulateMapChanges(cs, adds, deletes, []Key{key}, value)
 		}
 		adds, deletes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, policyFeatures(0), nil)
 		policyMapState.validatePortProto(t)
@@ -2379,13 +2430,13 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			if x.cs != nil {
 				cs = x.cs
 			}
-			key := Key{DestPort: x.port, Nexthdr: x.proto, TrafficDirection: dir.Uint8()}
+			key := Key{DestPort: x.port, PortMask: api.FullPortMask, Nexthdr: x.proto, TrafficDirection: dir.Uint8()}
 			var proxyPort uint16
 			if x.redirect {
 				proxyPort = 1
 			}
 			value := NewMapStateEntry(cs, nil, proxyPort, "", 0, x.deny, DefaultAuthType, AuthTypeDisabled)
-			policyMaps.AccumulateMapChanges(cs, adds, deletes, key, value)
+			policyMaps.AccumulateMapChanges(cs, adds, deletes, []Key{key}, value)
 		}
 		adds, deletes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, denyRules, nil)
 		changes = ChangeState{
@@ -2535,7 +2586,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
 		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
 		outcomeKeys.validatePortProto(t)
-		require.EqualValues(t, expectedKeys, outcomeKeys, tt.name)
+		require.True(t, expectedKeys.Equals(outcomeKeys), "%s (MapState):\n%s", tt.name, expectedKeys.Diff(nil, outcomeKeys))
 	}
 	// Now test all cases with different traffic directions.
 	// This should result in both entries being inserted with

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -29,64 +29,100 @@ func Test_IsSuperSetOf(t *testing.T) {
 		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 1},
 		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 1},
 		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 1},
-		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 3},
+		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 3}, // port is the same
 		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 2},
+		{Key{0, 64, 0xffc0, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 2}, // port range 64-127,80
 		{Key{0, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 3},
+		{Key{0, 64, 0xffc0, 6, 0}, Key{42, 64, 0xffc0, 6, 0}, 3},                       // port ranges are the same
 		{Key{0, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 17, 0}, 0},  // proto is different
 		{Key{2, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 0},   // id is different
 		{Key{0, 8080, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 0}, // port is different
+		{Key{0, 64, 0xffc0, 6, 0}, Key{42, 8080, api.FullPortMask, 6, 0}, 0},           // port range is different from port
 		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},    // same key
 		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 4},
 		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 4},
+		{Key{42, 64, 0xffc0, 0, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 4}, // port range 64-127,80
 		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 17, 0}, 4},
 		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 80, api.FullPortMask, 17, 0}, 4},
+		{Key{42, 64, 0xffc0, 0, 0}, Key{42, 80, api.FullPortMask, 17, 0}, 4},
 		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 0}, // same key
 		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 5},
+		{Key{42, 64, 0xffc0, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 5},
 		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 8080, api.FullPortMask, 6, 0}, 5},
 		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 0},    // same key
+		{Key{42, 64, 0xffc0, 6, 0}, Key{42, 64, 0xffc0, 6, 0}, 0},                        // same key
 		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 8080, api.FullPortMask, 6, 0}, 0},  // different port
+		{Key{42, 64, 0xffc0, 6, 0}, Key{42, 128, 0xff80, 6, 0}, 0},                       // different port ranges
 		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 17, 0}, 0},   // different proto
 		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 8080, api.FullPortMask, 17, 0}, 0}, // different port and proto
 
 		// increasing specificity for a L3/L4 key
 		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 1},
+		{Key{0, 64, 0xffc0, 0, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 1},
 		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 2},
+		{Key{0, 64, 0xffc0, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 2},
 		{Key{0, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 3},
+		{Key{0, 64, 0xffc0, 6, 0}, Key{42, 64, 0xffc0, 6, 0}, 3},
 		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 4},
+		{Key{42, 64, 0xffc0, 0, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 4},
 		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 5},
+		{Key{42, 64, 0xffc0, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 5},
 		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 0}, // same key
+		{Key{42, 64, 0xffc0, 6, 0}, Key{42, 64, 0xffc0, 6, 0}, 0},                     // same key
 
 		// increasing specificity for a L3-only key
 		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 1},
+		{Key{0, 64, 0xffc0, 0, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 1},
 		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},   // not a superset
 		{Key{0, 80, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},  // not a superset
+		{Key{0, 64, 0xffc0, 6, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},            // not a superset
 		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},  // same key
 		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},  // not a superset
+		{Key{42, 64, 0xffc0, 6, 0}, Key{42, 64, 0xffc0, 0, 0}, 0},                    // not a superset
 		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0}, // not a superset
+		{Key{42, 64, 0xffc0, 6, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},           // not a superset
 
 		// increasing specificity for a L3/proto key
-		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 1},
-		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 3},
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 1}, // wildcard
+		{Key{0, 64, 0xffc0, 0, 0}, Key{42, 64, 0xffc0, 6, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 3},  // ports are the same
+		{Key{0, 64, 0xffc0, 6, 0}, Key{42, 64, 0xffc0, 6, 0}, 3},                    // port ranges are the same
 		{Key{0, 80, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 0}, // not a superset
+		{Key{0, 80, api.FullPortMask, 6, 0}, Key{42, 64, 0xffc0, 6, 0}, 0},          // not a superset
 		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 4},
+		{Key{42, 64, 0xffc0, 0, 0}, Key{42, 64, 0xffc0, 6, 0}, 4},
 		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 0},  // same key
+		{Key{42, 64, 0xffc0, 6, 0}, Key{42, 64, 0xffc0, 6, 0}, 0},                    // same key
 		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 0}, // not a superset
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 64, 0xffc0, 6, 0}, 0},          // not a superset
 
 		// increasing specificity for a proto-only key
 		{Key{0, 0, api.FullPortMask, 0, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 1},
+		{Key{0, 64, 0xffc0, 0, 0}, Key{0, 64, 0xffc0, 6, 0}, 1},
 		{Key{0, 0, api.FullPortMask, 6, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 0},   // same key
+		{Key{0, 64, 0xffc0, 6, 0}, Key{0, 64, 0xffc0, 6, 0}, 0},                     // same key
 		{Key{0, 80, api.FullPortMask, 6, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 0},  // not a superset
+		{Key{0, 80, api.FullPortMask, 6, 0}, Key{0, 64, 0xffc0, 6, 0}, 0},           // not a superset
 		{Key{42, 0, api.FullPortMask, 0, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 0},  // not a superset
+		{Key{42, 64, 0xffc0, 0, 0}, Key{0, 64, 0xffc0, 6, 0}, 0},                    // not a superset
 		{Key{42, 0, api.FullPortMask, 6, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 0},  // not a superset
+		{Key{42, 64, 0xffc0, 6, 0}, Key{0, 64, 0xffc0, 6, 0}, 0},                    // not a superset
 		{Key{42, 80, api.FullPortMask, 6, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 0}, // not a superset
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{0, 64, 0xffc0, 6, 0}, 0},          // not a superset
 
 		// increasing specificity for a L4-only key
 		{Key{0, 0, api.FullPortMask, 0, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 1},
+		{Key{0, 64, 0xffc0, 0, 0}, Key{0, 64, 0xffc0, 6, 0}, 1},
 		{Key{0, 0, api.FullPortMask, 6, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 2},
+		{Key{0, 64, 0xffc0, 6, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 2},
 		{Key{0, 80, api.FullPortMask, 6, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 0},  // same key
+		{Key{0, 64, 0xffc0, 6, 0}, Key{0, 64, 0xffc0, 6, 0}, 0},                      // same key
 		{Key{42, 0, api.FullPortMask, 0, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 0},  // not a superset
+		{Key{42, 64, 0xffc0, 0, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 0},           // not a superset
 		{Key{42, 0, api.FullPortMask, 6, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 0},  // not a superset
+		{Key{42, 64, 0xffc0, 6, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 0},           // not a superset
 		{Key{42, 80, api.FullPortMask, 6, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 0}, // not a superset
+		{Key{42, 64, 0xffc0, 6, 0}, Key{0, 64, 0xffc0, 6, 0}, 0},                     // not a superset
 
 	}
 	for i, tt := range tests {
@@ -200,7 +236,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
-			name: "test-2 - L3 allow KV should not overwrite deny entry",
+			name: "test-2a - L3 allow KV should not overwrite deny entry",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -262,7 +298,72 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
-			name: "test-3 - L3-L4 allow KV should not overwrite deny entry",
+			name: "test-2b - L3 port-range allow KV should not overwrite deny entry",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         80,
+					PortMask:         api.FullPortMask,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         80,
+					PortMask:         api.FullPortMask,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
+		},
+		{
+			name: "test-3a - L3-L4 allow KV should not overwrite deny entry",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -308,7 +409,53 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
-			name: "test-4 - L3-L4 deny KV should overwrite allow entry",
+			name: "test-3b - L3-L4 port-range allow KV should not overwrite deny entry",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds:    Keys{},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
+		},
+		{
+			name: "test-4a - L3-L4 deny KV should overwrite allow entry",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -374,7 +521,81 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 		},
 		{
-			name: "test-5 - L3 deny KV should overwrite all L3-L4 allow and L3 allow entries for the same L3",
+			name: "test-4b - L3-L4 port-range deny KV should overwrite allow entry",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         80,
+					PortMask:         api.FullPortMask,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantDeletes: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         80,
+					PortMask:         api.FullPortMask,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantOld: map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         80,
+					PortMask:         api.FullPortMask,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+		},
+		{
+			name: "test-5a - L3 deny KV should overwrite all L3-L4 allow and L3 allow entries for the same L3",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -507,7 +728,147 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 		},
 		{
-			name: "test-6 - L3 egress deny KV should not overwrite any existing ingress allow",
+			name: "test-5b - L3 port-range deny KV should overwrite all L3-L4 allow and L3 allow entries for the same L3",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         80,
+					PortMask:         api.FullPortMask,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         2,
+					DestPort:         80,
+					PortMask:         api.FullPortMask,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         2,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+				{
+					Identity:         2,
+					DestPort:         80,
+					PortMask:         api.FullPortMask,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         2,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantDeletes: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         80,
+					PortMask:         api.FullPortMask,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantOld: map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         80,
+					PortMask:         api.FullPortMask,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+		},
+		{
+			name: "test-6a - L3 egress deny KV should not overwrite any existing ingress allow",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -631,7 +992,138 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
-			name: "test-7 - L3 ingress deny KV should not be overwritten by a L3-L4 ingress allow",
+			name: "test-6b - L3 egress port-range deny KV should not overwrite any existing ingress allow",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         80,
+					PortMask:         api.FullPortMask,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         2,
+					DestPort:         80,
+					PortMask:         api.FullPortMask,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         2,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Egress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         80,
+					PortMask:         api.FullPortMask,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Egress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+				{
+					Identity:         2,
+					DestPort:         80,
+					PortMask:         api.FullPortMask,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         2,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Egress.Uint8(),
+				}: struct{}{},
+			},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
+		},
+		{
+			name: "test-7a - L3 ingress deny KV should not be overwritten by a L3-L4 ingress allow",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -675,7 +1167,51 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
-			name: "test-8 - L3 ingress deny KV should not be overwritten by a L3-L4-L7 ingress allow",
+			name: "test-7b - L3 ingress deny KV should not be overwritten by a L3-L4 port-range ingress allow",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds:    Keys{},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
+		},
+		{
+			name: "test-8a - L3 ingress deny KV should not be overwritten by a L3-L4-L7 ingress allow",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -720,7 +1256,52 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
-			name: "test-9 - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow",
+			name: "test-8b - L3 ingress deny KV should not be overwritten by a L3-L4-L7 port-range ingress allow",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds:    Keys{},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
+		},
+		{
+			name: "test-9a - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -793,7 +1374,80 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 		},
 		{
-			name: "test-10 - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow and a L3-L4 deny",
+			name: "test-9b - L3 ingress deny KV should overwrite a L3-L4-L7 port-range ingress allow",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantDeletes: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantOld: map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+		},
+		{
+			name: "test-10a - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow and a L3-L4 deny",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -895,7 +1549,109 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 		},
 		{
-			name: "test-11 - L3 ingress allow should not be allowed if there is a L3 'all' deny",
+			name: "test-10b - L3 ingress deny KV should overwrite a L3-L4-L7 port-range ingress allow and a L3-L4 port-range deny",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantDeletes: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantOld: map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			},
+		},
+		{
+			name: "test-11a - L3 ingress allow should not be allowed if there is a L3 'all' deny",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -960,8 +1716,76 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			wantAdds:    Keys{},
 			wantDeletes: Keys{},
 			wantOld:     map[Key]MapStateEntry{},
-		}, {
-			name: "test-12 - inserting a L3 'all' deny should delete all entries for that direction",
+		},
+		{
+			name: "test-11b - L3 ingress allow should not be allowed if there is a L3 'all' deny",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Egress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         0,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         100,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Egress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         0,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds:    Keys{},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
+		},
+		{
+			name: "test-12a - inserting a L3 'all' deny should delete all entries for that direction",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -1087,8 +1911,137 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           false,
 				},
 			},
-		}, {
-			name: "test-13 - L3-L4-L7 ingress allow should overwrite a L3-L4-L7 ingress allow due to lower priority",
+		},
+		{
+			name: "test-12b - inserting a L3 'all' deny should delete all entries for that direction (including port ranges)",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         4,
+					PortMask:         0xfffc, // port range 4-7
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         100,
+					DestPort:         4,
+					PortMask:         0xfffc, // port range 4-7
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Egress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         0,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         0,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+				{
+					Identity:         100,
+					DestPort:         4,
+					PortMask:         0xfffc, // port range 4-7
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Egress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         0,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantDeletes: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+				Key{
+					Identity:         1,
+					DestPort:         4,
+					PortMask:         0xfffc, // port range 4-7
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantOld: map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0, // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         4,
+					PortMask:         0xfffc, // port range 4-7
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+		},
+		{
+			name: "test-13a - L3-L4-L7 ingress allow should overwrite a L3-L4-L7 ingress allow due to lower priority",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -1152,8 +2105,75 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					Listener:  "listener1",
 				},
 			},
-		}, {
-			name: "test-14 - L4-L7 ingress allow should overwrite a L3-L4-L7 ingress allow due to lower priority on the same port",
+		},
+		{
+			name: "test-13b - L3-L4-L7 port-range ingress allow should overwrite a L3-L4-L7 port-range ingress allow due to lower priority",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort: 8080,
+					priority:  8080,
+					Listener:  "listener1",
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort: 9090,
+					priority:  1,
+					Listener:  "listener2",
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort: 9090,
+					priority:  1,
+					Listener:  "listener2",
+				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantDeletes: Keys{},
+			wantOld: map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort: 8080,
+					priority:  8080,
+					Listener:  "listener1",
+				},
+			},
+		},
+		{
+			name: "test-14a - L4-L7 ingress allow should overwrite a L3-L4-L7 ingress allow due to lower priority on the same port",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -1201,6 +2221,64 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					Identity:         1,
 					DestPort:         80,
 					PortMask:         api.FullPortMask,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort: 8080,
+					priority:  8080,
+					Listener:  "listener1",
+				},
+			},
+		},
+		{
+			name: "test-14b - L4-L7 port-range ingress allow should overwrite a L3-L4-L7 port-range ingress allow due to lower priority on the same port",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort: 8080,
+					priority:  8080,
+					Listener:  "listener1",
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort: 8080,
+					priority:  1,
+					Listener:  "listener1",
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort: 8080,
+					priority:  1,
+					Listener:  "listener1",
+				},
+			}),
+			wantAdds:    Keys{},
+			wantDeletes: Keys{},
+			wantOld: map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					PortMask:         0xffc0,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {

--- a/pkg/policy/portrange.go
+++ b/pkg/policy/portrange.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policy
+
+import (
+	"fmt"
+	"math"
+	"math/bits"
+)
+
+// MaskedPort is a port with a wild card mask value
+type MaskedPort struct {
+	port uint16
+	mask uint16
+}
+
+func (m MaskedPort) String() string {
+	return fmt.Sprintf("{port: 0x%x, mask: 0x%x}", m.port, m.mask)
+}
+
+// maskedPort returns a new MaskedPort where 'wildcardBits' lowest bits are wildcarded.
+func maskedPort(port uint16, wildcardBits int) MaskedPort {
+	mask := uint16(math.MaxUint16) << wildcardBits
+	return MaskedPort{port & mask, mask}
+}
+
+// PortRangeToMaskedPorts returns a slice of masked ports for the given port range.
+// If the end port is equal to or less than the the start port than the start port is returned,
+// as a fully masked port.
+// Ports are not returned in any particular order, so testing code needs to sort them
+// for consistency.
+func PortRangeToMaskedPorts(start uint16, end uint16) (ports []MaskedPort) {
+	// This is a wildcard.
+	if start == 0 && (end == 0 || end == math.MaxUint16) {
+		return []MaskedPort{{0, 0}}
+	}
+	// This is a single port.
+	if end <= start {
+		return []MaskedPort{{start, 0xffff}}
+	}
+	// Find the number of common leading bits. The first uncommon bit will be 0 for the start
+	// and 1 for the end.
+	commonBits := bits.LeadingZeros16(start ^ end)
+
+	// Cover the case where all the bits after the common bits are zeros on start and ones on
+	// end. In this case the range can be represented by a single masked port instead of two
+	// that would be produced below.
+	// For example, if the range is from 16-31 (0b10000 - 0b11111), then we return 0b1xxxx
+	// instead of 0b10xxx and 0b11xxx that would be produced when approaching the middle from
+	// the two sides.
+	//
+	// This also covers the trivial case where all the bits are in common (i.e., start == end).
+	mask := uint16(math.MaxUint16) >> commonBits
+	if start&mask == 0 && ^end&mask == 0 {
+		return append(ports, maskedPort(start, 16-commonBits))
+	}
+
+	// Find the "middle point" toward which the masked ports approach from both sides.
+	// This "middle point" is the highest bit that differs between the range start and end.
+	middleBit := 16 - 1 - commonBits
+	middle := uint16(1 << middleBit)
+
+	// Wildcard the trailing zeroes to the right of the middle bit of the range start.
+	// This covers the values immediately following the port range start, including the start itself.
+	// The middle bit is added to avoid counting zeroes past it.
+	bit := bits.TrailingZeros16(start | middle)
+	ports = append(ports, maskedPort(start, bit))
+
+	// Find all 0-bits between the trailing zeroes and the middle bit and add MaskedPorts where
+	// each found 0-bit is set and the lower bits are wildcarded. This covers the range from the
+	// start to the middle not covered by the trailing zeroes above.
+	// The current 'bit' is skipped since we know it is 1.
+	for bit++; bit < middleBit; bit++ {
+		if start&(1<<bit) == 0 {
+			// Adding 1<<bit will set the bit since we know it is not set
+			ports = append(ports, maskedPort(start+1<<bit, bit))
+		}
+	}
+
+	// Wildcard the trailing ones to the right of the middle bit of the range end.
+	// This covers the values immediately preceding and including the range end.
+	// The middle bit is added to avoid counting ones past it.
+	bit = bits.TrailingZeros16(^end | middle)
+	ports = append(ports, maskedPort(end, bit))
+
+	// Find all 1-bits between the trailing ones and the middle bit and add MaskedPorts where
+	// each found 1-bit is cleared and the lower bits are wildcarded. This covers the range from
+	// the end to the middle not covered by the trailing ones above.
+	// The current 'bit' is skipped since we know it is 0.
+	for bit++; bit < middleBit; bit++ {
+		if end&(1<<bit) != 0 {
+			// Subtracting 1<<bit will clear the bit since we know it is set
+			ports = append(ports, maskedPort(end-1<<bit, bit))
+		}
+	}
+
+	return ports
+}

--- a/pkg/policy/portrange.go
+++ b/pkg/policy/portrange.go
@@ -25,6 +25,33 @@ func maskedPort(port uint16, wildcardBits int) MaskedPort {
 	return MaskedPort{port & mask, mask}
 }
 
+// maskPrefixMap is the map of all the possible portMasks and their
+// associated prefix lengths.
+var maskPrefixMap = map[uint16]uint{
+	0xffff: 0,
+	0x7fff: 1,
+	0x3fff: 2,
+	0x1fff: 3,
+	0xfff:  4,
+	0x7ff:  5,
+	0x3ff:  6,
+	0x1ff:  7,
+	0xff:   8,
+	0x7f:   9,
+	0x3f:   10,
+	0x1f:   11,
+	0xf:    12,
+	0x7:    13,
+	0x3:    14,
+	0x1:    15,
+	0x0:    16,
+}
+
+// MaskToPrefix returns the prefix length of the given mask.
+func MaskToPrefix(mask uint16) uint {
+	return maskPrefixMap[mask]
+}
+
 // PortRangeToMaskedPorts returns a slice of masked ports for the given port range.
 // If the end port is equal to or less than the the start port than the start port is returned,
 // as a fully masked port.

--- a/pkg/policy/portrange_test.go
+++ b/pkg/policy/portrange_test.go
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policy
+
+import (
+	"sort"
+
+	. "github.com/cilium/checkmate"
+
+	"github.com/cilium/cilium/pkg/checker"
+)
+
+// maskedPorts have to be sorted for this check
+func validateMaskedPorts(c *C, maskedPorts []MaskedPort, start, end uint16) {
+	// Wildcard case.
+	if start == 0 && end == 0 {
+		c.Assert(len(maskedPorts), Equals, 1)
+		c.Assert(maskedPorts[0].port, Equals, uint16(0))
+		c.Assert(maskedPorts[0].mask, Equals, uint16(0))
+		return
+	}
+	c.Assert(maskedPorts, NotNil)
+	c.Assert(len(maskedPorts), Not(Equals), 0)
+	// validate that range elements are continuous and non-overlapping
+	first := maskedPorts[0].port
+	last := first + ^maskedPorts[0].mask
+	for i := 1; i < len(maskedPorts); i++ {
+		c.Assert(maskedPorts[i].port, Equals, last+1)
+		last = maskedPorts[i].port + ^maskedPorts[i].mask
+	}
+	// Check that the computed range matches the given range
+	c.Assert(first, Equals, start)
+	c.Assert(last, Equals, end)
+}
+
+func (ds *PolicyTestSuite) TestPortRange(c *C) {
+	type testCase struct {
+		start, end uint16
+		expected   []MaskedPort
+	}
+
+	testCases := []testCase{
+		// worst case test
+		{
+			start: 1,
+			end:   65534,
+			expected: []MaskedPort{
+				{port: 0x1, mask: 0xffff},    // 1
+				{port: 0x2, mask: 0xfffe},    // 2-3
+				{port: 0x4, mask: 0xfffc},    // 4-7
+				{port: 0x8, mask: 0xfff8},    // 8-15
+				{port: 0x10, mask: 0xfff0},   // 16-31
+				{port: 0x20, mask: 0xffe0},   // 32-63
+				{port: 0x40, mask: 0xffc0},   // 64-127
+				{port: 0x80, mask: 0xff80},   // 128-255
+				{port: 0x100, mask: 0xff00},  // 256-511
+				{port: 0x200, mask: 0xfe00},  // 512-1023
+				{port: 0x400, mask: 0xfc00},  // 1024-2047
+				{port: 0x800, mask: 0xf800},  // 2048-4095
+				{port: 0x1000, mask: 0xf000}, // 4096-8191
+				{port: 0x2000, mask: 0xe000}, // 8192-16383
+				{port: 0x4000, mask: 0xc000}, // 16384-32767
+				{port: 0x8000, mask: 0xc000}, // 32768-49151
+				{port: 0xc000, mask: 0xe000}, // 49152-57343
+				{port: 0xe000, mask: 0xf000}, // 57344-61439
+				{port: 0xf000, mask: 0xf800}, // 61440-63487
+				{port: 0xf800, mask: 0xfc00}, // 63488-64511
+				{port: 0xfc00, mask: 0xfe00}, // 64512-65023
+				{port: 0xfe00, mask: 0xff00}, // 65024-65279
+				{port: 0xff00, mask: 0xff80}, // 65280-65407
+				{port: 0xff80, mask: 0xffc0}, // 65408-65471
+				{port: 0xffc0, mask: 0xffe0}, // 65472-65503
+				{port: 0xffe0, mask: 0xfff0}, // 65504-65519
+				{port: 0xfff0, mask: 0xfff8}, // 65520-65527
+				{port: 0xfff8, mask: 0xfffc}, // 65528-65531
+				{port: 0xfffc, mask: 0xfffe}, // 65532-65533
+				{port: 0xfffe, mask: 0xffff}, // 65534
+			},
+		},
+		{
+			start: 1,
+			end:   1023,
+			expected: []MaskedPort{
+				{port: 0x1, mask: 0xffff},   // 1
+				{port: 0x2, mask: 0xfffe},   // 2-3
+				{port: 0x4, mask: 0xfffc},   // 4-7
+				{port: 0x8, mask: 0xfff8},   // 8-15
+				{port: 0x10, mask: 0xfff0},  // 16-31
+				{port: 0x20, mask: 0xffe0},  // 32-63
+				{port: 0x40, mask: 0xffc0},  // 64-127
+				{port: 0x80, mask: 0xff80},  // 128-255
+				{port: 0x100, mask: 0xff00}, // 256-511
+				{port: 0x200, mask: 0xfe00}, // 512-1023
+			},
+		},
+		{
+			start: 0,
+			end:   1023,
+			expected: []MaskedPort{
+				{port: 0, mask: 0xfc00}, // 0-1023
+			},
+		},
+		// A typical large case test
+		{
+			start: 1024,
+			end:   65535,
+			expected: []MaskedPort{
+				{port: 0x400, mask: 0xfc00},  // 1024-2047
+				{port: 0x800, mask: 0xf800},  // 2048-4095
+				{port: 0x1000, mask: 0xf000}, // 4096-8191
+				{port: 0x2000, mask: 0xe000}, // 8192-16383
+				{port: 0x4000, mask: 0xc000}, // 16384-32767
+				{port: 0x8000, mask: 0x8000}, // 32768-65535
+			},
+		},
+		// Another typical large case test
+		{
+			start: 10000,
+			end:   20000,
+			expected: []MaskedPort{
+				{port: 0x2710, mask: 0xfff0}, // 10000 - 10015
+				{port: 0x2720, mask: 0xffe0}, // 10016 - 10047
+				{port: 0x2740, mask: 0xffc0}, // 10048 - 10111
+				{port: 0x2780, mask: 0xff80}, // 10112 - 10239
+				{port: 0x2800, mask: 0xf800}, // 10240 - 12287
+				{port: 0x3000, mask: 0xf000}, // 12288 - 16383
+				{port: 0x4000, mask: 0xf800}, // 16384 - 18431
+				{port: 0x4800, mask: 0xfc00}, // 18432 - 19455
+				{port: 0x4c00, mask: 0xfe00}, // 19456 - 19967
+				{port: 0x4e00, mask: 0xffe0}, // 19968 - 19999
+				{port: 0x4e20, mask: 0xffff}, // 20000
+			},
+		},
+		{
+			start: 1000,
+			end:   1999,
+			expected: []MaskedPort{
+				{port: 0x3e8, mask: 0xfff8},
+				{port: 0x3f0, mask: 0xfff0},
+				{port: 0x400, mask: 0xfe00},
+				{port: 0x600, mask: 0xff00},
+				{port: 0x700, mask: 0xff80},
+				{port: 0x780, mask: 0xffc0},
+				{port: 0x7c0, mask: 0xfff0},
+			},
+		},
+		{
+			start: 0,
+			end:   1,
+			expected: []MaskedPort{
+				{port: 0, mask: 0xfffe}, // 0-1
+			},
+		},
+		{
+			start: 16,
+			end:   31,
+			expected: []MaskedPort{
+				{port: 0x10, mask: 0xfff0}, // 16-31
+			},
+		},
+		{
+			start: 0xff00, // 65280
+			end:   0xffff, // 65535
+			expected: []MaskedPort{
+				{port: 0xff00, mask: 0xff00}, // 65280-65535
+			},
+		},
+		{
+			start: 0,
+			end:   0xffff,
+			expected: []MaskedPort{
+				{port: 0x0, mask: 0x0000}, // 0-0xffff
+			},
+		},
+		{
+			start: 1,
+			end:   7,
+			expected: []MaskedPort{
+				{port: 0x1, mask: 0xffff}, // 1
+				{port: 0x2, mask: 0xfffe}, // 2-3
+				{port: 0x4, mask: 0xfffc}, // 4-7
+			},
+		},
+		{
+			start: 0,
+			end:   7,
+			expected: []MaskedPort{
+				{port: 0x0, mask: 0xfff8}, // 0-7
+			},
+		},
+		{
+			start: 5,
+			end:   10,
+			expected: []MaskedPort{
+				{0b0000000000000101, 0b1111111111111111}, // 5
+				{0b0000000000000110, 0b1111111111111110}, // 6-7
+				{0b0000000000001000, 0b1111111111111110}, // 8-9
+				{0b0000000000001010, 0b1111111111111111}, // 10
+			},
+		},
+		{
+			start: 0,
+			end:   16,
+			expected: []MaskedPort{
+				{0b0000000000000000, 0b1111111111110000}, // 0xxxx
+				{0b0000000000010000, 0b1111111111111111}, // 10000
+			},
+		},
+		{
+			start: 0b0000000000010000, // 16
+			end:   0b0000000110000111, // 391
+			expected: []MaskedPort{
+				{0b0000000000010000, 0b1111111111110000}, // 00001xxxx, 16-31
+				{0b0000000000100000, 0b1111111111100000}, // 0001xxxxx, 32-63
+				{0b0000000001000000, 0b1111111111000000}, // 001xxxxxx, 64-127
+				{0b0000000010000000, 0b1111111110000000}, // 01xxxxxxx, 128-255
+				{0b0000000100000000, 0b1111111110000000}, // 01xxxxxxx, 256-383
+				{0b0000000110000000, 0b1111111111111000}, // 10000000x, 384-391
+			},
+		},
+		{
+			start: 22,
+			end:   23,
+			expected: []MaskedPort{
+				{0b0000000000010110, 0b1111111111111110}, // 22-23
+			},
+		},
+		{
+			start: 23,
+			end:   24,
+			expected: []MaskedPort{
+				{0b0000000000010111, 0b1111111111111111}, // 23
+				{0b0000000000011000, 0b1111111111111111}, // 24
+			},
+		},
+		{
+			start: 0,
+			end:   0x7fff,
+			expected: []MaskedPort{
+				{port: 0x0, mask: 0x8000}, // 0-0x7fff
+			},
+		},
+		{
+			start: 256,
+			end:   256,
+			expected: []MaskedPort{
+				{port: 0x100, mask: 0xffff},
+			},
+		},
+		{
+			start: 65535,
+			end:   65535,
+			expected: []MaskedPort{
+				{port: 65535, mask: 0xffff},
+			},
+		},
+		{
+			start: 32767,
+			end:   32768,
+			expected: []MaskedPort{
+				{port: 0x7fff, mask: 0xffff},
+				{port: 0x8000, mask: 0xffff},
+			},
+		},
+		{
+			start: 0b0101010101010101, // 0x5555
+			end:   0b0101010111010101, // 0x55d5
+			expected: []MaskedPort{
+				{port: 0b0101010101010101, mask: 0b1111111111111111},
+				{port: 0b0101010101010110, mask: 0b1111111111111110},
+				{port: 0b0101010101011000, mask: 0b1111111111111000},
+				{port: 0b0101010101100000, mask: 0b1111111111100000},
+				{port: 0b0101010110000000, mask: 0b1111111111000000},
+				{port: 0b0101010111000000, mask: 0b1111111111110000},
+				{port: 0b0101010111010000, mask: 0b1111111111111100},
+				{port: 0b0101010111010100, mask: 0b1111111111111110},
+			},
+		},
+		// This is all ports.
+		{
+			start: 0,
+			end:   0,
+			expected: []MaskedPort{
+				{port: 0, mask: 0},
+			},
+		},
+		// This is too.
+		{
+			start: 0,
+			end:   65535,
+			expected: []MaskedPort{
+				{port: 0, mask: 0},
+			},
+		},
+		// This is valid, as "0" defines no range.
+		{
+			start: 65535,
+			end:   0,
+			expected: []MaskedPort{
+				{port: 0xffff, mask: 0xffff}, // 65535
+			},
+		},
+		// These remaining tests are testing invalid cases where start >= end.
+		// For now, these cases return the start port with a full mask,
+		// indicating that only the start port should be part of the range.
+		// This is technically correct for the case of end port being "0"
+		// and the value of the port, but is ambiguous otherwise.
+		{
+			start: 65535,
+			end:   1,
+			expected: []MaskedPort{
+				{port: 0xffff, mask: 0xffff}, // 65535
+			},
+		},
+		{
+			start: 65530,
+			end:   5,
+			expected: []MaskedPort{
+				{port: 0xfffa, mask: 0xffff}, // 65530
+			},
+		},
+		{
+			start: 10,
+			end:   5,
+			expected: []MaskedPort{
+				{port: 0xa, mask: 0xffff}, // 10
+			},
+		},
+	}
+
+	for i := 0; i < len(testCases); i++ {
+		test := &testCases[i]
+		maskedPorts := PortRangeToMaskedPorts(test.start, test.end)
+		// Sort the returned slice so that PortRangeToMaskedPorts() can return masked ports
+		// in any order that is convenient for it.
+		sort.Slice(maskedPorts, func(i, j int) bool {
+			return maskedPorts[i].port < maskedPorts[j].port
+		})
+		c.Logf("TestPortRange test case: 0x%x-0x%x (%d-%d)", test.start, test.end, test.start, test.end)
+		c.Assert(maskedPorts, checker.Equals, test.expected)
+		// Validate when given a proper range
+		if test.start <= test.end {
+			// Validation checks that the masked ports form a continuous range
+			validateMaskedPorts(c, maskedPorts, test.start, test.end)
+		}
+	}
+}

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -1469,7 +1469,7 @@ Resolving ingress policy for [any:bar]
     Denies from labels {"matchLabels":{"reserved:host":""}}
     Denies from labels {"matchLabels":{"any:baz":""}}
       Found all required labels
-      Denies port [{80 }]
+      Denies port [{80 0 }]
 2/2 rules selected
 Found no allow rule
 Found deny rule
@@ -1546,7 +1546,7 @@ Resolving ingress policy for [any:bar]
     Denies from labels {"matchLabels":{"reserved:host":""},"matchExpressions":[{"key":"any:baz","operator":"In","values":[""]}]}
     Denies from labels {"matchLabels":{"any:baz":""},"matchExpressions":[{"key":"any:baz","operator":"In","values":[""]}]}
       Found all required labels
-      Denies port [{80 }]
+      Denies port [{80 0 }]
         No port match found
 * Rule {"matchLabels":{"any:bar":""}}: selected
 3/3 rules selected

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -2173,7 +2173,7 @@ Resolving ingress policy for [any:bar]
     Allows from labels {"matchLabels":{"reserved:host":""}}
     Allows from labels {"matchLabels":{"any:baz":""}}
       Found all required labels
-      Allows port [{80 ANY}]
+      Allows port [{80 0 ANY}]
 2/2 rules selected
 Found allow rule
 Found no deny rule
@@ -2250,7 +2250,7 @@ Resolving ingress policy for [any:bar]
     Allows from labels {"matchLabels":{"reserved:host":""},"matchExpressions":[{"key":"any:baz","operator":"In","values":[""]}]}
     Allows from labels {"matchLabels":{"any:baz":""},"matchExpressions":[{"key":"any:baz","operator":"In","values":[""]}]}
       Found all required labels
-      Allows port [{80 ANY}]
+      Allows port [{80 0 ANY}]
         No port match found
 * Rule {"matchLabels":{"any:bar":""}}: selected
 3/3 rules selected

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 )
 
@@ -246,6 +247,7 @@ func (p *EndpointPolicy) ConsumeMapChanges() (adds, deletes Keys) {
 func (p *EndpointPolicy) AllowsIdentity(identity identity.NumericIdentity) (ingress, egress bool) {
 	key := Key{
 		Identity: uint32(identity),
+		PortMask: api.FullPortMask,
 	}
 
 	if !p.IngressPolicyEnabled {

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -338,8 +338,8 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 		policyMapState: newMapState(map[Key]MapStateEntry{
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
-			{TrafficDirection: trafficdirection.Egress.Uint8()}: allowEgressMapStateEntry,
-			{DestPort: 80, Nexthdr: 6}:                          rule1MapStateEntry,
+			{PortMask: api.FullPortMask, TrafficDirection: trafficdirection.Egress.Uint8()}: allowEgressMapStateEntry,
+			{DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}:                          rule1MapStateEntry,
 		}),
 	}
 
@@ -493,12 +493,12 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 		policyMapState: newMapState(map[Key]MapStateEntry{
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
-			{TrafficDirection: trafficdirection.Egress.Uint8()}:                              allowEgressMapStateEntry,
-			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}:     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
-			{Identity: uint32(identity.ReservedIdentityWorldIPv4), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorldV4, cachedSelectorWorld),
-			{Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorldV6, cachedSelectorWorld),
-			{Identity: 192, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry,
-			{Identity: 194, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry,
+			{TrafficDirection: trafficdirection.Egress.Uint8(), PortMask: api.FullPortMask}:                              allowEgressMapStateEntry,
+			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}:     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
+			{Identity: uint32(identity.ReservedIdentityWorldIPv4), DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorldV4, cachedSelectorWorld),
+			{Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorldV6, cachedSelectorWorld),
+			{Identity: 192, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}:                                        rule1MapStateEntry,
+			{Identity: 194, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}:                                        rule1MapStateEntry,
 		}),
 	}
 
@@ -506,11 +506,11 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	// maps on the policy got cleared
 
 	require.Equal(t, Keys{
-		{Identity: 192, DestPort: 80, Nexthdr: 6}: {},
-		{Identity: 194, DestPort: 80, Nexthdr: 6}: {},
+		{Identity: 192, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: {},
+		{Identity: 194, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: {},
 	}, adds)
 	require.Equal(t, Keys{
-		{Identity: 193, DestPort: 80, Nexthdr: 6}: {},
+		{Identity: 193, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: {},
 	}, deletes)
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -352,6 +352,12 @@ func TestL7WithIngressWildcard(t *testing.T) {
 	// difference of the internal time.Time from the lock_debug.go.
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
 	require.EqualValues(t, &expectedEndpointPolicy, policy)
+	// policyMapState cannot be compared via DeepEqual
+	// c.Assert(policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState), checker.Equals, true,
+	// 	check.Commentf("%s", policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState)))
+	// policy.policyMapState = nil
+	// expectedEndpointPolicy.policyMapState = nil
+	// c.Assert(policy, checker.DeepEquals, &expectedEndpointPolicy)
 }
 
 func TestL7WithLocalHostWildcard(t *testing.T) {
@@ -449,6 +455,12 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 	// difference of the internal time.Time from the lock_debug.go.
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
 	require.EqualValues(t, &expectedEndpointPolicy, policy)
+	// policyMapState cannot be compared via DeepEqual
+	// c.Assert(policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState), checker.Equals, true,
+	// 	check.Commentf("%s", policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState)))
+	// policy.policyMapState = nil
+	// expectedEndpointPolicy.policyMapState = nil
+	// c.Assert(policy, checker.DeepEquals, &expectedEndpointPolicy)
 }
 
 func TestMapStateWithIngressWildcard(t *testing.T) {
@@ -545,6 +557,12 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 	// difference of the internal time.Time from the lock_debug.go.
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
 	require.Equal(t, &expectedEndpointPolicy, policy)
+	// policyMapState cannot be compared via DeepEqual
+	// c.Assert(policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState), checker.Equals, true,
+	// 	check.Commentf("%s", policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState)))
+	// policy.policyMapState = nil
+	// expectedEndpointPolicy.policyMapState = nil
+	// c.Assert(policy, checker.Equals, &expectedEndpointPolicy)
 }
 
 func TestMapStateWithIngress(t *testing.T) {
@@ -717,6 +735,12 @@ func TestMapStateWithIngress(t *testing.T) {
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
+	// policyMapState cannot be compared via DeepEqual
+	// c.Assert(policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState), checker.Equals, true,
+	// 	check.Commentf("%s", policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState)))
+	// policy.policyMapState = nil
+	// expectedEndpointPolicy.policyMapState = nil
+	// c.Assert(policy, checker.Equals, &expectedEndpointPolicy)
 }
 
 func TestEndpointPolicy_AllowsIdentity(t *testing.T) {

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -534,8 +534,8 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 		},
 		PolicyOwner: DummyOwner{},
 		policyMapState: newMapState(map[Key]MapStateEntry{
-			{TrafficDirection: trafficdirection.Egress.Uint8()}: allowEgressMapStateEntry,
-			{DestPort: 80, Nexthdr: 6}:                          rule1MapStateEntry,
+			{PortMask: api.FullPortMask, TrafficDirection: trafficdirection.Egress.Uint8()}: allowEgressMapStateEntry,
+			{DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}:                          rule1MapStateEntry,
 		}),
 	}
 
@@ -702,12 +702,12 @@ func TestMapStateWithIngress(t *testing.T) {
 		},
 		PolicyOwner: DummyOwner{},
 		policyMapState: newMapState(map[Key]MapStateEntry{
-			{TrafficDirection: trafficdirection.Egress.Uint8()}:                              allowEgressMapStateEntry,
-			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}:     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
-			{Identity: uint32(identity.ReservedIdentityWorldIPv4), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld, cachedSelectorWorldV4),
-			{Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld, cachedSelectorWorldV6),
-			{Identity: 192, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry.WithAuthType(AuthTypeDisabled),
-			{Identity: 194, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry.WithAuthType(AuthTypeDisabled),
+			{TrafficDirection: trafficdirection.Egress.Uint8(), PortMask: api.FullPortMask}:                              allowEgressMapStateEntry,
+			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}:     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
+			{Identity: uint32(identity.ReservedIdentityWorldIPv4), DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld, cachedSelectorWorldV4),
+			{Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld, cachedSelectorWorldV6),
+			{Identity: 192, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}:                                        rule1MapStateEntry.WithAuthType(AuthTypeDisabled),
+			{Identity: 194, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}:                                        rule1MapStateEntry.WithAuthType(AuthTypeDisabled),
 		}),
 	}
 
@@ -723,11 +723,11 @@ func TestMapStateWithIngress(t *testing.T) {
 	require.Nil(t, policy.policyMapChanges.changes)
 
 	require.Equal(t, Keys{
-		{Identity: 192, DestPort: 80, Nexthdr: 6}: {},
-		{Identity: 194, DestPort: 80, Nexthdr: 6}: {},
+		{Identity: 192, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: {},
+		{Identity: 194, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: {},
 	}, adds)
 	require.Equal(t, Keys{
-		{Identity: 193, DestPort: 80, Nexthdr: 6}: {},
+		{Identity: 193, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: {},
 	}, deletes)
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
@@ -799,6 +799,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					{
 						Identity:         0,
 						DestPort:         0,
+						PortMask:         api.FullPortMask,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Ingress.Uint8(),
 					}: {},
@@ -821,6 +822,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					{
 						Identity:         0,
 						DestPort:         0,
+						PortMask:         api.FullPortMask,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Egress.Uint8(),
 					}: {},
@@ -843,6 +845,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					{
 						Identity:         0,
 						DestPort:         0,
+						PortMask:         api.FullPortMask,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Ingress.Uint8(),
 					}: {IsDeny: true},
@@ -865,6 +868,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					{
 						Identity:         0,
 						DestPort:         0,
+						PortMask:         api.FullPortMask,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Ingress.Uint8(),
 					}: {IsDeny: true},
@@ -887,6 +891,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					{
 						Identity:         0,
 						DestPort:         0,
+						PortMask:         api.FullPortMask,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Egress.Uint8(),
 					}: {IsDeny: true},
@@ -909,6 +914,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					{
 						Identity:         0,
 						DestPort:         0,
+						PortMask:         api.FullPortMask,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Egress.Uint8(),
 					}: {IsDeny: true},

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1790,7 +1790,7 @@ func TestIngressL4AllowAll(t *testing.T) {
 
 	filter, ok := l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.Equal(t, 1, len(filter.PerSelectorPolicies))
@@ -1835,7 +1835,7 @@ func TestIngressL4AllowAllNamedPort(t *testing.T) {
 
 	filter, ok := l4IngressPolicy["port-80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 0, filter.Port)
+	require.Equal(t, uint16(0), filter.Port)
 	require.Equal(t, "port-80", filter.PortName)
 	require.True(t, filter.Ingress)
 
@@ -1907,7 +1907,7 @@ func TestEgressL4AllowAll(t *testing.T) {
 
 	filter, ok := l4EgressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.Equal(t, false, filter.Ingress)
 
 	require.Equal(t, 1, len(filter.PerSelectorPolicies))
@@ -1963,7 +1963,7 @@ func TestEgressL4AllowWorld(t *testing.T) {
 
 	filter, ok := l4EgressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.Equal(t, false, filter.Ingress)
 
 	require.Equal(t, 3, len(filter.PerSelectorPolicies))
@@ -2018,7 +2018,7 @@ func TestEgressL4AllowAllEntity(t *testing.T) {
 
 	filter, ok := l4EgressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.Equal(t, false, filter.Ingress)
 
 	require.Equal(t, 1, len(filter.PerSelectorPolicies))
@@ -2193,7 +2193,7 @@ func TestL4WildcardMerge(t *testing.T) {
 
 	filter, ok := l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.Equal(t, 2, len(filter.PerSelectorPolicies))
@@ -2220,7 +2220,7 @@ func TestL4WildcardMerge(t *testing.T) {
 
 	filterL7, ok := l4IngressPolicy["7000/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 7000, filterL7.Port)
+	require.Equal(t, uint16(7000), filterL7.Port)
 	require.True(t, filterL7.Ingress)
 
 	require.Equal(t, 1, len(filterL7.PerSelectorPolicies))
@@ -2300,7 +2300,7 @@ func TestL4WildcardMerge(t *testing.T) {
 
 	filter, ok = l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.Equal(t, 2, len(filter.PerSelectorPolicies))
@@ -2311,7 +2311,7 @@ func TestL4WildcardMerge(t *testing.T) {
 
 	filterL7, ok = l4IngressPolicy["7000/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 7000, filterL7.Port)
+	require.Equal(t, uint16(7000), filterL7.Port)
 	require.True(t, filterL7.Ingress)
 
 	require.Equal(t, 1, len(filterL7.PerSelectorPolicies))
@@ -2365,7 +2365,7 @@ func TestL4WildcardMerge(t *testing.T) {
 
 	filter, ok = l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.Equal(t, ParserTypeHTTP, filter.L7Parser)
@@ -2419,7 +2419,7 @@ func TestL4WildcardMerge(t *testing.T) {
 
 	filter, ok = l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.Equal(t, ParserTypeHTTP, filter.L7Parser)
@@ -2478,7 +2478,7 @@ func TestL3L4L7Merge(t *testing.T) {
 
 	filter, ok := l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.Equal(t, 2, len(filter.PerSelectorPolicies))
@@ -2547,7 +2547,7 @@ func TestL3L4L7Merge(t *testing.T) {
 
 	filter, ok = l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.Equal(t, ParserTypeHTTP, filter.L7Parser)


### PR DESCRIPTION
See commits.

Fixes: #16622

```release-note
policy: Add support for port ranges in network policies.
```
