### PR TITLE
hive: cast ModuleID to string

### DIFF
--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -55,7 +55,7 @@ func New(cells ...cell.Cell) *Hive {
 	// Scope logging and health by module ID.
 	moduleDecorators := []cell.ModuleDecorator{
 		func(log logrus.FieldLogger, mid cell.ModuleID) logrus.FieldLogger {
-			return log.WithField(logfields.LogSubsys, mid)
+			return log.WithField(logfields.LogSubsys, string(mid))
 		},
 		func(hp healthTypes.Provider, fmid cell.FullModuleID) cell.Health {
 			return hp.ForModule(fmid)


### PR DESCRIPTION
The `pkg/metrics` logging hook explicitly wants a string, not a newtype of string, hence it complained the type of the subsys field for module-decorated logrus loggers with unformatted loglines like:

`Failed to fire hook: type of the 'subsystem' log entry field is not string but cell.ModuleID`

Since the logging hook only looks at warnings and errors, I missed this in the original cilium/hive PR.

Fixes: #32388

cc @joestringer as the reporter