### PR TITLE
Use GH_RUNNER_EXTRA_POWER for CI image workflow

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -36,7 +36,7 @@ jobs:
   build-and-push-prs:
     timeout-minutes: 45
     name: Build and Push Images
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER }}
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Similar to #30496, use GH_RUNNER_EXTRA_POWER for the CI image workflow.