### PR TITLE
CI: enable CiliumEndpointSlice in conformance-e2e

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -52,6 +52,9 @@ inputs:
   misc:
     description: 'Misc helm rarely set by a user coma separated values'
     default: ''
+  ciliumendpointslice:
+    description: 'Enable CiliumEndpointSlice'
+    default: false
 outputs:
   config:
     description: 'Cilium installation config'
@@ -157,6 +160,10 @@ runs:
               INGRESS_CONTROLLER+=" --helm-set=ingressController.service.type=NodePort"
             fi
           fi
+
+          if [ "${{ inputs.ciliumendpointslice }}" == "true" ]; then
+            CILIUMENDPOINTSLICE="--helm-set=enableCiliumEndpointSlice=true"
+          fi
         
-          CONFIG="${DEFAULTS} ${IMAGE} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION} ${INGRESS_CONTROLLER}"
+          CONFIG="${DEFAULTS} ${IMAGE} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION} ${INGRESS_CONTROLLER} ${CILIUMENDPOINTSLICE}"
           echo "config=${CONFIG}" >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -251,6 +251,7 @@ jobs:
             tunnel: 'disabled'
             ingress-controller: 'true'
             misc: 'bpf.tproxy=true'
+            ciliumendpointslice: 'true'
 
           - name: '16'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -264,6 +265,7 @@ jobs:
             encryption: 'wireguard'
             encryption-node: 'false'
             host-fw: 'true'
+            ciliumendpointslice: 'true'
 
     timeout-minutes: 60
     steps:
@@ -310,6 +312,7 @@ jobs:
           host-fw: ${{ matrix.host-fw }}
           ingress-controller: ${{ matrix.ingress-controller }}
           misc: ${{ matrix.misc }}
+          ciliumendpointslice: ${{ matrix.ciliumendpointslice }}
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@bfa4f93a41da410a1b4c9373c1694ca6d5c35ade # v0.16.6

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -258,6 +258,7 @@ jobs:
             # Disable bpf.tproxy=true until https://github.com/cilium/cilium/issues/31918
             # has been resolved.
             misc: 'bpfClockProbe=false,cni.uninstall=false'
+            ciliumendpointslice: 'true'
 
           - name: '16'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -271,6 +272,7 @@ jobs:
             encryption: 'wireguard'
             encryption-node: 'false'
             host-fw: 'true'
+            ciliumendpointslice: 'true'
 
     timeout-minutes: 60
     steps:
@@ -320,6 +322,7 @@ jobs:
           mutual-auth: false
           ingress-controller: ${{ matrix.ingress-controller }}
           misc: ${{ matrix.misc || 'bpfClockProbe=false,cni.uninstall=false' }}
+          ciliumendpointslice: ${{ matrix.ciliumendpointslice }}
 
       - name: Derive newest Cilium installation config
         id: cilium-newest-config
@@ -341,6 +344,7 @@ jobs:
           mutual-auth: false
           ingress-controller: ${{ matrix.ingress-controller }}
           misc: ${{ matrix.misc || 'bpfClockProbe=false,cni.uninstall=false' }}
+          ciliumendpointslice: ${{ matrix.ciliumendpointslice }}
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@bfa4f93a41da410a1b4c9373c1694ca6d5c35ade # v0.16.6


### PR DESCRIPTION
Enable CiliumEndpointSlice in the conformance-e2e and upgrade workflows for coverage with tunneling enabled and disabled.
