### PR TITLE
[v1.15] cilium-cni: Reserve ports that can conflict with transparent DNS proxy

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -73,6 +73,7 @@ cilium-agent [flags]
       --config-dir string                                         Configuration directory that contains a file for each option
       --conntrack-gc-interval duration                            Overwrite the connection-tracking garbage collection interval
       --conntrack-gc-max-interval duration                        Set the maximum interval for the connection-tracking garbage collection
+      --container-ip-local-reserved-ports string                  Instructs the Cilium CNI plugin to reserve the provided comma-separated list of ports in the container network namespace. Prevents the container from using these ports as ephemeral source ports (see Linux ip_local_reserved_ports). Use this flag if you observe port conflicts between transparent DNS proxy requests and host network namespace services. Value "auto" reserves the WireGuard and VXLAN ports used by Cilium (default "auto")
       --controller-group-metrics strings                          List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --crd-wait-timeout duration                                 Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
       --datapath-mode string                                      Datapath mode name (default "veth")

--- a/api/v1/models/daemon_configuration_status.go
+++ b/api/v1/models/daemon_configuration_status.go
@@ -53,6 +53,9 @@ type DaemonConfigurationStatus struct {
 	// Immutable configuration (read-only)
 	Immutable ConfigurationMap `json:"immutable,omitempty"`
 
+	// Comma-separated list of IP ports should be reserved in the workload network namespace
+	IPLocalReservedPorts string `json:"ipLocalReservedPorts,omitempty"`
+
 	// Configured IPAM mode
 	IpamMode string `json:"ipam-mode,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2807,6 +2807,9 @@ definitions:
       GROIPv4MaxSize:
         description: Maximum IPv4 GRO size on workload facing devices
         type: integer
+      ipLocalReservedPorts:
+        description: Comma-separated list of IP ports should be reserved in the workload network namespace
+        type: string
   DatapathMode:
     description: Datapath mode
     type: string

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2705,6 +2705,10 @@ func init() {
           "description": "Immutable configuration (read-only)",
           "$ref": "#/definitions/ConfigurationMap"
         },
+        "ipLocalReservedPorts": {
+          "description": "Comma-separated list of IP ports should be reserved in the workload network namespace",
+          "type": "string"
+        },
         "ipam-mode": {
           "description": "Configured IPAM mode",
           "type": "string"
@@ -8545,6 +8549,10 @@ func init() {
         "immutable": {
           "description": "Immutable configuration (read-only)",
           "$ref": "#/definitions/ConfigurationMap"
+        },
+        "ipLocalReservedPorts": {
+          "description": "Comma-separated list of IP ports should be reserved in the workload network namespace",
+          "type": "string"
         },
         "ipam-mode": {
           "description": "Configured IPAM mode",

--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -6,17 +6,22 @@ package cmd
 import (
 	"fmt"
 	"reflect"
+	"strconv"
+	"strings"
 
 	"github.com/go-openapi/runtime/middleware"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/api"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 // ConfigModifyEvent is a wrapper around the parameters for configModify.
@@ -134,6 +139,39 @@ func patchConfigHandler(d *Daemon, params PatchConfigParams) middleware.Responde
 	return api.Error(PatchConfigFailureCode, msg)
 }
 
+// getIPLocalReservedPorts returns a comma-separated list of ports which
+// we need to reserve in the container network namespace.
+// These ports are typically used in the host network namespace and thus can
+// conflict when running with DNS transparent proxy mode.
+// This is a workaround for cilium/cilium#31535
+func getIPLocalReservedPorts(d *Daemon) string {
+	if option.Config.ContainerIPLocalReservedPorts != defaults.ContainerIPLocalReservedPortsAuto {
+		return option.Config.ContainerIPLocalReservedPorts
+	}
+
+	if !option.Config.DNSProxyEnableTransparentMode {
+		return "" // no ports to reserve
+	}
+
+	// Reserves the WireGuard port. This is usually part of the ephemeral port
+	// range and thus may conflict with the ephemeral source port of DNS clients
+	// in the container network namespace.
+	var ports []string
+	if option.Config.EnableWireguard {
+		ports = append(ports, strconv.Itoa(wgTypes.ListenPort))
+	}
+
+	// Reserves the tunnel port. This is not part of the ephemeral port range by
+	// default, but is user configurable and thus should be included regardless.
+	// The Linux kernel documentation explicitly allows to reserve ports which
+	// are not part of the ephemeral port range, in which case this is a no-op.
+	if d.tunnelConfig.Protocol() != tunnel.Disabled {
+		ports = append(ports, fmt.Sprintf("%d", d.tunnelConfig.Port()))
+	}
+
+	return strings.Join(ports, ",")
+}
+
 func getConfigHandler(d *Daemon, params GetConfigParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /config request")
 
@@ -185,6 +223,7 @@ func getConfigHandler(d *Daemon, params GetConfigParams) middleware.Responder {
 		GSOMaxSize:                  int64(d.bigTCPConfig.GetGSOIPv6MaxSize()),
 		GROIPV4MaxSize:              int64(d.bigTCPConfig.GetGROIPv4MaxSize()),
 		GSOIPV4MaxSize:              int64(d.bigTCPConfig.GetGSOIPv4MaxSize()),
+		IPLocalReservedPorts:        getIPLocalReservedPorts(d),
 	}
 
 	cfg := &models.DaemonConfiguration{

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1047,6 +1047,11 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.InstallNoConntrackIptRules, defaults.InstallNoConntrackIptRules, "Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.")
 	option.BindEnv(vp, option.InstallNoConntrackIptRules)
 
+	flags.String(option.ContainerIPLocalReservedPorts, defaults.ContainerIPLocalReservedPortsAuto, "Instructs the Cilium CNI plugin to reserve the provided comma-separated list of ports in the container network namespace. "+
+		"Prevents the container from using these ports as ephemeral source ports (see Linux ip_local_reserved_ports). Use this flag if you observe port conflicts between transparent DNS proxy requests and host network namespace services. "+
+		"Value \"auto\" reserves the WireGuard and VXLAN ports used by Cilium")
+	option.BindEnv(vp, option.ContainerIPLocalReservedPorts)
+
 	flags.Bool(option.EnableCustomCallsName, false, "Enable tail call hooks for custom eBPF programs")
 	option.BindEnv(vp, option.EnableCustomCallsName)
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -507,6 +507,10 @@ const (
 	// InstallNoConntrackRules instructs Cilium to install Iptables rules to skip netfilter connection tracking on all pod traffic.
 	InstallNoConntrackIptRules = false
 
+	// ContainerIPLocalReservedPortsAuto instructs the Cilium CNI plugin to reserve
+	// an auto-generated list of ports in the container network namespace
+	ContainerIPLocalReservedPortsAuto = "auto"
+
 	// ExternalClusterIP enables cluster external access to ClusterIP services.
 	// Defaults to false to retain prior behaviour of not routing external packets to ClusterIPs.
 	ExternalClusterIP = false

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -507,12 +507,6 @@ const (
 	// InstallNoConntrackRules instructs Cilium to install Iptables rules to skip netfilter connection tracking on all pod traffic.
 	InstallNoConntrackIptRules = false
 
-	// WireguardSubnetV4 is a default WireGuard tunnel subnet
-	WireguardSubnetV4 = "172.16.43.0/24"
-
-	// WireguardSubnetV6 is a default WireGuard tunnel subnet
-	WireguardSubnetV6 = "fdc9:281f:04d7:9ee9::1/64"
-
 	// ExternalClusterIP enables cluster external access to ClusterIP services.
 	// Defaults to false to retain prior behaviour of not routing external packets to ClusterIPs.
 	ExternalClusterIP = false

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -14,6 +14,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -387,6 +388,10 @@ const (
 	// InstallNoConntrackIptRules instructs Cilium to install Iptables rules
 	// to skip netfilter connection tracking on all pod traffic.
 	InstallNoConntrackIptRules = "install-no-conntrack-iptables-rules"
+
+	// ContainerIPLocalReservedPorts instructs the Cilium CNI plugin to reserve
+	// the provided comma-separated list of ports in the container network namespace
+	ContainerIPLocalReservedPorts = "container-ip-local-reserved-ports"
 
 	// IPv6NodeAddr is the IPv6 address of node
 	IPv6NodeAddr = "ipv6-node"
@@ -2331,6 +2336,10 @@ type DaemonConfig struct {
 	// InstallNoConntrackIptRules instructs Cilium to install Iptables rules to skip netfilter connection tracking on all pod traffic.
 	InstallNoConntrackIptRules bool
 
+	// ContainerIPLocalReservedPorts instructs the Cilium CNI plugin to reserve
+	// the provided comma-separated list of ports in the container network namespace
+	ContainerIPLocalReservedPorts string
+
 	// EnableCustomCalls enables tail call hooks for user-defined custom
 	// eBPF programs, typically used to collect custom per-endpoint
 	// metrics.
@@ -2807,6 +2816,18 @@ func (c *DaemonConfig) validateHubbleRedact() error {
 	return nil
 }
 
+func (c *DaemonConfig) validateContainerIPLocalReservedPorts() error {
+	if c.ContainerIPLocalReservedPorts == "" || c.ContainerIPLocalReservedPorts == defaults.ContainerIPLocalReservedPortsAuto {
+		return nil
+	}
+
+	if regexp.MustCompile(`^(\d+(-\d+)?)(,\d+(-\d+)?)*$`).MatchString(c.ContainerIPLocalReservedPorts) {
+		return nil
+	}
+
+	return fmt.Errorf("Invalid comma separated list of of ranges for %s option", ContainerIPLocalReservedPorts)
+}
+
 // Validate validates the daemon configuration
 func (c *DaemonConfig) Validate(vp *viper.Viper) error {
 	if err := c.validateIPv6ClusterAllocCIDR(); err != nil {
@@ -2901,6 +2922,10 @@ func (c *DaemonConfig) Validate(vp *viper.Viper) error {
 	}
 
 	if err := c.validatePolicyCIDRMatchMode(); err != nil {
+		return err
+	}
+
+	if err := c.validateContainerIPLocalReservedPorts(); err != nil {
 		return err
 	}
 
@@ -3166,6 +3191,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.LoadBalancerRSSv4CIDR = vp.GetString(LoadBalancerRSSv4CIDR)
 	c.LoadBalancerRSSv6CIDR = vp.GetString(LoadBalancerRSSv6CIDR)
 	c.InstallNoConntrackIptRules = vp.GetBool(InstallNoConntrackIptRules)
+	c.ContainerIPLocalReservedPorts = vp.GetString(ContainerIPLocalReservedPorts)
 	c.EnableCustomCalls = vp.GetBool(EnableCustomCallsName)
 	c.BGPAnnounceLBIP = vp.GetBool(BGPAnnounceLBIP)
 	c.BGPAnnouncePodCIDR = vp.GetBool(BGPAnnouncePodCIDR)

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -1233,3 +1233,93 @@ func Test_parseEventBufferTupleString(t *testing.T) {
 	c, err = ParseEventBufferTupleString("enabled,123,x")
 	assert.Error(err)
 }
+
+func TestDaemonConfig_validateContainerIPLocalReservedPorts(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "default",
+			value:   "auto",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "empty",
+			value:   "",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "single port",
+			value:   "1000",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "single range",
+			value:   "1000-2000",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "port list",
+			value:   "1000,2000",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "port range list",
+			value:   "1000-1001,2000-2002",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "mixed",
+			value:   "1000,2000-2002,3000,4000-4004",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "trailing comma",
+			value:   "1,2,3,",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "leading comma",
+			value:   ",1,2,3",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "invalid range",
+			value:   "-",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "invalid range end",
+			value:   "1000-",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "invalid range start",
+			value:   "-1000",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "invalid port",
+			value:   "foo",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "too many commas",
+			value:   "1000,,2000",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "invalid second value",
+			value:   "1000,-",
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &DaemonConfig{ContainerIPLocalReservedPorts: tt.value}
+			tt.wantErr(t, c.validateContainerIPLocalReservedPorts(), "validateContainerIPLocalReservedPorts()")
+		})
+	}
+}

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -45,10 +45,6 @@ import (
 	"github.com/cilium/cilium/pkg/wireguard/types"
 )
 
-const (
-	listenPort = 51871
-)
-
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "wireguard")
 
 // wireguardClient is an interface to mock wgctrl.Client
@@ -98,7 +94,7 @@ func NewAgent(privKeyPath string) (*Agent, error) {
 	return &Agent{
 		wgClient:   wgClient,
 		privKey:    key,
-		listenPort: listenPort,
+		listenPort: types.ListenPort,
 
 		peerByNodeName:   map[string]*peerConfig{},
 		nodeNameByNodeIP: map[string]string{},
@@ -402,9 +398,9 @@ func (a *Agent) UpdatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP
 
 	ep := ""
 	if option.Config.EnableIPv4 && nodeIPv4 != nil {
-		ep = net.JoinHostPort(nodeIPv4.String(), strconv.Itoa(listenPort))
+		ep = net.JoinHostPort(nodeIPv4.String(), strconv.Itoa(types.ListenPort))
 	} else if option.Config.EnableIPv6 && nodeIPv6 != nil {
-		ep = net.JoinHostPort(nodeIPv6.String(), strconv.Itoa(listenPort))
+		ep = net.JoinHostPort(nodeIPv6.String(), strconv.Itoa(types.ListenPort))
 	} else {
 		return fmt.Errorf("missing node IP for node %q", nodeName)
 	}

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -17,6 +17,7 @@ import (
 	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 type AgentSuite struct{}
@@ -86,7 +87,7 @@ func newTestAgent(ctx context.Context) (*Agent, *ipcache.IPCache) {
 	wgAgent := &Agent{
 		wgClient:         &fakeWgClient{},
 		ipCache:          ipCache,
-		listenPort:       listenPort,
+		listenPort:       types.ListenPort,
 		peerByNodeName:   map[string]*peerConfig{},
 		nodeNameByNodeIP: map[string]string{},
 		nodeNameByPubKey: map[wgtypes.Key]string{},

--- a/pkg/wireguard/types/types.go
+++ b/pkg/wireguard/types/types.go
@@ -5,6 +5,8 @@
 package types
 
 const (
+	// ListenPort is the port on which the WireGuard tunnel device listens on
+	ListenPort = 51871
 	// IfaceName is the name of the WireGuard tunnel device
 	IfaceName = "cilium_wg0"
 	// PrivKeyFilename is the name of the WireGuard private key file


### PR DESCRIPTION
 * [x] #32128 (@gandro) :warning: resolved conflicts

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 32128
```
