### PR TITLE
[v1.13] cilium-cni: Reserve ports that can conflict with transparent DNS proxy

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -66,6 +66,7 @@ cilium-agent [flags]
       --config-dir string                                       Configuration directory that contains a file for each option
       --conntrack-gc-interval duration                          Overwrite the connection-tracking garbage collection interval
       --conntrack-gc-max-interval duration                      Set the maximum interval for the connection-tracking garbage collection
+      --container-ip-local-reserved-ports string                Instructs the Cilium CNI plugin to reserve the provided comma-separated list of ports in the container network namespace. Prevents the container from using these ports as ephemeral source ports (see Linux ip_local_reserved_ports). Use this flag if you observe port conflicts between transparent DNS proxy requests and host network namespace services. Value "auto" reserves the WireGuard and VXLAN ports used by Cilium (default "auto")
       --crd-wait-timeout duration                               Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
       --datapath-mode string                                    Datapath mode name (default "veth")
   -D, --debug                                                   Enable debugging mode

--- a/api/v1/models/daemon_configuration_status.go
+++ b/api/v1/models/daemon_configuration_status.go
@@ -47,6 +47,9 @@ type DaemonConfigurationStatus struct {
 	// Immutable configuration (read-only)
 	Immutable ConfigurationMap `json:"immutable,omitempty"`
 
+	// Comma-separated list of IP ports should be reserved in the workload network namespace
+	IPLocalReservedPorts string `json:"ipLocalReservedPorts,omitempty"`
+
 	// Configured IPAM mode
 	IpamMode string `json:"ipam-mode,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2411,6 +2411,9 @@ definitions:
       GROMaxSize:
         description: Maximum GRO size on workload facing devices
         type: integer
+      ipLocalReservedPorts:
+        description: Comma-separated list of IP ports should be reserved in the workload network namespace
+        type: string
   DatapathMode:
     description: Datapath mode
     type: string

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2189,6 +2189,10 @@ func init() {
           "description": "Immutable configuration (read-only)",
           "$ref": "#/definitions/ConfigurationMap"
         },
+        "ipLocalReservedPorts": {
+          "description": "Comma-separated list of IP ports should be reserved in the workload network namespace",
+          "type": "string"
+        },
         "ipam-mode": {
           "description": "Configured IPAM mode",
           "type": "string"
@@ -7097,6 +7101,10 @@ func init() {
         "immutable": {
           "description": "Immutable configuration (read-only)",
           "$ref": "#/definitions/ConfigurationMap"
+        },
+        "ipLocalReservedPorts": {
+          "description": "Comma-separated list of IP ports should be reserved in the workload network namespace",
+          "type": "string"
         },
         "ipam-mode": {
           "description": "Configured IPAM mode",

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1037,6 +1037,11 @@ func initializeFlags() {
 	flags.Bool(option.InstallNoConntrackIptRules, defaults.InstallNoConntrackIptRules, "Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.")
 	option.BindEnv(Vp, option.InstallNoConntrackIptRules)
 
+	flags.String(option.ContainerIPLocalReservedPorts, defaults.ContainerIPLocalReservedPortsAuto, "Instructs the Cilium CNI plugin to reserve the provided comma-separated list of ports in the container network namespace. "+
+		"Prevents the container from using these ports as ephemeral source ports (see Linux ip_local_reserved_ports). Use this flag if you observe port conflicts between transparent DNS proxy requests and host network namespace services. "+
+		"Value \"auto\" reserves the WireGuard and VXLAN ports used by Cilium")
+	option.BindEnv(Vp, option.ContainerIPLocalReservedPorts)
+
 	flags.Bool(option.EnableCustomCallsName, false, "Enable tail call hooks for custom eBPF programs")
 	option.BindEnv(Vp, option.EnableCustomCallsName)
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -512,6 +512,10 @@ const (
 	// WireguardSubnetV6 is a default wireguard tunnel subnet
 	WireguardSubnetV6 = "fdc9:281f:04d7:9ee9::1/64"
 
+	// ContainerIPLocalReservedPortsAuto instructs the Cilium CNI plugin to reserve
+	// an auto-generated list of ports in the container network namespace
+	ContainerIPLocalReservedPortsAuto = "auto"
+
 	// ExternalClusterIP enables cluster external access to ClusterIP services.
 	// Defaults to false to retain prior behaviour of not routing external packets to ClusterIPs.
 	ExternalClusterIP = false

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -13,6 +13,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -400,6 +401,10 @@ const (
 
 	// IPTablesRandomFully sets iptables flag random-fully on masquerading rules
 	IPTablesRandomFully = "iptables-random-fully"
+
+	// ContainerIPLocalReservedPorts instructs the Cilium CNI plugin to reserve
+	// the provided comma-separated list of ports in the container network namespace
+	ContainerIPLocalReservedPorts = "container-ip-local-reserved-ports"
 
 	// IPv6NodeAddr is the IPv6 address of node
 	IPv6NodeAddr = "ipv6-node"
@@ -2257,6 +2262,10 @@ type DaemonConfig struct {
 	// InstallNoConntrackIptRules instructs Cilium to install Iptables rules to skip netfilter connection tracking on all pod traffic.
 	InstallNoConntrackIptRules bool
 
+	// ContainerIPLocalReservedPorts instructs the Cilium CNI plugin to reserve
+	// the provided comma-separated list of ports in the container network namespace
+	ContainerIPLocalReservedPorts string
+
 	// EnableCustomCalls enables tail call hooks for user-defined custom
 	// eBPF programs, typically used to collect custom per-endpoint
 	// metrics.
@@ -2685,6 +2694,18 @@ func (c *DaemonConfig) validateIPv6NAT46x64CIDR() error {
 	return nil
 }
 
+func (c *DaemonConfig) validateContainerIPLocalReservedPorts() error {
+	if c.ContainerIPLocalReservedPorts == "" || c.ContainerIPLocalReservedPorts == defaults.ContainerIPLocalReservedPortsAuto {
+		return nil
+	}
+
+	if regexp.MustCompile(`^(\d+(-\d+)?)(,\d+(-\d+)?)*$`).MatchString(c.ContainerIPLocalReservedPorts) {
+		return nil
+	}
+
+	return fmt.Errorf("Invalid comma separated list of of ranges for %s option", ContainerIPLocalReservedPorts)
+}
+
 // Validate validates the daemon configuration
 func (c *DaemonConfig) Validate(vp *viper.Viper) error {
 	if err := c.validateIPv6ClusterAllocCIDR(); err != nil {
@@ -2776,6 +2797,10 @@ func (c *DaemonConfig) Validate(vp *viper.Viper) error {
 		if err != nil {
 			return fmt.Errorf("Failed to validate VTEP configuration: %w", err)
 		}
+	}
+
+	if err := c.validateContainerIPLocalReservedPorts(); err != nil {
+		return err
 	}
 
 	return nil
@@ -3053,6 +3078,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.LoadBalancerRSSv4CIDR = vp.GetString(LoadBalancerRSSv4CIDR)
 	c.LoadBalancerRSSv6CIDR = vp.GetString(LoadBalancerRSSv6CIDR)
 	c.InstallNoConntrackIptRules = vp.GetBool(InstallNoConntrackIptRules)
+	c.ContainerIPLocalReservedPorts = vp.GetString(ContainerIPLocalReservedPorts)
 	c.EnableCustomCalls = vp.GetBool(EnableCustomCallsName)
 	c.BGPAnnounceLBIP = vp.GetBool(BGPAnnounceLBIP)
 	c.BGPAnnouncePodCIDR = vp.GetBool(BGPAnnouncePodCIDR)

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -1182,3 +1182,93 @@ func Test_parseEventBufferTupleString(t *testing.T) {
 	c, err = ParseEventBufferTupleString("enabled,123,x")
 	assert.Error(err)
 }
+
+func TestDaemonConfig_validateContainerIPLocalReservedPorts(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "default",
+			value:   "auto",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "empty",
+			value:   "",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "single port",
+			value:   "1000",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "single range",
+			value:   "1000-2000",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "port list",
+			value:   "1000,2000",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "port range list",
+			value:   "1000-1001,2000-2002",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "mixed",
+			value:   "1000,2000-2002,3000,4000-4004",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "trailing comma",
+			value:   "1,2,3,",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "leading comma",
+			value:   ",1,2,3",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "invalid range",
+			value:   "-",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "invalid range end",
+			value:   "1000-",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "invalid range start",
+			value:   "-1000",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "invalid port",
+			value:   "foo",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "too many commas",
+			value:   "1000,,2000",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "invalid second value",
+			value:   "1000,-",
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &DaemonConfig{ContainerIPLocalReservedPorts: tt.value}
+			tt.wantErr(t, c.validateContainerIPLocalReservedPorts(), "validateContainerIPLocalReservedPorts()")
+		})
+	}
+}

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -40,10 +40,6 @@ import (
 	"github.com/cilium/cilium/pkg/wireguard/types"
 )
 
-const (
-	listenPort = 51871
-)
-
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "wireguard")
 
 // wireguardClient is an interface to mock wgctrl.Client
@@ -89,7 +85,7 @@ func NewAgent(privKeyPath string) (*Agent, error) {
 	return &Agent{
 		wgClient:         wgClient,
 		privKey:          key,
-		listenPort:       listenPort,
+		listenPort:       types.ListenPort,
 		peerByNodeName:   map[string]*peerConfig{},
 		nodeNameByNodeIP: map[string]string{},
 		nodeNameByPubKey: map[wgtypes.Key]string{},
@@ -377,9 +373,9 @@ func (a *Agent) UpdatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP
 
 	ep := ""
 	if option.Config.EnableIPv4 && nodeIPv4 != nil {
-		ep = net.JoinHostPort(nodeIPv4.String(), strconv.Itoa(listenPort))
+		ep = net.JoinHostPort(nodeIPv4.String(), strconv.Itoa(types.ListenPort))
 	} else if option.Config.EnableIPv6 && nodeIPv6 != nil {
-		ep = net.JoinHostPort(nodeIPv6.String(), strconv.Itoa(listenPort))
+		ep = net.JoinHostPort(nodeIPv6.String(), strconv.Itoa(types.ListenPort))
 	} else {
 		return fmt.Errorf("missing node IP for node %q", nodeName)
 	}

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -17,6 +17,7 @@ import (
 	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 type AgentSuite struct{}
@@ -89,7 +90,7 @@ func (a *AgentSuite) TestAgent_PeerConfig(c *C) {
 	wgAgent := &Agent{
 		wgClient:         &fakeWgClient{},
 		ipCache:          ipCache,
-		listenPort:       listenPort,
+		listenPort:       types.ListenPort,
 		peerByNodeName:   map[string]*peerConfig{},
 		nodeNameByNodeIP: map[string]string{},
 		nodeNameByPubKey: map[wgtypes.Key]string{},

--- a/pkg/wireguard/types/types.go
+++ b/pkg/wireguard/types/types.go
@@ -5,6 +5,8 @@
 package types
 
 const (
+	// ListenPort is the port on which the WireGuard tunnel device listens on
+	ListenPort = 51871
 	// IfaceName is the name of the Wireguard tunnel device
 	IfaceName = "cilium_wg0"
 	// PrivKeyFilename is the name of the Wireguard private key file

--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -357,6 +357,30 @@ func setupLogging(n *types.NetConf) error {
 	return nil
 }
 
+func reserveLocalIPPorts(conf *models.DaemonConfigurationStatus) error {
+	if conf.IPLocalReservedPorts == "" {
+		return nil
+	}
+
+	// Note: This setting applies to IPv4 and IPv6
+	const param = "net.ipv4.ip_local_reserved_ports"
+	var reserved = conf.IPLocalReservedPorts
+
+	// Append our reserved ports to the ones which might already be reserved.
+	existing, err := sysctl.Read(param)
+	if err != nil {
+		return err
+	}
+
+	// Merging the two sets of ports. Note that the kernel merges any redundant
+	// ports or port ranges for us, so we do not have to check if `existing`
+	// and `reserved` contain any overlapping ports.
+	if existing != "" {
+		reserved = existing + "," + reserved
+	}
+	return sysctl.Write(param, reserved)
+}
+
 func cmdAdd(args *skel.CmdArgs) (err error) {
 	var (
 		ipConfig *cniTypesV1.IPConfig
@@ -576,6 +600,10 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	var macAddrStr string
 	if err = netNs.Do(func(_ ns.NetNS) error {
 		if ipv6IsEnabled(ipam) {
+			if err := reserveLocalIPPorts(conf); err != nil {
+				logger.WithError(err).Warn("unable to reserve local ip ports")
+			}
+
 			if err := sysctl.Disable("net.ipv6.conf.all.disable_ipv6"); err != nil {
 				logger.WithError(err).Warn("unable to enable ipv6 on all interfaces")
 			}


### PR DESCRIPTION
 * [x] #32128 (@gandro) :warning: resolved conflicts

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 32128
```
