### PR TITLE
daemon: Reserve Geneve tunnel port if enabled

### DIFF
--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -162,11 +162,11 @@ func getIPLocalReservedPorts(d *Daemon) string {
 		ports = append(ports, strconv.Itoa(wgTypes.ListenPort))
 	}
 
-	// Reserves the VXLAN port. This is not part of the ephemeral port range by
+	// Reserves the tunnel port. This is not part of the ephemeral port range by
 	// default, but is user configurable and thus should be included regardless.
 	// The Linux kernel documentation explicitly allows to reserve ports which
 	// are not part of the ephemeral port range, in which case this is a no-op.
-	if d.tunnelConfig.Protocol() == tunnel.VXLAN {
+	if d.tunnelConfig.Protocol() != tunnel.Disabled {
 		ports = append(ports, fmt.Sprintf("%d", d.tunnelConfig.Port()))
 	}
 


### PR DESCRIPTION
This is a follow-up suggested by Julian in a previous PR: https://github.com/cilium/cilium/pull/32128#discussion_r1591927219

Fixes: 11fe7cc144aa ("cilium-cni: Reserve ports that can conflict with transparent DNS proxy")

Note: This fix has already been applied to the backported version of the above commit.
