### PR TITLE
bgp: Enable usage of BGPv2 APIs

### DIFF
--- a/pkg/bgpv1/agent/routermgr.go
+++ b/pkg/bgpv1/agent/routermgr.go
@@ -35,6 +35,10 @@ type BGPRouterManager interface {
 	// and disconnect from the peers.
 	ConfigurePeers(ctx context.Context, policy *v2alpha1api.CiliumBGPPeeringPolicy, ciliumNode *v2api.CiliumNode) error
 
+	// ReconcileInstances evaluates the provided CiliumBGPNodeConfig
+	// and the implementation will configure itself to apply this configuration.
+	ReconcileInstances(ctx context.Context, bgpnc *v2alpha1api.CiliumBGPNodeConfig, ciliumNode *v2api.CiliumNode) error
+
 	// GetPeers fetches BGP peering state from underlying routing daemon.
 	//
 	// List of all peers will be returned and if there are multiple instances of

--- a/pkg/bgpv1/gobgp/conversions.go
+++ b/pkg/bgpv1/gobgp/conversions.go
@@ -73,6 +73,7 @@ func ToAgentPath(p *gobgp.Path) (*types.Path, error) {
 
 	return &types.Path{
 		NLRI:           nlri,
+		Family:         toAgentFamily(p.Family),
 		PathAttributes: pattrs,
 		AgeNanoseconds: ageNano,
 		Best:           p.Best,
@@ -377,6 +378,13 @@ func toAgentSessionState(s gobgp.PeerState_SessionState) types.SessionState {
 		return types.SessionEstablished
 	default:
 		return types.SessionUnknown
+	}
+}
+
+func toAgentFamily(family *gobgp.Family) types.Family {
+	return types.Family{
+		Afi:  toAgentAfi(family.Afi),
+		Safi: toAgentSafi(family.Safi),
 	}
 }
 

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -53,7 +53,6 @@ type ServiceReconciler struct {
 
 func NewServiceReconciler(in ServiceReconcilerIn) ServiceReconcilerOut {
 	if in.SvcDiffStore == nil || in.EPDiffStore == nil || in.LBIPPoolStore == nil {
-		in.Logger.Warn("ServiceReconciler: missing required stores, skipping ServiceReconciler")
 		return ServiceReconcilerOut{}
 	}
 

--- a/pkg/bgpv1/mock/mocks.go
+++ b/pkg/bgpv1/mock/mocks.go
@@ -36,15 +36,20 @@ func (m *MockNodeLister) Get(name string) (*v1.Node, error) {
 var _ agent.BGPRouterManager = (*MockBGPRouterManager)(nil)
 
 type MockBGPRouterManager struct {
-	ConfigurePeers_   func(ctx context.Context, policy *v2alpha1.CiliumBGPPeeringPolicy, ciliumNode *v2.CiliumNode) error
-	GetPeers_         func(ctx context.Context) ([]*models.BgpPeer, error)
-	GetRoutes_        func(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error)
-	GetRoutePolicies_ func(ctx context.Context, params restapi.GetBgpRoutePoliciesParams) ([]*models.BgpRoutePolicy, error)
-	Stop_             func()
+	ConfigurePeers_     func(ctx context.Context, policy *v2alpha1.CiliumBGPPeeringPolicy, ciliumNode *v2.CiliumNode) error
+	ReconcileInstances_ func(ctx context.Context, bgpnc *v2alpha1.CiliumBGPNodeConfig, ciliumNode *v2.CiliumNode) error
+	GetPeers_           func(ctx context.Context) ([]*models.BgpPeer, error)
+	GetRoutes_          func(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error)
+	GetRoutePolicies_   func(ctx context.Context, params restapi.GetBgpRoutePoliciesParams) ([]*models.BgpRoutePolicy, error)
+	Stop_               func()
 }
 
 func (m *MockBGPRouterManager) ConfigurePeers(ctx context.Context, policy *v2alpha1.CiliumBGPPeeringPolicy, ciliumNode *v2.CiliumNode) error {
 	return m.ConfigurePeers_(ctx, policy, ciliumNode)
+}
+
+func (m *MockBGPRouterManager) ReconcileInstances(ctx context.Context, bgpnc *v2alpha1.CiliumBGPNodeConfig, ciliumNode *v2.CiliumNode) error {
+	return m.ReconcileInstances_(ctx, bgpnc, ciliumNode)
 }
 
 func (m *MockBGPRouterManager) GetPeers(ctx context.Context) ([]*models.BgpPeer, error) {


### PR DESCRIPTION
This change enables bgpv2 reconciliation in BGP control plane.

Updating reconcile logic in BGP agent, to toggle between v1 and v2 reconciliation. BGPv1 will take precedence, which is detected by the presence of active CiliumBGPPeeringPolicy on the node.

```release-note
BGP: New BGP APIs can be used to configure Cilium BGP Control Plane.
```
