### PR TITLE
bpf: egw: delay SNAT for local client to actual egress interface

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1380,6 +1380,9 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 #endif
 
 #ifdef ENABLE_HOST_FIREWALL
+	/* This was initially added for Egress GW. There it's no longer needed,
+	 * but it potentially also helps other paths (LB-to-remote-backend ?).
+	 */
 	if (ctx_snat_done(ctx))
 		goto skip_host_firewall;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1710,7 +1710,21 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 	if (IS_ERR(ret))
 		goto out;
 
+#if defined(ENABLE_EGRESS_GATEWAY_COMMON) && defined(IS_BPF_HOST)
+	if (target.egress_gateway) {
+		/* Send packet to the correct egress interface, and SNAT it there. */
+		ret = egress_gw_fib_lookup_and_redirect(ctx, target.addr,
+							tuple.daddr, ext_err);
+		if (ret != CTX_ACT_OK)
+			return ret;
+
+		if (!revalidate_data(ctx, &data, &data_end, &ip4))
+			return DROP_INVALID;
+	}
+#endif
+
 apply_snat:
+
 	*saddr = tuple.saddr;
 	ret = snat_v4_nat(ctx, &tuple, ip4, l4_off, ipv4_has_l4_header(ip4),
 			  &target, trace, ext_err);
@@ -1727,11 +1741,6 @@ apply_snat:
 	 */
 	if (is_defined(IS_BPF_HOST))
 		ctx_snat_done_set(ctx);
-
-#if defined(ENABLE_EGRESS_GATEWAY_COMMON) && defined(IS_BPF_HOST)
-	if (target.egress_gateway)
-		return egress_gw_fib_lookup_and_redirect(ctx, target.addr, tuple.daddr, ext_err);
-#endif
 
 out:
 	if (ret == NAT_PUNT_TO_STACK)

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -191,8 +191,8 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx,
 			if (memcmp(l2->h_dest, (__u8 *)mac_zero, ETH_ALEN) != 0)
 				test_fatal("dst MAC is not the external svc MAC")
 
-			if (l3->saddr != EGRESS_IP2)
-				test_fatal("src IP hasn't been NATed to egress gateway IP 2");
+			if (l3->saddr != CLIENT_IP)
+				test_fatal("src IP has changed before redirecting to egress iface");
 		} else {
 			if (memcmp(l2->h_source, (__u8 *)client_mac, ETH_ALEN) != 0)
 				test_fatal("src MAC is not the client MAC")
@@ -208,43 +208,46 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx,
 			test_fatal("dst IP has changed");
 	}
 
-	/* Lookup the SNAT mapping for the original packet to determine the new source port */
-	struct ipv4_ct_tuple tuple = {
-		.daddr   = CLIENT_IP,
-		.saddr   = EXTERNAL_SVC_IP,
-		.dport   = EXTERNAL_SVC_PORT,
-		.sport   = client_port(test_ctx.test),
-		.nexthdr = IPPROTO_TCP,
-		.flags = TUPLE_F_OUT,
-	};
-	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+	/* SNAT happens *after* redirect: */
+	if (!test_ctx.redirect) {
+		/* Lookup the SNAT mapping for the original packet to determine the new source port */
+		struct ipv4_ct_tuple tuple = {
+			.daddr   = CLIENT_IP,
+			.saddr   = EXTERNAL_SVC_IP,
+			.dport   = EXTERNAL_SVC_PORT,
+			.sport   = client_port(test_ctx.test),
+			.nexthdr = IPPROTO_TCP,
+			.flags = TUPLE_F_OUT,
+		};
+		struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
 
-	if (!ct_entry)
-		test_fatal("no CT entry found");
-	if (ct_entry->packets != test_ctx.packets)
-		test_fatal("bad packet count (expected %u, actual %u)",
-			   test_ctx.packets, ct_entry->packets)
+		if (!ct_entry)
+			test_fatal("no CT entry found");
+		if (ct_entry->packets != test_ctx.packets)
+			test_fatal("bad packet count (expected %u, actual %u)",
+				   test_ctx.packets, ct_entry->packets)
 
-	tuple.saddr = CLIENT_IP;
-	tuple.daddr = EXTERNAL_SVC_IP;
+		tuple.saddr = CLIENT_IP;
+		tuple.daddr = EXTERNAL_SVC_IP;
 
-	struct ipv4_nat_entry *nat_entry = __snat_lookup(&SNAT_MAPPING_IPV4, &tuple);
+		struct ipv4_nat_entry *nat_entry = __snat_lookup(&SNAT_MAPPING_IPV4, &tuple);
 
-	if (!nat_entry)
-		test_fatal("could not find a NAT entry for the packet");
+		if (!nat_entry)
+			test_fatal("could not find a NAT entry for the packet");
 
-	if (test_ctx.dir == CT_INGRESS) {
-		if (l4->source != EXTERNAL_SVC_PORT)
-			test_fatal("src port has changed");
+		if (test_ctx.dir == CT_INGRESS) {
+			if (l4->source != EXTERNAL_SVC_PORT)
+				test_fatal("src port has changed");
 
-		if (l4->dest != client_port(test_ctx.test))
-			test_fatal("dst TCP port hasn't been revSNATed to client port");
-	} else { /* CT_EGRESS */
-		if (l4->source != nat_entry->to_sport)
-			test_fatal("src TCP port hasn't been NATed to egress gateway port");
+			if (l4->dest != client_port(test_ctx.test))
+				test_fatal("dst TCP port hasn't been revSNATed to client port");
+		} else { /* CT_EGRESS */
+			if (l4->source != nat_entry->to_sport)
+				test_fatal("src TCP port hasn't been NATed to egress gateway port");
 
-		if (l4->dest != EXTERNAL_SVC_PORT)
-			test_fatal("dst port has changed");
+			if (l4->dest != EXTERNAL_SVC_PORT)
+				test_fatal("dst port has changed");
+		}
 	}
 
 	test_finish();


### PR DESCRIPTION
To let EGW traffic exit the gateway through the correct interface,
we've introduced FIB lookup-driven redirects in the to-netdev path
(https://github.com/cilium/cilium/pull/26215). This is needed for cases
where the traffic first hits one interface via the default route, but then
needs to bounce to some other interface that matches the actual egressIP.
In this approach we masquerade the packet on its first pass through
to-netdev, set the SNAT_DONE mark, and then redirect to the actual egress
interface. Due to the SNAT_DONE mark we then skip the SNAT logic in the
second pass through to-netdev.

https://github.com/cilium/cilium/pull/29379 then improved the situation for
any EGW traffic that enters the gateway from the overlay network (==
anything that's not by a pod on the gateway). We now redirect in
from-overlay, straight to the actual egress interface and masquerade the
packet there.

Now also harmonize the approach for local pods, and defer the masquerade
until the packet hits the actual egress interface. This simplifies the
overall picture. But it also allows us to raise TO_NETWORK datapath trace
events that are enriched with the packet's original source IP - this event
is raised on the *second* pass through to-netdev, so we need the SNAT to
happen at the same time.

Also add a comment to clarify the check to skip HostFW for SNATed traffic.
