### PR TITLE
policy: Add Port Range Support for Policies Part 1

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -93,7 +93,7 @@ func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string
 // and the resolved destination port and protocol numbers, if any.
 // Must be called with e.mutex held.
 func (e *Endpoint) proxyID(l4 *policy.L4Filter, listener string) (string, uint16, uint8) {
-	port := uint16(l4.Port)
+	port := l4.Port
 	protocol := uint8(l4.U8Proto)
 	// Calculate protocol if it is 0 (default) and
 	// is not "ANY" (that is, it was not calculated).

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1596,7 +1596,7 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 			continue
 		}
 
-		port := uint16(l4.Port)
+		port := l4.Port
 		if port == 0 && l4.PortName != "" {
 			port = ep.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
 			if port == 0 {

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -752,11 +752,11 @@ func testCaseToMapState(t generatedBPFKey) MapState {
 
 	if t.L3Key.L3 != nil {
 		if t.L3Key.Deny != nil && *t.L3Key.Deny {
-			m.denies[mapKeyDeny_Foo__] = mapEntryL7Deny_()
+			m.denies.Upsert(mapKeyDeny_Foo__, mapEntryL7Deny_())
 		} else {
 			// If L7 is not set or if it explicitly set but it's false
 			if t.L3Key.L7 == nil || !*t.L3Key.L7 {
-				m.allows[mapKeyAllowFoo__] = mapEntryL7None_()
+				m.allows.Upsert(mapKeyAllowFoo__, mapEntryL7None_())
 			}
 			// there's no "else" because we don't support L3L7 policies, i.e.,
 			// a L4 port needs to be specified.
@@ -764,40 +764,40 @@ func testCaseToMapState(t generatedBPFKey) MapState {
 	}
 	if t.L4Key.L3 != nil {
 		if t.L4Key.Deny != nil && *t.L4Key.Deny {
-			m.denies[mapKeyDeny____L4] = mapEntryL7Deny_()
+			m.denies.Upsert(mapKeyDeny____L4, mapEntryL7Deny_())
 		} else {
 			// If L7 is not set or if it explicitly set but it's false
 			if t.L4Key.L7 == nil || !*t.L4Key.L7 {
-				m.allows[mapKeyAllow___L4] = mapEntryL7None_()
+				m.allows.Upsert(mapKeyAllow___L4, mapEntryL7None_())
 			} else {
 				// L7 is set and it's true then we should expected a mapEntry
 				// with L7 redirection.
-				m.allows[mapKeyAllow___L4] = mapEntryL7Proxy()
+				m.allows.Upsert(mapKeyAllow___L4, mapEntryL7Proxy())
 			}
 		}
 	}
 	if t.L3L4Key.L3 != nil {
 		if t.L3L4Key.Deny != nil && *t.L3L4Key.Deny {
-			m.denies[mapKeyDeny_FooL4] = mapEntryL7Deny_()
+			m.denies.Upsert(mapKeyDeny_FooL4, mapEntryL7Deny_())
 		} else {
 			// If L7 is not set or if it explicitly set but it's false
 			if t.L3L4Key.L7 == nil || !*t.L3L4Key.L7 {
-				m.allows[mapKeyAllowFooL4] = mapEntryL7None_()
+				m.allows.Upsert(mapKeyAllowFooL4, mapEntryL7None_())
 			} else {
 				// L7 is set and it's true then we should expected a mapEntry
 				// with L7 redirection only if we haven't set it already
 				// for an existing L4-only.
 				if t.L4Key.L7 == nil || !*t.L4Key.L7 {
-					m.allows[mapKeyAllowFooL4] = mapEntryL7Proxy()
+					m.allows.Upsert(mapKeyAllowFooL4, mapEntryL7Proxy())
 				}
 			}
 		}
 	}
 
 	// Add dependency deny-L3->deny-L3L4 if allow-L4 exists
-	denyL3, denyL3exists := m.denies[mapKeyDeny_Foo__]
-	denyL3L4, denyL3L4exists := m.denies[mapKeyDeny_FooL4]
-	allowL4, allowL4exists := m.allows[mapKeyAllow___L4]
+	denyL3, denyL3exists := m.denies.Lookup(mapKeyDeny_Foo__)
+	denyL3L4, denyL3L4exists := m.denies.Lookup(mapKeyDeny_FooL4)
+	allowL4, allowL4exists := m.allows.Lookup(mapKeyAllow___L4)
 	if allowL4exists && !allowL4.IsDeny && denyL3exists && denyL3.IsDeny && denyL3L4exists && denyL3L4.IsDeny {
 		m.AddDependent(mapKeyDeny_Foo__, mapKeyDeny_FooL4, ChangeState{})
 	}

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -431,7 +431,7 @@ func (a L7ParserType) Merge(b L7ParserType) (L7ParserType, error) {
 type L4Filter struct {
 	// Port is the destination port to allow. Port 0 indicates that all traffic
 	// is allowed at L4.
-	Port     int    `json:"port"`
+	Port     uint16 `json:"port"`
 	PortName string `json:"port-name,omitempty"`
 	// Protocol is the L4 protocol to allow or NONE
 	Protocol api.L4Proto `json:"protocol"`
@@ -493,7 +493,7 @@ func (l4 *L4Filter) GetIngress() bool {
 
 // GetPort returns the port at which the L4Filter applies as a uint16.
 func (l4 *L4Filter) GetPort() uint16 {
-	return uint16(l4.Port)
+	return l4.Port
 }
 
 // ChangeState allows caller to revert changes made by (multiple) toMapState call(s)
@@ -512,7 +512,7 @@ type ChangeState struct {
 // 'redirects' is the map of currently realized redirects, it is used to find the proxy port for any redirects.
 // SelectorCache is also in read-locked state during this call.
 func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redirects map[string]uint16, changes ChangeState) {
-	port := uint16(l4.Port)
+	port := l4.Port
 	proto := uint8(l4.U8Proto)
 
 	direction := trafficdirection.Egress
@@ -776,8 +776,8 @@ func createL4Filter(policyCtx PolicyContext, peerEndpoints api.EndpointSelectorS
 	u8p, _ := u8proto.ParseProtocol(string(protocol))
 
 	l4 := &L4Filter{
-		Port:                int(p),   // 0 for L3-only rules and named ports
-		PortName:            portName, // non-"" for named ports
+		Port:                uint16(p), // 0 for L3-only rules and named ports
+		PortName:            portName,  // non-"" for named ports
 		Protocol:            protocol,
 		U8Proto:             u8p,
 		PerSelectorPolicies: make(L7DataMap),

--- a/pkg/policy/l4_filter_deny_test.go
+++ b/pkg/policy/l4_filter_deny_test.go
@@ -94,7 +94,7 @@ func TestMergeDenyAllL3(t *testing.T) {
 
 	filter, ok := l4IngressDenyPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.True(t, filter.SelectsAllEndpoints())

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -168,7 +168,7 @@ func TestMergeAllowAllL3AndAllowAllL7(t *testing.T) {
 
 	filter, ok := l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.True(t, filter.SelectsAllEndpoints())
@@ -335,7 +335,7 @@ func TestMergeAllowAllL3AndShadowedL7(t *testing.T) {
 
 	filter, ok := l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.True(t, filter.SelectsAllEndpoints())

--- a/pkg/policy/portrange.go
+++ b/pkg/policy/portrange.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policy
+
+import (
+	"fmt"
+	"math"
+	"math/bits"
+)
+
+// MaskedPort is a port with a wild card mask value.
+// The port range is represented by a masked port
+// because we need to use masks for policy Keys
+// that are indexed in the datapath by a bitwise
+// longest-prefix-match trie.
+type MaskedPort struct {
+	port uint16
+	mask uint16
+}
+
+func (m MaskedPort) String() string {
+	return fmt.Sprintf("{port: 0x%x, mask: 0x%x}", m.port, m.mask)
+}
+
+// maskedPort returns a new MaskedPort where 'wildcardBits' lowest bits are wildcarded.
+func maskedPort(port uint16, wildcardBits int) MaskedPort {
+	mask := uint16(math.MaxUint16) << wildcardBits
+	return MaskedPort{port & mask, mask}
+}
+
+// PortRangeToMaskedPorts returns a slice of masked ports for the given port range.
+// If the end port is equal to or less then the start port than the start port is returned,
+// as a fully masked port.
+// Ports are not returned in any particular order, so testing code needs to sort them
+// for consistency.
+func PortRangeToMaskedPorts(start uint16, end uint16) (ports []MaskedPort) {
+	// This is a wildcard.
+	if start == 0 && (end == 0 || end == math.MaxUint16) {
+		return []MaskedPort{{0, 0}}
+	}
+	// This is a single port.
+	if end <= start {
+		return []MaskedPort{{start, 0xffff}}
+	}
+	// Find the number of common leading bits. The first uncommon bit will be 0 for the start
+	// and 1 for the end.
+	commonBits := bits.LeadingZeros16(start ^ end)
+
+	// Cover the case where all the bits after the common bits are zeros on start and ones on
+	// end. In this case the range can be represented by a single masked port instead of two
+	// that would be produced below.
+	// For example, if the range is from 16-31 (0b10000 - 0b11111), then we return 0b1xxxx
+	// instead of 0b10xxx and 0b11xxx that would be produced when approaching the middle from
+	// the two sides.
+	//
+	// This also covers the trivial case where all the bits are in common (i.e., start == end).
+	mask := uint16(math.MaxUint16) >> commonBits
+	if start&mask == 0 && ^end&mask == 0 {
+		return []MaskedPort{maskedPort(start, 16-commonBits)}
+	}
+
+	// Find the "middle point" toward which the masked ports approach from both sides.
+	// This "middle point" is the highest bit that differs between the range start and end.
+	middleBit := 16 - 1 - commonBits
+	middle := uint16(1 << middleBit)
+
+	// Wildcard the trailing zeroes to the right of the middle bit of the range start.
+	// This covers the values immediately following the port range start, including the start itself.
+	// The middle bit is added to avoid counting zeroes past it.
+	bit := bits.TrailingZeros16(start | middle)
+	ports = append(ports, maskedPort(start, bit))
+
+	// Find all 0-bits between the trailing zeroes and the middle bit and add MaskedPorts where
+	// each found 0-bit is set and the lower bits are wildcarded. This covers the range from the
+	// start to the middle not covered by the trailing zeroes above.
+	// The current 'bit' is skipped since we know it is 1.
+	for bit++; bit < middleBit; bit++ {
+		if start&(1<<bit) == 0 {
+			// Adding 1<<bit will set the bit since we know it is not set
+			ports = append(ports, maskedPort(start+1<<bit, bit))
+		}
+	}
+
+	// Wildcard the trailing ones to the right of the middle bit of the range end.
+	// This covers the values immediately preceding and including the range end.
+	// The middle bit is added to avoid counting ones past it.
+	bit = bits.TrailingZeros16(^end | middle)
+	ports = append(ports, maskedPort(end, bit))
+
+	// Find all 1-bits between the trailing ones and the middle bit and add MaskedPorts where
+	// each found 1-bit is cleared and the lower bits are wildcarded. This covers the range from
+	// the end to the middle not covered by the trailing ones above.
+	// The current 'bit' is skipped since we know it is 0.
+	for bit++; bit < middleBit; bit++ {
+		if end&(1<<bit) != 0 {
+			// Subtracting 1<<bit will clear the bit since we know it is set
+			ports = append(ports, maskedPort(end-1<<bit, bit))
+		}
+	}
+
+	return ports
+}

--- a/pkg/policy/portrange_test.go
+++ b/pkg/policy/portrange_test.go
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policy
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// maskedPorts have to be sorted for this check
+func validateMaskedPorts(t *testing.T, maskedPorts []MaskedPort, start, end uint16) {
+	// Wildcard case.
+	if start == 0 && end == 0 {
+		require.Equal(t, len(maskedPorts), 1)
+		require.Equal(t, maskedPorts[0].port, uint16(0))
+		require.Equal(t, maskedPorts[0].mask, uint16(0))
+		return
+	}
+	require.NotNil(t, maskedPorts)
+	require.NotEqual(t, len(maskedPorts), 0)
+	// validate that range elements are continuous and non-overlapping
+	first := maskedPorts[0].port
+	last := first + ^maskedPorts[0].mask
+	for i := 1; i < len(maskedPorts); i++ {
+		require.Equal(t, maskedPorts[i].port, last+1)
+		last = maskedPorts[i].port + ^maskedPorts[i].mask
+	}
+	// Check that the computed range matches the given range
+	require.Equal(t, first, start)
+	require.Equal(t, last, end)
+}
+
+func TestPortRange(t *testing.T) {
+	type testCase struct {
+		start, end uint16
+		expected   []MaskedPort
+	}
+
+	testCases := []testCase{
+		// worst case test
+		{
+			start: 1,
+			end:   65534,
+			expected: []MaskedPort{
+				{port: 0x1, mask: 0xffff},    // 1
+				{port: 0x2, mask: 0xfffe},    // 2-3
+				{port: 0x4, mask: 0xfffc},    // 4-7
+				{port: 0x8, mask: 0xfff8},    // 8-15
+				{port: 0x10, mask: 0xfff0},   // 16-31
+				{port: 0x20, mask: 0xffe0},   // 32-63
+				{port: 0x40, mask: 0xffc0},   // 64-127
+				{port: 0x80, mask: 0xff80},   // 128-255
+				{port: 0x100, mask: 0xff00},  // 256-511
+				{port: 0x200, mask: 0xfe00},  // 512-1023
+				{port: 0x400, mask: 0xfc00},  // 1024-2047
+				{port: 0x800, mask: 0xf800},  // 2048-4095
+				{port: 0x1000, mask: 0xf000}, // 4096-8191
+				{port: 0x2000, mask: 0xe000}, // 8192-16383
+				{port: 0x4000, mask: 0xc000}, // 16384-32767
+				{port: 0x8000, mask: 0xc000}, // 32768-49151
+				{port: 0xc000, mask: 0xe000}, // 49152-57343
+				{port: 0xe000, mask: 0xf000}, // 57344-61439
+				{port: 0xf000, mask: 0xf800}, // 61440-63487
+				{port: 0xf800, mask: 0xfc00}, // 63488-64511
+				{port: 0xfc00, mask: 0xfe00}, // 64512-65023
+				{port: 0xfe00, mask: 0xff00}, // 65024-65279
+				{port: 0xff00, mask: 0xff80}, // 65280-65407
+				{port: 0xff80, mask: 0xffc0}, // 65408-65471
+				{port: 0xffc0, mask: 0xffe0}, // 65472-65503
+				{port: 0xffe0, mask: 0xfff0}, // 65504-65519
+				{port: 0xfff0, mask: 0xfff8}, // 65520-65527
+				{port: 0xfff8, mask: 0xfffc}, // 65528-65531
+				{port: 0xfffc, mask: 0xfffe}, // 65532-65533
+				{port: 0xfffe, mask: 0xffff}, // 65534
+			},
+		},
+		{
+			start: 1,
+			end:   1023,
+			expected: []MaskedPort{
+				{port: 0x1, mask: 0xffff},   // 1
+				{port: 0x2, mask: 0xfffe},   // 2-3
+				{port: 0x4, mask: 0xfffc},   // 4-7
+				{port: 0x8, mask: 0xfff8},   // 8-15
+				{port: 0x10, mask: 0xfff0},  // 16-31
+				{port: 0x20, mask: 0xffe0},  // 32-63
+				{port: 0x40, mask: 0xffc0},  // 64-127
+				{port: 0x80, mask: 0xff80},  // 128-255
+				{port: 0x100, mask: 0xff00}, // 256-511
+				{port: 0x200, mask: 0xfe00}, // 512-1023
+			},
+		},
+		{
+			start: 0,
+			end:   1023,
+			expected: []MaskedPort{
+				{port: 0, mask: 0xfc00}, // 0-1023
+			},
+		},
+		// A typical large case test
+		{
+			start: 1024,
+			end:   65535,
+			expected: []MaskedPort{
+				{port: 0x400, mask: 0xfc00},  // 1024-2047
+				{port: 0x800, mask: 0xf800},  // 2048-4095
+				{port: 0x1000, mask: 0xf000}, // 4096-8191
+				{port: 0x2000, mask: 0xe000}, // 8192-16383
+				{port: 0x4000, mask: 0xc000}, // 16384-32767
+				{port: 0x8000, mask: 0x8000}, // 32768-65535
+			},
+		},
+		// Another typical large case test
+		{
+			start: 10000,
+			end:   20000,
+			expected: []MaskedPort{
+				{port: 0x2710, mask: 0xfff0}, // 10000 - 10015
+				{port: 0x2720, mask: 0xffe0}, // 10016 - 10047
+				{port: 0x2740, mask: 0xffc0}, // 10048 - 10111
+				{port: 0x2780, mask: 0xff80}, // 10112 - 10239
+				{port: 0x2800, mask: 0xf800}, // 10240 - 12287
+				{port: 0x3000, mask: 0xf000}, // 12288 - 16383
+				{port: 0x4000, mask: 0xf800}, // 16384 - 18431
+				{port: 0x4800, mask: 0xfc00}, // 18432 - 19455
+				{port: 0x4c00, mask: 0xfe00}, // 19456 - 19967
+				{port: 0x4e00, mask: 0xffe0}, // 19968 - 19999
+				{port: 0x4e20, mask: 0xffff}, // 20000
+			},
+		},
+		{
+			start: 1000,
+			end:   1999,
+			expected: []MaskedPort{
+				{port: 0x3e8, mask: 0xfff8},
+				{port: 0x3f0, mask: 0xfff0},
+				{port: 0x400, mask: 0xfe00},
+				{port: 0x600, mask: 0xff00},
+				{port: 0x700, mask: 0xff80},
+				{port: 0x780, mask: 0xffc0},
+				{port: 0x7c0, mask: 0xfff0},
+			},
+		},
+		{
+			start: 0,
+			end:   1,
+			expected: []MaskedPort{
+				{port: 0, mask: 0xfffe}, // 0-1
+			},
+		},
+		{
+			start: 16,
+			end:   31,
+			expected: []MaskedPort{
+				{port: 0x10, mask: 0xfff0}, // 16-31
+			},
+		},
+		{
+			start: 0xff00, // 65280
+			end:   0xffff, // 65535
+			expected: []MaskedPort{
+				{port: 0xff00, mask: 0xff00}, // 65280-65535
+			},
+		},
+		{
+			start: 0,
+			end:   0xffff,
+			expected: []MaskedPort{
+				{port: 0x0, mask: 0x0000}, // 0-0xffff
+			},
+		},
+		{
+			start: 1,
+			end:   7,
+			expected: []MaskedPort{
+				{port: 0x1, mask: 0xffff}, // 1
+				{port: 0x2, mask: 0xfffe}, // 2-3
+				{port: 0x4, mask: 0xfffc}, // 4-7
+			},
+		},
+		{
+			start: 0,
+			end:   7,
+			expected: []MaskedPort{
+				{port: 0x0, mask: 0xfff8}, // 0-7
+			},
+		},
+		{
+			start: 5,
+			end:   10,
+			expected: []MaskedPort{
+				{0b0000000000000101, 0b1111111111111111}, // 5
+				{0b0000000000000110, 0b1111111111111110}, // 6-7
+				{0b0000000000001000, 0b1111111111111110}, // 8-9
+				{0b0000000000001010, 0b1111111111111111}, // 10
+			},
+		},
+		{
+			start: 0,
+			end:   16,
+			expected: []MaskedPort{
+				{0b0000000000000000, 0b1111111111110000}, // 0xxxx
+				{0b0000000000010000, 0b1111111111111111}, // 10000
+			},
+		},
+		{
+			start: 0b0000000000010000, // 16
+			end:   0b0000000110000111, // 391
+			expected: []MaskedPort{
+				{0b0000000000010000, 0b1111111111110000}, // 00001xxxx, 16-31
+				{0b0000000000100000, 0b1111111111100000}, // 0001xxxxx, 32-63
+				{0b0000000001000000, 0b1111111111000000}, // 001xxxxxx, 64-127
+				{0b0000000010000000, 0b1111111110000000}, // 01xxxxxxx, 128-255
+				{0b0000000100000000, 0b1111111110000000}, // 01xxxxxxx, 256-383
+				{0b0000000110000000, 0b1111111111111000}, // 10000000x, 384-391
+			},
+		},
+		{
+			start: 22,
+			end:   23,
+			expected: []MaskedPort{
+				{0b0000000000010110, 0b1111111111111110}, // 22-23
+			},
+		},
+		{
+			start: 23,
+			end:   24,
+			expected: []MaskedPort{
+				{0b0000000000010111, 0b1111111111111111}, // 23
+				{0b0000000000011000, 0b1111111111111111}, // 24
+			},
+		},
+		{
+			start: 0,
+			end:   0x7fff,
+			expected: []MaskedPort{
+				{port: 0x0, mask: 0x8000}, // 0-0x7fff
+			},
+		},
+		{
+			start: 256,
+			end:   256,
+			expected: []MaskedPort{
+				{port: 0x100, mask: 0xffff},
+			},
+		},
+		{
+			start: 65535,
+			end:   65535,
+			expected: []MaskedPort{
+				{port: 65535, mask: 0xffff},
+			},
+		},
+		{
+			start: 32767,
+			end:   32768,
+			expected: []MaskedPort{
+				{port: 0x7fff, mask: 0xffff},
+				{port: 0x8000, mask: 0xffff},
+			},
+		},
+		{
+			start: 0b0101010101010101, // 0x5555
+			end:   0b0101010111010101, // 0x55d5
+			expected: []MaskedPort{
+				{port: 0b0101010101010101, mask: 0b1111111111111111},
+				{port: 0b0101010101010110, mask: 0b1111111111111110},
+				{port: 0b0101010101011000, mask: 0b1111111111111000},
+				{port: 0b0101010101100000, mask: 0b1111111111100000},
+				{port: 0b0101010110000000, mask: 0b1111111111000000},
+				{port: 0b0101010111000000, mask: 0b1111111111110000},
+				{port: 0b0101010111010000, mask: 0b1111111111111100},
+				{port: 0b0101010111010100, mask: 0b1111111111111110},
+			},
+		},
+		// This is all ports.
+		{
+			start: 0,
+			end:   0,
+			expected: []MaskedPort{
+				{port: 0, mask: 0},
+			},
+		},
+		// This is too.
+		{
+			start: 0,
+			end:   65535,
+			expected: []MaskedPort{
+				{port: 0, mask: 0},
+			},
+		},
+		// This is valid, as "0" defines no range.
+		{
+			start: 65535,
+			end:   0,
+			expected: []MaskedPort{
+				{port: 0xffff, mask: 0xffff}, // 65535
+			},
+		},
+		// These remaining tests are testing invalid cases where start >= end.
+		// For now, these cases return the start port with a full mask,
+		// indicating that only the start port should be part of the range.
+		// This is technically correct for the case of end port being "0"
+		// and the value of the port, but is ambiguous otherwise.
+		{
+			start: 65535,
+			end:   1,
+			expected: []MaskedPort{
+				{port: 0xffff, mask: 0xffff}, // 65535
+			},
+		},
+		{
+			start: 65530,
+			end:   5,
+			expected: []MaskedPort{
+				{port: 0xfffa, mask: 0xffff}, // 65530
+			},
+		},
+		{
+			start: 10,
+			end:   5,
+			expected: []MaskedPort{
+				{port: 0xa, mask: 0xffff}, // 10
+			},
+		},
+	}
+
+	for i := 0; i < len(testCases); i++ {
+		test := &testCases[i]
+		maskedPorts := PortRangeToMaskedPorts(test.start, test.end)
+		// Sort the returned slice so that PortRangeToMaskedPorts() can return masked ports
+		// in any order that is convenient for it.
+		sort.Slice(maskedPorts, func(i, j int) bool {
+			return maskedPorts[i].port < maskedPorts[j].port
+		})
+		t.Logf("TestPortRange test case: 0x%x-0x%x (%d-%d)", test.start, test.end, test.start, test.end)
+		require.Equal(t, maskedPorts, test.expected)
+		// Validate when given a proper range
+		if test.start <= test.end {
+			// Validation checks that the masked ports form a continuous range
+			validateMaskedPorts(t, maskedPorts, test.start, test.end)
+		}
+	}
+}

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -177,7 +177,12 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
-	require.EqualValues(t, &expectedEndpointPolicy, policy)
+	// policyMapState cannot be compared via DeepEqual
+	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
+		policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState))
+	policy.policyMapState = nil
+	expectedEndpointPolicy.policyMapState = nil
+	require.Equal(t, policy, &expectedEndpointPolicy)
 }
 
 func TestL3WithLocalHostWildcardd(t *testing.T) {
@@ -262,7 +267,12 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
-	require.EqualValues(t, &expectedEndpointPolicy, policy)
+	// policyMapState cannot be compared via DeepEqual
+	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
+		policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState))
+	policy.policyMapState = nil
+	expectedEndpointPolicy.policyMapState = nil
+	require.Equal(t, policy, &expectedEndpointPolicy)
 }
 
 func TestMapStateWithIngressDenyWildcard(t *testing.T) {
@@ -360,7 +370,12 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
-	require.EqualValues(t, &expectedEndpointPolicy, policy)
+	// policyMapState cannot be compared via DeepEqual
+	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
+		policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState))
+	policy.policyMapState = nil
+	expectedEndpointPolicy.policyMapState = nil
+	require.Equal(t, policy, &expectedEndpointPolicy)
 }
 
 func TestMapStateWithIngressDeny(t *testing.T) {
@@ -524,5 +539,10 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	// difference of the internal time.Time from the lock_debug.go.
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
 	policy.policyMapChanges.mutex = lock.Mutex{}
-	require.EqualValues(t, &expectedEndpointPolicy, policy)
+	// policyMapState cannot be compared via DeepEqual
+	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
+		policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState))
+	policy.policyMapState = nil
+	expectedEndpointPolicy.policyMapState = nil
+	require.Equal(t, policy, &expectedEndpointPolicy)
 }

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -351,7 +351,12 @@ func TestL7WithIngressWildcard(t *testing.T) {
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
-	require.EqualValues(t, &expectedEndpointPolicy, policy)
+	// policyMapState cannot be compared via DeepEqual
+	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
+		policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState))
+	policy.policyMapState = nil
+	expectedEndpointPolicy.policyMapState = nil
+	require.Equal(t, policy, &expectedEndpointPolicy)
 }
 
 func TestL7WithLocalHostWildcard(t *testing.T) {
@@ -448,7 +453,12 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
-	require.EqualValues(t, &expectedEndpointPolicy, policy)
+	// policyMapState cannot be compared via DeepEqual
+	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
+		policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState))
+	policy.policyMapState = nil
+	expectedEndpointPolicy.policyMapState = nil
+	require.Equal(t, policy, &expectedEndpointPolicy)
 }
 
 func TestMapStateWithIngressWildcard(t *testing.T) {
@@ -544,7 +554,12 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
-	require.Equal(t, &expectedEndpointPolicy, policy)
+	// policyMapState cannot be compared via DeepEqual
+	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
+		policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState))
+	policy.policyMapState = nil
+	expectedEndpointPolicy.policyMapState = nil
+	require.Equal(t, policy, &expectedEndpointPolicy)
 }
 
 func TestMapStateWithIngress(t *testing.T) {
@@ -716,6 +731,11 @@ func TestMapStateWithIngress(t *testing.T) {
 	// difference of the internal time.Time from the lock_debug.go.
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
 	policy.policyMapChanges.mutex = lock.Mutex{}
+	// policyMapState cannot be compared via DeepEqual
+	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
+		policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState))
+	policy.policyMapState = nil
+	expectedEndpointPolicy.policyMapState = nil
 	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
 }
 

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1790,7 +1790,7 @@ func TestIngressL4AllowAll(t *testing.T) {
 
 	filter, ok := l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.Equal(t, 1, len(filter.PerSelectorPolicies))
@@ -1835,7 +1835,7 @@ func TestIngressL4AllowAllNamedPort(t *testing.T) {
 
 	filter, ok := l4IngressPolicy["port-80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 0, filter.Port)
+	require.Equal(t, uint16(0), filter.Port)
 	require.Equal(t, "port-80", filter.PortName)
 	require.True(t, filter.Ingress)
 
@@ -1907,7 +1907,7 @@ func TestEgressL4AllowAll(t *testing.T) {
 
 	filter, ok := l4EgressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.Equal(t, false, filter.Ingress)
 
 	require.Equal(t, 1, len(filter.PerSelectorPolicies))
@@ -1963,7 +1963,7 @@ func TestEgressL4AllowWorld(t *testing.T) {
 
 	filter, ok := l4EgressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.Equal(t, false, filter.Ingress)
 
 	require.Equal(t, 3, len(filter.PerSelectorPolicies))
@@ -2018,7 +2018,7 @@ func TestEgressL4AllowAllEntity(t *testing.T) {
 
 	filter, ok := l4EgressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.Equal(t, false, filter.Ingress)
 
 	require.Equal(t, 1, len(filter.PerSelectorPolicies))
@@ -2193,7 +2193,7 @@ func TestL4WildcardMerge(t *testing.T) {
 
 	filter, ok := l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.Equal(t, 2, len(filter.PerSelectorPolicies))
@@ -2220,7 +2220,7 @@ func TestL4WildcardMerge(t *testing.T) {
 
 	filterL7, ok := l4IngressPolicy["7000/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 7000, filterL7.Port)
+	require.Equal(t, uint16(7000), filterL7.Port)
 	require.True(t, filterL7.Ingress)
 
 	require.Equal(t, 1, len(filterL7.PerSelectorPolicies))
@@ -2300,7 +2300,7 @@ func TestL4WildcardMerge(t *testing.T) {
 
 	filter, ok = l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.Equal(t, 2, len(filter.PerSelectorPolicies))
@@ -2311,7 +2311,7 @@ func TestL4WildcardMerge(t *testing.T) {
 
 	filterL7, ok = l4IngressPolicy["7000/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 7000, filterL7.Port)
+	require.Equal(t, uint16(7000), filterL7.Port)
 	require.True(t, filterL7.Ingress)
 
 	require.Equal(t, 1, len(filterL7.PerSelectorPolicies))
@@ -2365,7 +2365,7 @@ func TestL4WildcardMerge(t *testing.T) {
 
 	filter, ok = l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.Equal(t, ParserTypeHTTP, filter.L7Parser)
@@ -2419,7 +2419,7 @@ func TestL4WildcardMerge(t *testing.T) {
 
 	filter, ok = l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.Equal(t, ParserTypeHTTP, filter.L7Parser)
@@ -2478,7 +2478,7 @@ func TestL3L4L7Merge(t *testing.T) {
 
 	filter, ok := l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.Equal(t, 2, len(filter.PerSelectorPolicies))
@@ -2547,7 +2547,7 @@ func TestL3L4L7Merge(t *testing.T) {
 
 	filter, ok = l4IngressPolicy["80/TCP"]
 	require.True(t, ok)
-	require.Equal(t, 80, filter.Port)
+	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.Equal(t, ParserTypeHTTP, filter.L7Parser)


### PR DESCRIPTION
This commit prepares the policy engine for adding port ranges
by changing the underlying datastructure for mapstate from the
go builtin "map" to bitlpm. It also adds a utility port range method
with its own tests that is needed to create mapstate keys.

See commits for details.

For an overview of what the next PR will do see https://github.com/cilium/cilium/pull/32389



Related: #16622
