### PR TITLE
pkg/endpoint: make state synchronization atomic

### DIFF
--- a/pkg/endpoint/directory_test.go
+++ b/pkg/endpoint/directory_test.go
@@ -70,7 +70,7 @@ func (s *EndpointSuite) TestMoveNewFilesTo(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		if err := moveNewFilesTo(tt.args.oldDir, tt.args.newDir); (err != nil) != tt.wantErr {
+		if err := copyExistingState(tt.args.oldDir, tt.args.newDir); (err != nil) != tt.wantErr {
 			require.Equal(t, tt.wantErr, err != nil)
 			compareDir(tt.args.oldDir, tt.wantOldDir)
 			compareDir(tt.args.newDir, tt.wantNewDir)
@@ -98,7 +98,7 @@ func benchmarkMoveNewFilesTo(b *testing.B, numFiles int) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := moveNewFilesTo(oldDir, newDir); err != nil {
+		if err := copyExistingState(oldDir, newDir); err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
pkg/endpoint: make state synchronization atomic

    BPF regeneration writes state into a new temporary directory. Once it has
    succeeded we need to swap the old and new directory. This is currently 
    achieved by "backing up" the current state by renaming the directory. This
    code has a bunch of corner cases around cleaning up old directories and so
    on which are necessary since the synchronization isn't truly atomic.

    Instead, use the RENAME_EXCHANGE flag to atomically exchange the two 
    existing directories. Also use hard links to retain existing state so that
    killing the agent during a synchronization doesn't lead to corruption.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

pkg/endpoint: always copy existing state during synchronization

    Endpoint regeneration goes to a lot of trouble to keep track of whether the
    on-disk state has changed, only to avoid doing a couple of readdir syscalls.
    The behaviour was added in commit  f6c4385a43
    ("pkg/endpoint: Keep BPF object files if compilation is skipped.") and the
    message does not indicate that performance was of particular concern.

    Do the safe thing and always perform the state copy.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

This is a pre-requisite to a large PR in which I'm reshuffling how the loader does Endpoint templating. The second commit in this PR makes that easier.