### PR TITLE
renovate: Don't remove images/cilium/download-hubble.sh yet

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -419,6 +419,7 @@
   "regexManagers": [
     {
       "fileMatch": [
+        "images/cilium/download-hubble\\.sh",
         "images/runtime/build-gops.sh",
         "images/hubble-relay/download-grpc-health-probe.sh"
       ],


### PR DESCRIPTION
This file got removed in main branch, but we still need to keep it updated in v1.13, v1.14, and v1.15 branches.

Fixes: 5aec7f58af0e ("Move cilium/hubble code to cilium/cilium repo")