### PR TITLE
.github: adding daemon/cmd/fqdn to sig/policy PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,6 +7,7 @@ sig/policy:
 - changed-files:
   - any-glob-to-any-file:
     - daemon/cmd/policy*
+    - daemon/cmd/fqdn*
     - pkg/fqdn/**
     - pkg/policy/**
     - pkg/identity/**


### PR DESCRIPTION
Updating the sig/policy labels to be added to `daemon/cmd/policy` as well 

