### PR TITLE
docs: Clarify that `--labels` does not override default set

### DIFF
--- a/Documentation/operations/performance/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/performance/scalability/identity-relevant-labels.rst
@@ -100,6 +100,9 @@ setting.
 
     kubectl delete pods -n kube-system -l k8s-app=cilium
 
+.. note:: Configuring Cilium with label patterns via ``labels`` Helm value does
+          **not** override the default set of label patterns.
+
 Existing identities will not change as a result of this new configuration. To
 apply the new label pattern setting to existing identities, restart the
 associated pods. Upon restart, new identities will be created. The old


### PR DESCRIPTION
While the docs hint at merging the user-provided configuration with the
default set, it can still be quite easy for the user to miss this
nuance.

To override the default set, the user must use `--label-prefix-file`
(which requires a volume mount when on K8s). This flag is currently not
exposed via Helm, I'll leave it for another time to expose it, if deemed
useful by the community.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
