### PR TITLE
[1.14][identitygc] Bugfix: Pass shared EnableMetrics into GC struct

### DIFF
--- a/operator/identitygc/gc.go
+++ b/operator/identitygc/gc.go
@@ -89,6 +89,7 @@ func registerGC(p params) {
 		identity:           p.Identity,
 		authIdentityClient: p.AuthIdentityClient,
 		allocationMode:     p.SharedCfg.IdentityAllocationMode,
+		enableMetrics:      p.SharedCfg.EnableMetrics,
 		gcInterval:         p.Cfg.Interval,
 		heartbeatTimeout:   p.Cfg.HeartbeatTimeout,
 		gcRateInterval:     p.Cfg.RateInterval,


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This is a 1.14 specific bug as on 1.15 and above there is https://github.com/cilium/cilium/pull/28166. 1.14 shipped with https://github.com/cilium/cilium/pull/22892 and it appears this got missed. 

Currently when you run the operator with `--enable-metrics` that arg gets plumbed into SharedCfg but we never passed it into the `GC` struct. As a result metrics like https://github.com/cilium/cilium/blob/v1.14/operator/identitygc/kvstore_gc.go#L73-L79 aren't getting emitted on 1.14 as they are checking against GC not the SharedCfg. This changes ensures that we pass through the `p.SharedCfg.EnableMetrics` parameter to allow the conditional logic to work as expected. 

I've tested this on a local 1.14 cluster and configured that with this change the metrics (i.e. `cilium_operator_identity_gc_entries` and `cilium_operator_identity_gc_runs`_ are once again emitted during identity GC. 

```release-note
Fix: Ensure enabling metrics turns on identity GC metrics
```
