### PR TITLE
ipsec: Safely delete Xfrm state

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -84,6 +84,11 @@ type ipSecKey struct {
 	Aead  *netlink.XfrmStateAlgo
 }
 
+type oldXfrmStateKey struct {
+	Spi int
+	Dst [16]byte
+}
+
 var (
 	ipSecLock lock.RWMutex
 
@@ -136,6 +141,11 @@ var (
 	// we've added the catch-all default-drop policy.
 	removeStaleIPv4XFRMOnce sync.Once
 	removeStaleIPv6XFRMOnce sync.Once
+
+	oldXFRMInMark *netlink.XfrmMark = &netlink.XfrmMark{
+		Value: linux_defaults.RouteMarkDecrypt,
+		Mask:  linux_defaults.IPsecMarkBitMask,
+	}
 )
 
 func getGlobalIPsecKey(ip net.IP) *ipSecKey {
@@ -329,10 +339,6 @@ func xfrmStateReplace(new *netlink.XfrmState, remoteRebooted bool) error {
 		oldXFRMOutMark = &netlink.XfrmMark{
 			Value: ipSecXfrmMarkSetSPI(linux_defaults.RouteMarkEncrypt, uint8(new.Spi)),
 			Mask:  linux_defaults.IPsecOldMarkMaskOut,
-		}
-		oldXFRMInMark = &netlink.XfrmMark{
-			Value: linux_defaults.RouteMarkDecrypt,
-			Mask:  linux_defaults.IPsecMarkBitMask,
 		}
 		errs = resiliency.NewErrorSet("failed to delete old xfrm states", len(states))
 	)
@@ -753,20 +759,73 @@ func ipsecDeleteXfrmState(nodeID uint16) error {
 	}
 
 	xfrmStatesToDelete := []netlink.XfrmState{}
+	oldXfrmInStates := map[oldXfrmStateKey]netlink.XfrmState{}
 	for _, s := range xfrmStateList {
 		if matchesOnNodeID(s.Mark) && ipsec.GetNodeIDFromXfrmMark(s.Mark) == nodeID {
 			xfrmStatesToDelete = append(xfrmStatesToDelete, s)
+		}
+		if xfrmMarkEqual(s.Mark, oldXFRMInMark) {
+			key := oldXfrmStateKey{
+				Spi: s.Spi,
+				Dst: [16]byte(s.Dst.To16()),
+			}
+			oldXfrmInStates[key] = s
 		}
 	}
 
 	errs := resiliency.NewErrorSet(fmt.Sprintf("failed to delete node (%d) xfrm states", nodeID), len(xfrmStateList))
 	for _, s := range xfrmStatesToDelete {
-		if err := netlink.XfrmStateDel(&s); err != nil {
+		key := oldXfrmStateKey{
+			Spi: s.Spi,
+			Dst: [16]byte(s.Dst.To16()),
+		}
+		var oldXfrmInState *netlink.XfrmState = nil
+		old, ok := oldXfrmInStates[key]
+		if ok {
+			oldXfrmInState = &old
+		}
+		if err := safeDeleteXfrmState(&s, oldXfrmInState); err != nil {
 			errs.Add(fmt.Errorf("failed to delete xfrm state (%s): %w", s.String(), err))
 		}
 	}
 
 	return errs.Error()
+}
+
+// safeDeleteXfrmState deletes the given XFRM state. Specifically, if the
+// state is to catch ingress traffic marked with nodeID (0xXXXX0d00), we
+// temporarily remove the old XFRM state that matches 0xd00/0xf00. This is to
+// workaround a kernel issue that prevents us from deleting a specific XFRM
+// state (e.g. catching 0xXXXX0d00/0xffff0f00) when there is also a general
+// xfrm state (e.g. catching 0xd00/0xf00). When both XFRM states coexist,
+// kernel deletes the general XFRM state instead of the specific one, even if
+// the deleting request is for the specific one.
+func safeDeleteXfrmState(state *netlink.XfrmState, oldState *netlink.XfrmState) (err error) {
+	if getDirFromXfrmMark(state.Mark) == dirIngress && ipsec.GetNodeIDFromXfrmMark(state.Mark) != 0 && oldState != nil {
+
+		errs := resiliency.NewErrorSet("failed to delete old xfrm states", 1)
+
+		scopedLog := log.WithFields(logrus.Fields{
+			logfields.SPI:              state.Spi,
+			logfields.SourceIP:         state.Src,
+			logfields.DestinationIP:    state.Dst,
+			logfields.TrafficDirection: getDirFromXfrmMark(state.Mark),
+			logfields.NodeID:           getNodeIDAsHexFromXfrmMark(state.Mark),
+		})
+
+		err, deferFn := xfrmTemporarilyRemoveState(scopedLog, *oldState, string(dirIngress))
+		if err != nil {
+			errs.Add(fmt.Errorf("Failed to remove old XFRM %s state %s: %w", string(dirIngress), oldState.String(), err))
+		} else {
+			defer deferFn()
+		}
+		if err := errs.Error(); err != nil {
+			scopedLog.WithError(err).Error("Failed to clean up old XFRM state")
+			return err
+		}
+	}
+
+	return netlink.XfrmStateDel(state)
 }
 
 func ipsecDeleteXfrmPolicy(nodeID uint16) error {


### PR DESCRIPTION
Commit messages elaborate details. Although this is to fix an upgrade issue from 1.13, it doesn't harm main.

If the cilium is upgraded from an old version, it's possible a latest version cilium cluster has the old xfrm states left over. In this case, this PR performs unnecessary xfrm churn, but won't affect any traffic.

If the cilium is installed from scratch, it indeed doesn't need this fix at all. In this situation, the `SafelyDeleteXfrmState()` doesn't even cause xfrm churn because it can't find the old style xfrm state to delete. 

This can be removed along with https://github.com/cilium/cilium/blob/v1.15.4/pkg/datapath/linux/ipsec/ipsec_linux.go#L351.