### PR TITLE
datapath: trivial cleanups for KPR config handling

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -171,9 +171,7 @@ func initKubeProxyReplacementOptions(sysctl sysctl.Sysctl, tunnelConfig tunnel.C
 				return fmt.Errorf("Failed to initialize maglev hash seeds: %w", err)
 			}
 		}
-	}
 
-	if option.Config.EnableNodePort {
 		if option.Config.TunnelingEnabled() && tunnelConfig.Protocol() == tunnel.VXLAN &&
 			option.Config.LoadBalancerUsesDSR() {
 			return fmt.Errorf("Node Port %q mode cannot be used with %s tunneling.", option.Config.NodePortMode, tunnel.VXLAN)

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -59,15 +59,6 @@ func initKubeProxyReplacementOptions(sysctl sysctl.Sysctl, tunnelConfig tunnel.C
 		option.Config.EnableSessionAffinity = true
 	}
 
-	if option.Config.KubeProxyReplacement != option.KubeProxyReplacementFalse &&
-		option.Config.EnableEnvoyConfig && !option.Config.EnableIPSec &&
-		!option.Config.EnableNodePort {
-		// CiliumEnvoyConfig L7 LB only works with bpf node port enabled
-		log.Infof("Auto-enabling %s for %s",
-			option.EnableNodePort, option.EnableEnvoyConfig)
-		option.Config.EnableNodePort = true
-	}
-
 	if option.Config.EnableNodePort {
 		if option.Config.NodePortMode != option.NodePortModeSNAT &&
 			option.Config.NodePortMode != option.NodePortModeDSR &&


### PR DESCRIPTION
Clean up two trivial aspects in the config handling for KPR.