### PR TITLE
CI: Add job name validation

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -1,7 +1,8 @@
 name: Build Commits
 
 # Any change in triggers needs to be reflected in the concurrency group.
-on: [pull_request]
+on: 
+  pull_request: {}
 
 permissions: read-all
 

--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -225,3 +225,27 @@ jobs:
             fi
           done
           exit ${EXIT}
+
+      - name: Validate Commit Status Start Job
+        shell: bash
+        run: |
+          EXIT=0
+          cd src/github.com/cilium/cilium/.github/workflows
+          for FILE in *.yaml; do
+            # we only care about workflows that has ariane workflow_dispatch events
+            IS_ARIANE_DISPATCH=$(yq '.on.workflow_dispatch.inputs.PR-number' $FILE)
+            if [ "$IS_ARIANE_DISPATCH" == "null" ]; then
+                continue
+            fi
+            JOB=$(yq '.jobs | to_entries | .[] | select(.key == "commit-status-start")' $FILE)
+            if [ "$JOB" == "" ]; then
+                echo "commit-status-start job is missing in file $FILE"
+                EXIT=1
+            fi
+            JOB_NAME=$(echo "${JOB}" | yq '.value.name')
+            if [ "$JOB_NAME" != "Commit Status Start" ]; then
+                echo "commit-status-start job name must be set as 'Commit Status Start' in file $FILE"
+                EXIT=1
+            fi
+          done
+          exit ${EXIT}


### PR DESCRIPTION
This PR adds validation for `commit_status_start` job. This job is used in workflows that is triggered by Ariane to set the run status to pending. Ariane is going to depend on this job being existed and its name is "Commit Status Start". So we are adding this check to make sure.
Also, the trigger syntax of `link-build-commits.yaml` is changed because `yq` is throwing an error.