### PR TITLE
Docs: add note about AKS kube-apiserver entity

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -361,24 +361,10 @@ all
     The all entity represents the combination of all known clusters as well
     world and whitelists all communication.
 
-Access to/from kube-apiserver
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Allow all endpoints with the label ``env=dev`` to access the kube-apiserver.
-
-.. only:: html
-
-   .. tabs::
-     .. group-tab:: k8s YAML
-
-        .. literalinclude:: ../../../examples/policies/l3/entities/apiserver.yaml
-     .. group-tab:: JSON
-
-        .. literalinclude:: ../../../examples/policies/l3/entities/apiserver.json
-
-.. only:: epub or latex
-
-        .. literalinclude:: ../../../examples/policies/l3/entities/apiserver.json
+.. note:: The ``kube-apiserver`` entity is unavailable in some Kubernetes 
+   distributions, such as Azure AKS. You could still use ``cluster`` which
+   is broader.
 
 Access to/from local host
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Adds a note to the docs that `kube-apiserver`
entity is not available in AKS.
