### PR TITLE
Docs: add note about AKS kube-apiserver entity

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -361,6 +361,10 @@ all
     The all entity represents the combination of all known clusters as well
     world and whitelists all communication.
 
+.. note:: The ``kube-apiserver`` entity is unavailable in some Kubernetes 
+   distributions, such as Azure AKS and GCP GKE for ingress traffic. You could still use ``cluster`` which
+   is broader.
+
 Access to/from kube-apiserver
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Adds a note to the docs that `kube-apiserver`
entity is not available in AKS.
