### PR TITLE
cilium: improve 16bit ifindex probe on old kernels

### DIFF
--- a/pkg/datapath/linux/probes/probes_test.go
+++ b/pkg/datapath/linux/probes/probes_test.go
@@ -344,3 +344,16 @@ func TestHaveTCX(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestDetectHaveFibIfindex(t *testing.T) {
+	testutils.PrivilegedTest(t)
+	testutils.SkipOnOldKernel(t, "5.10", "bpf: Always return target ifindex in bpf_fib_lookup")
+
+	//Note this should be tested in the 3 scenarios:
+	// * Kernels with support: True
+	// * Kernels with support via backport: True
+	// * Kernels without support: False
+	if err := HaveFibIfindex(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Previously, `HaveFibIfindex` probe checked the presence of commit `d1c362e1dd68` in the Linux kernel indirectly, by verifying the presence of the redirect helpers (which were merged alongside).

Since `d1c362e1dd68` has been backported to older kernels - but not helpers -, this commit improves `HaveFibIfindex` detection by running a live probe.

Fixes: #27642

```release-note
On kernels where `d1c362e1dd68` has been backported, don't store `ifindex` in the CT map
```