### PR TITLE
clustermesh: drop node observer global variables from tests

### DIFF
--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -149,7 +149,7 @@ func TestRemoteClusterRun(t *testing.T) {
 			cm := ClusterMesh{
 				conf: Configuration{
 					NodeKeyCreator:        testNodeCreator,
-					NodeObserver:          &testObserver{},
+					NodeObserver:          newNodesObserver(),
 					IPCache:               &ipc,
 					RemoteIdentityWatcher: allocator,
 					ClusterIDsManager:     NewClusterMeshUsedIDs(),

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -109,7 +109,7 @@ func setup(tb testing.TB) *ClusterMeshServicesTestSuite {
 		Config:                common.Config{ClusterMeshConfig: dir},
 		ClusterInfo:           cmtypes.ClusterInfo{ID: 255, Name: "test2", MaxConnectedClusters: 255},
 		NodeKeyCreator:        testNodeCreator,
-		NodeObserver:          &testObserver{},
+		NodeObserver:          newNodesObserver(),
 		ServiceMerger:         s.svcCache,
 		RemoteIdentityWatcher: mgr,
 		IPCache:               ipc,


### PR DESCRIPTION
Move them as fields of the `testObserver` struct, to prevent possible flakes caused by interference and leftover state due to the usage of global variables accessed by multiple tests.