### PR TITLE
bgpv2: Exporting peer, route and route-policy states of BGPv2 via CLI.  

### DIFF
--- a/pkg/bgpv1/agent/mode/mode.go
+++ b/pkg/bgpv1/agent/mode/mode.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mode
+
+import (
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// Mode defines the modes in which BGP agent can be configured.
+type Mode int
+
+const (
+	// Disabled mode, BGP control plane is not enabled
+	Disabled Mode = iota
+	// BGPv1 mode is enabled, BGP configuration of the agent will rely on matching CiliumBGPPeeringPolicy for the node.
+	BGPv1
+	// BGPv2 mode is enabled, BGP configuration of the agent will rely on CiliumBGPNodeConfig, CiliumBGPAdvertisement and CiliumBGPPeerConfig.
+	BGPv2
+)
+
+func NewConfigMode() *ConfigMode {
+	return &ConfigMode{}
+}
+
+type ConfigMode struct {
+	lock.RWMutex
+	configMode Mode
+}
+
+func (m *ConfigMode) Get() Mode {
+	m.RLock()
+	defer m.RUnlock()
+	return m.configMode
+}
+
+func (m *ConfigMode) Set(mode Mode) {
+	m.Lock()
+	defer m.Unlock()
+	m.configMode = mode
+}

--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/bgpv1/agent/mode"
 	"github.com/cilium/cilium/pkg/bgpv1/agent/signaler"
 	"github.com/cilium/cilium/pkg/bgpv1/api"
 	"github.com/cilium/cilium/pkg/bgpv1/manager"
@@ -35,7 +36,7 @@ var Cell = cell.Module(
 	"BGP Control Plane",
 
 	// The Controller which is the entry point of the module
-	cell.Provide(agent.NewController, signaler.NewBGPCPSignaler),
+	cell.Provide(agent.NewController, signaler.NewBGPCPSignaler, mode.NewConfigMode),
 	cell.ProvidePrivate(
 		// BGP Peering Policy resource provides the module with a stream of events for the BGPPeeringPolicy resource.
 		newBGPPeeringPolicyResource,

--- a/pkg/bgpv1/manager/manager_test.go
+++ b/pkg/bgpv1/manager/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/bgp"
+	"github.com/cilium/cilium/pkg/bgpv1/agent/mode"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -167,7 +168,11 @@ func TestGetRoutes(t *testing.T) {
 				LocalASN:  int64(testRouterASN),
 				Neighbors: []v2alpha1api.CiliumBGPNeighbor{},
 			}
+			cm := mode.NewConfigMode()
+			cm.Set(mode.BGPv1)
+
 			brm := &BGPRouterManager{
+				ConfigMode: cm,
 				Servers: map[int64]*instance.ServerWithConfig{
 					int64(testRouterASN): testSC,
 				},


### PR DESCRIPTION
This change exposes various BGP states from BGPInstances ( BGPv2 implementation ) into existing CLIs. It adds a thin switch layer in BGP manager to get v1 or v2 states.

There is no change to CLI or http API and how users interact with Cilium to get BGP state. 

Please see individual commits for peers, routes and route-policies changes.

```release-note
BGP:  Exporting peers, routes and route-policy states of BGPv2 via CLI. 
```
