### PR TITLE
bpf: lxc: simplify RevNAT path for loopback replies

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -773,8 +773,7 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 #endif
 
 		return ipv4_local_delivery(ctx, l3_off, secctx, magic, ip4, ep,
-					   METRIC_INGRESS, from_host, false,
-					   false, 0);
+					   METRIC_INGRESS, from_host, false, 0);
 	}
 
 	/* Below remainder is only relevant when traffic is pushed via cilium_host.

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1124,7 +1124,7 @@ ct_recreate4:
 			return ipv4_local_delivery(ctx, ETH_HLEN, SECLABEL_IPV4,
 						   MARK_MAGIC_IDENTITY, ip4,
 						   ep, METRIC_EGRESS, from_l7lb,
-						   false, false, 0);
+						   false, 0);
 		}
 	}
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -851,7 +851,6 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	struct ct_buffer4 *ct_buffer;
 	__u8 audited = 0;
 	__u8 auth_type = 0;
-	bool has_l4_header = false;
 	enum ct_status ct_status;
 	__u16 proxy_port = 0;
 	bool from_l7lb = false;
@@ -860,8 +859,6 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
-
-	has_l4_header = ipv4_has_l4_header(ip4);
 
 #ifdef ENABLE_PER_PACKET_LB
 	/* Restore ct_state from per packet lb handling in the previous tail call. */
@@ -1020,26 +1017,12 @@ ct_recreate4:
 			return tail_call_internal(ctx, CILIUM_CALL_IPV4_NODEPORT_REVNAT,
 						  ext_err);
 		}
-
 #endif /* ENABLE_NODEPORT */
 
-		/* RevNAT for replies on a loopback connection: */
-		if (ct_state->rev_nat_index && ct_state->loopback) {
-			ret = lb4_rev_nat(ctx, ETH_HLEN, l4_off,
-					  ct_state->rev_nat_index,
-					  true, tuple, has_l4_header);
-			if (IS_ERR(ret))
-				return ret;
-		}
 		break;
-
 	default:
 		return DROP_UNKNOWN_CT;
 	}
-
-	/* After L4 write in port mapping: revalidate for direct packet access */
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
-		return DROP_INVALID;
 
 #ifdef ENABLE_SRV6
 	{
@@ -1103,17 +1086,18 @@ ct_recreate4:
 	 */
 	if (is_defined(ENABLE_ROUTING) || hairpin_flow ||
 	    is_defined(ENABLE_HOST_ROUTING)) {
-		/* Hairpin requests need to pass through the backend's to-container
-		 * path, to create a CT_INGRESS entry with .lb_loopback set. This
-		 * drives RevNAT in the backend's from-container path.
-		 *
-		 * Hairpin replies are fully RevNATed in the backend's from-container
-		 * path. Thus they don't match the CT_EGRESS entry, and we can't rely
-		 * on a CT_REPLY result that would provide bypass of ingress policy.
-		 * Thus manually skip the ingress policy path.
-		 */
-		bool bypass_ingress_policy = hairpin_flow && ct_status == CT_REPLY;
+		__be32 daddr = ip4->daddr;
 		struct endpoint_info *ep;
+
+		/* Loopback replies are addressed to IPV4_LOOPBACK, so
+		 * an endpoint lookup with ip4->daddr won't work.
+		 *
+		 * But as it is loopback traffic, the clientIP and backendIP
+		 * are identical and we can just use the packet's saddr
+		 * for the destination endpoint lookup.
+		 */
+		if (ct_status == CT_REPLY && hairpin_flow)
+			daddr = ip4->saddr;
 
 		/* Lookup IPv4 address, this will return a match if:
 		 *  - The destination IP address belongs to a local endpoint
@@ -1122,7 +1106,7 @@ ct_recreate4:
 		 *    host itself
 		 *  - The destination IP address belongs to endpoint itself.
 		 */
-		ep = lookup_ip4_endpoint(ip4);
+		ep = __lookup_ip4_endpoint(daddr);
 		if (ep) {
 #if defined(ENABLE_HOST_ROUTING) || defined(ENABLE_ROUTING)
 			if (ep->flags & ENDPOINT_F_HOST) {
@@ -1140,7 +1124,7 @@ ct_recreate4:
 			return ipv4_local_delivery(ctx, ETH_HLEN, SECLABEL_IPV4,
 						   MARK_MAGIC_IDENTITY, ip4,
 						   ep, METRIC_EGRESS, from_l7lb,
-						   bypass_ingress_policy, false, 0);
+						   false, false, 0);
 		}
 	}
 
@@ -1866,14 +1850,15 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, int ifindex, __u32 src_la
 		}
 
 		/* Reverse NAT applies to return traffic only. */
-		if (unlikely(ct_state->rev_nat_index && !ct_state->loopback)) {
+		if (unlikely(ct_state->rev_nat_index)) {
 			bool has_l4_header = false;
 			int ret2;
 
 			has_l4_header = ipv4_has_l4_header(ip4);
 
 			ret2 = lb4_rev_nat(ctx, ETH_HLEN, l4_off,
-					   ct_state->rev_nat_index, false,
+					   ct_state->rev_nat_index,
+					   ct_state->loopback,
 					   tuple, has_l4_header);
 			if (IS_ERR(ret2))
 				return ret2;
@@ -1897,6 +1882,9 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, int ifindex, __u32 src_la
 	 * connection. Populate
 	 * - .loopback, so that policy enforcement is bypassed, and
 	 * - .rev_nat_index, so that replies can be RevNATed.
+	 *
+	 * TODO: in v1.17, remove the rev_nat_index part. We're no longer driving
+	 * RevNAT from this CT entry.
 	 */
 	if (ret == CT_NEW && ip4->saddr == IPV4_LOOPBACK &&
 	    ct_has_loopback_egress_entry4(get_ct_map4(tuple), tuple,
@@ -2051,76 +2039,6 @@ drop_err:
 				    ret, ext_err, CTX_ACT_DROP, METRIC_INGRESS);
 }
 
-static __always_inline bool
-ipv4_to_endpoint_is_hairpin_flow(struct __ctx_buff *ctx, struct iphdr *ip4)
-{
-	__be16 client_port, backend_port, service_port;
-	struct ipv4_ct_tuple tuple = {};
-	struct lb4_backend *backend;
-	__be32 pod_ip, service_ip;
-	struct ct_entry *entry;
-	struct ct_map *map;
-	int err, l4_off;
-
-	/* Extract the tuple from the packet so we can freely access addrs and ports.
-	 * All values are in network byte order.
-	 */
-	err = lb4_extract_tuple(ctx, ip4, ETH_HLEN, &l4_off, &tuple);
-	if (IS_ERR(err))
-		return false;
-
-	/* If the packet originates from a regular, non-loopback address, it will look
-	 * like service_ip:client_port -> pod_ip:service_port.
-	 *
-	 * In order to determine whether the packet has been hairpinned, we need to
-	 * obtain the backend (listen) port first, requiring a CT lookup with the
-	 * TUPLE_F_SERVICE flag, followed by a backend lookup. After this, the regular
-	 * CT TUPLE_F_OUT lookup can proceed.
-	 */
-	service_ip = tuple.saddr;
-	pod_ip = tuple.daddr;
-	client_port = tuple.sport;
-	service_port = tuple.dport;
-
-	tuple.daddr = service_ip;
-	tuple.saddr = pod_ip;
-	tuple.dport = client_port;
-	tuple.sport = service_port;
-
-	tuple.flags = TUPLE_F_SERVICE;
-
-	map = get_ct_map4(&tuple);
-	entry = map_lookup_elem(map, &tuple);
-	if (!entry)
-		return false;
-
-	backend = lb4_lookup_backend(ctx, entry->backend_id);
-	if (!backend)
-		return false;
-
-	backend_port = backend->port;
-
-	/* Now the backend (listen) port inside the container is known, an egress CT
-	 * lookup can be performed.
-	 */
-	tuple.daddr = IPV4_LOOPBACK;
-	tuple.saddr = pod_ip;
-	tuple.dport = backend_port;
-	tuple.sport = client_port;
-
-	tuple.flags = TUPLE_F_OUT;
-
-	map = get_ct_map4(&tuple);
-	entry = map_lookup_elem(map, &tuple);
-	if (entry)
-		/* The packet is considered hairpinned if its egress CT entry has the
-		 * loopback flag set.
-		 */
-		return entry->lb_loopback == 1;
-
-	return false;
-}
-
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_TO_ENDPOINT)
 int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 {
@@ -2167,24 +2085,6 @@ int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 #ifdef LOCAL_DELIVERY_METRICS
 	update_metrics(ctx_full_len(ctx), METRIC_INGRESS, REASON_FORWARDED);
 #endif
-
-	/* Check if packet is locally hairpinned (pod reaching itself through a
-	 * service) and skip the policy check if that is the case. Otherwise, pods may
-	 * need to explicitly allow traffic to themselves in some network
-	 * configurations.
-	 */
-	if (ipv4_to_endpoint_is_hairpin_flow(ctx, ip4)) {
-		send_trace_notify4(ctx, TRACE_TO_LXC,
-				   src_sec_identity,
-				   SECLABEL, ip4->saddr, LXC_ID,
-				   ctx->ingress_ifindex,
-				   TRACE_REASON_UNKNOWN, 0);
-
-		/* Skip policy check for hairpinned flow */
-		cilium_dbg(ctx, DBG_SKIP_POLICY, LXC_ID, src_sec_identity);
-		ret = CTX_ACT_OK;
-		goto out;
-	}
 
 	ret = ipv4_policy(ctx, ip4, 0, src_sec_identity, NULL, &ext_err,
 			  &proxy_port, false);

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -251,7 +251,7 @@ static __always_inline int handle_inter_cluster_revsnat(struct __ctx_buff *ctx,
 
 		return ipv4_local_delivery(ctx, ETH_HLEN, src_sec_identity,
 					   MARK_MAGIC_IDENTITY, ip4, ep,
-					   METRIC_INGRESS, false, false, true,
+					   METRIC_INGRESS, false, true,
 					   cluster_id);
 	}
 
@@ -446,8 +446,7 @@ not_esp:
 	ep = lookup_ip4_endpoint(ip4);
 	if (ep && !(ep->flags & ENDPOINT_F_HOST))
 		return ipv4_local_delivery(ctx, ETH_HLEN, *identity, MARK_MAGIC_IDENTITY,
-					   ip4, ep, METRIC_INGRESS, false, false, true,
-					   0);
+					   ip4, ep, METRIC_INGRESS, false, true, 0);
 
 	ret = overlay_ingress_policy_hook(ctx, ip4, *identity, ext_err);
 	if (ret != CTX_ACT_OK)

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -74,7 +74,7 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 		  __u32 magic __maybe_unused,
 		  const struct endpoint_info *ep __maybe_unused,
 		  __u8 direction __maybe_unused,
-		  bool from_host __maybe_unused, bool hairpin_flow __maybe_unused,
+		  bool from_host __maybe_unused,
 		  bool from_tunnel __maybe_unused, __u32 cluster_id __maybe_unused)
 {
 #ifdef LOCAL_DELIVERY_METRICS
@@ -106,15 +106,6 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 
 	return redirect_ep(ctx, ep->ifindex, from_host, from_tunnel);
 #else
-# ifndef DISABLE_LOOPBACK_LB
-	/* Skip ingress policy enforcement for hairpin traffic. As the hairpin
-	 * traffic is destined to a local pod (more specifically, the same pod
-	 * the traffic originated from) we skip the tail call for ingress policy
-	 * enforcement, and directly redirect it to the endpoint.
-	 */
-	if (unlikely(hairpin_flow))
-		return redirect_ep(ctx, ep->ifindex, from_host, from_tunnel);
-# endif /* DISABLE_LOOPBACK_LB */
 
 	/* Jumps to destination pod's BPF program to enforce ingress policies. */
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);
@@ -150,7 +141,7 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 		return ret;
 
 	return l3_local_delivery(ctx, seclabel, magic, ep, direction, from_host,
-				 false, from_tunnel, 0);
+				 from_tunnel, 0);
 }
 #endif /* ENABLE_IPV6 */
 
@@ -164,8 +155,7 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 					       struct iphdr *ip4,
 					       const struct endpoint_info *ep,
 					       __u8 direction, bool from_host,
-					       bool hairpin_flow, bool from_tunnel,
-					       __u32 cluster_id)
+					       bool from_tunnel, __u32 cluster_id)
 {
 	mac_t router_mac = ep->node_mac;
 	mac_t lxc_mac = ep->mac;
@@ -178,6 +168,6 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 		return ret;
 
 	return l3_local_delivery(ctx, seclabel, magic, ep, direction, from_host,
-				 hairpin_flow, from_tunnel, cluster_id);
+				 from_tunnel, cluster_id);
 }
 #endif /* SKIP_POLICY_MAP */

--- a/bpf/tests/hairpin_sctp_flow.c
+++ b/bpf/tests/hairpin_sctp_flow.c
@@ -19,7 +19,7 @@
 #define ENABLE_IPV4
 #define ENABLE_SCTP
 
-/* Skip ingress policy checks, not needed to validate hairpin flow */
+/* Use to-container for ingress policy: */
 #define USE_BPF_PROG_FOR_INGRESS_POLICY
 #undef FORCE_LOCAL_POLICY_EVAL_AT_SOURCE
 
@@ -297,6 +297,93 @@ int hairpin_flow_rev_check(__maybe_unused const struct __ctx_buff *ctx)
 	status_code = data;
 
 	assert(*status_code == TC_ACT_REDIRECT);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->saddr != v4_pod_one)
+		test_fatal("src IP changed");
+
+	if (l3->daddr != IPV4_LOOPBACK)
+		test_fatal("dest IP changed");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+
+	if ((void *)l4 + sizeof(struct sctphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != tcp_svc_one)
+		test_fatal("src SCTP port changed");
+
+	if (l4->dest != tcp_src_one)
+		test_fatal("dst SCTP port changed");
+
+	test_finish();
+}
+
+PKTGEN("tc", "hairpin_sctp_flow_4_reverse_ingress_v4")
+int hairpin_sctp_flow_4_reverse_ingress_v4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	volatile const __u8 *src = mac_one;
+	volatile const __u8 *dst = mac_two;
+	struct iphdr *l3;
+	struct sctphdr *l4;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l3 = pktgen__push_ipv4_packet(&builder, (__u8 *)src, (__u8 *)dst,
+				      v4_pod_one, IPV4_LOOPBACK);
+	if (!l3)
+		return TEST_ERROR;
+
+	/* Push SCTP header */
+	l4 = pktgen__push_sctphdr(&builder);
+
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = tcp_svc_one;
+	l4->dest = tcp_src_one;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "hairpin_sctp_flow_4_reverse_ingress_v4")
+int hairpin_sctp_flow_4_reverse_ingress_v4_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, 1);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hairpin_sctp_flow_4_reverse_ingress_v4")
+int hairpin_sctp_flow_4_reverse_ingress_v4_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct iphdr *l3;
+	struct sctphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
 
 	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
 

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -372,6 +372,93 @@ int hairpin_flow_rev_check(__maybe_unused const struct __ctx_buff *ctx)
 	if ((void *)l3 + sizeof(struct iphdr) > data_end)
 		test_fatal("l3 out of bounds");
 
+	if (l3->saddr != v4_pod_one)
+		test_fatal("src IP changed");
+
+	if (l3->daddr != IPV4_LOOPBACK)
+		test_fatal("dest IP changed");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != tcp_dst_one)
+		test_fatal("src TCP port changed");
+
+	if (l4->dest != tcp_src_one)
+		test_fatal("dst TCP port changed");
+
+	test_finish();
+}
+
+PKTGEN("tc", "hairpin_flow_4_reverse_ingress_v4")
+int hairpin_flow_reverse_ingress_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	volatile const __u8 *src = mac_one;
+	volatile const __u8 *dst = mac_two;
+	struct tcphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)src, (__u8 *)dst,
+					  v4_pod_one, IPV4_LOOPBACK,
+					  tcp_dst_one, tcp_src_one);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->ack = 1;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "hairpin_flow_4_reverse_ingress_v4")
+int hairpin_flow_reverse_ingress_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, 1);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hairpin_flow_4_reverse_ingress_v4")
+int hairpin_flow_reverse_ingress_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct iphdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
 	if (l3->saddr != v4_svc_one)
 		test_fatal("src IP was not NAT'ed back to the svc IP");
 


### PR DESCRIPTION
This PR aims to clean up some long-standing tech debt, in how we handle reply traffic for a loopback connection (a client connecting to itself through a service).

Quoting from the first patch
```
 The usual flow for handling service traffic to a local backend is as
follows:
* requests are load-balanced in from-container. This entails selecting
a backend (and caching the selection in a CT_SERVICE entry), DNATing the
packet, creating a CT_EGRESS entry for the resulting `client -> backend`
flow, applying egress network policy, and local delivery to the backend
pod. As part of the local delivery, we also create a CT_INGRESS entry and
apply ingress network policy.
* replies bypass the backend's egress network policy (because the CT
lookup returns CT_REPLY), and pass to the client via local delivery. In
the client's ingress path they bypass ingress network policy (the packets
match as reply against the CT_EGRESS entry), and we apply RevDNAT based on
the `rev_nat_index` in the CT_EGRESS entry.

For a loopback connection (where the client pod is selected as backend for
the connection) this looks slightly more complicated:
* As we can't establish a `client -> client` connection, the requests are
also SNATed with IPV4_LOOPBACK. Network policy in forward direction is
explicitly skipped (as the matched CT entries have the `.loopback` flag
set).
* In reply direction, we can't deliver to IPV4_LOOPBACK (as that's not a
valid IP for an endpoint lookup). So a reply already gets fully RevNATed
by from-container, using the CT_INGRESS entry's `rev_nat_index`. But this
means that when passing into the client pod (either via to-container, or
via the ingress policy tail-call), the packet doesn't match as reply to the
CT_EGRESS entry - and so we don't benefit from automatic network policy
bypass. We ended up with two workarounds for this aspect:
(1) when to-container is installed, it contains custom logic to match the
    packet as a loopback reply, and skip ingress policy
    (see https://github.com/cilium/cilium/pull/27798).
(2) otherwise we skip the ingress policy tailcall, and forward the packet
    straight into the client pod.

The downside of these workarounds is that we bypass the *whole* ingress
program, not just the network policy part. So the CT_EGRESS entry doesn't
get updated (lifetime, statistics, observed packet flags, ...), and we
have the hidden risk that when we add more logic to the ingress program,
it doesn't get executed for loopback replies.

This patch aims to eliminate the need for such workarounds. At its core,
it detects loopback replies in from-container and overrides the packet's
destination IP. Instead of attempting an endpoint lookup for IPV4_LOOPBACK,
we can now look up the actual client endpoint - and deliver to the ingress
policy program, *without* needing to early-RevNAT the packet. Instead the
replies follow the usual packet flow, match the CT_EGRESS entry in the
ingress program, naturally bypass ingress network policy, and are *then*
RevNATed based on the CT_EGRESS entry's `rev_nat_index`.

Consequently we follow the standard datapath, without needing to skip over
policy programs. The CT_EGRESS entry is updated for every reply.

Thus we can also remove the manual policy bypass for loopback replies,
when using per-EP routing. It's no longer needed and in fact the
replies will no longer match the lookup logic, as they haven't
been RevNATed yet. This effectively reverts
e2829a061a53 ("bpf: lxc: support Pod->Service->Pod hairpinning with endpoint routes").
``` 