### PR TITLE
ci: remove k8s version 1.26 from ci-aks

### DIFF
--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -1,16 +1,13 @@
 # List of k8s version for AKS tests
 ---
 include:
-  - version: "1.26"
-    location: westus3
-    index: 1
   - version: "1.27"
     location: westus2
-    index: 2
+    index: 1
   - version: "1.28"
     location: eastus2
-    index: 3
+    index: 2
   - version: "1.29"
     location: eastus
-    index: 4
+    index: 3
     default: true


### PR DESCRIPTION
This commit removes the deleted k8s version from the ci-aks workflow.

Note: As of now, k8s 1.30 is not available on Azure AKS. From the `AKS Kubernetes release schedule Gantt chart` it looks like there are always 3 overlapping versions available. IMO it's seems OK to reduce the number of configured k8s versions to this number.

https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli