### PR TITLE
ci: update unsupported ci-aks k8s version from 1.26 to 1.27

### DIFF
--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -1,7 +1,7 @@
 # List of k8s version for AKS tests
 ---
 include:
-  - version: "1.26"
+  - version: "1.27"
     location: westus2
     index: 1
     default: true


### PR DESCRIPTION
ci-aks started to fail because the only configured k8s version 1.26 is no longer available on Azure AKS.

https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli

Therefore, this commit updates the k8s version to 1.27.

Example of a failing job: https://github.com/cilium/cilium/actions/runs/8971858117/job/24638554909

Note that it fails on the job `Merge and upload artifacts` as the newly introduced k8s version filtering is applied and results in filtering out all versions (in this case only one version configured) (https://github.com/cilium/cilium/pull/32303)

Suggested-by: Marcel Zieba <marcel.zieba@isovalent.com>