### PR TITLE
Unconditionally require the clustermesh cluster configuration to be always present

### DIFF
--- a/clustermesh-apiserver/clustermesh/root.go
+++ b/clustermesh-apiserver/clustermesh/root.go
@@ -368,7 +368,7 @@ func startServer(
 		},
 	}
 
-	if err := cmutils.SetClusterConfig(context.Background(), cinfo.Name, &config, backend); err != nil {
+	if err := cmutils.SetClusterConfig(context.Background(), cinfo.Name, config, backend); err != nil {
 		log.WithError(err).Fatal("Unable to set local cluster config on kvstore")
 	}
 

--- a/operator/cmd/kvstore_watchdog.go
+++ b/operator/cmd/kvstore_watchdog.go
@@ -107,7 +107,7 @@ func startKvstoreWatchdog() {
 				cfg := cmtypes.CiliumClusterConfig{
 					ID:           option.Config.ClusterID,
 					Capabilities: cmtypes.CiliumClusterConfigCapabilities{MaxConnectedClusters: option.Config.MaxConnectedClusters}}
-				if err := cmutils.SetClusterConfig(ctx, option.Config.ClusterName, &cfg, kvstore.Client()); err != nil {
+				if err := cmutils.SetClusterConfig(ctx, option.Config.ClusterName, cfg, kvstore.Client()); err != nil {
 					log.WithError(err).Warning("Unable to set local cluster config")
 				}
 			}

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -62,10 +62,6 @@ type Configuration struct {
 	// ServiceIPGetter, if not nil, is used to create a custom dialer for service resolution.
 	ServiceIPGetter k8s.ServiceIPGetter
 
-	// ConfigValidationMode defines whether the CiliumClusterConfig is always
-	// expected to be exposed by remote clusters.
-	ConfigValidationMode cmtypes.ValidationMode `optional:"true"`
-
 	// IPCacheWatcherExtraOpts returns extra options for watching ipcache entries.
 	IPCacheWatcherExtraOpts IPCacheWatcherOptsFn `optional:"true"`
 

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -144,6 +144,7 @@ func NewClusterMesh(lifecycle cell.Lifecycle, c Configuration) *ClusterMesh {
 func (cm *ClusterMesh) NewRemoteCluster(name string, status common.StatusFunc) common.RemoteCluster {
 	rc := &remoteCluster{
 		name:         name,
+		clusterID:    cmtypes.ClusterIDUnset,
 		mesh:         cm,
 		usedIDs:      cm.conf.ClusterIDsManager,
 		status:       status,

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -119,7 +119,7 @@ func TestClusterMesh(t *testing.T) {
 			config.Capabilities.SyncedCanaries = true
 		}
 
-		err := cmutils.SetClusterConfig(ctx, name, &config, kvstore.Client())
+		err := cmutils.SetClusterConfig(ctx, name, config, kvstore.Client())
 		require.NoErrorf(t, err, "Failed to set cluster config for %s", name)
 	}
 
@@ -184,7 +184,7 @@ func TestClusterMesh(t *testing.T) {
 			MaxConnectedClusters: 255,
 		},
 	}
-	err := cmutils.SetClusterConfig(ctx, "cluster1", &config, kvstore.Client())
+	err := cmutils.SetClusterConfig(ctx, "cluster1", config, kvstore.Client())
 	require.NoErrorf(t, err, "Failed to set cluster config for cluster1")
 	// Ugly hack to trigger config update
 	etcdConfigNew := append(etcdConfig, []byte("\n")...)

--- a/pkg/clustermesh/common/config_test.go
+++ b/pkg/clustermesh/common/config_test.go
@@ -33,7 +33,7 @@ var (
 
 type fakeRemoteCluster struct{}
 
-func (*fakeRemoteCluster) Run(_ context.Context, _ kvstore.BackendOperations, _ *types.CiliumClusterConfig, ready chan<- error) {
+func (*fakeRemoteCluster) Run(_ context.Context, _ kvstore.BackendOperations, _ types.CiliumClusterConfig, ready chan<- error) {
 	close(ready)
 }
 func (*fakeRemoteCluster) Stop()   {}

--- a/pkg/clustermesh/common/config_test.go
+++ b/pkg/clustermesh/common/config_test.go
@@ -36,9 +36,8 @@ type fakeRemoteCluster struct{}
 func (*fakeRemoteCluster) Run(_ context.Context, _ kvstore.BackendOperations, _ *types.CiliumClusterConfig, ready chan<- error) {
 	close(ready)
 }
-func (*fakeRemoteCluster) ClusterConfigRequired() bool { return false }
-func (*fakeRemoteCluster) Stop()                       {}
-func (*fakeRemoteCluster) Remove()                     {}
+func (*fakeRemoteCluster) Stop()   {}
+func (*fakeRemoteCluster) Remove() {}
 
 func writeFile(t *testing.T, name, content string) {
 	t.Helper()

--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -34,7 +34,7 @@ var (
 type RemoteCluster interface {
 	// Run implements the actual business logic once the connection to the remote cluster has been established.
 	// The ready channel shall be closed when the initialization tasks completed, possibly returning an error.
-	Run(ctx context.Context, backend kvstore.BackendOperations, config *types.CiliumClusterConfig, ready chan<- error)
+	Run(ctx context.Context, backend kvstore.BackendOperations, config types.CiliumClusterConfig, ready chan<- error)
 
 	Stop()
 	Remove()
@@ -251,7 +251,7 @@ func (rc *remoteCluster) watchdog(ctx context.Context, backend kvstore.BackendOp
 	}
 }
 
-func (rc *remoteCluster) getClusterConfig(ctx context.Context, backend kvstore.BackendOperations) (*types.CiliumClusterConfig, error) {
+func (rc *remoteCluster) getClusterConfig(ctx context.Context, backend kvstore.BackendOperations) (types.CiliumClusterConfig, error) {
 	var (
 		clusterConfigRetrievalTimeout = 3 * time.Minute
 	)
@@ -263,7 +263,7 @@ func (rc *remoteCluster) getClusterConfig(ctx context.Context, backend kvstore.B
 	rc.config = &models.RemoteClusterConfig{Required: true}
 	rc.mutex.Unlock()
 
-	cfgch := make(chan *types.CiliumClusterConfig)
+	cfgch := make(chan types.CiliumClusterConfig)
 	defer close(cfgch)
 
 	// We retry here rather than simply returning an error and relying on the external
@@ -300,7 +300,7 @@ func (rc *remoteCluster) getClusterConfig(ctx context.Context, backend kvstore.B
 
 		return config, nil
 	case <-ctx.Done():
-		return nil, fmt.Errorf("failed to retrieve cluster configuration")
+		return types.CiliumClusterConfig{}, fmt.Errorf("failed to retrieve cluster configuration")
 	}
 }
 

--- a/pkg/clustermesh/endpointslicesync/remote_cluster.go
+++ b/pkg/clustermesh/endpointslicesync/remote_cluster.go
@@ -80,8 +80,6 @@ func (rc *remoteCluster) Remove() {
 	rc.globalServices.OnClusterDelete(rc.name)
 }
 
-func (rc *remoteCluster) ClusterConfigRequired() bool { return false }
-
 type synced struct {
 	wait.SyncedCommon
 	services *lock.StoppableWaitGroup

--- a/pkg/clustermesh/endpointslicesync/remote_cluster.go
+++ b/pkg/clustermesh/endpointslicesync/remote_cluster.go
@@ -36,21 +36,16 @@ type remoteCluster struct {
 	synced synced
 }
 
-func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperations, config *types.CiliumClusterConfig, ready chan<- error) {
-	var capabilities types.CiliumClusterConfigCapabilities
-	if config != nil {
-		capabilities = config.Capabilities
-	}
-
+func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperations, config types.CiliumClusterConfig, ready chan<- error) {
 	var mgr store.WatchStoreManager
-	if capabilities.SyncedCanaries {
+	if config.Capabilities.SyncedCanaries {
 		mgr = rc.storeFactory.NewWatchStoreManager(backend, rc.name)
 	} else {
 		mgr = store.NewWatchStoreManagerImmediate(rc.name)
 	}
 
 	adapter := func(prefix string) string { return prefix }
-	if capabilities.Cached {
+	if config.Capabilities.Cached {
 		adapter = kvstore.StateToCachePrefix
 	}
 

--- a/pkg/clustermesh/idsmgr.go
+++ b/pkg/clustermesh/idsmgr.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cilium/hive/cell"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/lock"
 )
 
@@ -48,6 +49,10 @@ func NewClusterMeshUsedIDs() *ClusterMeshUsedIDs {
 }
 
 func (cm *ClusterMeshUsedIDs) ReserveClusterID(clusterID uint32) error {
+	if clusterID == cmtypes.ClusterIDUnset {
+		return fmt.Errorf("clusterID %d is reserved", clusterID)
+	}
+
 	cm.UsedClusterIDsMutex.Lock()
 	defer cm.UsedClusterIDsMutex.Unlock()
 

--- a/pkg/clustermesh/idsmgr_test.go
+++ b/pkg/clustermesh/idsmgr_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/clustermesh/types"
 )
 
 func TestClusterIDsManagerProvisioner(t *testing.T) {
@@ -28,4 +30,8 @@ func TestClusterMeshUsedIDs(t *testing.T) {
 
 	mgr.ReleaseClusterID(250)
 	require.NoError(t, mgr.ReserveClusterID(55), "Reserving a released cluster ID should succeed")
+
+	require.Error(t, mgr.ReserveClusterID(types.ClusterIDUnset), "Reserving ClusterID 0 should fail")
+	mgr.ReleaseClusterID(types.ClusterIDUnset)
+	require.Error(t, mgr.ReserveClusterID(types.ClusterIDUnset), "Releasing ClusterID 0 should be a no-op")
 }

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
@@ -97,14 +97,14 @@ func TestRemoteClusterRun(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		srccfg *types.CiliumClusterConfig
-		dstcfg *types.CiliumClusterConfig
+		srccfg types.CiliumClusterConfig
+		dstcfg types.CiliumClusterConfig
 		kvs    map[string]string
 	}{
 		{
-			name:   "remote cluster has no cluster config",
-			srccfg: nil,
-			dstcfg: &types.CiliumClusterConfig{
+			name:   "remote cluster has empty cluster config",
+			srccfg: types.CiliumClusterConfig{},
+			dstcfg: types.CiliumClusterConfig{
 				Capabilities: types.CiliumClusterConfigCapabilities{
 					SyncedCanaries: true,
 					Cached:         true,
@@ -119,12 +119,12 @@ func TestRemoteClusterRun(t *testing.T) {
 		},
 		{
 			name: "remote cluster supports the synced canaries",
-			srccfg: &types.CiliumClusterConfig{
+			srccfg: types.CiliumClusterConfig{
 				Capabilities: types.CiliumClusterConfigCapabilities{
 					SyncedCanaries: true,
 				},
 			},
-			dstcfg: &types.CiliumClusterConfig{
+			dstcfg: types.CiliumClusterConfig{
 				Capabilities: types.CiliumClusterConfigCapabilities{
 					SyncedCanaries: true,
 					Cached:         true,
@@ -139,13 +139,13 @@ func TestRemoteClusterRun(t *testing.T) {
 		},
 		{
 			name: "remote cluster supports the cached prefixes",
-			srccfg: &types.CiliumClusterConfig{
+			srccfg: types.CiliumClusterConfig{
 				ID: 10,
 				Capabilities: types.CiliumClusterConfigCapabilities{
 					Cached: true,
 				},
 			},
-			dstcfg: &types.CiliumClusterConfig{
+			dstcfg: types.CiliumClusterConfig{
 				ID: 10,
 				Capabilities: types.CiliumClusterConfigCapabilities{
 					SyncedCanaries: true,
@@ -161,14 +161,14 @@ func TestRemoteClusterRun(t *testing.T) {
 		},
 		{
 			name: "remote cluster supports both synced canaries and cached prefixes",
-			srccfg: &types.CiliumClusterConfig{
+			srccfg: types.CiliumClusterConfig{
 				ID: 10,
 				Capabilities: types.CiliumClusterConfigCapabilities{
 					SyncedCanaries: true,
 					Cached:         true,
 				},
 			},
-			dstcfg: &types.CiliumClusterConfig{
+			dstcfg: types.CiliumClusterConfig{
 				ID: 10,
 				Capabilities: types.CiliumClusterConfigCapabilities{
 					SyncedCanaries: true,
@@ -199,7 +199,7 @@ func TestRemoteClusterRun(t *testing.T) {
 			remoteClient := &remoteEtcdClientWrapper{
 				BackendOperations: kvstore.Client(),
 				name:              "foo",
-				cached:            tt.srccfg != nil && tt.srccfg.Capabilities.Cached,
+				cached:            tt.srccfg.Capabilities.Cached,
 				kvs:               tt.kvs,
 			}
 			st := store.NewFactory(store.MetricsProvider())
@@ -253,7 +253,7 @@ func TestRemoteClusterRun(t *testing.T) {
 			}
 
 			// Assert that synced canaries have been watched if expected
-			require.Equal(t, tt.srccfg != nil && tt.srccfg.Capabilities.SyncedCanaries, remoteClient.syncedCanariesWatched)
+			require.Equal(t, tt.srccfg.Capabilities.SyncedCanaries, remoteClient.syncedCanariesWatched)
 		})
 	}
 }
@@ -316,7 +316,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		rc.Run(ctx, remoteClient, &cfg, ready)
+		rc.Run(ctx, remoteClient, cfg, ready)
 		rc.Stop()
 		wg.Done()
 	}()

--- a/pkg/clustermesh/kvstoremesh/remote_cluster.go
+++ b/pkg/clustermesh/kvstoremesh/remote_cluster.go
@@ -140,8 +140,6 @@ func (rc *remoteCluster) Remove() {
 	// disappear once the associated lease expires.
 }
 
-func (rc *remoteCluster) ClusterConfigRequired() bool { return false }
-
 // waitForConnection waits for a connection to be established to the remote cluster.
 // If the connection is not established within the timeout, the remote cluster is
 // removed from readiness checks.

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -68,7 +68,7 @@ type remoteCluster struct {
 }
 
 func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperations, config *cmtypes.CiliumClusterConfig, ready chan<- error) {
-	if err := rc.mesh.conf.ClusterInfo.ValidateRemoteConfig(rc.ClusterConfigRequired(), config); err != nil {
+	if err := rc.mesh.conf.ClusterInfo.ValidateRemoteConfig(config); err != nil {
 		ready <- err
 		close(ready)
 		return
@@ -171,10 +171,6 @@ func (rc *remoteCluster) Status() *models.RemoteCluster {
 		status.Synced.Identities && status.Synced.Endpoints
 
 	return status
-}
-
-func (rc *remoteCluster) ClusterConfigRequired() bool {
-	return rc.mesh.conf.ConfigValidationMode == cmtypes.Strict
 }
 
 func (rc *remoteCluster) onUpdateConfig(newConfig *cmtypes.CiliumClusterConfig) error {

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -66,12 +66,12 @@ func TestRemoteClusterRun(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		srccfg *types.CiliumClusterConfig
+		srccfg types.CiliumClusterConfig
 		kvs    map[string]string
 	}{
 		{
 			name:   "remote cluster has no capabilities",
-			srccfg: &types.CiliumClusterConfig{ID: 1},
+			srccfg: types.CiliumClusterConfig{ID: 1},
 			kvs: map[string]string{
 				"cilium/state/nodes/v1/foo/bar":      `{"name": "bar"}`,
 				"cilium/state/services/v1/foo/bar":   `{"name": "bar"}`,
@@ -81,7 +81,7 @@ func TestRemoteClusterRun(t *testing.T) {
 		},
 		{
 			name: "remote cluster supports sync canaries",
-			srccfg: &types.CiliumClusterConfig{
+			srccfg: types.CiliumClusterConfig{
 				ID: 255,
 				Capabilities: types.CiliumClusterConfigCapabilities{
 					SyncedCanaries:       true,
@@ -102,7 +102,7 @@ func TestRemoteClusterRun(t *testing.T) {
 		},
 		{
 			name: "remote cluster supports both sync canaries and cached prefixes",
-			srccfg: &types.CiliumClusterConfig{
+			srccfg: types.CiliumClusterConfig{
 				ID: 255,
 				Capabilities: types.CiliumClusterConfigCapabilities{
 					SyncedCanaries:       true,
@@ -200,7 +200,7 @@ func TestRemoteClusterRun(t *testing.T) {
 			}, timeout, tick, "Identities are not watched correctly")
 
 			// Assert that synced canaries have been watched if expected
-			require.Equal(t, tt.srccfg != nil && tt.srccfg.Capabilities.SyncedCanaries, remoteClient.syncedCanariesWatched)
+			require.Equal(t, tt.srccfg.Capabilities.SyncedCanaries, remoteClient.syncedCanariesWatched)
 		})
 	}
 }

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -70,8 +70,8 @@ func TestRemoteClusterRun(t *testing.T) {
 		kvs    map[string]string
 	}{
 		{
-			name:   "remote cluster has no cluster config",
-			srccfg: nil,
+			name:   "remote cluster has no capabilities",
+			srccfg: &types.CiliumClusterConfig{ID: 1},
 			kvs: map[string]string{
 				"cilium/state/nodes/v1/foo/bar":      `{"name": "bar"}`,
 				"cilium/state/services/v1/foo/bar":   `{"name": "bar"}`,
@@ -82,6 +82,7 @@ func TestRemoteClusterRun(t *testing.T) {
 		{
 			name: "remote cluster supports sync canaries",
 			srccfg: &types.CiliumClusterConfig{
+				ID: 255,
 				Capabilities: types.CiliumClusterConfigCapabilities{
 					SyncedCanaries:       true,
 					MaxConnectedClusters: 255,
@@ -102,6 +103,7 @@ func TestRemoteClusterRun(t *testing.T) {
 		{
 			name: "remote cluster supports both sync canaries and cached prefixes",
 			srccfg: &types.CiliumClusterConfig{
+				ID: 255,
 				Capabilities: types.CiliumClusterConfigCapabilities{
 					SyncedCanaries:       true,
 					Cached:               true,

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -88,7 +88,7 @@ func setup(tb testing.TB) *ClusterMeshServicesTestSuite {
 				MaxConnectedClusters: 255,
 			},
 		}
-		err := cmutils.SetClusterConfig(ctx, cluster, &config, kvstore.Client())
+		err := cmutils.SetClusterConfig(ctx, cluster, config, kvstore.Client())
 		require.NoError(tb, err)
 	}
 

--- a/pkg/clustermesh/types/option.go
+++ b/pkg/clustermesh/types/option.go
@@ -4,7 +4,6 @@
 package types
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/pflag"
@@ -82,11 +81,7 @@ func (c ClusterInfo) ExtendedClusterMeshEnabled() bool {
 
 // ValidateRemoteConfig validates the remote CiliumClusterConfig to ensure
 // compatibility with this cluster's configuration.
-func (c ClusterInfo) ValidateRemoteConfig(config *CiliumClusterConfig) error {
-	if config == nil {
-		return errors.New("remote cluster is missing cluster configuration")
-	}
-
+func (c ClusterInfo) ValidateRemoteConfig(config CiliumClusterConfig) error {
 	if err := ValidateClusterID(config.ID); err != nil {
 		return err
 	}

--- a/pkg/clustermesh/types/option.go
+++ b/pkg/clustermesh/types/option.go
@@ -81,16 +81,10 @@ func (c ClusterInfo) ExtendedClusterMeshEnabled() bool {
 }
 
 // ValidateRemoteConfig validates the remote CiliumClusterConfig to ensure
-// compatibility with this cluster's configuration. When configRequired is
-// false, a missing configuration or one with ID=0 is allowed for backward
-// compatibility, otherwise it is flagged as an error.
-func (c ClusterInfo) ValidateRemoteConfig(configRequired bool, config *CiliumClusterConfig) error {
-	if config == nil || config.ID == 0 {
-		if configRequired || c.ExtendedClusterMeshEnabled() {
-			return errors.New("remote cluster is missing cluster configuration")
-		}
-
-		return nil
+// compatibility with this cluster's configuration.
+func (c ClusterInfo) ValidateRemoteConfig(config *CiliumClusterConfig) error {
+	if config == nil {
+		return errors.New("remote cluster is missing cluster configuration")
 	}
 
 	if err := ValidateClusterID(config.ID); err != nil {

--- a/pkg/clustermesh/types/option_test.go
+++ b/pkg/clustermesh/types/option_test.go
@@ -94,107 +94,54 @@ func TestValidateRemoteConfig(t *testing.T) {
 		name      string
 		cfg       *CiliumClusterConfig
 		mcc       uint32
-		mode      ValidationMode
 		assertion func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool
 	}{
 		{
-			name:      "Nil config (Backward)",
+			name:      "Nil config",
 			cfg:       nil,
 			mcc:       255,
-			mode:      BackwardCompatible,
-			assertion: assert.NoError,
-		},
-		{
-			name:      "Nil config (Strict)",
-			cfg:       nil,
-			mcc:       255,
-			mode:      Strict,
 			assertion: assert.Error,
 		},
 		{
-			name:      "Empty config (Backward)",
+			name:      "Empty config",
 			cfg:       &CiliumClusterConfig{},
 			mcc:       255,
-			mode:      BackwardCompatible,
-			assertion: assert.NoError,
-		},
-		{
-			name:      "Empty config (Strict)",
-			cfg:       &CiliumClusterConfig{},
-			mcc:       255,
-			mode:      Strict,
 			assertion: assert.Error,
 		},
 		{
-			name:      "Valid config (Backward)",
-			cfg:       &CiliumClusterConfig{ID: 255},
-			mcc:       255,
-			mode:      BackwardCompatible,
-			assertion: assert.NoError,
-		},
-		{
-			name:      "Valid config (Strict)",
+			name:      "Valid config",
 			cfg:       &CiliumClusterConfig{ID: 255, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 255}},
 			mcc:       255,
-			mode:      Strict,
 			assertion: assert.NoError,
 		},
 		{
-			name:      "Invalid config (Backward)",
+			name:      "Invalid config",
 			cfg:       &CiliumClusterConfig{ID: 256},
 			mcc:       255,
-			mode:      BackwardCompatible,
-			assertion: assert.Error,
-		},
-		{
-			name:      "Invalid config (Strict)",
-			cfg:       &CiliumClusterConfig{ID: 256},
-			mcc:       255,
-			mode:      Strict,
-			assertion: assert.Error,
-		},
-		// Extended ClusterMesh requires CiliumClusterConfig, so use
-		// BackwardCompatible mode for these tests (most permissive)
-		{
-			name:      "Nil config (ClusterMesh511)",
-			cfg:       nil,
-			mcc:       511,
-			mode:      BackwardCompatible,
-			assertion: assert.Error,
-		},
-		{
-			name:      "Empty config (ClusterMesh511)",
-			cfg:       &CiliumClusterConfig{},
-			mcc:       511,
-			mode:      BackwardCompatible,
 			assertion: assert.Error,
 		},
 		{
 			name:      "Invalid config, MaxConnectedClusters mismatch (ClusterMesh255)",
 			cfg:       &CiliumClusterConfig{ID: 511, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 511}},
 			mcc:       255,
-			mode:      BackwardCompatible,
 			assertion: assert.Error,
 		},
 		{
 			name:      "Valid config (ClusterMesh511)",
 			cfg:       &CiliumClusterConfig{ID: 511, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 511}},
 			mcc:       511,
-			mode:      BackwardCompatible,
 			assertion: assert.NoError,
 		},
 		{
 			name:      "Invalid config, MaxConnectedClusters mismatch (ClusterMesh511)",
 			cfg:       &CiliumClusterConfig{ID: 511, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 255}},
 			mcc:       511,
-			mode:      BackwardCompatible,
 			assertion: assert.Error,
 		},
 		{
 			name:      "Invalid config (ClusterMesh511)",
 			cfg:       &CiliumClusterConfig{ID: 512, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 511}},
 			mcc:       511,
-			mode:      BackwardCompatible,
 			assertion: assert.Error,
 		},
 	}
@@ -203,9 +150,9 @@ func TestValidateRemoteConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cinfo := ClusterInfo{MaxConnectedClusters: tt.mcc}
 			// ClusterIDMax needs to be initialized here. This is ordinarily
-			// executed during agent intialization.
+			// executed during agent initialization.
 			cinfo.InitClusterIDMax()
-			tt.assertion(t, cinfo.ValidateRemoteConfig(bool(tt.mode), tt.cfg))
+			tt.assertion(t, cinfo.ValidateRemoteConfig(tt.cfg))
 		})
 	}
 }

--- a/pkg/clustermesh/types/option_test.go
+++ b/pkg/clustermesh/types/option_test.go
@@ -92,55 +92,49 @@ func TestClusterInfoValidate(t *testing.T) {
 func TestValidateRemoteConfig(t *testing.T) {
 	tests := []struct {
 		name      string
-		cfg       *CiliumClusterConfig
+		cfg       CiliumClusterConfig
 		mcc       uint32
 		assertion func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool
 	}{
 		{
-			name:      "Nil config",
-			cfg:       nil,
-			mcc:       255,
-			assertion: assert.Error,
-		},
-		{
 			name:      "Empty config",
-			cfg:       &CiliumClusterConfig{},
+			cfg:       CiliumClusterConfig{},
 			mcc:       255,
 			assertion: assert.Error,
 		},
 		{
 			name:      "Valid config",
-			cfg:       &CiliumClusterConfig{ID: 255, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 255}},
+			cfg:       CiliumClusterConfig{ID: 255, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 255}},
 			mcc:       255,
 			assertion: assert.NoError,
 		},
 		{
 			name:      "Invalid config",
-			cfg:       &CiliumClusterConfig{ID: 256},
+			cfg:       CiliumClusterConfig{ID: 256},
 			mcc:       255,
 			assertion: assert.Error,
 		},
 		{
 			name:      "Invalid config, MaxConnectedClusters mismatch (ClusterMesh255)",
-			cfg:       &CiliumClusterConfig{ID: 511, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 511}},
+			cfg:       CiliumClusterConfig{ID: 511, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 511}},
 			mcc:       255,
 			assertion: assert.Error,
 		},
 		{
 			name:      "Valid config (ClusterMesh511)",
-			cfg:       &CiliumClusterConfig{ID: 511, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 511}},
+			cfg:       CiliumClusterConfig{ID: 511, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 511}},
 			mcc:       511,
 			assertion: assert.NoError,
 		},
 		{
 			name:      "Invalid config, MaxConnectedClusters mismatch (ClusterMesh511)",
-			cfg:       &CiliumClusterConfig{ID: 511, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 255}},
+			cfg:       CiliumClusterConfig{ID: 511, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 255}},
 			mcc:       511,
 			assertion: assert.Error,
 		},
 		{
 			name:      "Invalid config (ClusterMesh511)",
-			cfg:       &CiliumClusterConfig{ID: 512, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 511}},
+			cfg:       CiliumClusterConfig{ID: 512, Capabilities: CiliumClusterConfigCapabilities{MaxConnectedClusters: 511}},
 			mcc:       511,
 			assertion: assert.Error,
 		},

--- a/pkg/clustermesh/types/types.go
+++ b/pkg/clustermesh/types/types.go
@@ -13,6 +13,8 @@ const (
 	// ClusterIDMin is the minimum value of the cluster ID
 	ClusterIDMin    = 0
 	ClusterIDExt511 = 511
+
+	ClusterIDUnset = ClusterIDMin
 )
 
 // ClusterIDMax is the maximum value of the cluster ID

--- a/pkg/clustermesh/types/types.go
+++ b/pkg/clustermesh/types/types.go
@@ -61,12 +61,3 @@ type CiliumClusterConfigCapabilities struct {
 	// The maximum number of clusters the given cluster can support in a ClusterMesh.
 	MaxConnectedClusters uint32 `json:"maxConnectedClusters,omitempty"`
 }
-
-// ValidationMode defines if a missing CiliumClusterConfig should be allowed for
-// backward compatibility, or it should be flagged as an error.
-type ValidationMode bool
-
-const (
-	BackwardCompatible ValidationMode = false
-	Strict             ValidationMode = true
-)

--- a/pkg/clustermesh/utils/clustercfg.go
+++ b/pkg/clustermesh/utils/clustercfg.go
@@ -20,7 +20,7 @@ var (
 	ErrClusterConfigNotFound = errors.New("not found")
 )
 
-func SetClusterConfig(ctx context.Context, clusterName string, config *cmtypes.CiliumClusterConfig, backend kvstore.BackendOperations) error {
+func SetClusterConfig(ctx context.Context, clusterName string, config cmtypes.CiliumClusterConfig, backend kvstore.BackendOperations) error {
 	key := path.Join(kvstore.ClusterConfigPrefix, clusterName)
 
 	val, err := json.Marshal(config)
@@ -39,7 +39,7 @@ func SetClusterConfig(ctx context.Context, clusterName string, config *cmtypes.C
 	return nil
 }
 
-func GetClusterConfig(ctx context.Context, clusterName string, backend kvstore.BackendOperations) (*cmtypes.CiliumClusterConfig, error) {
+func GetClusterConfig(ctx context.Context, clusterName string, backend kvstore.BackendOperations) (cmtypes.CiliumClusterConfig, error) {
 	var config cmtypes.CiliumClusterConfig
 
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
@@ -47,16 +47,16 @@ func GetClusterConfig(ctx context.Context, clusterName string, backend kvstore.B
 
 	val, err := backend.Get(ctx, path.Join(kvstore.ClusterConfigPrefix, clusterName))
 	if err != nil {
-		return nil, err
+		return cmtypes.CiliumClusterConfig{}, err
 	}
 
 	if val == nil {
-		return nil, ErrClusterConfigNotFound
+		return cmtypes.CiliumClusterConfig{}, ErrClusterConfigNotFound
 	}
 
 	if err := json.Unmarshal(val, &config); err != nil {
-		return nil, err
+		return cmtypes.CiliumClusterConfig{}, err
 	}
 
-	return &config, nil
+	return config, nil
 }

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -39,6 +39,8 @@ const (
 	// falling back to the backward compatible behavior. It must be set before that
 	// the agents have the possibility to connect to the kvstore (that is, when
 	// it is not yet exposed). The corresponding values is ignored.
+	// Starting from v1.16, Cilium always expects the cluster configuration to be
+	// present. This key is now deprecated and shall be removed in Cilium v1.17.
 	HasClusterConfigPath = BaseKeyPrefix + "/.has-cluster-config"
 
 	// ClusterConfigPrefix is the kvstore prefix to cluster configuration


### PR DESCRIPTION
Given that the CiliumClusterConfig has been introduced in Cilium v1.14, it is propagated by the operator as well starting from v1.15, and we support a maximum version skew of one minor version in clustermesh, let's now always enforce its presence. This enables to simplify the overall retrieval logic, which has grown more and more complex over time to account for possible cases which mandate the presence of the configuration for correct operations (e.g., KVStoreMesh).

Please review commit by commit, and refer to the individual descriptions for additional details.