### PR TITLE
clustermesh: fix rare panic due to race condition on stop

### DIFF
--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -394,7 +394,7 @@ func (rc *remoteCluster) onInsert() {
 // In this case, we don't want to drain the known entries, otherwise
 // we would break existing connections when the agent gets restarted.
 func (rc *remoteCluster) onStop() {
-	rc.controllers.RemoveAllAndWait()
+	_ = rc.controllers.RemoveControllerAndWait(rc.remoteConnectionControllerName)
 	close(rc.changed)
 	rc.Stop()
 }


### PR DESCRIPTION
The clustermesh logic is currently affected by a possible, although rare, race condition occurring if the cluster configuration is being retrieved while the connection to the remote cluster is stopped. Indeed, this operation stops two controllers -- the one handling the connection to the remote cluster and the one responsible for the retrieval of the cluster config. However, this causes the `getRemoteCluster` function to possibly terminate before the termination of the second controller, in turn leading to a panic due to send on closed channel. Let's fix this issue by explicitly removing only the first controller, and letting the other terminate normally due to the parent context having been terminated. Hence, ensuring that the controller has always terminated before closing the `cfgch` channel.

<!-- Description of change -->

Fixes: #32179

```release-note
Fix rare race condition afflicting clustermesh when disconnecting from a remote cluster, possibly causing the agent to panic
```
