### PR TITLE
Add fqdn perf test

### DIFF
--- a/.github/actions/cl2-modules/fqdn/config.yaml
+++ b/.github/actions/cl2-modules/fqdn/config.yaml
@@ -1,0 +1,104 @@
+# Total number of DNS requests per node is qps * namespaces
+{{$namespaces := 3}}
+{{$qps := 10}}
+{{$dnsBuckets := 10}}
+
+name: load
+namespace:
+  number: {{$namespaces}}
+tuningSets:
+- name: default
+  globalQPSLoad:
+    qps: 10
+    burst: 1
+
+steps:
+- name: Create configmap and CNP
+  phases:
+  - namespaceRange:
+      min: 1
+      max: {{$namespaces}}
+    replicasPerNamespace: 1
+    tuningSet: default
+    objectBundle:
+    - basename: dns-prober
+      objectTemplatePath: configmap.yaml
+      templateFillMap:
+        NumberOfBuckets: {{$dnsBuckets}}
+    - basename: fqdn-cnp
+      objectTemplatePath: fqdn-cnp.yaml
+
+- name: Starting measurement
+  measurements:
+  - Method: WaitForControlledPodsRunning
+    Instances:
+    - Identifier: WaitForRunningDaemonSets
+      Params:
+        apiVersion: apps/v1
+        kind: DaemonSet
+    Params:
+      action: start
+      labelSelector: group = load
+      operationTimeout: 2m
+
+- name: Create Daemonset that performs DNS requests
+  phases:
+  - namespaceRange:
+      min: 1
+      max: {{$namespaces}}
+    replicasPerNamespace: 1
+    tuningSet: default
+    objectBundle:
+    - basename: dns-prober
+      objectTemplatePath: dns-prober.yaml
+      templateFillMap:
+        qps: {{$qps}}
+
+- name: Waiting for Daemonset to be running
+  measurements:
+  - Method: WaitForControlledPodsRunning
+    Instances:
+    - Identifier: WaitForRunningDaemonSets
+    Params:
+      action: gather
+
+- module:
+    path: ./modules/dns-performance-metrics.yaml
+    params:
+      action: start
+
+- module:
+    path: ./modules/profiles.yaml
+    params:
+      action: start
+
+- name: Gather resources
+  measurements:
+  - Identifier: ResourceUsageSummary
+    Method: ResourceUsageSummary
+    Params:
+      action: start
+
+- name: Wait for DNS queries
+  measurements:
+  - Identifier: sleep
+    Method: Sleep
+    Params:
+      duration: 3m
+
+- module:
+    path: ./modules/dns-performance-metrics.yaml
+    params:
+      action: gather
+
+- module:
+    path: ./modules/profiles.yaml
+    params:
+      action: gather
+
+- name: Gather resources
+  measurements:
+  - Identifier: ResourceUsageSummary
+    Method: ResourceUsageSummary
+    Params:
+      action: gather

--- a/.github/actions/cl2-modules/fqdn/configmap.yaml
+++ b/.github/actions/cl2-modules/fqdn/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{.Name}}
+data:
+  all-queries: |
+{{ range $dnsIndex := Loop .NumberOfBuckets }}
+      my-bucket-test-{{$dnsIndex}}.s3.us-west-2.amazonaws.com
+{{ end }}

--- a/.github/actions/cl2-modules/fqdn/dns-prober.yaml
+++ b/.github/actions/cl2-modules/fqdn/dns-prober.yaml
@@ -1,0 +1,43 @@
+{{$dnsQPSPerClient := DefaultParam .qps 1}}
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{.Name}}
+  labels:
+    group: load
+spec:
+  selector:
+    matchLabels:
+      name: {{.Name}}
+  template:
+    metadata:
+      labels:
+        group: load
+        dns-test: dnsperfgo
+        name: {{.Name}}
+    spec:
+      containers:
+      - name: {{.Name}}
+        image: gcr.io/k8s-staging-perf-tests/dnsperfgo:v1.4.0
+        command:
+        - sh
+        - -c
+        - server=$(cat /etc/resolv.conf | grep nameserver | cut -d ' ' -f 2); echo
+          "Using nameserver ${server}";
+          ./dnsperfgo -timeout 10s -duration 300s -idle-duration 0s -inputfile /var/configmap/all-queries -qps {{$dnsQPSPerClient}};
+        ports:
+        - containerPort: 9153
+          name: dnsperfmetrics
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 1000m
+            memory: "20M"
+        volumeMounts:
+          - name: configmap
+            mountPath: /var/configmap
+      volumes:
+        - name: configmap
+          configMap:
+            name: {{.BaseName}}-{{.Index}}

--- a/.github/actions/cl2-modules/fqdn/fqdn-cnp.yaml
+++ b/.github/actions/cl2-modules/fqdn/fqdn-cnp.yaml
@@ -1,0 +1,24 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{.Name}}
+  labels:
+    group: load
+spec:
+  endpointSelector:
+    matchLabels:
+      group: load
+  egress:
+    - toEndpoints:
+      - matchLabels:
+          "k8s:io.kubernetes.pod.namespace": kube-system
+          "k8s:k8s-app": kube-dns
+      toPorts:
+        - ports:
+           - port: "53"
+             protocol: ANY
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toFQDNs:
+        - matchPattern: "*"

--- a/.github/actions/cl2-modules/fqdn/modules/dns-performance-metrics.yaml
+++ b/.github/actions/cl2-modules/fqdn/modules/dns-performance-metrics.yaml
@@ -1,0 +1,63 @@
+# Valid actions: "start", "gather"
+{{$action := .action}}
+
+steps:
+- name: "{{$action}}ing measurements"
+  measurements:
+  - Identifier: DNSPerformanceMetrics
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: DNS Performance
+      metricVersion: v1
+      unit: s
+      queries:
+      - name: DNS Lookup Count
+        query: sum(increase(dns_lookups_total[%v]))
+      - name: DNS Timeout Count
+        query: sum(increase(dns_timeouts_total[%v]))
+      - name: DNS Error Count
+        query: sum(increase(dns_errors_total[%v]))
+      - name: DNS Error Percentage
+        query: sum(increase(dns_errors_total[%v])) / sum(increase(dns_lookups_total[%v])) * 100
+      - name: DNS Lookup Latency - Perc50
+        query: histogram_quantile(0.5, sum(rate(dns_lookup_latency_bucket[%v])) by (le))
+      - name: DNS Lookup Latency - Perc99
+        query: histogram_quantile(0.99, sum(rate(dns_lookup_latency_bucket[%v])) by (le))
+
+  - Identifier: CiliumDNSPerformanceMetrics
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: Cilium DNS Performance
+      metricVersion: v1
+      unit: s
+      queries:
+      - name: DNS Proxy total time - Perc50
+        query: histogram_quantile(0.5, sum(rate(cilium_proxy_upstream_reply_seconds_bucket{scope="totalTime"}[%v])) by (le))
+      - name: DNS Proxy total time - Perc99
+        query: histogram_quantile(0.99, sum(rate(cilium_proxy_upstream_reply_seconds_bucket{scope="totalTime"}[%v])) by (le))
+      - name: DNS Proxy processing time - Perc50
+        query: histogram_quantile(0.5, sum(rate(cilium_proxy_upstream_reply_seconds_bucket{scope="processingTime"}[%v])) by (le))
+      - name: DNS Proxy processing time - Perc99
+        query: histogram_quantile(0.99, sum(rate(cilium_proxy_upstream_reply_seconds_bucket{scope="processingTime"}[%v])) by (le))
+      - name: DNS Proxy dataplane time - Perc50
+        query: histogram_quantile(0.5, sum(rate(cilium_proxy_upstream_reply_seconds_bucket{scope="dataplaneTime"}[%v])) by (le))
+      - name: DNS Proxy dataplane time - Perc99
+        query: histogram_quantile(0.99, sum(rate(cilium_proxy_upstream_reply_seconds_bucket{scope="dataplaneTime"}[%v])) by (le))
+      - name: DNS Proxy policy check time - Perc50
+        query: histogram_quantile(0.5, sum(rate(cilium_proxy_upstream_reply_seconds_bucket{scope="policyCheckTime"}[%v])) by (le))
+      - name: DNS Proxy policy check time - Perc99
+        query: histogram_quantile(0.99, sum(rate(cilium_proxy_upstream_reply_seconds_bucket{scope="policyCheckTime"}[%v])) by (le))
+      - name: DNS Proxy policy generation time - Perc50
+        query: histogram_quantile(0.5, sum(rate(cilium_proxy_upstream_reply_seconds_bucket{scope="policyGenerationTime"}[%v])) by (le))
+      - name: DNS Proxy policy generation time - Perc99
+        query: histogram_quantile(0.99, sum(rate(cilium_proxy_upstream_reply_seconds_bucket{scope="policyGenerationTime"}[%v])) by (le))
+      - name: DNS Proxy policy semaphore time - Perc50
+        query: histogram_quantile(0.5, sum(rate(cilium_proxy_upstream_reply_seconds_bucket{scope="semaphoreTime"}[%v])) by (le))
+      - name: DNS Proxy policy semaphore time - Perc99
+        query: histogram_quantile(0.99, sum(rate(cilium_proxy_upstream_reply_seconds_bucket{scope="semaphoreTime"}[%v])) by (le))
+      - name: DNS Proxy upstream time - Perc50
+        query: histogram_quantile(0.5, sum(rate(cilium_proxy_upstream_reply_seconds_bucket{scope="upstreamTime"}[%v])) by (le))
+      - name: DNS Proxy upstream time - Perc99
+        query: histogram_quantile(0.99, sum(rate(cilium_proxy_upstream_reply_seconds_bucket{scope="upstreamTime"}[%v])) by (le))

--- a/.github/actions/cl2-modules/fqdn/modules/profiles.yaml
+++ b/.github/actions/cl2-modules/fqdn/modules/profiles.yaml
@@ -1,0 +1,24 @@
+{{$action := .action}}
+
+steps:
+  - name: {{$action}} Cilium Agent PProfs
+    measurements:
+    - identifier: cilium-agent-PodPeriodicCommand
+      method: PodPeriodicCommand
+      params:
+        action: {{$action}}
+        labelSelector: k8s-app=cilium
+        interval: 60s
+        container: cilium-agent
+        limit: 3
+        failOnCommandError: true
+        failOnExecError: true
+        failOnTimeout: true
+        commands:
+        - name: Profiles
+          command:
+          - cilium-bugtool
+          - --get-pprof
+          - --pprof-trace-seconds=40
+          - -t=-
+          timeout: 55s

--- a/.github/workflows/fqdn-perf.yaml
+++ b/.github/workflows/fqdn-perf.yaml
@@ -1,0 +1,242 @@
+name: FQDN perf test
+
+on:
+  schedule:
+    - cron: '39 6 * * 1-5'
+
+# For testing uncomment following lines:
+#  push:
+#    branches:
+#      - your_branch_name
+
+permissions:
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To be able to request the JWT from GitHub's OIDC provider
+  id-token: write
+
+concurrency:
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - workflow_dispatch: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing, such that re-runs will cancel the previous run.
+  group: |
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+    }}
+  cancel-in-progress: true
+
+env:
+  # renovate: datasource=golang-version depName=go
+  go_version: 1.22.2
+  test_name: perf-fqdn
+  # Adding k8s.local to the end makes kops happy-
+  # has stricter DNS naming requirements.
+  cluster_base_name: ${{ github.run_id }}-${{ github.run_attempt }}.k8s.local
+
+jobs:
+  install-and-fqdn-perf-test:
+    runs-on: ubuntu-latest
+    name: Install and FQDN Perf Test
+    timeout-minutes: 60
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up job variables
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] ; then
+            SHA="${{ inputs.image-tag }}"
+          else
+            SHA="${{ github.sha }}"
+          fi
+
+          CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
+            --set pprof.enabled=true \
+            --helm-set=prometheus.enabled=true \
+            --helm-set=dnsProxy.proxyResponseMaxDelay=100s \
+            --wait=false"
+
+          # only add SHA to the image tags if it was set
+          if [ -n "${SHA}" ]; then
+            echo sha=${SHA} >> $GITHUB_OUTPUT
+            CILIUM_INSTALL_DEFAULTS+=" --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
+            --helm-set=image.useDigest=false \
+            --helm-set=image.tag=${SHA} \
+            --helm-set=operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
+            --helm-set=operator.image.suffix=-ci \
+            --helm-set=operator.image.tag=${SHA} \
+            --helm-set=operator.image.useDigest=false \
+            --helm-set=clustermesh.apiserver.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci \
+            --helm-set=clustermesh.apiserver.image.tag=${SHA} \
+            --helm-set=clustermesh.apiserver.image.useDigest=false \
+            --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
+            --helm-set=hubble.relay.image.tag=${SHA} \
+            --helm-set=hubble.relay.image.useDigest=false"
+          fi
+
+          CLUSTER_NAME="${{ env.test_name }}-${{ env.cluster_base_name }}"
+
+          echo SHA=${SHA} >> $GITHUB_OUTPUT
+          echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
+          echo CLUSTER_NAME=${CLUSTER_NAME} >> $GITHUB_OUTPUT
+
+      - name: Wait for images to be available
+        timeout-minutes: 30
+        shell: bash
+        run: |
+          for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.SHA }} &> /dev/null; do sleep 45s; done
+          done
+
+      - name: Install Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: ${{ env.go_version }}
+
+      - name: Install Cilium CLI
+        uses: cilium/cilium-cli@bfa4f93a41da410a1b4c9373c1694ca6d5c35ade # v0.16.6
+        with:
+          repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
+          release-version: ${{ env.CILIUM_CLI_VERSION }}
+
+      - name: Install Kops
+        uses: cilium/scale-tests-action/install-kops@238d773bd07754bfd693a6b22c94eddf3a12778d # main
+
+      - name: Setup gcloud credentials
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_PERF_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_PERF_SA }}
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
+        with:
+          project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
+          version: "405.0.0"
+
+      - name: Clone ClusterLoader2
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          repository: kubernetes/perf-tests
+          # Avoid using renovate to update this dependency because: (1)
+          # perf-tests does not tag or release, so renovate will pull
+          # all updates to the default branch and (2) continually
+          # updating CL2 may impact the stability of the scale test
+          # results.
+          ref: 6eb52ac89d5de15a0ad13cfeb2b2026e57ce4f64
+          persist-credentials: false
+          sparse-checkout: clusterloader2
+          path: perf-tests
+
+      - name: Display version info of installed tools
+        run: |
+          echo "--- go ---"
+          go version
+          echo "--- cilium-cli ---"
+          cilium version --client
+          echo "--- kops ---"
+          ./kops version
+          echo "--- gcloud ---"
+          gcloud version
+
+      - name: Deploy cluster
+        id: deploy-cluster
+        uses: cilium/scale-tests-action/create-cluster@238d773bd07754bfd693a6b22c94eddf3a12778d # main
+        timeout-minutes: 30
+        with:
+          cluster_name: ${{ steps.vars.outputs.cluster_name }}
+          control_plane_size: n1-standard-4
+          control_plane_count: 1
+          node_size: e2-standard-8
+          node_count: 2
+          kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
+          project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
+
+      - name: Setup firewall rules
+        uses: cilium/scale-tests-action/setup-firewall@238d773bd07754bfd693a6b22c94eddf3a12778d # main
+        with:
+          cluster_name: ${{ steps.vars.outputs.cluster_name }}
+
+      - name: Install Cilium
+        run: |
+          cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
+
+      - name: Wait for cluster to be ready
+        uses: cilium/scale-tests-action/validate-cluster@238d773bd07754bfd693a6b22c94eddf3a12778d # main
+        timeout-minutes: 20
+        with:
+          cluster_name: ${{ steps.vars.outputs.cluster_name }}
+          kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
+
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
+
+      - name: Run CL2
+        id: run-cl2
+        working-directory: ./perf-tests/clusterloader2
+        shell: bash
+        timeout-minutes: 30
+        run: |
+          mkdir ./report
+          export CL2_PROMETHEUS_PVC_ENABLED=false
+          export CL2_PROMETHEUS_SCRAPE_CILIUM_OPERATOR=true
+          export CL2_PROMETHEUS_SCRAPE_CILIUM_AGENT=true
+          export CL2_ENABLE_DNSTESTS=true
+
+          # CL2 needs ssh access to control plane nodes
+          gcloud compute config-ssh
+
+          cp -r ../../.github/actions/cl2-modules/fqdn ./testing/
+
+          go run ./cmd/clusterloader.go \
+            -v=2 \
+            --testconfig=./testing/fqdn/config.yaml \
+            --provider=gce \
+            --enable-prometheus-server \
+            --tear-down-prometheus-server=false \
+            --report-dir=./report \
+            --experimental-prometheus-snapshot-to-report-dir=true \
+            --kubeconfig=$HOME/.kube/config \
+            --testoverrides=./testing/prometheus/not-scrape-kube-proxy.yaml \
+            2>&1 | tee cl2-output.txt
+
+      - name: Get sysdump
+        if: ${{ always() && steps.run-cl2.outcome != 'skipped' && steps.run-cl2.outcome != 'cancelled' }}
+        run: |
+          cilium status
+          cilium sysdump --output-filename cilium-sysdump-final
+
+      - name: Cleanup cluster
+        if: ${{ always() && steps.deploy-cluster.outcome != 'skipped' }}
+        uses: cilium/scale-tests-action/cleanup-cluster@238d773bd07754bfd693a6b22c94eddf3a12778d # main
+        with:
+          cluster_name: ${{ steps.vars.outputs.cluster_name }}
+          kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
+
+      - name: Export results and sysdump to GS bucket
+        if: ${{ always() && steps.run-cl2.outcome != 'skipped' && steps.run-cl2.outcome != 'cancelled' }}
+        uses: cilium/scale-tests-action/export-results@238d773bd07754bfd693a6b22c94eddf3a12778d # main
+        with:
+          test_name: ${{ env.test_name }}
+          results_bucket: ${{ env.GCP_PERF_RESULTS_BUCKET }}
+          artifacts: ./perf-tests/clusterloader2/report/*
+          other_files: cilium-sysdump-final.zip ./perf-tests/clusterloader2/cl2-output.txt

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -241,6 +241,7 @@
 /.github/workflows/*hubble*.yaml @cilium/sig-hubble @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*ipsec*.yaml @cilium/ipsec @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*ingress*.yaml @cilium/sig-servicemesh @cilium/github-sec @cilium/ci-structure
+/.github/actions/cl2-modules/ @cilium/sig-scalability
 /.github/workflows/*scale*.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*perf*.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure
 /.gitignore @cilium/contributing


### PR DESCRIPTION
Start measuing fqdn performance. This test runs 30 qps of DNS requests
to S3, which return different set of IPs with each request.
We keep track of client-side latency, latencies reported by cilium-agent
metrics and also cpu/memory usage while also gathering profiling
information.
