### PR TITLE
loader: refactor replaceDatapath to loadDatapath

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -163,7 +163,7 @@ func cleanIngressQdisc(devices []string) error {
 }
 
 // reinitializeIPSec is used to recompile and load encryption network programs.
-func (l *loader) reinitializeIPSec(ctx context.Context) error {
+func (l *loader) reinitializeIPSec() error {
 	// We need to take care not to load bpf_network and bpf_host onto the same
 	// device. If devices are required, we load bpf_host and hence don't need
 	// the code below, specific to EncryptInterface. Specifically, we will load
@@ -204,7 +204,7 @@ func (l *loader) reinitializeIPSec(ctx context.Context) error {
 		return fmt.Errorf("loading eBPF ELF %s: %w", networkObj, err)
 	}
 
-	coll, finalize, err := loadDatapath(ctx, spec, nil, nil)
+	coll, finalize, err := loadDatapath(spec, nil, nil)
 	if err != nil {
 		return fmt.Errorf("loading %s: %w", networkObj, err)
 	}
@@ -449,7 +449,7 @@ func (l *loader) Reinitialize(ctx context.Context, tunnelConfig tunnel.Config, d
 			log.WithError(err).Fatal("failed to compile encryption programs")
 		}
 
-		if err := l.reinitializeIPSec(ctx); err != nil {
+		if err := l.reinitializeIPSec(); err != nil {
 			return err
 		}
 	}

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -138,7 +138,7 @@ func TestReload(t *testing.T) {
 		spec, err := bpf.LoadCollectionSpec(objPath)
 		require.NoError(t, err)
 
-		coll, finalize, err := loadDatapath(ctx, spec, nil, nil)
+		coll, finalize, err := loadDatapath(spec, nil, nil)
 		require.NoError(t, err)
 
 		require.NoError(t, attachSKBProgram(l, coll.Programs[symbolFromEndpoint],
@@ -285,7 +285,7 @@ func BenchmarkReplaceDatapath(b *testing.B) {
 			b.Fatal(err)
 		}
 
-		coll, finalize, err := loadDatapath(ctx, spec, nil, nil)
+		coll, finalize, err := loadDatapath(spec, nil, nil)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -37,23 +37,8 @@ func directionToParent(dir string) uint32 {
 	return 0
 }
 
-type progDefinition struct {
-	progName  string
-	direction string
-}
-
-type replaceDatapathOptions struct {
-	device     string            // name of the netlink interface we attach to
-	elf        string            // path to object file
-	programs   []progDefinition  // programs that we want to attach/replace
-	xdpMode    string            // XDP driver mode, only applies when attaching XDP programs
-	linkDir    string            // path to bpffs dir holding bpf_links for the device/endpoint
-	tcx        bool              // attempt attaching skb programs using tcx
-	mapRenames map[string]string // renames from old map name to new map name
-	constants  map[string]uint64 // overrides for constant values
-}
-
-// replaceDatapath replaces the qdisc and BPF program for an endpoint or XDP program.
+// loadDatapath returns a Collection given the ELF obj, renames maps according
+// to mapRenames and overrides the given constants.
 //
 // When successful, returns a finalizer to allow the map cleanup operation to be
 // deferred by the caller. On error, any maps pending migration are immediately
@@ -66,59 +51,23 @@ type replaceDatapathOptions struct {
 // For example, this is the case with from-netdev and to-netdev. If eth0:to-netdev
 // gets its program and maps replaced and unpinned, its eth0:from-netdev counterpart
 // will miss tail calls (and drop packets) until it has been replaced as well.
-func replaceDatapath(ctx context.Context, opts replaceDatapathOptions) (_ func(), err error) {
-	l := log.WithField("device", opts.device).WithField("objPath", opts.elf)
-
-	// Load the ELF from disk.
-	l.Debug("Loading CollectionSpec from ELF")
-	spec, err := bpf.LoadCollectionSpec(opts.elf)
-	if err != nil {
-		return nil, fmt.Errorf("loading eBPF ELF %s: %w", opts.elf, err)
-	}
-
-	opts.elf = ""
-	return replaceDatapathFromSpec(ctx, spec, opts)
-}
-
-func replaceDatapathFromSpec(ctx context.Context, spec *ebpf.CollectionSpec, opts replaceDatapathOptions) (_ func(), err error) {
+func loadDatapath(ctx context.Context, spec *ebpf.CollectionSpec, mapRenames map[string]string, constants map[string]uint64) (_ *ebpf.Collection, _ func(), err error) {
 	// Avoid unnecessarily loading a prog.
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-
-	if opts.linkDir == "" {
-		return nil, errors.New("opts.linkDir not set in replaceDatapath")
-	}
-
-	if opts.elf != "" {
-		return nil, errors.New("opts.elf is set")
-	}
-
-	link, err := netlink.LinkByName(opts.device)
-	if err != nil {
-		return nil, fmt.Errorf("getting interface %s by name: %w", opts.device, err)
-	}
-
-	l := log.WithField("device", opts.device).
-		WithField("ifindex", link.Attrs().Index)
 
 	revert := func() {
 		// Program replacement unsuccessful, revert bpffs migration.
-		l.Debug("Reverting bpffs map migration")
+		log.Debug("Reverting bpffs map migration")
 		if err := bpf.FinalizeBPFFSMigration(bpf.TCGlobalsPath(), spec, true); err != nil {
-			l.WithError(err).Error("Failed to revert bpffs map migration")
+			log.WithError(err).Error("Failed to revert bpffs map migration")
 		}
 	}
 
-	for _, prog := range opts.programs {
-		if spec.Programs[prog.progName] == nil {
-			return nil, fmt.Errorf("no program %s found in eBPF ELF", prog.progName)
-		}
-	}
-
-	spec, err = renameMaps(spec, opts.mapRenames)
+	spec, err = renameMaps(spec, mapRenames)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Unconditionally repin cilium_calls_* maps to prevent them from being
@@ -129,7 +78,7 @@ func replaceDatapathFromSpec(ctx context.Context, spec *ebpf.CollectionSpec, opt
 		}
 
 		if err := bpf.RepinMap(bpf.TCGlobalsPath(), ms.Name, ms); err != nil {
-			return nil, fmt.Errorf("repinning map %s: %w", ms.Name, err)
+			return nil, nil, fmt.Errorf("repinning map %s: %w", ms.Name, err)
 		}
 
 		defer func() {
@@ -140,7 +89,7 @@ func replaceDatapathFromSpec(ctx context.Context, spec *ebpf.CollectionSpec, opt
 			}
 
 			if err := bpf.FinalizeMap(bpf.TCGlobalsPath(), ms.Name, revert); err != nil {
-				l.WithError(err).Error("Could not finalize map")
+				log.WithError(err).Error("Could not finalize map")
 			}
 		}()
 
@@ -170,42 +119,51 @@ func replaceDatapathFromSpec(ctx context.Context, spec *ebpf.CollectionSpec, opt
 		CollectionOptions: ebpf.CollectionOptions{
 			Maps: ebpf.MapOptions{PinPath: pinPath},
 		},
-		Constants: opts.constants,
+		Constants: constants,
 	}
 	if err := bpf.MkdirBPF(pinPath); err != nil {
-		return nil, fmt.Errorf("creating bpffs pin path: %w", err)
+		return nil, nil, fmt.Errorf("creating bpffs pin path: %w", err)
 	}
-	l.Debug("Loading Collection into kernel")
+	log.Debug("Loading Collection into kernel")
 	coll, err := bpf.LoadCollection(spec, &collOpts)
 	if errors.Is(err, ebpf.ErrMapIncompatible) {
 		// Temporarily rename bpffs pins of maps whose definitions have changed in
 		// a new version of a datapath ELF.
-		l.Debug("Starting bpffs map migration")
+		log.Debug("Starting bpffs map migration")
 		if err := bpf.StartBPFFSMigration(bpf.TCGlobalsPath(), spec); err != nil {
-			return nil, fmt.Errorf("Failed to start bpffs map migration: %w", err)
+			return nil, nil, fmt.Errorf("Failed to start bpffs map migration: %w", err)
 		}
 
 		finalize = func() {
-			l.Debug("Finalizing bpffs map migration")
+			log.Debug("Finalizing bpffs map migration")
 			if err := bpf.FinalizeBPFFSMigration(bpf.TCGlobalsPath(), spec, false); err != nil {
-				l.WithError(err).Error("Could not finalize bpffs map migration")
+				log.WithError(err).Error("Could not finalize bpffs map migration")
 			}
 		}
 
 		// Retry loading the Collection after starting map migration.
-		l.Debug("Retrying loading Collection into kernel after map migration")
+		log.Debug("Retrying loading Collection into kernel after map migration")
 		coll, err = bpf.LoadCollection(spec, &collOpts)
 	}
 	var ve *ebpf.VerifierError
 	if errors.As(err, &ve) {
 		if _, err := fmt.Fprintf(os.Stderr, "Verifier error: %s\nVerifier log: %+v\n", err, ve); err != nil {
-			return nil, fmt.Errorf("writing verifier log to stderr: %w", err)
+			revert()
+			return nil, nil, fmt.Errorf("writing verifier log to stderr: %w", err)
 		}
 	}
 	if err != nil {
-		return nil, fmt.Errorf("loading eBPF collection into the kernel: %w", err)
+		revert()
+		return nil, nil, fmt.Errorf("loading eBPF collection into the kernel: %w", err)
 	}
-	defer coll.Close()
+
+	// TODO(tb): Reverts don't really make sense after this point. Once a policy
+	// prog is inserted, the new Collection will be handling some part of the
+	// datapath. Reverting will clear the new prog array and result in missed tail
+	// calls in the 'new' code path, so the whole endpoint will break anyway.
+	// Since there is no atomicity in attaching a program, let's not create the
+	// illusion that reverts are actually possible. As a follow-up, remove the
+	// map migration system in favor of a 'commit' system.
 
 	// If an ELF contains one of the policy call maps, resolve and insert the
 	// programs it refers to into the map. This always needs to happen _before_
@@ -222,43 +180,17 @@ func replaceDatapathFromSpec(ctx context.Context, spec *ebpf.CollectionSpec, opt
 	// first, or we risk missing tail calls.
 	if len(policyProgs) != 0 {
 		if err := resolveAndInsertCalls(coll, policymap.PolicyCallMapName, policyProgs); err != nil {
-			revert()
-			return nil, fmt.Errorf("inserting policy programs: %w", err)
+			return nil, nil, fmt.Errorf("inserting policy programs: %w", err)
 		}
 	}
 
 	if len(egressPolicyProgs) != 0 {
 		if err := resolveAndInsertCalls(coll, policymap.PolicyEgressCallMapName, egressPolicyProgs); err != nil {
-			revert()
-			return nil, fmt.Errorf("inserting egress policy programs: %w", err)
+			return nil, nil, fmt.Errorf("inserting egress policy programs: %w", err)
 		}
 	}
 
-	// Finally, attach the endpoint's tc or xdp entry points to allow traffic to
-	// flow in.
-	for _, prog := range opts.programs {
-		scopedLog := l.WithField("progName", prog.progName).WithField("direction", prog.direction)
-
-		if err := bpf.MkdirBPF(opts.linkDir); err != nil {
-			return nil, fmt.Errorf("creating bpffs link dir for device %s: %w", link.Attrs().Name, err)
-		}
-
-		if opts.xdpMode != "" {
-			scopedLog.Debug("Attaching XDP program to interface")
-			err = attachXDPProgram(link, coll.Programs[prog.progName], prog.progName, opts.linkDir, xdpConfigModeToFlag(opts.xdpMode))
-		} else {
-			scopedLog.Debug("Attaching SKB program to interface")
-			err = attachSKBProgram(link, coll.Programs[prog.progName], prog.progName, opts.linkDir, directionToParent(prog.direction), opts.tcx)
-		}
-
-		if err != nil {
-			revert()
-			return nil, fmt.Errorf("program %s: %w", prog.progName, err)
-		}
-		scopedLog.Debug("Successfully attached program to interface")
-	}
-
-	return finalize, nil
+	return coll, finalize, nil
 }
 
 // resolveAndInsertCalls resolves a given slice of ebpf.MapKV containing u32 keys

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -4,7 +4,6 @@
 package loader
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -51,12 +50,7 @@ func directionToParent(dir string) uint32 {
 // For example, this is the case with from-netdev and to-netdev. If eth0:to-netdev
 // gets its program and maps replaced and unpinned, its eth0:from-netdev counterpart
 // will miss tail calls (and drop packets) until it has been replaced as well.
-func loadDatapath(ctx context.Context, spec *ebpf.CollectionSpec, mapRenames map[string]string, constants map[string]uint64) (_ *ebpf.Collection, _ func(), err error) {
-	// Avoid unnecessarily loading a prog.
-	if err := ctx.Err(); err != nil {
-		return nil, nil, err
-	}
-
+func loadDatapath(spec *ebpf.CollectionSpec, mapRenames map[string]string, constants map[string]uint64) (_ *ebpf.Collection, _ func(), err error) {
 	revert := func() {
 		// Program replacement unsuccessful, revert bpffs migration.
 		log.Debug("Reverting bpffs map migration")

--- a/pkg/datapath/loader/tc.go
+++ b/pkg/datapath/loader/tc.go
@@ -20,6 +20,10 @@ import (
 // attachSKBProgram attaches prog to device using tcx if available and enabled,
 // or legacy tc as a fallback.
 func attachSKBProgram(device netlink.Link, prog *ebpf.Program, progName, bpffsDir string, parent uint32, tcxEnabled bool) error {
+	if prog == nil {
+		return fmt.Errorf("program %s is nil", progName)
+	}
+
 	if tcxEnabled {
 		// Attach using tcx if available. This is seamless on interfaces with
 		// existing tc programs since attaching tcx disables legacy tc evaluation.

--- a/pkg/datapath/loader/tcx.go
+++ b/pkg/datapath/loader/tcx.go
@@ -50,6 +50,10 @@ func upsertTCXProgram(device netlink.Link, prog *ebpf.Program, progName, bpffsDi
 //
 // progName is typically the Program's key in CollectionSpec.Programs.
 func attachTCX(device netlink.Link, prog *ebpf.Program, progName, bpffsDir string, attach ebpf.AttachType) error {
+	if err := bpf.MkdirBPF(bpffsDir); err != nil {
+		return fmt.Errorf("creating bpffs link dir for tcx attachment to device %s: %w", device.Attrs().Name, err)
+	}
+
 	l, err := link.AttachTCX(link.TCXOptions{
 		Program:   prog,
 		Attach:    attach,

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -162,7 +162,7 @@ func compileAndLoadXDPProg(ctx context.Context, xdpDev, xdpMode string, extraCAr
 		return fmt.Errorf("loading eBPF ELF %s: %w", objPath, err)
 	}
 
-	coll, finalize, err := loadDatapath(ctx, spec, nil, nil)
+	coll, finalize, err := loadDatapath(spec, nil, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
```
loader: refactor replaceDatapath to loadDatapath

This unblocks cilium/cilium#29333. See cilium/cilium#32468 for more context.

This commit refactors replaceDatapath() to loadDatapath() by factoring device attachment
out of the function into the caller. The main reasons are flexibility and transparency.
replaceDatapath() was called from many places and needed to do a lot. This change is the
first step to handing individual callers an object representing actual bpf object handles,
so they can correctly manage its lifecycle. In the future, ebpf.LoadAndAssign will be used
for better readability.

Some callers attach the same program to multiple interfaces, some attach multiple programs
(ingress/egress) to the same interface, and some use a mixture of both. This has caused
loops to creep into replaceDatapath, giving it many arguments and many overall
responsibilities, making it hard to form intuition around.

Major changes made in this commit:
- lifted attach{SKB,XDP}Program out of the function, into all callers, making them
  call attach* methods explicitly
- removed `replaceDatapathOptions`
- reduced the window a potential 'rollback' can happen in (see code comments) due to the
  risks involved, and it never being correct to begin with.
- removed a few points where context cancellations are obeyed, to be continued in a
  subsequent commit

Fixes: #32468
```

```
loader: remove ctx from uncancellable functions

Loading bpf objects used to be done by iproute2, where propagating ctx to the
exec.Cmd invocations made sense, since realistically any shellout can hang for
arbitrary reasons.

Now the loader is fully hosted in the agent process, this no longer makes sense.
Once we're blocked in a bpf() syscall, e.g. for loading a program, the verifier
can be interrupted by sending a signal to the calling thread. Since the Go runtime
routinely sends these signals under normal operation, ebpf-go will retry a few
times when bpf() returns EINTR. The API currently doesn't expose a way to cancel
program loading/verification, and there's no clear benefit to doing so in the first
place.

Verification is relatively lightweight compared to datapath compilation, so
interrupting it during teardown is of questionable benefit. The agent doesn't expect
it to be interruptible, it's bound to leave endpoints in an undefined state.

This commit introduces the assumption that, once endpoint loading/attachment is
kicked off (after compilation), it cannot be cancelled. This is reflected in the
interface exposed to the rest of the system, by removing the ctx parameter on many
methods. Only compilation can be interrupted, since it can take a long time on some
systems, especially lower-spec.
```

Fixes: #32468