### PR TITLE
loader: misc fixes

### DIFF
--- a/pkg/bpf/collection_test.go
+++ b/pkg/bpf/collection_test.go
@@ -67,9 +67,9 @@ func TestInlineGlobalData(t *testing.T) {
 			globalDataMap: {
 				Value: &btf.Datasec{
 					Vars: []btf.VarSecinfo{
-						{Offset: 0, Size: 4},
-						{Offset: 4, Size: 2},
-						{Offset: 8, Size: 8},
+						{Offset: 0, Size: 4, Type: &btf.Var{}},
+						{Offset: 4, Size: 2, Type: &btf.Var{}},
+						{Offset: 8, Size: 8, Type: &btf.Var{}},
 					},
 				},
 				Contents: []ebpf.MapKV{{Value: []byte{

--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -167,7 +167,7 @@ func (o *objectCache) serialize(key string) *cachedObject {
 
 // build attempts to compile and cache a datapath template object file
 // corresponding to the specified endpoint configuration.
-func (o *objectCache) build(ctx context.Context, cfg *templateCfg, dir *directoryInfo, hash string) (string, error) {
+func (o *objectCache) build(ctx context.Context, cfg datapath.EndpointConfiguration, stats *metrics.SpanStat, dir *directoryInfo, hash string) (string, error) {
 	isHost := cfg.IsHost()
 	templatePath := filepath.Join(o.workingDirectory, defaults.TemplatesDir, hash)
 	dir = &directoryInfo{
@@ -197,16 +197,16 @@ func (o *objectCache) build(ctx context.Context, cfg *templateCfg, dir *director
 		return "", fmt.Errorf("failed to write template header: %w", err)
 	}
 
-	cfg.stats.BpfCompilation.Start()
+	stats.BpfCompilation.Start()
 	err = compileDatapath(ctx, dir, isHost, log)
-	cfg.stats.BpfCompilation.End(err == nil)
+	stats.BpfCompilation.End(err == nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to compile template program: %w", err)
 	}
 
 	log.WithFields(logrus.Fields{
 		logfields.Path:               objectPath,
-		logfields.BPFCompilationTime: cfg.stats.BpfCompilation.Total(),
+		logfields.BPFCompilationTime: stats.BpfCompilation.Total(),
 	}).Info("Compiled new BPF template")
 
 	return objectPath, nil
@@ -221,6 +221,8 @@ func (o *objectCache) build(ctx context.Context, cfg *templateCfg, dir *director
 // Returns the path to the compiled template datapath object and whether the
 // object was compiled, or an error.
 func (o *objectCache) fetchOrCompile(ctx context.Context, cfg datapath.EndpointConfiguration, dir *directoryInfo, stats *metrics.SpanStat) (file *os.File, compiled bool, err error) {
+	cfg = wrap(cfg)
+
 	var hash string
 	hash, err = o.baseHash.sumEndpoint(o, cfg, false)
 	if err != nil {
@@ -255,7 +257,11 @@ func (o *objectCache) fetchOrCompile(ctx context.Context, cfg datapath.EndpointC
 		}
 	}
 
-	path, err := o.build(ctx, wrap(cfg, stats), dir, hash)
+	if stats == nil {
+		stats = &metrics.SpanStat{}
+	}
+
+	path, err := o.build(ctx, cfg, stats, dir, hash)
 	if err != nil {
 		if !errors.Is(err, context.Canceled) {
 			scopedLog.WithError(err).Error("BPF template object creation failed")

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
-	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -319,14 +318,8 @@ func TestSubstituteConfiguration(t *testing.T) {
 	ep := testutils.NewTestEndpoint()
 	initEndpoint(t, &ep)
 
-	option.Config.DryMode = true
-	defer func() {
-		option.Config.DryMode = false
-	}()
-
 	l := newTestLoader(t)
 	stats := &metrics.SpanStat{}
-	l.templateCache = newObjectCache(&config.HeaderfileWriter{}, nil, t.TempDir())
 	if err := l.CompileOrLoad(ctx, &ep, stats); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
-	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/mac"
@@ -64,7 +63,6 @@ type templateCfg struct {
 	// endpoint configuration, while the rest of the EndpointConfiguration
 	// interface is implemented directly here through receiver functions.
 	datapath.CompileTimeConfiguration
-	stats *metrics.SpanStat
 }
 
 // GetID returns a uint64, but in practice on the datapath side it is
@@ -129,13 +127,9 @@ func (t *templateCfg) GetPolicyVerdictLogFilter() uint32 {
 // it inside a templateCfg which hides static data from callers that wish to
 // generate header files based on the configuration, substituting it for
 // template data.
-func wrap(cfg datapath.CompileTimeConfiguration, stats *metrics.SpanStat) *templateCfg {
-	if stats == nil {
-		stats = &metrics.SpanStat{}
-	}
+func wrap(cfg datapath.CompileTimeConfiguration) *templateCfg {
 	return &templateCfg{
 		CompileTimeConfiguration: cfg,
-		stats:                    stats,
 	}
 }
 

--- a/pkg/datapath/loader/template_test.go
+++ b/pkg/datapath/loader/template_test.go
@@ -19,7 +19,7 @@ func TestWrap(t *testing.T) {
 	)
 
 	realEP := testutils.NewTestEndpoint()
-	template := wrap(&realEP, nil)
+	template := wrap(&realEP)
 	cfg := configWriterForTest(t)
 
 	// Write the configuration that should be the same, and verify it is.


### PR DESCRIPTION
This PR pulls out a couple of fixes from #32059.

pkg/bpf: fix globalData big-endian issues

    globalData extracts constants from an array of bytes using BTF. It does this
    by copying up to 8 bytes into a temporary buffer and then using
    ByteOrder.Uint64 to convert that to a uint64. This only works on little
    endian machines.

    Fix this by using the correct methods to convert to uint64. Since there are
    approximately zero big-endian machines out there this isn't a particularly
    critical fix.

    Fixes: d10e8ebed3 ("bpf: dynamic-width static data inlining") Signed-off-by:
    Lorenz Bauer <lmb@isovalent.com>

loader: consistently use wrapped config in objectCache.build

    The object cache computes a hash to decide whether a rebuild is necessary.
    Use the same wrapped config as we later use for the build to avoid any
    inconsistencies.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

loader: remove unnecessary global variable mangling from test

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
