### PR TITLE
Operator/CES: Simplify rate limit configuration

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -162,7 +162,7 @@ runs:
           fi
 
           if [ "${{ inputs.ciliumendpointslice }}" == "true" ]; then
-            CILIUMENDPOINTSLICE="--helm-set=enableCiliumEndpointSlice=true"
+            CILIUMENDPOINTSLICE="--helm-set=ciliumEndpointSlice.enabled=true"
           fi
         
           CONFIG="${DEFAULTS} ${IMAGE} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION} ${INGRESS_CONTROLLER} ${CILIUMENDPOINTSLICE}"

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -16,14 +16,9 @@ cilium-operator-alibabacloud [flags]
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -12,14 +12,9 @@ cilium-operator-alibabacloud hive [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -18,14 +18,9 @@ cilium-operator-alibabacloud hive dot-graph [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -19,14 +19,9 @@ cilium-operator-aws [flags]
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -12,14 +12,9 @@ cilium-operator-aws hive [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -18,14 +18,9 @@ cilium-operator-aws hive dot-graph [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -19,14 +19,9 @@ cilium-operator-azure [flags]
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -12,14 +12,9 @@ cilium-operator-azure hive [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -18,14 +18,9 @@ cilium-operator-azure hive dot-graph [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -15,14 +15,9 @@ cilium-operator-generic [flags]
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -12,14 +12,9 @@ cilium-operator-generic hive [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -18,14 +18,9 @@ cilium-operator-generic hive dot-graph [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -24,14 +24,9 @@ cilium-operator [flags]
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -12,14 +12,9 @@ cilium-operator hive [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -18,14 +18,9 @@ cilium-operator hive dot-graph [flags]
 
 ```
       --bgp-v2-api-enabled                                   Enables BGPv2 APIs in Cilium
-      --ces-dynamic-rate-limit-nodes strings                 List of nodes used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-burst strings             List of qps burst used for the dynamic rate limit steps
-      --ces-dynamic-rate-limit-qps-limit strings             List of qps limits used for the dynamic rate limit steps
-      --ces-enable-dynamic-rate-limit                        Flag to enable dynamic rate limit specified in separate fields instead of the static one
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
-      --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
-      --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -448,6 +448,14 @@
      - Configure cgroup root where cgroup2 filesystem is mounted on the host (see also: ``cgroup.autoMount``\ )
      - string
      - ``"/run/cilium/cgroupv2"``
+   * - :spelling:ignore:`ciliumEndpointSlice.enabled`
+     - Enable Cilium EndpointSlice feature.
+     - bool
+     - ``false``
+   * - :spelling:ignore:`ciliumEndpointSlice.rateLimits`
+     - List of rate limit options to be used for the CiliumEndpointSlice controller. Each object in the list must have the following fields: nodes: Count of nodes at which to apply the rate limit. limit: The sustained request rate in requests per second. The maximum rate that can be configured is 50. burst: The burst request rate in requests per second. The maximum burst that can be configured is 100.
+     - list
+     - ``[{"burst":20,"limit":10,"nodes":0},{"burst":15,"limit":7,"nodes":100},{"burst":10,"limit":5,"nodes":500}]``
    * - :spelling:ignore:`cleanBpfState`
      - Clean all eBPF datapath state from the initContainer of the cilium-agent DaemonSet.  WARNING: Use with care!
      - bool
@@ -949,7 +957,7 @@
      - string
      - ``"1s"``
    * - :spelling:ignore:`enableCiliumEndpointSlice`
-     - Enable CiliumEndpointSlice feature.
+     - Enable CiliumEndpointSlice feature (deprecated, please use ``ciliumEndpointSlice.enabled`` instead).
      - bool
      - ``false``
    * - :spelling:ignore:`enableCriticalPriorityClass`

--- a/Documentation/network/kubernetes/ciliumendpointslice.rst
+++ b/Documentation/network/kubernetes/ciliumendpointslice.rst
@@ -63,7 +63,7 @@ Migration Procedure
 In order to minimize endpoint propagation delays, it is recommended to upgrade the Operator first,
 let it create all CES objects, and then upgrade the Agents afterwards.
 
-#. Enable CES on the Operator by setting the ``enableCiliumEndpointSlice`` value to ``true`` in your Helm chart or
+#. Enable CES on the Operator by setting the ``ciliumEndpointSlice.enabled`` value to ``true`` in your Helm chart or
    by directly setting the ``--enable-cilium-endpoint-slice`` flag to ``true`` on the Operator. Re-deploy the Operator.
 
 #. Once the Operator is running, verify that the ``CiliumEndpointSlice`` CRD has been successfully registered:

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -340,6 +340,13 @@ Annotations:
   commands.
 * Service connections that use ``Direct-Server-Return`` and were established prior to Cilium v1.13.3
   will be disrupted, and need to be re-established.
+* Cilium Operator now uses dynamic rate limiting based on cluster size for the CiliumEndpointSlice
+  controller. The ``ces-rate-limits`` flag or the Helm value ``ciliumEndpointSlice.rateLimits`` can
+  be used to supply a custom configuration. The following list of flags for static and dynamic rate
+  limits have been deprecated and their usage will be ignored:
+  ``ces-write-qps-limit``, ``ces-write-qps-burst``, ``ces-enable-dynamic-rate-limit``,
+  ``ces-dynamic-rate-limit-nodes``, ``ces-dynamic-rate-limit-qps-limit``,
+  ``ces-dynamic-rate-limit-qps-burst``
 
 Removed Options
 ~~~~~~~~~~~~~~~
@@ -375,6 +382,8 @@ Helm Options
 * Helm option ``enableRuntimeDeviceDetection`` is now deprecated and is a no-op.
 * The IP addresses on which to expose NodePort services can now be configured with ``nodePort.addresses``. Prior to this, Cilium only
   exposed NodePort services on the first (preferably private) IPv4 and IPv6 address of each device.
+* Helm option ``enableCiliumEndpointSlice`` has been deprecated and will be removed in a future release.
+  The option has been replaced by ``ciliumEndpointSlice.enabled``.
 
 Added Metrics
 ~~~~~~~~~~~~~

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -162,6 +162,8 @@ contributors across the globe, there is almost always someone available to help.
 | cgroup.autoMount.enabled | bool | `true` | Enable auto mount of cgroup2 filesystem. When `autoMount` is enabled, cgroup2 filesystem is mounted at `cgroup.hostRoot` path on the underlying host and inside the cilium agent pod. If users disable `autoMount`, it's expected that users have mounted cgroup2 filesystem at the specified `cgroup.hostRoot` volume, and then the volume will be mounted inside the cilium agent pod at the same path. |
 | cgroup.autoMount.resources | object | `{}` | Init Container Cgroup Automount resource limits & requests |
 | cgroup.hostRoot | string | `"/run/cilium/cgroupv2"` | Configure cgroup root where cgroup2 filesystem is mounted on the host (see also: `cgroup.autoMount`) |
+| ciliumEndpointSlice.enabled | bool | `false` | Enable Cilium EndpointSlice feature. |
+| ciliumEndpointSlice.rateLimits | list | `[{"burst":20,"limit":10,"nodes":0},{"burst":15,"limit":7,"nodes":100},{"burst":10,"limit":5,"nodes":500}]` | List of rate limit options to be used for the CiliumEndpointSlice controller. Each object in the list must have the following fields: nodes: Count of nodes at which to apply the rate limit. limit: The sustained request rate in requests per second. The maximum rate that can be configured is 50. burst: The burst request rate in requests per second. The maximum burst that can be configured is 100. |
 | cleanBpfState | bool | `false` | Clean all eBPF datapath state from the initContainer of the cilium-agent DaemonSet.  WARNING: Use with care! |
 | cleanState | bool | `false` | Clean all local Cilium state from the initContainer of the cilium-agent DaemonSet. Implies cleanBpfState: true.  WARNING: Use with care! |
 | cluster.id | int | `0` | Unique ID of the cluster. Must be unique across all connected clusters and in the range of 1 to 255. Only required for Cluster Mesh, may be 0 if Cluster Mesh is not used. |
@@ -287,7 +289,7 @@ contributors across the globe, there is almost always someone available to help.
 | dnsProxy.proxyResponseMaxDelay | string | `"100ms"` | The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. |
 | egressGateway.enabled | bool | `false` | Enables egress gateway to redirect and SNAT the traffic that leaves the cluster. |
 | egressGateway.reconciliationTriggerInterval | string | `"1s"` | Time between triggers of egress gateway state reconciliations |
-| enableCiliumEndpointSlice | bool | `false` | Enable CiliumEndpointSlice feature. |
+| enableCiliumEndpointSlice | bool | `false` | Enable CiliumEndpointSlice feature (deprecated, please use `ciliumEndpointSlice.enabled` instead). |
 | enableCriticalPriorityClass | bool | `true` | Explicitly enable or disable priority class. .Capabilities.KubeVersion is unsettable in `helm template` calls, it depends on k8s libraries version that Helm was compiled against. This option allows to explicitly disable setting the priority class, which is useful for rendering charts for gke clusters in advance. |
 | enableIPv4BIGTCP | bool | `false` | Enables IPv4 BIG TCP support which increases maximum IPv4 GSO/GRO limits for nodes and pods |
 | enableIPv4Masquerade | bool | `true` | Enables masquerading of IPv4 traffic leaving the node from endpoints. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1148,8 +1148,11 @@ data:
   disable-external-ip-mitigation: {{ .Values.bpf.disableExternalIPMitigation | quote }}
 {{- end }}
 
-{{- if .Values.enableCiliumEndpointSlice }}
+{{- if or .Values.ciliumEndpointSlice.enabled .Values.enableCiliumEndpointSlice }}
   enable-cilium-endpoint-slice: "true"
+  {{- if .Values.ciliumEndpointSlice.rateLimits }}
+  ces-rate-limits: {{ .Values.ciliumEndpointSlice.rateLimits | toJson | quote }}
+  {{- end }}
 {{- end }}
 
 {{- if hasKey .Values "enableK8sTerminatingEndpoint" }}

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -73,9 +73,9 @@
 {{- end }}
 
 {{/* validate Cilium operator */}}
-{{- if eq .Values.enableCiliumEndpointSlice true }}
+{{- if or .Values.ciliumEndpointSlice.enabled .Values.enableCiliumEndpointSlice }}
   {{- if eq .Values.disableEndpointCRD true }}
-    {{ fail "if Cilium Endpoint Slice is enabled (.Values.enableCiliumEndpointSlice=true), it requires .Values.disableEndpointCRD=false" }}
+    {{ fail "if Cilium Endpoint Slice is enabled (.Values.ciliumEndpointSlice.enabled=true), it requires .Values.disableEndpointCRD=false" }}
   {{- end }}
 {{- end }}
 

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -713,6 +713,60 @@
       },
       "type": "object"
     },
+    "ciliumEndpointSlice": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "rateLimits": {
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "burst": {
+                    "type": "integer"
+                  },
+                  "limit": {
+                    "type": "integer"
+                  },
+                  "nodes": {
+                    "type": "integer"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "burst": {
+                    "type": "integer"
+                  },
+                  "limit": {
+                    "type": "integer"
+                  },
+                  "nodes": {
+                    "type": "integer"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "burst": {
+                    "type": "integer"
+                  },
+                  "limit": {
+                    "type": "integer"
+                  },
+                  "nodes": {
+                    "type": "integer"
+                  }
+                }
+              }
+            ]
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "cleanBpfState": {
       "type": "boolean"
     },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -702,8 +702,26 @@ enableRuntimeDeviceDetection: true
 # -- Enable Kubernetes EndpointSlice feature in Cilium if the cluster supports it.
 # enableK8sEndpointSlice: true
 
-# -- Enable CiliumEndpointSlice feature.
+# -- Enable CiliumEndpointSlice feature (deprecated, please use `ciliumEndpointSlice.enabled` instead).
 enableCiliumEndpointSlice: false
+ciliumEndpointSlice:
+  # -- Enable Cilium EndpointSlice feature.
+  enabled: false
+  # -- List of rate limit options to be used for the CiliumEndpointSlice controller.
+  # Each object in the list must have the following fields:
+  # nodes: Count of nodes at which to apply the rate limit.
+  # limit: The sustained request rate in requests per second. The maximum rate that can be configured is 50.
+  # burst: The burst request rate in requests per second. The maximum burst that can be configured is 100.
+  rateLimits:
+    - nodes: 0
+      limit: 10
+      burst: 20
+    - nodes: 100
+      limit: 7
+      burst: 15
+    - nodes: 500
+      limit: 5
+      burst: 10
 envoyConfig:
   # -- Enable CiliumEnvoyConfig CRD
   # CiliumEnvoyConfig CRD can also be implicitly enabled by other options.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -701,8 +701,28 @@ enableRuntimeDeviceDetection: true
 # -- Enable Kubernetes EndpointSlice feature in Cilium if the cluster supports it.
 # enableK8sEndpointSlice: true
 
-# -- Enable CiliumEndpointSlice feature.
+# -- Enable CiliumEndpointSlice feature (deprecated, please use `ciliumEndpointSlice.enabled` instead).
 enableCiliumEndpointSlice: false
+
+ciliumEndpointSlice:
+  # -- Enable Cilium EndpointSlice feature.
+  enabled: false
+  # -- List of rate limit options to be used for the CiliumEndpointSlice controller.
+  # Each object in the list must have the following fields:
+  # nodes: Count of nodes at which to apply the rate limit.
+  # limit: The sustained request rate in requests per second. The maximum rate that can be configured is 50.
+  # burst: The burst request rate in requests per second. The maximum burst that can be configured is 100.
+  rateLimits:
+  - nodes: 0
+    limit: 10
+    burst: 20
+  - nodes: 100
+    limit: 7
+    burst: 15
+  - nodes: 500
+    limit: 5
+    burst: 10
+
 envoyConfig:
   # -- Enable CiliumEnvoyConfig CRD
   # CiliumEnvoyConfig CRD can also be implicitly enabled by other options.

--- a/operator/pkg/ciliumendpointslice/cell.go
+++ b/operator/pkg/ciliumendpointslice/cell.go
@@ -4,6 +4,8 @@
 package ciliumendpointslice
 
 import (
+	"fmt"
+
 	"github.com/cilium/hive/cell"
 	"github.com/spf13/pflag"
 
@@ -43,6 +45,9 @@ const (
 	// CESDynamicRateLimitQPSBurst is used to specify the list of qps bursts for the
 	// dynamic rate limit steps.
 	CESDynamicRateLimitQPSBurst = "ces-dynamic-rate-limit-qps-burst"
+
+	// CESRateLimits can be used to configure a custom, stepped dynamic rate limit based on cluster size.
+	CESRateLimits = "ces-rate-limits"
 )
 
 // Cell is a cell that implements a Cilium Endpoint Slice Controller.
@@ -65,29 +70,34 @@ type Config struct {
 	CESDynamicRateLimitNodes    []string `mapstructure:"ces-dynamic-rate-limit-nodes"`
 	CESDynamicRateLimitQPSLimit []string `mapstructure:"ces-dynamic-rate-limit-qps-limit"`
 	CESDynamicRateLimitQPSBurst []string `mapstructure:"ces-dynamic-rate-limit-qps-burst"`
+	CESDynamicRateLimitConfig   string   `mapstructure:"ces-rate-limits"`
 }
 
 var defaultConfig = Config{
-	CESMaxCEPsInCES:             100,
-	CESSlicingMode:              "cesSliceModeIdentity",
-	CESWriteQPSLimit:            10,
-	CESWriteQPSBurst:            20,
-	CESEnableDynamicRateLimit:   false,
-	CESDynamicRateLimitNodes:    []string{},
-	CESDynamicRateLimitQPSLimit: []string{},
-	CESDynamicRateLimitQPSBurst: []string{},
+	CESMaxCEPsInCES:           100,
+	CESSlicingMode:            "cesSliceModeIdentity",
+	CESDynamicRateLimitConfig: "[{\"nodes\":0,\"limit\":10,\"burst\":20}]",
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {
+	depUseDLR := fmt.Sprintf("dynamic rate limiting is now configured by default. Please use --%s to supply a custom config", CESRateLimits)
 	flags.Int(CESMaxCEPsInCES, def.CESMaxCEPsInCES, "Maximum number of CiliumEndpoints allowed in a CES")
 	flags.String(CESSlicingMode, def.CESSlicingMode, "Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity (\"cesSliceModeIdentity\") or batched on a \"First Come, First Served\" basis (\"cesSliceModeFCFS\")")
 	flags.Float64(CESWriteQPSLimit, def.CESWriteQPSLimit, "CES work queue rate limit. Ignored when "+CESEnableDynamicRateLimit+" is set")
+	flags.MarkDeprecated(CESWriteQPSLimit, depUseDLR)
 	flags.Int(CESWriteQPSBurst, def.CESWriteQPSBurst, "CES work queue burst rate. Ignored when "+CESEnableDynamicRateLimit+" is set")
+	flags.MarkDeprecated(CESWriteQPSBurst, depUseDLR)
 
 	flags.Bool(CESEnableDynamicRateLimit, def.CESEnableDynamicRateLimit, "Flag to enable dynamic rate limit specified in separate fields instead of the static one")
+	flags.MarkDeprecated(CESEnableDynamicRateLimit, depUseDLR)
 	flags.StringSlice(CESDynamicRateLimitNodes, def.CESDynamicRateLimitNodes, "List of nodes used for the dynamic rate limit steps")
+	flags.MarkDeprecated(CESDynamicRateLimitNodes, depUseDLR)
 	flags.StringSlice(CESDynamicRateLimitQPSLimit, def.CESDynamicRateLimitQPSLimit, "List of qps limits used for the dynamic rate limit steps")
+	flags.MarkDeprecated(CESDynamicRateLimitQPSLimit, depUseDLR)
 	flags.StringSlice(CESDynamicRateLimitQPSBurst, def.CESDynamicRateLimitQPSBurst, "List of qps burst used for the dynamic rate limit steps")
+	flags.MarkDeprecated(CESDynamicRateLimitQPSBurst, depUseDLR)
+
+	flags.String(CESRateLimits, def.CESDynamicRateLimitConfig, "Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string.")
 }
 
 // SharedConfig contains the configuration that is shared between

--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -75,11 +75,21 @@ type Controller struct {
 }
 
 // registerController creates and initializes the CES controller
-func registerController(p params) {
+func registerController(p params) error {
 	clientset, err := p.NewClient("ciliumendpointslice-controller")
-	if err != nil || !clientset.IsEnabled() || !p.SharedCfg.EnableCiliumEndpointSlice {
-		return
+	if err != nil {
+		return err
 	}
+	if !clientset.IsEnabled() || !p.SharedCfg.EnableCiliumEndpointSlice {
+		return nil
+	}
+
+	rateLimitConfig, err := getRateLimitConfig(p)
+	if err != nil {
+		return err
+	}
+
+	checkDeprecatedOpts(p.Cfg, p.Logger)
 
 	cesController := &Controller{
 		logger:              p.Logger,
@@ -89,10 +99,28 @@ func registerController(p params) {
 		ciliumNodes:         p.CiliumNodes,
 		slicingMode:         p.Cfg.CESSlicingMode,
 		maxCEPsInCES:        p.Cfg.CESMaxCEPsInCES,
-		rateLimit:           getRateLimitConfig(p),
+		rateLimit:           rateLimitConfig,
 		enqueuedAt:          make(map[CESName]time.Time),
 		metrics:             p.Metrics,
 	}
 
 	p.Lifecycle.Append(cesController)
+	return nil
+}
+
+// checkDeprecatedOpts will log an error if the user has supplied any of the
+// no-op, deprecated rate limit options.
+// TODO: Remove this function when the deprecated options are removed.
+func checkDeprecatedOpts(cfg Config, logger logrus.FieldLogger) {
+	switch {
+	case cfg.CESWriteQPSLimit > 0:
+	case cfg.CESWriteQPSBurst > 0:
+	case cfg.CESEnableDynamicRateLimit:
+	case len(cfg.CESDynamicRateLimitNodes) > 0:
+	case len(cfg.CESDynamicRateLimitQPSLimit) > 0:
+	case len(cfg.CESDynamicRateLimitQPSBurst) > 0:
+	default:
+		return
+	}
+	logger.Errorf("You are using deprecated rate limit option(s) that have no effect. To configure custom rate limits please use --%s", CESRateLimits)
 }

--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -34,10 +34,6 @@ const (
 	maxRetries = 15
 	// CEPs are batched into a CES, based on its Identity
 	cesIdentityBasedSlicing = "cesSliceModeIdentity"
-	// default qps limit value for workqueues, this only for retries.
-	CESControllerWorkQueueQPSLimit = 10
-	// default burst limit value for workqueues.
-	CESControllerWorkQueueBurstLimit = 100
 	// Default CES Synctime, multiple consecutive syncs with k8s-apiserver are
 	// batched and synced together after a short delay.
 	DefaultCESSyncTime = 500 * time.Millisecond
@@ -131,9 +127,7 @@ func (c *Controller) Start(ctx cell.HookContext) error {
 	c.wp = workerpool.New(3)
 	c.wp.Submit("cilium-endpoints-updater", c.runCiliumEndpointsUpdater)
 	c.wp.Submit("cilium-endpoint-slices-updater", c.runCiliumEndpointSliceUpdater)
-	if c.rateLimit.hasDynamicRateLimiting() {
-		c.wp.Submit("cilium-nodes-updater", c.runCiliumNodesUpdater)
-	}
+	c.wp.Submit("cilium-nodes-updater", c.runCiliumNodesUpdater)
 
 	c.logger.Info("Starting CES controller reconciler.")
 	go c.worker()

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -50,6 +50,8 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 	hive.Start(tlog, context.Background())
 	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
+	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
+	assert.NoError(t, err)
 	cesController := &Controller{
 		logger:              log,
 		clientset:           fakeClient.Clientset,
@@ -57,7 +59,7 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 		ciliumEndpointSlice: ciliumEndpointSlice,
 		reconciler:          r,
 		manager:             m,
-		rateLimit:           getRateLimitConfig(params{Cfg: Config{CESWriteQPSLimit: 2, CESWriteQPSBurst: 1}}),
+		rateLimit:           rateLimitConfig,
 		enqueuedAt:          make(map[CESName]time.Time),
 	}
 	cesController.initializeQueue()
@@ -118,6 +120,8 @@ func TestIdentityModeSyncCESsInLocalCache(t *testing.T) {
 	hive.Start(tlog, context.Background())
 	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
+	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
+	assert.NoError(t, err)
 	cesController := &Controller{
 		logger:              log,
 		clientset:           fakeClient.Clientset,
@@ -125,7 +129,7 @@ func TestIdentityModeSyncCESsInLocalCache(t *testing.T) {
 		ciliumEndpointSlice: ciliumEndpointSlice,
 		reconciler:          r,
 		manager:             m,
-		rateLimit:           getRateLimitConfig(params{Cfg: Config{CESWriteQPSLimit: 2, CESWriteQPSBurst: 1}}),
+		rateLimit:           rateLimitConfig,
 		enqueuedAt:          make(map[CESName]time.Time),
 	}
 	cesController.initializeQueue()

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2576,10 +2576,10 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		options["imagePullSecrets[0].name"] = config.RegistrySecretName
 	}
 
-	if _, found := options["enableCiliumEndpointSlice"]; !found &&
+	if _, found := options["ciliumEndpointSlice.enabled"]; !found &&
 		CiliumEndpointSliceFeatureEnabled() {
 
-		options["enableCiliumEndpointSlice"] = "true"
+		options["ciliumEndpointSlice.enabled"] = "true"
 	}
 
 	if !SupportIPv6Connectivity() {


### PR DESCRIPTION
The CiliumEndpointSlice controller has 6 rate limit related config options. This PR attempts to simplify configuration by reducing that set to 2: one for supplying a custom, dynamic rate limit config, and another to supply a base multiplier for simple tuning of an existing config.

Note: The supplied default dynamic rate limit may need some adjustment. This will likely be updated after future scale testing and/or PR feedback.

See individual commits for more details

```release-note
Simplify rate limit configuration options for the CiliumEndpointSlice controller.
```
