### PR TITLE
bpf: trace: identify ifindex 0 as TRACE_IFINDEX_UNKNOWN

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1224,8 +1224,8 @@ handle_netdev(struct __ctx_buff *ctx, const bool from_host)
 		return send_drop_notify(ctx, sec_label, id, 0, ret,
 					CTX_ACT_DROP, METRIC_EGRESS);
 #else
-		send_trace_notify(ctx, TRACE_TO_STACK, HOST_ID, 0, 0, 0,
-				  TRACE_REASON_UNKNOWN, 0);
+		send_trace_notify(ctx, TRACE_TO_STACK, HOST_ID, 0, 0,
+				  TRACE_IFINDEX_UNKNOWN, TRACE_REASON_UNKNOWN, 0);
 		/* Pass unknown traffic to the stack */
 		return CTX_ACT_OK;
 #endif /* ENABLE_HOST_FIREWALL */
@@ -1441,7 +1441,8 @@ skip_host_firewall:
 			 * for tracepoint
 			 */
 			send_trace_notify(ctx, TRACE_TO_STACK, 0, 0, 0,
-					  0, TRACE_REASON_ENCRYPT_OVERLAY, 0);
+					  TRACE_IFINDEX_UNKNOWN,
+					  TRACE_REASON_ENCRYPT_OVERLAY, 0);
 			return ret;
 		}
 		if (IS_ERR(ret))
@@ -1510,7 +1511,7 @@ exit:
 		goto drop_err;
 
 	send_trace_notify(ctx, TRACE_TO_NETWORK, 0, 0, 0,
-			  0, trace.reason, trace.monitor);
+			  TRACE_IFINDEX_UNKNOWN, trace.reason, trace.monitor);
 
 	return ret;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1300,7 +1300,8 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 			return CTX_ACT_OK;
 
 		send_trace_notify(ctx, TRACE_TO_PROXY, src_sec_identity, 0,
-				  bpf_ntohs((__u16)svc->l7_lb_proxy_port), 0,
+				  bpf_ntohs((__u16)svc->l7_lb_proxy_port),
+				  TRACE_IFINDEX_UNKNOWN,
 				  TRACE_REASON_POLICY, monitor);
 		return ctx_redirect_to_proxy_hairpin_ipv6(ctx,
 							  (__be16)svc->l7_lb_proxy_port);
@@ -2833,7 +2834,8 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 			return CTX_ACT_OK;
 
 		send_trace_notify(ctx, TRACE_TO_PROXY, src_sec_identity, 0,
-				  bpf_ntohs((__u16)svc->l7_lb_proxy_port), 0,
+				  bpf_ntohs((__u16)svc->l7_lb_proxy_port),
+				  TRACE_IFINDEX_UNKNOWN,
 				  TRACE_REASON_POLICY, monitor);
 		return ctx_redirect_to_proxy_hairpin_ipv4(ctx, ip4,
 							  (__be16)svc->l7_lb_proxy_port);

--- a/bpf/lib/srv6.h
+++ b/bpf/lib/srv6.h
@@ -479,8 +479,8 @@ int tail_srv6_encap(struct __ctx_buff *ctx)
 		return send_drop_notify_error(ctx, SECLABEL_IPV6, ret, CTX_ACT_DROP,
 					      METRIC_EGRESS);
 
-	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL_IPV6, 0, 0, 0,
-			  TRACE_REASON_SRV6_ENCAP, 0);
+	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL_IPV6, 0, 0,
+			  TRACE_IFINDEX_UNKNOWN, TRACE_REASON_SRV6_ENCAP, 0);
 
 	return ret;
 }
@@ -498,8 +498,8 @@ int tail_srv6_decap(struct __ctx_buff *ctx)
 	if (ret < 0)
 		goto error_drop;
 
-	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL_IPV6, 0, 0, 0,
-			  TRACE_REASON_SRV6_DECAP, 0);
+	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL_IPV6, 0, 0,
+			  TRACE_IFINDEX_UNKNOWN, TRACE_REASON_SRV6_DECAP, 0);
 	return CTX_ACT_OK;
 error_drop:
 		return send_drop_notify_error(ctx, SECLABEL_IPV6, ret, CTX_ACT_DROP,

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -68,6 +68,8 @@ enum {
 	TRACE_AGGREGATE_ACTIVE_CT = 3, /* Ratelimit active connection traces */
 };
 
+#define TRACE_IFINDEX_UNKNOWN		0	/* Linux kernel doesn't use ifindex 0 */
+
 #ifndef MONITOR_AGGREGATION
 #define MONITOR_AGGREGATION TRACE_AGGREGATE_NONE
 #endif


### PR DESCRIPTION
Self-document what the ifindex 0 actually means, and make it easier to spot locations that would benefit from additional trace information.

The naming is aligned with TRACE_REASON_UNKNOWN.