### PR TITLE
ci: increase wait duration after upgrade/downgrade in E2E upgrade test

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -432,7 +432,7 @@ jobs:
           ./cilium-cli upgrade \
             ${{ steps.cilium-newest-config.outputs.config }}
 
-          ./cilium-cli status --wait
+          ./cilium-cli status --wait --wait-duration=10m
           kubectl get pods --all-namespaces -o wide
           kubectl -n kube-system exec daemonset/cilium -- cilium status
 
@@ -463,7 +463,7 @@ jobs:
           ./cilium-cli upgrade \
             ${{ steps.cilium-stable-config.outputs.config }}
 
-          ./cilium-cli status --wait
+          ./cilium-cli status --wait --wait-duration=10m
           kubectl get pods --all-namespaces -o wide
           kubectl -n kube-system exec daemonset/cilium -- cilium status
 


### PR DESCRIPTION
E2E Upgrade tests randomly fail if health endpoints aren't available after an upgrade within the given default timeout of 5min.

```
Errors:                cilium             cilium-c4qkb    controller cilium-health-ep is failing since 2m7s (15x): Get "http://10.244.2.186:4240/hello": dial tcp 10.244.2.186:4240: connect: no route to host
```

It looks like the health server unix listener isn't available at that time. (log message `Serving cilium health API at unix:///var/run/cilium/health.sock` is still missing)


Therefore, this commit increases the timeout from 5 to 10 minutes.

Suggested-by: Marco Iorio <marco.iorio@isovalent.com>