### PR TITLE
healthv2: change count to be the total update count.

### DIFF
--- a/pkg/health/client/modules.go
+++ b/pkg/health/client/modules.go
@@ -109,7 +109,7 @@ func upsertTree(r *node, report *types.Status, stack []string) {
 	if len(stack) == 1 {
 		name := stack[0]
 		meta := fmt.Sprintf("[%s] %s", strings.ToUpper(string(report.Level)), report.Message)
-		meta += fmt.Sprintf(" (%s, x%d)", ToAgeHuman(report.Updated), report.Count)
+		meta += fmt.Sprintf(" (%s, x%d)", ToAgeHuman(report.LastChange), report.Count)
 		for _, c := range r.nodes {
 			if c.val == name {
 				c.meta = meta

--- a/pkg/healthv2/provider_test.go
+++ b/pkg/healthv2/provider_test.go
@@ -72,7 +72,7 @@ func TestProvider(t *testing.T) {
 
 			assert.Len(degraded, 1)
 			assert.Equal(fmt.Errorf("err0"), degraded[0].Error)
-			assert.Equal(degraded[0].Count, uint64(1))
+			assert.Equal(degraded[0].Count, uint64(2), "ensure total update count is correct")
 
 			ok := byLevel(db, statusTable, types.LevelOK)
 			assert.Len(ok, 2)

--- a/pkg/healthv2/types/types.go
+++ b/pkg/healthv2/types/types.go
@@ -56,12 +56,19 @@ type Status struct {
 	Level   Level
 	Message string
 	Error   error
-	LastOK  time.Time
+
+	// Updated is the time of the last update.
 	Updated time.Time
 	Stopped time.Time
 	// Final is the final message set when a status is stopped.
 	Final string
+
+	// Count is the total number of times this status has been updated,
+	// initialized upon the first upsert of a status with this ID.
 	Count uint64
+
+	// LastChange is the time of the last level state transition.
+	LastChange time.Time
 }
 
 func (Status) TableHeader() []string {
@@ -69,7 +76,7 @@ func (Status) TableHeader() []string {
 }
 
 func (s Status) TableRow() []string {
-	return []string{s.ID.Module.String(), s.ID.Component.String(), string(s.Level), s.Message, s.LastOK.Format(time.RFC3339),
+	return []string{s.ID.Module.String(), s.ID.Component.String(), string(s.Level), s.Message, s.LastChange.Format(time.RFC3339),
 		s.Updated.Format(time.RFC3339), fmt.Sprintf("%d", s.Count)}
 }
 


### PR DESCRIPTION
Previously, this was the number of updates in this state level which was reset after a transition.
This would be more intuitive and useful if its just a counter of total updates since the reporter was created.

As well, we'll now store a "time in state level" timestamp which is how long it's been in the current state.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
