### PR TITLE
bpf: Remove `__always_inline`

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -58,12 +58,12 @@
 #define FROM_HOST_FLAG_NEED_HOSTFW (1 << 1)
 #define FROM_HOST_FLAG_HOST_ID (1 << 2)
 
-static __always_inline bool allow_vlan(__u32 __maybe_unused ifindex, __u32 __maybe_unused vlan_id) {
+static  bool allow_vlan(__u32 __maybe_unused ifindex, __u32 __maybe_unused vlan_id) {
 	VLAN_FILTER(ifindex, vlan_id);
 }
 
 #if defined(ENABLE_IPV4) || defined(ENABLE_IPV6)
-static __always_inline int rewrite_dmac_to_host(struct __ctx_buff *ctx)
+static  int rewrite_dmac_to_host(struct __ctx_buff *ctx)
 {
 	/* When attached to cilium_host, we rewrite the DMAC to the mac of
 	 * cilium_host (peer) to ensure the packet is being considered to be
@@ -83,14 +83,14 @@ static __always_inline int rewrite_dmac_to_host(struct __ctx_buff *ctx)
 # define SECCTX_FROM_IPCACHE	0
 #endif
 
-static __always_inline bool identity_from_ipcache_ok(void)
+static  bool identity_from_ipcache_ok(void)
 {
 	return SECCTX_FROM_IPCACHE == SECCTX_FROM_IPCACHE_OK;
 }
 #endif
 
 #ifdef ENABLE_IPV6
-static __always_inline __u32
+static  __u32
 resolve_srcid_ipv6(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 		   __u32 srcid_from_ipcache, __u32 *sec_identity,
 		   const bool from_host)
@@ -136,7 +136,7 @@ struct {
 	__uint(max_entries, 1);
 } CT_TAIL_CALL_BUFFER6 __section_maps_btf;
 
-static __always_inline int
+static  int
 handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 	    __u32 ipcache_srcid __maybe_unused,
 	    const bool from_host __maybe_unused,
@@ -226,7 +226,7 @@ skip_host_firewall:
 	return CTX_ACT_OK;
 }
 
-static __always_inline int
+static  int
 handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		 __s8 *ext_err __maybe_unused)
 {
@@ -403,7 +403,7 @@ skip_tunnel:
 	return CTX_ACT_OK;
 }
 
-static __always_inline int
+static  int
 tail_handle_ipv6_cont(struct __ctx_buff *ctx, bool from_host)
 {
 	__u32 src_sec_identity = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);
@@ -418,20 +418,20 @@ tail_handle_ipv6_cont(struct __ctx_buff *ctx, bool from_host)
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_CONT_FROM_HOST)
-static __always_inline
+static
 int tail_handle_ipv6_cont_from_host(struct __ctx_buff *ctx)
 {
 	return tail_handle_ipv6_cont(ctx, true);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_CONT_FROM_NETDEV)
-static __always_inline
+static
 int tail_handle_ipv6_cont_from_netdev(struct __ctx_buff *ctx)
 {
 	return tail_handle_ipv6_cont(ctx, false);
 }
 
-static __always_inline int
+static  int
 tail_handle_ipv6(struct __ctx_buff *ctx, __u32 ipcache_srcid, const bool from_host)
 {
 	__u32 src_sec_identity = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);
@@ -482,7 +482,7 @@ int tail_handle_ipv6_from_netdev(struct __ctx_buff *ctx)
 }
 
 # ifdef ENABLE_HOST_FIREWALL
-static __always_inline int
+static  int
 handle_to_netdev_ipv6(struct __ctx_buff *ctx, __u32 src_sec_identity,
 		      struct trace_ctx *trace, __s8 *ext_err)
 {
@@ -518,7 +518,7 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx, __u32 src_sec_identity,
 #endif /* ENABLE_IPV6 */
 
 #ifdef ENABLE_IPV4
-static __always_inline __u32
+static  __u32
 resolve_srcid_ipv4(struct __ctx_buff *ctx, struct iphdr *ip4,
 		   __u32 srcid_from_proxy, __u32 *sec_identity,
 		   const bool from_host)
@@ -566,7 +566,7 @@ struct {
 	__uint(max_entries, 1);
 } CT_TAIL_CALL_BUFFER4 __section_maps_btf;
 
-static __always_inline int
+static  int
 handle_ipv4(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 	    __u32 ipcache_srcid __maybe_unused,
 	    const bool from_host __maybe_unused,
@@ -653,7 +653,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 	return CTX_ACT_OK;
 }
 
-static __always_inline int
+static  int
 handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		 __s8 *ext_err __maybe_unused)
 {
@@ -859,7 +859,7 @@ skip_tunnel:
 	return CTX_ACT_OK;
 }
 
-static __always_inline int
+static  int
 tail_handle_ipv4_cont(struct __ctx_buff *ctx, bool from_host)
 {
 	__u32 src_sec_identity = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);
@@ -874,20 +874,20 @@ tail_handle_ipv4_cont(struct __ctx_buff *ctx, bool from_host)
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_CONT_FROM_HOST)
-static __always_inline
+static
 int tail_handle_ipv4_cont_from_host(struct __ctx_buff *ctx)
 {
 	return tail_handle_ipv4_cont(ctx, true);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_CONT_FROM_NETDEV)
-static __always_inline
+static
 int tail_handle_ipv4_cont_from_netdev(struct __ctx_buff *ctx)
 {
 	return tail_handle_ipv4_cont(ctx, false);
 }
 
-static __always_inline int
+static  int
 tail_handle_ipv4(struct __ctx_buff *ctx, __u32 ipcache_srcid, const bool from_host)
 {
 	__u32 src_sec_identity = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);
@@ -938,7 +938,7 @@ int tail_handle_ipv4_from_netdev(struct __ctx_buff *ctx)
 }
 
 #ifdef ENABLE_HOST_FIREWALL
-static __always_inline int
+static  int
 handle_to_netdev_ipv4(struct __ctx_buff *ctx, __u32 src_sec_identity,
 		      struct trace_ctx *trace, __s8 *ext_err)
 {
@@ -961,7 +961,7 @@ handle_to_netdev_ipv4(struct __ctx_buff *ctx, __u32 src_sec_identity,
 #endif /* ENABLE_IPV4 */
 
 #if defined(ENABLE_IPSEC) && defined(TUNNEL_MODE)
-static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx, __u32 src_id)
+static  int do_netdev_encrypt_encap(struct __ctx_buff *ctx, __u32 src_id)
 {
 	struct trace_ctx trace = {
 		.reason = TRACE_REASON_ENCRYPTED,
@@ -1003,7 +1003,7 @@ static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx, __u32
 #endif /* ENABLE_IPSEC && TUNNEL_MODE */
 
 #ifdef ENABLE_L2_ANNOUNCEMENTS
-static __always_inline int handle_l2_announcement(struct __ctx_buff *ctx)
+static  int handle_l2_announcement(struct __ctx_buff *ctx)
 {
 	union macaddr mac = NODE_MAC;
 	union macaddr smac;
@@ -1044,7 +1044,7 @@ static __always_inline int handle_l2_announcement(struct __ctx_buff *ctx)
 };
 #endif
 
-static __always_inline int
+static  int
 do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 {
 	enum trace_point trace = from_host ? TRACE_FROM_HOST :
@@ -1200,7 +1200,7 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
  *
  * Handle netdev traffic coming towards the Cilium-managed network.
  */
-static __always_inline int
+static  int
 handle_netdev(struct __ctx_buff *ctx, const bool from_host)
 {
 	__u16 proto;
@@ -1317,7 +1317,7 @@ int cil_from_host(struct __ctx_buff *ctx)
  *
  * IS_ERR can be used to determine if this function ran into an error.
  */
-static __always_inline int do_encrypt_overlay(struct __ctx_buff *ctx)
+static  int do_encrypt_overlay(struct __ctx_buff *ctx)
 {
 	int ret = CTX_ACT_OK;
 	struct iphdr __maybe_unused *ipv4;
@@ -1610,7 +1610,7 @@ out:
 #if defined(ENABLE_HOST_FIREWALL)
 #ifdef ENABLE_IPV6
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_TO_HOST_POLICY_ONLY)
-static __always_inline
+static
 int tail_ipv6_host_policy_ingress(struct __ctx_buff *ctx)
 {
 	struct trace_ctx __maybe_unused trace = {
@@ -1631,7 +1631,7 @@ int tail_ipv6_host_policy_ingress(struct __ctx_buff *ctx)
 
 #ifdef ENABLE_IPV4
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_TO_HOST_POLICY_ONLY)
-static __always_inline
+static
 int tail_ipv4_host_policy_ingress(struct __ctx_buff *ctx)
 {
 	struct trace_ctx __maybe_unused trace = {
@@ -1650,7 +1650,7 @@ int tail_ipv4_host_policy_ingress(struct __ctx_buff *ctx)
 }
 #endif /* ENABLE_IPV4 */
 
-static __always_inline int
+static  int
 /* Handles packet from a local endpoint entering the host namespace. Applies
  * ingress host policies.
  */
@@ -1707,7 +1707,7 @@ out:
  * endpoint's namespace. Applies egress host policies before handling
  * control back to bpf_lxc.
  */
-static __always_inline int
+static  int
 from_host_to_lxc(struct __ctx_buff *ctx, __s8 *ext_err)
 {
 	struct trace_ctx trace = {

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -72,7 +72,7 @@
 #ifdef ENABLE_PER_PACKET_LB
 
 #ifdef ENABLE_IPV4
-static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *ip4,
+static  int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *ip4,
 						       __s8 *ext_err)
 {
 	struct ipv4_ct_tuple tuple = {};
@@ -126,7 +126,7 @@ skip_service_lookup:
 #endif /* ENABLE_IPV4 */
 
 #ifdef ENABLE_IPV6
-static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr *ip6,
+static  int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr *ip6,
 						       __s8 *ext_err)
 {
 	struct ipv6_ct_tuple tuple = {};
@@ -189,7 +189,7 @@ skip_service_lookup:
 #endif
 
 #ifdef ENABLE_IPV4
-static __always_inline void *
+static  void *
 select_ct_map4(struct __ctx_buff *ctx __maybe_unused, int dir __maybe_unused,
 	       struct ipv4_ct_tuple *tuple)
 {
@@ -205,7 +205,7 @@ select_ct_map4(struct __ctx_buff *ctx __maybe_unused, int dir __maybe_unused,
 #endif
 
 #if defined ENABLE_IPV4 || defined ENABLE_IPV6
-static __always_inline int drop_for_direction(struct __ctx_buff *ctx,
+static  int drop_for_direction(struct __ctx_buff *ctx,
 					      enum ct_dir dir, __u32 reason,
 					      __s8 ext_err)
 {
@@ -251,7 +251,7 @@ static __always_inline int drop_for_direction(struct __ctx_buff *ctx,
 
 #define TAIL_CT_LOOKUP4(ID, NAME, DIR, CONDITION, TARGET_ID, TARGET_NAME)	\
 __section_tail(CILIUM_MAP_CALLS, ID)						\
-static __always_inline								\
+static 								\
 int NAME(struct __ctx_buff *ctx)						\
 {										\
 	struct ct_buffer4 ct_buffer = {};					\
@@ -297,7 +297,7 @@ int NAME(struct __ctx_buff *ctx)						\
 
 #define TAIL_CT_LOOKUP6(ID, NAME, DIR, CONDITION, TARGET_ID, TARGET_NAME)	\
 __section_tail(CILIUM_MAP_CALLS, ID)						\
-static __always_inline								\
+static 								\
 int NAME(struct __ctx_buff *ctx)						\
 {										\
 	struct ct_buffer6 ct_buffer = {};					\
@@ -351,7 +351,7 @@ int NAME(struct __ctx_buff *ctx)						\
  * We encode it so that custom programs can retrieve it and use it at their
  * convenience.
  */
-static __always_inline int
+static  int
 encode_custom_prog_meta(struct __ctx_buff *ctx, int ret, __u32 identity)
 {
 	__u32 custom_meta = 0;
@@ -382,7 +382,7 @@ struct {
  * In the case of the caller doing the service translation it passes in state via CB,
  * which we take in with lb6_ctx_restore_state().
  */
-static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *dst_sec_identity,
+static  int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *dst_sec_identity,
 						__s8 *ext_err)
 {
 	struct ct_state *ct_state, ct_state_new = {};
@@ -738,7 +738,7 @@ encrypt_to_stack:
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_FROM_LXC_CONT)
-static __always_inline
+static
 int tail_handle_ipv6_cont(struct __ctx_buff *ctx)
 {
 	__u32 dst_sec_identity = 0;
@@ -765,7 +765,7 @@ TAIL_CT_LOOKUP6(CILIUM_CALL_IPV6_CT_EGRESS, tail_ipv6_ct_egress, CT_EGRESS,
 		is_defined(ENABLE_PER_PACKET_LB),
 		CILIUM_CALL_IPV6_FROM_LXC_CONT, tail_handle_ipv6_cont)
 
-static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx,
+static  int __tail_handle_ipv6(struct __ctx_buff *ctx,
 					      __s8 *ext_err __maybe_unused)
 {
 	void *data, *data_end;
@@ -818,7 +818,7 @@ struct {
  * In the case of the caller doing the service translation it passes in state via CB,
  * which we take in with lb4_ctx_restore_state().
  */
-static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *dst_sec_identity,
+static  int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *dst_sec_identity,
 						__s8 *ext_err)
 {
 	struct ct_state *ct_state, ct_state_new = {};
@@ -1330,7 +1330,7 @@ encrypt_to_stack:
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_FROM_LXC_CONT)
-static __always_inline
+static
 int tail_handle_ipv4_cont(struct __ctx_buff *ctx)
 {
 	__u32 dst_sec_identity = 0;
@@ -1358,7 +1358,7 @@ TAIL_CT_LOOKUP4(CILIUM_CALL_IPV4_CT_EGRESS, tail_ipv4_ct_egress, CT_EGRESS,
 		is_defined(ENABLE_PER_PACKET_LB),
 		CILIUM_CALL_IPV4_FROM_LXC_CONT, tail_handle_ipv4_cont)
 
-static __always_inline int __tail_handle_ipv4(struct __ctx_buff *ctx,
+static  int __tail_handle_ipv4(struct __ctx_buff *ctx,
 					      __s8 *ext_err __maybe_unused)
 {
 	void *data, *data_end;
@@ -1511,7 +1511,7 @@ out:
 }
 
 #ifdef ENABLE_IPV6
-static __always_inline int
+static  int
 ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, int ifindex, __u32 src_label,
 	    struct ipv6_ct_tuple *tuple_out, __s8 *ext_err, __u16 *proxy_port,
 	    bool from_tunnel)
@@ -1662,7 +1662,7 @@ skip_policy_enforcement:
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_TO_LXC_POLICY_ONLY)
-static __always_inline
+static
 int tail_ipv6_policy(struct __ctx_buff *ctx)
 {
 	struct ipv6_ct_tuple tuple = {};
@@ -1833,7 +1833,7 @@ TAIL_CT_LOOKUP6(CILIUM_CALL_IPV6_CT_INGRESS, tail_ipv6_ct_ingress, CT_INGRESS,
 #endif /* ENABLE_IPV6 */
 
 #ifdef ENABLE_IPV4
-static __always_inline int
+static  int
 ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, int ifindex, __u32 src_label,
 	    struct ipv4_ct_tuple *tuple_out, __s8 *ext_err, __u16 *proxy_port,
 	    bool from_tunnel)
@@ -2020,7 +2020,7 @@ skip_policy_enforcement:
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_TO_LXC_POLICY_ONLY)
-static __always_inline
+static
 int tail_ipv4_policy(struct __ctx_buff *ctx)
 {
 	struct ipv4_ct_tuple tuple = {};
@@ -2102,7 +2102,7 @@ drop_err:
 				    ret, ext_err, CTX_ACT_DROP, METRIC_INGRESS);
 }
 
-static __always_inline bool
+static  bool
 ipv4_to_endpoint_is_hairpin_flow(struct __ctx_buff *ctx, struct iphdr *ip4)
 {
 	__be16 client_port, backend_port, service_port;

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -44,7 +44,7 @@
 #define overlay_ingress_policy_hook(ctx, ip4, identity, ext_err) CTX_ACT_OK
 
 #ifdef ENABLE_IPV6
-static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
+static  int handle_ipv6(struct __ctx_buff *ctx,
 				       __u32 *identity,
 				       __s8 *ext_err __maybe_unused)
 {
@@ -181,7 +181,7 @@ int tail_handle_ipv6(struct __ctx_buff *ctx)
 #endif /* ENABLE_IPV6 */
 
 #ifdef ENABLE_IPV4
-static __always_inline int ipv4_host_delivery(struct __ctx_buff *ctx, struct iphdr *ip4)
+static  int ipv4_host_delivery(struct __ctx_buff *ctx, struct iphdr *ip4)
 {
 #ifdef HOST_IFINDEX
 	if (1) {
@@ -203,7 +203,7 @@ static __always_inline int ipv4_host_delivery(struct __ctx_buff *ctx, struct iph
 }
 
 #if defined(ENABLE_CLUSTER_AWARE_ADDRESSING) && defined(ENABLE_INTER_CLUSTER_SNAT)
-static __always_inline int handle_inter_cluster_revsnat(struct __ctx_buff *ctx,
+static  int handle_inter_cluster_revsnat(struct __ctx_buff *ctx,
 							__u32 src_sec_identity,
 							__s8 *ext_err)
 {
@@ -273,7 +273,7 @@ int tail_handle_inter_cluster_revsnat(struct __ctx_buff *ctx)
 }
 #endif
 
-static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
+static  int handle_ipv4(struct __ctx_buff *ctx,
 				       __u32 *identity,
 				       __s8 *ext_err __maybe_unused)
 {
@@ -531,7 +531,7 @@ pass_to_stack:
 #endif /* ENABLE_IPV4 */
 
 #ifdef ENABLE_IPSEC
-static __always_inline bool is_esp(struct __ctx_buff *ctx, __u16 proto)
+static  bool is_esp(struct __ctx_buff *ctx, __u16 proto)
 {
 	void *data, *data_end;
 	__u8 protocol = 0;

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -83,7 +83,7 @@ struct {
 #endif /* CIDR6_FILTER */
 #endif /* ENABLE_PREFILTER */
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 bpf_xdp_exit(struct __ctx_buff *ctx, const int verdict)
 {
 	if (verdict == CTX_ACT_OK)
@@ -199,7 +199,7 @@ out:
 	return bpf_xdp_exit(ctx, ret);
 }
 
-static __always_inline int check_v4_lb(struct __ctx_buff *ctx)
+static  int check_v4_lb(struct __ctx_buff *ctx)
 {
 	__s8 ext_err = 0;
 	int ret;
@@ -209,14 +209,14 @@ static __always_inline int check_v4_lb(struct __ctx_buff *ctx)
 					  METRIC_INGRESS);
 }
 #else
-static __always_inline int check_v4_lb(struct __ctx_buff *ctx __maybe_unused)
+static  int check_v4_lb(struct __ctx_buff *ctx __maybe_unused)
 {
 	return CTX_ACT_OK;
 }
 #endif /* ENABLE_NODEPORT_ACCELERATION */
 
 #ifdef ENABLE_PREFILTER
-static __always_inline int check_v4(struct __ctx_buff *ctx)
+static  int check_v4(struct __ctx_buff *ctx)
 {
 	void *data_end = ctx_data_end(ctx);
 	void *data = ctx_data(ctx);
@@ -241,7 +241,7 @@ static __always_inline int check_v4(struct __ctx_buff *ctx)
 #endif /* CIDR4_FILTER */
 }
 #else
-static __always_inline int check_v4(struct __ctx_buff *ctx)
+static  int check_v4(struct __ctx_buff *ctx)
 {
 	return check_v4_lb(ctx);
 }
@@ -278,7 +278,7 @@ drop_err:
 					  CTX_ACT_DROP, METRIC_INGRESS);
 }
 
-static __always_inline int check_v6_lb(struct __ctx_buff *ctx)
+static  int check_v6_lb(struct __ctx_buff *ctx)
 {
 	__s8 ext_err = 0;
 	int ret;
@@ -288,14 +288,14 @@ static __always_inline int check_v6_lb(struct __ctx_buff *ctx)
 					  METRIC_INGRESS);
 }
 #else
-static __always_inline int check_v6_lb(struct __ctx_buff *ctx __maybe_unused)
+static  int check_v6_lb(struct __ctx_buff *ctx __maybe_unused)
 {
 	return CTX_ACT_OK;
 }
 #endif /* ENABLE_NODEPORT_ACCELERATION */
 
 #ifdef ENABLE_PREFILTER
-static __always_inline int check_v6(struct __ctx_buff *ctx)
+static  int check_v6(struct __ctx_buff *ctx)
 {
 	void *data_end = ctx_data_end(ctx);
 	void *data = ctx_data(ctx);
@@ -320,14 +320,14 @@ static __always_inline int check_v6(struct __ctx_buff *ctx)
 #endif /* CIDR6_FILTER */
 }
 #else
-static __always_inline int check_v6(struct __ctx_buff *ctx)
+static  int check_v6(struct __ctx_buff *ctx)
 {
 	return check_v6_lb(ctx);
 }
 #endif /* ENABLE_PREFILTER */
 #endif /* ENABLE_IPV6 */
 
-static __always_inline int check_filters(struct __ctx_buff *ctx)
+static  int check_filters(struct __ctx_buff *ctx)
 {
 	int ret = CTX_ACT_OK;
 	__u16 proto;

--- a/bpf/custom/bytecount.h
+++ b/bpf/custom/bytecount.h
@@ -8,7 +8,7 @@ struct {
 	__uint(max_entries, 1024);
 } bytecount_map __section_maps_btf;
 
-static __always_inline
+static
 void custom_prog(const struct __ctx_buff *ctx, __u32 identity)
 {
 	__u64 len, *bytecount;

--- a/bpf/include/bpf/access.h
+++ b/bpf/include/bpf/access.h
@@ -7,7 +7,7 @@
 #include "compiler.h"
 
 #if defined(__bpf__)
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 map_array_get_32(const __u32 *array, __u32 index, const __u32 limit)
 {
 	__u32 datum = 0;

--- a/bpf/include/bpf/builtins.h
+++ b/bpf/include/bpf/builtins.h
@@ -33,7 +33,7 @@
 		__it_fwd(a, op); __it_fwd(b, op);	\
 	} while (0)
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 __bpf_memset_builtin(void *d, __u8 c, __u64 len)
 {
 	/* Everything non-zero or non-const (currently unsupported) as c
@@ -42,7 +42,7 @@ __bpf_memset_builtin(void *d, __u8 c, __u64 len)
 	__builtin_memset(d, c, len);
 }
 
-static __always_inline void __bpf_memzero(void *d, __u64 len)
+static  void __bpf_memzero(void *d, __u64 len)
 {
 #if __clang_major__ >= 10
 	if (!__builtin_constant_p(len))
@@ -128,7 +128,7 @@ static __always_inline void __bpf_memzero(void *d, __u64 len)
 #endif
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 __bpf_no_builtin_memset(void *d __maybe_unused, __u8 c __maybe_unused,
 			__u64 len __maybe_unused)
 {
@@ -138,7 +138,7 @@ __bpf_no_builtin_memset(void *d __maybe_unused, __u8 c __maybe_unused,
 /* Redirect any direct use in our code to throw an error. */
 #define __builtin_memset	__bpf_no_builtin_memset
 
-static __always_inline __nobuiltin("memset") void memset(void *d, int c,
+static  __nobuiltin("memset") void memset(void *d, int c,
 							 __u64 len)
 {
 	if (__builtin_constant_p(len) && __builtin_constant_p(c) && c == 0)
@@ -147,14 +147,14 @@ static __always_inline __nobuiltin("memset") void memset(void *d, int c,
 		__bpf_memset_builtin(d, (__u8)c, len);
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 __bpf_memcpy_builtin(void *d, const void *s, __u64 len)
 {
 	/* Explicit opt-in for __builtin_memcpy(). */
 	__builtin_memcpy(d, s, len);
 }
 
-static __always_inline void __bpf_memcpy(void *d, const void *s, __u64 len)
+static  void __bpf_memcpy(void *d, const void *s, __u64 len)
 {
 #if __clang_major__ >= 10
 	if (!__builtin_constant_p(len))
@@ -241,7 +241,7 @@ static __always_inline void __bpf_memcpy(void *d, const void *s, __u64 len)
 #endif
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 __bpf_no_builtin_memcpy(void *d __maybe_unused, const void *s __maybe_unused,
 			__u64 len __maybe_unused)
 {
@@ -251,13 +251,13 @@ __bpf_no_builtin_memcpy(void *d __maybe_unused, const void *s __maybe_unused,
 /* Redirect any direct use in our code to throw an error. */
 #define __builtin_memcpy	__bpf_no_builtin_memcpy
 
-static __always_inline __nobuiltin("memcpy") void memcpy(void *d, const void *s,
+static  __nobuiltin("memcpy") void memcpy(void *d, const void *s,
 							 __u64 len)
 {
 	return __bpf_memcpy(d, s, len);
 }
 
-static __always_inline __maybe_unused __u64
+static  __maybe_unused __u64
 __bpf_memcmp_builtin(const void *x, const void *y, __u64 len)
 {
 	/* Explicit opt-in for __builtin_memcmp(). We use the bcmp builtin
@@ -272,7 +272,7 @@ __bpf_memcmp_builtin(const void *x, const void *y, __u64 len)
 	return __builtin_bcmp(x, y, len);
 }
 
-static __always_inline __u64 __bpf_memcmp(const void *x, const void *y,
+static  __u64 __bpf_memcmp(const void *x, const void *y,
 					  __u64 len)
 {
 #if __clang_major__ >= 10
@@ -347,7 +347,7 @@ static __always_inline __u64 __bpf_memcmp(const void *x, const void *y,
 #endif
 }
 
-static __always_inline __maybe_unused __u64
+static  __maybe_unused __u64
 __bpf_no_builtin_memcmp(const void *x __maybe_unused,
 			const void *y __maybe_unused, __u64 len __maybe_unused)
 {
@@ -361,27 +361,27 @@ __bpf_no_builtin_memcmp(const void *x __maybe_unused,
 /* Modified for our needs in that we only return either zero (x and y
  * are equal) or non-zero (x and y are non-equal).
  */
-static __always_inline __nobuiltin("memcmp") __u64 memcmp(const void *x,
+static  __nobuiltin("memcmp") __u64 memcmp(const void *x,
 							  const void *y,
 							  __u64 len)
 {
 	return __bpf_memcmp(x, y, len);
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 __bpf_memmove_builtin(void *d, const void *s, __u64 len)
 {
 	/* Explicit opt-in for __builtin_memmove(). */
 	__builtin_memmove(d, s, len);
 }
 
-static __always_inline void __bpf_memmove_bwd(void *d, const void *s, __u64 len)
+static  void __bpf_memmove_bwd(void *d, const void *s, __u64 len)
 {
 	/* Our internal memcpy implementation walks backwards by default. */
 	__bpf_memcpy(d, s, len);
 }
 
-static __always_inline void __bpf_memmove_fwd(void *d, const void *s, __u64 len)
+static  void __bpf_memmove_fwd(void *d, const void *s, __u64 len)
 {
 #if __clang_major__ >= 10
 	if (!__builtin_constant_p(len))
@@ -460,7 +460,7 @@ static __always_inline void __bpf_memmove_fwd(void *d, const void *s, __u64 len)
 #endif
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 __bpf_no_builtin_memmove(void *d __maybe_unused, const void *s __maybe_unused,
 			 __u64 len __maybe_unused)
 {
@@ -470,7 +470,7 @@ __bpf_no_builtin_memmove(void *d __maybe_unused, const void *s __maybe_unused,
 /* Redirect any direct use in our code to throw an error. */
 #define __builtin_memmove	__bpf_no_builtin_memmove
 
-static __always_inline void __bpf_memmove(void *d, const void *s, __u64 len)
+static  void __bpf_memmove(void *d, const void *s, __u64 len)
 {
 	/* Note, the forward walking memmove() might not work with on-stack data
 	 * since we'll end up walking the memory unaligned even when __align_stack_8
@@ -487,7 +487,7 @@ static __always_inline void __bpf_memmove(void *d, const void *s, __u64 len)
 		return __bpf_memmove_bwd(d, s, len);
 }
 
-static __always_inline __nobuiltin("memmove") void memmove(void *d,
+static  __nobuiltin("memmove") void memmove(void *d,
 							   const void *s,
 							   __u64 len)
 {

--- a/bpf/include/bpf/csum.h
+++ b/bpf/include/bpf/csum.h
@@ -7,30 +7,30 @@
 #include "compiler.h"
 #include "helpers.h"
 
-static __always_inline __sum16 csum_fold(__wsum csum)
+static  __sum16 csum_fold(__wsum csum)
 {
 	csum = (csum & 0xffff) + (csum >> 16);
 	csum = (csum & 0xffff) + (csum >> 16);
 	return (__sum16)~csum;
 }
 
-static __always_inline __wsum csum_unfold(__sum16 csum)
+static  __wsum csum_unfold(__sum16 csum)
 {
 	return (__wsum)csum;
 }
 
-static __always_inline __wsum csum_add(__wsum csum, __wsum addend)
+static  __wsum csum_add(__wsum csum, __wsum addend)
 {
 	csum += addend;
 	return csum + (csum < addend);
 }
 
-static __always_inline __wsum csum_sub(__wsum csum, __wsum addend)
+static  __wsum csum_sub(__wsum csum, __wsum addend)
 {
 	return csum_add(csum, ~addend);
 }
 
-static __always_inline __wsum csum_diff(const void *from, __u32 size_from,
+static  __wsum csum_diff(const void *from, __u32 size_from,
 					const void *to,   __u32 size_to,
 					__u32 seed)
 {

--- a/bpf/include/bpf/ctx/common.h
+++ b/bpf/include/bpf/ctx/common.h
@@ -13,17 +13,17 @@
 #define __ctx_skb		1
 #define __ctx_xdp		2
 
-static __always_inline bool ctx_no_room(const void *needed, const void *limit)
+static  bool ctx_no_room(const void *needed, const void *limit)
 {
 	return unlikely(needed > limit);
 }
 
-static __always_inline bool ctx_is_skb(void)
+static  bool ctx_is_skb(void)
 {
 	return __ctx_is == __ctx_skb;
 }
 
-static __always_inline bool ctx_is_xdp(void)
+static  bool ctx_is_xdp(void)
 {
 	return __ctx_is == __ctx_xdp;
 }

--- a/bpf/include/bpf/ctx/skb.h
+++ b/bpf/include/bpf/ctx/skb.h
@@ -63,7 +63,7 @@
 #define get_hash_recalc(ctx)	get_hash(ctx)
 
 #define DEFINE_FUNC_CTX_POINTER(FIELD)						\
-static __always_inline void *							\
+static  void *							\
 ctx_ ## FIELD(const struct __sk_buff *ctx)					\
 {										\
 	void *ptr;								\
@@ -85,49 +85,49 @@ DEFINE_FUNC_CTX_POINTER(data_end)
 DEFINE_FUNC_CTX_POINTER(data_meta)
 #undef DEFINE_FUNC_CTX_POINTER
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 ctx_redirect(const struct __sk_buff *ctx __maybe_unused, int ifindex, __u32 flags)
 {
 	return redirect(ifindex, flags);
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 ctx_redirect_peer(const struct __sk_buff *ctx __maybe_unused, int ifindex, __u32 flags)
 {
 	return redirect_peer(ifindex, flags);
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 ctx_adjust_troom(struct __sk_buff *ctx, const __s32 len_diff)
 {
 	return skb_change_tail(ctx, ctx->len + len_diff, 0);
 }
 
-static __always_inline __maybe_unused __u64
+static  __maybe_unused __u64
 ctx_full_len(const struct __sk_buff *ctx)
 {
 	return ctx->len;
 }
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 ctx_wire_len(const struct __sk_buff *ctx)
 {
 	return ctx->wire_len;
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 ctx_store_meta(struct __sk_buff *ctx, const __u32 off, __u32 data)
 {
 	ctx->cb[off] = data;
 }
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 ctx_load_meta(const struct __sk_buff *ctx, const __u32 off)
 {
 	return ctx->cb[off];
 }
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 ctx_load_and_clear_meta(struct __sk_buff *ctx, const __u32 off)
 {
 	__u32 val = ctx_load_meta(ctx, off);
@@ -136,19 +136,19 @@ ctx_load_and_clear_meta(struct __sk_buff *ctx, const __u32 off)
 	return val;
 }
 
-static __always_inline __maybe_unused __u16
+static  __maybe_unused __u16
 ctx_get_protocol(const struct __sk_buff *ctx)
 {
 	return (__u16)ctx->protocol;
 }
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 ctx_get_ifindex(const struct __sk_buff *ctx)
 {
 	return ctx->ifindex;
 }
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 ctx_get_ingress_ifindex(const struct __sk_buff *ctx)
 {
 	return ctx->ingress_ifindex;

--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -34,7 +34,7 @@
 #define __CTX_OFF_MAX			0xff
 
 #ifndef HAVE_XDP_LOAD_BYTES
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 xdp_load_bytes(const struct xdp_md *ctx, __u64 off, void *to, const __u64 len)
 {
 	void *from;
@@ -64,7 +64,7 @@ xdp_load_bytes(const struct xdp_md *ctx, __u64 off, void *to, const __u64 len)
 #endif
 
 #ifndef HAVE_XDP_STORE_BYTES
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 xdp_store_bytes(const struct xdp_md *ctx, __u64 off, const void *from,
 		const __u64 len, __u64 flags __maybe_unused)
 {
@@ -116,7 +116,7 @@ xdp_store_bytes(const struct xdp_md *ctx, __u64 off, const void *from,
 #define get_hash_recalc(ctx)		get_hash(ctx)
 
 #define DEFINE_FUNC_CTX_POINTER(FIELD)						\
-static __always_inline void *							\
+static  void *							\
 ctx_ ## FIELD(const struct xdp_md *ctx)						\
 {										\
 	void *ptr;								\
@@ -138,19 +138,19 @@ DEFINE_FUNC_CTX_POINTER(data_end)
 DEFINE_FUNC_CTX_POINTER(data_meta)
 #undef DEFINE_FUNC_CTX_POINTER
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 __csum_replace_by_diff(__sum16 *sum, __wsum diff)
 {
 	*sum = csum_fold(csum_add(diff, ~csum_unfold(*sum)));
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 __csum_replace_by_4(__sum16 *sum, __wsum from, __wsum to)
 {
 	__csum_replace_by_diff(sum, csum_add(~from, to));
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 l3_csum_replace(const struct xdp_md *ctx, __u64 off, const __u32 from,
 		__u32 to,
 		__u32 flags)
@@ -186,7 +186,7 @@ l3_csum_replace(const struct xdp_md *ctx, __u64 off, const __u32 from,
 
 #define CSUM_MANGLED_0		((__sum16)0xffff)
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 l4_csum_replace(const struct xdp_md *ctx, __u64 off, __u32 from, __u32 to,
 		__u32 flags)
 {
@@ -226,7 +226,7 @@ l4_csum_replace(const struct xdp_md *ctx, __u64 off, __u32 from, __u32 to,
 	return ret;
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 ctx_change_proto(struct xdp_md *ctx __maybe_unused,
 		 const __be16 proto __maybe_unused,
 		 const __u64 flags __maybe_unused)
@@ -264,13 +264,13 @@ ctx_change_proto(struct xdp_md *ctx __maybe_unused,
 	return ret;
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 ctx_adjust_troom(struct xdp_md *ctx, const __s32 len_diff)
 {
 	return xdp_adjust_tail(ctx, len_diff);
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 ctx_adjust_hroom(struct xdp_md *ctx, const __s32 len_diff, const __u32 mode,
 		 const __u64 flags __maybe_unused)
 {
@@ -340,7 +340,7 @@ ctx_adjust_hroom(struct xdp_md *ctx, const __s32 len_diff, const __u32 mode,
 	return ret;
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 ctx_redirect(const struct xdp_md *ctx, int ifindex, const __u32 flags)
 {
 	if ((__u32)ifindex == ctx->ingress_ifindex)
@@ -349,7 +349,7 @@ ctx_redirect(const struct xdp_md *ctx, int ifindex, const __u32 flags)
 	return redirect(ifindex, flags);
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 ctx_redirect_peer(const struct xdp_md *ctx __maybe_unused,
 		  int ifindex __maybe_unused,
 		  const __u32 flags __maybe_unused)
@@ -359,13 +359,13 @@ ctx_redirect_peer(const struct xdp_md *ctx __maybe_unused,
 }
 
 #ifdef HAVE_XDP_GET_BUFF_LEN
-static __always_inline __maybe_unused __u64
+static  __maybe_unused __u64
 ctx_full_len(const struct xdp_md *ctx)
 {
 	return xdp_get_buff_len((struct xdp_md *)ctx);
 }
 #else
-static __always_inline __maybe_unused __u64
+static  __maybe_unused __u64
 ctx_full_len(const struct xdp_md *ctx)
 {
 	__u64 len;
@@ -384,7 +384,7 @@ ctx_full_len(const struct xdp_md *ctx)
 }
 #endif
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 ctx_wire_len(const struct xdp_md *ctx)
 {
 	return ctx_full_len(ctx);
@@ -398,7 +398,7 @@ struct {
 	__uint(max_entries, 1);
 } cilium_xdp_scratch __section_maps_btf;
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 ctx_store_meta(struct xdp_md *ctx __maybe_unused, const __u64 off, __u32 datum)
 {
 	__u32 zero = 0, *data_meta = map_lookup_elem(&cilium_xdp_scratch, &zero);
@@ -408,7 +408,7 @@ ctx_store_meta(struct xdp_md *ctx __maybe_unused, const __u64 off, __u32 datum)
 	build_bug_on((off + 1) * sizeof(__u32) > META_PIVOT);
 }
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 ctx_load_meta(const struct xdp_md *ctx __maybe_unused, const __u64 off)
 {
 	__u32 zero = 0, *data_meta = map_lookup_elem(&cilium_xdp_scratch, &zero);
@@ -419,7 +419,7 @@ ctx_load_meta(const struct xdp_md *ctx __maybe_unused, const __u64 off)
 	return 0;
 }
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 ctx_load_and_clear_meta(const struct xdp_md *ctx __maybe_unused, const __u64 off)
 {
 	__u32 val, zero = 0, *data_meta = map_lookup_elem(&cilium_xdp_scratch, &zero);
@@ -434,7 +434,7 @@ ctx_load_and_clear_meta(const struct xdp_md *ctx __maybe_unused, const __u64 off
 	return 0;
 }
 
-static __always_inline __maybe_unused __u16
+static  __maybe_unused __u16
 ctx_get_protocol(const struct xdp_md *ctx)
 {
 	void *data_end = ctx_data_end(ctx);
@@ -446,13 +446,13 @@ ctx_get_protocol(const struct xdp_md *ctx)
 	return eth->h_proto;
 }
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 ctx_get_ifindex(const struct xdp_md *ctx)
 {
 	return ctx->ingress_ifindex;
 }
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 ctx_get_ingress_ifindex(const struct xdp_md *ctx)
 {
 	return ctx->ingress_ifindex;

--- a/bpf/include/bpf/tailcall.h
+++ b/bpf/include/bpf/tailcall.h
@@ -35,7 +35,7 @@
 		: "r0", "r1", "r2", "r3", "r4", "r5");		\
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 tail_call_dynamic(struct __ctx_buff *ctx, const void *map, __u32 slot)
 {
 	if (__builtin_constant_p(slot))

--- a/bpf/lib/arp.h
+++ b/bpf/lib/arp.h
@@ -18,7 +18,7 @@ struct arp_eth {
 } __packed;
 
 /* Check if packet is ARP request for IP */
-static __always_inline int arp_check(struct ethhdr *eth,
+static  int arp_check(struct ethhdr *eth,
 				     const struct arphdr *arp,
 				     union macaddr *mac)
 {
@@ -29,7 +29,7 @@ static __always_inline int arp_check(struct ethhdr *eth,
 	       (eth_is_bcast(dmac) || !eth_addrcmp(dmac, mac));
 }
 
-static __always_inline int
+static  int
 arp_prepare_response(struct __ctx_buff *ctx, union macaddr *smac, __be32 sip,
 		     union macaddr *dmac, __be32 tip)
 {
@@ -48,7 +48,7 @@ arp_prepare_response(struct __ctx_buff *ctx, union macaddr *smac, __be32 sip,
 	return 0;
 }
 
-static __always_inline bool
+static  bool
 arp_validate(const struct __ctx_buff *ctx, union macaddr *mac,
 	     union macaddr *smac, __be32 *sip, __be32 *tip)
 {
@@ -72,7 +72,7 @@ arp_validate(const struct __ctx_buff *ctx, union macaddr *mac,
 	return true;
 }
 
-static __always_inline int
+static  int
 arp_respond(struct __ctx_buff *ctx, union macaddr *smac, __be32 sip,
 	    union macaddr *dmac, __be32 tip, int direction)
 {

--- a/bpf/lib/auth.h
+++ b/bpf/lib/auth.h
@@ -9,7 +9,7 @@
 #include "utime.h"
 #include "signal.h"
 
-static __always_inline int
+static  int
 auth_lookup(struct __ctx_buff *ctx, __u32 local_id, __u32 remote_id, __u32 remote_node_ip,
 	    __u8 auth_type)
 {

--- a/bpf/lib/clustermesh.h
+++ b/bpf/lib/clustermesh.h
@@ -11,7 +11,7 @@
 #define IDENTITY_LEN get_identity_len()
 #define IDENTITY_MAX get_max_identity()
 
-static __always_inline __u32
+static  __u32
 get_identity_len()
 {
 	__u32 identity_len = CONFIG(identity_length);
@@ -21,25 +21,25 @@ get_identity_len()
 #endif /* __CLUSTERMESH_HELPERS__ */
 
 
-static __always_inline __u32
+static  __u32
 extract_cluster_id_from_identity(__u32 identity)
 {
 	return (__u32)(identity >> IDENTITY_LEN);
 }
 
-static __always_inline __u32
+static  __u32
 get_max_identity()
 {
 	return (__u32)((1 << IDENTITY_LEN) - 1);
 }
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 get_cluster_id_upper_mask()
 {
 	return (CLUSTER_ID_MAX & ~CLUSTER_ID_LOWER_MASK) << (8 + IDENTITY_LEN);
 }
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 get_mark_magic_cluster_id_mask()
 {
 	return CLUSTER_ID_LOWER_MASK | get_cluster_id_upper_mask();

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -156,7 +156,7 @@ union v6addr {
 	__u8 addr[16];
 } __packed;
 
-static __always_inline bool validate_ethertype_l2_off(struct __ctx_buff *ctx,
+static  bool validate_ethertype_l2_off(struct __ctx_buff *ctx,
 						      int l2_off, __u16 *proto)
 {
 	const __u64 tot_len = l2_off + ETH_HLEN;
@@ -184,13 +184,13 @@ static __always_inline bool validate_ethertype_l2_off(struct __ctx_buff *ctx,
 	return true;
 }
 
-static __always_inline bool validate_ethertype(struct __ctx_buff *ctx,
+static  bool validate_ethertype(struct __ctx_buff *ctx,
 					       __u16 *proto)
 {
 	return validate_ethertype_l2_off(ctx, 0, proto);
 }
 
-static __always_inline __maybe_unused bool
+static  __maybe_unused bool
 ____revalidate_data_pull(struct __ctx_buff *ctx, void **data_, void **data_end_,
 			 void **l3, const __u32 l3_len, const bool pull,
 			 __u32 l3_off)
@@ -215,7 +215,7 @@ ____revalidate_data_pull(struct __ctx_buff *ctx, void **data_, void **data_end_,
 	return true;
 }
 
-static __always_inline __maybe_unused bool
+static  __maybe_unused bool
 __revalidate_data_pull(struct __ctx_buff *ctx, void **data, void **data_end,
 		       void **l3, const __u32 l3_off, const __u32 l3_len,
 		       const bool pull)
@@ -224,7 +224,7 @@ __revalidate_data_pull(struct __ctx_buff *ctx, void **data, void **data_end,
 					l3_off);
 }
 
-static __always_inline __u32 get_tunnel_id(__u32 identity)
+static  __u32 get_tunnel_id(__u32 identity)
 {
 #if defined ENABLE_IPV4 && defined ENABLE_IPV6
 	if (identity == WORLD_IPV4_ID || identity == WORLD_IPV6_ID)
@@ -233,7 +233,7 @@ static __always_inline __u32 get_tunnel_id(__u32 identity)
 	return identity;
 }
 
-static __always_inline __u32 get_id_from_tunnel_id(__u32 tunnel_id, __u16 proto  __maybe_unused)
+static  __u32 get_id_from_tunnel_id(__u32 tunnel_id, __u16 proto  __maybe_unused)
 {
 #if defined ENABLE_IPV4 && defined ENABLE_IPV6
 	if (tunnel_id == WORLD_ID) {
@@ -783,7 +783,7 @@ struct encrypt_config {
 /**
  * or_encrypt_key - mask and shift key into encryption format
  */
-static __always_inline __u32 or_encrypt_key(__u8 key)
+static  __u32 or_encrypt_key(__u8 key)
 {
 	return (((__u32)key & 0x0F) << 12) | MARK_MAGIC_ENCRYPT;
 }
@@ -1163,7 +1163,7 @@ struct ct_state {
 	__u32 backend_id;	/* Backend ID in lb4_backends */
 };
 
-static __always_inline bool ct_state_is_from_l7lb(const struct ct_state *ct_state __maybe_unused)
+static  bool ct_state_is_from_l7lb(const struct ct_state *ct_state __maybe_unused)
 {
 #ifdef ENABLE_L7_LB
 	return ct_state->from_l7lb;
@@ -1189,7 +1189,7 @@ struct lb6_src_range_key {
 	union v6addr addr;
 };
 
-static __always_inline int redirect_ep(struct __ctx_buff *ctx __maybe_unused,
+static  int redirect_ep(struct __ctx_buff *ctx __maybe_unused,
 				       int ifindex __maybe_unused,
 				       bool needs_backlog __maybe_unused,
 				       bool from_tunnel)
@@ -1212,7 +1212,7 @@ static __always_inline int redirect_ep(struct __ctx_buff *ctx __maybe_unused,
 	return ctx_redirect_peer(ctx, ifindex, 0);
 }
 
-static __always_inline __u64 ctx_adjust_hroom_flags(void)
+static  __u64 ctx_adjust_hroom_flags(void)
 {
 #ifdef HAVE_CSUM_LEVEL
 	return BPF_F_ADJ_ROOM_NO_CSUM_RESET;

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -54,7 +54,7 @@ struct ct_buffer6 {
 };
 #endif
 
-static __always_inline enum ct_action ct_tcp_select_action(union tcp_flags flags)
+static  enum ct_action ct_tcp_select_action(union tcp_flags flags)
 {
 	if (unlikely(flags.value & (TCP_FLAG_RST | TCP_FLAG_FIN)))
 		return ACTION_CLOSE;
@@ -65,7 +65,7 @@ static __always_inline enum ct_action ct_tcp_select_action(union tcp_flags flags
 	return ACTION_UNSPEC;
 }
 
-static __always_inline bool ct_entry_seen_both_syns(const struct ct_entry *entry)
+static  bool ct_entry_seen_both_syns(const struct ct_entry *entry)
 {
 	bool rx_syn = entry->rx_flags_seen & TCP_FLAG_SYN;
 	bool tx_syn = entry->tx_flags_seen & TCP_FLAG_SYN;
@@ -92,7 +92,7 @@ static __always_inline bool ct_entry_seen_both_syns(const struct ct_entry *entry
  * - Zero if this flow was recently monitored.
  * - Non-zero if this flow has not been monitored recently.
  */
-static __always_inline __u32 __ct_update_timeout(struct ct_entry *entry,
+static  __u32 __ct_update_timeout(struct ct_entry *entry,
 						 __u32 lifetime, enum ct_dir dir,
 						 union tcp_flags flags,
 						 __u8 report_mask)
@@ -164,7 +164,7 @@ static __always_inline __u32 __ct_update_timeout(struct ct_entry *entry,
  * If CT_REPORT_INTERVAL has elapsed since the last update, updates the
  * last_updated timestamp and returns true. Otherwise returns false.
  */
-static __always_inline __u32 ct_update_timeout(struct ct_entry *entry,
+static  __u32 ct_update_timeout(struct ct_entry *entry,
 					       bool tcp, enum ct_dir dir,
 					       union tcp_flags seen_flags)
 {
@@ -188,7 +188,7 @@ static __always_inline __u32 ct_update_timeout(struct ct_entry *entry,
 				   CT_REPORT_FLAGS);
 }
 
-static __always_inline void
+static  void
 ct_lookup_fill_state(struct ct_state *state, const struct ct_entry *entry,
 		     enum ct_dir dir, bool syn)
 {
@@ -211,29 +211,29 @@ ct_lookup_fill_state(struct ct_state *state, const struct ct_entry *entry,
 	}
 }
 
-static __always_inline void ct_reset_seen_flags(struct ct_entry *entry)
+static  void ct_reset_seen_flags(struct ct_entry *entry)
 {
 	entry->rx_flags_seen = 0;
 	entry->tx_flags_seen = 0;
 }
 
-static __always_inline void ct_reset_closing(struct ct_entry *entry)
+static  void ct_reset_closing(struct ct_entry *entry)
 {
 	entry->rx_closing = 0;
 	entry->tx_closing = 0;
 }
 
-static __always_inline bool ct_entry_alive(const struct ct_entry *entry)
+static  bool ct_entry_alive(const struct ct_entry *entry)
 {
 	return !entry->rx_closing || !entry->tx_closing;
 }
 
-static __always_inline bool ct_entry_closing(const struct ct_entry *entry)
+static  bool ct_entry_closing(const struct ct_entry *entry)
 {
 	return entry->tx_closing || entry->rx_closing;
 }
 
-static __always_inline bool
+static  bool
 ct_entry_expired_rebalance(const struct ct_entry *entry)
 {
 	__u32 wait_time = bpf_sec_to_mono(CT_SERVICE_CLOSE_REBALANCE);
@@ -244,7 +244,7 @@ ct_entry_expired_rebalance(const struct ct_entry *entry)
 	return READ_ONCE(entry->last_tx_report) + wait_time <= bpf_mono_now();
 }
 
-static __always_inline bool
+static  bool
 ct_entry_matches_types(const struct ct_entry *entry __maybe_unused,
 		       __u32 ct_entry_types, const struct ct_state *state)
 {
@@ -277,7 +277,7 @@ ct_entry_matches_types(const struct ct_entry *entry __maybe_unused,
 }
 
 /* Returns CT_NEW, CT_REOPENED or CT_ESTABLISHED. */
-static __always_inline enum ct_status
+static  enum ct_status
 __ct_lookup(const void *map, struct __ctx_buff *ctx, const void *tuple,
 	    enum ct_action action, enum ct_dir dir, __u32 ct_entry_types,
 	    struct ct_state *ct_state, bool is_tcp, union tcp_flags seen_flags,
@@ -359,7 +359,7 @@ ct_new: __maybe_unused;
 	return CT_NEW;
 }
 
-static __always_inline __u8
+static  __u8
 ct_lookup_select_tuple_type(enum ct_dir dir, enum ct_scope scope)
 {
 	if (dir == CT_SERVICE)
@@ -386,7 +386,7 @@ ct_lookup_select_tuple_type(enum ct_dir dir, enum ct_scope scope)
  * flow is a reply.
  */
 #define DEFINE_FUNC_CT_IS_REPLY(FAMILY)						\
-static __always_inline bool							\
+static  bool							\
 ct_is_reply ## FAMILY(const void *map,						\
 		      struct ipv ## FAMILY ## _ct_tuple *tuple)			\
 {										\
@@ -404,7 +404,7 @@ ct_is_reply ## FAMILY(const void *map,						\
 	return is_reply;							\
 }
 
-static __always_inline int
+static  int
 ipv6_extract_tuple(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple)
 {
 	void *data, *data_end;
@@ -436,7 +436,7 @@ ipv6_extract_tuple(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple)
 	return CTX_ACT_OK;
 }
 
-static __always_inline void ct_flip_tuple_dir6(struct ipv6_ct_tuple *tuple)
+static  void ct_flip_tuple_dir6(struct ipv6_ct_tuple *tuple)
 {
 	if (tuple->flags & TUPLE_F_IN)
 		tuple->flags &= ~TUPLE_F_IN;
@@ -444,7 +444,7 @@ static __always_inline void ct_flip_tuple_dir6(struct ipv6_ct_tuple *tuple)
 		tuple->flags |= TUPLE_F_IN;
 }
 
-static __always_inline void
+static  void
 ipv6_ct_tuple_swap_addrs(struct ipv6_ct_tuple *tuple)
 {
 	union v6addr tmp_addr = {};
@@ -454,7 +454,7 @@ ipv6_ct_tuple_swap_addrs(struct ipv6_ct_tuple *tuple)
 	ipv6_addr_copy(&tuple->daddr, &tmp_addr);
 }
 
-static __always_inline void
+static  void
 ipv6_ct_tuple_swap_ports(struct ipv6_ct_tuple *tuple)
 {
 	__be16 tmp;
@@ -469,21 +469,21 @@ ipv6_ct_tuple_swap_ports(struct ipv6_ct_tuple *tuple)
 	tuple->dport = tmp;
 }
 
-static __always_inline void
+static  void
 __ipv6_ct_tuple_reverse(struct ipv6_ct_tuple *tuple)
 {
 	ipv6_ct_tuple_swap_addrs(tuple);
 	ipv6_ct_tuple_swap_ports(tuple);
 }
 
-static __always_inline void
+static  void
 ipv6_ct_tuple_reverse(struct ipv6_ct_tuple *tuple)
 {
 	__ipv6_ct_tuple_reverse(tuple);
 	ct_flip_tuple_dir6(tuple);
 }
 
-static __always_inline int
+static  int
 ct_extract_ports6(struct __ctx_buff *ctx, int off, struct ipv6_ct_tuple *tuple)
 {
 	switch (tuple->nexthdr) {
@@ -546,7 +546,7 @@ ct_extract_ports6(struct __ctx_buff *ctx, int off, struct ipv6_ct_tuple *tuple)
 /* This defines the ct_is_reply6 function. */
 DEFINE_FUNC_CT_IS_REPLY(6)
 
-static __always_inline int
+static  int
 __ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, struct __ctx_buff *ctx,
 	     int l4_off, enum ct_dir dir, enum ct_scope scope, __u32 ct_entry_types,
 	     struct ct_state *ct_state, __u32 *monitor)
@@ -604,7 +604,7 @@ out:
 }
 
 /* An IPv6 version of ct_lazy_lookup4. */
-static __always_inline int
+static  int
 ct_lazy_lookup6(const void *map, struct ipv6_ct_tuple *tuple,
 		struct __ctx_buff *ctx, int l4_off, enum ct_dir dir,
 		enum ct_scope scope, __u32 ct_entry_types,
@@ -617,7 +617,7 @@ ct_lazy_lookup6(const void *map, struct ipv6_ct_tuple *tuple,
 }
 
 /* Offset must point to IPv6 */
-static __always_inline int ct_lookup6(const void *map,
+static  int ct_lookup6(const void *map,
 				      struct ipv6_ct_tuple *tuple,
 				      struct __ctx_buff *ctx, int l4_off,
 				      enum ct_dir dir, struct ct_state *ct_state,
@@ -635,7 +635,7 @@ static __always_inline int ct_lookup6(const void *map,
 			    CT_ENTRY_ANY, ct_state, monitor);
 }
 
-static __always_inline int
+static  int
 ipv4_extract_tuple(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple)
 {
 	void *data, *data_end;
@@ -665,7 +665,7 @@ ipv4_extract_tuple(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple)
 	return CTX_ACT_OK;
 }
 
-static __always_inline void ct_flip_tuple_dir4(struct ipv4_ct_tuple *tuple)
+static  void ct_flip_tuple_dir4(struct ipv4_ct_tuple *tuple)
 {
 	if (tuple->flags & TUPLE_F_IN)
 		tuple->flags &= ~TUPLE_F_IN;
@@ -673,7 +673,7 @@ static __always_inline void ct_flip_tuple_dir4(struct ipv4_ct_tuple *tuple)
 		tuple->flags |= TUPLE_F_IN;
 }
 
-static __always_inline void
+static  void
 ipv4_ct_tuple_swap_addrs(struct ipv4_ct_tuple *tuple)
 {
 	__be32 tmp_addr = tuple->saddr;
@@ -682,7 +682,7 @@ ipv4_ct_tuple_swap_addrs(struct ipv4_ct_tuple *tuple)
 	tuple->daddr = tmp_addr;
 }
 
-static __always_inline void
+static  void
 ipv4_ct_tuple_swap_ports(struct ipv4_ct_tuple *tuple)
 {
 	__be16 tmp;
@@ -697,33 +697,33 @@ ipv4_ct_tuple_swap_ports(struct ipv4_ct_tuple *tuple)
 	tuple->dport = tmp;
 }
 
-static __always_inline void
+static  void
 __ipv4_ct_tuple_reverse(struct ipv4_ct_tuple *tuple)
 {
 	ipv4_ct_tuple_swap_addrs(tuple);
 	ipv4_ct_tuple_swap_ports(tuple);
 }
 
-static __always_inline void
+static  void
 ipv4_ct_tuple_reverse(struct ipv4_ct_tuple *tuple)
 {
 	__ipv4_ct_tuple_reverse(tuple);
 	ct_flip_tuple_dir4(tuple);
 }
 
-static __always_inline __be32
+static  __be32
 ipv4_ct_reverse_tuple_saddr(const struct ipv4_ct_tuple *rtuple)
 {
 	return rtuple->daddr;
 }
 
-static __always_inline __be32
+static  __be32
 ipv4_ct_reverse_tuple_daddr(const struct ipv4_ct_tuple *rtuple)
 {
 	return rtuple->saddr;
 }
 
-static __always_inline int
+static  int
 ct_extract_ports4(struct __ctx_buff *ctx, struct iphdr *ip4, int off,
 		  enum ct_dir dir, struct ipv4_ct_tuple *tuple, bool *has_l4_header)
 {
@@ -787,7 +787,7 @@ ct_extract_ports4(struct __ctx_buff *ctx, struct iphdr *ip4, int off,
 /* This defines the ct_is_reply4 function. */
 DEFINE_FUNC_CT_IS_REPLY(4)
 
-static __always_inline int
+static  int
 __ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff *ctx,
 	     int l4_off, bool has_l4_header, bool is_fragment __maybe_unused,
 	     enum ct_dir dir, enum ct_scope scope, __u32 ct_entry_types,
@@ -875,7 +875,7 @@ out:
  * tuple->flags, but this works well in LB and NAT flows that don't pass these
  * ICMP types to ct_lazy_lookup4.
  */
-static __always_inline int
+static  int
 ct_lazy_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff *ctx,
 		bool is_fragment, int l4_off, bool has_l4_header,
 		enum ct_dir dir, enum ct_scope scope, __u32 ct_entry_types,
@@ -888,7 +888,7 @@ ct_lazy_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff 
 }
 
 /* Offset must point to IPv4 header */
-static __always_inline int ct_lookup4(const void *map,
+static  int ct_lookup4(const void *map,
 				      struct ipv4_ct_tuple *tuple,
 				      struct __ctx_buff *ctx, struct iphdr *ip4,
 				      int off, enum ct_dir dir,
@@ -908,7 +908,7 @@ static __always_inline int ct_lookup4(const void *map,
 			    dir, SCOPE_BIDIR, CT_ENTRY_ANY, ct_state, monitor);
 }
 
-static __always_inline void
+static  void
 ct_create_fill_entry(struct ct_entry *entry, const struct ct_state *state,
 		     enum ct_dir dir)
 {
@@ -936,7 +936,7 @@ ct_create_fill_entry(struct ct_entry *entry, const struct ct_state *state,
 }
 
 /* Offset must point to IPv6 */
-static __always_inline int ct_create6(const void *map_main, const void *map_related,
+static  int ct_create6(const void *map_main, const void *map_related,
 				      struct ipv6_ct_tuple *tuple,
 				      struct __ctx_buff *ctx, const enum ct_dir dir,
 				      const struct ct_state *ct_state, __s8 *ext_err)
@@ -991,7 +991,7 @@ err_ct_fill_up:
 	return DROP_CT_CREATE_FAILED;
 }
 
-static __always_inline int ct_create4(const void *map_main,
+static  int ct_create4(const void *map_main,
 				      const void *map_related,
 				      struct ipv4_ct_tuple *tuple,
 				      struct __ctx_buff *ctx, const enum ct_dir dir,
@@ -1052,7 +1052,7 @@ err_ct_fill_up:
 }
 
 #ifndef DISABLE_LOOPBACK_LB
-static __always_inline bool
+static  bool
 ct_has_loopback_egress_entry4(const void *map, struct ipv4_ct_tuple *tuple,
 			      __u16 *rev_nat_index)
 {
@@ -1072,7 +1072,7 @@ ct_has_loopback_egress_entry4(const void *map, struct ipv4_ct_tuple *tuple,
 }
 #endif
 
-static __always_inline bool
+static  bool
 __ct_has_nodeport_egress_entry(const struct ct_entry *entry,
 			       __u16 *rev_nat_index, bool check_dsr)
 {
@@ -1094,7 +1094,7 @@ __ct_has_nodeport_egress_entry(const struct ct_entry *entry,
  * (saddr=client,daddr=backend) tuple. So, to derive whether the reply packet
  * backend => client belongs to the LB flow we can query the CT_EGRESS entry.
  */
-static __always_inline bool
+static  bool
 ct_has_nodeport_egress_entry4(const void *map,
 			      struct ipv4_ct_tuple *ingress_tuple,
 			      __u16 *rev_nat_index, bool check_dsr)
@@ -1112,7 +1112,7 @@ ct_has_nodeport_egress_entry4(const void *map,
 	return __ct_has_nodeport_egress_entry(entry, rev_nat_index, check_dsr);
 }
 
-static __always_inline bool
+static  bool
 ct_has_dsr_egress_entry4(const void *map, struct ipv4_ct_tuple *ingress_tuple)
 {
 	__u8 prev_flags = ingress_tuple->flags;
@@ -1128,7 +1128,7 @@ ct_has_dsr_egress_entry4(const void *map, struct ipv4_ct_tuple *ingress_tuple)
 	return 0;
 }
 
-static __always_inline bool
+static  bool
 ct_has_nodeport_egress_entry6(const void *map,
 			      struct ipv6_ct_tuple *ingress_tuple,
 			      __u16 *rev_nat_index, bool check_dsr)
@@ -1146,7 +1146,7 @@ ct_has_nodeport_egress_entry6(const void *map,
 	return __ct_has_nodeport_egress_entry(entry, rev_nat_index, check_dsr);
 }
 
-static __always_inline bool
+static  bool
 ct_has_dsr_egress_entry6(const void *map, struct ipv6_ct_tuple *ingress_tuple)
 {
 	__u8 prev_flags = ingress_tuple->flags;
@@ -1162,7 +1162,7 @@ ct_has_dsr_egress_entry6(const void *map, struct ipv6_ct_tuple *ingress_tuple)
 	return 0;
 }
 
-static __always_inline void
+static  void
 ct_update_svc_entry(const void *map, const void *tuple,
 		    __u32 backend_id, __u16 rev_nat_index)
 {
@@ -1176,7 +1176,7 @@ ct_update_svc_entry(const void *map, const void *tuple,
 	entry->rev_nat_index = rev_nat_index;
 }
 
-static __always_inline void
+static  void
 ct_update_dsr(const void *map, const void *tuple, const bool dsr)
 {
 	struct ct_entry *entry;
@@ -1188,7 +1188,7 @@ ct_update_dsr(const void *map, const void *tuple, const bool dsr)
 	entry->dsr_internal = dsr;
 }
 
-static __always_inline void
+static  void
 ct_update_nodeport(const void *map, const void *tuple, const bool node_port)
 {
 	struct ct_entry *entry;

--- a/bpf/lib/conntrack_map.h
+++ b/bpf/lib/conntrack_map.h
@@ -68,7 +68,7 @@ struct {
 } PER_CLUSTER_CT_ANY6 __section_maps_btf;
 #endif
 
-static __always_inline void *
+static  void *
 get_ct_map6(const struct ipv6_ct_tuple *tuple)
 {
 	if (tuple->nexthdr == IPPROTO_TCP)
@@ -77,7 +77,7 @@ get_ct_map6(const struct ipv6_ct_tuple *tuple)
 	return &CT_MAP_ANY6;
 }
 
-static __always_inline void *
+static  void *
 get_cluster_ct_map6(const struct ipv6_ct_tuple *tuple, __u32 cluster_id __maybe_unused)
 {
 #ifdef ENABLE_CLUSTER_AWARE_ADDRESSING
@@ -92,7 +92,7 @@ get_cluster_ct_map6(const struct ipv6_ct_tuple *tuple, __u32 cluster_id __maybe_
 	return get_ct_map6(tuple);
 }
 
-static __always_inline void *
+static  void *
 get_cluster_ct_any_map6(__u32 cluster_id __maybe_unused)
 {
 #ifdef ENABLE_CLUSTER_AWARE_ADDRESSING
@@ -172,7 +172,7 @@ struct {
 #endif
 #endif
 
-static __always_inline void *
+static  void *
 get_ct_map4(const struct ipv4_ct_tuple *tuple)
 {
 	if (tuple->nexthdr == IPPROTO_TCP)
@@ -181,7 +181,7 @@ get_ct_map4(const struct ipv4_ct_tuple *tuple)
 	return &CT_MAP_ANY4;
 }
 
-static __always_inline void *
+static  void *
 get_cluster_ct_map4(const struct ipv4_ct_tuple *tuple, __u32 cluster_id __maybe_unused)
 {
 #ifdef ENABLE_CLUSTER_AWARE_ADDRESSING
@@ -196,7 +196,7 @@ get_cluster_ct_map4(const struct ipv4_ct_tuple *tuple, __u32 cluster_id __maybe_
 	return get_ct_map4(tuple);
 }
 
-static __always_inline void *
+static  void *
 get_cluster_ct_any_map4(__u32 cluster_id __maybe_unused)
 {
 #ifdef ENABLE_CLUSTER_AWARE_ADDRESSING

--- a/bpf/lib/csum.h
+++ b/bpf/lib/csum.h
@@ -26,7 +26,7 @@ struct csum_offset {
  * For unknown L4 protocols or L4 protocols which do not have a checksum
  * field, off is initialied to 0.
  */
-static __always_inline void csum_l4_offset_and_flags(__u8 nexthdr,
+static  void csum_l4_offset_and_flags(__u8 nexthdr,
 						     struct csum_offset *off)
 {
 	switch (nexthdr) {
@@ -71,7 +71,7 @@ static __always_inline void csum_l4_offset_and_flags(__u8 nexthdr,
  * @arg to	To value or a csum diff
  * @arg flags	Additional flags to be passed to l4_csum_replace()
  */
-static __always_inline int csum_l4_replace(struct __ctx_buff *ctx, __u64 l4_off,
+static  int csum_l4_replace(struct __ctx_buff *ctx, __u64 l4_off,
 					   const struct csum_offset *csum,
 					   __be32 from, __be32 to, int flags)
 {

--- a/bpf/lib/dbg.h
+++ b/bpf/lib/dbg.h
@@ -181,7 +181,7 @@ struct debug_msg {
 	__u32		arg3;
 };
 
-static __always_inline void cilium_dbg(struct __ctx_buff *ctx, __u8 type,
+static  void cilium_dbg(struct __ctx_buff *ctx, __u8 type,
 				       __u32 arg1, __u32 arg2)
 {
 	struct debug_msg msg = {
@@ -194,7 +194,7 @@ static __always_inline void cilium_dbg(struct __ctx_buff *ctx, __u8 type,
 			 &msg, sizeof(msg));
 }
 
-static __always_inline void cilium_dbg3(struct __ctx_buff *ctx, __u8 type,
+static  void cilium_dbg3(struct __ctx_buff *ctx, __u8 type,
 					__u32 arg1, __u32 arg2, __u32 arg3)
 {
 	struct debug_msg msg = {
@@ -214,7 +214,7 @@ struct debug_capture_msg {
 	__u32		arg2;
 };
 
-static __always_inline void cilium_dbg_capture2(struct __ctx_buff *ctx, __u8 type,
+static  void cilium_dbg_capture2(struct __ctx_buff *ctx, __u8 type,
 						__u32 arg1, __u32 arg2)
 {
 	__u64 ctx_len = ctx_full_len(ctx);
@@ -231,7 +231,7 @@ static __always_inline void cilium_dbg_capture2(struct __ctx_buff *ctx, __u8 typ
 			 &msg, sizeof(msg));
 }
 
-static __always_inline void cilium_dbg_capture(struct __ctx_buff *ctx, __u8 type,
+static  void cilium_dbg_capture(struct __ctx_buff *ctx, __u8 type,
 					       __u32 arg1)
 {
 	cilium_dbg_capture2(ctx, type, arg1, 0);
@@ -240,26 +240,26 @@ static __always_inline void cilium_dbg_capture(struct __ctx_buff *ctx, __u8 type
 # define printk(fmt, ...)					\
 		do { } while (0)
 
-static __always_inline
+static
 void cilium_dbg(struct __ctx_buff *ctx __maybe_unused, __u8 type __maybe_unused,
 		__u32 arg1 __maybe_unused, __u32 arg2 __maybe_unused)
 {
 }
 
-static __always_inline
+static
 void cilium_dbg3(struct __ctx_buff *ctx __maybe_unused,
 		 __u8 type __maybe_unused, __u32 arg1 __maybe_unused,
 		 __u32 arg2 __maybe_unused, __u32 arg3 __maybe_unused)
 {
 }
 
-static __always_inline
+static
 void cilium_dbg_capture(struct __ctx_buff *ctx __maybe_unused,
 			__u8 type __maybe_unused, __u32 arg1 __maybe_unused)
 {
 }
 
-static __always_inline
+static
 void cilium_dbg_capture2(struct __ctx_buff *ctx __maybe_unused,
 			 __u8 type __maybe_unused, __u32 arg1 __maybe_unused,
 			 __u32 arg2 __maybe_unused)

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -94,7 +94,7 @@ int __send_drop_notify(struct __ctx_buff *ctx)
  *
  * NOTE: This is terminal function and will cause the BPF program to exit
  */
-static __always_inline int
+static  int
 _send_drop_notify(__u8 file, __u16 line, struct __ctx_buff *ctx,
 		  __u32 src, __u32 dst, __u32 dst_id,
 		  __u32 reason, __u32 exitcode, enum metric_dir direction)
@@ -124,7 +124,7 @@ _send_drop_notify(__u8 file, __u16 line, struct __ctx_buff *ctx,
 	return exitcode;
 }
 #else
-static __always_inline
+static
 int _send_drop_notify(__u8 file __maybe_unused, __u16 line __maybe_unused,
 		      struct __ctx_buff *ctx, __u32 src __maybe_unused,
 		      __u32 dst __maybe_unused, __u32 dst_id __maybe_unused,

--- a/bpf/lib/edt.h
+++ b/bpf/lib/edt.h
@@ -14,14 +14,14 @@
  * from here, hence nothing to be set.
  */
 #if defined(ENABLE_BANDWIDTH_MANAGER) && __ctx_is == __ctx_skb
-static __always_inline void edt_set_aggregate(struct __ctx_buff *ctx,
+static  void edt_set_aggregate(struct __ctx_buff *ctx,
 					      __u32 aggregate)
 {
 	/* 16 bit as current used aggregate, and preserved in host ns. */
 	ctx->queue_mapping = aggregate;
 }
 
-static __always_inline __u32 edt_get_aggregate(struct __ctx_buff *ctx)
+static  __u32 edt_get_aggregate(struct __ctx_buff *ctx)
 {
 	__u32 aggregate = ctx->queue_mapping;
 
@@ -33,7 +33,7 @@ static __always_inline __u32 edt_get_aggregate(struct __ctx_buff *ctx)
 	return aggregate;
 }
 
-static __always_inline int edt_sched_departure(struct __ctx_buff *ctx)
+static  int edt_sched_departure(struct __ctx_buff *ctx)
 {
 	__u64 delay, now, t, t_next;
 	struct edt_id aggregate;
@@ -76,7 +76,7 @@ static __always_inline int edt_sched_departure(struct __ctx_buff *ctx)
 	return CTX_ACT_OK;
 }
 #else
-static __always_inline void
+static  void
 edt_set_aggregate(struct __ctx_buff *ctx __maybe_unused,
 		  __u32 aggregate __maybe_unused)
 {

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -24,7 +24,7 @@
 #define EGRESS_GATEWAY_NO_GATEWAY (0)
 #define EGRESS_GATEWAY_EXCLUDED_CIDR bpf_htonl(1)
 
-static __always_inline
+static
 int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, __be32 daddr,
 				      __s8 *ext_err)
 {
@@ -57,7 +57,7 @@ int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, 
 }
 
 #ifdef ENABLE_EGRESS_GATEWAY
-static __always_inline
+static
 struct egress_gw_policy_entry *lookup_ip4_egress_gw_policy(__be32 saddr, __be32 daddr)
 {
 	struct egress_gw_policy_key key = {
@@ -69,7 +69,7 @@ struct egress_gw_policy_entry *lookup_ip4_egress_gw_policy(__be32 saddr, __be32 
 }
 #endif /* ENABLE_EGRESS_GATEWAY */
 
-static __always_inline int
+static  int
 egress_gw_request_needs_redirect(struct ipv4_ct_tuple *rtuple __maybe_unused,
 				 __be32 *gateway_ip __maybe_unused)
 {
@@ -96,7 +96,7 @@ egress_gw_request_needs_redirect(struct ipv4_ct_tuple *rtuple __maybe_unused,
 #endif /* ENABLE_EGRESS_GATEWAY */
 }
 
-static __always_inline
+static
 bool egress_gw_snat_needed(__be32 saddr __maybe_unused,
 			   __be32 daddr __maybe_unused,
 			   __be32 *snat_addr __maybe_unused)
@@ -119,7 +119,7 @@ bool egress_gw_snat_needed(__be32 saddr __maybe_unused,
 #endif /* ENABLE_EGRESS_GATEWAY */
 }
 
-static __always_inline
+static
 bool egress_gw_reply_matches_policy(struct iphdr *ip4 __maybe_unused)
 {
 #if defined(ENABLE_EGRESS_GATEWAY)
@@ -150,7 +150,7 @@ bool egress_gw_reply_matches_policy(struct iphdr *ip4 __maybe_unused)
  * * CTX_ACT_OK if no EGW logic should be applied,
  * * DROP_* for error conditions.
  */
-static __always_inline int
+static  int
 egress_gw_request_needs_redirect_hook(struct ipv4_ct_tuple *rtuple,
 				      enum ct_status ct_status,
 				      __be32 *gateway_ip)
@@ -166,7 +166,7 @@ egress_gw_request_needs_redirect_hook(struct ipv4_ct_tuple *rtuple,
 	return egress_gw_request_needs_redirect(rtuple, gateway_ip);
 }
 
-static __always_inline
+static
 bool egress_gw_snat_needed_hook(__be32 saddr, __be32 daddr, __be32 *snat_addr)
 {
 	struct remote_endpoint_info *remote_ep;
@@ -183,7 +183,7 @@ bool egress_gw_snat_needed_hook(__be32 saddr, __be32 daddr, __be32 *snat_addr)
 	return egress_gw_snat_needed(saddr, daddr, snat_addr);
 }
 
-static __always_inline
+static
 bool egress_gw_reply_needs_redirect_hook(struct iphdr *ip4, __u32 *tunnel_endpoint,
 					 __u32 *dst_sec_identity)
 {

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -17,7 +17,7 @@
 #include "high_scale_ipcache.h"
 
 #ifdef HAVE_ENCAP
-static __always_inline int
+static  int
 __encap_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 		    __be32 tunnel_endpoint,
 		    __u32 seclabel, __u32 dstid, __u32 vni __maybe_unused,
@@ -43,7 +43,7 @@ __encap_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 				  NULL, 0, ifindex);
 }
 
-static __always_inline int
+static  int
 __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip __maybe_unused,
 				 __be32 tunnel_endpoint,
 				 __u32 seclabel, __u32 dstid, __u32 vni,
@@ -66,7 +66,7 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip __maybe_un
  * returns CTX_ACT_REDIRECT on successful redirect to tunnel device.
  * On error returns a DROP_* reason.
  */
-static __always_inline int
+static  int
 encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 			       __u8 encrypt_key __maybe_unused,
 			       __u32 seclabel, __u32 dstid,
@@ -86,7 +86,7 @@ encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 /* __encap_and_redirect_lxc() is a variant of encap_and_redirect_lxc()
  * that requires a valid tunnel_endpoint.
  */
-static __always_inline int
+static  int
 __encap_and_redirect_lxc(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 			 __u8 encrypt_key __maybe_unused, __u32 seclabel,
 			 __u32 dstid, const struct trace_ctx *trace)
@@ -114,7 +114,7 @@ __encap_and_redirect_lxc(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
  * handling), a DROP_* reason on error, and finally on successful redirect returns
  * CTX_ACT_REDIRECT.
  */
-static __always_inline int
+static  int
 encap_and_redirect_lxc(struct __ctx_buff *ctx,
 		       __be32 tunnel_endpoint __maybe_unused,
 		       __u32 src_ip __maybe_unused,
@@ -155,7 +155,7 @@ encap_and_redirect_lxc(struct __ctx_buff *ctx,
 #endif /* ENABLE_HIGH_SCALE_IPCACHE */
 }
 
-static __always_inline int
+static  int
 encap_and_redirect_netdev(struct __ctx_buff *ctx, struct tunnel_key *k,
 			  __u8 encrypt_key __maybe_unused,
 			  __u32 seclabel, const struct trace_ctx *trace)
@@ -177,7 +177,7 @@ encap_and_redirect_netdev(struct __ctx_buff *ctx, struct tunnel_key *k,
 }
 #endif /* TUNNEL_MODE || ENABLE_HIGH_SCALE_IPCACHE */
 
-static __always_inline __be16
+static  __be16
 tunnel_gen_src_port_v4(struct ipv4_ct_tuple *tuple __maybe_unused)
 {
 #if __ctx_is == __ctx_xdp
@@ -189,7 +189,7 @@ tunnel_gen_src_port_v4(struct ipv4_ct_tuple *tuple __maybe_unused)
 #endif
 }
 
-static __always_inline __be16
+static  __be16
 tunnel_gen_src_port_v6(struct ipv6_ct_tuple *tuple __maybe_unused)
 {
 #if __ctx_is == __ctx_xdp
@@ -202,7 +202,7 @@ tunnel_gen_src_port_v6(struct ipv6_ct_tuple *tuple __maybe_unused)
 }
 
 #if defined(ENABLE_DSR) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-static __always_inline int
+static  int
 __encap_with_nodeid_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 			__u32 tunnel_endpoint,
 			__u32 seclabel, __u32 dstid, __u32 vni,
@@ -230,7 +230,7 @@ __encap_with_nodeid_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 				  opt_len, ifindex);
 }
 
-static __always_inline void
+static  void
 set_geneve_dsr_opt4(__be16 port, __be32 addr, struct geneve_dsr_opt4 *gopt)
 {
 	memset(gopt, 0, sizeof(*gopt));
@@ -241,7 +241,7 @@ set_geneve_dsr_opt4(__be16 port, __be32 addr, struct geneve_dsr_opt4 *gopt)
 	gopt->port = port;
 }
 
-static __always_inline void
+static  void
 set_geneve_dsr_opt6(__be16 port, const union v6addr *addr,
 		    struct geneve_dsr_opt6 *gopt)
 {

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -14,7 +14,7 @@
 #include "lib/eps.h"
 #include "lib/vxlan.h"
 
-static __always_inline __u8 get_min_encrypt_key(__u8 peer_key __maybe_unused)
+static  __u8 get_min_encrypt_key(__u8 peer_key __maybe_unused)
 {
 #ifdef ENABLE_IPSEC
 	__u8 local_key = 0;
@@ -46,7 +46,7 @@ static __always_inline __u8 get_min_encrypt_key(__u8 peer_key __maybe_unused)
 
 #ifdef ENABLE_IPSEC
 # ifdef ENABLE_IPV4
-static __always_inline __u16
+static  __u16
 lookup_ip4_node_id(__u32 ip4)
 {
 	struct node_key node_ip = {};
@@ -64,7 +64,7 @@ lookup_ip4_node_id(__u32 ip4)
 # endif /* ENABLE_IPV4 */
 
 # ifdef ENABLE_IPV6
-static __always_inline __u16
+static  __u16
 lookup_ip6_node_id(const union v6addr *ip6)
 {
 	struct node_key node_ip = {};
@@ -81,14 +81,14 @@ lookup_ip6_node_id(const union v6addr *ip6)
 }
 # endif /* ENABLE_IPV6 */
 
-static __always_inline void
+static  void
 set_ipsec_decrypt_mark(struct __ctx_buff *ctx, __u16 node_id)
 {
 	/* Decrypt "key" is determined by SPI and originating node */
 	ctx->mark = MARK_MAGIC_DECRYPT | node_id << 16;
 }
 
-static __always_inline int
+static  int
 set_ipsec_encrypt(struct __ctx_buff *ctx, __u8 spi, __u32 tunnel_endpoint,
 		  __u32 seclabel, bool use_meta, bool use_spi_from_map)
 {
@@ -120,7 +120,7 @@ set_ipsec_encrypt(struct __ctx_buff *ctx, __u8 spi, __u32 tunnel_endpoint,
 	return CTX_ACT_OK;
 }
 
-static __always_inline int
+static  int
 do_decrypt(struct __ctx_buff *ctx, __u16 proto)
 {
 	void *data, *data_end;
@@ -214,7 +214,7 @@ do_decrypt(struct __ctx_buff *ctx, __u16 proto)
  *   - net.ipv4.conf.default.rp_filter = 0
  *   - net.ipv4.conf.default.accept_local = 1
  */
-static __always_inline int
+static  int
 encrypt_overlay_and_redirect(struct __ctx_buff *ctx, void *data,
 			     void *data_end, struct iphdr *ip4)
 {
@@ -269,7 +269,7 @@ encrypt_overlay_and_redirect(struct __ctx_buff *ctx, void *data,
 #endif /* ENABLE_ENCRYPTED_OVERLAY */
 
 #else
-static __always_inline int
+static  int
 do_decrypt(struct __ctx_buff __maybe_unused *ctx, __u16 __maybe_unused proto)
 {
 	return CTX_ACT_OK;

--- a/bpf/lib/eps.h
+++ b/bpf/lib/eps.h
@@ -9,7 +9,7 @@
 
 #include "maps.h"
 
-static __always_inline __maybe_unused struct endpoint_info *
+static  __maybe_unused struct endpoint_info *
 __lookup_ip6_endpoint(const union v6addr *ip6)
 {
 	struct endpoint_key key = {};
@@ -20,13 +20,13 @@ __lookup_ip6_endpoint(const union v6addr *ip6)
 	return map_lookup_elem(&ENDPOINTS_MAP, &key);
 }
 
-static __always_inline __maybe_unused struct endpoint_info *
+static  __maybe_unused struct endpoint_info *
 lookup_ip6_endpoint(const struct ipv6hdr *ip6)
 {
 	return __lookup_ip6_endpoint((union v6addr *)&ip6->daddr);
 }
 
-static __always_inline __maybe_unused struct endpoint_info *
+static  __maybe_unused struct endpoint_info *
 __lookup_ip4_endpoint(__u32 ip)
 {
 	struct endpoint_key key = {};
@@ -37,7 +37,7 @@ __lookup_ip4_endpoint(__u32 ip)
 	return map_lookup_elem(&ENDPOINTS_MAP, &key);
 }
 
-static __always_inline __maybe_unused struct endpoint_info *
+static  __maybe_unused struct endpoint_info *
 lookup_ip4_endpoint(const struct iphdr *ip4)
 {
 	return __lookup_ip4_endpoint(ip4->daddr);
@@ -51,7 +51,7 @@ lookup_ip4_endpoint(const struct iphdr *ip4)
 
 #define V6_CACHE_KEY_LEN (sizeof(union v6addr)*8)
 
-static __always_inline __maybe_unused struct remote_endpoint_info *
+static  __maybe_unused struct remote_endpoint_info *
 ipcache_lookup6(const void *map, const union v6addr *addr,
 		__u32 prefix, __u32 cluster_id)
 {
@@ -73,7 +73,7 @@ ipcache_lookup6(const void *map, const union v6addr *addr,
 
 #define V4_CACHE_KEY_LEN (sizeof(__u32)*8)
 
-static __always_inline __maybe_unused struct remote_endpoint_info *
+static  __maybe_unused struct remote_endpoint_info *
 ipcache_lookup4(const void *map, __be32 addr, __u32 prefix, __u32 cluster_id)
 {
 	struct ipcache_key key = {

--- a/bpf/lib/eth.h
+++ b/bpf/lib/eth.h
@@ -22,7 +22,7 @@ union macaddr {
 	__u8 addr[6];
 };
 
-static __always_inline int eth_addrcmp(const union macaddr *a,
+static  int eth_addrcmp(const union macaddr *a,
 				       const union macaddr *b)
 {
 	int tmp;
@@ -34,7 +34,7 @@ static __always_inline int eth_addrcmp(const union macaddr *a,
 	return tmp;
 }
 
-static __always_inline int eth_is_bcast(const union macaddr *a)
+static  int eth_is_bcast(const union macaddr *a)
 {
 	union macaddr bcast;
 
@@ -47,19 +47,19 @@ static __always_inline int eth_is_bcast(const union macaddr *a)
 		return 0;
 }
 
-static __always_inline int eth_load_saddr(struct __ctx_buff *ctx, __u8 *mac,
+static  int eth_load_saddr(struct __ctx_buff *ctx, __u8 *mac,
 					  int off)
 {
 	return ctx_load_bytes(ctx, off + ETH_ALEN, mac, ETH_ALEN);
 }
 
-static __always_inline int eth_store_saddr_aligned(struct __ctx_buff *ctx,
+static  int eth_store_saddr_aligned(struct __ctx_buff *ctx,
 						   const __u8 *mac, int off)
 {
 	return ctx_store_bytes(ctx, off + ETH_ALEN, mac, ETH_ALEN, 0);
 }
 
-static __always_inline int eth_store_saddr(struct __ctx_buff *ctx,
+static  int eth_store_saddr(struct __ctx_buff *ctx,
 					   const __u8 *mac, int off)
 {
 #if !CTX_DIRECT_WRITE_OK
@@ -78,19 +78,19 @@ static __always_inline int eth_store_saddr(struct __ctx_buff *ctx,
 #endif
 }
 
-static __always_inline int eth_load_daddr(struct __ctx_buff *ctx, __u8 *mac,
+static  int eth_load_daddr(struct __ctx_buff *ctx, __u8 *mac,
 					  int off)
 {
 	return ctx_load_bytes(ctx, off, mac, ETH_ALEN);
 }
 
-static __always_inline int eth_store_daddr_aligned(struct __ctx_buff *ctx,
+static  int eth_store_daddr_aligned(struct __ctx_buff *ctx,
 						   const __u8 *mac, int off)
 {
 	return ctx_store_bytes(ctx, off, mac, ETH_ALEN, 0);
 }
 
-static __always_inline int eth_store_daddr(struct __ctx_buff *ctx,
+static  int eth_store_daddr(struct __ctx_buff *ctx,
 					   const __u8 *mac, int off)
 {
 #if !CTX_DIRECT_WRITE_OK
@@ -109,7 +109,7 @@ static __always_inline int eth_store_daddr(struct __ctx_buff *ctx,
 #endif
 }
 
-static __always_inline int eth_store_proto(struct __ctx_buff *ctx,
+static  int eth_store_proto(struct __ctx_buff *ctx,
 					   const __u16 proto, int off)
 {
 	return ctx_store_bytes(ctx, off + ETH_ALEN + ETH_ALEN,

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -11,7 +11,7 @@
 #include "neigh.h"
 #include "l3.h"
 
-static __always_inline int
+static  int
 maybe_add_l2_hdr(struct __ctx_buff *ctx __maybe_unused,
 		 __u32 ifindex __maybe_unused,
 		 bool *l2_hdr_required __maybe_unused)
@@ -35,7 +35,7 @@ maybe_add_l2_hdr(struct __ctx_buff *ctx __maybe_unused,
 	return 0;
 }
 
-static __always_inline bool fib_ok(int ret)
+static  bool fib_ok(int ret)
 {
 	return likely(ret == CTX_ACT_TX || ret == CTX_ACT_REDIRECT);
 }
@@ -74,7 +74,7 @@ static __always_inline bool fib_ok(int ret)
   * (due to ARP failing, see Kernel commit d1c362e1dd68) the provided 'oif'
   * will be used as output interface for redirect.
   */
-static __always_inline int
+static  int
 fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 		const struct bpf_fib_lookup_padded *fib_params,
 		bool allow_neigh_map, __s8 *fib_ret, int *oif)
@@ -169,7 +169,7 @@ out_send:
 	return ctx_redirect(ctx, *oif, 0);
 }
 
-static __always_inline int
+static  int
 fib_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 	     struct bpf_fib_lookup_padded *fib_params __maybe_unused,
 	     bool use_neigh_map, __s8 *fib_err __maybe_unused, int *oif)
@@ -201,7 +201,7 @@ fib_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
  * after the function returns 'fib_params' will have the results of the fib lookup
  * if successful.
  */
-static __always_inline int
+static  int
 fib_lookup_v6(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
 	      const struct in6_addr *ipv6_src, const struct in6_addr *ipv6_dst,
 	      int flags)
@@ -217,7 +217,7 @@ fib_lookup_v6(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
 	return fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), flags);
 };
 
-static __always_inline int
+static  int
 fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 		struct ipv6hdr *ip6 __maybe_unused, const bool needs_l2_check,
 		bool allow_neigh_map, __s8 *fib_err __maybe_unused, int *oif)
@@ -259,7 +259,7 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
  * after the function returns 'fib_params' will have the results of the fib lookup
  * if successful.
  */
-static __always_inline int
+static  int
 fib_lookup_v4(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
 	      __be32 ipv4_src, __be32 ipv4_dst, int flags) {
 	fib_params->l.family	= AF_INET;
@@ -270,7 +270,7 @@ fib_lookup_v4(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
 	return fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), flags);
 }
 
-static __always_inline int
+static  int
 fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
 		struct iphdr *ip4 __maybe_unused, const bool needs_l2_check,
 		bool allow_neigh_map, __s8 *fib_err __maybe_unused, int *oif)

--- a/bpf/lib/ghash.h
+++ b/bpf/lib/ghash.h
@@ -51,7 +51,7 @@
  * [1]: Knuth. The Art of Computer Programming (2nd edition), vol. 3, sec. 6.4,
  * ex. 9 (page 550, solution on page 729).
  */
-static __always_inline __u32 hash_32(__u32 key, __u32 bits)
+static  __u32 hash_32(__u32 key, __u32 bits)
 {
 	return (key * U32MAX_DIV_GOLDEN_RATIO) >> (32 - bits);
 }

--- a/bpf/lib/hash.h
+++ b/bpf/lib/hash.h
@@ -10,14 +10,14 @@
 /* The daddr is explicitly excluded from the hash here in order to allow for
  * backend selection to choose the same backend even on different service VIPs.
  */
-static __always_inline __u32 hash_from_tuple_v4(const struct ipv4_ct_tuple *tuple)
+static  __u32 hash_from_tuple_v4(const struct ipv4_ct_tuple *tuple)
 {
 	return jhash_3words(tuple->saddr,
 			    ((__u32)tuple->dport << 16) | tuple->sport,
 			    tuple->nexthdr, HASH_INIT4_SEED);
 }
 
-static __always_inline __u32 hash_from_tuple_v6(const struct ipv6_ct_tuple *tuple)
+static  __u32 hash_from_tuple_v6(const struct ipv6_ct_tuple *tuple)
 {
 	__u32 a, b, c;
 

--- a/bpf/lib/high_scale_ipcache.h
+++ b/bpf/lib/high_scale_ipcache.h
@@ -15,7 +15,7 @@
 	      - sizeof(__u32)))
 #define WORLD_CIDR_PREFIX_LEN4(PREFIX) (WORLD_CIDR_STATIC_PREFIX4 + (PREFIX))
 
-static __always_inline __maybe_unused bool
+static  __maybe_unused bool
 world_cidrs_lookup4(__u32 addr)
 {
 	__u8 *matches;
@@ -29,7 +29,7 @@ world_cidrs_lookup4(__u32 addr)
 	return matches != NULL;
 }
 
-static __always_inline bool
+static  bool
 needs_encapsulation(__u32 addr)
 {
 # ifndef ENABLE_ROUTING
@@ -50,7 +50,7 @@ needs_encapsulation(__u32 addr)
 	return !world_cidrs_lookup4(addr);
 }
 
-static __always_inline int
+static  int
 decapsulate_overlay(struct __ctx_buff *ctx, __u32 *src_id)
 {
 	struct geneve_dsr_opt4 dsr_opt __maybe_unused;

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -16,7 +16,7 @@
 
 # ifdef ENABLE_IPV6
 #  ifndef ENABLE_MASQUERADE_IPV6
-static __always_inline int
+static  int
 ipv6_whitelist_snated_egress_connections(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 					 enum ct_status ct_ret, __s8 *ext_err)
 {
@@ -41,7 +41,7 @@ ipv6_whitelist_snated_egress_connections(struct __ctx_buff *ctx, struct ipv6_ct_
 }
 #  endif /* ENABLE_MASQUERADE_IPV6 */
 
-static __always_inline bool
+static  bool
 ipv6_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 			       __u32 ipcache_srcid, struct ipv6hdr *ip6,
 			       struct ct_buffer6 *ct_buffer)
@@ -74,7 +74,7 @@ ipv6_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 	return true;
 }
 
-static __always_inline int
+static  int
 __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused,
 			  struct ipv6hdr *ip6, struct ct_buffer6 *ct_buffer,
 			  struct trace_ctx *trace, __s8 *ext_err)
@@ -150,7 +150,7 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 	return verdict;
 }
 
-static __always_inline int
+static  int
 ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 			__u32 ipcache_srcid, struct ipv6hdr *ip6,
 			struct trace_ctx *trace, __s8 *ext_err)
@@ -166,7 +166,7 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 					ip6, &ct_buffer, trace, ext_err);
 }
 
-static __always_inline bool
+static  bool
 ipv6_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 				struct ct_buffer6 *ct_buffer)
 {
@@ -202,7 +202,7 @@ ipv6_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 	return true;
 }
 
-static __always_inline int
+static  int
 __ipv6_host_policy_ingress(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 			   struct ct_buffer6 *ct_buffer, __u32 *src_sec_identity,
 			   struct trace_ctx *trace, __s8 *ext_err)
@@ -276,7 +276,7 @@ out:
 	return verdict;
 }
 
-static __always_inline int
+static  int
 ipv6_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_sec_identity,
 			 struct trace_ctx *trace, __s8 *ext_err)
 {
@@ -298,7 +298,7 @@ ipv6_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_sec_identity,
 
 # ifdef ENABLE_IPV4
 #  ifndef ENABLE_MASQUERADE_IPV4
-static __always_inline int
+static  int
 ipv4_whitelist_snated_egress_connections(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 					 enum ct_status ct_ret, __s8 *ext_err)
 {
@@ -323,7 +323,7 @@ ipv4_whitelist_snated_egress_connections(struct __ctx_buff *ctx, struct ipv4_ct_
 }
 #  endif /* ENABLE_MASQUERADE_IPV4 */
 
-static __always_inline bool
+static  bool
 ipv4_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 			       __u32 ipcache_srcid, struct iphdr *ip4,
 			       struct ct_buffer4 *ct_buffer)
@@ -350,7 +350,7 @@ ipv4_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 	return true;
 }
 
-static __always_inline int
+static  int
 __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused,
 			  struct iphdr *ip4, struct ct_buffer4 *ct_buffer,
 			  struct trace_ctx *trace, __s8 *ext_err)
@@ -426,7 +426,7 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 	return verdict;
 }
 
-static __always_inline int
+static  int
 ipv4_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 			__u32 ipcache_srcid, struct iphdr *ip4,
 			struct trace_ctx *trace, __s8 *ext_err)
@@ -441,7 +441,7 @@ ipv4_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 	return __ipv4_host_policy_egress(ctx, src_id == HOST_ID, ip4, &ct_buffer, trace, ext_err);
 }
 
-static __always_inline bool
+static  bool
 ipv4_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct iphdr *ip4,
 				struct ct_buffer4 *ct_buffer)
 {
@@ -472,7 +472,7 @@ ipv4_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct iphdr *ip4,
 	return true;
 }
 
-static __always_inline int
+static  int
 __ipv4_host_policy_ingress(struct __ctx_buff *ctx, struct iphdr *ip4,
 			   struct ct_buffer4 *ct_buffer, __u32 *src_sec_identity,
 			   struct trace_ctx *trace, __s8 *ext_err)
@@ -554,7 +554,7 @@ out:
 	return verdict;
 }
 
-static __always_inline int
+static  int
 ipv4_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_sec_identity,
 			 struct trace_ctx *trace, __s8 *ext_err)
 {

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -40,12 +40,12 @@
 #define ACTION_UNKNOWN_ICMP6_NS DROP_UNKNOWN_TARGET
 #endif
 
-static __always_inline int icmp6_load_type(struct __ctx_buff *ctx, int l4_off, __u8 *type)
+static  int icmp6_load_type(struct __ctx_buff *ctx, int l4_off, __u8 *type)
 {
 	return ctx_load_bytes(ctx, l4_off + ICMP6_TYPE_OFFSET, type, sizeof(*type));
 }
 
-static __always_inline int icmp6_send_reply(struct __ctx_buff *ctx, int nh_off)
+static  int icmp6_send_reply(struct __ctx_buff *ctx, int nh_off)
 {
 	union macaddr smac, dmac = NODE_MAC;
 	const int csum_off = nh_off + ICMP6_CSUM_OFFSET;
@@ -95,7 +95,7 @@ static __always_inline int icmp6_send_reply(struct __ctx_buff *ctx, int nh_off)
  *
  * Send an ICMPv6 nadv reply in return to an ICMPv6 ndisc.
  */
-static __always_inline int
+static  int
 send_icmp6_ndisc_adv(struct __ctx_buff *ctx, int nh_off,
 		     const union macaddr *mac, bool to_router)
 {
@@ -159,7 +159,7 @@ send_icmp6_ndisc_adv(struct __ctx_buff *ctx, int nh_off,
 	return icmp6_send_reply(ctx, nh_off);
 }
 
-static __always_inline __be32 compute_icmp6_csum(char data[80], __u16 payload_len,
+static  __be32 compute_icmp6_csum(char data[80], __u16 payload_len,
 						 struct ipv6hdr *ipv6hdr)
 {
 	__be32 sum;
@@ -171,7 +171,7 @@ static __always_inline __be32 compute_icmp6_csum(char data[80], __u16 payload_le
 	return sum;
 }
 
-static __always_inline int __icmp6_send_time_exceeded(struct __ctx_buff *ctx,
+static  int __icmp6_send_time_exceeded(struct __ctx_buff *ctx,
 						      int nh_off)
 {
 	/* FIXME: Fix code below to not require this init */
@@ -279,7 +279,7 @@ int tail_icmp6_send_time_exceeded(struct __ctx_buff *ctx __maybe_unused)
  *
  * NOTE: This is terminal function and will cause the BPF program to exit
  */
-static __always_inline int icmp6_send_time_exceeded(struct __ctx_buff *ctx,
+static  int icmp6_send_time_exceeded(struct __ctx_buff *ctx,
 						    int nh_off, enum metric_dir direction)
 {
 	ctx_store_meta(ctx, 0, nh_off);
@@ -289,7 +289,7 @@ static __always_inline int icmp6_send_time_exceeded(struct __ctx_buff *ctx,
 }
 #endif
 
-static __always_inline int __icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off)
+static  int __icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off)
 {
 	union v6addr target, router;
 	struct endpoint_info *ep;
@@ -357,7 +357,7 @@ int tail_icmp6_handle_ns(struct __ctx_buff *ctx)
  *
  * NOTE: This is terminal function and will cause the BPF program to exit
  */
-static __always_inline int icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off,
+static  int icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off,
 					   enum metric_dir direction,
 					   __s8 *ext_err)
 {
@@ -367,7 +367,7 @@ static __always_inline int icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off,
 	return tail_call_internal(ctx, CILIUM_CALL_HANDLE_ICMP6_NS, ext_err);
 }
 
-static __always_inline bool
+static  bool
 is_icmp6_ndp(struct __ctx_buff *ctx, const struct ipv6hdr *ip6, int nh_off)
 {
 	__u8 type;
@@ -379,7 +379,7 @@ is_icmp6_ndp(struct __ctx_buff *ctx, const struct ipv6hdr *ip6, int nh_off)
 	       (type == ICMP6_NS_MSG_TYPE || type == ICMP6_NA_MSG_TYPE);
 }
 
-static __always_inline int icmp6_ndp_handle(struct __ctx_buff *ctx, int nh_off,
+static  int icmp6_ndp_handle(struct __ctx_buff *ctx, int nh_off,
 					    enum metric_dir direction,
 					    __s8 *ext_err)
 {
@@ -398,7 +398,7 @@ static __always_inline int icmp6_ndp_handle(struct __ctx_buff *ctx, int nh_off,
 	return 0;
 }
 
-static __always_inline int
+static  int
 icmp6_host_handle(struct __ctx_buff *ctx, int l4_off, __s8 *ext_err, bool handle_ns)
 {
 	__u8 type;

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -6,7 +6,7 @@
 
 #include "dbg.h"
 
-static __always_inline bool identity_in_range(__u32 identity, __u32 range_start, __u32 range_end)
+static  bool identity_in_range(__u32 identity, __u32 range_start, __u32 range_end)
 {
 	return range_start <= identity && identity <= range_end;
 }
@@ -14,12 +14,12 @@ static __always_inline bool identity_in_range(__u32 identity, __u32 range_start,
 #define IDENTITY_LOCAL_SCOPE_MASK 0xFF000000
 #define IDENTITY_LOCAL_SCOPE_REMOTE_NODE 0x02000000
 
-static __always_inline bool identity_is_host(__u32 identity)
+static  bool identity_is_host(__u32 identity)
 {
 	return identity == HOST_ID;
 }
 
-static __always_inline bool identity_is_remote_node(__u32 identity)
+static  bool identity_is_remote_node(__u32 identity)
 {
 	/* KUBE_APISERVER_NODE_ID is the reserved identity that corresponds to
 	 * the labels 'reserved:remote-node' and 'reserved:kube-apiserver'. As
@@ -45,7 +45,7 @@ static __always_inline bool identity_is_remote_node(__u32 identity)
 		(identity & IDENTITY_LOCAL_SCOPE_MASK) == IDENTITY_LOCAL_SCOPE_REMOTE_NODE;
 }
 
-static __always_inline bool identity_is_node(__u32 identity)
+static  bool identity_is_node(__u32 identity)
 {
 	return identity_is_host(identity) || identity_is_remote_node(identity);
 }
@@ -70,7 +70,7 @@ static __always_inline bool identity_is_node(__u32 identity)
  *
  * Identities 128 and higher are guaranteed to be generated based on user input.
  */
-static __always_inline bool identity_is_reserved(__u32 identity)
+static  bool identity_is_reserved(__u32 identity)
 {
 #if defined ENABLE_IPV4 && defined ENABLE_IPV6
 		return identity < UNMANAGED_ID || identity_is_remote_node(identity) ||
@@ -88,7 +88,7 @@ static __always_inline bool identity_is_reserved(__u32 identity)
  * - ReservedIdentityWorld
  * - ReservedIdentityWorldIPv4
  */
-static __always_inline bool identity_is_world_ipv4(__u32 identity)
+static  bool identity_is_world_ipv4(__u32 identity)
 {
 #if defined ENABLE_IPV4 && defined ENABLE_IPV6
 		return identity == WORLD_ID || identity == WORLD_IPV4_ID;
@@ -105,7 +105,7 @@ static __always_inline bool identity_is_world_ipv4(__u32 identity)
  * - ReservedIdentityWorld
  * - ReservedIdentityWorldIPv6
  */
-static __always_inline bool identity_is_world_ipv6(__u32 identity)
+static  bool identity_is_world_ipv6(__u32 identity)
 {
 #if defined ENABLE_IPV4 && defined ENABLE_IPV6
 		return identity == WORLD_ID || identity == WORLD_IPV6_ID;
@@ -118,7 +118,7 @@ static __always_inline bool identity_is_world_ipv6(__u32 identity)
  * identity_is_cidr_range is used to determine whether an identity is assigned
  * to a CIDR range.
  */
-static __always_inline bool identity_is_cidr_range(__u32 identity)
+static  bool identity_is_cidr_range(__u32 identity)
 {
 	return identity_in_range(identity, CIDR_IDENTITY_RANGE_START, CIDR_IDENTITY_RANGE_END);
 }
@@ -143,7 +143,7 @@ static __always_inline bool identity_is_cidr_range(__u32 identity)
  * - ReservedIdentityIngress
  * - all other identifies
  */
-static __always_inline bool identity_is_cluster(__u32 identity)
+static  bool identity_is_cluster(__u32 identity)
 {
 #if defined ENABLE_IPV4 && defined ENABLE_IPV6
 	if (identity == WORLD_ID || identity == WORLD_IPV4_ID || identity == WORLD_IPV6_ID)
@@ -160,7 +160,7 @@ static __always_inline bool identity_is_cluster(__u32 identity)
 }
 
 #if __ctx_is == __ctx_skb
-static __always_inline __u32 inherit_identity_from_host(struct __ctx_buff *ctx, __u32 *identity)
+static  __u32 inherit_identity_from_host(struct __ctx_buff *ctx, __u32 *identity)
 {
 	__u32 magic = ctx->mark & MARK_MAGIC_HOST_MASK;
 
@@ -240,7 +240,7 @@ static __always_inline __u32 inherit_identity_from_host(struct __ctx_buff *ctx, 
  * identity_is_local is used to determine whether an identity is locally
  * allocated.
  */
-static __always_inline bool identity_is_local(__u32 identity)
+static  bool identity_is_local(__u32 identity)
 {
 	return (identity & IDENTITY_LOCAL_SCOPE_MASK) != 0;
 }

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -36,7 +36,7 @@ struct {
 } IPV4_FRAG_DATAGRAMS_MAP __section_maps_btf;
 #endif
 
-static __always_inline int
+static  int
 ipv4_csum_update_by_value(struct __ctx_buff *ctx, int l3_off, __u64 old_val,
 			  __u64 new_val, __u32 len)
 {
@@ -44,20 +44,20 @@ ipv4_csum_update_by_value(struct __ctx_buff *ctx, int l3_off, __u64 old_val,
 			       old_val, new_val, len);
 }
 
-static __always_inline int
+static  int
 ipv4_csum_update_by_diff(struct __ctx_buff *ctx, int l3_off, __u64 diff)
 {
 	return l3_csum_replace(ctx, l3_off + offsetof(struct iphdr, check),
 			       0, diff, 0);
 }
 
-static __always_inline int ipv4_load_daddr(struct __ctx_buff *ctx, int off,
+static  int ipv4_load_daddr(struct __ctx_buff *ctx, int off,
 					   __u32 *dst)
 {
 	return ctx_load_bytes(ctx, off + offsetof(struct iphdr, daddr), dst, 4);
 }
 
-static __always_inline int ipv4_dec_ttl(struct __ctx_buff *ctx, int off,
+static  int ipv4_dec_ttl(struct __ctx_buff *ctx, int off,
 					struct iphdr *ip4)
 {
 	__u8 new_ttl, ttl = ip4->ttl;
@@ -75,12 +75,12 @@ static __always_inline int ipv4_dec_ttl(struct __ctx_buff *ctx, int off,
 	return 0;
 }
 
-static __always_inline int ipv4_hdrlen(const struct iphdr *ip4)
+static  int ipv4_hdrlen(const struct iphdr *ip4)
 {
 	return ip4->ihl * 4;
 }
 
-static __always_inline bool ipv4_is_fragment(const struct iphdr *ip4)
+static  bool ipv4_is_fragment(const struct iphdr *ip4)
 {
 	/* The frag_off portion of the header consists of:
 	 *
@@ -94,26 +94,26 @@ static __always_inline bool ipv4_is_fragment(const struct iphdr *ip4)
 	return ip4->frag_off & bpf_htons(0x3FFF);
 }
 
-static __always_inline bool ipv4_is_not_first_fragment(const struct iphdr *ip4)
+static  bool ipv4_is_not_first_fragment(const struct iphdr *ip4)
 {
 	/* Ignore "More fragments" bit to catch all fragments but the first */
 	return ip4->frag_off & bpf_htons(0x1FFF);
 }
 
 /* Simply a reverse of ipv4_is_not_first_fragment to avoid double negative. */
-static __always_inline bool ipv4_has_l4_header(const struct iphdr *ip4)
+static  bool ipv4_has_l4_header(const struct iphdr *ip4)
 {
 	return !ipv4_is_not_first_fragment(ip4);
 }
 
-static __always_inline bool ipv4_is_in_subnet(__be32 addr,
+static  bool ipv4_is_in_subnet(__be32 addr,
 					      __be32 subnet, int prefixlen)
 {
 	return (addr & bpf_htonl(~((1 << (32 - prefixlen)) - 1))) == subnet;
 }
 
 #ifdef ENABLE_IPV4_FRAGMENTS
-static __always_inline int
+static  int
 ipv4_frag_get_l4ports(const struct ipv4_frag_id *frag_id,
 		      struct ipv4_frag_l4ports *ports)
 {
@@ -128,7 +128,7 @@ ipv4_frag_get_l4ports(const struct ipv4_frag_id *frag_id,
 	return 0;
 }
 
-static __always_inline int
+static  int
 ipv4_handle_fragmentation(struct __ctx_buff *ctx,
 			  const struct iphdr *ip4, int l4_off,
 			  enum ct_dir ct_dir,
@@ -179,7 +179,7 @@ ipv4_handle_fragmentation(struct __ctx_buff *ctx,
 }
 #endif
 
-static __always_inline int
+static  int
 ipv4_load_l4_ports(struct __ctx_buff *ctx, struct iphdr *ip4 __maybe_unused,
 		   int l4_off, enum ct_dir dir __maybe_unused,
 		   __be16 *ports, bool *has_l4_header __maybe_unused)

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -31,17 +31,17 @@
 #define IPV6_SADDR_OFF		offsetof(struct ipv6hdr, saddr)
 #define IPV6_DADDR_OFF		offsetof(struct ipv6hdr, daddr)
 
-static __always_inline int ipv6_optlen(const struct ipv6_opt_hdr *opthdr)
+static  int ipv6_optlen(const struct ipv6_opt_hdr *opthdr)
 {
 	return (opthdr->hdrlen + 1) << 3;
 }
 
-static __always_inline int ipv6_authlen(const struct ipv6_opt_hdr *opthdr)
+static  int ipv6_authlen(const struct ipv6_opt_hdr *opthdr)
 {
 	return (opthdr->hdrlen + 2) << 2;
 }
 
-static __always_inline int ipv6_hdrlen_offset(struct __ctx_buff *ctx, __u8 *nexthdr, int l3_off)
+static  int ipv6_hdrlen_offset(struct __ctx_buff *ctx, __u8 *nexthdr, int l3_off)
 {
 	int i, len = sizeof(struct ipv6hdr);
 	struct ipv6_opt_hdr opthdr __align_stack_8;
@@ -81,25 +81,25 @@ static __always_inline int ipv6_hdrlen_offset(struct __ctx_buff *ctx, __u8 *next
 	return DROP_INVALID_EXTHDR;
 }
 
-static __always_inline int ipv6_hdrlen(struct __ctx_buff *ctx, __u8 *nexthdr)
+static  int ipv6_hdrlen(struct __ctx_buff *ctx, __u8 *nexthdr)
 {
 	return ipv6_hdrlen_offset(ctx, nexthdr, ETH_HLEN);
 }
 
-static __always_inline void ipv6_addr_copy(union v6addr *dst,
+static  void ipv6_addr_copy(union v6addr *dst,
 					   const union v6addr *src)
 {
 	memcpy(dst, src, sizeof(*dst));
 }
 
-static __always_inline void ipv6_addr_copy_unaligned(union v6addr *dst,
+static  void ipv6_addr_copy_unaligned(union v6addr *dst,
 						     const union v6addr *src)
 {
 	dst->d1 = src->d1;
 	dst->d2 = src->d2;
 }
 
-static __always_inline bool ipv6_addr_equals(const union v6addr *a,
+static  bool ipv6_addr_equals(const union v6addr *a,
 					     const union v6addr *b)
 {
 	if (a->d1 != b->d1)
@@ -108,7 +108,7 @@ static __always_inline bool ipv6_addr_equals(const union v6addr *a,
 }
 
 /* Only works with contiguous masks. */
-static __always_inline int ipv6_addr_in_net(const union v6addr *addr,
+static  int ipv6_addr_in_net(const union v6addr *addr,
 					    const union v6addr *net,
 					    const union v6addr *mask)
 {
@@ -124,7 +124,7 @@ static __always_inline int ipv6_addr_in_net(const union v6addr *addr,
 	bpf_htonl(PREFIX <= 0 ? 0 : PREFIX < 32 ? ((1<<PREFIX) - 1) << (32-PREFIX)	\
 			      : 0xFFFFFFFF)
 
-static __always_inline void ipv6_addr_clear_suffix(union v6addr *addr,
+static  void ipv6_addr_clear_suffix(union v6addr *addr,
 						   int prefix)
 {
 	addr->p1 &= GET_PREFIX(prefix);
@@ -136,7 +136,7 @@ static __always_inline void ipv6_addr_clear_suffix(union v6addr *addr,
 	addr->p4 &= GET_PREFIX(prefix);
 }
 
-static __always_inline int ipv6_dec_hoplimit(struct __ctx_buff *ctx, int off)
+static  int ipv6_dec_hoplimit(struct __ctx_buff *ctx, int off)
 {
 	__u8 hl;
 
@@ -153,7 +153,7 @@ static __always_inline int ipv6_dec_hoplimit(struct __ctx_buff *ctx, int off)
 	return 0;
 }
 
-static __always_inline int ipv6_load_saddr(struct __ctx_buff *ctx, int off,
+static  int ipv6_load_saddr(struct __ctx_buff *ctx, int off,
 					   union v6addr *dst)
 {
 	return ctx_load_bytes(ctx, off + offsetof(struct ipv6hdr, saddr), dst->addr,
@@ -161,13 +161,13 @@ static __always_inline int ipv6_load_saddr(struct __ctx_buff *ctx, int off,
 }
 
 /* Assumes that caller fixes checksum csum_diff() and l4_csum_replace() */
-static __always_inline int ipv6_store_saddr(struct __ctx_buff *ctx, __u8 *addr,
+static  int ipv6_store_saddr(struct __ctx_buff *ctx, __u8 *addr,
 					    int off)
 {
 	return ctx_store_bytes(ctx, off + offsetof(struct ipv6hdr, saddr), addr, 16, 0);
 }
 
-static __always_inline int ipv6_load_daddr(struct __ctx_buff *ctx, int off,
+static  int ipv6_load_daddr(struct __ctx_buff *ctx, int off,
 					   union v6addr *dst)
 {
 	return ctx_load_bytes(ctx, off + offsetof(struct ipv6hdr, daddr), dst->addr,
@@ -175,13 +175,13 @@ static __always_inline int ipv6_load_daddr(struct __ctx_buff *ctx, int off,
 }
 
 /* Assumes that caller fixes checksum csum_diff() and l4_csum_replace() */
-static __always_inline int
+static  int
 ipv6_store_daddr(struct __ctx_buff *ctx, const __u8 *addr, int off)
 {
 	return ctx_store_bytes(ctx, off + offsetof(struct ipv6hdr, daddr), addr, 16, 0);
 }
 
-static __always_inline int ipv6_load_nexthdr(struct __ctx_buff *ctx, int off,
+static  int ipv6_load_nexthdr(struct __ctx_buff *ctx, int off,
 					     __u8 *nexthdr)
 {
 	return ctx_load_bytes(ctx, off + offsetof(struct ipv6hdr, nexthdr), nexthdr,
@@ -189,14 +189,14 @@ static __always_inline int ipv6_load_nexthdr(struct __ctx_buff *ctx, int off,
 }
 
 /* Assumes that caller fixes checksum csum_diff() and l4_csum_replace() */
-static __always_inline int ipv6_store_nexthdr(struct __ctx_buff *ctx, __u8 *nexthdr,
+static  int ipv6_store_nexthdr(struct __ctx_buff *ctx, __u8 *nexthdr,
 					      int off)
 {
 	return ctx_store_bytes(ctx, off + offsetof(struct ipv6hdr, nexthdr), nexthdr,
 			      sizeof(__u8), 0);
 }
 
-static __always_inline int ipv6_load_paylen(struct __ctx_buff *ctx, int off,
+static  int ipv6_load_paylen(struct __ctx_buff *ctx, int off,
 					    __be16 *len)
 {
 	return ctx_load_bytes(ctx, off + offsetof(struct ipv6hdr, payload_len),
@@ -204,14 +204,14 @@ static __always_inline int ipv6_load_paylen(struct __ctx_buff *ctx, int off,
 }
 
 /* Assumes that caller fixes checksum csum_diff() and l4_csum_replace() */
-static __always_inline int ipv6_store_paylen(struct __ctx_buff *ctx, int off,
+static  int ipv6_store_paylen(struct __ctx_buff *ctx, int off,
 					     __be16 *len)
 {
 	return ctx_store_bytes(ctx, off + offsetof(struct ipv6hdr, payload_len),
 			       len, sizeof(*len), 0);
 }
 
-static __always_inline __be32 ipv6_pseudohdr_checksum(struct ipv6hdr *hdr,
+static  __be32 ipv6_pseudohdr_checksum(struct ipv6hdr *hdr,
 						      __u8 next_hdr,
 						      __u16 payload_len, __be32 sum)
 {
@@ -229,7 +229,7 @@ static __always_inline __be32 ipv6_pseudohdr_checksum(struct ipv6hdr *hdr,
 /*
  * Ipv4 mapped address - 0:0:0:0:0:FFFF::/96
  */
-static __always_inline int ipv6_addr_is_mapped(const union v6addr *addr)
+static  int ipv6_addr_is_mapped(const union v6addr *addr)
 {
 	return addr->p1 == 0 && addr->p2 == 0 && addr->p3 == 0xFFFF0000;
 }

--- a/bpf/lib/jhash.h
+++ b/bpf/lib/jhash.h
@@ -11,7 +11,7 @@
 
 #define JHASH_INITVAL	0xdeadbeef
 
-static __always_inline __u32 rol32(__u32 word, __u32 shift)
+static  __u32 rol32(__u32 word, __u32 shift)
 {
 	return (word << shift) | (word >> ((-shift) & 31));
 }
@@ -37,7 +37,7 @@ static __always_inline __u32 rol32(__u32 word, __u32 shift)
 	c ^= b; c -= rol32(b, 24);		\
 }
 
-static __always_inline __u32 jhash(const void *key, __u32 length,
+static  __u32 jhash(const void *key, __u32 length,
 				   __u32 initval)
 {
 	const unsigned char *k = key;
@@ -81,7 +81,7 @@ static __always_inline __u32 jhash(const void *key, __u32 length,
 	return c;
 }
 
-static __always_inline __u32 __jhash_nwords(__u32 a, __u32 b, __u32 c,
+static  __u32 __jhash_nwords(__u32 a, __u32 b, __u32 c,
 					    __u32 initval)
 {
 	a += initval;
@@ -91,18 +91,18 @@ static __always_inline __u32 __jhash_nwords(__u32 a, __u32 b, __u32 c,
 	return c;
 }
 
-static __always_inline __u32 jhash_3words(__u32 a, __u32 b, __u32 c,
+static  __u32 jhash_3words(__u32 a, __u32 b, __u32 c,
 					  __u32 initval)
 {
 	return __jhash_nwords(a, b, c, initval + JHASH_INITVAL + (3 << 2));
 }
 
-static __always_inline __u32 jhash_2words(__u32 a, __u32 b, __u32 initval)
+static  __u32 jhash_2words(__u32 a, __u32 b, __u32 initval)
 {
 	return __jhash_nwords(a, b, 0, initval + JHASH_INITVAL + (2 << 2));
 }
 
-static __always_inline __u32 jhash_1word(__u32 a, __u32 initval)
+static  __u32 jhash_1word(__u32 a, __u32 initval)
 {
 	return __jhash_nwords(a, 0, 0, initval + JHASH_INITVAL + (1 << 2));
 }

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifdef ENABLE_IPV6
-static __always_inline int ipv6_l3(struct __ctx_buff *ctx, int l3_off,
+static  int ipv6_l3(struct __ctx_buff *ctx, int l3_off,
 				   const __u8 *smac, const __u8 *dmac,
 				   __u8 __maybe_unused direction)
 {
@@ -50,7 +50,7 @@ static __always_inline int ipv6_l3(struct __ctx_buff *ctx, int l3_off,
 }
 #endif /* ENABLE_IPV6 */
 
-static __always_inline int ipv4_l3(struct __ctx_buff *ctx, int l3_off,
+static  int ipv4_l3(struct __ctx_buff *ctx, int l3_off,
 				   const __u8 *smac, const __u8 *dmac,
 				   struct iphdr *ip4)
 {
@@ -70,7 +70,7 @@ static __always_inline int ipv4_l3(struct __ctx_buff *ctx, int l3_off,
 }
 
 #ifndef SKIP_POLICY_MAP
-static __always_inline int
+static  int
 l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 		  __u32 magic __maybe_unused,
 		  const struct endpoint_info *ep __maybe_unused,
@@ -134,7 +134,7 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
  * Depending on the configuration, it may also enforce ingress policies for the
  * destination pod via a tail call.
  */
-static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_off,
+static  int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_off,
 					       __u32 seclabel, __u32 magic,
 					       const struct endpoint_info *ep,
 					       __u8 direction, bool from_host,
@@ -160,7 +160,7 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
  * Depending on the configuration, it may also enforce ingress policies for the
  * destination pod via a tail call.
  */
-static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_off,
+static  int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_off,
 					       __u32 seclabel, __u32 magic,
 					       struct iphdr *ip4,
 					       const struct endpoint_info *ep,

--- a/bpf/lib/l4.h
+++ b/bpf/lib/l4.h
@@ -24,12 +24,12 @@ union tcp_flags {
 	__u32 value;
 };
 
-static __always_inline __u8 tcp_flags_to_u8(__be32 value)
+static  __u8 tcp_flags_to_u8(__be32 value)
 {
 	return ((union tcp_flags)value).lower_bits;
 }
 
-static __always_inline int
+static  int
 l4_store_port(struct __ctx_buff *ctx, int l4_off, int port_off, __be16 port)
 {
 	return ctx_store_bytes(ctx, l4_off + port_off, &port, sizeof(port), 0);
@@ -52,7 +52,7 @@ l4_store_port(struct __ctx_buff *ctx, int l4_off, int port_off, __be16 port)
  *
  * Return 0 on success or a negative DROP_* reason
  */
-static __always_inline int l4_modify_port(struct __ctx_buff *ctx, int l4_off,
+static  int l4_modify_port(struct __ctx_buff *ctx, int l4_off,
 					  int off, struct csum_offset *csum_off,
 					  __be16 port, __be16 old_port)
 {
@@ -65,19 +65,19 @@ static __always_inline int l4_modify_port(struct __ctx_buff *ctx, int l4_off,
 	return 0;
 }
 
-static __always_inline int l4_load_port(struct __ctx_buff *ctx, int off,
+static  int l4_load_port(struct __ctx_buff *ctx, int off,
 					__be16 *port)
 {
 	return ctx_load_bytes(ctx, off, port, sizeof(__be16));
 }
 
-static __always_inline int l4_load_ports(struct __ctx_buff *ctx, int off,
+static  int l4_load_ports(struct __ctx_buff *ctx, int off,
 					 __be16 *ports)
 {
 	return ctx_load_bytes(ctx, off, ports, 2 * sizeof(__be16));
 }
 
-static __always_inline int l4_load_tcp_flags(struct __ctx_buff *ctx, int l4_off,
+static  int l4_load_tcp_flags(struct __ctx_buff *ctx, int l4_off,
 					     union tcp_flags *flags)
 {
 	return ctx_load_bytes(ctx, l4_off + 12, flags, 2);

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -194,7 +194,7 @@ struct {
 #define cilium_dbg_lb(a, b, c, d)
 #endif
 
-static __always_inline bool lb_is_svc_proto(__u8 proto)
+static  bool lb_is_svc_proto(__u8 proto)
 {
 	switch (proto) {
 	case IPPROTO_TCP:
@@ -208,19 +208,19 @@ static __always_inline bool lb_is_svc_proto(__u8 proto)
 	}
 }
 
-static __always_inline
+static
 bool lb4_svc_is_loadbalancer(const struct lb4_service *svc __maybe_unused)
 {
 	return svc->flags & SVC_FLAG_LOADBALANCER;
 }
 
-static __always_inline
+static
 bool lb6_svc_is_loadbalancer(const struct lb6_service *svc __maybe_unused)
 {
 	return svc->flags & SVC_FLAG_LOADBALANCER;
 }
 
-static __always_inline
+static
 bool lb4_svc_is_nodeport(const struct lb4_service *svc __maybe_unused)
 {
 #ifdef ENABLE_NODEPORT
@@ -230,7 +230,7 @@ bool lb4_svc_is_nodeport(const struct lb4_service *svc __maybe_unused)
 #endif /* ENABLE_NODEPORT */
 }
 
-static __always_inline
+static
 bool lb6_svc_is_nodeport(const struct lb6_service *svc __maybe_unused)
 {
 #ifdef ENABLE_NODEPORT
@@ -240,43 +240,43 @@ bool lb6_svc_is_nodeport(const struct lb6_service *svc __maybe_unused)
 #endif /* ENABLE_NODEPORT */
 }
 
-static __always_inline
+static
 bool lb4_svc_is_external_ip(const struct lb4_service *svc __maybe_unused)
 {
 	return svc->flags & SVC_FLAG_EXTERNAL_IP;
 }
 
-static __always_inline
+static
 bool lb6_svc_is_external_ip(const struct lb6_service *svc __maybe_unused)
 {
 	return svc->flags & SVC_FLAG_EXTERNAL_IP;
 }
 
-static __always_inline
+static
 bool lb4_svc_is_hostport(const struct lb4_service *svc __maybe_unused)
 {
 	return svc->flags & SVC_FLAG_HOSTPORT;
 }
 
-static __always_inline
+static
 bool lb6_svc_is_hostport(const struct lb6_service *svc __maybe_unused)
 {
 	return svc->flags & SVC_FLAG_HOSTPORT;
 }
 
-static __always_inline
+static
 bool lb4_svc_is_loopback(const struct lb4_service *svc __maybe_unused)
 {
 	return svc->flags2 & SVC_FLAG_LOOPBACK;
 }
 
-static __always_inline
+static
 bool lb6_svc_is_loopback(const struct lb6_service *svc __maybe_unused)
 {
 	return svc->flags2 & SVC_FLAG_LOOPBACK;
 }
 
-static __always_inline
+static
 bool lb4_svc_has_src_range_check(const struct lb4_service *svc __maybe_unused)
 {
 #ifdef ENABLE_SRC_RANGE_CHECK
@@ -286,7 +286,7 @@ bool lb4_svc_has_src_range_check(const struct lb4_service *svc __maybe_unused)
 #endif /* ENABLE_SRC_RANGE_CHECK */
 }
 
-static __always_inline
+static
 bool lb6_svc_has_src_range_check(const struct lb6_service *svc __maybe_unused)
 {
 #ifdef ENABLE_SRC_RANGE_CHECK
@@ -296,67 +296,67 @@ bool lb6_svc_has_src_range_check(const struct lb6_service *svc __maybe_unused)
 #endif /* ENABLE_SRC_RANGE_CHECK */
 }
 
-static __always_inline bool lb_skip_l4_dnat(void)
+static  bool lb_skip_l4_dnat(void)
 {
 	return DSR_XLATE_MODE == DSR_XLATE_FRONTEND;
 }
 
-static __always_inline
+static
 bool lb4_svc_is_two_scopes(const struct lb4_service *svc)
 {
 	return svc->flags2 & SVC_FLAG_TWO_SCOPES;
 }
 
-static __always_inline
+static
 bool lb6_svc_is_two_scopes(const struct lb6_service *svc)
 {
 	return svc->flags2 & SVC_FLAG_TWO_SCOPES;
 }
 
-static __always_inline
+static
 bool lb4_svc_is_affinity(const struct lb4_service *svc)
 {
 	return svc->flags & SVC_FLAG_AFFINITY;
 }
 
-static __always_inline
+static
 bool lb6_svc_is_affinity(const struct lb6_service *svc)
 {
 	return svc->flags & SVC_FLAG_AFFINITY;
 }
 
-static __always_inline bool __lb_svc_is_routable(__u8 flags)
+static  bool __lb_svc_is_routable(__u8 flags)
 {
 	return (flags & SVC_FLAG_ROUTABLE) != 0;
 }
 
-static __always_inline
+static
 bool lb4_svc_is_routable(const struct lb4_service *svc)
 {
 	return __lb_svc_is_routable(svc->flags);
 }
 
-static __always_inline
+static
 bool lb6_svc_is_routable(const struct lb6_service *svc)
 {
 	return __lb_svc_is_routable(svc->flags);
 }
 
 #ifdef ENABLE_LOCAL_REDIRECT_POLICY
-static __always_inline
+static
 bool lb4_svc_is_localredirect(const struct lb4_service *svc)
 {
 	return svc->flags2 & SVC_FLAG_LOCALREDIRECT;
 }
 
-static __always_inline
+static
 bool lb6_svc_is_localredirect(const struct lb6_service *svc)
 {
 	return svc->flags2 & SVC_FLAG_LOCALREDIRECT;
 }
 #endif /* ENABLE_LOCAL_REDIRECT_POLICY */
 
-static __always_inline
+static
 bool lb4_svc_is_l7loadbalancer(const struct lb4_service *svc __maybe_unused)
 {
 #ifdef ENABLE_L7_LB
@@ -366,7 +366,7 @@ bool lb4_svc_is_l7loadbalancer(const struct lb4_service *svc __maybe_unused)
 #endif
 }
 
-static __always_inline
+static
 bool lb6_svc_is_l7loadbalancer(const struct lb6_service *svc __maybe_unused)
 {
 #ifdef ENABLE_L7_LB
@@ -376,7 +376,7 @@ bool lb6_svc_is_l7loadbalancer(const struct lb6_service *svc __maybe_unused)
 #endif
 }
 
-static __always_inline int reverse_map_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
+static  int reverse_map_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
 					       __be16 old_port, __be16 port, int l4_off,
 					       struct csum_offset *csum_off)
 {
@@ -416,7 +416,7 @@ static __always_inline int reverse_map_l4_port(struct __ctx_buff *ctx, __u8 next
 	return 0;
 }
 
-static __always_inline int
+static  int
 lb_l4_xlate(struct __ctx_buff *ctx, __u8 nexthdr __maybe_unused, int l4_off,
 	    struct csum_offset *csum_off, __be16 dport, __be16 backend_port)
 {
@@ -442,7 +442,7 @@ lb_l4_xlate(struct __ctx_buff *ctx, __u8 nexthdr __maybe_unused, int l4_off,
 }
 
 #ifdef ENABLE_IPV6
-static __always_inline int __lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
+static  int __lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 					 struct ipv6_ct_tuple *tuple,
 					 struct lb6_reverse_nat *nat)
 {
@@ -477,7 +477,7 @@ static __always_inline int __lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 	return 0;
 }
 
-static __always_inline struct lb6_reverse_nat *
+static  struct lb6_reverse_nat *
 lb6_lookup_rev_nat_entry(struct __ctx_buff *ctx __maybe_unused, __u16 index)
 {
 	cilium_dbg_lb(ctx, DBG_LB6_REVERSE_NAT_LOOKUP, index, 0);
@@ -491,7 +491,7 @@ lb6_lookup_rev_nat_entry(struct __ctx_buff *ctx __maybe_unused, __u16 index)
  * @arg index		reverse NAT index
  * @arg tuple		tuple
  */
-static __always_inline int lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
+static  int lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 				       __u16 index, struct ipv6_ct_tuple *tuple)
 {
 	struct lb6_reverse_nat *nat;
@@ -503,7 +503,7 @@ static __always_inline int lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 	return __lb6_rev_nat(ctx, l4_off, tuple, nat);
 }
 
-static __always_inline void
+static  void
 lb6_fill_key(struct lb6_key *key, struct ipv6_ct_tuple *tuple)
 {
 	/* FIXME: set after adding support for different L4 protocols in LB */
@@ -526,7 +526,7 @@ lb6_fill_key(struct lb6_key *key, struct ipv6_ct_tuple *tuple)
  *   - DROP_UNKNOWN_L4 if packet should be ignore (sent to stack)
  *   - Negative error code
  */
-static __always_inline int
+static  int
 lb6_extract_tuple(struct __ctx_buff *ctx, struct ipv6hdr *ip6, int l3_off,
 		  int *l4_off, struct ipv6_ct_tuple *tuple)
 {
@@ -566,7 +566,7 @@ lb6_extract_tuple(struct __ctx_buff *ctx, struct ipv6hdr *ip6, int l3_off,
 	}
 }
 
-static __always_inline
+static
 bool lb6_src_range_ok(const struct lb6_service *svc __maybe_unused,
 		      const union v6addr *saddr __maybe_unused)
 {
@@ -591,7 +591,7 @@ bool lb6_src_range_ok(const struct lb6_service *svc __maybe_unused,
 #endif /* ENABLE_SRC_RANGE_CHECK */
 }
 
-static __always_inline bool
+static  bool
 lb6_to_lb4_service(const struct lb6_service *svc __maybe_unused)
 {
 #ifdef ENABLE_NAT_46X64
@@ -601,7 +601,7 @@ lb6_to_lb4_service(const struct lb6_service *svc __maybe_unused)
 #endif
 }
 
-static __always_inline
+static
 struct lb6_service *lb6_lookup_service(struct lb6_key *key,
 				       const bool scope_switch)
 {
@@ -620,12 +620,12 @@ struct lb6_service *lb6_lookup_service(struct lb6_key *key,
 	return svc;
 }
 
-static __always_inline struct lb6_backend *__lb6_lookup_backend(__u32 backend_id)
+static  struct lb6_backend *__lb6_lookup_backend(__u32 backend_id)
 {
 	return map_lookup_elem(&LB6_BACKEND_MAP, &backend_id);
 }
 
-static __always_inline struct lb6_backend *
+static  struct lb6_backend *
 lb6_lookup_backend(struct __ctx_buff *ctx __maybe_unused, __u32 backend_id)
 {
 	struct lb6_backend *backend;
@@ -637,13 +637,13 @@ lb6_lookup_backend(struct __ctx_buff *ctx __maybe_unused, __u32 backend_id)
 	return backend;
 }
 
-static __always_inline
+static
 struct lb6_service *__lb6_lookup_backend_slot(struct lb6_key *key)
 {
 	return map_lookup_elem(&LB6_SERVICES_MAP_V2, key);
 }
 
-static __always_inline
+static
 struct lb6_service *lb6_lookup_backend_slot(struct __ctx_buff *ctx __maybe_unused,
 					    struct lb6_key *key, __u16 slot)
 {
@@ -662,7 +662,7 @@ struct lb6_service *lb6_lookup_backend_slot(struct __ctx_buff *ctx __maybe_unuse
 
 /* Backend slot 0 is always reserved for the service frontend. */
 #if LB_SELECTION == LB_SELECTION_RANDOM
-static __always_inline __u32
+static  __u32
 lb6_select_backend_id(struct __ctx_buff *ctx,
 		      struct lb6_key *key,
 		      const struct ipv6_ct_tuple *tuple __maybe_unused,
@@ -674,7 +674,7 @@ lb6_select_backend_id(struct __ctx_buff *ctx,
 	return be ? be->backend_id : 0;
 }
 #elif LB_SELECTION == LB_SELECTION_MAGLEV
-static __always_inline __u32
+static  __u32
 lb6_select_backend_id(struct __ctx_buff *ctx __maybe_unused,
 		      struct lb6_key *key __maybe_unused,
 		      const struct ipv6_ct_tuple *tuple,
@@ -697,7 +697,7 @@ lb6_select_backend_id(struct __ctx_buff *ctx __maybe_unused,
 }
 #elif LB_SELECTION == LB_SELECTION_FIRST
 /* Backend selection for tests that always chooses first slot. */
-static __always_inline __u32
+static  __u32
 lb6_select_backend_id(struct __ctx_buff *ctx __maybe_unused,
 		      struct lb6_key *key __maybe_unused,
 		      const struct ipv6_ct_tuple *tuple,
@@ -711,7 +711,7 @@ lb6_select_backend_id(struct __ctx_buff *ctx __maybe_unused,
 # error "Invalid load balancer backend selection algorithm!"
 #endif /* LB_SELECTION */
 
-static __always_inline int lb6_xlate(struct __ctx_buff *ctx, __u8 nexthdr,
+static  int lb6_xlate(struct __ctx_buff *ctx, __u8 nexthdr,
 				     int l3_off, int l4_off,
 				     const struct lb6_key *key,
 				     const struct lb6_backend *backend,
@@ -742,7 +742,7 @@ l4_xlate:
 }
 
 #ifdef ENABLE_SESSION_AFFINITY
-static __always_inline __u32
+static  __u32
 __lb6_affinity_backend_id(const struct lb6_service *svc, bool netns_cookie,
 			  union lb6_affinity_client_id *id)
 {
@@ -783,14 +783,14 @@ __lb6_affinity_backend_id(const struct lb6_service *svc, bool netns_cookie,
 	return 0;
 }
 
-static __always_inline __u32
+static  __u32
 lb6_affinity_backend_id_by_addr(const struct lb6_service *svc,
 				union lb6_affinity_client_id *id)
 {
 	return __lb6_affinity_backend_id(svc, false, id);
 }
 
-static __always_inline void
+static  void
 __lb6_update_affinity(const struct lb6_service *svc, bool netns_cookie,
 		      union lb6_affinity_client_id *id, __u32 backend_id)
 {
@@ -812,7 +812,7 @@ __lb6_update_affinity(const struct lb6_service *svc, bool netns_cookie,
 	map_update_elem(&LB6_AFFINITY_MAP, &key, &val, 0);
 }
 
-static __always_inline void
+static  void
 lb6_update_affinity_by_addr(const struct lb6_service *svc,
 			    union lb6_affinity_client_id *id, __u32 backend_id)
 {
@@ -820,7 +820,7 @@ lb6_update_affinity_by_addr(const struct lb6_service *svc,
 }
 #endif /* ENABLE_SESSION_AFFINITY */
 
-static __always_inline __u32
+static  __u32
 lb6_affinity_backend_id_by_netns(const struct lb6_service *svc __maybe_unused,
 				 union lb6_affinity_client_id *id __maybe_unused)
 {
@@ -831,7 +831,7 @@ lb6_affinity_backend_id_by_netns(const struct lb6_service *svc __maybe_unused,
 #endif
 }
 
-static __always_inline void
+static  void
 lb6_update_affinity_by_netns(const struct lb6_service *svc __maybe_unused,
 			     union lb6_affinity_client_id *id __maybe_unused,
 			     __u32 backend_id __maybe_unused)
@@ -841,7 +841,7 @@ lb6_update_affinity_by_netns(const struct lb6_service *svc __maybe_unused,
 #endif
 }
 
-static __always_inline int
+static  int
 lb6_to_lb4(struct __ctx_buff *ctx __maybe_unused,
 	   const struct ipv6hdr *ip6 __maybe_unused)
 {
@@ -857,7 +857,7 @@ lb6_to_lb4(struct __ctx_buff *ctx __maybe_unused,
 #endif
 }
 
-static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
+static  int lb6_local(const void *map, struct __ctx_buff *ctx,
 				     int l3_off, int l4_off,
 				     struct lb6_key *key,
 				     struct ipv6_ct_tuple *tuple,
@@ -980,7 +980,7 @@ drop_err:
  * NOTE: if lb_skip_l4_dnat() this is not the case as xlate is skipped. We
  * lose the updated tuple daddr in that case.
  */
-static __always_inline void lb6_ctx_store_state(struct __ctx_buff *ctx,
+static  void lb6_ctx_store_state(struct __ctx_buff *ctx,
 						const struct ct_state *state,
 					       __u16 proxy_port)
 {
@@ -993,7 +993,7 @@ static __always_inline void lb6_ctx_store_state(struct __ctx_buff *ctx,
  * tuple->flags does not need to be restored, as it will be reinitialized from
  * the packet.
  */
-static __always_inline void lb6_ctx_restore_state(struct __ctx_buff *ctx,
+static  void lb6_ctx_restore_state(struct __ctx_buff *ctx,
 						  struct ct_state *state,
 						 __u16 *proxy_port)
 {
@@ -1009,26 +1009,26 @@ static __always_inline void lb6_ctx_restore_state(struct __ctx_buff *ctx,
 /* Stubs for v4-in-v6 socket cgroup hook case when only v4 is enabled to avoid
  * additional map management.
  */
-static __always_inline
+static
 struct lb6_service *lb6_lookup_service(struct lb6_key *key __maybe_unused,
 				       const bool scope_switch __maybe_unused)
 {
 	return NULL;
 }
 
-static __always_inline
+static
 struct lb6_service *__lb6_lookup_backend_slot(struct lb6_key *key __maybe_unused)
 {
 	return NULL;
 }
 
-static __always_inline struct lb6_backend *
+static  struct lb6_backend *
 __lb6_lookup_backend(__u16 backend_id __maybe_unused)
 {
 	return NULL;
 }
 
-static __always_inline bool
+static  bool
 lb6_to_lb4_service(const struct lb6_service *svc __maybe_unused)
 {
 	return false;
@@ -1036,7 +1036,7 @@ lb6_to_lb4_service(const struct lb6_service *svc __maybe_unused)
 #endif /* ENABLE_IPV6 */
 
 #ifdef ENABLE_IPV4
-static __always_inline int __lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l4_off,
+static  int __lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l4_off,
 					 struct ipv4_ct_tuple *tuple,
 					 const struct lb4_reverse_nat *nat,
 					 bool loopback __maybe_unused, bool has_l4_header)
@@ -1103,7 +1103,7 @@ static __always_inline int __lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int
 	return 0;
 }
 
-static __always_inline struct lb4_reverse_nat *
+static  struct lb4_reverse_nat *
 lb4_lookup_rev_nat_entry(struct __ctx_buff *ctx __maybe_unused, __u16 index)
 {
 	cilium_dbg_lb(ctx, DBG_LB4_REVERSE_NAT_LOOKUP, index, 0);
@@ -1119,7 +1119,7 @@ lb4_lookup_rev_nat_entry(struct __ctx_buff *ctx __maybe_unused, __u16 index)
  * @arg loopback	loopback connection
  * @arg tuple		tuple
  */
-static __always_inline int lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l4_off,
+static  int lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l4_off,
 				       __u16 index, bool loopback,
 				       struct ipv4_ct_tuple *tuple, bool has_l4_header)
 {
@@ -1133,7 +1133,7 @@ static __always_inline int lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l
 			     loopback, has_l4_header);
 }
 
-static __always_inline void
+static  void
 lb4_fill_key(struct lb4_key *key, const struct ipv4_ct_tuple *tuple)
 {
 	/* FIXME: set after adding support for different L4 protocols in LB */
@@ -1155,7 +1155,7 @@ lb4_fill_key(struct lb4_key *key, const struct ipv4_ct_tuple *tuple)
  *   - DROP_UNKNOWN_L4 if packet should be ignore (sent to stack)
  *   - Negative error code
  */
-static __always_inline int
+static  int
 lb4_extract_tuple(struct __ctx_buff *ctx, struct iphdr *ip4, int l3_off, int *l4_off,
 		  struct ipv4_ct_tuple *tuple)
 {
@@ -1186,7 +1186,7 @@ lb4_extract_tuple(struct __ctx_buff *ctx, struct iphdr *ip4, int l3_off, int *l4
 	}
 }
 
-static __always_inline
+static
 bool lb4_src_range_ok(const struct lb4_service *svc __maybe_unused,
 		      __u32 saddr __maybe_unused)
 {
@@ -1211,7 +1211,7 @@ bool lb4_src_range_ok(const struct lb4_service *svc __maybe_unused,
 #endif /* ENABLE_SRC_RANGE_CHECK */
 }
 
-static __always_inline bool
+static  bool
 lb4_to_lb6_service(const struct lb4_service *svc __maybe_unused)
 {
 #ifdef ENABLE_NAT_46X64
@@ -1221,7 +1221,7 @@ lb4_to_lb6_service(const struct lb4_service *svc __maybe_unused)
 #endif
 }
 
-static __always_inline
+static
 struct lb4_service *lb4_lookup_service(struct lb4_key *key,
 				       const bool scope_switch)
 {
@@ -1240,12 +1240,12 @@ struct lb4_service *lb4_lookup_service(struct lb4_key *key,
 	return svc;
 }
 
-static __always_inline struct lb4_backend *__lb4_lookup_backend(__u32 backend_id)
+static  struct lb4_backend *__lb4_lookup_backend(__u32 backend_id)
 {
 	return map_lookup_elem(&LB4_BACKEND_MAP, &backend_id);
 }
 
-static __always_inline struct lb4_backend *
+static  struct lb4_backend *
 lb4_lookup_backend(struct __ctx_buff *ctx __maybe_unused, __u32 backend_id)
 {
 	struct lb4_backend *backend;
@@ -1257,13 +1257,13 @@ lb4_lookup_backend(struct __ctx_buff *ctx __maybe_unused, __u32 backend_id)
 	return backend;
 }
 
-static __always_inline
+static
 struct lb4_service *__lb4_lookup_backend_slot(struct lb4_key *key)
 {
 	return map_lookup_elem(&LB4_SERVICES_MAP_V2, key);
 }
 
-static __always_inline
+static
 struct lb4_service *lb4_lookup_backend_slot(struct __ctx_buff *ctx __maybe_unused,
 					    struct lb4_key *key, __u16 slot)
 {
@@ -1282,7 +1282,7 @@ struct lb4_service *lb4_lookup_backend_slot(struct __ctx_buff *ctx __maybe_unuse
 
 /* Backend slot 0 is always reserved for the service frontend. */
 #if LB_SELECTION == LB_SELECTION_RANDOM
-static __always_inline __u32
+static  __u32
 lb4_select_backend_id(struct __ctx_buff *ctx,
 		      struct lb4_key *key,
 		      const struct ipv4_ct_tuple *tuple __maybe_unused,
@@ -1294,7 +1294,7 @@ lb4_select_backend_id(struct __ctx_buff *ctx,
 	return be ? be->backend_id : 0;
 }
 #elif LB_SELECTION == LB_SELECTION_MAGLEV
-static __always_inline __u32
+static  __u32
 lb4_select_backend_id(struct __ctx_buff *ctx __maybe_unused,
 		      struct lb4_key *key __maybe_unused,
 		      const struct ipv4_ct_tuple *tuple,
@@ -1317,7 +1317,7 @@ lb4_select_backend_id(struct __ctx_buff *ctx __maybe_unused,
 }
 #elif LB_SELECTION == LB_SELECTION_FIRST
 /* Backend selection for tests that always chooses first slot. */
-static __always_inline __u32
+static  __u32
 lb4_select_backend_id(struct __ctx_buff *ctx,
 		      struct lb4_key *key,
 		      const struct ipv4_ct_tuple *tuple __maybe_unused,
@@ -1331,7 +1331,7 @@ lb4_select_backend_id(struct __ctx_buff *ctx,
 # error "Invalid load balancer backend selection algorithm!"
 #endif /* LB_SELECTION */
 
-static __always_inline int
+static  int
 lb4_xlate(struct __ctx_buff *ctx, __be32 *new_saddr __maybe_unused,
 	  __be32 *old_saddr __maybe_unused, __u8 nexthdr __maybe_unused, int l3_off,
 	  int l4_off, struct lb4_key *key,
@@ -1382,7 +1382,7 @@ l4_xlate:
 }
 
 #ifdef ENABLE_SESSION_AFFINITY
-static __always_inline __u32
+static  __u32
 __lb4_affinity_backend_id(const struct lb4_service *svc, bool netns_cookie,
 			  const union lb4_affinity_client_id *id)
 {
@@ -1424,14 +1424,14 @@ __lb4_affinity_backend_id(const struct lb4_service *svc, bool netns_cookie,
 	return 0;
 }
 
-static __always_inline __u32
+static  __u32
 lb4_affinity_backend_id_by_addr(const struct lb4_service *svc,
 				union lb4_affinity_client_id *id)
 {
 	return __lb4_affinity_backend_id(svc, false, id);
 }
 
-static __always_inline void
+static  void
 __lb4_update_affinity(const struct lb4_service *svc, bool netns_cookie,
 		      const union lb4_affinity_client_id *id,
 		      __u32 backend_id)
@@ -1450,7 +1450,7 @@ __lb4_update_affinity(const struct lb4_service *svc, bool netns_cookie,
 	map_update_elem(&LB4_AFFINITY_MAP, &key, &val, 0);
 }
 
-static __always_inline void
+static  void
 lb4_update_affinity_by_addr(const struct lb4_service *svc,
 			    union lb4_affinity_client_id *id, __u32 backend_id)
 {
@@ -1458,7 +1458,7 @@ lb4_update_affinity_by_addr(const struct lb4_service *svc,
 }
 #endif /* ENABLE_SESSION_AFFINITY */
 
-static __always_inline __u32
+static  __u32
 lb4_affinity_backend_id_by_netns(const struct lb4_service *svc __maybe_unused,
 				 union lb4_affinity_client_id *id __maybe_unused)
 {
@@ -1469,7 +1469,7 @@ lb4_affinity_backend_id_by_netns(const struct lb4_service *svc __maybe_unused,
 #endif
 }
 
-static __always_inline void
+static  void
 lb4_update_affinity_by_netns(const struct lb4_service *svc __maybe_unused,
 			     union lb4_affinity_client_id *id __maybe_unused,
 			     __u32 backend_id __maybe_unused)
@@ -1479,7 +1479,7 @@ lb4_update_affinity_by_netns(const struct lb4_service *svc __maybe_unused,
 #endif
 }
 
-static __always_inline int
+static  int
 lb4_to_lb6(struct __ctx_buff *ctx __maybe_unused,
 	   const struct iphdr *ip4 __maybe_unused,
 	   int l3_off __maybe_unused)
@@ -1496,7 +1496,7 @@ lb4_to_lb6(struct __ctx_buff *ctx __maybe_unused,
 #endif
 }
 
-static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
+static  int lb4_local(const void *map, struct __ctx_buff *ctx,
 				     bool is_fragment, int l3_off, int l4_off,
 				     struct lb4_key *key,
 				     struct ipv4_ct_tuple *tuple,
@@ -1643,7 +1643,7 @@ drop_err:
  * NOTE: if lb_skip_l4_dnat() this is not the case as xlate is skipped. We
  * lose the updated tuple daddr in that case.
  */
-static __always_inline void lb4_ctx_store_state(struct __ctx_buff *ctx,
+static  void lb4_ctx_store_state(struct __ctx_buff *ctx,
 						const struct ct_state *state,
 					       __u16 proxy_port, __u32 cluster_id)
 {
@@ -1662,7 +1662,7 @@ static __always_inline void lb4_ctx_store_state(struct __ctx_buff *ctx,
  * tuple->flags does not need to be restored, as it will be reinitialized from
  * the packet.
  */
-static __always_inline void
+static  void
 lb4_ctx_restore_state(struct __ctx_buff *ctx, struct ct_state *state,
 		       __u16 *proxy_port, __u32 *cluster_id __maybe_unused)
 {
@@ -1686,10 +1686,10 @@ lb4_ctx_restore_state(struct __ctx_buff *ctx, struct ct_state *state,
 
 #define ICMP_PACKET_MAX_SAMPLE_SIZE 64
 
-static __always_inline
+static
 __wsum icmp_wsum_accumulate(void *data_start, void *data_end, int sample_len);
 
-static __always_inline
+static
 int __tail_no_service_ipv4(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -1823,7 +1823,7 @@ int tail_no_service_ipv4(struct __ctx_buff *ctx)
 
 #define ICMPV6_PACKET_MAX_SAMPLE_SIZE 1280 - sizeof(struct ipv6hdr) - sizeof(struct icmp6hdr)
 
-static __always_inline
+static
 __wsum icmp_wsum_accumulate(void *data_start, void *data_end, int sample_len);
 
 /* The IPv6 pseudo-header */
@@ -1840,7 +1840,7 @@ struct ipv6_pseudo_header_t {
 	};
 };
 
-static __always_inline
+static
 int __tail_no_service_ipv6(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -1988,7 +1988,7 @@ int tail_no_service_ipv6(struct __ctx_buff *ctx)
 
 #ifdef SERVICE_NO_BACKEND_RESPONSE
 
-static __always_inline
+static
 __wsum icmp_wsum_accumulate(void *data_start, void *data_end, int sample_len)
 {
 	/* Unrolled loop to calculate the checksum of the ICMP sample
@@ -2034,7 +2034,7 @@ __wsum icmp_wsum_accumulate(void *data_start, void *data_end, int sample_len)
 /* sock_local_cookie retrieves the socket cookie for the
  * passed socket structure.
  */
-static __always_inline __maybe_unused
+static  __maybe_unused
 __sock_cookie sock_local_cookie(struct bpf_sock_addr *ctx)
 {
 #ifdef HAVE_SOCKET_COOKIE

--- a/bpf/lib/lxc.h
+++ b/bpf/lib/lxc.h
@@ -19,7 +19,7 @@
 #define TEMPLATE_LXC_ID 0xffff
 
 #ifdef ENABLE_SIP_VERIFICATION
-static __always_inline
+static
 int is_valid_lxc_src_ip(struct ipv6hdr *ip6 __maybe_unused)
 {
 #ifdef ENABLE_IPV6
@@ -33,7 +33,7 @@ int is_valid_lxc_src_ip(struct ipv6hdr *ip6 __maybe_unused)
 #endif
 }
 
-static __always_inline
+static
 int is_valid_lxc_src_ipv4(const struct iphdr *ip4 __maybe_unused)
 {
 #ifdef ENABLE_IPV4
@@ -44,13 +44,13 @@ int is_valid_lxc_src_ipv4(const struct iphdr *ip4 __maybe_unused)
 #endif
 }
 #else /* ENABLE_SIP_VERIFICATION */
-static __always_inline
+static
 int is_valid_lxc_src_ip(struct ipv6hdr *ip6 __maybe_unused)
 {
 	return 1;
 }
 
-static __always_inline
+static
 int is_valid_lxc_src_ipv4(struct iphdr *ip4 __maybe_unused)
 {
 	return 1;

--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -40,7 +40,7 @@ struct bpf_elf_map __section_maps POLICY_CALL_MAP = {
 	.max_elem	= POLICY_PROG_MAP_SIZE,
 };
 
-static __always_inline __must_check int
+static  __must_check int
 tail_call_policy(struct __ctx_buff *ctx, __u16 endpoint_id)
 {
 	if (__builtin_constant_p(endpoint_id)) {
@@ -69,7 +69,7 @@ struct bpf_elf_map __section_maps POLICY_EGRESSCALL_MAP = {
 	.max_elem	= POLICY_PROG_MAP_SIZE,
 };
 
-static __always_inline __must_check int
+static  __must_check int
 tail_call_egress_policy(struct __ctx_buff *ctx, __u16 endpoint_id)
 {
 	tail_call_dynamic(ctx, &POLICY_EGRESSCALL_MAP, endpoint_id);
@@ -329,7 +329,7 @@ struct {
 #endif /* ENABLE_HIGH_SCALE_IPCACHE */
 
 #ifndef SKIP_CALLS_MAP
-static __always_inline __must_check int
+static  __must_check int
 tail_call_internal(struct __ctx_buff *ctx, const __u32 index, __s8 *ext_err)
 {
 	tail_call_static(ctx, CALLS_MAP, index);

--- a/bpf/lib/mcast.h
+++ b/bpf/lib/mcast.h
@@ -78,13 +78,13 @@ struct {
 /* lookup a subscriber map for the given ipv4 multicast group
  * returns a void pointer to a inner subscriper map if one exists
  */
-static __always_inline void *mcast_lookup_subscriber_map(__be32 *group)
+static  void *mcast_lookup_subscriber_map(__be32 *group)
 {
 	return map_lookup_elem(&cilium_mcast_group_outer_v4_map, group);
 }
 
 /* returns 1 if ip4 header is followed by an IGMP payload, 0 if not */
-static __always_inline bool mcast_ipv4_is_igmp(const struct iphdr *ip4)
+static  bool mcast_ipv4_is_igmp(const struct iphdr *ip4)
 {
 	if (ip4->protocol == IPPROTO_IGMP)
 		return 1;
@@ -95,7 +95,7 @@ static __always_inline bool mcast_ipv4_is_igmp(const struct iphdr *ip4)
  * a call to 'mcast_ipv4_is_igmp' must be used prior to this call to ensure an
  * igmp message follows the ipv4 header
  */
-static __always_inline __s32 mcast_ipv4_igmp_type(const struct iphdr *ip4,
+static  __s32 mcast_ipv4_igmp_type(const struct iphdr *ip4,
 						  const void *data,
 						  const void *data_end)
 {
@@ -111,7 +111,7 @@ static __always_inline __s32 mcast_ipv4_igmp_type(const struct iphdr *ip4,
 
 /* add a subscriber to a subscriber map */
 /* returns 1 on success or DROP_INVALID for error */
-static __always_inline __s32 mcast_ipv4_add_subscriber(void *map,
+static  __s32 mcast_ipv4_add_subscriber(void *map,
 						       struct mcast_subscriber_v4 *sub)
 {
 	if ((map_update_elem(map, &sub->saddr, sub, BPF_ANY) != 0))
@@ -121,13 +121,13 @@ static __always_inline __s32 mcast_ipv4_add_subscriber(void *map,
 
 /* remove a subscriber to a subscriber map */
 /* always returns 1 */
-static __always_inline void mcast_ipv4_remove_subscriber(void *map,
+static  void mcast_ipv4_remove_subscriber(void *map,
 							 struct mcast_subscriber_v4 *sub)
 {
 	map_delete_elem(map, &sub->saddr);
 }
 
-static __always_inline __s32 mcast_ipv4_handle_v3_membership_report(void *ctx,
+static  __s32 mcast_ipv4_handle_v3_membership_report(void *ctx,
 								    void *group_map,
 								    const struct iphdr *ip4,
 								    const void *data,
@@ -212,7 +212,7 @@ static __always_inline __s32 mcast_ipv4_handle_v3_membership_report(void *ctx,
 	return DROP_IGMP_HANDLED;
 }
 
-static __always_inline __s32 mcast_ipv4_handle_v2_membership_report(void *ctx,
+static  __s32 mcast_ipv4_handle_v2_membership_report(void *ctx,
 								    void *group_map,
 								    const struct iphdr *ip4,
 								    const void *data,
@@ -245,7 +245,7 @@ static __always_inline __s32 mcast_ipv4_handle_v2_membership_report(void *ctx,
 	return DROP_IGMP_HANDLED;
 }
 
-static __always_inline __s32 mcast_ipv4_handle_igmp_leave(void *group_map,
+static  __s32 mcast_ipv4_handle_igmp_leave(void *group_map,
 							  const struct iphdr *ip4,
 							  const void *data,
 							  const void *data_end)
@@ -276,7 +276,7 @@ static __always_inline __s32 mcast_ipv4_handle_igmp_leave(void *group_map,
 }
 
 /* ipv4 igmp handler which dispatches to specific igmp message handlers */
-static __always_inline __s32 mcast_ipv4_handle_igmp(void *ctx,
+static  __s32 mcast_ipv4_handle_igmp(void *ctx,
 						    struct iphdr *ip4,
 						    void *data,
 						    void *data_end)
@@ -312,7 +312,7 @@ static __always_inline __s32 mcast_ipv4_handle_igmp(void *ctx,
 /* encodes a multicast mac address given a ipv4 group address
  * results are in big endian format and written directly into 'mac'
  */
-static __always_inline void mcast_encode_ipv4_mac(union macaddr *mac,
+static  void mcast_encode_ipv4_mac(union macaddr *mac,
 						  const __u8 group[4])
 {
 	mac->addr[0] = 0x01;

--- a/bpf/lib/metrics.h
+++ b/bpf/lib/metrics.h
@@ -23,7 +23,7 @@
  */
 #define update_metrics(bytes, direction, reason) \
 		_update_metrics(bytes, direction, reason, __MAGIC_LINE__, __MAGIC_FILE__)
-static __always_inline void _update_metrics(__u64 bytes, __u8 direction,
+static  void _update_metrics(__u64 bytes, __u8 direction,
 					    __u8 reason, __u16 line, __u8 file)
 {
 	struct metrics_value *entry, new_entry = {};
@@ -50,7 +50,7 @@ static __always_inline void _update_metrics(__u64 bytes, __u8 direction,
  * @direction:	1: Ingress 2: Egress 3: Service
  * Convert a CT direction into the corresponding one for metrics.
  */
-static __always_inline enum metric_dir ct_to_metrics_dir(enum ct_dir ct_dir)
+static  enum metric_dir ct_to_metrics_dir(enum ct_dir ct_dir)
 {
 	switch (ct_dir) {
 	case CT_INGRESS:

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -41,26 +41,26 @@ struct nat_entry {
 
 #define snat_v4_needs_masquerade_hook(ctx, target) 0
 
-static __always_inline __u16 __snat_clamp_port_range(__u16 start, __u16 end,
+static  __u16 __snat_clamp_port_range(__u16 start, __u16 end,
 						     __u16 val)
 {
 	return (val % (__u16)(end - start)) + start;
 }
 
-static __always_inline __maybe_unused __u16
+static  __maybe_unused __u16
 __snat_try_keep_port(__u16 start, __u16 end, __u16 val)
 {
 	return val >= start && val <= end ? val :
 	       __snat_clamp_port_range(start, end, (__u16)get_prandom_u32());
 }
 
-static __always_inline __maybe_unused void *
+static  __maybe_unused void *
 __snat_lookup(const void *map, const void *tuple)
 {
 	return map_lookup_elem(map, tuple);
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 __snat_update(const void *map, const void *otuple, const void *ostate,
 	      const void *rtuple, const void *rstate)
 {
@@ -152,7 +152,7 @@ struct {
 } IP_MASQ_AGENT_IPV4 __section_maps_btf;
 #endif
 
-static __always_inline void *
+static  void *
 get_cluster_snat_map_v4(__u32 cluster_id __maybe_unused)
 {
 #if defined(ENABLE_CLUSTER_AWARE_ADDRESSING) && defined(ENABLE_INTER_CLUSTER_SNAT)
@@ -162,13 +162,13 @@ get_cluster_snat_map_v4(__u32 cluster_id __maybe_unused)
 	return &SNAT_MAPPING_IPV4;
 }
 
-static __always_inline
+static
 struct ipv4_nat_entry *snat_v4_lookup(const struct ipv4_ct_tuple *tuple)
 {
 	return __snat_lookup(&SNAT_MAPPING_IPV4, tuple);
 }
 
-static __always_inline int snat_v4_new_mapping(struct __ctx_buff *ctx, void *map,
+static  int snat_v4_new_mapping(struct __ctx_buff *ctx, void *map,
 					       struct ipv4_ct_tuple *otuple,
 					       struct ipv4_nat_entry *ostate,
 					       const struct ipv4_nat_target *target,
@@ -249,7 +249,7 @@ out:
 	return ret;
 }
 
-static __always_inline int
+static  int
 snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 			   struct ipv4_ct_tuple *tuple,
 			   bool has_l4_header,
@@ -303,7 +303,7 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 	return snat_v4_new_mapping(ctx, map, tuple, tmp, target, needs_ct, ext_err);
 }
 
-static __always_inline int
+static  int
 snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 			       struct ipv4_ct_tuple *tuple,
 			       bool has_l4_header,
@@ -349,7 +349,7 @@ snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 	return DROP_NAT_NO_MAPPING;
 }
 
-static __always_inline int
+static  int
 snat_v4_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 			bool has_l4_header, int l4_off,
 			__be32 old_addr, __be32 new_addr, __u16 addr_off,
@@ -416,7 +416,7 @@ snat_v4_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 	return 0;
 }
 
-static __always_inline bool
+static  bool
 snat_v4_nat_can_skip(const struct ipv4_nat_target *target,
 		     const struct ipv4_ct_tuple *tuple)
 {
@@ -430,7 +430,7 @@ snat_v4_nat_can_skip(const struct ipv4_nat_target *target,
 	return (!target->from_local_endpoint && sport < NAT_MIN_EGRESS);
 }
 
-static __always_inline bool
+static  bool
 snat_v4_rev_nat_can_skip(const struct ipv4_nat_target *target, const struct ipv4_ct_tuple *tuple)
 {
 	__u16 dport = bpf_ntohs(tuple->dport);
@@ -442,7 +442,7 @@ snat_v4_rev_nat_can_skip(const struct ipv4_nat_target *target, const struct ipv4
  * - extracted from a request packet,
  * - on CT_NEW (ie. the tuple is reversed)
  */
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 snat_v4_create_dsr(const struct ipv4_ct_tuple *tuple,
 		   __be32 to_saddr, __be16 to_sport, __s8 *ext_err)
 {
@@ -469,7 +469,7 @@ snat_v4_create_dsr(const struct ipv4_ct_tuple *tuple,
 	return CTX_ACT_OK;
 }
 
-static __always_inline void snat_v4_init_tuple(const struct iphdr *ip4,
+static  void snat_v4_init_tuple(const struct iphdr *ip4,
 					       enum nat_dir dir,
 					       struct ipv4_ct_tuple *tuple)
 {
@@ -493,7 +493,7 @@ static __always_inline void snat_v4_init_tuple(const struct iphdr *ip4,
  * or NAT_PUNT_TO_STACK if it should not. On failure, it returns a negative
  * error code (distinct from NAT_PUNT_TO_STACK).
  */
-static __always_inline int
+static  int
 snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 			 struct ipv4_ct_tuple *tuple __maybe_unused,
 			 struct iphdr *ip4 __maybe_unused,
@@ -644,7 +644,7 @@ skip_egress_gateway:
 	return NAT_PUNT_TO_STACK;
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 snat_v4_nat_handle_icmp_frag_needed(struct __ctx_buff *ctx, __u64 off,
 				    bool has_l4_header)
 {
@@ -722,7 +722,7 @@ snat_v4_nat_handle_icmp_frag_needed(struct __ctx_buff *ctx, __u64 off,
 				       0, 0, 0);
 }
 
-static __always_inline int
+static  int
 __snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 	      struct iphdr *ip4, bool has_l4_header, int l4_off,
 	      bool update_tuple, const struct ipv4_nat_target *target,
@@ -748,7 +748,7 @@ __snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 	return ret;
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 	    struct iphdr *ip4, int off, bool has_l4_header,
 	    const struct ipv4_nat_target *target,
@@ -805,7 +805,7 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 			     port_off, trace, ext_err);
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 snat_v4_rev_nat_handle_icmp_frag_needed(struct __ctx_buff *ctx,
 					__u64 inner_l3_off,
 					struct ipv4_nat_entry **state)
@@ -874,7 +874,7 @@ snat_v4_rev_nat_handle_icmp_frag_needed(struct __ctx_buff *ctx,
 				       tuple.dport, (*state)->to_dport, port_off);
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 		struct trace_ctx *trace, __s8 *ext_err __maybe_unused)
 {
@@ -958,14 +958,14 @@ rewrite:
 				       tuple.dport, to_dport, port_off);
 }
 #else
-static __always_inline __maybe_unused
+static  __maybe_unused
 int snat_v4_nat(struct __ctx_buff *ctx __maybe_unused,
 		const struct ipv4_nat_target *target __maybe_unused)
 {
 	return CTX_ACT_OK;
 }
 
-static __always_inline __maybe_unused
+static  __maybe_unused
 int snat_v4_rev_nat(struct __ctx_buff *ctx __maybe_unused,
 		    const struct ipv4_nat_target *target __maybe_unused)
 {
@@ -1032,7 +1032,7 @@ struct {
 } IP_MASQ_AGENT_IPV6 __section_maps_btf;
 #endif
 
-static __always_inline void *
+static  void *
 get_cluster_snat_map_v6(__u32 cluster_id __maybe_unused)
 {
 #if defined(ENABLE_CLUSTER_AWARE_ADDRESSING) && defined(ENABLE_INTER_CLUSTER_SNAT)
@@ -1042,13 +1042,13 @@ get_cluster_snat_map_v6(__u32 cluster_id __maybe_unused)
 	return &SNAT_MAPPING_IPV6;
 }
 
-static __always_inline
+static
 struct ipv6_nat_entry *snat_v6_lookup(const struct ipv6_ct_tuple *tuple)
 {
 	return __snat_lookup(&SNAT_MAPPING_IPV6, tuple);
 }
 
-static __always_inline int snat_v6_update(struct ipv6_ct_tuple *otuple,
+static  int snat_v6_update(struct ipv6_ct_tuple *otuple,
 					  struct ipv6_nat_entry *ostate,
 					  struct ipv6_ct_tuple *rtuple,
 					  struct ipv6_nat_entry *rstate)
@@ -1057,7 +1057,7 @@ static __always_inline int snat_v6_update(struct ipv6_ct_tuple *otuple,
 			     rtuple, rstate);
 }
 
-static __always_inline int snat_v6_new_mapping(struct __ctx_buff *ctx,
+static  int snat_v6_new_mapping(struct __ctx_buff *ctx,
 					       struct ipv6_ct_tuple *otuple,
 					       struct ipv6_nat_entry *ostate,
 					       const struct ipv6_nat_target *target,
@@ -1126,7 +1126,7 @@ out:
 	return ret;
 }
 
-static __always_inline int
+static  int
 snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 			   struct ipv6_ct_tuple *tuple,
 			   struct ipv6_nat_entry **state,
@@ -1173,7 +1173,7 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 	return snat_v6_new_mapping(ctx, tuple, tmp, target, needs_ct, ext_err);
 }
 
-static __always_inline int
+static  int
 snat_v6_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 			       struct ipv6_ct_tuple *tuple,
 			       struct ipv6_nat_entry **state,
@@ -1210,7 +1210,7 @@ snat_v6_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 	return DROP_NAT_NO_MAPPING;
 }
 
-static __always_inline int
+static  int
 snat_v6_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off, int l4_off,
 			union v6addr *old_addr, union v6addr *new_addr, __u16 addr_off,
 			__be16 old_port, __be16 new_port, __u16 port_off)
@@ -1257,7 +1257,7 @@ snat_v6_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off, int l4
 	return 0;
 }
 
-static __always_inline bool
+static  bool
 snat_v6_nat_can_skip(const struct ipv6_nat_target *target,
 		     const struct ipv6_ct_tuple *tuple)
 {
@@ -1266,7 +1266,7 @@ snat_v6_nat_can_skip(const struct ipv6_nat_target *target,
 	return (!target->from_local_endpoint && sport < NAT_MIN_EGRESS);
 }
 
-static __always_inline bool
+static  bool
 snat_v6_rev_nat_can_skip(const struct ipv6_nat_target *target, const struct ipv6_ct_tuple *tuple)
 {
 	__u16 dport = bpf_ntohs(tuple->dport);
@@ -1274,7 +1274,7 @@ snat_v6_rev_nat_can_skip(const struct ipv6_nat_target *target, const struct ipv6
 	return dport < target->min_port || dport > target->max_port;
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 snat_v6_create_dsr(const struct ipv6_ct_tuple *tuple, union v6addr *to_saddr,
 		   __be16 to_sport, __s8 *ext_err)
 {
@@ -1301,7 +1301,7 @@ snat_v6_create_dsr(const struct ipv6_ct_tuple *tuple, union v6addr *to_saddr,
 	return CTX_ACT_OK;
 }
 
-static __always_inline void snat_v6_init_tuple(const struct ipv6hdr *ip6,
+static  void snat_v6_init_tuple(const struct ipv6hdr *ip6,
 					       enum nat_dir dir,
 					       struct ipv6_ct_tuple *tuple)
 {
@@ -1310,7 +1310,7 @@ static __always_inline void snat_v6_init_tuple(const struct ipv6hdr *ip6,
 	tuple->flags = dir;
 }
 
-static __always_inline int
+static  int
 snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 			 struct ipv6_ct_tuple *tuple __maybe_unused,
 			 int l4_off __maybe_unused,
@@ -1404,7 +1404,7 @@ snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 	return NAT_PUNT_TO_STACK;
 }
 
-static __always_inline int
+static  int
 __snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 	      int l4_off, bool update_tuple,
 	      const struct ipv6_nat_target *target, __u16 port_off,
@@ -1430,7 +1430,7 @@ __snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 	return ret;
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple, int off,
 	    const struct ipv6_nat_target *target, struct trace_ctx *trace,
 	    __s8 *ext_err)
@@ -1487,7 +1487,7 @@ snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple, int off,
 			     trace, ext_err);
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 				       __u32 inner_l3_off,
 				       struct ipv6_nat_entry **state)
@@ -1568,7 +1568,7 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 				       tuple.dport, (*state)->to_dport, port_off);
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 		struct trace_ctx *trace, __s8 *ext_err __maybe_unused)
 {
@@ -1658,14 +1658,14 @@ rewrite:
 				       tuple.dport, to_dport, port_off);
 }
 #else
-static __always_inline __maybe_unused
+static  __maybe_unused
 int snat_v6_nat(struct __ctx_buff *ctx __maybe_unused,
 		const struct ipv6_nat_target *target __maybe_unused)
 {
 	return CTX_ACT_OK;
 }
 
-static __always_inline __maybe_unused
+static  __maybe_unused
 int snat_v6_rev_nat(struct __ctx_buff *ctx __maybe_unused,
 		    const struct ipv6_nat_target *target __maybe_unused)
 {
@@ -1674,7 +1674,7 @@ int snat_v6_rev_nat(struct __ctx_buff *ctx __maybe_unused,
 #endif
 
 #if defined(ENABLE_IPV6) && defined(ENABLE_NODEPORT)
-static __always_inline int
+static  int
 snat_remap_rfc8215(struct __ctx_buff *ctx, const struct iphdr *ip4, int l3_off)
 {
 	union v6addr src6, dst6;
@@ -1684,7 +1684,7 @@ snat_remap_rfc8215(struct __ctx_buff *ctx, const struct iphdr *ip4, int l3_off)
 	return ipv4_to_ipv6(ctx, l3_off, &src6, &dst6);
 }
 
-static __always_inline bool
+static  bool
 __snat_v6_has_v4_complete(struct ipv6_ct_tuple *tuple6,
 			  const struct ipv4_ct_tuple *tuple4)
 {
@@ -1697,7 +1697,7 @@ __snat_v6_has_v4_complete(struct ipv6_ct_tuple *tuple6,
 	return snat_v6_lookup(tuple6);
 }
 
-static __always_inline bool
+static  bool
 snat_v6_has_v4_match_rfc8215(const struct ipv4_ct_tuple *tuple4)
 {
 	struct ipv6_ct_tuple tuple6;
@@ -1707,7 +1707,7 @@ snat_v6_has_v4_match_rfc8215(const struct ipv4_ct_tuple *tuple4)
 	return __snat_v6_has_v4_complete(&tuple6, tuple4);
 }
 
-static __always_inline bool
+static  bool
 snat_v6_has_v4_match(const struct ipv4_ct_tuple *tuple4)
 {
 	struct ipv6_ct_tuple tuple6;
@@ -1717,7 +1717,7 @@ snat_v6_has_v4_match(const struct ipv4_ct_tuple *tuple4)
 	return __snat_v6_has_v4_complete(&tuple6, tuple4);
 }
 #else
-static __always_inline bool
+static  bool
 snat_v6_has_v4_match(const struct ipv4_ct_tuple *tuple4 __maybe_unused)
 {
 	return false;

--- a/bpf/lib/nat_46x64.h
+++ b/bpf/lib/nat_46x64.h
@@ -13,7 +13,7 @@
 #include "ipv6.h"
 #include "eth.h"
 
-static __always_inline __maybe_unused bool is_v4_in_v6(const union v6addr *daddr)
+static  __maybe_unused bool is_v4_in_v6(const union v6addr *daddr)
 {
 	/* Check for ::FFFF:<IPv4 address>. */
 	union v6addr dprobe  = {
@@ -28,7 +28,7 @@ static __always_inline __maybe_unused bool is_v4_in_v6(const union v6addr *daddr
 	return ipv6_addr_equals(&dprobe, &dmasked);
 }
 
-static __always_inline __maybe_unused bool is_v4_in_v6_rfc8215(const union v6addr *daddr)
+static  __maybe_unused bool is_v4_in_v6_rfc8215(const union v6addr *daddr)
 {
 	union v6addr dprobe  = {
 		.addr[0] = NAT_46X64_PREFIX_0,
@@ -44,7 +44,7 @@ static __always_inline __maybe_unused bool is_v4_in_v6_rfc8215(const union v6add
 	return ipv6_addr_equals(&dprobe, &dmasked);
 }
 
-static __always_inline __maybe_unused
+static  __maybe_unused
 void build_v4_in_v6(union v6addr *daddr, __be32 v4)
 {
 	memset(daddr, 0, sizeof(*daddr));
@@ -53,7 +53,7 @@ void build_v4_in_v6(union v6addr *daddr, __be32 v4)
 	daddr->p4 = v4;
 }
 
-static __always_inline __maybe_unused
+static  __maybe_unused
 void build_v4_in_v6_rfc8215(union v6addr *daddr, __be32 v4)
 {
 	memset(daddr, 0, sizeof(*daddr));
@@ -64,13 +64,13 @@ void build_v4_in_v6_rfc8215(union v6addr *daddr, __be32 v4)
 	daddr->p4 = v4;
 }
 
-static __always_inline __maybe_unused
+static  __maybe_unused
 void build_v4_from_v6(const union v6addr *v6, __be32 *daddr)
 {
 	*daddr = v6->p4;
 }
 
-static __always_inline int get_csum_offset(__u8 protocol)
+static  int get_csum_offset(__u8 protocol)
 {
 	int csum_off;
 
@@ -100,7 +100,7 @@ static __always_inline int get_csum_offset(__u8 protocol)
 	return csum_off;
 }
 
-static __always_inline int icmp4_to_icmp6(struct __ctx_buff *ctx, int nh_off)
+static  int icmp4_to_icmp6(struct __ctx_buff *ctx, int nh_off)
 {
 	struct icmphdr icmp4 __align_stack_8;
 	struct icmp6hdr icmp6 __align_stack_8 = {};
@@ -180,7 +180,7 @@ static __always_inline int icmp4_to_icmp6(struct __ctx_buff *ctx, int nh_off)
 	return csum_diff(&icmp4, sizeof(icmp4), &icmp6, sizeof(icmp6), 0);
 }
 
-static __always_inline int icmp6_to_icmp4(struct __ctx_buff *ctx, int nh_off)
+static  int icmp6_to_icmp4(struct __ctx_buff *ctx, int nh_off)
 {
 	struct icmphdr icmp4 __align_stack_8 = {};
 	struct icmp6hdr icmp6 __align_stack_8;
@@ -257,7 +257,7 @@ static __always_inline int icmp6_to_icmp4(struct __ctx_buff *ctx, int nh_off)
 	return csum_diff(&icmp6, sizeof(icmp6), &icmp4, sizeof(icmp4), 0);
 }
 
-static __always_inline int ipv4_to_ipv6(struct __ctx_buff *ctx, int nh_off,
+static  int ipv4_to_ipv6(struct __ctx_buff *ctx, int nh_off,
 					const union v6addr *src6,
 					const union v6addr *dst6)
 {
@@ -314,7 +314,7 @@ static __always_inline int ipv4_to_ipv6(struct __ctx_buff *ctx, int nh_off,
 	return 0;
 }
 
-static __always_inline int ipv6_to_ipv4(struct __ctx_buff *ctx,
+static  int ipv6_to_ipv4(struct __ctx_buff *ctx,
 					__be32 src4, __be32 dst4)
 {
 	__be16 protocol = bpf_htons(ETH_P_IP);
@@ -371,7 +371,7 @@ static __always_inline int ipv6_to_ipv4(struct __ctx_buff *ctx,
 	return 0;
 }
 
-static __always_inline int
+static  int
 nat46_rfc8215(struct __ctx_buff *ctx __maybe_unused,
 	      const struct iphdr *ip4 __maybe_unused,
 	      int l3_off __maybe_unused)
@@ -384,7 +384,7 @@ nat46_rfc8215(struct __ctx_buff *ctx __maybe_unused,
 	return ipv4_to_ipv6(ctx, l3_off, &src6, &dst6);
 }
 
-static __always_inline int
+static  int
 nat64_rfc8215(struct __ctx_buff *ctx __maybe_unused,
 	      const struct ipv6hdr *ip6 __maybe_unused)
 {
@@ -399,12 +399,12 @@ nat64_rfc8215(struct __ctx_buff *ctx __maybe_unused,
 #define NAT46x64_MODE_XLATE	1
 #define NAT46x64_MODE_ROUTE	2
 
-static __always_inline bool nat46x64_cb_route(struct __ctx_buff *ctx)
+static  bool nat46x64_cb_route(struct __ctx_buff *ctx)
 {
 	return ctx_load_meta(ctx, CB_NAT_46X64) == NAT46x64_MODE_ROUTE;
 }
 
-static __always_inline bool nat46x64_cb_xlate(struct __ctx_buff *ctx)
+static  bool nat46x64_cb_xlate(struct __ctx_buff *ctx)
 {
 	return ctx_load_meta(ctx, CB_NAT_46X64) == NAT46x64_MODE_XLATE;
 }

--- a/bpf/lib/neigh.h
+++ b/bpf/lib/neigh.h
@@ -19,7 +19,7 @@ struct {
 	__uint(max_entries, NODEPORT_NEIGH6_SIZE);
 } NODEPORT_NEIGH6 __section_maps_btf;
 
-static __always_inline int neigh_record_ip6(struct __ctx_buff *ctx)
+static  int neigh_record_ip6(struct __ctx_buff *ctx)
 {
 	union macaddr smac = {}, *mac;
 	void *data, *data_end;
@@ -41,12 +41,12 @@ static __always_inline int neigh_record_ip6(struct __ctx_buff *ctx)
 	return 0;
 }
 
-static __always_inline union macaddr *neigh_lookup_ip6(const union v6addr *addr)
+static  union macaddr *neigh_lookup_ip6(const union v6addr *addr)
 {
 	return map_lookup_elem(&NODEPORT_NEIGH6, addr);
 }
 #else
-static __always_inline union macaddr *
+static  union macaddr *
 neigh_lookup_ip6(const union v6addr *addr __maybe_unused)
 {
 	return NULL;
@@ -62,7 +62,7 @@ struct {
 	__uint(max_entries, NODEPORT_NEIGH4_SIZE);
 } NODEPORT_NEIGH4 __section_maps_btf;
 
-static __always_inline int neigh_record_ip4(struct __ctx_buff *ctx)
+static  int neigh_record_ip4(struct __ctx_buff *ctx)
 {
 	union macaddr smac = {}, *mac;
 	void *data, *data_end;
@@ -84,12 +84,12 @@ static __always_inline int neigh_record_ip4(struct __ctx_buff *ctx)
 	return 0;
 }
 
-static __always_inline union macaddr *neigh_lookup_ip4(const __be32 *addr)
+static  union macaddr *neigh_lookup_ip4(const __be32 *addr)
 {
 	return map_lookup_elem(&NODEPORT_NEIGH4, addr);
 }
 #else
-static __always_inline union macaddr *
+static  union macaddr *
 neigh_lookup_ip4(const __be32 *addr __maybe_unused)
 {
 	return NULL;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -50,7 +50,7 @@ struct dsr_opt_v4 {
 	__u32 addr;
 };
 
-static __always_inline bool nodeport_uses_dsr(__u8 nexthdr __maybe_unused)
+static  bool nodeport_uses_dsr(__u8 nexthdr __maybe_unused)
 {
 # if defined(ENABLE_DSR) && !defined(ENABLE_DSR_HYBRID)
 	return true;
@@ -64,7 +64,7 @@ static __always_inline bool nodeport_uses_dsr(__u8 nexthdr __maybe_unused)
 }
 
 #ifdef HAVE_ENCAP
-static __always_inline int
+static  int
 nodeport_add_tunnel_encap(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 			  __be32 dst_ip, __u32 src_sec_identity, __u32 dst_sec_identity,
 			  enum trace_reason ct_reason, __u32 monitor, int *ifindex)
@@ -79,7 +79,7 @@ nodeport_add_tunnel_encap(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 }
 
 # if defined(ENABLE_DSR) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-static __always_inline int
+static  int
 nodeport_add_tunnel_encap_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 			      __be32 dst_ip, __u32 src_sec_identity, __u32 dst_sec_identity,
 			      void *opt, __u32 opt_len, enum trace_reason ct_reason,
@@ -96,7 +96,7 @@ nodeport_add_tunnel_encap_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_p
 # endif
 #endif /* HAVE_ENCAP */
 
-static __always_inline bool dsr_fail_needs_reply(int code __maybe_unused)
+static  bool dsr_fail_needs_reply(int code __maybe_unused)
 {
 #ifdef ENABLE_DSR_ICMP_ERRORS
 	if (code == DROP_FRAG_NEEDED)
@@ -105,7 +105,7 @@ static __always_inline bool dsr_fail_needs_reply(int code __maybe_unused)
 	return false;
 }
 
-static __always_inline bool dsr_is_too_big(struct __ctx_buff *ctx __maybe_unused,
+static  bool dsr_is_too_big(struct __ctx_buff *ctx __maybe_unused,
 					   __u16 expanded_len __maybe_unused)
 {
 #ifdef ENABLE_DSR_ICMP_ERRORS
@@ -115,7 +115,7 @@ static __always_inline bool dsr_is_too_big(struct __ctx_buff *ctx __maybe_unused
 	return false;
 }
 
-static __always_inline int
+static  int
 nodeport_fib_lookup_and_redirect(struct __ctx_buff *ctx,
 				 struct bpf_fib_lookup_padded *fib_params,
 				 __s8 *ext_err)
@@ -139,12 +139,12 @@ nodeport_fib_lookup_and_redirect(struct __ctx_buff *ctx,
 }
 
 #ifdef ENABLE_IPV6
-static __always_inline bool nodeport_uses_dsr6(const struct ipv6_ct_tuple *tuple)
+static  bool nodeport_uses_dsr6(const struct ipv6_ct_tuple *tuple)
 {
 	return nodeport_uses_dsr(tuple->nexthdr);
 }
 
-static __always_inline bool
+static  bool
 nodeport_has_nat_conflict_ipv6(const struct ipv6hdr *ip6 __maybe_unused,
 			       struct ipv6_nat_target *target __maybe_unused)
 {
@@ -177,7 +177,7 @@ nodeport_has_nat_conflict_ipv6(const struct ipv6hdr *ip6 __maybe_unused,
 	return false;
 }
 
-static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
+static  int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 						  union v6addr *saddr,
 						  struct trace_ctx *trace,
 						  __s8 *ext_err)
@@ -230,7 +230,7 @@ out:
 
 #ifdef ENABLE_DSR
 #if DSR_ENCAP_MODE == DSR_ENCAP_IPIP
-static __always_inline void rss_gen_src6(union v6addr *src,
+static  void rss_gen_src6(union v6addr *src,
 					 const union v6addr *client,
 					 __be32 l4_hint)
 {
@@ -259,7 +259,7 @@ static __always_inline void rss_gen_src6(union v6addr *src,
 	}
 }
 
-static __always_inline int dsr_set_ipip6(struct __ctx_buff *ctx,
+static  int dsr_set_ipip6(struct __ctx_buff *ctx,
 					 const struct ipv6hdr *ip6,
 					 const union v6addr *backend_addr,
 					 __be32 l4_hint, int *ohead)
@@ -299,7 +299,7 @@ static __always_inline int dsr_set_ipip6(struct __ctx_buff *ctx,
 	return 0;
 }
 #elif DSR_ENCAP_MODE == DSR_ENCAP_NONE
-static __always_inline int dsr_set_ext6(struct __ctx_buff *ctx,
+static  int dsr_set_ext6(struct __ctx_buff *ctx,
 					struct ipv6hdr *ip6,
 					const union v6addr *svc_addr,
 					__be16 svc_port, int *ohead)
@@ -352,7 +352,7 @@ static __always_inline int dsr_set_ext6(struct __ctx_buff *ctx,
 	return 0;
 }
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
+static  int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 						 struct ipv6hdr *ip6,
 						 const union v6addr *svc_addr,
 						 __be16 svc_port,
@@ -436,7 +436,7 @@ static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 }
 #endif /* DSR_ENCAP_MODE */
 
-static __always_inline int find_dsr_v6(struct __ctx_buff *ctx, __u8 nexthdr,
+static  int find_dsr_v6(struct __ctx_buff *ctx, __u8 nexthdr,
 				       struct dsr_opt_v6 *dsr_opt, bool *found)
 {
 	struct ipv6_opt_hdr opthdr __align_stack_8;
@@ -487,7 +487,7 @@ static __always_inline int find_dsr_v6(struct __ctx_buff *ctx, __u8 nexthdr,
 	return DROP_INVALID_EXTHDR;
 }
 
-static __always_inline int
+static  int
 nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 			struct ipv6hdr *ip6 __maybe_unused,
 			const struct ipv6_ct_tuple *tuple, int l4_off,
@@ -549,13 +549,13 @@ nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 	return 0;
 }
 
-static __always_inline struct ipv6_nat_entry *
+static  struct ipv6_nat_entry *
 nodeport_dsr_lookup_v6_nat_entry(const struct ipv6_ct_tuple *nat_tuple)
 {
 	return snat_v6_lookup(nat_tuple);
 }
 
-static __always_inline int xlate_dsr_v6(struct __ctx_buff *ctx,
+static  int xlate_dsr_v6(struct __ctx_buff *ctx,
 					const struct ipv6_ct_tuple *tuple,
 					int l4_off)
 {
@@ -576,7 +576,7 @@ static __always_inline int xlate_dsr_v6(struct __ctx_buff *ctx,
 				       nat_tup.sport, entry->to_sport, TCP_SPORT_OFF);
 }
 
-static __always_inline int dsr_reply_icmp6(struct __ctx_buff *ctx,
+static  int dsr_reply_icmp6(struct __ctx_buff *ctx,
 					   const struct ipv6hdr *ip6 __maybe_unused,
 					   const union v6addr *svc_addr __maybe_unused,
 					   __be16 dport __maybe_unused,
@@ -766,7 +766,7 @@ drop_err:
 					  CTX_ACT_DROP, METRIC_EGRESS);
 }
 
-static __always_inline int
+static  int
 nodeport_dsr_ingress_ipv6(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 			  int l4_off, union v6addr *addr, __be16 port,
 			  __s8 *ext_err)
@@ -813,7 +813,7 @@ create_ct:
 }
 #endif /* ENABLE_DSR */
 
-static __always_inline struct lb6_reverse_nat *
+static  struct lb6_reverse_nat *
 nodeport_rev_dnat_get_info_ipv6(struct __ctx_buff *ctx,
 				struct ipv6_ct_tuple *tuple)
 {
@@ -907,7 +907,7 @@ drop_err:
 }
 #endif /* ENABLE_NAT_46X64_GATEWAY */
 
-static __always_inline int
+static  int
 nodeport_rev_dnat_ingress_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 			       __s8 *ext_err)
 {
@@ -1032,7 +1032,7 @@ fib_redirect:
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_REVNAT)
-static __always_inline
+static
 int tail_nodeport_rev_dnat_ingress_ipv6(struct __ctx_buff *ctx)
 {
 	struct trace_ctx trace = {
@@ -1067,7 +1067,7 @@ drop:
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_NAT_INGRESS)
-static __always_inline
+static
 int tail_nodeport_nat_ingress_ipv6(struct __ctx_buff *ctx)
 {
 	struct ipv6_nat_target target = {
@@ -1141,7 +1141,7 @@ drop_err:
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_NAT_EGRESS)
-static __always_inline
+static
 int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 {
 	const bool nat_46x64 = nat46x64_cb_xlate(ctx);
@@ -1272,7 +1272,7 @@ drop_err:
 					  CTX_ACT_DROP, METRIC_EGRESS);
 }
 
-static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
+static  int nodeport_svc_lb6(struct __ctx_buff *ctx,
 					    struct ipv6_ct_tuple *tuple,
 					    struct lb6_service *svc,
 					    struct lb6_key *key,
@@ -1403,7 +1403,7 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 }
 
 /* See nodeport_lb4(). */
-static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
+static  int nodeport_lb6(struct __ctx_buff *ctx,
 					struct ipv6hdr *ip6,
 					__u32 src_sec_identity,
 					__s8 *ext_err,
@@ -1483,7 +1483,7 @@ skip_service_lookup:
 	}
 }
 
-static __always_inline int
+static  int
 nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, bool *snat_done,
 			   struct trace_ctx *trace, __s8 *ext_err __maybe_unused)
 {
@@ -1574,7 +1574,7 @@ int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 	return ret;
 }
 
-static __always_inline int
+static  int
 __handle_nat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 		      __s8 *ext_err)
 {
@@ -1599,7 +1599,7 @@ __handle_nat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	return ret;
 }
 
-static __always_inline int
+static  int
 handle_nat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 		    __s8 *ext_err)
 {
@@ -1607,7 +1607,7 @@ handle_nat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_NAT_FWD)
-static __always_inline
+static
 int tail_handle_nat_fwd_ipv6(struct __ctx_buff *ctx)
 {
 	struct trace_ctx trace = {
@@ -1638,12 +1638,12 @@ int tail_handle_nat_fwd_ipv6(struct __ctx_buff *ctx)
 #endif /* ENABLE_IPV6 */
 
 #ifdef ENABLE_IPV4
-static __always_inline bool nodeport_uses_dsr4(const struct ipv4_ct_tuple *tuple)
+static  bool nodeport_uses_dsr4(const struct ipv4_ct_tuple *tuple)
 {
 	return nodeport_uses_dsr(tuple->nexthdr);
 }
 
-static __always_inline bool
+static  bool
 nodeport_has_nat_conflict_ipv4(const struct iphdr *ip4 __maybe_unused,
 			       struct ipv4_nat_target *target __maybe_unused)
 {
@@ -1675,7 +1675,7 @@ nodeport_has_nat_conflict_ipv4(const struct iphdr *ip4 __maybe_unused,
 	return false;
 }
 
-static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
+static  int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 						  __u32 cluster_id __maybe_unused,
 						  __be32 *saddr,
 						  struct trace_ctx *trace,
@@ -1742,7 +1742,7 @@ out:
 
 #ifdef ENABLE_DSR
 #if DSR_ENCAP_MODE == DSR_ENCAP_IPIP
-static __always_inline __be32 rss_gen_src4(__be32 client, __be32 l4_hint)
+static  __be32 rss_gen_src4(__be32 client, __be32 l4_hint)
 {
 	const __u32 bits = 32 - IPV4_RSS_PREFIX_BITS;
 	__be32 src = IPV4_RSS_PREFIX;
@@ -1758,7 +1758,7 @@ static __always_inline __be32 rss_gen_src4(__be32 client, __be32 l4_hint)
  * After DSR IPIP:  [rssSrcIP -> backendIP]                        } IP
  *                  [clientIP:clientPort -> serviceIP:servicePort] } IP/L4
  */
-static __always_inline int dsr_set_ipip4(struct __ctx_buff *ctx,
+static  int dsr_set_ipip4(struct __ctx_buff *ctx,
 					 const struct iphdr *ip4,
 					 __be32 backend_addr,
 					 __be32 l4_hint, __be16 *ohead)
@@ -1811,7 +1811,7 @@ static __always_inline int dsr_set_ipip4(struct __ctx_buff *ctx,
 	return 0;
 }
 #elif DSR_ENCAP_MODE == DSR_ENCAP_NONE
-static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
+static  int dsr_set_opt4(struct __ctx_buff *ctx,
 					struct iphdr *ip4, __be32 svc_addr,
 					__be16 svc_port, __be16 *ohead)
 {
@@ -1869,7 +1869,7 @@ static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 	return 0;
 }
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, int l3_off __maybe_unused,
+static  int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, int l3_off __maybe_unused,
 						 struct iphdr *ip4, __be32 svc_addr,
 						 __be16 svc_port, int *ifindex, __be16 *ohead)
 {
@@ -2031,7 +2031,7 @@ static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, int l3_
 }
 #endif /* DSR_ENCAP_MODE */
 
-static __always_inline int
+static  int
 nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 			const struct iphdr *ip4 __maybe_unused,
 			const struct ipv4_ct_tuple *tuple, int l4_off,
@@ -2111,13 +2111,13 @@ nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 	return 0;
 }
 
-static __always_inline struct ipv4_nat_entry *
+static  struct ipv4_nat_entry *
 nodeport_dsr_lookup_v4_nat_entry(const struct ipv4_ct_tuple *nat_tuple)
 {
 	return snat_v4_lookup(nat_tuple);
 }
 
-static __always_inline int xlate_dsr_v4(struct __ctx_buff *ctx,
+static  int xlate_dsr_v4(struct __ctx_buff *ctx,
 					const struct ipv4_ct_tuple *tuple,
 					int l4_off, bool has_l4_header)
 {
@@ -2138,7 +2138,7 @@ static __always_inline int xlate_dsr_v4(struct __ctx_buff *ctx,
 				       nat_tup.sport, entry->to_sport, TCP_SPORT_OFF);
 }
 
-static __always_inline int dsr_reply_icmp4(struct __ctx_buff *ctx,
+static  int dsr_reply_icmp4(struct __ctx_buff *ctx,
 					   struct iphdr *ip4 __maybe_unused,
 					   __be32 svc_addr __maybe_unused,
 					   __be16 dport __maybe_unused,
@@ -2312,7 +2312,7 @@ drop_err:
 					  CTX_ACT_DROP, METRIC_EGRESS);
 }
 
-static __always_inline int
+static  int
 nodeport_dsr_ingress_ipv4(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 			  struct iphdr *ip4, bool has_l4_header, int l4_off,
 			  __be32 addr, __be16 port, __s8 *ext_err)
@@ -2372,7 +2372,7 @@ create_ct:
 }
 #endif /* ENABLE_DSR */
 
-static __always_inline struct lb4_reverse_nat *
+static  struct lb4_reverse_nat *
 nodeport_rev_dnat_get_info_ipv4(struct __ctx_buff *ctx,
 				struct ipv4_ct_tuple *tuple)
 {
@@ -2412,7 +2412,7 @@ nodeport_rev_dnat_get_info_ipv4(struct __ctx_buff *ctx,
  * CILIUM_CALL_IPV{4,6}_NODEPORT_REVNAT is plugged into CILIUM_MAP_CALLS
  * of the bpf_host, bpf_overlay and of the bpf_lxc.
  */
-static __always_inline int
+static  int
 nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 			       __s8 *ext_err)
 {
@@ -2534,7 +2534,7 @@ redirect:
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_REVNAT)
-static __always_inline
+static
 int tail_nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx)
 {
 	struct trace_ctx trace = {
@@ -2574,7 +2574,7 @@ drop_err:
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_NAT_INGRESS)
-static __always_inline
+static
 int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 {
 	struct ipv4_nat_target target = {
@@ -2664,7 +2664,7 @@ drop_err:
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_NAT_EGRESS)
-static __always_inline
+static
 int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 {
 	struct bpf_fib_lookup_padded fib_params = {
@@ -2799,7 +2799,7 @@ drop_err:
 					  CTX_ACT_DROP, METRIC_EGRESS);
 }
 
-static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
+static  int nodeport_svc_lb4(struct __ctx_buff *ctx,
 					    struct ipv4_ct_tuple *tuple,
 					    struct lb4_service *svc,
 					    struct lb4_key *key,
@@ -2953,7 +2953,7 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
  * which handles the case of: i) backend is local EP, ii) backend is remote EP,
  * iii) reply from remote backend EP.
  */
-static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
+static  int nodeport_lb4(struct __ctx_buff *ctx,
 					struct iphdr *ip4,
 					int l3_off,
 					__u32 src_sec_identity,
@@ -3062,7 +3062,7 @@ skip_service_lookup:
 	}
 }
 
-static __always_inline int
+static  int
 nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, bool *snat_done,
 			   struct trace_ctx *trace, __s8 *ext_err __maybe_unused)
 {
@@ -3188,7 +3188,7 @@ int tail_handle_snat_fwd_ipv4(struct __ctx_buff *ctx)
 	return ret;
 }
 
-static __always_inline int
+static  int
 __handle_nat_fwd_ipv4(struct __ctx_buff *ctx, __u32 cluster_id __maybe_unused,
 		      struct trace_ctx *trace, __s8 *ext_err)
 {
@@ -3216,7 +3216,7 @@ __handle_nat_fwd_ipv4(struct __ctx_buff *ctx, __u32 cluster_id __maybe_unused,
 	return ret;
 }
 
-static __always_inline int
+static  int
 handle_nat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 		    __s8 *ext_err)
 {
@@ -3226,7 +3226,7 @@ handle_nat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_NAT_FWD)
-static __always_inline
+static
 int tail_handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
 {
 	struct trace_ctx trace = {
@@ -3258,7 +3258,7 @@ int tail_handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
 #endif /* ENABLE_IPV4 */
 
 #ifdef ENABLE_HEALTH_CHECK
-static __always_inline int
+static  int
 health_encap_v4(struct __ctx_buff *ctx, __u32 tunnel_ep,
 		__u32 seclabel)
 {
@@ -3280,7 +3280,7 @@ health_encap_v4(struct __ctx_buff *ctx, __u32 tunnel_ep,
 	return 0;
 }
 
-static __always_inline int
+static  int
 health_encap_v6(struct __ctx_buff *ctx, const union v6addr *tunnel_ep,
 		__u32 seclabel)
 {
@@ -3302,7 +3302,7 @@ health_encap_v6(struct __ctx_buff *ctx, const union v6addr *tunnel_ep,
 	return 0;
 }
 
-static __always_inline int
+static  int
 lb_handle_health(struct __ctx_buff *ctx __maybe_unused)
 {
 	void *data __maybe_unused, *data_end __maybe_unused;
@@ -3351,7 +3351,7 @@ lb_handle_health(struct __ctx_buff *ctx __maybe_unused)
 }
 #endif /* ENABLE_HEALTH_CHECK */
 
-static __always_inline int
+static  int
 handle_nat_fwd(struct __ctx_buff *ctx, __u32 cluster_id,
 	       struct trace_ctx *trace __maybe_unused,
 	       __s8 *ext_err __maybe_unused)

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -9,7 +9,7 @@
 #include "lib/clustermesh.h"
 
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 bpf_clear_meta(struct __sk_buff *ctx)
 {
 	__u32 zero = 0;
@@ -42,7 +42,7 @@ bpf_clear_meta(struct __sk_buff *ctx)
  * The agent flag 'max-connected-clusters' can effect the allocation of bits
  * for identity and cluster_id in the mark (see comment in set_identity_mark).
  */
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 get_identity(const struct __sk_buff *ctx)
 {
 	__u32 cluster_id_lower = ctx->mark & CLUSTER_ID_LOWER_MASK;
@@ -55,7 +55,7 @@ get_identity(const struct __sk_buff *ctx)
 /**
  * get_epid - returns source endpoint identity from the mark field
  */
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 get_epid(const struct __sk_buff *ctx)
 {
 	return ctx->mark >> 16;
@@ -78,7 +78,7 @@ get_epid(const struct __sk_buff *ctx)
  * like the following:
  * CIIIIIII IIIIIIII XXXXXXXX CCCCCCCC
  */
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 set_identity_mark(struct __sk_buff *ctx, __u32 identity, __u32 magic)
 {
 	__u32 cluster_id = (identity >> IDENTITY_LEN) & CLUSTER_ID_MAX;
@@ -90,7 +90,7 @@ set_identity_mark(struct __sk_buff *ctx, __u32 identity, __u32 magic)
 	ctx->mark |= (identity & IDENTITY_MAX) << 16 | cluster_id_lower | cluster_id_upper;
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 set_identity_meta(struct __sk_buff *ctx, __u32 identity)
 {
 	ctx->cb[CB_ENCRYPT_IDENTITY] = identity;
@@ -99,13 +99,13 @@ set_identity_meta(struct __sk_buff *ctx, __u32 identity)
 /**
  * set_encrypt_key - pushes 8 bit key, 16 bit node ID, and encryption marker into ctx mark value.
  */
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 set_encrypt_key_mark(struct __sk_buff *ctx, __u8 key, __u32 node_id)
 {
 	ctx->mark = or_encrypt_key(key) | node_id << 16;
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 set_encrypt_key_meta(struct __sk_buff *ctx, __u8 key, __u32 node_id)
 {
 	ctx->cb[CB_ENCRYPT_MAGIC] = or_encrypt_key(key) | node_id << 16;
@@ -114,7 +114,7 @@ set_encrypt_key_meta(struct __sk_buff *ctx, __u8 key, __u32 node_id)
 /**
  * set_cluster_id_mark - sets the cluster_id mark.
  */
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 ctx_set_cluster_id_mark(struct __sk_buff *ctx, __u32 cluster_id)
 {
 	__u32 cluster_id_lower = (cluster_id & 0xFF);
@@ -123,7 +123,7 @@ ctx_set_cluster_id_mark(struct __sk_buff *ctx, __u32 cluster_id)
 	ctx->mark |=  cluster_id_lower | cluster_id_upper | MARK_MAGIC_CLUSTER_ID;
 }
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 ctx_get_cluster_id_mark(struct __sk_buff *ctx)
 {
 	__u32 ret = 0;
@@ -139,7 +139,7 @@ ctx_get_cluster_id_mark(struct __sk_buff *ctx)
 	return ret;
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 redirect_self(const struct __sk_buff *ctx)
 {
 	/* Looping back the packet into the originating netns. We xmit into the
@@ -148,13 +148,13 @@ redirect_self(const struct __sk_buff *ctx)
 	return ctx_redirect(ctx, ctx->ifindex, 0);
 }
 
-static __always_inline __maybe_unused bool
+static  __maybe_unused bool
 neigh_resolver_available(void)
 {
 	return is_defined(HAVE_FIB_NEIGH);
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 ctx_skip_nodeport_clear(struct __sk_buff *ctx __maybe_unused)
 {
 #ifdef ENABLE_NODEPORT
@@ -162,7 +162,7 @@ ctx_skip_nodeport_clear(struct __sk_buff *ctx __maybe_unused)
 #endif
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 ctx_skip_nodeport_set(struct __sk_buff *ctx __maybe_unused)
 {
 #ifdef ENABLE_NODEPORT
@@ -170,7 +170,7 @@ ctx_skip_nodeport_set(struct __sk_buff *ctx __maybe_unused)
 #endif
 }
 
-static __always_inline __maybe_unused bool
+static  __maybe_unused bool
 ctx_skip_nodeport(struct __sk_buff *ctx __maybe_unused)
 {
 #ifdef ENABLE_NODEPORT
@@ -183,13 +183,13 @@ ctx_skip_nodeport(struct __sk_buff *ctx __maybe_unused)
 }
 
 #ifdef ENABLE_HOST_FIREWALL
-static __always_inline void
+static  void
 ctx_skip_host_fw_set(struct __sk_buff *ctx)
 {
 	ctx->tc_index |= TC_INDEX_F_SKIP_HOST_FIREWALL;
 }
 
-static __always_inline bool
+static  bool
 ctx_skip_host_fw(struct __sk_buff *ctx)
 {
 	volatile __u32 tc_index = ctx->tc_index;
@@ -199,7 +199,7 @@ ctx_skip_host_fw(struct __sk_buff *ctx)
 }
 #endif /* ENABLE_HOST_FIREWALL */
 
-static __always_inline __maybe_unused __u32 ctx_get_xfer(struct __sk_buff *ctx,
+static  __maybe_unused __u32 ctx_get_xfer(struct __sk_buff *ctx,
 							 __u32 off)
 {
 	__u32 *data_meta = ctx_data_meta(ctx);
@@ -208,42 +208,42 @@ static __always_inline __maybe_unused __u32 ctx_get_xfer(struct __sk_buff *ctx,
 	return !ctx_no_room(data_meta + off + 1, data) ? data_meta[off] : 0;
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 ctx_set_xfer(struct __sk_buff *ctx __maybe_unused, __u32 meta __maybe_unused)
 {
 	/* Only possible from XDP -> SKB. */
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 ctx_move_xfer(struct __sk_buff *ctx __maybe_unused)
 {
 	/* Only possible from XDP -> SKB. */
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 ctx_change_head(struct __sk_buff *ctx, __u32 head_room, __u64 flags)
 {
 	return skb_change_head(ctx, head_room, flags);
 }
 
-static __always_inline void ctx_snat_done_set(struct __sk_buff *ctx)
+static  void ctx_snat_done_set(struct __sk_buff *ctx)
 {
 	ctx->mark &= ~MARK_MAGIC_HOST_MASK;
 	ctx->mark |= MARK_MAGIC_SNAT_DONE;
 }
 
-static __always_inline bool ctx_snat_done(const struct __sk_buff *ctx)
+static  bool ctx_snat_done(const struct __sk_buff *ctx)
 {
 	return (ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_SNAT_DONE;
 }
 
-static __always_inline void ctx_set_overlay_mark(struct __sk_buff *ctx)
+static  void ctx_set_overlay_mark(struct __sk_buff *ctx)
 {
 	ctx->mark &= ~MARK_MAGIC_HOST_MASK;
 	ctx->mark |= MARK_MAGIC_OVERLAY;
 }
 
-static __always_inline bool ctx_is_overlay(const struct __sk_buff *ctx)
+static  bool ctx_is_overlay(const struct __sk_buff *ctx)
 {
 	if (!is_defined(HAVE_ENCAP))
 		return false;
@@ -252,7 +252,7 @@ static __always_inline bool ctx_is_overlay(const struct __sk_buff *ctx)
 }
 
 #ifdef HAVE_ENCAP
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 ctx_set_encap_info(struct __sk_buff *ctx, __u32 src_ip,
 		   __be16 src_port __maybe_unused, __u32 node_id,
 		   __u32 seclabel, __u32 vni __maybe_unused,

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -7,59 +7,59 @@
 #include <linux/udp.h>
 #include <linux/ip.h>
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 bpf_clear_meta(struct xdp_md *ctx __maybe_unused)
 {
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 get_identity(struct xdp_md *ctx __maybe_unused)
 {
 	return 0;
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 set_identity_mark(struct xdp_md *ctx __maybe_unused, __u32 identity __maybe_unused,
 		  __u32 magic __maybe_unused)
 {
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 set_identity_meta(struct xdp_md *ctx __maybe_unused,
 		__u32 identity __maybe_unused)
 {
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 set_encrypt_key_mark(struct xdp_md *ctx __maybe_unused, __u8 key __maybe_unused,
 		     __u32 node_id __maybe_unused)
 {
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 set_encrypt_key_meta(struct __sk_buff *ctx __maybe_unused, __u8 key __maybe_unused,
 		     __u32 node_id __maybe_unused)
 {
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 ctx_set_cluster_id_mark(struct xdp_md *ctx __maybe_unused, __u32 cluster_id __maybe_unused)
 {
 }
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 ctx_get_cluster_id_mark(struct __sk_buff *ctx __maybe_unused)
 {
 	return 0;
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 redirect_self(struct xdp_md *ctx __maybe_unused)
 {
 	return XDP_TX;
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 redirect_neigh(int ifindex __maybe_unused,
 	       struct bpf_redir_neigh *params __maybe_unused,
 	       int plen __maybe_unused,
@@ -68,7 +68,7 @@ redirect_neigh(int ifindex __maybe_unused,
 	return XDP_DROP;
 }
 
-static __always_inline __maybe_unused bool
+static  __maybe_unused bool
 neigh_resolver_available(void)
 {
 	return false;
@@ -77,7 +77,7 @@ neigh_resolver_available(void)
 #define RECIRC_MARKER	5 /* tail call recirculation */
 #define XFER_MARKER	6 /* xdp -> skb meta transfer */
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 ctx_skip_nodeport_clear(struct xdp_md *ctx __maybe_unused)
 {
 #ifdef ENABLE_NODEPORT
@@ -85,7 +85,7 @@ ctx_skip_nodeport_clear(struct xdp_md *ctx __maybe_unused)
 #endif
 }
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 ctx_skip_nodeport_set(struct xdp_md *ctx __maybe_unused)
 {
 #ifdef ENABLE_NODEPORT
@@ -93,7 +93,7 @@ ctx_skip_nodeport_set(struct xdp_md *ctx __maybe_unused)
 #endif
 }
 
-static __always_inline __maybe_unused bool
+static  __maybe_unused bool
 ctx_skip_nodeport(struct xdp_md *ctx __maybe_unused)
 {
 #ifdef ENABLE_NODEPORT
@@ -103,13 +103,13 @@ ctx_skip_nodeport(struct xdp_md *ctx __maybe_unused)
 #endif
 }
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 ctx_get_xfer(struct xdp_md *ctx __maybe_unused, __u32 off __maybe_unused)
 {
 	return 0; /* Only intended for SKB context. */
 }
 
-static __always_inline __maybe_unused void ctx_set_xfer(struct xdp_md *ctx,
+static  __maybe_unused void ctx_set_xfer(struct xdp_md *ctx,
 							__u32 meta)
 {
 	__u32 val = ctx_load_meta(ctx, XFER_MARKER);
@@ -118,7 +118,7 @@ static __always_inline __maybe_unused void ctx_set_xfer(struct xdp_md *ctx,
 	ctx_store_meta(ctx, XFER_MARKER, val);
 }
 
-static __always_inline __maybe_unused void ctx_move_xfer(struct xdp_md *ctx)
+static  __maybe_unused void ctx_move_xfer(struct xdp_md *ctx)
 {
 	__u32 meta_xfer = ctx_load_meta(ctx, XFER_MARKER);
 	/* We transfer data from XFER_MARKER. This specifically
@@ -136,7 +136,7 @@ static __always_inline __maybe_unused void ctx_move_xfer(struct xdp_md *ctx)
 	}
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 ctx_change_head(struct xdp_md *ctx __maybe_unused,
 		__u32 head_room __maybe_unused,
 		__u64 flags __maybe_unused)
@@ -144,19 +144,19 @@ ctx_change_head(struct xdp_md *ctx __maybe_unused,
 	return 0; /* Only intended for SKB context. */
 }
 
-static __always_inline void ctx_snat_done_set(struct xdp_md *ctx)
+static  void ctx_snat_done_set(struct xdp_md *ctx)
 {
 	ctx_set_xfer(ctx, XFER_PKT_SNAT_DONE);
 }
 
-static __always_inline bool ctx_snat_done(struct xdp_md *ctx)
+static  bool ctx_snat_done(struct xdp_md *ctx)
 {
 	/* shouldn't be needed, there's no relevant Egress hook in XDP */
 	return ctx_load_meta(ctx, XFER_MARKER) & XFER_PKT_SNAT_DONE;
 }
 
 #ifdef HAVE_ENCAP
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 ctx_set_encap_info(struct xdp_md *ctx, __u32 src_ip, __be16 src_port,
 		   __u32 daddr, __u32 seclabel __maybe_unused,
 		   __u32 vni __maybe_unused, void *opt, __u32 opt_len, int *ifindex)
@@ -241,7 +241,7 @@ ctx_set_encap_info(struct xdp_md *ctx, __u32 src_ip, __be16 src_port,
 	return CTX_ACT_REDIRECT;
 }
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 ctx_set_tunnel_opt(struct xdp_md *ctx, void *opt, __u32 opt_len)
 {
 	const __u32 geneve_off = ETH_HLEN + sizeof(struct iphdr) + sizeof(struct udphdr);

--- a/bpf/lib/pcap.h
+++ b/bpf/lib/pcap.h
@@ -45,7 +45,7 @@ struct capture_msg {
 	struct pcap_pkthdr hdr;
 };
 
-static __always_inline void cilium_capture(struct __ctx_buff *ctx,
+static  void cilium_capture(struct __ctx_buff *ctx,
 					   const __u8 subtype,
 					   const __u16 rule_id,
 					   const __u64 tstamp,
@@ -74,7 +74,7 @@ static __always_inline void cilium_capture(struct __ctx_buff *ctx,
 			 &msg, sizeof(msg));
 }
 
-static __always_inline void __cilium_capture_in(struct __ctx_buff *ctx,
+static  void __cilium_capture_in(struct __ctx_buff *ctx,
 						__u16 rule_id, __u32 cap_len)
 {
 	/* For later pcap file generation, we export boot time to the RB
@@ -85,7 +85,7 @@ static __always_inline void __cilium_capture_in(struct __ctx_buff *ctx,
 		       bpf_ktime_cache_set(boot_ns), cap_len);
 }
 
-static __always_inline void __cilium_capture_out(struct __ctx_buff *ctx,
+static  void __cilium_capture_out(struct __ctx_buff *ctx,
 						 __u16 rule_id, __u32 cap_len)
 {
 	cilium_capture(ctx, CAPTURE_EGRESS, rule_id,
@@ -155,7 +155,7 @@ struct {
 	__uint(map_flags, BPF_F_NO_PREALLOC);
 } CAPTURE4_RULES __section_maps_btf;
 
-static __always_inline void
+static  void
 cilium_capture4_masked_key(const struct capture4_wcard *orig,
 			   const struct capture4_wcard *mask,
 			   struct capture4_wcard *out)
@@ -214,7 +214,7 @@ cilium_capture4_masked_key(const struct capture4_wcard *orig,
 	},
 #endif /* PREFIX_MASKS4 */
 
-static __always_inline struct capture_rule *
+static  struct capture_rule *
 cilium_capture4_classify_wcard(struct __ctx_buff *ctx)
 {
 	struct capture4_wcard prefix_masks[] = { PREFIX_MASKS4 };
@@ -266,7 +266,7 @@ struct {
 	__uint(map_flags, BPF_F_NO_PREALLOC);
 } CAPTURE6_RULES __section_maps_btf;
 
-static __always_inline void
+static  void
 cilium_capture6_masked_key(const struct capture6_wcard *orig,
 			   const struct capture6_wcard *mask,
 			   struct capture6_wcard *out)
@@ -335,7 +335,7 @@ cilium_capture6_masked_key(const struct capture6_wcard *orig,
 	},
 #endif /* PREFIX_MASKS6 */
 
-static __always_inline struct capture_rule *
+static  struct capture_rule *
 cilium_capture6_classify_wcard(struct __ctx_buff *ctx)
 {
 	struct capture6_wcard prefix_masks[] = { PREFIX_MASKS6 };
@@ -380,7 +380,7 @@ _Pragma("unroll")
 }
 #endif /* ENABLE_IPV6 */
 
-static __always_inline struct capture_rule *
+static  struct capture_rule *
 cilium_capture_classify_wcard(struct __ctx_buff *ctx)
 {
 	struct capture_rule *ret = NULL;
@@ -405,7 +405,7 @@ cilium_capture_classify_wcard(struct __ctx_buff *ctx)
 	return ret;
 }
 
-static __always_inline bool
+static  bool
 cilium_capture_candidate(struct __ctx_buff *ctx __maybe_unused,
 			 __u16 *rule_id __maybe_unused,
 			 __u16 *cap_len __maybe_unused)
@@ -429,7 +429,7 @@ cilium_capture_candidate(struct __ctx_buff *ctx __maybe_unused,
 	return false;
 }
 
-static __always_inline bool
+static  bool
 cilium_capture_cached(struct __ctx_buff *ctx __maybe_unused,
 		      __u16 *rule_id __maybe_unused,
 		      __u32 *cap_len __maybe_unused)
@@ -452,7 +452,7 @@ cilium_capture_cached(struct __ctx_buff *ctx __maybe_unused,
 	return false;
 }
 
-static __always_inline void
+static  void
 cilium_capture_in(struct __ctx_buff *ctx __maybe_unused)
 {
 	__u16 cap_len;
@@ -462,7 +462,7 @@ cilium_capture_in(struct __ctx_buff *ctx __maybe_unused)
 		__cilium_capture_in(ctx, rule_id, cap_len);
 }
 
-static __always_inline void
+static  void
 cilium_capture_out(struct __ctx_buff *ctx __maybe_unused)
 {
 	__u32 cap_len;
@@ -478,12 +478,12 @@ cilium_capture_out(struct __ctx_buff *ctx __maybe_unused)
 
 #else /* ENABLE_CAPTURE */
 
-static __always_inline void
+static  void
 cilium_capture_in(struct __ctx_buff *ctx __maybe_unused)
 {
 }
 
-static __always_inline void
+static  void
 cilium_capture_out(struct __ctx_buff *ctx __maybe_unused)
 {
 }

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -11,7 +11,7 @@
 #include "eps.h"
 #include "maps.h"
 
-static __always_inline int
+static  int
 __account_and_check(struct __ctx_buff *ctx __maybe_unused, struct policy_entry *policy,
 		    __s8 *ext_err, __u16 *proxy_port)
 {
@@ -33,7 +33,7 @@ __account_and_check(struct __ctx_buff *ctx __maybe_unused, struct policy_entry *
 	return CTX_ACT_OK;
 }
 
-static __always_inline int
+static  int
 __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 		    __u32 remote_id, __u16 ethertype __maybe_unused, __u16 dport,
 		    __u8 proto, int off __maybe_unused, int dir,
@@ -196,7 +196,7 @@ check_l4_policy:
  *   - CTX_ACT_OK if the policy allows this traffic based only on labels/L3/L4
  *   - Negative error code if the packet should be dropped
  */
-static __always_inline int
+static  int
 policy_can_ingress(struct __ctx_buff *ctx, const void *map, __u32 src_id, __u32 dst_id,
 		   __u16 ethertype, __u16 dport, __u8 proto, int l4_off,
 		   bool is_untracked_fragment, __u8 *match_type, __u8 *audited,
@@ -223,7 +223,7 @@ policy_can_ingress(struct __ctx_buff *ctx, const void *map, __u32 src_id, __u32 
 	return ret;
 }
 
-static __always_inline int policy_can_ingress6(struct __ctx_buff *ctx, const void *map,
+static  int policy_can_ingress6(struct __ctx_buff *ctx, const void *map,
 					       const struct ipv6_ct_tuple *tuple,
 					       int l4_off,  __u32 src_id, __u32 dst_id,
 					       __u8 *match_type, __u8 *audited,
@@ -234,7 +234,7 @@ static __always_inline int policy_can_ingress6(struct __ctx_buff *ctx, const voi
 				 ext_err, proxy_port);
 }
 
-static __always_inline int policy_can_ingress4(struct __ctx_buff *ctx,
+static  int policy_can_ingress4(struct __ctx_buff *ctx,
 		const void *map,
 					       const struct ipv4_ct_tuple *tuple,
 					       int l4_off, bool is_untracked_fragment,
@@ -248,13 +248,13 @@ static __always_inline int policy_can_ingress4(struct __ctx_buff *ctx,
 }
 
 #ifdef HAVE_ENCAP
-static __always_inline bool is_encap(__u16 dport, __u8 proto)
+static  bool is_encap(__u16 dport, __u8 proto)
 {
 	return proto == IPPROTO_UDP && dport == bpf_htons(TUNNEL_PORT);
 }
 #endif
 
-static __always_inline int
+static  int
 policy_can_egress(struct __ctx_buff *ctx, const void *map, __u32 src_id, __u32 dst_id,
 		  __u16 ethertype, __u16 dport, __u8 proto, int l4_off, __u8 *match_type,
 		  __u8 *audited, __s8 *ext_err, __u16 *proxy_port)
@@ -281,7 +281,7 @@ policy_can_egress(struct __ctx_buff *ctx, const void *map, __u32 src_id, __u32 d
 	return ret;
 }
 
-static __always_inline int policy_can_egress6(struct __ctx_buff *ctx, const void *map,
+static  int policy_can_egress6(struct __ctx_buff *ctx, const void *map,
 					      const struct ipv6_ct_tuple *tuple,
 					      int l4_off, __u32 src_id, __u32 dst_id,
 					      __u8 *match_type, __u8 *audited, __s8 *ext_err,
@@ -292,7 +292,7 @@ static __always_inline int policy_can_egress6(struct __ctx_buff *ctx, const void
 				 ext_err, proxy_port);
 }
 
-static __always_inline int policy_can_egress4(struct __ctx_buff *ctx, const void *map,
+static  int policy_can_egress4(struct __ctx_buff *ctx, const void *map,
 					      const struct ipv4_ct_tuple *tuple,
 					      int l4_off, __u32 src_id, __u32 dst_id,
 					      __u8 *match_type, __u8 *audited, __s8 *ext_err,
@@ -310,12 +310,12 @@ static __always_inline int policy_can_egress4(struct __ctx_buff *ctx, const void
  * Will cause the packet to ignore the policy enforcement verdict for allow rules and
  * be considered accepted despite of the policy outcome. Has no effect on deny rules.
  */
-static __always_inline void policy_mark_skip(struct __ctx_buff *ctx)
+static  void policy_mark_skip(struct __ctx_buff *ctx)
 {
 	ctx_store_meta(ctx, CB_POLICY, 1);
 }
 
-static __always_inline void policy_clear_mark(struct __ctx_buff *ctx)
+static  void policy_clear_mark(struct __ctx_buff *ctx)
 {
 	ctx_store_meta(ctx, CB_POLICY, 0);
 }

--- a/bpf/lib/policy_log.h
+++ b/bpf/lib/policy_log.h
@@ -38,7 +38,7 @@ struct policy_verdict_notify {
 	__u16	pad2; /* align with 64 bits */
 };
 
-static __always_inline bool policy_verdict_filter_allow(__u32 filter, __u8 dir)
+static  bool policy_verdict_filter_allow(__u32 filter, __u8 dir)
 {
 	/* Make dir being volatile to avoid compiler optimizing out
 	 * filter (thinking it to be zero).
@@ -48,7 +48,7 @@ static __always_inline bool policy_verdict_filter_allow(__u32 filter, __u8 dir)
 	return ((filter & d) > 0);
 }
 
-static __always_inline void
+static  void
 send_policy_verdict_notify(struct __ctx_buff *ctx, __u32 remote_label, __u16 dst_port,
 			   __u8 proto, __u8 dir, __u8 is_ipv6, int verdict, __u16 proxy_port,
 			   __u8 match_type, __u8 is_audited, __u8 auth_type)
@@ -82,7 +82,7 @@ send_policy_verdict_notify(struct __ctx_buff *ctx, __u32 remote_label, __u16 dst
 			 &msg, sizeof(msg));
 }
 #else
-static __always_inline void
+static  void
 send_policy_verdict_notify(struct __ctx_buff *ctx __maybe_unused,
 			   __u32 remote_label __maybe_unused, __u16 dst_port __maybe_unused,
 			   __u8 proto __maybe_unused, __u8 dir __maybe_unused,

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -11,7 +11,7 @@
 #endif
 
 #ifdef ENABLE_TPROXY
-static __always_inline int
+static  int
 assign_socket_tcp(struct __ctx_buff *ctx,
 		  struct bpf_sock_tuple *tuple, __u32 len, bool established)
 {
@@ -41,7 +41,7 @@ out:
 	return result;
 }
 
-static __always_inline int
+static  int
 assign_socket_udp(struct __ctx_buff *ctx,
 		  struct bpf_sock_tuple *tuple, __u32 len,
 		  bool established __maybe_unused)
@@ -66,7 +66,7 @@ out:
 	return result;
 }
 
-static __always_inline int
+static  int
 assign_socket(struct __ctx_buff *ctx,
 	      struct bpf_sock_tuple *tuple, __u32 len,
 	      __u8 nexthdr, bool established)
@@ -89,7 +89,7 @@ assign_socket(struct __ctx_buff *ctx,
  * combine_ports joins the specified ports in a manner consistent with
  * pkg/monitor/dataapth_debug.go to report the ports ino monitor messages.
  */
-static __always_inline __u32
+static  __u32
 combine_ports(__u16 dport, __u16 sport)
 {
 	return (bpf_ntohs(dport) << 16) | bpf_ntohs(sport);
@@ -106,7 +106,7 @@ combine_ports(__u16 dport, __u16 sport)
  * Prefetch the proxy socket and associate with the ctx. Must be run on tc	\
  * ingress. Will modify 'tuple'!						\
  */										\
-static __always_inline int							\
+static  int							\
 NAME(struct __ctx_buff *ctx, const CT_TUPLE_TYPE * ct_tuple,			\
      __be16 proxy_port, void *tproxy_addr)					\
 {										\
@@ -197,7 +197,7 @@ CTX_REDIRECT_FN(ctx_redirect_to_proxy_ingress6, struct ipv6_ct_tuple, ipv6,
  *   a BPF program configured upon ingress to transfer the cb[] to the mark
  *   before passing the traffic up to the stack towards the proxy.
  */
-static __always_inline int
+static  int
 __ctx_redirect_to_proxy(struct __ctx_buff *ctx, void *tuple __maybe_unused,
 			__be16 proxy_port, bool from_host __maybe_unused,
 			bool ipv4 __maybe_unused)
@@ -238,7 +238,7 @@ __ctx_redirect_to_proxy(struct __ctx_buff *ctx, void *tuple __maybe_unused,
 }
 
 #ifdef ENABLE_IPV4
-static __always_inline int
+static  int
 ctx_redirect_to_proxy4(struct __ctx_buff *ctx, void *tuple __maybe_unused,
 		       __be16 proxy_port, bool from_host __maybe_unused)
 {
@@ -247,7 +247,7 @@ ctx_redirect_to_proxy4(struct __ctx_buff *ctx, void *tuple __maybe_unused,
 #endif /* ENABLE_IPV4 */
 
 #ifdef ENABLE_IPV6
-static __always_inline int
+static  int
 ctx_redirect_to_proxy6(struct __ctx_buff *ctx, void *tuple __maybe_unused,
 		       __be16 proxy_port, bool from_host __maybe_unused)
 {
@@ -265,7 +265,7 @@ ctx_redirect_to_proxy6(struct __ctx_buff *ctx, void *tuple __maybe_unused,
  * Note that it doesn't fully initialize 'tuple' as the directionality	\
  * bit is unused in the proxy paths.					\
  */									\
-static __always_inline int						\
+static  int						\
 NAME(struct __ctx_buff *ctx, struct PREFIX ## _ct_tuple *tuple)		\
 {									\
 	int err;							\
@@ -292,7 +292,7 @@ IP_TUPLE_EXTRACT_FN(extract_tuple6, ipv6)
  * the packet towards the proxy. It is designed to run as the first function
  * that accesses the context from the current BPF program.
  */
-static __always_inline int
+static  int
 ctx_redirect_to_proxy_first(struct __ctx_buff *ctx, __be16 proxy_port)
 {
 	int ret = CTX_ACT_OK;
@@ -361,7 +361,7 @@ out: __maybe_unused;
 /**
  * tc_index_from_ingress_proxy - returns true if packet originates from ingress proxy
  */
-static __always_inline bool tc_index_from_ingress_proxy(struct __ctx_buff *ctx)
+static  bool tc_index_from_ingress_proxy(struct __ctx_buff *ctx)
 {
 	volatile __u32 tc_index = ctx->tc_index;
 #ifdef DEBUG
@@ -375,7 +375,7 @@ static __always_inline bool tc_index_from_ingress_proxy(struct __ctx_buff *ctx)
 /**
  * tc_index_from_egress_proxy - returns true if packet originates from egress proxy
  */
-static __always_inline bool tc_index_from_egress_proxy(struct __ctx_buff *ctx)
+static  bool tc_index_from_egress_proxy(struct __ctx_buff *ctx)
 {
 	volatile __u32 tc_index = ctx->tc_index;
 #ifdef DEBUG

--- a/bpf/lib/proxy_hairpin.h
+++ b/bpf/lib/proxy_hairpin.h
@@ -23,7 +23,7 @@
  * @arg ip4		Pointer to IPv4 header. NULL for IPv6 packet.
  * @arg proxy_port	Proxy port
  */
-static __always_inline int
+static  int
 ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, struct iphdr *ip4,
 			      __be16 proxy_port)
 {
@@ -62,7 +62,7 @@ ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, struct iphdr *ip4,
 }
 
 #ifdef ENABLE_IPV4
-static __always_inline int
+static  int
 ctx_redirect_to_proxy_hairpin_ipv4(struct __ctx_buff *ctx, struct iphdr *ip4,
 				   __be16 proxy_port)
 {
@@ -71,7 +71,7 @@ ctx_redirect_to_proxy_hairpin_ipv4(struct __ctx_buff *ctx, struct iphdr *ip4,
 #endif
 
 #ifdef ENABLE_IPV6
-static __always_inline int
+static  int
 ctx_redirect_to_proxy_hairpin_ipv6(struct __ctx_buff *ctx, __be16 proxy_port)
 {
 	return ctx_redirect_to_proxy_hairpin(ctx, NULL, proxy_port);

--- a/bpf/lib/signal.h
+++ b/bpf/lib/signal.h
@@ -51,19 +51,19 @@ struct signal_msg {
 			 sizeof(msg.signal_nr) + sizeof(msg.MEMBER));	\
   }
 
-static __always_inline void send_signal_nat_fill_up(struct __ctx_buff *ctx,
+static  void send_signal_nat_fill_up(struct __ctx_buff *ctx,
 						    __u32 proto)
 {
 	SEND_SIGNAL(ctx, SIGNAL_NAT_FILL_UP, proto, proto);
 }
 
-static __always_inline void send_signal_ct_fill_up(struct __ctx_buff *ctx,
+static  void send_signal_ct_fill_up(struct __ctx_buff *ctx,
 						   __u32 proto)
 {
 	SEND_SIGNAL(ctx, SIGNAL_CT_FILL_UP, proto, proto);
 }
 
-static __always_inline void send_signal_auth_required(struct __ctx_buff *ctx,
+static  void send_signal_auth_required(struct __ctx_buff *ctx,
 						      const struct auth_key *auth)
 {
 	SEND_SIGNAL(ctx, SIGNAL_AUTH_REQUIRED, auth, *auth);

--- a/bpf/lib/source_info.h
+++ b/bpf/lib/source_info.h
@@ -27,7 +27,7 @@
  * The following list of files is static, but it is validated during build with
  * the pkg/datapath/loader/check-sources.sh tool.
  */
-static __always_inline int
+static  int
 __id_for_file(const char *const header_name)
 {
 	/* @@ source files list begin */

--- a/bpf/lib/srv6.h
+++ b/bpf/lib/srv6.h
@@ -29,7 +29,7 @@ struct srv6_srh {
 	      - 4))
 #  define SRV6_VRF_PREFIX4_LEN(PREFIX) (SRV6_VRF_STATIC_PREFIX4 + (PREFIX))
 #  define SRV6_VRF_IPV4_PREFIX SRV6_VRF_PREFIX4_LEN(32)
-static __always_inline __u32*
+static  __u32*
 srv6_lookup_vrf4(__be32 sip, __be32 dip)
 {
 	struct srv6_vrf_key4 key = {
@@ -48,7 +48,7 @@ srv6_lookup_vrf4(__be32 sip, __be32 dip)
 	      - 4))
 #  define SRV6_POLICY_PREFIX4_LEN(PREFIX) (SRV6_POLICY_STATIC_PREFIX4 + (PREFIX))
 #  define SRV6_POLICY_IPV4_PREFIX SRV6_POLICY_PREFIX4_LEN(32)
-static __always_inline union v6addr *
+static  union v6addr *
 srv6_lookup_policy4(__u32 vrf_id, __be32 dip)
 {
 	struct srv6_policy_key4 key = {
@@ -68,7 +68,7 @@ srv6_lookup_policy4(__u32 vrf_id, __be32 dip)
 	      - 4))
 #  define SRV6_VRF_PREFIX6_LEN(PREFIX) (SRV6_VRF_STATIC_PREFIX6 + (PREFIX))
 #  define SRV6_VRF_IPV6_PREFIX SRV6_VRF_PREFIX6_LEN(32)
-static __always_inline __u32*
+static  __u32*
 srv6_lookup_vrf6(const struct in6_addr *sip, const struct in6_addr *dip)
 {
 	struct srv6_vrf_key6 key = {
@@ -88,7 +88,7 @@ srv6_lookup_vrf6(const struct in6_addr *sip, const struct in6_addr *dip)
 # define SRV6_POLICY_PREFIX6_LEN(PREFIX) (SRV6_POLICY_STATIC_PREFIX6 + (PREFIX))
 # define SRV6_POLICY_IPV6_PREFIX SRV6_POLICY_PREFIX6_LEN(128)
 
-static __always_inline union v6addr *
+static  union v6addr *
 srv6_lookup_policy6(__u32 vrf_id, const struct in6_addr *dip)
 {
 	struct srv6_policy_key6 key = {
@@ -99,7 +99,7 @@ srv6_lookup_policy6(__u32 vrf_id, const struct in6_addr *dip)
 	return map_lookup_elem(&SRV6_POLICY_MAP6, &key);
 }
 
-static __always_inline __u32
+static  __u32
 srv6_lookup_sid(const struct in6_addr *sid)
 {
 	__u32 *vrf_id;
@@ -110,7 +110,7 @@ srv6_lookup_sid(const struct in6_addr *sid)
 	return 0;
 }
 
-static __always_inline bool
+static  bool
 is_srv6_packet(const struct ipv6hdr *ip6)
 {
 #ifdef ENABLE_SRV6_SRH_ENCAP
@@ -122,7 +122,7 @@ is_srv6_packet(const struct ipv6hdr *ip6)
 }
 
 # ifndef SKIP_SRV6_HANDLING
-static __always_inline int
+static  int
 srv6_encapsulation(struct __ctx_buff *ctx, int growth, __u16 new_payload_len,
 		   __u8 nexthdr, union v6addr *saddr, struct in6_addr *sid)
 {
@@ -183,7 +183,7 @@ srv6_encapsulation(struct __ctx_buff *ctx, int growth, __u16 new_payload_len,
 	return 0;
 }
 
-static __always_inline int
+static  int
 srv6_decapsulation(struct __ctx_buff *ctx)
 {
 	__u16 new_proto = bpf_htons(ETH_P_IP);
@@ -247,7 +247,7 @@ parse_outer_ipv6: __maybe_unused;
 	return 0;
 }
 
-static __always_inline int
+static  int
 srv6_handling4(struct __ctx_buff *ctx, union v6addr *src_sid,
 	       struct in6_addr *dst_sid)
 {
@@ -284,7 +284,7 @@ srv6_handling4(struct __ctx_buff *ctx, union v6addr *src_sid,
 				  src_sid, dst_sid);
 }
 
-static __always_inline int
+static  int
 srv6_handling6(struct __ctx_buff *ctx, union v6addr *src_sid,
 	       struct in6_addr *dst_sid)
 {
@@ -310,7 +310,7 @@ srv6_handling6(struct __ctx_buff *ctx, union v6addr *src_sid,
 				  src_sid, dst_sid);
 }
 
-static __always_inline int
+static  int
 srv6_handling(struct __ctx_buff *ctx, struct in6_addr *dst_sid)
 {
 	void *data, *data_end;
@@ -348,7 +348,7 @@ srv6_handling(struct __ctx_buff *ctx, struct in6_addr *dst_sid)
 	}
 }
 
-static __always_inline void
+static  void
 srv6_load_meta_sid(struct __ctx_buff *ctx, struct in6_addr *sid)
 {
 	sid->s6_addr32[0] = ctx_load_meta(ctx, CB_SRV6_SID_1);
@@ -357,7 +357,7 @@ srv6_load_meta_sid(struct __ctx_buff *ctx, struct in6_addr *sid)
 	sid->s6_addr32[3] = ctx_load_meta(ctx, CB_SRV6_SID_4);
 }
 
-static __always_inline void
+static  void
 srv6_store_meta_sid(struct __ctx_buff *ctx, const union v6addr *sid)
 {
 	ctx_store_meta(ctx, CB_SRV6_SID_1, sid->p1);

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -84,7 +84,7 @@ enum {
  */
 #define update_trace_metrics(ctx, obs_point, reason) \
 	_update_trace_metrics(ctx, obs_point, reason, __MAGIC_LINE__, __MAGIC_FILE__)
-static __always_inline void
+static  void
 _update_trace_metrics(struct __ctx_buff *ctx, enum trace_point obs_point,
 		      enum trace_reason reason, __u16 line, __u8 file)
 {
@@ -158,7 +158,7 @@ struct trace_notify {
 	};
 };
 
-static __always_inline bool
+static  bool
 emit_trace_notify(enum trace_point obs_point, __u32 monitor)
 {
 	if (MONITOR_AGGREGATION >= TRACE_AGGREGATE_RX) {
@@ -191,7 +191,7 @@ emit_trace_notify(enum trace_point obs_point, __u32 monitor)
 #define send_trace_notify(ctx, obs_point, src, dst, dst_id, ifindex, reason, monitor) \
 		_send_trace_notify(ctx, obs_point, src, dst, dst_id, ifindex, reason, monitor, \
 		__MAGIC_LINE__, __MAGIC_FILE__)
-static __always_inline void
+static  void
 _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 		   __u32 src, __u32 dst, __u16 dst_id, __u32 ifindex,
 		   enum trace_reason reason, __u32 monitor, __u16 line, __u8 file)
@@ -222,7 +222,7 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 			 &msg, sizeof(msg));
 }
 
-static __always_inline void
+static  void
 send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 		   __u32 src, __u32 dst, __be32 orig_addr, __u16 dst_id,
 		   __u32 ifindex, enum trace_reason reason, __u32 monitor)
@@ -254,7 +254,7 @@ send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 			 &msg, sizeof(msg));
 }
 
-static __always_inline void
+static  void
 send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 		   __u32 src, __u32 dst, const union v6addr *orig_addr,
 		   __u16 dst_id, __u32 ifindex, enum trace_reason reason,
@@ -288,7 +288,7 @@ send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 			 &msg, sizeof(msg));
 }
 #else
-static __always_inline void
+static  void
 send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 		  __u32 src __maybe_unused, __u32 dst __maybe_unused,
 		  __u16 dst_id __maybe_unused, __u32 ifindex __maybe_unused,
@@ -297,7 +297,7 @@ send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 	update_trace_metrics(ctx, obs_point, reason);
 }
 
-static __always_inline void
+static  void
 send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 		   __u32 src __maybe_unused, __u32 dst __maybe_unused,
 		   __be32 orig_addr __maybe_unused, __u16 dst_id __maybe_unused,
@@ -307,7 +307,7 @@ send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 	update_trace_metrics(ctx, obs_point, reason);
 }
 
-static __always_inline void
+static  void
 send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 		   __u32 src __maybe_unused, __u32 dst __maybe_unused,
 		   union v6addr *orig_addr __maybe_unused,

--- a/bpf/lib/trace_sock.h
+++ b/bpf/lib/trace_sock.h
@@ -63,7 +63,7 @@ struct trace_sock_notify {
 	__u8 pad : 7;
 } __packed;
 
-static __always_inline enum l4_protocol
+static  enum l4_protocol
 parse_protocol(__u32 l4_proto) {
 	switch (l4_proto) {
 	case IPPROTO_TCP:
@@ -75,7 +75,7 @@ parse_protocol(__u32 l4_proto) {
 	}
 }
 
-static __always_inline void
+static  void
 send_trace_sock_notify4(struct __ctx_sock *ctx,
 			enum xlate_point xlate_point,
 			__u32 dst_ip, __u16 dst_port)
@@ -100,7 +100,7 @@ send_trace_sock_notify4(struct __ctx_sock *ctx,
 	ctx_event_output(ctx, &EVENTS_MAP, BPF_F_CURRENT_CPU, &msg, sizeof(msg));
 }
 
-static __always_inline void
+static  void
 send_trace_sock_notify6(struct __ctx_sock *ctx,
 			enum xlate_point xlate_point,
 			union v6addr *dst_addr,
@@ -125,14 +125,14 @@ send_trace_sock_notify6(struct __ctx_sock *ctx,
 	ctx_event_output(ctx, &EVENTS_MAP, BPF_F_CURRENT_CPU, &msg, sizeof(msg));
 }
 #else
-static __always_inline void
+static  void
 send_trace_sock_notify4(struct __ctx_sock *ctx __maybe_unused,
 			enum xlate_point xlate_point __maybe_unused,
 			__u32 dst_ip __maybe_unused, __u16 dst_port __maybe_unused)
 {
 }
 
-static __always_inline void
+static  void
 send_trace_sock_notify6(struct __ctx_sock *ctx __maybe_unused,
 			enum xlate_point xlate_point __maybe_unused,
 			union v6addr *dst_addr __maybe_unused,

--- a/bpf/lib/tunnel.h
+++ b/bpf/lib/tunnel.h
@@ -77,7 +77,7 @@ struct vxlanhdr {
 	__be32 vx_vni;
 };
 
-static __always_inline __u32
+static  __u32
 tunnel_vni_to_sec_identity(__be32 vni)
 {
 	return bpf_ntohl(vni) >> 8;

--- a/bpf/lib/utime.h
+++ b/bpf/lib/utime.h
@@ -16,7 +16,7 @@
  */
 #define UTIME_SHIFT 9
 
-static __always_inline __u64
+static  __u64
 _utime_get_offset()
 {
 	__u32 index = RUNTIME_CONFIG_UTIME_OFFSET;
@@ -33,7 +33,7 @@ _utime_get_offset()
  * Return the current time in "utime" unit (512 ns per unit) that is directly
  * comparable to expirations times in bpf maps.
  */
-static __always_inline __u64
+static  __u64
 utime_get_time()
 {
 	return (ktime_get_ns() >> UTIME_SHIFT) + _utime_get_offset();

--- a/bpf/lib/vxlan.h
+++ b/bpf/lib/vxlan.h
@@ -19,7 +19,7 @@
  * This can be done by calling 'vxlan_skb_is_vxlan_v4'
  *
  */
-static __always_inline __u32
+static  __u32
 vxlan_get_vni(const void *data, const void *data_end,
 	      const struct iphdr *ipv4)
 {
@@ -46,7 +46,7 @@ vxlan_get_vni(const void *data, const void *data_end,
  * Returns 'true' if 'inner' now points to a bounds-checked inner IPv4 header.
  * Returns 'false' if an error occurred.
  */
-static __always_inline bool
+static  bool
 vxlan_get_inner_ipv4(const void *data, const void *data_end,
 		     const struct iphdr *ipv4, struct iphdr **inner) {
 	int l3_size = ipv4->ihl * 4;
@@ -74,7 +74,7 @@ vxlan_get_inner_ipv4(const void *data, const void *data_end,
  *
  * This can be done by calling 'vxlan_skb_is_vxlan_v4'
  */
-static __always_inline bool
+static  bool
 vxlan_rewrite_vni(void *ctx, const void *data, const void *data_end,
 		  const struct iphdr *ipv4, __u32 vni)
 {

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -16,7 +16,7 @@
 
 #include "lib/proxy.h"
 
-static __always_inline int
+static  int
 wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 {
 	struct remote_endpoint_info *dst = NULL;
@@ -165,7 +165,7 @@ out:
 #ifdef ENCRYPTION_STRICT_MODE
 
 /* strict_allow checks whether the packet is allowed to pass through the strict mode. */
-static __always_inline bool
+static  bool
 strict_allow(struct __ctx_buff *ctx) {
 	struct remote_endpoint_info __maybe_unused *dest_info, __maybe_unused *src_info;
 	bool __maybe_unused in_strict_cidr = false;

--- a/bpf/tests/bpf_ct_tests.c
+++ b/bpf/tests/bpf_ct_tests.c
@@ -19,7 +19,7 @@
 #include <lib/conntrack_map.h>
 #include <lib/time.h>
 
-__always_inline int mkpkt(void *dst, bool first)
+ int mkpkt(void *dst, bool first)
 {
 	void *orig = dst;
 	struct ethhdr *l2 = dst;

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -27,7 +27,7 @@
 
 static char pkt[100];
 
-__always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr, bool egress)
+ int mk_icmp4_error_pkt(void *dst, __u8 error_hdr, bool egress)
 {
 	void *orig = dst;
 

--- a/bpf/tests/builtin_test.h
+++ b/bpf/tests/builtin_test.h
@@ -6,7 +6,7 @@
 /* Manual slow versions, but doesn't matter for the sake of testing here.
  * Mainly to make sure we don't end up using the overridden builtin.
  */
-static __always_inline __u32 __cmp_mem(const void *x, const void *y, __u32 len)
+static  __u32 __cmp_mem(const void *x, const void *y, __u32 len)
 {
 	const __u8 *x8 = x, *y8 = y;
 	__u32 i;
@@ -19,7 +19,7 @@ static __always_inline __u32 __cmp_mem(const void *x, const void *y, __u32 len)
 	return 0;
 }
 
-static __always_inline void __cpy_mem(void *d, void *s, __u32 len)
+static  void __cpy_mem(void *d, void *s, __u32 len)
 {
 	__u8 *d8 = d, *s8 = s;
 	__u32 i;
@@ -37,7 +37,7 @@ static void __fill_rnd(void *buff, __u32 len)
 		dest[i] = random();
 }
 
-static __always_inline bool __corrupt_mem(void *d, __u32 len)
+static  bool __corrupt_mem(void *d, __u32 len)
 {
 	bool corrupted = random() % 2 == 1;
 	__u32 pos = random() % len;

--- a/bpf/tests/common.h
+++ b/bpf/tests/common.h
@@ -261,7 +261,7 @@ test_result_cursor = 0;
 #define CHECK(progtype, name) __section(progtype "/test/" name "/check")
 
 #define LPM_LOOKUP_FN(NAME, IPTYPE, PREFIXES, MAP, LOOKUP_FN)	\
-static __always_inline int __##NAME(IPTYPE addr)		\
+static  int __##NAME(IPTYPE addr)		\
 {								\
 	int prefixes[] = { PREFIXES };				\
 	const int size = ARRAY_SIZE(prefixes);			\

--- a/bpf/tests/hairpin_sctp_flow.c
+++ b/bpf/tests/hairpin_sctp_flow.c
@@ -25,7 +25,7 @@
 #undef FORCE_LOCAL_POLICY_EVAL_AT_SOURCE
 
 #define ctx_redirect_peer mock_ctx_redirect_peer
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 mock_ctx_redirect_peer(const struct __sk_buff *ctx __maybe_unused, int ifindex __maybe_unused,
 		       __u32 flags __maybe_unused)
 {

--- a/bpf/tests/host_only_socket_lb_test.c
+++ b/bpf/tests/host_only_socket_lb_test.c
@@ -22,7 +22,7 @@
 /* Replace the get_netns_cookie with a version that returns
  * the HOST_NETNS_COOKIE when destination is DST_PORT_HOSTNS
  */
-static __always_inline
+static
 int my_get_netns_cookie(__maybe_unused const struct bpf_sock_addr *addr)
 {
 	return addr->user_port == DST_PORT_HOSTNS ? HOST_NETNS_COOKIE : 1;

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
@@ -81,7 +81,7 @@ struct {
 	},
 };
 
-static __always_inline int
+static  int
 pktgen_to_lxc(struct __ctx_buff *ctx, bool syn, bool ack)
 {
 	struct pktgen builder;
@@ -110,7 +110,7 @@ pktgen_to_lxc(struct __ctx_buff *ctx, bool syn, bool ack)
 	return 0;
 }
 
-static __always_inline int
+static  int
 pktgen_from_lxc(struct __ctx_buff *ctx, bool syn, bool ack)
 {
 	struct pktgen builder;

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
@@ -88,7 +88,7 @@ int mock_skb_get_tunnel_key(struct __ctx_buff *ctx __maybe_unused, struct bpf_tu
 
 #define _send_drop_notify mock_send_drop_notify
 
-static __always_inline
+static
 int mock_send_drop_notify(__u8 file __maybe_unused, __u16 line __maybe_unused,
 			  struct __ctx_buff *ctx, __u32 src __maybe_unused,
 			  __u32 dst __maybe_unused, __u32 dst_id __maybe_unused,
@@ -122,7 +122,7 @@ struct {
 	},
 };
 
-static __always_inline int
+static  int
 pktgen_to_overlay(struct __ctx_buff *ctx, bool syn, bool ack)
 {
 	struct pktgen builder;
@@ -151,7 +151,7 @@ pktgen_to_overlay(struct __ctx_buff *ctx, bool syn, bool ack)
 	return 0;
 }
 
-static __always_inline int
+static  int
 pktgen_from_overlay(struct __ctx_buff *ctx, bool syn, bool ack)
 {
 	struct pktgen builder;

--- a/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
@@ -85,7 +85,7 @@ struct {
 	},
 };
 
-static __always_inline int
+static  int
 pktgen_from_lxc(struct __ctx_buff *ctx, bool syn, bool ack)
 {
 	struct pktgen builder;
@@ -113,7 +113,7 @@ pktgen_from_lxc(struct __ctx_buff *ctx, bool syn, bool ack)
 	return 0;
 }
 
-static __always_inline int
+static  int
 pktgen_to_lxc(struct __ctx_buff *ctx, bool syn, bool ack)
 {
 	struct pktgen builder;

--- a/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
@@ -72,7 +72,7 @@
 /* Mock out get_tunnel_key to emulate input from tunnel device */
 #define skb_get_tunnel_key mock_skb_get_tunnel_key
 
-static __always_inline
+static
 int mock_skb_get_tunnel_key(struct __ctx_buff *ctx __maybe_unused, struct bpf_tunnel_key *to,
 			    __u32 size __maybe_unused, __u32 flags __maybe_unused)
 {
@@ -91,7 +91,7 @@ int mock_skb_get_tunnel_key(struct __ctx_buff *ctx __maybe_unused, struct bpf_tu
 
 #define _send_drop_notify mock_send_drop_notify
 
-static __always_inline
+static
 int mock_send_drop_notify(__u8 file __maybe_unused, __u16 line __maybe_unused,
 			  struct __ctx_buff *ctx, __u32 src __maybe_unused,
 			  __u32 dst __maybe_unused, __u32 dst_id __maybe_unused,
@@ -125,7 +125,7 @@ struct {
 	},
 };
 
-static __always_inline int
+static  int
 pktgen_to_overlay(struct __ctx_buff *ctx, bool syn, bool ack)
 {
 	struct pktgen builder;
@@ -153,7 +153,7 @@ pktgen_to_overlay(struct __ctx_buff *ctx, bool syn, bool ack)
 	return 0;
 }
 
-static __always_inline int
+static  int
 pktgen_from_overlay(struct __ctx_buff *ctx, bool syn, bool ack)
 {
 	struct pktgen builder;

--- a/bpf/tests/ipsec_from_lxc_generic.h
+++ b/bpf/tests/ipsec_from_lxc_generic.h
@@ -33,7 +33,7 @@ struct {
 	},
 };
 
-static __always_inline int
+static  int
 pktgen_from_lxc(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;

--- a/bpf/tests/ipsec_from_overlay_generic.h
+++ b/bpf/tests/ipsec_from_overlay_generic.h
@@ -67,7 +67,7 @@ struct {
 };
 
 #define tail_call_dynamic mock_tail_call_dynamic
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 mock_tail_call_dynamic(struct __ctx_buff *ctx __maybe_unused,
 		       const void *map __maybe_unused, __u32 slot __maybe_unused)
 {

--- a/bpf/tests/l4lb_ipip_health_check_host.c
+++ b/bpf/tests/l4lb_ipip_health_check_host.c
@@ -48,7 +48,7 @@ __u64 mock_get_socket_cookie(const struct __sk_buff *ctx __maybe_unused)
 
 #define ctx_redirect mock_ctx_redirect
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
 {

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -36,13 +36,13 @@ struct egressgw_test_ctx {
 	__u32 status_code;
 };
 
-static __always_inline __be16 client_port(__u16 t)
+static  __be16 client_port(__u16 t)
 {
 	return CLIENT_PORT + bpf_htons(t);
 }
 
 #ifdef ENABLE_EGRESS_GATEWAY
-static __always_inline void add_egressgw_policy_entry(__be32 saddr, __be32 daddr, __u8 cidr,
+static  void add_egressgw_policy_entry(__be32 saddr, __be32 daddr, __u8 cidr,
 						      __be32 gateway_ip, __be32 egress_ip)
 {
 	struct egress_gw_policy_key in_key = {
@@ -59,7 +59,7 @@ static __always_inline void add_egressgw_policy_entry(__be32 saddr, __be32 daddr
 	map_update_elem(&EGRESS_POLICY_MAP, &in_key, &in_val, 0);
 }
 
-static __always_inline void del_egressgw_policy_entry(__be32 saddr, __be32 daddr, __u8 cidr)
+static  void del_egressgw_policy_entry(__be32 saddr, __be32 daddr, __u8 cidr)
 {
 	struct egress_gw_policy_key in_key = {
 		.lpm_key = { EGRESS_PREFIX_LEN(cidr), {} },
@@ -71,7 +71,7 @@ static __always_inline void del_egressgw_policy_entry(__be32 saddr, __be32 daddr
 }
 #endif /* ENABLE_EGRESS_GATEWAY */
 
-static __always_inline int egressgw_pktgen(struct __ctx_buff *ctx,
+static  int egressgw_pktgen(struct __ctx_buff *ctx,
 					   struct egressgw_test_ctx test_ctx)
 {
 	struct pktgen builder;
@@ -141,7 +141,7 @@ static __always_inline int egressgw_pktgen(struct __ctx_buff *ctx,
 	return 0;
 }
 
-static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx,
+static  int egressgw_snat_check(const struct __ctx_buff *ctx,
 					       struct egressgw_test_ctx test_ctx)
 {
 	void *data, *data_end;
@@ -250,7 +250,7 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx,
 	test_finish();
 }
 
-static __always_inline int egressgw_status_check(const struct __ctx_buff *ctx,
+static  int egressgw_status_check(const struct __ctx_buff *ctx,
 						 struct egressgw_test_ctx test_ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/lib/endpoint.h
+++ b/bpf/tests/lib/endpoint.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
-static __always_inline void
+static  void
 endpoint_v4_add_entry(__be32 addr, __u32 ifindex, __u16 lxc_id, __u32 flags,
 		      const __u8 *ep_mac_addr, const __u8 *node_mac_addr)
 {
@@ -23,7 +23,7 @@ endpoint_v4_add_entry(__be32 addr, __u32 ifindex, __u16 lxc_id, __u32 flags,
 	map_update_elem(&ENDPOINTS_MAP, &key, &value, BPF_ANY);
 }
 
-static __always_inline void
+static  void
 endpoint_v6_add_entry(const union v6addr *addr, __u32 ifindex, __u16 lxc_id,
 		      __u32 flags, const __u8 *ep_mac_addr, const __u8 *node_mac_addr)
 {

--- a/bpf/tests/lib/ipcache.h
+++ b/bpf/tests/lib/ipcache.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
-static __always_inline void
+static  void
 __ipcache_v4_add_entry(__be32 addr, __u8 cluster_id, __u32 sec_identity,
 		       __u32 tunnel_ep, __u8 spi, bool flag_skip_tunnel)
 {
@@ -21,21 +21,21 @@ __ipcache_v4_add_entry(__be32 addr, __u8 cluster_id, __u32 sec_identity,
 	map_update_elem(&IPCACHE_MAP, &key, &value, BPF_ANY);
 }
 
-static __always_inline void
+static  void
 ipcache_v4_add_entry(__be32 addr, __u8 cluster_id, __u32 sec_identity,
 		     __u32 tunnel_ep, __u8 spi)
 {
 	__ipcache_v4_add_entry(addr, cluster_id, sec_identity, tunnel_ep, spi, false);
 }
 
-static __always_inline void
+static  void
 ipcache_v4_add_entry_with_flags(__be32 addr, __u8 cluster_id, __u32 sec_identity,
 				__u32 tunnel_ep, __u8 spi, bool flag_skip_tunnel)
 {
 	__ipcache_v4_add_entry(addr, cluster_id, sec_identity, tunnel_ep, spi, flag_skip_tunnel);
 }
 
-static __always_inline void
+static  void
 __ipcache_v6_add_entry(const union v6addr *addr, __u8 cluster_id, __u32 sec_identity,
 		       __u32 tunnel_ep, __u8 spi, bool flag_skip_tunnel)
 {
@@ -56,14 +56,14 @@ __ipcache_v6_add_entry(const union v6addr *addr, __u8 cluster_id, __u32 sec_iden
 	map_update_elem(&IPCACHE_MAP, &key, &value, BPF_ANY);
 }
 
-static __always_inline void
+static  void
 ipcache_v6_add_entry(const union v6addr *addr, __u8 cluster_id, __u32 sec_identity,
 		     __u32 tunnel_ep, __u8 spi)
 {
 	__ipcache_v6_add_entry(addr, cluster_id, sec_identity, tunnel_ep, spi, false);
 }
 
-static __always_inline void
+static  void
 ipcache_v6_add_entry_with_flags(const union v6addr *addr, __u8 cluster_id, __u32 sec_identity,
 				__u32 tunnel_ep, __u8 spi, bool flag_skip_tunnel)
 {

--- a/bpf/tests/lib/lb.h
+++ b/bpf/tests/lib/lb.h
@@ -2,7 +2,7 @@
 /* Copyright Authors of Cilium */
 
 #ifdef ENABLE_IPV4
-static __always_inline void
+static  void
 lb_v4_upsert_service(__be32 addr, __be16 port, __u16 backend_count, __u16 rev_nat_index)
 {
 	struct lb4_key svc_key = {
@@ -21,7 +21,7 @@ lb_v4_upsert_service(__be32 addr, __be16 port, __u16 backend_count, __u16 rev_na
 	map_update_elem(&LB4_SERVICES_MAP_V2, &svc_key, &svc_value, BPF_ANY);
 }
 
-static __always_inline void
+static  void
 lb_v4_add_service(__be32 addr, __be16 port, __u16 backend_count, __u16 rev_nat_index)
 {
 	/* Register with both scopes: */
@@ -35,7 +35,7 @@ lb_v4_add_service(__be32 addr, __be16 port, __u16 backend_count, __u16 rev_nat_i
 	map_update_elem(&LB4_REVERSE_NAT_MAP, &rev_nat_index, &revnat_value, BPF_ANY);
 }
 
-static __always_inline void
+static  void
 lb_v4_add_service_with_flags(__be32 addr, __be16 port, __u16 backend_count, __u16 rev_nat_index,
 			     __u8 flags, __u8 flags2)
 {
@@ -56,7 +56,7 @@ lb_v4_add_service_with_flags(__be32 addr, __be16 port, __u16 backend_count, __u1
 	map_update_elem(&LB4_SERVICES_MAP_V2, &svc_key, &svc_value, BPF_ANY);
 }
 
-static __always_inline void
+static  void
 lb_v4_upsert_backend(__u32 backend_id, __be32 backend_addr, __be16 backend_port,
 		     __u8 backend_proto, __u8 flags, __u8 cluster_id)
 {
@@ -71,7 +71,7 @@ lb_v4_upsert_backend(__u32 backend_id, __be32 backend_addr, __be16 backend_port,
 	map_update_elem(&LB4_BACKEND_MAP, &backend_id, &backend, BPF_ANY);
 }
 
-static __always_inline void
+static  void
 lb_v4_add_backend(__be32 svc_addr, __be16 svc_port, __u16 backend_slot,
 		  __u32 backend_id, __be32 backend_addr, __be16 backend_port,
 		  __u8 backend_proto, __u8 cluster_id)
@@ -96,7 +96,7 @@ lb_v4_add_backend(__be32 svc_addr, __be16 svc_port, __u16 backend_slot,
 #endif
 
 #ifdef ENABLE_IPV6
-static __always_inline void
+static  void
 __lb_v6_add_service(const union v6addr *addr, __be16 port, __u16 backend_count, __u16 rev_nat_index,
 		    __u8 flags, __u8 flags2)
 {
@@ -125,21 +125,21 @@ __lb_v6_add_service(const union v6addr *addr, __be16 port, __u16 backend_count, 
 	map_update_elem(&LB6_REVERSE_NAT_MAP, &rev_nat_index, &revnat_value, BPF_ANY);
 }
 
-static __always_inline void
+static  void
 lb_v6_add_service(const union v6addr *addr, __be16 port, __u16 backend_count,
 		  __u16 rev_nat_index)
 {
 	__lb_v6_add_service(addr, port, backend_count, rev_nat_index, SVC_FLAG_ROUTABLE, 0);
 }
 
-static __always_inline void
+static  void
 lb_v6_add_service_with_flags(const union v6addr *addr, __be16 port, __u16 backend_count,
 			     __u16 rev_nat_index, __u8 flags, __u8 flags2)
 {
 	__lb_v6_add_service(addr, port, backend_count, rev_nat_index, flags, flags2);
 }
 
-static __always_inline void
+static  void
 lb_v6_add_backend(const union v6addr *svc_addr, __be16 svc_port, __u16 backend_slot,
 		  __u32 backend_id, const union v6addr *backend_addr,
 		  __be16 backend_port, __u8 backend_proto, __u8 cluster_id)

--- a/bpf/tests/lib/policy.h
+++ b/bpf/tests/lib/policy.h
@@ -2,7 +2,7 @@
 /* Copyright Authors of Cilium */
 
 #ifndef SKIP_POLICY_MAP
-static __always_inline void
+static  void
 policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport, bool deny)
 {
 	struct policy_key key = {
@@ -18,29 +18,29 @@ policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport, bool 
 	map_update_elem(&POLICY_MAP, &key, &value, BPF_ANY);
 }
 
-static __always_inline void
+static  void
 policy_add_ingress_allow_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {
 	policy_add_entry(false, sec_label, protocol, dport, false);
 }
 
-static __always_inline void
+static  void
 policy_add_egress_allow_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {
 	policy_add_entry(true, sec_label, protocol, dport, false);
 }
 
-static __always_inline void policy_add_egress_allow_all_entry(void)
+static  void policy_add_egress_allow_all_entry(void)
 {
 	policy_add_entry(true, 0, 0, 0, false);
 }
 
-static __always_inline void policy_add_egress_deny_all_entry(void)
+static  void policy_add_egress_deny_all_entry(void)
 {
 	policy_add_entry(true, 0, 0, 0, true);
 }
 
-static __always_inline void policy_delete_egress_entry(void)
+static  void policy_delete_egress_entry(void)
 {
 	struct policy_key key = {
 		.egress = 1,

--- a/bpf/tests/mcast_tests.c
+++ b/bpf/tests/mcast_tests.c
@@ -17,7 +17,7 @@
 #include <linux/in.h>
 #include "../lib/mcast.h"
 
-static __always_inline int default_packet(struct __ctx_buff *ctx)
+static  int default_packet(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	struct ethhdr *eh;
@@ -38,7 +38,7 @@ static __always_inline int default_packet(struct __ctx_buff *ctx)
 	return 0;
 }
 
-static __always_inline int igmpv3_join_packet(struct __ctx_buff *ctx)
+static  int igmpv3_join_packet(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	struct ethhdr *eh;

--- a/bpf/tests/mock_skb_metadata.h
+++ b/bpf/tests/mock_skb_metadata.h
@@ -29,7 +29,7 @@ struct {
 	__uint(max_entries, 1);
 } mock_skb_meta_map __section_maps_btf;
 
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 mock_skb_store_meta(struct __sk_buff *ctx __maybe_unused, const __u32 off,
 		    __u32 data)
 {
@@ -43,7 +43,7 @@ mock_skb_store_meta(struct __sk_buff *ctx __maybe_unused, const __u32 off,
 	meta->cb[off] = data;
 }
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 mock_skb_load_meta(const struct __sk_buff *ctx __maybe_unused, const __u32 off)
 {
 	__u32 idx = 0;
@@ -56,7 +56,7 @@ mock_skb_load_meta(const struct __sk_buff *ctx __maybe_unused, const __u32 off)
 	return meta->cb[off];
 }
 
-static __always_inline __maybe_unused __u32
+static  __maybe_unused __u32
 mock_skb_load_and_clear_meta(struct __sk_buff *ctx __maybe_unused, const __u32 off)
 {
 	__u32 val = mock_skb_load_meta(ctx, off);

--- a/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
+++ b/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
@@ -58,7 +58,7 @@ static volatile const __u8 *backend_node_mac = mac_six;
 static bool fail_fib;
 
 #define ctx_redirect mock_ctx_redirect
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 mock_ctx_redirect(const struct __ctx_buff *ctx __maybe_unused, int ifindex __maybe_unused,
 		  __u32 flags __maybe_unused)
 {

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -181,7 +181,7 @@ struct pktgen {
 	enum pkt_layer layers[PKT_BUILDER_LAYERS];
 };
 
-static __always_inline
+static
 void pktgen__init(struct pktgen *builder, struct __ctx_buff *ctx)
 {
 	builder->cur_off = 0;
@@ -193,7 +193,7 @@ void pktgen__init(struct pktgen *builder, struct __ctx_buff *ctx)
 	}
 };
 
-static __always_inline
+static
 int pktgen__free_layer(const struct pktgen *builder)
 {
 	#pragma unroll
@@ -205,7 +205,7 @@ int pktgen__free_layer(const struct pktgen *builder)
 	return -1;
 }
 
-static __always_inline
+static
 __attribute__((warn_unused_result))
 void *pktgen__push_rawhdr(struct pktgen *builder, __u32 hdrsize, enum pkt_layer type)
 {
@@ -240,7 +240,7 @@ void *pktgen__push_rawhdr(struct pktgen *builder, __u32 hdrsize, enum pkt_layer 
 }
 
 /* Push an empty ethernet header onto the packet */
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct ethhdr *pktgen__push_ethhdr(struct pktgen *builder)
 {
@@ -248,7 +248,7 @@ struct ethhdr *pktgen__push_ethhdr(struct pktgen *builder)
 }
 
 /* helper to set the source and destination mac address at the same time */
-static __always_inline
+static
 void ethhdr__set_macs(struct ethhdr *l2, unsigned char *src, unsigned char *dst)
 {
 	memcpy(l2->h_source, src, ETH_ALEN);
@@ -256,7 +256,7 @@ void ethhdr__set_macs(struct ethhdr *l2, unsigned char *src, unsigned char *dst)
 }
 
 /* Push an empty IPv4 header onto the packet */
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct iphdr *pktgen__push_iphdr(struct pktgen *builder, __u32 option_bytes)
 {
@@ -269,14 +269,14 @@ struct iphdr *pktgen__push_iphdr(struct pktgen *builder, __u32 option_bytes)
 }
 
 /* helper to set the source and destination ipv6 address at the same time */
-static __always_inline
+static
 void ipv6hdr__set_addrs(struct ipv6hdr *l3, __u8 *src, __u8 *dst)
 {
 	memcpy((__u8 *)&l3->saddr, src, 16);
 	memcpy((__u8 *)&l3->daddr, dst, 16);
 }
 
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct ipv6hdr *pktgen__push_ipv6hdr(struct pktgen *builder)
 {
@@ -284,7 +284,7 @@ struct ipv6hdr *pktgen__push_ipv6hdr(struct pktgen *builder)
 }
 
 /* Push a IPv4 header with sane defaults and options onto the packet */
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct iphdr *pktgen__push_default_iphdr_with_options(struct pktgen *builder,
 						      __u8 option_words)
@@ -305,14 +305,14 @@ struct iphdr *pktgen__push_default_iphdr_with_options(struct pktgen *builder,
 	return hdr;
 }
 
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct iphdr *pktgen__push_default_iphdr(struct pktgen *builder)
 {
 	return pktgen__push_default_iphdr_with_options(builder, 0);
 }
 
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct ipv6_opt_hdr *pktgen__append_ipv6_extension_header(struct pktgen *builder,
 							  __u8 nexthdr,
@@ -348,7 +348,7 @@ struct ipv6_opt_hdr *pktgen__append_ipv6_extension_header(struct pktgen *builder
 	return hdr;
 }
 
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct ipv6hdr *pktgen__push_default_ipv6hdr(struct pktgen *builder)
 {
@@ -366,14 +366,14 @@ struct ipv6hdr *pktgen__push_default_ipv6hdr(struct pktgen *builder)
 }
 
 /* Push an empty ARP header onto the packet */
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct arphdreth *pktgen__push_arphdr_ethernet(struct pktgen *builder)
 {
 	return pktgen__push_rawhdr(builder, sizeof(struct arphdreth), PKT_LAYER_ARP);
 }
 
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct arphdreth *pktgen__push_default_arphdr_ethernet(struct pktgen *builder)
 {
@@ -390,7 +390,7 @@ struct arphdreth *pktgen__push_default_arphdr_ethernet(struct pktgen *builder)
 }
 
 /* Push an empty TCP header onto the packet */
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct tcphdr *pktgen__push_tcphdr(struct pktgen *builder)
 {
@@ -398,7 +398,7 @@ struct tcphdr *pktgen__push_tcphdr(struct pktgen *builder)
 }
 
 /* Push a TCP header with sane defaults onto the packet */
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct tcphdr *pktgen__push_default_tcphdr(struct pktgen *builder)
 {
@@ -419,7 +419,7 @@ struct tcphdr *pktgen__push_default_tcphdr(struct pktgen *builder)
 	return hdr;
 }
 
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct icmp6hdr *pktgen__push_icmp6hdr(struct pktgen *builder)
 {
@@ -427,7 +427,7 @@ struct icmp6hdr *pktgen__push_icmp6hdr(struct pktgen *builder)
 }
 
 /* Push an empty ESP header onto the packet */
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct ip_esp_hdr *pktgen__push_esphdr(struct pktgen *builder)
 {
@@ -435,7 +435,7 @@ struct ip_esp_hdr *pktgen__push_esphdr(struct pktgen *builder)
 }
 
 /* Push a ESP header with sane defaults onto the packet */
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct ip_esp_hdr *pktgen__push_default_esphdr(struct pktgen *builder)
 {
@@ -451,7 +451,7 @@ struct ip_esp_hdr *pktgen__push_default_esphdr(struct pktgen *builder)
 }
 
 /* Push an empty SCTP header onto the packet */
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct sctphdr *pktgen__push_sctphdr(struct pktgen *builder)
 {
@@ -459,14 +459,14 @@ struct sctphdr *pktgen__push_sctphdr(struct pktgen *builder)
 }
 
 /* Push an empty UDP header onto the packet */
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct udphdr *pktgen__push_udphdr(struct pktgen *builder)
 {
 	return pktgen__push_rawhdr(builder, sizeof(struct udphdr), PKT_LAYER_UDP);
 }
 
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct udphdr *pktgen__push_default_udphdr(struct pktgen *builder)
 {
@@ -481,14 +481,14 @@ struct udphdr *pktgen__push_default_udphdr(struct pktgen *builder)
 }
 
 /* Push an empty VXLAN header onto the packet */
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct vxlanhdr *pktgen__push_vxlanhdr(struct pktgen *builder)
 {
 	return pktgen__push_rawhdr(builder, sizeof(struct vxlanhdr), PKT_LAYER_VXLAN);
 }
 
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct vxlanhdr *pktgen__push_default_vxlanhdr(struct pktgen *builder)
 {
@@ -505,7 +505,7 @@ struct vxlanhdr *pktgen__push_default_vxlanhdr(struct pktgen *builder)
 }
 
 /* Push an empty GENEVE header onto the packet */
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct genevehdr *pktgen__push_genevehdr(struct pktgen *builder,
 					 __u8 option_bytes)
@@ -515,7 +515,7 @@ struct genevehdr *pktgen__push_genevehdr(struct pktgen *builder,
 	return pktgen__push_rawhdr(builder, length, PKT_LAYER_GENEVE);
 }
 
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct genevehdr *pktgen__push_default_genevehdr_with_options(struct pktgen *builder,
 							      __u8 option_bytes)
@@ -530,7 +530,7 @@ struct genevehdr *pktgen__push_default_genevehdr_with_options(struct pktgen *bui
 	return hdr;
 }
 
-static __always_inline
+static
 __attribute__((warn_unused_result))
 struct genevehdr *pktgen__push_default_genevehdr(struct pktgen *builder)
 {
@@ -545,7 +545,7 @@ struct genevehdr *pktgen__push_default_genevehdr(struct pktgen *builder)
 }
 
 /* Push room for x bytes of data onto the packet */
-static __always_inline
+static
 __attribute__((warn_unused_result))
 void *pktgen__push_data_room(struct pktgen *builder, int len)
 {
@@ -578,7 +578,7 @@ void *pktgen__push_data_room(struct pktgen *builder, int len)
 }
 
 /* Push data onto the packet */
-static __always_inline
+static
 __attribute__((warn_unused_result))
 void *pktgen__push_data(struct pktgen *builder, void *data, int len)
 {
@@ -594,7 +594,7 @@ void *pktgen__push_data(struct pktgen *builder, void *data, int len)
 	return pkt_data;
 }
 
-static __always_inline struct iphdr *
+static  struct iphdr *
 pktgen__push_ipv4_packet(struct pktgen *builder,
 			 __u8 *smac, __u8 *dmac,
 			 __be32 saddr, __be32 daddr)
@@ -618,7 +618,7 @@ pktgen__push_ipv4_packet(struct pktgen *builder,
 	return l3;
 }
 
-static __always_inline struct tcphdr *
+static  struct tcphdr *
 pktgen__push_ipv4_tcp_packet(struct pktgen *builder,
 			     __u8 *smac, __u8 *dmac,
 			     __be32 saddr, __be32 daddr,
@@ -641,7 +641,7 @@ pktgen__push_ipv4_tcp_packet(struct pktgen *builder,
 	return l4;
 }
 
-static __always_inline struct udphdr *
+static  struct udphdr *
 pktgen__push_ipv4_udp_packet(struct pktgen *builder,
 			     __u8 *smac, __u8 *dmac,
 			     __be32 saddr, __be32 daddr,
@@ -664,7 +664,7 @@ pktgen__push_ipv4_udp_packet(struct pktgen *builder,
 	return l4;
 }
 
-static __always_inline struct tcphdr *
+static  struct tcphdr *
 pktgen__push_ipv6_tcp_packet(struct pktgen *builder,
 			     __u8 *smac, __u8 *dmac,
 			     __u8 *saddr, __u8 *daddr,
@@ -696,7 +696,7 @@ pktgen__push_ipv6_tcp_packet(struct pktgen *builder,
 	return l4;
 }
 
-static __always_inline struct icmp6hdr *
+static  struct icmp6hdr *
 pktgen__push_ipv6_icmp6_packet(struct pktgen *builder,
 			       __u8 *smac, __u8 *dmac,
 			       __u8 *saddr, __u8 *daddr,
@@ -729,7 +729,7 @@ pktgen__push_ipv6_icmp6_packet(struct pktgen *builder,
 	return l4;
 }
 
-static __always_inline void pktgen__finish_eth(const struct pktgen *builder, int i)
+static  void pktgen__finish_eth(const struct pktgen *builder, int i)
 {
 	struct ethhdr *eth_layer;
 	__u64 layer_off;
@@ -764,7 +764,7 @@ static __always_inline void pktgen__finish_eth(const struct pktgen *builder, int
 	}
 }
 
-static __always_inline void pktgen__finish_ipv4(const struct pktgen *builder, int i)
+static  void pktgen__finish_ipv4(const struct pktgen *builder, int i)
 {
 	struct iphdr *ipv4_layer;
 	__u64 layer_off;
@@ -809,7 +809,7 @@ static __always_inline void pktgen__finish_ipv4(const struct pktgen *builder, in
 	ipv4_layer->tot_len = __bpf_htons(v4len);
 }
 
-static __always_inline void pktgen__finish_ipv6(const struct pktgen *builder, int i)
+static  void pktgen__finish_ipv6(const struct pktgen *builder, int i)
 {
 	struct ipv6hdr *ipv6_layer;
 	__u64 layer_off;
@@ -866,7 +866,7 @@ static __always_inline void pktgen__finish_ipv6(const struct pktgen *builder, in
 	ipv6_layer->payload_len = __bpf_htons(v6len);
 }
 
-static __always_inline void pktgen__finish_ipv6_opt(const struct pktgen *builder, int i)
+static  void pktgen__finish_ipv6_opt(const struct pktgen *builder, int i)
 {
 	struct ipv6_opt_hdr *ipv6_opt_layer;
 	__u64 layer_off;
@@ -909,7 +909,7 @@ static __always_inline void pktgen__finish_ipv6_opt(const struct pktgen *builder
 	}
 }
 
-static __always_inline void pktgen__finish_tcp(const struct pktgen *builder, int i)
+static  void pktgen__finish_tcp(const struct pktgen *builder, int i)
 {
 	struct tcphdr *tcp_layer;
 	__u64 layer_off;
@@ -945,7 +945,7 @@ static __always_inline void pktgen__finish_tcp(const struct pktgen *builder, int
 	tcp_layer->doff = (__u16)hdr_size / 4;
 }
 
-static __always_inline void pktgen__finish_udp(const struct pktgen *builder, int i)
+static  void pktgen__finish_udp(const struct pktgen *builder, int i)
 {
 	struct udphdr *udp_layer;
 	__u64 layer_off;
@@ -963,7 +963,7 @@ static __always_inline void pktgen__finish_udp(const struct pktgen *builder, int
 		return;
 }
 
-static __always_inline void pktgen__finish_geneve(const struct pktgen *builder, int i)
+static  void pktgen__finish_geneve(const struct pktgen *builder, int i)
 {
 	struct genevehdr *geneve_layer;
 	__u64 layer_off;
@@ -995,7 +995,7 @@ static __always_inline void pktgen__finish_geneve(const struct pktgen *builder, 
 /* Do a finishing pass on all the layers, which will set correct next layer
  * fields and length values. TODO checksum calculation?
  */
-static __always_inline
+static
 void pktgen__finish(const struct pktgen *builder)
 {
 	#pragma unroll

--- a/bpf/tests/session_affinity_test.c
+++ b/bpf/tests/session_affinity_test.c
@@ -50,7 +50,7 @@ struct {
 #define BACKEND_ID1 7
 #define BACKEND_ID2 42
 
-static __always_inline int craft_packet(struct __ctx_buff *ctx)
+static  int craft_packet(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	struct ethhdr *eh;

--- a/bpf/tests/skip_lb_xlate_socket_lb.c
+++ b/bpf/tests/skip_lb_xlate_socket_lb.c
@@ -27,7 +27,7 @@
  * populated in real CGROUP_SOCK_ADDR hooks, we use it only for testing to
  * mock netns_cookies for different source pods.
  */
-static __always_inline
+static
 int test_get_netns_cookie(__maybe_unused const struct bpf_sock_addr *addr)
 {
 	struct bpf_sock *sk = addr->sk;

--- a/bpf/tests/skip_tunnel_from_host.c
+++ b/bpf/tests/skip_tunnel_from_host.c
@@ -69,7 +69,7 @@ struct {
 	},
 };
 
-static __always_inline int
+static  int
 pktgen_from_host(struct __ctx_buff *ctx, bool v4)
 {
 	struct pktgen builder;
@@ -101,7 +101,7 @@ pktgen_from_host(struct __ctx_buff *ctx, bool v4)
 	return 0;
 }
 
-static __always_inline int
+static  int
 setup(struct __ctx_buff *ctx, bool flag_skip_tunnel, bool v4)
 {
 	/*
@@ -129,7 +129,7 @@ setup(struct __ctx_buff *ctx, bool flag_skip_tunnel, bool v4)
 	return TEST_ERROR;
 }
 
-static __always_inline int
+static  int
 check_ctx(const struct __ctx_buff *ctx, __u32 expected_result, bool v4)
 {
 	void *data;

--- a/bpf/tests/skip_tunnel_from_lxc.c
+++ b/bpf/tests/skip_tunnel_from_lxc.c
@@ -57,7 +57,7 @@ struct {
 	},
 };
 
-static __always_inline int
+static  int
 pktgen_from_lxc(struct __ctx_buff *ctx, bool v4)
 {
 	struct pktgen builder;
@@ -89,7 +89,7 @@ pktgen_from_lxc(struct __ctx_buff *ctx, bool v4)
 	return 0;
 }
 
-static __always_inline int
+static  int
 setup(struct __ctx_buff *ctx, bool flag_skip_tunnel, bool v4)
 {
 	/*
@@ -117,7 +117,7 @@ setup(struct __ctx_buff *ctx, bool flag_skip_tunnel, bool v4)
 	return TEST_ERROR;
 }
 
-static __always_inline int
+static  int
 check_ctx(const struct __ctx_buff *ctx, __u32 expected_result, bool v4)
 {
 	void *data;

--- a/bpf/tests/skip_tunnel_nodeport_masq.c
+++ b/bpf/tests/skip_tunnel_nodeport_masq.c
@@ -63,7 +63,7 @@ struct {
 	},
 };
 
-static __always_inline int
+static  int
 pktgen(struct __ctx_buff *ctx, bool v4)
 {
 	struct pktgen builder;
@@ -101,7 +101,7 @@ pktgen(struct __ctx_buff *ctx, bool v4)
  * to a remote node with the address DST_IP. In the case of tunnel mode where
  * flag_skip_tunnel=true, bpf masquerading should be skipped.
  */
-static __always_inline int
+static  int
 setup(struct __ctx_buff *ctx, bool v4, bool flag_skip_tunnel)
 {
 	/*
@@ -141,7 +141,7 @@ setup(struct __ctx_buff *ctx, bool v4, bool flag_skip_tunnel)
 	return TEST_ERROR;
 }
 
-static __always_inline int
+static  int
 check_ctx(const struct __ctx_buff *ctx, bool v4, bool snat)
 {
 	void *data;

--- a/bpf/tests/skip_tunnel_nodeport_nat.c
+++ b/bpf/tests/skip_tunnel_nodeport_nat.c
@@ -106,7 +106,7 @@ struct {
 	},
 };
 
-static __always_inline int
+static  int
 pktgen(struct __ctx_buff *ctx, bool v4)
 {
 	struct pktgen builder;
@@ -146,7 +146,7 @@ pktgen(struct __ctx_buff *ctx, bool v4)
  *     SRC_IP -> NODEPORT_IP:NODEPORT_PORT -> DST_IP:DST_PORT
  *
  */
-static __always_inline int
+static  int
 setup(struct __ctx_buff *ctx, bool v4, bool flag_skip_tunnel)
 {
 	/*
@@ -191,7 +191,7 @@ setup(struct __ctx_buff *ctx, bool v4, bool flag_skip_tunnel)
 	return TEST_ERROR;
 }
 
-static __always_inline int
+static  int
 check_ctx(const struct __ctx_buff *ctx, bool v4, __u32 expected_result)
 {
 	void *data;

--- a/bpf/tests/skip_tunnel_nodeport_revnat.c
+++ b/bpf/tests/skip_tunnel_nodeport_revnat.c
@@ -104,7 +104,7 @@ struct {
 	},
 };
 
-static __always_inline int
+static  int
 pktgen(struct __ctx_buff *ctx, bool v4)
 {
 	struct pktgen builder;
@@ -141,7 +141,7 @@ pktgen(struct __ctx_buff *ctx, bool v4)
  * Setup scenario where NODEPORT_IP is receiving reply traffic from DST_IP
  * that needs to be redirected to SRC_IP on node through tunnel SRC_TUNNEL_IP
  */
-static __always_inline int
+static  int
 setup(struct __ctx_buff *ctx, bool v4, bool flag_skip_tunnel)
 {
 	/*
@@ -258,7 +258,7 @@ setup(struct __ctx_buff *ctx, bool v4, bool flag_skip_tunnel)
 	return TEST_ERROR;
 }
 
-static __always_inline int
+static  int
 check_ctx(const struct __ctx_buff *ctx, bool v4, __u32 expected_result)
 {
 	void *data;

--- a/bpf/tests/tc_egressgw_redirect_from_overlay.c
+++ b/bpf/tests/tc_egressgw_redirect_from_overlay.c
@@ -27,12 +27,12 @@
 #define SECCTX_FROM_IPCACHE 1
 
 #define ctx_redirect mock_ctx_redirect
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 		  int ifindex __maybe_unused, __u32 flags __maybe_unused);
 
 #define fib_lookup mock_fib_lookup
-static __always_inline __maybe_unused long
+static  __maybe_unused long
 mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_unused,
 		int plen __maybe_unused, __u32 flags __maybe_unused);
 
@@ -53,7 +53,7 @@ static int mock_skb_get_tunnel_key(__maybe_unused struct __sk_buff *skb,
 #include "lib/egressgw.h"
 #include "lib/ipcache.h"
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
 {
@@ -63,7 +63,7 @@ mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 	return CTX_ACT_OK;
 }
 
-static __always_inline __maybe_unused long
+static  __maybe_unused long
 mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_unused,
 		int plen __maybe_unused, __u32 flags __maybe_unused)
 {

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -21,12 +21,12 @@
 #define SECCTX_FROM_IPCACHE 1
 
 #define ctx_redirect mock_ctx_redirect
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 		  int ifindex __maybe_unused, __u32 flags __maybe_unused);
 
 #define fib_lookup mock_fib_lookup
-static __always_inline __maybe_unused long
+static  __maybe_unused long
 mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_unused,
 		int plen __maybe_unused, __u32 flags __maybe_unused);
 
@@ -35,7 +35,7 @@ mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_
 #include "lib/egressgw.h"
 #include "lib/ipcache.h"
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
 {
@@ -47,7 +47,7 @@ mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 	return CTX_ACT_DROP;
 }
 
-static __always_inline __maybe_unused long
+static  __maybe_unused long
 mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_unused,
 		int plen __maybe_unused, __u32 flags __maybe_unused)
 {

--- a/bpf/tests/tc_l2_announcement.c
+++ b/bpf/tests/tc_l2_announcement.c
@@ -52,7 +52,7 @@ struct {
 
 static volatile const __u8 mac_bcast[] =   {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
-static __always_inline int build_packet(struct __ctx_buff *ctx)
+static  int build_packet(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	volatile const __u8 *src = mac_one;

--- a/bpf/tests/tc_nodeport_l3_dev.c
+++ b/bpf/tests/tc_nodeport_l3_dev.c
@@ -42,7 +42,7 @@ struct {
 };
 
 #define tail_call_dynamic mock_tail_call_dynamic
-static __always_inline __maybe_unused void
+static  __maybe_unused void
 mock_tail_call_dynamic(struct __ctx_buff *ctx __maybe_unused,
 		       const void *map __maybe_unused, __u32 slot __maybe_unused)
 {

--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -59,7 +59,7 @@ long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 
 #define ctx_redirect mock_ctx_redirect
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
 {
@@ -275,7 +275,7 @@ int nodeport_dsr_backend_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-static __always_inline int build_reply(struct __ctx_buff *ctx)
+static  int build_reply(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	struct tcphdr *l4;
@@ -301,7 +301,7 @@ static __always_inline int build_reply(struct __ctx_buff *ctx)
 	return 0;
 }
 
-static __always_inline int check_reply(const struct __ctx_buff *ctx)
+static  int check_reply(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
 	__u32 *status_code;

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -80,7 +80,7 @@ long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 
 #define ctx_redirect mock_ctx_redirect
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
 {
@@ -715,7 +715,7 @@ int nodeport_nat_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-static __always_inline int build_reply(struct __ctx_buff *ctx)
+static  int build_reply(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	struct tcphdr *l4;
@@ -741,7 +741,7 @@ static __always_inline int build_reply(struct __ctx_buff *ctx)
 	return 0;
 }
 
-static __always_inline int check_reply(const struct __ctx_buff *ctx)
+static  int check_reply(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
 	__u32 *status_code;

--- a/bpf/tests/tc_nodeport_lb6_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb6_dsr_backend.c
@@ -248,7 +248,7 @@ int nodeport_dsr_backend_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-static __always_inline
+static
 int build_reply(struct __ctx_buff *ctx)
 {
 	union v6addr backend_ip = BACKEND_IP;
@@ -277,7 +277,7 @@ int build_reply(struct __ctx_buff *ctx)
 	return 0;
 }
 
-static __always_inline
+static
 int check_reply(const struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IP;

--- a/bpf/tests/tc_nodeport_lb_terminating_backend.c
+++ b/bpf/tests/tc_nodeport_lb_terminating_backend.c
@@ -46,7 +46,7 @@ static volatile const __u8 *local_backend_mac = mac_four;
 
 #define ctx_redirect mock_ctx_redirect
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
 {

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -24,7 +24,7 @@
 #undef FORCE_LOCAL_POLICY_EVAL_AT_SOURCE
 
 #define ctx_redirect_peer mock_ctx_redirect_peer
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 mock_ctx_redirect_peer(const struct __sk_buff *ctx __maybe_unused, int ifindex __maybe_unused,
 		       __u32 flags __maybe_unused)
 {
@@ -58,7 +58,7 @@ struct {
  *            \---------------------------/
  */
 
-static __always_inline int build_packet(struct __ctx_buff *ctx,
+static  int build_packet(struct __ctx_buff *ctx,
 					__be16 sport)
 {
 	struct pktgen builder;

--- a/bpf/tests/vxlan_helpers_tests.c
+++ b/bpf/tests/vxlan_helpers_tests.c
@@ -20,7 +20,7 @@
  * use layer accounting and will fail when pushing an ipv4 header past its
  * assumed layer
  */
-static __always_inline void
+static  void
 mk_data(const __u8 *buff) {
 	struct ethhdr *eth = (struct ethhdr *)buff;
 
@@ -34,7 +34,7 @@ mk_data(const __u8 *buff) {
 	ipv4->daddr = v4_pod_two;
 }
 
-static __always_inline int
+static  int
 mk_packet(struct __ctx_buff *ctx) {
 	struct pktgen builder;
 	struct udphdr *l4;
@@ -75,7 +75,7 @@ mk_packet(struct __ctx_buff *ctx) {
 }
 
 PKTGEN("tc", "vxlan_get_vni_success")
-static __always_inline int
+static  int
 pktgen_vxlan_mock_check3(struct __ctx_buff *ctx) {
 	return mk_packet(ctx);
 }
@@ -95,7 +95,7 @@ int check3(struct __ctx_buff *ctx)
 }
 
 PKTGEN("tc", "vxlan_get_inner_ipv4_success")
-static __always_inline int
+static  int
 pktgen_vxlan_mock_check4(struct __ctx_buff *ctx) {
 	return mk_packet(ctx);
 }
@@ -119,7 +119,7 @@ int check4(struct __ctx_buff *ctx)
 }
 
 PKTGEN("tc", "vxlan_rewrite_vni_success")
-static __always_inline int
+static  int
 pktgen_vxlan_mock_check5(struct __ctx_buff *ctx) {
 	return mk_packet(ctx);
 }

--- a/bpf/tests/xdp_egressgw_reply.c
+++ b/bpf/tests/xdp_egressgw_reply.c
@@ -30,12 +30,12 @@
 #define DIRECT_ROUTING_IFINDEX	25
 
 #define ctx_redirect mock_ctx_redirect
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 mock_ctx_redirect(const struct __ctx_buff *ctx __maybe_unused, int ifindex __maybe_unused,
 		  __u32 flags __maybe_unused);
 
 #define fib_lookup mock_fib_lookup
-static __always_inline __maybe_unused long
+static  __maybe_unused long
 mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 		__maybe_unused int plen, __maybe_unused __u32 flags);
 
@@ -44,7 +44,7 @@ mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 #include "lib/egressgw.h"
 #include "lib/ipcache.h"
 
-static __always_inline __maybe_unused int
+static  __maybe_unused int
 mock_ctx_redirect(const struct __ctx_buff *ctx __maybe_unused, int ifindex __maybe_unused,
 		  __u32 flags __maybe_unused)
 {
@@ -54,7 +54,7 @@ mock_ctx_redirect(const struct __ctx_buff *ctx __maybe_unused, int ifindex __may
 	return CTX_ACT_REDIRECT;
 }
 
-static __always_inline __maybe_unused long
+static  __maybe_unused long
 mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 		__maybe_unused int plen, __maybe_unused __u32 flags)
 {

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -297,7 +297,7 @@ int nodeport_nat_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-static __always_inline int build_reply(struct __ctx_buff *ctx)
+static  int build_reply(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	struct tcphdr *l4;
@@ -323,7 +323,7 @@ static __always_inline int build_reply(struct __ctx_buff *ctx)
 	return 0;
 }
 
-static __always_inline int check_reply(const struct __ctx_buff *ctx)
+static  int check_reply(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
 	__u32 *status_code;

--- a/bpf/tests/xdp_nodeport_lb4_test.c
+++ b/bpf/tests/xdp_nodeport_lb4_test.c
@@ -45,7 +45,7 @@ struct {
 
 static long (*bpf_xdp_adjust_tail)(struct xdp_md *xdp_md, int delta) = (void *)65;
 
-static __always_inline int build_packet(struct __ctx_buff *ctx)
+static  int build_packet(struct __ctx_buff *ctx)
 {
 	/* Create room for our packet to be crafted */
 	unsigned int data_len = ctx->data_end - ctx->data;


### PR DESCRIPTION
...This could simplify ifdefs and related `unused function` warnings from clang.  