### PR TITLE
bgpv1: filter terminating backends from endpoint selection

### DIFF
--- a/pkg/bgpv1/manager/reconciler/service.go
+++ b/pkg/bgpv1/manager/reconciler/service.go
@@ -132,7 +132,7 @@ endpointsLoop:
 		svcID := eps.ServiceID
 
 		for _, be := range eps.Backends {
-			if be.NodeName == localNodeName {
+			if !be.Terminating && be.NodeName == localNodeName {
 				// At least one endpoint is available on this node. We
 				// can make unavailable to available.
 				if _, found := ls[svcID]; !found {

--- a/pkg/bgpv1/manager/reconciler/service_test.go
+++ b/pkg/bgpv1/manager/reconciler/service_test.go
@@ -127,6 +127,26 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 	}
 
+	eps1IPv4LocalTerminating := &k8s.Endpoints{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "svc-1-ipv4",
+			Namespace: "default",
+		},
+		EndpointSliceID: k8s.EndpointSliceID{
+			ServiceID: k8s.ServiceID{
+				Name:      "svc-1",
+				Namespace: "default",
+			},
+			EndpointSliceName: "svc-1-ipv4",
+		},
+		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
+			cmtypes.MustParseAddrCluster("10.0.0.1"): {
+				NodeName:    "node1",
+				Terminating: true,
+			},
+		},
+	}
+
 	eps1IPv4Remote := &k8s.Endpoints{
 		ObjectMeta: slim_metav1.ObjectMeta{
 			Name:      "svc-1-ipv4",
@@ -446,6 +466,16 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 			advertised:         map[resource.Key][]string{},
 			upsertedServices:   []*slim_corev1.Service{svc1ETPLocal},
 			upsertedEndpoints:  []*k8s.Endpoints{},
+			updated:            map[resource.Key][]string{},
+		},
+		// Service with terminating endpoint
+		{
+			name:               "etp-local-terminating-endpoint",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1ETPLocal},
+			upsertedEndpoints:  []*k8s.Endpoints{eps1IPv4LocalTerminating},
 			updated:            map[resource.Key][]string{},
 		},
 		// externalTrafficPolicy=Local && IPv4 && single slice && local endpoint


### PR DESCRIPTION
Filtering out backends which are terminating when creating local endpoint state. This will result in quicker route withdrawal if local backends go into terminating state, without waiting for graceful shutdown period of the backend pod.

Fixes: #32487

```release-note
bgp: service eTP=local, withdraw route when last backend on the node goes in terminating state
```
