### PR TITLE
bgpv2: filter terminating backends from endpoint selection

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -462,7 +462,7 @@ endpointsLoop:
 		}
 
 		for _, be := range eps.Backends {
-			if be.NodeName == localNodeName {
+			if !be.Terminating && be.NodeName == localNodeName {
 				// At least one endpoint is available on this node. We
 				// can add service to the local services set.
 				ls.Insert(svcKey)


### PR DESCRIPTION
Filtering out backends which are terminating when creating local endpoint state. This will result in quicker route withdrawal if local backends go into terminating state, without waiting for graceful shutdown period of the pods.

This is similar change to [PR](https://github.com/cilium/cilium/pull/32536). Since this change does not need to be backported, created an independent PR for BGPv2.