### PR TITLE
bpf: xdp replace inline asm in csum helpers

### DIFF
--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -150,48 +150,35 @@ __csum_replace_by_4(__sum16 *sum, __wsum from, __wsum to)
 }
 
 static __always_inline __maybe_unused int
-l3_csum_replace(const struct xdp_md *ctx, __u64 off, const __u32 from,
+l3_csum_replace(struct xdp_md *ctx, __u64 off, const __u32 from,
 		__u32 to,
 		__u32 flags)
 {
 	__u32 size = flags & BPF_F_HDR_FIELD_MASK;
-	__sum16 *sum;
-	int ret;
+	__sum16 sum;
+	int ret = 0;
 
 	if (unlikely(flags & ~(BPF_F_HDR_FIELD_MASK)))
 		return -EINVAL;
 	if (unlikely(size != 0 && size != 2))
 		return -EINVAL;
-	/* See xdp_load_bytes(). */
-	asm volatile("r1 = *(u32 *)(%[ctx] +0)\n\t"
-		     "r2 = *(u32 *)(%[ctx] +4)\n\t"
-		     "%[off] &= %[offmax]\n\t"
-		     "r1 += %[off]\n\t"
-		     "%[sum] = r1\n\t"
-		     "r1 += 2\n\t"
-		     "if r1 > r2 goto +2\n\t"
-		     "%[ret] = 0\n\t"
-		     "goto +1\n\t"
-		     "%[ret] = %[errno]\n\t"
-		     : [ret]"=r"(ret), [sum]"=r"(sum)
-		     : [ctx]"r"(ctx), [off]"r"(off),
-		       [offmax]"i"(__CTX_OFF_MAX), [errno]"i"(-EINVAL)
-		     : "r1", "r2");
+	ret = xdp_load_bytes(ctx, off, &sum, 2);
+
 	if (!ret)
-		from ? __csum_replace_by_4(sum, from, to) :
-		       __csum_replace_by_diff(sum, to);
+		from ? __csum_replace_by_4(&sum, from, to) :
+		       __csum_replace_by_diff(&sum, to);
 	return ret;
 }
 
 #define CSUM_MANGLED_0		((__sum16)0xffff)
 
 static __always_inline __maybe_unused int
-l4_csum_replace(const struct xdp_md *ctx, __u64 off, __u32 from, __u32 to,
+l4_csum_replace(struct xdp_md *ctx, __u64 off, __u32 from, __u32 to,
 		__u32 flags)
 {
 	bool is_mmzero = flags & BPF_F_MARK_MANGLED_0;
 	__u32 size = flags & BPF_F_HDR_FIELD_MASK;
-	__sum16 *sum;
+	__sum16 sum;
 	int ret;
 
 	if (unlikely(flags & ~(BPF_F_MARK_MANGLED_0 | BPF_F_PSEUDO_HDR |
@@ -199,28 +186,15 @@ l4_csum_replace(const struct xdp_md *ctx, __u64 off, __u32 from, __u32 to,
 		return -EINVAL;
 	if (unlikely(size != 0 && size != 2))
 		return -EINVAL;
-	/* See xdp_load_bytes(). */
-	asm volatile("r1 = *(u32 *)(%[ctx] +0)\n\t"
-		     "r2 = *(u32 *)(%[ctx] +4)\n\t"
-		     "%[off] &= %[offmax]\n\t"
-		     "r1 += %[off]\n\t"
-		     "%[sum] = r1\n\t"
-		     "r1 += 2\n\t"
-		     "if r1 > r2 goto +2\n\t"
-		     "%[ret] = 0\n\t"
-		     "goto +1\n\t"
-		     "%[ret] = %[errno]\n\t"
-		     : [ret]"=r"(ret), [sum]"=r"(sum)
-		     : [ctx]"r"(ctx), [off]"r"(off),
-		       [offmax]"i"(__CTX_OFF_MAX), [errno]"i"(-EINVAL)
-		     : "r1", "r2");
+	ret = xdp_load_bytes(ctx, off, &sum, 2);
+
 	if (!ret) {
-		if (is_mmzero && !*sum)
+		if (is_mmzero && !sum)
 			return 0;
-		from ? __csum_replace_by_4(sum, from, to) :
-		       __csum_replace_by_diff(sum, to);
-		if (is_mmzero && !*sum)
-			*sum = CSUM_MANGLED_0;
+		from ? __csum_replace_by_4(&sum, from, to) :
+		       __csum_replace_by_diff(&sum, to);
+		if (is_mmzero && !sum)
+			sum = CSUM_MANGLED_0;
 	}
 	return ret;
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->
This commit is a refactoring due to native support for the bpf_xdp_load_bytes.
replace inline asm to native support xdp_load_bytes()

Fixes: #29487 