### PR TITLE
helm: add nodeSelector to preflight DaemonSet

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -177,6 +177,10 @@ spec:
       serviceAccountName: {{ .Values.serviceAccounts.preflight.name | quote }}
       automountServiceAccountToken: {{ .Values.serviceAccounts.preflight.automount }}
       terminationGracePeriodSeconds: {{ .Values.preflight.terminationGracePeriodSeconds }}
+      {{- with .Values.preflight.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.preflight.tolerations }}
       tolerations:
         {{- toYaml . | trim | nindent 8 }}


### PR DESCRIPTION
We had the value, but forgot to plumb it in.

Fixes: #32497 

```release-note
Fixes accidentally ignoring the preflight.nodeSelector Helm value.
```
