### PR TITLE
healthv2: Various fixes

### DIFF
--- a/pkg/healthv2/provider.go
+++ b/pkg/healthv2/provider.go
@@ -128,7 +128,11 @@ func (p *HealthProvider) ForModule(mid cell.FullModuleID) cell.Health {
 			tx := p.db.WriteTxn(p.statusTable)
 			defer tx.Abort()
 			old, _, found := p.statusTable.Get(tx, PrimaryIndex.Query(i.HealthID()))
-			if found && !old.Stopped.IsZero() {
+			if !found {
+				// Nothing to do.
+				return nil
+			}
+			if !old.Stopped.IsZero() {
 				return fmt.Errorf("reporting for %q has been stopped", i)
 			}
 			old.Stopped = time.Now()

--- a/pkg/healthv2/provider.go
+++ b/pkg/healthv2/provider.go
@@ -100,7 +100,7 @@ func (p *HealthProvider) ForModule(mid cell.FullModuleID) cell.Health {
 			tx := p.db.WriteTxn(p.statusTable)
 			defer tx.Abort()
 			q := PrimaryIndex.Query(types.HealthID(i.String()))
-			iter, _ := p.statusTable.LowerBound(tx, q)
+			iter, _ := p.statusTable.Prefix(tx, q)
 			var deleted int
 			for {
 				o, _, ok := iter.Next()

--- a/pkg/healthv2/provider.go
+++ b/pkg/healthv2/provider.go
@@ -199,6 +199,7 @@ func (r *moduleReporter) Degraded(msg string, err error) {
 	if err := r.upsert(types.Status{
 		ID:      r.id,
 		Level:   types.LevelDegraded,
+		Message: msg,
 		Error:   err.Error(),
 		Updated: time.Now(),
 	}); err != nil {

--- a/pkg/healthv2/provider.go
+++ b/pkg/healthv2/provider.go
@@ -80,7 +80,7 @@ func (p *HealthProvider) ForModule(mid cell.FullModuleID) cell.Health {
 			s.Count = 1
 			// If a similar status already exists, increment count, otherwise start back
 			// at zero.
-			if found && old.Level == s.Level && old.Message == s.Message {
+			if found && old.Level == s.Level && old.Message == s.Message && old.Error == s.Error {
 				s.Count = old.Count + 1
 			}
 			if _, _, err := p.statusTable.Insert(tx, s); err != nil {

--- a/pkg/healthv2/provider.go
+++ b/pkg/healthv2/provider.go
@@ -127,7 +127,7 @@ func (p *HealthProvider) ForModule(mid cell.FullModuleID) cell.Health {
 			}
 			tx := p.db.WriteTxn(p.statusTable)
 			defer tx.Abort()
-			old, _, found := p.statusTable.Get(tx, PrimaryIndex.QueryFromObject(types.Status{ID: i}))
+			old, _, found := p.statusTable.Get(tx, PrimaryIndex.Query(i.HealthID()))
 			if found && !old.Stopped.IsZero() {
 				return fmt.Errorf("reporting for %q has been stopped", i)
 			}

--- a/pkg/healthv2/provider_test.go
+++ b/pkg/healthv2/provider_test.go
@@ -61,6 +61,7 @@ func TestProvider(t *testing.T) {
 			degraded := byLevel(db, statusTable, types.LevelDegraded)
 
 			assert.Len(degraded, 1)
+			assert.Equal("noo", degraded[0].Message)
 			assert.Equal("err0", degraded[0].Error)
 			assert.Equal(degraded[0].Count, uint64(1))
 

--- a/pkg/healthv2/types/types.go
+++ b/pkg/healthv2/types/types.go
@@ -51,6 +51,10 @@ func (i Identifier) String() string {
 	return strings.Join([]string{i.Module.String(), i.Component.String()}, ".")
 }
 
+func (i Identifier) HealthID() HealthID {
+	return HealthID(i.String())
+}
+
 // Status represents a current health status update.
 type Status struct {
 	ID      Identifier

--- a/pkg/healthv2/types/types.go
+++ b/pkg/healthv2/types/types.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -65,16 +66,28 @@ type Status struct {
 }
 
 func (Status) TableHeader() []string {
-	return []string{"Module", "Component", "Level", "Message", "LastOK", "UpdatedAt", "Count"}
+	return []string{"Module", "Component", "Level", "Message", "Error", "LastOK", "UpdatedAt", "Count"}
 }
 
 func (s Status) TableRow() []string {
-	return []string{s.ID.Module.String(), s.ID.Component.String(), string(s.Level), s.Message, s.LastOK.Format(time.RFC3339),
-		s.Updated.Format(time.RFC3339), fmt.Sprintf("%d", s.Count)}
+	return []string{
+		s.ID.Module.String(),
+		s.ID.Component.String(),
+		string(s.Level),
+		s.Message,
+		s.Error,
+		s.LastOK.Format(time.RFC3339),
+		s.Updated.Format(time.RFC3339),
+		strconv.FormatUint(s.Count, 10),
+	}
 }
 
 func (s Status) String() string {
-	return fmt.Sprintf("%s: [%s] %s", s.ID.String(), s.Level, s.Message)
+	if s.Error != "" {
+		return fmt.Sprintf("%s: [%s] %s: %s", s.ID.String(), s.Level, s.Message, s.Error)
+	} else {
+		return fmt.Sprintf("%s: [%s] %s", s.ID.String(), s.Level, s.Message)
+	}
 }
 
 type Level string


### PR DESCRIPTION
This fixes a set of small issues with healthv2:
- Degraded message was not passed onto the status
- Error not shown in table dump or in debug logs
- deletePrefix deleted beyond just the prefix (everything that had id equal to or larger got deleted)
- Empty status was inserted on stop() if a health provider was unused

Marking this as `release-note/misc` as healthv2 is not yet part of any released version.