### PR TITLE
devices: Fix panic in tests when logger used after stopping

### DIFF
--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -195,6 +195,13 @@ func (dc *devicesController) subscribeAndProcess(ctx context.Context) {
 	// It cancels the context to unsubscribe from netlink updates
 	// which stops the processing.
 	errorCallback := func(err error) {
+		if ctx.Err() != nil {
+			// The netlink unsubscribe can lead to errorCallback being called after
+			// context cancellation with a "receive called on closed socket".
+			// Thus ignore the error if the context was cancelled.
+			return
+		}
+
 		dc.log.Warn("Netlink error received, restarting", logfields.Error, err)
 
 		// Cancel the context to stop the subscriptions.


### PR DESCRIPTION
The netlink unsubscribing is async and the error callback is sometimes called with an error after unsubscribing:
```
  panic: Log in goroutine after TestDevicesController has completed:
  time=2024-05-14T15:40:53.086Z level=WARN
  msg="Netlink error received, restarting" module=devices-controller
  error="Receive failed: Receive called on a closed socket"
```
Ignore the error if we've cancelled the context.

Before this fix:
```
$ PRIVILEGED_TESTS=1 sudo -E stress go test . -test.v -test.run Devices -test.count 2
20s: 32 runs so far, 25 failures (78.12%)
```

After this fix:
```
$ PRIVILEGED_TESTS=1 sudo -E stress go test . -test.v -test.run Devices -test.count 2
30s: 51 runs so far, 0 failures
```
