### PR TITLE
Miscellaneous improvements to the clustermesh troubleshooting guide

### DIFF
--- a/Documentation/network/clustermesh/clustermesh.rst
+++ b/Documentation/network/clustermesh/clustermesh.rst
@@ -291,15 +291,14 @@ Troubleshooting
 
 Use the following list of steps to troubleshoot issues with ClusterMesh:
 
- #. Validate that the ``cilium-xxx`` as well as the ``cilium-operator-xxx`` pods
-    are healthy and ready. 
+ #. Validate that Cilium pods are healthy and ready:
 
     .. code-block:: shell-session
 
        cilium status --context $CLUSTER1
        cilium status --context $CLUSTER2
 
- #. Validate the Cluster Mesh is enabled correctly and operational:
+ #. Validate that Cluster Mesh is enabled and operational:
 
     .. code-block:: shell-session
 

--- a/Documentation/operations/troubleshooting_clustermesh.rst
+++ b/Documentation/operations/troubleshooting_clustermesh.rst
@@ -74,6 +74,14 @@ Manual Verification of Setup
            └  remote configuration: expected=true, retrieved=true, cluster-id=3, kvstoremesh=false, sync-canaries=true
            └  synchronization status: nodes=true, endpoints=true, identities=true, services=true
 
+    When KVStoreMesh is enabled, additionally check its status and validate that
+    it is correctly connected to all remote clusters:
+
+    .. code-block:: shell-session
+
+      $ kubectl --context $CLUSTER1 exec -it -n kube-system deploy/clustermesh-apiserver \
+          -c kvstoremesh -- clustermesh-apiserver kvstoremesh-dbg status --verbose
+
  #. Validate that the required TLS secrets are set up properly. By default, the
     following TLS secrets must be available in the namespace in which Cilium is
     installed:

--- a/Documentation/operations/troubleshooting_clustermesh.rst
+++ b/Documentation/operations/troubleshooting_clustermesh.rst
@@ -7,21 +7,46 @@ Install the Cilium CLI
 
 .. include:: /installation/cli-download.rst
 
-Generic
--------
+Automatic Verification
+----------------------
 
- #. Validate that the ``cilium-xxx`` as well as the ``cilium-operator-xxx`` pods
-    are healthy and ready.
+ #. Validate that Cilium pods are healthy and ready:
 
     .. code-block:: shell-session
 
        cilium status
 
- #. Validate that Cluster Mesh is enabled correctly and operational:
+ #. Validate that Cluster Mesh is enabled and operational:
 
     .. code-block:: shell-session
 
        cilium clustermesh status
+
+ #. In case of errors, run the troubleshoot command to automatically investigate
+    Cilium agents connectivity issues towards the ClusterMesh control plane in
+    remote clusters:
+
+    .. code-block:: shell-session
+
+       kubectl exec -it -n kube-system ds/cilium -c cilium-agent -- cilium-dbg troubleshoot clustermesh
+
+    The troubleshoot command performs a set of automatic checks to validate
+    DNS resolution, network connectivity, TLS authentication, etcd authorization
+    and more, and reports the output in a user friendly format.
+
+    When KVStoreMesh is enabled, additionally run the troubleshoot command
+    inside the clustermesh-apiserver to investigate KVStoreMesh connectivity
+    issues towards the ClusterMesh control plane in remote clusters:
+
+    .. code-block:: shell-session
+
+      kubectl exec -it -n kube-system deploy/clustermesh-apiserver -c kvstoremesh -- \
+        clustermesh-apiserver kvstoremesh-dbg troubleshoot
+
+    .. tip::
+
+      You can specify one or more cluster names as parameters of the troubleshoot
+      command to run the checks only towards a subset of remote clusters.
 
 
 Manual Verification of Setup

--- a/Documentation/operations/troubleshooting_clustermesh.rst
+++ b/Documentation/operations/troubleshooting_clustermesh.rst
@@ -169,66 +169,31 @@ State Propagation
 -----------------
 
  #. Run ``cilium-dbg node list`` in one of the Cilium pods and validate that it
-    lists both local nodes and nodes from remote clusters. If this discovery
-    does not work, validate the following:
-
-    * In each cluster, check that the kvstore contains information about
-      *local* nodes by running:
-
-      .. code-block:: shell-session
-
-          cilium-dbg kvstore get --recursive cilium/state/nodes/v1/
-
-      .. note::
-
-         The kvstore will only contain nodes of the **local cluster**. It will
-         **not** contain nodes of remote clusters. The state in the kvstore is
-         used for other clusters to discover all nodes so it is important that
-         local nodes are listed.
+    lists both local nodes and nodes from remote clusters. If remote nodes are
+    not present, validate that Cilium agents (or KVStoreMesh, if enabled)
+    are correctly connected to the given remote cluster. Additionally, verify
+    that the initial nodes synchronization from all clusters has completed.
 
  #. Validate the connectivity health matrix across clusters by running
     ``cilium-health status`` inside any Cilium pod. It will list the status of
-    the connectivity health check to each remote node.
-
-    If this fails:
-
-    * Make sure that the network allows the health checking traffic as
-      specified in the section :ref:`firewall_requirements`.
+    the connectivity health check to each remote node. If this fails, make sure
+    that the network allows the health checking traffic as specified in the
+    :ref:`firewall_requirements` section.
 
  #. Validate that identities are synchronized correctly by running ``cilium-dbg
     identity list`` in one of the Cilium pods. It must list identities from all
     clusters. You can determine what cluster an identity belongs to by looking
-    at the label ``io.cilium.k8s.policy.cluster``.
-
-    If this fails:
-
-    * Is the identity information available in the kvstore of each cluster? You
-      can confirm this by running ``cilium-dbg kvstore get --recursive
-      cilium/state/identities/v1/``.
-
-      .. note::
-
-         The kvstore will only contain identities of the **local cluster**. It
-         will **not** contain identities of remote clusters. The state in the
-         kvstore is used for other clusters to discover all identities so it is
-         important that local identities are listed.
+    at the label ``io.cilium.k8s.policy.cluster``. If remote identities are
+    not present, validate that Cilium agents (or KVStoreMesh, if enabled)
+    are correctly connected to the given remote cluster. Additionally, verify
+    that the initial identities synchronization from all clusters has completed.
 
  #. Validate that the IP cache is synchronized correctly by running ``cilium-dbg
     bpf ipcache list`` or ``cilium-dbg map get cilium_ipcache``. The output must
-    contain pod IPs from local and remote clusters.
-
-    If this fails:
-
-    * Is the IP cache information available in the kvstore of each cluster? You
-      can confirm this by running ``cilium-dbg kvstore get --recursive
-      cilium/state/ip/v1/``.
-
-      .. note::
-
-         The kvstore will only contain IPs of the **local cluster**. It will
-         **not** contain IPs of remote clusters. The state in the kvstore is
-         used for other clusters to discover all pod IPs so it is important
-         that local identities are listed.
+    contain pod IPs from local and remote clusters. If remote IP addresses are
+    not present, validate that Cilium agents (or KVStoreMesh, if enabled)
+    are correctly connected to the given remote cluster. Additionally, verify
+    that the initial IPs synchronization from all clusters has completed.
 
  #. When using global services, ensure that global services are configured with
     endpoints from all clusters. Run ``cilium-dbg service list`` in any Cilium pod
@@ -238,10 +203,6 @@ State Propagation
     maps.
 
     If this fails:
-
-    * Are services available in the kvstore of each cluster? You can confirm
-      this by running ``cilium-dbg kvstore get --recursive
-      cilium/state/services/v1/``.
 
     * Run ``cilium-dbg debuginfo`` and look for the section ``k8s-service-cache``. In
       that section, you will find the contents of the service correlation

--- a/Documentation/operations/troubleshooting_clustermesh.rst
+++ b/Documentation/operations/troubleshooting_clustermesh.rst
@@ -49,8 +49,11 @@ Automatic Verification
       command to run the checks only towards a subset of remote clusters.
 
 
-Manual Verification of Setup
-----------------------------
+Manual Verification
+-------------------
+
+As an alternative to leveraging the tools presented in the previous section,
+you may perform the following steps to troubleshoot ClusterMesh issues.
 
  #. Validate that each cluster is assigned a **unique** human-readable name as well
     as a numeric cluster ID (1-255).
@@ -66,7 +69,7 @@ Manual Verification of Setup
         level=info msg="Initial etcd session established" config=/var/lib/cilium/etcd-config.yaml endpoints="[https://127.0.0.1:2379]" subsys=kvstore
         level=info msg="Successfully verified version of etcd endpoint" config=/var/lib/cilium/etcd-config.yaml endpoints="[https://127.0.0.1:2379]" etcdEndpoint="https://127.0.0.1:2379" subsys=kvstore version=3.4.13
 
- #. Validate that ClusterMesh is healthy running ``cilium status --all-clusters`` inside each Cilium agent::
+ #. Validate that ClusterMesh is healthy running ``cilium-dbg status --all-clusters`` inside each Cilium agent::
 
         ClusterMesh:   1/1 clusters ready, 10 global-services
            k8s-c2: ready, 3 nodes, 25 endpoints, 8 identities, 10 services, 0 failures (last: never)
@@ -97,15 +100,6 @@ Manual Verification of Setup
     * ``clustermesh-apiserver-remote-cert``, which is used by Cilium agents, and
       optionally the kvstoremesh container in the clustermesh-apiserver deployment,
       to authenticate against remote etcd instances (either internal or external).
-
-    If any of the prior secrets is not configured correctly, there will be a potential
-    error message like the following::
-
-       level=warning msg="Error observed on etcd connection, reconnecting etcd" clusterName=eks-dev-1 config=/var/lib/cilium/clustermesh/eks-dev-1 error="not able to connect to any etcd endpoints" kvstoreErr="quorum check failed 12 times in a row: timeout while waiting for initial connection" kvstoreStatus="quorum check failed 12 times in a row: timeout while waiting for initial connection" subsys=clustermesh
-
-    or::
-
-        {"level":"warn","ts":"2022-06-08T14:06:29.198Z","caller":"clientv3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"passthrough:///https://eks-dev-1.mesh.cilium.io:2379","attempt":0,"error":"rpc error: code = DeadlineExceeded desc = latest balancer error: connection error: desc = \"transport: authentication handshake failed: remote error: tls: bad certificate\""}
 
  #. Validate that the configuration for remote clusters is picked up correctly.
     For each remote cluster, an info log message ``New remote cluster
@@ -148,7 +142,7 @@ Manual Verification of Setup
     * When KVStoreMesh is disabled, validate that the ``hostAliases`` section in the Cilium DaemonSet maps
       each remote cluster to the IP of the LoadBalancer that makes the remote
       control plane available; When KVStoreMesh is enabled,
-      validate that the ``hostAliases`` section in the clustermesh-apiserver Deployment.
+      validate the ``hostAliases`` section in the clustermesh-apiserver Deployment.
 
     * Validate that a local node in the source cluster can reach the IP
       specified in the ``hostAliases`` section. When KVStoreMesh is disabled, the ``cilium-clustermesh``


### PR DESCRIPTION
Improve the clustermesh troubleshooting guide:
* Document the usage of the newly introduced `troubleshoot` command to automatically perform sanity checks;
* Document the retrieval of KVstoreMesh status;
* Minor changes to the *manual verification* section:
* Drop kvstore-specific steps, which apply only when Cilium operates in kvstore mode.

Please refer to the individual commit descriptions for additional details.

I'm marking this PR for backport to all stable versions to match https://github.com/cilium/cilium/pull/32336. Marking as backport/author as well to perform the necessary adaptations based on the features available in each version.
