### PR TITLE
eks: Don't use spot instances

### DIFF
--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -218,7 +218,7 @@ jobs:
           region: ${{ matrix.region }}
           owner: "${{ steps.vars.outputs.owner }}"
           version: ${{ matrix.version }}
-          spot: ${{ github.event_name != 'schedule' }}
+          spot: false
 
       - name: Wait for images to be available
         timeout-minutes: 30

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -219,7 +219,7 @@ jobs:
           region: ${{ matrix.region }}
           owner: "${{ steps.vars.outputs.owner }}"
           version: ${{ matrix.version }}
-          spot: ${{ github.event_name != 'schedule' }}
+          spot: false
 
       - name: Create IPsec key
         if: ${{ matrix.ipsec == true }}

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -125,7 +125,6 @@ jobs:
     timeout-minutes: 45
     env:
       job_name: "Installation and Connectivity Test"
-      preemptible: ${{ github.event_name != 'schedule' && '--preemptible' || '' }}
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
@@ -224,7 +223,6 @@ jobs:
               --machine-type e2-custom-2-4096 \
               --boot-disk-type pd-standard \
               --boot-disk-size 10GB \
-              ${{ env.preemptible }} \
               --image-project ubuntu-os-cloud \
               --image-family ubuntu-2004-lts \
               --metadata hostname=${{ env.vmName }}-${{ matrix.vmIndex }} \
@@ -244,8 +242,7 @@ jobs:
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
-            --disk-size 20GB \
-            ${{ env.preemptible }}
+            --disk-size 20GB
 
       - name: Get cluster credentials
         run: |

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -130,7 +130,6 @@ jobs:
     timeout-minutes: 75
     env:
       job_name: "Installation and Connectivity Test"
-      preemptible: ${{ github.event_name != 'schedule' && '--preemptible' || '' }}
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
@@ -228,8 +227,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 20GB \
-            --node-taints ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready=true:NoExecute \
-            ${{ env.preemptible }}
+            --node-taints ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready=true:NoExecute
 
       - name: Get cluster credentials
         run: |


### PR DESCRIPTION
It's causing unnecessary flakes. Money is not a concern so let's not bother using spot instances.

edit: now there are 2 commits:

- don't use spot instances in eks.
- don't use preemptible instances in gke.