### PR TITLE
clustermesh: fix a few issues in the new mcs api service controller

### DIFF
--- a/pkg/clustermesh/mcsapi/cell.go
+++ b/pkg/clustermesh/mcsapi/cell.go
@@ -117,12 +117,14 @@ func initMCSAPIController(params mcsAPIParams) error {
 		return fmt.Errorf("Failed to register MCSAPIServiceReconciler: %w", err)
 	}
 
-	svcImportReconciler := mcsapicontrollers.ServiceImportReconciler{
+	// Upstream controller that we use as is to update the ServiceImport
+	// objects with the IPs of the derived Services.
+	svcReconciler := mcsapicontrollers.ServiceReconciler{
 		Client: params.CtrlRuntimeManager.GetClient(),
 		Log:    params.CtrlRuntimeManager.GetLogger(),
 	}
-	if err := svcImportReconciler.SetupWithManager(params.CtrlRuntimeManager); err != nil {
-		return fmt.Errorf("Failed to register svcImportReconciler: %w", err)
+	if err := svcReconciler.SetupWithManager(params.CtrlRuntimeManager); err != nil {
+		return fmt.Errorf("Failed to register mcsapicontrollers.ServiceReconciler: %w", err)
 	}
 
 	params.Logger.Info("Multi-Cluster Services API support enabled")

--- a/pkg/clustermesh/mcsapi/service_controller_test.go
+++ b/pkg/clustermesh/mcsapi/service_controller_test.go
@@ -183,6 +183,7 @@ var (
 				Ports: []corev1.ServicePort{{
 					Name: "my-port-3",
 				}},
+				ClusterIP: corev1.ClusterIPNone,
 			},
 		},
 
@@ -359,6 +360,8 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 
 		require.Len(t, svc.Spec.Ports, 1)
 		require.Equal(t, "my-port-3", svc.Spec.Ports[0].Name)
+
+		require.Equal(t, corev1.ClusterIPNone, svc.Spec.ClusterIP)
 	})
 
 	t.Run("Test service creation with export but no exported service", func(t *testing.T) {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

This commit does 3 small fixes:
- Use the correct upstream MCS-API controller. The controller used
  is now the ones that sync the service IP to the ServiceImport resources.
  The rest of the controllers are Cilium specific and will (or already is)
  be implemented soon.
- Also add a shortcut on creation to save a delete/recreate on
  of the derived service if there is no ServiceImport and the local is
  headless.
- Fix the watch on Services to also issue a reconcile if the locally
  exported Service has changed

Related to #27902 

```release-note
Fix a few issues with the newly added MCS-API controllers
```
