### PR TITLE
ctmap: dump CT entry's BackendID

### DIFF
--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -627,7 +627,7 @@ func (c *CtEntry) StringWithTimeDiff(toRemSecs func(uint32) string) string {
 		timeDiff = ""
 	}
 
-	return fmt.Sprintf("expires=%d%s Packets=%d Bytes=%d RxFlagsSeen=%#02x LastRxReport=%d TxFlagsSeen=%#02x LastTxReport=%d %s RevNAT=%d SourceSecurityID=%d IfIndex=%d \n",
+	return fmt.Sprintf("expires=%d%s Packets=%d Bytes=%d RxFlagsSeen=%#02x LastRxReport=%d TxFlagsSeen=%#02x LastTxReport=%d %s RevNAT=%d SourceSecurityID=%d IfIndex=%d BackendID=%d \n",
 		c.Lifetime,
 		timeDiff,
 		c.Packets,
@@ -639,7 +639,8 @@ func (c *CtEntry) StringWithTimeDiff(toRemSecs func(uint32) string) string {
 		c.flagsString(),
 		byteorder.NetworkToHost16(c.RevNAT),
 		c.SourceSecurityID,
-		c.IfIndex)
+		c.IfIndex,
+		c.BackendID)
 }
 
 // String returns the readable format


### PR DESCRIPTION
Service connections store their selected backend ID in the SVC-type CT entry. Dump this field on `cilium-dbg bpf ct list global`.

This then looks like:
TCP SVC 10.244.0.62:55394 -> 10.96.0.1:443 expires=158116 ... BackendID=1
