### PR TITLE
ci: l4lb: gather more infos about docker-in-docker issues

### DIFF
--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -133,6 +133,13 @@ jobs:
         run: |
           cd ${{ github.workspace }}/test/nat46x64 && sudo ./test.sh ${{ env.QUAY_ORGANIZATION_DEV }} ${{ steps.vars.outputs.sha }}
 
+      - name: Fetch DinD information
+        if: ${{ !success() && steps.lb-test.outcome != 'skipped' }}
+        run: |
+          docker ps
+          docker logs -f lb-node
+          docker exec -t lb-node docker ps
+
       - name: Fetch Cilium Standalone LB logs
         if: ${{ !success() && steps.lb-test.outcome != 'skipped' }}
         run: |


### PR DESCRIPTION
Sometimes, the L4LB tests timeout waiting for the docker (in docker) instance to get ready.

```
+[06:55:18] docker run --privileged --name lb-node -d --network cilium-l4lb -v /lib/modules:/lib/modules docker:dind
ca31f2a72a098bf612d569fee976e7e17779a1546337748dc62b63c99da13271
+[06:55:18] docker exec -t lb-node mount bpffs /sys/fs/bpf -t bpf
+[06:55:18] docker run --name nginx -d --network cilium-l4lb nginx
544abbd0503584c582da50480d5f96eae5ecadb426d48d6fee078558b45451b2
+[06:55:18] docker exec -t lb-node docker ps
+[06:55:18] sleep 1
+[06:55:19] docker exec -t lb-node docker ps
+[06:55:19] sleep 1
+[06:55:20] docker exec -t lb-node docker ps
Error response from daemon: Container ca31f2a72a098bf612d569fee976e7e17779a1546337748dc62b63c99da13271 is not running
+[06:55:20] sleep 1
+[06:55:21] docker exec -t lb-node docker ps
Error response from daemon: Container ca31f2a72a098bf612d569fee976e7e17779a1546337748dc62b63c99da13271 is not running
+[06:55:21] sleep 1
+[06:55:22] docker exec -t lb-node docker ps
Error response from daemon: Container ca31f2a72a098bf612d569fee976e7e17779a1546337748dc62b63c99da13271 is not running
+[06:55:22] sleep 1
+[06:55:23] docker exec -t lb-node docker ps
Error response from daemon: Container ca31f2a72a098bf612d569fee976e7e17779a1546337748dc62b63c99da13271 is not running
+[06:55:20] docker exec -t lb-node docker ps
Error response from daemon: Container ca31f2a72a098bf612d569fee976e7e17779a1546337748dc62b63c99da13271 is not running
```

Unfortunately, fetching the LB logs after the failed test doesn't help either, as this fails with the same error.

```
Run docker exec -t lb-node docker logs cilium-lb
  docker exec -t lb-node docker logs cilium-lb
...
Error response from daemon: Container ca31f2a72a098bf612d569fee976e7e17779a1546337748dc62b63c99da13271 is not running
```

Therefore, this commit adds an additional job step that fetches the status and logs of the docker instance itself.

Examples:
* https://github.com/cilium/cilium/actions/runs/9053573212/job/24872468158
* https://github.com/cilium/cilium/actions/runs/9067978554/job/24914256383
* https://github.com/cilium/cilium/actions/runs/9074981805/job/24934711124
* https://github.com/cilium/cilium/actions/runs/9083769577/job/24963174702
