### PR TITLE
gha: Enable Ingress controller for more e2e test

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -268,6 +268,7 @@ jobs:
             encryption-node: 'false'
             host-fw: 'true'
             ciliumendpointslice: 'true'
+            ingress-controller: 'true'
 
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
The more coverage the better it is