### PR TITLE
daemon: updates the CEP in-place

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -484,6 +484,7 @@ Makefile* @cilium/build
 /pkg/l2announcer/ @cilium/sig-agent
 /pkg/labels @cilium/sig-policy @cilium/api
 /pkg/labelsfilter @cilium/sig-policy
+/pkg/labelsfilterdynamic @cilium/sig-policy
 /pkg/launcher @cilium/sig-agent
 /pkg/loadbalancer @cilium/sig-lb
 /pkg/loadinfo/ @cilium/sig-agent

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -108,6 +108,7 @@ cilium-agent [flags]
       --enable-cilium-endpoint-slice                              Enable the CiliumEndpointSlice watcher in place of the CiliumEndpoint watcher (beta)
       --enable-cilium-health-api-server-access strings            List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-custom-calls                                       Enable tail call hooks for custom eBPF programs
+      --enable-dynamic-label-filter                               Enables support for dynamically limiting the labels used for CIDs
       --enable-encryption-strict-mode                             Enable encryption strict mode
       --enable-endpoint-health-checking                           Enable connectivity health checking between virtual endpoints (default true)
       --enable-endpoint-routes                                    Use per endpoint routes instead of routing via cilium_host

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -37,6 +37,7 @@ import (
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/l2announcer"
+	"github.com/cilium/cilium/pkg/labelsfilterdynamic"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -227,6 +228,8 @@ var (
 		// The node discovery cell provides the local node configuration and node discovery
 		// which communicate changes in local node information to the API server or KVStore.
 		nodediscovery.Cell,
+
+		labelsfilterdynamic.Cell,
 	)
 )
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1112,6 +1112,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.StringSlice(option.NodeLabels, []string{}, "List of label prefixes used to determine identity of a node (used only when enable-node-selector-labels is enabled)")
 	option.BindEnv(vp, option.NodeLabels)
 
+	flags.Bool(option.EnableDynamicLabelFilter, defaults.EnableDynamicLabelFilter, "Enables support for dynamically limiting the labels used for CIDs")
+	option.BindEnv(vp, option.EnableDynamicLabelFilter)
+
 	if err := vp.BindPFlags(flags); err != nil {
 		log.Fatalf("BindPFlags failed: %s", err)
 	}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -559,6 +559,9 @@ const (
 	// EnableNodeSelectorLabels is the default value for option.EnableNodeSelectorLabels
 	EnableNodeSelectorLabels = false
 
+	// EnableDynamicLabelFilter is the default value for option.EnableDynamicalLabelFilter
+	EnableDynamicLabelFilter = false
+
 	// BPFEventsDropEnabled controls whether the Cilium datapath exposes "drop" events to Cilium monitor and Hubble.
 	BPFEventsDropEnabled = true
 

--- a/pkg/labelsfilterdynamic/cell.go
+++ b/pkg/labelsfilterdynamic/cell.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package labelsfilterdynamic
+
+import (
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/labelsfilterdynamic/signals"
+)
+
+var Cell = cell.Module(
+	"dlf-policy-watcher",
+	"Watches network policies events to update dynamic label filter",
+
+	cell.ProvidePrivate(signals.NewSignal),
+	cell.Invoke(registerController),
+)

--- a/pkg/labelsfilterdynamic/manager.go
+++ b/pkg/labelsfilterdynamic/manager.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package labelsfilterdynamic
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/hive"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_networking_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/labelsfilter"
+	"github.com/cilium/cilium/pkg/labelsfilterdynamic/signals"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "dynamic-labels-filter")
+)
+
+type controller struct {
+
+	// Signal informs the Controller that a Kubernetes event of interest has occurred.
+	// The signal itself provides no other information, when it occurs the Controller will query each informer for the latest API information required to drive its control loop.
+	Signal                              *signals.Signal
+	CiliumNetworkPolicy                 resource.Resource[*cilium_v2.CiliumNetworkPolicy]
+	CiliumClusterwideNetworkPolicy      resource.Resource[*cilium_v2.CiliumClusterwideNetworkPolicy]
+	NetworkPolicy                       resource.Resource[*slim_networking_v1.NetworkPolicy]
+	CiliumNetworkPolicyStore            resource.Store[*cilium_v2.CiliumNetworkPolicy]
+	CiliumClusterwideNetworkPolicyStore resource.Store[*cilium_v2.CiliumClusterwideNetworkPolicy]
+	NetworkPolicyStore                  resource.Store[*slim_networking_v1.NetworkPolicy]
+}
+
+type controllerParams struct {
+	cell.In
+
+	Lifecycle                        cell.Lifecycle
+	Health                           cell.Health
+	JobGroup                         job.Group
+	Shutdowner                       hive.Shutdowner
+	Signal                           *signals.Signal
+	CiliumNetworkPolicy              resource.Resource[*cilium_v2.CiliumNetworkPolicy]
+	CiliumClusterWideNetworkPolicies resource.Resource[*cilium_v2.CiliumClusterwideNetworkPolicy]
+	NetworkPolicy                    resource.Resource[*slim_networking_v1.NetworkPolicy]
+	DaemonConfig                     *option.DaemonConfig
+}
+
+func registerController(params controllerParams) (*controller, error) {
+	c := &controller{
+		Signal:                         params.Signal,
+		CiliumNetworkPolicy:            params.CiliumNetworkPolicy,
+		CiliumClusterwideNetworkPolicy: params.CiliumClusterWideNetworkPolicies,
+		NetworkPolicy:                  params.NetworkPolicy,
+	}
+
+	params.JobGroup.Add(
+		job.OneShot("dlf-cilium-network-policy-observer", func(ctx context.Context, health cell.Health) (err error) {
+			for ev := range c.CiliumNetworkPolicy.Events(ctx) {
+				switch ev.Kind {
+				case resource.Upsert, resource.Delete:
+					c.Signal.Event(struct{}{})
+				}
+				ev.Done(nil)
+			}
+			return nil
+		}),
+
+		job.OneShot("dlf-cilium-clusterwide-policy-observer", func(ctx context.Context, health cell.Health) (err error) {
+			for ev := range c.CiliumClusterwideNetworkPolicy.Events(ctx) {
+				switch ev.Kind {
+				case resource.Upsert, resource.Delete:
+					c.Signal.Event(struct{}{})
+				}
+				ev.Done(nil)
+			}
+			return nil
+		}),
+
+		job.OneShot("dlf-network-policy-observer", func(ctx context.Context, health cell.Health) (err error) {
+			for ev := range c.NetworkPolicy.Events(ctx) {
+				switch ev.Kind {
+				case resource.Upsert, resource.Delete:
+					c.Signal.Event(struct{}{})
+				}
+				ev.Done(nil)
+			}
+			return nil
+		}),
+
+		job.OneShot("dlf-controller",
+			func(ctx context.Context, health cell.Health) (err error) {
+				if c.initStore(ctx) != nil {
+					health.Degraded("failed to init stores", err)
+					return fmt.Errorf("error creating Dynamic Label Filter resource stores: %w", err)
+				}
+
+				c.Run(ctx)
+				health.OK("Ready")
+				return nil
+			},
+			job.WithRetry(3, &job.ExponentialBackoff{Min: 100 * time.Millisecond, Max: time.Second}),
+			job.WithShutdown()),
+	)
+
+	return c, nil
+}
+
+func (c *controller) initStore(ctx context.Context) (err error) {
+	c.CiliumNetworkPolicyStore, err = c.CiliumNetworkPolicy.Store(ctx)
+	if err != nil {
+		return
+	}
+	c.NetworkPolicyStore, err = c.NetworkPolicy.Store(ctx)
+	if err != nil {
+		return
+	}
+	c.CiliumClusterwideNetworkPolicyStore, err = c.CiliumClusterwideNetworkPolicy.Store(ctx)
+	if err != nil {
+		return
+	}
+
+	return nil
+}
+
+// Run places the Controller into its control loop.
+//
+// When new events trigger a signal the control loop will be evaluated.
+//
+// A cancel of the provided ctx will kill the control loop along with the running
+// informers.
+func (c *controller) Run(ctx context.Context) {
+	var (
+		l = log.WithFields(logrus.Fields{
+			"component": "Controller.Run",
+		})
+	)
+
+	// add an initial signal
+	c.Signal.Event(struct{}{})
+
+	l.Info("Cilium Dynamic Label Filter Controller now running...")
+	for {
+		select {
+		case <-ctx.Done():
+			l.Info("Cilium Dynamic Label Filter Controller shut down")
+			return
+		case <-c.Signal.Signal:
+			if err := c.Reconcile(ctx); err != nil {
+				l.WithError(err).Error("Cilium Dynamic Label Filter Controller encountered error during reconciliation")
+			} else {
+				l.Debug("Cilium Dynamic Label Filter Controller successfully completed reconciliation")
+			}
+		}
+	}
+}
+
+// Reconcile is the control loop for the Controller.
+//
+// Reconcile will be invoked when one or more event sources trigger a signal
+// via the Controller's Signal structure.
+//
+// On signal, Reconcile will read all network policies selector key labels, construct a set,
+// updates the labels filter and TODO reconcile in-place the affected pods generating new CIDs.
+func (c *controller) Reconcile(ctx context.Context) error {
+	var (
+		l = log.WithFields(logrus.Fields{
+			"component": "Controller.Reconcile",
+		})
+	)
+	keyLabels := sets.New[string]()
+
+	for _, policy := range c.CiliumNetworkPolicyStore.List() {
+		keyLabels = keyLabels.Union(getRelevantKeyLabels(policy.Spec.EndpointSelector.MatchLabels, policy.Spec.EndpointSelector.MatchExpressions))
+	}
+	for _, policy := range c.CiliumClusterwideNetworkPolicyStore.List() {
+		keyLabels = keyLabels.Union(getRelevantKeyLabels(policy.Spec.EndpointSelector.MatchLabels, policy.Spec.EndpointSelector.MatchExpressions))
+	}
+	for _, policy := range c.NetworkPolicyStore.List() {
+		keyLabels = keyLabels.Union(getRelevantKeyLabels(policy.Spec.PodSelector.MatchLabels, policy.Spec.PodSelector.MatchExpressions))
+	}
+
+	l.Debug("dynamic labels to parse: ", keyLabels.UnsortedList())
+
+	if err := labelsfilter.ParseLabelPrefixCfg(keyLabels.UnsortedList(), option.Config.NodeLabels, option.Config.LabelPrefixFile); err != nil {
+		return fmt.Errorf("unable to parse Dynamic Label prefix")
+	}
+
+	// TODO Phase 2: reconcile affected pods, update in-place so the old identities can be garbage collected
+
+	return nil
+}
+
+// getRelevantKeyLabels extracts the label key from the MatchLabels and MatchExpressions.
+// The extracted keys are being normalized to SOURCE:KEY from the extended format.
+// If the SOURCE is any, the SOURCE will be an empty string to align with the default labels filters config.
+func getRelevantKeyLabels(matchLabels map[string]slim_metav1.MatchLabelsValue, matchExpressionLabels []slim_metav1.LabelSelectorRequirement) sets.Set[string] {
+	keyLabels := sets.New[string]()
+
+	for key := range matchLabels {
+		keyLabels.Insert(normalizeKeyLabel(key))
+	}
+	for _, expression := range matchExpressionLabels {
+		keyLabels.Insert(normalizeKeyLabel(expression.Key))
+	}
+
+	return keyLabels
+}
+
+// normalizeKeyLabel converts the labels from the extended format source.key to SOURCE:KEY
+// If the SOURCE is any the transformed value will be empty
+// k8s.Foo converts to k8s:Foo, any.Foo converts to :Foo
+func normalizeKeyLabel(labelWithSourcePrefix string) string {
+	before, after, found := strings.Cut(labelWithSourcePrefix, ".")
+
+	if found {
+		if before == "any" {
+			return ":" + after
+		} else {
+			return before + ":" + after
+		}
+	}
+
+	return labelWithSourcePrefix
+}

--- a/pkg/labelsfilterdynamic/manager.go
+++ b/pkg/labelsfilterdynamic/manager.go
@@ -58,6 +58,9 @@ type controllerParams struct {
 }
 
 func registerController(params controllerParams) (*controller, error) {
+	if !params.DaemonConfig.DynamicLabelFilterEnabled() {
+		return nil, nil
+	}
 	c := &controller{
 		Signal:                         params.Signal,
 		CiliumNetworkPolicy:            params.CiliumNetworkPolicy,

--- a/pkg/labelsfilterdynamic/manager_test.go
+++ b/pkg/labelsfilterdynamic/manager_test.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package labelsfilterdynamic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_networking_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/labelsfilter"
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+type mockStore[T comparable] []T
+
+func (m mockStore[T]) List() []T {
+	return m
+}
+
+func (m mockStore[T]) IterKeys() resource.KeyIter {
+	panic("implement me")
+}
+
+func (m mockStore[T]) Get(obj T) (item T, exists bool, err error) {
+	panic("implement me")
+}
+
+func (m mockStore[T]) GetByKey(key resource.Key) (item T, exists bool, err error) {
+	panic("implement me")
+}
+
+func (m mockStore[T]) IndexKeys(indexName, indexedValue string) ([]string, error) {
+	panic("implement me")
+}
+
+func (m mockStore[T]) ByIndex(indexName, indexedValue string) ([]T, error) {
+	panic("implement me")
+}
+
+func (m mockStore[T]) CacheStore() cache.Store {
+	panic("implement me")
+}
+
+func (m mockStore[T]) Release() {
+	panic("implement me")
+}
+
+// TestControllerSanity ensures that the controller calls the correct methods,
+// with the correct arguments, during its Reconcile loop.
+func TestControllerSanity(t *testing.T) {
+	allLabels := map[string]string{
+		"dummy_match_nps":             "dummy",
+		"dummy_expression_nps":        "dummy",
+		"dummy_cnps":                  "dummy",
+		"dummy_cwnps":                 "dummy",
+		"io.kubernetes.pod.namespace": "default",
+		"excluded":                    "excluded",
+	}
+
+	var table = []struct {
+		// name of test case
+		name                                string
+		err                                 error
+		networkPolicyStore                  resource.Store[*slim_networking_v1.NetworkPolicy]
+		ciliumNetworkPolicyStore            resource.Store[*cilium_v2.CiliumNetworkPolicy]
+		ciliumClusterwideNetworkPolicyStore resource.Store[*cilium_v2.CiliumClusterwideNetworkPolicy]
+	}{
+		// test the normal control flow of a policy being selected and applied.
+		{
+			name: "successful reconcile",
+			err:  nil,
+			networkPolicyStore: mockStore[*slim_networking_v1.NetworkPolicy]{
+				&slim_networking_v1.NetworkPolicy{
+					TypeMeta: slim_metav1.TypeMeta{
+						APIVersion: "networking.k8s.io/v1",
+						Kind:       "NetworkPolicy",
+					},
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: slim_networking_v1.NetworkPolicySpec{
+						PodSelector: slim_metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"dummy_match_nps": "bar",
+							},
+							MatchExpressions: []slim_metav1.LabelSelectorRequirement{
+								{
+									Key:      "dummy_expression_nps",
+									Operator: slim_metav1.LabelSelectorOpExists,
+									Values:   []string{},
+								},
+							},
+						},
+					},
+				},
+				&slim_networking_v1.NetworkPolicy{
+					TypeMeta: slim_metav1.TypeMeta{
+						APIVersion: "networking.k8s.io/v1",
+						Kind:       "NetworkPolicy",
+					},
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Name:      "test-policy-empty",
+						Namespace: "test-namespace",
+					},
+					Spec: slim_networking_v1.NetworkPolicySpec{
+						PodSelector: slim_metav1.LabelSelector{
+							MatchLabels:      map[string]string{},
+							MatchExpressions: []slim_metav1.LabelSelectorRequirement{},
+						},
+					},
+				},
+			},
+			ciliumNetworkPolicyStore: mockStore[*cilium_v2.CiliumNetworkPolicy]{
+				&cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: meta_v1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("dummy_cnps=bar")),
+					},
+				},
+			},
+			ciliumClusterwideNetworkPolicyStore: mockStore[*cilium_v2.CiliumClusterwideNetworkPolicy]{
+				&cilium_v2.CiliumClusterwideNetworkPolicy{
+					TypeMeta: meta_v1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumClusterwideNetworkPolicy",
+					},
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("dummy_cwnps=bar")),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+
+			c := controller{
+				NetworkPolicyStore:                  tt.networkPolicyStore,
+				CiliumNetworkPolicyStore:            tt.ciliumNetworkPolicyStore,
+				CiliumClusterwideNetworkPolicyStore: tt.ciliumClusterwideNetworkPolicyStore,
+			}
+
+			err := c.Reconcile(context.Background())
+
+			allLabels := labels.Map2Labels(allLabels, labels.LabelSourceContainer)
+			filtered, _ := labelsfilter.Filter(allLabels)
+			assert.Equal(t, 5, len(filtered))
+
+			if (tt.err == nil) != (err == nil) {
+				t.Fatalf("want: %v, got: %v", tt.err, err)
+			}
+		})
+	}
+}
+
+func TestGetRelevantKeyLabels(t *testing.T) {
+	matchLabels := map[string]slim_metav1.MatchLabelsValue{
+		"Foo":        "dummy",
+		"MatchLabel": "dummy",
+	}
+	matchExpressionLabels := []slim_metav1.LabelSelectorRequirement{
+		{Key: "Foo", Operator: "", Values: []string{"", ""}},
+		{Key: "Bar", Operator: "", Values: []string{"", ""}},
+	}
+	expectedLabels := sets.New[string]("Foo", "Bar", "MatchLabel")
+
+	assert.Equal(t, expectedLabels, getRelevantKeyLabels(matchLabels, matchExpressionLabels))
+}
+
+func TestNormalizeKeyLabel(t *testing.T) {
+	assert.Equal(t, ":Foo", normalizeKeyLabel("any.Foo"))
+	assert.Equal(t, "k8s:Foo", normalizeKeyLabel("k8s.Foo"))
+	assert.Equal(t, "other_sources:foo", normalizeKeyLabel("other_sources.foo"))
+}

--- a/pkg/labelsfilterdynamic/signals/signal.go
+++ b/pkg/labelsfilterdynamic/signals/signal.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package signals
+
+type Signal struct {
+	Signal chan struct{}
+}
+
+func NewSignal() *Signal {
+	return &Signal{
+		Signal: make(chan struct{}, 1),
+	}
+}
+
+// Event adds an edge triggered event to the Signal.
+//
+// A controller which uses this Signal will be notified of this event some
+// time after.
+//
+// This signature adheres to the common event handling signatures of
+// cache.ResourceEventHandlerFuncs for convenience.
+func (s Signal) Event(_ interface{}) {
+	select {
+	case s.Signal <- struct{}{}:
+	default:
+	}
+}

--- a/pkg/labelsfilterdynamic/signals/signal_test.go
+++ b/pkg/labelsfilterdynamic/signals/signal_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package signals
+
+import "testing"
+
+// Make sure that the receiver only observes a single event even if multiple
+// events are sent.
+func TestEventCorrelation(t *testing.T) {
+	s := NewSignal()
+
+	// Send two events
+	s.Event(nil)
+	s.Event(nil)
+
+	// One event should be received
+	select {
+	case <-s.Signal:
+	default:
+		t.Fatal("expected event to be received")
+	}
+
+	// The second event should be correlated and shouldn't be received
+	select {
+	case <-s.Signal:
+		t.Fatal("expected event to be correlated")
+	default:
+	}
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1192,6 +1192,9 @@ const (
 	// EnableNodeSelectorLabels)
 	NodeLabels = "node-labels"
 
+	// EnableDynamicLabelFilter enables support for dynamically limiting the labels used for CIDs
+	EnableDynamicLabelFilter = "enable-dynamic-label-filter"
+
 	// BPFEventsDropEnabled defines the DropNotification setting for any endpoint
 	BPFEventsDropEnabled = "bpf-events-drop-enabled"
 
@@ -2379,6 +2382,10 @@ type DaemonConfig struct {
 	// NodeLabels is the list of label prefixes used to determine identity of a node (requires enabling of
 	// EnableNodeSelectorLabels)
 	NodeLabels []string
+
+	// EnableDynamicLabelFilter enables to filter dynamically the label prefixes used to determine identities based
+	// on network policy labels.
+	EnableDynamicLabelFilter bool
 }
 
 var (
@@ -2660,6 +2667,10 @@ func (c *DaemonConfig) PolicyCIDRMatchesNodes() bool {
 // is enabled
 func (c *DaemonConfig) PerNodeLabelsEnabled() bool {
 	return c.EnableNodeSelectorLabels
+}
+
+func (c *DaemonConfig) DynamicLabelFilterEnabled() bool {
+	return c.EnableDynamicLabelFilter
 }
 
 func (c *DaemonConfig) validatePolicyCIDRMatchMode() error {
@@ -3494,6 +3505,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.PolicyCIDRMatchMode = vp.GetStringSlice(PolicyCIDRMatchMode)
 	c.EnableNodeSelectorLabels = vp.GetBool(EnableNodeSelectorLabels)
 	c.NodeLabels = vp.GetStringSlice(NodeLabels)
+	c.EnableDynamicLabelFilter = vp.GetBool(EnableDynamicLabelFilter)
 
 	// Parse node label patterns
 	nodeLabelPatterns := vp.GetStringSlice(ExcludeNodeLabelPatterns)


### PR DESCRIPTION
based on https://github.com/cilium/cilium/pull/32501

Adds the logic required to update the CEP in-place when dynamic label filter detect any changes to network policy.
The reconcile loop will fetch all the CEP and compute the labels that needs to be added and removed considering the pod labels, namespace labels and the existing CEP labels. 

Fixes: https://github.com/cilium/cilium/issues/32576

```release-note
Add logic to update the CEP labels in-place when there are dynamic label filter changes.
```