### PR TITLE
background-sync: spread node updates over time.

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -16,13 +16,13 @@ import (
 	"github.com/cilium/workerpool"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
 
 	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
@@ -340,58 +340,80 @@ func (m *manager) backgroundSyncInterval() time.Duration {
 // backgroundSync ensures that local node has a valid datapath in-place for
 // each node in the cluster. See NodeValidateImplementation().
 func (m *manager) backgroundSync(ctx context.Context) error {
-	syncTimer, syncTimerDone := inctimer.New()
-	defer syncTimerDone()
 	for {
 		syncInterval := m.backgroundSyncInterval()
-		log.WithField("syncInterval", syncInterval.String()).Debug("Performing regular background work")
 
-		var errs error
-		// get a copy of the node identities to avoid locking the entire manager
-		// throughout the process of running the datapath validation.
-		nodes := m.GetNodeIdentities()
-		for _, nodeIdentity := range nodes {
-			// Retrieve latest node information in case any event
-			// changed the node since the call to GetNodes()
-			m.mutex.RLock()
-			entry, ok := m.nodes[nodeIdentity]
-			if !ok {
-				m.mutex.RUnlock()
-				continue
-			}
-			m.mutex.RUnlock()
+		log.WithField("syncInterval", syncInterval.String()).Debug("Starting new iteration of background sync")
+		err := m.singleBackgroundLoop(ctx, syncInterval)
+		log.WithField("syncInterval", syncInterval.String()).Debug("Finished iteration of background sync")
 
-			entry.mutex.Lock()
-			{
-				m.Iter(func(nh datapath.NodeHandler) {
-					if err := nh.NodeValidateImplementation(entry.node); err != nil {
-						log.WithFields(logrus.Fields{
-							"handler": nh.Name(),
-							"node":    entry.node.Name,
-						}).WithError(err).
-							Error("Failed to apply node handler during background sync. Cilium may have degraded functionality. See error message for details.")
-						errs = errors.Join(errs, fmt.Errorf("failed while handling %s on node %s: %w", nh.Name(), entry.node.Name, err))
-					}
-				})
-			}
-			entry.mutex.Unlock()
-
-			m.metrics.DatapathValidations.Inc()
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
 		}
 
 		hr := m.health.NewScope("background-sync")
-		if errs != nil {
-			hr.Degraded("Failed to apply node validation", errs)
+		if err != nil {
+			hr.Degraded("Failed to apply node validation", err)
 		} else {
 			hr.OK("Node validation successful")
+		}
+	}
+}
+
+func (m *manager) singleBackgroundLoop(ctx context.Context, expectedLoopTime time.Duration) error {
+	var errs error
+	// get a copy of the node identities to avoid locking the entire manager
+	// throughout the process of running the datapath validation.
+	nodes := m.GetNodeIdentities()
+	limiter := rate.NewLimiter(
+		rate.Limit(float64(len(nodes))/float64(expectedLoopTime.Seconds())),
+		1, // One token in bucket to amortize for latency of the operation
+	)
+	for _, nodeIdentity := range nodes {
+		if err := limiter.Wait(ctx); err != nil {
+			log.WithError(err).Debug("Error while rate limiting backgroundSync updates")
 		}
 
 		select {
 		case <-ctx.Done():
 			return nil
-		case <-syncTimer.After(syncInterval):
+		default:
 		}
+		// Retrieve latest node information in case any event
+		// changed the node since the call to GetNodes()
+		m.mutex.RLock()
+		entry, ok := m.nodes[nodeIdentity]
+		if !ok {
+			m.mutex.RUnlock()
+			continue
+		}
+		m.mutex.RUnlock()
+
+		// TODO(marseel): Isn't that a bug?
+		// In mean time entry m.nodes[nodeIdentity] can change
+		// and trigger dp update in NodeUpdated,
+		// node entry would have different lock than this stale entry.
+		// In that case we would override that update with stale node here.
+		entry.mutex.Lock()
+		{
+			m.Iter(func(nh datapath.NodeHandler) {
+				if err := nh.NodeValidateImplementation(entry.node); err != nil {
+					log.WithFields(logrus.Fields{
+						"handler": nh.Name(),
+						"node":    entry.node.Name,
+					}).WithError(err).
+						Error("Failed to apply node handler during background sync. Cilium may have degraded functionality. See error message for details.")
+					errs = errors.Join(errs, fmt.Errorf("failed while handling %s on node %s: %w", nh.Name(), entry.node.Name, err))
+				}
+			})
+		}
+		entry.mutex.Unlock()
+
+		m.metrics.DatapathValidations.Inc()
 	}
+	return errs
 }
 
 func (m *manager) nodeAddressHasTunnelIP(address nodeTypes.Address) bool {


### PR DESCRIPTION
Before, depending on cluster-size we were triggering node update for
each node at fixed intervals depending on cluster-size. This resulted in
high cpu usage spike in agent. While the intent is to fix state that got
stale and shouldn't be the primary source of updates, it makes sense to
spread these updates over time to average out cpu usage.

Also, reenable backgroundSync test.

GC CPU usage on 100-node cluster with IPSec enabled before:
![image](https://github.com/cilium/cilium/assets/2011575/1634bd36-3cc4-4fc0-bdee-391d5c2ba654)
After:
![image](https://github.com/cilium/cilium/assets/2011575/315dc473-29f1-4a55-a144-e7e8af2a9f13)


```release-note
Improved background resynchronization of nodes. Before all nodes were being updated at the same time, now we spread updates over time to average out CPU usage.
```
