### PR TITLE
ipcache: Introduce the ability to inherit CIDR prefixes

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -202,7 +202,7 @@ func ScopeForLabels(lbls labels.Labels) NumericIdentity {
 
 	for _, label := range lbls {
 		switch label.Source {
-		case labels.LabelSourceCIDR, labels.LabelSourceReserved:
+		case labels.LabelSourceCIDR, labels.LabelSourceFQDN, labels.LabelSourceReserved:
 			scope = IdentityScopeLocal
 		default:
 			return IdentityScopeGlobal

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -183,15 +183,6 @@ func (m *metadata) upsertLocked(prefix netip.Prefix, src source.Source, resource
 	m.m[prefix].logConflicts(log.WithField(logfields.CIDR, prefix))
 }
 
-// GetMetadataLabelsByIP returns the associated labels with an IP.
-func (ipc *IPCache) GetMetadataLabelsByIP(addr netip.Addr) labels.Labels {
-	prefix := netip.PrefixFrom(addr, addr.BitLen())
-	if info := ipc.GetMetadataByPrefix(prefix); info != nil {
-		return info.ToLabels()
-	}
-	return nil
-}
-
 // GetMetadataByPrefix returns full metadata for a given IP as a copy.
 func (ipc *IPCache) GetMetadataByPrefix(prefix netip.Prefix) PrefixInfo {
 	ipc.metadata.RLock()

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -444,14 +444,12 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 				"Failed to release previously allocated identity during ipcache metadata injection.",
 			)
 		}
-		// Note that not all subsystems currently funnel their
-		// IP prefix => metadata mappings through this code. Notably,
-		// CIDR policy currently allocates its own identities.
-		// Therefore it's possible that the identity that was
-		// previously allocated is still in use or referred in that
-		// policy. Avoid removing references in the policy engine
-		// since those other subsystems should have their own cleanup
-		// logic for handling the removal of these identities.
+
+		// A local identity can be shared by multiple IPCache entries.
+		// Therefore, it's possible that the identity that was
+		// previously allocated is still in use by other entries.
+		// Avoid removing references in the policy engine until we've
+		// removed reference to the identity.
 		if released {
 			idsToDelete[id.ID] = nil // SelectorCache removal
 		}

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -183,16 +183,12 @@ func (m *metadata) upsertLocked(prefix netip.Prefix, src source.Source, resource
 	m.m[prefix].logConflicts(log.WithField(logfields.CIDR, prefix))
 }
 
-// GetMetadataByPrefix returns full metadata for a given IP as a copy.
-func (ipc *IPCache) GetMetadataByPrefix(prefix netip.Prefix) PrefixInfo {
+// GetMetadataSourceByPrefix returns the highest precedence source which has
+// provided metadata for this prefix
+func (ipc *IPCache) GetMetadataSourceByPrefix(prefix netip.Prefix) source.Source {
 	ipc.metadata.RLock()
 	defer ipc.metadata.RUnlock()
-	m := ipc.metadata.getLocked(prefix)
-	n := make(PrefixInfo, len(m))
-	for k, v := range m {
-		n[k] = v.DeepCopy()
-	}
-	return n
+	return ipc.metadata.getLocked(prefix).Source()
 }
 
 func (m *metadata) getLocked(prefix netip.Prefix) PrefixInfo {

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -166,6 +166,15 @@ func (s prefixInfo) ToLabels() labels.Labels {
 	return l
 }
 
+func (s prefixInfo) hasLabelSource(source string) bool {
+	for _, v := range s {
+		if v.labels.HasSource(source) {
+			return true
+		}
+	}
+	return false
+}
+
 func (s prefixInfo) Source() source.Source {
 	src := source.Unspec
 	for _, v := range s {

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -19,14 +19,14 @@ import (
 	"github.com/cilium/cilium/pkg/types"
 )
 
-// PrefixInfo holds all of the information (labels, etc.) about a given prefix
+// prefixInfo holds all of the information (labels, etc.) about a given prefix
 // independently based on the ResourceID of the origin of that information, and
 // provides convenient accessors to consistently merge the stored information
 // to generate ipcache output based on a range of inputs.
 //
 // Note that when making a copy of this object, resourceInfo is pointer which
 // means it needs to be deep-copied via (*resourceInfo).DeepCopy().
-type PrefixInfo map[ipcachetypes.ResourceID]*resourceInfo
+type prefixInfo map[ipcachetypes.ResourceID]*resourceInfo
 
 // IdentityOverride can be used to override the identity of a given prefix.
 // Must be provided together with a set of labels. Any other labels associated
@@ -136,7 +136,7 @@ func (m *resourceInfo) DeepCopy() *resourceInfo {
 	return n
 }
 
-func (s PrefixInfo) isValid() bool {
+func (s prefixInfo) isValid() bool {
 	for _, v := range s {
 		if v.isValid() {
 			return true
@@ -145,7 +145,7 @@ func (s PrefixInfo) isValid() bool {
 	return false
 }
 
-func (s PrefixInfo) sortedBySourceThenResourceID() []ipcachetypes.ResourceID {
+func (s prefixInfo) sortedBySourceThenResourceID() []ipcachetypes.ResourceID {
 	resourceIDs := maps.Keys(s)
 	sort.Slice(resourceIDs, func(i, j int) bool {
 		a := resourceIDs[i]
@@ -158,7 +158,7 @@ func (s PrefixInfo) sortedBySourceThenResourceID() []ipcachetypes.ResourceID {
 	return resourceIDs
 }
 
-func (s PrefixInfo) ToLabels() labels.Labels {
+func (s prefixInfo) ToLabels() labels.Labels {
 	l := labels.NewLabelsFromModel(nil)
 	for _, v := range s {
 		l.MergeLabels(v.labels)
@@ -166,7 +166,7 @@ func (s PrefixInfo) ToLabels() labels.Labels {
 	return l
 }
 
-func (s PrefixInfo) Source() source.Source {
+func (s prefixInfo) Source() source.Source {
 	src := source.Unspec
 	for _, v := range s {
 		if source.AllowOverwrite(src, v.source) {
@@ -176,7 +176,7 @@ func (s PrefixInfo) Source() source.Source {
 	return src
 }
 
-func (s PrefixInfo) EncryptKey() ipcachetypes.EncryptKey {
+func (s prefixInfo) EncryptKey() ipcachetypes.EncryptKey {
 	for _, rid := range s.sortedBySourceThenResourceID() {
 		if k := s[rid].encryptKey; k.IsValid() {
 			return k
@@ -185,7 +185,7 @@ func (s PrefixInfo) EncryptKey() ipcachetypes.EncryptKey {
 	return ipcachetypes.EncryptKeyEmpty
 }
 
-func (s PrefixInfo) TunnelPeer() ipcachetypes.TunnelPeer {
+func (s prefixInfo) TunnelPeer() ipcachetypes.TunnelPeer {
 	for _, rid := range s.sortedBySourceThenResourceID() {
 		if t := s[rid].tunnelPeer; t.IsValid() {
 			return t
@@ -194,7 +194,7 @@ func (s PrefixInfo) TunnelPeer() ipcachetypes.TunnelPeer {
 	return ipcachetypes.TunnelPeer{}
 }
 
-func (s PrefixInfo) RequestedIdentity() ipcachetypes.RequestedIdentity {
+func (s prefixInfo) RequestedIdentity() ipcachetypes.RequestedIdentity {
 	for _, rid := range s.sortedBySourceThenResourceID() {
 		if id := s[rid].requestedIdentity; id.IsValid() {
 			return id
@@ -207,7 +207,7 @@ func (s PrefixInfo) RequestedIdentity() ipcachetypes.RequestedIdentity {
 // the prefix info. If no override identity is present, this returns nil.
 // This pre-determined identity will overwrite any other identity which may
 // be derived from the prefix labels.
-func (s PrefixInfo) identityOverride() (lbls labels.Labels, hasOverride bool) {
+func (s prefixInfo) identityOverride() (lbls labels.Labels, hasOverride bool) {
 	identities := make([]labels.Labels, 0, 1)
 	for _, info := range s {
 		// We emit a warning in logConflicts if an identity override
@@ -236,7 +236,7 @@ func (s PrefixInfo) identityOverride() (lbls labels.Labels, hasOverride bool) {
 	return identities[0], true
 }
 
-func (s PrefixInfo) logConflicts(scopedLog *logrus.Entry) {
+func (s prefixInfo) logConflicts(scopedLog *logrus.Entry) {
 	var (
 		override           labels.Labels
 		overrideResourceID ipcachetypes.ResourceID

--- a/pkg/ipcache/types_test.go
+++ b/pkg/ipcache/types_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Test_sortedByResourceIDsAndSource(t *testing.T) {
-	pi := make(PrefixInfo, 1)
+	pi := make(prefixInfo, 1)
 	pi["a-restored-uid"] = &resourceInfo{
 		source: source.Restored,
 	}

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -141,6 +141,9 @@ const (
 	// LabelSourceNode is the label source for remote-nodes.
 	LabelSourceNode = "node"
 
+	// LabelSourceFQDN is the label source for IPs resolved by fqdn lookups
+	LabelSourceFQDN = "fqdn"
+
 	// LabelSourceReservedKeyPrefix is the prefix of a reserved label
 	LabelSourceReservedKeyPrefix = LabelSourceReserved + "."
 

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -659,6 +659,16 @@ func (l Labels) Has(label Label) bool {
 	return false
 }
 
+// HasSource returns true if l contains the given label source.
+func (l Labels) HasSource(source string) bool {
+	for _, lbl := range l {
+		if lbl.Source == source {
+			return true
+		}
+	}
+	return false
+}
+
 // parseSource returns the parsed source of the given str. It also returns the next piece
 // of text that is after the source.
 // Example:

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -430,6 +430,56 @@ func TestLabels_GetFromSource(t *testing.T) {
 	}
 }
 
+func TestLabels_HasSource(t *testing.T) {
+	type args struct {
+		source string
+	}
+	tests := []struct {
+		name string
+		l    Labels
+		args args
+		want bool
+	}{
+		{
+			name: "should return false for empty set",
+			l:    Labels{},
+			args: args{
+				source: "my-source",
+			},
+			want: false,
+		},
+		{
+			name: "should contain label with the given source",
+			l: Labels{
+				"foo":   NewLabel("foo", "bar", "my-source"),
+				"other": NewLabel("other", "bar", ""),
+			},
+			args: args{
+				source: "my-source",
+			},
+			want: true,
+		},
+		{
+			name: "should return false as there are not labels for the given source",
+			l: Labels{
+				"foo":   NewLabel("foo", "bar", "any"),
+				"other": NewLabel("other", "bar", ""),
+			},
+			args: args{
+				source: "my-source",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.l.HasSource(tt.args.source); got != tt.want {
+				t.Errorf("Labels.GetFromSource() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func BenchmarkNewFrom(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -69,7 +69,7 @@ type nodeEntry struct {
 
 // IPCache is the set of interactions the node manager performs with the ipcache
 type IPCache interface {
-	GetMetadataByPrefix(prefix netip.Prefix) ipcache.PrefixInfo
+	GetMetadataSourceByPrefix(prefix netip.Prefix) source.Source
 	UpsertMetadata(prefix netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata)
 	OverrideIdentity(prefix netip.Prefix, identityLabels labels.Labels, src source.Source, resource ipcacheTypes.ResourceID)
 	RemoveMetadata(prefix netip.Prefix, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata)
@@ -554,7 +554,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		// * CiliumInternal IP addresses that match configured local router IP.
 		//   In that case, we still want to inform subscribers about a new node
 		//   even when IP addresses may seem repeated across the nodes.
-		existing := m.ipcache.GetMetadataByPrefix(prefix).Source()
+		existing := m.ipcache.GetMetadataSourceByPrefix(prefix)
 		overwrite := source.AllowOverwrite(existing, n.Source)
 		if !overwrite && existing != source.KubeAPIServer &&
 			!(address.Type == addressing.NodeCiliumInternalIP && m.conf.IsLocalRouterIP(address.ToString())) {
@@ -597,7 +597,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		if !healthIP.IsValid() {
 			continue
 		}
-		if !source.AllowOverwrite(m.ipcache.GetMetadataByPrefix(healthIP).Source(), n.Source) {
+		if !source.AllowOverwrite(m.ipcache.GetMetadataSourceByPrefix(healthIP), n.Source) {
 			dpUpdate = false
 		}
 
@@ -613,7 +613,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		if !ingressIP.IsValid() {
 			continue
 		}
-		if !source.AllowOverwrite(m.ipcache.GetMetadataByPrefix(ingressIP).Source(), n.Source) {
+		if !source.AllowOverwrite(m.ipcache.GetMetadataSourceByPrefix(ingressIP), n.Source) {
 			dpUpdate = false
 		}
 

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -85,8 +85,8 @@ func (i *ipcacheMock) Delete(ip string, source source.Source) bool {
 	return false
 }
 
-func (i *ipcacheMock) GetMetadataByPrefix(prefix netip.Prefix) ipcache.PrefixInfo {
-	return ipcache.PrefixInfo{}
+func (i *ipcacheMock) GetMetadataSourceByPrefix(prefix netip.Prefix) source.Source {
+	return source.Unspec
 }
 func (i *ipcacheMock) UpsertMetadata(prefix netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata) {
 	i.Upsert(prefix.String(), nil, 0, nil, ipcache.Identity{})


### PR DESCRIPTION
This PR introduces a new feature in the IPCache metadata subsystem:
The ability for prefixes with local identities to inherit CIDR labels
from encompassing prefixes. This is needed to implement
https://github.com/cilium/design-cfps/pull/17 where we want to introduce a new way to manage
identities for IPs allowlisted by DNS lookups. Without going into too
much detail, the key point of that CFP is that IPs returned by DNS
lookups will be associated with a `fqdn:` label.

Those IPs returned by a DNS lookup however might also be selected by a
CIDR prefix, and thus might also optionally need a `cidr:` label if (but
only if) a selecting CIDR policy is present.

To give an example: If we perform a DNS lookup on `one.one.one.one` on a
pod with DNS redirects enabled, we may observe IP `1.1.1.1` and thus
associated that IP with a `fqdn:` label. If at the same time, we also
have a separate CIDR policy allowing traffic to `1.0.0.0/8`, then that
IP also needs the `cidr:1.0.0.0/8` label, to make it is selected by both
the FQDN and the CIDR policy.

To implement this, the IPCache metadata subsystem is slightly augmented:

1. Whenever metadata for a prefix is upserted or removed, we no longer
   enqueue only the prefix it self, but also all potentially affected
   prefixes or IPs contained by it. This allows `InjectLabels` to then
   down-propagate the changes to any child prefixes.
2. In `resolveIdentity` (called by `InjectLabels`), we check if there
   are any parent prefixes with a CIDR label that we want to inherit.

At the moment, only local identities without a `reserved:` label may
inherit a CIDR label from a parent prefix. This currently therefore only
applies to identities containing `fqdn:` labels. Going forward, this
infrastructure might however also be useful to implement non-K8s label
sources.