### PR TITLE
Active connection tracking in ebpf

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -97,6 +97,7 @@ cilium-agent [flags]
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
       --egress-masquerade-interfaces strings                      Limit iptables-based egress masquerading to interface selector
       --egress-multi-home-ip-rule-compat                          Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.
+      --enable-active-connection-tracking                         Count open and active connections to services, grouped by zones defined in fixed-zone-mapping.
       --enable-auto-protect-node-port-range                       Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
       --enable-bandwidth-manager                                  Enable BPF bandwidth manager
       --enable-bbr                                                Enable BBR for the bandwidth manager

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -30,6 +30,7 @@ cilium-agent hive [flags]
       --disable-iptables-feeder-rules strings                     Chains to ignore when installing feeder rules.
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
+      --enable-active-connection-tracking                         Count open and active connections to services, grouped by zones defined in fixed-zone-mapping.
       --enable-bandwidth-manager                                  Enable BPF bandwidth manager
       --enable-bbr                                                Enable BBR for the bandwidth manager
       --enable-cilium-api-server-access strings                   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -36,6 +36,7 @@ cilium-agent hive dot-graph [flags]
       --disable-iptables-feeder-rules strings                     Chains to ignore when installing feeder rules.
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
+      --enable-active-connection-tracking                         Count open and active connections to services, grouped by zones defined in fixed-zone-mapping.
       --enable-bandwidth-manager                                  Enable BPF bandwidth manager
       --enable-bbr                                                Enable BBR for the bandwidth manager
       --enable-cilium-api-server-access strings                   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])

--- a/bpf/lib/act.h
+++ b/bpf/lib/act.h
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#ifndef __ACT_H_
+#define __ACT_H_
+
+#ifdef ENABLE_ACTIVE_CONNECTION_TRACKING
+struct lb_act_key {
+	__u16 svc_id;
+	__u8 zone;
+	__u8 pad;
+};
+
+struct lb_act_value {
+	__u32 opened;
+	__u32 closed;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__type(key, struct lb_act_key);
+	__type(value, struct lb_act_value);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, CILIUM_LB_ACT_MAP_MAX_ENTRIES);
+} LB_ACT_MAP __section_maps_btf;
+
+static __always_inline void _lb_act_conn_closed(__u16 svc_id, __u8 zone)
+{
+	struct lb_act_key key = { .svc_id = svc_id, .zone = zone };
+	struct lb_act_value *lookup;
+
+	if (key.zone == 0)
+		return;
+	lookup = map_lookup_elem(&LB_ACT_MAP, &key);
+	if (!lookup)
+		return;
+	__sync_fetch_and_add(&lookup->closed, 1);
+}
+
+static __always_inline void _lb_act_conn_open(__u16 svc_id, __u8 zone)
+{
+	struct lb_act_key key = { .svc_id = svc_id, .zone = zone };
+	struct lb_act_value val;
+	struct lb_act_value *lookup;
+
+	if (key.zone == 0)
+		return;
+	lookup = map_lookup_elem(&LB_ACT_MAP, &key);
+	if (!lookup) {
+		val.opened = 1;
+		val.closed = 0;
+		map_update_elem(&LB_ACT_MAP, &key, &val, BPF_ANY);
+		return;
+	}
+	__sync_fetch_and_add(&lookup->opened, 1);
+}
+#endif /* ENABLE_ACTIVE_CONNECTION_TRACKING */
+
+#endif /* __ACT_H */

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -1158,7 +1158,8 @@ struct ct_state {
 	      from_l7lb:1,	/* Connection is originated from an L7 LB proxy */
 	      reserved1:1,	/* Was auth_required, not used in production anywhere */
 	      from_tunnel:1,	/* Connection is from tunnel */
-	      reserved:8;
+		  closing:1,
+	      reserved:7;
 	__u32 src_sec_id;
 #ifndef HAVE_FIB_IFINDEX
 	__u16 ifindex;

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -345,6 +345,8 @@ __ct_lookup(const void *map, struct __ctx_buff *ctx, const void *tuple,
 			} else {
 				entry->tx_closing = 1;
 			}
+			if (ct_state)
+				ct_state->closing = 1;
 
 			*monitor = TRACE_PAYLOAD_LEN;
 			if (ct_entry_alive(entry))

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -167,6 +167,7 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #define LB4_REVERSE_NAT_MAP test_cilium_lb4_reverse_nat
 #define LB4_SERVICES_MAP_V2 test_cilium_lb4_services
 #define LB4_BACKEND_MAP test_cilium_lb4_backends
+#define LB_ACT_MAP test_cilium_lb_act
 #define LB4_REVERSE_NAT_SK_MAP test_cilium_lb4_reverse_sk
 #define LB4_REVERSE_NAT_SK_MAP_SIZE 262144
 #define LB4_AFFINITY_MAP test_cilium_lb4_affinity
@@ -191,6 +192,7 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #define CILIUM_LB_REV_NAT_MAP_MAX_ENTRIES	65536
 #define CILIUM_LB_MAGLEV_MAP_MAX_ENTRIES	65536
 #define CILIUM_LB_SKIP_MAP_MAX_ENTRIES		100
+#define CILIUM_LB_ACT_MAP_MAX_ENTRIES	    65536
 #define POLICY_MAP_SIZE 16384
 #define AUTH_MAP_SIZE 512000
 #define CONFIG_MAP_SIZE 256

--- a/pkg/maps/act/act.go
+++ b/pkg/maps/act/act.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package act
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
+	"github.com/cilium/cilium/pkg/ebpf"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/service"
+)
+
+const ActiveConnectionTrackingMapName = "cilium_lb_act"
+
+// Cell provides the ActiveConnectionTrackingMap which contains information about opened
+// and closed connection to each service-zone pair.
+var Cell = cell.Module(
+	"active-connection-tracking",
+	"eBPF map with counts of open-closed connections for each service-zone pair",
+
+	cell.Provide(newActiveConnectionTrackingMap),
+	cell.Config(defaultConfig),
+)
+
+type Config struct {
+	EnableActiveConnectionTracking bool
+}
+
+func (c Config) Flags(fs *pflag.FlagSet) {
+	fs.Bool("enable-active-connection-tracking", defaultConfig.EnableActiveConnectionTracking,
+		"Count open and active connections to services, grouped by zones defined in fixed-zone-mapping.")
+}
+
+var defaultConfig = Config{
+	EnableActiveConnectionTracking: false,
+}
+
+type ActiveConnectionTrackingIterateCallback func(*ActiveConnectionTrackerKey, *ActiveConnectionTrackerValue)
+
+type ActiveConnectionTrackingMap interface {
+	IterateWithCallback(ActiveConnectionTrackingIterateCallback) error
+}
+
+type actMap struct {
+	m *bpf.Map
+}
+
+func newActiveConnectionTrackingMap(in struct {
+	cell.In
+
+	Lifecycle cell.Lifecycle
+	Conf      Config
+}) (out struct {
+	cell.Out
+
+	bpf.MapOut[ActiveConnectionTrackingMap]
+	defines.NodeOut
+}) {
+	if !in.Conf.EnableActiveConnectionTracking {
+		return
+	}
+	size := option.Config.LBServiceMapEntries * len(option.Config.FixedZoneMapping)
+	if size == 0 {
+		return
+	}
+
+	out.NodeDefines = map[string]string{
+		"ENABLE_ACTIVE_CONNECTION_TRACKING": "1",
+		"LB_ACT_MAP":                        ActiveConnectionTrackingMapName,
+		"CILIUM_LB_ACT_MAP_MAX_ENTRIES":     strconv.Itoa(size),
+	}
+
+	out.MapOut = bpf.NewMapOut(ActiveConnectionTrackingMap(createActiveConnectionTrackingMap(in.Lifecycle, size)))
+	return
+}
+
+func createActiveConnectionTrackingMap(lc cell.Lifecycle, size int) *actMap {
+	m := bpf.NewMap(ActiveConnectionTrackingMapName,
+		ebpf.LRUHash,
+		&ActiveConnectionTrackerKey{},
+		&ActiveConnectionTrackerValue{},
+		size,
+		0,
+	)
+
+	lc.Append(cell.Hook{
+		OnStart: func(context cell.HookContext) error {
+			return m.OpenOrCreate()
+		},
+		OnStop: func(context cell.HookContext) error {
+			return m.Close()
+		},
+	})
+
+	return &actMap{m}
+}
+
+func (m actMap) IterateWithCallback(cb ActiveConnectionTrackingIterateCallback) error {
+	return m.m.DumpWithCallback(func(k bpf.MapKey, v bpf.MapValue) {
+		key := k.(*ActiveConnectionTrackerKey)
+		value := v.(*ActiveConnectionTrackerValue)
+
+		cb(key, value)
+	})
+}
+
+// ActiveConnectionTrackerKey is the key to ActiveConnectionTrackingMap.
+//
+// It must match 'struct lb_act_key' in "bpf/lib/act.h".
+type ActiveConnectionTrackerKey struct {
+	SvcID uint16 `align:"svc_id"`
+	Zone  uint8  `align:"zone"`
+	Pad   uint8  `align:"pad"`
+}
+
+func (s *ActiveConnectionTrackerKey) New() bpf.MapKey { return &ActiveConnectionTrackerKey{} }
+
+func (v *ActiveConnectionTrackerKey) String() string {
+	svcID := byteorder.HostToNetwork16(v.SvcID)
+	if svcAddr, err := service.GetID(uint32(svcID)); err == nil && svcAddr != nil {
+		return fmt.Sprintf("%s[%s]", svcAddr.String(), option.Config.GetZone(v.Zone))
+	}
+	return fmt.Sprintf("%d[%s]", svcID, option.Config.GetZone(v.Zone))
+}
+
+// ActiveConnectionTrackerValue is the value in ActiveConnectionTrackingMap.
+//
+// It must match 'struct lb_act_value' in "bpf/lib/act.h".
+type ActiveConnectionTrackerValue struct {
+	Opened uint32 `align:"opened"`
+	Closed uint32 `align:"closed"`
+}
+
+func (s *ActiveConnectionTrackerValue) New() bpf.MapValue { return &ActiveConnectionTrackerValue{} }
+
+func (s *ActiveConnectionTrackerValue) String() string {
+	return fmt.Sprintf("+%d -%d", s.Opened, s.Closed)
+}

--- a/pkg/maps/cells.go
+++ b/pkg/maps/cells.go
@@ -6,6 +6,7 @@ package maps
 import (
 	"github.com/cilium/hive/cell"
 
+	"github.com/cilium/cilium/pkg/maps/act"
 	"github.com/cilium/cilium/pkg/maps/authmap"
 	"github.com/cilium/cilium/pkg/maps/bwmap"
 	"github.com/cilium/cilium/pkg/maps/configmap"
@@ -55,6 +56,9 @@ var Cell = cell.Module(
 	// Bandwidth (cilium_throttle) map contains the per-endpoint bandwidth limits.
 	// Provides RWTable[bwmap.Edt] for configuring the limits.
 	bwmap.Cell,
+
+	// Provides access to ActiveConnectionTracking map.
+	act.Cell,
 
 	// Provides access to NAT maps.
 	nat.Cell,


### PR DESCRIPTION
As described in https://github.com/cilium/design-cfps/pull/31, this is part of https://github.com/cilium/cilium/issues/31752

Example configuration (in `cilium-config`) for KIND cluster:
```
  fixed-zone-mapping: zone-a=123,zone-b=129
  enable-active-connection-tracking: "true"
```
where topology labels were set on the nodes:
```
kubectl label node kind-control-plane topology.kubernetes.io/zone=zone-a
kubectl label node kind-worker topology.kubernetes.io/zone=zone-b
```

Zone mapping can be verified with `cilium map get cilium_lb4_backends_v3`:
```
Key   Value                        State   Error
16    ANY://10.244.1.74[zone-b]    sync
17    ANY://10.244.1.74[zone-b]    sync
18    ANY://10.244.1.202[zone-b]   sync
19    ANY://10.244.1.202[zone-b]   sync
13    ANY://192.168.11.2[zone-b]   sync
14    ANY://10.244.0.178[zone-a]   sync
15    ANY://10.244.0.178[zone-a]   sync
```

LRS accounting can be verified with `cilium map get cilium_lb_act`:
```
Key                       Value     State   Error
10.96.138.80:80[zone-b]   +72 -72
10.96.138.80:80[zone-a]   +28 -28
```

```release-note
Add cilium_lb_act BPF map with counters of opened and closed connections
```
