### PR TITLE
ci: ginkgo: increase cilium readiness timeout from 240 to 360s

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -451,7 +451,7 @@ func (kub *Kubectl) WaitForCiliumReadiness(offset int, errMsg string) {
 	gomega.EventuallyWithOffset(1+offset, func() error {
 		_, err := kub.DaemonSetIsReady(CiliumNamespace, "cilium")
 		return err
-	}, 4*time.Minute, time.Second).Should(gomega.BeNil(), errMsg)
+	}, 6*time.Minute, time.Second).Should(gomega.BeNil(), errMsg)
 }
 
 // DeleteResourceInAnyNamespace deletes all objects with the provided name of


### PR DESCRIPTION
Some ginkgo tests are sporadicly failing with timeouts while waiting for all Cilium Agents to become ready. It seems as 240s aren't enough from the creation of the Cilium Agent daemonset until all Pods are ready.

Since the definition of this timeout, the Cilium Agent bootstrap logic changed quite a bit.

* Many parts of the boostrap logic are refactored to use the Hive framework
* Health Endpoint waits until datapath is ready

Therefore, this commit increases the timeout from 240s to 360s.

Related to: https://github.com/cilium/cilium/issues/32404