### PR TITLE
ipsec: cache xfrm state list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -484,6 +484,8 @@ endif
 	$(QUIET) contrib/scripts/check-go-testdata.sh
 	@$(ECHO_CHECK) contrib/scripts/check-source-info.sh
 	$(QUIET) contrib/scripts/check-source-info.sh
+	@$(ECHO_CHECK) contrib/scripts/check-xfrmstate.sh
+	$(QUIET) contrib/scripts/check-xfrmstate.sh
 
 pprof-heap: ## Get Go pprof heap profile.
 	$(QUIET)$(GO) tool pprof http://localhost:6060/debug/pprof/heap

--- a/contrib/scripts/check-xfrmstate.sh
+++ b/contrib/scripts/check-xfrmstate.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Authors of Cilium
+
+set -eu
+
+GOIMPORTS=("golang.org/x/tools/cmd/goimports" "-w")
+MATCHES=(
+    "netlink.XfrmStateAdd"
+    "netlink.XfrmStateUpdate"
+    "netlink.XfrmStateDel"
+    "netlink.XfrmStateFlush"
+)
+
+find_match() {
+  local target="./pkg/datapath"
+
+  MATCHES_ORED=$(printf "|%s" "${MATCHES[@]}")
+  MATCHES_ORED=${MATCHES_ORED:1}
+
+  grep -lr --include \*.go \
+       --exclude \*_test.go \
+       --exclude xfrm_state_cache.go \
+       --exclude probe_linux.go \
+       -E "$MATCHES_ORED" \
+        "$target"
+  if [ $? -eq 0 ] ; then
+    return 0
+  fi
+
+  # Let's check now that we can detect it correctly
+  NO_MATCHES=$(grep -or --include xfrm_state_cache.go \
+       -E "$MATCHES_ORED" \
+       "$target" | wc -l)
+
+  if [ "$NO_MATCHES" -eq "4" ] ; then
+    return 1
+  fi
+  # Incorrect number of matches
+  echo "Found incorrect number of matches: $NO_MATCHES"
+  return 0
+}
+
+check() {
+  if find_match ; then
+    # shellcheck disable=SC2145
+    >&2 echo "Found match for '${MATCHES[@]}'. Please use xfrmStateCache instead.";
+    exit 1
+  fi
+}
+
+main() {
+  check
+}
+
+main "$@"

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -395,6 +395,10 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableIPsecKeyWatcher, defaults.EnableIPsecKeyWatcher, "Enable watcher for IPsec key. If disabled, a restart of the agent will be necessary on key rotations.")
 	option.BindEnv(vp, option.EnableIPsecKeyWatcher)
 
+	flags.Bool(option.EnableIPSecXfrmStateCaching, defaults.EnableIPSecXfrmStateCaching, "Enable XfrmState cache for IPSec. Significantly reduces CPU usage in large clusters.")
+	flags.MarkHidden(option.EnableIPSecXfrmStateCaching)
+	option.BindEnv(vp, option.EnableIPSecXfrmStateCaching)
+
 	flags.Bool(option.EnableIPSecEncryptedOverlay, defaults.EnableIPSecEncryptedOverlay, "Enable IPsec encrypted overlay. If enabled tunnel traffic will be encrypted before leaving the host.")
 	option.BindEnv(vp, option.EnableIPSecEncryptedOverlay)
 

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -146,6 +146,14 @@ var (
 		Value: linux_defaults.RouteMarkDecrypt,
 		Mask:  linux_defaults.IPsecMarkBitMask,
 	}
+	// xfrmStateCache is a cache of XFRM states to avoid querying each time.
+	// This is especially important for backgroundSync that is used to validate
+	// if the XFRM state is correct, without usually modyfing anything.
+	// The cache is invalidated whenever a new XFRM state is added/updated/removed,
+	// but also in case of TTL expiration.
+	// It provides XfrmStateAdd/Update/Del wrappers that ensure cache
+	// is correctly invalidate.
+	xfrmStateCache = NewXfrmStateListCache(time.Minute)
 )
 
 func getGlobalIPsecKey(ip net.IP) *ipSecKey {
@@ -286,7 +294,7 @@ func ipSecAttachPolicyTempl(policy *netlink.XfrmPolicy, keys *ipSecKey, srcIP, d
 // already exist. If it doesn't but some other XFRM state conflicts, then
 // we attempt to remove the conflicting state before trying to add again.
 func xfrmStateReplace(new *netlink.XfrmState, remoteRebooted bool) error {
-	states, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+	states, err := xfrmStateCache.XfrmStateList()
 	if err != nil {
 		return fmt.Errorf("Cannot get XFRM state: %w", err)
 	}
@@ -308,13 +316,13 @@ func xfrmStateReplace(new *netlink.XfrmState, remoteRebooted bool) error {
 				// encryption key changed. This is expected on upgrade because
 				// we changed the way we compute the per-node-pair key.
 				scopedLog.Info("Removing XFRM state with old IPsec key")
-				netlink.XfrmStateDel(&s)
+				xfrmStateCache.XfrmStateDel(&s)
 				break
 			}
 			if !xfrmMarkEqual(s.OutputMark, new.OutputMark) {
 				// If only the output-marks differ, then we should be able
 				// to simply update the XFRM state atomically.
-				return netlink.XfrmStateUpdate(new)
+				return xfrmStateCache.XfrmStateUpdate(new)
 			}
 			if remoteRebooted && new.ESN {
 				// This should happen only when a node reboots when the boot ID
@@ -328,7 +336,7 @@ func xfrmStateReplace(new *netlink.XfrmState, remoteRebooted bool) error {
 				//   packets if the state is missing. At most we will drop a
 				//   few encrypted packets while updating.
 				scopedLog.Info("Non-atomically updating IPsec XFRM state due to remote boot ID change")
-				netlink.XfrmStateDel(&s)
+				xfrmStateCache.XfrmStateDel(&s)
 				break
 			}
 			return nil
@@ -384,7 +392,7 @@ func xfrmStateReplace(new *netlink.XfrmState, remoteRebooted bool) error {
 	}
 
 	// It doesn't exist so let's attempt to add it.
-	firstAttemptErr := netlink.XfrmStateAdd(new)
+	firstAttemptErr := xfrmStateCache.XfrmStateAdd(new)
 	if !os.IsExist(firstAttemptErr) {
 		return firstAttemptErr
 	}
@@ -402,7 +410,7 @@ func xfrmStateReplace(new *netlink.XfrmState, remoteRebooted bool) error {
 	if !deletedSomething {
 		return firstAttemptErr
 	}
-	return netlink.XfrmStateAdd(new)
+	return xfrmStateCache.XfrmStateAdd(new)
 }
 
 // Temporarily remove an XFRM state to allow the addition of another,
@@ -422,11 +430,11 @@ func xfrmTemporarilyRemoveState(scopedLog *logrus.Entry, state netlink.XfrmState
 	}
 
 	start := time.Now()
-	if err := netlink.XfrmStateDel(&state); err != nil {
+	if err := xfrmStateCache.XfrmStateDel(&state); err != nil {
 		return err, nil
 	}
 	return nil, func() {
-		if err := netlink.XfrmStateAdd(&state); err != nil {
+		if err := xfrmStateCache.XfrmStateAdd(&state); err != nil {
 			scopedLog.WithError(err).Errorf("Failed to re-add old XFRM %s state", dir)
 		}
 		elapsed := time.Since(start)
@@ -459,7 +467,7 @@ func xfrmDeleteConflictingState(states []netlink.XfrmState, new *netlink.XfrmSta
 		if new.Spi == s.Spi && (new.Mark == nil) == (s.Mark == nil) &&
 			(new.Mark == nil || new.Mark.Value&new.Mark.Mask&s.Mark.Mask == s.Mark.Value) &&
 			xfrmIPEqual(new.Src, s.Src) && xfrmIPEqual(new.Dst, s.Dst) {
-			if err := netlink.XfrmStateDel(&s); err != nil {
+			if err := xfrmStateCache.XfrmStateDel(&s); err != nil {
 				errs.Add(err)
 				continue
 			}
@@ -752,7 +760,7 @@ func ipsecDeleteXfrmState(nodeID uint16) error {
 		logfields.NodeID: nodeID,
 	})
 
-	xfrmStateList, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+	xfrmStateList, err := xfrmStateCache.XfrmStateList()
 	if err != nil {
 		scopedLog.WithError(err).Warning("Failed to list XFRM states for deletion")
 		return err
@@ -825,7 +833,7 @@ func safeDeleteXfrmState(state *netlink.XfrmState, oldState *netlink.XfrmState) 
 		}
 	}
 
-	return netlink.XfrmStateDel(state)
+	return xfrmStateCache.XfrmStateDel(state)
 }
 
 func ipsecDeleteXfrmPolicy(nodeID uint16) error {
@@ -1007,7 +1015,7 @@ func DeleteXfrm() error {
 		return err
 	}
 
-	xfrmStateList, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+	xfrmStateList, err := xfrmStateCache.XfrmStateList()
 	if err != nil {
 		log.WithError(err).Warning("unable to fetch xfrm state list")
 		return err
@@ -1015,7 +1023,7 @@ func DeleteXfrm() error {
 	ee = resiliency.NewErrorSet("failed to delete XFRM states", len(xfrmStateList))
 	for _, s := range xfrmStateList {
 		if isXfrmStateCilium(s) {
-			if err := netlink.XfrmStateDel(&s); err != nil {
+			if err := xfrmStateCache.XfrmStateDel(&s); err != nil {
 				ee.Add(err)
 			}
 		}
@@ -1325,7 +1333,7 @@ func ipSecSPICanBeReclaimed(spi uint8, reclaimTimestamp time.Time) bool {
 }
 
 func deleteStaleXfrmStates(reclaimTimestamp time.Time) error {
-	xfrmStateList, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+	xfrmStateList, err := xfrmStateCache.XfrmStateList()
 	if err != nil {
 		return err
 	}
@@ -1336,7 +1344,7 @@ func deleteStaleXfrmStates(reclaimTimestamp time.Time) error {
 		if !ipSecSPICanBeReclaimed(stateSPI, reclaimTimestamp) {
 			continue
 		}
-		if err := netlink.XfrmStateDel(&s); err != nil {
+		if err := xfrmStateCache.XfrmStateDel(&s); err != nil {
 			errs.Add(fmt.Errorf("failed to delete stale xfrm state spi (%d): %w", stateSPI, err))
 		}
 	}

--- a/pkg/datapath/linux/ipsec/xfrm_state_cache.go
+++ b/pkg/datapath/linux/ipsec/xfrm_state_cache.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipsec
+
+import (
+	"github.com/vishvananda/netlink"
+	"k8s.io/utils/clock"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type xfrmStateListCache struct {
+	stateList []netlink.XfrmState
+	timeout   time.Time
+	mutex     lock.Mutex
+	ttl       time.Duration
+	clock     clock.PassiveClock
+}
+
+func NewXfrmStateListCache(ttl time.Duration) *xfrmStateListCache {
+	return &xfrmStateListCache{
+		ttl:   ttl,
+		clock: clock.RealClock{},
+	}
+}
+
+func (c *xfrmStateListCache) XfrmStateList() ([]netlink.XfrmState, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if c.isExpired() {
+		result, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+		if err != nil {
+			return nil, err
+		}
+		c.stateList = result
+		c.timeout = c.clock.Now().Add(c.ttl)
+	}
+	return c.stateList, nil
+}
+
+func (c *xfrmStateListCache) XfrmStateDel(state *netlink.XfrmState) error {
+	c.invalidate()
+	return netlink.XfrmStateDel(state)
+}
+
+func (c *xfrmStateListCache) XfrmStateUpdate(state *netlink.XfrmState) error {
+	c.invalidate()
+	return netlink.XfrmStateUpdate(state)
+}
+
+func (c *xfrmStateListCache) XfrmStateAdd(state *netlink.XfrmState) error {
+	c.invalidate()
+	return netlink.XfrmStateAdd(state)
+}
+
+func (c *xfrmStateListCache) XfrmStateFlush(proto netlink.Proto) error {
+	c.invalidate()
+	return netlink.XfrmStateFlush(proto)
+}
+
+func (c *xfrmStateListCache) isExpired() bool {
+	return !option.Config.EnableIPSecXfrmStateCaching || c.stateList == nil || c.timeout.Before(c.clock.Now())
+}
+
+func (c *xfrmStateListCache) invalidate() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.stateList = nil
+}
+
+func newTestableXfrmStateListCache(ttl time.Duration, clock clock.PassiveClock) *xfrmStateListCache {
+	return &xfrmStateListCache{
+		ttl:   ttl,
+		clock: clock,
+	}
+}

--- a/pkg/datapath/linux/ipsec/xfrm_state_cache_test.go
+++ b/pkg/datapath/linux/ipsec/xfrm_state_cache_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipsec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
+
+	baseclocktest "k8s.io/utils/clock/testing"
+)
+
+func TestXfrmStateListCache(t *testing.T) {
+	setupIPSecSuitePrivileged(t)
+
+	backupOption := option.Config.EnableIPSecXfrmStateCaching
+	defer func() {
+		option.Config.EnableIPSecXfrmStateCaching = backupOption
+	}()
+	option.Config.EnableIPSecXfrmStateCaching = true
+
+	fakeClock := baseclocktest.NewFakeClock(time.Now())
+	xfrmStateCache := newTestableXfrmStateListCache(
+		time.Second,
+		fakeClock,
+	)
+
+	require.True(t, xfrmStateCache.isExpired(), "Cache should be expired in the beginning")
+
+	cleanIPSecStatesAndPolicies(t)
+	state := initDummyXfrmState()
+	err := createDummyXfrmState(state)
+	require.NoError(t, err)
+
+	// Make sure that cache is correctly fetched in the beginning
+	stateList, err := xfrmStateCache.XfrmStateList()
+	require.NoError(t, err)
+	require.Len(t, stateList, 1)
+	require.Equal(t, state.Spi, stateList[0].Spi)
+
+	cleanIPSecStatesAndPolicies(t)
+	// Check that cache does not expire instantly
+	stateList, err = xfrmStateCache.XfrmStateList()
+	require.NoError(t, err)
+	require.Len(t, stateList, 1)
+
+	// Move time by half second and make sure cache still did not expire
+	fakeClock.Step(time.Millisecond * 500)
+	require.False(t, xfrmStateCache.isExpired(), "Cache should not be expired before timeout")
+	stateList, err = xfrmStateCache.XfrmStateList()
+	require.NoError(t, err)
+	require.Len(t, stateList, 1)
+
+	// Invalidate cache by moving time by 501 more miliseconds
+	fakeClock.Step(time.Millisecond * 501)
+	require.True(t, xfrmStateCache.isExpired(), "Cache should be expired after timeout")
+	stateList, err = xfrmStateCache.XfrmStateList()
+	require.NoError(t, err)
+	require.Len(t, stateList, 0)
+
+	// Create new xfrm state and check that cache is atomatically updated
+	require.True(t, xfrmStateCache.isExpired(), "Cache should be expired when list is empty")
+	err = xfrmStateCache.XfrmStateAdd(state)
+	require.NoError(t, err)
+	require.True(t, xfrmStateCache.isExpired(), "Cache should be expired after adding new state")
+	stateList, err = xfrmStateCache.XfrmStateList()
+	require.NoError(t, err)
+	require.Len(t, stateList, 1)
+	require.Equal(t, stateList[0].OutputMark.Value, uint32(linux_defaults.RouteMarkDecrypt))
+
+	// Update xfrm state and check that cache is automatically updated
+	require.False(t, xfrmStateCache.isExpired(), "Cache should not be expired before timeout")
+	// Switch to encrypt as this is the only value we update
+	state.OutputMark.Value = linux_defaults.RouteMarkEncrypt
+	err = xfrmStateCache.XfrmStateUpdate(state)
+	require.NoError(t, err)
+	require.True(t, xfrmStateCache.isExpired(), "Cache should be expired after updating state")
+	stateList, err = xfrmStateCache.XfrmStateList()
+	require.NoError(t, err)
+	require.Len(t, stateList, 1)
+	require.Equal(t, stateList[0].OutputMark.Value, uint32(linux_defaults.RouteMarkEncrypt))
+
+	// Delete xfrm state and check that cache is automatically updated
+	require.False(t, xfrmStateCache.isExpired(), "Cache should not be expired before timeout")
+	err = xfrmStateCache.XfrmStateDel(state)
+	require.NoError(t, err)
+	require.True(t, xfrmStateCache.isExpired(), "Cache should be expired after deleting state")
+	stateList, err = xfrmStateCache.XfrmStateList()
+	require.NoError(t, err)
+	require.Len(t, stateList, 0)
+}
+
+func TestXfrmStateListCacheDisabled(t *testing.T) {
+	setupIPSecSuitePrivileged(t)
+
+	backupOption := option.Config.EnableIPSecXfrmStateCaching
+	defer func() {
+		option.Config.EnableIPSecXfrmStateCaching = backupOption
+	}()
+	option.Config.EnableIPSecXfrmStateCaching = false
+
+	xfrmStateCache := newTestableXfrmStateListCache(
+		time.Second,
+		baseclocktest.NewFakeClock(time.Now()),
+	)
+
+	state := initDummyXfrmState()
+	err := createDummyXfrmState(state)
+	require.NoError(t, err)
+
+	require.True(t, xfrmStateCache.isExpired(), "Cache should be expired in the beginning")
+	// Make sure that cache is correctly fetched in the beginning
+	stateList, err := xfrmStateCache.XfrmStateList()
+	require.NoError(t, err)
+	require.Len(t, stateList, 1)
+
+	// And is still expired
+	require.True(t, xfrmStateCache.isExpired(), "Cache should be stil expired as it's disabled")
+}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -253,6 +253,10 @@ const (
 	// be necessary on key rotations.
 	EnableIPsecKeyWatcher = true
 
+	// Enable caching for XfrmState for IPSec. Significantly reduces CPU usage
+	// in large clusters.
+	EnableIPSecXfrmStateCaching = true
+
 	// Enable IPSec encrypted overlay
 	//
 	// This feature will encrypt overlay traffic before it leaves the cluster.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -720,6 +720,10 @@ const (
 	// be necessary on key rotations.
 	EnableIPsecKeyWatcher = "enable-ipsec-key-watcher"
 
+	// Enable caching for XfrmState for IPSec. Significantly reduces CPU usage
+	// in large clusters.
+	EnableIPSecXfrmStateCaching = "enable-ipsec-xfrm-state-caching"
+
 	// IPSecKeyFileName is the name of the option for ipsec key file
 	IPSecKeyFileName = "ipsec-key-file"
 
@@ -1595,6 +1599,9 @@ type DaemonConfig struct {
 	// Enable watcher for IPsec key. If disabled, a restart of the agent will
 	// be necessary on key rotations.
 	EnableIPsecKeyWatcher bool
+
+	// EnableIPSecXfrmStateCaching enables IPSec XfrmState caching.
+	EnableIPSecXfrmStateCaching bool
 
 	// EnableIPSecEncryptedOverlay enables IPSec encryption for overlay traffic.
 	EnableIPSecEncryptedOverlay bool
@@ -3051,6 +3058,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.IPSecKeyFile = vp.GetString(IPSecKeyFileName)
 	c.IPsecKeyRotationDuration = vp.GetDuration(IPsecKeyRotationDuration)
 	c.EnableIPsecKeyWatcher = vp.GetBool(EnableIPsecKeyWatcher)
+	c.EnableIPSecXfrmStateCaching = vp.GetBool(EnableIPSecXfrmStateCaching)
 	c.MonitorAggregation = vp.GetString(MonitorAggregationName)
 	c.MonitorAggregationInterval = vp.GetDuration(MonitorAggregationInterval)
 	c.MTU = vp.GetInt(MTUName)


### PR DESCRIPTION
Reduces GC CPU usage and memory allocations coming from XfrmStateList.
To ensure we have up-to-date cache, wrap all XfrmState related
functions inside cache, which is invalidated whenever XfrmState changes.

This is follow-up to https://github.com/cilium/cilium/pull/32577
While that PR averages out CPU usage over time, in large cluster 100+
nodes amount of allocations coming from netlink.XfrmStateList() is high
due to backgroundSync where we usually don't change any Xfrm states.
This becomes more and more expensive as number of nodes increases.

Some pprofs/GC CPU time graphs.
Before:
Number of alloc objects:
![image](https://github.com/cilium/cilium/assets/2011575/13995dcf-cfbe-4232-a36b-105d6dfc56e3)
Total GC time for 100 nodes:
![image](https://github.com/cilium/cilium/assets/2011575/8398f1d6-1b56-4cb8-904d-aefe9f214b7b)
After:
Number of alloc objects:
![image](https://github.com/cilium/cilium/assets/2011575/e602a5f8-8f42-4cd9-91b1-726c51a9b4e1)
Total GC time for 100 nodes:
![image](https://github.com/cilium/cilium/assets/2011575/b65f6a51-5f6f-4326-910b-ccd1655d7949)

This would become even more important for larger clusters, as XfrmStateList allocations in backgroundSync are essentially O(n^2). 

```release-note
ipsec: Improve CPU usage of cilum-agent in large clusters
```
