### PR TITLE
helm: Grant the cilium-operator pod:delete permissions by default

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -18,13 +18,11 @@ rules:
   - get
   - list
   - watch
-{{- if hasKey .Values "disableEndpointCRD" }}
 {{- if not .Values.disableEndpointCRD }}
 {{- if (and .Values.operator.unmanagedPodWatcher.restart (ne (.Values.operator.unmanagedPodWatcher.intervalSeconds | int64) 0 ) ) }}
   # to automatically delete [core|kube]dns pods so that are starting to being
   # managed by Cilium
   - delete
-{{- end }}
 {{- end }}
 {{- end }}
 {{- if or .Values.operator.removeNodeTaints .Values.operator.setNodeNetworkStatus (include "hasDuration" .Values.operator.endpointGCInterval) }}


### PR DESCRIPTION
cilium-operator requires the pod:delete permission to manage [core|kube]dns pods that are managed by cilium.

These pods are only managed by cilium if disableEndpointCRD is false.

`disableEndpointCRD` is false by default, but the operator doesn't get the permission unless you _explicitly_ set `disableEndpointCRD` to false. This is very unintuitive; I would expect that setting something to `false` that is `false` by default should be a noop.

This PR simply removes the explicit `hasKey` check and leaves the key value checks in, which should be the only ones that matter anyway.

Looks like this check was originally introduced in https://github.com/cilium/cilium/commit/f612c97aacbb44e6cc7c3587541c53dd0296d5ea which I think had the right idea – this permission should only exist when delete is needed – but it shouldn't require a user to explicitly re-set a default.

Before this change, with default values:

```
❯ kubectl describe clusterroles -n cilium cilium-operator | grep pods
  pods                                                   []                 []              [get list watch]
```

After this change, with default values:

```
❯ kubectl describe clusterroles -n cilium cilium-operator | grep pods
  pods                                                   []                 []              [get list watch delete]
```

Explicitly setting `disableEndpointCRD` to `true` removes the `delete` permission.

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

