### PR TITLE
gha: Correct number of connect retry param in LVH

### DIFF
--- a/.github/actions/lvh-kind/action.yaml
+++ b/.github/actions/lvh-kind/action.yaml
@@ -31,7 +31,7 @@ runs:
         mem: 12G
         install-dependencies: 'true'
         port-forward: '6443:6443'
-        ssh-startup-wait-retries: 600
+        ssh-connect-wait-retries: 600
         cmd: |
           git config --global --add safe.directory /host
 


### PR DESCRIPTION
As per below [^1], the correct parameter is ssh-connect-wait-retries instead of ssh-startup-wait-retries.

[^1]: https://github.com/cilium/little-vm-helper/blob/3c748d6fc9d6c44a433de85a66f70e8f7043be04/action.yaml#L30

