### PR TITLE
feat: Watch and Read cilium network policies from static directory path

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -338,6 +338,7 @@ cilium-agent [flags]
       --service-no-backend-response string                        Response to traffic for a service without backends (default "reject")
       --socket-path string                                        Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
       --state-dir string                                          Directory path to store runtime state (default "/var/run/cilium")
+      --static-cnp-path string                                    Directory path to watch and load static cilium network policy yaml files.
       --tofqdns-dns-reject-response-code string                   DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
       --tofqdns-enable-dns-compression                            Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
       --tofqdns-endpoint-max-ip-per-hostname int                  Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -105,6 +105,7 @@ cilium-agent hive [flags]
       --proxy-xff-num-trusted-hops-egress uint32                  Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
       --proxy-xff-num-trusted-hops-ingress uint32                 Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
+      --static-cnp-path string                                    Directory path to watch and load static cilium network policy yaml files.
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")
       --use-full-tls-context                                      If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -110,6 +110,7 @@ cilium-agent hive dot-graph [flags]
       --proxy-xff-num-trusted-hops-egress uint32                  Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
       --proxy-xff-num-trusted-hops-ingress uint32                 Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
+      --static-cnp-path string                                    Directory path to watch and load static cilium network policy yaml files.
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")
       --use-full-tls-context                                      If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -49,6 +49,7 @@ import (
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/option"
+	policyDirectory "github.com/cilium/cilium/pkg/policy/directory"
 	policyK8s "github.com/cilium/cilium/pkg/policy/k8s"
 	"github.com/cilium/cilium/pkg/pprof"
 	"github.com/cilium/cilium/pkg/proxy"
@@ -214,6 +215,9 @@ var (
 
 		// K8s policy resource watcher cell.
 		policyK8s.Cell,
+
+		// Directory policy watcher cell.
+		policyDirectory.Cell,
 
 		// ClusterMesh is the Cilium's multicluster implementation.
 		cell.Config(cmtypes.DefaultClusterInfo),

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -728,6 +728,10 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		}
 	}
 
+	if params.DirectoryPolicyWatcher != nil {
+		params.DirectoryPolicyWatcher.WatchDirectoryPolicyResources(d.ctx, &d)
+	}
+
 	// Some of the k8s watchers rely on option flags set above (specifically
 	// EnableBPFMasquerade), so we should only start them once the flag values
 	// are set.

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -44,6 +44,7 @@ var (
 	ResourceKindCCNP     = ResourceKind("ccnp")
 	ResourceKindDaemon   = ResourceKind("daemon")
 	ResourceKindEndpoint = ResourceKind("ep")
+	ResourceKindFile     = ResourceKind("file")
 	ResourceKindNetpol   = ResourceKind("netpol")
 	ResourceKindNode     = ResourceKind("node")
 )

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -147,6 +147,9 @@ const (
 	// LabelSourceReservedKeyPrefix is the prefix of a reserved label
 	LabelSourceReservedKeyPrefix = LabelSourceReserved + "."
 
+	// LabelSourceDirectory is the label source for policies read from files
+	LabelSourceDirectory = "directory"
+
 	// LabelKeyFixedIdentity is the label that can be used to define a fixed
 	// identity.
 	LabelKeyFixedIdentity = "io.cilium.fixed-identity"

--- a/pkg/policy/directory/cell.go
+++ b/pkg/policy/directory/cell.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package directory
+
+import (
+	"context"
+
+	"github.com/cilium/hive/cell"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+// Cell provides the Directory policy watcher. The Directory policy watcher watches
+// CiliumNetworkPolicy, CiliumClusterWideNetworkPolicy created/deleted under a directory
+// specified through cilium config. It reads and translates them to Cilium's own
+// policy representation (api.Rules) and updates the policy repository
+// (via PolicyManager) accordingly.
+var Cell = cell.Module(
+	"policy-directory-watcher",
+	"Watches Directory for cilium network policy file updates",
+	cell.Config(defaultConfig),
+	cell.Provide(newDirectoryPolicyResourcesWatcher,
+		func() DirectoryWatcherReadStatus {
+			return make(DirectoryWatcherReadStatus)
+		}),
+)
+
+type PolicyManager interface {
+	PolicyAdd(rules api.Rules, opts *policy.AddOptions) (newRev uint64, err error)
+	PolicyDelete(labels labels.LabelArray, opts *policy.DeleteOptions) (newRev uint64, err error)
+}
+
+type DirectoryWatcherReadStatus chan struct{}
+
+type PolicyWatcherParams struct {
+	cell.In
+
+	ReadStatus DirectoryWatcherReadStatus
+	Lifecycle  cell.Lifecycle
+	Logger     logrus.FieldLogger
+}
+
+type PolicyResourcesWatcher struct {
+	params PolicyWatcherParams
+	cfg    Config
+}
+
+type Config struct {
+	StaticCNPPath string
+}
+
+const (
+	// StaticCNPPath defines the directory path for static cilium network policy yaml files.
+	staticCNPPath = "static-cnp-path"
+)
+
+var defaultConfig = Config{}
+
+func (cfg Config) Flags(flags *pflag.FlagSet) {
+	flags.String(staticCNPPath, defaultConfig.StaticCNPPath, "Directory path to watch and load static cilium network policy yaml files.")
+}
+
+func newDirectoryPolicyResourcesWatcher(p PolicyWatcherParams, cfg Config) *PolicyResourcesWatcher {
+	if cfg.StaticCNPPath == "" {
+		close(p.ReadStatus)
+		return nil
+	}
+
+	return &PolicyResourcesWatcher{
+		params: p,
+		cfg:    cfg,
+	}
+}
+
+// WatchDirectoryPolicyResources starts watching Cilium Network policy files created under a directory.
+func (p *PolicyResourcesWatcher) WatchDirectoryPolicyResources(ctx context.Context, policyManager PolicyManager) {
+	w := newPolicyWatcher(ctx, policyManager, p)
+	w.watchDirectory(ctx)
+}
+
+// newPolicyWatcher constructs a new policy watcher.
+// This constructor unfortunately cannot be started via the Hive lifecycle as
+// there exists a circular dependency between this watcher and the Daemon:
+// The constructor newDaemon cannot complete before all pre-existing
+// Cilium Network Policy defined as yaml under specific directory have been added via the PolicyManager
+// (i.e. watchDirectory has observed the CNP file addition).
+// Because the PolicyManager interface itself is implemented by the Daemon
+// struct, we have a circular dependency.
+func newPolicyWatcher(ctx context.Context, policyManager PolicyManager, p *PolicyResourcesWatcher) *policyWatcher {
+	w := &policyWatcher{
+		log:                p.params.Logger,
+		policyManager:      policyManager,
+		readStatus:         p.params.ReadStatus,
+		config:             p.cfg,
+		fileNameToCnpCache: make(map[string]*cilium_v2.CiliumNetworkPolicy),
+	}
+	return w
+}

--- a/pkg/policy/directory/watcher.go
+++ b/pkg/policy/directory/watcher.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package directory
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/yaml"
+
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	k8sCiliumUtils "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+type policyWatcher struct {
+	log           logrus.FieldLogger
+	config        Config
+	policyManager PolicyManager
+	readStatus    DirectoryWatcherReadStatus
+	// maps cnp file name to cnp object. this is required to retrieve data during delete.
+	fileNameToCnpCache map[string]*cilium_v2.CiliumNetworkPolicy
+}
+
+func (p *policyWatcher) translateToCNPObject(file string) (*cilium_v2.CiliumNetworkPolicy, error) {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	// yaml to json conversion
+	jsonData, err := yaml.YAMLToJSON([]byte(data))
+	if err != nil {
+		return nil, err
+	}
+
+	// translate json to cnp object
+	cnp := &cilium_v2.CiliumNetworkPolicy{}
+	err = json.Unmarshal(jsonData, cnp)
+	if err != nil {
+		return nil, err
+	}
+
+	return cnp, nil
+}
+
+func getLabels(fileName string, cnp *cilium_v2.CiliumNetworkPolicy) labels.LabelArray {
+	labelsArr := labels.LabelArray{
+		labels.NewLabel("filename", fileName, labels.LabelSourceDirectory),
+	}
+
+	ns := cnp.ObjectMeta.Namespace
+	// For clusterwide policy namespace will be empty.
+	if ns != "" {
+		nsLabel := labels.NewLabel(k8sConst.PolicyLabelNamespace, ns, labels.LabelSourceDirectory)
+		labelsArr = append(labelsArr, nsLabel)
+		srcLabel := labels.NewLabel("policy-derived-from", k8sCiliumUtils.ResourceTypeCiliumNetworkPolicy, labels.LabelSourceDirectory)
+		labelsArr = append(labelsArr, srcLabel)
+	} else {
+		srcLabel := labels.NewLabel("policy-derived-from", k8sCiliumUtils.ResourceTypeCiliumClusterwideNetworkPolicy, labels.LabelSourceDirectory)
+		labelsArr = append(labelsArr, srcLabel)
+	}
+
+	return labelsArr
+}
+
+// read cilium network policy yaml file and convert to policy object and
+// add rules to policy engine.
+func (p *policyWatcher) addToPolicyEngine(cnpFilePath string) error {
+	// read from file and convert to cnp object
+	cnp, err := p.translateToCNPObject(cnpFilePath)
+	if err != nil {
+		return err
+	}
+
+	fileName := filepath.Base(cnpFilePath)
+
+	resourceID := ipcacheTypes.NewResourceID(
+		ipcacheTypes.ResourceKindFile,
+		p.config.StaticCNPPath,
+		fileName,
+	)
+
+	// convert to rules
+	rules, err := cnp.Parse()
+	if err != nil {
+		return err
+	}
+
+	// update labels
+	lbls := getLabels(fileName, cnp)
+	for _, r := range rules {
+		r.Labels = lbls
+	}
+
+	// add to policy engine
+	_, err = p.policyManager.PolicyAdd(rules, &policy.AddOptions{
+		ReplaceByResource: true,
+		Source:            source.Directory,
+		Resource:          resourceID,
+	})
+
+	if err == nil {
+		p.fileNameToCnpCache[fileName] = cnp
+	}
+
+	return err
+}
+
+func (p *policyWatcher) deleteFromPolicyEngine(cnpFilePath string) error {
+	fileName := filepath.Base(cnpFilePath)
+	cnp := p.fileNameToCnpCache[fileName]
+	if cnp == nil {
+		p.log.WithField("file", fileName).Error("BUG: Policy deletion request for file which was never added")
+		return nil
+	}
+
+	resourceID := ipcacheTypes.NewResourceID(
+		ipcacheTypes.ResourceKindFile,
+		p.config.StaticCNPPath,
+		fileName,
+	)
+	_, err := p.policyManager.PolicyDelete(getLabels(fileName, cnp), &policy.DeleteOptions{
+		Source:           source.Directory,
+		DeleteByResource: true,
+		Resource:         resourceID})
+
+	delete(p.fileNameToCnpCache, fileName)
+	return err
+}
+
+func (p *policyWatcher) isValidCNPFileName(filePath string) bool {
+	if filepath.Ext(filePath) != ".yaml" {
+		return false
+	}
+	if reasons := validation.IsDNS1123Subdomain(filepath.Base(filePath)); len(reasons) > 0 {
+		p.log.WithFields(logrus.Fields{
+			"name":    filepath.Base(filePath),
+			"reasons": reasons,
+		}).Error("CNP name parse validation failed")
+		return false
+	}
+	return true
+}
+
+func (p *policyWatcher) watchDirectory(ctx context.Context) {
+	go func() {
+		p.log.Info("Directory policy watcher started")
+		watcher, err := fsnotify.NewWatcher()
+		if err != nil {
+			p.log.WithError(err).Fatal("Initializing NewWatcher failed")
+			return
+		}
+		defer watcher.Close()
+
+		dir := p.config.StaticCNPPath
+		err = watcher.Add(dir)
+		if err != nil {
+			p.log.WithError(err).WithField(logfields.Path, dir).Fatal("Failed to watch policy directory. Policies will not be loaded from disk")
+			return
+		}
+
+		files, err := os.ReadDir(dir)
+		if err != nil {
+			p.log.WithError(err).WithField(logfields.Path, dir).Fatal("Failed to read policy directory")
+			return
+		}
+
+		// Read existing cnp files before watcher was added
+		for _, f := range files {
+			absPath := filepath.Join(dir, f.Name())
+			if !p.isValidCNPFileName(absPath) {
+				continue
+			}
+			err := p.addToPolicyEngine(absPath)
+			if err != nil {
+				p.log.WithError(err).WithField(logfields.Path, absPath).Fatal("Failed to add network policy to policy engine")
+			}
+			reportCNPChangeMetrics(err)
+		}
+		close(p.readStatus)
+		// Listen for file add, update, rename and delete
+		for {
+			select {
+			case event := <-watcher.Events:
+				if !p.isValidCNPFileName(event.Name) {
+					continue
+				}
+				if event.Op.Has(fsnotify.Create) || event.Op.Has(fsnotify.Write) {
+					p.log.WithField(logfields.Path, event.Name).Debug("CNP file added/updated in directory..")
+					err := p.addToPolicyEngine(event.Name)
+					if err != nil {
+						p.log.WithError(err).WithField(logfields.Path, event.Name).Error("Failed to add network policy to policy engine")
+					}
+				}
+				if event.Op.Has(fsnotify.Remove) || event.Op.Has(fsnotify.Rename) {
+					p.log.WithField(logfields.Path, event.Name).Debug("CNP file removed from directory..")
+					err := p.deleteFromPolicyEngine(event.Name)
+					if err != nil {
+						p.log.WithError(err).WithField(logfields.Path, event.Name).Error("Failed to remove network policy from policy engine")
+					}
+				}
+				reportCNPChangeMetrics(err)
+			case err := <-watcher.Errors:
+				p.log.WithError(err).Error("Unexpected error thrown by fsnotify watcher when watching policy directory")
+			}
+		}
+	}()
+}
+
+func reportCNPChangeMetrics(err error) {
+	if err != nil {
+		metrics.PolicyChangeTotal.WithLabelValues(metrics.LabelValueOutcomeFail).Inc()
+	} else {
+		metrics.PolicyChangeTotal.WithLabelValues(metrics.LabelValueOutcomeSuccess).Inc()
+	}
+}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -48,6 +48,10 @@ const (
 	// by the previous agent instance. Can be overwritten by all other
 	// sources (except for unspec).
 	Restored Source = "restored"
+
+	// Directory is the source used for watching and reading
+	// cilium network policy files from specific directory.
+	Directory Source = "directory"
 )
 
 // AllowOverwrite returns true if new state from a particular source is allowed


### PR DESCRIPTION
Cilium reads CNP files from directory if path is configured via `static-cnp-path` field in cilium config. It watches the directory for any changes and read those files and convert to CNP object and add it to policy engine. This allows admin to configure policy to not allow traffic to certain endpoints without showing up as policy resource in kubernetes. This is implemented based on this discussion: https://github.com/cilium/cilium/pull/30060#issuecomment-1955250995 


Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
policy: Add support to watch and read CNP files from directory
```
