### PR TITLE
ci: l4lb: restart docker-in-docker container on failure

### DIFF
--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -136,8 +136,9 @@ jobs:
       - name: Fetch DinD information
         if: ${{ !success() && steps.lb-test.outcome != 'skipped' }}
         run: |
-          docker ps
+          docker ps -a
           docker logs -f lb-node
+          docker inspect lb-node
           docker exec -t lb-node docker ps
 
       - name: Fetch Cilium Standalone LB logs

--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -34,7 +34,7 @@ clang -O2 -Wall --target=bpf -c test_tc_tunnel.c -o test_tc_tunnel.o
 # * "nginx" runs the nginx server.
 
 docker network create cilium-l4lb
-docker run --privileged --name lb-node -d \
+docker run --privileged --name lb-node -d --restart=on-failure:10 \
     --network cilium-l4lb -v /lib/modules:/lib/modules \
     docker:dind
 docker run --name nginx -d --network cilium-l4lb nginx

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -104,7 +104,7 @@ function initialize_docker_env {
     trace_offset "${BASH_LINENO[0]}" "Initializing docker environment..."
 
     docker network create --subnet="172.12.42.0/24,2001:db8:1::/64" --ipv6 cilium-l4lb
-    docker run --privileged --name lb-node -d \
+    docker run --privileged --name lb-node -d --restart=on-failure:10 \
         --network cilium-l4lb -v /lib/modules:/lib/modules \
         docker:dind
     docker exec -t lb-node mount bpffs /sys/fs/bpf -t bpf


### PR DESCRIPTION
Docker in Docker container used within L4LB tests occasionally fails to start due to a `sed: write error`. (see https://github.com/cilium/cilium/actions/runs/9117466169/job/25068387379)

log output of failed container ([now getting printed in additional GH action step](https://github.com/cilium/cilium/pull/32570)) :

```
Certificate request self-signature ok
/certs/server/cert.pem: OK
subject=CN = docker:dind server
Certificate request self-signature ok
subject=CN = docker:dind client
cat: can't open '/proc/net/arp_tables_names': No such file or directory
sed: write error
/certs/client/cert.pem: OK
iptables v1.8.10 (nf_tables)
```

(It seems as `cat: can't open '/proc/net/arp_tables_names': No such file or directory` is ok - at least it also occurs when starting DinD locally (in my case))

To prevent this error from causing the entire test to fail, this commit tries to fix this by restarting the container in case of a failure up to 10 times.

In addition, this PR enhances the previously introduced "fetch dind information" GH action step from the L4LB test to output all containers (including stopped ones) and details about the lb-node container.

Follow up of: https://github.com/cilium/cilium/pull/32570
Related to: https://github.com/cilium/cilium/issues/24728
