### PR TITLE
ipam: lower loglevel from error to warn if eni link list can't be listed

### DIFF
--- a/pkg/ipam/crd_eni.go
+++ b/pkg/ipam/crd_eni.go
@@ -136,7 +136,7 @@ func waitForNetlinkDevices(configByMac configMap) (linkByMac linkMap, err error)
 	for try := 0; try < waitForNetlinkDevicesMaxTries; try++ {
 		links, err := netlink.LinkList()
 		if err != nil {
-			log.WithError(err).Error("failed to obtain eni link list")
+			log.WithError(err).Warn("failed to obtain eni link list - retrying")
 		} else {
 			linkByMac = linkMap{}
 			for _, link := range links {


### PR DESCRIPTION
Currently, failing attempts to obtain the eni link list while waiting for net link devices are logged as error.

This leads to CI flakes due to the check `check-log-errors` in our test suite.

```
❌ Found 1 logs in cilium-cilium-9121495685-1.us-west-1.eksctl.io/kube-system/cilium-vkddg (cilium-agent) matching list of errors that must be investigated:
time="2024-05-17T01:39:54Z" level=error msg="failed to obtain eni link list" error="interrupted system call" subsys=ipam (1 occurrences)
```

(https://github.com/cilium/cilium/actions/runs/9121495685/job/25080745128)

Recent changes included this failure into the existing retry loop. Therefore it would be sufficient (and better (not only for CI but also the users), as this failure is kind of expected in some cases) to log this failure as warning (instead of an error). Exceeding the retries would result in an error anyway.

Therefore, this commit lowers the loglevel from `error` to `warn` and improves the log message by indicating the retry.

Fixes: https://github.com/cilium/cilium/pull/32099
