### PR TITLE
pkg/endpoint: clean up DatapathRegenerationLevel

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1006,8 +1006,7 @@ func (d *Daemon) Close() {
 	d.controllers.RemoveAllAndWait()
 }
 
-// TriggerReloadWithoutCompile causes all BPF programs and maps to be reloaded,
-// without recompiling the datapath logic for each endpoint. It first attempts
+// TriggerReload causes all BPF programs and maps to be reloaded. It first attempts
 // to recompile the base programs, and if this fails returns an error. If base
 // program load is successful, it subsequently triggers regeneration of all
 // endpoints and returns a waitgroup that may be used by the caller to wait for
@@ -1016,7 +1015,7 @@ func (d *Daemon) Close() {
 // If an error is returned, then no regeneration was successful. If no error
 // is returned, then the base programs were successfully regenerated, but
 // endpoints may or may not have successfully regenerated.
-func (d *Daemon) TriggerReloadWithoutCompile(reason string) (*sync.WaitGroup, error) {
+func (d *Daemon) TriggerReload(reason string) (*sync.WaitGroup, error) {
 	log.Debugf("BPF reload triggered from %s", reason)
 	if err := d.Datapath().Orchestrator().Reinitialize(d.ctx); err != nil {
 		return nil, fmt.Errorf("unable to recompile base programs from %s: %w", reason, err)
@@ -1024,7 +1023,7 @@ func (d *Daemon) TriggerReloadWithoutCompile(reason string) (*sync.WaitGroup, er
 
 	regenRequest := &regeneration.ExternalRegenerationMetadata{
 		Reason:            reason,
-		RegenerationLevel: regeneration.RegenerateWithDatapathLoad,
+		RegenerationLevel: regeneration.RegenerateWithDatapath,
 	}
 	return d.endpointManager.RegenerateAllEndpoints(regenRequest), nil
 }
@@ -1034,7 +1033,7 @@ func (d *Daemon) datapathRegen(reasons []string) {
 
 	regenerationMetadata := &regeneration.ExternalRegenerationMetadata{
 		Reason:            reason,
-		RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
+		RegenerationLevel: regeneration.RegenerateWithDatapath,
 	}
 	d.endpointManager.RegenerateAllEndpoints(regenerationMetadata)
 }

--- a/daemon/cmd/device-reloader.go
+++ b/daemon/cmd/device-reloader.go
@@ -117,7 +117,7 @@ func (d *deviceReloader) reload(ctx context.Context) error {
 	}
 
 	// Reload the datapath.
-	wg, err := daemon.TriggerReloadWithoutCompile("devices changed")
+	wg, err := daemon.TriggerReload("devices changed")
 	if err != nil {
 		log.WithError(err).Warn("Failed to reload datapath")
 	} else {

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -549,7 +549,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 		regenMetadata := &regeneration.ExternalRegenerationMetadata{
 			Reason:            "Initial build on endpoint creation",
 			ParentContext:     ctx,
-			RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
+			RegenerationLevel: regeneration.RegenerateWithDatapath,
 		}
 		build, err := ep.SetRegenerateStateIfAlive(regenMetadata)
 		if err != nil {
@@ -735,7 +735,7 @@ func patchEndpointIDHandler(d *Daemon, params PatchEndpointIDParams) middleware.
 	if reason != "" {
 		regenMetadata := &regeneration.ExternalRegenerationMetadata{
 			Reason:            reason,
-			RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
+			RegenerationLevel: regeneration.RegenerateWithDatapath,
 		}
 		if !<-ep.Regenerate(regenMetadata) {
 			err := api.Error(PatchEndpointIDFailedCode,

--- a/daemon/cmd/watchdogs.go
+++ b/daemon/cmd/watchdogs.go
@@ -131,7 +131,7 @@ func (d *Daemon) checkEndpointBPFPrograms(ctx context.Context, p epBPFProgWatchd
 				"Consider investigating whether other software running on this machine is removing Cilium's endpoint BPF programs. " +
 				"If endpoint BPF programs are removed, the associated pods will lose connectivity and only reinstating the programs will restore connectivity.",
 		)
-	wg, err := d.TriggerReloadWithoutCompile(epBPFProgWatchdog)
+	wg, err := d.TriggerReload(epBPFProgWatchdog)
 	if err != nil {
 		log.WithError(err).Error("Failed to reload Cilium endpoints BPF programs")
 	} else {

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -582,8 +582,8 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 		default:
 			// Caller skips regeneration if reason == "". Bump the skipped regeneration level so that next
 			// regeneration will realise endpoint changes.
-			if e.skippedRegenerationLevel < regeneration.RegenerateWithDatapathRewrite {
-				e.skippedRegenerationLevel = regeneration.RegenerateWithDatapathRewrite
+			if e.skippedRegenerationLevel < regeneration.RegenerateWithDatapath {
+				e.skippedRegenerationLevel = regeneration.RegenerateWithDatapath
 			}
 		}
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -910,10 +910,10 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 				Debugf("BPF header file hashed (was: %q)", e.bpfHeaderfileHash)
 		}
 
-		datapathRegenCtxt.regenerationLevel = regeneration.RegenerateWithDatapathRewrite
+		datapathRegenCtxt.regenerationLevel = regeneration.RegenerateWithDatapath
 	}
 
-	if datapathRegenCtxt.regenerationLevel >= regeneration.RegenerateWithDatapathRewrite {
+	if datapathRegenCtxt.regenerationLevel >= regeneration.RegenerateWithDatapath {
 		if err := e.writeHeaderfile(nextDir); err != nil {
 			return fmt.Errorf("unable to write header file: %w", err)
 		}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1074,7 +1074,7 @@ func (e *Endpoint) Update(cfg *models.EndpointConfigurationSpec) error {
 
 	// Only regenerate if necessary.
 	if cfg.Options == nil || e.updateAndOverrideEndpointOptions(om) || e.status.CurrentStatus() != OK {
-		regenCtx.RegenerationLevel = regeneration.RegenerateWithDatapathRewrite
+		regenCtx.RegenerationLevel = regeneration.RegenerateWithDatapath
 
 		e.getLogger().Debug("need to regenerate endpoint; checking state before" +
 			" attempting to regenerate")
@@ -2274,7 +2274,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) (
 	readyToRegenerate := false
 	regenMetadata := &regeneration.ExternalRegenerationMetadata{
 		Reason:            "updated security labels",
-		RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
+		RegenerationLevel: regeneration.RegenerateWithDatapath,
 	}
 
 	// Regeneration is only triggered once the endpoint ID has been

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -775,7 +775,7 @@ func (e *Endpoint) startRegenerationFailureHandler() {
 				Reason:        reasonRegenRetry,
 				// Completely rewrite the endpoint - we don't know the nature
 				// of the failure, simply that something failed.
-				RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
+				RegenerationLevel: regeneration.RegenerateWithDatapath,
 			}
 			regen, _ := e.SetRegenerateStateIfAlive(regenMetadata)
 			if !regen {

--- a/pkg/endpoint/regeneration/regeneration_context.go
+++ b/pkg/endpoint/regeneration/regeneration_context.go
@@ -18,12 +18,9 @@ const (
 	// RegenerateWithoutDatapath indicates that datapath rebuild or reload
 	// is not required to implement this regeneration.
 	RegenerateWithoutDatapath
-	// RegenerateWithDatapathLoad indicates that the datapath must be
-	// reloaded but not recompiled to implement this regeneration.
-	RegenerateWithDatapathLoad
-	// RegenerateWithDatapathRewrite indicates that the datapath must be
+	// RegenerateWithDatapath indicates that the datapath must be
 	// recompiled and reloaded to implement this regeneration.
-	RegenerateWithDatapathRewrite
+	RegenerateWithDatapath
 )
 
 // String converts a DatapathRegenerationLevel into a human-readable string.
@@ -33,9 +30,7 @@ func (r DatapathRegenerationLevel) String() string {
 		return "invalid"
 	case RegenerateWithoutDatapath:
 		return "no-rebuild"
-	case RegenerateWithDatapathLoad:
-		return "reload"
-	case RegenerateWithDatapathRewrite:
+	case RegenerateWithDatapath:
 		return "rewrite+load"
 	default:
 		break

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -205,7 +205,7 @@ func (e *Endpoint) RegenerateAfterRestore(regenerator *Regenerator, bwm dptypes.
 
 	regenerationMetadata := &regeneration.ExternalRegenerationMetadata{
 		Reason:            "syncing state to host",
-		RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
+		RegenerationLevel: regeneration.RegenerateWithDatapath,
 	}
 	if buildSuccess := <-e.Regenerate(regenerationMetadata); !buildSuccess {
 		return fmt.Errorf("failed while regenerating endpoint")


### PR DESCRIPTION
regeneration.RegenerateWithDatapathLoad is now equivalent to RegenerateWithDatapathRewrite since the loader itself decides if and when it has to recompile programs.

Rename RegenerateWithDatapathRewrite to RegenerateWithDatapath and do other misc cleanups.