### PR TITLE
node-manager: fix race-condition

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -389,14 +389,8 @@ func (m *manager) singleBackgroundLoop(ctx context.Context, expectedLoopTime tim
 			m.mutex.RUnlock()
 			continue
 		}
-		m.mutex.RUnlock()
-
-		// TODO(marseel): Isn't that a bug?
-		// In mean time entry m.nodes[nodeIdentity] can change
-		// and trigger dp update in NodeUpdated,
-		// node entry would have different lock than this stale entry.
-		// In that case we would override that update with stale node here.
 		entry.mutex.Lock()
+		m.mutex.RUnlock()
 		{
 			m.Iter(func(nh datapath.NodeHandler) {
 				if err := nh.NodeValidateImplementation(entry.node); err != nil {


### PR DESCRIPTION
There was potential race-conditions in handling nodes in manager. In background-sync where we were releasing manager mutex before holding entry mutex which would result in updating node information with stale informantion.

This race-condition could cause stale node information up until next background sync or node update, so it was evenually resolved though, but it could take up to 15+ minutes for large clusters, depending on number of nodes.

Follow up from https://github.com/cilium/cilium/pull/32577

Edit: seems like this was introduced on main and it's not present on v1.15 branch, so removing release-note.
Regression was introduced by https://github.com/cilium/cilium/pull/29415
I've requested review from Fernand, just to make sure I haven't missed anything. 
