### PR TITLE
[v1.15] fix: correctly set scope_switch for service lookup

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -857,6 +857,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 				     const struct lb6_service *svc,
 				     struct ct_state *state,
 				     const bool skip_l3_xlate,
+				     const bool scope_switch,
 				     __s8 *ext_err)
 {
 	__u32 monitor; /* Deliberately ignored; regular CT will determine monitoring. */
@@ -947,7 +948,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 			if (backend && !state->syn)
 				break;
 
-			svc = lb6_lookup_service(key, false, true);
+			svc = lb6_lookup_service(key, scope_switch, true);
 			if (!svc)
 				goto no_service;
 
@@ -1539,6 +1540,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 				     struct ct_state *state,
 				     bool has_l4_header,
 				     const bool skip_l3_xlate,
+				     const bool scope_switch,
 				     __u32 *cluster_id __maybe_unused,
 				     __s8 *ext_err)
 {
@@ -1643,7 +1645,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 			if (backend && !state->syn)
 				break;
 
-			svc = lb4_lookup_service(key, false, true);
+			svc = lb4_lookup_service(key, scope_switch, true);
 			if (!svc)
 				goto no_service;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1330,7 +1330,7 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 #endif
 		ret = lb6_local(get_ct_map6(&tuple), ctx, l3_off, l4_off,
 				&key, &tuple, svc, &ct_state_new,
-				skip_l3_xlate, ext_err);
+				skip_l3_xlate, false, ext_err);
 
 #ifdef SERVICE_NO_BACKEND_RESPONSE
 		if (ret == DROP_NO_SERVICE) {
@@ -2839,7 +2839,7 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 		} else {
 			ret = lb4_local(get_ct_map4(&tuple), ctx, is_fragment, l3_off, l4_off,
 					&key, &tuple, svc, &ct_state_new,
-					has_l4_header, skip_l3_xlate, &cluster_id,
+					has_l4_header, skip_l3_xlate, false, &cluster_id,
 					ext_err);
 #ifdef SERVICE_NO_BACKEND_RESPONSE
 			if (ret == DROP_NO_SERVICE) {


### PR DESCRIPTION
When looking up a loadbalancer service in lxc `from-container`, `scope_switch` value for flows matching an existing conntrack entry may skip the correct return path. Set scope switch value to be consistent with earlier service lookup.

Note: this change only applies to v1.15 and below, as v1.16 has been refactored to prevent the lb4_lookup_service call.

This can lead to packet drops due to failed service lookup when a stale CT entry maps to a backend ID that is no longer present in the service map.

Fixes: #32472

```release-note
Fix: LB service lookup for flow matching conntrack entry 
```
