### PR TITLE
bitlpm: Add ExactLookup Method

### DIFF
--- a/pkg/container/bitlpm/cidr_test.go
+++ b/pkg/container/bitlpm/cidr_test.go
@@ -42,9 +42,9 @@ loop:
 				continue loop
 			}
 		}
-		have, _ := trie.Lookup(prefixes[name].Addr())
+		have, _ := trie.LongestPrefixMatch(prefixes[name].Addr())
 		if have != name {
-			t.Errorf("Lookup(%s) returned %s want %s", prefixes[name].String(), have, name)
+			t.Errorf("LongestPrefixMatch(%s) returned %s want %s", prefixes[name].String(), have, name)
 		}
 	}
 
@@ -92,7 +92,7 @@ loop:
 			"0",
 		},
 	} {
-		v, ok := trie.Lookup(netip.MustParsePrefix(tc.k).Addr())
+		v, ok := trie.LongestPrefixMatch(netip.MustParsePrefix(tc.k).Addr())
 		assert.True(t, ok)
 		assert.Equal(t, tc.v, v)
 	}

--- a/pkg/container/bitlpm/unsigned.go
+++ b/pkg/container/bitlpm/unsigned.go
@@ -50,8 +50,12 @@ func (tu *trieUint[K, T]) Delete(prefix uint, k K) bool {
 	return tu.t.Delete(prefix, tu.getKey(k))
 }
 
-func (tu *trieUint[K, T]) Lookup(k K) (T, bool) {
-	return tu.t.Lookup(tu.getKey(k))
+func (tu *trieUint[K, T]) ExactLookup(prefix uint, k K) (T, bool) {
+	return tu.t.ExactLookup(prefix, tu.getKey(k))
+}
+
+func (tu *trieUint[K, T]) LongestPrefixMatch(k K) (T, bool) {
+	return tu.t.LongestPrefixMatch(tu.getKey(k))
 }
 
 func (tu *trieUint[K, T]) Ancestors(prefix uint, k K, fn func(prefix uint, key K, value T) bool) {


### PR DESCRIPTION
It has become clear that bitlpm needs an
ExactLookup method. This commit adds that method,
renames the previous Lookup to LongestPrefixMatch, 
and adds unit tests for the new method.
