### PR TITLE
bpf: Reset CT entry for CT_REOPENED

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -1187,16 +1187,4 @@ ct_update_dsr(const void *map, const void *tuple, const bool dsr)
 
 	entry->dsr_internal = dsr;
 }
-
-static __always_inline void
-ct_update_nodeport(const void *map, const void *tuple, const bool node_port)
-{
-	struct ct_entry *entry;
-
-	entry = map_lookup_elem(map, tuple);
-	if (!entry)
-		return;
-
-	entry->node_port = node_port;
-}
 #endif /* __LIB_CONNTRACK_H_ */


### PR DESCRIPTION
Reset the CT entry when an old entry has been found when looking up an entry for TCP SYN packet (CT_REOPENED). This way the old entry has no effect to the entry for the new connection and security identity, as well as proxy and nodeport related flags get set correctly for the new connection.

This prevents failing proxy redirect when the CT entry of a non-redirected connection would have been reused for a redirected connection, which has happened in the CI where an egress L7 policy was applied and an old CT entry from time without the L7 policy existed.

For this bug to trigger a pod needs to open a new TCP connection using the same (ephemeral) source port to the same destination before and after a change in policy adding an L7 policy applicable to that connection. While this is a bug that has surfaced in CI, this bug is less likely to be hit when policies are more stable. Given this we need further discussion about backporting this bug fix to the stable releases.

Fixes: #27762 (see https://github.com/cilium/cilium/issues/27762#issuecomment-2118311808)

```release-note
Datapath conntrack entries for reopened connections are fully reinitialized to fix rare L7 proxy redirect failures.
```
