### PR TITLE
CNI: Update skel.PluginMain to skel.PluginMainFunc for cni 1.2.0

### DIFF
--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -19,9 +19,12 @@ func init() {
 
 func main() {
 	c := cmd.NewCmd()
-	skel.PluginMain(c.Add,
-		c.Check,
-		c.Del,
+	funcs := skel.CNIFuncs{
+		Add:   c.Add,
+		Del:   c.Del,
+		Check: c.Check,
+	}
+	skel.PluginMainFuncs(funcs,
 		cniVersion.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0"),
 		"Cilium CNI plugin "+version.Version)
 }


### PR DESCRIPTION
[CNI: Update skel.PluginMain to skel.PluginMainFunc](https://github.com/cilium/cilium/pull/32618/commits/8b2f09cda099c8bcff66d25ff63ea9f55f89bc1f) 

Deprecated: Use github.com/containernetworking/cni/pkg/skel.PluginMainFuncs instead.
https://github.com/containernetworking/cni/blob/c04330ee9e0bb932e1e3eda757813e2f212e746b/pkg/skel/skel.go#L431C1-L432C1

Upstream release: https://github.com/containernetworking/cni/releases/tag/v1.2.0