### PR TITLE
Decouple k8s client heartbeat from connection timeout and keep alive

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -259,6 +259,8 @@ cilium-agent [flags]
       --join-cluster                                              Join a Cilium cluster via kvstore registration
       --k8s-api-server string                                     Kubernetes API server URL
       --k8s-client-burst int                                      Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration                 Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                    Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                                    Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                                Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -67,6 +67,8 @@ cilium-agent hive [flags]
       --iptables-random-fully                                     Set iptables flag random-fully on masquerading rules
       --k8s-api-server string                                     Kubernetes API server URL
       --k8s-client-burst int                                      Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration                 Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                    Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                                    Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                                Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -72,6 +72,8 @@ cilium-agent hive dot-graph [flags]
       --iptables-random-fully                                     Set iptables flag random-fully on masquerading rules
       --k8s-api-server string                                     Kubernetes API server URL
       --k8s-client-burst int                                      Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration                 Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                    Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                                    Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                                Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-dbg_build-config.md
+++ b/Documentation/cmdref/cilium-dbg_build-config.md
@@ -11,19 +11,21 @@ cilium-dbg build-config --node-name $K8S_NODE_NAME [flags]
 ### Options
 
 ```
-      --allow-config-keys strings        List of configuration keys that are allowed to be overridden (e.g. set from not the first source. Takes precedence over deny-config-keys
-      --deny-config-keys strings         List of configuration keys that are not allowed to be overridden (e.g. set from not the first source. If allow-config-keys is set, this field is ignored
-      --dest string                      Destination directory to write the fully-resolved configuration. (default "/tmp/cilium/config-map")
-      --enable-k8s                       Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery         Enable discovery of Kubernetes API groups and resources with the discovery API
-  -h, --help                             help for build-config
-      --k8s-api-server string            Kubernetes API server URL
-      --k8s-client-burst int             Burst value allowed for the K8s client
-      --k8s-client-qps float32           Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration   Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string       Absolute path of the kubernetes kubeconfig file
-      --node-name string                 The name of the node on which we are running. Also set via K8S_NODE_NAME environment.
-      --source strings                   Ordered list of configuration sources. Supported values: config-map:<namespace>/name - a ConfigMap with <name>, optionally in namespace <namespace>. cilium-node-config:<NAMESPACE> - any CiliumNodeConfigs in namespace <NAMESPACE>.  node:<NODENAME> - Annotations on the node. Namespace and nodename are optional (default [config-map:cilium-config,cilium-node-config:])
+      --allow-config-keys strings                   List of configuration keys that are allowed to be overridden (e.g. set from not the first source. Takes precedence over deny-config-keys
+      --deny-config-keys strings                    List of configuration keys that are not allowed to be overridden (e.g. set from not the first source. If allow-config-keys is set, this field is ignored
+      --dest string                                 Destination directory to write the fully-resolved configuration. (default "/tmp/cilium/config-map")
+      --enable-k8s                                  Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                    Enable discovery of Kubernetes API groups and resources with the discovery API
+  -h, --help                                        help for build-config
+      --k8s-api-server string                       Kubernetes API server URL
+      --k8s-client-burst int                        Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration   Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration      Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-qps float32                      Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration              Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                  Absolute path of the kubernetes kubeconfig file
+      --node-name string                            The name of the node on which we are running. Also set via K8S_NODE_NAME environment.
+      --source strings                              Ordered list of configuration sources. Supported values: config-map:<namespace>/name - a ConfigMap with <name>, optionally in namespace <namespace>. cilium-node-config:<NAMESPACE> - any CiliumNodeConfigs in namespace <NAMESPACE>.  node:<NODENAME> - Annotations on the node. Namespace and nodename are optional (default [config-map:cilium-config,cilium-node-config:])
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_preflight_migrate-identity.md
+++ b/Documentation/cmdref/cilium-dbg_preflight_migrate-identity.md
@@ -22,16 +22,18 @@ cilium-dbg preflight migrate-identity [flags]
 ### Options
 
 ```
-      --enable-k8s                       Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery         Enable discovery of Kubernetes API groups and resources with the discovery API
-  -h, --help                             help for migrate-identity
-      --k8s-api-server string            Kubernetes API server URL
-      --k8s-client-burst int             Burst value allowed for the K8s client
-      --k8s-client-qps float32           Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration   Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string       Absolute path of the kubernetes kubeconfig file
-      --kvstore string                   Key-value store type
-      --kvstore-opt map                  Key-value store options e.g. etcd.address=127.0.0.1:4001
+      --enable-k8s                                  Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                    Enable discovery of Kubernetes API groups and resources with the discovery API
+  -h, --help                                        help for migrate-identity
+      --k8s-api-server string                       Kubernetes API server URL
+      --k8s-client-burst int                        Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration   Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration      Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-qps float32                      Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration              Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                  Absolute path of the kubernetes kubeconfig file
+      --kvstore string                              Key-value store type
+      --kvstore-opt map                             Key-value store options e.g. etcd.address=127.0.0.1:4001
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_preflight_validate-cnp.md
+++ b/Documentation/cmdref/cilium-dbg_preflight_validate-cnp.md
@@ -18,14 +18,16 @@ cilium-dbg preflight validate-cnp [flags]
 ### Options
 
 ```
-      --enable-k8s                       Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery         Enable discovery of Kubernetes API groups and resources with the discovery API
-  -h, --help                             help for validate-cnp
-      --k8s-api-server string            Kubernetes API server URL
-      --k8s-client-burst int             Burst value allowed for the K8s client
-      --k8s-client-qps float32           Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration   Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string       Absolute path of the kubernetes kubeconfig file
+      --enable-k8s                                  Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                    Enable discovery of Kubernetes API groups and resources with the discovery API
+  -h, --help                                        help for validate-cnp
+      --k8s-api-server string                       Kubernetes API server URL
+      --k8s-client-burst int                        Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration   Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration      Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-qps float32                      Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration              Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                  Absolute path of the kubernetes kubeconfig file
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -83,6 +83,8 @@ cilium-operator-alibabacloud [flags]
       --ipam string                                          Backend to use for IPAM (default "alibabacloud")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                               Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -62,6 +62,8 @@ cilium-operator-alibabacloud hive [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                               Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -67,6 +67,8 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                               Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -91,6 +91,8 @@ cilium-operator-aws [flags]
       --ipam string                                          Backend to use for IPAM (default "eni")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                               Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -62,6 +62,8 @@ cilium-operator-aws hive [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                               Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -67,6 +67,8 @@ cilium-operator-aws hive dot-graph [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                               Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -86,6 +86,8 @@ cilium-operator-azure [flags]
       --ipam string                                          Backend to use for IPAM (default "azure")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                               Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -62,6 +62,8 @@ cilium-operator-azure hive [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                               Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -67,6 +67,8 @@ cilium-operator-azure hive dot-graph [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                               Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -82,6 +82,8 @@ cilium-operator-generic [flags]
       --ipam string                                          Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                               Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -62,6 +62,8 @@ cilium-operator-generic hive [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                               Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -67,6 +67,8 @@ cilium-operator-generic hive dot-graph [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                               Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -96,6 +96,8 @@ cilium-operator [flags]
       --ipam string                                          Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                               Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -62,6 +62,8 @@ cilium-operator hive [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                               Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -67,6 +67,8 @@ cilium-operator hive dot-graph [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
+      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-client-qps float32                               Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file

--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -379,12 +379,12 @@ func (c *compositeClientset) waitForConn(ctx context.Context) error {
 }
 
 func setDialer(cfg Config, restConfig *rest.Config) func() {
-	if cfg.K8sHeartbeatTimeout == 0 {
+	if cfg.K8sClientConnectionTimeout == 0 || cfg.K8sClientConnectionKeepAlive == 0 {
 		return func() {}
 	}
 	ctx := (&net.Dialer{
-		Timeout:   cfg.K8sHeartbeatTimeout,
-		KeepAlive: cfg.K8sHeartbeatTimeout,
+		Timeout:   cfg.K8sClientConnectionTimeout,
+		KeepAlive: cfg.K8sClientConnectionKeepAlive,
 	}).DialContext
 	dialer := connrotation.NewDialer(ctx)
 	restConfig.Dial = dialer.DialContext

--- a/pkg/k8s/client/config.go
+++ b/pkg/k8s/client/config.go
@@ -32,6 +32,12 @@ type Config struct {
 	// K8sClientBurst is the burst value allowed for the K8s client. Defaults to k8s client defaults.
 	K8sClientBurst int
 
+	// K8sClientConnectionTimeout configures the timeout for K8s client connections.
+	K8sClientConnectionTimeout time.Duration
+
+	// K8sClientConnectionKeepAlive configures the keep alive duration for K8s client connections.
+	K8sClientConnectionKeepAlive time.Duration
+
 	// K8sHeartbeatTimeout configures the timeout for apiserver heartbeat
 	K8sHeartbeatTimeout time.Duration
 
@@ -40,13 +46,15 @@ type Config struct {
 }
 
 var defaultConfig = Config{
-	EnableK8s:             true,
-	K8sAPIServer:          "",
-	K8sKubeConfigPath:     "",
-	K8sClientQPS:          defaults.K8sClientQPSLimit,
-	K8sClientBurst:        defaults.K8sClientBurst,
-	K8sHeartbeatTimeout:   30 * time.Second,
-	EnableK8sAPIDiscovery: defaults.K8sEnableAPIDiscovery,
+	EnableK8s:                    true,
+	K8sAPIServer:                 "",
+	K8sKubeConfigPath:            "",
+	K8sClientQPS:                 defaults.K8sClientQPSLimit,
+	K8sClientBurst:               defaults.K8sClientBurst,
+	K8sClientConnectionTimeout:   30 * time.Second,
+	K8sClientConnectionKeepAlive: 30 * time.Second,
+	K8sHeartbeatTimeout:          30 * time.Second,
+	EnableK8sAPIDiscovery:        defaults.K8sEnableAPIDiscovery,
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {
@@ -55,6 +63,8 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 	flags.String(option.K8sKubeConfigPath, def.K8sKubeConfigPath, "Absolute path of the kubernetes kubeconfig file")
 	flags.Float32(option.K8sClientQPSLimit, def.K8sClientQPS, "Queries per second limit for the K8s client")
 	flags.Int(option.K8sClientBurst, def.K8sClientBurst, "Burst value allowed for the K8s client")
+	flags.Duration(option.K8sClientConnectionTimeout, def.K8sClientConnectionTimeout, "Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0")
+	flags.Duration(option.K8sClientConnectionKeepAlive, def.K8sClientConnectionKeepAlive, "Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0")
 	flags.Duration(option.K8sHeartbeatTimeout, def.K8sHeartbeatTimeout, "Configures the timeout for api-server heartbeat, set to 0 to disable")
 	flags.Bool(option.K8sEnableAPIDiscovery, def.EnableK8sAPIDiscovery, "Enable discovery of Kubernetes API groups and resources with the discovery API")
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1059,6 +1059,12 @@ const (
 	// HubbleDropEventsReasons controls which drop reasons to emit events for
 	HubbleDropEventsReasons = "hubble-drop-events-reasons"
 
+	// K8sClientConnectionTimeout configures the timeout for K8s client connections.
+	K8sClientConnectionTimeout = "k8s-client-connection-timeout"
+
+	// K8sClientConnectionKeepAlive configures the keep alive duration for K8s client connections.
+	K8sClientConnectionKeepAlive = "k8s-client-connection-keep-alive"
+
 	// K8sHeartbeatTimeout configures the timeout for apiserver heartbeat
 	K8sHeartbeatTimeout = "k8s-heartbeat-timeout"
 


### PR DESCRIPTION
The main reason to introduce this is to be able to increase the heartbeat interval without affecting the k8s client connection settings.

It also allows the possibility to disable heartbeat, by setting `k8s-heartbeat-timeout` to 0, without disable the k8s client itself.

```release-note
When upgrading, users can experience a change to their configuration if they were overriding the `k8s-heartbeat-timeout` flag.
K8s client timeout and keep alive are no longer getting values from the `k8s-heartbeat-timeout` flag, but have default values (30 seconds).
```

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>
