### PR TITLE
bpf: add test for encrypted overlay

### DIFF
--- a/bpf/lib/tunnel.h
+++ b/bpf/lib/tunnel.h
@@ -83,4 +83,10 @@ tunnel_vni_to_sec_identity(__be32 vni)
 	return bpf_ntohl(vni) >> 8;
 }
 
+static __always_inline __be32
+sec_identity_to_tunnel_vni(__u32 sec_identity)
+{
+	return bpf_htonl(sec_identity << 8);
+}
+
 #endif /* __LIB_TUNNEL_H_ */

--- a/bpf/tests/hairpin_sctp_flow.c
+++ b/bpf/tests/hairpin_sctp_flow.c
@@ -100,7 +100,7 @@ int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 	/* Add an IPCache entry for pod 1 */
 	ipcache_v4_add_entry(v4_pod_one, 0, 112233, 0, 0);
 
-	endpoint_v4_add_entry(v4_pod_one, 0, 0, 0, NULL, NULL);
+	endpoint_v4_add_entry(v4_pod_one, 0, 0, 0, 0, NULL, NULL);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, 0);

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
@@ -192,7 +192,7 @@ int from_overlay_syn_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "01_from_overlay_syn")
 int from_overlay_syn_setup(struct __ctx_buff *ctx)
 {
-	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFINDEX, 0, 0,
+	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFINDEX, 0, 0, 0,
 			      (__u8 *)BACKEND_MAC, (__u8 *)BACKEND_ROUTER_MAC);
 
 	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);

--- a/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
@@ -286,7 +286,7 @@ int from_overlay_synack_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "02_from_overlay_synack")
 int from_overlay_synack_setup(struct __ctx_buff *ctx)
 {
-	endpoint_v4_add_entry(CLIENT_IP, CLIENT_IFINDEX, 0, 0,
+	endpoint_v4_add_entry(CLIENT_IP, CLIENT_IFINDEX, 0, 0, 0,
 			      (__u8 *)CLIENT_MAC, (__u8 *)CLIENT_ROUTER_MAC);
 
 	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);

--- a/bpf/tests/ipsec_from_lxc_generic.h
+++ b/bpf/tests/ipsec_from_lxc_generic.h
@@ -18,6 +18,7 @@
 #include "bpf_lxc.c"
 
 #include "lib/ipcache.h"
+#include "lib/node.h"
 #include "lib/policy.h"
 
 #define FROM_CONTAINER 0
@@ -122,15 +123,7 @@ int ipv4_from_lxc_encrypt_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "02_ipv4_from_lxc_encrypt")
 int ipv4_from_lxc_encrypt_setup(struct __ctx_buff *ctx)
 {
-	struct node_key node_ip = {};
-	struct node_value node_value = {
-		.id = NODE_ID,
-		.spi = 0,
-	};
-
-	node_ip.family = ENDPOINT_KEY_IPV4;
-	node_ip.ip4 = v4_node_two;
-	map_update_elem(&NODE_MAP_V2, &node_ip, &node_value, BPF_ANY);
+	node_v4_add_entry(v4_node_two, NODE_ID, 0);
 
 	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
 	return TEST_ERROR;
@@ -330,15 +323,7 @@ int ipv6_from_lxc_encrypt_setup(struct __ctx_buff *ctx)
 
 	map_update_elem(&ENCRYPT_MAP, &encrypt_key, &encrypt_value, BPF_ANY);
 
-	struct node_key node_ip = {};
-	struct node_value node_value = {
-		.id = NODE_ID,
-		.spi = 0,
-	};
-
-	node_ip.family = ENDPOINT_KEY_IPV4;
-	node_ip.ip4 = v4_node_two;
-	map_update_elem(&NODE_MAP_V2, &node_ip, &node_value, BPF_ANY);
+	node_v4_add_entry(v4_node_two, NODE_ID, 0);
 
 	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
 	return TEST_ERROR;

--- a/bpf/tests/ipsec_from_network_generic.h
+++ b/bpf/tests/ipsec_from_network_generic.h
@@ -48,6 +48,7 @@ static volatile const __u8 *DEST_NODE_MAC = mac_four;
 #include "bpf_network.c"
 
 #include "lib/endpoint.h"
+#include "lib/node.h"
 
 #define FROM_NETWORK 0
 #define ESP_SEQUENCE 69865
@@ -102,18 +103,10 @@ int ipv4_not_decrypted_ipsec_from_network_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "ipv4_not_decrypted_ipsec_from_network")
 int ipv4_not_decrypted_ipsec_from_network_setup(struct __ctx_buff *ctx)
 {
-	struct node_key node_ip = {};
-	struct node_value node_value = {
-		.id = NODE_ID,
-		.spi = 0,
-	};
-
 	/* We need to populate the node ID map because we'll lookup into it on
 	 * ingress to find the node ID to use to match against XFRM IN states.
 	 */
-	node_ip.family = ENDPOINT_KEY_IPV4;
-	node_ip.ip4 = v4_pod_one;
-	map_update_elem(&NODE_MAP_V2, &node_ip, &node_value, BPF_ANY);
+	node_v4_add_entry(v4_pod_one, NODE_ID, 0);
 
 	tail_call_static(ctx, entry_call_map, FROM_NETWORK);
 	return TEST_ERROR;

--- a/bpf/tests/ipsec_from_network_generic.h
+++ b/bpf/tests/ipsec_from_network_generic.h
@@ -348,7 +348,7 @@ int ipv4_decrypted_ipsec_from_network_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "ipv4_decrypted_ipsec_from_network")
 int ipv4_decrypted_ipsec_from_network_setup(struct __ctx_buff *ctx)
 {
-	endpoint_v4_add_entry(v4_pod_two, DEST_IFINDEX, DEST_LXC_ID, 0,
+	endpoint_v4_add_entry(v4_pod_two, DEST_IFINDEX, DEST_LXC_ID, 0, 0,
 			      (__u8 *)DEST_EP_MAC, (__u8 *)DEST_NODE_MAC);
 
 	ctx->mark = MARK_MAGIC_DECRYPT;
@@ -453,7 +453,7 @@ SETUP("tc", "ipv6_decrypted_ipsec_from_network")
 int ipv6_decrypted_ipsec_from_network_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v6_add_entry((union v6addr *)v6_pod_two, DEST_IFINDEX, DEST_LXC_ID,
-			      0, (__u8 *)DEST_EP_MAC, (__u8 *)DEST_NODE_MAC);
+			      0, 0, (__u8 *)DEST_EP_MAC, (__u8 *)DEST_NODE_MAC);
 
 	ctx->mark = MARK_MAGIC_DECRYPT;
 	tail_call_static(ctx, entry_call_map, FROM_NETWORK);

--- a/bpf/tests/ipsec_from_overlay_generic.h
+++ b/bpf/tests/ipsec_from_overlay_generic.h
@@ -81,6 +81,7 @@ static volatile const __u8 *DEST_NODE_MAC = mac_four;
 
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"
+#include "lib/node.h"
 
 #define FROM_OVERLAY 0
 #define ESP_SEQUENCE 69865
@@ -135,18 +136,10 @@ int ipv4_not_decrypted_ipsec_from_overlay_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "ipv4_not_decrypted_ipsec_from_overlay")
 int ipv4_not_decrypted_ipsec_from_overlay_setup(struct __ctx_buff *ctx)
 {
-	struct node_key node_ip = {};
-	struct node_value node_value = {
-		.id = NODE_ID,
-		.spi = 0,
-	};
-
 	/* We need to populate the node ID map because we'll lookup into it on
 	 * ingress to find the node ID to use to match against XFRM IN states.
 	 */
-	node_ip.family = ENDPOINT_KEY_IPV4;
-	node_ip.ip4 = v4_pod_one;
-	map_update_elem(&NODE_MAP_V2, &node_ip, &node_value, BPF_ANY);
+	node_v4_add_entry(v4_pod_one, NODE_ID, 0);
 
 	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);
 	return TEST_ERROR;

--- a/bpf/tests/ipsec_from_overlay_generic.h
+++ b/bpf/tests/ipsec_from_overlay_generic.h
@@ -381,7 +381,7 @@ int ipv4_decrypted_ipsec_from_overlay_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "ipv4_decrypted_ipsec_from_overlay")
 int ipv4_decrypted_ipsec_from_overlay_setup(struct __ctx_buff *ctx)
 {
-	endpoint_v4_add_entry(v4_pod_two, DEST_IFINDEX, DEST_LXC_ID, 0,
+	endpoint_v4_add_entry(v4_pod_two, DEST_IFINDEX, DEST_LXC_ID, 0, 0,
 			      (__u8 *)DEST_EP_MAC, (__u8 *)DEST_NODE_MAC);
 
 	ctx->mark = MARK_MAGIC_DECRYPT;
@@ -486,7 +486,7 @@ SETUP("tc", "ipv6_decrypted_ipsec_from_overlay")
 int ipv6_decrypted_ipsec_from_overlay_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v6_add_entry((union v6addr *)v6_pod_two, DEST_IFINDEX, DEST_LXC_ID,
-			      0, (__u8 *)DEST_EP_MAC, (__u8 *)DEST_NODE_MAC);
+			      0, 0, (__u8 *)DEST_EP_MAC, (__u8 *)DEST_NODE_MAC);
 
 	ctx->mark = MARK_MAGIC_DECRYPT;
 	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);

--- a/bpf/tests/ipv6_ndp_from_netdev_test.c
+++ b/bpf/tests/ipv6_ndp_from_netdev_test.c
@@ -63,7 +63,7 @@ int ipv6_from_netdev_ns_for_pod_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "01_ipv6_from_netdev_ns_for_pod")
 int ipv6_from_netdev_ns_for_pod_setup(struct __ctx_buff *ctx)
 {
-	endpoint_v6_add_entry((union v6addr *)v6_pod_three, 0, 0, 0,
+	endpoint_v6_add_entry((union v6addr *)v6_pod_three, 0, 0, 0, 0,
 			      (__u8 *)mac_three, (__u8 *)mac_two);
 	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
 	return TEST_ERROR;
@@ -184,7 +184,7 @@ int ipv6_from_netdev_ns_for_node_ip_setup(struct __ctx_buff *ctx)
 	union v6addr node_ip;
 
 	BPF_V6(node_ip, HOST_IP);
-	endpoint_v6_add_entry((union v6addr *)&node_ip, 0, 0, ENDPOINT_F_HOST,
+	endpoint_v6_add_entry((union v6addr *)&node_ip, 0, 0, ENDPOINT_F_HOST, 0,
 			      (__u8 *)mac_three, (__u8 *)mac_two);
 	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
 	return TEST_ERROR;

--- a/bpf/tests/lib/endpoint.h
+++ b/bpf/tests/lib/endpoint.h
@@ -2,7 +2,7 @@
 /* Copyright Authors of Cilium */
 
 static __always_inline void
-endpoint_v4_add_entry(__be32 addr, __u32 ifindex, __u16 lxc_id, __u32 flags,
+endpoint_v4_add_entry(__be32 addr, __u32 ifindex, __u16 lxc_id, __u32 flags, __u32 sec_id,
 		      const __u8 *ep_mac_addr, const __u8 *node_mac_addr)
 {
 	struct endpoint_key key = {
@@ -13,6 +13,7 @@ endpoint_v4_add_entry(__be32 addr, __u32 ifindex, __u16 lxc_id, __u32 flags,
 		.ifindex = ifindex,
 		.lxc_id = lxc_id,
 		.flags = flags,
+		.sec_id = sec_id,
 	};
 
 	if (ep_mac_addr)
@@ -25,7 +26,8 @@ endpoint_v4_add_entry(__be32 addr, __u32 ifindex, __u16 lxc_id, __u32 flags,
 
 static __always_inline void
 endpoint_v6_add_entry(const union v6addr *addr, __u32 ifindex, __u16 lxc_id,
-		      __u32 flags, const __u8 *ep_mac_addr, const __u8 *node_mac_addr)
+		      __u32 flags, __u32 sec_id,
+		      const __u8 *ep_mac_addr, const __u8 *node_mac_addr)
 {
 	struct endpoint_key key = {
 		.family = ENDPOINT_KEY_IPV6,
@@ -35,6 +37,7 @@ endpoint_v6_add_entry(const union v6addr *addr, __u32 ifindex, __u16 lxc_id,
 		.ifindex = ifindex,
 		.lxc_id = lxc_id,
 		.flags = flags,
+		.sec_id = sec_id,
 	};
 
 	memcpy(&key.ip6, addr, sizeof(*addr));

--- a/bpf/tests/lib/node.h
+++ b/bpf/tests/lib/node.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+static __always_inline void
+node_v4_add_entry(__be32 node_ip, __u16 node_id, __u8 spi)
+{
+	struct node_key key = {
+		.family = ENDPOINT_KEY_IPV4,
+		.ip4 = node_ip,
+	};
+	struct node_value value = {
+		.id = node_id,
+		.spi = spi,
+	};
+
+	map_update_elem(&NODE_MAP_V2, &key, &value, BPF_ANY);
+}

--- a/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
+++ b/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
@@ -146,7 +146,7 @@ int nodeport_geneve_dsr_lb_xdp1_local_backend_setup(struct __ctx_buff *ctx)
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
 
 	/* add local backend */
-	endpoint_v4_add_entry(BACKEND_IP_LOCAL, 0, 0, 0,
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, 0, 0, 0, 0,
 			      (__u8 *)local_backend_mac, (__u8 *)node_mac);
 
 	ipcache_v4_add_entry(BACKEND_IP_LOCAL, 0, 112233, 0, 0);

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -664,6 +664,22 @@ pktgen__push_ipv4_udp_packet(struct pktgen *builder,
 	return l4;
 }
 
+static __always_inline struct vxlanhdr *
+pktgen__push_ipv4_vxlan_packet(struct pktgen *builder,
+			       __u8 *smac, __u8 *dmac,
+			       __be32 saddr, __be32 daddr,
+			       __be16 sport, __be16 dport)
+{
+	struct udphdr *l4;
+
+	l4 = pktgen__push_ipv4_udp_packet(builder, smac, dmac, saddr, daddr,
+					  sport, dport);
+	if (!l4)
+		return NULL;
+
+	return pktgen__push_default_vxlanhdr(builder);
+}
+
 static __always_inline struct tcphdr *
 pktgen__push_ipv6_tcp_packet(struct pktgen *builder,
 			     __u8 *smac, __u8 *dmac,

--- a/bpf/tests/skip_tunnel_nodeport_masq.c
+++ b/bpf/tests/skip_tunnel_nodeport_masq.c
@@ -125,12 +125,12 @@ setup(struct __ctx_buff *ctx, bool v4, bool flag_skip_tunnel)
 	 */
 
 	if (v4) {
-		endpoint_v4_add_entry(SRC_IPV4, 0, 0, 0, (__u8 *)SRC_MAC, (__u8 *)SRC_MAC);
+		endpoint_v4_add_entry(SRC_IPV4, 0, 0, 0, 0, (__u8 *)SRC_MAC, (__u8 *)SRC_MAC);
 		ipcache_v4_add_entry_with_flags(DST_IPV4,
 						0, REMOTE_NODE_ID, 0,
 						0, flag_skip_tunnel);
 	} else {
-		endpoint_v6_add_entry((union v6addr *)SRC_IPV6, 0, 0, 0,
+		endpoint_v6_add_entry((union v6addr *)SRC_IPV6, 0, 0, 0, 0,
 				      (__u8 *)SRC_MAC, (__u8 *)SRC_MAC);
 		ipcache_v6_add_entry_with_flags((union v6addr *)DST_IPV6,
 						0, REMOTE_NODE_ID, 0,

--- a/bpf/tests/tc_host_encrypted_overlay.c
+++ b/bpf/tests/tc_host_encrypted_overlay.c
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+
+/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
+#define ETH_HLEN 14
+
+/* Enable code paths under test */
+#define ENABLE_IPV4			1
+#define ENABLE_IPSEC			1
+#define ENABLE_ENCRYPTED_OVERLAY	1
+
+#define TUNNEL_MODE			1
+#define TUNNEL_PROTOCOL			TUNNEL_PROTOCOL_VXLAN
+#define TUNNEL_PORT			8472
+#define ENCAP_IFINDEX			25
+
+#define NODE1_IP			v4_ext_one
+#define NODE1_TUNNEL_SPORT		1337
+
+#define NODE2_IP			v4_ext_two
+#define NODE1_SPI			5
+#define NODE2_ID			123
+#define NODE2_SPI			6
+
+#define POD1_IP				v4_pod_one
+#define POD1_IFACE			100
+#define POD2_IP				v4_pod_two
+
+#define POD1_SEC_IDENTITY		112233
+
+static volatile const __u8 *node1_mac = mac_one;
+static volatile const __u8 *node2_mac = mac_two;
+
+static volatile const __u8 *pod1_mac = mac_three;
+static volatile const __u8 *pod2_mac = mac_four;
+
+#define ctx_redirect mock_ctx_redirect
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
+{
+	if ((__u32)ifindex != ctx->ifindex)
+		return CTX_ACT_DROP;
+	if (flags != BPF_F_INGRESS)
+		return CTX_ACT_DROP;
+
+	return CTX_ACT_REDIRECT;
+}
+
+#define SECCTX_FROM_IPCACHE 1
+
+#include "config_replacement.h"
+
+#include "bpf_host.c"
+
+#include "lib/endpoint.h"
+#include "lib/node.h"
+
+#define TO_NETDEV	0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[TO_NETDEV] = &cil_to_netdev,
+	},
+};
+
+PKTGEN("tc", "tc_host_encrypted_overlay_01")
+int host_encrypted_overlay_01_pktgen(struct __ctx_buff *ctx)
+{
+	struct vxlanhdr *vxlan;
+	struct iphdr *inner_l3;
+	struct pktgen builder;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	vxlan = pktgen__push_ipv4_vxlan_packet(&builder,
+					       (__u8 *)node1_mac, (__u8 *)node2_mac,
+					       NODE1_IP, NODE2_IP,
+					       NODE1_TUNNEL_SPORT, TUNNEL_PORT);
+	if (!vxlan)
+		return TEST_ERROR;
+
+	vxlan->vx_vni = sec_identity_to_tunnel_vni(ENCRYPTED_OVERLAY_ID);
+
+	inner_l3 = pktgen__push_ipv4_packet(&builder,
+					    (__u8 *)pod1_mac, (__u8 *)pod2_mac,
+					    POD1_IP, POD2_IP);
+	if (!inner_l3)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_host_encrypted_overlay_01")
+int tc_host_encrypted_overlay_01_setup(struct __ctx_buff *ctx)
+{
+	struct encrypt_config encrypt_value = { .encrypt_key = NODE1_SPI };
+	__u32 encrypt_key = 0;
+
+	endpoint_v4_add_entry(POD1_IP, POD1_IFACE, 0, 0, POD1_SEC_IDENTITY,
+			      (__u8 *)pod1_mac, (__u8 *)node1_mac);
+	node_v4_add_entry(NODE2_IP, NODE2_ID, NODE2_SPI);
+	map_update_elem(&ENCRYPT_MAP, &encrypt_key, &encrypt_value, BPF_ANY);
+
+	ctx_set_overlay_mark(ctx);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_host_encrypted_overlay_01")
+int tc_host_encrypted_overlay_01_check(const struct __ctx_buff *ctx)
+{
+	struct vxlanhdr *vxlan;
+	void *data, *data_end;
+	__u32 *status_code;
+	struct udphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(*l2) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(*l2);
+	if ((void *)l3 + sizeof(*l3) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(*l3);
+	if ((void *)l4 + sizeof(*l4) > data_end)
+		test_fatal("l4 out of bounds");
+
+	vxlan = (void *)l4 + sizeof(*l4);
+	if ((void *)vxlan + sizeof(*vxlan) > data_end)
+		test_fatal("vxlan out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)node1_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the node MAC")
+	if (memcmp(l2->h_dest, (__u8 *)node1_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC has not been updated")
+
+	if (l3->saddr != NODE1_IP)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != NODE2_IP)
+		test_fatal("dst IP has changed");
+
+	if (l4->source != NODE1_TUNNEL_SPORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != TUNNEL_PORT)
+		test_fatal("dst port has changed");
+
+	if (tunnel_vni_to_sec_identity(vxlan->vx_vni) != POD1_SEC_IDENTITY)
+		test_fatal("VNI has not been updated");
+
+	assert(ctx->mark == (or_encrypt_key(NODE1_SPI) | (NODE2_ID << 16)));
+	assert(ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY) == POD1_SEC_IDENTITY);
+
+	test_finish();
+}

--- a/bpf/tests/tc_nodeport_l3_dev.c
+++ b/bpf/tests/tc_nodeport_l3_dev.c
@@ -109,7 +109,7 @@ int ipv4_l3_to_l2_fast_redirect_setup(struct __ctx_buff *ctx)
 	void *data_end = (void *)(long)ctx->data_end;
 	__u64 flags = BPF_F_ADJ_ROOM_FIXED_GSO;
 
-	endpoint_v4_add_entry(TEST_IP_LOCAL, 0, TEST_LXC_ID_LOCAL, 0,
+	endpoint_v4_add_entry(TEST_IP_LOCAL, 0, TEST_LXC_ID_LOCAL, 0, 0,
 			      (__u8 *)ep_mac, (__u8 *)node_mac);
 
 	/* As commented in PKTGEN, now we strip the L2 header. Bpf helper
@@ -237,7 +237,7 @@ int ipv6_l3_to_l2_fast_redirect_setup(struct __ctx_buff *ctx)
 	void *data_end = (void *)(long)ctx->data_end;
 	__u64 flags = BPF_F_ADJ_ROOM_FIXED_GSO;
 
-	endpoint_v6_add_entry((union v6addr *)TEST_IPV6_LOCAL, 0, TEST_LXC_ID_LOCAL, 0,
+	endpoint_v6_add_entry((union v6addr *)TEST_IPV6_LOCAL, 0, TEST_LXC_ID_LOCAL, 0, 0,
 			      (__u8 *)ep_mac, (__u8 *)node_mac);
 
 	/* As commented in PKTGEN, now we strip the L2 header. Bpf helper

--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -167,7 +167,7 @@ SETUP("tc", "tc_nodeport_dsr_backend")
 int nodeport_dsr_backend_setup(struct __ctx_buff *ctx)
 {
 	/* add local backend */
-	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFACE, 0, 0,
+	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFACE, 0, 0, 0,
 			      (__u8 *)backend_mac, (__u8 *)node_mac);
 
 	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, 0, 0);

--- a/bpf/tests/tc_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_backend.c
@@ -98,7 +98,7 @@ int nodeport_nat_backend_setup(struct __ctx_buff *ctx)
 	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, 1, 124,
 			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
 
-	endpoint_v4_add_entry(BACKEND_IP, 0, 0, 0,
+	endpoint_v4_add_entry(BACKEND_IP, 0, 0, 0, 0,
 			      (__u8 *)backend_mac, (__u8 *)node_mac);
 
 	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, 0, 0);

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -175,7 +175,7 @@ int nodeport_local_backend_setup(struct __ctx_buff *ctx)
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
 
 	/* add local backend */
-	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, 0, 0,
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, 0, 0, 0,
 			      (__u8 *)local_backend_mac, (__u8 *)node_mac);
 
 	ipcache_v4_add_entry(BACKEND_IP_LOCAL, 0, 112233, 0, 0);

--- a/bpf/tests/tc_nodeport_lb6_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb6_dsr_backend.c
@@ -129,7 +129,7 @@ int nodeport_dsr_backend_setup(struct __ctx_buff *ctx)
 	union v6addr backend_ip = BACKEND_IP;
 
 	/* add local backend */
-	endpoint_v6_add_entry(&backend_ip, 0, 0, 0,
+	endpoint_v6_add_entry(&backend_ip, 0, 0, 0, 0,
 			      (__u8 *)backend_mac, (__u8 *)node_mac);
 
 	ipcache_v6_add_entry(&backend_ip, 0, 112233, 0, 0);

--- a/bpf/tests/tc_nodeport_lb_terminating_backend.c
+++ b/bpf/tests/tc_nodeport_lb_terminating_backend.c
@@ -129,7 +129,7 @@ int tc_nodeport_lb_terminating_backend_0_setup(struct __ctx_buff *ctx)
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_UDP, 0);
 
 	/* add local backend */
-	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, 0, 0,
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, 0, 0, 0,
 			      (__u8 *)local_backend_mac, (__u8 *)node_mac);
 
 	ipcache_v4_add_entry(BACKEND_IP_LOCAL, 0, 112233, 0, 0);

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -109,7 +109,7 @@ int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 	/* Add an IPCache entry for pod 1 */
 	ipcache_v4_add_entry(v4_pod_one, 0, 112233, 0, 0);
 
-	endpoint_v4_add_entry(v4_pod_one, 0, 0, 0, NULL, NULL);
+	endpoint_v4_add_entry(v4_pod_one, 0, 0, 0, 0, NULL, NULL);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, 0);

--- a/bpf/tests/xdp_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_backend.c
@@ -93,7 +93,7 @@ int nodeport_nat_backend_setup(struct __ctx_buff *ctx)
 			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
 
 	/* add local backend */
-	endpoint_v4_add_entry(BACKEND_IP, 0, 0, 0, NULL, NULL);
+	endpoint_v4_add_entry(BACKEND_IP, 0, 0, 0, 0, NULL, NULL);
 
 	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, 0, 0);
 

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -125,7 +125,7 @@ int nodeport_local_backend_setup(struct __ctx_buff *ctx)
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
 
 	/* add local backend */
-	endpoint_v4_add_entry(BACKEND_IP_LOCAL, 0, 0, 0,
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, 0, 0, 0, 0,
 			      (__u8 *)local_backend_mac, (__u8 *)node_mac);
 	ipcache_v4_add_entry(BACKEND_IP_LOCAL, 0, 112233, 0, 0);
 


### PR DESCRIPTION
Add a full integration test for the new [encrypted overlay path](https://github.com/cilium/cilium/pull/31073) in `to-netdev`.