### PR TITLE
Formally define and validate the cluster name format

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -60,6 +60,8 @@ env:
   cilium_cli_ci_version:
   clusterName1: cluster1-${{ github.run_id }}
   clusterName2: cluster2-${{ github.run_id }}
+  ciliumClusterName1: c1
+  ciliumClusterName2: cluster2-ultra-long-name-with-all-supported-characters-01234567
   contextName1: kind-cluster1-${{ github.run_id }}
   contextName2: kind-cluster2-${{ github.run_id }}
 
@@ -408,8 +410,8 @@ jobs:
         run: |
           echo "cilium_install_clustermesh= \
             --set=clustermesh.config.enabled=true \
-            --set clustermesh.config.clusters[0].name=${{ env.clusterName1 }} \
-            --set clustermesh.config.clusters[1].name=${{ env.clusterName2 }} \
+            --set clustermesh.config.clusters[0].name=${{ env.ciliumClusterName1 }} \
+            --set clustermesh.config.clusters[1].name=${{ env.ciliumClusterName2 }} \
             ${{ steps.kvstore.outputs.cilium_install_clustermesh }} \
           " >> $GITHUB_OUTPUT
 
@@ -448,7 +450,7 @@ jobs:
           # each cluster, to workaround #24692
           cilium --context ${{ env.contextName1 }} install \
             ${{ steps.vars.outputs.cilium_install_defaults }} \
-            --helm-set cluster.name=${{ env.clusterName1 }} \
+            --helm-set cluster.name=${{ env.ciliumClusterName1 }} \
             --helm-set cluster.id=1 \
             --helm-set clustermesh.apiserver.service.nodePort=32379 \
             --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.cm-auth-mode-1 }} \
@@ -469,7 +471,7 @@ jobs:
           # each cluster, to workaround #24692
           cilium --context ${{ env.contextName2 }} install \
             ${{ steps.vars.outputs.cilium_install_defaults }} \
-            --helm-set cluster.name=${{ env.clusterName2 }} \
+            --helm-set cluster.name=${{ env.ciliumClusterName2 }} \
             --helm-set cluster.id=${{ matrix.maxConnectedClusters }} \
             --helm-set clustermesh.apiserver.service.nodePort=32380 \
             --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.cm-auth-mode-2 }} \

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -64,7 +64,7 @@ cilium-agent [flags]
       --cgroup-root string                                        Path to Cgroup2 filesystem
       --cluster-health-port int                                   TCP port for cluster-wide network connectivity health API (default 4240)
       --cluster-id uint32                                         Unique identifier of the cluster
-      --cluster-name string                                       Name of the cluster (default "default")
+      --cluster-name string                                       Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
       --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -16,7 +16,7 @@ cilium-agent hive [flags]
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --cluster-id uint32                                         Unique identifier of the cluster
-      --cluster-name string                                       Name of the cluster (default "default")
+      --cluster-name string                                       Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
       --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -22,7 +22,7 @@ cilium-agent hive dot-graph [flags]
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --cluster-id uint32                                         Unique identifier of the cluster
-      --cluster-name string                                       Name of the cluster (default "default")
+      --cluster-name string                                       Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
       --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -28,7 +28,7 @@ cilium-operator-alibabacloud [flags]
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
       --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
       --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -21,7 +21,7 @@ cilium-operator-alibabacloud hive [flags]
       --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
       --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -27,7 +27,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
       --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -31,7 +31,7 @@ cilium-operator-aws [flags]
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
       --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
       --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -21,7 +21,7 @@ cilium-operator-aws hive [flags]
       --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
       --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -27,7 +27,7 @@ cilium-operator-aws hive dot-graph [flags]
       --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
       --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -31,7 +31,7 @@ cilium-operator-azure [flags]
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
       --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
       --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -21,7 +21,7 @@ cilium-operator-azure hive [flags]
       --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
       --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -27,7 +27,7 @@ cilium-operator-azure hive dot-graph [flags]
       --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
       --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -27,7 +27,7 @@ cilium-operator-generic [flags]
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
       --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
       --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -21,7 +21,7 @@ cilium-operator-generic hive [flags]
       --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
       --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -27,7 +27,7 @@ cilium-operator-generic hive dot-graph [flags]
       --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
       --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -36,7 +36,7 @@ cilium-operator [flags]
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
       --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
       --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -21,7 +21,7 @@ cilium-operator hive [flags]
       --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
       --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -27,7 +27,7 @@ cilium-operator hive dot-graph [flags]
       --ces-write-qps-burst int                              CES work queue burst rate. Ignored when ces-enable-dynamic-rate-limit is set (default 20)
       --ces-write-qps-limit float                            CES work queue rate limit. Ignored when ces-enable-dynamic-rate-limit is set (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character). (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -461,7 +461,7 @@
      - int
      - ``0``
    * - :spelling:ignore:`cluster.name`
-     - Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE.
+     - Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE. It must be a valid RFC 1123 DNS label name: * It must contain at most 63 characters; * It must begin and end with a lower case alphanumeric character; * It may contain lower case alphanumerics and dashes between. The "default" name cannot be used if the Cluster ID is different from 0.
      - string
      - ``"default"``
    * - :spelling:ignore:`clustermesh.annotations`
@@ -981,7 +981,7 @@
      - bool
      - ``false``
    * - :spelling:ignore:`enableRuntimeDeviceDetection`
-     - Enables experimental support for the detection of new and removed datapath devices. When devices change the eBPF datapath is reloaded and services updated. If "devices" is set then only those devices, or devices matching a wildcard will be considered.   This option has been deprecated and is a no-op.
+     - Enables experimental support for the detection of new and removed datapath devices. When devices change the eBPF datapath is reloaded and services updated. If "devices" is set then only those devices, or devices matching a wildcard will be considered.  This option has been deprecated and is a no-op.
      - bool
      - ``true``
    * - :spelling:ignore:`enableXTSocketFallback`

--- a/Documentation/network/clustermesh/clustermesh.rst
+++ b/Documentation/network/clustermesh/clustermesh.rst
@@ -126,8 +126,14 @@ Specify the Cluster Name and ID
 Cilium needs to be installed onto each cluster.
 
 Each cluster must be assigned a unique human-readable name as well as a numeric
-cluster ID (1-255). It is best to assign both these attributes at installation
-time of Cilium:
+cluster ID (1-255). The cluster name must be a valid
+`RFC 1123 DNS label name <https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names>`__:
+
+* It must contain at most 63 characters;
+* It must begin and end with a lower case alphanumeric character;
+* It may contain lower case alphanumerics and dashes between.
+
+It is best to assign both the cluster name and the cluster ID at installation time:
 
  * ConfigMap options ``cluster-name`` and ``cluster-id``
  * Helm options ``cluster.name`` and ``cluster.id``

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -338,6 +338,9 @@ Annotations:
   removed in future release. The devices and the addresses Cilium considers the node's addresses
   can be inspected with the ``cilium-dbg statedb devices`` and ``cilium-dbg statedb node-addresses``
   commands.
+* The Cilium cluster name is now strictly enforced to be a valid
+  `RFC 1123 DNS label name <https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names>`__.
+  Users shall verify and update invalid Cilium cluster names before upgrading.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/cilium-dbg/cmd/troubleshoot_clustermesh.go
+++ b/cilium-dbg/cmd/troubleshoot_clustermesh.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/cilium/cilium/pkg/clustermesh/common"
+	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/kvstore"
 )
 
@@ -71,6 +72,11 @@ func TroubleshootClusterMesh(
 
 	for _, cluster := range clusters {
 		fmt.Fprintf(stdout, "\nRemote cluster %q:\n", cluster)
+
+		if err := types.ValidateClusterName(cluster); err != nil {
+			fmt.Fprintln(stdout, "❌ Invalid cluster name:", err)
+			continue
+		}
 
 		cfg, ok := cfgs[cluster]
 		if !ok {

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -165,7 +165,7 @@ contributors across the globe, there is almost always someone available to help.
 | cleanBpfState | bool | `false` | Clean all eBPF datapath state from the initContainer of the cilium-agent DaemonSet.  WARNING: Use with care! |
 | cleanState | bool | `false` | Clean all local Cilium state from the initContainer of the cilium-agent DaemonSet. Implies cleanBpfState: true.  WARNING: Use with care! |
 | cluster.id | int | `0` | Unique ID of the cluster. Must be unique across all connected clusters and in the range of 1 to 255. Only required for Cluster Mesh, may be 0 if Cluster Mesh is not used. |
-| cluster.name | string | `"default"` | Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE. |
+| cluster.name | string | `"default"` | Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE. It must be a valid RFC 1123 DNS label name: * It must contain at most 63 characters; * It must begin and end with a lower case alphanumeric character; * It may contain lower case alphanumerics and dashes between. The "default" name cannot be used if the Cluster ID is different from 0. |
 | clustermesh.annotations | object | `{}` | Annotations to be added to all top-level clustermesh objects (resources under templates/clustermesh-apiserver and templates/clustermesh-config) |
 | clustermesh.apiserver.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"clustermesh-apiserver"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for clustermesh.apiserver |
 | clustermesh.apiserver.etcd.init.extraArgs | list | `[]` | Additional arguments to `clustermesh-apiserver etcdinit`. |
@@ -295,7 +295,7 @@ contributors across the globe, there is almost always someone available to help.
 | enableIPv6Masquerade | bool | `true` | Enables masquerading of IPv6 traffic leaving the node from endpoints. |
 | enableK8sTerminatingEndpoint | bool | `true` | Configure whether to enable auto detect of terminating state for endpoints in order to support graceful termination. |
 | enableMasqueradeRouteSource | bool | `false` | Enables masquerading to the source of the route for traffic leaving the node from endpoints. |
-| enableRuntimeDeviceDetection | bool | `true` | Enables experimental support for the detection of new and removed datapath devices. When devices change the eBPF datapath is reloaded and services updated. If "devices" is set then only those devices, or devices matching a wildcard will be considered.   This option has been deprecated and is a no-op. |
+| enableRuntimeDeviceDetection | bool | `true` | Enables experimental support for the detection of new and removed datapath devices. When devices change the eBPF datapath is reloaded and services updated. If "devices" is set then only those devices, or devices matching a wildcard will be considered.  This option has been deprecated and is a no-op. |
 | enableXTSocketFallback | bool | `true` | Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: https://docs.cilium.io/en/stable/operations/system_requirements/#linux-kernel. |
 | encryption.enabled | bool | `false` | Enable transparent network encryption. |
 | encryption.ipsec.encryptedOverlay | bool | `false` | Enable IPsec encrypted overlay |

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -79,6 +79,20 @@
   {{- end }}
 {{- end }}
 
+{{/* validate cluster name */}}
+{{- if eq .Values.cluster.name "" }}
+  {{ fail "The cluster name is invalid: cannot be empty" }}
+{{- end }}
+{{- if gt (len .Values.cluster.name) 63 }}
+  {{ fail "The cluster name is invalid: must not be more than 63 characters" }}
+{{- end }}
+{{- if not (regexMatch "^([a-z0-9][-a-z0-9]*)?[a-z0-9]$" .Values.cluster.name) }}
+  {{ fail "The cluster name is invalid: must consist of lower case alphanumeric characters and '-', and must start and end with an alphanumeric character" }}
+{{- end }}
+{{- if and (eq .Values.cluster.name "default") (ne (int .Values.cluster.id) 0) }}
+  {{ fail "The cluster name is invalid: cannot use default value with cluster.id != 0" }}
+{{- end }}
+
 {{/* validate clustermesh-apiserver */}}
 {{- if .Values.clustermesh.useAPIServer }}
   {{- if ne .Values.identityAllocationMode "crd" }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -67,6 +67,11 @@ k8sClientRateLimit:
   burst:
 cluster:
   # -- Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE.
+  # It must be a valid RFC 1123 DNS label name:
+  # * It must contain at most 63 characters;
+  # * It must begin and end with a lower case alphanumeric character;
+  # * It may contain lower case alphanumerics and dashes between.
+  # The "default" name cannot be used if the Cluster ID is different from 0.
   name: default
   # -- (int) Unique ID of the cluster. Must be unique across all connected
   # clusters and in the range of 1 to 255. Only required for Cluster Mesh,
@@ -686,7 +691,7 @@ daemon:
 # -- Enables experimental support for the detection of new and removed datapath
 # devices. When devices change the eBPF datapath is reloaded and services updated.
 # If "devices" is set then only those devices, or devices matching a wildcard will
-# be considered. 
+# be considered.
 #
 # This option has been deprecated and is a no-op.
 enableRuntimeDeviceDetection: true

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -65,6 +65,11 @@ k8sClientRateLimit:
   burst:
 cluster:
   # -- Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE.
+  # It must be a valid RFC 1123 DNS label name:
+  # * It must contain at most 63 characters;
+  # * It must begin and end with a lower case alphanumeric character;
+  # * It may contain lower case alphanumerics and dashes between.
+  # The "default" name cannot be used if the Cluster ID is different from 0.
   name: default
   # -- (int) Unique ID of the cluster. Must be unique across all connected
   # clusters and in the range of 1 to 255. Only required for Cluster Mesh,
@@ -684,7 +689,7 @@ daemon:
 # -- Enables experimental support for the detection of new and removed datapath
 # devices. When devices change the eBPF datapath is reloaded and services updated.
 # If "devices" is set then only those devices, or devices matching a wildcard will
-# be considered. 
+# be considered.
 #
 # This option has been deprecated and is a no-op.
 enableRuntimeDeviceDetection: true

--- a/pkg/clustermesh/common/clustermesh.go
+++ b/pkg/clustermesh/common/clustermesh.go
@@ -150,6 +150,13 @@ func (cm *clusterMesh) add(name, path string) {
 		return
 	}
 
+	if err := types.ValidateClusterName(name); err != nil {
+		log.WithField(fieldClusterName, name).
+			WithError(fmt.Errorf("invalid cluster name: %w", err)).
+			Error("Cannot connect to remote cluster")
+		return
+	}
+
 	inserted := false
 	cm.mutex.Lock()
 	cluster, ok := cm.clusters[name]

--- a/pkg/clustermesh/types/option.go
+++ b/pkg/clustermesh/types/option.go
@@ -40,7 +40,7 @@ var DefaultClusterInfo = ClusterInfo{
 // Flags implements the cell.Flagger interface, to register the given flags.
 func (def ClusterInfo) Flags(flags *pflag.FlagSet) {
 	flags.Uint32(OptClusterID, def.ID, "Unique identifier of the cluster")
-	flags.String(OptClusterName, def.Name, "Name of the cluster")
+	flags.String(OptClusterName, def.Name, "Name of the cluster. It must be a valid RFC 1123 DNS label name (consist of at most 63 lower case alphanumeric characters and '-', start and end with an alphanumeric character).")
 	flags.Uint32(OptMaxConnectedClusters, def.MaxConnectedClusters, "Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511].")
 }
 
@@ -66,6 +66,10 @@ func (c ClusterInfo) ValidateStrict() error {
 }
 
 func (c ClusterInfo) validateName() error {
+	if err := ValidateClusterName(c.Name); err != nil {
+		return fmt.Errorf("invalid cluster name: %w", err)
+	}
+
 	if c.ID != 0 && c.Name == defaults.ClusterName {
 		return fmt.Errorf("cannot use default cluster name (%s) with option %s",
 			defaults.ClusterName, OptClusterID)

--- a/pkg/clustermesh/types/option_test.go
+++ b/pkg/clustermesh/types/option_test.go
@@ -63,6 +63,11 @@ func TestClusterInfoValidate(t *testing.T) {
 			wantErr:       true,
 			wantStrictErr: true,
 		},
+		{
+			cinfo:         ClusterInfo{ID: 10, Name: "invAlid", MaxConnectedClusters: 511},
+			wantErr:       true,
+			wantStrictErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/clustermesh/types/types_test.go
+++ b/pkg/clustermesh/types/types_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClusterNameValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		check       assert.ErrorAssertionFunc
+	}{
+		{
+			name:        "empty",
+			clusterName: "",
+			check:       assert.Error,
+		},
+		{
+			name:        "single character",
+			clusterName: "a",
+			check:       assert.NoError,
+		},
+		{
+			name:        "63 characters",
+			clusterName: "abcdefghijklmnopqrstuvwxyz0123456789-abcdefghijklmnopqrstuvwxyz",
+			check:       assert.NoError,
+		},
+		{
+			name:        "64 characters",
+			clusterName: "abcdefghijklmnopqrstuvwxyz0123456789-abcdefghijklmnopqrstuvwxyz0",
+			check:       assert.Error,
+		},
+		{
+			name:        "start and end with lowercase letter",
+			clusterName: "az",
+			check:       assert.NoError,
+		},
+		{
+			name:        "start and end with number",
+			clusterName: "09",
+			check:       assert.NoError,
+		},
+		{
+			name:        "start with a dash",
+			clusterName: "-a",
+			check:       assert.Error,
+		},
+		{
+			name:        "end with a dash",
+			clusterName: "0-",
+			check:       assert.Error,
+		},
+		{
+			name:        "uppercase letters",
+			clusterName: "aBYz",
+			check:       assert.Error,
+		},
+		{
+			name:        "invalid characters",
+			clusterName: "a^x",
+			check:       assert.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.check(t, ValidateClusterName(tt.clusterName))
+		})
+	}
+}


### PR DESCRIPTION
Formally define and validate that a cluster name must be a valid lower case RFC 1123 label name [1], and specifically respect the following constraints:

* It must contain at most 63 characters;
* It must begin and end with a lower case alphanumeric character;
* It may contain lower case alphanumerics and dashes between;
* The "default" name is reserved, and forbidden with ClusterID != 0.

The specification matches the cluster name definition from the Kubernetes multi-cluster services API \[2\], and matches the already implicit requirements due to the usage of the cluster name as a k8s label value \[3\] (for CiliumIdentities), and as a hostname \[3\] when  configuring the host aliases during clustermesh interconnection. Given the above constraints, the vast majority of existing deployments are not expected to affected by this change.  

The explicit validation ensures that Cilium components fail to start with a clear error if the cluster name is invalid, rather than failing silently at a later stage.

\[1\]: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
\[2\]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#proposal
\[3\]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set

<!-- Description of change -->

```release-note
Formally define and validate the cluster name format
```
