### PR TITLE
Formally define and validate the cluster name format

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -60,6 +60,8 @@ env:
   cilium_cli_ci_version:
   clusterName1: cluster1-${{ github.run_id }}
   clusterName2: cluster2-${{ github.run_id }}
+  ciliumClusterName1: c1
+  ciliumClusterName2: cluster2-with-long-name-01234567
   contextName1: kind-cluster1-${{ github.run_id }}
   contextName2: kind-cluster2-${{ github.run_id }}
 
@@ -460,8 +462,8 @@ jobs:
         run: |
           echo "cilium_install_clustermesh= \
             --set=clustermesh.config.enabled=true \
-            --set clustermesh.config.clusters[0].name=${{ env.clusterName1 }} \
-            --set clustermesh.config.clusters[1].name=${{ env.clusterName2 }} \
+            --set clustermesh.config.clusters[0].name=${{ env.ciliumClusterName1 }} \
+            --set clustermesh.config.clusters[1].name=${{ env.ciliumClusterName2 }} \
             ${{ steps.kvstore.outputs.cilium_install_clustermesh }} \
           " >> $GITHUB_OUTPUT
 
@@ -500,7 +502,7 @@ jobs:
           # each cluster, to workaround #24692
           cilium --context ${{ env.contextName1 }} install \
             ${{ steps.vars.outputs.cilium_install_defaults }} \
-            --helm-set cluster.name=${{ env.clusterName1 }} \
+            --helm-set cluster.name=${{ env.ciliumClusterName1 }} \
             --helm-set cluster.id=1 \
             --helm-set clustermesh.apiserver.service.nodePort=32379 \
             --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.cm-auth-mode-1 }} \
@@ -522,7 +524,7 @@ jobs:
           # each cluster, to workaround #24692
           cilium --context ${{ env.contextName2 }} install \
             ${{ steps.vars.outputs.cilium_install_defaults }} \
-            --helm-set cluster.name=${{ env.clusterName2 }} \
+            --helm-set cluster.name=${{ env.ciliumClusterName2 }} \
             --helm-set cluster.id=${{ matrix.maxConnectedClusters }} \
             --helm-set clustermesh.apiserver.service.nodePort=32380 \
             --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.cm-auth-mode-2 }} \

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -64,7 +64,7 @@ cilium-agent [flags]
       --cgroup-root string                                        Path to Cgroup2 filesystem
       --cluster-health-port int                                   TCP port for cluster-wide network connectivity health API (default 4240)
       --cluster-id uint32                                         Unique identifier of the cluster
-      --cluster-name string                                       Name of the cluster (default "default")
+      --cluster-name string                                       Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
       --clustermesh-sync-timeout duration                         Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -16,7 +16,7 @@ cilium-agent hive [flags]
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --cluster-id uint32                                         Unique identifier of the cluster
-      --cluster-name string                                       Name of the cluster (default "default")
+      --cluster-name string                                       Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
       --clustermesh-sync-timeout duration                         Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -22,7 +22,7 @@ cilium-agent hive dot-graph [flags]
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --cluster-id uint32                                         Unique identifier of the cluster
-      --cluster-name string                                       Name of the cluster (default "default")
+      --cluster-name string                                       Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
       --clustermesh-sync-timeout duration                         Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -22,7 +22,7 @@ cilium-operator-alibabacloud [flags]
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
       --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
       --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -15,7 +15,7 @@ cilium-operator-alibabacloud hive [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -21,7 +21,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -25,7 +25,7 @@ cilium-operator-aws [flags]
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
       --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
       --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -15,7 +15,7 @@ cilium-operator-aws hive [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -21,7 +21,7 @@ cilium-operator-aws hive dot-graph [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -25,7 +25,7 @@ cilium-operator-azure [flags]
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
       --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
       --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -15,7 +15,7 @@ cilium-operator-azure hive [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -21,7 +21,7 @@ cilium-operator-azure hive dot-graph [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -21,7 +21,7 @@ cilium-operator-generic [flags]
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
       --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
       --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -15,7 +15,7 @@ cilium-operator-generic hive [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -21,7 +21,7 @@ cilium-operator-generic hive dot-graph [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -30,7 +30,7 @@ cilium-operator [flags]
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
       --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
       --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -15,7 +15,7 @@ cilium-operator hive [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -21,7 +21,7 @@ cilium-operator hive dot-graph [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --ces-slice-mode string                                Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity ("cesSliceModeIdentity") or batched on a "First Come, First Served" basis ("cesSliceModeFCFS") (default "cesSliceModeIdentity")
       --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
+      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -465,7 +465,7 @@
      - int
      - ``0``
    * - :spelling:ignore:`cluster.name`
-     - Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE.
+     - Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE. It must respect the following constraints: * It must contain at most 32 characters; * It must begin and end with a lower case alphanumeric character; * It may contain lower case alphanumeric characters and dashes between. The "default" name cannot be used if the Cluster ID is different from 0.
      - string
      - ``"default"``
    * - :spelling:ignore:`clustermesh.annotations`

--- a/Documentation/network/clustermesh/clustermesh.rst
+++ b/Documentation/network/clustermesh/clustermesh.rst
@@ -126,8 +126,13 @@ Specify the Cluster Name and ID
 Cilium needs to be installed onto each cluster.
 
 Each cluster must be assigned a unique human-readable name as well as a numeric
-cluster ID (1-255). It is best to assign both these attributes at installation
-time of Cilium:
+cluster ID (1-255). The cluster name must respect the following constraints:
+
+* It must contain at most 32 characters;
+* It must begin and end with a lower case alphanumeric character;
+* It may contain lower case alphanumeric characters and dashes between.
+
+It is best to assign both the cluster name and the cluster ID at installation time:
 
  * ConfigMap options ``cluster-name`` and ``cluster-id``
  * Helm options ``cluster.name`` and ``cluster.id``

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -351,6 +351,10 @@ Annotations:
   ``policy_regeneration_time_stats_seconds`` have been deprecated in favor of
   ``endpoint_regenerations_total`` and
   ``endpoint_regeneration_time_stats_seconds``, respectively.
+* The Cilium cluster name is now validated to consist of at most 32 lower case
+  alphanumeric characters and '-', start and end with an alphanumeric character.
+  Validation can be currently bypassed configuring ``upgradeCompatibility`` to
+  v1.15 or earlier, but will be strictly enforced starting from Cilium v1.17.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -32,8 +32,8 @@ var Cell = cell.Module(
 	// ClusterName is not the default one), because they are valid in
 	// case we only use the external workloads feature, and not clustermesh.
 	cell.Config(cmtypes.DefaultClusterInfo),
-	cell.Invoke(func(cinfo cmtypes.ClusterInfo) error { return cinfo.InitClusterIDMax() }),
-	cell.Invoke(func(cinfo cmtypes.ClusterInfo) error { return cinfo.Validate() }),
+	cell.Invoke(cmtypes.ClusterInfo.InitClusterIDMax),
+	cell.Invoke(cmtypes.ClusterInfo.Validate),
 
 	pprof.Cell,
 	cell.Config(pprof.Config{

--- a/clustermesh-apiserver/kvstoremesh/root.go
+++ b/clustermesh-apiserver/kvstoremesh/root.go
@@ -50,13 +50,13 @@ func NewCmd(h *hive.Hive) *cobra.Command {
 	return rootCmd
 }
 
-func registerClusterInfoValidator(lc cell.Lifecycle, cinfo types.ClusterInfo) {
+func registerClusterInfoValidator(lc cell.Lifecycle, cinfo types.ClusterInfo, log logrus.FieldLogger) {
 	lc.Append(cell.Hook{
 		OnStart: func(cell.HookContext) error {
 			if err := cinfo.InitClusterIDMax(); err != nil {
 				return err
 			}
-			if err := cinfo.ValidateStrict(); err != nil {
+			if err := cinfo.ValidateStrict(log); err != nil {
 				return err
 			}
 			return nil

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -166,7 +166,7 @@ contributors across the globe, there is almost always someone available to help.
 | cleanBpfState | bool | `false` | Clean all eBPF datapath state from the initContainer of the cilium-agent DaemonSet.  WARNING: Use with care! |
 | cleanState | bool | `false` | Clean all local Cilium state from the initContainer of the cilium-agent DaemonSet. Implies cleanBpfState: true.  WARNING: Use with care! |
 | cluster.id | int | `0` | Unique ID of the cluster. Must be unique across all connected clusters and in the range of 1 to 255. Only required for Cluster Mesh, may be 0 if Cluster Mesh is not used. |
-| cluster.name | string | `"default"` | Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE. |
+| cluster.name | string | `"default"` | Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE. It must respect the following constraints: * It must contain at most 32 characters; * It must begin and end with a lower case alphanumeric character; * It may contain lower case alphanumeric characters and dashes between. The "default" name cannot be used if the Cluster ID is different from 0. |
 | clustermesh.annotations | object | `{}` | Annotations to be added to all top-level clustermesh objects (resources under templates/clustermesh-apiserver and templates/clustermesh-config) |
 | clustermesh.apiserver.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"clustermesh-apiserver"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for clustermesh.apiserver |
 | clustermesh.apiserver.etcd.init.extraArgs | list | `[]` | Additional arguments to `clustermesh-apiserver etcdinit`. |

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -79,6 +79,22 @@
   {{- end }}
 {{- end }}
 
+{{/* validate cluster name */}}
+{{- if eq .Values.cluster.name "" }}
+  {{ fail "The cluster name is invalid: cannot be empty" }}
+{{- end }}
+{{- if semverCompare ">=1.16" (default "1.16" .Values.upgradeCompatibility) }}
+{{- if gt (len .Values.cluster.name) 32 }}
+  {{ fail "The cluster name is invalid: must not be more than 32 characters. Configure 'upgradeCompatibility' to 1.15 or earlier to temporarily skip this check at your own risk" }}
+{{- end }}
+{{- if not (regexMatch "^([a-z0-9][-a-z0-9]*)?[a-z0-9]$" .Values.cluster.name) }}
+  {{ fail "The cluster name is invalid: must consist of lower case alphanumeric characters and '-', and must start and end with an alphanumeric character. Configure 'upgradeCompatibility' to 1.15 or earlier to temporarily skip this check at your own risk" }}
+{{- end }}
+{{- end }}
+{{- if and (eq .Values.cluster.name "default") (ne (int .Values.cluster.id) 0) }}
+  {{ fail "The cluster name is invalid: cannot use default value with cluster.id != 0" }}
+{{- end }}
+
 {{/* validate clustermesh-apiserver */}}
 {{- if .Values.clustermesh.useAPIServer }}
   {{- if ne .Values.identityAllocationMode "crd" }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -67,6 +67,11 @@ k8sClientRateLimit:
   burst:
 cluster:
   # -- Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE.
+  # It must respect the following constraints:
+  # * It must contain at most 32 characters;
+  # * It must begin and end with a lower case alphanumeric character;
+  # * It may contain lower case alphanumeric characters and dashes between.
+  # The "default" name cannot be used if the Cluster ID is different from 0.
   name: default
   # -- (int) Unique ID of the cluster. Must be unique across all connected
   # clusters and in the range of 1 to 255. Only required for Cluster Mesh,

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -65,6 +65,11 @@ k8sClientRateLimit:
   burst:
 cluster:
   # -- Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE.
+  # It must respect the following constraints:
+  # * It must contain at most 32 characters;
+  # * It must begin and end with a lower case alphanumeric character;
+  # * It may contain lower case alphanumeric characters and dashes between.
+  # The "default" name cannot be used if the Cluster ID is different from 0.
   name: default
   # -- (int) Unique ID of the cluster. Must be unique across all connected
   # clusters and in the range of 1 to 255. Only required for Cluster Mesh,

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -127,8 +127,8 @@ var (
 		"Operator Control Plane",
 
 		cell.Config(cmtypes.DefaultClusterInfo),
-		cell.Invoke(func(cinfo cmtypes.ClusterInfo) error { return cinfo.InitClusterIDMax() }),
-		cell.Invoke(func(cinfo cmtypes.ClusterInfo) error { return cinfo.Validate() }),
+		cell.Invoke(cmtypes.ClusterInfo.InitClusterIDMax),
+		cell.Invoke(cmtypes.ClusterInfo.Validate),
 
 		cell.Invoke(
 			registerOperatorHooks,

--- a/pkg/clustermesh/common/clustermesh.go
+++ b/pkg/clustermesh/common/clustermesh.go
@@ -150,6 +150,11 @@ func (cm *clusterMesh) add(name, path string) {
 		return
 	}
 
+	if err := types.ValidateClusterName(name); err != nil {
+		log.WithField(fieldClusterName, name).WithError(err).
+			Error("Remote cluster name is invalid. The connection will be forbidden starting from Cilium v1.17")
+	}
+
 	inserted := false
 	cm.mutex.Lock()
 	cluster, ok := cm.clusters[name]

--- a/pkg/clustermesh/types/option.go
+++ b/pkg/clustermesh/types/option.go
@@ -6,9 +6,11 @@ package types
 import (
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 const (
@@ -39,32 +41,37 @@ var DefaultClusterInfo = ClusterInfo{
 // Flags implements the cell.Flagger interface, to register the given flags.
 func (def ClusterInfo) Flags(flags *pflag.FlagSet) {
 	flags.Uint32(OptClusterID, def.ID, "Unique identifier of the cluster")
-	flags.String(OptClusterName, def.Name, "Name of the cluster")
+	flags.String(OptClusterName, def.Name, "Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character.")
 	flags.Uint32(OptMaxConnectedClusters, def.MaxConnectedClusters, "Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511].")
 }
 
 // Validate validates that the ClusterID is in the valid range (including ClusterID == 0),
 // and that the ClusterName is different from the default value if the ClusterID != 0.
-func (c ClusterInfo) Validate() error {
+func (c ClusterInfo) Validate(log logrus.FieldLogger) error {
 	if c.ID < ClusterIDMin || c.ID > ClusterIDMax {
 		return fmt.Errorf("invalid cluster id %d: must be in range %d..%d",
 			c.ID, ClusterIDMin, ClusterIDMax)
 	}
 
-	return c.validateName()
+	return c.validateName(log)
 }
 
 // ValidateStrict validates that the ClusterID is in the valid range, but not 0,
 // and that the ClusterName is different from the default value.
-func (c ClusterInfo) ValidateStrict() error {
+func (c ClusterInfo) ValidateStrict(log logrus.FieldLogger) error {
 	if err := ValidateClusterID(c.ID); err != nil {
 		return err
 	}
 
-	return c.validateName()
+	return c.validateName(log)
 }
 
-func (c ClusterInfo) validateName() error {
+func (c ClusterInfo) validateName(log logrus.FieldLogger) error {
+	if err := ValidateClusterName(c.Name); err != nil {
+		log.WithField(logfields.ClusterName, c.Name).WithError(err).
+			Error("Invalid cluster name. This may cause degraded functionality, and will be strictly forbidden starting from Cilium v1.17")
+	}
+
 	if c.ID != 0 && c.Name == defaults.ClusterName {
 		return fmt.Errorf("cannot use default cluster name (%s) with option %s",
 			defaults.ClusterName, OptClusterID)

--- a/pkg/clustermesh/types/option_test.go
+++ b/pkg/clustermesh/types/option_test.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestClusterInfoValidate(t *testing.T) {
+	log := logrus.New()
+
 	// this test involves changing the global ClusterIDMax variable, so we need
 	// to save its value and restore it at the end of the test
 	oldMaxClusterID := ClusterIDMax
@@ -63,6 +66,11 @@ func TestClusterInfoValidate(t *testing.T) {
 			wantErr:       true,
 			wantStrictErr: true,
 		},
+		{
+			cinfo:         ClusterInfo{ID: 10, Name: "invAlid", MaxConnectedClusters: 511},
+			wantErr:       false, // Cluster name validation is not yet enforced in Cilium v1.16.
+			wantStrictErr: false, // Cluster name validation is not yet enforced in Cilium v1.16.
+		},
 	}
 
 	for _, tt := range tests {
@@ -75,15 +83,15 @@ func TestClusterInfoValidate(t *testing.T) {
 			}
 
 			if tt.wantErr {
-				assert.Error(t, tt.cinfo.Validate())
+				assert.Error(t, tt.cinfo.Validate(log))
 			} else {
-				assert.NoError(t, tt.cinfo.Validate())
+				assert.NoError(t, tt.cinfo.Validate(log))
 			}
 
 			if tt.wantStrictErr {
-				assert.Error(t, tt.cinfo.ValidateStrict())
+				assert.Error(t, tt.cinfo.ValidateStrict(log))
 			} else {
-				assert.NoError(t, tt.cinfo.ValidateStrict())
+				assert.NoError(t, tt.cinfo.ValidateStrict(log))
 			}
 		})
 	}

--- a/pkg/clustermesh/types/types.go
+++ b/pkg/clustermesh/types/types.go
@@ -4,7 +4,9 @@
 package types
 
 import (
+	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/cilium/cilium/pkg/defaults"
 )
@@ -19,6 +21,19 @@ const (
 
 // ClusterIDMax is the maximum value of the cluster ID
 var ClusterIDMax uint32 = defaults.MaxConnectedClusters
+
+// A cluster name must respect the following constraints:
+// * It must contain at most 32 characters;
+// * It must begin and end with a lower case alphanumeric character;
+// * It may contain lower case alphanumeric characters and dashes between.
+const (
+	// clusterNameMaxLength is the maximum allowed length of a cluster name.
+	clusterNameMaxLength = 32
+	// clusterNameRegexStr is the regex to validate a cluster name.
+	clusterNameRegexStr = `^([a-z0-9][-a-z0-9]*)?[a-z0-9]$`
+)
+
+var clusterNameRegex = regexp.MustCompile(clusterNameRegexStr)
 
 // InitClusterIDMax validates and sets the ClusterIDMax package level variable.
 func (c ClusterInfo) InitClusterIDMax() error {
@@ -40,6 +55,23 @@ func ValidateClusterID(clusterID uint32) error {
 
 	if clusterID > ClusterIDMax {
 		return fmt.Errorf("ClusterID > %d is not supported", ClusterIDMax)
+	}
+
+	return nil
+}
+
+// ValidateClusterName validates that the given name matches the cluster name specifications.
+func ValidateClusterName(name string) error {
+	if name == "" {
+		return errors.New("must not be empty")
+	}
+
+	if len(name) > clusterNameMaxLength {
+		return fmt.Errorf("must not be more than %d characters", clusterNameMaxLength)
+	}
+
+	if !clusterNameRegex.MatchString(name) {
+		return errors.New("must consist of lower case alphanumeric characters and '-', and must start and end with an alphanumeric character")
 	}
 
 	return nil

--- a/pkg/clustermesh/types/types_test.go
+++ b/pkg/clustermesh/types/types_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClusterNameValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		check       assert.ErrorAssertionFunc
+	}{
+		{
+			name:        "empty",
+			clusterName: "",
+			check:       assert.Error,
+		},
+		{
+			name:        "single character",
+			clusterName: "a",
+			check:       assert.NoError,
+		},
+		{
+			name:        "32 characters",
+			clusterName: "abcdefghijklmnopqrstuvwxyz-01234",
+			check:       assert.NoError,
+		},
+		{
+			name:        "33 characters",
+			clusterName: "abcdefghijklmnopqrstuvwxyz-012345",
+			check:       assert.Error,
+		},
+		{
+			name:        "start and end with lowercase letter",
+			clusterName: "az",
+			check:       assert.NoError,
+		},
+		{
+			name:        "start and end with number",
+			clusterName: "09",
+			check:       assert.NoError,
+		},
+		{
+			name:        "start with a dash",
+			clusterName: "-a",
+			check:       assert.Error,
+		},
+		{
+			name:        "end with a dash",
+			clusterName: "0-",
+			check:       assert.Error,
+		},
+		{
+			name:        "uppercase letters",
+			clusterName: "aBYz",
+			check:       assert.Error,
+		},
+		{
+			name:        "invalid characters",
+			clusterName: "a^x",
+			check:       assert.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.check(t, ValidateClusterName(tt.clusterName))
+		})
+	}
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2778,7 +2778,7 @@ func (c *DaemonConfig) Validate(vp *viper.Viper) error {
 	if err := cinfo.InitClusterIDMax(); err != nil {
 		return err
 	}
-	if err := cinfo.Validate(); err != nil {
+	if err := cinfo.Validate(log); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Formally define and validate that a cluster name must respect the following constraints:

* It must contain at most 32 characters;
* It must begin and end with a lower case alphanumeric character;
* It may contain lower case alphanumerics and dashes between;
* The "default" name is reserved, and forbidden with ClusterID != 0.

The specification almost matches the cluster name definition from the Kubernetes multi-cluster services API [1] (except for the shorter maximum length), and derives from the already implicit requirements due to the usage of the cluster name as:
    
* a k8s label value [2] (for CiliumIdentities),
* a hostname [3] when configuring the host aliases during clustermesh interconnection;
* part of TLS certificates common name [4].
    
The goal of the explicit validation is to ensure that Cilium components fail to start with a clear error if the cluster name is invalid, rather than failing silently at a later stage.
    
Given the above constraints, the vast majority of existing deployments are not expected to affected by this change. Still, to enable users performing a smooth transition, we currently only emit an error log in case of invalid cluster names. The cluster name format will start being strictly enforced starting from the Cilium version. Similarly, helm validation can be temporarily skipped setting `upgradeCompatibility` to 1.15 or earlier.
    
\[1\]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#proposal
\[2\]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
\[3\]: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
\[4\]: https://stackoverflow.com/a/5142550

<!-- Description of change -->

```release-note
Formally define and validate the cluster name format
```
