### PR TITLE
ingress: Support headless service

### DIFF
--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -289,13 +289,109 @@ jobs:
           fi
           docker exec -i chart-testing-control-plane curl -s -v --connect-timeout 5 --max-time 20 --retry 3 --fail http://localhost:$node_port/details/1 
 
+      - name: Run Sanity check (headless service)
+        timeout-minutes: 5
+        run: |
+          BACKEND_IP=$(kubectl get pod -l app=details -o jsonpath="{.items[*].status.podIP}")
+          cat << EOF > ingress-with-headless-service.yaml
+          apiVersion: v1
+          kind: Endpoints
+          metadata:
+            name: details-headless
+          subsets:
+          - addresses:
+            - ip: ${BACKEND_IP}
+            ports:
+            - name: http
+              port: 9080
+              protocol: TCP
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: details-headless
+          spec:
+            ports:
+            - name: http
+              port: 9080
+              protocol: TCP
+              targetPort: 9080
+            clusterIP: None
+            ipFamilies:
+            - IPv4
+            ipFamilyPolicy: SingleStack
+          ---
+          apiVersion: discovery.k8s.io/v1
+          kind: EndpointSlice
+          metadata:
+            name: details-headless-endpoint-slice
+            labels:
+              kubernetes.io/service-name: details-headless-endpoint-slice
+          addressType: IPv4
+          endpoints:
+            - addresses:
+                - ${BACKEND_IP}
+          ports:
+            - name: http
+              port: 9080
+              protocol: TCP
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: details-headless-endpoint-slice
+          spec:
+            ports:
+              - name: http
+                port: 9082
+                protocol: TCP
+                targetPort: 9080
+            clusterIP: None
+            ipFamilies:
+              - IPv4
+            ipFamilyPolicy: SingleStack
+          ---
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: basic-ingress-headless
+          spec:
+            ingressClassName: cilium
+            rules:
+            - http:
+                paths:
+                - backend:
+                    service:
+                      name: details-headless
+                      port:
+                        number: 9080
+                  path: /details/1
+                  pathType: Prefix
+                - backend:
+                    service:
+                      name: details-headless-endpoint-slice
+                      port:
+                        number: 9082
+                  path: /details/2
+                  pathType: Prefix
+          EOF
+          kubectl apply -n default -f ingress-with-headless-service.yaml
+          until [ -n "$(kubectl get ingress basic-ingress-headless -o jsonpath='{.status.loadBalancer.ingress[0].ip}')" ]; do
+            sleep 3
+          done
+          lb=$(kubectl get ingress basic-ingress-headless -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          curl -s -v --connect-timeout 2 --max-time 20 --retry 3 --retry-all-errors --retry-delay 3 --fail -- http://"$lb"/details/1      
+          curl -s -v --connect-timeout 2 --max-time 20 --retry 3 --retry-all-errors --retry-delay 3 --fail -- http://"$lb"/details/2
+
       - name: Cleanup Sanity check
         timeout-minutes: 5
         run: |
           # Clean up after sanity check to avoid any conflicts with the conformance test
           kubectl delete -n default -f untrusted/examples/kubernetes/servicemesh/basic-ingress.yaml
+          kubectl delete -n default -f ingress-with-headless-service.yaml
           kubectl delete -n default -f https://raw.githubusercontent.com/istio/istio/release-1.11/samples/bookinfo/platform/kube/bookinfo.yaml
           kubectl wait ingress basic-ingress --for=delete
+          kubectl wait ingress basic-ingress-headless --for=delete
 
       - name: Run Ingress conformance test
         timeout-minutes: 30

--- a/pkg/ciliumenvoyconfig/cec_manager_test.go
+++ b/pkg/ciliumenvoyconfig/cec_manager_test.go
@@ -12,9 +12,16 @@ import (
 	envoy_config_http "github.com/cilium/proxy/go/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/util/intstr"
+	"github.com/cilium/cilium/pkg/loadbalancer"
 )
 
 var envoySpec = []byte(`apiVersion: cilium.io/v2
@@ -246,4 +253,267 @@ spec:
 	err = json.Unmarshal(jsonBytes, ccec)
 	assert.NoError(t, err)
 	assert.True(t, useOriginalSourceAddress(&ccec.ObjectMeta))
+}
+
+func Test_convertToLBService(t *testing.T) {
+	type args struct {
+		svc *slim_corev1.Service
+		ep  *k8s.Endpoints
+	}
+	tests := []struct {
+		name string
+		args args
+		want []*loadbalancer.SVC
+	}{
+		{
+			name: "headless with one port and one address",
+			args: args{
+				svc: &slim_corev1.Service{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Name:      "headless-service",
+						Namespace: "default",
+					},
+					Spec: slim_corev1.ServiceSpec{
+						ClusterIP: "None",
+						Ports: []slim_corev1.ServicePort{
+							{
+								Name:       "http",
+								Protocol:   "TCP",
+								Port:       8080,
+								TargetPort: intstr.FromInt32(3000),
+							},
+						},
+					},
+				},
+				ep: &k8s.Endpoints{
+					Backends: map[cmtypes.AddrCluster]*k8s.Backend{
+						cmtypes.MustParseAddrCluster("10.0.0.1"): {
+							Ports: map[string]*loadbalancer.L4Addr{
+								"http": {
+									Protocol: "TCP",
+									Port:     3000,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []*loadbalancer.SVC{
+				{
+					Name: loadbalancer.ServiceName{
+						Name:      "headless-service",
+						Namespace: "default",
+					},
+					Frontend: loadbalancer.L3n4AddrID{
+						L3n4Addr: loadbalancer.L3n4Addr{
+							L4Addr: loadbalancer.L4Addr{
+								Protocol: "TCP",
+								Port:     8080,
+							},
+						},
+					},
+					Backends: []*loadbalancer.Backend{
+						{
+							FEPortName: "http",
+							L3n4Addr: loadbalancer.L3n4Addr{
+								AddrCluster: cmtypes.MustParseAddrCluster("10.0.0.1"),
+								L4Addr: loadbalancer.L4Addr{
+									Protocol: "TCP",
+									Port:     3000,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "headless with one port and two addresses",
+			args: args{
+				svc: &slim_corev1.Service{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Name:      "headless-service",
+						Namespace: "default",
+					},
+					Spec: slim_corev1.ServiceSpec{
+						ClusterIP: "None",
+						Ports: []slim_corev1.ServicePort{
+							{
+								Name:     "http",
+								Protocol: "TCP",
+								Port:     8080,
+							},
+						},
+					},
+				},
+				ep: &k8s.Endpoints{
+					Backends: map[cmtypes.AddrCluster]*k8s.Backend{
+						cmtypes.MustParseAddrCluster("10.0.0.1"): {
+							Ports: map[string]*loadbalancer.L4Addr{
+								"http": {
+									Protocol: "TCP",
+									Port:     8080,
+								},
+							},
+						},
+						cmtypes.MustParseAddrCluster("10.0.0.2"): {
+							Ports: map[string]*loadbalancer.L4Addr{
+								"http": {
+									Protocol: "TCP",
+									Port:     8080,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []*loadbalancer.SVC{
+				{
+					Name: loadbalancer.ServiceName{
+						Name:      "headless-service",
+						Namespace: "default",
+					},
+					Frontend: loadbalancer.L3n4AddrID{
+						L3n4Addr: loadbalancer.L3n4Addr{
+							L4Addr: loadbalancer.L4Addr{
+								Protocol: "TCP",
+								Port:     8080,
+							},
+						},
+					},
+					Backends: []*loadbalancer.Backend{
+						{
+							FEPortName: "http",
+							L3n4Addr: loadbalancer.L3n4Addr{
+								AddrCluster: cmtypes.MustParseAddrCluster("10.0.0.1"),
+								L4Addr: loadbalancer.L4Addr{
+									Protocol: "TCP",
+									Port:     8080,
+								},
+							},
+						},
+						{
+							FEPortName: "http",
+							L3n4Addr: loadbalancer.L3n4Addr{
+								AddrCluster: cmtypes.MustParseAddrCluster("10.0.0.2"),
+								L4Addr: loadbalancer.L4Addr{
+									Protocol: "TCP",
+									Port:     8080,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "headless with two ports and one address",
+			args: args{
+				svc: &slim_corev1.Service{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Name:      "headless-service",
+						Namespace: "default",
+					},
+					Spec: slim_corev1.ServiceSpec{
+						ClusterIP: "None",
+						Ports: []slim_corev1.ServicePort{
+							{
+								Name:     "http",
+								Protocol: "TCP",
+								Port:     8080,
+							},
+							{
+								Name:     "https",
+								Protocol: "TCP",
+								Port:     8443,
+							},
+						},
+					},
+				},
+				ep: &k8s.Endpoints{
+					Backends: map[cmtypes.AddrCluster]*k8s.Backend{
+						cmtypes.MustParseAddrCluster("10.0.0.1"): {
+							Ports: map[string]*loadbalancer.L4Addr{
+								"http": {
+									Protocol: "TCP",
+									Port:     8080,
+								},
+								"https": {
+									Protocol: "TCP",
+									Port:     8443,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []*loadbalancer.SVC{
+				{
+					Name: loadbalancer.ServiceName{
+						Name:      "headless-service",
+						Namespace: "default",
+					},
+					Frontend: loadbalancer.L3n4AddrID{
+						L3n4Addr: loadbalancer.L3n4Addr{
+							L4Addr: loadbalancer.L4Addr{
+								Protocol: "TCP",
+								Port:     8080,
+							},
+						},
+					},
+					Backends: []*loadbalancer.Backend{
+						{
+							FEPortName: "http",
+							L3n4Addr: loadbalancer.L3n4Addr{
+								AddrCluster: cmtypes.MustParseAddrCluster("10.0.0.1"),
+								L4Addr: loadbalancer.L4Addr{
+									Protocol: "TCP",
+									Port:     8080,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: loadbalancer.ServiceName{
+						Name:      "headless-service",
+						Namespace: "default",
+					},
+					Frontend: loadbalancer.L3n4AddrID{
+						L3n4Addr: loadbalancer.L3n4Addr{
+							L4Addr: loadbalancer.L4Addr{
+								Protocol: "TCP",
+								Port:     8443,
+							},
+						},
+					},
+					Backends: []*loadbalancer.Backend{
+						{
+							FEPortName: "https",
+							L3n4Addr: loadbalancer.L3n4Addr{
+								AddrCluster: cmtypes.MustParseAddrCluster("10.0.0.1"),
+								L4Addr: loadbalancer.L4Addr{
+									Protocol: "TCP",
+									Port:     8443,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svcs := convertToLBService(tt.args.svc, tt.args.ep)
+			require.Len(t, svcs, len(tt.want))
+			for i := 0; i < len(svcs); i++ {
+				require.Equal(t, tt.want[i].Name, svcs[i].Name)
+				require.Equal(t, tt.want[i].Frontend, svcs[i].Frontend)
+				require.Len(t, svcs[i].Backends, len(tt.want[i].Backends))
+				require.ElementsMatch(t, tt.want[i].Backends, svcs[i].Backends)
+			}
+		})
+	}
 }

--- a/pkg/ciliumenvoyconfig/cell.go
+++ b/pkg/ciliumenvoyconfig/cell.go
@@ -12,8 +12,10 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/envoy"
+	"github.com/cilium/cilium/pkg/k8s"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
@@ -112,8 +114,12 @@ type managerParams struct {
 	XdsServer      envoy.XDSServer
 	BackendSyncer  *envoyServiceBackendSyncer
 	ResourceParser *cecResourceParser
+
+	Services  resource.Resource[*slim_corev1.Service]
+	Endpoints resource.Resource[*k8s.Endpoints]
 }
 
 func newCECManager(params managerParams) ciliumEnvoyConfigManager {
-	return newCiliumEnvoyConfigManager(params.Logger, params.PolicyUpdater, params.ServiceManager, params.XdsServer, params.BackendSyncer, params.ResourceParser, params.Config.EnvoyConfigTimeout)
+	return newCiliumEnvoyConfigManager(params.Logger, params.PolicyUpdater, params.ServiceManager, params.XdsServer,
+		params.BackendSyncer, params.ResourceParser, params.Config.EnvoyConfigTimeout, params.Services, params.Endpoints)
 }

--- a/pkg/k8s/slim/k8s/api/core/v1/types.go
+++ b/pkg/k8s/slim/k8s/api/core/v1/types.go
@@ -964,6 +964,12 @@ type Service struct {
 	Status ServiceStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
+const (
+	// ClusterIPNone - do not assign a cluster IP
+	// no proxying required and no environment variables should be created for pods
+	ClusterIPNone = "None"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ServiceList holds a list of services.


### PR DESCRIPTION
Currently, we don't inject headless endpoints into envoy XDS, hence the response is coming with error `no healthy upstream`. This commit is to explicitly handle headless service in CEC controller.

Fixes: #23182 
