### PR TITLE
iptables: Do not set no-track rules with empty native routing CIDR

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1555,9 +1555,8 @@ func (m *Manager) installRules(state desiredState) error {
 		}
 	}
 
-	if m.sharedCfg.InstallNoConntrackIptRules {
-		podsCIDR := state.localNodeInfo.ipv4NativeRoutingCIDR
-
+	podsCIDR := state.localNodeInfo.ipv4NativeRoutingCIDR
+	if m.sharedCfg.InstallNoConntrackIptRules && podsCIDR != "" {
 		if err := m.addNoTrackPodTrafficRules(ip4tables, podsCIDR); err != nil {
 			return fmt.Errorf("cannot install pod traffic no CT rules: %w", err)
 		}


### PR DESCRIPTION
With the introduction of the iptables reconciler in https://github.com/cilium/cilium/pull/31372 we added a check for a nil `IPv4NativeRoutingCIDR` in the node structure:

https://github.com/cilium/cilium/blob/598209ebb8135b591e0a73d4422f15edc4b2789d/pkg/datapath/iptables/reconciler.go#L64-L66

This prevented crashes like [this one](https://github.com/cilium/cilium/issues/32607) in v1.15.
However, in case of a nil `n.IPv4NativeRoutingCIDR`, we end up with an empty string in `localNodeInfo.ipv4NativeRoutingCIDR` and this can lead to failures when trying to install the NOTRACK rules for pod in `addNoTrackPodTrafficRules`:

https://github.com/cilium/cilium/blob/598209ebb8135b591e0a73d4422f15edc4b2789d/pkg/datapath/iptables/iptables.go#L1722-L1744

The commit fixes this preventing the iptables command to run in case `localNodeInfo.ipv4NativeRoutingCIDR` is empty.

Related: https://github.com/cilium/cilium/issues/32607
