### PR TITLE
[v1.15] iptables: Do not install NOTRACK rules if IPv4NativeRoutingCIDR is nil

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1716,11 +1716,12 @@ func (m *Manager) installRules(ifName string) error {
 		}
 	}
 
-	if skipPodTrafficConntrack(false, m.sharedCfg.InstallNoConntrackIptRules) {
+	if m.sharedCfg.IPv4NativeRoutingCIDR != nil {
 		podsCIDR := m.sharedCfg.IPv4NativeRoutingCIDR.String()
-
-		if err := m.addNoTrackPodTrafficRules(ip4tables, podsCIDR); err != nil {
-			return fmt.Errorf("cannot install pod traffic no CT rules: %w", err)
+		if skipPodTrafficConntrack(false, m.sharedCfg.InstallNoConntrackIptRules) && podsCIDR != "" {
+			if err := m.addNoTrackPodTrafficRules(ip4tables, podsCIDR); err != nil {
+				return fmt.Errorf("cannot install pod traffic no CT rules: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
In case IPv4NativeRoutingCIDR is left unspecified, the related config option will be nil. To avoid panicking, check for this case before converting the CIDR to a string. Moreover, do not try to run the iptables command to install the NOTRACK rules if the resulting string is empty.

Fixes: #32607