### PR TITLE
[v1.14] iptables: Do not install NOTRACK rules if IPv4NativeRoutingCIDR is nil

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1595,11 +1595,12 @@ func (m *IptablesManager) installRules(ifName string) error {
 		}
 	}
 
-	if skipPodTrafficConntrack(false) {
+	if option.Config.GetIPv4NativeRoutingCIDR() != nil {
 		podsCIDR := option.Config.GetIPv4NativeRoutingCIDR().String()
-
-		if err := m.addNoTrackPodTrafficRules(ip4tables, podsCIDR); err != nil {
-			return fmt.Errorf("cannot install pod traffic no CT rules: %w", err)
+		if skipPodTrafficConntrack(false) && podsCIDR != "" {
+			if err := m.addNoTrackPodTrafficRules(ip4tables, podsCIDR); err != nil {
+				return fmt.Errorf("cannot install pod traffic no CT rules: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
In case IPv4NativeRoutingCIDR is left unspecified, the related config option will be nil. To avoid panicking, check for this case before converting the CIDR to a string. Moreover, do not try to run the iptables command to install the NOTRACK rules if the resulting string is empty.

Related: #32607