### PR TITLE
pkg: Fix Deny Insert Fuzz Test

### DIFF
--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -44,7 +44,7 @@ func FuzzDenyPreferredInsert(f *testing.F) {
 		key := Key{}
 		entry := MapStateEntry{}
 		ff := fuzz.NewConsumer(data)
-		ff.GenerateStruct(&keys)
+		ff.GenerateStruct(keys)
 		ff.GenerateStruct(&key)
 		ff.GenerateStruct(&entry)
 		keys.denyPreferredInsert(key, entry, nil, allFeatures)


### PR DESCRIPTION
"newMapState" returns a pointer on initialization
compared to the simple convenience type "mapState"
that used to be initialized directly before. The fuzz test for
"denyPreferredInsert" was updated to
initialize the mapState correctly, but the call
to "GenerateStruct" in the fuzz test was not
updated to account for the fact "mapState"
is already a pointer. The method no longer
obtains a reference to "mapState" but
receives the extant pointer as an
argument.

