### PR TITLE
helm: drop localhost SAN from the clustermesh admin certificate

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
@@ -14,7 +14,5 @@ spec:
     {{- toYaml .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef | nindent 4 }}
   secretName: clustermesh-apiserver-admin-cert
   commonName: {{ include "clustermesh-apiserver-generate-certs.admin-common-name" . }}
-  dnsNames:
-  - localhost
   duration: {{ printf "%dh0m0s" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/admin-secret.yaml
@@ -1,8 +1,7 @@
 {{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "helm") }}
 {{- $_ := include "cilium.ca.setup" . -}}
 {{- $cn := include "clustermesh-apiserver-generate-certs.admin-common-name" . -}}
-{{- $dns := list "localhost" }}
-{{- $cert := genSignedCert $cn nil $dns (.Values.clustermesh.apiserver.tls.auto.certValidityDuration | int) .commonCA -}}
+{{- $cert := genSignedCert $cn nil nil (.Values.clustermesh.apiserver.tls.auto.certValidityDuration | int) .commonCA -}}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
The admin certificate is used by the clustermesh-apiserver for client authentication against the sidecar etcd instance. Etcd leverages the common name to determine the user name, while SANs are ignored. Hence, let's just remove it, as not necessary.

<!-- Description of change -->

```release-note
Do not include the unnecessary "localhost" SAN in autogenerated clustermesh admin certificates
```
