### PR TITLE
[v1.13-hf] ipsec: cache xfrm state list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -567,6 +567,8 @@ endif
 check-sources:
 	@$(ECHO_CHECK) pkg/datapath/loader/check-sources.sh
 	$(QUIET) pkg/datapath/loader/check-sources.sh
+	@$(ECHO_CHECK) contrib/scripts/check-xfrmstate.sh
+	$(QUIET) contrib/scripts/check-xfrmstate.sh
 
 pprof-heap: ## Get Go pprof heap profile.
 	$(QUIET)$(GO) tool pprof http://localhost:6060/debug/pprof/heap

--- a/contrib/scripts/check-xfrmstate.sh
+++ b/contrib/scripts/check-xfrmstate.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Authors of Cilium
+
+set -eu
+
+GOIMPORTS=("golang.org/x/tools/cmd/goimports" "-w")
+MATCHES=(
+    "netlink.XfrmStateAdd"
+    "netlink.XfrmStateUpdate"
+    "netlink.XfrmStateDel"
+    "netlink.XfrmStateFlush"
+)
+
+find_match() {
+  local target="./pkg/datapath"
+
+  MATCHES_ORED=$(printf "|%s" "${MATCHES[@]}")
+  MATCHES_ORED=${MATCHES_ORED:1}
+
+  grep -lr --include \*.go \
+       --exclude \*_test.go \
+       --exclude xfrm_state_cache.go \
+       --exclude probe_linux.go \
+       -E "$MATCHES_ORED" \
+        "$target"
+  if [ $? -eq 0 ] ; then
+    return 0
+  fi
+
+  # Let's check now that we can detect it correctly
+  NO_MATCHES=$(grep -or --include xfrm_state_cache.go \
+       -E "$MATCHES_ORED" \
+       "$target" | wc -l)
+
+  if [ "$NO_MATCHES" -eq "4" ] ; then
+    return 1
+  fi
+  # Incorrect number of matches
+  echo "Found incorrect number of matches: $NO_MATCHES"
+  return 0
+}
+
+check() {
+  if find_match ; then
+    # shellcheck disable=SC2145
+    >&2 echo "Found match for '${MATCHES[@]}'. Please use xfrmStateCache instead.";
+    exit 1
+  fi
+}
+
+main() {
+  check
+}
+
+main "$@"

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -357,6 +357,10 @@ func initializeFlags() {
 	flags.Bool(option.EnableIPsecKeyWatcher, defaults.EnableIPsecKeyWatcher, "Enable watcher for IPsec key. If disabled, a restart of the agent will be necessary on key rotations.")
 	option.BindEnv(Vp, option.EnableIPsecKeyWatcher)
 
+	flags.Bool(option.EnableIPSecXfrmStateCaching, defaults.EnableIPSecXfrmStateCaching, "Enable XfrmState cache for IPSec. Significantly reduces CPU usage in large clusters.")
+	flags.MarkHidden(option.EnableIPSecXfrmStateCaching)
+	option.BindEnv(Vp, option.EnableIPSecXfrmStateCaching)
+
 	flags.Bool(option.EnableWireguard, false, "Enable wireguard")
 	option.BindEnv(Vp, option.EnableWireguard)
 

--- a/pkg/datapath/linux/ipsec/xfrm_state_cache.go
+++ b/pkg/datapath/linux/ipsec/xfrm_state_cache.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipsec
+
+import (
+	"time"
+
+	"github.com/vishvananda/netlink"
+	"k8s.io/utils/clock"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+type xfrmStateListCache struct {
+	stateList []netlink.XfrmState
+	timeout   time.Time
+	mutex     lock.Mutex
+	ttl       time.Duration
+	clock     clock.PassiveClock
+}
+
+func NewXfrmStateListCache(ttl time.Duration) *xfrmStateListCache {
+	return &xfrmStateListCache{
+		ttl:   ttl,
+		clock: clock.RealClock{},
+	}
+}
+
+func (c *xfrmStateListCache) XfrmStateList() ([]netlink.XfrmState, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if c.isExpired() {
+		result, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+		if err != nil {
+			return nil, err
+		}
+		c.stateList = result
+		c.timeout = c.clock.Now().Add(c.ttl)
+	}
+	return c.stateList, nil
+}
+
+func (c *xfrmStateListCache) XfrmStateDel(state *netlink.XfrmState) error {
+	c.invalidate()
+	return netlink.XfrmStateDel(state)
+}
+
+func (c *xfrmStateListCache) XfrmStateUpdate(state *netlink.XfrmState) error {
+	c.invalidate()
+	return netlink.XfrmStateUpdate(state)
+}
+
+func (c *xfrmStateListCache) XfrmStateAdd(state *netlink.XfrmState) error {
+	c.invalidate()
+	return netlink.XfrmStateAdd(state)
+}
+
+func (c *xfrmStateListCache) XfrmStateFlush(proto netlink.Proto) error {
+	c.invalidate()
+	return netlink.XfrmStateFlush(proto)
+}
+
+func (c *xfrmStateListCache) isExpired() bool {
+	return !option.Config.EnableIPSecXfrmStateCaching || c.stateList == nil || c.timeout.Before(c.clock.Now())
+}
+
+func (c *xfrmStateListCache) invalidate() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.stateList = nil
+}
+
+func newTestableXfrmStateListCache(ttl time.Duration, clock clock.PassiveClock) *xfrmStateListCache {
+	return &xfrmStateListCache{
+		ttl:   ttl,
+		clock: clock,
+	}
+}

--- a/pkg/datapath/linux/ipsec/xfrm_state_cache_test.go
+++ b/pkg/datapath/linux/ipsec/xfrm_state_cache_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipsec
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/option"
+
+	baseclocktest "k8s.io/utils/clock/testing"
+)
+
+func (p *IPSecSuitePrivileged) TestXfrmStateListCache(c *C) {
+	backupOption := option.Config.EnableIPSecXfrmStateCaching
+	defer func() {
+		option.Config.EnableIPSecXfrmStateCaching = backupOption
+	}()
+	option.Config.EnableIPSecXfrmStateCaching = true
+
+	fakeClock := baseclocktest.NewFakeClock(time.Now())
+	xfrmStateCache := newTestableXfrmStateListCache(
+		time.Second,
+		fakeClock,
+	)
+
+	c.Assert(xfrmStateCache.isExpired(), Equals, true)
+
+	cleanIPSecStatesAndPolicies(c)
+	state := initDummyXfrmState()
+	err := createDummyXfrmState(state)
+	c.Assert(err, IsNil)
+
+	// Make sure that cache is correctly fetched in the beginning
+	stateList, err := xfrmStateCache.XfrmStateList()
+	c.Assert(err, IsNil)
+	c.Assert(len(stateList), Equals, 1)
+	c.Assert(state.Spi, Equals, stateList[0].Spi)
+
+	cleanIPSecStatesAndPolicies(c)
+	// Check that cache does not expire instantly
+	stateList, err = xfrmStateCache.XfrmStateList()
+	c.Assert(err, IsNil)
+	c.Assert(len(stateList), Equals, 1)
+
+	// Move time by half second and make sure cache still did not expire
+	fakeClock.Step(time.Millisecond * 500)
+	c.Assert(xfrmStateCache.isExpired(), Equals, false)
+	stateList, err = xfrmStateCache.XfrmStateList()
+	c.Assert(err, IsNil)
+	c.Assert(len(stateList), Equals, 1)
+
+	// Invalidate cache by moving time by 501 more miliseconds
+	fakeClock.Step(time.Millisecond * 501)
+	c.Assert(xfrmStateCache.isExpired(), Equals, true)
+	stateList, err = xfrmStateCache.XfrmStateList()
+	c.Assert(err, IsNil)
+	c.Assert(len(stateList), Equals, 0)
+
+	// Create new xfrm state and check that cache is utomatically updated
+	c.Assert(xfrmStateCache.isExpired(), Equals, false)
+	xfrmStateCache.XfrmStateAdd(state)
+	c.Assert(xfrmStateCache.isExpired(), Equals, true)
+	stateList, err = xfrmStateCache.XfrmStateList()
+	c.Assert(err, IsNil)
+	c.Assert(len(stateList), Equals, 1)
+
+	// Update xfrm state and check that cache is automatically updated
+	c.Assert(xfrmStateCache.isExpired(), Equals, false)
+	state.Spi = 43
+	xfrmStateCache.XfrmStateUpdate(state)
+	c.Assert(xfrmStateCache.isExpired(), Equals, true)
+	stateList, err = xfrmStateCache.XfrmStateList()
+	c.Assert(err, IsNil)
+	c.Assert(len(stateList), Equals, 1)
+	c.Assert(43, Equals, stateList[0].Spi)
+
+	// Delete xfrm state and check that cache is automatically updated
+	c.Assert(xfrmStateCache.isExpired(), Equals, false)
+	xfrmStateCache.XfrmStateDel(state)
+	c.Assert(xfrmStateCache.isExpired(), Equals, true)
+	stateList, err = xfrmStateCache.XfrmStateList()
+	c.Assert(err, IsNil)
+	c.Assert(len(stateList), Equals, 0)
+}
+
+func (p *IPSecSuitePrivileged) TestXfrmStateListCacheDisabled(c *C) {
+	backupOption := option.Config.EnableIPSecXfrmStateCaching
+	defer func() {
+		option.Config.EnableIPSecXfrmStateCaching = backupOption
+	}()
+	option.Config.EnableIPSecXfrmStateCaching = false
+
+	xfrmStateCache := newTestableXfrmStateListCache(
+		time.Second,
+		baseclocktest.NewFakeClock(time.Now()),
+	)
+
+	c.Assert(xfrmStateCache.isExpired(), Equals, true)
+	// Make sure that cache is correctly fetched in the beginning
+	_, err := xfrmStateCache.XfrmStateList()
+	c.Assert(err, IsNil)
+
+	c.Assert(xfrmStateCache.isExpired(), Equals, true)
+}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -233,6 +233,10 @@ const (
 	// be necessary on key rotations.
 	EnableIPsecKeyWatcher = true
 
+	// Enable caching for XfrmState for IPSec. Significantly reduces CPU usage
+	// in large clusters.
+	EnableIPSecXfrmStateCaching = true
+
 	// EncryptNode enables encrypting traffic from host networking applications
 	// which are not part of Cilium manged pods.
 	EncryptNode = false

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -743,6 +743,10 @@ const (
 	// be necessary on key rotations.
 	EnableIPsecKeyWatcher = "enable-ipsec-key-watcher"
 
+	// Enable caching for XfrmState for IPSec. Significantly reduces CPU usage
+	// in large clusters.
+	EnableIPSecXfrmStateCaching = "enable-ipsec-xfrm-state-caching"
+
 	// IPSecKeyFileName is the name of the option for ipsec key file
 	IPSecKeyFileName = "ipsec-key-file"
 
@@ -1631,6 +1635,9 @@ type DaemonConfig struct {
 	// Enable watcher for IPsec key. If disabled, a restart of the agent will
 	// be necessary on key rotations.
 	EnableIPsecKeyWatcher bool
+
+	// EnableIPSecXfrmStateCaching enables IPSec XfrmState caching.
+	EnableIPSecXfrmStateCaching bool
 
 	// EnableWireguard enables Wireguard encryption
 	EnableWireguard bool
@@ -3006,6 +3013,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.IPSecKeyFile = vp.GetString(IPSecKeyFileName)
 	c.EnableIPsecKeyWatcher = vp.GetBool(EnableIPsecKeyWatcher)
 	c.EnableMonitor = vp.GetBool(EnableMonitorName)
+	c.EnableIPSecXfrmStateCaching = vp.GetBool(EnableIPSecXfrmStateCaching)
 	c.MonitorAggregation = vp.GetString(MonitorAggregationName)
 	c.MonitorAggregationInterval = vp.GetDuration(MonitorAggregationInterval)
 	c.MonitorQueueSize = vp.GetInt(MonitorQueueSizeName)


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/32588

Changes compared to original PR:
- Use `time` instead of `pkg/time`
- Some minor changes with replacing correctly `netlink.XfrmState*` in `ipsec_linux.go`
- switching `t *testing.T` -> `check.v1`

I've manually verified turning off caching with following helm values:
```
extraArgs:
  - --enable-ipsec-xfrm-state-caching=false
```