### PR TITLE
Add metric for identity GC latency

### DIFF
--- a/operator/identitygc/crd_gc.go
+++ b/operator/identitygc/crd_gc.go
@@ -95,7 +95,6 @@ func (igc *GC) gc(ctx context.Context) error {
 	deletedEntries := 0
 
 	timeNow := time.Now()
-	igc.metrics.IdentityGCLatency.Set(float64(0))
 	for _, identity := range identities {
 		foundInCES := false
 		if cesEnabled {
@@ -161,6 +160,7 @@ func (igc *GC) gc(ctx context.Context) error {
 	} else {
 		igc.failedRuns++
 		igc.metrics.IdentityGCRuns.WithLabelValues(LabelValueOutcomeFail).Set(float64(igc.failedRuns))
+		igc.metrics.IdentityGCLatency.Set(float64(0))
 	}
 	aliveEntries := totalEntries - deletedEntries
 	igc.metrics.IdentityGCSize.WithLabelValues(LabelValueOutcomeAlive).Set(float64(aliveEntries))

--- a/operator/identitygc/crd_gc.go
+++ b/operator/identitygc/crd_gc.go
@@ -95,6 +95,7 @@ func (igc *GC) gc(ctx context.Context) error {
 	deletedEntries := 0
 
 	timeNow := time.Now()
+	igc.metrics.IdentityGCLatency.Set(float64(0))
 	for _, identity := range identities {
 		foundInCES := false
 		if cesEnabled {
@@ -156,6 +157,7 @@ func (igc *GC) gc(ctx context.Context) error {
 	if ctx.Err() == nil {
 		igc.successfulRuns++
 		igc.metrics.IdentityGCRuns.WithLabelValues(LabelValueOutcomeSuccess).Set(float64(igc.successfulRuns))
+		igc.metrics.IdentityGCLatency.Set(float64(time.Since(timeNow).Milliseconds()))
 	} else {
 		igc.failedRuns++
 		igc.metrics.IdentityGCRuns.WithLabelValues(LabelValueOutcomeFail).Set(float64(igc.failedRuns))

--- a/operator/identitygc/kvstore_gc.go
+++ b/operator/identitygc/kvstore_gc.go
@@ -47,6 +47,7 @@ func (igc *GC) runKVStoreModeGC(ctx context.Context) error {
 	defer gcTimerDone()
 	for {
 		now := time.Now()
+		igc.metrics.IdentityGCLatency.Set(float64(0))
 
 		keysToDelete, gcStats, err := igc.allocator.RunGC(igc.rateLimiter, keysToDeletePrev)
 		gcDuration := time.Since(now)
@@ -71,6 +72,7 @@ func (igc *GC) runKVStoreModeGC(ctx context.Context) error {
 
 			igc.metrics.IdentityGCSize.WithLabelValues(LabelValueOutcomeAlive).Set(float64(gcStats.Alive))
 			igc.metrics.IdentityGCSize.WithLabelValues(LabelValueOutcomeDeleted).Set(float64(gcStats.Deleted))
+			igc.metrics.IdentityGCLatency.Set(float64(time.Since(now).Milliseconds()))
 		}
 
 		if igc.gcInterval <= gcDuration {

--- a/operator/identitygc/kvstore_gc.go
+++ b/operator/identitygc/kvstore_gc.go
@@ -47,7 +47,6 @@ func (igc *GC) runKVStoreModeGC(ctx context.Context) error {
 	defer gcTimerDone()
 	for {
 		now := time.Now()
-		igc.metrics.IdentityGCLatency.Set(float64(0))
 
 		keysToDelete, gcStats, err := igc.allocator.RunGC(igc.rateLimiter, keysToDeletePrev)
 		gcDuration := time.Since(now)
@@ -56,6 +55,7 @@ func (igc *GC) runKVStoreModeGC(ctx context.Context) error {
 
 			igc.failedRuns++
 			igc.metrics.IdentityGCRuns.WithLabelValues(LabelValueOutcomeFail).Set(float64(igc.failedRuns))
+			igc.metrics.IdentityGCLatency.Set(float64(0))
 		} else {
 			// Best effort to run auth identity GC
 			err = igc.runAuthGC(ctx, keysToDeletePrev)

--- a/operator/identitygc/metrics.go
+++ b/operator/identitygc/metrics.go
@@ -43,6 +43,12 @@ func NewMetrics() *Metrics {
 			Name:      "identity_gc_runs",
 			Help:      "The number of times identity garbage collector has run",
 		}, []string{LabelOutcome}),
+
+		IdentityGCLatency: metric.NewGauge(metric.GaugeOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "identity_gc_latency",
+			Help:      "The duration of the last successful identity GC run",
+		}),
 	}
 }
 
@@ -52,4 +58,7 @@ type Metrics struct {
 
 	// IdentityGCRuns records how many times identity GC has run
 	IdentityGCRuns metric.Vec[metric.Gauge]
+
+	// IdentityGCLatency records the duration of the last successful identity GC run
+	IdentityGCLatency metric.Gauge
 }


### PR DESCRIPTION
This PR adds a metric for measuring the time taken for identity GC to run.

We have found this useful for evaluating the identity GC performance when making changes to relevant config e.g. qps throttling and moving from CRD -> kvstore etc.

Given it's a low volume operation, I've made the metric a gauge instead of a histogram so I can see the actual latency. I'm also clearing it each run and only updating on success. Happy to change any of these details if required.