### PR TITLE
clustermesh: introduce circuit breaker in wait for synchronization operations

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -66,7 +66,7 @@ cilium-agent [flags]
       --cluster-id uint32                                         Unique identifier of the cluster
       --cluster-name string                                       Name of the cluster (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
-      --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
+      --clustermesh-sync-timeout duration                         Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                                CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                             Whether to remove other CNI configurations

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -18,7 +18,7 @@ cilium-agent hive [flags]
       --cluster-id uint32                                         Unique identifier of the cluster
       --cluster-name string                                       Name of the cluster (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
-      --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
+      --clustermesh-sync-timeout duration                         Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                                CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                             Whether to remove other CNI configurations

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -24,7 +24,7 @@ cilium-agent hive dot-graph [flags]
       --cluster-id uint32                                         Unique identifier of the cluster
       --cluster-name string                                       Name of the cluster (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
-      --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
+      --clustermesh-sync-timeout duration                         Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                                CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                             Whether to remove other CNI configurations

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -39,6 +39,7 @@ cilium-operator-alibabacloud [flags]
       --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cnp-status-cleanup-burst int                         Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
       --cnp-status-cleanup-qps float                         Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
       --config string                                        Configuration file (default "$HOME/ciliumd.yaml")

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -28,6 +28,7 @@ cilium-operator-alibabacloud hive [flags]
       --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -34,6 +34,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -42,6 +42,7 @@ cilium-operator-aws [flags]
       --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cnp-status-cleanup-burst int                         Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
       --cnp-status-cleanup-qps float                         Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
       --config string                                        Configuration file (default "$HOME/ciliumd.yaml")

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -28,6 +28,7 @@ cilium-operator-aws hive [flags]
       --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -34,6 +34,7 @@ cilium-operator-aws hive dot-graph [flags]
       --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -42,6 +42,7 @@ cilium-operator-azure [flags]
       --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cnp-status-cleanup-burst int                         Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
       --cnp-status-cleanup-qps float                         Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
       --config string                                        Configuration file (default "$HOME/ciliumd.yaml")

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -28,6 +28,7 @@ cilium-operator-azure hive [flags]
       --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -34,6 +34,7 @@ cilium-operator-azure hive dot-graph [flags]
       --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -38,6 +38,7 @@ cilium-operator-generic [flags]
       --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cnp-status-cleanup-burst int                         Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
       --cnp-status-cleanup-qps float                         Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
       --config string                                        Configuration file (default "$HOME/ciliumd.yaml")

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -28,6 +28,7 @@ cilium-operator-generic hive [flags]
       --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -34,6 +34,7 @@ cilium-operator-generic hive dot-graph [flags]
       --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -47,6 +47,7 @@ cilium-operator [flags]
       --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cnp-status-cleanup-burst int                         Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
       --cnp-status-cleanup-qps float                         Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
       --config string                                        Configuration file (default "$HOME/ciliumd.yaml")

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -28,6 +28,7 @@ cilium-operator hive [flags]
       --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -34,6 +34,7 @@ cilium-operator hive dot-graph [flags]
       --clustermesh-enable-mcs-api                           Whether or not the MCS API support is enabled.
       --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -354,6 +354,12 @@ Removed Options
   More information can be found in the following Helm upgrade notes.
 * The deprecated flag ``install-egress-gateway-routes`` has been removed.
 
+Deprecated Options
+~~~~~~~~~~~~~~~~~~
+
+* The ``clustermesh-ip-identities-sync-timeout`` flag has been deprecated in
+  favor of ``clustermesh-sync-timeout``, and will be removed in Cilium 1.17.
+
 Helm Options
 ~~~~~~~~~~~~
 

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -499,7 +499,7 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState, endpointsR
 
 					err := d.clustermesh.ServicesSynced(d.ctx)
 					if err != nil {
-						log.WithError(err).Fatal("timeout while waiting for all clusters to be locally synchronized")
+						return // The parent context expired, and we are already terminating
 					}
 					log.Debug("all clusters have been correctly synchronized locally")
 				}

--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/pkg/clustermesh/common"
+	"github.com/cilium/cilium/pkg/clustermesh/wait"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -32,6 +33,7 @@ var Cell = cell.Module(
 	cell.ProvidePrivate(idsMgrProvider),
 
 	cell.Config(common.Config{}),
+	cell.Config(wait.TimeoutConfigDefault),
 
 	metrics.Metric(NewMetrics),
 	metrics.Metric(common.MetricsProvider(subsystem)),

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -7,6 +7,7 @@ import (
 	"cmp"
 	"context"
 	"slices"
+	"sync"
 
 	"github.com/cilium/hive/cell"
 
@@ -35,6 +36,7 @@ type Configuration struct {
 	cell.In
 
 	common.Config
+	wait.TimeoutConfig
 
 	// ClusterInfo is the id/name of the local cluster. This is used for logging and metrics
 	ClusterInfo cmtypes.ClusterInfo
@@ -111,6 +113,10 @@ type ClusterMesh struct {
 
 	// nodeName is the name of the local node. This is used for logging and metrics
 	nodeName string
+
+	// syncTimeoutLogOnce ensures that the warning message triggered upon failure
+	// waiting for remote clusters synchronization is output only once.
+	syncTimeoutLogOnce sync.Once
 }
 
 // NewClusterMesh creates a new remote cluster cache based on the
@@ -184,26 +190,34 @@ func (cm *ClusterMesh) NumReadyClusters() int {
 	return cm.common.NumReadyClusters()
 }
 
-// NodesSynced returns after that the initial list of nodes has been received
-// from all remote clusters, and synchronized with the different subscribers.
+// NodesSynced returns after that either the initial list of nodes has been received
+// from all remote clusters, and synchronized with the different subscribers, or the
+// maximum wait period controlled by the clustermesh-sync-timeout flag elapsed. It
+// returns an error if the given context expired.
 func (cm *ClusterMesh) NodesSynced(ctx context.Context) error {
 	return cm.synced(ctx, func(rc *remoteCluster) wait.Fn { return rc.synced.Nodes })
 }
 
-// ServicesSynced returns after that the initial list of shared services has been
-// received from all remote clusters, and synchronized with the BPF datapath.
+// ServicesSynced returns after that either the initial list of shared services has
+// been received from all remote clusters, and synchronized with the BPF datapath, or
+// the maximum wait period controlled by the clustermesh-sync-timeout flag elapsed.
+// It returns an error if the given context expired.
 func (cm *ClusterMesh) ServicesSynced(ctx context.Context) error {
 	return cm.synced(ctx, func(rc *remoteCluster) wait.Fn { return rc.synced.Services })
 }
 
-// IPIdentitiesSynced returns after that the initial list of ipcache entries and
-// identities has been received from all remote clusters, and synchronized with
-// the BPF datapath.
+// IPIdentitiesSynced returns after that either the initial list of ipcache entries
+// and identities has been received from all remote clusters, and synchronized with
+// the BPF datapath, or the maximum wait period controlled by the clustermesh-sync-timeout
+// flag elapsed. It returns an error if the given context expired.
 func (cm *ClusterMesh) IPIdentitiesSynced(ctx context.Context) error {
 	return cm.synced(ctx, func(rc *remoteCluster) wait.Fn { return rc.synced.IPIdentities })
 }
 
 func (cm *ClusterMesh) synced(ctx context.Context, toWaitFn func(*remoteCluster) wait.Fn) error {
+	wctx, cancel := context.WithTimeout(ctx, cm.conf.Timeout())
+	defer cancel()
+
 	waiters := make([]wait.Fn, 0)
 	cm.common.ForEachRemoteCluster(func(rci common.RemoteCluster) error {
 		rc := rci.(*remoteCluster)
@@ -211,7 +225,20 @@ func (cm *ClusterMesh) synced(ctx context.Context, toWaitFn func(*remoteCluster)
 		return nil
 	})
 
-	return wait.ForAll(ctx, waiters)
+	err := wait.ForAll(wctx, waiters)
+	if ctx.Err() == nil && wctx.Err() != nil {
+		// The sync timeout expired, but the parent context is still valid, which
+		// means that the circuit breaker was triggered. Print a warning message
+		// and continue normally, as if the synchronization completed successfully.
+		// This ensures that we don't block forever in case of misconfigurations.
+		cm.syncTimeoutLogOnce.Do(func() {
+			log.Warning("Failed waiting for clustermesh synchronization, expect possible disruption of cross-cluster connections")
+		})
+
+		return nil
+	}
+
+	return err
 }
 
 // Status returns the status of the ClusterMesh subsystem

--- a/pkg/clustermesh/endpointslicesync/cell.go
+++ b/pkg/clustermesh/endpointslicesync/cell.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/clustermesh/common"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/clustermesh/wait"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -37,6 +38,7 @@ var Cell = cell.Module(
 	cell.Invoke(func(ClusterMesh) {}),
 
 	cell.Config(common.Config{}),
+	cell.Config(wait.TimeoutConfigDefault),
 
 	metrics.Metric(NewMetrics),
 	metrics.Metric(common.MetricsProvider(subsystem)),
@@ -46,6 +48,7 @@ type clusterMeshParams struct {
 	cell.In
 
 	common.Config
+	wait.TimeoutConfig
 	Cfg ClusterMeshConfig
 
 	// ClusterInfo is the id/name of the local cluster. This is used for logging and metrics

--- a/pkg/clustermesh/wait/synced.go
+++ b/pkg/clustermesh/wait/synced.go
@@ -6,9 +6,48 @@ package wait
 import (
 	"context"
 	"errors"
+	"time"
+
+	"github.com/spf13/pflag"
 )
 
+type TimeoutConfig struct {
+	// ClusterMeshSyncTimeout is the timeout when waiting for the initial
+	// synchronization from all remote clusters, before triggering the
+	// circuit breaker and possibly disrupting cross-cluster connections.
+	ClusterMeshSyncTimeout time.Duration
+
+	// ClusterMeshIPIdentitiesSyncTimeout is the timeout when waiting for the
+	// initial synchronization of ipcache entries and identities from all remote
+	// clusters before regenerating the local endpoints.
+	// Deprecated in favor of ClusterMeshSyncTimeout.
+	ClusterMeshIPIdentitiesSyncTimeout time.Duration
+}
+
+func (def TimeoutConfig) Flags(flags *pflag.FlagSet) {
+	flags.Duration("clustermesh-sync-timeout", def.ClusterMeshSyncTimeout,
+		"Timeout waiting for the initial synchronization of information from remote clusters")
+
+	flags.Duration("clustermesh-ip-identities-sync-timeout", def.ClusterMeshIPIdentitiesSyncTimeout,
+		"Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration")
+	flags.MarkDeprecated("clustermesh-ip-identities-sync-timeout", "Use --clustermesh-sync-timeout instead")
+}
+
+func (tc TimeoutConfig) Timeout() time.Duration {
+	if tc.ClusterMeshSyncTimeout != TimeoutConfigDefault.ClusterMeshSyncTimeout {
+		return tc.ClusterMeshSyncTimeout
+	}
+
+	return tc.ClusterMeshIPIdentitiesSyncTimeout
+}
+
 var (
+	// TimeoutConfigDefault is the default timeout configuration.
+	TimeoutConfigDefault = TimeoutConfig{
+		ClusterMeshSyncTimeout:             1 * time.Minute,
+		ClusterMeshIPIdentitiesSyncTimeout: 1 * time.Minute,
+	}
+
 	// ErrRemoteClusterDisconnected is the error returned by wait for sync
 	// operations if the remote cluster is disconnected while still waiting.
 	ErrRemoteClusterDisconnected = errors.New("remote cluster disconnected")

--- a/pkg/endpoint/regenerator.go
+++ b/pkg/endpoint/regenerator.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/clustermesh/wait"
@@ -22,35 +21,17 @@ var (
 		"endpoint-regeneration",
 		"Endpoints regeneration",
 
-		cell.Config(RegeneratorConfigDefault),
 		cell.Provide(newRegenerator),
 	)
 )
 
 // Regenerator wraps additional functionalities for endpoint regeneration.
 type Regenerator struct {
-	RegeneratorConfig
-
-	cmWaitFn wait.Fn
+	cmWaitFn      wait.Fn
+	cmWaitTimeout time.Duration
 
 	logger        logrus.FieldLogger
 	cmSyncLogOnce sync.Once
-}
-
-type RegeneratorConfig struct {
-	// ClusterMeshIPIdentitiesSyncTimeout is the timeout when waiting for the
-	// initial synchronization of ipcache entries and identities from all remote
-	// clusters before regenerating the local endpoints.
-	ClusterMeshIPIdentitiesSyncTimeout time.Duration
-}
-
-func (def RegeneratorConfig) Flags(flags *pflag.FlagSet) {
-	flags.Duration("clustermesh-ip-identities-sync-timeout", def.ClusterMeshIPIdentitiesSyncTimeout,
-		"Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration")
-}
-
-var RegeneratorConfigDefault = RegeneratorConfig{
-	ClusterMeshIPIdentitiesSyncTimeout: 1 * time.Minute,
 }
 
 func newRegenerator(in struct {
@@ -58,7 +39,7 @@ func newRegenerator(in struct {
 
 	Logger logrus.FieldLogger
 
-	Config      RegeneratorConfig
+	Config      wait.TimeoutConfig
 	ClusterMesh *clustermesh.ClusterMesh
 }) *Regenerator {
 	waitFn := func(context.Context) error { return nil }
@@ -67,9 +48,9 @@ func newRegenerator(in struct {
 	}
 
 	return &Regenerator{
-		RegeneratorConfig: in.Config,
-		logger:            in.Logger,
-		cmWaitFn:          waitFn,
+		logger:        in.Logger,
+		cmWaitFn:      waitFn,
+		cmWaitTimeout: in.Config.Timeout(),
 	}
 }
 
@@ -81,15 +62,15 @@ func newRegenerator(in struct {
 // forgetting to remove it when the synchronous regeneration is removed.
 func (r *Regenerator) CapTimeoutForSynchronousRegeneration() {
 	const maxTimeout = 5 * time.Second
-	if r.ClusterMeshIPIdentitiesSyncTimeout > maxTimeout {
-		r.ClusterMeshIPIdentitiesSyncTimeout = maxTimeout
+	if r.cmWaitTimeout > maxTimeout {
+		r.cmWaitTimeout = maxTimeout
 		r.logger.WithField(logfields.Value, maxTimeout).
-			Info("Capped clustermesh-ip-identities-sync-timeout because endpoint regeneration needs to be performed synchronously")
+			Info("Capped clustermesh-sync-timeout because endpoint regeneration needs to be performed synchronously")
 	}
 }
 
 func (r *Regenerator) WaitForClusterMeshIPIdentitiesSync(ctx context.Context) error {
-	wctx, cancel := context.WithTimeout(ctx, r.ClusterMeshIPIdentitiesSyncTimeout)
+	wctx, cancel := context.WithTimeout(ctx, r.cmWaitTimeout)
 	defer cancel()
 	err := r.cmWaitFn(wctx)
 

--- a/pkg/endpoint/regenerator_test.go
+++ b/pkg/endpoint/regenerator_test.go
@@ -25,9 +25,7 @@ func TestRegeneratorWaitForIPCacheSync(t *testing.T) {
 			return ctx.Err()
 		},
 
-		RegeneratorConfig: RegeneratorConfig{
-			ClusterMeshIPIdentitiesSyncTimeout: 10 * time.Millisecond,
-		},
+		cmWaitTimeout: 10 * time.Millisecond,
 	}
 
 	tests := []struct {


### PR DESCRIPTION
Upon agent and operator restart, we need to wait for full clustermesh synchronization in multiple subsystems, to prevent breaking existing cross-cluster connections due to e.g., garbage collection of valid but not yet retrieved entries for a given remote cluster. However, the absence of a timeout controlling this process is problematic as well, as the impossibility of connecting to a remote cluster (e.g., due to a misconfiguration) can cause issues for local communication to the blocked GC operations.

Let's standardize the different wait for synchronization functions to automatically return after a user configurable timeout (tunable via the clustermesh-sync-timeout, and set to 1 minute by default) elapses. This mimics and replaces the already existing timeout used to unblock endpoint regeneration, generalizing it to all the other resources as well. The existing flag is deprecated, but it still takes precedence for consistency with the existing behavior.

<!-- Description of change -->

```release-note
Introduce timeout when waiting for the initial synchronization from remote clusters, to avoid blocking forever necessary GC operations in case of clustermesh misconfigurations.
```
