### PR TITLE
ci: lint commit-status-final

### DIFF
--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -226,7 +226,7 @@ jobs:
           done
           exit ${EXIT}
 
-      - name: Validate Commit Status Start Job
+      - name: Validate Commit Status Start/Finish Jobs
         shell: bash
         run: |
           EXIT=0
@@ -245,6 +245,16 @@ jobs:
             JOB_NAME=$(echo "${JOB}" | yq '.value.name')
             if [ "$JOB_NAME" != "Commit Status Start" ]; then
                 echo "commit-status-start job name must be set as 'Commit Status Start' in file $FILE"
+                EXIT=1
+            fi
+            JOB=$(yq '.jobs | to_entries | .[] | select(.key == "commit-status-final")' $FILE)
+            if [ "$JOB" == "" ]; then
+                echo "commit-status-final job is missing in file $FILE"
+                EXIT=1
+            fi
+            JOB_NAME=$(echo "${JOB}" | yq '.value.name')
+            if [ "$JOB_NAME" != "Commit Status Final" ]; then
+                echo "commit-status-final job name must be set as 'Commit Status Final' in file $FILE"
                 EXIT=1
             fi
           done


### PR DESCRIPTION
The PR improves lint workflow with the `commit-status-final` job existence check.
So, if the `commit-status-start` job exists, the `commit-status-final` must also be present.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!