### PR TITLE
daemon: Cleanup after a failed start

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1698,6 +1698,8 @@ func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
 		OnStart: func(cell.HookContext) error {
 			d, restoredEndpoints, err := newDaemon(daemonCtx, cleaner, &params)
 			if err != nil {
+				cancelDaemonCtx()
+				cleaner.Clean()
 				return fmt.Errorf("daemon creation failed: %w", err)
 			}
 			daemon = d
@@ -1705,6 +1707,8 @@ func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
 			if !option.Config.DryMode {
 				if err := startDaemon(daemon, restoredEndpoints, cleaner, params); err != nil {
 					daemonResolver.Reject(err)
+					cancelDaemonCtx()
+					cleaner.Clean()
 					return err
 				}
 			}
@@ -1713,9 +1717,6 @@ func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
 		},
 		OnStop: func(cell.HookContext) error {
 			cancelDaemonCtx()
-			if daemon.statusCollector != nil {
-				daemon.statusCollector.Close()
-			}
 			cleaner.Clean()
 			wg.Wait()
 			return nil

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -1136,5 +1136,7 @@ func (d *Daemon) startStatusCollector(cleaner *daemonCleanup) {
 			}).Error("KVStore state not OK")
 
 		}
+
+		d.statusCollector.Close()
 	})
 }


### PR DESCRIPTION
If the daemon start failed due to e.g. invalid configuration the cleanup was not performed as it was only done from the stop function that was not invoked since the daemon start had failed.

This in some situations lead to confusing crashes as hive did stop all the dependencies of the legacy daemon, for example this crash was reported:

```
   level=fatal msg="failed to start: daemon creation failed: failed to detect devices: ...
   ... bunch of "stopping" messages omitted ...
   panic: runtime error: invalid memory address or nil pointer dereference
   [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1dfa041]
   goroutine 460 [running]:
     github.com/cilium/cilium/pkg/node.(*LocalNodeStore).Observe(0x3f4cfb0? ...
     	<autogenerated>:1 +0x21
```

The crash was caused by the LocalNodeStore stopping and clearing the global variable in the node package (to make sure for example our tests don't leak data across them and to make sure we do cleanup correctly), while the DNSProxy was still running in the background processing DNS packets and using the globals in the node package.

To fix this, run the cleanup functions also when "newDaemon" or "startDaemon" fails with an error.

Fixes: f21f303003d9 ("daemon: bubble up error from startDaemon instead of fataling")

```release-note
cilium-agent: Fix crash due to skipped resource cleanup when agent is stopping due to failed start.
```
