### PR TITLE
policy: Add Port Range Support for Policies Part 2/3

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -548,15 +548,15 @@ spec:
                               description: PortProtocol specifies an L4 port with
                                 an optional transport protocol
                               properties:
+                                endPort:
+                                  description: EndPort can only be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
+                                  description: Port can be an L4 port number, or a
+                                    name in the form of "http" or "http-8080".
                                   pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
@@ -1377,15 +1377,15 @@ spec:
                               description: PortProtocol specifies an L4 port with
                                 an optional transport protocol
                               properties:
+                                endPort:
+                                  description: EndPort can only be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
+                                  description: Port can be an L4 port number, or a
+                                    name in the form of "http" or "http-8080".
                                   pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
@@ -2156,15 +2156,15 @@ spec:
                               description: PortProtocol specifies an L4 port with
                                 an optional transport protocol
                               properties:
+                                endPort:
+                                  description: EndPort can only be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
+                                  description: Port can be an L4 port number, or a
+                                    name in the form of "http" or "http-8080".
                                   pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
@@ -2897,15 +2897,15 @@ spec:
                               description: PortProtocol specifies an L4 port with
                                 an optional transport protocol
                               properties:
+                                endPort:
+                                  description: EndPort can only be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
+                                  description: Port can be an L4 port number, or a
+                                    name in the form of "http" or "http-8080".
                                   pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
@@ -3531,15 +3531,15 @@ spec:
                                 description: PortProtocol specifies an L4 port with
                                   an optional transport protocol
                                 properties:
+                                  endPort:
+                                    description: EndPort can only be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
+                                    description: Port can be an L4 port number, or
+                                      a name in the form of "http" or "http-8080".
                                     pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
@@ -4373,15 +4373,15 @@ spec:
                                 description: PortProtocol specifies an L4 port with
                                   an optional transport protocol
                                 properties:
+                                  endPort:
+                                    description: EndPort can only be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
+                                    description: Port can be an L4 port number, or
+                                      a name in the form of "http" or "http-8080".
                                     pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
@@ -5162,15 +5162,15 @@ spec:
                                 description: PortProtocol specifies an L4 port with
                                   an optional transport protocol
                                 properties:
+                                  endPort:
+                                    description: EndPort can only be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
+                                    description: Port can be an L4 port number, or
+                                      a name in the form of "http" or "http-8080".
                                     pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
@@ -5914,15 +5914,15 @@ spec:
                                 description: PortProtocol specifies an L4 port with
                                   an optional transport protocol
                                 properties:
+                                  endPort:
+                                    description: EndPort can only be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
+                                    description: Port can be an L4 port number, or
+                                      a name in the form of "http" or "http-8080".
                                     pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -552,15 +552,15 @@ spec:
                               description: PortProtocol specifies an L4 port with
                                 an optional transport protocol
                               properties:
+                                endPort:
+                                  description: EndPort can only be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
+                                  description: Port can be an L4 port number, or a
+                                    name in the form of "http" or "http-8080".
                                   pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
@@ -1381,15 +1381,15 @@ spec:
                               description: PortProtocol specifies an L4 port with
                                 an optional transport protocol
                               properties:
+                                endPort:
+                                  description: EndPort can only be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
+                                  description: Port can be an L4 port number, or a
+                                    name in the form of "http" or "http-8080".
                                   pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
@@ -2160,15 +2160,15 @@ spec:
                               description: PortProtocol specifies an L4 port with
                                 an optional transport protocol
                               properties:
+                                endPort:
+                                  description: EndPort can only be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
+                                  description: Port can be an L4 port number, or a
+                                    name in the form of "http" or "http-8080".
                                   pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
@@ -2901,15 +2901,15 @@ spec:
                               description: PortProtocol specifies an L4 port with
                                 an optional transport protocol
                               properties:
+                                endPort:
+                                  description: EndPort can only be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
+                                  description: Port can be an L4 port number, or a
+                                    name in the form of "http" or "http-8080".
                                   pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
@@ -3535,15 +3535,15 @@ spec:
                                 description: PortProtocol specifies an L4 port with
                                   an optional transport protocol
                                 properties:
+                                  endPort:
+                                    description: EndPort can only be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
+                                    description: Port can be an L4 port number, or
+                                      a name in the form of "http" or "http-8080".
                                     pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
@@ -4377,15 +4377,15 @@ spec:
                                 description: PortProtocol specifies an L4 port with
                                   an optional transport protocol
                                 properties:
+                                  endPort:
+                                    description: EndPort can only be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
+                                    description: Port can be an L4 port number, or
+                                      a name in the form of "http" or "http-8080".
                                     pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
@@ -5166,15 +5166,15 @@ spec:
                                 description: PortProtocol specifies an L4 port with
                                   an optional transport protocol
                                 properties:
+                                  endPort:
+                                    description: EndPort can only be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
+                                    description: Port can be an L4 port number, or
+                                      a name in the form of "http" or "http-8080".
                                     pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
@@ -5918,15 +5918,15 @@ spec:
                                 description: PortProtocol specifies an L4 port with
                                   an optional transport protocol
                                 properties:
+                                  endPort:
+                                    description: EndPort can only be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
+                                    description: Port can be an L4 port number, or
+                                      a name in the form of "http" or "http-8080".
                                     pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:

--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -30,15 +30,18 @@ func (l4 L4Proto) IsAny() bool {
 
 // PortProtocol specifies an L4 port with an optional transport protocol
 type PortProtocol struct {
-	// Port is an L4 port number. For now the string will be strictly
-	// parsed as a single uint16. In the future, this field may support
-	// ranges in the form "1024-2048
-	// Port can also be a port name, which must contain at least one [a-z],
-	// and may also contain [0-9] and '-' anywhere except adjacent to another
-	// '-' or in the beginning or the end.
+	// Port can be an L4 port number, or a name in the form of "http"
+	// or "http-8080".
 	//
 	// +kubebuilder:validation:Pattern=`^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$`
 	Port string `json:"port"`
+
+	// EndPort can only be an L4 port number.
+	//
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
+	// +kubebuilder:validation:Optional
+	EndPort int32 `json:"endPort,omitempty"`
 
 	// Protocol is the L4 protocol. If omitted or empty, any protocol
 	// matches. Accepted values: "TCP", "UDP", "SCTP", "ANY"

--- a/pkg/policy/api/zz_generated.deepequal.go
+++ b/pkg/policy/api/zz_generated.deepequal.go
@@ -987,6 +987,9 @@ func (in *PortProtocol) DeepEqual(other *PortProtocol) bool {
 	if in.Port != other.Port {
 		return false
 	}
+	if in.EndPort != other.EndPort {
+		return false
+	}
 	if in.Protocol != other.Protocol {
 		return false
 	}

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -83,6 +83,6 @@ func FuzzAccumulateMapChange(f *testing.F) {
 		key := Key{DestPort: port, Nexthdr: proto, TrafficDirection: dir.Uint8()}
 		value := NewMapStateEntry(csFoo, nil, proxyPort, "", 0, deny, DefaultAuthType, AuthTypeDisabled)
 		policyMaps := MapChanges{}
-		policyMaps.AccumulateMapChanges(csFoo, adds, deletes, key, value)
+		policyMaps.AccumulateMapChanges(csFoo, adds, deletes, []Key{key}, value)
 	})
 }

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -431,7 +431,9 @@ func (a L7ParserType) Merge(b L7ParserType) (L7ParserType, error) {
 type L4Filter struct {
 	// Port is the destination port to allow. Port 0 indicates that all traffic
 	// is allowed at L4.
-	Port     uint16 `json:"port"`
+	Port uint16 `json:"port"`
+	// EndPort is zero for a singular port
+	EndPort  uint16 `json:"endPort,omitempty"`
 	PortName string `json:"port-name,omitempty"`
 	// Protocol is the L4 protocol to allow or NONE
 	Protocol api.L4Proto `json:"protocol"`
@@ -538,11 +540,15 @@ func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redir
 		}
 	}
 
-	keyToAdd := Key{
-		Identity:         0,    // Set in the loop below (if not wildcard)
-		DestPort:         port, // NOTE: Port is in host byte-order!
-		Nexthdr:          proto,
-		TrafficDirection: direction.Uint8(),
+	var keysToAdd []Key
+	for _, mp := range PortRangeToMaskedPorts(port, l4.EndPort) {
+		keysToAdd = append(keysToAdd, Key{
+			Identity:         0,       // Set in the loop below (if not wildcard)
+			DestPort:         mp.port, // NOTE: Port is in host byte-order!
+			InvertedPortMask: ^mp.mask,
+			Nexthdr:          proto,
+			TrafficDirection: direction.Uint8(),
+		})
 	}
 
 	// find the L7 rules for the wildcard entry, if any
@@ -589,15 +595,17 @@ func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redir
 		entry := NewMapStateEntry(cs, l4.RuleOrigin[cs], proxyPort, currentRule.GetListener(), currentRule.GetPriority(), isDenyRule, hasAuth, authType)
 
 		if cs.IsWildcard() {
-			keyToAdd.Identity = 0
-			p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
+			for _, keyToAdd := range keysToAdd {
+				keyToAdd.Identity = 0
+				p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
 
-			if port == 0 {
-				// Allow-all
-				logger.WithField(logfields.EndpointSelector, cs).Debug("ToMapState: allow all")
-			} else {
-				// L4 allow
-				logger.WithField(logfields.EndpointSelector, cs).Debug("ToMapState: L4 allow all")
+				if port == 0 {
+					// Allow-all
+					logger.WithField(logfields.EndpointSelector, cs).Debug("ToMapState: allow all")
+				} else {
+					// L4 allow
+					logger.WithField(logfields.EndpointSelector, cs).Debug("ToMapState: L4 allow all")
+				}
 			}
 			continue
 		}
@@ -617,16 +625,18 @@ func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redir
 			}
 		}
 		for _, id := range idents {
-			keyToAdd.Identity = id.Uint32()
-			p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
-			// If Cilium is in dual-stack mode then the "World" identity
-			// needs to be split into two identities to represent World
-			// IPv6 and IPv4 traffic distinctly from one another.
-			if id == identity.ReservedIdentityWorld && option.Config.IsDualStack() {
-				keyToAdd.Identity = identity.ReservedIdentityWorldIPv4.Uint32()
+			for _, keyToAdd := range keysToAdd {
+				keyToAdd.Identity = id.Uint32()
 				p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
-				keyToAdd.Identity = identity.ReservedIdentityWorldIPv6.Uint32()
-				p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
+				// If Cilium is in dual-stack mode then the "World" identity
+				// needs to be split into two identities to represent World
+				// IPv6 and IPv4 traffic distinctly from one another.
+				if id == identity.ReservedIdentityWorld && option.Config.IsDualStack() {
+					keyToAdd.Identity = identity.ReservedIdentityWorldIPv4.Uint32()
+					p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
+					keyToAdd.Identity = identity.ReservedIdentityWorldIPv6.Uint32()
+					p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
+				}
 			}
 		}
 	}
@@ -776,8 +786,9 @@ func createL4Filter(policyCtx PolicyContext, peerEndpoints api.EndpointSelectorS
 	u8p, _ := u8proto.ParseProtocol(string(protocol))
 
 	l4 := &L4Filter{
-		Port:                uint16(p), // 0 for L3-only rules and named ports
-		PortName:            portName,  // non-"" for named ports
+		Port:                uint16(p),            // 0 for L3-only rules and named ports
+		EndPort:             uint16(port.EndPort), // 0 for a single port, >= 'Port' for a range
+		PortName:            portName,             // non-"" for named ports
 		Protocol:            protocol,
 		U8Proto:             u8p,
 		PerSelectorPolicies: make(L7DataMap),
@@ -1337,7 +1348,15 @@ func (l4Policy *L4Policy) AccumulateMapChanges(l4 *L4Filter, cs CachedSelector, 
 				proxyPort = unrealizedRedirectPort
 			}
 		}
-		key := Key{DestPort: port, Nexthdr: proto, TrafficDirection: direction.Uint8()}
+		var keysToAdd []Key
+		for _, mp := range PortRangeToMaskedPorts(port, l4.EndPort) {
+			keysToAdd = append(keysToAdd, Key{
+				DestPort:         mp.port, // NOTE: Port is in host byte-order!
+				InvertedPortMask: ^mp.mask,
+				Nexthdr:          proto,
+				TrafficDirection: direction.Uint8(),
+			})
+		}
 		value := NewMapStateEntry(cs, derivedFrom, proxyPort, listener, priority, isDeny, hasAuth, authType)
 
 		if option.Config.Debug {
@@ -1358,7 +1377,7 @@ func (l4Policy *L4Policy) AccumulateMapChanges(l4 *L4Filter, cs CachedSelector, 
 				logfields.ListenerPriority: priority,
 			}).Debug("AccumulateMapChanges")
 		}
-		epPolicy.policyMapChanges.AccumulateMapChanges(cs, adds, deletes, key, value)
+		epPolicy.policyMapChanges.AccumulateMapChanges(cs, adds, deletes, keysToAdd, value)
 	}
 }
 

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -27,64 +27,100 @@ func Test_IsSuperSetOf(t *testing.T) {
 		{key(0, 0, 0, 0), key(42, 0, 6, 0), 1},
 		{key(0, 0, 0, 0), key(42, 80, 6, 0), 1},
 		{key(0, 0, 0, 0), key(42, 0, 0, 0), 1},
-		{key(0, 0, 6, 0), key(42, 0, 6, 0), 3},
+		{key(0, 0, 6, 0), key(42, 0, 6, 0), 3}, // port is the same
 		{key(0, 0, 6, 0), key(42, 80, 6, 0), 2},
+		{keyWithPortMask(0, 64, 0xffc0, 6, 0), key(42, 80, 6, 0), 2}, // port range 64-127,80
 		{key(0, 80, 6, 0), key(42, 80, 6, 0), 3},
-		{key(0, 80, 6, 0), key(42, 80, 17, 0), 0},  // proto is different
-		{key(2, 80, 6, 0), key(42, 80, 6, 0), 0},   // id is different
-		{key(0, 8080, 6, 0), key(42, 80, 6, 0), 0}, // port is different
-		{key(42, 0, 0, 0), key(42, 0, 0, 0), 0},    // same key
+		{keyWithPortMask(0, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 3}, // port ranges are the same
+		{key(0, 80, 6, 0), key(42, 80, 17, 0), 0},                                        // proto is different
+		{key(2, 80, 6, 0), key(42, 80, 6, 0), 0},                                         // id is different
+		{key(0, 8080, 6, 0), key(42, 80, 6, 0), 0},                                       // port is different
+		{keyWithPortMask(0, 64, 0xffc0, 6, 0), key(42, 8080, 6, 0), 0},                   // port range is different from port
+		{key(42, 0, 0, 0), key(42, 0, 0, 0), 0},                                          // same key
 		{key(42, 0, 0, 0), key(42, 0, 6, 0), 4},
 		{key(42, 0, 0, 0), key(42, 80, 6, 0), 4},
+		{keyWithPortMask(42, 64, 0xffc0, 0, 0), key(42, 80, 6, 0), 4}, // port range 64-127,80
 		{key(42, 0, 0, 0), key(42, 0, 17, 0), 4},
 		{key(42, 0, 0, 0), key(42, 80, 17, 0), 4},
+		{keyWithPortMask(42, 64, 0xffc0, 0, 0), key(42, 80, 17, 0), 4},
 		{key(42, 0, 6, 0), key(42, 0, 6, 0), 0}, // same key
 		{key(42, 0, 6, 0), key(42, 80, 6, 0), 5},
+		{keyWithPortMask(42, 64, 0xffc0, 6, 0), key(42, 80, 6, 0), 5},
 		{key(42, 0, 6, 0), key(42, 8080, 6, 0), 5},
-		{key(42, 80, 6, 0), key(42, 80, 6, 0), 0},    // same key
-		{key(42, 80, 6, 0), key(42, 8080, 6, 0), 0},  // different port
-		{key(42, 80, 6, 0), key(42, 80, 17, 0), 0},   // different proto
-		{key(42, 80, 6, 0), key(42, 8080, 17, 0), 0}, // different port and proto
+		{key(42, 80, 6, 0), key(42, 80, 6, 0), 0},                                          // same key
+		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 0},  // same key
+		{key(42, 80, 6, 0), key(42, 8080, 6, 0), 0},                                        // different port
+		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(42, 128, 0xff80, 6, 0), 0}, // different port ranges
+		{key(42, 80, 6, 0), key(42, 80, 17, 0), 0},                                         // different proto
+		{key(42, 80, 6, 0), key(42, 8080, 17, 0), 0},                                       // different port and proto
 
 		// increasing specificity for a L3/L4 key
 		{key(0, 0, 0, 0), key(42, 80, 6, 0), 1},
+		{keyWithPortMask(0, 64, 0xffc0, 0, 0), key(42, 80, 6, 0), 1},
 		{key(0, 0, 6, 0), key(42, 80, 6, 0), 2},
+		{keyWithPortMask(0, 64, 0xffc0, 6, 0), key(42, 80, 6, 0), 2},
 		{key(0, 80, 6, 0), key(42, 80, 6, 0), 3},
+		{keyWithPortMask(0, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 3},
 		{key(42, 0, 0, 0), key(42, 80, 6, 0), 4},
+		{keyWithPortMask(42, 64, 0xffc0, 0, 0), key(42, 80, 6, 0), 4},
 		{key(42, 0, 6, 0), key(42, 80, 6, 0), 5},
-		{key(42, 80, 6, 0), key(42, 80, 6, 0), 0}, // same key
+		{keyWithPortMask(42, 64, 0xffc0, 6, 0), key(42, 80, 6, 0), 5},
+		{key(42, 80, 6, 0), key(42, 80, 6, 0), 0},                                         // same key
+		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 0}, // same key
 
 		// increasing specificity for a L3-only key
 		{key(0, 0, 0, 0), key(42, 0, 0, 0), 1},
-		{key(0, 0, 6, 0), key(42, 0, 0, 0), 0},   // not a superset
-		{key(0, 80, 6, 0), key(42, 0, 0, 0), 0},  // not a superset
-		{key(42, 0, 0, 0), key(42, 0, 0, 0), 0},  // same key
-		{key(42, 0, 6, 0), key(42, 0, 0, 0), 0},  // not a superset
-		{key(42, 80, 6, 0), key(42, 0, 0, 0), 0}, // not a superset
+		{keyWithPortMask(0, 64, 0xffc0, 0, 0), key(42, 0, 0, 0), 1},
+		{key(0, 0, 6, 0), key(42, 0, 0, 0), 0},                                            // not a superset
+		{key(0, 80, 6, 0), key(42, 0, 0, 0), 0},                                           // not a superset
+		{keyWithPortMask(0, 64, 0xffc0, 6, 0), key(42, 0, 0, 0), 0},                       // not a superset
+		{key(42, 0, 0, 0), key(42, 0, 0, 0), 0},                                           // same key
+		{key(42, 0, 6, 0), key(42, 0, 0, 0), 0},                                           // not a superset
+		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 0, 0), 0}, // not a superset
+		{key(42, 80, 6, 0), key(42, 0, 0, 0), 0},                                          // not a superset
+		{keyWithPortMask(42, 64, 0xffc0, 6, 0), key(42, 0, 0, 0), 0},                      // not a superset
 
 		// increasing specificity for a L3/proto key
-		{key(0, 0, 0, 0), key(42, 0, 6, 0), 1},
-		{key(0, 0, 6, 0), key(42, 0, 6, 0), 3},
-		{key(0, 80, 6, 0), key(42, 0, 6, 0), 0}, // not a superset
+		{key(0, 0, 0, 0), key(42, 0, 6, 0), 1}, // wildcard
+		{keyWithPortMask(0, 64, 0xffc0, 0, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 1},
+		{key(0, 0, 6, 0), key(42, 0, 6, 0), 3},                                           // ports are the same
+		{keyWithPortMask(0, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 3}, // port ranges are the same
+		{key(0, 80, 6, 0), key(42, 0, 6, 0), 0},                                          // not a superset
+		{key(0, 80, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 0},                     // not a superset
 		{key(42, 0, 0, 0), key(42, 0, 6, 0), 4},
-		{key(42, 0, 6, 0), key(42, 0, 6, 0), 0},  // same key
-		{key(42, 80, 6, 0), key(42, 0, 6, 0), 0}, // not a superset
+		{keyWithPortMask(42, 64, 0xffc0, 0, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 4},
+		{key(42, 0, 6, 0), key(42, 0, 6, 0), 0},                                           // same key
+		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 0}, // same key
+		{key(42, 80, 6, 0), key(42, 0, 6, 0), 0},                                          // not a superset
+		{key(42, 80, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 0},                     // not a superset
 
 		// increasing specificity for a proto-only key
 		{key(0, 0, 0, 0), key(0, 0, 6, 0), 1},
-		{key(0, 0, 6, 0), key(0, 0, 6, 0), 0},   // same key
-		{key(0, 80, 6, 0), key(0, 0, 6, 0), 0},  // not a superset
-		{key(42, 0, 0, 0), key(0, 0, 6, 0), 0},  // not a superset
-		{key(42, 0, 6, 0), key(0, 0, 6, 0), 0},  // not a superset
-		{key(42, 80, 6, 0), key(0, 0, 6, 0), 0}, // not a superset
+		{keyWithPortMask(0, 64, 0xffc0, 0, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 1},
+		{key(0, 0, 6, 0), key(0, 0, 6, 0), 0},                                            // same key
+		{keyWithPortMask(0, 64, 0xffc0, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0},  // same key
+		{key(0, 80, 6, 0), key(0, 0, 6, 0), 0},                                           // not a superset
+		{key(0, 80, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0},                      // not a superset
+		{key(42, 0, 0, 0), key(0, 0, 6, 0), 0},                                           // not a superset
+		{keyWithPortMask(42, 64, 0xffc0, 0, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0}, // not a superset
+		{key(42, 0, 6, 0), key(0, 0, 6, 0), 0},                                           // not a superset
+		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0}, // not a superset
+		{key(42, 80, 6, 0), key(0, 0, 6, 0), 0},                                          // not a superset
+		{key(42, 80, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0},                     // not a superset
 
 		// increasing specificity for a L4-only key
 		{key(0, 0, 0, 0), key(0, 80, 6, 0), 1},
+		{keyWithPortMask(0, 64, 0xffc0, 0, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 1},
 		{key(0, 0, 6, 0), key(0, 80, 6, 0), 2},
-		{key(0, 80, 6, 0), key(0, 80, 6, 0), 0},  // same key
-		{key(42, 0, 0, 0), key(0, 80, 6, 0), 0},  // not a superset
-		{key(42, 0, 6, 0), key(0, 80, 6, 0), 0},  // not a superset
-		{key(42, 80, 6, 0), key(0, 80, 6, 0), 0}, // not a superset
+		{keyWithPortMask(0, 64, 0xffc0, 6, 0), key(0, 80, 6, 0), 2},
+		{key(0, 80, 6, 0), key(0, 80, 6, 0), 0},                                          // same key
+		{keyWithPortMask(0, 64, 0xffc0, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0},  // same key
+		{key(42, 0, 0, 0), key(0, 80, 6, 0), 0},                                          // not a superset
+		{keyWithPortMask(42, 64, 0xffc0, 0, 0), key(0, 80, 6, 0), 0},                     // not a superset
+		{key(42, 0, 6, 0), key(0, 80, 6, 0), 0},                                          // not a superset
+		{keyWithPortMask(42, 64, 0xffc0, 6, 0), key(0, 80, 6, 0), 0},                     // not a superset
+		{key(42, 80, 6, 0), key(0, 80, 6, 0), 0},                                         // not a superset
+		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0}, // not a superset
 
 	}
 	for i, tt := range tests {
@@ -198,7 +234,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
-			name: "test-2 - L3 allow KV should not overwrite deny entry",
+			name: "test-2a - L3 allow KV should not overwrite deny entry",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -258,7 +294,70 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
-			name: "test-3 - L3-L4 allow KV should not overwrite deny entry",
+			name: "test-2b - L3 port-range allow KV should not overwrite deny entry",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         80,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         80,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
+		},
+		{
+			name: "test-3a - L3-L4 allow KV should not overwrite deny entry",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -301,7 +400,53 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
-			name: "test-4 - L3-L4 deny KV should overwrite allow entry",
+			name: "test-3b - L3-L4 port-range allow KV should not overwrite deny entry",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds:    Keys{},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
+		},
+		{
+			name: "test-4a - L3-L4 deny KV should overwrite allow entry",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -362,7 +507,78 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 		},
 		{
-			name: "test-5 - L3 deny KV should overwrite all L3-L4 allow and L3 allow entries for the same L3",
+			name: "test-4b - L3-L4 port-range deny KV should overwrite allow entry",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         80,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantDeletes: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         80,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantOld: map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         80,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+		},
+		{
+			name: "test-5a - L3 deny KV should overwrite all L3-L4 allow and L3 allow entries for the same L3",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -490,7 +706,142 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 		},
 		{
-			name: "test-6 - L3 egress deny KV should not overwrite any existing ingress allow",
+			name: "test-5b - L3 port-range deny KV should overwrite all L3-L4 allow and L3 allow entries for the same L3",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         80,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         2,
+					DestPort:         80,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         2,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+				{
+					Identity:         2,
+					DestPort:         80,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         2,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantDeletes: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         80,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantOld: map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         80,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+		},
+		{
+			name: "test-6a - L3 egress deny KV should not overwrite any existing ingress allow",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -610,7 +961,134 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
-			name: "test-7 - L3 ingress deny KV should not be overwritten by a L3-L4 ingress allow",
+			name: "test-6b - L3 egress port-range deny KV should not overwrite any existing ingress allow",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         80,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         2,
+					DestPort:         80,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         2,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Egress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         80,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Egress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+				{
+					Identity:         2,
+					DestPort:         80,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         2,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Egress.Uint8(),
+				}: struct{}{},
+			},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
+		},
+		{
+			name: "test-7a - L3 ingress deny KV should not be overwritten by a L3-L4 ingress allow",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -653,7 +1131,51 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
-			name: "test-8 - L3 ingress deny KV should not be overwritten by a L3-L4-L7 ingress allow",
+			name: "test-7b - L3 ingress deny KV should not be overwritten by a L3-L4 port-range ingress allow",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds:    Keys{},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
+		},
+		{
+			name: "test-8a - L3 ingress deny KV should not be overwritten by a L3-L4-L7 ingress allow",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -697,7 +1219,52 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
-			name: "test-9 - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow",
+			name: "test-8b - L3 ingress deny KV should not be overwritten by a L3-L4-L7 port-range ingress allow",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds:    Keys{},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
+		},
+		{
+			name: "test-9a - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -767,7 +1334,80 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 		},
 		{
-			name: "test-10 - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow and a L3-L4 deny",
+			name: "test-9b - L3 ingress deny KV should overwrite a L3-L4-L7 port-range ingress allow",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantDeletes: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantOld: map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+		},
+		{
+			name: "test-10a - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow and a L3-L4 deny",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -863,7 +1503,109 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 		},
 		{
-			name: "test-11 - L3 ingress allow should not be allowed if there is a L3 'all' deny",
+			name: "test-10b - L3 ingress deny KV should overwrite a L3-L4-L7 port-range ingress allow and a L3-L4 port-range deny",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantDeletes: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantOld: map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			},
+		},
+		{
+			name: "test-11a - L3 ingress allow should not be allowed if there is a L3 'all' deny",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -926,8 +1668,76 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			wantAdds:    Keys{},
 			wantDeletes: Keys{},
 			wantOld:     map[Key]MapStateEntry{},
-		}, {
-			name: "test-12 - inserting a L3 'all' deny should delete all entries for that direction",
+		},
+		{
+			name: "test-11b - L3 ingress allow should not be allowed if there is a L3 'all' deny",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Egress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         0,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         100,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Egress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         0,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds:    Keys{},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
+		},
+		{
+			name: "test-12a - inserting a L3 'all' deny should delete all entries for that direction",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -1045,8 +1855,137 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           false,
 				},
 			},
-		}, {
-			name: "test-13 - L3-L4-L7 ingress allow should overwrite a L3-L4-L7 ingress allow due to lower priority",
+		},
+		{
+			name: "test-12b - inserting a L3 'all' deny should delete all entries for that direction (including port ranges)",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         4,
+					InvertedPortMask: ^uint16(0xfffc), // port range 4-7
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         100,
+					DestPort:         4,
+					InvertedPortMask: ^uint16(0xfffc), // port range 4-7
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Egress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         0,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         0,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        0,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+				{
+					Identity:         100,
+					DestPort:         4,
+					InvertedPortMask: ^uint16(0xfffc), // port range 4-7
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Egress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           true,
+				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         0,
+					DestPort:         0,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantDeletes: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+				Key{
+					Identity:         1,
+					DestPort:         4,
+					InvertedPortMask: ^uint16(0xfffc), // port range 4-7
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantOld: map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+				{
+					Identity:         1,
+					DestPort:         4,
+					InvertedPortMask: ^uint16(0xfffc), // port range 4-7
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort:        8080,
+					priority:         8080,
+					DerivedFromRules: nil,
+					IsDeny:           false,
+				},
+			},
+		},
+		{
+			name: "test-13a - L3-L4-L7 ingress allow should overwrite a L3-L4-L7 ingress allow due to lower priority",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -1105,8 +2044,75 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					Listener:  "listener1",
 				},
 			},
-		}, {
-			name: "test-14 - L4-L7 ingress allow should overwrite a L3-L4-L7 ingress allow due to lower priority on the same port",
+		},
+		{
+			name: "test-13b - L3-L4-L7 port-range ingress allow should overwrite a L3-L4-L7 port-range ingress allow due to lower priority",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0),
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort: 8080,
+					priority:  8080,
+					Listener:  "listener1",
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0),
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort: 9090,
+					priority:  1,
+					Listener:  "listener2",
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0),
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort: 9090,
+					priority:  1,
+					Listener:  "listener2",
+				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0),
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
+			},
+			wantDeletes: Keys{},
+			wantOld: map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0),
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort: 8080,
+					priority:  8080,
+					Listener:  "listener1",
+				},
+			},
+		},
+		{
+			name: "test-14a - L4-L7 ingress allow should overwrite a L3-L4-L7 ingress allow due to lower priority on the same port",
 			ms: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
@@ -1150,6 +2156,64 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         80,
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort: 8080,
+					priority:  8080,
+					Listener:  "listener1",
+				},
+			},
+		},
+		{
+			name: "test-14b - L4-L7 port-range ingress allow should overwrite a L3-L4-L7 port-range ingress allow due to lower priority on the same port",
+			ms: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0),
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort: 8080,
+					priority:  8080,
+					Listener:  "listener1",
+				},
+			}),
+			args: args{
+				key: Key{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0),
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				},
+				entry: MapStateEntry{
+					ProxyPort: 8080,
+					priority:  1,
+					Listener:  "listener1",
+				},
+			},
+			want: newMapState(map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0),
+					Nexthdr:          3,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: {
+					ProxyPort: 8080,
+					priority:  1,
+					Listener:  "listener1",
+				},
+			}),
+			wantAdds:    Keys{},
+			wantDeletes: Keys{},
+			wantOld: map[Key]MapStateEntry{
+				{
+					Identity:         1,
+					DestPort:         64,
+					InvertedPortMask: ^uint16(0xffc0),
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -27,7 +27,7 @@ func Test_IsSuperSetOf(t *testing.T) {
 		{key(0, 0, 0, 0), key(42, 0, 6, 0), 1},
 		{key(0, 0, 0, 0), key(42, 80, 6, 0), 1},
 		{key(0, 0, 0, 0), key(42, 0, 0, 0), 1},
-		{key(0, 0, 6, 0), key(42, 0, 6, 0), 2},
+		{key(0, 0, 6, 0), key(42, 0, 6, 0), 3},
 		{key(0, 0, 6, 0), key(42, 80, 6, 0), 2},
 		{key(0, 80, 6, 0), key(42, 80, 6, 0), 3},
 		{key(0, 80, 6, 0), key(42, 80, 17, 0), 0},  // proto is different
@@ -64,7 +64,7 @@ func Test_IsSuperSetOf(t *testing.T) {
 
 		// increasing specificity for a L3/proto key
 		{key(0, 0, 0, 0), key(42, 0, 6, 0), 1},
-		{key(0, 0, 6, 0), key(42, 0, 6, 0), 2},
+		{key(0, 0, 6, 0), key(42, 0, 6, 0), 3},
 		{key(0, 80, 6, 0), key(42, 0, 6, 0), 0}, // not a superset
 		{key(42, 0, 0, 0), key(42, 0, 6, 0), 4},
 		{key(42, 0, 6, 0), key(42, 0, 6, 0), 0},  // same key
@@ -1596,7 +1596,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 				proxyPort = 1
 			}
 			value := NewMapStateEntry(cs, nil, proxyPort, "", 0, x.deny, DefaultAuthType, AuthTypeDisabled)
-			policyMaps.AccumulateMapChanges(cs, adds, deletes, key, value)
+			policyMaps.AccumulateMapChanges(cs, adds, deletes, []Key{key}, value)
 		}
 		adds, deletes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, denyRules, nil)
 		policyMapState.validatePortProto(t)
@@ -1817,7 +1817,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 				proxyPort = 1
 			}
 			value := NewMapStateEntry(cs, nil, proxyPort, "", 0, x.deny, x.hasAuth, x.authType)
-			policyMaps.AccumulateMapChanges(cs, adds, deletes, key, value)
+			policyMaps.AccumulateMapChanges(cs, adds, deletes, []Key{key}, value)
 		}
 		adds, deletes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, policyFeatures(0), nil)
 		policyMapState.validatePortProto(t)
@@ -2384,7 +2384,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 				proxyPort = 1
 			}
 			value := NewMapStateEntry(cs, nil, proxyPort, "", 0, x.deny, DefaultAuthType, AuthTypeDisabled)
-			policyMaps.AccumulateMapChanges(cs, adds, deletes, key, value)
+			policyMaps.AccumulateMapChanges(cs, adds, deletes, []Key{key}, value)
 		}
 		adds, deletes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, denyRules, nil)
 		changes = ChangeState{
@@ -2534,7 +2534,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
 		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
 		outcomeKeys.validatePortProto(t)
-		require.EqualValues(t, expectedKeys, outcomeKeys, tt.name)
+		require.True(t, expectedKeys.Equals(outcomeKeys), "%s (MapState):\n%s", tt.name, expectedKeys.Diff(nil, outcomeKeys))
 	}
 	// Now test all cases with different traffic directions.
 	// This should result in both entries being inserted with

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -1469,7 +1469,7 @@ Resolving ingress policy for [any:bar]
     Denies from labels {"matchLabels":{"reserved:host":""}}
     Denies from labels {"matchLabels":{"any:baz":""}}
       Found all required labels
-      Denies port [{80 }]
+      Denies port [{80 0 }]
 2/2 rules selected
 Found no allow rule
 Found deny rule
@@ -1546,7 +1546,7 @@ Resolving ingress policy for [any:bar]
     Denies from labels {"matchLabels":{"reserved:host":""},"matchExpressions":[{"key":"any:baz","operator":"In","values":[""]}]}
     Denies from labels {"matchLabels":{"any:baz":""},"matchExpressions":[{"key":"any:baz","operator":"In","values":[""]}]}
       Found all required labels
-      Denies port [{80 }]
+      Denies port [{80 0 }]
         No port match found
 * Rule {"matchLabels":{"any:bar":""}}: selected
 3/3 rules selected

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -2173,7 +2173,7 @@ Resolving ingress policy for [any:bar]
     Allows from labels {"matchLabels":{"reserved:host":""}}
     Allows from labels {"matchLabels":{"any:baz":""}}
       Found all required labels
-      Allows port [{80 ANY}]
+      Allows port [{80 0 ANY}]
 2/2 rules selected
 Found allow rule
 Found no deny rule
@@ -2250,7 +2250,7 @@ Resolving ingress policy for [any:bar]
     Allows from labels {"matchLabels":{"reserved:host":""},"matchExpressions":[{"key":"any:baz","operator":"In","values":[""]}]}
     Allows from labels {"matchLabels":{"any:baz":""},"matchExpressions":[{"key":"any:baz","operator":"In","values":[""]}]}
       Found all required labels
-      Allows port [{80 ANY}]
+      Allows port [{80 0 ANY}]
         No port match found
 * Rule {"matchLabels":{"any:bar":""}}: selected
 3/3 rules selected


### PR DESCRIPTION
This PR prepares the policy engine for adding port ranges
by enabling the underlying userspace cache to calculate
insertion, deletion, and lookups with port ranges, as well
as adding unit tests to ensure that the logic works. It does
not add support for adding policy port ranges at the API
level that will be addressed in the final PR.

The Policy CRD is modified by this PR without
supporting port ranges at the policy repository level
(this will be added in the final PR). This has to be done 
because the "PortProtocol" struct is shared by both 
the CRD (aka the API level) and the L4Filter struct
(aka the cache level).


See commits for details.

