### PR TITLE
Consolidate regeneration metrics accounting

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -391,8 +391,8 @@ Policy
 Name                                       Labels                                             Default    Description
 ========================================== ================================================== ========== ========================================================
 ``policy``                                                                                    Enabled    Number of policies currently loaded
-``policy_regeneration_total``                                                                 Enabled    Total number of policies regenerated successfully
-``policy_regeneration_time_stats_seconds`` ``scope``                                          Enabled    Policy regeneration time stats labeled by the scope
+``policy_regeneration_total``                                                                 Enabled    Deprecated, will be removed in Cilium 1.17 - use ``endpoint_regenerations_total`` instead. Total number of policies regenerated successfully
+``policy_regeneration_time_stats_seconds`` ``scope``                                          Enabled    Deprecated, will be removed in Cilium 1.17 - use ``endpoint_regeneration_time_stats_seconds`` instead. Policy regeneration time stats labeled by the scope
 ``policy_max_revision``                                                                       Enabled    Highest policy revision number in the agent
 ``policy_change_total``                                                                       Enabled    Number of policy changes by outcome
 ``policy_endpoint_enforcement_status``                                                        Enabled    Number of endpoints labeled by policy enforcement status

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -332,7 +332,7 @@ Annotations:
 * Detection and reconfiguration on changes to native network devices and their addresses is now
   the default. Cilium will now load the native device BPF program onto devices that appear after
   Cilium has started. NodePort services are now available on addresses assigned after Cilium has
-  started. The set of addresses to use for NodePort can be configured with the Helm option 
+  started. The set of addresses to use for NodePort can be configured with the Helm option
   ``nodePort.addresses``.
   The related Helm option ``enableRuntimeDeviceDetection`` has been deprecated and will be
   removed in future release. The devices and the addresses Cilium considers the node's addresses
@@ -347,6 +347,10 @@ Annotations:
   ``ces-write-qps-limit``, ``ces-write-qps-burst``, ``ces-enable-dynamic-rate-limit``,
   ``ces-dynamic-rate-limit-nodes``, ``ces-dynamic-rate-limit-qps-limit``,
   ``ces-dynamic-rate-limit-qps-burst``
+* Metrics ``policy_regeneration_total`` and
+  ``policy_regeneration_time_stats_seconds`` have been deprecated in favor of
+  ``endpoint_regenerations_total`` and
+  ``endpoint_regeneration_time_stats_seconds``, respectively.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -692,7 +692,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 	// This is because policy generation needs the ipcache to make progress, and the ipcache needs to call
 	// endpoint.ApplyPolicyMapChanges()
 	stats.policyCalculation.Start()
-	policyResult, err := e.regeneratePolicy()
+	policyResult, err := e.regeneratePolicy(stats)
 	stats.policyCalculation.End(err == nil)
 	if err != nil {
 		return fmt.Errorf("unable to regenerate policy for '%s': %w", e.StringID(), err)

--- a/pkg/endpoint/metrics.go
+++ b/pkg/endpoint/metrics.go
@@ -90,29 +90,6 @@ func (s *regenerationStatistics) GetMap() map[string]*spanstat.SpanStat {
 	return result
 }
 
-type policyRegenerationStatistics struct {
-	success                    bool
-	totalTime                  spanstat.SpanStat
-	waitingForIdentityCache    spanstat.SpanStat
-	waitingForPolicyRepository spanstat.SpanStat
-	policyCalculation          spanstat.SpanStat
-}
-
-func (ps *policyRegenerationStatistics) SendMetrics() {
-	metrics.PolicyRegenerationCount.Inc()
-
-	sendMetrics(ps, metrics.PolicyRegenerationTimeStats)
-}
-
-func (ps *policyRegenerationStatistics) GetMap() map[string]*spanstat.SpanStat {
-	return map[string]*spanstat.SpanStat{
-		"waitingForIdentityCache":    &ps.waitingForIdentityCache,
-		"waitingForPolicyRepository": &ps.waitingForPolicyRepository,
-		"policyCalculation":          &ps.policyCalculation,
-		"total":                      &ps.totalTime,
-	}
-}
-
 // endpointPolicyStatusMap is a map to store the endpoint id and the policy
 // enforcement status. It is used only to send metrics to prometheus.
 type endpointPolicyStatusMap struct {

--- a/pkg/endpoint/metrics.go
+++ b/pkg/endpoint/metrics.go
@@ -38,19 +38,21 @@ func sendMetrics(stats statistics, metric metric.Vec[metric.Observer]) {
 }
 
 type regenerationStatistics struct {
-	success                bool
-	endpointID             uint16
-	policyStatus           models.EndpointPolicyEnabled
-	totalTime              spanstat.SpanStat
-	waitingForLock         spanstat.SpanStat
-	waitingForCTClean      spanstat.SpanStat
-	policyCalculation      spanstat.SpanStat
-	proxyConfiguration     spanstat.SpanStat
-	proxyPolicyCalculation spanstat.SpanStat
-	proxyWaitForAck        spanstat.SpanStat
-	datapathRealization    loaderMetrics.SpanStat
-	mapSync                spanstat.SpanStat
-	prepareBuild           spanstat.SpanStat
+	success                    bool
+	endpointID                 uint16
+	policyStatus               models.EndpointPolicyEnabled
+	totalTime                  spanstat.SpanStat
+	waitingForLock             spanstat.SpanStat
+	waitingForIdentityCache    spanstat.SpanStat
+	waitingForPolicyRepository spanstat.SpanStat
+	waitingForCTClean          spanstat.SpanStat
+	policyCalculation          spanstat.SpanStat
+	proxyConfiguration         spanstat.SpanStat
+	proxyPolicyCalculation     spanstat.SpanStat
+	proxyWaitForAck            spanstat.SpanStat
+	datapathRealization        loaderMetrics.SpanStat
+	mapSync                    spanstat.SpanStat
+	prepareBuild               spanstat.SpanStat
 }
 
 // SendMetrics sends the regeneration statistics for this endpoint to
@@ -72,15 +74,17 @@ func (s *regenerationStatistics) SendMetrics() {
 // GetMap returns a map which key is the stat name and the value is the stat
 func (s *regenerationStatistics) GetMap() map[string]*spanstat.SpanStat {
 	result := map[string]*spanstat.SpanStat{
-		"waitingForLock":         &s.waitingForLock,
-		"waitingForCTClean":      &s.waitingForCTClean,
-		"policyCalculation":      &s.policyCalculation,
-		"proxyConfiguration":     &s.proxyConfiguration,
-		"proxyPolicyCalculation": &s.proxyPolicyCalculation,
-		"proxyWaitForAck":        &s.proxyWaitForAck,
-		"mapSync":                &s.mapSync,
-		"prepareBuild":           &s.prepareBuild,
-		"total":                  &s.totalTime,
+		"waitingForLock":             &s.waitingForLock,
+		"waitingForIdentityCache":    &s.waitingForIdentityCache,
+		"waitingForPolicyRepository": &s.waitingForPolicyRepository,
+		"waitingForCTClean":          &s.waitingForCTClean,
+		"policyCalculation":          &s.policyCalculation,
+		"proxyConfiguration":         &s.proxyConfiguration,
+		"proxyPolicyCalculation":     &s.proxyPolicyCalculation,
+		"proxyWaitForAck":            &s.proxyWaitForAck,
+		"mapSync":                    &s.mapSync,
+		"prepareBuild":               &s.prepareBuild,
+		"total":                      &s.totalTime,
 	}
 	for k, v := range s.datapathRealization.GetMap() {
 		result[k] = v

--- a/pkg/endpoint/metrics.go
+++ b/pkg/endpoint/metrics.go
@@ -43,7 +43,6 @@ type regenerationStatistics struct {
 	policyStatus               models.EndpointPolicyEnabled
 	totalTime                  spanstat.SpanStat
 	waitingForLock             spanstat.SpanStat
-	waitingForIdentityCache    spanstat.SpanStat
 	waitingForPolicyRepository spanstat.SpanStat
 	waitingForCTClean          spanstat.SpanStat
 	policyCalculation          spanstat.SpanStat
@@ -75,7 +74,6 @@ func (s *regenerationStatistics) SendMetrics() {
 func (s *regenerationStatistics) GetMap() map[string]*spanstat.SpanStat {
 	result := map[string]*spanstat.SpanStat{
 		"waitingForLock":             &s.waitingForLock,
-		"waitingForIdentityCache":    &s.waitingForIdentityCache,
 		"waitingForPolicyRepository": &s.waitingForPolicyRepository,
 		"waitingForCTClean":          &s.waitingForCTClean,
 		"policyCalculation":          &s.policyCalculation,

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -332,31 +332,6 @@ func (e *Endpoint) setDesiredPolicy(res *policyGenerateResult) error {
 	return nil
 }
 
-func (e *Endpoint) updatePolicyRegenerationStatistics(stats *policyRegenerationStatistics, forceRegeneration bool, err error) {
-	success := err == nil
-
-	stats.totalTime.End(success)
-	stats.success = success
-
-	stats.SendMetrics()
-
-	fields := logrus.Fields{
-		"waitingForIdentityCache":    &stats.waitingForIdentityCache,
-		"waitingForPolicyRepository": &stats.waitingForPolicyRepository,
-		"policyCalculation":          &stats.policyCalculation,
-		"forcedRegeneration":         forceRegeneration,
-	}
-
-	if err != nil {
-		e.getLogger().WithFields(fields).WithError(err).Warn("Regeneration of policy failed")
-		return
-	}
-
-	if logger := e.getLogger(); logging.CanLogAt(logger.Logger, logrus.DebugLevel) {
-		logger.WithFields(fields).Debug("Completed endpoint policy recalculation")
-	}
-}
-
 // updateAndOverrideEndpointOptions updates the boolean configuration options for the endpoint
 // based off of policy configuration, daemon policy enforcement mode, and any
 // configuration options provided in opts. Returns whether the options changed

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -195,7 +195,7 @@ type policyGenerateResult struct {
 //
 // Returns a result that should be passed to setDesiredPolicy after the endpoint's
 // write lock has been acquired, or err if recomputing policy failed.
-func (e *Endpoint) regeneratePolicy() (*policyGenerateResult, error) {
+func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics) (*policyGenerateResult, error) {
 	var err error
 
 	// lock the endpoint, read our values, then unlock
@@ -229,11 +229,6 @@ func (e *Endpoint) regeneratePolicy() (*policyGenerateResult, error) {
 	e.runlock()
 
 	e.getLogger().Debug("Starting policy recalculation...")
-	stats := &policyRegenerationStatistics{}
-	stats.totalTime.Start()
-	defer func() {
-		e.updatePolicyRegenerationStatistics(stats, forcePolicyCompute, err)
-	}()
 
 	stats.waitingForPolicyRepository.Start()
 	repo := e.policyGetter.GetPolicyRepository()

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -170,10 +170,11 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 		done = true
 	}()
 
+	stats := new(regenerationStatistics)
 	// Continuously compute policy for the pod and ensure we never missed an incremental update.
 	for {
 		t.Log("Calculating policy...")
-		res, err := ep.regeneratePolicy()
+		res, err := ep.regeneratePolicy(stats)
 		assert.Nil(t, err)
 
 		// Sleep a random amount, so we accumulate some changes

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -35,6 +35,7 @@ type RedirectSuite struct {
 	mgr             *cache.CachingIdentityAllocator
 	do              *DummyOwner
 	rsp             *RedirectSuiteProxy
+	stats           *regenerationStatistics
 }
 
 func setupRedirectSuite(tb testing.TB) *RedirectSuite {
@@ -73,6 +74,8 @@ func setupRedirectSuite(tb testing.TB) *RedirectSuite {
 		},
 		redirectPortUserMap: make(map[uint16][]string),
 	}
+
+	s.stats = new(regenerationStatistics)
 
 	tb.Cleanup(func() {
 		identitymanager.RemoveAll()
@@ -210,7 +213,7 @@ func TestAddVisibilityRedirects(t *testing.T) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return firstAnno, nil
 	})
-	res, err := ep.regeneratePolicy()
+	res, err := ep.regeneratePolicy(s.stats)
 	require.Nil(t, err)
 	err = ep.setDesiredPolicy(res)
 	require.Nil(t, err)
@@ -235,7 +238,7 @@ func TestAddVisibilityRedirects(t *testing.T) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return secondAnno, nil
 	})
-	res, err = ep.regeneratePolicy()
+	res, err = ep.regeneratePolicy(s.stats)
 	require.Nil(t, err)
 	err = ep.setDesiredPolicy(res)
 	require.Nil(t, err)
@@ -258,7 +261,7 @@ func TestAddVisibilityRedirects(t *testing.T) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return thirdAnno, nil
 	})
-	res, err = ep.regeneratePolicy()
+	res, err = ep.regeneratePolicy(s.stats)
 	require.Nil(t, err)
 	err = ep.setDesiredPolicy(res)
 	require.Nil(t, err)
@@ -309,7 +312,7 @@ func TestAddVisibilityRedirects(t *testing.T) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return noAnno, nil
 	})
-	res, err = ep.regeneratePolicy()
+	res, err = ep.regeneratePolicy(s.stats)
 	require.Nil(t, err)
 	err = ep.setDesiredPolicy(res)
 	require.Nil(t, err)
@@ -400,7 +403,7 @@ func TestRedirectWithDeny(t *testing.T) {
 		ruleL4L7Allow.WithEndpointSelector(selectBar_),
 	})
 
-	res, err := ep.regeneratePolicy()
+	res, err := ep.regeneratePolicy(s.stats)
 	require.Nil(t, err)
 	err = ep.setDesiredPolicy(res)
 	require.Nil(t, err)
@@ -561,7 +564,7 @@ func TestRedirectWithPriority(t *testing.T) {
 		ruleL4L7AllowListener2Priority1.WithEndpointSelector(selectBar_),
 	})
 
-	res, err := ep.regeneratePolicy()
+	res, err := ep.regeneratePolicy(s.stats)
 	require.Nil(t, err)
 	err = ep.setDesiredPolicy(res)
 	require.Nil(t, err)
@@ -640,7 +643,7 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 		ruleL4L7AllowListener2Priority1.WithEndpointSelector(selectBar_),
 	})
 
-	res, err := ep.regeneratePolicy()
+	res, err := ep.regeneratePolicy(s.stats)
 	require.Nil(t, err)
 	err = ep.setDesiredPolicy(res)
 	require.Nil(t, err)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -316,9 +316,11 @@ var (
 
 	// PolicyRegenerationCount is the total number of successful policy
 	// regenerations.
+	// Deprecated: Use EndpointRegenerationTotal.
 	PolicyRegenerationCount = NoOpCounter
 
-	// PolicyRegenerationTimeStats is the total time taken to generate policies
+	// PolicyRegenerationTimeStats is the total time taken to generate policies.
+	// Deprecated: Use EndpointRegenerationTimeStats.
 	PolicyRegenerationTimeStats = NoOpObserverVec
 
 	// PolicyRevision is the current policy revision number for this agent


### PR DESCRIPTION
- **endpoint: Consolidate regeneration metrics accounting**
- **endpoint: Remove unused span stat**
- **endpoint: Remove unused policy regeneration stat code**
- **metrics, docs: Deprecate some policy regeneration metrics**

Review commit by commit.

Main commit for ease of review:

>    endpoint: Consolidate regeneration metrics accounting
>     
>     This commit consolidates the policy regeneration/recalculation metrics
>     into the broader `regenerationStatistics` struct.
>     
>     The policy regeneration count metric is equivalent to the endpoint
>     regeneration count, by inspecting the values on a local deployment of
>     Cilium. Additionally through code inspection, it occurred to me that the
>     entirety of the `policyRegenerationStatistics` struct already exists in
>     `regenerationStatistics` struct, except for the policy repository span.
>     Therefore, it is waste to have duplicated metrics because it
>     unnecessarily increases the number of metrics Cilium sends to Prometheus
>     which has costs to the user.
>     
>     Subsequent commits will remove this redundancy altogether and deprecate
>     the corresponding metrics to reduce cardinality.
