### PR TITLE
egressgw: Let the EGW manager relax rp_filter on egress device

### DIFF
--- a/pkg/datapath/linux/netdevice/netdevice.go
+++ b/pkg/datapath/linux/netdevice/netdevice.go
@@ -36,15 +36,24 @@ func GetIfaceFirstIPv4Address(ifaceName string) (netip.Addr, error) {
 }
 
 func TestForIfaceWithIPv4Address(ip netip.Addr) error {
+	_, err := getIfaceWithIPv4Address(ip)
+	return err
+}
+
+func GetIfaceWithIPv4Address(ip netip.Addr) (string, error) {
+	return getIfaceWithIPv4Address(ip)
+}
+
+func getIfaceWithIPv4Address(ip netip.Addr) (string, error) {
 	links, err := netlink.LinkList()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	for _, l := range links {
 		addrs, err := netlink.AddrList(l, netlink.FAMILY_V4)
 		if err != nil {
-			return err
+			return "", err
 		}
 
 		for _, addr := range addrs {
@@ -53,10 +62,10 @@ func TestForIfaceWithIPv4Address(ip netip.Addr) error {
 				continue
 			}
 			if a == ip {
-				return nil
+				return l.Attrs().Name, nil
 			}
 		}
 	}
 
-	return fmt.Errorf("no interface with %s IPv4 assigned to", ip)
+	return "", fmt.Errorf("no interface with %s IPv4 assigned to", ip)
 }


### PR DESCRIPTION
Pods running on the Egress GW node fail to communicate with an external endpoint through the Egress GW due to the rp_filter in an environment where egress IP is assigned to a different interface than the one with the default route. The reply packets from the external endpoints are dropped by the rp_filter

- A request from a local pod hits eth0 with the default route. It matches an IEGP, gets masqueraded & bpf-redirected to eth1 with Egress IP.
- Replies hit eth1, are revSNATed, and passed on to the stack. rp-filter complains that they are received on eth1, when the route doesn't point towards eth1.

This PR fixes this issue by relaxing rp_filter on interfaces with Egress IP.
