### PR TITLE
ipsec: Fix unencrypted traffic when IPsec is used with L7 egress proxy

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -398,7 +398,11 @@ skip_tunnel:
 	if (from_proxy && info->tunnel_endpoint && encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
 					 info->sec_identity, true, false);
-#endif
+
+	if (from_proxy &&
+	    (!info || !identity_is_cluster(info->sec_identity)))
+		ctx->mark = MARK_MAGIC_PROXY_TO_WORLD;
+#endif /* ENABLE_IPSEC && !TUNNEL_MODE */
 
 	return CTX_ACT_OK;
 }
@@ -854,7 +858,11 @@ skip_tunnel:
 	if (from_proxy && info->tunnel_endpoint && encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
 					 info->sec_identity, true, false);
-#endif
+
+	if (from_proxy &&
+	    (!info || !identity_is_cluster(info->sec_identity)))
+		ctx->mark = MARK_MAGIC_PROXY_TO_WORLD;
+#endif /* ENABLE_IPSEC && !TUNNEL_MODE */
 
 	return CTX_ACT_OK;
 }

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -709,6 +709,7 @@ enum metric_dir {
  *    In the IPsec case this becomes the SPI on the wire.
  */
 #define MARK_MAGIC_HOST_MASK		0x0F00
+#define MARK_MAGIC_PROXY_TO_WORLD	0x0800
 #define MARK_MAGIC_PROXY_EGRESS_EPID	0x0900 /* mark carries source endpoint ID */
 #define MARK_MAGIC_PROXY_INGRESS	0x0A00
 #define MARK_MAGIC_PROXY_EGRESS		0x0B00

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -502,11 +502,13 @@ func (m *Manager) inboundProxyRedirectRule(cmd string) []string {
 	//    by ip_early_demux
 	toProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
 	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
+	matchProxyToWorld := fmt.Sprintf("%#08x/%#08x", linux_defaults.MarkProxyToWorld, linux_defaults.RouteMarkMask)
 	return []string{
 		"-t", "mangle",
 		cmd, ciliumPreMangleChain,
 		"-m", "socket", "--transparent",
 		"-m", "mark", "!", "--mark", matchFromIPSecEncrypt,
+		"-m", "mark", "!", "--mark", matchProxyToWorld,
 		"-m", "comment", "--comment", "cilium: any->pod redirect proxied traffic to host proxy",
 		"-j", "MARK",
 		"--set-mark", toProxyMark}

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -27,6 +27,10 @@ const (
 	// table which is between 253-255. See ip-route(8).
 	RouteTableInterfacesOffset = 10
 
+	// MarkProxyToWorld is the default mark to use to indicate that a packet
+	// from proxy needs to be sent to the world.
+	MarkProxyToWorld = 0x800
+
 	// RouteMarkDecrypt is the default route mark to use to indicate datapath
 	// needs to decrypt a packet.
 	RouteMarkDecrypt = 0x0D00

--- a/pkg/proxy/routes_test.go
+++ b/pkg/proxy/routes_test.go
@@ -72,7 +72,7 @@ func TestRoutes(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Install routes and rules the first time.
-				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName))
+				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName, true, true))
 
 				rules, err := route.ListRules(netlink.FAMILY_V4, &fromIngressProxyRule)
 				assert.NoError(t, err)
@@ -85,10 +85,10 @@ func TestRoutes(t *testing.T) {
 				assert.Len(t, rt, 2)
 
 				// Ensure idempotence.
-				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName))
+				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName, true, true))
 
 				// Remove routes installed before.
-				assert.NoError(t, removeFromIngressProxyRoutesIPv4())
+				assert.NoError(t, removeFromProxyRoutesIPv4())
 
 				rules, err = route.ListRules(netlink.FAMILY_V4, &fromIngressProxyRule)
 				assert.NoError(t, err)
@@ -159,7 +159,7 @@ func TestRoutes(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Install routes and rules the first time.
-				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName))
+				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName, true, true))
 
 				rules, err := route.ListRules(netlink.FAMILY_V6, &fromIngressProxyRule)
 				assert.NoError(t, err)
@@ -172,10 +172,10 @@ func TestRoutes(t *testing.T) {
 				assert.Len(t, rt, 2)
 
 				// Ensure idempotence.
-				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName))
+				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName, true, true))
 
 				// Remove routes installed before.
-				assert.NoError(t, removeFromIngressProxyRoutesIPv6())
+				assert.NoError(t, removeFromProxyRoutesIPv6())
 
 				rules, err = route.ListRules(netlink.FAMILY_V6, &fromIngressProxyRule)
 				assert.NoError(t, err)


### PR DESCRIPTION
This PR fixes unencrypted traffic among nodes when IPsec is used with L7 egress proxy.

This PR supersedes #31955 that didn't take https://github.com/cilium/proxy/pull/742 into consideration.

(The last three patches are temporarily added to run leak detection in CI, they'll be dropped after approval. Leak detection will be added separately soon.)

Fixes:  #31984

```release-note
Fixes unencrypted traffic among nodes when IPsec is used with L7 egress proxy.
```