### PR TITLE
docs: Remove outdated note on IPv6 BPF masqerading being incompatible with the Host Firewall

### DIFF
--- a/Documentation/network/concepts/masquerading.rst
+++ b/Documentation/network/concepts/masquerading.rst
@@ -147,10 +147,6 @@ and ``--set ipMasqAgent.config.masqLinkLocal=false`` (or with the corresponding
 option, for IPv6) when installing Cilium via Helm to
 configure the ``ip-masq-agent`` as above.
 
-.. note::
-
-    eBPF-based masquerading for IPv6 is not compatible with the host firewall.
-
 iptables-based
 **************
 


### PR DESCRIPTION
Since commits 9c1031e31719 ("bpf: fix missing ipv6 ct entry for snated traffic") and cfed66ee55c5 ("Revert "daemon: Forbid IPv6 BPF masquerading with the host firewall""), IPv6 BPF masquerading is compatible with the Host Firewall. The documentation still states the opposite, as we forgot to remove the related note. Clean it up now.
