### PR TITLE
test: Re-enable few test suites missed as part of recent migration

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -18,11 +18,8 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-type IPSecSuitePrivileged struct{}
-
-func setupIPSecSuitePrivileged(tb testing.TB) *IPSecSuitePrivileged {
+func setupIPSecSuitePrivileged(tb testing.TB) {
 	testutils.PrivilegedTest(tb)
-	s := &IPSecSuitePrivileged{}
 	node.SetTestLocalNodeStore()
 	err := rlimit.RemoveMemlock()
 	require.NoError(tb, err)
@@ -31,7 +28,6 @@ func setupIPSecSuitePrivileged(tb testing.TB) *IPSecSuitePrivileged {
 		node.UnsetTestLocalNodeStore()
 		_ = DeleteXfrm()
 	})
-	return s
 }
 
 var (
@@ -114,7 +110,9 @@ func TestParseSPI(t *testing.T) {
 	}
 }
 
-func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(t *testing.T) {
+func TestUpsertIPSecEquals(t *testing.T) {
+	setupIPSecSuitePrivileged(t)
+
 	_, local, err := net.ParseCIDR("1.2.3.4/16")
 	require.NoError(t, err)
 	_, remote, err := net.ParseCIDR("1.2.3.4/16")
@@ -160,7 +158,9 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(t *testing.T) {
 	ipSecKeysGlobal[""] = nil
 }
 
-func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(t *testing.T) {
+func TestUpsertIPSecEndpoint(t *testing.T) {
+	setupIPSecSuitePrivileged(t)
+
 	_, local, err := net.ParseCIDR("1.1.3.4/16")
 	require.NoError(t, err)
 	_, remote, err := net.ParseCIDR("1.2.3.4/16")
@@ -224,7 +224,9 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(t *testing.T) {
 	ipSecKeysGlobal[""] = nil
 }
 
-func (p *IPSecSuitePrivileged) TestUpsertIPSecKeyMissing(t *testing.T) {
+func TestUpsertIPSecKeyMissing(t *testing.T) {
+	setupIPSecSuitePrivileged(t)
+
 	_, local, err := net.ParseCIDR("1.1.3.4/16")
 	require.NoError(t, err)
 	_, remote, err := net.ParseCIDR("1.2.3.4/16")
@@ -236,7 +238,9 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecKeyMissing(t *testing.T) {
 	cleanIPSecStatesAndPolicies(t)
 }
 
-func (p *IPSecSuitePrivileged) TestUpdateExistingIPSecEndpoint(t *testing.T) {
+func TestUpdateExistingIPSecEndpoint(t *testing.T) {
+	setupIPSecSuitePrivileged(t)
+
 	_, local, err := net.ParseCIDR("1.1.3.4/16")
 	require.NoError(t, err)
 	_, remote, err := net.ParseCIDR("1.2.3.4/16")

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -18,7 +18,9 @@ import (
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
 
-func (s *EndpointSuite) TestWriteInformationalComments(t *testing.T) {
+func TestWriteInformationalComments(t *testing.T) {
+	s := setupEndpointSuite(t)
+
 	e := NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
 
 	var f bytes.Buffer

--- a/pkg/endpoint/directory_test.go
+++ b/pkg/endpoint/directory_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func (s *EndpointSuite) TestMoveNewFilesTo(t *testing.T) {
+func TestMoveNewFilesTo(t *testing.T) {
+	setupEndpointSuite(t)
+
 	oldDir := t.TempDir()
 	newDir := t.TempDir()
 	f1, err := os.CreateTemp(oldDir, "")

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -14,7 +14,9 @@ import (
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
 
-func (s *EndpointSuite) TestGetCiliumEndpointStatus(t *testing.T) {
+func TestGetCiliumEndpointStatus(t *testing.T) {
+	s := setupEndpointSuite(t)
+
 	e, err := NewEndpointFromChangeModel(context.TODO(), s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, s.mgr, &models.EndpointChangeRequest{
 		Addressing: &models.AddressPair{
 			IPV4: "192.168.1.100",

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -19,7 +19,9 @@ import (
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
 
-func (s *EndpointSuite) TestEndpointLogFormat(t *testing.T) {
+func TestEndpointLogFormat(t *testing.T) {
+	setupEndpointSuite(t)
+
 	// Default log format is text
 	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
 	ep := NewTestEndpointWithState(t, do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
@@ -39,7 +41,9 @@ func (s *EndpointSuite) TestEndpointLogFormat(t *testing.T) {
 	require.Equal(t, true, ok)
 }
 
-func (s *EndpointSuite) TestPolicyLog(t *testing.T) {
+func TestPolicyLog(t *testing.T) {
+	setupEndpointSuite(t)
+
 	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
 	ep := NewTestEndpointWithState(t, do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -27,7 +27,8 @@ import (
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
-func (s *EndpointSuite) TestUpdateVisibilityPolicy(t *testing.T) {
+func TestUpdateVisibilityPolicy(t *testing.T) {
+	setupEndpointSuite(t)
 	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
 	ep := NewTestEndpointWithState(t, do, do, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 	ep.UpdateVisibilityPolicy(func(_, _ string) (string, error) {

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -202,7 +202,8 @@ func (s *RedirectSuite) TearDownTest(t *testing.T) {
 	policy.SetPolicyEnabled(s.oldPolicyEnable)
 }
 
-func (s *RedirectSuite) TestAddVisibilityRedirects(t *testing.T) {
+func TestAddVisibilityRedirects(t *testing.T) {
+	s := setupRedirectSuite(t)
 	ep := s.NewTestEndpoint(t)
 
 	firstAnno := "<Ingress/80/TCP/HTTP>"


### PR DESCRIPTION
Please refer to individual commit for more details.

Thanks to @marseel and @giorio94 to highlight this.


Just a note that I have  performed the scanning with below grep  command to make sure that nothing else is missed.

```
# node_linux_test file is having TestAll to call below functions.
$ grep -r -E 'func \(.*\) Test.*' **/*_test.go
pkg/datapath/linux/node_linux_test.go:func (s *linuxPrivilegedBaseTestSuite) TestUpdateNodeRoute(t *testing.T) {
pkg/datapath/linux/node_linux_test.go:func (s *linuxPrivilegedBaseTestSuite) TestAuxiliaryPrefixes(t *testing.T) {
pkg/datapath/linux/node_linux_test.go:func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(t *testing.T) {
pkg/datapath/linux/node_linux_test.go:func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulationWithOverride(t *testing.T) {
pkg/datapath/linux/node_linux_test.go:func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateIDs(t *testing.T) {
pkg/datapath/linux/node_linux_test.go:func (s *linuxPrivilegedBaseTestSuite) TestNodeChurnXFRMLeaks(t *testing.T) {
pkg/datapath/linux/node_linux_test.go:func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateDirectRouting(t *testing.T) {
pkg/datapath/linux/node_linux_test.go:func (s *linuxPrivilegedBaseTestSuite) TestAgentRestartOptionChanges(t *testing.T) {
pkg/datapath/linux/node_linux_test.go:func (s *linuxPrivilegedBaseTestSuite) TestNodeValidationDirectRouting(t *testing.T) {
```