### PR TITLE
Cilium BGPv1 Reconciler - Handle updated and deprecated Cidr fields for CiliumLoadBalancerIPPool

### DIFF
--- a/pkg/bgpv1/manager/reconciler/route_policy.go
+++ b/pkg/bgpv1/manager/reconciler/route_policy.go
@@ -238,10 +238,30 @@ func (r *RoutePolicyReconciler) pathAttributesToPolicy(attrs v2alpha1api.CiliumB
 			if attrs.Selector != nil && !labelSelector.Matches(labels.Set(pool.Labels)) {
 				continue
 			}
+			prefixesSeen := sets.New[netip.Prefix]()
+			for _, cidrBlock := range pool.Spec.Blocks {
+				cidr, err := netip.ParsePrefix(string(cidrBlock.Cidr))
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse IPAM pool CIDR %s: %w", cidrBlock.Cidr, err)
+				}
+				if cidr.Addr().Is4() {
+					v4Prefixes = append(v4Prefixes, &types.RoutePolicyPrefixMatch{CIDR: cidr, PrefixLenMin: maxPrefixLenIPv4, PrefixLenMax: maxPrefixLenIPv4})
+				} else {
+					v6Prefixes = append(v6Prefixes, &types.RoutePolicyPrefixMatch{CIDR: cidr, PrefixLenMin: maxPrefixLenIPv6, PrefixLenMax: maxPrefixLenIPv6})
+				}
+				prefixesSeen.Insert(cidr)
+			}
+			// Note: CiliumLoadBalancerIPPool.Spec.Cidrs was deprecated as of
+			// https://github.com/cilium/cilium/commit/27322f3959c3fa05b9b1c4f9827527b4a3642687
+			// It was replaced by CiliumLoadBalancerIPPool.Spec.Blocks.
 			for _, cidrBlock := range pool.Spec.Cidrs {
 				cidr, err := netip.ParsePrefix(string(cidrBlock.Cidr))
 				if err != nil {
 					return nil, fmt.Errorf("failed to parse IPAM pool CIDR %s: %w", cidrBlock.Cidr, err)
+				}
+				// If the same prefix was specified in Spec.Blocks and Spec.Cidrs, ignore the duplicate.
+				if prefixesSeen.Has(cidr) {
+					continue
 				}
 				if cidr.Addr().Is4() {
 					v4Prefixes = append(v4Prefixes, &types.RoutePolicyPrefixMatch{CIDR: cidr, PrefixLenMin: maxPrefixLenIPv4, PrefixLenMax: maxPrefixLenIPv4})

--- a/pkg/bgpv1/manager/reconciler/route_policy_test.go
+++ b/pkg/bgpv1/manager/reconciler/route_policy_test.go
@@ -32,6 +32,24 @@ var (
 			},
 		},
 		Spec: v2alpha1api.CiliumLoadBalancerIPPoolSpec{
+			Blocks: []v2alpha1api.CiliumLoadBalancerIPPoolIPBlock{
+				{
+					Cidr: "192.168.0.0/24",
+				},
+			},
+		},
+	}
+
+	lbPoolDeprecated = &v2alpha1api.CiliumLoadBalancerIPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"label1": "value1",
+			},
+		},
+		Spec: v2alpha1api.CiliumLoadBalancerIPPoolSpec{
+			// Note: CiliumLoadBalancerIPPool.Spec.Cidrs was deprecated as of
+			// https://github.com/cilium/cilium/commit/27322f3959c3fa05b9b1c4f9827527b4a3642687
+			// It was replaced by CiliumLoadBalancerIPPool.Spec.Blocks.
 			Cidrs: []v2alpha1api.CiliumLoadBalancerIPPoolIPBlock{
 				{
 					Cidr: "192.168.0.0/24",
@@ -39,6 +57,53 @@ var (
 			},
 		},
 	}
+
+	lbPoolMixed = &v2alpha1api.CiliumLoadBalancerIPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"label1": "value1",
+			},
+		},
+		Spec: v2alpha1api.CiliumLoadBalancerIPPoolSpec{
+			Blocks: []v2alpha1api.CiliumLoadBalancerIPPoolIPBlock{
+				{
+					Cidr: "192.168.0.0/24",
+				},
+			},
+			// Note: CiliumLoadBalancerIPPool.Spec.Cidrs was deprecated as of
+			// https://github.com/cilium/cilium/commit/27322f3959c3fa05b9b1c4f9827527b4a3642687
+			// It was replaced by CiliumLoadBalancerIPPool.Spec.Blocks.
+			Cidrs: []v2alpha1api.CiliumLoadBalancerIPPoolIPBlock{
+				{
+					Cidr: "192.168.1.0/24",
+				},
+			},
+		},
+	}
+
+	lbPoolMixedDuplicate = &v2alpha1api.CiliumLoadBalancerIPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"label1": "value1",
+			},
+		},
+		Spec: v2alpha1api.CiliumLoadBalancerIPPoolSpec{
+			Blocks: []v2alpha1api.CiliumLoadBalancerIPPoolIPBlock{
+				{
+					Cidr: "192.168.0.0/24",
+				},
+			},
+			// Note: CiliumLoadBalancerIPPool.Spec.Cidrs was deprecated as of
+			// https://github.com/cilium/cilium/commit/27322f3959c3fa05b9b1c4f9827527b4a3642687
+			// It was replaced by CiliumLoadBalancerIPPool.Spec.Blocks.
+			Cidrs: []v2alpha1api.CiliumLoadBalancerIPPoolIPBlock{
+				{
+					Cidr: "192.168.0.0/24",
+				},
+			},
+		},
+	}
+
 	lbPoolUpdated = &v2alpha1api.CiliumLoadBalancerIPPool{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
@@ -46,7 +111,7 @@ var (
 			},
 		},
 		Spec: v2alpha1api.CiliumLoadBalancerIPPoolSpec{
-			Cidrs: []v2alpha1api.CiliumLoadBalancerIPPoolIPBlock{
+			Blocks: []v2alpha1api.CiliumLoadBalancerIPPoolIPBlock{
 				{
 					Cidr: "10.100.99.0/24", // UPDATED
 				},
@@ -217,7 +282,357 @@ func TestRoutePolicyReconciler(t *testing.T) {
 									MatchNeighbors: []string{peerAddress},
 									MatchPrefixes: []*types.RoutePolicyPrefixMatch{
 										{
-											CIDR:         netip.MustParsePrefix(string(lbPool.Spec.Cidrs[0].Cidr)),
+											CIDR:         netip.MustParsePrefix(string(lbPool.Spec.Blocks[0].Cidr)),
+											PrefixLenMin: maxPrefixLenIPv4,
+											PrefixLenMax: maxPrefixLenIPv4,
+										},
+									},
+								},
+								Actions: types.RoutePolicyActions{
+									RouteAction:         types.RoutePolicyActionNone,
+									AddCommunities:      []string{standardCommunity, wellKnownCommunity},
+									AddLargeCommunities: []string{largeCommunity},
+								},
+							},
+						},
+					},
+					{
+						Name: pathAttributesPolicyName(attrSelectPodPool, peerAddress),
+						Type: types.RoutePolicyTypeExport,
+						Statements: []*types.RoutePolicyStatement{
+							{
+								Conditions: types.RoutePolicyConditions{
+									MatchNeighbors: []string{peerAddress},
+									MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+										{
+											CIDR:         netip.MustParsePrefix(string(podPool.Spec.IPv4.CIDRs[0])),
+											PrefixLenMin: int(podPool.Spec.IPv4.MaskSize),
+											PrefixLenMax: int(podPool.Spec.IPv4.MaskSize),
+										},
+									},
+								},
+								Actions: types.RoutePolicyActions{
+									RouteAction:         types.RoutePolicyActionNone,
+									AddCommunities:      []string{standardCommunity, wellKnownCommunity},
+									AddLargeCommunities: []string{largeCommunity},
+								},
+							},
+							{
+								Conditions: types.RoutePolicyConditions{
+									MatchNeighbors: []string{peerAddress},
+									MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+										{
+											CIDR:         netip.MustParsePrefix(string(podPool.Spec.IPv6.CIDRs[0])),
+											PrefixLenMin: int(podPool.Spec.IPv6.MaskSize),
+											PrefixLenMax: int(podPool.Spec.IPv6.MaskSize),
+										},
+									},
+								},
+								Actions: types.RoutePolicyActions{
+									RouteAction:         types.RoutePolicyActionNone,
+									AddCommunities:      []string{standardCommunity, wellKnownCommunity},
+									AddLargeCommunities: []string{largeCommunity},
+								},
+							},
+						},
+					},
+					{
+						Name: pathAttributesPolicyName(attrSelectAnyNode, peerAddress),
+						Type: types.RoutePolicyTypeExport,
+						Statements: []*types.RoutePolicyStatement{
+							{
+								Conditions: types.RoutePolicyConditions{
+									MatchNeighbors: []string{peerAddress},
+									MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+										{
+											CIDR:         podCIDRPrefix,
+											PrefixLenMin: podCIDRPrefix.Bits(),
+											PrefixLenMax: podCIDRPrefix.Bits(),
+										},
+									},
+								},
+								Actions: types.RoutePolicyActions{
+									RouteAction:        types.RoutePolicyActionNone,
+									SetLocalPreference: attrSelectAnyNode.LocalPreference,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "add complex policy (pod CIDR + LB pool deprecated + Pod pool)",
+			initial: &routePolicyTestInputs{
+				podCIDRs: []string{
+					podCIDR,
+				},
+				LBPools: []*v2alpha1api.CiliumLoadBalancerIPPool{
+					lbPoolDeprecated,
+				},
+				PodPools: []*v2alpha1api.CiliumPodIPPool{
+					podPool,
+				},
+				NodePools: []ipamTypes.IPAMPoolAllocation{
+					nodePool,
+				},
+				neighbors: []v2alpha1api.CiliumBGPNeighbor{
+					{
+						PeerAddress: peerAddress,
+						AdvertisedPathAttributes: []v2alpha1api.CiliumBGPPathAttributes{
+							attrSelectLBPool,
+							attrSelectPodPool,
+							attrSelectAnyNode,
+						},
+					},
+				},
+				expectedPolicies: []*types.RoutePolicy{
+					{
+						Name: pathAttributesPolicyName(attrSelectLBPool, peerAddress),
+						Type: types.RoutePolicyTypeExport,
+						Statements: []*types.RoutePolicyStatement{
+							{
+								Conditions: types.RoutePolicyConditions{
+									MatchNeighbors: []string{peerAddress},
+									MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+										{
+											CIDR:         netip.MustParsePrefix(string(lbPoolDeprecated.Spec.Cidrs[0].Cidr)),
+											PrefixLenMin: maxPrefixLenIPv4,
+											PrefixLenMax: maxPrefixLenIPv4,
+										},
+									},
+								},
+								Actions: types.RoutePolicyActions{
+									RouteAction:         types.RoutePolicyActionNone,
+									AddCommunities:      []string{standardCommunity, wellKnownCommunity},
+									AddLargeCommunities: []string{largeCommunity},
+								},
+							},
+						},
+					},
+					{
+						Name: pathAttributesPolicyName(attrSelectPodPool, peerAddress),
+						Type: types.RoutePolicyTypeExport,
+						Statements: []*types.RoutePolicyStatement{
+							{
+								Conditions: types.RoutePolicyConditions{
+									MatchNeighbors: []string{peerAddress},
+									MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+										{
+											CIDR:         netip.MustParsePrefix(string(podPool.Spec.IPv4.CIDRs[0])),
+											PrefixLenMin: int(podPool.Spec.IPv4.MaskSize),
+											PrefixLenMax: int(podPool.Spec.IPv4.MaskSize),
+										},
+									},
+								},
+								Actions: types.RoutePolicyActions{
+									RouteAction:         types.RoutePolicyActionNone,
+									AddCommunities:      []string{standardCommunity, wellKnownCommunity},
+									AddLargeCommunities: []string{largeCommunity},
+								},
+							},
+							{
+								Conditions: types.RoutePolicyConditions{
+									MatchNeighbors: []string{peerAddress},
+									MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+										{
+											CIDR:         netip.MustParsePrefix(string(podPool.Spec.IPv6.CIDRs[0])),
+											PrefixLenMin: int(podPool.Spec.IPv6.MaskSize),
+											PrefixLenMax: int(podPool.Spec.IPv6.MaskSize),
+										},
+									},
+								},
+								Actions: types.RoutePolicyActions{
+									RouteAction:         types.RoutePolicyActionNone,
+									AddCommunities:      []string{standardCommunity, wellKnownCommunity},
+									AddLargeCommunities: []string{largeCommunity},
+								},
+							},
+						},
+					},
+					{
+						Name: pathAttributesPolicyName(attrSelectAnyNode, peerAddress),
+						Type: types.RoutePolicyTypeExport,
+						Statements: []*types.RoutePolicyStatement{
+							{
+								Conditions: types.RoutePolicyConditions{
+									MatchNeighbors: []string{peerAddress},
+									MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+										{
+											CIDR:         podCIDRPrefix,
+											PrefixLenMin: podCIDRPrefix.Bits(),
+											PrefixLenMax: podCIDRPrefix.Bits(),
+										},
+									},
+								},
+								Actions: types.RoutePolicyActions{
+									RouteAction:        types.RoutePolicyActionNone,
+									SetLocalPreference: attrSelectAnyNode.LocalPreference,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "add complex policy (pod CIDR + LB pool mixed + Pod pool)",
+			initial: &routePolicyTestInputs{
+				podCIDRs: []string{
+					podCIDR,
+				},
+				LBPools: []*v2alpha1api.CiliumLoadBalancerIPPool{
+					lbPoolMixed,
+				},
+				PodPools: []*v2alpha1api.CiliumPodIPPool{
+					podPool,
+				},
+				NodePools: []ipamTypes.IPAMPoolAllocation{
+					nodePool,
+				},
+				neighbors: []v2alpha1api.CiliumBGPNeighbor{
+					{
+						PeerAddress: peerAddress,
+						AdvertisedPathAttributes: []v2alpha1api.CiliumBGPPathAttributes{
+							attrSelectLBPool,
+							attrSelectPodPool,
+							attrSelectAnyNode,
+						},
+					},
+				},
+				expectedPolicies: []*types.RoutePolicy{
+					{
+						Name: pathAttributesPolicyName(attrSelectLBPool, peerAddress),
+						Type: types.RoutePolicyTypeExport,
+						Statements: []*types.RoutePolicyStatement{
+							{
+								Conditions: types.RoutePolicyConditions{
+									MatchNeighbors: []string{peerAddress},
+									MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+										{
+											CIDR:         netip.MustParsePrefix(string(lbPoolMixed.Spec.Blocks[0].Cidr)),
+											PrefixLenMin: maxPrefixLenIPv4,
+											PrefixLenMax: maxPrefixLenIPv4,
+										},
+										{
+											CIDR:         netip.MustParsePrefix(string(lbPoolMixed.Spec.Cidrs[0].Cidr)),
+											PrefixLenMin: maxPrefixLenIPv4,
+											PrefixLenMax: maxPrefixLenIPv4,
+										},
+									},
+								},
+								Actions: types.RoutePolicyActions{
+									RouteAction:         types.RoutePolicyActionNone,
+									AddCommunities:      []string{standardCommunity, wellKnownCommunity},
+									AddLargeCommunities: []string{largeCommunity},
+								},
+							},
+						},
+					},
+					{
+						Name: pathAttributesPolicyName(attrSelectPodPool, peerAddress),
+						Type: types.RoutePolicyTypeExport,
+						Statements: []*types.RoutePolicyStatement{
+							{
+								Conditions: types.RoutePolicyConditions{
+									MatchNeighbors: []string{peerAddress},
+									MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+										{
+											CIDR:         netip.MustParsePrefix(string(podPool.Spec.IPv4.CIDRs[0])),
+											PrefixLenMin: int(podPool.Spec.IPv4.MaskSize),
+											PrefixLenMax: int(podPool.Spec.IPv4.MaskSize),
+										},
+									},
+								},
+								Actions: types.RoutePolicyActions{
+									RouteAction:         types.RoutePolicyActionNone,
+									AddCommunities:      []string{standardCommunity, wellKnownCommunity},
+									AddLargeCommunities: []string{largeCommunity},
+								},
+							},
+							{
+								Conditions: types.RoutePolicyConditions{
+									MatchNeighbors: []string{peerAddress},
+									MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+										{
+											CIDR:         netip.MustParsePrefix(string(podPool.Spec.IPv6.CIDRs[0])),
+											PrefixLenMin: int(podPool.Spec.IPv6.MaskSize),
+											PrefixLenMax: int(podPool.Spec.IPv6.MaskSize),
+										},
+									},
+								},
+								Actions: types.RoutePolicyActions{
+									RouteAction:         types.RoutePolicyActionNone,
+									AddCommunities:      []string{standardCommunity, wellKnownCommunity},
+									AddLargeCommunities: []string{largeCommunity},
+								},
+							},
+						},
+					},
+					{
+						Name: pathAttributesPolicyName(attrSelectAnyNode, peerAddress),
+						Type: types.RoutePolicyTypeExport,
+						Statements: []*types.RoutePolicyStatement{
+							{
+								Conditions: types.RoutePolicyConditions{
+									MatchNeighbors: []string{peerAddress},
+									MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+										{
+											CIDR:         podCIDRPrefix,
+											PrefixLenMin: podCIDRPrefix.Bits(),
+											PrefixLenMax: podCIDRPrefix.Bits(),
+										},
+									},
+								},
+								Actions: types.RoutePolicyActions{
+									RouteAction:        types.RoutePolicyActionNone,
+									SetLocalPreference: attrSelectAnyNode.LocalPreference,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "add complex policy (pod CIDR + LB pool mixed duplicate + Pod pool)",
+			initial: &routePolicyTestInputs{
+				podCIDRs: []string{
+					podCIDR,
+				},
+				LBPools: []*v2alpha1api.CiliumLoadBalancerIPPool{
+					lbPoolMixedDuplicate,
+				},
+				PodPools: []*v2alpha1api.CiliumPodIPPool{
+					podPool,
+				},
+				NodePools: []ipamTypes.IPAMPoolAllocation{
+					nodePool,
+				},
+				neighbors: []v2alpha1api.CiliumBGPNeighbor{
+					{
+						PeerAddress: peerAddress,
+						AdvertisedPathAttributes: []v2alpha1api.CiliumBGPPathAttributes{
+							attrSelectLBPool,
+							attrSelectPodPool,
+							attrSelectAnyNode,
+						},
+					},
+				},
+				expectedPolicies: []*types.RoutePolicy{
+					{
+						Name: pathAttributesPolicyName(attrSelectLBPool, peerAddress),
+						Type: types.RoutePolicyTypeExport,
+						Statements: []*types.RoutePolicyStatement{
+							{
+								Conditions: types.RoutePolicyConditions{
+									MatchNeighbors: []string{peerAddress},
+									MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+										{
+											CIDR:         netip.MustParsePrefix(string(lbPoolMixed.Spec.Blocks[0].Cidr)),
 											PrefixLenMin: maxPrefixLenIPv4,
 											PrefixLenMax: maxPrefixLenIPv4,
 										},
@@ -321,7 +736,7 @@ func TestRoutePolicyReconciler(t *testing.T) {
 									MatchNeighbors: []string{peerAddress},
 									MatchPrefixes: []*types.RoutePolicyPrefixMatch{
 										{
-											CIDR:         netip.MustParsePrefix(string(lbPool.Spec.Cidrs[0].Cidr)),
+											CIDR:         netip.MustParsePrefix(string(lbPoolMixed.Spec.Blocks[0].Cidr)),
 											PrefixLenMin: maxPrefixLenIPv4,
 											PrefixLenMax: maxPrefixLenIPv4,
 										},
@@ -359,7 +774,7 @@ func TestRoutePolicyReconciler(t *testing.T) {
 									MatchNeighbors: []string{peerAddress},
 									MatchPrefixes: []*types.RoutePolicyPrefixMatch{
 										{
-											CIDR:         netip.MustParsePrefix(string(lbPoolUpdated.Spec.Cidrs[0].Cidr)),
+											CIDR:         netip.MustParsePrefix(string(lbPoolUpdated.Spec.Blocks[0].Cidr)),
 											PrefixLenMin: maxPrefixLenIPv4,
 											PrefixLenMax: maxPrefixLenIPv4,
 										},


### PR DESCRIPTION
## Cilium BGPv1 Reconciler - Handle updated and deprecated Cidr fields for CiliumLoadBalancerIPPool

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #32693

## Description
In https://github.com/cilium/cilium/commit/27322f3959c3fa05b9b1c4f9827527b4a3642687, the CiliumLoadBalancerIPPool's field named "cidrs" was deprecated.  The documentation on https://docs.cilium.io/en/stable/network/lb-ipam/ provides an example of configuring a CiliumLoadBalancerIPPool using the field named "blocks".  While testing a BGP policy configured with the Advertised Path Attributes feature (https://docs.cilium.io/en/stable/network/bgp-control-plane/#advertised-path-attributes), I was not able to achieve the desired policy.  BGP attributes configured were not being applied.

While discussing this in Cilium's Slack channel, it was pointed out that the BGPv1 reconciler was only aware of the deprecated field.

This commit updates Cilium's BGPv1 reconciler to support both the deprecated and updated fields.

## Unit Tests
Unit tests were updated as follows:
* To ensure that the deprecated field continues to be supported
* To ensure that the new field is supported
* To ensure that mixing both new and deprecated fields is supported
* To ensure that mixing both new and deprecated fields containing the same prefix is handled (by removing duplicate prefixes)

## Manual Testing
For manual testing, I brought up the BGP development environment (see https://docs.cilium.io/en/stable/contributing/development/bgp_cplane/).

Steps included:
```
make kind-bgp-v4

KIND_CLUSTER_NAME=bgp-cplane-dev-v4 make kind-image
cilium install --chart-directory install/kubernetes/cilium -f contrib/containerlab/bgp-cplane-dev-v4/values.yaml --set image.override="localhost:5000/cilium/cilium-dev:local" --set image.pullPolicy=Never --set operator.image.override="localhost:5000/cilium/operator-generic:local" --set operator.image.pullPolicy=Never
```

Next, I applied the policy below:
```
cat bgpp.yaml
---
apiVersion: cilium.io/v2alpha1
kind: CiliumBGPPeeringPolicy
metadata:
  name: control-plane
spec:
  nodeSelector:
    matchLabels:
      kubernetes.io/hostname: bgp-cplane-dev-v4-control-plane
  virtualRouters:
  - localASN: 65001
    neighbors:
    - peerASN: 65000
      peerAddress: 10.0.1.1/32
---
apiVersion: cilium.io/v2alpha1
kind: CiliumBGPPeeringPolicy
metadata:
  name: worker
spec:
  nodeSelector:
    matchLabels:
      kubernetes.io/hostname: bgp-cplane-dev-v4-worker
  virtualRouters:
  - localASN: 65002
    serviceSelector:
      matchExpressions:
       - { key: app, operator: In, values: [hello-node, hello-node2, hello-node3] }
    serviceAdvertisements:
      - LoadBalancerIP # <-- default
      #- ClusterIP      # <-- options
      #- ExternalIP     # <-- options
    neighbors:
    - peerASN: 65000
      peerAddress: 10.0.2.1/32
      gracefulRestart:
        enabled: true
        restartTimeSeconds: 60
      advertisedPathAttributes:
      - selectorType: CiliumLoadBalancerIPPool
        selector:
          matchLabels:
            environment: mgmt
        communities:
          standard:
          - 65002:100
          large:
          - 65002:100:1
---
apiVersion: "cilium.io/v2alpha1"
kind: CiliumLoadBalancerIPPool
metadata:
  name: "mgmt"
  labels:
    environment: mgmt
spec:
  cidrs:
    - cidr: "100.64.8.0/22"
```

Using:
```
k apply -f bgpp.yaml
```

Next, I checked the state of the peers:
```
$  cilium bgp peers
Node                              Local AS   Peer AS   Peer Address   Session State   Uptime   Family         Received   Advertised
bgp-cplane-dev-v4-control-plane   65001      65000     10.0.1.1       established     3m24s    ipv4/unicast   0          0
                                                                                               ipv6/unicast   0          0
bgp-cplane-dev-v4-worker          65002      65000     10.0.2.1       established     3m27s    ipv4/unicast   0          1
                                                                                               ipv6/unicast   0          1
```

At this point, I have not yet spun up any services/pods.  I then brought up a "hello-world" application using:

```
kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.39 -- /agnhost netexec --http-port=8080

kubectl expose deployment hello-node --type=LoadBalancer --port=8080
```

And observed:
```
$  k get services
NAME         TYPE           CLUSTER-IP    EXTERNAL-IP   PORT(S)          AGE
hello-node   LoadBalancer   10.2.118.17   100.64.8.1    8080:30934/TCP   21s
```

Followed by:
```
$  cilium bgp routes
(Defaulting to `available ipv4 unicast` routes, please see help for more options)

Node                              VRouter   Prefix          NextHop    Age   Attrs
bgp-cplane-dev-v4-control-plane   65001     100.64.8.1/32   10.0.1.1   38s   [{Origin: i} {AsPath: 65000 65002} {Nexthop: 10.0.1.1} {Communities: 65002:100} {LargeCommunity: [ 65002:100:1]}]
bgp-cplane-dev-v4-worker          65002     100.64.8.1/32   0.0.0.0    38s   [{Origin: i} {Nexthop: 0.0.0.0}]
```

Prior to this PR, when a prefix was defined on a `CiliumLoadBalancerIPPool` using `cidrs`, there were no routes advertised.  In the above, we see routes advertised.

Next, I tore down the lab by running:
```
make kind-bgp-v4-down
```

After rebuilding the lab, I changed to: 
```
---
apiVersion: "cilium.io/v2alpha1"
kind: CiliumLoadBalancerIPPool
metadata:
  name: "mgmt"
  labels:
    environment: mgmt
spec:
  blocks:
  - cidr: "100.64.8.0/22"
```

After applying, I see routes as expected:
```
$  cilium bgp routes
(Defaulting to `available ipv4 unicast` routes, please see help for more options)

Node                              VRouter   Prefix          NextHop    Age     Attrs
bgp-cplane-dev-v4-control-plane   65001     100.64.8.1/32   10.0.1.1   1m34s   [{Origin: i} {AsPath: 65000 65002} {Nexthop: 10.0.1.1} {Communities: 65002:100} {LargeCommunity: [ 65002:100:1]}]
bgp-cplane-dev-v4-worker          65002     100.64.8.1/32   0.0.0.0    1m42s   [{Origin: i} {Nexthop: 0.0.0.0}]
```

In one test, I specified both the new and deprecated fields:
```
apiVersion: "cilium.io/v2alpha1"
kind: CiliumLoadBalancerIPPool
metadata:
  name: "mgmt"
  labels:
    environment: mgmt
spec:
  blocks:
    - cidr: "100.64.8.0/22"
  cidrs:
    - cidr: "100.64.12.0/22"
```

Here, I observed the last prefix being used:
```
$  k get services
NAME         TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
hello-node   LoadBalancer   10.2.238.103   100.64.12.1   8080:30608/TCP   2m30s
kubernetes   ClusterIP      10.2.0.1       <none>        443/TCP          4m34s

$  cilium bgp routes
(Defaulting to `available ipv4 unicast` routes, please see help for more options)

Node                              VRouter   Prefix           NextHop    Age     Attrs
bgp-cplane-dev-v4-control-plane   65001     100.64.12.1/32   10.0.1.1   1m36s   [{Origin: i} {AsPath: 65000 65002} {Nexthop: 10.0.1.1} {Communities: 65002:100} {LargeCommunity: [ 65002:100:1]}]
bgp-cplane-dev-v4-worker          65002     100.64.12.1/32   0.0.0.0    1m44s   [{Origin: i} {Nexthop: 0.0.0.0}]
```

```release-note
Cilium BGPv1 Reconciler - Handle updated and deprecated Cidr fields for CiliumLoadBalancerIPPool
```
