### PR TITLE
k8s: use cilium slices sort utility to sort Pod IP's from status

### DIFF
--- a/pkg/k8s/utils/utils.go
+++ b/pkg/k8s/utils/utils.go
@@ -5,7 +5,6 @@ package utils
 
 import (
 	"net"
-	"sort"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -18,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/selection"
 	labelsPkg "github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/slices"
 )
 
 const (
@@ -149,22 +149,18 @@ func ValidIPs(podStatus slim_corev1.PodStatus) []string {
 	}
 
 	// make it a set first to avoid repeated IP addresses
-	ipsMap := make(map[string]struct{}, 1+len(podStatus.PodIPs))
+	ips := []string{}
 	if podStatus.PodIP != "" {
-		ipsMap[podStatus.PodIP] = struct{}{}
+		ips = append(ips, podStatus.PodIP)
 	}
+
 	for _, podIP := range podStatus.PodIPs {
 		if podIP.IP != "" {
-			ipsMap[podIP.IP] = struct{}{}
+			ips = append(ips, podIP.IP)
 		}
 	}
 
-	ips := make([]string, 0, len(ipsMap))
-	for ipStr := range ipsMap {
-		ips = append(ips, ipStr)
-	}
-	sort.Strings(ips)
-	return ips
+	return slices.SortedUnique(ips)
 }
 
 // IsPodRunning returns true if the pod is considered to be in running state.

--- a/pkg/k8s/utils/utils_test.go
+++ b/pkg/k8s/utils/utils_test.go
@@ -168,6 +168,24 @@ func TestValidIPs(t *testing.T) {
 			want: []string{"10.0.0.1", "127.0.0.2", "127.0.0.3"},
 		},
 		{
+			name: "multiple pod ip sorted",
+			args: slim_corev1.PodStatus{
+				HostIP: "127.0.0.1",
+				PodIPs: []slim_corev1.PodIP{
+					{
+						IP: "10.0.0.1",
+					},
+					{
+						IP: "127.0.0.3",
+					},
+					{
+						IP: "127.0.0.2",
+					},
+				},
+			},
+			want: []string{"10.0.0.1", "127.0.0.2", "127.0.0.3"},
+		},
+		{
 			name: "have empty pod ip",
 			args: slim_corev1.PodStatus{
 				HostIP: "127.0.0.1",


### PR DESCRIPTION
This commit refactors the k8s utility function `ValidIPs` to use the existing slices utility `slices.SortedUnique` to sort the IPs of the Pod. Stumbled across this while working on something else. 