### PR TITLE
loader: remove datapathSHA256

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,9 @@ SKIP_CUSTOMVET_CHECK ?= "false"
 JOB_BASE_NAME ?= cilium_test
 
 TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyAddress=https://consul:8443 \
-	-X github.com/cilium/cilium/pkg/kvstore.etcdDummyAddress=http://etcd:4002 \
-	-X github.com/cilium/cilium/pkg/datapath.datapathSHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	-X github.com/cilium/cilium/pkg/kvstore.etcdDummyAddress=http://etcd:4002"
 
-TEST_UNITTEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/datapath.datapathSHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+TEST_UNITTEST_LDFLAGS=
 
 build: $(SUBDIRS) ## Builds all the components for Cilium by executing make in the respective sub directories.
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -142,8 +142,6 @@ endif
 
 # ROOT_DIR can be either `../` or absolute path, each of these need to be stripped
 BPF_SRCFILES := $(filter-out $(BPF_SRCFILES_IGNORE),$(subst ../,,$(subst $(ROOT_DIR)/,,$(BPF_SRCFILES))))
-CILIUM_DATAPATH_SHA256=$(shell cd $(ROOT_DIR); cat $(BPF_SRCFILES) | sha256sum | awk '{print $$1}')
-GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/datapath/loader.datapathSHA256=$(CILIUM_DATAPATH_SHA256)"
 
 GO_BUILD_FLAGS += -mod=vendor
 GO_TEST_FLAGS += -mod=vendor -vet=all

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -330,7 +330,9 @@ func (l *loader) Reinitialize(ctx context.Context, cfg datapath.LocalNodeConfigu
 
 	// Store the new LocalNodeConfiguration
 	l.nodeConfig.Store(&cfg)
-	l.initTemplateCache(&cfg)
+	// Startup relies on not returning an error here, maybe something we
+	// can fix in the future.
+	_ = l.templateCache.UpdateDatapathHash(&cfg)
 
 	var internalIPv4, internalIPv6 net.IP
 	if option.Config.EnableIPv4 {

--- a/pkg/datapath/loader/cache_test.go
+++ b/pkg/datapath/loader/cache_test.go
@@ -26,7 +26,7 @@ func TestObjectCache(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
 	defer cancel()
 
-	cache := newObjectCache(configWriterForTest(t), &localNodeConfig, tmpDir)
+	cache := newObjectCache(configWriterForTest(t), tmpDir)
 	realEP := testutils.NewTestEndpoint()
 
 	dir := getDirs(t)
@@ -107,7 +107,7 @@ func TestObjectCacheParallel(t *testing.T) {
 		t.Logf("  %s", test.description)
 
 		results := make(chan buildResult, test.builds)
-		cache := newObjectCache(configWriterForTest(t), &localNodeConfig, tmpDir)
+		cache := newObjectCache(configWriterForTest(t), tmpDir)
 		for i := 0; i < test.builds; i++ {
 			go func(i int) {
 				ep := testutils.NewTestEndpoint()

--- a/pkg/datapath/loader/hash.go
+++ b/pkg/datapath/loader/hash.go
@@ -5,89 +5,42 @@ package loader
 
 import (
 	"crypto/sha256"
-	"encoding"
 	"encoding/hex"
-	"hash"
-	"io"
 
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
-	"github.com/cilium/cilium/pkg/option"
 )
 
-var (
-	// datapathSHA256 is set during build to the SHA across all datapath BPF
-	// code. See the definition of CILIUM_DATAPATH_SHA256 in Makefile.defs for
-	// details.
-	datapathSHA256 string
-)
-
-// datapathHash represents a unique enumeration of the datapath implementation.
-type datapathHash struct {
-	hash.Hash
-}
-
-// newDatapathHash creates a new datapath hash based on the contents of the datapath
-// template files under bpf/.
-func newDatapathHash() *datapathHash {
-	d := sha256.New()
-	io.WriteString(d, datapathSHA256)
-	return &datapathHash{
-		Hash: d,
-	}
-}
+// datapathHash represents a unique enumeration of the datapath configuration.
+type datapathHash []byte
 
 // hashDatapath returns a new datapath hash based on the specified datapath.
-//
-// The endpoint's static data is NOT included in this hash, for that perform:
-//
-//	hash := hashDatapath(dp, nodeCfg, netdevCfg, ep)
-//	hashStr := hash.sumEndpoint(ep)
-func hashDatapath(c datapath.ConfigWriter, nodeCfg *datapath.LocalNodeConfiguration, netdevCfg datapath.DeviceConfiguration, epCfg datapath.EndpointConfiguration) *datapathHash {
-	d := newDatapathHash()
-
-	// Writes won't fail; it's an in-memory hash.
-	if nodeCfg != nil {
-		_ = c.WriteNodeConfig(d, nodeCfg)
+func hashDatapath(c datapath.ConfigWriter, nodeCfg *datapath.LocalNodeConfiguration) (datapathHash, error) {
+	d := sha256.New()
+	err := c.WriteNodeConfig(d, nodeCfg)
+	if err != nil {
+		return nil, err
 	}
-	if netdevCfg != nil {
-		_ = c.WriteNetdevConfig(d, option.Config.Opts)
-	}
-	if epCfg != nil {
-		_ = c.WriteTemplateConfig(d, nodeCfg, epCfg)
-	}
-
-	return d
+	return datapathHash(d.Sum(nil)), nil
 }
 
-// sumEndpoint returns the hash of the complete datapath for an endpoint.
-// It does not change the underlying hash state.
-func (d *datapathHash) sumEndpoint(c datapath.ConfigWriter, nodeCfg *datapath.LocalNodeConfiguration, epCfg datapath.EndpointConfiguration, staticData bool) (string, error) {
-	result, err := d.Copy()
-	if err != nil {
+func (d datapathHash) hashEndpoint(c datapath.ConfigWriter, nodeCfg *datapath.LocalNodeConfiguration, epCfg datapath.EndpointConfiguration) (string, error) {
+	h := sha256.New()
+	_, _ = h.Write(d)
+	if err := c.WriteEndpointConfig(h, nodeCfg, epCfg); err != nil {
 		return "", err
 	}
-	if staticData {
-		c.WriteEndpointConfig(result, nodeCfg, epCfg)
-	} else {
-		c.WriteTemplateConfig(result, nodeCfg, epCfg)
-	}
-	return result.String(), nil
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
-func (d *datapathHash) Copy() (*datapathHash, error) {
-	state, err := d.Hash.(encoding.BinaryMarshaler).MarshalBinary()
-	if err != nil {
-		return nil, err
+func (d datapathHash) hashTemplate(c datapath.ConfigWriter, nodeCfg *datapath.LocalNodeConfiguration, epCfg datapath.EndpointConfiguration) (string, error) {
+	h := sha256.New()
+	_, _ = h.Write(d)
+	if err := c.WriteTemplateConfig(h, nodeCfg, epCfg); err != nil {
+		return "", err
 	}
-	newDatapathHash := sha256.New()
-	if err := newDatapathHash.(encoding.BinaryUnmarshaler).UnmarshalBinary(state); err != nil {
-		return nil, err
-	}
-	return &datapathHash{
-		Hash: newDatapathHash,
-	}, nil
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
-func (d *datapathHash) String() string {
-	return hex.EncodeToString(d.Sum(nil))
+func (d datapathHash) String() string {
+	return hex.EncodeToString(d)
 }

--- a/pkg/datapath/loader/hash_test.go
+++ b/pkg/datapath/loader/hash_test.go
@@ -4,86 +4,105 @@
 package loader
 
 import (
-	"context"
+	"errors"
+	"io"
 	"testing"
 
-	"github.com/cilium/hive/cell"
-	"github.com/cilium/hive/hivetest"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 
-	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
-	"github.com/cilium/cilium/pkg/datapath/linux/config"
-	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
-	"github.com/cilium/cilium/pkg/hive"
-	"github.com/cilium/cilium/pkg/maps/nodemap"
-	"github.com/cilium/cilium/pkg/maps/nodemap/fake"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
 var (
-	dummyDevCfg = testutils.NewTestEndpoint()
-	dummyEPCfg  = testutils.NewTestEndpoint()
+	dummyNodeCfg = datapath.LocalNodeConfiguration{}
 )
 
 // TestHashDatapath is done in this package just for easy access to dummy
 // configuration objects.
 func TestHashDatapath(t *testing.T) {
-	var cfg datapath.ConfigWriter
-	hv := hive.New(
-		provideNodemap,
-		cell.Provide(
-			func() datapath.BandwidthManager { return &fakeTypes.BandwidthManager{} },
-			func() sysctl.Sysctl { return sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc") },
-			config.NewHeaderfileWriter,
-			fakeTypes.NewNodeAddressing,
-		),
-		cell.Invoke(func(writer_ datapath.ConfigWriter) {
-			cfg = writer_
-		}),
-	)
+	// Error from ConfigWriter is forwarded.
+	_, err := hashDatapath(fakeConfigWriter{}, nil)
+	require.Error(t, err)
 
-	tlog := hivetest.Logger(t)
-	require.NoError(t, hv.Start(tlog, context.TODO()))
-	t.Cleanup(func() { require.Nil(t, hv.Stop(tlog, context.TODO())) })
+	// Ensure we get different hashes when config is changed
+	a, err := hashDatapath(fakeConfigWriter("a"), &dummyNodeCfg)
+	require.NoError(t, err)
 
-	h := newDatapathHash()
-	baseHash := h.String()
+	b, err := hashDatapath(fakeConfigWriter("b"), &dummyNodeCfg)
+	require.NoError(t, err)
+	require.NotEqual(t, a, b)
 
-	// Ensure we get different hashes when config is added
-	h = hashDatapath(cfg, &localNodeConfig, &dummyDevCfg, &dummyEPCfg)
-	dummyHash := h.String()
-	require.NotEqual(t, dummyHash, baseHash)
+	// Ensure we get the same base hash when config is the same.
+	b, err = hashDatapath(fakeConfigWriter("a"), &dummyNodeCfg)
+	require.NoError(t, err)
+	require.Equal(t, a, b)
+}
 
-	// Ensure we get the same base hash when config is removed via Reset()
-	h.Reset()
-	require.Equal(t, h.String(), baseHash)
-	require.NotEqual(t, h.String(), dummyHash)
+func TestHashEndpoint(t *testing.T) {
+	var base datapathHash
+	ep := testutils.NewTestEndpoint()
+	cfg := configWriterForTest(t)
 
-	// Ensure that with a copy of the endpoint config we get the same hash
-	newEPCfg := dummyEPCfg
-	h = hashDatapath(cfg, &localNodeConfig, &dummyDevCfg, &newEPCfg)
-	require.NotEqual(t, h.String(), baseHash)
-	require.Equal(t, h.String(), dummyHash)
+	// Error from ConfigWriter is forwarded.
+	_, err := base.hashEndpoint(fakeConfigWriter{}, nil, nil)
+	require.Error(t, err)
+
+	// Hashing the endpoint gives a hash distinct from the base.
+	a, err := base.hashEndpoint(cfg, &localNodeConfig, &ep)
+	require.NoError(t, err)
+	require.NotEqual(t, base.String(), a)
+
+	// When we configure the endpoint differently, it's different
+	ep.Opts.SetBool("foo", true)
+	b, err := base.hashEndpoint(cfg, &localNodeConfig, &ep)
+	require.NoError(t, err)
+	require.NotEqual(t, a, b)
+}
+
+func TestHashTemplate(t *testing.T) {
+	var base datapathHash
+	ep := testutils.NewTestEndpoint()
+	cfg := configWriterForTest(t)
+
+	// Error from ConfigWriter is forwarded.
+	_, err := base.hashTemplate(fakeConfigWriter{}, nil, nil)
+	require.Error(t, err)
+
+	// Hashing the endpoint gives a hash distinct from the base.
+	a, err := base.hashTemplate(cfg, &localNodeConfig, &ep)
+	require.NoError(t, err)
+	require.NotEqual(t, base.String(), a)
 
 	// Even with different endpoint IDs, we get the same hash
 	//
 	// This is the key to avoiding recompilation per endpoint; static
 	// data substitution is performed via pkg/elf instead.
-	newEPCfg.Id++
-	h = hashDatapath(cfg, &localNodeConfig, &dummyDevCfg, &newEPCfg)
-	require.NotEqual(t, h.String(), baseHash)
-	require.Equal(t, h.String(), dummyHash)
-
-	// But when we configure the endpoint differently, it's different
-	newEPCfg = testutils.NewTestEndpoint()
-	newEPCfg.Opts.SetBool("foo", true)
-	h = hashDatapath(cfg, &localNodeConfig, &dummyDevCfg, &newEPCfg)
-	require.NotEqual(t, h.String(), baseHash)
-	require.NotEqual(t, h.String(), dummyHash)
+	ep.Id++
+	b, err := base.hashTemplate(cfg, &localNodeConfig, &ep)
+	require.NoError(t, err)
+	require.Equal(t, a, b)
 }
 
-var provideNodemap = cell.Provide(func() nodemap.MapV2 {
-	return fake.NewFakeNodeMapV2()
-})
+type fakeConfigWriter []byte
+
+func (fc fakeConfigWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeConfiguration) error {
+	if cfg == nil {
+		return errors.New("LocalNodeConfiguration is nil")
+	}
+	_, err := w.Write(fc)
+	return err
+}
+
+func (fc fakeConfigWriter) WriteNetdevConfig(w io.Writer, opts *option.IntOptions) error {
+	return errors.New("not implemented")
+}
+
+func (fc fakeConfigWriter) WriteTemplateConfig(w io.Writer, _ *datapath.LocalNodeConfiguration, cfg datapath.EndpointConfiguration) error {
+	return errors.New("not implemented")
+}
+
+func (fc fakeConfigWriter) WriteEndpointConfig(w io.Writer, _ *datapath.LocalNodeConfiguration, cfg datapath.EndpointConfiguration) error {
+	return errors.New("not implemented")
+}

--- a/pkg/datapath/loader/util_test.go
+++ b/pkg/datapath/loader/util_test.go
@@ -65,6 +65,6 @@ func newTestLoader(tb testing.TB) *loader {
 	})
 	l.nodeConfig.Store(&localNodeConfig)
 	cw := configWriterForTest(tb)
-	l.templateCache = newObjectCache(cw, &localNodeConfig, tb.TempDir())
+	l.templateCache = newObjectCache(cw, tb.TempDir())
 	return l
 }


### PR DESCRIPTION
loader: remove datapathSHA256

    datapathSHA256 was added in commit a530ac0b70 ("loader: Hash datapath 
    objects and store results"). It is fed into the endpoint / template hash to
    ensure that templates are recompiled when bundled source code changes.

    Since at least 48591d8f42 ("loader: simplify template cache invalidation")
    the endpoint program cache doesn't reuse results from an older / different
    cilium process. This means that we're always using the correct source code
    by construction. Remove datapathSHA256 and related machinery.

    In the process of refactoring it turns out that we swallow errors from 
    WriteNodeConfig in hashDatapath, which has so far obscured failing tests. 
    The comment that writing to an in-memory hash is correct, but misleading. 
    WriteNodeConfig also returns errors when certain devices are missing.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
