### PR TITLE
[v1.14] ipsec: Safely delete Xfrm state

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -740,11 +740,15 @@ func ipsecDeleteXfrmState(nodeID uint16) {
 		scopedLog.WithError(err).Warning("Failed to list XFRM states for deletion")
 		return
 	}
+	xfrmStatesToDelete := []netlink.XfrmState{}
 	for _, s := range xfrmStateList {
 		if matchesOnNodeID(s.Mark) && ipsec.GetNodeIDFromXfrmMark(s.Mark) == nodeID {
-			if err := netlink.XfrmStateDel(&s); err != nil {
-				scopedLog.WithError(err).Warning("Failed to delete XFRM state")
-			}
+			xfrmStatesToDelete = append(xfrmStatesToDelete, s)
+		}
+	}
+	for _, s := range xfrmStatesToDelete {
+		if err := netlink.XfrmStateDel(&s); err != nil {
+			scopedLog.WithError(err).Warning("Failed to delete XFRM state")
 		}
 	}
 }


### PR DESCRIPTION
- [ ] #32450 @jschwinger233 

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
32450
```