### PR TITLE
cni: Reserve local ports for DNS proxy even if IPv6 is disabled

### DIFF
--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -170,6 +170,9 @@ func getIPLocalReservedPorts(d *Daemon) string {
 		ports = append(ports, fmt.Sprintf("%d", d.tunnelConfig.Port()))
 	}
 
+	log.WithField(logfields.Ports, ports).
+		Info("Auto-detected local ports to reserve in the container namespace for transparent DNS proxy")
+
 	return strings.Join(ports, ",")
 }
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -205,6 +205,9 @@ const (
 	// Port is a L4 port
 	Port = "port"
 
+	// Ports is a list of L4 ports
+	Ports = "ports"
+
 	// PortName is a k8s ContainerPort Name
 	PortName = "portName"
 

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -627,11 +627,11 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 		var macAddrStr string
 
 		if err = ns.Do(func() error {
-			if ipv6IsEnabled(ipam) {
-				if err := reserveLocalIPPorts(conf, sysctl); err != nil {
-					logger.WithError(err).Warn("unable to reserve local ip ports")
-				}
+			if err := reserveLocalIPPorts(conf, sysctl); err != nil {
+				logger.WithError(err).Warn("unable to reserve local ip ports")
+			}
 
+			if ipv6IsEnabled(ipam) {
 				if err := sysctl.Disable("net.ipv6.conf.all.disable_ipv6"); err != nil {
 					logger.WithError(err).Warn("unable to enable ipv6 on all interfaces")
 				}


### PR DESCRIPTION
This fixes a bug where the port reservation of ports which can conflict with transparent DNS proxy where only reserved if IPv6 was enabled.

The call to `reserveLocalIPPorts` was accidentally added in the "IPv6-only" branch. This commit fixes that by unconditionally reserving local ports.

Fixes: https://github.com/cilium/cilium/commit/11fe7cc144aaff1a44b6ed9c733a9025c674e683 ("cilium-cni: Reserve ports that can conflict with transparent DNS proxy")