### PR TITLE
pkg/controller: ensure latest controller params are updated 

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -152,6 +152,28 @@ func TestRunController(t *testing.T) {
 	require.NoError(t, mngr.RemoveController("test"))
 }
 
+func TestUpdateControllerOverwrite(t *testing.T) {
+	// Create a manager and a mock managedController
+	m := NewManager()
+	ctrl := &managedController{
+		controller: controller{
+			update: make(chan ControllerParams, 1),
+		},
+	}
+	m.controllers = controllerMap{"test": ctrl}
+
+	params1 := ControllerParams{RunInterval: 5 * time.Second}
+	params2 := ControllerParams{RunInterval: 10 * time.Second}
+
+	m.updateController("test", params1)
+	m.updateController("test", params2)
+
+	updatedParams := <-ctrl.controller.update
+	if updatedParams.RunInterval != params2.RunInterval {
+		t.Errorf("Expected RunInterval from params2, got %v", updatedParams.RunInterval)
+	}
+}
+
 func TestCancellation(t *testing.T) {
 	mngr := NewManager()
 

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -75,8 +75,10 @@ func (m *Manager) updateController(name string, params ControllerParams) *manage
 
 		// Notify the goroutine of the params update.
 		select {
-		case ctrl.update <- ctrl.params:
-		default:
+		case ctrl.update <- ctrl.params: // Send if empty
+		default: // Overwrite if full
+			<-ctrl.update // Discard existing value
+			ctrl.update <- ctrl.params
 		}
 
 		ctrl.getLogger().Debug("Controller update time: ", time.Since(start))


### PR DESCRIPTION
Improved the `updateController` function to ensure that the most recent update is always sent to the controller go routine, even if the update channel is full. Old values in the channel are discarded to prevent stale updates.

The root cause of this was discovered during a discovery testing of K8s namespace watcher around updating namespace labels. If there are multiple updates to the same namespace (same CEP) the updated controller could receive stale params.  In our specific case, a stale revision number resulted in CEP being stuck in `waiting-for-identity.` 

For example, running the following, on an existing namespace with some deployment
```
kubectl label namespaces ns-10 lns=new --overwrite=true && kubectl label namespaces ns-10 lns- && kubectl label namespaces ns-10 lns=new --overwrite=true  && kubectl label namespaces ns-10 lns- 
----
kubectl get cep -n ns-10
----
NAME                         SECURITY IDENTITY   ENDPOINT STATE         IPV4           IPV6
client-10-554c76d5dc-7tslp   5738                waiting-for-identity   10.92.10.220
client-10-554c76d5dc-qbm88   5738                waiting-for-identity   10.92.0.164
server-10-795ddf5d89-5wgmj   18819               waiting-for-identity   10.92.10.40
server-10-795ddf5d89-hlgrf   18819               waiting-for-identity   10.92.0.146
```
The following code is invoked ([here](https://github.com/cilium/cilium/blob/ddc8b127146986270419eefdedfb5fb699e5988b/pkg/endpoint/endpoint.go#L2128)) and we expect to receive an update controller with the latest revision ([here](https://github.com/cilium/cilium/blob/ddc8b127146986270419eefdedfb5fb699e5988b/pkg/endpoint/endpoint.go#L2159)), the proposed changes will guarantee that we always send the last params. I think this could potentially fix other controllers that have similar undiscovered issues. 


```release-note
Improved the `updateController` function to ensure that the most recent update is always sent to the controller go routine, even if the update channel is full. Old values in the channel are discarded to prevent stale updates.
```
