### PR TITLE
[v1.15] Introduce --enforce-device-detection option

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -167,6 +167,7 @@ cilium-agent [flags]
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
       --endpoint-queue-size int                                   Size of EventQueue per-endpoint (default 25)
       --endpoint-status strings                                   Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
+      --enforce-device-detection                                  Enforces the auto-detection of devices, even if specific devices are explicitly listed
       --envoy-config-timeout duration                             Timeout duration for Envoy Config acknowledgements (default 2m0s)
       --envoy-log string                                          Path to a separate Envoy log file, if any
       --exclude-local-address strings                             Exclude CIDR from being recognized as local address

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1036,6 +1036,10 @@
      - Enable endpoint status. Status can be: policy, health, controllers, log and / or state. For 2 or more options use a space.
      - object
      - ``{"enabled":false,"status":""}``
+   * - :spelling:ignore:`enforceDeviceDetection`
+     - Enforces the auto-detection of devices, even if specific devices are explicitly listed
+     - bool
+     - ``false``
    * - :spelling:ignore:`eni.awsEnablePrefixDelegation`
      - Enable ENI prefix delegation
      - bool

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -222,6 +222,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.StringSlice(option.Devices, []string{}, "List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'")
 	option.BindEnv(vp, option.Devices)
 
+	flags.Bool(option.EnforceDeviceDetection, false, "Enforces the auto-detection of devices, even if specific devices are explicitly listed")
+	option.BindEnv(vp, option.EnforceDeviceDetection)
+
 	flags.String(option.DirectRoutingDevice, "", "Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)")
 	option.BindEnv(vp, option.DirectRoutingDevice)
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -309,6 +309,7 @@ contributors across the globe, there is almost always someone available to help.
 | endpointHealthChecking.enabled | bool | `true` | Enable connectivity health checking between virtual endpoints. |
 | endpointRoutes.enabled | bool | `false` | Enable use of per endpoint routes instead of routing via the cilium_host interface. |
 | endpointStatus | object | `{"enabled":false,"status":""}` | Enable endpoint status. Status can be: policy, health, controllers, log and / or state. For 2 or more options use a space. |
+| enforceDeviceDetection | bool | `false` | Enforces the auto-detection of devices, even if specific devices are explicitly listed |
 | eni.awsEnablePrefixDelegation | bool | `false` | Enable ENI prefix delegation |
 | eni.awsReleaseExcessIPs | bool | `false` | Release IPs not used from the ENI |
 | eni.ec2APIEndpoint | string | `""` | EC2 API endpoint to use |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -688,6 +688,10 @@ data:
   enable-runtime-device-detection: "true"
 {{- end }}
 
+{{- if .Values.enforceDeviceDetection }}
+  enforce-device-detection: "true"
+{{- end }}
+
   kube-proxy-replacement: {{ $kubeProxyReplacement | quote }}
 
 {{- if ne $kubeProxyReplacement "disabled" }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -690,6 +690,9 @@ daemon:
 # be considered.
 enableRuntimeDeviceDetection: false
 
+# -- Enforces the auto-detection of devices, even if specific devices are explicitly listed
+enforceDeviceDetection: false
+
 # -- Chains to ignore when installing feeder rules.
 # disableIptablesFeederRules: ""
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -687,6 +687,9 @@ daemon:
 # be considered.
 enableRuntimeDeviceDetection: false
 
+# -- Enforces the auto-detection of devices, even if specific devices are explicitly listed
+enforceDeviceDetection: false
+
 # -- Chains to ignore when installing feeder rules.
 # disableIptablesFeederRules: ""
 

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -114,7 +114,8 @@ var Cell = cell.Module(
 		// This is temporary until DevicesController takes ownership of the
 		// device-related configuration options.
 		return linuxdatapath.DevicesConfig{
-			Devices: cfg.GetDevices(),
+			Devices:                cfg.GetDevices(),
+			EnforceDeviceDetection: option.Config.EnforceDeviceDetection,
 		}
 	}),
 

--- a/pkg/datapath/linux/devices_test.go
+++ b/pkg/datapath/linux/devices_test.go
@@ -254,7 +254,36 @@ func (s *DevicesSuite) TestDetect(c *C) {
 		c.Assert(devices, checker.DeepEquals, []string{"bond0", "dummy0", "dummy1", "dummy_v6", "veth0"})
 		option.Config.SetDevices([]string{})
 		dm.Stop()
+
+		// EnforceDeviceDetection enabled with specific devices
+		option.Config.SetDevices([]string{"dummy1"})
+		option.Config.EnforceDeviceDetection = true
+		c.Assert(createDummy("dummy0", "192.168.0.1/24", false), IsNil)
+		c.Assert(createDummy("dummy1", "192.168.1.1/24", false), IsNil)
+
+		dm, err = newDeviceManagerForTests()
+		c.Assert(err, IsNil)
+		devices, err = dm.Detect(true)
+		c.Assert(err, IsNil)
+		c.Assert(devices, checker.DeepEquals, []string{"dummy0", "dummy1"})
+		option.Config.SetDevices([]string{})
+		option.Config.DirectRoutingDevice = ""
+		dm.Stop()
+
+		// EnforceDeviceDetection disabled with specific devices
+		option.Config.SetDevices([]string{"dummy1"})
+		option.Config.EnforceDeviceDetection = false
+
+		dm, err = newDeviceManagerForTests()
+		c.Assert(err, IsNil)
+		devices, err = dm.Detect(true)
+		c.Assert(err, IsNil)
+		c.Assert(devices, checker.DeepEquals, []string{"dummy1"})
+		option.Config.SetDevices([]string{})
+		option.Config.DirectRoutingDevice = ""
+		dm.Stop()
 	})
+
 }
 
 func (s *DevicesSuite) TestExpandDevices(c *C) {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -557,6 +557,10 @@ const (
 
 	// EnableEnvoyConfig is the default value for option.EnableEnvoyConfig
 	EnableEnvoyConfig = false
+
+	// EnforceDevicesDetection enforces the auto-detection of devices,
+	// even if specific devices are explicitly listed
+	EnforceDeviceDetection = false
 )
 
 var (

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -123,6 +123,9 @@ const (
 	// Devices facing cluster/external network for attaching bpf_host
 	Devices = "devices"
 
+	// Enforces the auto-detection of devices, even if specific devices are explicitly listed
+	EnforceDeviceDetection = "enforce-device-detection"
+
 	// DirectRoutingDevice is the name of a device used to connect nodes in
 	// direct routing mode (only required by BPF NodePort)
 	DirectRoutingDevice = "direct-routing-device"
@@ -2447,6 +2450,10 @@ type DaemonConfig struct {
 
 	// ServiceNoBackendResponse determines how we handle traffic to a service with no backends.
 	ServiceNoBackendResponse string
+
+	// EnforceDeviceDetection forces the auto-detection of devices,
+	// even if specific devices are explicitly listed
+	EnforceDeviceDetection bool
 }
 
 var (
@@ -2490,6 +2497,7 @@ var (
 		AllocatorListTimeout:            defaults.AllocatorListTimeout,
 		EnableICMPRules:                 defaults.EnableICMPRules,
 		UseCiliumInternalIPForIPsec:     defaults.UseCiliumInternalIPForIPsec,
+		EnforceDeviceDetection:          defaults.EnforceDeviceDetection,
 
 		K8sEnableLeasesFallbackDiscovery: defaults.K8sEnableLeasesFallbackDiscovery,
 
@@ -3564,6 +3572,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.UseCiliumInternalIPForIPsec = vp.GetBool(UseCiliumInternalIPForIPsec)
 	c.BypassIPAvailabilityUponRestore = vp.GetBool(BypassIPAvailabilityUponRestore)
 	c.EnableK8sTerminatingEndpoint = vp.GetBool(EnableK8sTerminatingEndpoint)
+	c.EnforceDeviceDetection = vp.GetBool(EnforceDeviceDetection)
 
 	// Disable Envoy version check if L7 proxy is disabled.
 	c.DisableEnvoyVersionCheck = vp.GetBool(DisableEnvoyVersionCheck)


### PR DESCRIPTION
- Introduce --enforce-device-detection option
- Helm chart: enforceDeviceDetection option
- Add tests for EnforceDeviceDetection option

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Added https://github.com/cilium/cilium/pull/32738
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: https://github.com/cilium/cilium/issues/32721

```release-note
Introduce --enforce-device-detection option to enable the auto-detection even if specific devices are explicitly listed
```
