### PR TITLE
Add port to Hubble peer's change notifications

### DIFF
--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -31,12 +31,13 @@ type handler struct {
 	hubblePort  int
 }
 
-func newHandler(withoutTLSInfo bool, addressPref serviceoption.AddressFamilyPreference) *handler {
+func newHandler(withoutTLSInfo bool, addressPref serviceoption.AddressFamilyPreference, hubblePort int) *handler {
 	return &handler{
 		stop:        make(chan struct{}),
 		C:           make(chan *peerpb.ChangeNotification),
 		tls:         !withoutTLSInfo,
 		addressPref: addressPref,
+		hubblePort:  hubblePort,
 	}
 }
 

--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -4,6 +4,8 @@
 package peer
 
 import (
+	"net"
+	"strconv"
 	"strings"
 
 	peerpb "github.com/cilium/cilium/api/v1/peer"
@@ -26,6 +28,7 @@ type handler struct {
 	C           chan *peerpb.ChangeNotification
 	tls         bool
 	addressPref serviceoption.AddressFamilyPreference
+	hubblePort  int
 }
 
 func newHandler(withoutTLSInfo bool, addressPref serviceoption.AddressFamilyPreference) *handler {
@@ -59,7 +62,7 @@ func (h *handler) NodeAdd(n types.Node) error {
 func (h *handler) NodeUpdate(o, n types.Node) error {
 	oAddr, nAddr := nodeAddress(o, h.addressPref), nodeAddress(n, h.addressPref)
 	if o.Fullname() == n.Fullname() {
-		if oAddr == nAddr {
+		if oAddr.String() == nAddr.String() {
 			// this corresponds to the same peer
 			// => no need to send a notification
 			return nil
@@ -130,9 +133,18 @@ func (h *handler) newChangeNotification(n types.Node, t peerpb.ChangeNotificatio
 			ServerName: TLSServerName(n.Name, n.Cluster),
 		}
 	}
+
+	addr := ""
+	if ip := nodeAddress(n, h.addressPref); ip != nil {
+		addr = ip.String()
+		if h.hubblePort != 0 {
+			addr = net.JoinHostPort(addr, strconv.Itoa(h.hubblePort))
+		}
+	}
+
 	return &peerpb.ChangeNotification{
 		Name:    n.Fullname(),
-		Address: nodeAddress(n, h.addressPref),
+		Address: addr,
 		Type:    t,
 		Tls:     tls,
 	}
@@ -140,20 +152,20 @@ func (h *handler) newChangeNotification(n types.Node, t peerpb.ChangeNotificatio
 
 // nodeAddress returns the node's address. If the node has both IPv4 and IPv6
 // addresses, pref controls which address type is returned.
-func nodeAddress(n types.Node, pref serviceoption.AddressFamilyPreference) string {
+func nodeAddress(n types.Node, pref serviceoption.AddressFamilyPreference) net.IP {
 	for _, family := range pref {
 		switch family {
 		case serviceoption.AddressFamilyIPv4:
 			if addr := n.GetNodeIP(false); addr.To4() != nil {
-				return addr.String()
+				return addr
 			}
 		case serviceoption.AddressFamilyIPv6:
 			if addr := n.GetNodeIP(true); addr.To4() == nil {
-				return addr.String()
+				return addr
 			}
 		}
 	}
-	return ""
+	return nil
 }
 
 // TLSServerName constructs a server name to be used as the TLS server name.

--- a/pkg/hubble/peer/handler_test.go
+++ b/pkg/hubble/peer/handler_test.go
@@ -190,7 +190,7 @@ func TestNodeAdd(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := newHandler(tt.withoutTLS, tt.addressPref)
+			h := newHandler(tt.withoutTLS, tt.addressPref, 0)
 			defer h.Close()
 
 			var got *peerpb.ChangeNotification
@@ -472,7 +472,7 @@ func TestNodeUpdate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := newHandler(tt.withoutTLS, tt.addressPref)
+			h := newHandler(tt.withoutTLS, tt.addressPref, 0)
 			defer h.Close()
 
 			var got []*peerpb.ChangeNotification
@@ -637,7 +637,7 @@ func TestNodeDelete(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := newHandler(tt.withoutTLS, tt.addressPref)
+			h := newHandler(tt.withoutTLS, tt.addressPref, 0)
 			defer h.Close()
 
 			var got *peerpb.ChangeNotification

--- a/pkg/hubble/peer/service.go
+++ b/pkg/hubble/peer/service.go
@@ -53,7 +53,7 @@ func (s *Service) Notify(_ *peerpb.NotifyRequest, stream peerpb.Peer_NotifyServe
 	g, ctx := errgroup.WithContext(ctx)
 
 	// monitor for global stop signal to tear down all routines
-	h := newHandler(s.opts.WithoutTLSInfo, s.opts.AddressFamilyPreference)
+	h := newHandler(s.opts.WithoutTLSInfo, s.opts.AddressFamilyPreference, s.opts.HubblePort)
 	g.Go(func() error {
 		defer h.Close()
 		select {

--- a/pkg/hubble/peer/serviceoption/option.go
+++ b/pkg/hubble/peer/serviceoption/option.go
@@ -8,6 +8,7 @@ type Options struct {
 	MaxSendBufferSize       int
 	WithoutTLSInfo          bool
 	AddressFamilyPreference AddressFamilyPreference
+	HubblePort              int
 }
 
 // Option customizes the peer service's configuration.
@@ -54,5 +55,12 @@ func WithoutTLSInfo() Option {
 func WithAddressFamilyPreference(pref AddressFamilyPreference) Option {
 	return func(o *Options) {
 		o.AddressFamilyPreference = pref
+	}
+}
+
+// WithHubblePort configures port used in the address field of change notifications.
+func WithHubblePort(port int) Option {
+	return func(o *Options) {
+		o.HubblePort = port
 	}
 }


### PR DESCRIPTION
This change allows a user to specify a different port for Hubble when using Hubble relay. It seems it is enough to pass port in `Address` field of `ChangeNotification`. This works well for agents that share the configuration (the usual case).

Alternative solution is to add port information to `cilium.Node` CRD and use it as a source of truth (instead of local configuration).

Fixes: #13034

```release-note
Hubble peer's port number is inferred from the agent's configuration instead of assuming defaults
```
