### PR TITLE
Introduce --force-device-detection option

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -185,6 +185,7 @@ cilium-agent [flags]
       --exclude-node-label-patterns strings                       List of k8s node label regex patterns to be excluded from CiliumNode
       --external-envoy-proxy                                      whether the Envoy is deployed externally in form of a DaemonSet or not
       --fixed-identity-mapping map                                Key-value for the fixed identity mapping which allows to use reserved label for fixed identities, e.g. 128=kv-store,129=kube-dns
+      --force-device-detection                                    Forces the auto-detection of devices, even if specific devices are explicitly listed
       --gateway-api-secrets-namespace string                      GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API
       --gops-port uint16                                          Port for gops server to listen on (default 9890)
   -h, --help                                                      help for cilium-agent

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -51,6 +51,7 @@ cilium-agent hive [flags]
       --envoy-keep-cap-netbindservice                             Keep capability NET_BIND_SERVICE for Envoy process
       --envoy-log string                                          Path to a separate Envoy log file, if any
       --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC
+      --force-device-detection                                    Forces the auto-detection of devices, even if specific devices are explicitly listed
       --gateway-api-secrets-namespace string                      GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API
       --gops-port uint16                                          Port for gops server to listen on (default 9890)
   -h, --help                                                      help for hive

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -57,6 +57,7 @@ cilium-agent hive dot-graph [flags]
       --envoy-keep-cap-netbindservice                             Keep capability NET_BIND_SERVICE for Envoy process
       --envoy-log string                                          Path to a separate Envoy log file, if any
       --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC
+      --force-device-detection                                    Forces the auto-detection of devices, even if specific devices are explicitly listed
       --gateway-api-secrets-namespace string                      GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API
       --gops-port uint16                                          Port for gops server to listen on (default 9890)
       --http-idle-timeout uint                                    Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1492,6 +1492,10 @@
      - Additional agent volumes.
      - list
      - ``[]``
+   * - :spelling:ignore:`forceDeviceDetection`
+     - Forces the auto-detection of devices, even if specific devices are explicitly listed
+     - bool
+     - ``false``
    * - :spelling:ignore:`gatewayAPI.enableAlpn`
      - Enable ALPN for all listeners configured with Gateway API. ALPN will attempt HTTP/2, then HTTP 1.1. Note that this will also enable ``appProtocol`` support, and services that wish to use HTTP/2 will need to indicate that via their ``appProtocol``.
      - bool

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -423,6 +423,7 @@ contributors across the globe, there is almost always someone available to help.
 | extraInitContainers | list | `[]` | Additional initContainers added to the cilium Daemonset. |
 | extraVolumeMounts | list | `[]` | Additional agent volumeMounts. |
 | extraVolumes | list | `[]` | Additional agent volumes. |
+| forceDeviceDetection | bool | `false` | Forces the auto-detection of devices, even if specific devices are explicitly listed |
 | gatewayAPI.enableAlpn | bool | `false` | Enable ALPN for all listeners configured with Gateway API. ALPN will attempt HTTP/2, then HTTP 1.1. Note that this will also enable `appProtocol` support, and services that wish to use HTTP/2 will need to indicate that via their `appProtocol`. |
 | gatewayAPI.enableAppProtocol | bool | `false` | Enable Backend Protocol selection support (GEP-1911) for Gateway API via appProtocol. |
 | gatewayAPI.enableProxyProtocol | bool | `false` | Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -701,6 +701,10 @@ data:
   enable-runtime-device-detection: "true"
 {{- end }}
 
+{{- if .Values.forceDeviceDetection }}
+  force-device-detection: "true"
+{{- end }}
+
   kube-proxy-replacement: {{ $kubeProxyReplacement | quote }}
 
 {{- if ne $kubeProxyReplacement "disabled" }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2375,6 +2375,9 @@
       "items": {},
       "type": "array"
     },
+    "forceDeviceDetection": {
+      "type": "boolean"
+    },
     "gatewayAPI": {
       "properties": {
         "enableAlpn": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -688,6 +688,8 @@ daemon:
 #
 # This option has been deprecated and is a no-op.
 enableRuntimeDeviceDetection: true
+# -- Forces the auto-detection of devices, even if specific devices are explicitly listed
+forceDeviceDetection: false
 # -- Chains to ignore when installing feeder rules.
 # disableIptablesFeederRules: ""
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -687,6 +687,9 @@ daemon:
 # This option has been deprecated and is a no-op.
 enableRuntimeDeviceDetection: true
 
+# -- Forces the auto-detection of devices, even if specific devices are explicitly listed
+forceDeviceDetection: false
+
 # -- Chains to ignore when installing feeder rules.
 # disableIptablesFeederRules: ""
 

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -71,6 +71,8 @@ var DevicesControllerCell = cell.Module(
 
 func (c DevicesConfig) Flags(flags *pflag.FlagSet) {
 	flags.StringSlice(option.Devices, []string{}, "List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'")
+
+	flags.Bool(option.ForceDeviceDetection, false, "Forces the auto-detection of devices, even if specific devices are explicitly listed")
 }
 
 var (
@@ -95,6 +97,9 @@ type DevicesConfig struct {
 	// If empty the devices are auto-detected according to rules defined
 	// by isSelectedDevice().
 	Devices []string
+	// ForceDeviceDetection forces the auto-detection of devices,
+	// even if user-specific devices are explicitly listed.
+	ForceDeviceDetection bool
 }
 
 type devicesControllerParams struct {
@@ -114,9 +119,10 @@ type devicesController struct {
 	params devicesControllerParams
 	log    *slog.Logger
 
-	initialized    chan struct{}
-	filter         deviceFilter
-	l3DevSupported bool
+	initialized          chan struct{}
+	filter               deviceFilter
+	enforceAutoDetection bool
+	l3DevSupported       bool
 
 	// deadLinkIndexes tracks the set of links that have been deleted. This is needed
 	// to avoid processing route or address updates after a link delete as they may
@@ -128,11 +134,12 @@ type devicesController struct {
 
 func newDevicesController(lc cell.Lifecycle, p devicesControllerParams) (*devicesController, statedb.Table[*tables.Device], statedb.Table[*tables.Route]) {
 	dc := &devicesController{
-		params:          p,
-		initialized:     make(chan struct{}),
-		filter:          deviceFilter(p.Config.Devices),
-		log:             p.Log,
-		deadLinkIndexes: sets.New[int](),
+		params:               p,
+		initialized:          make(chan struct{}),
+		filter:               deviceFilter(p.Config.Devices),
+		enforceAutoDetection: p.Config.ForceDeviceDetection,
+		log:                  p.Log,
+		deadLinkIndexes:      sets.New[int](),
 	}
 	lc.Append(dc)
 	return dc, p.DeviceTable, p.RouteTable
@@ -543,12 +550,15 @@ func (dc *devicesController) isSelectedDevice(d *tables.Device, txn statedb.Writ
 	}
 
 	// If user specified devices or wildcards, then skip the device if it doesn't match.
-	// If the device does match, then skip further checks.
+	// If the device does match and user not requested auto detection, then skip further checks.
+	// If the device does match and user requested auto detection, then continue to further checks.
 	if dc.filter.nonEmpty() {
 		if dc.filter.match(d.Name) {
 			return true, ""
 		}
-		return false, fmt.Sprintf("not matching user filter %v", dc.filter)
+		if !dc.enforceAutoDetection {
+			return false, fmt.Sprintf("not matching user filter %v", dc.filter)
+		}
 	}
 
 	// Skip devices that have an excluded interface flag set.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -123,6 +123,9 @@ const (
 	// Devices facing cluster/external network for attaching bpf_host
 	Devices = "devices"
 
+	// Forces the auto-detection of devices, even if specific devices are explicitly listed
+	ForceDeviceDetection = "force-device-detection"
+
 	// DirectRoutingDevice is the name of a device used to connect nodes in
 	// direct routing mode (only required by BPF NodePort)
 	DirectRoutingDevice = "direct-routing-device"


### PR DESCRIPTION
- Introduce --enforce-device-detection option
- Helm chart: enforceDeviceDetection option
- Add tests for EnforceDeviceDetection option

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Added https://github.com/cilium/cilium/pull/32738
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: https://github.com/cilium/cilium/issues/32721

```release-note
Introduce --force-device-detection option to apply the auto-detection criteria also when devices are explicitly listed with --devices.
```
