### PR TITLE
golangci-lint: change renamed linter goerr113 -> err113

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -99,7 +99,7 @@ issues:
       text: "SA9003: empty branch"
     - linters: [staticcheck]
       text: "SA2001: empty critical section"
-    - linters: [goerr113]
+    - linters: [err113]
       text: "do not define dynamic errors, use wrapped static errors instead" # This rule to avoid opinionated check fmt.Errorf("text")
     # Skip goimports check on generated files
     - path: \\.(generated\\.deepcopy|pb)\\.go$
@@ -115,7 +115,7 @@ linters:
   enable:
     - depguard
     - errorlint
-    - goerr113
+    - err113
     - gofmt
     - goimports
     - govet


### PR DESCRIPTION
This commit gets rid of the deprecation message when using golangci-lint with the renamed linter `goerr113` that has been renamed to `err113`.

```
WARN [lintersdb] The name "goerr113" is deprecated. The linter has been renamed to: err113.
```