### PR TITLE
bpf: nodeport: clean up stale comment

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1666,8 +1666,6 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 	struct ipv4_nat_target target = {
 		.min_port = NODEPORT_PORT_MIN_NAT,
 		.max_port = NODEPORT_PORT_MAX_NAT,
-		.addr = 0, /* set by snat_v4_prepare_state() */
-		.egress_gateway = 0,
 #if defined(ENABLE_CLUSTER_AWARE_ADDRESSING) && defined(ENABLE_INTER_CLUSTER_SNAT)
 		.cluster_id = cluster_id,
 #endif


### PR DESCRIPTION
snat_v4_prepare_state() no longer exists. Remove the comment, along with the redundant 0-initializations.