### PR TITLE
Add GAMMA support to Cilium Operator

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -131,11 +131,13 @@ jobs:
         run: |
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
           
-          EXEMPT_FEATURES="GatewayPort8080,GatewayStaticAddresses,Mesh,HTTPRouteParentRefPort"
+          EXEMPT_FEATURES="GatewayStaticAddresses,HTTPRouteParentRefPort"
           if [ ${{ matrix.crd-channel }} == "standard" ]; then
             EXEMPT_FEATURES+=",HTTPRouteDestinationPortMatching,HTTPRouteRequestTimeout,HTTPRouteBackendTimeout"
           fi
 
+          SKIPPED_TESTS="MeshConsumerRoute"
+          
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=kubeProxyReplacement=true \
             --helm-set=gatewayAPI.enabled=true \

--- a/Documentation/network/servicemesh/gateway-api/gamma.rst
+++ b/Documentation/network/servicemesh/gateway-api/gamma.rst
@@ -1,0 +1,76 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _gs_gamma:
+
+*******************
+GAMMA Support
+*******************
+
+What is GAMMA?
+####################
+
+(From the `GAMMA page <https://gateway-api.sigs.k8s.io/mesh/gamma/>`__
+on the Gateway API site):
+
+The GAMMA initiative is a dedicated workstream within the Gateway API
+subproject, shepherded by the GAMMA leads, rather than being a separate
+subproject. GAMMA’s goal is to define how Gateway API can be used to configure
+a service mesh, with the intention of making minimal changes to Gateway API and
+always preserving the role-oriented nature of Gateway API. Additionally, GAMMA
+strives to advocate for consistency between implementations of Gateway API by
+service mesh projects, regardless of their technology stack or proxy.
+
+In Gateway API v1.0, GAMMA supports adding extra HTTP routing to Services by
+binding a HTTPRoute to a Service as a parent (as opposed to the north/south
+Gateway API usage of binding a HTTPRoute to a Gateway as a parent).
+
+This allows Cilium to intercept layer 7 traffic flowing to a parent Service and
+route the traffic through the per-node Envoy proxy. Because of this, GAMMA
+performs the same function as Cilium's
+:ref:`Layer 7 traffic management <gs_l7_traffic_management>`, without the user
+needing to know anything about configuring Envoy directly.
+
+Types of GAMMA configuration
+############################
+
+In GAMMA, there are two types of HTTPRoutes: "producer" and "consumer" Routes.
+
+"Producer" routes are HTTPRoutes that bind to a Service that lives in the same
+namespace and have the same owner as the owner of the Service whose traffic is
+being managed. So, for an application ``foo``, in the namespace ``foo``, with a
+Service called ``foo-svc``, the owner of ``foo`` would create a HTTPRoute in the ``foo``
+namespace that lists ``foo-svc`` as its parent. The routing then affects all traffic
+coming to the ``foo`` service from the whole cluster, and is controlled by the
+"producer" of the ``foo`` service - its owner.
+
+"Consumer" routes are HTTPRoutes that bind to a Service that lives in a different
+namespace than that Service. These Routes are called "consumer" Routes because
+they are owned by the _consumer_ of the Service they bind to. For the ``foo`` Service
+above, a Route in the ``bar`` namespace, to be used by the app in that namespace,
+that binds to the ``foo-svc`` Service in the ``foo`` namespace is a _consumer_ Service
+because it changes the routing for the ``bar`` service, which _consumes_ the ``foo``
+Service.
+
+Cilium currently supports only "Producer" Routes, and so HTTPRoutes must be
+in the same namespace as the Service that they are binding to.
+
+Cilium GAMMA Support
+##########################
+
+Cilium supports GAMMA v1.0.0 for the following resources:  
+
+- `HTTPRoute <https://gateway-api.sigs.k8s.io/api-types/httproute/>`_  
+- `ReferenceGrant <https://gateway-api.sigs.k8s.io/api-types/referencegrant/>`_  
+
+Cilium support is limited to passing the Core conformance  
+tests and two out of three Extended Mesh tests. Note that GAMMA is itself  
+experimental as at Gateway API v1.0.0.  
+
+Cilium currently does not support "consumer" HTTPRoutes, and so does not  
+support the ``MeshConsumerRoute`` feature of the Mesh conformance profile.  
+
+.. include:: installation.rst

--- a/Documentation/network/servicemesh/index.rst
+++ b/Documentation/network/servicemesh/index.rst
@@ -57,6 +57,7 @@ HTTP, Kafka, gRPC, and DNS are parsed using a proxy such as Envoy.
 
    ingress
    gateway-api/gateway-api
+   gateway-api/gamma
    ingress-to-gateway/ingress-to-gateway
    istio
    mutual-authentication/mutual-authentication

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -787,6 +787,7 @@ webservice
 whitespace
 wildcarded
 workqueue
+workstream
 www
 xDS
 xdp

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -215,6 +215,7 @@ func registerReconcilers(mgr ctrlRuntime.Manager, translator translation.Transla
 		newGatewayReconciler(mgr, translator),
 		newReferenceGrantReconciler(mgr),
 		newHTTPRouteReconciler(mgr),
+		newGammaHttpRouteReconciler(mgr),
 		newGRPCRouteReconciler(mgr),
 		newTLSRouteReconciler(mgr),
 	}

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -215,7 +215,7 @@ func registerReconcilers(mgr ctrlRuntime.Manager, translator translation.Transla
 		newGatewayReconciler(mgr, translator),
 		newReferenceGrantReconciler(mgr),
 		newHTTPRouteReconciler(mgr),
-		newGammaHttpRouteReconciler(mgr),
+		newGammaHttpRouteReconciler(mgr, translator),
 		newGRPCRouteReconciler(mgr),
 		newTLSRouteReconciler(mgr),
 	}

--- a/operator/pkg/gateway-api/controller.go
+++ b/operator/pkg/gateway-api/controller.go
@@ -28,6 +28,8 @@ const (
 	backendServiceIndex       = "backendServiceIndex"
 	backendServiceImportIndex = "backendServiceImportIndex"
 	gatewayIndex              = "gatewayIndex"
+	gammaBackendServiceIndex  = "gammaBackendServiceIndex"
+	gammaListenerServiceIndex = "gammaListenerServiceIndex"
 )
 
 func hasMatchingController(ctx context.Context, c client.Client, controllerName string) func(object client.Object) bool {

--- a/operator/pkg/gateway-api/grpcroute_reconcile.go
+++ b/operator/pkg/gateway-api/grpcroute_reconcile.go
@@ -89,7 +89,7 @@ func (r *grpcRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		})
 
 		// run the actual validators
-		for _, fn := range []routechecks.CheckGatewayFunc{
+		for _, fn := range []routechecks.CheckParentFunc{
 			routechecks.CheckGatewayAllowedForNamespace,
 			routechecks.CheckGatewayRouteKindAllowed,
 			routechecks.CheckGatewayMatchingPorts,

--- a/operator/pkg/gateway-api/helpers/types.go
+++ b/operator/pkg/gateway-api/helpers/types.go
@@ -20,9 +20,14 @@ func IsGateway(parent gatewayv1.ParentReference) bool {
 	return (parent.Kind == nil || *parent.Kind == kindGateway) && (parent.Group == nil || *parent.Group == gatewayv1.GroupName)
 }
 
+func IsGammaService(parent gatewayv1.ParentReference) bool {
+	return (parent.Kind == nil || *parent.Kind == kindService) && (parent.Group == nil || *parent.Group == corev1.GroupName)
+}
+
 func IsService(be gatewayv1.BackendObjectReference) bool {
 	return (be.Kind == nil || *be.Kind == kindService) && (be.Group == nil || *be.Group == corev1.GroupName)
 }
+
 func IsServiceImport(be gatewayv1.BackendObjectReference) bool {
 	return be.Kind != nil && *be.Kind == kindServiceImport && be.Group != nil && *be.Group == mcsapiv1alpha1.GroupName
 }

--- a/operator/pkg/gateway-api/httproute_gamma.go
+++ b/operator/pkg/gateway-api/httproute_gamma.go
@@ -19,28 +19,27 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
-	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
-// httpRouteReconciler reconciles a HTTPRoute object
-type httpRouteReconciler struct {
+// gammaHttpRouteReconciler reconciles a HTTPRoute object
+type gammaHttpRouteReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 }
 
-func newHTTPRouteReconciler(mgr ctrl.Manager) *httpRouteReconciler {
-	return &httpRouteReconciler{
+func newGammaHttpRouteReconciler(mgr ctrl.Manager) *gammaHttpRouteReconciler {
+	return &gammaHttpRouteReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *httpRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.HTTPRoute{}, backendServiceIndex,
+func (r *gammaHttpRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.HTTPRoute{}, gammaBackendServiceIndex,
 		func(rawObj client.Object) []string {
 			route, ok := rawObj.(*gatewayv1.HTTPRoute)
 			if !ok {
@@ -72,48 +71,22 @@ func (r *httpRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1beta1.HTTPRoute{}, backendServiceImportIndex,
-		func(rawObj client.Object) []string {
-			hr, ok := rawObj.(*gatewayv1beta1.HTTPRoute)
-			if !ok {
-				return nil
-			}
-			var backendServiceImports []string
-			for _, rule := range hr.Spec.Rules {
-				for _, backend := range rule.BackendRefs {
-					if !helpers.IsServiceImport(backend.BackendObjectReference) {
-						continue
-					}
-					backendServiceImports = append(backendServiceImports,
-						types.NamespacedName{
-							Namespace: helpers.NamespaceDerefOr(backend.Namespace, hr.Namespace),
-							Name:      string(backend.Name),
-						}.String(),
-					)
-				}
-			}
-			return backendServiceImports
-		},
-	); err != nil {
-		return err
-	}
-
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.HTTPRoute{}, gatewayIndex,
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.HTTPRoute{}, gammaListenerServiceIndex,
 		func(rawObj client.Object) []string {
 			hr := rawObj.(*gatewayv1.HTTPRoute)
-			var gateways []string
+			var services []string
 			for _, parent := range hr.Spec.ParentRefs {
-				if !helpers.IsGateway(parent) {
+				if !helpers.IsGammaService(parent) {
 					continue
 				}
-				gateways = append(gateways,
+				services = append(services,
 					types.NamespacedName{
 						Namespace: helpers.NamespaceDerefOr(parent.Namespace, hr.Namespace),
 						Name:      string(parent.Name),
 					}.String(),
 				)
 			}
-			return gateways
+			return services
 		},
 	); err != nil {
 		return err
@@ -122,25 +95,18 @@ func (r *httpRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		// Watch for changes to HTTPRoute
 		For(&gatewayv1.HTTPRoute{},
-			builder.WithPredicates(predicate.NewPredicateFuncs(r.hasGatewayParent()))).
+			builder.WithPredicates(predicate.NewPredicateFuncs(r.hasGammaParent()))).
 		// Watch for changes to Backend services
 		Watches(&corev1.Service{}, r.enqueueRequestForBackendService()).
+		// Watch for changes to GAMMA Listening services
+		Watches(&corev1.Service{}, r.enqueueRequestForGammaService()).
 		// Watch for changes to Reference Grants
-		Watches(&gatewayv1beta1.ReferenceGrant{}, r.enqueueRequestForReferenceGrant()).
-		// Watch for changes to Gateways and enqueue HTTPRoutes that reference them
-		Watches(&gatewayv1.Gateway{}, r.enqueueRequestForGateway(),
-			builder.WithPredicates(
-				predicate.NewPredicateFuncs(hasMatchingController(context.Background(), mgr.GetClient(), controllerName))))
-
-	if helpers.HasServiceImportSupport(r.Client.Scheme()) {
-		// Watch for changes to Backend Service Imports
-		builder = builder.Watches(&mcsapiv1alpha1.ServiceImport{}, r.enqueueRequestForBackendServiceImport())
-	}
+		Watches(&gatewayv1beta1.ReferenceGrant{}, r.enqueueRequestForReferenceGrant())
 
 	return builder.Complete(r)
 }
 
-func (r *httpRouteReconciler) hasGatewayParent() func(object client.Object) bool {
+func (r *gammaHttpRouteReconciler) hasGammaParent() func(object client.Object) bool {
 	return func(obj client.Object) bool {
 		hr, ok := obj.(*gatewayv1.HTTPRoute)
 		if !ok {
@@ -148,7 +114,7 @@ func (r *httpRouteReconciler) hasGatewayParent() func(object client.Object) bool
 		}
 
 		for _, parent := range hr.Spec.ParentRefs {
-			if helpers.IsGateway(parent) {
+			if helpers.IsGammaService(parent) {
 				return true
 			}
 		}
@@ -159,27 +125,21 @@ func (r *httpRouteReconciler) hasGatewayParent() func(object client.Object) bool
 
 // enqueueRequestForBackendService makes sure that HTTP Routes are reconciled
 // if the backend services are updated.
-func (r *httpRouteReconciler) enqueueRequestForBackendService() handler.EventHandler {
+func (r *gammaHttpRouteReconciler) enqueueRequestForBackendService() handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(r.enqueueFromIndex(backendServiceIndex))
-}
-
-// enqueueRequestForBackendServiceImport makes sure that HTTP Routes are reconciled
-// if the backend Service Imports are updated.
-func (r *httpRouteReconciler) enqueueRequestForBackendServiceImport() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(r.enqueueFromIndex(backendServiceImportIndex))
 }
 
 // enqueueRequestForReferenceGrant makes sure that all HTTP Routes are reconciled
 // if a ReferenceGrant changes
-func (r *httpRouteReconciler) enqueueRequestForReferenceGrant() handler.EventHandler {
+func (r *gammaHttpRouteReconciler) enqueueRequestForReferenceGrant() handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(r.enqueueAll())
 }
 
-func (r *httpRouteReconciler) enqueueRequestForGateway() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(r.enqueueFromIndex(gatewayIndex))
+func (r *gammaHttpRouteReconciler) enqueueRequestForGammaService() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(r.enqueueFromIndex(gammaListenerServiceIndex))
 }
 
-func (r *httpRouteReconciler) enqueueFromIndex(index string) handler.MapFunc {
+func (r *gammaHttpRouteReconciler) enqueueFromIndex(index string) handler.MapFunc {
 	return func(ctx context.Context, o client.Object) []reconcile.Request {
 		scopedLog := log.WithFields(logrus.Fields{
 			logfields.Controller: "httpRoute",
@@ -209,7 +169,7 @@ func (r *httpRouteReconciler) enqueueFromIndex(index string) handler.MapFunc {
 	}
 }
 
-func (r *httpRouteReconciler) enqueueAll() handler.MapFunc {
+func (r *gammaHttpRouteReconciler) enqueueAll() handler.MapFunc {
 	return func(ctx context.Context, o client.Object) []reconcile.Request {
 		scopedLog := log.WithFields(logrus.Fields{
 			logfields.Controller: "httpRoute",

--- a/operator/pkg/gateway-api/httproute_gamma.go
+++ b/operator/pkg/gateway-api/httproute_gamma.go
@@ -21,19 +21,22 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/model/translation"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 // gammaHttpRouteReconciler reconciles a HTTPRoute object
 type gammaHttpRouteReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme     *runtime.Scheme
+	translator translation.Translator
 }
 
-func newGammaHttpRouteReconciler(mgr ctrl.Manager) *gammaHttpRouteReconciler {
+func newGammaHttpRouteReconciler(mgr ctrl.Manager, translator translation.Translator) *gammaHttpRouteReconciler {
 	return &gammaHttpRouteReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:     mgr.GetClient(),
+		Scheme:     mgr.GetScheme(),
+		translator: translator,
 	}
 }
 

--- a/operator/pkg/gateway-api/httproute_gamma.go
+++ b/operator/pkg/gateway-api/httproute_gamma.go
@@ -55,7 +55,7 @@ func (r *gammaHttpRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					backendServiceName, err := helpers.GetBackendServiceName(r.Client, namespace, backend.BackendObjectReference)
 					if err != nil {
 						log.WithFields(logrus.Fields{
-							logfields.Controller: "httpRoute",
+							logfields.Controller: "gammaHttpRoute",
 							logfields.Resource:   client.ObjectKeyFromObject(rawObj),
 						}).WithError(err).Error("Failed to get backend service name")
 						continue

--- a/operator/pkg/gateway-api/httproute_reconcile.go
+++ b/operator/pkg/gateway-api/httproute_reconcile.go
@@ -85,7 +85,7 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		})
 
 		// run the actual validators
-		for _, fn := range []routechecks.CheckGatewayFunc{
+		for _, fn := range []routechecks.CheckParentFunc{
 			routechecks.CheckGatewayAllowedForNamespace,
 			routechecks.CheckGatewayRouteKindAllowed,
 			routechecks.CheckGatewayMatchingPorts,

--- a/operator/pkg/gateway-api/routechecks/gamma_checks.go
+++ b/operator/pkg/gateway-api/routechecks/gamma_checks.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package routechecks
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func CheckGammaServiceAllowedForNamespace(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
+	svc, err := input.GetParentGammaService(parentRef)
+	if err != nil {
+		input.SetParentCondition(parentRef, metav1.Condition{
+			Type:    "Accepted",
+			Status:  metav1.ConditionFalse,
+			Reason:  "Invalid" + input.GetGVK().Kind,
+			Message: err.Error(),
+		})
+		return false, nil
+	}
+
+	if input.GetNamespace() != svc.GetNamespace() {
+		input.SetParentCondition(parentRef, metav1.Condition{
+			Type:    "Accepted",
+			Status:  metav1.ConditionFalse,
+			Reason:  string(gatewayv1.RouteReasonNoMatchingParent),
+			Message: input.GetGVK().Kind + " is not allowed to attach to this Service - it and the Service must be in the same namespace",
+		})
+		return false, nil
+	}
+	return true, nil
+}

--- a/operator/pkg/gateway-api/routechecks/gamma_checks.go
+++ b/operator/pkg/gateway-api/routechecks/gamma_checks.go
@@ -14,7 +14,7 @@ func CheckGammaServiceAllowedForNamespace(input Input, parentRef gatewayv1.Paren
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    "Accepted",
 			Status:  metav1.ConditionFalse,
-			Reason:  "Invalid" + input.GetGVK().Kind,
+			Reason:  "Invalid " + input.GetGVK().Kind,
 			Message: err.Error(),
 		})
 		return false, nil

--- a/operator/pkg/gateway-api/routechecks/grpcroute.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -111,6 +112,10 @@ func (g *GRPCRouteInput) GetGateway(parent gatewayv1.ParentReference) (*gatewayv
 
 	g.gateways[parent] = gw
 	return gw, nil
+}
+
+func (g *GRPCRouteInput) GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error) {
+	return nil, fmt.Errorf("GAMMA support is not implemented in this reconciler")
 }
 
 func (g *GRPCRouteInput) GetHostnames() []gatewayv1beta1.Hostname {

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -29,7 +30,8 @@ type HTTPRouteInput struct {
 	Grants    *gatewayv1beta1.ReferenceGrantList
 	HTTPRoute *gatewayv1.HTTPRoute
 
-	gateways map[gatewayv1.ParentReference]*gatewayv1.Gateway
+	gateways      map[gatewayv1.ParentReference]*gatewayv1.Gateway
+	gammaServices map[gatewayv1.ParentReference]*corev1.Service
 }
 
 func (h *HTTPRouteInput) SetParentCondition(ref gatewayv1.ParentReference, condition metav1.Condition) {
@@ -40,7 +42,6 @@ func (h *HTTPRouteInput) SetParentCondition(ref gatewayv1.ParentReference, condi
 	h.mergeStatusConditions(ref, []metav1.Condition{
 		condition,
 	})
-
 }
 
 func (h *HTTPRouteInput) SetAllParentCondition(condition metav1.Condition) {
@@ -53,7 +54,6 @@ func (h *HTTPRouteInput) SetAllParentCondition(condition metav1.Condition) {
 			condition,
 		})
 	}
-
 }
 
 func (h *HTTPRouteInput) mergeStatusConditions(parentRef gatewayv1alpha2.ParentReference, updates []metav1.Condition) {
@@ -132,6 +132,33 @@ func (h *HTTPRouteInput) GetGateway(parent gatewayv1.ParentReference) (*gatewayv
 	h.gateways[parent] = gw
 
 	return gw, nil
+}
+
+func (h *HTTPRouteInput) GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error) {
+	if h.gammaServices == nil {
+		h.gammaServices = make(map[gatewayv1.ParentReference]*corev1.Service)
+	}
+
+	if s, exists := h.gammaServices[parent]; exists {
+		return s, nil
+	}
+
+	ns := helpers.NamespaceDerefOr(parent.Namespace, h.GetNamespace())
+	s := &corev1.Service{}
+
+	if err := h.Client.Get(h.Ctx, client.ObjectKey{Namespace: ns, Name: string(parent.Name)}, s); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			// if it is not just a not found error, we should return the error as something is bad
+			return nil, fmt.Errorf("error while getting gateway: %w", err)
+		}
+
+		// Gateway does not exist skip further checks
+		return nil, fmt.Errorf("service %q does not exist: %w", parent.Name, err)
+	}
+
+	h.gammaServices[parent] = s
+
+	return s, nil
 }
 
 func (h *HTTPRouteInput) Log() *logrus.Entry {

--- a/operator/pkg/gateway-api/routechecks/input.go
+++ b/operator/pkg/gateway-api/routechecks/input.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,6 +32,7 @@ type Input interface {
 	GetGVK() schema.GroupVersionKind
 	GetGrants() []gatewayv1beta1.ReferenceGrant
 	GetGateway(parent gatewayv1.ParentReference) (*gatewayv1.Gateway, error)
+	GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error)
 	GetHostnames() []gatewayv1.Hostname
 
 	SetParentCondition(ref gatewayv1.ParentReference, condition metav1.Condition)
@@ -38,5 +40,7 @@ type Input interface {
 	Log() *logrus.Entry
 }
 
-type CheckRuleFunc func(input Input) (bool, error)
-type CheckGatewayFunc func(input Input, ref gatewayv1.ParentReference) (bool, error)
+type (
+	CheckRuleFunc   func(input Input) (bool, error)
+	CheckParentFunc func(input Input, ref gatewayv1.ParentReference) (bool, error)
+)

--- a/operator/pkg/gateway-api/routechecks/tlsroute.go
+++ b/operator/pkg/gateway-api/routechecks/tlsroute.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -40,7 +41,6 @@ func (t *TLSRouteInput) SetParentCondition(ref gatewayv1.ParentReference, condit
 	t.mergeStatusConditions(ref, []metav1.Condition{
 		condition,
 	})
-
 }
 
 func (t *TLSRouteInput) SetAllParentCondition(condition metav1.Condition) {
@@ -53,7 +53,6 @@ func (t *TLSRouteInput) SetAllParentCondition(condition metav1.Condition) {
 			condition,
 		})
 	}
-
 }
 
 func (t *TLSRouteInput) mergeStatusConditions(parentRef gatewayv1alpha2.ParentReference, updates []metav1.Condition) {
@@ -141,6 +140,10 @@ func (t *TLSRouteInput) GetGateway(parent gatewayv1.ParentReference) (*gatewayv1
 	t.gateways[parent] = gw
 
 	return gw, nil
+}
+
+func (t *TLSRouteInput) GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error) {
+	return nil, fmt.Errorf("GAMMA support is not implemented in this reconciler")
 }
 
 func (t *TLSRouteInput) Log() *logrus.Entry {

--- a/operator/pkg/model/ingestion/gamma.go
+++ b/operator/pkg/model/ingestion/gamma.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ingestion
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/model"
+)
+
+// Input is the input for GatewayAPI.
+type GammaInput struct {
+	HTTPRoutes      []gatewayv1.HTTPRoute
+	ReferenceGrants []gatewayv1beta1.ReferenceGrant
+	Services        []corev1.Service
+}
+
+// GammaHTTPRoutes takes a GammaInput and gives back the associated HTTP Listeners
+// It does not support TLS Routes because GAMMA is only for cleartext config -
+// it is assumed that any TLS will be performed transparently by the underlying
+// implementation in the spec.
+func GammaHTTPRoutes(input GammaInput) []model.HTTPListener {
+	// GAMMA processing process:
+	// Process HTTPRoutes
+	var resHTTP []model.HTTPListener
+
+	// Search algorithm:
+	// Loop through all HTTPRoutes in input, validate that each is parented by a
+	//   svc that's also in input, in the same namespace, etc.
+	// Add each parentRef service to some tracker to know if we need to create
+	//   a new HTTPListener or not.
+	// Add the rules from the HTTPRoute to the relevant HTTPListener.
+	//   unresolved: How to order these rules?
+	// ReferenceGrants are only relevant for backends, I think, because parents
+	//  _can_ be across namespace boundaries, but that makes them a consumer
+	// route, not a producer one.
+
+	// Set of services that will be parents for these HTTPRoutes
+	parentServices := make(map[types.NamespacedName]model.FullyQualifiedResource)
+
+	for _, hr := range input.HTTPRoutes {
+		// First, we find which parentRefs are Services, so that we can add the
+		// route rules to Listeners for those Services.
+		var gammaParents []gatewayv1.ParentReference
+		for _, parent := range hr.Spec.ParentRefs {
+			if helpers.IsGammaService(parent) {
+				gammaParents = append(gammaParents, parent)
+			}
+		}
+
+		// We shouldn't be able to do this, because the reconciliation should
+		// screen out HTTPRoutes with zero GAMMA parents.
+		if len(gammaParents) == 0 {
+			continue
+		}
+
+		for _, gp := range gammaParents {
+
+			if gp.Name == "" {
+				continue
+			}
+
+			parentName := types.NamespacedName{
+				Name: string(gp.Name),
+			}
+
+			if gp.Namespace != nil {
+				parentName.Namespace = string(*gp.Namespace)
+			}
+
+			parentSvc, err := getMatchingService(parentName.Name, parentName.Namespace, hr.GetNamespace(), input.Services)
+			if err != nil {
+				fmt.Printf("Can't find parent Service %s/%s in input\n", parentName.Namespace, parentName.Name)
+				continue
+			}
+
+			if parentSvc.GetName() == "" {
+				// skip processing this parent because it's not in the input.
+				// This situation should not arise - there should be multiple
+				// layers of protection.
+				// TODO: figure out how to handle this.
+				fmt.Printf("Can't find any parent Service in input\n")
+				continue
+			}
+
+			// Record the service as relevant if it's not already
+			if _, ok := parentServices[parentName]; !ok {
+				parentServices[parentName] = model.FullyQualifiedResource{
+					Name:      parentSvc.GetName(),
+					Namespace: parentSvc.GetNamespace(),
+					Group:     corev1.GroupName,
+					Kind:      "Service",
+					Version:   corev1.SchemeGroupVersion.Version,
+				}
+			}
+
+			// Pick which ports from the Service are relevant.
+			var relevantPorts []uint32
+			// If there's a Port set in the parentRef, then that's the only relevant port.
+			if gp.Port != nil && *gp.Port != 0 {
+				relevantPorts = append(relevantPorts, uint32(*gp.Port))
+			} else {
+				// Otherwise, we find ones where appProtocol is http
+				for _, port := range parentSvc.Spec.Ports {
+					if port.Protocol == "" || port.Protocol == "TCP" {
+						// This is a little suspect, but we should only be using ones where AppProtocol is http
+						// _apparently_
+						if (port.AppProtocol == nil) || (port.AppProtocol != nil && *port.AppProtocol != "http") {
+							continue
+						}
+					}
+
+					relevantPorts = append(relevantPorts, uint32(port.Port))
+				}
+			}
+
+			// We need a Listener per port on the Service that we are handling.
+			for _, portVal := range relevantPorts {
+				res := model.HTTPListener{}
+				// Record the parent Service as the source of the Listener.
+				res.Sources = append(res.Sources, parentServices[parentName])
+				res.Name = fmt.Sprintf("%s-%s-%d", parentSvc.GetNamespace(), parentSvc.GetName(), portVal)
+				res.Port = portVal
+				// GAMMA spec _explicitly_ says that we must not filter by hostname, only address and port
+				res.Hostname = "*"
+
+				res.Service = &model.Service{
+					Type: string(corev1.ServiceTypeClusterIP),
+				}
+
+				res.Routes = append(res.Routes, extractRoutes(int32(portVal), []string{res.Hostname}, hr, input.Services, []v1alpha1.ServiceImport{}, input.ReferenceGrants)...)
+				resHTTP = append(resHTTP, res)
+			}
+
+		}
+	}
+	return resHTTP
+}
+
+func getMatchingService(name string, parentNamespace string, hrNamespace string, services []corev1.Service) (corev1.Service, error) {
+	for _, svc := range services {
+		if svc.GetName() == name {
+			if (parentNamespace == svc.GetNamespace()) || (parentNamespace == "" && hrNamespace == svc.GetNamespace()) {
+				return svc, nil
+			}
+		}
+	}
+
+	return corev1.Service{}, fmt.Errorf("service not found in input")
+}

--- a/operator/pkg/model/ingestion/gamma.go
+++ b/operator/pkg/model/ingestion/gamma.go
@@ -60,7 +60,7 @@ func GammaHTTPRoutes(input GammaInput) []model.HTTPListener {
 			Name:      hr.GetName(),
 			Namespace: hr.GetNamespace(),
 			Group:     gatewayv1.GroupVersion.Group,
-			Kind:      hr.Kind,
+			Kind:      "HTTPRoute",
 			Version:   gatewayv1.GroupVersion.Version,
 			UID:       string(hr.GetUID()),
 		}
@@ -87,7 +87,7 @@ func GammaHTTPRoutes(input GammaInput) []model.HTTPListener {
 
 			parentSvc, err := getMatchingService(parentName.Name, parentName.Namespace, hr.GetNamespace(), input.Services)
 			if err != nil {
-				fmt.Printf("Can't find parent Service %s/%s in input\n", parentName.Namespace, parentName.Name)
+				log.Warnf("Can't find parent Service %s/%s in input. This is a bug, please report it to the developers.", parentName.Namespace, parentName.Name)
 				continue
 			}
 
@@ -95,8 +95,7 @@ func GammaHTTPRoutes(input GammaInput) []model.HTTPListener {
 				// skip processing this parent because it's not in the input.
 				// This situation should not arise - there should be multiple
 				// layers of protection.
-				// TODO: figure out how to handle this.
-				fmt.Printf("Can't find any parent Service in input\n")
+				log.Warn("Can't find any parent Service in input. This is a bug, please report it to the developers.")
 				continue
 			}
 

--- a/operator/pkg/model/ingestion/gamma_fixture_test.go
+++ b/operator/pkg/model/ingestion/gamma_fixture_test.go
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ingestion
+
+import (
+	"github.com/cilium/cilium/operator/pkg/model"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// Gateway API Mesh Conformance test resources
+// https://github.com/kubernetes-sigs/gateway-api/tree/main/conformance/tests
+
+// Base manifest
+// https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/mesh/manifests.yaml
+
+var (
+	httpAppProtocol string = "http"
+	grpcAppProtocol string = "grpc"
+)
+
+// echo-v1 Service
+
+var gammaEchoV1Service = corev1.Service{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "echo-v1",
+		Namespace: "gateway-conformance-mesh",
+	},
+	Spec: corev1.ServiceSpec{
+		Ports: []corev1.ServicePort{
+			{
+				Name:        "http",
+				Port:        80,
+				TargetPort:  intstr.FromInt(8080),
+				AppProtocol: &httpAppProtocol,
+			},
+			{
+				Name:        "http-alt",
+				Port:        8080,
+				AppProtocol: &httpAppProtocol,
+			},
+			{
+				Name:       "https",
+				Port:       443,
+				TargetPort: intstr.FromInt(8443),
+			},
+			{
+				Name: "tcp",
+				Port: 9090,
+			},
+			{
+				Name:        "grpc",
+				Port:        7070,
+				AppProtocol: &grpcAppProtocol,
+			},
+		},
+		Selector: map[string]string{
+			"app":     "echo",
+			"version": "v1",
+		},
+	},
+}
+
+// echo-v2 Service
+
+var gammaEchoV2Service = corev1.Service{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "echo-v2",
+		Namespace: "gateway-conformance-mesh",
+	},
+	Spec: corev1.ServiceSpec{
+		Ports: []corev1.ServicePort{
+			{
+				Name:        "http",
+				Port:        80,
+				TargetPort:  intstr.FromInt(8080),
+				AppProtocol: &httpAppProtocol,
+			},
+			{
+				Name:        "http-alt",
+				Port:        8080,
+				AppProtocol: &httpAppProtocol,
+			},
+			{
+				Name:       "https",
+				Port:       443,
+				TargetPort: intstr.FromInt(8443),
+			},
+			{
+				Name: "tcp",
+				Port: 9090,
+			},
+			{
+				Name:        "grpc",
+				Port:        7070,
+				AppProtocol: &grpcAppProtocol,
+			},
+		},
+		Selector: map[string]string{
+			"app":     "echo",
+			"version": "v2",
+		},
+	},
+}
+
+// echo Service
+
+var gammaEchoService = corev1.Service{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "echo",
+		Namespace: "gateway-conformance-mesh",
+	},
+	Spec: corev1.ServiceSpec{
+		Ports: []corev1.ServicePort{
+			{
+				Name:        "http",
+				Port:        80,
+				TargetPort:  intstr.FromInt(8080),
+				AppProtocol: &httpAppProtocol,
+			},
+			{
+				Name:        "http-alt",
+				Port:        8080,
+				AppProtocol: &httpAppProtocol,
+			},
+			{
+				Name:       "https",
+				Port:       443,
+				TargetPort: intstr.FromInt(8443),
+			},
+			{
+				Name: "tcp",
+				Port: 9090,
+			},
+			{
+				Name:        "grpc",
+				Port:        7070,
+				AppProtocol: &grpcAppProtocol,
+			},
+		},
+		Selector: map[string]string{
+			"app": "echo",
+		},
+	},
+}
+
+// mesh-split HTTPRoute
+var meshSplitHTTPRoute = gatewayv1.HTTPRoute{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "mesh-split",
+		Namespace: "gateway-conformance-mesh",
+	},
+	Spec: gatewayv1.HTTPRouteSpec{
+		CommonRouteSpec: gatewayv1.CommonRouteSpec{
+			ParentRefs: []gatewayv1.ParentReference{
+				{
+					Name:  "echo",
+					Group: GroupPtr(corev1.SchemeGroupVersion.Group),
+					Kind:  KindPtr("Service"),
+				},
+			},
+		},
+		Rules: []gatewayv1.HTTPRouteRule{
+			{
+				Matches: []gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  model.AddressOf(gatewayv1.PathMatchExact),
+							Value: model.AddressOf("/v1"),
+						},
+					},
+				},
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					{
+						BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: "echo-v1",
+								Port: model.AddressOf[gatewayv1.PortNumber](80),
+							},
+						},
+					},
+				},
+			},
+			{
+				Matches: []gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  model.AddressOf(gatewayv1.PathMatchExact),
+							Value: model.AddressOf("/v2"),
+						},
+					},
+				},
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					{
+						BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: "echo-v2",
+								Port: model.AddressOf[gatewayv1.PortNumber](80),
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+// mesh-ports HTTPRoute
+var meshPortsHTTPRoute = gatewayv1.HTTPRoute{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "mesh-ports",
+		Namespace: "gateway-conformance-mesh",
+	},
+	Spec: gatewayv1.HTTPRouteSpec{
+		CommonRouteSpec: gatewayv1.CommonRouteSpec{
+			ParentRefs: []gatewayv1.ParentReference{
+				{
+					Name:  "echo-v1",
+					Group: GroupPtr(corev1.SchemeGroupVersion.Group),
+					Kind:  KindPtr("Service"),
+					Port:  model.AddressOf[gatewayv1.PortNumber](80),
+				},
+			},
+		},
+		Rules: []gatewayv1.HTTPRouteRule{
+			{
+				Filters: []gatewayv1.HTTPRouteFilter{
+					{
+						Type: gatewayv1.HTTPRouteFilterResponseHeaderModifier,
+						ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+							Set: []gatewayv1.HTTPHeader{
+								{
+									Name:  gatewayv1.HTTPHeaderName("X-Header-Set"),
+									Value: "v1",
+								},
+							},
+						},
+					},
+				},
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					{
+						BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: "echo-v1",
+								Port: model.AddressOf[gatewayv1.PortNumber](80),
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+// mesh-frontend HTTPRoute
+var meshFrontendHTTPRoute = gatewayv1.HTTPRoute{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "mesh-split-v1",
+		Namespace: "gateway-conformance-mesh",
+	},
+	Spec: gatewayv1.HTTPRouteSpec{
+		CommonRouteSpec: gatewayv1.CommonRouteSpec{
+			ParentRefs: []gatewayv1.ParentReference{
+				{
+					Name:  "echo-v2",
+					Group: GroupPtr(corev1.SchemeGroupVersion.Group),
+					Kind:  KindPtr("Service"),
+					Port:  model.AddressOf[gatewayv1.PortNumber](80),
+				},
+			},
+		},
+		Rules: []gatewayv1.HTTPRouteRule{
+			{
+				Filters: []gatewayv1.HTTPRouteFilter{
+					{
+						Type: gatewayv1.HTTPRouteFilterResponseHeaderModifier,
+						ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+							Set: []gatewayv1.HTTPHeader{
+								{
+									Name:  gatewayv1.HTTPHeaderName("X-Header-Set"),
+									Value: "set",
+								},
+							},
+						},
+					},
+				},
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					{
+						BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: "echo-v2",
+								Port: model.AddressOf[gatewayv1.PortNumber](80),
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}

--- a/operator/pkg/model/ingestion/gamma_fixture_test.go
+++ b/operator/pkg/model/ingestion/gamma_fixture_test.go
@@ -4,11 +4,12 @@
 package ingestion
 
 import (
-	"github.com/cilium/cilium/operator/pkg/model"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/model"
 )
 
 // Gateway API Mesh Conformance test resources

--- a/operator/pkg/model/ingestion/gamma_test.go
+++ b/operator/pkg/model/ingestion/gamma_test.go
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ingestion
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/operator/pkg/model"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+var meshSplitInput = GammaInput{
+	Services: []corev1.Service{
+		gammaEchoService,
+		gammaEchoV1Service,
+		gammaEchoV2Service,
+	},
+	HTTPRoutes: []gatewayv1.HTTPRoute{
+		meshSplitHTTPRoute,
+	},
+}
+
+var meshSplitListeners = []model.HTTPListener{
+	{
+		Name: "gateway-conformance-mesh-echo-80",
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "echo",
+				Namespace: "gateway-conformance-mesh",
+				Version:   "v1",
+				Kind:      "Service",
+			},
+		},
+		Port:     80,
+		Hostname: "*",
+		Routes: []model.HTTPRoute{
+			{
+				Hostnames: []string{
+					"*",
+				},
+				PathMatch: model.StringMatch{
+					Exact: "/v1",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "echo-v1",
+						Namespace: "gateway-conformance-mesh",
+						Port: &model.BackendPort{
+							Port: 80,
+						},
+						AppProtocol: model.AddressOf("http"),
+					},
+				},
+			},
+			{
+				Hostnames: []string{
+					"*",
+				},
+				PathMatch: model.StringMatch{
+					Exact: "/v2",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "echo-v2",
+						Namespace: "gateway-conformance-mesh",
+						Port: &model.BackendPort{
+							Port: 80,
+						},
+						AppProtocol: model.AddressOf("http"),
+					},
+				},
+			},
+		},
+		Service: &model.Service{
+			Type: "ClusterIP",
+		},
+	},
+	{
+		Name: "gateway-conformance-mesh-echo-8080",
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "echo",
+				Namespace: "gateway-conformance-mesh",
+				Version:   "v1",
+				Kind:      "Service",
+			},
+		},
+		Port:     8080,
+		Hostname: "*",
+		Routes: []model.HTTPRoute{
+			{
+				Hostnames: []string{
+					"*",
+				},
+				PathMatch: model.StringMatch{
+					Exact: "/v1",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "echo-v1",
+						Namespace: "gateway-conformance-mesh",
+						Port: &model.BackendPort{
+							Port: 80,
+						},
+						AppProtocol: model.AddressOf("http"),
+					},
+				},
+			},
+			{
+				Hostnames: []string{
+					"*",
+				},
+				PathMatch: model.StringMatch{
+					Exact: "/v2",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "echo-v2",
+						Namespace: "gateway-conformance-mesh",
+						Port: &model.BackendPort{
+							Port: 80,
+						},
+						AppProtocol: model.AddressOf("http"),
+					},
+				},
+			},
+		},
+		Service: &model.Service{
+			Type: "ClusterIP",
+		},
+	},
+}
+
+var meshPortsInput = GammaInput{
+	Services: []corev1.Service{
+		gammaEchoService,
+		gammaEchoV1Service,
+		gammaEchoV2Service,
+	},
+	HTTPRoutes: []gatewayv1.HTTPRoute{
+		meshPortsHTTPRoute,
+	},
+}
+
+var meshPortsListeners = []model.HTTPListener{
+	{
+		Name: "gateway-conformance-mesh-echo-v1-80",
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "echo-v1",
+				Namespace: "gateway-conformance-mesh",
+				Version:   "v1",
+				Kind:      "Service",
+			},
+		},
+		Port:     80,
+		Hostname: "*",
+		Routes: []model.HTTPRoute{
+			{
+				Hostnames: []string{
+					"*",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "echo-v1",
+						Namespace: "gateway-conformance-mesh",
+						Port: &model.BackendPort{
+							Port: 80,
+						},
+						AppProtocol: model.AddressOf("http"),
+					},
+				},
+				ResponseHeaderModifier: &model.HTTPHeaderFilter{
+					HeadersToSet: []model.Header{
+						{
+							Name:  "X-Header-Set",
+							Value: "v1",
+						},
+					},
+				},
+			},
+		},
+		Service: &model.Service{
+			Type: "ClusterIP",
+		},
+	},
+}
+
+var meshFrontendInput = GammaInput{
+	Services: []corev1.Service{
+		gammaEchoService,
+		gammaEchoV1Service,
+		gammaEchoV2Service,
+	},
+	HTTPRoutes: []gatewayv1.HTTPRoute{
+		meshFrontendHTTPRoute,
+	},
+}
+
+var meshFrontendListeners = []model.HTTPListener{
+	{
+		Name: "gateway-conformance-mesh-echo-v2-80",
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "echo-v2",
+				Namespace: "gateway-conformance-mesh",
+				Version:   "v1",
+				Kind:      "Service",
+			},
+		},
+		Port:     80,
+		Hostname: "*",
+		Routes: []model.HTTPRoute{
+			{
+				Hostnames: []string{
+					"*",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "echo-v2",
+						Namespace: "gateway-conformance-mesh",
+						Port: &model.BackendPort{
+							Port: 80,
+						},
+						AppProtocol: model.AddressOf("http"),
+					},
+				},
+				ResponseHeaderModifier: &model.HTTPHeaderFilter{
+					HeadersToSet: []model.Header{
+						{
+							Name:  "X-Header-Set",
+							Value: "set",
+						},
+					},
+				},
+			},
+		},
+		Service: &model.Service{
+			Type: "ClusterIP",
+		},
+	},
+}
+
+func TestGammaConformance(t *testing.T) {
+	tests := map[string]struct {
+		input GammaInput
+		want  []model.HTTPListener
+	}{
+		"Mesh Split": {
+			input: meshSplitInput,
+			want:  meshSplitListeners,
+		},
+		"Mesh Ports": {
+			input: meshPortsInput,
+			want:  meshPortsListeners,
+		},
+		"Mesh Frontend": {
+			input: meshFrontendInput,
+			want:  meshFrontendListeners,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			listeners := GammaHTTPRoutes(tc.input)
+			assert.Equal(t, tc.want, listeners, "Listeners did not match")
+		})
+	}
+}

--- a/operator/pkg/model/ingestion/gamma_test.go
+++ b/operator/pkg/model/ingestion/gamma_test.go
@@ -6,10 +6,11 @@ package ingestion
 import (
 	"testing"
 
-	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/model"
 )
 
 var meshSplitInput = GammaInput{
@@ -32,6 +33,13 @@ var meshSplitListeners = []model.HTTPListener{
 				Namespace: "gateway-conformance-mesh",
 				Version:   "v1",
 				Kind:      "Service",
+			},
+			{
+				Name:      "mesh-split",
+				Namespace: "gateway-conformance-mesh",
+				Version:   "v1",
+				Group:     "gateway.networking.k8s.io",
+				Kind:      "HTTPRoute",
 			},
 		},
 		Port:     80,
@@ -86,6 +94,13 @@ var meshSplitListeners = []model.HTTPListener{
 				Namespace: "gateway-conformance-mesh",
 				Version:   "v1",
 				Kind:      "Service",
+			},
+			{
+				Name:      "mesh-split",
+				Namespace: "gateway-conformance-mesh",
+				Version:   "v1",
+				Group:     "gateway.networking.k8s.io",
+				Kind:      "HTTPRoute",
 			},
 		},
 		Port:     8080,
@@ -155,6 +170,13 @@ var meshPortsListeners = []model.HTTPListener{
 				Version:   "v1",
 				Kind:      "Service",
 			},
+			{
+				Name:      "mesh-ports",
+				Namespace: "gateway-conformance-mesh",
+				Version:   "v1",
+				Group:     "gateway.networking.k8s.io",
+				Kind:      "HTTPRoute",
+			},
 		},
 		Port:     80,
 		Hostname: "*",
@@ -209,6 +231,13 @@ var meshFrontendListeners = []model.HTTPListener{
 				Namespace: "gateway-conformance-mesh",
 				Version:   "v1",
 				Kind:      "Service",
+			},
+			{
+				Name:      "mesh-split-v1",
+				Namespace: "gateway-conformance-mesh",
+				Version:   "v1",
+				Group:     "gateway.networking.k8s.io",
+				Kind:      "HTTPRoute",
 			},
 		},
 		Port:     80,

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -157,129 +157,137 @@ func toHTTPRoutes(listener gatewayv1.Listener, input []gatewayv1.HTTPRoute, serv
 		if len(computedHost) == 1 && computedHost[0] == allHosts {
 			computedHost = nil
 		}
-		for _, rule := range r.Spec.Rules {
-			var backendHTTPFilters []*model.BackendHTTPFilter
-			bes := make([]model.Backend, 0, len(rule.BackendRefs))
-			for _, be := range rule.BackendRefs {
-				if !helpers.IsBackendReferenceAllowed(r.GetNamespace(), be.BackendRef, gatewayv1.SchemeGroupVersion.WithKind("HTTPRoute"), grants) {
-					continue
+
+		httpRoutes = append(httpRoutes, extractRoutes(int32(listener.Port), computedHost, r, services, serviceImports, grants)...)
+
+	}
+	return httpRoutes
+}
+
+func extractRoutes(listenerPort int32, hostnames []string, hr gatewayv1.HTTPRoute, services []corev1.Service, serviceImports []mcsapiv1alpha1.ServiceImport, grants []gatewayv1beta1.ReferenceGrant) []model.HTTPRoute {
+	var httpRoutes []model.HTTPRoute
+	for _, rule := range hr.Spec.Rules {
+		var backendHTTPFilters []*model.BackendHTTPFilter
+		bes := make([]model.Backend, 0, len(rule.BackendRefs))
+		for _, be := range rule.BackendRefs {
+			if !helpers.IsBackendReferenceAllowed(hr.GetNamespace(), be.BackendRef, gatewayv1.SchemeGroupVersion.WithKind("HTTPRoute"), grants) {
+				continue
+			}
+			svcName, err := getBackendServiceName(helpers.NamespaceDerefOr(be.Namespace, hr.Namespace), services, serviceImports, be.BackendObjectReference)
+			if err != nil {
+				continue
+			}
+			if svcName != string(be.Name) {
+				be = *be.DeepCopy()
+				be.BackendRef.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
+					Name:      gatewayv1beta1.ObjectName(svcName),
+					Port:      be.Port,
+					Namespace: be.Namespace,
 				}
-				svcName, err := getBackendServiceName(helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services, serviceImports, be.BackendObjectReference)
-				if err != nil {
-					continue
-				}
-				if svcName != string(be.Name) {
-					be = *be.DeepCopy()
-					be.BackendRef.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
-						Name:      gatewayv1beta1.ObjectName(svcName),
-						Port:      be.Port,
-						Namespace: be.Namespace,
+			}
+			if be.BackendRef.Port == nil {
+				// must have port for Service reference
+				continue
+			}
+			svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, hr.Namespace), services)
+			if svc != nil {
+				bes = append(bes, backendToModelBackend(*svc, be.BackendRef, hr.Namespace))
+				for _, f := range be.Filters {
+					switch f.Type {
+					case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
+						backendHTTPFilters = append(backendHTTPFilters, &model.BackendHTTPFilter{
+							Name: fmt.Sprintf("%s:%s:%d", helpers.NamespaceDerefOr(be.Namespace, hr.Namespace), be.Name, uint32(*be.Port)),
+							RequestHeaderFilter: &model.HTTPHeaderFilter{
+								HeadersToAdd:    toHTTPHeaders(f.RequestHeaderModifier.Add),
+								HeadersToSet:    toHTTPHeaders(f.RequestHeaderModifier.Set),
+								HeadersToRemove: f.RequestHeaderModifier.Remove,
+							},
+						})
+					case gatewayv1.HTTPRouteFilterResponseHeaderModifier:
+						backendHTTPFilters = append(backendHTTPFilters, &model.BackendHTTPFilter{
+							Name: fmt.Sprintf("%s:%s:%d", helpers.NamespaceDerefOr(be.Namespace, hr.Namespace), be.Name, uint32(*be.Port)),
+							ResponseHeaderModifier: &model.HTTPHeaderFilter{
+								HeadersToAdd:    toHTTPHeaders(f.ResponseHeaderModifier.Add),
+								HeadersToSet:    toHTTPHeaders(f.ResponseHeaderModifier.Set),
+								HeadersToRemove: f.ResponseHeaderModifier.Remove,
+							},
+						})
 					}
 				}
-				if be.BackendRef.Port == nil {
-					// must have port for Service reference
-					continue
+			}
+		}
+
+		var dr *model.DirectResponse
+		if len(bes) == 0 {
+			dr = &model.DirectResponse{
+				StatusCode: 500,
+			}
+		}
+
+		var requestHeaderFilter *model.HTTPHeaderFilter
+		var responseHeaderFilter *model.HTTPHeaderFilter
+		var requestRedirectFilter *model.HTTPRequestRedirectFilter
+		var rewriteFilter *model.HTTPURLRewriteFilter
+		var requestMirrors []*model.HTTPRequestMirror
+
+		for _, f := range rule.Filters {
+			switch f.Type {
+			case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
+				requestHeaderFilter = &model.HTTPHeaderFilter{
+					HeadersToAdd:    toHTTPHeaders(f.RequestHeaderModifier.Add),
+					HeadersToSet:    toHTTPHeaders(f.RequestHeaderModifier.Set),
+					HeadersToRemove: f.RequestHeaderModifier.Remove,
 				}
-				svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services)
+			case gatewayv1.HTTPRouteFilterResponseHeaderModifier:
+				responseHeaderFilter = &model.HTTPHeaderFilter{
+					HeadersToAdd:    toHTTPHeaders(f.ResponseHeaderModifier.Add),
+					HeadersToSet:    toHTTPHeaders(f.ResponseHeaderModifier.Set),
+					HeadersToRemove: f.ResponseHeaderModifier.Remove,
+				}
+			case gatewayv1.HTTPRouteFilterRequestRedirect:
+				requestRedirectFilter = toHTTPRequestRedirectFilter(listenerPort, f.RequestRedirect)
+			case gatewayv1.HTTPRouteFilterURLRewrite:
+				rewriteFilter = toHTTPRewriteFilter(f.URLRewrite)
+			case gatewayv1.HTTPRouteFilterRequestMirror:
+				svc := getServiceSpec(string(f.RequestMirror.BackendRef.Name), helpers.NamespaceDerefOr(f.RequestMirror.BackendRef.Namespace, hr.Namespace), services)
 				if svc != nil {
-					bes = append(bes, backendToModelBackend(*svc, be.BackendRef, r.Namespace))
-					for _, f := range be.Filters {
-						switch f.Type {
-						case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
-							backendHTTPFilters = append(backendHTTPFilters, &model.BackendHTTPFilter{
-								Name: fmt.Sprintf("%s:%s:%d", helpers.NamespaceDerefOr(be.Namespace, r.Namespace), be.Name, uint32(*be.Port)),
-								RequestHeaderFilter: &model.HTTPHeaderFilter{
-									HeadersToAdd:    toHTTPHeaders(f.RequestHeaderModifier.Add),
-									HeadersToSet:    toHTTPHeaders(f.RequestHeaderModifier.Set),
-									HeadersToRemove: f.RequestHeaderModifier.Remove,
-								},
-							})
-						case gatewayv1.HTTPRouteFilterResponseHeaderModifier:
-							backendHTTPFilters = append(backendHTTPFilters, &model.BackendHTTPFilter{
-								Name: fmt.Sprintf("%s:%s:%d", helpers.NamespaceDerefOr(be.Namespace, r.Namespace), be.Name, uint32(*be.Port)),
-								ResponseHeaderModifier: &model.HTTPHeaderFilter{
-									HeadersToAdd:    toHTTPHeaders(f.ResponseHeaderModifier.Add),
-									HeadersToSet:    toHTTPHeaders(f.ResponseHeaderModifier.Set),
-									HeadersToRemove: f.ResponseHeaderModifier.Remove,
-								},
-							})
-						}
-					}
+					requestMirrors = append(requestMirrors, toHTTPRequestMirror(*svc, f.RequestMirror, hr.Namespace))
 				}
 			}
+		}
 
-			var dr *model.DirectResponse
-			if len(bes) == 0 {
-				dr = &model.DirectResponse{
-					StatusCode: 500,
-				}
-			}
+		if len(rule.Matches) == 0 {
+			httpRoutes = append(httpRoutes, model.HTTPRoute{
+				Hostnames:              hostnames,
+				Backends:               bes,
+				BackendHTTPFilters:     backendHTTPFilters,
+				DirectResponse:         dr,
+				RequestHeaderFilter:    requestHeaderFilter,
+				ResponseHeaderModifier: responseHeaderFilter,
+				RequestRedirect:        requestRedirectFilter,
+				Rewrite:                rewriteFilter,
+				RequestMirrors:         requestMirrors,
+				Timeout:                toTimeout(rule.Timeouts),
+			})
+		}
 
-			var requestHeaderFilter *model.HTTPHeaderFilter
-			var responseHeaderFilter *model.HTTPHeaderFilter
-			var requestRedirectFilter *model.HTTPRequestRedirectFilter
-			var rewriteFilter *model.HTTPURLRewriteFilter
-			var requestMirrors []*model.HTTPRequestMirror
-
-			for _, f := range rule.Filters {
-				switch f.Type {
-				case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
-					requestHeaderFilter = &model.HTTPHeaderFilter{
-						HeadersToAdd:    toHTTPHeaders(f.RequestHeaderModifier.Add),
-						HeadersToSet:    toHTTPHeaders(f.RequestHeaderModifier.Set),
-						HeadersToRemove: f.RequestHeaderModifier.Remove,
-					}
-				case gatewayv1.HTTPRouteFilterResponseHeaderModifier:
-					responseHeaderFilter = &model.HTTPHeaderFilter{
-						HeadersToAdd:    toHTTPHeaders(f.ResponseHeaderModifier.Add),
-						HeadersToSet:    toHTTPHeaders(f.ResponseHeaderModifier.Set),
-						HeadersToRemove: f.ResponseHeaderModifier.Remove,
-					}
-				case gatewayv1.HTTPRouteFilterRequestRedirect:
-					requestRedirectFilter = toHTTPRequestRedirectFilter(listener, f.RequestRedirect)
-				case gatewayv1.HTTPRouteFilterURLRewrite:
-					rewriteFilter = toHTTPRewriteFilter(f.URLRewrite)
-				case gatewayv1.HTTPRouteFilterRequestMirror:
-					svc := getServiceSpec(string(f.RequestMirror.BackendRef.Name), helpers.NamespaceDerefOr(f.RequestMirror.BackendRef.Namespace, r.Namespace), services)
-					if svc != nil {
-						requestMirrors = append(requestMirrors, toHTTPRequestMirror(*svc, f.RequestMirror, r.Namespace))
-					}
-				}
-			}
-
-			if len(rule.Matches) == 0 {
-				httpRoutes = append(httpRoutes, model.HTTPRoute{
-					Hostnames:              computedHost,
-					Backends:               bes,
-					BackendHTTPFilters:     backendHTTPFilters,
-					DirectResponse:         dr,
-					RequestHeaderFilter:    requestHeaderFilter,
-					ResponseHeaderModifier: responseHeaderFilter,
-					RequestRedirect:        requestRedirectFilter,
-					Rewrite:                rewriteFilter,
-					RequestMirrors:         requestMirrors,
-					Timeout:                toTimeout(rule.Timeouts),
-				})
-			}
-
-			for _, match := range rule.Matches {
-				httpRoutes = append(httpRoutes, model.HTTPRoute{
-					Hostnames:              computedHost,
-					PathMatch:              toPathMatch(match),
-					HeadersMatch:           toHeaderMatch(match),
-					QueryParamsMatch:       toQueryMatch(match),
-					Method:                 (*string)(match.Method),
-					Backends:               bes,
-					BackendHTTPFilters:     backendHTTPFilters,
-					DirectResponse:         dr,
-					RequestHeaderFilter:    requestHeaderFilter,
-					ResponseHeaderModifier: responseHeaderFilter,
-					RequestRedirect:        requestRedirectFilter,
-					Rewrite:                rewriteFilter,
-					RequestMirrors:         requestMirrors,
-					Timeout:                toTimeout(rule.Timeouts),
-				})
-			}
+		for _, match := range rule.Matches {
+			httpRoutes = append(httpRoutes, model.HTTPRoute{
+				Hostnames:              hostnames,
+				PathMatch:              toPathMatch(match),
+				HeadersMatch:           toHeaderMatch(match),
+				QueryParamsMatch:       toQueryMatch(match),
+				Method:                 (*string)(match.Method),
+				Backends:               bes,
+				BackendHTTPFilters:     backendHTTPFilters,
+				DirectResponse:         dr,
+				RequestHeaderFilter:    requestHeaderFilter,
+				ResponseHeaderModifier: responseHeaderFilter,
+				RequestRedirect:        requestRedirectFilter,
+				Rewrite:                rewriteFilter,
+				RequestMirrors:         requestMirrors,
+				Timeout:                toTimeout(rule.Timeouts),
+			})
 		}
 	}
 	return httpRoutes
@@ -475,7 +483,7 @@ func toTLSRoutes(listener gatewayv1beta1.Listener, input []gatewayv1alpha2.TLSRo
 	return tlsRoutes
 }
 
-func toHTTPRequestRedirectFilter(listener gatewayv1beta1.Listener, redirect *gatewayv1.HTTPRequestRedirectFilter) *model.HTTPRequestRedirectFilter {
+func toHTTPRequestRedirectFilter(listenerPort int32, redirect *gatewayv1.HTTPRequestRedirectFilter) *model.HTTPRequestRedirectFilter {
 	if redirect == nil {
 		return nil
 	}
@@ -496,7 +504,7 @@ func toHTTPRequestRedirectFilter(listener gatewayv1beta1.Listener, redirect *gat
 			// If redirect scheme is empty, the redirect port MUST be the Gateway
 			// Listener port.
 			// Refer to: https://github.com/kubernetes-sigs/gateway-api/blob/35fe25d1384a41c9b89dd5af7ae3214c431f008c/apis/v1/httproute_types.go#L1040-L1041
-			redirectPort = model.AddressOf(int32(listener.Port))
+			redirectPort = model.AddressOf(listenerPort)
 		}
 	} else {
 		redirectPort = (*int32)(redirect.Port)

--- a/operator/pkg/model/ingestion/gateway_fixture_test.go
+++ b/operator/pkg/model/ingestion/gateway_fixture_test.go
@@ -184,6 +184,7 @@ var infraBackEndV1Service = corev1.Service{
 		},
 	},
 }
+
 var infraBackEndV2Service = corev1.Service{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "infra-backend-v2",
@@ -202,6 +203,7 @@ var infraBackEndV2Service = corev1.Service{
 		},
 	},
 }
+
 var infraBackEndV3Service = corev1.Service{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "infra-backend-v3",
@@ -220,6 +222,7 @@ var infraBackEndV3Service = corev1.Service{
 		},
 	},
 }
+
 var appBackEndV1Service = corev1.Service{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "app-backend-v1",
@@ -238,6 +241,7 @@ var appBackEndV1Service = corev1.Service{
 		},
 	},
 }
+
 var appBackEndV2Service = corev1.Service{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "app-backend-v2",
@@ -256,6 +260,7 @@ var appBackEndV2Service = corev1.Service{
 		},
 	},
 }
+
 var webBackendService = corev1.Service{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "web-backend",
@@ -583,6 +588,7 @@ var hostnameIntersectionGateway = &gatewayv1beta1.Gateway{
 		},
 	},
 }
+
 var hostnameIntersectionHTTPRoutes = []gatewayv1beta1.HTTPRoute{
 	{
 		ObjectMeta: metav1.ObjectMeta{
@@ -646,7 +652,7 @@ var hostnameIntersectionHTTPRoutes = []gatewayv1beta1.HTTPRoute{
 				"wildcard.io",
 				"foo.wildcard.io",     // matches listener-2's wildcard host
 				"bar.wildcard.io",     // matches listener-2's wildcard host
-				"foo.bar.wildcard.io", //matches listener-2's wildcard host
+				"foo.bar.wildcard.io", // matches listener-2's wildcard host
 			},
 			Rules: []gatewayv1beta1.HTTPRouteRule{
 				{
@@ -856,6 +862,7 @@ var listenerHostnameMatchingGateway = &gatewayv1beta1.Gateway{
 		},
 	},
 }
+
 var listenerHostnameMatchingHTTPRoutes = []gatewayv1beta1.HTTPRoute{
 	{
 		ObjectMeta: metav1.ObjectMeta{

--- a/operator/pkg/model/translation/cec_translator.go
+++ b/operator/pkg/model/translation/cec_translator.go
@@ -11,6 +11,7 @@ import (
 
 	envoy_config_cluster_v3 "github.com/cilium/proxy/go/envoy/config/cluster/v3"
 	envoy_config_route_v3 "github.com/cilium/proxy/go/envoy/config/route/v3"
+	"golang.org/x/exp/maps"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/operator/pkg/model"
@@ -95,7 +96,7 @@ func (i *cecTranslator) Translate(namespace string, name string, model *model.Mo
 	}
 
 	cec.Spec.BackendServices = i.getBackendServices(model)
-	cec.Spec.Services = i.getServices(namespace, name)
+	cec.Spec.Services = i.getServicesWithPorts(namespace, name, model)
 	cec.Spec.Resources = i.getResources(model)
 
 	if i.hostNetworkEnabled {
@@ -132,11 +133,32 @@ func (i *cecTranslator) getBackendServices(m *model.Model) []*ciliumv2.Service {
 	return res
 }
 
-func (i *cecTranslator) getServices(namespace string, name string) []*ciliumv2.ServiceListener {
+func (i *cecTranslator) getServicesWithPorts(namespace string, name string, model *model.Model) []*ciliumv2.ServiceListener {
+	// Find all the ports used in the model and build a set of them
+	allPorts := make(map[uint16]struct{})
+
+	for _, hl := range model.HTTP {
+		if _, ok := allPorts[uint16(hl.Port)]; !ok {
+			allPorts[uint16(hl.Port)] = struct{}{}
+		}
+	}
+	for _, tlsl := range model.TLSPassthrough {
+		if _, ok := allPorts[uint16(tlsl.Port)]; !ok {
+			allPorts[uint16(tlsl.Port)] = struct{}{}
+		}
+	}
+
+	ports := maps.Keys(allPorts)
+	// ensure the ports are stably sorted
+	goslices.SortStableFunc(ports, func(a, b uint16) int {
+		return cmp.Compare(a, b)
+	})
+
 	return []*ciliumv2.ServiceListener{
 		{
 			Namespace: namespace,
 			Name:      name,
+			Ports:     ports,
 		},
 	}
 }

--- a/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
@@ -49,9 +49,7 @@ var (
 	routeActionBackendV3 = toRouteAction("gateway-conformance-infra", "infra-backend-v3", "8080")
 )
 
-var (
-	backendProtocolH2CAppProtocol = translation.AppProtocolH2C
-)
+var backendProtocolH2CAppProtocol = translation.AppProtocolH2C
 
 var httpInsecureListenerXDSResource = toAny(&envoy_config_listener.Listener{
 	Name: "listener",
@@ -226,7 +224,7 @@ func basicHTTPListeners(port uint32) []model.HTTPListener {
 					Name:      "my-gateway",
 					Namespace: "default",
 					Group:     "gateway.networking.k8s.io",
-					Version:   "v1beta1",
+					Version:   "v1",
 					Kind:      "Gateway",
 				},
 			},
@@ -275,6 +273,9 @@ var basicHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-gateway-my-gateway",
 				Namespace: "default",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -334,6 +335,9 @@ var basicHTTPListenersCiliumEnvoyConfigWithXff = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-gateway-my-gateway",
 				Namespace: "default",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -395,6 +399,9 @@ func basicHostPortHTTPListenersCiliumEnvoyConfig(address string, port uint32, no
 				{
 					Name:      "cilium-gateway-my-gateway",
 					Namespace: "default",
+					Ports: []uint16{
+						uint16(port),
+					},
 				},
 			},
 			BackendServices: []*ciliumv2.Service{
@@ -442,7 +449,7 @@ var basicTLSListeners = []model.TLSPassthroughListener{
 				Name:      "my-gateway",
 				Namespace: "default",
 				Group:     "gateway.networking.k8s.io",
-				Version:   "v1alpha2",
+				Version:   "v1",
 				Kind:      "Gateway",
 			},
 		},
@@ -487,6 +494,9 @@ var basicTLSListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-gateway-my-gateway",
 				Namespace: "default",
+				Ports: []uint16{
+					443,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -558,9 +568,11 @@ var simpleSameNamespaceHTTPListeners = []model.HTTPListener{
 		Name: "http",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Name:      "same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -602,6 +614,9 @@ var simpleSameNamespaceHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyCon
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -645,9 +660,11 @@ var backendProtocolDisabledH2CHTTPListeners = []model.HTTPListener{
 		Name: "http",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Name:      "same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -675,9 +692,11 @@ var backendProtocolEnabledH2CHTTPListeners = []model.HTTPListener{
 		Name: "http",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Name:      "same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -720,6 +739,9 @@ var backendProtocolEnabledH2CHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEn
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -765,6 +787,8 @@ var crossNamespaceHTTPListeners = []model.HTTPListener{
 			{
 				Name:      "backend-namespaces",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
 				Kind:      "Gateway",
 			},
 		},
@@ -807,6 +831,9 @@ var crossNamespaceHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-gateway-backend-namespaces",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -851,8 +878,10 @@ var exactPathMatchingHTTPListeners = []model.HTTPListener{
 		Sources: []model.FullyQualifiedResource{
 			{
 				Name:      "same-namespace",
-				Kind:      "Gateway",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -907,6 +936,9 @@ var exactPathMatchingHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfi
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -966,6 +998,9 @@ var headerMatchingHTTPListeners = []model.HTTPListener{
 			{
 				Name:      "same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -1109,6 +1144,7 @@ var headerMatchingHTTPCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				APIVersion: "gateway.networking.k8s.io/v1",
 				Name:       "same-namespace",
+				Kind:       "Gateway",
 				Controller: model.AddressOf(true),
 			},
 		},
@@ -1118,6 +1154,9 @@ var headerMatchingHTTPCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -1309,9 +1348,11 @@ var hostnameIntersectionHTTPListeners = []model.HTTPListener{
 		Name: "listener-1",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Name:      "httproute-hostname-intersection",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -1349,9 +1390,11 @@ var hostnameIntersectionHTTPListeners = []model.HTTPListener{
 		Name: "listener-2",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Namespace: "gateway-conformance-infra",
 				Name:      "httproute-hostname-intersection",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -1376,9 +1419,11 @@ var hostnameIntersectionHTTPListeners = []model.HTTPListener{
 		Name: "listener-3",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Name:      "httproute-hostname-intersection",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -1422,6 +1467,9 @@ var hostnameIntersectionHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyCo
 			{
 				Name:      "cilium-gateway-httproute-hostname-intersection",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -1543,6 +1591,9 @@ var listenerHostnameMatchingHTTPListeners = []model.HTTPListener{
 			{
 				Name:      "httproute-listener-hostname-matching",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -1568,6 +1619,9 @@ var listenerHostnameMatchingHTTPListeners = []model.HTTPListener{
 			{
 				Name:      "httproute-listener-hostname-matching",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -1593,6 +1647,9 @@ var listenerHostnameMatchingHTTPListeners = []model.HTTPListener{
 			{
 				Name:      "httproute-listener-hostname-matching",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -1618,6 +1675,9 @@ var listenerHostnameMatchingHTTPListeners = []model.HTTPListener{
 			{
 				Name:      "httproute-listener-hostname-matching",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -1650,6 +1710,7 @@ var listenerHostNameMatchingCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 		OwnerReferences: []metav1.OwnerReference{
 			{
 				APIVersion: "gateway.networking.k8s.io/v1",
+				Kind:       "Gateway",
 				Name:       "httproute-listener-hostname-matching",
 				Controller: model.AddressOf(true),
 			},
@@ -1660,6 +1721,9 @@ var listenerHostNameMatchingCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-gateway-httproute-listener-hostname-matching",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -1757,9 +1821,11 @@ var matchingAcrossHTTPListeners = []model.HTTPListener{
 		Name: "http",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Name:      "same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -1823,6 +1889,9 @@ var matchingAcrossHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -1931,9 +2000,11 @@ var matchingHTTPListeners = []model.HTTPListener{
 		Name: "http",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Name:      "same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port: 80, Hostname: "*",
@@ -1999,6 +2070,9 @@ var matchingHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -2080,9 +2154,11 @@ var queryParamMatchingHTTPListeners = []model.HTTPListener{
 		Name: "http",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Name:      "same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -2185,6 +2261,9 @@ var queryParamMatchingHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConf
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -2322,9 +2401,11 @@ var methodMatchingHTTPListeners = []model.HTTPListener{
 		Name: "http",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Name:      "same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -2379,6 +2460,9 @@ var methodMatchingHTTPListenersHTTPListenersCiliumEnvoyConfig = &ciliumv2.Cilium
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -2460,9 +2544,11 @@ var requestHeaderModifierHTTPListeners = []model.HTTPListener{
 		Name: "http",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Name:      "same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port: 80, Hostname: "*",
@@ -2618,6 +2704,9 @@ var requestHeaderModifierHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyC
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -2767,9 +2856,11 @@ var backendRefsRequestHeaderModifierHTTPListeners = []model.HTTPListener{
 		Name: "http",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Name:      "same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port: 80, Hostname: "*",
@@ -3102,6 +3193,9 @@ var backendRefsRequestHeaderModifierHTTPListenersCiliumEnvoyConfig = &ciliumv2.C
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -3423,9 +3517,11 @@ var backendRefsResponseHeaderModifierHTTPListeners = []model.HTTPListener{
 		Name: "http",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Name:      "same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port: 80, Hostname: "*",
@@ -3758,6 +3854,9 @@ var backendRefsResponseHeaderModifierHTTPListenersCiliumEnvoyConfig = &ciliumv2.
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -4079,9 +4178,11 @@ var requestRedirectHTTPListeners = []model.HTTPListener{
 		Name: "http",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Name:      "same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -4153,6 +4254,9 @@ var requestRedirectHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -4226,9 +4330,11 @@ var requestRedirectWithMultiHTTPListeners = []model.HTTPListener{
 		Name: "http",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Name:      "same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -4264,9 +4370,11 @@ var requestRedirectWithMultiHTTPListeners = []model.HTTPListener{
 		Name: "https",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Name:      "same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     443,
@@ -4327,6 +4435,10 @@ var requestRedirectWithMultiHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnv
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+					443,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -4421,9 +4533,11 @@ var responseHeaderModifierHTTPListeners = []model.HTTPListener{
 		Name: "http",
 		Sources: []model.FullyQualifiedResource{
 			{
-				Kind:      "Gateway",
 				Name:      "same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port: 80, Hostname: "*",
@@ -4595,6 +4709,9 @@ var responseHeaderModifierHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoy
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -4774,6 +4891,8 @@ var rewriteHostHTTPListeners = []model.HTTPListener{
 			{
 				Name:      "same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
 				Kind:      "Gateway",
 			},
 		},
@@ -4836,6 +4955,9 @@ var rewriteHostHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -4918,8 +5040,10 @@ var rewritePathHTTPListeners = []model.HTTPListener{
 		Sources: []model.FullyQualifiedResource{
 			{
 				Name:      "same-namespace",
-				Kind:      "Gateway",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -5056,6 +5180,9 @@ var rewritePathHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -5222,8 +5349,10 @@ var mirrorHTTPListeners = []model.HTTPListener{
 		Sources: []model.FullyQualifiedResource{
 			{
 				Name:      "same-namespace",
-				Kind:      "Gateway",
 				Namespace: "gateway-conformance-infra",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
 			},
 		},
 		Port:     80,
@@ -5277,6 +5406,9 @@ var mirrorHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-gateway-same-namespace",
 				Namespace: "gateway-conformance-infra",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{

--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -71,7 +71,15 @@ func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 	// Set the name to avoid any breaking change during upgrade.
 	cec.Name = cecName
 
-	return cec, d.getService(sourceResource, modelService), getEndpoints(sourceResource), err
+	dedicatedService := d.getService(sourceResource, modelService)
+	if dedicatedService.Spec.Type == corev1.ServiceTypeNodePort {
+		// clear out the CEC Port field for NodePort services.
+		for i := range cec.Spec.Services {
+			cec.Spec.Services[i].Ports = nil
+		}
+	}
+
+	return cec, dedicatedService, getEndpoints(sourceResource), err
 }
 
 func (d *dedicatedIngressTranslator) getService(resource model.FullyQualifiedResource, service *model.Service) *corev1.Service {

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
@@ -313,6 +313,9 @@ var defaultBackendListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-ingress-load-balancing",
 				Namespace: "random-namespace",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -461,6 +464,10 @@ var hostRulesListenersEnforceHTTPSCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfi
 			{
 				Name:      "cilium-ingress-host-rules",
 				Namespace: "random-namespace",
+				Ports: []uint16{
+					80,
+					443,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -663,6 +670,10 @@ var hostRulesListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-ingress-host-rules",
 				Namespace: "random-namespace",
+				Ports: []uint16{
+					80,
+					443,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -945,6 +956,9 @@ var pathRulesListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-ingress-path-rules",
 				Namespace: "random-namespace",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -1158,6 +1172,9 @@ var proxyProtoListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-ingress-load-balancing",
 				Namespace: "random-namespace",
+				Ports: []uint16{
+					80,
+				},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{
@@ -1210,6 +1227,9 @@ func hostNetworkListenersCiliumEnvoyConfig(address string, port uint32, nodeLabe
 				{
 					Name:      "cilium-ingress-load-balancing",
 					Namespace: "random-namespace",
+					Ports: []uint16{
+						uint16(port),
+					},
 				},
 			},
 			BackendServices: []*ciliumv2.Service{
@@ -1254,4 +1274,496 @@ func toAny(message proto.Message) *anypb.Any {
 		return nil
 	}
 	return a
+}
+
+// default timeout for the ingress conformance tests
+var listenerDefaultTimeout = model.Timeout{
+	Request: nil,
+}
+
+func uint32p(in uint32) *uint32 {
+	return &in
+}
+
+var complexNodePortIngressListeners = []model.HTTPListener{
+	{
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "dummy-ingress",
+				Namespace: "dummy-namespace",
+				Version:   "v1",
+				Kind:      "Ingress",
+				UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+			},
+		},
+		Port:     80,
+		Hostname: "*",
+		Routes: []model.HTTPRoute{
+			{
+				Backends: []model.Backend{
+					{
+						Name:      "default-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+				Timeout: listenerDefaultTimeout,
+			},
+			{
+				PathMatch: model.StringMatch{
+					Exact: "/dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+				Timeout: listenerDefaultTimeout,
+			},
+			{
+				PathMatch: model.StringMatch{
+					Prefix: "/another-dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "another-dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8081,
+						},
+					},
+				},
+				Timeout: listenerDefaultTimeout,
+			},
+		},
+		Service: &model.Service{
+			Type:             "NodePort",
+			InsecureNodePort: uint32p(30000),
+			SecureNodePort:   uint32p(30001),
+		},
+	},
+	{
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "dummy-ingress",
+				Namespace: "dummy-namespace",
+				Version:   "v1",
+				Kind:      "Ingress",
+				UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+			},
+		},
+		Port:     443,
+		Hostname: "another-very-secure.server.com",
+		TLS: []model.TLSSecret{
+			{
+				Name:      "tls-another-very-secure-server-com",
+				Namespace: "dummy-namespace",
+			},
+		},
+		Routes: []model.HTTPRoute{
+			{
+				Backends: []model.Backend{
+					{
+						Name:      "default-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+				Timeout: listenerDefaultTimeout,
+			},
+			{
+				PathMatch: model.StringMatch{
+					Exact: "/dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+				Timeout: listenerDefaultTimeout,
+			},
+			{
+				PathMatch: model.StringMatch{
+					Prefix: "/another-dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "another-dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8081,
+						},
+					},
+				},
+				Timeout: listenerDefaultTimeout,
+			},
+		},
+		Service: &model.Service{
+			Type:             "NodePort",
+			InsecureNodePort: uint32p(30000),
+			SecureNodePort:   uint32p(30001),
+		},
+	},
+	{
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "dummy-ingress",
+				Namespace: "dummy-namespace",
+				Version:   "v1",
+				Kind:      "Ingress",
+				UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+			},
+		},
+		Port:     443,
+		Hostname: "not-in-use.another-very-secure.server.com",
+		TLS: []model.TLSSecret{
+			{
+				Name:      "tls-another-very-secure-server-com",
+				Namespace: "dummy-namespace",
+			},
+		},
+		Routes: []model.HTTPRoute{
+			{
+				Backends: []model.Backend{
+					{
+						Name:      "default-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+				Timeout: listenerDefaultTimeout,
+			},
+			{
+				PathMatch: model.StringMatch{
+					Exact: "/dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+				Timeout: listenerDefaultTimeout,
+			},
+			{
+				PathMatch: model.StringMatch{
+					Prefix: "/another-dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "another-dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8081,
+						},
+					},
+				},
+				Timeout: listenerDefaultTimeout,
+			},
+		},
+		Service: &model.Service{
+			Type:             "NodePort",
+			InsecureNodePort: uint32p(30000),
+			SecureNodePort:   uint32p(30001),
+		},
+	},
+	{
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "dummy-ingress",
+				Namespace: "dummy-namespace",
+				Version:   "v1",
+				Kind:      "Ingress",
+				UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+			},
+		},
+		Port:     443,
+		Hostname: "very-secure.server.com",
+		TLS: []model.TLSSecret{
+			{
+				Name:      "tls-very-secure-server-com",
+				Namespace: "dummy-namespace",
+			},
+		},
+		Routes: []model.HTTPRoute{
+			{
+				Backends: []model.Backend{
+					{
+						Name:      "default-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+				Timeout: listenerDefaultTimeout,
+			},
+			{
+				PathMatch: model.StringMatch{
+					Exact: "/dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+				Timeout: listenerDefaultTimeout,
+			},
+			{
+				PathMatch: model.StringMatch{
+					Prefix: "/another-dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "another-dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8081,
+						},
+					},
+				},
+				Timeout: listenerDefaultTimeout,
+			},
+		},
+		Service: &model.Service{
+			Type:             "NodePort",
+			InsecureNodePort: uint32p(30000),
+			SecureNodePort:   uint32p(30001),
+		},
+	},
+}
+
+var complexNodePortIngressCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "cilium-ingress-dummy-namespace-dummy-ingress",
+		Namespace: "dummy-namespace",
+		Labels: map[string]string{
+			"cilium.io/use-original-source-address": "false",
+		},
+	},
+	Spec: ciliumv2.CiliumEnvoyConfigSpec{
+		NodeSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]slim_metav1.MatchLabelsValue{"a": "b"}},
+		Services: []*ciliumv2.ServiceListener{
+			{
+				Name:      "cilium-ingress-dummy-ingress",
+				Namespace: "dummy-namespace",
+			},
+		},
+		BackendServices: []*ciliumv2.Service{
+			{
+				Name:      "another-dummy-backend",
+				Namespace: "dummy-namespace",
+				Ports:     []string{"8081"},
+			},
+			{
+				Name:      "default-backend",
+				Namespace: "dummy-namespace",
+				Ports:     []string{"8080"},
+			},
+			{
+				Name:      "dummy-backend",
+				Namespace: "dummy-namespace",
+				Ports:     []string{"8080"},
+			},
+		},
+		Resources: []ciliumv2.XDSResource{
+			{Any: toAny(
+				&envoy_config_listener.Listener{
+					Name: "listener",
+					FilterChains: []*envoy_config_listener.FilterChain{
+						toInsecureListenerFilterChain(),
+						toSecureListenerFilterChain([]string{"another-very-secure.server.com", "not-in-use.another-very-secure.server.com"}, "cilium-secrets/dummy-namespace-tls-another-very-secure-server-com"),
+						toSecureListenerFilterChain([]string{"very-secure.server.com"}, "cilium-secrets/dummy-namespace-tls-very-secure-server-com"),
+					},
+					AdditionalAddresses: []*envoy_config_listener.AdditionalAddress{
+						{
+							Address: &envoy_config_core_v3.Address{
+								Address: &envoy_config_core_v3.Address_SocketAddress{
+									SocketAddress: &envoy_config_core_v3.SocketAddress{
+										Address: "0.0.0.0",
+										PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+											PortValue: 443,
+										},
+									},
+								},
+							},
+						},
+					},
+					Address: &envoy_config_core_v3.Address{
+						Address: &envoy_config_core_v3.Address_SocketAddress{
+							SocketAddress: &envoy_config_core_v3.SocketAddress{
+								Address: "0.0.0.0",
+								PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+									PortValue: 80,
+								},
+							},
+						},
+					},
+					ListenerFilters: []*envoy_config_listener.ListenerFilter{
+						{
+							Name: "envoy.filters.listener.tls_inspector",
+							ConfigType: &envoy_config_listener.ListenerFilter_TypedConfig{
+								TypedConfig: toAny(&envoy_extensions_listener_tls_inspector_v3.TlsInspector{}),
+							},
+						},
+					},
+					SocketOptions: socketOptions,
+				})},
+			{
+				Any: toAny(&envoy_config_route_v3.RouteConfiguration{
+					Name: "listener-insecure",
+					VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+						{
+							Name:    "*",
+							Domains: domainsHelper("*"),
+							Routes: []*envoy_config_route_v3.Route{
+								{
+									Match:  envoyRouteMatchExactPath("/dummy-path"),
+									Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
+								},
+								{
+									Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
+									Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
+								},
+								{
+									Match:  envoyRouteMatchRootPath(),
+									Action: envoyRouteAction("dummy-namespace", "default-backend", "8080"),
+								},
+							},
+						},
+					},
+				}),
+			},
+			{
+				Any: toAny(&envoy_config_route_v3.RouteConfiguration{
+					Name: "listener-secure",
+					VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+						{
+							Name:    "another-very-secure.server.com",
+							Domains: domainsHelper("another-very-secure.server.com"),
+							Routes: []*envoy_config_route_v3.Route{
+								{
+									Match:  envoyRouteMatchExactPath("/dummy-path"),
+									Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
+								},
+								{
+									Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
+									Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
+								},
+								{
+									Match:  envoyRouteMatchRootPath(),
+									Action: envoyRouteAction("dummy-namespace", "default-backend", "8080"),
+								},
+							},
+						},
+						{
+							Name:    "not-in-use.another-very-secure.server.com",
+							Domains: domainsHelper("not-in-use.another-very-secure.server.com"),
+							Routes: []*envoy_config_route_v3.Route{
+								{
+									Match:  envoyRouteMatchExactPath("/dummy-path"),
+									Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
+								},
+								{
+									Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
+									Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
+								},
+								{
+									Match:  envoyRouteMatchRootPath(),
+									Action: envoyRouteAction("dummy-namespace", "default-backend", "8080"),
+								},
+							},
+						},
+						{
+							Name:    "very-secure.server.com",
+							Domains: domainsHelper("very-secure.server.com"),
+							Routes: []*envoy_config_route_v3.Route{
+								{
+									Match:  envoyRouteMatchExactPath("/dummy-path"),
+									Action: envoyRouteAction("dummy-namespace", "dummy-backend", "8080"),
+								},
+								{
+									Match:  envoyRouteMatchPrefixPath("/another-dummy-path"),
+									Action: envoyRouteAction("dummy-namespace", "another-dummy-backend", "8081"),
+								},
+								{
+									Match:  envoyRouteMatchRootPath(),
+									Action: envoyRouteAction("dummy-namespace", "default-backend", "8080"),
+								},
+							},
+						},
+					},
+				}),
+			},
+			{Any: toAny(toEnvoyCluster("dummy-namespace", "another-dummy-backend", "8081"))},
+			{Any: toAny(toEnvoyCluster("dummy-namespace", "default-backend", "8080"))},
+			{Any: toAny(toEnvoyCluster("dummy-namespace", "dummy-backend", "8080"))},
+		},
+	},
+}
+
+func domainsHelper(domain string) []string {
+	if domain == "*" {
+		return []string{domain}
+	}
+
+	return []string{domain, fmt.Sprintf("%s:*", domain)}
+}
+
+func envoyRouteMatchExactPath(path string) *envoy_config_route_v3.RouteMatch {
+	return &envoy_config_route_v3.RouteMatch{
+		PathSpecifier: &envoy_config_route_v3.RouteMatch_Path{
+			Path: path,
+		},
+	}
+}
+
+func envoyRouteMatchRootPath() *envoy_config_route_v3.RouteMatch {
+	return &envoy_config_route_v3.RouteMatch{
+		PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
+			Prefix: "/",
+		},
+	}
+}
+
+func envoyRouteMatchPrefixPath(path string) *envoy_config_route_v3.RouteMatch {
+	return &envoy_config_route_v3.RouteMatch{
+		PathSpecifier: &envoy_config_route_v3.RouteMatch_PathSeparatedPrefix{
+			PathSeparatedPrefix: path,
+		},
+	}
+}
+
+func envoyRouteAction(namespace, backend, port string) *envoy_config_route_v3.Route_Route {
+	return &envoy_config_route_v3.Route_Route{
+		Route: &envoy_config_route_v3.RouteAction{
+			ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
+				Cluster: fmt.Sprintf("%s:%s:%s", namespace, backend, port),
+			},
+			MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+				MaxStreamDuration: &durationpb.Duration{Seconds: 0},
+			},
+		},
+	}
 }

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
@@ -260,6 +260,19 @@ func Test_translator_Translate(t *testing.T) {
 			want:          hostNetworkListenersCiliumEnvoyConfig("0.0.0.0", 55555, &slim_metav1.LabelSelector{MatchLabels: map[string]slim_metav1.MatchLabelsValue{"a": "b"}}),
 			wantLBSvcType: corev1.ServiceTypeClusterIP,
 		},
+		{
+			name: "ComplexNodePortIngress",
+			args: args{
+				m: &model.Model{
+					HTTP: complexNodePortIngressListeners,
+				},
+				hostNetworkEnabled:           true,
+				hostNetworkNodeLabelSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]slim_metav1.MatchLabelsValue{"a": "b"}},
+				ipv4Enabled:                  true,
+			},
+			want:          complexNodePortIngressCiliumEnvoyConfig,
+			wantLBSvcType: corev1.ServiceTypeNodePort,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adds a separate ingestion step for GAMMA objects, with predicates added to both the GAMMA ingestion and the standard Gateway API ingestion to ensure that each only sees relevant HTTPRoute updates.

GAMMA listeners use the existing Gateway API translator, some changes have been made there:
* Add the HTTPRoute as a second source to each Listener in the `model.Model`, which allows the HTTPRoute to be set as the
owner of the generated CiliumEnvoyConfig.
* GAMMA conformance requires supporting the Port field in parentRef. This adds support for this for GAMMA only.
This change also does groundwork necessary to support the Gateway API feature `HTTPRouteListenerPortMatching`
for regular Gateway API objects, which allows HTTPRoutes to select Gateway parents using the Port field in parentRef.
A followup PR will implement this feature.

As part of this GAMMA work, we now support the `GatewayPort8080` Gateway API feature, which allows the use of ports other than `80` or `443` as well, so that is now added to the conformance test workflow.

The `MeshConsumerRoute` feature cannot be supported without significant changes to the model (it requires _egress_
CiliumEnvoyConfigs, which are still being worked on.)

Fixes: #22512

```release-note
Cilium now supports the Gateway API GAMMA initiative, allowing configuration of east-west Layer 7 interception using simpler resources.
```
