### PR TITLE
Bump timeout of lint-build-commits.yaml

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -14,7 +14,7 @@ jobs:
   build_commits:
     name: Check if build works for every commit
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 180
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0


### PR DESCRIPTION
In the latest state, lint-build-commits takes over 90min (depends on the number of commit, especially problematic for backports). While it is not desirable to take time, bump it to 180min as a workaround.

```release-note
Bump timeout of lint-build-commits.yaml
```
