### PR TITLE
clustermesh: drop redundant OnClusterDelete from GlobalServiceCache

### DIFF
--- a/pkg/clustermesh/common/services.go
+++ b/pkg/clustermesh/common/services.go
@@ -180,17 +180,6 @@ func (c *GlobalServiceCache) OnDelete(svc *serviceStore.ClusterService) bool {
 	}
 }
 
-func (c *GlobalServiceCache) OnClusterDelete(clusterName string) {
-	scopedLog := log.WithFields(logrus.Fields{logfields.ClusterName: clusterName})
-	scopedLog.Debugf("Cluster deletion event")
-
-	c.mutex.Lock()
-	for serviceNN, globalService := range c.byName {
-		c.delete(globalService, clusterName, serviceNN)
-	}
-	c.mutex.Unlock()
-}
-
 // Size returns the number of global services in the cache
 func (c *GlobalServiceCache) Size() (num int) {
 	c.mutex.RLock()

--- a/pkg/clustermesh/endpointslicesync/remote_cluster.go
+++ b/pkg/clustermesh/endpointslicesync/remote_cluster.go
@@ -76,7 +76,6 @@ func (rc *remoteCluster) Remove() {
 	// is removed, and not in case the operator is shutting down, otherwise we
 	// would break existing connections on restart.
 	rc.remoteServices.Drain()
-	rc.globalServices.OnClusterDelete(rc.name)
 }
 
 type synced struct {

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -135,7 +135,6 @@ func (rc *remoteCluster) Remove() {
 	rc.ipCacheWatcher.Drain()
 
 	rc.mesh.conf.RemoteIdentityWatcher.RemoveRemoteIdentities(rc.name)
-	rc.mesh.globalServices.OnClusterDelete(rc.name)
 
 	rc.usedIDs.ReleaseClusterID(rc.clusterID)
 }


### PR DESCRIPTION
This method was called upon remote cluster disconnection to remove the corresponding shared services from the cache. However, the same operation is already performed upon draining the corresponding watch store, which in turn emits a deletion event for all known objects. Hence, let's just drop this redundant logic.