### PR TITLE
Fix threat model typo

### DIFF
--- a/Documentation/security/threat-model.rst
+++ b/Documentation/security/threat-model.rst
@@ -222,7 +222,7 @@ network controls, as described below:
 |                 |   attacker will be able |                            |
 |                 |   to tamper with the    |                            |
 |                 |   Cilium agent running  |                            |
-|                 |   on the node.*         |                            |
+|                 |   on the node.          |                            |
 |                 | - Denial of service is  |                            |
 |                 |   also possible via     |                            |
 |                 |   spawning workloads    |                            |


### PR DESCRIPTION
Remove an asterisk that was pointing to nowhere.
