### PR TITLE
envoy: Keep original destination hosts alive as long as needed

### DIFF
--- a/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.json
+++ b/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.json
@@ -383,7 +383,8 @@
         "staticLayer": {
           "overload": {
             "global_downstream_max_connections": 50000
-          }
+          },
+          "envoy.reloadable_features.original_dst_rely_on_idle_timeout": true
         }
       }
     ]

--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -483,6 +483,7 @@ func writeBootstrapConfigFile(config bootstrapConfig) {
 							"overload": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
 								"global_downstream_max_connections": {Kind: &structpb.Value_NumberValue{NumberValue: 50000}},
 							}}}},
+							"envoy.reloadable_features.original_dst_rely_on_idle_timeout": {Kind: &structpb.Value_BoolValue{BoolValue: true}},
 						}},
 					},
 				},


### PR DESCRIPTION
Keep the representation of the desination host stable within Envoy as long as any connection pools have open connections to the host by setting the runtime feature
`envoy.reloadable_features.original_dst_rely_on_idle_timeout`. This helps avoid rate '503' errors due to Envoy creating a new connection to the destination while already having an open connection the same destination for a given pod source address and port.

Related-to: https://github.com/envoyproxy/envoy/pull/22371
