### PR TITLE
Add dispatch for fqdn_perf test

### DIFF
--- a/.github/actions/cl2-modules/fqdn/modules/dns-performance-metrics.yaml
+++ b/.github/actions/cl2-modules/fqdn/modules/dns-performance-metrics.yaml
@@ -12,18 +12,27 @@ steps:
       metricVersion: v1
       unit: s
       queries:
-      - name: DNS Lookup Count
-        query: sum(increase(dns_lookups_total[%v]))
-      - name: DNS Timeout Count
-        query: sum(increase(dns_timeouts_total[%v]))
-      - name: DNS Error Count
-        query: sum(increase(dns_errors_total[%v]))
       - name: DNS Error Percentage
         query: sum(increase(dns_errors_total[%v])) / sum(increase(dns_lookups_total[%v])) * 100
       - name: DNS Lookup Latency - Perc50
         query: histogram_quantile(0.5, sum(rate(dns_lookup_latency_bucket[%v])) by (le))
       - name: DNS Lookup Latency - Perc99
         query: histogram_quantile(0.99, sum(rate(dns_lookup_latency_bucket[%v])) by (le))
+
+  - Identifier: DNSPerformanceCounters
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: DNS Performance Counters
+      metricVersion: v1
+      unit: count
+      queries:
+      - name: DNS Lookup Count
+        query: sum(increase(dns_lookups_total[%v]))
+      - name: DNS Timeout Count
+        query: sum(increase(dns_timeouts_total[%v]))
+      - name: DNS Error Count
+        query: sum(increase(dns_errors_total[%v]))
 
   - Identifier: CiliumDNSPerformanceMetrics
     Method: GenericPrometheusQuery

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -78,6 +78,9 @@ triggers:
   /ci-l4lb:
     workflows:
     - tests-l4lb.yaml
+  /fqdn-perf:
+    workflows:
+    - fqdn-perf.yaml
 
 workflows:
   conformance-aks.yaml:

--- a/.github/workflows/fqdn-perf.yaml
+++ b/.github/workflows/fqdn-perf.yaml
@@ -1,8 +1,24 @@
-name: FQDN perf test
+name: FQDN perf test (fqdn-perf)
 
 on:
   schedule:
     - cron: '39 6 * * 1-5'
+
+  workflow_dispatch:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: true
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: true
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: true
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        default: '{}'
 
 # For testing uncomment following lines:
 #  push:
@@ -14,6 +30,10 @@ permissions:
   contents: read
   # To be able to request the JWT from GitHub's OIDC provider
   id-token: write
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # To be able to set commit status
+  statuses: write
 
 concurrency:
   # Structure:
@@ -43,6 +63,24 @@ env:
   cluster_base_name: ${{ github.run_id }}-${{ github.run_attempt }}.k8s.local
 
 jobs:
+  echo-inputs:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    name: Echo Workflow Dispatch Inputs
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Echo Workflow Dispatch Inputs
+        run: |
+          echo '${{ tojson(inputs) }}'
+
+  commit-status-start:
+    name: Commit Status Start
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set initial commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+
   install-and-fqdn-perf-test:
     runs-on: ubuntu-latest
     name: Install and FQDN Perf Test
@@ -61,7 +99,7 @@ jobs:
         id: vars
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] ; then
-            SHA="${{ inputs.image-tag }}"
+            SHA="${{ inputs.SHA }}"
           else
             SHA="${{ github.sha }}"
           fi
@@ -240,3 +278,15 @@ jobs:
           results_bucket: ${{ env.GCP_PERF_RESULTS_BUCKET }}
           artifacts: ./perf-tests/clusterloader2/report/*
           other_files: cilium-sysdump-final.zip ./perf-tests/clusterloader2/cl2-output.txt
+
+  commit-status-final:
+    if: ${{ always() }}
+    name: Commit Status Final
+    needs: install-and-fqdn-perf-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set final commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+          status: ${{ needs.install-and-fqdn-perf-test.result }}


### PR DESCRIPTION
Add Ariane dispatch so it's possible to manually trigger test.
Also, separate latency metrics from count metrics, so it can be easily visible in perfdash.
Now, the count metric was skewing visualization:
![image](https://github.com/cilium/cilium/assets/2011575/c9edcd04-dc08-4efb-8f6d-ce4e5ed38ff0)

