### PR TITLE
renovate: fix config (missing comma)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -422,8 +422,8 @@
         "images/cilium/download-hubble\\.sh",
         "images/builder/install-protoc.sh",
         "images/builder/install-protoplugins.sh",
-        "images/hubble-relay/download-grpc-health-probe.sh"
-        "images/runtime/build-gops.sh",
+        "images/hubble-relay/download-grpc-health-probe.sh",
+        "images/runtime/build-gops.sh"
       ],
       // These regexes manage version and digest strings in shell scripts,
       // similar to the examples shown here:


### PR DESCRIPTION
Commit 1bf4f0b683a71edbc3738ef2021945af46550418 broke Renovate's config by messing up with commas. This patch fixes the issue.
