### PR TITLE
fqdn: Improve performance by using selectors as labels

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1760,6 +1760,12 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 		<-params.CacheStatus
 	}
 	bootstrapStats.k8sInit.End(true)
+
+	// After K8s caches have been synced, IPCache can start label injection.
+	// Ensure that the initial labels are injected before we regenerate endpoints
+	log.Debug("Waiting for initial IPCache revision")
+	d.ipcache.WaitForRevision(1)
+
 	d.initRestore(restoredEndpoints, params.EndpointRegenerator)
 
 	bootstrapStats.enableConntrack.Start()

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -72,10 +72,9 @@ func setupDaemonFQDNSuite(tb testing.TB) *DaemonFQDNSuite {
 		DatapathHandler:   d.endpointManager,
 	})
 	d.dnsNameManager = fqdn.NewNameManager(fqdn.Config{
-		MinTTL:          1,
-		Cache:           fqdn.NewDNSCache(0),
-		UpdateSelectors: d.updateSelectors,
-		IPCache:         d.ipcache,
+		MinTTL:  1,
+		Cache:   fqdn.NewDNSCache(0),
+		IPCache: d.ipcache,
 	})
 	d.policy.GetSelectorCache().SetLocalIdentityNotifier(d.dnsNameManager)
 

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -4,13 +4,7 @@
 package fqdn
 
 import (
-	"context"
-	"net/netip"
-	"sync"
-
-	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
-	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/ipcache"
 )
 
 // Config is a simple configuration structure to set how pkg/fqdn subcomponents
@@ -22,10 +16,6 @@ type Config struct {
 	// Cache is where the poller stores DNS data used to generate rules.
 	// When set to nil, it uses fqdn.DefaultDNSCache, a global cache instance.
 	Cache *DNSCache
-
-	// UpdateSelectors is a callback to update the mapping of FQDNSelector to
-	// sets of IPs.
-	UpdateSelectors func(ctx context.Context, selectorsToIPs map[api.FQDNSelector][]netip.Addr, ipcacheRevision uint64) *sync.WaitGroup
 
 	// GetEndpointsDNSInfo is a function that returns a list of fqdn-relevant fields from all Endpoints known to the agent.
 	// The endpoint's DNSHistory and DNSZombies are used as part of the garbage collection and restoration processes.
@@ -44,6 +34,7 @@ type EndpointDNSInfo struct {
 }
 
 type IPCache interface {
-	UpsertPrefixes(prefixes []netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID) uint64
-	RemovePrefixes(prefixes []netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID)
+	UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64)
+	RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64)
+	WaitForRevision(rev uint64)
 }

--- a/pkg/fqdn/fuzz_test.go
+++ b/pkg/fqdn/fuzz_test.go
@@ -7,23 +7,19 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/policy/api"
 )
 
-func FuzzMapSelectorsToIPsLocked(f *testing.F) {
+func FuzzMapSelectorsToNamesLocked(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		ff := fuzz.NewConsumer(data)
-		fqdnSelectors := make(sets.Set[api.FQDNSelector])
-		ff.FuzzMap(&fqdnSelectors)
-		if len(fqdnSelectors) == 0 {
-			t.Skip()
-		}
+		fqdnSelector := api.FQDNSelector{}
+		ff.FuzzMap(fqdnSelector)
 		nameManager := NewNameManager(Config{
 			MinTTL: 1,
 			Cache:  NewDNSCache(0),
 		})
-		nameManager.mapSelectorsToIPsLocked(fqdnSelectors)
+		nameManager.mapSelectorsToNamesLocked(fqdnSelector)
 	})
 }

--- a/pkg/fqdn/helpers_test.go
+++ b/pkg/fqdn/helpers_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -46,31 +45,28 @@ func TestMapIPsToSelectors(t *testing.T) {
 	now := time.Now()
 	cache := nameManager.cache
 
-	selectors := sets.New[api.FQDNSelector](ciliumIOSel)
-
 	// Empty cache.
-	selIPMapping := nameManager.mapSelectorsToIPsLocked(selectors)
-	require.Equal(t, 1, len(selIPMapping))
-	ips, exists := selIPMapping[ciliumIOSel]
-	require.Equal(t, true, exists)
-	require.Equal(t, 0, len(ips))
+	nameIPMapping := nameManager.mapSelectorsToNamesLocked(ciliumIOSel)
+	require.Empty(t, nameIPMapping)
 
 	// Just one IP.
-	changed := cache.Update(now, prepareMatchName(ciliumIOSel.MatchName), []netip.Addr{ciliumIP1}, 100)
+	ciliumIOName := prepareMatchName(ciliumIOSel.MatchName)
+	changed := cache.Update(now, ciliumIOName, []netip.Addr{ciliumIP1}, 100)
 	require.Equal(t, true, changed)
-	selIPMapping = nameManager.mapSelectorsToIPsLocked(selectors)
-	require.Equal(t, 1, len(selIPMapping))
-	ciliumIPs, ok := selIPMapping[ciliumIOSel]
+	nameIPMapping = nameManager.mapSelectorsToNamesLocked(ciliumIOSel)
+	require.Equal(t, 1, len(nameIPMapping))
+	println(ciliumIOSel.MatchName)
+	ciliumIPs, ok := nameIPMapping[ciliumIOName]
 	require.Equal(t, true, ok)
 	require.Equal(t, 1, len(ciliumIPs))
 	require.Equal(t, ciliumIP1, ciliumIPs[0])
 
 	// Two IPs now.
-	changed = cache.Update(now, prepareMatchName(ciliumIOSel.MatchName), []netip.Addr{ciliumIP1, ciliumIP2}, 100)
+	changed = cache.Update(now, ciliumIOName, []netip.Addr{ciliumIP1, ciliumIP2}, 100)
 	require.Equal(t, true, changed)
-	selIPMapping = nameManager.mapSelectorsToIPsLocked(selectors)
-	require.Equal(t, 1, len(selIPMapping))
-	ciliumIPs, ok = selIPMapping[ciliumIOSel]
+	nameIPMapping = nameManager.mapSelectorsToNamesLocked(ciliumIOSel)
+	require.Equal(t, 1, len(nameIPMapping))
+	ciliumIPs, ok = nameIPMapping[ciliumIOName]
 	require.Equal(t, true, ok)
 	require.Equal(t, 2, len(ciliumIPs))
 	ip.SortAddrList(ciliumIPs)
@@ -78,28 +74,9 @@ func TestMapIPsToSelectors(t *testing.T) {
 	require.Equal(t, ciliumIP2, ciliumIPs[1])
 
 	// Test with a MatchPattern.
-	selectors = sets.New(ciliumIOSelMatchPattern)
-
-	selIPMapping = nameManager.mapSelectorsToIPsLocked(selectors)
-	require.Equal(t, 1, len(selIPMapping))
-	ciliumIPs, ok = selIPMapping[ciliumIOSelMatchPattern]
-	require.Equal(t, true, ok)
-	require.Equal(t, 2, len(ciliumIPs))
-	ip.SortAddrList(ciliumIPs)
-	require.Equal(t, ciliumIP1, ciliumIPs[0])
-	require.Equal(t, ciliumIP2, ciliumIPs[1])
-
-	selectors = sets.New(ciliumIOSelMatchPattern, ciliumIOSel)
-
-	selIPMapping = nameManager.mapSelectorsToIPsLocked(selectors)
-	require.Equal(t, 2, len(selIPMapping))
-	ciliumIPs, ok = selIPMapping[ciliumIOSelMatchPattern]
-	require.Equal(t, true, ok)
-	require.Equal(t, 2, len(ciliumIPs))
-	ip.SortAddrList(ciliumIPs)
-	require.Equal(t, ciliumIP1, ciliumIPs[0])
-	require.Equal(t, ciliumIP2, ciliumIPs[1])
-	ciliumIPs, ok = selIPMapping[ciliumIOSel]
+	nameIPMapping = nameManager.mapSelectorsToNamesLocked(ciliumIOSelMatchPattern)
+	require.Equal(t, 1, len(nameIPMapping))
+	ciliumIPs, ok = nameIPMapping[ciliumIOName]
 	require.Equal(t, true, ok)
 	require.Equal(t, 2, len(ciliumIPs))
 	ip.SortAddrList(ciliumIPs)

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -6,8 +6,9 @@ package fqdn
 import (
 	"context"
 	"hash/fnv"
-	"net"
 	"net/netip"
+	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"sync"
@@ -19,6 +20,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
@@ -51,6 +53,11 @@ type NameManager struct {
 	cache *DNSCache
 
 	bootstrapCompleted bool
+
+	// restoredPrefixes contains all prefixes for which we have restored the
+	// IPCache metadata from previous Cilium v1.15 installation.
+	// Cleared by CompleteBoostrap
+	restoredPrefixes sets.Set[netip.Prefix]
 
 	manager *controller.Manager
 
@@ -167,30 +174,15 @@ func (n *NameManager) GetDNSHistoryModel(endpointID string, prefixMatcher Prefix
 	return lookups, nil
 }
 
-// Lock must be held during any calls to RegisterForIPUpdatesLocked or
-// UnregisterForIPUpdatesLocked.
-// Because the NameManager and SelectorCache have interleaving locks, we
-// must ALWAYS lock the NameManager first before locking the SelectorCache.
-func (n *NameManager) Lock() {
-	n.RWMutex.Lock()
-}
+// RegisterFQDNSelector exposes this FQDNSelector so that the identity labels
+// of IPs contained in a DNS response that matches said selector can be
+// associated with that selector.
+// This function also evaluates if any DNS names in the cache are matched by
+// this new selector and updates the labels for those DNS names accordingly.
+func (n *NameManager) RegisterFQDNSelector(selector api.FQDNSelector) {
+	n.Lock()
+	defer n.Unlock()
 
-// Unlock must be called after calls to RegisterForIPUpdatesLocked or
-// UnregisterForIPUpdatesLocked are done.
-func (n *NameManager) Unlock() {
-	n.RWMutex.Unlock()
-}
-
-// RegisterForIPUpdatesLocked exposes this FQDNSelector so that updates to
-// IPs for names that this selector maches can be
-// propagated back to the SelectorCache via `UpdateFQDNSelector`. All DNS names
-// contained within the NameManager's cache are iterated over to see if they match
-// the FQDNSelector. All already-existing IPs which correspond to the DNS names
-// which match this Selector will be returned so the selector is ready for updates.
-//
-// Because this method is called by the SelectorCache, we cannot make any calls
-// back in to the SelectorCache from this method.
-func (n *NameManager) RegisterForIPUpdatesLocked(selector api.FQDNSelector) []netip.Addr {
 	_, exists := n.allSelectors[selector]
 	if exists {
 		log.WithField("fqdnSelector", selector).Warning("FQDNSelector was already registered for updates.")
@@ -200,26 +192,33 @@ func (n *NameManager) RegisterForIPUpdatesLocked(selector api.FQDNSelector) []ne
 		regex, err := selector.ToRegex()
 		if err != nil {
 			log.WithError(err).WithField("fqdnSelector", selector).Error("FQDNSelector did not compile to valid regex")
-			return nil
+			return
 		}
 
 		n.allSelectors[selector] = regex
 	}
 
-	selectorIPMapping := n.mapSelectorsToIPsLocked(sets.New(selector))
-
-	// We may have skipped inserting these IPs in to the ipcache earlier, if they
-	// were not previously selected. Upsert them now.
-	n.upsertMetadata(selectorIPMapping[selector])
-
-	return selectorIPMapping[selector]
+	// The newly added FQDN selector could match DNS Names in the cache. If
+	// that is the case, we want to update the IPCache metadata for all
+	// associated IPs
+	selectedNamesAndIPs := n.mapSelectorsToNamesLocked(selector)
+	n.updateMetadata(deriveLabelsForNames(selectedNamesAndIPs, n.allSelectors))
 }
 
-// UnregisterForIPUpdatesLocked removes this FQDNSelector from the set of
-// FQDNSelectors which are being tracked by the NameManager. No more updates
-// for IPs which correspond to said selector are propagated.
-func (n *NameManager) UnregisterForIPUpdatesLocked(selector api.FQDNSelector) {
+// UnregisterFQDNSelector removes this FQDNSelector from the set of
+// IPs which are being tracked by the identityNotifier. The result
+// of this is that an IP may be evicted from IPCache if it is no longer
+// selected by any other FQDN selector.
+func (n *NameManager) UnregisterFQDNSelector(selector api.FQDNSelector) {
+	n.Lock()
+	defer n.Unlock()
+
+	// Remove selector
 	delete(n.allSelectors, selector)
+
+	// Re-compute labels for affected names and IPs
+	selectedNamesAndIPs := n.mapSelectorsToNamesLocked(selector)
+	n.updateMetadata(deriveLabelsForNames(selectedNamesAndIPs, n.allSelectors))
 }
 
 // NewNameManager creates an initialized NameManager.
@@ -230,11 +229,6 @@ func NewNameManager(config Config) *NameManager {
 		config.Cache = NewDNSCache(0)
 	}
 
-	if config.UpdateSelectors == nil {
-		config.UpdateSelectors = func(ctx context.Context, selectorsToIPs map[api.FQDNSelector][]netip.Addr, _ uint64) *sync.WaitGroup {
-			return &sync.WaitGroup{}
-		}
-	}
 	if config.GetEndpointsDNSInfo == nil {
 		config.GetEndpointsDNSInfo = func(_ string) []EndpointDNSInfo {
 			return nil
@@ -263,61 +257,61 @@ func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Tim
 	defer n.RWMutex.Unlock()
 
 	// Update IPs in n
-	fqdnSelectorsToUpdate, updatedDNSNames, ipcacheRevision := n.updateDNSIPs(lookupTime, updatedDNSIPs)
+	updatedDNSNames, ipcacheRevision := n.updateDNSIPs(lookupTime, updatedDNSIPs)
 	for dnsName, IPs := range updatedDNSNames {
 		log.WithFields(logrus.Fields{
-			"matchName":             dnsName,
-			"IPs":                   IPs,
-			"fqdnSelectorsToUpdate": fqdnSelectorsToUpdate,
+			"matchName": dnsName,
+			"IPs":       IPs,
 		}).Debug("Updated FQDN with new IPs")
 	}
 
-	selectorIPMapping := n.mapSelectorsToIPsLocked(fqdnSelectorsToUpdate)
-
-	// Update SelectorCache selectors and push changes down in to BPF.
-	return n.config.UpdateSelectors(ctx, selectorIPMapping, ipcacheRevision)
-}
-
-// ForceGenerateDNS unconditionally regenerates all rules that refer to DNS
-// names in namesToRegen. These names are FQDNs and toFQDNs.matchPatterns or
-// matchNames that match them will cause these rules to regenerate.
-// Note: This is used only when DNS entries are cleaned up, not when new results
-// are ingested.
-func (n *NameManager) ForceGenerateDNS(ctx context.Context, namesToRegen []string) *sync.WaitGroup {
-	n.RWMutex.Lock()
-	defer n.RWMutex.Unlock()
-
-	affectedFQDNSels := make(sets.Set[api.FQDNSelector], 0)
-	for _, dnsName := range namesToRegen {
-		for fqdnSel, fqdnRegEx := range n.allSelectors {
-			if fqdnRegEx.MatchString(dnsName) {
-				affectedFQDNSels.Insert(fqdnSel)
-			}
-		}
-	}
-
-	selectorIPMapping := n.mapSelectorsToIPsLocked(affectedFQDNSels)
-
-	// Update SelectorCache selectors and push changes down in to BPF.
-	return n.config.UpdateSelectors(ctx, selectorIPMapping, 0)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		n.config.IPCache.WaitForRevision(ipcacheRevision)
+		wg.Done()
+	}()
+	return wg
 }
 
 func (n *NameManager) CompleteBootstrap() {
 	n.Lock()
+	defer n.Unlock()
+
 	n.bootstrapCompleted = true
-	n.Unlock()
+	if len(n.restoredPrefixes) > 0 {
+		log.WithField("prefixes", len(n.restoredPrefixes)).Debug("Removing restored IPCache labels")
+
+		// The following logic needs to match the restoration logic in RestoreCaches
+		ipcacheUpdates := make([]ipcache.MU, 0, len(n.restoredPrefixes))
+		for prefix := range n.restoredPrefixes {
+			ipcacheUpdates = append(ipcacheUpdates, ipcache.MU{
+				Prefix:   prefix,
+				Source:   source.Restored,
+				Resource: restorationIPCacheResource,
+				Metadata: []ipcache.IPMetadata{
+					labels.Labels{}, // remove restored labels
+				},
+			})
+		}
+		n.config.IPCache.RemoveMetadataBatch(ipcacheUpdates...)
+		n.restoredPrefixes = nil
+
+		checkpointPath := filepath.Join(option.Config.StateDir, checkpointFile)
+		if err := os.Remove(checkpointPath); err != nil {
+			log.WithError(err).WithField(logfields.Path, checkpointPath).
+				Debug("Failed to remove checkpoint file")
+		}
+	}
 }
 
 // updateDNSIPs updates the IPs for each DNS name in updatedDNSIPs.
 // It returns:
-// affectedSelectors: a set of all FQDNSelectors which match DNS Names whose
-// corresponding set of IPs has changed.
 // updatedNames: a map of DNS names to all the valid IPs we store for each.
 // ipcacheRevision: a revision number to pass to WaitForRevision()
-func (n *NameManager) updateDNSIPs(lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (affectedSelectors sets.Set[api.FQDNSelector], updatedNames map[string][]net.IP, ipcacheRevision uint64) {
-	updatedNames = make(map[string][]net.IP, len(updatedDNSIPs))
-	affectedSelectors = make(sets.Set[api.FQDNSelector], len(updatedDNSIPs))
-	addrsToUpsert := sets.Set[netip.Addr]{}
+func (n *NameManager) updateDNSIPs(lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (updatedNames map[string][]netip.Addr, ipcacheRevision uint64) {
+	updatedNames = make(map[string][]netip.Addr, len(updatedDNSIPs))
+	updatedMetadata := make(map[string]nameMetadata, len(updatedDNSIPs))
 
 	for dnsName, lookupIPs := range updatedDNSIPs {
 		addrs := ip.MustAddrsFromIPs(lookupIPs.IPs)
@@ -332,36 +326,37 @@ func (n *NameManager) updateDNSIPs(lookupTime time.Time, updatedDNSIPs map[strin
 			continue
 		}
 
-		addrsToUpsert.Insert(addrs...)
-
 		// record the IPs that were different
-		updatedNames[dnsName] = lookupIPs.IPs
+		updatedNames[dnsName] = addrs
 
-		// accumulate the new selectors affected by new IPs
+		// accumulate the new labels affected by new IPs
 		if len(n.allSelectors) == 0 {
 			log.WithFields(logrus.Fields{
 				"dnsName":   dnsName,
 				"lookupIPs": lookupIPs,
 			}).Debug("FQDN: No selectors registered for updates")
+			continue
 		}
-		for fqdnSel, fqdnRegex := range n.allSelectors {
-			matches := fqdnRegex.MatchString(dnsName)
-			if matches {
-				affectedSelectors.Insert(fqdnSel)
-			}
+
+		// derive labels for this DNS name
+		nameLabels := deriveLabelsForName(dnsName, n.allSelectors)
+		if len(nameLabels) == 0 {
+			// If no selectors care about this name, then skip IPCache updates
+			// for this name.
+			// If any selectors/ are added later, ipcache insertion will happen then.
+			continue
+		}
+
+		updatedMetadata[dnsName] = nameMetadata{
+			addrs:  addrs,
+			labels: nameLabels,
 		}
 	}
 
 	// If new IPs were detected, and these IPs are selected by selectors,
 	// then ensure they have an identity allocated to them via the ipcache.
-	//
-	// If no selectors care about this name, then skip this step. If any selectors
-	// are added later, ipcache insertion will happen then.
-	if len(addrsToUpsert) > 0 && affectedSelectors.Len() > 0 {
-		ipcacheRevision = n.upsertMetadata(addrsToUpsert.UnsortedList())
-	}
-
-	return affectedSelectors, updatedNames, ipcacheRevision
+	ipcacheRevision = n.updateMetadata(updatedMetadata)
+	return updatedNames, ipcacheRevision
 }
 
 // updateIPsName will update the IPs for dnsName. It always retains a copy of
@@ -394,37 +389,83 @@ func (n *NameManager) updateIPsForName(lookupTime time.Time, dnsName string, new
 	return !slices.Equal(oldCacheIPs, newCacheIPs)
 }
 
-var ipcacheResource = ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindDaemon, "", "fqdn-name-manager")
-
-// upsertMetadata adds an entry in the ipcache metadata layer for the set of IPs.
-// Returns the ipcache queue revision (to pass to .WaitForRevision()).
-func (n *NameManager) upsertMetadata(ips []netip.Addr) uint64 {
-	prefixes := make([]netip.Prefix, 0, len(ips))
-	for _, ip := range ips {
-		prefixes = append(prefixes, netip.PrefixFrom(ip, ip.BitLen()))
-	}
-	return n.config.IPCache.UpsertPrefixes(prefixes, source.Generated, ipcacheResource)
+func ipcacheResource(dnsName string) ipcacheTypes.ResourceID {
+	return ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindDaemon, "fqdn-name-manager", dnsName)
 }
 
-// maybeRemoveMetadata removes the ipcache metadata from every IP in maybeRemoved,
-// as long as that IP is not still in the dns cache.
-func (n *NameManager) maybeRemoveMetadata(maybeRemoved sets.Set[netip.Addr]) {
+// updateMetadata updates (i.e. upserts or removes) the metadata in IPCache for
+// each (name, IP) pair provided in nameToMetadata.
+func (n *NameManager) updateMetadata(nameToMetadata map[string]nameMetadata) (ipcacheRevision uint64) {
+	var ipcacheUpserts, ipcacheRemovals []ipcache.MU
+
+	for dnsName, metadata := range nameToMetadata {
+		var updates []ipcache.MU
+		resource := ipcacheResource(dnsName)
+
+		if option.Config.Debug {
+			log.WithFields(logrus.Fields{
+				"name":     dnsName,
+				"prefixes": metadata.addrs,
+				"labels":   metadata.labels,
+			}).Debug("Updating prefix labels in IPCache")
+		}
+
+		for _, addr := range metadata.addrs {
+			updates = append(updates, ipcache.MU{
+				Prefix:   netip.PrefixFrom(addr, addr.BitLen()),
+				Source:   source.Generated,
+				Resource: resource,
+				Metadata: []ipcache.IPMetadata{
+					metadata.labels,
+				},
+			})
+		}
+
+		// If labels are empty (i.e. this domain is no longer selected),
+		// then we want to the labels of our resource owner
+		if len(metadata.labels) > 0 {
+			ipcacheUpserts = append(ipcacheUpserts, updates...)
+		} else {
+			ipcacheRemovals = append(ipcacheRemovals, updates...)
+		}
+	}
+
+	if len(ipcacheUpserts) > 0 {
+		ipcacheRevision = n.config.IPCache.UpsertMetadataBatch(ipcacheUpserts...)
+	}
+	if len(ipcacheRemovals) > 0 {
+		ipcacheRevision = n.config.IPCache.RemoveMetadataBatch(ipcacheRemovals...)
+	}
+
+	return ipcacheRevision
+}
+
+// maybeRemoveMetadata removes the ipcache metadata from every (name, IP) pair
+// in maybeRemoved, as long as that (name, IP) is not still in the dns cache.
+func (n *NameManager) maybeRemoveMetadata(maybeRemoved map[netip.Addr][]string) {
 	// Need to take an RLock here so that no DNS updates are processed.
 	// Otherwise, we might accidentally remove an IP that is newly inserted.
 	n.RWMutex.RLock()
 	defer n.RWMutex.RUnlock()
 
 	n.cache.RLock()
-	prefixes := make([]netip.Prefix, 0, len(maybeRemoved))
-	for ip := range maybeRemoved {
-		if !n.cache.ipExistsLocked(ip) {
-			prefixes = append(prefixes, netip.PrefixFrom(ip, ip.BitLen()))
+	ipCacheUpdates := make([]ipcache.MU, 0, len(maybeRemoved))
+	for ip, names := range maybeRemoved {
+		for _, name := range names {
+			if !n.cache.entryExistsLocked(name, ip) {
+				ipCacheUpdates = append(ipCacheUpdates, ipcache.MU{
+					Prefix:   netip.PrefixFrom(ip, ip.BitLen()),
+					Source:   source.Generated,
+					Resource: ipcacheResource(name),
+					Metadata: []ipcache.IPMetadata{
+						labels.Labels{}, // remove all labels for this (ip, name) pair
+					},
+				})
+			}
 		}
 	}
 	n.cache.RUnlock()
-
-	log.WithField(logfields.Prefix, prefixes).Debug("Removing fqdn entry from ipcache metadata layer")
-	n.config.IPCache.RemovePrefixes(prefixes, source.Generated, ipcacheResource)
+	n.config.IPCache.RemoveMetadataBatch(ipCacheUpdates...)
 }
 
 // LockName is used to serialize  parallel end-to-end updates to the same name.

--- a/pkg/fqdn/name_manager_bench_test.go
+++ b/pkg/fqdn/name_manager_bench_test.go
@@ -46,14 +46,14 @@ func BenchmarkUpdateGenerateDNS(b *testing.B) {
 	})
 
 	for i := 0; i < numSelectors; i++ {
-		nameManager.RegisterForIPUpdatesLocked(api.FQDNSelector{
+		nameManager.RegisterFQDNSelector(api.FQDNSelector{
 			MatchName: fmt.Sprintf("%d.example.com", i),
 		})
-		nameManager.RegisterForIPUpdatesLocked(api.FQDNSelector{
+		nameManager.RegisterFQDNSelector(api.FQDNSelector{
 			MatchPattern: fmt.Sprintf("*.%d.example.com", i),
 		})
 	}
-	nameManager.RegisterForIPUpdatesLocked(api.FQDNSelector{
+	nameManager.RegisterFQDNSelector(api.FQDNSelector{
 		MatchPattern: "*.example.com",
 	})
 

--- a/pkg/fqdn/name_manager_gc.go
+++ b/pkg/fqdn/name_manager_gc.go
@@ -5,8 +5,12 @@ package fqdn
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"net/netip"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -14,8 +18,14 @@ import (
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
+	"github.com/cilium/cilium/pkg/ipcache"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -26,6 +36,18 @@ const dnsGCJobName = "dns-garbage-collector-job"
 var (
 	dnsGCControllerGroup = controller.NewGroup(dnsGCJobName)
 )
+
+var (
+	checkpointFile = "fqdn-name-manager-selectors.json"
+
+	restorationIPCacheResource = ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindDaemon, "", "fqdn-name-manager-restoration")
+)
+
+// serializedSelector is the schema of the serialized selectors on disk
+type serializedSelector struct {
+	Regex    string           `json:"re"`
+	Selector api.FQDNSelector `json:"sel"`
+}
 
 // This implements some garbage collection and cleanup functions for the NameManager
 
@@ -130,7 +152,6 @@ func (n *NameManager) GC(ctx context.Context) error {
 	n.cache.ReplaceFromCacheByNames(namesToCleanSlice, caches...)
 
 	metrics.FQDNGarbageCollectorCleanedTotal.Add(float64(len(namesToCleanSlice)))
-	n.ForceGenerateDNS(ctx, namesToCleanSlice)
 	namesCount := len(namesToCleanSlice)
 	// Limit the amount of info level logging to some sane amount
 	if namesCount > 20 {
@@ -192,9 +213,6 @@ func (n *NameManager) DeleteDNSLookups(expireLookupsBefore time.Time, matchPatte
 		n.cache.UpdateFromCache(activeConnections, nil)
 	}
 
-	// Swallow error here; the caller doesn't care if this fails
-	n.ForceGenerateDNS(context.TODO(), namesToRegen.UnsortedList())
-
 	// We may have removed entries; remove them from the ipcache metadata layer
 	n.maybeRemoveMetadata(maybeStaleIPs)
 	return nil
@@ -246,8 +264,85 @@ func (n *NameManager) RestoreCache(preCachePath string, restoredEPs []EndpointDN
 		}
 	}
 
-	// Ensure there's a metadata entry for the fqdn subsystem in ipcache.
-	n.upsertMetadata(n.cache.GetIPs().UnsortedList())
+	if option.Config.RestoreState {
+		checkpointPath := filepath.Join(option.Config.StateDir, checkpointFile)
+
+		// Restore selector labels in IPCache when upgrading from v1.15. This is needed
+		// because Cilium v1.15 and older used to use CIDR identities for ToFQDN identities.
+		// This can be removed once Cilium v1.15 is end of life. When restoring from
+		// Cilium v1.16 and newer, we can rely on identity restoration to inject the
+		// correct identities into IPCache
+		oldSelectors, err := restoreSelectors(checkpointPath)
+		if err != nil {
+			log.WithError(err).WithField(logfields.Path, checkpointPath).Error("Failed to restore FQDN selectors. " +
+				"Expect brief traffic disruptions for ToFQDN destinations during initial endpoint regeneration")
+			return
+		}
+		if len(oldSelectors) == 0 {
+			log.Info("No FQDN selectors to restore from previous Cilium v1.15 installations")
+			return
+		}
+
+		// If we are upgrading from Cilium v1.15, we need to provide the expected
+		// FQDN labels into IPCache before label injection and endpoint restoration starts.
+		// This ensures that the prefix labels (and thus the numeric identity of the prefix)
+		// will not change once the real selectors are discovered during initial endpoint regeneration.
+		// Without this, the initial endpoint regeneration might cause drops as old and new IPCache
+		// will use different identities for the prefixes in IPCache.
+		// These restored labels are removed in CompleteBootstrap, which is invoked after the real
+		// labels have been discovered in endpoint regeneration.
+		log.Info("Detected upgrade from Cilium v1.15. Building IPCache metadata from restored FQDN selectors")
+
+		ipsToNames := n.cache.GetIPs()
+		ipcacheUpdates := make([]ipcache.MU, 0, len(ipsToNames))
+		n.restoredPrefixes = make(sets.Set[netip.Prefix], len(ipsToNames))
+
+		for addr, names := range ipsToNames {
+			lbls := labels.Labels{}
+			for _, name := range names {
+				lbls.MergeLabels(deriveLabelsForName(name, oldSelectors))
+			}
+
+			prefix := netip.PrefixFrom(addr, addr.BitLen())
+			ipcacheUpdates = append(ipcacheUpdates, ipcache.MU{
+				Prefix:   prefix,
+				Source:   source.Restored,
+				Resource: restorationIPCacheResource,
+				Metadata: []ipcache.IPMetadata{
+					lbls,
+				},
+			})
+			n.restoredPrefixes.Insert(prefix)
+		}
+		n.config.IPCache.UpsertMetadataBatch(ipcacheUpdates...)
+	}
+}
+
+func restoreSelectors(checkpointPath string) (map[api.FQDNSelector]*regexp.Regexp, error) {
+	f, err := os.Open(checkpointPath)
+	if err != nil {
+		// If not upgrading from Cilium v1.15, the file will not exist
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to open selector checkpoint file: %w", err)
+	}
+
+	var restoredSelectors []serializedSelector
+	err = json.NewDecoder(f).Decode(&restoredSelectors)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode checkpointed selectors from: %w", err)
+	}
+
+	oldSelectors := make(map[api.FQDNSelector]*regexp.Regexp, len(restoredSelectors))
+	for _, s := range restoredSelectors {
+		re, err := regexp.Compile(s.Regex)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regex %q in checkpointed selectors: %w", s.Regex, err)
+		}
+		oldSelectors[s.Selector] = re
+	}
+	return oldSelectors, nil
 }
 
 // readPreCache returns a fqdn.DNSCache object created from the json data at

--- a/pkg/fqdn/name_manager_test.go
+++ b/pkg/fqdn/name_manager_test.go
@@ -8,146 +8,135 @@ import (
 	"net"
 	"net/netip"
 	"regexp"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/fqdn/dns"
-	"github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/ipcache"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
-	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
+	"github.com/cilium/cilium/pkg/time"
 )
 
-// TestNameManagerCIDRGeneration tests rule generation output:
-// add a rule, get correct IP4/6 in ToCIDRSet
-// add a rule, lookup twice, get correct IP4/6 in TOCIDRSet after change
-// add a rule w/ToCIDRSet, get correct IP4/6 and old rules
-// add a rule, get same UUID label on repeat generations
-func TestNameManagerCIDRGeneration(t *testing.T) {
-	var (
-		selIPMap map[api.FQDNSelector][]netip.Addr
-
-		nameManager = NewNameManager(Config{
-			MinTTL:  1,
-			Cache:   NewDNSCache(0),
-			IPCache: testipcache.NewMockIPCache(),
-
-			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]netip.Addr, _ uint64) *sync.WaitGroup {
-				for k, v := range selectorIPMapping {
-					selIPMap[k] = v
-				}
-				return &sync.WaitGroup{}
-			},
-		})
-	)
-
-	// add rules
-	nameManager.Lock()
-	nameManager.RegisterForIPUpdatesLocked(ciliumIOSel)
-	nameManager.Unlock()
-
-	// poll DNS once, check that we only generate 1 rule (for 1 IP) and that we
-	// still have 1 ToFQDN rule, and that the IP is correct
-	selIPMap = make(map[api.FQDNSelector][]netip.Addr)
-	nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
-	require.Len(t, selIPMap, 1, "Incorrect length for testCase with single ToFQDNs entry")
-
-	expectedIPs := []netip.Addr{netip.MustParseAddr("1.1.1.1")}
-	ips := selIPMap[ciliumIOSel]
-	require.Equal(t, expectedIPs[0], ips[0])
-
-	// poll DNS once, check that we only generate 1 rule (for 2 IPs that we
-	// inserted) and that we still have 1 ToFQDN rule, and that the IP, now
-	// different, is correct
-	selIPMap = make(map[api.FQDNSelector][]netip.Addr)
-	nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("10.0.0.2")}}})
-	require.Len(t, selIPMap, 1, "Only one entry per FQDNSelector should be present")
-	expectedIPs = []netip.Addr{netip.MustParseAddr("1.1.1.1"), netip.MustParseAddr("10.0.0.2")}
-	cips := selIPMap[ciliumIOSel]
-	ip.SortAddrList(cips)
-	require.EqualValues(t, expectedIPs, cips)
+type mockIPCache struct {
+	metadata map[netip.Prefix]map[ipcacheTypes.ResourceID]labels.Labels
 }
 
-// Test that all IPs are updated when one is
-func TestNameManagerMultiIPUpdate(t *testing.T) {
-	var (
-		selIPMap map[api.FQDNSelector][]netip.Addr
-
-		nameManager = NewNameManager(Config{
-			MinTTL:  1,
-			Cache:   NewDNSCache(0),
-			IPCache: testipcache.NewMockIPCache(),
-
-			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]netip.Addr, _ uint64) *sync.WaitGroup {
-				for k, v := range selectorIPMapping {
-					selIPMap[k] = v
-				}
-				return &sync.WaitGroup{}
-			},
-		})
-	)
-
-	// add rules
-	selectorsToAdd := api.FQDNSelectorSlice{ciliumIOSel, githubSel}
-	nameManager.Lock()
-	for _, sel := range selectorsToAdd {
-		nameManager.RegisterForIPUpdatesLocked(sel)
+func newMockIPCache() *mockIPCache {
+	return &mockIPCache{
+		metadata: make(map[netip.Prefix]map[ipcacheTypes.ResourceID]labels.Labels),
 	}
-	nameManager.Unlock()
+}
 
-	// poll DNS once, check that we only generate 1 IP for cilium.io
-	selIPMap = make(map[api.FQDNSelector][]netip.Addr)
-	nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
-	require.Len(t, selIPMap, 1, "Incorrect number of plumbed FQDN selectors")
-	require.Equal(t, netip.MustParseAddr("1.1.1.1"), selIPMap[ciliumIOSel][0])
+func (m *mockIPCache) labelsForPrefix(prefix netip.Prefix) labels.Labels {
+	lbls := labels.Labels{}
+	for _, l := range m.metadata[prefix] {
+		lbls.MergeLabels(l)
+	}
+	return lbls
+}
 
-	// poll DNS once, check that we only generate 3 IPs, 2 cached from before and 1 new one for github.com
-	selIPMap = make(map[api.FQDNSelector][]netip.Addr)
-	nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
-		dns.FQDN("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("10.0.0.2")}},
-		dns.FQDN("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("10.0.0.3")}}})
-	require.Len(t, selIPMap, 2, "More than 2 FQDN selectors while only 2 were added")
-	require.Len(t, selIPMap[ciliumIOSel], 2, "Incorrect number of IPs for cilium.io selector")
-	require.Len(t, selIPMap[githubSel], 1, "Incorrect number of IPs for github.com selector")
-	cips := selIPMap[ciliumIOSel]
-	ip.SortAddrList(cips)
-	require.Equal(t, cips[0], netip.MustParseAddr("1.1.1.1"), "Incorrect IP mapping to FQDN")
-	require.Equal(t, cips[1], netip.MustParseAddr("10.0.0.2"), "Incorrect IP mapping to FQDN")
-	require.Equal(t, selIPMap[githubSel][0], netip.MustParseAddr("10.0.0.3"), "Incorrect IP mapping to FQDN")
+func (m *mockIPCache) UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64) {
+	for _, mu := range updates {
+		prefixMetadata, ok := m.metadata[mu.Prefix]
+		if !ok {
+			prefixMetadata = make(map[ipcacheTypes.ResourceID]labels.Labels)
+		}
 
-	// poll DNS once, check that we only generate 4 IPs, 2 cilium.io cached IPs, 1 cached github.com IP, 1 new github.com IP
-	selIPMap = make(map[api.FQDNSelector][]netip.Addr)
-	nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
-		dns.FQDN("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("10.0.0.2")}},
-		dns.FQDN("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("10.0.0.4")}}})
-	require.Len(t, selIPMap[ciliumIOSel], 2, "Incorrect number of IPs for cilium.io selector")
-	require.Len(t, selIPMap[githubSel], 2, "Incorrect number of IPs for github.com selector")
-	cips = selIPMap[ciliumIOSel]
-	ip.SortAddrList(cips)
-	require.Equal(t, netip.MustParseAddr("1.1.1.1"), cips[0], "Incorrect IP mapping to FQDN")
-	require.Equal(t, netip.MustParseAddr("10.0.0.2"), cips[1], "Incorrect IP mapping to FQDN")
+		for _, aux := range mu.Metadata {
+			if lbls, ok := aux.(labels.Labels); ok {
+				prefixMetadata[mu.Resource] = lbls
+				break
+			}
+		}
 
-	ghips := selIPMap[githubSel]
-	ip.SortAddrList(ghips)
-	require.Equal(t, netip.MustParseAddr("10.0.0.3"), ghips[0], "Incorrect IP mapping to FQDN")
-	require.Equal(t, netip.MustParseAddr("10.0.0.4"), ghips[1], "Incorrect IP mapping to FQDN")
+		m.metadata[mu.Prefix] = prefixMetadata
+	}
 
-	// Second registration fails because IdentityAllocator is not initialized
-	nameManager.Lock()
-	nameManager.RegisterForIPUpdatesLocked(githubSel)
+	return 0
+}
 
-	nameManager.UnregisterForIPUpdatesLocked(githubSel)
-	_, exists := nameManager.allSelectors[githubSel]
-	require.Equal(t, false, exists)
+func (m *mockIPCache) RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64) {
+	for _, mu := range updates {
+		for _, aux := range mu.Metadata {
+			if _, ok := aux.(labels.Labels); ok {
+				delete(m.metadata[mu.Prefix], mu.Resource)
+				break
+			}
+		}
 
-	nameManager.UnregisterForIPUpdatesLocked(ciliumIOSel)
-	_, exists = nameManager.allSelectors[ciliumIOSel]
-	require.Equal(t, false, exists)
-	nameManager.Unlock()
+		if len(m.metadata[mu.Prefix]) == 0 {
+			delete(m.metadata, mu.Prefix)
+		}
+	}
 
+	return 0
+}
+
+func (m *mockIPCache) WaitForRevision(rev uint64) {
+	// no-op
+}
+
+func ipsFromPrefixes(t *testing.T, prefixes ...netip.Prefix) (ips []net.IP) {
+	t.Helper()
+
+	for _, p := range prefixes {
+		if !p.IsSingleIP() {
+			t.Fatalf("invalid prefix: %s", p)
+		}
+
+		ips = append(ips, p.Addr().AsSlice())
+	}
+
+	return ips
+}
+
+func TestNameManagerIPCacheUpdates(t *testing.T) {
+	ipc := newMockIPCache()
+	nameManager := NewNameManager(Config{
+		MinTTL:  1,
+		Cache:   NewDNSCache(0),
+		IPCache: ipc,
+	})
+
+	nameManager.RegisterFQDNSelector(ciliumIOSel)
+
+	// Simulate lookup for single selector
+	prefix := netip.MustParsePrefix("1.1.1.1/32")
+	nameManager.UpdateGenerateDNS(context.TODO(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: ipsFromPrefixes(t, prefix)}})
+	require.Equal(t, ipc.labelsForPrefix(prefix), labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}))
+
+	// Add match pattern
+	nameManager.RegisterFQDNSelector(ciliumIOSelMatchPattern)
+	require.Equal(t, ipc.labelsForPrefix(prefix), labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel(), ciliumIOSelMatchPattern.IdentityLabel()}))
+
+	// Remove cilium.io matchname, add github.com match name
+	nameManager.RegisterFQDNSelector(githubSel)
+	nameManager.UnregisterFQDNSelector(ciliumIOSel)
+	require.Equal(t, ipc.labelsForPrefix(prefix), labels.FromSlice([]labels.Label{ciliumIOSelMatchPattern.IdentityLabel()}))
+
+	// Same IP matched by two selectors
+	nameManager.UpdateGenerateDNS(context.TODO(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("github.com"): {TTL: 60, IPs: ipsFromPrefixes(t, prefix)}})
+	require.Equal(t, ipc.labelsForPrefix(prefix), labels.FromSlice([]labels.Label{ciliumIOSelMatchPattern.IdentityLabel(), githubSel.IdentityLabel()}))
+
+	// Additional unique IPs for each selector
+	githubPrefix := netip.MustParsePrefix("10.0.0.2/32")
+	awesomePrefix := netip.MustParsePrefix("10.0.0.3/32")
+	nameManager.UpdateGenerateDNS(context.TODO(), time.Now(), map[string]*DNSIPRecords{
+		dns.FQDN("github.com"):       {TTL: 60, IPs: ipsFromPrefixes(t, githubPrefix)},
+		dns.FQDN("awesomecilium.io"): {TTL: 60, IPs: ipsFromPrefixes(t, awesomePrefix)},
+	})
+	require.Equal(t, ipc.labelsForPrefix(prefix), labels.FromSlice([]labels.Label{ciliumIOSelMatchPattern.IdentityLabel(), githubSel.IdentityLabel()}))
+	require.Equal(t, ipc.labelsForPrefix(githubPrefix), labels.FromSlice([]labels.Label{githubSel.IdentityLabel()}))
+	require.Equal(t, ipc.labelsForPrefix(awesomePrefix), labels.FromSlice([]labels.Label{ciliumIOSelMatchPattern.IdentityLabel()}))
+
+	// Removing selector should remove from IPCache
+	nameManager.UnregisterFQDNSelector(ciliumIOSelMatchPattern)
+	require.NotContains(t, ipc.metadata, awesomePrefix)
+	require.Equal(t, ipc.labelsForPrefix(prefix), labels.FromSlice([]labels.Label{githubSel.IdentityLabel()}))
+	require.Equal(t, ipc.labelsForPrefix(githubPrefix), labels.FromSlice([]labels.Label{githubSel.IdentityLabel()}))
 }
 
 func Test_deriveLabelsForNames(t *testing.T) {

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -574,6 +574,11 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 		}
 	}
 
+	// Ensure any prefix with a FQDN label also has the world label set
+	if lbls.HasSource(labels.LabelSourceFQDN) {
+		labels.AddWorldLabel(prefix.Addr(), lbls)
+	}
+
 	// If the prefix is associated with the host or remote-node, then
 	// force-remove the world label.
 	if lbls.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode]) ||

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -845,7 +845,7 @@ func TestUpsertMetadataInheritedCIDRPrefix(t *testing.T) {
 	ident = IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.TODO(), id.ID)
 	require.True(t, ok)
 	require.NotNil(t, ident)
-	require.Equal(t, "fqdn:*.internal", ident.Labels.String())
+	require.Equal(t, "fqdn:*.internal,reserved:world-ipv4", ident.Labels.String())
 	newID, ok = IPIdentityCache.LookupByPrefix(child.String())
 	require.True(t, ok)
 	require.Equal(t, id.ID, newID.ID)

--- a/pkg/labels/cidr.go
+++ b/pkg/labels/cidr.go
@@ -93,12 +93,12 @@ func GetCIDRLabels(prefix netip.Prefix) Labels {
 		l.cidr = &prefix
 		lbls[l.Key] = l
 	}
-	addWorldLabel(prefix.Addr(), lbls)
+	AddWorldLabel(prefix.Addr(), lbls)
 
 	return lbls
 }
 
-func addWorldLabel(addr netip.Addr, lbls Labels) {
+func AddWorldLabel(addr netip.Addr, lbls Labels) {
 	switch {
 	case !option.Config.IsDualStack():
 		lbls[worldLabelNonDualStack.Key] = worldLabelNonDualStack

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -644,12 +644,7 @@ func (l Labels) FindReserved() Labels {
 
 // IsReserved returns true if any of the labels has a reserved source.
 func (l Labels) IsReserved() bool {
-	for _, lbl := range l {
-		if lbl.Source == LabelSourceReserved {
-			return true
-		}
-	}
-	return false
+	return l.HasSource(LabelSourceReserved)
 }
 
 // Has returns true if l contains the given label.

--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
+	"github.com/cilium/cilium/pkg/labels"
 )
 
 var (
@@ -72,6 +73,19 @@ func (s *FQDNSelector) String() string {
 	str.WriteString(mm)
 	str.WriteString(s.MatchPattern)
 	return str.String()
+}
+
+// IdentityLabel returns the label which needs to be added to each identity
+// selected by this selector. The identity label is based on the MatchName
+// if set, otherwise on the MatchPattern. This matches the behavior of the
+// ToRegex function
+func (s *FQDNSelector) IdentityLabel() labels.Label {
+	match := s.MatchPattern
+	if s.MatchName != "" {
+		match = s.MatchName
+	}
+
+	return labels.NewLabel(match, "", labels.LabelSourceFQDN)
 }
 
 // sanitize for FQDNSelector is a little wonky. While we do more processing

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -5,7 +5,6 @@ package policy
 
 import (
 	"net"
-	"net/netip"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -216,150 +215,23 @@ var (
 
 // identityNotifier provides a means for other subsystems to be made aware of a
 // given FQDNSelector (currently pkg/fqdn) so that said subsystems can notify
-// the SelectorCache about new IPs (via CIDR Identities) which correspond to
-// said FQDNSelector. This is necessary since there is nothing intrinsic to a
-// CIDR Identity that says that it corresponds to a given FQDNSelector; this
-// relationship is contained only via DNS responses, which are handled
-// externally.
+// the IPCache about IPs which correspond to said FQDNSelector.
+// This is necessary as there is nothing intrinsic about an IP that says that
+// it corresponds to a given FQDNSelector; this relationship is contained only
+// via DNS responses, which are handled externally.
 type identityNotifier interface {
-	// Lock must be held during any calls to *Locked functions below.
-	Lock()
+	// RegisterFQDNSelector exposes this FQDNSelector so that the identity labels
+	// of IPs contained in a DNS response that matches said selector can be
+	// associated with that selector.
+	RegisterFQDNSelector(selector api.FQDNSelector)
 
-	// Unlock must be called after calls to *Locked functions below.
-	Unlock()
-
-	// RegisterForIPUpdatesLocked exposes this FQDNSelector so that identities
-	// for IPs contained in a DNS response that matches said selector can
-	// be propagated back to the SelectorCache via `UpdateFQDNSelector`.
-	//
-	// This function should only be called when the SelectorCache has been
-	// made aware of the FQDNSelector for the first time; subsequent
-	// updates to the selectors should be made via `UpdateFQDNSelector`.
-	//
-	// This function returns the set of IPs for which this selector already applies.
-	RegisterForIPUpdatesLocked(selector api.FQDNSelector) []netip.Addr
-
-	// UnregisterForIPUpdatesLocked removes this FQDNSelector from the set of
-	// FQDNSelectors which are being tracked by the identityNotifier. The result
-	// of this is that no more updates for IPs which correspond to said selector
-	// are propagated back to the SelectorCache via `UpdateFQDNSelector`.
+	// UnregisterFQDNSelector removes this FQDNSelector from the set of
+	// IPs which are being tracked by the identityNotifier. The result
+	// of this is that an IP may be evicted from IPCache if it is no longer
+	// selected by any other FQDN selector.
 	// This occurs when there are no more users of a given FQDNSelector for the
 	// SelectorCache.
-	UnregisterForIPUpdatesLocked(selector api.FQDNSelector)
-}
-
-//
-// CachedSelector implementation (== Public API)
-//
-// No locking needed.
-//
-
-// UpdateResult is a bitfield that indicates what parts of the policy engines
-// need to update in order to implement a policy
-type UpdateResult uint32
-
-const (
-	// UpdateResultUpdatePolicyMaps indicates the caller should call EndpointManager.UpdatePolicyMaps()
-	UpdateResultUpdatePolicyMaps = UpdateResult(1) << iota
-
-	// UpdateResultIdentitiesNeeded indicates the caller should wait for a complete ipcache label injection,
-	// as the selector is missing identities
-	UpdateResultIdentitiesNeeded
-
-	UpdateResultUnchanged = UpdateResult(0)
-)
-
-// UpdateFQDNSelector updates the mapping of fqdnKey (the FQDNSelector from a
-// policy rule as a string) to to the provided list of IPs.
-//
-// If the supplied IPs are already known to the SelectorCache (i.e. they already)
-// have identities allocated for them), the selector's cachedSelections changes, and
-// users are notified asynchronously. Caller must then call Wait() on the supplied
-// sync.WaitGroup before triggering any policy updates via UpdatePolicyMaps().
-// Policy updates may need Endpoint locks, so this Wait() can deadlock if the caller
-// is holding any endpoint locks. When this is the case, the returned UpdateResult has
-// the UpdateResultUpdatePolicyMaps bit set.
-//
-// In the case where identities are not found for all supplied IPs, the returned
-// result has the IdentitiesNeeded bit set to signify that an ipcache update is needed.
-//
-// The caller must always ensure that all selected IP addresses are known to the ipcache.
-//
-// Returns an UpdateResult that indicates if the caller should call UpdatePolicyMaps() and/or
-// wait for ipcache UpsertMetadata() to finish.
-func (sc *SelectorCache) UpdateFQDNSelector(fqdnSelec api.FQDNSelector, ips []netip.Addr, wg *sync.WaitGroup) UpdateResult {
-	sc.mutex.Lock()
-	defer sc.mutex.Unlock()
-	return sc.updateFQDNSelector(fqdnSelec, ips, wg)
-}
-
-func (sc *SelectorCache) updateFQDNSelector(fqdnSelec api.FQDNSelector, ips []netip.Addr, wg *sync.WaitGroup) UpdateResult {
-	key := fqdnSelec.String()
-
-	idSelector, exists := sc.selectors[key]
-	if !exists || idSelector == nil {
-		log.WithField(logfields.Selector, fqdnSelec.String()).Error("UpdateFQDNSelector of selector not registered in SelectorCache!")
-	}
-
-	fqdnSelect, ok := idSelector.source.(*fqdnSelector)
-	if !ok {
-		log.Error("UpdateFQDNSelector for non-FQDN selector!")
-		return UpdateResultUnchanged
-	}
-
-	// update wantLabels, then determine set of added and removed identities
-	fqdnSelect.setSelectorIPs(ips) // this updates wantLabels
-
-	// Note that 'added' and 'deleted' are guaranteed to be
-	// disjoint, as one of them is left as nil, or an identity
-	// being in 'identities' is a precondition for an
-	// identity to be appended to 'added', while the inverse is
-	// true for 'deleted'.
-	var added, deleted []identity.NumericIdentity
-
-	// Delete any non-matching entries from cachedSelections
-	for nid := range idSelector.cachedSelections {
-		identity := sc.idCache[nid]
-		if !idSelector.source.matches(identity) {
-			deleted = append(deleted, nid)
-			delete(idSelector.cachedSelections, nid)
-		}
-	}
-
-	// Scan the cached set of IDs to determine any new matchers
-	for nid, identity := range sc.idCache {
-		if idSelector.source.matches(identity) {
-			if _, exists := idSelector.cachedSelections[nid]; !exists {
-				added = append(added, nid)
-				idSelector.cachedSelections[nid] = struct{}{}
-			}
-		}
-	}
-
-	// Result indicates whether or not the caller should call UpdatePolicyMaps
-	// and / or wait for ipcache to finish.
-	result := UpdateResultUnchanged
-
-	// If we're missing identities, then the caller also needs to wait for ipcache to do a
-	// allocation + injection round
-	//
-	// This assumes we should have a 1:1 mapping from label to IPs, which is currently the case.
-	// If this changes, this conditional will be wrong.
-	if len(idSelector.cachedSelections) != len(fqdnSelect.wantLabels) {
-		result |= UpdateResultIdentitiesNeeded
-	}
-
-	idSelector.updateSelections()
-
-	// If the set of selections has changed, then we need to push out an
-	// incremental update. This will add an incremental change to all users,
-	// and tell the caller that a call to UpdatePolicyMaps is required.
-	if len(added)+len(deleted) > 0 {
-		result |= UpdateResultUpdatePolicyMaps
-		idSelector.notifyUsers(sc, added, deleted, wg) // disjoint sets, see the comment above
-	}
-
-	return result
+	UnregisterFQDNSelector(selector api.FQDNSelector)
 }
 
 // AddFQDNSelector adds the given api.FQDNSelector in to the selector cache. If
@@ -368,11 +240,6 @@ func (sc *SelectorCache) updateFQDNSelector(fqdnSelec api.FQDNSelector, ips []ne
 func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, lbls labels.LabelArray, fqdnSelec api.FQDNSelector) (cachedSelector CachedSelector, added bool) {
 	key := fqdnSelec.String()
 
-	// Lock NameManager before the SelectorCache. Always.
-	// This is because SelectorCache and NameManager have interleaving locks,
-	// so we must always acquire the NameManager lock first
-	sc.localIdentityNotifier.Lock()
-	defer sc.localIdentityNotifier.Unlock()
 	sc.mutex.Lock()
 	defer sc.mutex.Unlock()
 
@@ -386,10 +253,8 @@ func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, lbls labels.L
 		selector: fqdnSelec,
 	}
 
-	// Make the FQDN subsystem aware of this selector and fetch ips
-	// that the FQDN subsystem is aware of.
-	currentIPs := sc.localIdentityNotifier.RegisterForIPUpdatesLocked(source.selector)
-	source.setSelectorIPs(currentIPs)
+	// Make the FQDN subsystem aware of this selector
+	sc.localIdentityNotifier.RegisterFQDNSelector(source.selector)
 
 	return sc.addSelector(user, lbls, key, source)
 }
@@ -479,23 +344,19 @@ func (sc *SelectorCache) removeSelectorLocked(selector CachedSelector, user Cach
 
 // RemoveSelector removes CachedSelector for the user.
 func (sc *SelectorCache) RemoveSelector(selector CachedSelector, user CachedSelectionUser) {
-	sc.localIdentityNotifier.Lock()
 	sc.mutex.Lock()
 	sc.removeSelectorLocked(selector, user)
 	sc.mutex.Unlock()
-	sc.localIdentityNotifier.Unlock()
 
 }
 
 // RemoveSelectors removes CachedSelectorSlice for the user.
 func (sc *SelectorCache) RemoveSelectors(selectors CachedSelectorSlice, user CachedSelectionUser) {
-	sc.localIdentityNotifier.Lock()
 	sc.mutex.Lock()
 	for _, selector := range selectors {
 		sc.removeSelectorLocked(selector, user)
 	}
 	sc.mutex.Unlock()
-	sc.localIdentityNotifier.Unlock()
 }
 
 // ChangeUser changes the CachedSelectionUser that gets updates on the

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/identity"
@@ -415,124 +414,6 @@ func TestIdentityUpdates(t *testing.T) {
 	require.Equal(t, 0, len(sc.selectors))
 }
 
-func TestFQDNSelectorUpdates(t *testing.T) {
-	sc := testNewSelectorCache(identity.IdentityMap{})
-	di := sc.localIdentityNotifier.(*testidentity.DummyIdentityNotifier)
-
-	// Add some identities to the identity cache
-	googleSel := api.FQDNSelector{MatchName: "google.com"}
-	ciliumSel := api.FQDNSelector{MatchName: "cilium.io"}
-
-	ciliumIPs := []netip.Addr{netip.MustParseAddr("1.1.1.1"), netip.MustParseAddr("2.1.1.1")}
-	googleIPs := []netip.Addr{netip.MustParseAddr("1.1.1.2"), netip.MustParseAddr("2.1.1.2")}
-
-	initialCiliumIdentities := identity.IdentityMap{
-		1111: labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.1/32")).LabelArray().Sort(),
-		2111: labels.GetCIDRLabels(netip.MustParsePrefix("2.1.1.1/32")).LabelArray().Sort(),
-	}
-
-	initialGoogleIdentities := identity.IdentityMap{
-		1112: labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.2/32")).LabelArray().Sort(),
-		2112: labels.GetCIDRLabels(netip.MustParsePrefix("2.1.1.2/32")).LabelArray().Sort(),
-	}
-
-	sc.UpdateIdentities(initialCiliumIdentities, nil, nil)
-	sc.UpdateIdentities(initialGoogleIdentities, nil, nil)
-
-	// Configure the dummy NameManager so that each selector has one IP
-	di.SetSelectorIPs(googleSel, googleIPs[:1])
-	di.SetSelectorIPs(ciliumSel, ciliumIPs[:1])
-
-	user1 := newUser(t, "user1", sc)
-	cached := user1.AddFQDNSelector(ciliumSel)
-
-	selections := cached.GetSelections()
-	require.Equal(t, 1, len(selections))
-	require.Equal(t, 1111, int(selections[0]))
-
-	// Add another selector from the same user
-	cached2 := user1.AddFQDNSelector(googleSel)
-	require.NotEqual(t, cached, cached2)
-
-	// Current selections contain the numeric identities of existing identities that match
-	selections2 := cached2.GetSelections()
-	require.Equal(t, 1, len(selections2))
-	require.Equal(t, 1112, int(selections2[0]))
-
-	// Add an additional IP to the selector (for which the identity exists)
-	user1.Reset()
-	wg := &sync.WaitGroup{}
-	sc.UpdateFQDNSelector(ciliumSel, ciliumIPs, wg)
-	wg.Wait()
-
-	adds, deletes := user1.WaitForUpdate()
-	require.Equal(t, 1, adds)
-	require.Equal(t, 0, deletes)
-
-	selections = cached.GetSelections()
-	require.Equal(t, 2, len(selections))
-	require.Equal(t, 1111, int(selections[0]))
-	require.Equal(t, 2111, int(selections[1]))
-
-	// Change to a different IP that does not yet exist
-	user1.Reset()
-	wg = &sync.WaitGroup{}
-	sc.UpdateFQDNSelector(ciliumSel, []netip.Addr{netip.MustParseAddr("4.4.4.4")}, wg)
-	wg.Wait()
-
-	adds, deletes = user1.WaitForUpdate()
-	require.Equal(t, 1, adds) // these values are not cleared on Reset(, adds), so this is the same as before
-	require.Equal(t, 2, deletes)
-
-	selections = cached.GetSelections()
-	require.Equal(t, 0, len(selections))
-
-	// Now, add the identity that the selector selects
-	newIdentities := identity.IdentityMap{
-		4444: labels.GetCIDRLabels(netip.MustParsePrefix("4.4.4.4/32")).LabelArray().Sort(),
-	}
-
-	user1.Reset()
-	wg = &sync.WaitGroup{}
-	sc.UpdateIdentities(newIdentities, nil, wg)
-	wg.Wait()
-
-	// We should now see another add
-	selections = cached.GetSelections()
-	require.Equal(t, 1, len(selections))
-	require.Equal(t, 4444, int(selections[0]))
-
-	adds, deletes = user1.WaitForUpdate()
-	require.Equal(t, 2, adds) // Again, this is one more than before
-	require.Equal(t, 2, deletes)
-
-	// Delete an unrelated identity, ensure nothing changes
-	user1.Reset()
-	wg = &sync.WaitGroup{}
-	sc.UpdateIdentities(nil, initialCiliumIdentities, wg)
-	wg.Wait()
-
-	// We should now see no changes
-	selections = cached.GetSelections()
-	require.Equal(t, 1, len(selections))
-	require.Equal(t, 4444, int(selections[0]))
-
-	// In this case, user1 will not get an update, since adds + deletes = 0
-
-	// Delete a selected identity, ensure we get the delete
-	user1.Reset()
-	wg = &sync.WaitGroup{}
-	sc.UpdateIdentities(nil, newIdentities, wg)
-	wg.Wait()
-
-	selections = cached.GetSelections()
-	require.Equal(t, 0, len(selections))
-
-	adds, deletes = user1.WaitForUpdate()
-	require.Equal(t, 2, adds)
-	require.Equal(t, 3, deletes)
-}
-
 func TestIdentityUpdatesMultipleUsers(t *testing.T) {
 	sc := testNewSelectorCache(identity.IdentityMap{})
 
@@ -632,38 +513,4 @@ func testNewSelectorCache(ids identity.IdentityMap) *SelectorCache {
 	sc := NewSelectorCache(ids)
 	sc.SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 	return sc
-}
-
-func TestFQDNSelectorMatches(t *testing.T) {
-
-	f := fqdnSelector{}
-
-	ip1 := netip.MustParseAddr("1.1.1.1")
-	ip2 := netip.MustParseAddr("1.1.1.2")
-
-	l1 := labels.GetCIDRLabels(netip.PrefixFrom(ip1, ip1.BitLen())).LabelArray()
-	l2 := labels.GetCIDRLabels(netip.PrefixFrom(ip2, ip2.BitLen())).LabelArray()
-
-	i1 := scIdentity{lbls: l1}
-	i2 := scIdentity{lbls: l2}
-	i3 := scIdentity{}
-
-	assert.False(t, f.matches(i1))
-	assert.False(t, f.matches(i2))
-	assert.False(t, f.matches(i3))
-
-	f.setSelectorIPs([]netip.Addr{ip1})
-	assert.True(t, f.matches(i1))
-	assert.False(t, f.matches(i2))
-	assert.False(t, f.matches(i3))
-
-	f.setSelectorIPs([]netip.Addr{ip2})
-	assert.False(t, f.matches(i1))
-	assert.True(t, f.matches(i2))
-	assert.False(t, f.matches(i3))
-
-	f.setSelectorIPs([]netip.Addr{ip1, ip2})
-	assert.True(t, f.matches(i1))
-	assert.True(t, f.matches(i2))
-	assert.False(t, f.matches(i3))
 }

--- a/pkg/testutils/identity/notifier.go
+++ b/pkg/testutils/identity/notifier.go
@@ -3,48 +3,18 @@
 
 package testidentity
 
-import (
-	"net/netip"
-
-	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/policy/api"
-)
+import "github.com/cilium/cilium/pkg/policy/api"
 
 type DummyIdentityNotifier struct {
-	mutex     lock.Mutex
-	selectors map[api.FQDNSelector][]netip.Addr
+	Registered map[api.FQDNSelector]struct{}
 }
 
 func NewDummyIdentityNotifier() *DummyIdentityNotifier {
 	return &DummyIdentityNotifier{
-		selectors: make(map[api.FQDNSelector][]netip.Addr),
+		Registered: make(map[api.FQDNSelector]struct{}),
 	}
 }
 
-// Lock must be held during any calls to RegisterForIPUpdatesLocked or
-// UnregisterForIPUpdatesLocked.
-func (d *DummyIdentityNotifier) Lock() {
-	d.mutex.Lock()
-}
+func (d DummyIdentityNotifier) RegisterFQDNSelector(selector api.FQDNSelector) {}
 
-// Unlock must be called after calls to RegisterForIPUpdatesLocked or
-// UnregisterForIPUpdatesLocked are done.
-func (d *DummyIdentityNotifier) Unlock() {
-	d.mutex.Unlock()
-}
-
-// RegisterForIPUpdatesLocked starts managing this selector.
-//
-// It doesn't implement the identity allocation semantics of the interface.
-func (d *DummyIdentityNotifier) RegisterForIPUpdatesLocked(selector api.FQDNSelector) []netip.Addr {
-	return d.selectors[selector]
-}
-
-// UnregisterForIPUpdatesLocked stops managing this selector.
-func (d *DummyIdentityNotifier) UnregisterForIPUpdatesLocked(selector api.FQDNSelector) {
-	delete(d.selectors, selector)
-}
-
-func (d *DummyIdentityNotifier) SetSelectorIPs(selector api.FQDNSelector, ips []netip.Addr) {
-	d.selectors[selector] = ips
-}
+func (d DummyIdentityNotifier) UnregisterFQDNSelector(selector api.FQDNSelector) {}

--- a/pkg/testutils/ipcache/ipcache.go
+++ b/pkg/testutils/ipcache/ipcache.go
@@ -58,6 +58,16 @@ func (m *MockIPCache) UpsertPrefixes(prefixes []netip.Prefix, src source.Source,
 func (m *MockIPCache) RemovePrefixes(prefixes []netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID) {
 }
 
+func (m *MockIPCache) UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64) {
+	return 0
+}
+
+func (m *MockIPCache) RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64) {
+	return 0
+}
+
+func (m *MockIPCache) WaitForRevision(rev uint64) {}
+
 func NewMockIPCache() *MockIPCache {
 	return &MockIPCache{}
 }


### PR DESCRIPTION
This is an implementation of the following CFP. Please refer to the CFP for details on the approach.

- https://github.com/cilium/design-cfps/pull/17

It is highly recommended to consult the CFP, as it contains all the high-level design decisions and mechanism found in these commits. The commit messages themselves only consider low-level details. The main commit is rather large, as I was unable to split it into smaller chunks that would the test suite by themselves. However, it contains a commit message explaining each code chunk in the diff.

Follow-up work not intended to be part of this PR:

- [ ] ~Instead of collecting all matching selectors and every one as a label, extract the least generic available selector (e.g. `matchName: cilium.io` instead of `matchPattern: *`) for a given domain and use that one, as it should reduce identity churn. This requires us to teach the selector cache about selector hierarchy.~
- [ ] ~Pre-allocating an identity for a registered selector, rather than waiting for the first IP to be observed~ https://github.com/cilium/cilium/pull/33068#issuecomment-2173271245
- [x] Update to documentation regarding upgrade impact
- [x] Improve upgrade tests to also cover ToFQDN policies
- [x] Merge https://github.com/cilium/cilium/pull/32872 needed for dropless upgrades


```release-note
Improved performance for DNS lookups (up to 5x reduction in tail latency) when using ToFQDN policies. To avoid drops during upgrades in clusters with ToFQDN policies, it is highly recommended to run Cilium v1.15.6 or newer before upgrading to Cilium v1.16 
```