### PR TITLE
k8s: remove unused policyRepository from k8swatcher

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -502,7 +502,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		d.endpointManager,
 		params.NodeManager,
 		&d,
-		d.policy,
 		d.svc,
 		d.lrpManager,
 		d.bgpSpeaker,

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -48,7 +48,6 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 	"github.com/cilium/cilium/pkg/safetime"
 	"github.com/cilium/cilium/pkg/service"
@@ -128,10 +127,6 @@ type policyManager interface {
 	TriggerPolicyUpdates(force bool, reason string)
 }
 
-type policyRepository interface {
-	GetSelectorCache() *policy.SelectorCache
-}
-
 type svcManager interface {
 	DeleteService(frontend loadbalancer.L3n4Addr) (bool, error)
 	GetDeepCopyServiceByFrontend(frontend loadbalancer.L3n4Addr) (*loadbalancer.SVC, bool)
@@ -191,7 +186,6 @@ type K8sWatcher struct {
 
 	nodeManager           nodeManager
 	policyManager         policyManager
-	policyRepository      policyRepository
 	svcManager            svcManager
 	redirectPolicyManager redirectPolicyManager
 	bgpSpeakerManager     bgpSpeakerManager
@@ -230,7 +224,6 @@ func NewK8sWatcher(
 	endpointManager endpointManager,
 	nodeManager nodeManager,
 	policyManager policyManager,
-	policyRepository policyRepository,
 	svcManager svcManager,
 	redirectPolicyManager redirectPolicyManager,
 	bgpSpeakerManager bgpSpeakerManager,
@@ -252,7 +245,6 @@ func NewK8sWatcher(
 		endpointManager:       endpointManager,
 		nodeManager:           nodeManager,
 		policyManager:         policyManager,
-		policyRepository:      policyRepository,
 		svcManager:            svcManager,
 		ipcache:               ipcache,
 		controllersStarted:    make(chan struct{}),

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -65,17 +65,6 @@ func (f *fakePolicyManager) PolicyDelete(labels labels.LabelArray, opts *policy.
 	panic("OnPolicyDelete(labels.LabelArray, *policy.DeleteOptions) (uint64, error) was called and is not set!")
 }
 
-type fakePolicyRepository struct {
-	OnGetSelectorCache func() *policy.SelectorCache
-}
-
-func (f *fakePolicyRepository) GetSelectorCache() *policy.SelectorCache {
-	if f.OnGetSelectorCache != nil {
-		return f.OnGetSelectorCache()
-	}
-	panic("OnGetSelectorCache() (*policy.SelectorCache) was called and is not set!")
-}
-
 type fakeSvcManager struct {
 	OnDeleteService func(frontend loadbalancer.L3n4Addr) (bool, error)
 	OnUpsertService func(*loadbalancer.SVC) (bool, loadbalancer.ID, error)
@@ -353,7 +342,6 @@ func Test_addK8sSVCs_ClusterIP(t *testing.T) {
 		OnTriggerPolicyUpdates: func(force bool, reason string) {
 		},
 	}
-	policyRepository := &fakePolicyRepository{}
 
 	svcUpsertManagerCalls, svcDeleteManagerCalls := 0, 0
 
@@ -397,7 +385,6 @@ func Test_addK8sSVCs_ClusterIP(t *testing.T) {
 		nil,
 		nil,
 		policyManager,
-		policyRepository,
 		svcManager,
 		nil,
 		nil,
@@ -522,7 +509,6 @@ func TestChangeSVCPort(t *testing.T) {
 		OnTriggerPolicyUpdates: func(force bool, reason string) {
 		},
 	}
-	policyRepository := &fakePolicyRepository{}
 
 	svcUpsertManagerCalls := 0
 
@@ -550,7 +536,6 @@ func TestChangeSVCPort(t *testing.T) {
 		nil,
 		nil,
 		policyManager,
-		policyRepository,
 		svcManager,
 		nil,
 		nil,
@@ -988,8 +973,6 @@ func Test_addK8sSVCs_NodePort(t *testing.T) {
 		OnTriggerPolicyUpdates: func(force bool, reason string) {
 		},
 	}
-	policyRepository := &fakePolicyRepository{}
-
 	svcUpsertManagerCalls, svcDeleteManagerCalls := 0, 0
 
 	svcManager := &fakeSvcManager{
@@ -1032,7 +1015,6 @@ func Test_addK8sSVCs_NodePort(t *testing.T) {
 		nil,
 		nil,
 		policyManager,
-		policyRepository,
 		svcManager,
 		nil,
 		nil,
@@ -1302,7 +1284,6 @@ func Test_addK8sSVCs_GH9576_1(t *testing.T) {
 		OnTriggerPolicyUpdates: func(force bool, reason string) {
 		},
 	}
-	policyRepository := &fakePolicyRepository{}
 
 	svcUpsertManagerCalls, svcDeleteManagerCalls := 0, 0
 	wantSvcUpsertManagerCalls := len(upsert1stWanted) + len(upsert2ndWanted)
@@ -1348,7 +1329,6 @@ func Test_addK8sSVCs_GH9576_1(t *testing.T) {
 		nil,
 		nil,
 		policyManager,
-		policyRepository,
 		svcManager,
 		nil,
 		nil,
@@ -1611,7 +1591,6 @@ func Test_addK8sSVCs_GH9576_2(t *testing.T) {
 		OnTriggerPolicyUpdates: func(force bool, reason string) {
 		},
 	}
-	policyRepository := &fakePolicyRepository{}
 
 	svcUpsertManagerCalls, svcDeleteManagerCalls := 0, 0
 	wantSvcUpsertManagerCalls := len(upsert1stWanted) + len(upsert2ndWanted)
@@ -1657,7 +1636,6 @@ func Test_addK8sSVCs_GH9576_2(t *testing.T) {
 		nil,
 		nil,
 		policyManager,
-		policyRepository,
 		svcManager,
 		nil,
 		nil,
@@ -2522,7 +2500,6 @@ func Test_addK8sSVCs_ExternalIPs(t *testing.T) {
 		OnTriggerPolicyUpdates: func(force bool, reason string) {
 		},
 	}
-	policyRepository := &fakePolicyRepository{}
 
 	svcUpsertManagerCalls, svcDeleteManagerCalls := 0, 0
 
@@ -2580,7 +2557,6 @@ func Test_addK8sSVCs_ExternalIPs(t *testing.T) {
 		nil,
 		nil,
 		policyManager,
-		policyRepository,
 		svcManager,
 		nil,
 		nil,
@@ -2626,7 +2602,6 @@ func Test_No_Resources_InitK8sSubsystem(t *testing.T) {
 	w := NewK8sWatcher(
 		fakeClientSet,
 		&synced.Resources{},
-		nil,
 		nil,
 		nil,
 		nil,

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -45,10 +45,6 @@ func NewPolicyCache(repo *Repository, subscribe bool) *PolicyCache {
 	return cache
 }
 
-func (cache *PolicyCache) GetSelectorCache() *SelectorCache {
-	return cache.repo.GetSelectorCache()
-}
-
 // lookupOrCreate adds the specified Identity to the policy cache, with a reference
 // from the specified Endpoint, then returns the threadsafe copy of the policy.
 func (cache *PolicyCache) lookupOrCreate(identity *identityPkg.Identity, create bool) SelectorPolicy {


### PR DESCRIPTION
This commit removes the unused field and interface `policyRepository` from the k8sWatcher.