### PR TITLE
bgpv2: update multi-homing lab to use config overrides

### DIFF
--- a/contrib/containerlab/bgpv2/multi-homing/bgp.yaml
+++ b/contrib/containerlab/bgpv2/multi-homing/bgp.yaml
@@ -13,12 +13,12 @@ spec:
     peers:
     - name: "65000"
       peerASN: 65000
-      peerAddress: fd00:10:0:1::1
+      peerAddress: fd00:10:0:0::1
       peerConfigRef:
         name: "cilium-peer"
     - name: "65011"
       peerASN: 65011
-      peerAddress: fd00:11:0:1::1
+      peerAddress: fd00:11:0:0::1
       peerConfigRef:
         name: "cilium-peer"
 
@@ -57,3 +57,33 @@ spec:
       attributes:
         communities:
           wellKnown: [ "no-export" ]
+
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPNodeConfigOverride
+metadata:
+  name: bgpv2-cplane-dev-multi-homing-control-plane
+spec:
+  bgpInstances:
+    - name: "65001"
+      routerID: "1.2.3.4"
+      peers:
+        - name: "65000"
+          localAddress: fd00:10:0:1::2
+        - name: "65011"
+          localAddress: fd00:11:0:1::2
+
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPNodeConfigOverride
+metadata:
+  name: bgpv2-cplane-dev-multi-homing-worker
+spec:
+  bgpInstances:
+    - name: "65001"
+      routerID: "5.6.7.8"
+      peers:
+        - name: "65000"
+          localAddress: fd00:10:0:2::2
+        - name: "65011"
+          localAddress: fd00:11:0:2::2

--- a/contrib/containerlab/bgpv2/multi-homing/topo.yaml
+++ b/contrib/containerlab/bgpv2/multi-homing/topo.yaml
@@ -11,6 +11,9 @@ topology:
         - ip addr add 10.0.2.1/24 dev net1
         - ip addr add 10.0.3.1/24 dev net2
         - sysctl net.ipv6.conf.all.forwarding=1
+        - ip link add name loopback type dummy
+        - ip link set dev loopback up
+        - ip addr add fd00:10:0:0::1/128 dev loopback
         - ip addr add fd00:10:0:1::1/64 dev net0
         - ip addr add fd00:10:0:2::1/64 dev net1
         - ip addr add fd00:10:0:3::1/64 dev net2
@@ -48,6 +51,9 @@ topology:
         - ip addr add 10.11.2.1/24 dev net1
         - ip addr add 10.11.3.1/24 dev net2
         - sysctl net.ipv6.conf.all.forwarding=1
+        - ip link add name loopback type dummy
+        - ip link set dev loopback up
+        - ip addr add fd00:11:0:0::1/128 dev loopback
         - ip addr add fd00:11:0:1::1/64 dev net0
         - ip addr add fd00:11:0:2::1/64 dev net1
         - ip addr add fd00:11:0:3::1/64 dev net2
@@ -91,6 +97,8 @@ topology:
         - ip route append 10.0.0.0/8 via 10.11.1.1 dev net1
         - ip route add fd00::/16 via fd00:10:0:1::1 dev net0
         - ip route append fd00::/16 via fd00:11:0:1::1 dev net1
+        - ip route add fd00:10:0:0::1/128 via fd00:10:0:1::1 dev net0
+        - ip route add fd00:11:0:0::1/128 via fd00:11:0:1::1 dev net1
     # Server with Cilium. It shares netns with kind node.
     server1:
       kind: linux
@@ -106,6 +114,8 @@ topology:
         - ip route append 10.0.0.0/8 via 10.11.2.1 dev net1
         - ip route add fd00::/16 via fd00:10:0:2::1 dev net0
         - ip route append fd00::/16 via fd00:11:0:2::1 dev net1
+        - ip route add fd00:10:0:0::1/128 via fd00:10:0:2::1 dev net0
+        - ip route add fd00:11:0:0::1/128 via fd00:11:0:2::1 dev net1
     # Server without Cilium. Useful for testing connectivity.
     server2:
       kind: linux


### PR DESCRIPTION
There are two changes to multi-homing container lab
- Use loopback address on FRR side for peering.
- Add example of CiliumBGPNodeConfigOverride resource to set custom router-id and local peering address.
