### PR TITLE
helm: Remove CILIUM_BRANCH variable

### DIFF
--- a/contrib/release/pull-docker-manifests.sh
+++ b/contrib/release/pull-docker-manifests.sh
@@ -68,7 +68,6 @@ main() {
     run_url_id="$(basename "${1}")"
     ersion="$(echo ${2:-$(cat VERSION)} | sed 's/^v//')"
     version="v${ersion}"
-    branch=$(echo $version | sed 's/.*v\([0-9]\+\.[0-9]\+\).*/\1/')
     username=$(get_user_remote ${3:-})
     upstream_remote="$(get_remote)"
 
@@ -82,11 +81,7 @@ main() {
     >&2 echo "Adding image SHAs to install/kubernetes/Makefile.digests"
     >&2 echo ""
     cp "${makefile_digest}" "${PWD}/install/kubernetes/Makefile.digests"
-    CILIUM_BRANCH="main"
-    if git branch -a | grep -q "${upstream_remote}/v${branch}$"; then
-        CILIUM_BRANCH="v${branch}"
-    fi
-    make -C install/kubernetes/ CILIUM_BRANCH=${CILIUM_BRANCH} RELEASE=yes
+    make -C install/kubernetes/ RELEASE=yes
 
     >&2 echo "Generating manifest text for release notes"
     >&2 echo ""

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -88,7 +88,7 @@ main() {
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
     sed -i 's/"[^"]*"/""/g' install/kubernetes/Makefile.digests
-    logrun make RELEASE=yes CILIUM_BRANCH="$branch" -C install/kubernetes all USE_DIGESTS=false
+    logrun make RELEASE=yes -C install/kubernetes all USE_DIGESTS=false
     if grep -q update-helm-values Documentation/Makefile; then
         logrun make -C Documentation update-helm-values
     fi

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -47,7 +47,7 @@ update-chart: $(ROOT_DIR)/VERSION # Update chart versions to point to the curren
 	$(ECHO_GEN)cilium/Chart.yaml
 	$(QUIET)grep -lR -e 'version:' -e 'appVersion:' $(CILIUM_CHARTS)/ \
 		| xargs -L 1 $(SED) -i -e 's/'$(CILIUM_CHART_REGEX)'/\1 '$(VERSION)'/g'
-	$(QUIET)$(SED) -i 's;icon:.*;icon: $(LOGO_BASE_URL)/cilium@$(CILIUM_BRANCH)/$(LOGO_PATH);' $(CHART_FILE)
+	$(QUIET)$(SED) -i 's;icon:.*;icon: $(LOGO_BASE_URL)/cilium@main/$(LOGO_PATH);' $(CHART_FILE)
 
 check-values-yaml: cilium/values.schema.json
 	$(ECHO_CHECK) $@

--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -16,7 +16,6 @@ ifeq ($(RELEASE),yes)
     export CLUSTERMESH_APISERVER_REPO:=${RELEASE_REGISTRY}/${RELEASE_ORG}/clustermesh-apiserver
     export HUBBLE_RELAY_REPO:=${RELEASE_REGISTRY}/${RELEASE_ORG}/hubble-relay
 else
-    export CILIUM_BRANCH:=main
     export PULL_POLICY:=Always
     export CILIUM_REPO:=${CI_REGISTRY}/${CI_ORG}/cilium-ci
     export CILIUM_OPERATOR_BASE_REPO:=${CI_REGISTRY}/${CI_ORG}/operator
@@ -24,10 +23,6 @@ else
     export CILIUM_VERSION:=latest
     export CLUSTERMESH_APISERVER_REPO:=${CI_REGISTRY}/${CI_ORG}/clustermesh-apiserver-ci
     export HUBBLE_RELAY_REPO:=${CI_REGISTRY}/${CI_ORG}/hubble-relay-ci
-endif
-
-ifndef CILIUM_BRANCH
-$(error "CILIUM_BRANCH needs to be defined")
 endif
 
 export CERTGEN_REPO:=quay.io/cilium/certgen


### PR DESCRIPTION
This variable is only used to construct the URL for Cilium icon. Remove CILIUM_BRANCH variable and always use the icon in the main branch [^1] so that there is one less thing to update when you create a stable branch from main. Also, one could potentially argue it's better to have a single up-to-date icon image for all the Helm charts.

[^1]: https://github.com/cilium/cilium/blob/main/Documentation/images/logo-solo.svg