### PR TITLE
config: remove ingress & gateway api leftovers from global agent config

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -353,12 +353,6 @@ const (
 	// EnableIPv4EgressGateway enables the IPv4 egress gateway
 	EnableIPv4EgressGateway = "enable-ipv4-egress-gateway"
 
-	// EnableIngressController enables Ingress Controller
-	EnableIngressController = "enable-ingress-controller"
-
-	// EnableGatewayAPI enables Gateway API support
-	EnableGatewayAPI = "enable-gateway-api"
-
 	// EnableEnvoyConfig enables processing of CiliumClusterwideEnvoyConfig and CiliumEnvoyConfig CRDs
 	EnableEnvoyConfig = "enable-envoy-config"
 
@@ -1690,8 +1684,6 @@ type DaemonConfig struct {
 	EnableBPFClockProbe     bool
 	EnableIPv4EgressGateway bool
 	EnableEnvoyConfig       bool
-	EnableIngressController bool
-	EnableGatewayAPI        bool
 	InstallIptRules         bool
 	MonitorAggregation      string
 	PreAllocateMaps         bool
@@ -2637,16 +2629,6 @@ func (c *DaemonConfig) K8sNetworkPolicyEnabled() bool {
 	return c.EnableK8sNetworkPolicy
 }
 
-// K8sIngressControllerEnabled returns true if ingress controller feature is enabled in Cilium
-func (c *DaemonConfig) K8sIngressControllerEnabled() bool {
-	return c.EnableIngressController
-}
-
-// K8sGatewayAPIEnabled returns true if Gateway API feature is enabled in Cilium
-func (c *DaemonConfig) K8sGatewayAPIEnabled() bool {
-	return c.EnableGatewayAPI
-}
-
 func (c *DaemonConfig) PolicyCIDRMatchesNodes() bool {
 	for _, mode := range c.PolicyCIDRMatchMode {
 		if mode == "nodes" {
@@ -3044,8 +3026,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableIPMasqAgent = vp.GetBool(EnableIPMasqAgent)
 	c.EnableIPv4EgressGateway = vp.GetBool(EnableIPv4EgressGateway)
 	c.EnableEnvoyConfig = vp.GetBool(EnableEnvoyConfig)
-	c.EnableIngressController = vp.GetBool(EnableIngressController)
-	c.EnableGatewayAPI = vp.GetBool(EnableGatewayAPI)
 	c.IPMasqAgentConfigPath = vp.GetString(IPMasqAgentConfigPath)
 	c.InstallIptRules = vp.GetBool(InstallIptRules)
 	c.IPSecKeyFile = vp.GetString(IPSecKeyFileName)
@@ -3720,12 +3700,9 @@ func (c *DaemonConfig) checkIPAMDelegatedPlugin() error {
 		if c.EnableEndpointHealthChecking {
 			return fmt.Errorf("--%s must be disabled with --%s=%s", EnableEndpointHealthChecking, IPAM, ipamOption.IPAMDelegatedPlugin)
 		}
-		// Ingress controller and envoy config require cilium-agent to create an IP address
-		// specifically for differentiating ingress and envoy traffic, which is not possible
+		// envoy config (Ingress, Gateway API, ...) require cilium-agent to create an IP address
+		// specifically for differentiating envoy traffic, which is not possible
 		// with delegated IPAM.
-		if c.EnableIngressController {
-			return fmt.Errorf("--%s must be disabled with --%s=%s", EnableIngressController, IPAM, ipamOption.IPAMDelegatedPlugin)
-		}
 		if c.EnableEnvoyConfig {
 			return fmt.Errorf("--%s must be disabled with --%s=%s", EnableEnvoyConfig, IPAM, ipamOption.IPAMDelegatedPlugin)
 		}

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -707,14 +707,6 @@ func TestCheckIPAMDelegatedPlugin(t *testing.T) {
 			expectErr: fmt.Errorf("--local-router-ipv6 must be provided when IPv6 is enabled with --ipam=delegated-plugin"),
 		},
 		{
-			name: "IPAMDelegatedPlugin with ingress controller enabled",
-			d: &DaemonConfig{
-				IPAM:                    ipamOption.IPAMDelegatedPlugin,
-				EnableIngressController: true,
-			},
-			expectErr: fmt.Errorf("--enable-ingress-controller must be disabled with --ipam=delegated-plugin"),
-		},
-		{
 			name: "IPAMDelegatedPlugin with envoy config enabled",
 			d: &DaemonConfig{
 				IPAM:              ipamOption.IPAMDelegatedPlugin,


### PR DESCRIPTION
After moving all of the Ingress Controller & Gateway API logic into dedicated Hive Cells with their own configs, the leftovers in the global config of the Cilium Agent can be removed.

The only use of of the config whether Ingress Controller is enabled, is during the IPAMDelegatedPlugin validation.

I think it's ok to remove this check and just keep the one that checks that the IPAMDelegate Plugin is disabled when CiliumEnvoyConfig is enabled. This is implicitly the case if Ingress Controller and/or Gateway API are enabled. Gateway API wasn't explicitly covered anyway.

Therefore, this commit removes the config properties from the global Agent config.

Note: Requesting explicit review from @cilium/sig-servicemesh 