### PR TITLE
ClusterMesh: improve validation of remote endpoints and identities

### DIFF
--- a/cilium-dbg/cmd/preflight_identity_crd_migrate.go
+++ b/cilium-dbg/cmd/preflight_identity_crd_migrate.go
@@ -268,7 +268,7 @@ func getKVStoreIdentities(ctx context.Context, kvstoreBackend allocator.Backend)
 	stopChan := make(chan struct{})
 
 	go kvstoreBackend.ListAndWatch(ctx, kvstoreListHandler{
-		onAdd: func(id idpool.ID, key allocator.AllocatorKey) {
+		onUpsert: func(id idpool.ID, key allocator.AllocatorKey) {
 			log.Debugf("kvstore listed ID: %+v -> %+v", id, key)
 			identities[id] = key
 		},
@@ -293,11 +293,10 @@ func getKVStoreIdentities(ctx context.Context, kvstoreBackend allocator.Backend)
 
 // kvstoreListHandler is a dummy type to receive callbacks from the kvstore subsystem
 type kvstoreListHandler struct {
-	onAdd      func(id idpool.ID, key allocator.AllocatorKey)
+	onUpsert   func(id idpool.ID, key allocator.AllocatorKey)
 	onListDone func()
 }
 
 func (h kvstoreListHandler) OnListDone()                                       { h.onListDone() }
-func (h kvstoreListHandler) OnAdd(id idpool.ID, key allocator.AllocatorKey)    { h.onAdd(id, key) }
-func (h kvstoreListHandler) OnModify(id idpool.ID, key allocator.AllocatorKey) {}
+func (h kvstoreListHandler) OnUpsert(id idpool.ID, key allocator.AllocatorKey) { h.onUpsert(id, key) }
 func (h kvstoreListHandler) OnDelete(id idpool.ID, key allocator.AllocatorKey) {}

--- a/cilium-dbg/cmd/preflight_identity_crd_migrate.go
+++ b/cilium-dbg/cmd/preflight_identity_crd_migrate.go
@@ -230,8 +230,8 @@ func initK8s(ctx context.Context, clientset k8sClient.Clientset, resources agent
 	//
 	// FIXME: add options to handle clustermesh with this constructor parameter:
 	//    allocator.WithPrefixMask(idpool.ID(option.Config.ClusterID<<identity.ClusterIDShift)))
-	minID := idpool.ID(identity.GetMinimalAllocationIdentity())
-	maxID := idpool.ID(identity.GetMaximumAllocationIdentity())
+	minID := idpool.ID(identity.GetMinimalAllocationIdentity(option.Config.ClusterID))
+	maxID := idpool.ID(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))
 	crdAllocator, err = allocator.NewAllocator(&cacheKey.GlobalIdentity{}, crdBackend,
 		allocator.WithMax(maxID), allocator.WithMin(minID))
 	if err != nil {

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgp/speaker"
 	"github.com/cilium/cilium/pkg/cgroups/manager"
 	"github.com/cilium/cilium/pkg/clustermesh"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
@@ -133,6 +134,7 @@ type Daemon struct {
 	// programs.
 	compilationLock datapath.CompilationLock
 
+	clusterInfo cmtypes.ClusterInfo
 	clustermesh *clustermesh.ClusterMesh
 
 	mtuConfig mtu.MTU
@@ -437,6 +439,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		egressGatewayManager: params.EgressGatewayManager,
 		ipamMetadata:         params.IPAMMetadataManager,
 		cniConfigManager:     params.CNIConfigManager,
+		clusterInfo:          params.ClusterInfo,
 		clustermesh:          params.ClusterMesh,
 		monitorAgent:         params.MonitorAgent,
 		svc:                  params.ServiceManager,

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -129,7 +129,7 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 			ID:   uint16(i),
 			IPv4: netip.MustParseAddr(fmt.Sprintf("10.96.%d.%d", i/256, i%256)),
 			SecurityIdentity: &identity.Identity{
-				ID: identity.NumericIdentity(i % int(identity.GetMaximumAllocationIdentity())),
+				ID: identity.NumericIdentity(i % int(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))),
 			},
 			DNSZombies: &fqdn.DNSZombieMappings{
 				Mutex: lock.Mutex{},

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -742,8 +742,8 @@ func (d *Daemon) getStatus(brief bool) models.StatusResponse {
 
 func (d *Daemon) getIdentityRange() *models.IdentityRange {
 	s := &models.IdentityRange{
-		MinIdentity: int64(identity.GetMinimalAllocationIdentity()),
-		MaxIdentity: int64(identity.GetMaximumAllocationIdentity()),
+		MinIdentity: int64(identity.GetMinimalAllocationIdentity(d.clusterInfo.ID)),
+		MaxIdentity: int64(identity.GetMaximumAllocationIdentity(d.clusterInfo.ID)),
 	}
 
 	return s

--- a/operator/cmd/kvstore_watchdog.go
+++ b/operator/cmd/kvstore_watchdog.go
@@ -67,8 +67,8 @@ func startKvstoreWatchdog() {
 		log.WithError(err).Fatal("Unable to initialize kvstore backend for identity garbage collection")
 	}
 
-	minID := idpool.ID(identity.GetMinimalAllocationIdentity())
-	maxID := idpool.ID(identity.GetMaximumAllocationIdentity())
+	minID := idpool.ID(identity.GetMinimalAllocationIdentity(option.Config.ClusterID))
+	maxID := idpool.ID(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))
 	a := allocator.NewAllocatorForGC(backend, allocator.WithMin(minID), allocator.WithMax(maxID))
 
 	keysToDelete := map[string]kvstore.Value{}

--- a/operator/identitygc/kvstore_gc.go
+++ b/operator/identitygc/kvstore_gc.go
@@ -27,8 +27,8 @@ func (igc *GC) startKVStoreModeGC(ctx context.Context) error {
 		return fmt.Errorf("unable to initialize kvstore backend for identity allocation")
 	}
 
-	minID := idpool.ID(ciliumIdentity.GetMinimalAllocationIdentity())
-	maxID := idpool.ID(ciliumIdentity.GetMaximumAllocationIdentity())
+	minID := idpool.ID(ciliumIdentity.GetMinimalAllocationIdentity(igc.clusterInfo.ID))
+	maxID := idpool.ID(ciliumIdentity.GetMaximumAllocationIdentity(igc.clusterInfo.ID))
 	log.WithFields(map[string]interface{}{
 		"min":        minID,
 		"max":        maxID,

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -151,6 +151,10 @@ type Allocator struct {
 	// disableAutostart prevents starting the allocator when it is initialized
 	disableAutostart bool
 
+	// cacheValidators implement extra validations of retrieved identities, e.g.,
+	// to ensure that they belong to the expected range.
+	cacheValidators []CacheValidator
+
 	// backend is the upstream, shared, backend to which we syncronize local
 	// information
 	backend Backend
@@ -158,6 +162,10 @@ type Allocator struct {
 
 // AllocatorOption is the base type for allocator options
 type AllocatorOption func(*Allocator)
+
+// CacheValidator is the type of the validation functions triggered to filter out
+// invalid notification events.
+type CacheValidator func(kind AllocatorChangeKind, id idpool.ID, key AllocatorKey) error
 
 // NewAllocatorForGC returns an allocator that can be used to run RunGC()
 //
@@ -398,6 +406,12 @@ func WithoutGC() AllocatorOption {
 // WithoutAutostart prevents starting the allocator when it is initialized
 func WithoutAutostart() AllocatorOption {
 	return func(a *Allocator) { a.disableAutostart = true }
+}
+
+// WithCacheValidator registers a validator triggered for each identity
+// notification event to filter out invalid IDs and keys.
+func WithCacheValidator(validator CacheValidator) AllocatorOption {
+	return func(a *Allocator) { a.cacheValidators = append(a.cacheValidators, validator) }
 }
 
 // GetEvents returns the events channel given to the allocator when

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -905,8 +905,8 @@ type AllocatorEventSendChan = chan<- AllocatorEvent
 
 // AllocatorEvent is an event sent over AllocatorEventChan
 type AllocatorEvent struct {
-	// Typ is the type of event (create / modify / delete)
-	Typ kvstore.EventType
+	// Typ is the type of event (upsert / delete)
+	Typ AllocatorChangeKind
 
 	// ID is the allocated ID
 	ID idpool.ID

--- a/pkg/allocator/cache.go
+++ b/pkg/allocator/cache.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/idpool"
-	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -88,12 +87,10 @@ type CacheMutations interface {
 	// OnListDone is called when the initial full-sync is complete.
 	OnListDone()
 
-	// OnAdd is called when a new key->ID appears.
-	OnAdd(id idpool.ID, key AllocatorKey)
-
-	// OnModify is called when a key->ID mapping is modified. This may happen
-	// when leases are updated, and does not mean the actual mapping had changed.
-	OnModify(id idpool.ID, key AllocatorKey)
+	// OnUpsert is called when either a new key->ID mapping appears or an existing
+	// one is modified. The latter case may occur e.g., when leases are updated,
+	// and does not mean that the actual mapping had changed.
+	OnUpsert(id idpool.ID, key AllocatorKey)
 
 	// OnDelete is called when a key->ID mapping is removed. This may trigger
 	// master-key protection, if enabled, where the local allocator will recreate
@@ -102,7 +99,7 @@ type CacheMutations interface {
 	OnDelete(id idpool.ID, key AllocatorKey)
 }
 
-func (c *cache) sendEvent(typ kvstore.EventType, id idpool.ID, key AllocatorKey) {
+func (c *cache) sendEvent(typ AllocatorChangeKind, id idpool.ID, key AllocatorKey) {
 	if events := c.allocator.events; events != nil {
 		events <- AllocatorEvent{Typ: typ, ID: id, Key: key}
 	}
@@ -123,22 +120,7 @@ func (c *cache) OnListDone() {
 	close(c.listDone)
 }
 
-func (c *cache) OnAdd(id idpool.ID, key AllocatorKey) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	c.nextCache[id] = key
-	if key != nil {
-		c.nextKeyCache[c.allocator.encodeKey(key)] = id
-	}
-	c.allocator.idPool.Remove(id)
-
-	c.emitChange(AllocatorChange{Kind: AllocatorChangeUpsert, ID: id, Key: key})
-
-	c.sendEvent(kvstore.EventTypeCreate, id, key)
-}
-
-func (c *cache) OnModify(id idpool.ID, key AllocatorKey) {
+func (c *cache) OnUpsert(id idpool.ID, key AllocatorKey) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -151,9 +133,11 @@ func (c *cache) OnModify(id idpool.ID, key AllocatorKey) {
 		c.nextKeyCache[c.allocator.encodeKey(key)] = id
 	}
 
+	c.allocator.idPool.Remove(id)
+
 	c.emitChange(AllocatorChange{Kind: AllocatorChangeUpsert, ID: id, Key: key})
 
-	c.sendEvent(kvstore.EventTypeModify, id, key)
+	c.sendEvent(AllocatorChangeUpsert, id, key)
 }
 
 func (c *cache) OnDelete(id idpool.ID, key AllocatorKey) {
@@ -222,7 +206,7 @@ func (c *cache) onDeleteLocked(id idpool.ID, key AllocatorKey, recreateMissingLo
 
 	c.emitChange(AllocatorChange{Kind: AllocatorChangeDelete, ID: id, Key: key})
 
-	c.sendEvent(kvstore.EventTypeDelete, id, key)
+	c.sendEvent(AllocatorChangeDelete, id, key)
 }
 
 // start requests a LIST operation from the kvstore and starts watching the

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -91,7 +91,7 @@ type RemoteIdentityWatcher interface {
 	// identity cache. remoteName should be unique unless replacing an existing
 	// remote's backend. When cachedPrefix is set, identities are assumed to be
 	// stored under the "cilium/cache" prefix, and the watcher is adapted accordingly.
-	WatchRemoteIdentities(remoteName string, backend kvstore.BackendOperations, cachedPrefix bool) (*allocator.RemoteCache, error)
+	WatchRemoteIdentities(remoteName string, remoteID uint32, backend kvstore.BackendOperations, cachedPrefix bool) (*allocator.RemoteCache, error)
 
 	// RemoveRemoteIdentities removes any reference to a remote identity source,
 	// emitting a deletion event for all previously known identities.

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -79,7 +79,7 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 		return
 	}
 
-	remoteIdentityCache, err := rc.mesh.conf.RemoteIdentityWatcher.WatchRemoteIdentities(rc.name, backend, config.Capabilities.Cached)
+	remoteIdentityCache, err := rc.mesh.conf.RemoteIdentityWatcher.WatchRemoteIdentities(rc.name, rc.clusterID, backend, config.Capabilities.Cached)
 	if err != nil {
 		ready <- err
 		close(ready)

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -78,7 +78,7 @@ func TestRemoteClusterRun(t *testing.T) {
 			kvs: map[string]string{
 				"cilium/state/nodes/v1/foo/bar":        `{"name": "bar", "cluster": "foo", "clusterID": 1}`,
 				"cilium/state/services/v1/foo/baz/bar": `{"name": "bar", "namespace": "baz", "cluster": "foo", "clusterID": 1}`,
-				"cilium/state/identities/v1/id/9999":   `key1=value1;key2=value2`,
+				"cilium/state/identities/v1/id/65538":  `key1=value1;key2=value2;k8s:io.cilium.k8s.policy.cluster=foo`,
 				"cilium/state/ip/v1/default/1.1.1.1":   `{"IP": "1.1.1.1"}`,
 			},
 		},
@@ -92,10 +92,10 @@ func TestRemoteClusterRun(t *testing.T) {
 				},
 			},
 			kvs: map[string]string{
-				"cilium/state/nodes/v1/foo/bar":        `{"name": "bar", "cluster": "foo", "clusterID": 255}`,
-				"cilium/state/services/v1/foo/baz/bar": `{"name": "bar", "namespace": "baz", "cluster": "foo", "clusterID": 255}`,
-				"cilium/state/identities/v1/id/9999":   `key1=value1;key2=value2`,
-				"cilium/state/ip/v1/default/1.1.1.1":   `{"IP": "1.1.1.1"}`,
+				"cilium/state/nodes/v1/foo/bar":          `{"name": "bar", "cluster": "foo", "clusterID": 255}`,
+				"cilium/state/services/v1/foo/baz/bar":   `{"name": "bar", "namespace": "baz", "cluster": "foo", "clusterID": 255}`,
+				"cilium/state/identities/v1/id/16711681": `key1=value1;key2=value2;k8s:io.cilium.k8s.policy.cluster=foo`,
+				"cilium/state/ip/v1/default/1.1.1.1":     `{"IP": "1.1.1.1"}`,
 
 				"cilium/synced/foo/cilium/state/nodes/v1":      "true",
 				"cilium/synced/foo/cilium/state/services/v1":   "true",
@@ -114,10 +114,10 @@ func TestRemoteClusterRun(t *testing.T) {
 				},
 			},
 			kvs: map[string]string{
-				"cilium/cache/nodes/v1/foo/bar":          `{"name": "bar", "cluster": "foo", "clusterID": 255}`,
-				"cilium/cache/services/v1/foo/baz/bar":   `{"name": "bar", "namespace": "baz", "cluster": "foo", "clusterID": 255}`,
-				"cilium/cache/identities/v1/foo/id/9999": `key1=value1;key2=value2`,
-				"cilium/cache/ip/v1/foo/1.1.1.1":         `{"IP": "1.1.1.1"}`,
+				"cilium/cache/nodes/v1/foo/bar":              `{"name": "bar", "cluster": "foo", "clusterID": 255}`,
+				"cilium/cache/services/v1/foo/baz/bar":       `{"name": "bar", "namespace": "baz", "cluster": "foo", "clusterID": 255}`,
+				"cilium/cache/identities/v1/foo/id/16711681": `key1=value1;key2=value2;k8s:io.cilium.k8s.policy.cluster=foo`,
+				"cilium/cache/ip/v1/foo/1.1.1.1":             `{"IP": "1.1.1.1"}`,
 
 				"cilium/synced/foo/cilium/cache/nodes/v1":      "true",
 				"cilium/synced/foo/cilium/cache/services/v1":   "true",

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -182,7 +182,7 @@ func testEventWatcherBatching(t *testing.T) {
 
 	for i := 1024; i < 1034; i++ {
 		events <- allocator.AllocatorEvent{
-			Typ: kvstore.EventTypeCreate,
+			Typ: allocator.AllocatorChangeUpsert,
 			ID:  idpool.ID(i),
 			Key: key,
 		}
@@ -191,21 +191,21 @@ func testEventWatcherBatching(t *testing.T) {
 	require.EqualValues(t, lbls.LabelArray(), owner.GetIdentity(identity.NumericIdentity(1033)))
 	for i := 1024; i < 1034; i++ {
 		events <- allocator.AllocatorEvent{
-			Typ: kvstore.EventTypeDelete,
+			Typ: allocator.AllocatorChangeDelete,
 			ID:  idpool.ID(i),
 		}
 	}
 	require.NotEqual(t, 0, owner.WaitUntilID(1033))
 	for i := 2048; i < 2058; i++ {
 		events <- allocator.AllocatorEvent{
-			Typ: kvstore.EventTypeCreate,
+			Typ: allocator.AllocatorChangeUpsert,
 			ID:  idpool.ID(i),
 			Key: key,
 		}
 	}
 	for i := 2048; i < 2053; i++ {
 		events <- allocator.AllocatorEvent{
-			Typ: kvstore.EventTypeDelete,
+			Typ: allocator.AllocatorChangeDelete,
 			ID:  idpool.ID(i),
 		}
 	}
@@ -214,7 +214,7 @@ func testEventWatcherBatching(t *testing.T) {
 
 	for i := 2053; i < 2058; i++ {
 		events <- allocator.AllocatorEvent{
-			Typ: kvstore.EventTypeDelete,
+			Typ: allocator.AllocatorChangeDelete,
 			ID:  idpool.ID(i),
 		}
 	}

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -166,8 +166,8 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 
 	log.Info("Initializing identity allocator")
 
-	minID := idpool.ID(identity.GetMinimalAllocationIdentity())
-	maxID := idpool.ID(identity.GetMaximumAllocationIdentity())
+	minID := idpool.ID(identity.GetMinimalAllocationIdentity(option.Config.ClusterID))
+	maxID := idpool.ID(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))
 
 	log.WithFields(map[string]interface{}{
 		"min":        minID,

--- a/pkg/identity/cache/local.go
+++ b/pkg/identity/cache/local.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/idpool"
-	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -138,7 +137,7 @@ func (l *localIdentityCache) lookupOrCreate(lbls labels.Labels, oldNID identity.
 
 	if l.events != nil && notifyOwner {
 		l.events <- allocator.AllocatorEvent{
-			Typ: kvstore.EventTypeCreate,
+			Typ: allocator.AllocatorChangeUpsert,
 			ID:  idpool.ID(id.ID),
 			Key: &key.GlobalIdentity{LabelArray: id.LabelArray},
 		}
@@ -168,7 +167,7 @@ func (l *localIdentityCache) release(id *identity.Identity, notifyOwner bool) bo
 
 			if l.events != nil && notifyOwner {
 				l.events <- allocator.AllocatorEvent{
-					Typ: kvstore.EventTypeDelete,
+					Typ: allocator.AllocatorChangeDelete,
 					ID:  idpool.ID(id.ID),
 				}
 			}

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -5,6 +5,7 @@ package identity
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"strconv"
 
@@ -74,10 +75,14 @@ func (pair *IPIdentityPair) GetKeyName() string { return pair.PrefixString() }
 func (pair *IPIdentityPair) Marshal() ([]byte, error) { return json.Marshal(pair) }
 
 // Unmarshal parses the JSON byte slice and updates the IPIdentityPair receiver
-func (pair *IPIdentityPair) Unmarshal(_ string, data []byte) error {
+func (pair *IPIdentityPair) Unmarshal(key string, data []byte) error {
 	newPair := IPIdentityPair{}
 	if err := json.Unmarshal(data, &newPair); err != nil {
 		return err
+	}
+
+	if got := newPair.GetKeyName(); got != key {
+		return fmt.Errorf("IP address does not match key: expected %s, got %s", key, got)
 	}
 
 	*pair = newPair

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -406,19 +406,19 @@ func initClusterIDShift() {
 
 // GetMinimalNumericIdentity returns the minimal numeric identity not used for
 // reserved purposes.
-func GetMinimalAllocationIdentity() NumericIdentity {
-	if option.Config.ClusterID > 0 {
+func GetMinimalAllocationIdentity(clusterID uint32) NumericIdentity {
+	if clusterID > 0 {
 		// For ClusterID > 0, the identity range just starts from cluster shift,
 		// no well-known-identities need to be reserved from the range.
-		return NumericIdentity((1 << GetClusterIDShift()) * option.Config.ClusterID)
+		return NumericIdentity((1 << GetClusterIDShift()) * clusterID)
 	}
 	return MinimalNumericIdentity
 }
 
 // GetMaximumAllocationIdentity returns the maximum numeric identity that
 // should be handed out by the identity allocator.
-func GetMaximumAllocationIdentity() NumericIdentity {
-	return NumericIdentity((1<<GetClusterIDShift())*(option.Config.ClusterID+1) - 1)
+func GetMaximumAllocationIdentity(clusterID uint32) NumericIdentity {
+	return NumericIdentity((1<<GetClusterIDShift())*(clusterID+1) - 1)
 }
 
 var (

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -367,7 +367,7 @@ func (c *crdBackend) ListAndWatch(ctx context.Context, handler allocator.CacheMu
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				if oldIdentity, ok := newObj.(*v2.CiliumIdentity); ok {
+				if oldIdentity, ok := oldObj.(*v2.CiliumIdentity); ok {
 					if newIdentity, ok := newObj.(*v2.CiliumIdentity); ok {
 						if oldIdentity.DeepEqual(newIdentity) {
 							return

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -362,7 +362,7 @@ func (c *crdBackend) ListAndWatch(ctx context.Context, handler allocator.CacheMu
 			AddFunc: func(obj interface{}) {
 				if identity, ok := obj.(*v2.CiliumIdentity); ok {
 					if id, err := strconv.ParseUint(identity.Name, 10, 64); err == nil {
-						handler.OnAdd(idpool.ID(id), c.KeyFunc(identity.SecurityLabels))
+						handler.OnUpsert(idpool.ID(id), c.KeyFunc(identity.SecurityLabels))
 					}
 				}
 			},
@@ -373,7 +373,7 @@ func (c *crdBackend) ListAndWatch(ctx context.Context, handler allocator.CacheMu
 							return
 						}
 						if id, err := strconv.ParseUint(newIdentity.Name, 10, 64); err == nil {
-							handler.OnModify(idpool.ID(id), c.KeyFunc(newIdentity.SecurityLabels))
+							handler.OnUpsert(idpool.ID(id), c.KeyFunc(newIdentity.SecurityLabels))
 						}
 					}
 				}

--- a/pkg/k8s/identitybackend/identity_test.go
+++ b/pkg/k8s/identitybackend/identity_test.go
@@ -85,19 +85,12 @@ func TestSanitizeK8sLabels(t *testing.T) {
 }
 
 type FakeHandler struct {
-	onAddFunc func()
+	onUpsertFunc func()
 }
 
 func (f FakeHandler) OnListDone() {}
 
-func (f FakeHandler) OnAdd(id idpool.ID, key allocator.AllocatorKey) {
-	if f.onAddFunc != nil {
-		f.onAddFunc()
-	}
-}
-
-func (f FakeHandler) OnModify(id idpool.ID, key allocator.AllocatorKey) {}
-
+func (f FakeHandler) OnUpsert(id idpool.ID, key allocator.AllocatorKey) { f.onUpsertFunc() }
 func (f FakeHandler) OnDelete(id idpool.ID, key allocator.AllocatorKey) {}
 
 func getLabelsKey(rawMap map[string]string) allocator.AllocatorKey {
@@ -220,7 +213,7 @@ func TestGetIdentity(t *testing.T) {
 				}
 			}
 
-			go backend.ListAndWatch(ctx, FakeHandler{onAddFunc: func() { addWaitGroup.Done() }}, stopChan)
+			go backend.ListAndWatch(ctx, FakeHandler{onUpsertFunc: func() { addWaitGroup.Done() }}, stopChan)
 
 			// Wait for watcher to process the identities in the background
 			addWaitGroup.Wait()

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -598,11 +598,8 @@ func (k *kvstoreBackend) ListAndWatch(ctx context.Context, handler allocator.Cac
 				}
 
 				switch event.Typ {
-				case kvstore.EventTypeCreate:
-					handler.OnAdd(id, key)
-
-				case kvstore.EventTypeModify:
-					handler.OnModify(id, key)
+				case kvstore.EventTypeCreate, kvstore.EventTypeModify:
+					handler.OnUpsert(id, key)
 
 				case kvstore.EventTypeDelete:
 					handler.OnDelete(id, key)


### PR DESCRIPTION
Explicitly validate that the identities retrieved from a remote cluster match the expected range based on the corresponding clusterID, to ensure improved consistency and prevent the propagation of corrupted data. Additionally, ensure that said identities include the cluster label matching the expected cluster name for the given cluster. Similarly, ensure that the unmarshaled endpoint data matches the kvstore key it was retrieved from.

Please review commit by commit, and refer to the individual descriptions for additional details.
Related: https://github.com/cilium/cilium/issues/29602, https://github.com/cilium/cilium/pull/32749