### PR TITLE
v1.13 Backports 2024-05-30

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -13,7 +13,7 @@ jobs:
   build_commits:
     name: Check if build works for every commit
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 180
     steps:
       - name: Configure git
         run: |

--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -177,6 +177,9 @@ func getIPLocalReservedPorts(d *Daemon) string {
 		ports = append(ports, fmt.Sprintf("%d", option.Config.TunnelPort))
 	}
 
+	log.WithField(logfields.Ports, ports).
+		Info("Auto-detected local ports to reserve in the container namespace for transparent DNS proxy")
+
 	return strings.Join(ports, ",")
 }
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -165,6 +165,9 @@ const (
 	// Port is a L4 port
 	Port = "port"
 
+	// Ports is a list of L4 ports
+	Ports = "ports"
+
 	// PortName is a k8s ContainerPort Name
 	PortName = "portName"
 

--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -599,11 +599,10 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 
 	var macAddrStr string
 	if err = netNs.Do(func(_ ns.NetNS) error {
+		if err := reserveLocalIPPorts(conf); err != nil {
+			logger.WithError(err).Warn("unable to reserve local ip ports")
+		}
 		if ipv6IsEnabled(ipam) {
-			if err := reserveLocalIPPorts(conf); err != nil {
-				logger.WithError(err).Warn("unable to reserve local ip ports")
-			}
-
 			if err := sysctl.Disable("net.ipv6.conf.all.disable_ipv6"); err != nil {
 				logger.WithError(err).Warn("unable to enable ipv6 on all interfaces")
 			}


### PR DESCRIPTION
 * [x] #32725 (@gandro) :warning: resolved conflicts
 * [x] #32746 (@YutaroHayakawa)

Fixed minor conflict in #32725 due to filename renames. Diff looks the same.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 32725 32746
```
