### PR TITLE
v1.14 Backports 2024-05-30

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -58,6 +58,9 @@ env:
   contextName1: kind-cluster1-${{ github.run_id }}
   contextName2: kind-cluster2-${{ github.run_id }}
 
+  # renovate: datasource=github-releases depName=cert-manager/cert-manager
+  CERT_MANAGER_VERSION: v1.14.5
+
 jobs:
   echo-inputs:
     if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -94,6 +97,7 @@ jobs:
             encryption: 'disabled'
             kube-proxy: 'iptables'
             mode: 'kvstoremesh'
+            tls-auto-method: helm
             cm-auth-mode-1: 'legacy'
             cm-auth-mode-2: 'legacy'
 
@@ -103,6 +107,7 @@ jobs:
             encryption: 'wireguard'
             kube-proxy: 'none'
             mode: 'clustermesh'
+            tls-auto-method: cronJob
             cm-auth-mode-1: 'migration'
             cm-auth-mode-2: 'migration'
 
@@ -113,6 +118,7 @@ jobs:
             encryption: 'ipsec'
             kube-proxy: 'iptables'
             mode: 'kvstoremesh'
+            tls-auto-method: certmanager
             cm-auth-mode-1: 'cluster'
             cm-auth-mode-2: 'cluster'
 
@@ -124,6 +130,7 @@ jobs:
             encryption: 'disabled'
             kube-proxy: 'none'
             mode: 'clustermesh'
+            tls-auto-method: certmanager
             cm-auth-mode-1: 'legacy'
             cm-auth-mode-2: 'migration'
 
@@ -134,6 +141,7 @@ jobs:
             encryption: 'ipsec'
             kube-proxy: 'iptables'
             mode: 'external'
+            tls-auto-method: helm
 
           - name: '6'
             tunnel: 'vxlan'
@@ -141,6 +149,7 @@ jobs:
             encryption: 'disabled'
             kube-proxy: 'none'
             mode: 'clustermesh'
+            tls-auto-method: helm
             cm-auth-mode-1: 'cluster'
             cm-auth-mode-2: 'cluster'
 
@@ -150,6 +159,7 @@ jobs:
             encryption: 'wireguard'
             kube-proxy: 'iptables'
             mode: 'kvstoremesh'
+            tls-auto-method: cronJob
             cm-auth-mode-1: 'migration'
             cm-auth-mode-2: 'cluster'
 
@@ -160,6 +170,7 @@ jobs:
             encryption: 'ipsec'
             kube-proxy: 'iptables'
             mode: 'clustermesh'
+            tls-auto-method: certmanager
             cm-auth-mode-1: 'cluster'
             cm-auth-mode-2: 'cluster'
 
@@ -170,6 +181,7 @@ jobs:
           #    encryption: 'disabled'
           #    kube-proxy: 'none'
           #    mode: 'kvstoremesh'
+          #    tls-auto-method: certmanager
           #    cm-auth-mode-1: 'cluster'
           #    cm-auth-mode-2: 'cluster'
 
@@ -179,6 +191,7 @@ jobs:
             encryption: 'wireguard'
             kube-proxy: 'iptables'
             mode: 'external'
+            tls-auto-method: helm
             maxConnectedClusters: '511'
 
     steps:
@@ -221,9 +234,17 @@ jobs:
             --helm-set=hubble.relay.enabled=true \
             --helm-set=hubble.relay.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci:${SHA} \
             --helm-set=hubble.relay.image.useDigest=false \
+            --helm-set=hubble.tls.auto.method=${{ matrix.tls-auto-method }} \
+            --helm-set=hubble.tls.auto.certManagerIssuerRef.group=cert-manager.io \
+            --helm-set=hubble.tls.auto.certManagerIssuerRef.kind=Issuer \
+            --helm-set=hubble.tls.auto.certManagerIssuerRef.name=cilium \
             --helm-set=clustermesh.useAPIServer=true \
             --helm-set=clustermesh.apiserver.replicas=${{ matrix.mode == 'external' && '0' || '1' }} \
             --helm-set=clustermesh.apiserver.kvstoremesh.enabled=${{ matrix.mode == 'kvstoremesh' }} \
+            --helm-set=clustermesh.apiserver.tls.auto.method=${{ matrix.tls-auto-method }} \
+            --helm-set=clustermesh.apiserver.tls.auto.certManagerIssuerRef.group=cert-manager.io \
+            --helm-set=clustermesh.apiserver.tls.auto.certManagerIssuerRef.kind=Issuer \
+            --helm-set=clustermesh.apiserver.tls.auto.certManagerIssuerRef.name=cilium \
             --helm-set=clustermesh.apiserver.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci:${SHA} \
             --helm-set=clustermesh.apiserver.image.useDigest=false \
             --helm-set=clustermesh.apiserver.kvstoremesh.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/kvstoremesh-ci:${SHA} \
@@ -383,6 +404,37 @@ jobs:
           kubectl --context ${{ env.contextName1 }} create -n kube-system -f ${{ steps.kvstore.outputs.cilium_etcd_secrets_path }}
           kubectl --context ${{ env.contextName2 }} create -n kube-system -f ${{ steps.kvstore.outputs.cilium_etcd_secrets_path }}
 
+      - name: Install cert-manager CRDs and create Cilium's issuer
+        if: matrix.tls-auto-method == 'certmanager'
+        run: |
+          # Generate the Cilium CA key and certificate
+          openssl genrsa 4096 > cilium-ca-key.pem
+          openssl req -new -x509 -nodes -days 1 -key cilium-ca-key.pem -out cilium-ca-crt.pem -subj "/CN=Cilium CA/"
+
+          cat << EOF > issuer.yaml
+          apiVersion: cert-manager.io/v1
+          kind: Issuer
+          metadata:
+            name: cilium
+            namespace: kube-system
+          spec:
+            ca:
+              secretName: cilium-root-ca
+          EOF
+
+          for ctx in ${{ env.contextName1 }} ${{ env.contextName2 }}; do
+            # Install the cert-manager CRDs
+            CRD_URL="https://github.com/cert-manager/cert-manager/releases/download/${{ env.CERT_MANAGER_VERSION }}/cert-manager.crds.yaml"
+            kubectl --context $ctx apply -f $CRD_URL
+
+            # Create the Cilium CA secret
+            kubectl --context $ctx create -n kube-system secret tls cilium-root-ca \
+              --key=cilium-ca-key.pem --cert=cilium-ca-crt.pem
+
+            # Create the cert-manager issuer
+            kubectl --context $ctx apply -f issuer.yaml
+          done
+
       - name: Set clustermesh connection parameters
         if: matrix.mode == 'external'
         id: clustermesh-vars
@@ -437,6 +489,7 @@ jobs:
             --nodes-without-cilium
 
       - name: Copy the Cilium CA secret to cluster2, as they must match
+        if: matrix.tls-auto-method != 'certmanager'
         run: |
           kubectl --context ${{ env.contextName1 }} get secret -n kube-system cilium-ca -o yaml |
             kubectl --context ${{ env.contextName2 }} create -f -
@@ -455,6 +508,18 @@ jobs:
             --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.mode != 'external' && matrix.cm-auth-mode-2 || 'legacy' }} \
             ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
             ${{ steps.clustermesh-vars.outputs.cilium_install_clustermesh }}
+
+      - name: Install cert-manager
+        if: matrix.tls-auto-method == 'certmanager'
+        run: |
+          helm repo add jetstack https://charts.jetstack.io
+          for ctx in ${{ env.contextName1 }} ${{ env.contextName2 }}; do
+            helm --kube-context $ctx install \
+              cert-manager jetstack/cert-manager \
+              --namespace cert-manager \
+              --create-namespace \
+              --version ${{ env.CERT_MANAGER_VERSION }}
+          done
 
       - name: Wait for cluster mesh status to be ready
         run: |

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -13,7 +13,7 @@ jobs:
   build_commits:
     name: Check if build works for every commit
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 180
     steps:
       - name: Configure git
         run: |

--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -177,6 +177,9 @@ func getIPLocalReservedPorts(d *Daemon) string {
 		ports = append(ports, fmt.Sprintf("%d", option.Config.TunnelPort))
 	}
 
+	log.WithField(logfields.Ports, ports).
+		Info("Auto-detected local ports to reserve in the container namespace for transparent DNS proxy")
+
 	return strings.Join(ports, ",")
 }
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -178,6 +178,9 @@ const (
 	// Port is a L4 port
 	Port = "port"
 
+	// Ports is a list of L4 ports
+	Ports = "ports"
+
 	// PortName is a k8s ContainerPort Name
 	PortName = "portName"
 

--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -598,11 +598,11 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 
 	var macAddrStr string
 	if err = netNs.Do(func(_ ns.NetNS) error {
-		if ipv6IsEnabled(ipam) {
-			if err := reserveLocalIPPorts(conf); err != nil {
-				logger.WithError(err).Warn("unable to reserve local ip ports")
-			}
+		if err := reserveLocalIPPorts(conf); err != nil {
+			logger.WithError(err).Warn("unable to reserve local ip ports")
+		}
 
+		if ipv6IsEnabled(ipam) {
 			if err := sysctl.Disable("net.ipv6.conf.all.disable_ipv6"); err != nil {
 				logger.WithError(err).Warn("unable to enable ipv6 on all interfaces")
 			}


### PR DESCRIPTION
 * [x] #32654 (@giorio94) :warning: resolved conflicts
 * [x] #32725 (@gandro) :warning: resolved conflicts
 * [x] #32746 (@YutaroHayakawa)

Fixed minor conflict in #32725 due to filename renames. Diff looks the same.

With #32654 there were some lines in the diff that did not exist in v1.14 version of conformance-clustermesh.yaml,
so fixed up manually. Please double-check that this patch makes sense for v1.14.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 32654 32725 32746
```
