### PR TITLE
LRP: Add explicit dependency to k8s ServiceCache

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -499,8 +499,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	)
 	params.NodeDiscovery.RegisterK8sGetters(d.k8sWatcher)
 
-	d.lrpManager.RegisterSvcCache(d.k8sWatcher.K8sSvcCache)
-
 	bootstrapStats.daemonInit.End(true)
 
 	// Stop all endpoints (its goroutines) on exit.

--- a/pkg/redirectpolicy/cell.go
+++ b/pkg/redirectpolicy/cell.go
@@ -8,6 +8,7 @@ import (
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/service"
 )
 
@@ -22,11 +23,12 @@ var Cell = cell.Module(
 type lrpManagerParams struct {
 	cell.In
 
-	Svc service.ServiceManager
-	Lpr agentK8s.LocalPodResource
-	Ep  endpointmanager.EndpointManager
+	Svc      service.ServiceManager
+	SvcCache *k8s.ServiceCache
+	Lpr      agentK8s.LocalPodResource
+	Ep       endpointmanager.EndpointManager
 }
 
 func newLRPManager(params lrpManagerParams) *Manager {
-	return NewRedirectPolicyManager(params.Svc, params.Lpr, params.Ep)
+	return NewRedirectPolicyManager(params.Svc, params.SvcCache, params.Lpr, params.Ep)
 }

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -98,9 +98,10 @@ type Manager struct {
 	noNetnsCookieSupport bool
 }
 
-func NewRedirectPolicyManager(svc svcManager, lpr agentK8s.LocalPodResource, epM endpointManager) *Manager {
+func NewRedirectPolicyManager(svc svcManager, svcCache *k8s.ServiceCache, lpr agentK8s.LocalPodResource, epM endpointManager) *Manager {
 	return &Manager{
 		svcManager:            svc,
+		svcCache:              svcCache,
 		epManager:             epM,
 		localPods:             lpr,
 		policyFrontendsByHash: make(map[string]policyID),
@@ -109,10 +110,6 @@ func NewRedirectPolicyManager(svc svcManager, lpr agentK8s.LocalPodResource, epM
 		policyConfigs:         make(map[policyID]*LRPConfig),
 		policyEndpoints:       make(map[podID]sets.Set[policyID]),
 	}
-}
-
-func (rpm *Manager) RegisterSvcCache(cache svcCache) {
-	rpm.svcCache = cache
 }
 
 // Event handlers

--- a/pkg/redirectpolicy/manager_test.go
+++ b/pkg/redirectpolicy/manager_test.go
@@ -44,7 +44,7 @@ func setupManagerSuite(tb testing.TB) *ManagerSuite {
 		fakePodStore{},
 	}
 	m.epM = &fakeEpManager{}
-	m.rpm = NewRedirectPolicyManager(m.svc, fpr, m.epM)
+	m.rpm = NewRedirectPolicyManager(m.svc, nil, fpr, m.epM)
 	configAddrType = LRPConfig{
 		id: k8s.ServiceID{
 			Name:      "test-foo",
@@ -687,7 +687,7 @@ func TestManager_OnAddRedirectPolicy(t *testing.T) {
 		K8sNamespace: pod.Namespace,
 		NetNsCookie:  1234,
 	}
-	m.rpm = NewRedirectPolicyManager(m.svc, fps, m.epM)
+	m.rpm = NewRedirectPolicyManager(m.svc, nil, fps, m.epM)
 	m.rpm.skipLBMap = &fakeSkipLBMap{lb4Events: lbEvents}
 
 	added, err := m.rpm.AddRedirectPolicy(pc)
@@ -752,7 +752,7 @@ func TestManager_OnAddRedirectPolicy(t *testing.T) {
 			},
 		},
 	}
-	m.rpm = NewRedirectPolicyManager(m.svc, fps, m.epM)
+	m.rpm = NewRedirectPolicyManager(m.svc, nil, fps, m.epM)
 	lbEvents = make(chan skipLBParams)
 	m.rpm.skipLBMap = &fakeSkipLBMap{lb4Events: lbEvents}
 
@@ -816,7 +816,7 @@ func TestManager_OnAddRedirectPolicy(t *testing.T) {
 			Pods: pods,
 		},
 	}
-	m.rpm = NewRedirectPolicyManager(m.svc, fps, m.epM)
+	m.rpm = NewRedirectPolicyManager(m.svc, nil, fps, m.epM)
 	lbEvents = make(chan skipLBParams)
 	m.rpm.skipLBMap = &fakeSkipLBMap{lb4Events: lbEvents}
 


### PR DESCRIPTION
Currently, the Agent daemon setup registers the k8s `ServiceCache` with the LRP Manager via the method `RegisterSvcCache`.

In the meantime, the k8s `ServiceCache` is provided by its own Hive Cell which makes it possible to have an explicit dependency from the LRP Manager to the `ServiceCache`.

Therefore, this commit adds the k8s `ServiceCache` as direct dependency to the LRP Manager and removes the method `RegisterSvcCache`.
