### PR TITLE
cilium-dbg: Reprint header line periodically with statedb

### DIFF
--- a/cilium-dbg/cmd/statedb.go
+++ b/cilium-dbg/cmd/statedb.go
@@ -73,6 +73,11 @@ func newTabWriter(out io.Writer) *tabwriter.Writer {
 	return tabwriter.NewWriter(out, minWidth, width, padding, padChar, flags)
 }
 
+const (
+	// The number of lines before the header is reprinted when watching.
+	watchReprintHeaderInterval = 100
+)
+
 func statedbTableCommand[Obj statedb.TableWritable](tableName string) *cobra.Command {
 	var watchInterval time.Duration
 	cmd := &cobra.Command{
@@ -83,10 +88,11 @@ func statedbTableCommand[Obj statedb.TableWritable](tableName string) *cobra.Com
 
 			w := newTabWriter(os.Stdout)
 			var obj Obj
-			fmt.Fprintf(w, "%s\n", strings.Join(obj.TableHeader(), "\t"))
+			fmt.Fprintf(w, "# %s\n", strings.Join(obj.TableHeader(), "\t"))
 			defer w.Flush()
 
 			revision := statedb.Revision(0)
+			numLinesSinceHeader := 0
 
 			for {
 				// Query the contents of the table by revision, so that objects
@@ -100,6 +106,7 @@ func statedbTableCommand[Obj statedb.TableWritable](tableName string) *cobra.Com
 							// Remember the latest revision to query from.
 							revision = rev + 1
 							_, err := fmt.Fprintf(w, "%s\n", strings.Join(obj.TableRow(), "\t"))
+							numLinesSinceHeader++
 							return err
 						})
 					w.Flush()
@@ -118,6 +125,12 @@ func statedbTableCommand[Obj statedb.TableWritable](tableName string) *cobra.Com
 				}
 
 				time.Sleep(watchInterval)
+
+				if numLinesSinceHeader > watchReprintHeaderInterval {
+					numLinesSinceHeader = 0
+					fmt.Fprintf(w, "# %s\n", strings.Join(obj.TableHeader(), "\t"))
+					w.Flush()
+				}
 			}
 
 		},


### PR DESCRIPTION
When watching a table for changes it's easy to get lost with what the columns meant. Add a periodic (every 100 lines) reprinting of the header line to make it easier to follow.

As this makes it easier to mix up the header line with the rows, add a '# ' to the front.

Output of `cilium-dbg statedb health --watch=100ms` looks like this now:

```
  ...
  agent.datapath.agent-liveness-updater            timer-job-agent-liveness-updater               OK         ...
  # Module                                         Component                                      Level      ...
  agent.datapath.agent-liveness-updater            timer-job-agent-liveness-updater               OK         ...
  ..
```