### PR TITLE
cgroup manager: introduce hive cell

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/auth"
 	"github.com/cilium/cilium/pkg/bgp/speaker"
 	"github.com/cilium/cilium/pkg/bgpv1"
+	cgroup "github.com/cilium/cilium/pkg/cgroups/manager"
 	"github.com/cilium/cilium/pkg/ciliumenvoyconfig"
 	"github.com/cilium/cilium/pkg/clustermesh"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
@@ -232,6 +233,10 @@ var (
 		// The node discovery cell provides the local node configuration and node discovery
 		// which communicate changes in local node information to the API server or KVStore.
 		nodediscovery.Cell,
+
+		// Cgroup manager maintains Kubernetes and low-level metadata (cgroup path and
+		// cgroup id) for local pods and their containers.
+		cgroup.Cell,
 
 		// NAT stats provides stat computation and tables for NAT map bpf maps.
 		natStats.Cell,

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -446,6 +446,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		tunnelConfig:         params.TunnelConfig,
 		bwManager:            params.BandwidthManager,
 		lrpManager:           params.LRPManager,
+		cgroupManager:        params.CGroupManager,
 		preFilter:            params.Prefilter,
 	}
 
@@ -475,8 +476,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 
 	d.endpointManager = params.EndpointManager
 
-	d.cgroupManager = manager.NewCgroupManager()
-
 	d.k8sWatcher = watchers.NewK8sWatcher(
 		params.Clientset,
 		params.K8sResourceSynced,
@@ -490,7 +489,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		params.MetalLBBgpSpeaker,
 		option.Config,
 		d.ipcache,
-		d.cgroupManager,
+		params.CGroupManager,
 		params.Resources,
 		params.ServiceCache,
 		d.bwManager,
@@ -969,7 +968,6 @@ func (d *Daemon) Close() {
 		d.datapathRegenTrigger.Shutdown()
 	}
 	identitymanager.RemoveAll()
-	d.cgroupManager.Close()
 
 	// Ensures all controllers are stopped!
 	d.controllers.RemoveAllAndWait()

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -177,7 +177,7 @@ type Daemon struct {
 
 	egressGatewayManager *egressgateway.Manager
 
-	cgroupManager *manager.CgroupManager
+	cgroupManager manager.CGroupManager
 
 	ipamMetadata *ipamMetadata.Manager
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgp/speaker"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
+	cgroup "github.com/cilium/cilium/pkg/cgroups/manager"
 	"github.com/cilium/cilium/pkg/clustermesh"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/common"
@@ -1678,6 +1679,7 @@ type daemonParams struct {
 	Prefilter           datapath.PreFilter
 	CompilationLock     datapath.CompilationLock
 	MetalLBBgpSpeaker   speaker.MetalLBBgpSpeaker
+	CGroupManager       *cgroup.CgroupManager
 }
 
 func newDaemonPromise(params daemonParams) (promise.Promise[*Daemon], promise.Promise[*option.DaemonConfig]) {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1679,7 +1679,7 @@ type daemonParams struct {
 	Prefilter           datapath.PreFilter
 	CompilationLock     datapath.CompilationLock
 	MetalLBBgpSpeaker   speaker.MetalLBBgpSpeaker
-	CGroupManager       *cgroup.CgroupManager
+	CGroupManager       cgroup.CGroupManager
 }
 
 func newDaemonPromise(params daemonParams) (promise.Promise[*Daemon], promise.Promise[*option.DaemonConfig]) {

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -18,7 +18,6 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/api/v1/models"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
-	cgroupManager "github.com/cilium/cilium/pkg/cgroups/manager"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/crypto/certloader"
 	"github.com/cilium/cilium/pkg/datapath/link"
@@ -495,8 +494,4 @@ func (d *Daemon) GetServiceByAddr(ip netip.Addr, port uint16) *flowpb.Service {
 // Hubble's events buffer.
 func getHubbleEventBufferCapacity(logger logrus.FieldLogger) (container.Capacity, error) {
 	return container.NewCapacity(option.Config.HubbleEventBufferCapacity)
-}
-
-func (d *Daemon) GetParentPodMetadata(cgroupId uint64) *cgroupManager.PodMetadata {
-	return d.cgroupManager.GetPodMetadataForContainer(cgroupId)
 }

--- a/pkg/cgroups/manager/cell.go
+++ b/pkg/cgroups/manager/cell.go
@@ -5,6 +5,7 @@ package manager
 
 import (
 	"github.com/cilium/hive/cell"
+	"github.com/sirupsen/logrus"
 )
 
 // Cell provides access to the cgroup manager.
@@ -18,11 +19,12 @@ var Cell = cell.Module(
 type cgroupManagerParams struct {
 	cell.In
 
+	Logger    logrus.FieldLogger
 	Lifecycle cell.Lifecycle
 }
 
 func newCGroupManager(params cgroupManagerParams) *CgroupManager {
-	cm := newManager(cgroupImpl{}, podEventsChannelSize)
+	cm := newManager(params.Logger, cgroupImpl{}, podEventsChannelSize)
 
 	params.Lifecycle.Append(cell.Hook{
 		OnStart: func(hookContext cell.HookContext) error {

--- a/pkg/cgroups/manager/cell.go
+++ b/pkg/cgroups/manager/cell.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package manager
+
+import (
+	"github.com/cilium/hive/cell"
+)
+
+// Cell provides access to the cgroup manager.
+var Cell = cell.Module(
+	"cgroup-manager",
+	"CGroup Manager",
+
+	cell.Provide(newCGroupManager),
+)
+
+type cgroupManagerParams struct {
+	cell.In
+
+	Lifecycle cell.Lifecycle
+}
+
+func newCGroupManager(params cgroupManagerParams) *CgroupManager {
+	cm := newManager(cgroupImpl{}, podEventsChannelSize)
+
+	params.Lifecycle.Append(cell.Hook{
+		OnStart: func(hookContext cell.HookContext) error {
+			cm.enable()
+			go cm.processPodEvents()
+
+			return nil
+		},
+		OnStop: func(cell.HookContext) error {
+			cm.Close()
+
+			return nil
+		},
+	})
+
+	return cm
+}

--- a/pkg/cgroups/manager/manager_test.go
+++ b/pkg/cgroups/manager/manager_test.go
@@ -121,17 +121,14 @@ var (
 	}
 )
 
-func newCgroupManagerTest(t testing.TB, pMock providerMock, cg cgroup, events chan podEventStatus) *CgroupManager {
+func newCgroupManagerTest(t testing.TB, pMock providerMock, cg cgroup, events chan podEventStatus) CGroupManager {
 	logger := logrus.New()
 	logger.SetOutput(io.Discard)
 
 	// Unbuffered channel tests to detect any issues on the caller side.
-	tcm := newManager(logger, cg, 0)
+	tcm := newManager(logger, cg, pMock, 0)
 
-	tcm.pathProvider = pMock
 	tcm.podEventsDone = events
-
-	tcm.enable()
 
 	go tcm.processPodEvents()
 	t.Cleanup(tcm.Close)
@@ -139,8 +136,7 @@ func newCgroupManagerTest(t testing.TB, pMock providerMock, cg cgroup, events ch
 	return tcm
 }
 
-func setup(tb testing.TB) {
-	option.Config.EnableSocketLBTracing = true
+func setup() {
 	nodetypes.SetName("n1")
 }
 
@@ -149,7 +145,7 @@ func getFullPath(path string) string {
 }
 
 func TestGetPodMetadataOnPodAdd(t *testing.T) {
-	setup(t)
+	setup()
 
 	c1CId := uint64(1234)
 	c2CId := uint64(4567)
@@ -192,7 +188,7 @@ func TestGetPodMetadataOnPodAdd(t *testing.T) {
 }
 
 func TestGetPodMetadataOnPodUpdate(t *testing.T) {
-	setup(t)
+	setup()
 
 	c3CId := uint64(2345)
 	c1CId := uint64(1234)
@@ -274,7 +270,7 @@ func TestGetPodMetadataOnManagerDisabled(t *testing.T) {
 }
 
 func BenchmarkGetPodMetadataForContainer(b *testing.B) {
-	setup(b)
+	setup()
 	c3CId := uint64(2345)
 	c1CId := uint64(1234)
 	cgMock := cgroupMock{cgroupIds: map[string]uint64{

--- a/pkg/cgroups/manager/manager_test.go
+++ b/pkg/cgroups/manager/manager_test.go
@@ -5,8 +5,10 @@ package manager
 
 import (
 	"fmt"
+	"io"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -120,8 +122,11 @@ var (
 )
 
 func newCgroupManagerTest(t testing.TB, pMock providerMock, cg cgroup, events chan podEventStatus) *CgroupManager {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
 	// Unbuffered channel tests to detect any issues on the caller side.
-	tcm := newManager(cg, 0)
+	tcm := newManager(logger, cg, 0)
 
 	tcm.pathProvider = pMock
 	tcm.podEventsDone = events


### PR DESCRIPTION
This PR introduces a Hive Cell for the cgroup manager.

Please review the individual commits.

* introduce hive cell for cgroup manager
* use injected logger in cgroup manager
* remove unused method GetParentPodMetadata
* introduce noop cgroup manager implementation