### PR TITLE
v1.15 Backports 2024-05-30

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -63,7 +63,7 @@ cilium-agent [flags]
       --cluster-id uint32                                         Unique identifier of the cluster
       --cluster-name string                                       Name of the cluster (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
-      --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
+      --clustermesh-sync-timeout duration                         Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                                CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                             Whether to remove other CNI configurations

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -18,7 +18,7 @@ cilium-agent hive [flags]
       --cluster-id uint32                                         Unique identifier of the cluster
       --cluster-name string                                       Name of the cluster (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
-      --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
+      --clustermesh-sync-timeout duration                         Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                                CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                             Whether to remove other CNI configurations

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -24,7 +24,7 @@ cilium-agent hive dot-graph [flags]
       --cluster-id uint32                                         Unique identifier of the cluster
       --cluster-name string                                       Name of the cluster (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
-      --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
+      --clustermesh-sync-timeout duration                         Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                                CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                             Whether to remove other CNI configurations

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -510,7 +510,7 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState, endpointsR
 
 					err := d.clustermesh.ServicesSynced(d.ctx)
 					if err != nil {
-						log.WithError(err).Fatal("timeout while waiting for all clusters to be locally synchronized")
+						return // The parent context expired, and we are already terminating
 					}
 					log.Debug("all clusters have been correctly synchronized locally")
 				}

--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -5,6 +5,7 @@ package clustermesh
 
 import (
 	"github.com/cilium/cilium/pkg/clustermesh/common"
+	"github.com/cilium/cilium/pkg/clustermesh/wait"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -30,6 +31,7 @@ var Cell = cell.Module(
 	cell.ProvidePrivate(idsMgrProvider),
 
 	cell.Config(common.Config{}),
+	cell.Config(wait.TimeoutConfigDefault),
 
 	cell.Metric(NewMetrics),
 	cell.Metric(common.MetricsProvider(subsystem)),

--- a/pkg/clustermesh/wait/synced.go
+++ b/pkg/clustermesh/wait/synced.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package wait
+
+import (
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+type TimeoutConfig struct {
+	// ClusterMeshSyncTimeout is the timeout when waiting for the initial
+	// synchronization from all remote clusters, before triggering the
+	// circuit breaker and possibly disrupting cross-cluster connections.
+	ClusterMeshSyncTimeout time.Duration
+
+	// ClusterMeshIPIdentitiesSyncTimeout is the timeout when waiting for the
+	// initial synchronization of ipcache entries and identities from all remote
+	// clusters before regenerating the local endpoints.
+	// Deprecated in favor of ClusterMeshSyncTimeout.
+	ClusterMeshIPIdentitiesSyncTimeout time.Duration
+}
+
+func (def TimeoutConfig) Flags(flags *pflag.FlagSet) {
+	flags.Duration("clustermesh-sync-timeout", def.ClusterMeshSyncTimeout,
+		"Timeout waiting for the initial synchronization of information from remote clusters")
+
+	flags.Duration("clustermesh-ip-identities-sync-timeout", def.ClusterMeshIPIdentitiesSyncTimeout,
+		"Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration")
+	flags.MarkDeprecated("clustermesh-ip-identities-sync-timeout", "Use --clustermesh-sync-timeout instead")
+}
+
+func (tc TimeoutConfig) Timeout() time.Duration {
+	if tc.ClusterMeshSyncTimeout != TimeoutConfigDefault.ClusterMeshSyncTimeout {
+		return tc.ClusterMeshSyncTimeout
+	}
+
+	return tc.ClusterMeshIPIdentitiesSyncTimeout
+}
+
+var (
+	// TimeoutConfigDefault is the default timeout configuration.
+	TimeoutConfigDefault = TimeoutConfig{
+		ClusterMeshSyncTimeout:             1 * time.Minute,
+		ClusterMeshIPIdentitiesSyncTimeout: 1 * time.Minute,
+	}
+)

--- a/pkg/endpoint/regenerator.go
+++ b/pkg/endpoint/regenerator.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/clustermesh"
+	"github.com/cilium/cilium/pkg/clustermesh/wait"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/time"
@@ -21,35 +21,17 @@ var (
 		"endpoint-regeneration",
 		"Endpoints regeneration",
 
-		cell.Config(RegeneratorConfigDefault),
 		cell.Provide(newRegenerator),
 	)
 )
 
 // Regenerator wraps additional functionalities for endpoint regeneration.
 type Regenerator struct {
-	RegeneratorConfig
-
-	cmWaitFn clustermesh.SyncedWaitFn
+	cmWaitFn      clustermesh.SyncedWaitFn
+	cmWaitTimeout time.Duration
 
 	logger        logrus.FieldLogger
 	cmSyncLogOnce sync.Once
-}
-
-type RegeneratorConfig struct {
-	// ClusterMeshIPIdentitiesSyncTimeout is the timeout when waiting for the
-	// initial synchronization of ipcache entries and identities from all remote
-	// clusters before regenerating the local endpoints.
-	ClusterMeshIPIdentitiesSyncTimeout time.Duration
-}
-
-func (def RegeneratorConfig) Flags(flags *pflag.FlagSet) {
-	flags.Duration("clustermesh-ip-identities-sync-timeout", def.ClusterMeshIPIdentitiesSyncTimeout,
-		"Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration")
-}
-
-var RegeneratorConfigDefault = RegeneratorConfig{
-	ClusterMeshIPIdentitiesSyncTimeout: 1 * time.Minute,
 }
 
 func newRegenerator(in struct {
@@ -57,7 +39,7 @@ func newRegenerator(in struct {
 
 	Logger logrus.FieldLogger
 
-	Config      RegeneratorConfig
+	Config      wait.TimeoutConfig
 	ClusterMesh *clustermesh.ClusterMesh
 }) *Regenerator {
 	waitFn := func(context.Context) error { return nil }
@@ -66,9 +48,9 @@ func newRegenerator(in struct {
 	}
 
 	return &Regenerator{
-		RegeneratorConfig: in.Config,
-		logger:            in.Logger,
-		cmWaitFn:          waitFn,
+		logger:        in.Logger,
+		cmWaitFn:      waitFn,
+		cmWaitTimeout: in.Config.Timeout(),
 	}
 }
 
@@ -80,15 +62,15 @@ func newRegenerator(in struct {
 // forgetting to remove it when the synchronous regeneration is removed.
 func (r *Regenerator) CapTimeoutForSynchronousRegeneration() {
 	const maxTimeout = 5 * time.Second
-	if r.ClusterMeshIPIdentitiesSyncTimeout > maxTimeout {
-		r.ClusterMeshIPIdentitiesSyncTimeout = maxTimeout
+	if r.cmWaitTimeout > maxTimeout {
+		r.cmWaitTimeout = maxTimeout
 		r.logger.WithField(logfields.Value, maxTimeout).
-			Info("Capped clustermesh-ip-identities-sync-timeout because endpoint regeneration needs to be performed synchronously")
+			Info("Capped clustermesh-sync-timeout because endpoint regeneration needs to be performed synchronously")
 	}
 }
 
 func (r *Regenerator) WaitForClusterMeshIPIdentitiesSync(ctx context.Context) error {
-	wctx, cancel := context.WithTimeout(ctx, r.ClusterMeshIPIdentitiesSyncTimeout)
+	wctx, cancel := context.WithTimeout(ctx, r.cmWaitTimeout)
 	defer cancel()
 	err := r.cmWaitFn(wctx)
 

--- a/pkg/endpoint/regenerator_test.go
+++ b/pkg/endpoint/regenerator_test.go
@@ -25,9 +25,7 @@ func TestRegeneratorWaitForIPCacheSync(t *testing.T) {
 			return ctx.Err()
 		},
 
-		RegeneratorConfig: RegeneratorConfig{
-			ClusterMeshIPIdentitiesSyncTimeout: 10 * time.Millisecond,
-		},
+		cmWaitTimeout: 10 * time.Millisecond,
 	}
 
 	tests := []struct {


### PR DESCRIPTION
 * [x] #32671 (@giorio94) :warning: resolved conflicts
    * Hit multiple conflicts in clustermesh.go due to the different surrounding context, addressed with minor adaptations; additionally dropped the endpointslicesync and release notes related hunks, as not relevant in this context.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 32671
```
