### PR TITLE
metallb bgp: introduce hive cell

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/daemon/restapi"
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/auth"
+	"github.com/cilium/cilium/pkg/bgp/speaker"
 	"github.com/cilium/cilium/pkg/bgpv1"
 	"github.com/cilium/cilium/pkg/ciliumenvoyconfig"
 	"github.com/cilium/cilium/pkg/clustermesh"
@@ -185,6 +186,9 @@ var (
 
 		// The BGP Control Plane which enables various BGP related interop.
 		bgpv1.Cell,
+
+		// The MetalLB BGP speaker enables support for MetalLB BGP.
+		speaker.Cell,
 
 		// Brokers datapath signals from signalmap
 		signal.Cell,

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -499,15 +499,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	)
 	params.NodeDiscovery.RegisterK8sGetters(d.k8sWatcher)
 
-	if option.Config.BGPAnnounceLBIP || option.Config.BGPAnnouncePodCIDR {
-		switch option.Config.IPAMMode() {
-		case ipamOption.IPAMKubernetes:
-			params.MetalLBBgpSpeaker.SubscribeToLocalNodeResource(ctx, params.Resources.LocalNode)
-		case ipamOption.IPAMClusterPool:
-			params.MetalLBBgpSpeaker.SubscribeToLocalCiliumNodeResource(ctx, params.Resources.LocalCiliumNode)
-		}
-	}
-
 	d.lrpManager.RegisterSvcCache(d.k8sWatcher.K8sSvcCache)
 
 	bootstrapStats.daemonInit.End(true)

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -509,9 +509,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	}
 
 	d.lrpManager.RegisterSvcCache(d.k8sWatcher.K8sSvcCache)
-	if option.Config.BGPAnnounceLBIP {
-		params.MetalLBBgpSpeaker.RegisterSvcCache(d.k8sWatcher.K8sSvcCache)
-	}
 
 	bootstrapStats.daemonInit.End(true)
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1677,7 +1677,7 @@ type daemonParams struct {
 	NodeDiscovery       *nodediscovery.NodeDiscovery
 	Prefilter           datapath.PreFilter
 	CompilationLock     datapath.CompilationLock
-	MetalLBBgpSpeaker   *speaker.MetalLBSpeaker
+	MetalLBBgpSpeaker   speaker.MetalLBBgpSpeaker
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -31,6 +31,7 @@ import (
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/auth"
 	"github.com/cilium/cilium/pkg/aws/eni"
+	"github.com/cilium/cilium/pkg/bgp/speaker"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/clustermesh"
@@ -1676,6 +1677,7 @@ type daemonParams struct {
 	NodeDiscovery       *nodediscovery.NodeDiscovery
 	Prefilter           datapath.PreFilter
 	CompilationLock     datapath.CompilationLock
+	MetalLBBgpSpeaker   *speaker.MetalLBSpeaker
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/pkg/bgp/speaker/cell.go
+++ b/pkg/bgp/speaker/cell.go
@@ -34,9 +34,9 @@ type speakerParams struct {
 	LocalCiliumNode daemonk8s.LocalCiliumNodeResource
 }
 
-func newMetalLBBGPSpeaker(params speakerParams) (*MetalLBSpeaker, error) {
+func newMetalLBBGPSpeaker(params speakerParams) (MetalLBBgpSpeaker, error) {
 	if !option.Config.BGPAnnounceLBIP && !option.Config.BGPAnnouncePodCIDR {
-		return nil, nil
+		return &noopSpeaker{}, nil
 	}
 
 	log.

--- a/pkg/bgp/speaker/cell.go
+++ b/pkg/bgp/speaker/cell.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package speaker
+
+import (
+	"context"
+
+	"github.com/cilium/hive/cell"
+
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// Cell provides access to the MetalLB BGP Speaker.
+var Cell = cell.Module(
+	"metallb-bgp",
+	"MetalLB BGP",
+
+	cell.Provide(newMetalLBBGPSpeaker),
+)
+
+type speakerParams struct {
+	cell.In
+
+	Lifecycle cell.Lifecycle
+
+	Clientset k8sClient.Clientset
+}
+
+func newMetalLBBGPSpeaker(params speakerParams) (*MetalLBSpeaker, error) {
+	if !option.Config.BGPAnnounceLBIP && !option.Config.BGPAnnouncePodCIDR {
+		return nil, nil
+	}
+
+	log.
+		WithField("url", "https://github.com/cilium/cilium/issues/22246").
+		Warn("You are using the legacy BGP feature, which will only receive security updates and bugfixes. " +
+			"It is recommended to migrate to the BGP Control Plane feature if possible, which has better support.")
+
+	speaker, err := newSpeaker(params.Clientset, Opts{
+		LoadBalancerIP: option.Config.BGPAnnounceLBIP,
+		PodCIDR:        option.Config.BGPAnnouncePodCIDR,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cf := context.WithCancel(context.Background())
+
+	params.Lifecycle.Append(cell.Hook{
+		OnStart: func(_ cell.HookContext) error {
+			go speaker.run(ctx)
+			log.Info("Started BGP speaker")
+
+			return nil
+		},
+		OnStop: func(_ cell.HookContext) error {
+			cf()
+			return nil
+		},
+	})
+
+	return speaker, nil
+}

--- a/pkg/bgp/speaker/cell.go
+++ b/pkg/bgp/speaker/cell.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cilium/hive/cell"
 
+	"github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -26,6 +27,7 @@ type speakerParams struct {
 	Lifecycle cell.Lifecycle
 
 	Clientset k8sClient.Clientset
+	SvcCache  *k8s.ServiceCache
 }
 
 func newMetalLBBGPSpeaker(params speakerParams) (*MetalLBSpeaker, error) {
@@ -38,7 +40,7 @@ func newMetalLBBGPSpeaker(params speakerParams) (*MetalLBSpeaker, error) {
 		Warn("You are using the legacy BGP feature, which will only receive security updates and bugfixes. " +
 			"It is recommended to migrate to the BGP Control Plane feature if possible, which has better support.")
 
-	speaker, err := newSpeaker(params.Clientset, Opts{
+	speaker, err := newSpeaker(params.Clientset, params.SvcCache, Opts{
 		LoadBalancerIP: option.Config.BGPAnnounceLBIP,
 		PodCIDR:        option.Config.BGPAnnouncePodCIDR,
 	})

--- a/pkg/bgp/speaker/events.go
+++ b/pkg/bgp/speaker/events.go
@@ -88,7 +88,7 @@ type nodeEvent struct {
 // loop is only stopped (implicitly) when the Agent is shutting down.
 //
 // Adapted from go.universe.tf/metallb/pkg/k8s/k8s.go.
-func (s *MetalLBSpeaker) run(ctx context.Context) {
+func (s *metallbspeaker) run(ctx context.Context) {
 	l := log.WithFields(
 		logrus.Fields{
 			"component": "MetalLBSpeaker.run",
@@ -132,7 +132,7 @@ func (s *MetalLBSpeaker) run(ctx context.Context) {
 // do performs the appropriate action depending on the event type. For example,
 // if it is a service event (svcEvent), then it will call into MetalLB's
 // SetService() to perform BGP announcements.
-func (s *MetalLBSpeaker) do(key interface{}) types.SyncState {
+func (s *metallbspeaker) do(key interface{}) types.SyncState {
 	l := log.WithFields(
 		logrus.Fields{
 			"component": "MetalLBSpeaker.do",
@@ -193,14 +193,12 @@ func (s *MetalLBSpeaker) do(key interface{}) types.SyncState {
 	}
 }
 
-func (s *MetalLBSpeaker) handleNodeEvent(k nodeEvent) types.SyncState {
-	var (
-		l = log.WithFields(logrus.Fields{
-			"component": "MetalLBSpeaker.handleNodeEvent",
-			"labels":    k.labels,
-			"cidrs":     k.podCIDRs,
-		})
-	)
+func (s *metallbspeaker) handleNodeEvent(k nodeEvent) types.SyncState {
+	l := log.WithFields(logrus.Fields{
+		"component": "MetalLBSpeaker.handleNodeEvent",
+		"labels":    k.labels,
+		"cidrs":     k.podCIDRs,
+	})
 
 	if k.withDraw {
 		// this is a best effort method call, so we don't

--- a/pkg/bgp/speaker/metallb.go
+++ b/pkg/bgp/speaker/metallb.go
@@ -4,7 +4,6 @@
 package speaker
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -59,7 +58,7 @@ type metalLBSpeaker struct {
 //
 // The MetalLB speaker will use the value of nodetypes.GetName() as
 // its node identity.
-func newMetalLBSpeaker(ctx context.Context, clientset client.Clientset) (Speaker, error) {
+func newMetalLBSpeaker(clientset client.Clientset) (Speaker, error) {
 	logger := &bgplog.Logger{Entry: log}
 	client := bgpk8s.New(logger.Logger, clientset)
 
@@ -97,12 +96,15 @@ func newMetalLBSpeaker(ctx context.Context, clientset client.Clientset) (Speaker
 func (m metalLBSpeaker) SetService(name string, svc *metallbspr.Service, eps *metallbspr.Endpoints) types.SyncState {
 	return m.C.SetService(m.logger, name, svc, eps)
 }
+
 func (m metalLBSpeaker) SetNodeLabels(labels map[string]string) types.SyncState {
 	return m.C.SetNodeLabels(m.logger, labels)
 }
+
 func (m metalLBSpeaker) PeerSessions() []metallbspr.Session {
 	return m.C.PeerSessions()
 }
+
 func (m metalLBSpeaker) GetBGPController() *metallbspr.BGPController {
 	return m.C.Protocols[config.BGP].(*metallbspr.BGPController)
 }

--- a/pkg/bgp/speaker/pod_cidr.go
+++ b/pkg/bgp/speaker/pod_cidr.go
@@ -13,9 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 )
 
-var (
-	emptyAdverts = []*metallbbgp.Advertisement{}
-)
+var emptyAdverts = []*metallbbgp.Advertisement{}
 
 // CidrSlice is a slice of Cidr strings with a method set for
 // converting them to MetalLB advertisements.
@@ -26,11 +24,9 @@ type CidrSlice []string
 // If a cidr cannot be parsed it is omitted from the array of Advertisements
 // returned an an error is logged.
 func (cs CidrSlice) ToAdvertisements() []*metallbbgp.Advertisement {
-	var (
-		l = log.WithFields(logrus.Fields{
-			"component": "CidrSlice.ToAdvertisements",
-		})
-	)
+	l := log.WithFields(logrus.Fields{
+		"component": "CidrSlice.ToAdvertisements",
+	})
 
 	adverts := make([]*metallbbgp.Advertisement, 0, len(cs))
 	for _, c := range cs {
@@ -54,12 +50,10 @@ func (cs CidrSlice) ToAdvertisements() []*metallbbgp.Advertisement {
 	return adverts
 }
 
-func (s *MetalLBSpeaker) withdraw() {
-	var (
-		l = log.WithFields(logrus.Fields{
-			"component": "MetalLBSpeaker.withdraw",
-		})
-	)
+func (s *metallbspeaker) withdraw() {
+	l := log.WithFields(logrus.Fields{
+		"component": "MetalLBSpeaker.withdraw",
+	})
 	// flip this bool so we start rejecting new events from
 	// entering the queue.
 	s.shutdown.Store(true)
@@ -88,12 +82,10 @@ func (s *MetalLBSpeaker) withdraw() {
 //
 // This function is not thread safe and should not be called while other functions that modify the underlying speaker
 // are being called.
-func (s *MetalLBSpeaker) announcePodCIDRs(cidrs CidrSlice) error {
-	var (
-		l = log.WithFields(logrus.Fields{
-			"component": "MetalLBSpeaker.announcePodCidrs",
-		})
-	)
+func (s *metallbspeaker) announcePodCIDRs(cidrs CidrSlice) error {
+	l := log.WithFields(logrus.Fields{
+		"component": "MetalLBSpeaker.announcePodCidrs",
+	})
 
 	ctl := s.speaker.GetBGPController()
 

--- a/pkg/bgp/speaker/speaker.go
+++ b/pkg/bgp/speaker/speaker.go
@@ -33,7 +33,7 @@ var ErrShutDown = errors.New("cannot enqueue event, speaker is shutdown")
 
 // newSpeaker creates a new MetalLB BGP speaker controller. Options are provided to
 // specify what the Speaker should announce via BGP.
-func newSpeaker(clientset client.Clientset, opts Opts) (*MetalLBSpeaker, error) {
+func newSpeaker(clientset client.Clientset, endpointsGetter endpointsGetter, opts Opts) (*MetalLBSpeaker, error) {
 	ctrl, err := newMetalLBSpeaker(clientset)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create MetalLB speaker: %w", err)
@@ -46,6 +46,7 @@ func newSpeaker(clientset client.Clientset, opts Opts) (*MetalLBSpeaker, error) 
 		announcePodCIDR: opts.PodCIDR,
 		queue:           workqueue.New(),
 		services:        make(map[k8s.ServiceID]*slim_corev1.Service),
+		endpointsGetter: endpointsGetter,
 	}
 
 	return spkr, nil
@@ -286,11 +287,6 @@ func eventLoop[T metaGetterObject](ctx context.Context, s *MetalLBSpeaker, res r
 			return
 		}
 	}
-}
-
-// RegisterSvcCache registers the K8s watcher cache with this Speaker.
-func (s *MetalLBSpeaker) RegisterSvcCache(cache endpointsGetter) {
-	s.endpointsGetter = cache
 }
 
 // endpointsGetter abstracts the github.com/cilium/cilium/pkg/k8s.ServiceCache

--- a/pkg/bgp/speaker/speaker.go
+++ b/pkg/bgp/speaker/speaker.go
@@ -240,11 +240,11 @@ func (s *MetalLBSpeaker) notifyNodeEvent(op Op, nodeMeta metaGetter, podCIDRs *[
 	return nil
 }
 
-func (s *MetalLBSpeaker) SubscribeToLocalNodeResource(ctx context.Context, lnr agentK8s.LocalNodeResource) {
+func (s *MetalLBSpeaker) subscribeToLocalNodeResource(ctx context.Context, lnr agentK8s.LocalNodeResource) {
 	go eventLoop[*slim_corev1.Node](ctx, s, lnr, nodePodCIDRs)
 }
 
-func (s *MetalLBSpeaker) SubscribeToLocalCiliumNodeResource(ctx context.Context, lcnr agentK8s.LocalCiliumNodeResource) {
+func (s *MetalLBSpeaker) subscribeToLocalCiliumNodeResource(ctx context.Context, lcnr agentK8s.LocalCiliumNodeResource) {
 	go eventLoop[*ciliumv2.CiliumNode](ctx, s, lcnr, ciliumNodePodCIDRs)
 }
 

--- a/pkg/bgp/speaker/speaker.go
+++ b/pkg/bgp/speaker/speaker.go
@@ -105,6 +105,11 @@ func (s *metallbspeaker) OnUpdateService(svc *slim_corev1.Service) error {
 	if s.shutDown() {
 		return ErrShutDown
 	}
+
+	if !s.announceLBIP {
+		return nil
+	}
+
 	var (
 		svcID = k8s.ParseServiceID(svc)
 		l     = log.WithFields(logrus.Fields{
@@ -143,6 +148,11 @@ func (s *metallbspeaker) OnDeleteService(svc *slim_corev1.Service) error {
 	if s.shutDown() {
 		return ErrShutDown
 	}
+
+	if !s.announceLBIP {
+		return nil
+	}
+
 	var (
 		svcID = k8s.ParseServiceID(svc)
 		l     = log.WithFields(logrus.Fields{
@@ -177,6 +187,11 @@ func (s *metallbspeaker) OnUpdateEndpoints(eps *k8s.Endpoints) error {
 	if s.shutDown() {
 		return ErrShutDown
 	}
+
+	if !s.announceLBIP {
+		return nil
+	}
+
 	var (
 		epSliceID = eps.EndpointSliceID
 		svcID     = epSliceID.ServiceID

--- a/pkg/bgp/speaker/speaker_test.go
+++ b/pkg/bgp/speaker/speaker_test.go
@@ -27,9 +27,7 @@ const (
 	DefaultTimeout = 60 * time.Second
 )
 
-var (
-	errTimeout = errors.New("timeout occurred before mock received event")
-)
+var errTimeout = errors.New("timeout occurred before mock received event")
 
 // TestSpeakerOnUpdateService confirms the speaker performs the correct
 // actions when an OnUpdateService event takes place.
@@ -74,7 +72,7 @@ func TestSpeakerOnUpdateService(t *testing.T) {
 		},
 	}
 
-	spkr := &MetalLBSpeaker{
+	spkr := &metallbspeaker{
 		Fencer:          fence.Fencer{},
 		speaker:         mock,
 		announceLBIP:    true,
@@ -157,7 +155,7 @@ func TestSpeakerOnDeleteService(t *testing.T) {
 
 	// in this test, we want to construct our speaker
 	// with a "known" service, and test that it is deleted.
-	spkr := &MetalLBSpeaker{
+	spkr := &metallbspeaker{
 		Fencer:          fence.Fencer{},
 		speaker:         mock,
 		announceLBIP:    true,
@@ -243,7 +241,7 @@ func TestSpeakerOnUpdateEndpoints(t *testing.T) {
 	// in this test we expect the service associated with the endpoints
 	// to exist as a lookup of the service is done in the OnUpdateEndpoints
 	// call.
-	spkr := &MetalLBSpeaker{
+	spkr := &metallbspeaker{
 		Fencer:          fence.Fencer{},
 		speaker:         mock,
 		announceLBIP:    true,
@@ -362,7 +360,7 @@ func TestSpeakerOnUpdateNode(t *testing.T) {
 		},
 	}
 
-	spkr := &MetalLBSpeaker{
+	spkr := &metallbspeaker{
 		Fencer:          fence.Fencer{},
 		speaker:         mock,
 		announceLBIP:    true,
@@ -466,7 +464,7 @@ func TestSpeakerOnDeleteNode(t *testing.T) {
 		},
 	}
 
-	spkr := &MetalLBSpeaker{
+	spkr := &metallbspeaker{
 		Fencer:          fence.Fencer{},
 		speaker:         mock,
 		announceLBIP:    true,
@@ -553,7 +551,7 @@ func TestSpeakerOnUpdateAndDeleteCiliumNode(t *testing.T) {
 		},
 	}
 
-	spkr := &MetalLBSpeaker{
+	spkr := &metallbspeaker{
 		Fencer:          fence.Fencer{},
 		speaker:         mockSpeaker,
 		announceLBIP:    true,

--- a/pkg/k8s/watchers/endpoints.go
+++ b/pkg/k8s/watchers/endpoints.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 )
 
@@ -64,9 +63,7 @@ func (k *K8sWatcher) endpointsInit() {
 
 func (k *K8sWatcher) updateEndpoint(eps *k8s.Endpoints, swgEps *lock.StoppableWaitGroup) {
 	k.K8sSvcCache.UpdateEndpoints(eps, swgEps)
-	if option.Config.BGPAnnounceLBIP {
-		k.bgpSpeakerManager.OnUpdateEndpoints(eps)
-	}
+	k.bgpSpeakerManager.OnUpdateEndpoints(eps)
 	k.addKubeAPIServerServiceEndpoints(eps)
 }
 

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -82,9 +82,7 @@ func (k *K8sWatcher) upsertK8sServiceV1(svc *slim_corev1.Service, swg *lock.Stop
 			k.redirectPolicyManager.OnAddService(svcID)
 		}
 	}
-	if option.Config.BGPAnnounceLBIP {
-		k.bgpSpeakerManager.OnUpdateService(svc)
-	}
+	k.bgpSpeakerManager.OnUpdateService(svc)
 }
 
 func (k *K8sWatcher) deleteK8sServiceV1(svc *slim_corev1.Service, swg *lock.StoppableWaitGroup) {
@@ -95,9 +93,7 @@ func (k *K8sWatcher) deleteK8sServiceV1(svc *slim_corev1.Service, swg *lock.Stop
 			k.redirectPolicyManager.OnDeleteService(svcID)
 		}
 	}
-	if option.Config.BGPAnnounceLBIP {
-		k.bgpSpeakerManager.OnDeleteService(svc)
-	}
+	k.bgpSpeakerManager.OnDeleteService(svc)
 }
 
 func (k *K8sWatcher) k8sServiceHandler() {


### PR DESCRIPTION
This PR introduces a Hive Cell for the MetalLB BGP speaker. (I'm aware that there are plans to deprecate and delete this functionality. But as long as this code exists, it's blocking other depending components from being properly modularized).

Please review the individual commits.

* introduce hive cell for speaker
* speaker explicitly depends on k8s service cache
* move speaker node subscription logic into cell
* introduce interface and noop implementation
* check announce LBIP in speaker