### PR TITLE
policy: Add Port Range Support for Policies 3/3

### DIFF
--- a/cilium-dbg/cmd/helpers.go
+++ b/cilium-dbg/cmd/helpers.go
@@ -346,15 +346,15 @@ func updatePolicyKey(pa *PolicyUpdateArgs, add bool) {
 				err       error
 			)
 			if pa.isDeny {
-				err = policyMap.Deny(pa.label, pa.port, u8p, pa.trafficDirection)
+				err = policyMap.Deny(pa.label, pa.port, policymap.SinglePortMask, u8p, pa.trafficDirection)
 			} else {
-				err = policyMap.Allow(pa.label, pa.port, u8p, pa.trafficDirection, authType, proxyPort)
+				err = policyMap.Allow(pa.label, pa.port, policymap.SinglePortMask, u8p, pa.trafficDirection, authType, proxyPort)
 			}
 			if err != nil {
 				Fatalf("Cannot add policy key '%s': %s\n", entry, err)
 			}
 		} else {
-			if err := policyMap.Delete(pa.label, pa.port, u8p, pa.trafficDirection); err != nil {
+			if err := policyMap.Delete(pa.label, pa.port, policymap.SinglePortMask, u8p, pa.trafficDirection); err != nil {
 				Fatalf("Cannot delete policy key '%s': %s\n", entry, err)
 			}
 		}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1097,7 +1097,7 @@ func (e *Endpoint) updatePolicyMapPressureMetric() {
 
 func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool) bool {
 	// Convert from policy.Key to policymap.Key
-	policymapKey := policymap.NewKey(keyToDelete.Identity, keyToDelete.DestPort,
+	policymapKey := policymap.NewKey(keyToDelete.Identity, keyToDelete.DestPort, keyToDelete.PortMask(),
 		keyToDelete.Nexthdr, keyToDelete.TrafficDirection)
 
 	// Do not error out if the map entry was already deleted from the bpf map.
@@ -1131,7 +1131,7 @@ func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool) boo
 
 func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry, incremental bool) bool {
 	// Convert from policy.Key to policymap.Key
-	policymapKey := policymap.NewKey(keyToAdd.Identity, keyToAdd.DestPort,
+	policymapKey := policymap.NewKey(keyToAdd.Identity, keyToAdd.DestPort, keyToAdd.PortMask(),
 		keyToAdd.Nexthdr, keyToAdd.TrafficDirection)
 
 	var err error

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -90,7 +90,9 @@ func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string
 }
 
 // proxyID returns a unique string to identify a proxy mapping,
-// and the resolved destination port and protocol numbers, if any.
+// and the resolved destination port number, if any.
+// For port ranges the proxy is identified by the first port in
+// the range, as overlapping proxy port ranges are not supported.
 // Must be called with e.mutex held.
 func (e *Endpoint) proxyID(l4 *policy.L4Filter, listener string) (string, uint16, uint8) {
 	port := l4.Port

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1626,7 +1626,7 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 		if port == 0 && l4.PortName != "" {
 			port = ep.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
 			if port == 0 {
-				return true
+				return true // Skip if a named port can not be resolved (yet)
 			}
 		}
 
@@ -1703,8 +1703,10 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 			return true
 		}
 
+		// NPDS supports port ranges.
 		PerPortPolicies = append(PerPortPolicies, &cilium.PortNetworkPolicy{
 			Port:     uint32(port),
+			EndPort:  uint32(l4.EndPort),
 			Protocol: protocol,
 			Rules:    SortPortNetworkPolicyRules(rules),
 		})

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -275,7 +275,7 @@ var ExpectedPortNetworkPolicyRule1Wildcard = &cilium.PortNetworkPolicyRule{
 	L7: ExpectedHttpRule1,
 }
 
-var L4PolicyMap1 = map[string]*policy.L4Filter{
+var L4PolicyMap1 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"80/TCP": {
 		Port:     80,
 		Protocol: api.ProtoTCP,
@@ -284,9 +284,9 @@ var L4PolicyMap1 = map[string]*policy.L4Filter{
 			cachedSelector1: L7Rules12,
 		},
 	},
-}
+})
 
-var L4PolicyMap1HeaderMatch = map[string]*policy.L4Filter{
+var L4PolicyMap1HeaderMatch = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"80/TCP": {
 		Port:     80,
 		Protocol: api.ProtoTCP,
@@ -295,9 +295,9 @@ var L4PolicyMap1HeaderMatch = map[string]*policy.L4Filter{
 			cachedSelector1: L7Rules12HeaderMatch,
 		},
 	},
-}
+})
 
-var L4PolicyMap1RequiresV2 = map[string]*policy.L4Filter{
+var L4PolicyMap1RequiresV2 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"80/TCP": {
 		Port:     80,
 		Protocol: api.ProtoTCP,
@@ -307,9 +307,9 @@ var L4PolicyMap1RequiresV2 = map[string]*policy.L4Filter{
 			cachedRequiresV2Selector1: L7Rules12,
 		},
 	},
-}
+})
 
-var L4PolicyMap2 = map[string]*policy.L4Filter{
+var L4PolicyMap2 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"8080/TCP": {
 		Port:     8080,
 		Protocol: api.ProtoTCP,
@@ -318,9 +318,9 @@ var L4PolicyMap2 = map[string]*policy.L4Filter{
 			cachedSelector2: L7Rules1,
 		},
 	},
-}
+})
 
-var L4PolicyMap3 = map[string]*policy.L4Filter{
+var L4PolicyMap3 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"80/TCP": {
 		Port:     80,
 		Protocol: api.ProtoTCP,
@@ -329,10 +329,10 @@ var L4PolicyMap3 = map[string]*policy.L4Filter{
 			wildcardCachedSelector: L7Rules12,
 		},
 	},
-}
+})
 
 // L4PolicyMap4 is an L4-only policy, with no L7 rules.
-var L4PolicyMap4 = map[string]*policy.L4Filter{
+var L4PolicyMap4 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"80/TCP": {
 		Port:     80,
 		Protocol: api.ProtoTCP,
@@ -340,10 +340,10 @@ var L4PolicyMap4 = map[string]*policy.L4Filter{
 			cachedSelector1: &policy.PerSelectorPolicy{L7Rules: api.L7Rules{}},
 		},
 	},
-}
+})
 
 // L4PolicyMap5 is an L4-only policy, with no L7 rules.
-var L4PolicyMap5 = map[string]*policy.L4Filter{
+var L4PolicyMap5 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"80/TCP": {
 		Port:     80,
 		Protocol: api.ProtoTCP,
@@ -351,10 +351,10 @@ var L4PolicyMap5 = map[string]*policy.L4Filter{
 			wildcardCachedSelector: &policy.PerSelectorPolicy{L7Rules: api.L7Rules{}},
 		},
 	},
-}
+})
 
 // L4PolicyMapSNI is an L4-only policy, with SNI enforcement
-var L4PolicyMapSNI = map[string]*policy.L4Filter{
+var L4PolicyMapSNI = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"443/TCP": {
 		Port:     443,
 		Protocol: api.ProtoTCP,
@@ -367,7 +367,7 @@ var L4PolicyMapSNI = map[string]*policy.L4Filter{
 			},
 		},
 	},
-}
+})
 
 var ExpectedPerPortPoliciesSNI = []*cilium.PortNetworkPolicy{
 	{
@@ -601,7 +601,7 @@ func TestGetNetworkPolicyEgressNotEnforced(t *testing.T) {
 }
 
 var L4PolicyL7 = &policy.L4Policy{
-	Ingress: policy.L4DirectionPolicy{PortRules: map[string]*policy.L4Filter{
+	Ingress: policy.L4DirectionPolicy{PortRules: policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 		"9090/TCP": {
 			Port: 9090, Protocol: api.ProtoTCP,
 			L7Parser: "tester",
@@ -622,7 +622,7 @@ var L4PolicyL7 = &policy.L4Policy{
 			},
 			Ingress: true,
 		},
-	}},
+	})},
 }
 
 var ExpectedPerPortPoliciesL7 = []*cilium.PortNetworkPolicy{
@@ -664,7 +664,7 @@ func TestGetNetworkPolicyL7(t *testing.T) {
 }
 
 var L4PolicyKafka = &policy.L4Policy{
-	Ingress: policy.L4DirectionPolicy{PortRules: map[string]*policy.L4Filter{
+	Ingress: policy.L4DirectionPolicy{PortRules: policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 		"9090/TCP": {
 			Port: 9092, Protocol: api.ProtoTCP,
 			L7Parser: "kafka",
@@ -678,7 +678,7 @@ var L4PolicyKafka = &policy.L4Policy{
 			},
 			Ingress: true,
 		},
-	}},
+	})},
 }
 
 var ExpectedPerPortPoliciesKafka = []*cilium.PortNetworkPolicy{
@@ -723,7 +723,7 @@ func TestGetNetworkPolicyKafka(t *testing.T) {
 }
 
 var L4PolicyMySQL = &policy.L4Policy{
-	Egress: policy.L4DirectionPolicy{PortRules: map[string]*policy.L4Filter{
+	Egress: policy.L4DirectionPolicy{PortRules: policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 		"3306/TCP": {
 			Port: 3306, Protocol: api.ProtoTCP,
 			L7Parser: "envoy.filters.network.mysql_proxy",
@@ -740,7 +740,7 @@ var L4PolicyMySQL = &policy.L4Policy{
 			},
 			Ingress: false,
 		},
-	}},
+	})},
 }
 
 var ExpectedPerPortPoliciesMySQL = []*cilium.PortNetworkPolicy{
@@ -849,7 +849,7 @@ func TestGetNetworkPolicyProxylibVisibility(t *testing.T) {
 }
 
 var L4PolicyTLSEgress = &policy.L4Policy{
-	Egress: policy.L4DirectionPolicy{PortRules: map[string]*policy.L4Filter{
+	Egress: policy.L4DirectionPolicy{PortRules: policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 		"443/TCP": {
 			Port: 443, Protocol: api.ProtoTCP,
 			L7Parser: "tls",
@@ -861,7 +861,7 @@ var L4PolicyTLSEgress = &policy.L4Policy{
 				},
 			},
 		},
-	}},
+	})},
 }
 
 var ExpectedPerPortPoliciesTLSEgress = []*cilium.PortNetworkPolicy{
@@ -888,7 +888,7 @@ func TestGetNetworkPolicyTLSEgress(t *testing.T) {
 }
 
 var L4PolicyTLSIngress = &policy.L4Policy{
-	Ingress: policy.L4DirectionPolicy{PortRules: map[string]*policy.L4Filter{
+	Ingress: policy.L4DirectionPolicy{PortRules: policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 		"443/TCP": {
 			Port: 443, Protocol: api.ProtoTCP,
 			L7Parser: "tls",
@@ -902,7 +902,7 @@ var L4PolicyTLSIngress = &policy.L4Policy{
 			},
 			Ingress: true,
 		},
-	}},
+	})},
 }
 
 var ExpectedPerPortPoliciesTLSIngress = []*cilium.PortNetworkPolicy{
@@ -930,7 +930,7 @@ func TestGetNetworkPolicyTLSIngress(t *testing.T) {
 }
 
 var L4PolicyTLSFullContext = &policy.L4Policy{
-	Ingress: policy.L4DirectionPolicy{PortRules: map[string]*policy.L4Filter{
+	Ingress: policy.L4DirectionPolicy{PortRules: policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 		"443/TCP": {
 			Port: 443, Protocol: api.ProtoTCP,
 			L7Parser: "tls",
@@ -950,7 +950,7 @@ var L4PolicyTLSFullContext = &policy.L4Policy{
 			},
 			Ingress: true,
 		},
-	}},
+	})},
 }
 
 var ExpectedPerPortPoliciesTLSFullContext = []*cilium.PortNetworkPolicy{

--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -251,26 +251,6 @@ func ParseNetworkPolicy(np *slim_networkingv1.NetworkPolicy) (api.Rules, error) 
 	return api.Rules{rule}, nil
 }
 
-// NetworkPolicyHasEndPort returns true if the network policy has an
-// EndPort.
-func NetworkPolicyHasEndPort(np *slim_networkingv1.NetworkPolicy) bool {
-	for _, iRule := range np.Spec.Ingress {
-		for _, port := range iRule.Ports {
-			if port.EndPort != nil && *port.EndPort > 0 {
-				return true
-			}
-		}
-	}
-	for _, eRule := range np.Spec.Egress {
-		for _, port := range eRule.Ports {
-			if port.EndPort != nil && *port.EndPort > 0 {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 func parsePodSelector(podSelectorIn *slim_metav1.LabelSelector, namespace string) *slim_metav1.LabelSelector {
 	podSelector := &slim_metav1.LabelSelector{
 		MatchLabels: make(map[string]slim_metav1.MatchLabelsValue, len(podSelectorIn.MatchLabels)),
@@ -317,13 +297,17 @@ func parsePorts(ports []slim_networkingv1.NetworkPolicyPort) []api.PortRule {
 		}
 
 		portStr := "0"
+		var endPort int32
 		if port.Port != nil {
 			portStr = port.Port.String()
+		}
+		if port.EndPort != nil {
+			endPort = *port.EndPort
 		}
 
 		portRule := api.PortRule{
 			Ports: []api.PortProtocol{
-				{Port: portStr, Protocol: protocol},
+				{Port: portStr, EndPort: endPort, Protocol: protocol},
 			},
 		}
 

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -73,6 +73,15 @@ var (
 		},
 	}
 
+	int8090        = int32(8090)
+	port8080to8090 = slim_networkingv1.NetworkPolicyPort{
+		Port: &intstr.IntOrString{
+			Type:   intstr.Int,
+			IntVal: 8080,
+		},
+		EndPort: &int8090,
+	}
+
 	dummySelectorCacheUser = &DummySelectorCacheUser{}
 )
 
@@ -577,6 +586,36 @@ func TestParseNetworkPolicyEgressL4AllowAll(t *testing.T) {
 	ctxAToC90 := ctxAToC
 	ctxAToC90.DPorts = []*models.Port{{Port: 90, Protocol: models.PortProtocolTCP}}
 	require.Equal(t, api.Denied, repo.AllowsEgressRLocked(&ctxAToC90))
+}
+
+func TestParseNetworkPolicyEgressL4PortRangeAllowAll(t *testing.T) {
+	repo := parseAndAddRules(t, &slim_networkingv1.NetworkPolicy{
+		Spec: slim_networkingv1.NetworkPolicySpec{
+			PodSelector: labelSelectorA,
+			Egress: []slim_networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []slim_networkingv1.NetworkPolicyPort{port8080to8090},
+					To:    []slim_networkingv1.NetworkPolicyPeer{},
+				},
+			},
+		},
+	})
+
+	ctxAToC8080 := ctxAToC
+	ctxAToC8080.DPorts = []*models.Port{{Port: 8080, Protocol: models.PortProtocolTCP}}
+	require.Equal(t, repo.AllowsEgressRLocked(&ctxAToC8080), api.Allowed)
+
+	ctxAToC8085 := ctxAToC
+	ctxAToC8085.DPorts = []*models.Port{{Port: 8085, Protocol: models.PortProtocolTCP}}
+	require.Equal(t, repo.AllowsEgressRLocked(&ctxAToC8085), api.Allowed)
+
+	ctxAToC8090 := ctxAToC
+	ctxAToC8090.DPorts = []*models.Port{{Port: 8090, Protocol: models.PortProtocolTCP}}
+	require.Equal(t, repo.AllowsEgressRLocked(&ctxAToC8090), api.Allowed)
+
+	ctxAToC8091 := ctxAToC
+	ctxAToC8091.DPorts = []*models.Port{{Port: 8091, Protocol: models.PortProtocolTCP}}
+	require.Equal(t, repo.AllowsEgressRLocked(&ctxAToC8091), api.Denied)
 }
 
 func TestParseNetworkPolicyIngressAllowAll(t *testing.T) {

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -156,7 +156,7 @@ func TestParseNetworkPolicyIngress(t *testing.T) {
 	ingressL4Policy, err := repo.ResolveL4IngressPolicy(&ctx)
 	require.NotNil(t, ingressL4Policy)
 	require.NoError(t, err)
-	require.EqualValues(t, policy.L4PolicyMap{
+	expected := policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 		"80/TCP": {
 			Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 			L7Parser:            policy.ParserTypeNone,
@@ -171,7 +171,8 @@ func TestParseNetworkPolicyIngress(t *testing.T) {
 				)},
 			},
 		},
-	}, ingressL4Policy)
+	})
+	require.True(t, ingressL4Policy.Equals(t, expected), ingressL4Policy.Diff(t, expected))
 	ingressL4Policy.Detach(repo.GetSelectorCache())
 
 	ctx.To = labels.LabelArray{
@@ -485,7 +486,7 @@ func TestParseNetworkPolicyEgress(t *testing.T) {
 	egressL4Policy, err := repo.ResolveL4EgressPolicy(&ctx)
 	require.NotNil(t, egressL4Policy)
 	require.NoError(t, err)
-	require.EqualValues(t, policy.L4PolicyMap{
+	expected := policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 		"80/TCP": {
 			Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 			L7Parser:            policy.ParserTypeNone,
@@ -495,7 +496,8 @@ func TestParseNetworkPolicyEgress(t *testing.T) {
 				cachedEPSelector: {rules[0].Labels},
 			},
 		},
-	}, egressL4Policy)
+	})
+	require.True(t, egressL4Policy.Equals(t, expected), egressL4Policy.Diff(t, expected))
 	egressL4Policy.Detach(repo.GetSelectorCache())
 
 	ctx.From = labels.LabelArray{

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -5,6 +5,7 @@ package policymap
 
 import (
 	"fmt"
+	"math/bits"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -44,6 +45,10 @@ const (
 	// PressureMetricThreshold sets the threshold over which map pressure will
 	// be reported for the policy map.
 	PressureMetricThreshold = 0.1
+
+	// SinglePortMask represents the mask argument required to lookup or
+	// insert a single port key into the bpf map.
+	SinglePortMask = 0xffff
 )
 
 // policyEntryFlags is a new type used to define the flags used in the policy
@@ -122,7 +127,16 @@ func (k *PolicyKey) GetPortMask() uint16 {
 	if k.DestPortNetwork == 0 {
 		return 0
 	}
-	return 0xffff
+	prefixLen := k.Prefixlen - StaticPrefixBits
+	if prefixLen == FullPrefixBits {
+		return 0xffff
+	}
+	if prefixLen == 0 || prefixLen == NexthdrBits {
+		return 0
+	}
+	portPrefixLen := prefixLen - NexthdrBits
+	portLen := prefixLenPortLenMap[portPrefixLen]
+	return ^portLen
 }
 
 const (
@@ -238,10 +252,34 @@ func (p PolicyEntriesDump) Less(i, j int) bool {
 		p[i].Key.Identity < p[j].Key.Identity
 }
 
+// prefixLenPortLenMaskMap is the map of all the possible prefix lengths
+// of the port field in the policy key, corresponding to the port
+// length of that mask. The "16" prefix len implies a full mask (that is,
+// 0 additional ports) and makes the default return value, 0, useful.
+var prefixLenPortLenMap = map[uint32]uint16{
+	0:  0xffff,
+	1:  0x7fff,
+	2:  0x3fff,
+	3:  0x1fff,
+	4:  0xfff,
+	5:  0x7ff,
+	6:  0x3ff,
+	7:  0x1ff,
+	8:  0xff,
+	9:  0x7f,
+	10: 0x3f,
+	11: 0x1f,
+	12: 0xf,
+	13: 0x7,
+	14: 0x3,
+	15: 0x1,
+}
+
 func (key *PolicyKey) PortProtoString() string {
 	dport := key.GetDestPort()
 	protoStr := u8proto.U8proto(key.Nexthdr).String()
 	prefixLen := key.Prefixlen - StaticPrefixBits
+	portPrefixLen := prefixLen - NexthdrBits
 
 	switch {
 	case prefixLen == 0, prefixLen == NexthdrBits:
@@ -249,7 +287,8 @@ func (key *PolicyKey) PortProtoString() string {
 		return protoStr
 	case prefixLen > NexthdrBits && prefixLen < FullPrefixBits:
 		// Protocol specified, partially wildcarded port
-		return fmt.Sprintf("0x%x/%d/%s", dport, prefixLen-NexthdrBits, protoStr)
+		portLen := prefixLenPortLenMap[portPrefixLen]
+		return fmt.Sprintf("%d-%d/%s", dport, dport+portLen, protoStr)
 	case prefixLen == FullPrefixBits:
 		// Both protocol and port specified, nothing wildcarded
 		return fmt.Sprintf("%d/%s", dport, protoStr)
@@ -269,14 +308,13 @@ func (key *PolicyKey) New() bpf.MapKey { return &PolicyKey{} }
 
 // NewKey returns a PolicyKey representing the specified parameters in network
 // byte-order.
-func NewKey(id uint32, dport uint16, proto uint8, trafficDirection uint8) PolicyKey {
-	// For now prefix length is derived from the proto and dport values
-	// This will have to be exposed to the caller when port ranges are supported.
+func NewKey(id uint32, dport, mask uint16, proto uint8, trafficDirection uint8) PolicyKey {
+
 	prefixLen := StaticPrefixBits
-	if proto != 0 {
+	if proto != 0 || dport != 0 {
 		prefixLen += NexthdrBits
 		if dport != 0 {
-			prefixLen += DestPortBits
+			prefixLen += DestPortBits - uint32(bits.TrailingZeros16(mask))
 		}
 	}
 	return PolicyKey{
@@ -290,8 +328,8 @@ func NewKey(id uint32, dport uint16, proto uint8, trafficDirection uint8) Policy
 
 // newKey returns a PolicyKey representing the specified parameters in network
 // byte-order.
-func newKey(id uint32, dport uint16, proto u8proto.U8proto, trafficDirection trafficdirection.TrafficDirection) PolicyKey {
-	return NewKey(id, dport, uint8(proto), trafficDirection.Uint8())
+func newKey(id uint32, dport, portMask uint16, proto u8proto.U8proto, trafficDirection trafficdirection.TrafficDirection) PolicyKey {
+	return NewKey(id, dport, portMask, uint8(proto), trafficDirection.Uint8())
 }
 
 // newEntry returns a PolicyEntry representing the specified parameters in
@@ -337,8 +375,8 @@ func (pm *PolicyMap) AllowKey(key PolicyKey, authType uint8, proxyPort uint16) e
 // Allow pushes an entry into the PolicyMap to allow traffic in the given
 // `trafficDirection` for identity `id` with destination port `dport` over
 // protocol `proto`. It is assumed that `dport` and `proxyPort` are in host byte-order.
-func (pm *PolicyMap) Allow(id uint32, dport uint16, proto u8proto.U8proto, trafficDirection trafficdirection.TrafficDirection, authType uint8, proxyPort uint16) error {
-	key := newKey(id, dport, proto, trafficDirection)
+func (pm *PolicyMap) Allow(id uint32, dport, portMask uint16, proto u8proto.U8proto, trafficDirection trafficdirection.TrafficDirection, authType uint8, proxyPort uint16) error {
+	key := newKey(id, dport, portMask, proto, trafficDirection)
 	return pm.AllowKey(key, authType, proxyPort)
 }
 
@@ -352,16 +390,16 @@ func (pm *PolicyMap) DenyKey(key PolicyKey) error {
 // Deny pushes an entry into the PolicyMap to deny traffic in the given
 // `trafficDirection` for identity `id` with destination port `dport` over
 // protocol `proto`. It is assumed that `dport` is in host byte-order.
-func (pm *PolicyMap) Deny(id uint32, dport uint16, proto u8proto.U8proto, trafficDirection trafficdirection.TrafficDirection) error {
-	key := newKey(id, dport, proto, trafficDirection)
+func (pm *PolicyMap) Deny(id uint32, dport, portMask uint16, proto u8proto.U8proto, trafficDirection trafficdirection.TrafficDirection) error {
+	key := newKey(id, dport, portMask, proto, trafficDirection)
 	return pm.DenyKey(key)
 }
 
 // Exists determines whether PolicyMap currently contains an entry that
 // allows traffic in `trafficDirection` for identity `id` with destination port
 // `dport`over protocol `proto`. It is assumed that `dport` is in host byte-order.
-func (pm *PolicyMap) Exists(id uint32, dport uint16, proto u8proto.U8proto, trafficDirection trafficdirection.TrafficDirection) bool {
-	key := newKey(id, dport, proto, trafficDirection)
+func (pm *PolicyMap) Exists(id uint32, dport, portMask uint16, proto u8proto.U8proto, trafficDirection trafficdirection.TrafficDirection) bool {
+	key := newKey(id, dport, portMask, proto, trafficDirection)
 	_, err := pm.Lookup(&key)
 	return err == nil
 }
@@ -376,8 +414,8 @@ func (pm *PolicyMap) DeleteKey(key PolicyKey) error {
 // sending traffic in direction `trafficDirection` with destination port `dport`
 // over protocol `proto`. It is assumed that `dport` is in host byte-order.
 // Returns an error if the deletion did not succeed.
-func (pm *PolicyMap) Delete(id uint32, dport uint16, proto u8proto.U8proto, trafficDirection trafficdirection.TrafficDirection) error {
-	k := newKey(id, dport, proto, trafficDirection)
+func (pm *PolicyMap) Delete(id uint32, dport, portMask uint16, proto u8proto.U8proto, trafficDirection trafficdirection.TrafficDirection) error {
+	k := newKey(id, dport, portMask, proto, trafficDirection)
 	return pm.Map.Delete(&k)
 }
 

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
+
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -44,7 +45,7 @@ func setupPolicyMapPrivilegedTestSuite(tb testing.TB) *PolicyMap {
 func TestPolicyMapDumpToSlice(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 
-	fooEntry := newKey(1, 1, 1, 1)
+	fooEntry := newKey(1, 1, SinglePortMask, 1, 1)
 	err := testMap.AllowKey(fooEntry, 0, 0)
 	require.Nil(t, err)
 
@@ -55,7 +56,7 @@ func TestPolicyMapDumpToSlice(t *testing.T) {
 	require.EqualValues(t, fooEntry, dump[0].Key)
 
 	// Special case: allow-all entry
-	barEntry := newKey(0, 0, 0, 0)
+	barEntry := newKey(0, 0, SinglePortMask, 0, 0)
 	err = testMap.AllowKey(barEntry, 0, 0)
 	require.Nil(t, err)
 
@@ -66,8 +67,7 @@ func TestPolicyMapDumpToSlice(t *testing.T) {
 
 func TestDeleteNonexistentKey(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
-
-	key := newKey(27, 80, u8proto.TCP, trafficdirection.Ingress)
+	key := newKey(27, 80, SinglePortMask, u8proto.TCP, trafficdirection.Ingress)
 	err := testMap.Map.Delete(&key)
 	require.NotNil(t, err)
 	var errno unix.Errno
@@ -78,7 +78,7 @@ func TestDeleteNonexistentKey(t *testing.T) {
 func TestDenyPolicyMapDumpToSlice(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 
-	fooKey := newKey(1, 1, 1, 1)
+	fooKey := newKey(1, 1, SinglePortMask, 1, 1)
 	fooEntry := newDenyEntry(fooKey)
 	err := testMap.DenyKey(fooKey)
 	require.Nil(t, err)
@@ -91,7 +91,7 @@ func TestDenyPolicyMapDumpToSlice(t *testing.T) {
 	require.EqualValues(t, fooEntry, dump[0].PolicyEntry)
 
 	// Special case: deny-all entry
-	barKey := newKey(0, 0, 0, 0)
+	barKey := newKey(0, 0, SinglePortMask, 0, 0)
 	err = testMap.DenyKey(barKey)
 	require.Nil(t, err)
 

--- a/pkg/maps/policymap/policymap_test.go
+++ b/pkg/maps/policymap/policymap_test.go
@@ -263,7 +263,7 @@ func TestPolicyMapWildcarding(t *testing.T) {
 		}
 
 		// Get key
-		key := newKey(uint32(tt.args.id), uint16(tt.args.dport), u8proto.U8proto(tt.args.proto),
+		key := newKey(uint32(tt.args.id), uint16(tt.args.dport), SinglePortMask, u8proto.U8proto(tt.args.proto),
 			trafficdirection.TrafficDirection(tt.args.trafficDirection))
 
 		// Compure entry & validate key and entry

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -34,7 +34,7 @@ func FuzzResolveEgressPolicy(f *testing.F) {
 		rule := &rule{Rule: r}
 		state := traceState{}
 		td := newTestData()
-		_, _ = rule.resolveEgressPolicy(td.testPolicyContext, fromBar, &state, L4PolicyMap{}, nil, nil)
+		_, _ = rule.resolveEgressPolicy(td.testPolicyContext, fromBar, &state, NewL4PolicyMap(), nil, nil)
 
 	})
 }

--- a/pkg/policy/k8s/network_policy.go
+++ b/pkg/policy/k8s/network_policy.go
@@ -31,10 +31,6 @@ func (p *policyWatcher) addK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPo
 	}
 	scopedLog = scopedLog.WithField(logfields.K8sNetworkPolicyName, k8sNP.ObjectMeta.Name)
 
-	if k8s.NetworkPolicyHasEndPort(k8sNP) {
-		scopedLog.Warning("EndPort in kubernetes NetworkPolicy is not supported")
-	}
-
 	opts := policy.AddOptions{
 		Source: source.Kubernetes,
 		Resource: ipcacheTypes.NewResourceID(

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -7,14 +7,18 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math/bits"
 	"sort"
 	"strconv"
+	"strings"
 	"sync/atomic"
+	"testing"
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/container/bitlpm"
 	"github.com/cilium/cilium/pkg/iana"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
@@ -496,6 +500,31 @@ func (l4 *L4Filter) GetIngress() bool {
 // GetPort returns the port at which the L4Filter applies as a uint16.
 func (l4 *L4Filter) GetPort() uint16 {
 	return l4.Port
+}
+
+// Equals returns true if two L4Filters are equal
+func (l4 *L4Filter) Equals(_ *testing.T, bL4 *L4Filter) bool {
+	if l4.Port == bL4.Port &&
+		l4.EndPort == bL4.EndPort &&
+		l4.PortName == bL4.PortName &&
+		l4.Protocol == bL4.Protocol &&
+		l4.Ingress == bL4.Ingress &&
+		l4.L7Parser == bL4.L7Parser &&
+		l4.wildcard == bL4.wildcard {
+
+		if len(l4.PerSelectorPolicies) != len(bL4.PerSelectorPolicies) {
+			return false
+		}
+		for k, v := range l4.PerSelectorPolicies {
+			bV, ok := bL4.PerSelectorPolicies[k]
+			if !ok || !bV.Equal(v) {
+				return false
+			}
+
+		}
+		return true
+	}
+	return false
 }
 
 // ChangeState allows caller to revert changes made by (multiple) toMapState call(s)
@@ -1061,10 +1090,9 @@ func addL4Filter(policyCtx PolicyContext,
 	filterToMerge *L4Filter,
 	ruleLabels labels.LabelArray) error {
 
-	key := p.Port + "/" + string(proto)
-	existingFilter, ok := resMap[key]
-	if !ok {
-		resMap[key] = filterToMerge
+	existingFilter := resMap.ExactLookup(p.Port, uint16(p.EndPort), string(proto))
+	if existingFilter == nil {
+		resMap.Upsert(p.Port, uint16(p.EndPort), string(proto), filterToMerge)
 		return nil
 	}
 
@@ -1084,13 +1112,287 @@ func addL4Filter(policyCtx PolicyContext,
 		}
 	}
 
-	resMap[key] = existingFilter
+	resMap.Upsert(p.Port, uint16(p.EndPort), string(proto), existingFilter)
 	return nil
 }
 
-// L4PolicyMap is a list of L4 filters indexable by protocol/port
-// key format: "port/proto"
-type L4PolicyMap map[string]*L4Filter
+// L4PolicyMap is a list of L4 filters indexable by port/endport/protocol
+type L4PolicyMap interface {
+	Upsert(port string, endPort uint16, protocol string, l4 *L4Filter)
+	Delete(port string, endPort uint16, protocol string)
+	ExactLookup(port string, endPort uint16, protocol string) *L4Filter
+	LongestPrefixMatch(port string, protocol string) *L4Filter
+	Detach(selectorCache *SelectorCache)
+	IngressCoversContext(ctx *SearchContext) api.Decision
+	EgressCoversContext(ctx *SearchContext) api.Decision
+	ForEach(func(l4 *L4Filter) bool)
+	Equals(t *testing.T, bMap L4PolicyMap) bool
+	Diff(t *testing.T, expectedMap L4PolicyMap) string
+	Len() int
+}
+
+// NewL4PolicyMap creates an new L4PolicMap.
+func NewL4PolicyMap() L4PolicyMap {
+	return &l4PolicyMap{
+		namedPortMap: make(map[string]*L4Filter),
+		rangePortMap: bitlpm.NewUintTrie[uint32, map[portProtoKey]*L4Filter](),
+	}
+}
+
+// NewL4PolicyMapWithValues creates an new L4PolicMap, with an initial
+// set of values. The initMap argument does not support port ranges.
+func NewL4PolicyMapWithValues(initMap map[string]*L4Filter) L4PolicyMap {
+	l4M := &l4PolicyMap{
+		namedPortMap: make(map[string]*L4Filter),
+		rangePortMap: bitlpm.NewUintTrie[uint32, map[portProtoKey]*L4Filter](),
+	}
+	for k, v := range initMap {
+		portProtoSlice := strings.Split(k, "/")
+		if len(portProtoSlice) < 2 {
+			continue
+		}
+		l4M.Upsert(portProtoSlice[0], 0, portProtoSlice[1], v)
+	}
+	return l4M
+}
+
+type portProtoKey struct {
+	port, endPort uint16
+	proto         uint8
+}
+
+// l4PolicyMap is the implementation of L4PolicyMap
+type l4PolicyMap struct {
+	// namedPortMap represents the named ports (a Kubernetes feature)
+	// that map to an L4Filter. They must be tracked at the selection
+	// level, because they can only be resolved at the endpoint/identity
+	// level. Named ports cannot have ranges.
+	namedPortMap map[string]*L4Filter
+	// rangePortMap has to keep a map of L4Filters rather than
+	// a single L4Filter reference so that the l4PolicyMap does
+	// not merge L4Filter that are not the same port range, but
+	// share an overlapping range in the trie.
+	rangePortMap *bitlpm.UintTrie[uint32, map[portProtoKey]*L4Filter]
+	// rangeMapLen counts the number of unique L4Filters in
+	// the rangePortMap. It must be tracked separately from
+	// rangePortMap as L4Filters are split up when
+	// the port range length is not a power of two.
+	rangeMapLen int
+}
+
+func parsePortProtocol(port, protocol string) (uint16, uint8) {
+	// These string values have been validated many times
+	// over at this point.
+	prt, _ := strconv.ParseUint(port, 10, 16)
+	proto, _ := u8proto.ParseProtocol(protocol)
+	return uint16(prt), uint8(proto)
+}
+
+// makePolicyMapKey creates a protocol-port uint32 with the
+// upper 16 bits containing the protocol and the lower 16
+// bits containing the port.
+func makePolicyMapKey(port, mask uint16, proto uint8) uint32 {
+	return (uint32(proto) << 16) | uint32(port&mask)
+}
+
+// Upsert L4Filter adds an L4Filter indexed by protocol/port-endPort.
+func (l4M *l4PolicyMap) Upsert(port string, endPort uint16, protocol string, l4 *L4Filter) {
+	if iana.IsSvcName(port) {
+		l4M.namedPortMap[port+"/"+protocol] = l4
+		return
+	}
+
+	portU, protoU := parsePortProtocol(port, protocol)
+	ppK := portProtoKey{
+		port:    portU,
+		endPort: endPort,
+		proto:   protoU,
+	}
+	var upsertHappened bool
+	for _, mp := range PortRangeToMaskedPorts(portU, endPort) {
+		k := makePolicyMapKey(mp.port, mp.mask, protoU)
+		prefix := 32 - uint(bits.TrailingZeros16(mp.mask))
+		portProtoMap, ok := l4M.rangePortMap.ExactLookup(prefix, k)
+		if !ok {
+			portProtoMap = make(map[portProtoKey]*L4Filter)
+			l4M.rangePortMap.Upsert(prefix, k, portProtoMap)
+		}
+		if !upsertHappened {
+			if _, ok := portProtoMap[ppK]; !ok {
+				l4M.rangeMapLen += 1
+				upsertHappened = true
+			}
+		}
+		portProtoMap[ppK] = l4
+	}
+}
+
+// Delete an L4Filter from the index by protocol/port-endPort
+func (l4M *l4PolicyMap) Delete(port string, endPort uint16, protocol string) {
+	if iana.IsSvcName(port) {
+		delete(l4M.namedPortMap, port+"/"+protocol)
+		return
+	}
+
+	portU, protoU := parsePortProtocol(port, protocol)
+	ppK := portProtoKey{
+		port:    portU,
+		endPort: endPort,
+		proto:   protoU,
+	}
+	var deleteHappened bool
+	for _, mp := range PortRangeToMaskedPorts(portU, endPort) {
+		k := makePolicyMapKey(mp.port, mp.mask, protoU)
+		prefix := 32 - uint(bits.TrailingZeros16(mp.mask))
+		portProtoMap, ok := l4M.rangePortMap.ExactLookup(prefix, k)
+		if !ok {
+			return
+		}
+		if _, ok := portProtoMap[ppK]; ok {
+			delete(portProtoMap, ppK)
+			if !deleteHappened {
+				l4M.rangeMapLen -= 1
+				deleteHappened = true
+			}
+		}
+		if len(portProtoMap) == 0 {
+			l4M.rangePortMap.Delete(prefix, k)
+		}
+	}
+}
+
+// ExactLookup looks up an L4Filter by protocol/port-endPort and looks for an exact match.
+func (l4M *l4PolicyMap) ExactLookup(port string, endPort uint16, protocol string) *L4Filter {
+	if iana.IsSvcName(port) {
+		return l4M.namedPortMap[port+"/"+protocol]
+	}
+
+	portU, protoU := parsePortProtocol(port, protocol)
+	ppK := portProtoKey{
+		port:    portU,
+		endPort: endPort,
+		proto:   protoU,
+	}
+	for _, mp := range PortRangeToMaskedPorts(portU, endPort) {
+		k := makePolicyMapKey(mp.port, mp.mask, protoU)
+		prefix := 32 - uint(bits.TrailingZeros16(mp.mask))
+		portProtoMap, ok := l4M.rangePortMap.ExactLookup(prefix, k)
+		if !ok {
+			return nil
+		}
+		if l4, ok := portProtoMap[ppK]; ok {
+			return l4
+		}
+	}
+	return nil
+}
+
+// LongestPrefixMatch looks up an L4Filter by protocol/port that contains the port and protocol
+// by longest prefix match. If a named port is passed, then a simple lookup in the named port
+// map is used, not a prefix match.
+func (l4M *l4PolicyMap) LongestPrefixMatch(port string, protocol string) *L4Filter {
+	if iana.IsSvcName(port) {
+		return l4M.namedPortMap[port+"/"+protocol]
+	}
+	portU, protoU := parsePortProtocol(port, protocol)
+	portProtoMap, ok := l4M.rangePortMap.LongestPrefixMatch(makePolicyMapKey(portU, 0xffff, protoU))
+	if !ok {
+		return nil
+	}
+	var (
+		shortestPortRange uint16 = 0xffff
+		lastL4            *L4Filter
+	)
+	// Use the smallest port range
+	for k, v := range portProtoMap {
+		// single port match
+		if k.endPort <= k.port {
+			return v
+		}
+		if shortestPortRange > (k.endPort - k.port) {
+			lastL4 = v
+			shortestPortRange = (k.endPort - k.port)
+		}
+	}
+	return lastL4
+}
+
+// ForEach iterates over all L4Filters in the l4PolicyMap.
+func (l4M *l4PolicyMap) ForEach(fn func(l4 *L4Filter) bool) {
+	for _, f := range l4M.namedPortMap {
+		fn(f)
+	}
+	l4PortProtoKeys := make(map[portProtoKey]struct{})
+	l4M.rangePortMap.ForEach(func(prefix uint, key uint32, portPortoMap map[portProtoKey]*L4Filter) bool {
+		for k, v := range portPortoMap {
+			// We check for redundant L4Filters, because we split them apart in the index.
+			if _, ok := l4PortProtoKeys[k]; !ok {
+				fn(v)
+				l4PortProtoKeys[k] = struct{}{}
+			}
+		}
+		return true
+	})
+}
+
+// Equals returns true if both L4PolicyMaps are equal.
+func (l4M *l4PolicyMap) Equals(_ *testing.T, bMap L4PolicyMap) bool {
+	if l4M.Len() != bMap.Len() {
+		return false
+	}
+	equal := true
+	l4M.ForEach(func(l4 *L4Filter) bool {
+		port := l4.PortName
+		if len(port) == 0 {
+			port = fmt.Sprintf("%d", l4.Port)
+		}
+		l4B := bMap.ExactLookup(port, l4.EndPort, string(l4.Protocol))
+		equal = l4.Equals(nil, l4B)
+		return equal
+	})
+	return equal
+}
+
+// Diff returns the difference between to L4PolicyMaps.
+func (l4M *l4PolicyMap) Diff(_ *testing.T, expected L4PolicyMap) (res string) {
+	res += "Missing (-), Unexpected (+):\n"
+	expected.ForEach(func(eV *L4Filter) bool {
+		port := eV.PortName
+		if len(port) == 0 {
+			port = fmt.Sprintf("%d", eV.Port)
+		}
+		oV := l4M.ExactLookup(port, eV.Port, string(eV.Protocol))
+		if oV != nil {
+			if !eV.Equals(nil, oV) {
+				res += "- " + eV.String() + "\n"
+				res += "+ " + oV.String() + "\n"
+			}
+		} else {
+			res += "- " + eV.String() + "\n"
+		}
+		return true
+	})
+	l4M.ForEach(func(oV *L4Filter) bool {
+		port := oV.PortName
+		if len(port) == 0 {
+			port = fmt.Sprintf("%d", oV.Port)
+		}
+		eV := expected.ExactLookup(port, oV.Port, string(oV.Protocol))
+		if eV == nil {
+			res += "+ " + oV.String() + "\n"
+		}
+		return true
+	})
+	return
+}
+
+// Len returns the number of entries in the map.
+func (l4M *l4PolicyMap) Len() int {
+	if l4M == nil {
+		return 0
+	}
+	return len(l4M.namedPortMap) + l4M.rangeMapLen
+}
 
 type policyFeatures uint8
 
@@ -1118,7 +1420,7 @@ type L4DirectionPolicy struct {
 
 func newL4DirectionPolicy() L4DirectionPolicy {
 	return L4DirectionPolicy{
-		PortRules: L4PolicyMap{},
+		PortRules: NewL4PolicyMap(),
 	}
 }
 
@@ -1130,10 +1432,11 @@ func (l4 L4DirectionPolicy) Detach(selectorCache *SelectorCache) {
 }
 
 // detach is used directly from tracing and testing functions
-func (l4 L4PolicyMap) Detach(selectorCache *SelectorCache) {
-	for _, f := range l4 {
-		f.detach(selectorCache)
-	}
+func (l4M *l4PolicyMap) Detach(selectorCache *SelectorCache) {
+	l4M.ForEach(func(l4 *L4Filter) bool {
+		l4.detach(selectorCache)
+		return true
+	})
 }
 
 // Attach makes all the L4Filters to point back to the L4Policy that contains them.
@@ -1142,10 +1445,11 @@ func (l4 L4PolicyMap) Detach(selectorCache *SelectorCache) {
 func (l4 *L4DirectionPolicy) attach(ctx PolicyContext, l4Policy *L4Policy) redirectTypes {
 	var redirectTypes redirectTypes
 	var features policyFeatures
-	for _, f := range l4.PortRules {
+	l4.PortRules.ForEach(func(f *L4Filter) bool {
 		features |= f.attach(ctx, l4Policy)
 		redirectTypes |= f.redirectType()
-	}
+		return true
+	})
 	l4.features = features
 	return redirectTypes
 }
@@ -1163,14 +1467,14 @@ func (l4 *L4DirectionPolicy) attach(ctx PolicyContext, l4Policy *L4Policy) redir
 // Otherwise, returns api.Allowed.
 //
 // Note: Only used for policy tracing
-func (l4 L4PolicyMap) containsAllL3L4(labels labels.LabelArray, ports []*models.Port) api.Decision {
-	if len(l4) == 0 {
+func (l4M *l4PolicyMap) containsAllL3L4(labels labels.LabelArray, ports []*models.Port) api.Decision {
+	if l4M.Len() == 0 {
 		return api.Allowed
 	}
 
 	// Check L3-only filters first.
-	filter, match := l4[api.PortProtocolAny]
-	if match {
+	filter := l4M.ExactLookup("0", 0, "ANY")
+	if filter != nil {
 
 		matches, isDeny := filter.matchesLabels(labels)
 		switch {
@@ -1190,20 +1494,20 @@ func (l4 L4PolicyMap) containsAllL3L4(labels labels.LabelArray, ports []*models.
 		var isUDPDeny, isTCPDeny, isSCTPDeny bool
 		switch lwrProtocol {
 		case "", models.PortProtocolANY:
-			tcpPort := portStr + "/TCP"
-			tcpFilter, tcpmatch := l4[tcpPort]
+			tcpFilter := l4M.LongestPrefixMatch(portStr, "TCP")
+			tcpmatch := tcpFilter != nil
 			if tcpmatch {
 				tcpmatch, isTCPDeny = tcpFilter.matchesLabels(labels)
 			}
 
-			udpPort := portStr + "/UDP"
-			udpFilter, udpmatch := l4[udpPort]
+			udpFilter := l4M.LongestPrefixMatch(portStr, "UDP")
+			udpmatch := udpFilter != nil
 			if udpmatch {
 				udpmatch, isUDPDeny = udpFilter.matchesLabels(labels)
 			}
 
-			sctpPort := portStr + "/SCTP"
-			sctpFilter, sctpmatch := l4[sctpPort]
+			sctpFilter := l4M.LongestPrefixMatch(portStr, "SCTP")
+			sctpmatch := sctpFilter != nil
 			if sctpmatch {
 				sctpmatch, isSCTPDeny = sctpFilter.matchesLabels(labels)
 			}
@@ -1212,9 +1516,8 @@ func (l4 L4PolicyMap) containsAllL3L4(labels labels.LabelArray, ports []*models.
 				return api.Denied
 			}
 		default:
-			port := portStr + "/" + lwrProtocol
-			filter, match := l4[port]
-			if !match {
+			filter := l4M.LongestPrefixMatch(portStr, lwrProtocol)
+			if filter == nil {
 				return api.Denied
 			}
 			matches, isDeny := filter.matchesLabels(labels)
@@ -1406,16 +1709,16 @@ func (l4 *L4Policy) Attach(ctx PolicyContext) {
 // all `dPorts` and `labels`.
 //
 // Note: Only used for policy tracing
-func (l4 *L4PolicyMap) IngressCoversContext(ctx *SearchContext) api.Decision {
-	return l4.containsAllL3L4(ctx.From, ctx.DPorts)
+func (l4M *l4PolicyMap) IngressCoversContext(ctx *SearchContext) api.Decision {
+	return l4M.containsAllL3L4(ctx.From, ctx.DPorts)
 }
 
 // EgressCoversContext checks if the receiver's egress L4Policy contains
 // all `dPorts` and `labels`.
 //
 // Note: Only used for policy tracing
-func (l4 *L4PolicyMap) EgressCoversContext(ctx *SearchContext) api.Decision {
-	return l4.containsAllL3L4(ctx.To, ctx.DPorts)
+func (l4M *l4PolicyMap) EgressCoversContext(ctx *SearchContext) api.Decision {
+	return l4M.containsAllL3L4(ctx.To, ctx.DPorts)
 }
 
 // HasRedirect returns true if the L4 policy contains at least one port redirection
@@ -1439,7 +1742,7 @@ func (l4 *L4Policy) GetModel() *models.L4Policy {
 	}
 
 	ingress := []*models.PolicyRule{}
-	for _, v := range l4.Ingress.PortRules {
+	l4.Ingress.PortRules.ForEach(func(v *L4Filter) bool {
 		rulesBySelector := map[string][][]string{}
 		derivedFrom := labels.LabelArrayList{}
 		for sel, rules := range v.RuleOrigin {
@@ -1451,10 +1754,11 @@ func (l4 *L4Policy) GetModel() *models.L4Policy {
 			DerivedFromRules: derivedFrom.GetModel(),
 			RulesBySelector:  rulesBySelector,
 		})
-	}
+		return true
+	})
 
 	egress := []*models.PolicyRule{}
-	for _, v := range l4.Egress.PortRules {
+	l4.Egress.PortRules.ForEach(func(v *L4Filter) bool {
 		derivedFrom := labels.LabelArrayList{}
 		for _, rules := range v.RuleOrigin {
 			derivedFrom.MergeSorted(rules)
@@ -1463,7 +1767,8 @@ func (l4 *L4Policy) GetModel() *models.L4Policy {
 			Rule:             v.Marshal(),
 			DerivedFromRules: derivedFrom.GetModel(),
 		})
-	}
+		return true
+	})
 
 	return &models.L4Policy{
 		Ingress: ingress,

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -344,7 +344,7 @@ func (p *Repository) AllowsIngressRLocked(ctx *SearchContext) api.Decision {
 	}
 
 	verdict := api.Denied
-	if err == nil && len(ingressPolicy) > 0 {
+	if err == nil && ingressPolicy.Len() > 0 {
 		verdict = ingressPolicy.IngressCoversContext(ctx)
 	}
 
@@ -377,7 +377,7 @@ func (p *Repository) AllowsEgressRLocked(ctx *SearchContext) api.Decision {
 		log.WithError(err).Warn("Evaluation error while resolving L4 egress policy")
 	}
 	verdict := api.Denied
-	if err == nil && len(egressPolicy) > 0 {
+	if err == nil && egressPolicy.Len() > 0 {
 		verdict = egressPolicy.EgressCoversContext(ctx)
 	}
 

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -739,7 +739,7 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 	policy, err := repo.ResolveL4IngressPolicy(ctx)
 	require.Nil(t, err)
 
-	expectedPolicy := L4PolicyMap{
+	expectedPolicy := NewL4PolicyMapWithValues(map[string]*L4Filter{
 		"0/ANY": {
 			Port:     0,
 			Protocol: api.ProtoAny,
@@ -819,8 +819,8 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 			},
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsL7}},
 		},
-	}
-	require.EqualValues(t, expectedPolicy, policy)
+	})
+	require.True(t, policy.Equals(t, expectedPolicy), policy.Diff(t, expectedPolicy))
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -936,7 +936,7 @@ func TestWildcardL4RulesIngress(t *testing.T) {
 	policy, err := repo.ResolveL4IngressPolicy(ctx)
 	require.Nil(t, err)
 
-	expectedPolicy := L4PolicyMap{
+	expectedPolicy := NewL4PolicyMapWithValues(map[string]*L4Filter{
 		"80/TCP": {
 			Port:     80,
 			Protocol: api.ProtoTCP,
@@ -977,8 +977,8 @@ func TestWildcardL4RulesIngress(t *testing.T) {
 				td.cachedSelectorBar2: {labelsL7Kafka},
 			},
 		},
-	}
-	require.EqualValues(t, expectedPolicy, policy)
+	})
+	require.True(t, policy.Equals(t, expectedPolicy), policy.Diff(t, expectedPolicy))
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -1035,8 +1035,8 @@ func TestL3DependentL4IngressFromRequires(t *testing.T) {
 	})
 	expectedCachedSelector, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, expectedSelector)
 
-	expectedPolicy := L4PolicyMap{
-		"80/TCP": &L4Filter{
+	expectedPolicy := NewL4PolicyMapWithValues(map[string]*L4Filter{
+		"80/TCP": {
 			Port:     80,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
@@ -1048,7 +1048,7 @@ func TestL3DependentL4IngressFromRequires(t *testing.T) {
 				expectedCachedSelector: {nil},
 			},
 		},
-	}
+	})
 	require.Equal(t, expectedPolicy, policy)
 	policy.Detach(repo.GetSelectorCache())
 }
@@ -1118,8 +1118,8 @@ func TestL3DependentL4EgressFromRequires(t *testing.T) {
 	expectedCachedSelector, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, expectedSelector)
 	expectedCachedSelector2, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, expectedSelector2)
 
-	expectedPolicy := L4PolicyMap{
-		"0/ANY": &L4Filter{
+	expectedPolicy := NewL4PolicyMapWithValues(map[string]*L4Filter{
+		"0/ANY": {
 			Port:     0,
 			Protocol: "ANY",
 			U8Proto:  0x0,
@@ -1130,7 +1130,7 @@ func TestL3DependentL4EgressFromRequires(t *testing.T) {
 				expectedCachedSelector2: {nil},
 			},
 		},
-		"80/TCP": &L4Filter{
+		"80/TCP": {
 			Port:     80,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
@@ -1141,8 +1141,8 @@ func TestL3DependentL4EgressFromRequires(t *testing.T) {
 				expectedCachedSelector: {nil},
 			},
 		},
-	}
-	if !assert.Equal(t, expectedPolicy, policy) {
+	})
+	if !assert.True(t, policy.Equals(t, expectedPolicy), policy.Diff(t, expectedPolicy)) {
 		t.Errorf("Policy doesn't match expected:\n%s", logBuffer.String())
 	}
 	policy.Detach(repo.GetSelectorCache())
@@ -1281,7 +1281,7 @@ func TestWildcardL3RulesEgress(t *testing.T) {
 	// Traffic to bar1 should not be forwarded to the DNS or HTTP
 	// proxy at all, but if it is (e.g., for visibility, the
 	// "0/ANY" rule should allow such traffic through.
-	expectedPolicy := L4PolicyMap{
+	expectedPolicy := NewL4PolicyMapWithValues(map[string]*L4Filter{
 		"53/UDP": {
 			Port:     53,
 			Protocol: api.ProtoUDP,
@@ -1345,8 +1345,8 @@ func TestWildcardL3RulesEgress(t *testing.T) {
 			Ingress:    false,
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL4}},
 		},
-	}
-	if !assert.Equal(t, expectedPolicy, policy) {
+	})
+	if !assert.True(t, policy.Equals(t, expectedPolicy), policy.Diff(t, expectedPolicy)) {
 		t.Logf("%s", logBuffer.String())
 		t.Errorf("Resolved policy did not match expected: \n%s", err)
 	}
@@ -1468,7 +1468,7 @@ func TestWildcardL4RulesEgress(t *testing.T) {
 
 	// Bar1 should not be forwarded to the proxy, but if it is (e.g., for visibility),
 	// the L3/L4 allow should pass it without an explicit L7 wildcard.
-	expectedPolicy := L4PolicyMap{
+	expectedPolicy := NewL4PolicyMapWithValues(map[string]*L4Filter{
 		"80/TCP": {
 			Port:     80,
 			Protocol: api.ProtoTCP,
@@ -1509,8 +1509,8 @@ func TestWildcardL4RulesEgress(t *testing.T) {
 				td.cachedSelectorBar2: {labelsL7DNS},
 			},
 		},
-	}
-	if !assert.EqualValues(t, expectedPolicy, policy) {
+	})
+	if !assert.True(t, policy.Equals(t, expectedPolicy), policy.Diff(t, expectedPolicy)) {
 		t.Logf("%s", logBuffer.String())
 		t.Error("Resolved policy did not match expected")
 	}
@@ -1594,7 +1594,7 @@ func TestWildcardCIDRRulesEgress(t *testing.T) {
 
 	// Port 80 policy does not need the wildcard, as the "0" port policy will allow the traffic.
 	// HTTP rules can have side-effects, so they need to be retained even if shadowed by a wildcard.
-	expectedPolicy := L4PolicyMap{
+	expectedPolicy := NewL4PolicyMapWithValues(map[string]*L4Filter{
 		"80/TCP": {
 			Port:     80,
 			Protocol: api.ProtoTCP,
@@ -1626,8 +1626,8 @@ func TestWildcardCIDRRulesEgress(t *testing.T) {
 			},
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectors[0]: {labelsL3}},
 		},
-	}
-	if !assert.EqualValues(t, expectedPolicy, policy) {
+	})
+	if !assert.True(t, policy.Equals(t, expectedPolicy), policy.Diff(t, expectedPolicy)) {
 		t.Logf("%s", logBuffer.String())
 		t.Error("Resolved policy did not match expected")
 	}
@@ -1718,9 +1718,9 @@ func TestWildcardL3RulesIngressFromEntities(t *testing.T) {
 
 	policy, err := repo.ResolveL4IngressPolicy(ctx)
 	require.Nil(t, err)
-	require.Equal(t, 3, len(policy))
+	require.Equal(t, 3, policy.Len())
 	selWorld := api.EntitySelectorMapping[api.EntityWorld][0]
-	require.Equal(t, 1, len(policy["80/TCP"].PerSelectorPolicies))
+	require.Equal(t, 1, len(policy.ExactLookup("80", 0, "TCP").PerSelectorPolicies))
 	cachedSelectorWorld := td.sc.FindCachedIdentitySelector(selWorld)
 	require.NotNil(t, cachedSelectorWorld)
 
@@ -1730,7 +1730,7 @@ func TestWildcardL3RulesIngressFromEntities(t *testing.T) {
 	cachedSelectorWorldV6 := td.sc.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv6])
 	require.NotNil(t, cachedSelectorWorldV6)
 
-	expectedPolicy := L4PolicyMap{
+	expectedPolicy := NewL4PolicyMapWithValues(map[string]*L4Filter{
 		"0/ANY": {
 			Port:     0,
 			Protocol: "ANY",
@@ -1780,9 +1780,9 @@ func TestWildcardL3RulesIngressFromEntities(t *testing.T) {
 			},
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsHTTP}},
 		},
-	}
+	})
 
-	require.EqualValues(t, expectedPolicy, policy)
+	require.True(t, policy.Equals(t, expectedPolicy), policy.Diff(t, expectedPolicy))
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -1870,9 +1870,9 @@ func TestWildcardL3RulesEgressToEntities(t *testing.T) {
 
 	policy, err := repo.ResolveL4EgressPolicy(ctx)
 	require.Nil(t, err)
-	require.Equal(t, 3, len(policy))
+	require.Equal(t, 3, policy.Len())
 	selWorld := api.EntitySelectorMapping[api.EntityWorld][0]
-	require.Equal(t, 1, len(policy["80/TCP"].PerSelectorPolicies))
+	require.Equal(t, 1, len(policy.ExactLookup("80", 0, "TCP").PerSelectorPolicies))
 	cachedSelectorWorld := td.sc.FindCachedIdentitySelector(selWorld)
 	require.NotNil(t, cachedSelectorWorld)
 
@@ -1882,7 +1882,7 @@ func TestWildcardL3RulesEgressToEntities(t *testing.T) {
 	cachedSelectorWorldV6 := td.sc.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorldIPv6])
 	require.NotNil(t, cachedSelectorWorldV6)
 
-	expectedPolicy := L4PolicyMap{
+	expectedPolicy := NewL4PolicyMapWithValues(map[string]*L4Filter{
 		"0/ANY": {
 			Port:     0,
 			Protocol: "ANY",
@@ -1932,9 +1932,9 @@ func TestWildcardL3RulesEgressToEntities(t *testing.T) {
 			},
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsHTTP}},
 		},
-	}
+	})
 
-	require.EqualValues(t, expectedPolicy, policy)
+	require.True(t, policy.Equals(t, expectedPolicy), policy.Diff(t, expectedPolicy))
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -2042,7 +2042,7 @@ func TestMinikubeGettingStarted(t *testing.T) {
 	require.NotNil(t, cachedSelectorApp2)
 
 	expected := NewL4Policy(repo.GetRevision())
-	expected.Ingress.PortRules["80/TCP"] = &L4Filter{
+	expected.Ingress.PortRules.Upsert("80", 0, "TCP", &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		L7Parser: ParserTypeHTTP,
 		PerSelectorPolicies: L7DataMap{
@@ -2055,7 +2055,7 @@ func TestMinikubeGettingStarted(t *testing.T) {
 		},
 		Ingress:    true,
 		RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectorApp2: {nil}},
-	}
+	})
 
 	if !assert.EqualValues(t, expected.Ingress.PortRules, l4IngressPolicy) {
 		t.Logf("%s", logBuffer.String())
@@ -2068,7 +2068,7 @@ func TestMinikubeGettingStarted(t *testing.T) {
 	expected = NewL4Policy(repo.GetRevision())
 	l4IngressPolicy, err = repo.ResolveL4IngressPolicy(fromApp3)
 	require.Nil(t, err)
-	require.Equal(t, 0, len(l4IngressPolicy))
+	require.Equal(t, 0, l4IngressPolicy.Len())
 	require.Equal(t, expected.Ingress.PortRules, l4IngressPolicy)
 	l4IngressPolicy.Detach(td.sc)
 	expected.Detach(td.sc)

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -182,9 +182,10 @@ func (p *EndpointPolicy) toMapState() {
 // PolicyOwner (aka Endpoint) is also unlocked during this call,
 // but the Endpoint's build mutex is held.
 func (l4policy L4DirectionPolicy) toMapState(p *EndpointPolicy) {
-	for _, l4 := range l4policy.PortRules {
+	l4policy.PortRules.ForEach(func(l4 *L4Filter) bool {
 		l4.toMapState(p, l4policy.features, p.PolicyOwner.GetRealizedRedirects(), ChangeState{})
-	}
+		return true
+	})
 }
 
 // createRedirectsFunc returns 'nil' if map changes should not be applied immemdiately,
@@ -208,11 +209,11 @@ func (l4policy L4DirectionPolicy) updateRedirects(p *EndpointPolicy, createRedir
 	p.SelectorCache.mutex.RLock()
 	defer p.SelectorCache.mutex.RUnlock()
 
-	for _, l4 := range l4policy.PortRules {
+	l4policy.PortRules.ForEach(func(l4 *L4Filter) bool {
 		if l4.IsRedirect() {
 			// Check if we are denying this specific L4 first regardless the L3, if there are any deny policies
 			if l4policy.features.contains(denyRules) && p.policyMapState.deniesL4(p.PolicyOwner, l4) {
-				continue
+				return true
 			}
 
 			redirects := createRedirects(l4)
@@ -221,7 +222,8 @@ func (l4policy L4DirectionPolicy) updateRedirects(p *EndpointPolicy, createRedir
 				l4.toMapState(p, l4policy.features, redirects, changes)
 			}
 		}
-	}
+		return true
+	})
 }
 
 // ConsumeMapChanges transfers the changes from MapChanges to the caller,

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -147,7 +147,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: L4Policy{
 				Revision: repo.GetRevision(),
-				Ingress: L4DirectionPolicy{PortRules: L4PolicyMap{
+				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
 						Port:     80,
 						Protocol: api.ProtoTCP,
@@ -160,7 +160,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 						},
 						RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
 					},
-				},
+				}),
 					features: denyRules,
 				},
 				Egress: newL4DirectionPolicy(),
@@ -240,7 +240,7 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: L4Policy{
 				Revision: repo.GetRevision(),
-				Ingress: L4DirectionPolicy{PortRules: L4PolicyMap{
+				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
 						Port:     80,
 						Protocol: api.ProtoTCP,
@@ -253,7 +253,7 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 						},
 						RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
 					},
-				},
+				}),
 					features: denyRules,
 				},
 				Egress: newL4DirectionPolicy(),
@@ -332,7 +332,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: L4Policy{
 				Revision: repo.GetRevision(),
-				Ingress: L4DirectionPolicy{PortRules: L4PolicyMap{
+				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
 						Port:     80,
 						Protocol: api.ProtoTCP,
@@ -345,7 +345,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 						},
 						RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {ruleLabel}},
 					},
-				},
+				}),
 					features: denyRules,
 				},
 				Egress: newL4DirectionPolicy(),
@@ -486,7 +486,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: L4Policy{
 				Revision: repo.GetRevision(),
-				Ingress: L4DirectionPolicy{PortRules: L4PolicyMap{
+				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
 						Port:     80,
 						Protocol: api.ProtoTCP,
@@ -506,7 +506,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 							cachedSelectorTest:    {ruleLabel},
 						},
 					},
-				},
+				}),
 					features: denyRules,
 				},
 				Egress: newL4DirectionPolicy(),

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -319,7 +319,7 @@ func TestL7WithIngressWildcard(t *testing.T) {
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: L4Policy{
 				Revision: repo.GetRevision(),
-				Ingress: L4DirectionPolicy{PortRules: L4PolicyMap{
+				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
 						Port:     80,
 						Protocol: api.ProtoTCP,
@@ -338,7 +338,7 @@ func TestL7WithIngressWildcard(t *testing.T) {
 						},
 						RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
 					},
-				}},
+				})},
 				Egress:        newL4DirectionPolicy(),
 				redirectTypes: redirectTypeEnvoy,
 			},
@@ -425,7 +425,7 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: L4Policy{
 				Revision: repo.GetRevision(),
-				Ingress: L4DirectionPolicy{PortRules: L4PolicyMap{
+				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
 						Port:     80,
 						Protocol: api.ProtoTCP,
@@ -445,7 +445,7 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 						},
 						RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
 					},
-				}},
+				})},
 				Egress:        newL4DirectionPolicy(),
 				redirectTypes: redirectTypeEnvoy,
 			},
@@ -526,7 +526,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: L4Policy{
 				Revision: repo.GetRevision(),
-				Ingress: L4DirectionPolicy{PortRules: L4PolicyMap{
+				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
 						Port:     80,
 						Protocol: api.ProtoTCP,
@@ -539,7 +539,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 						},
 						RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {ruleLabel}},
 					},
-				}},
+				})},
 				Egress: newL4DirectionPolicy(),
 			},
 			IngressPolicyEnabled: true,
@@ -681,7 +681,7 @@ func TestMapStateWithIngress(t *testing.T) {
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: L4Policy{
 				Revision: repo.GetRevision(),
-				Ingress: L4DirectionPolicy{PortRules: L4PolicyMap{
+				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
 						Port:     80,
 						Protocol: api.ProtoTCP,
@@ -706,7 +706,7 @@ func TestMapStateWithIngress(t *testing.T) {
 							cachedSelectorTest:    {ruleLabel},
 						},
 					},
-				},
+				}),
 					features: authRules,
 				},
 				Egress: newL4DirectionPolicy(),

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -14,7 +14,7 @@ import (
 type ruleSlice []*rule
 
 func (rules ruleSlice) resolveL4IngressPolicy(policyCtx PolicyContext, ctx *SearchContext) (L4PolicyMap, error) {
-	result := L4PolicyMap{}
+	result := NewL4PolicyMap()
 
 	ctx.PolicyTrace("\n")
 	ctx.PolicyTrace("Resolving ingress policy for %+v\n", ctx.To)
@@ -64,7 +64,7 @@ func (rules ruleSlice) resolveL4IngressPolicy(policyCtx PolicyContext, ctx *Sear
 }
 
 func (rules ruleSlice) resolveL4EgressPolicy(policyCtx PolicyContext, ctx *SearchContext) (L4PolicyMap, error) {
-	result := L4PolicyMap{}
+	result := NewL4PolicyMap()
 
 	ctx.PolicyTrace("\n")
 	ctx.PolicyTrace("Resolving egress policy for %+v\n", ctx.From)

--- a/pkg/policy/types/types.go
+++ b/pkg/policy/types/types.go
@@ -121,12 +121,6 @@ func (k Key) PortIsEqual(c Key) bool {
 		k.InvertedPortMask == c.InvertedPortMask
 }
 
-// MaskToPrefix returns the amount by which
-// a mask should negate a full prefix.
-func MaskToPrefix(mask uint16) uint {
-	return uint(bits.TrailingZeros16(mask))
-}
-
 // PrefixLength returns the prefix lenth of the key
 // for indexing it for the userspace cache (not the
 // BPF map or datapath).
@@ -138,7 +132,7 @@ func (k Key) PrefixLength() uint {
 		// to be incorrectly set, but even if
 		// it was the default value of "0" is
 		// what we want.
-		portPrefix = MaskToPrefix(k.PortMask())
+		portPrefix = uint(bits.TrailingZeros16(k.PortMask()))
 	}
 	keyPrefix -= portPrefix
 	// If the port is fully wildcarded then


### PR DESCRIPTION
See commits.

Fixes: #16622

Note: I'll address all missing documentation in a separate PR.

This builds on the following PRs:
- https://github.com/cilium/cilium/pull/23885
- https://github.com/cilium/proxy/pull/373
- https://github.com/cilium/cilium/pull/29717
- https://github.com/cilium/cilium/pull/32430
- https://github.com/cilium/cilium/pull/32675

```release-note
policy: Add support for port ranges in network policies.
```

