### PR TITLE
cleanup: untangle unnecessarily complex policy initialization

### DIFF
--- a/clustermesh-apiserver/clustermesh/vmmanager.go
+++ b/clustermesh-apiserver/clustermesh/vmmanager.go
@@ -137,7 +137,7 @@ type VMManager struct {
 //
 
 // UpdateIdentities will be called when identities have changed
-func (m *VMManager) UpdateIdentities(added, deleted identityCache.IdentityCache) {}
+func (m *VMManager) UpdateIdentities(added, deleted identity.IdentityMap) {}
 
 // GetNodeSuffix must return the node specific suffix to use
 func (m *VMManager) GetNodeSuffix() string {

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -63,7 +63,7 @@ func setupDaemonFQDNSuite(tb testing.TB) *DaemonFQDNSuite {
 	ds := &DaemonFQDNSuite{}
 	d := &Daemon{}
 	d.ctx = context.Background()
-	d.policy = policy.NewPolicyRepository(d.identityAllocator, nil, nil, nil)
+	d.policy = policy.NewPolicyRepository(nil, nil, nil)
 	d.endpointManager = endpointmanager.New(&dummyEpSyncher{}, nil, nil)
 	d.ipcache = ipcache.NewIPCache(&ipcache.Configuration{
 		Context:           context.TODO(),

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -104,7 +104,6 @@ func newPolicyTrifecta(params policyParams) (policyOut, error) {
 	idAlloc.EnableCheckpointing()
 
 	iao.policy = policy.NewStoppedPolicyRepository(
-		idAlloc,
 		idAlloc.GetIdentityCache(),
 		params.CertManager,
 		params.SecretManager,

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -173,7 +173,7 @@ type identityAllocatorOwner struct {
 //
 // The caller is responsible for making sure the same identity is not
 // present in both 'added' and 'deleted'.
-func (iao *identityAllocatorOwner) UpdateIdentities(added, deleted cache.IdentityCache) {
+func (iao *identityAllocatorOwner) UpdateIdentities(added, deleted identity.IdentityMap) {
 	wg := &sync.WaitGroup{}
 	iao.policy.GetSelectorCache().UpdateIdentities(added, deleted, wg)
 	// Wait for update propagation to endpoints before triggering policy updates

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -1110,11 +1110,11 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 							},
 						},
 					},
-					repo: policy.NewPolicyRepository(nil, nil, nil, nil),
+					repo: policy.NewPolicyRepository(nil, nil, nil),
 				}
 			},
 			setupWanted: func() wanted {
-				r := policy.NewPolicyRepository(nil, nil, nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil)
 				r.AddList(api.Rules{
 					api.NewRule().
 						WithEndpointSelector(api.EndpointSelector{
@@ -1143,7 +1143,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 		{
 			name: "have a rule with user labels and update it without user labels, all other rules should be deleted",
 			setupArgs: func() args {
-				r := policy.NewPolicyRepository(nil, nil, nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil)
 				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...).Sort()
 				r.AddList(api.Rules{
@@ -1186,7 +1186,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 				}
 			},
 			setupWanted: func() wanted {
-				r := policy.NewPolicyRepository(nil, nil, nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil)
 				r.AddList(api.Rules{
 					api.NewRule().
 						WithEndpointSelector(api.EndpointSelector{
@@ -1215,7 +1215,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 		{
 			name: "have a rule without user labels and update it with user labels, all other rules should be deleted",
 			setupArgs: func() args {
-				r := policy.NewPolicyRepository(nil, nil, nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil)
 				r.AddList(api.Rules{
 					{
 						EndpointSelector: api.EndpointSelector{
@@ -1257,7 +1257,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 				}
 			},
 			setupWanted: func() wanted {
-				r := policy.NewPolicyRepository(nil, nil, nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil)
 				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...).Sort()
 				r.AddList(api.Rules{
@@ -1283,7 +1283,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 		{
 			name: "have a rule policy installed with multiple rules and apply an empty spec should delete all rules installed",
 			setupArgs: func() args {
-				r := policy.NewPolicyRepository(nil, nil, nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil)
 				r.AddList(api.Rules{
 					{
 						EndpointSelector: api.EndpointSelector{
@@ -1330,7 +1330,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 				}
 			},
 			setupWanted: func() wanted {
-				r := policy.NewPolicyRepository(nil, nil, nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil)
 				r.AddList(api.Rules{
 					{
 						EndpointSelector: api.EndpointSelector{

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -55,7 +55,7 @@ func setupEndpointSuite(tb testing.TB) *EndpointSuite {
 	testutils.IntegrationTest(tb)
 
 	s := &EndpointSuite{}
-	s.repo = policy.NewPolicyRepository(nil, nil, nil, nil)
+	s.repo = policy.NewPolicyRepository(nil, nil, nil)
 	// GetConfig the default labels prefix filter
 	err := labelsfilter.ParseLabelPrefixCfg(nil, nil, "")
 	if err != nil {

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -23,7 +23,7 @@ func TestEndpointLogFormat(t *testing.T) {
 	setupEndpointSuite(t)
 
 	// Default log format is text
-	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
+	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil)}
 	ep := NewTestEndpointWithState(t, do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 
 	_, ok := ep.getLogger().Logger.Formatter.(*logrus.TextFormatter)
@@ -34,7 +34,7 @@ func TestEndpointLogFormat(t *testing.T) {
 	defer func() {
 		logging.SetLogFormat(logging.LogFormatText)
 	}()
-	do = &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
+	do = &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil)}
 	ep = NewTestEndpointWithState(t, do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 
 	_, ok = ep.getLogger().Logger.Formatter.(*logrus.JSONFormatter)
@@ -44,7 +44,7 @@ func TestEndpointLogFormat(t *testing.T) {
 func TestPolicyLog(t *testing.T) {
 	setupEndpointSuite(t)
 
-	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
+	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil)}
 	ep := NewTestEndpointWithState(t, do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 
 	// Initially nil

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestUpdateVisibilityPolicy(t *testing.T) {
 	setupEndpointSuite(t)
-	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
+	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil)}
 	ep := NewTestEndpointWithState(t, do, do, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 	ep.UpdateVisibilityPolicy(func(_, _ string) (string, error) {
 		return "", nil
@@ -74,7 +74,7 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 
 	idcache := make(cache.IdentityCache, testfactor)
 	fakeAllocator := testidentity.NewMockIdentityAllocator(idcache)
-	repo := policy.NewPolicyRepository(fakeAllocator, fakeAllocator.GetIdentityCache(), nil, nil)
+	repo := policy.NewPolicyRepository(fakeAllocator.GetIdentityCache(), nil, nil)
 
 	defer func() {
 		repo.RepositoryChangeQueue.Stop()

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
@@ -72,7 +71,7 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 	policy.SetPolicyEnabled("always")
 	defer policy.SetPolicyEnabled(pe)
 
-	idcache := make(cache.IdentityCache, testfactor)
+	idcache := make(identity.IdentityMap, testfactor)
 	fakeAllocator := testidentity.NewMockIdentityAllocator(idcache)
 	repo := policy.NewPolicyRepository(fakeAllocator.GetIdentityCache(), nil, nil)
 
@@ -96,7 +95,7 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 		// t.Logf("allocated label %s id %d", labelKeys, id.ID) // commented out for speed
 
 		wg := &sync.WaitGroup{}
-		repo.GetSelectorCache().UpdateIdentities(cache.IdentityCache{
+		repo.GetSelectorCache().UpdateIdentities(identity.IdentityMap{
 			id.ID: id.LabelArray,
 		}, nil, wg)
 		wg.Wait()

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -53,7 +53,7 @@ func setupRedirectSuite(tb testing.TB) *RedirectSuite {
 	s.mgr = cache.NewCachingIdentityAllocator(idAllocatorOwner)
 	<-s.mgr.InitIdentityAllocator(nil)
 
-	identityCache := cache.IdentityCache{
+	identityCache := identity.IdentityMap{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 		identity.NumericIdentity(identityBar): labelsBar,
 	}
@@ -118,7 +118,7 @@ func (r *RedirectSuiteProxy) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource)
 type DummyIdentityAllocatorOwner struct{}
 
 // UpdateIdentities does nothing.
-func (d *DummyIdentityAllocatorOwner) UpdateIdentities(added, deleted cache.IdentityCache) {
+func (d *DummyIdentityAllocatorOwner) UpdateIdentities(added, deleted identity.IdentityMap) {
 }
 
 // GetNodeSuffix does nothing.
@@ -174,7 +174,7 @@ func (d *DummyOwner) GetNodeSuffix() string {
 }
 
 // UpdateIdentities does nothing.
-func (d *DummyOwner) UpdateIdentities(added, deleted cache.IdentityCache) {}
+func (d *DummyOwner) UpdateIdentities(added, deleted identity.IdentityMap) {}
 
 const (
 	httpPort  = uint16(19001)

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -59,7 +59,7 @@ func setupRedirectSuite(tb testing.TB) *RedirectSuite {
 	}
 
 	s.do = &DummyOwner{
-		repo: policy.NewPolicyRepository(s.mgr, identityCache, nil, nil),
+		repo: policy.NewPolicyRepository(identityCache, nil, nil),
 	}
 	s.do.repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 	identitymanager.Subscribe(s.do.repo)

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -54,8 +54,7 @@ type EndpointManagerSuite struct {
 
 func setupEndpointManagerSuite(tb testing.TB) *EndpointManagerSuite {
 	s := &EndpointManagerSuite{}
-	idAllocator := testidentity.NewMockIdentityAllocator(nil)
-	s.repo = policy.NewPolicyRepository(idAllocator, nil, nil, nil)
+	s.repo = policy.NewPolicyRepository(nil, nil, nil)
 
 	return s
 }

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -181,7 +180,7 @@ var ExpectedHeaders3 = []*envoy_config_route.HeaderMatcher{
 var (
 	dummySelectorCacheUser = &DummySelectorCacheUser{}
 
-	IdentityCache = cache.IdentityCache{
+	IdentityCache = identity.IdentityMap{
 		1001: labels.LabelArray{
 			labels.NewLabel("app", "etcd", labels.LabelSourceK8s),
 			labels.NewLabel("version", "v1", labels.LabelSourceK8s),

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/proxy/endpoint/test"
-	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -196,8 +195,7 @@ var (
 			labels.NewLabel("version", "v1", labels.LabelSourceK8s),
 		},
 	}
-	identityAllocator = testidentity.NewMockIdentityAllocator(IdentityCache)
-	testSelectorCache = policy.NewSelectorCache(identityAllocator, IdentityCache)
+	testSelectorCache = policy.NewSelectorCache(IdentityCache)
 
 	wildcardCachedSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, api.WildcardEndpointSelector)
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -57,7 +57,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 
 	// Add these identities
 	wg := &sync.WaitGroup{}
-	testSelectorCache.UpdateIdentities(cache.IdentityCache{
+	testSelectorCache.UpdateIdentities(identity.IdentityMap{
 		dstID1: labels.Labels{"Dst1": labels.NewLabel("Dst1", "test", labels.LabelSourceK8s)}.LabelArray(),
 		dstID2: labels.Labels{"Dst2": labels.NewLabel("Dst2", "test", labels.LabelSourceK8s)}.LabelArray(),
 		dstID3: labels.Labels{"Dst3": labels.NewLabel("Dst3", "test", labels.LabelSourceK8s)}.LabelArray(),

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -65,7 +65,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 	}, nil, wg)
 	wg.Wait()
 
-	s.repo = policy.NewPolicyRepository(nil, nil, nil, nil)
+	s.repo = policy.NewPolicyRepository(nil, nil, nil)
 	s.dnsTCPClient = &dns.Client{Net: "tcp", Timeout: time.Second, SingleInflight: true}
 	s.dnsServer = setupServer(tb)
 	require.NotNil(tb, s.dnsServer, "unable to setup DNS server")
@@ -230,8 +230,7 @@ func (d *DummySelectorCacheUser) IdentitySelectionUpdated(selector policy.Cached
 // Setup identities, ports and endpoint IDs we will need
 var (
 	cacheAllocator          = cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
-	fakeAllocator           = testidentity.NewMockIdentityAllocator(cacheAllocator.GetIdentityCache())
-	testSelectorCache       = policy.NewSelectorCache(fakeAllocator, cacheAllocator.GetIdentityCache())
+	testSelectorCache       = policy.NewSelectorCache(cacheAllocator.GetIdentityCache())
 	dummySelectorCacheUser  = &DummySelectorCacheUser{}
 	DstID1Selector          = api.NewESFromLabels(labels.ParseSelectLabel("k8s:Dst1=test"))
 	cachedDstID1Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, DstID1Selector)

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -98,17 +98,17 @@ func testAllocateIdentityReserved(t *testing.T) {
 type dummyOwner struct {
 	updated chan identity.NumericIdentity
 	mutex   lock.Mutex
-	cache   IdentityCache
+	cache   identity.IdentityMap
 }
 
 func newDummyOwner() *dummyOwner {
 	return &dummyOwner{
-		cache:   IdentityCache{},
+		cache:   identity.IdentityMap{},
 		updated: make(chan identity.NumericIdentity, 1024),
 	}
 }
 
-func (d *dummyOwner) UpdateIdentities(added, deleted IdentityCache) {
+func (d *dummyOwner) UpdateIdentities(added, deleted identity.IdentityMap) {
 	d.mutex.Lock()
 	log.Debugf("Dummy UpdateIdentities(added: %v, deleted: %v)", added, deleted)
 	for id, lbls := range added {

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -68,6 +68,8 @@ type IPIdentityPair struct {
 	NamedPorts   []NamedPort     `json:"NamedPorts,omitempty"`
 }
 
+type IdentityMap map[NumericIdentity]labels.LabelArray
+
 // GetKeyName returns the kvstore key to be used for the IPIdentityPair
 func (pair *IPIdentityPair) GetKeyName() string { return pair.PrefixString() }
 

--- a/pkg/identity/reserved.go
+++ b/pkg/identity/reserved.go
@@ -62,3 +62,13 @@ func IterateReservedIdentities(f func(_ NumericIdentity, _ *Identity)) {
 		f(ni, identity)
 	}
 }
+
+func ListReservedIdentities() IdentityMap {
+	cacheMU.RLock()
+	defer cacheMU.RUnlock()
+	out := make(IdentityMap, len(reservedIdentityCache))
+	for ni, identity := range reservedIdentityCache {
+		out[ni] = identity.LabelArray
+	}
+	return out
+}

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/container/bitlpm"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
@@ -836,7 +835,7 @@ type mockUpdater struct {
 	identities map[identity.NumericIdentity]labels.LabelArray
 }
 
-func (m *mockUpdater) UpdateIdentities(added, deleted cache.IdentityCache, _ *sync.WaitGroup) {
+func (m *mockUpdater) UpdateIdentities(added, deleted identity.IdentityMap, _ *sync.WaitGroup) {
 	for nid, lbls := range added {
 		m.identities[nid] = lbls
 	}

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -12,13 +12,12 @@ import (
 	"sync"
 
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 )
 
 // PolicyHandler is responsible for handling identity updates into the core
 // policy engine. See SelectorCache.UpdateIdentities() for more details.
 type PolicyHandler interface {
-	UpdateIdentities(added, deleted cache.IdentityCache, wg *sync.WaitGroup)
+	UpdateIdentities(added, deleted identity.IdentityMap, wg *sync.WaitGroup)
 }
 
 // DatapathHandler is responsible for ensuring that policy updates in the

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -79,8 +79,7 @@ var (
 type DummySelectorCacheUser struct{}
 
 func testNewPolicyRepository() *policy.Repository {
-	idAllocator := testidentity.NewMockIdentityAllocator(nil)
-	repo := policy.NewPolicyRepository(idAllocator, nil, nil, nil)
+	repo := policy.NewPolicyRepository(nil, nil, nil)
 	repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 	return repo
 }

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/health"
 	"github.com/cilium/cilium/pkg/hive/health/types"
-	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
@@ -921,7 +921,7 @@ type testParams struct {
 
 type mockUpdater struct{}
 
-func (m *mockUpdater) UpdateIdentities(_, _ cache.IdentityCache, _ *sync.WaitGroup) {}
+func (m *mockUpdater) UpdateIdentities(_, _ identity.IdentityMap, _ *sync.WaitGroup) {}
 
 type mockTriggerer struct{}
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/testutils"
-	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
 
 var (
@@ -37,7 +36,7 @@ func localIdentity(n uint32) identity.NumericIdentity {
 
 }
 func TestCacheManagement(t *testing.T) {
-	repo := NewPolicyRepository(nil, nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	cache := repo.policyCache
 	identity := ep1.GetSecurityIdentity()
 	require.Equal(t, identity, ep2.GetSecurityIdentity())
@@ -73,7 +72,7 @@ func TestCacheManagement(t *testing.T) {
 }
 
 func TestCachePopulation(t *testing.T) {
-	repo := NewPolicyRepository(nil, nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.revision.Store(42)
 	cache := repo.policyCache
 
@@ -406,9 +405,8 @@ type policyDistillery struct {
 }
 
 func newPolicyDistillery(selectorCache *SelectorCache) *policyDistillery {
-	identityAllocator := testidentity.NewMockIdentityAllocator(nil)
 	ret := &policyDistillery{
-		Repository: NewPolicyRepository(identityAllocator, nil, nil, nil),
+		Repository: NewPolicyRepository(nil, nil, nil),
 	}
 	ret.selectorCache = selectorCache
 	return ret

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -17,7 +17,6 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -479,7 +478,7 @@ func Test_MergeL3(t *testing.T) {
 
 	SetPolicyEnabled(option.DefaultEnforcement)
 
-	identityCache := cache.IdentityCache{
+	identityCache := identity.IdentityMap{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 		identity.NumericIdentity(identityBar): labelsBar,
 	}
@@ -1120,7 +1119,7 @@ func Test_MergeRules(t *testing.T) {
 
 	SetPolicyEnabled(option.DefaultEnforcement)
 
-	identityCache := cache.IdentityCache{
+	identityCache := identity.IdentityMap{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 	}
 	selectorCache := testNewSelectorCache(identityCache)
@@ -1245,7 +1244,7 @@ func Test_MergeRulesWithNamedPorts(t *testing.T) {
 
 	SetPolicyEnabled(option.DefaultEnforcement)
 
-	identityCache := cache.IdentityCache{
+	identityCache := identity.IdentityMap{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 	}
 	selectorCache := testNewSelectorCache(identityCache)
@@ -1321,7 +1320,7 @@ func Test_AllowAll(t *testing.T) {
 
 	SetPolicyEnabled(option.DefaultEnforcement)
 
-	identityCache := cache.IdentityCache{
+	identityCache := identity.IdentityMap{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 		identity.NumericIdentity(identityBar): labelsBar,
 	}
@@ -1653,7 +1652,7 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 
 	SetPolicyEnabled(option.DefaultEnforcement)
 
-	identityCache := cache.IdentityCache{
+	identityCache := identity.IdentityMap{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 		identity.ReservedIdentityWorld:        labels.LabelWorld.LabelArray(),
 		worldIPIdentity:                       lblWorldIP,                  // "192.0.2.3/32"
@@ -1761,7 +1760,7 @@ func Test_EnsureEntitiesSelectableByCIDR(t *testing.T) {
 	hostLabel := labels.NewFrom(labels.LabelHost)
 	hostLabel.MergeLabels(lblHostIPv4CIDR)
 	hostLabel.MergeLabels(lblHostIPv6CIDR)
-	identityCache := cache.IdentityCache{
+	identityCache := identity.IdentityMap{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 		identity.ReservedIdentityHost:         hostLabel.LabelArray(),
 	}

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -54,7 +54,7 @@ type testData struct {
 func newTestData() *testData {
 	td := &testData{
 		sc:   testNewSelectorCache(nil),
-		repo: NewPolicyRepository(nil, nil, nil, nil),
+		repo: NewPolicyRepository(nil, nil, nil),
 
 		testPolicyContext: &testPolicyContextType{},
 	}
@@ -79,7 +79,7 @@ func newTestData() *testData {
 // resetRepo clears only the policy repository.
 // Some tests rely on the accumulated state, but a clean repo.
 func (td *testData) resetRepo() *Repository {
-	td.repo = NewPolicyRepository(nil, nil, nil, nil)
+	td.repo = NewPolicyRepository(nil, nil, nil)
 	td.repo.selectorCache = td.sc
 	return td.repo
 }

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -3472,7 +3471,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 }
 
 func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
-	identityCache := cache.IdentityCache{
+	identityCache := identity.IdentityMap{
 		identity.ReservedIdentityWorld: labels.LabelWorld.LabelArray(),
 		worldIPIdentity:                lblWorldIP,                  // "192.0.2.3/32"
 		worldSubnetIdentity:            lblWorldSubnet.LabelArray(), // "192.0.2.0/24"

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -175,13 +175,13 @@ func (p *Repository) GetPolicyCache() *PolicyCache {
 }
 
 // NewPolicyRepository creates a new policy repository.
+// Only used for unit tests.
 func NewPolicyRepository(
-	idAllocator cache.IdentityAllocator,
-	idCache cache.IdentityCache,
+	initialIDs cache.IdentityCache,
 	certManager certificatemanager.CertificateManager,
 	secretManager certificatemanager.SecretManager,
 ) *Repository {
-	repo := NewStoppedPolicyRepository(idAllocator, idCache, certManager, secretManager)
+	repo := NewStoppedPolicyRepository(initialIDs, certManager, secretManager)
 	repo.Start()
 	return repo
 }
@@ -192,12 +192,11 @@ func NewPolicyRepository(
 // Qeues must be allocated via [Repository.Start]. The function serves to
 // satisfy hive invariants.
 func NewStoppedPolicyRepository(
-	idAllocator cache.IdentityAllocator,
-	idCache cache.IdentityCache,
+	initialIDs cache.IdentityCache,
 	certManager certificatemanager.CertificateManager,
 	secretManager certificatemanager.SecretManager,
 ) *Repository {
-	selectorCache := NewSelectorCache(idAllocator, idCache)
+	selectorCache := NewSelectorCache(initialIDs)
 	repo := &Repository{
 		rules:           make(map[ruleKey]*rule),
 		rulesByResource: make(map[ipcachetypes.ResourceID]map[ruleKey]*rule),

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
@@ -177,7 +176,7 @@ func (p *Repository) GetPolicyCache() *PolicyCache {
 // NewPolicyRepository creates a new policy repository.
 // Only used for unit tests.
 func NewPolicyRepository(
-	initialIDs cache.IdentityCache,
+	initialIDs identity.IdentityMap,
 	certManager certificatemanager.CertificateManager,
 	secretManager certificatemanager.SecretManager,
 ) *Repository {
@@ -192,7 +191,7 @@ func NewPolicyRepository(
 // Qeues must be allocated via [Repository.Start]. The function serves to
 // satisfy hive invariants.
 func NewStoppedPolicyRepository(
-	initialIDs cache.IdentityCache,
+	initialIDs identity.IdentityMap,
 	certManager certificatemanager.CertificateManager,
 	secretManager certificatemanager.SecretManager,
 ) *Repository {

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -2534,7 +2534,7 @@ func TestDefaultAllow(t *testing.T) {
 }
 
 func TestReplaceByResource(t *testing.T) {
-	repo := NewPolicyRepository(nil, nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 
 	numRules := 10
 	rules := make(api.Rules, 0, numRules)

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
@@ -360,7 +359,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	}
 
 	// Add new identity to test accumulation of MapChanges
-	added1 := cache.IdentityCache{
+	added1 := identity.IdentityMap{
 		identity.NumericIdentity(192): labels.ParseSelectLabelArray("id=resolve_test_1"),
 	}
 	wg := &sync.WaitGroup{}
@@ -444,7 +443,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
 
 	// Add new identity to test accumulation of MapChanges
-	added1 := cache.IdentityCache{
+	added1 := identity.IdentityMap{
 		identity.NumericIdentity(192): labels.ParseSelectLabelArray("id=resolve_test_1", "num=1"),
 		identity.NumericIdentity(193): labels.ParseSelectLabelArray("id=resolve_test_1", "num=2"),
 		identity.NumericIdentity(194): labels.ParseSelectLabelArray("id=resolve_test_1", "num=3"),
@@ -454,7 +453,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	wg.Wait()
 	require.Len(t, policy.policyMapChanges.changes, 3)
 
-	deleted1 := cache.IdentityCache{
+	deleted1 := identity.IdentityMap{
 		identity.NumericIdentity(193): labels.ParseSelectLabelArray("id=resolve_test_1", "num=2"),
 	}
 	wg = &sync.WaitGroup{}

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -202,38 +202,6 @@ func (d DummyOwner) PolicyDebug(fields logrus.Fields, msg string) {
 	log.WithFields(fields).Info(msg)
 }
 
-/*
-func bootstrapRepo(ruleGenFunc func(int) api.Rules, numRules int, tb testing.TB) *Repository {
-	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
-	ids := mgr.GetIdentityCache()
-	fakeAllocator := testidentity.NewMockIdentityAllocator(ids)
-	testRepo := NewPolicyRepository(fakeAllocator, ids, nil, nil)
-
-	SetPolicyEnabled(option.DefaultEnforcement)
-	wg := &sync.WaitGroup{}
-	testSelectorCache.UpdateIdentities(generateNumIdentities(3000), nil, wg)
-	wg.Wait()
-	testRepo.selectorCache = testSelectorCache
-	rulez, _ := testRepo.AddList(ruleGenFunc(numRules))
-
-	epSet := NewEndpointSet(map[Endpoint]struct{}{
-		&dummyEndpoint{
-			ID:               9001,
-			SecurityIdentity: fooIdentity,
-		}: {},
-	})
-
-	epsToRegen := NewEndpointSet(nil)
-	wg = &sync.WaitGroup{}
-	rulez.UpdateRulesEndpointsCaches(epSet, epsToRegen, wg)
-	wg.Wait()
-
-	require.Equal(tb, 0, epSet.Len())
-	require.Equal(tb, 1, epsToRegen.Len())
-
-	return testRepo
-}*/
-
 func (td *testData) bootstrapRepo(ruleGenFunc func(int) api.Rules, numRules int, tb testing.TB) {
 	SetPolicyEnabled(option.DefaultEnforcement)
 	wg := &sync.WaitGroup{}

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -92,10 +92,6 @@ type userNotification struct {
 type SelectorCache struct {
 	mutex lock.RWMutex
 
-	// idAllocator is used to allocate and release identities. It is used
-	// by the NameManager to manage identities corresponding to FQDNs.
-	idAllocator cache.IdentityAllocator
-
 	// idCache contains all known identities as informed by the
 	// kv-store and the local identity facility via our
 	// UpdateIdentities() function.
@@ -192,11 +188,10 @@ func (sc *SelectorCache) queueUserNotification(user CachedSelectionUser, selecto
 }
 
 // NewSelectorCache creates a new SelectorCache with the given identities.
-func NewSelectorCache(allocator cache.IdentityAllocator, ids cache.IdentityCache) *SelectorCache {
+func NewSelectorCache(ids cache.IdentityCache) *SelectorCache {
 	sc := &SelectorCache{
-		idAllocator: allocator,
-		idCache:     getIdentityCache(ids),
-		selectors:   make(map[string]*identitySelector),
+		idCache:   getIdentityCache(ids),
+		selectors: make(map[string]*identitySelector),
 	}
 	sc.userCond = sync.NewCond(&sc.userMutex)
 	return sc

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
@@ -67,7 +66,7 @@ func getLocalScopeNets(id identity.NumericIdentity, lbls labels.LabelArray) []*n
 	return nil
 }
 
-func getIdentityCache(ids cache.IdentityCache) scIdentityCache {
+func getIdentityCache(ids identity.IdentityMap) scIdentityCache {
 	idCache := make(map[identity.NumericIdentity]scIdentity, len(ids))
 	for nid, lbls := range ids {
 		idCache[nid] = newIdentity(nid, lbls)
@@ -188,7 +187,7 @@ func (sc *SelectorCache) queueUserNotification(user CachedSelectionUser, selecto
 }
 
 // NewSelectorCache creates a new SelectorCache with the given identities.
-func NewSelectorCache(ids cache.IdentityCache) *SelectorCache {
+func NewSelectorCache(ids identity.IdentityMap) *SelectorCache {
 	sc := &SelectorCache{
 		idCache:   getIdentityCache(ids),
 		selectors: make(map[string]*identitySelector),
@@ -523,7 +522,7 @@ func (sc *SelectorCache) ChangeUser(selector CachedSelector, from, to CachedSele
 // Caller should Wait() on the returned sync.WaitGroup before triggering any
 // policy updates. Policy updates may need Endpoint locks, so this Wait() can
 // deadlock if the caller is holding any endpoint locks.
-func (sc *SelectorCache) UpdateIdentities(added, deleted cache.IdentityCache, wg *sync.WaitGroup) {
+func (sc *SelectorCache) UpdateIdentities(added, deleted identity.IdentityMap, wg *sync.WaitGroup) {
 	sc.mutex.Lock()
 	defer sc.mutex.Unlock()
 

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -630,7 +630,7 @@ func TestSelectorManagerCanGetBeforeSet(t *testing.T) {
 }
 
 func testNewSelectorCache(ids cache.IdentityCache) *SelectorCache {
-	sc := NewSelectorCache(testidentity.NewMockIdentityAllocator(ids), ids)
+	sc := NewSelectorCache(ids)
 	sc.SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 	return sc
 }

--- a/pkg/policy/trigger.go
+++ b/pkg/policy/trigger.go
@@ -28,7 +28,7 @@ func (u *Updater) TriggerPolicyUpdates(force bool, reason string) {
 
 // NewUpdater returns a new Updater instance to handle triggering policy
 // updates ready for use.
-func NewUpdater(r *Repository, regen regenerator) (*Updater, error) {
+func NewUpdater(r *Repository, regen regenerator) *Updater {
 	t, err := trigger.NewTrigger(trigger.Parameters{
 		Name:            "policy_update",
 		MetricsObserver: &TriggerMetrics{},
@@ -49,12 +49,12 @@ func NewUpdater(r *Repository, regen regenerator) (*Updater, error) {
 		},
 	})
 	if err != nil {
-		return nil, err
+		panic(err) // unreachable, only occurs if TriggerFunc is nil
 	}
 	return &Updater{
 		Trigger: t,
 		repo:    r,
-	}, nil
+	}
 }
 
 // Updater is responsible for triggering policy updates, in order to perform


### PR DESCRIPTION
The `policy.NewPolicyRepository()` took a reference to an ID allocator, but it only used this to determine the initial set of identities. This funny little parameter created a circular reference that is tricky to untangle during initialization.

We can remove this; the initial set of identities is well known and we don't need to create the allocator just to provide that parameter.

So, remove unnecessary parameters and un-circular-ize the policy cell initialization.