### PR TITLE
k8s: use `netip.IPv{4,6}Unspecified`

### DIFF
--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -205,11 +205,11 @@ func ParseService(svc *slim_corev1.Service, nodePortAddrs []netip.Addr) (Service
 
 	ipv4 := option.Config.EnableIPv4 && utils.GetClusterIPByFamily(slim_corev1.IPv4Protocol, svc) != ""
 	if ipv4 {
-		nodePortAddrs = append(nodePortAddrs, ip.MustAddrFromIP(net.IPv4zero))
+		nodePortAddrs = append(nodePortAddrs, netip.IPv4Unspecified())
 	}
 	ipv6 := option.Config.EnableIPv6 && utils.GetClusterIPByFamily(slim_corev1.IPv6Protocol, svc) != ""
 	if ipv6 {
-		nodePortAddrs = append(nodePortAddrs, ip.MustAddrFromIP(net.IPv6zero))
+		nodePortAddrs = append(nodePortAddrs, netip.IPv6Unspecified())
 	}
 
 	for _, port := range svc.Spec.Ports {

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -633,8 +633,8 @@ func (k *K8sWatcher) genServiceMappings(pod *slim_corev1.Pod, podIPs []string, l
 				for addr, _, ok := iter.Next(); ok; addr, _, ok = iter.Next() {
 					nodeAddrAll = append(nodeAddrAll, addr.Addr)
 				}
-				nodeAddrAll = append(nodeAddrAll, ip.MustAddrFromIP(net.IPv4zero))
-				nodeAddrAll = append(nodeAddrAll, ip.MustAddrFromIP(net.IPv6zero))
+				nodeAddrAll = append(nodeAddrAll, netip.IPv4Unspecified())
+				nodeAddrAll = append(nodeAddrAll, netip.IPv6Unspecified())
 			}
 			for _, addr := range nodeAddrAll {
 				fe := loadbalancer.L3n4AddrID{


### PR DESCRIPTION
Instead of converting it from the respective `net.IPv{4,6}zero` constants which may induce an additional allocation.

For #24246
