### PR TITLE
Strictly validate the cluster name format 

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -319,6 +319,9 @@ communicating via the proxy must reconnect to re-establish connections.
   ``--mtu`` agent flag or ``mtu`` option in CNI configuration.
 * Support for L7 protocol visibility using Pod annotations (``policy.cilium.io/proxy-visibility``),
   deprecated since v1.15, has been removed.
+* The Cilium cluster name validation cannot be bypassed anymore, both for the local and
+  remote clusters. The cluster name is strictly enforced to consist of at most 32 lower
+  case alphanumeric characters and '-', start and end with an alphanumeric character.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/cilium-dbg/cmd/troubleshoot_clustermesh.go
+++ b/cilium-dbg/cmd/troubleshoot_clustermesh.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/pkg/clustermesh/common"
+	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/kvstore"
 )
 
@@ -74,6 +75,11 @@ func TroubleshootClusterMesh(
 		fmt.Fprintf(stdout, "\nCluster %q:\n", cluster)
 		if cluster == local {
 			fmt.Fprintln(stdout, "ℹ️  This entry corresponds to the local cluster")
+		}
+
+		if err := types.ValidateClusterName(cluster); err != nil {
+			fmt.Fprintln(stdout, "❌ Invalid cluster name:", err)
+			continue
 		}
 
 		cfg, ok := cfgs[cluster]

--- a/clustermesh-apiserver/kvstoremesh/root.go
+++ b/clustermesh-apiserver/kvstoremesh/root.go
@@ -54,7 +54,7 @@ func registerClusterInfoValidator(lc cell.Lifecycle, cinfo types.ClusterInfo, lo
 			if err := cinfo.InitClusterIDMax(); err != nil {
 				return err
 			}
-			if err := cinfo.ValidateStrict(log); err != nil {
+			if err := cinfo.ValidateStrict(); err != nil {
 				return err
 			}
 			return nil

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -139,13 +139,11 @@
 {{- if eq .Values.cluster.name "" }}
   {{ fail "The cluster name is invalid: cannot be empty" }}
 {{- end }}
-{{- if semverCompare ">=1.16" (default "1.16" .Values.upgradeCompatibility) }}
 {{- if gt (len .Values.cluster.name) 32 }}
-  {{ fail "The cluster name is invalid: must not be more than 32 characters. Configure 'upgradeCompatibility' to 1.15 or earlier to temporarily skip this check at your own risk" }}
+  {{ fail "The cluster name is invalid: must not be more than 32 characters" }}
 {{- end }}
 {{- if not (regexMatch "^([a-z0-9][-a-z0-9]*)?[a-z0-9]$" .Values.cluster.name) }}
-  {{ fail "The cluster name is invalid: must consist of lower case alphanumeric characters and '-', and must start and end with an alphanumeric character. Configure 'upgradeCompatibility' to 1.15 or earlier to temporarily skip this check at your own risk" }}
-{{- end }}
+  {{ fail "The cluster name is invalid: must consist of lower case alphanumeric characters and '-', and must start and end with an alphanumeric character" }}
 {{- end }}
 {{- if and (eq .Values.cluster.name "default") (ne (int .Values.cluster.id) 0) }}
   {{ fail "The cluster name is invalid: cannot use default value with cluster.id != 0" }}

--- a/pkg/clustermesh/common/clustermesh.go
+++ b/pkg/clustermesh/common/clustermesh.go
@@ -168,8 +168,10 @@ func (cm *clusterMesh) add(name, path string) {
 	}
 
 	if err := types.ValidateClusterName(name); err != nil {
-		log.WithField(fieldClusterName, name).WithError(err).
-			Error("Remote cluster name is invalid. The connection will be forbidden starting from Cilium v1.17")
+		log.WithField(fieldClusterName, name).
+			WithError(fmt.Errorf("invalid cluster name: %w", err)).
+			Error("Cannot connect to remote cluster")
+		return
 	}
 
 	cm.mutex.Lock()

--- a/pkg/clustermesh/types/option.go
+++ b/pkg/clustermesh/types/option.go
@@ -7,12 +7,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 const (
@@ -49,23 +47,23 @@ func (def ClusterInfo) Flags(flags *pflag.FlagSet) {
 
 // Validate validates that the ClusterID is in the valid range (including ClusterID == 0),
 // and that the ClusterName is different from the default value if the ClusterID != 0.
-func (c ClusterInfo) Validate(log logrus.FieldLogger) error {
+func (c ClusterInfo) Validate() error {
 	if c.ID < ClusterIDMin || c.ID > ClusterIDMax {
 		return fmt.Errorf("invalid cluster id %d: must be in range %d..%d",
 			c.ID, ClusterIDMin, ClusterIDMax)
 	}
 
-	return c.validateName(log)
+	return c.validateName()
 }
 
 // ValidateStrict validates that the ClusterID is in the valid range, but not 0,
 // and that the ClusterName is different from the default value.
-func (c ClusterInfo) ValidateStrict(log logrus.FieldLogger) error {
+func (c ClusterInfo) ValidateStrict() error {
 	if err := ValidateClusterID(c.ID); err != nil {
 		return err
 	}
 
-	return c.validateName(log)
+	return c.validateName()
 }
 
 // ValidateBuggyClusterID returns an error if a buggy cluster ID (i.e., with the
@@ -82,10 +80,9 @@ func (c ClusterInfo) ValidateBuggyClusterID(ipamMode, chainingMode string) error
 	return nil
 }
 
-func (c ClusterInfo) validateName(log logrus.FieldLogger) error {
+func (c ClusterInfo) validateName() error {
 	if err := ValidateClusterName(c.Name); err != nil {
-		log.WithField(logfields.ClusterName, c.Name).WithError(err).
-			Error("Invalid cluster name. This may cause degraded functionality, and will be strictly forbidden starting from Cilium v1.17")
+		return fmt.Errorf("invalid cluster name: %w", err)
 	}
 
 	if c.ID != 0 && c.Name == defaults.ClusterName {

--- a/pkg/clustermesh/types/option_test.go
+++ b/pkg/clustermesh/types/option_test.go
@@ -7,15 +7,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 )
 
 func TestClusterInfoValidate(t *testing.T) {
-	log := logrus.New()
-
 	// this test involves changing the global ClusterIDMax variable, so we need
 	// to save its value and restore it at the end of the test
 	oldMaxClusterID := ClusterIDMax
@@ -70,8 +67,8 @@ func TestClusterInfoValidate(t *testing.T) {
 		},
 		{
 			cinfo:         ClusterInfo{ID: 10, Name: "invAlid", MaxConnectedClusters: 511},
-			wantErr:       false, // Cluster name validation is not yet enforced in Cilium v1.16.
-			wantStrictErr: false, // Cluster name validation is not yet enforced in Cilium v1.16.
+			wantErr:       true,
+			wantStrictErr: true,
 		},
 	}
 
@@ -85,15 +82,15 @@ func TestClusterInfoValidate(t *testing.T) {
 			}
 
 			if tt.wantErr {
-				assert.Error(t, tt.cinfo.Validate(log))
+				assert.Error(t, tt.cinfo.Validate())
 			} else {
-				assert.NoError(t, tt.cinfo.Validate(log))
+				assert.NoError(t, tt.cinfo.Validate())
 			}
 
 			if tt.wantStrictErr {
-				assert.Error(t, tt.cinfo.ValidateStrict(log))
+				assert.Error(t, tt.cinfo.ValidateStrict())
 			} else {
-				assert.NoError(t, tt.cinfo.ValidateStrict(log))
+				assert.NoError(t, tt.cinfo.ValidateStrict())
 			}
 		})
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2618,7 +2618,7 @@ func (c *DaemonConfig) Validate(vp *viper.Viper) error {
 	if err := cinfo.InitClusterIDMax(); err != nil {
 		return err
 	}
-	if err := cinfo.Validate(log); err != nil {
+	if err := cinfo.Validate(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Following the formalization of the cluster name format in the previous Cilium version \[1\], let's now make the validation strict, and reject invalid cluster names.
    
\[1\]: 3ba429d0f2f6 ("options: formalize and validate cluster name format")

<!-- Description of change -->

```release-note
Strictly validate the cluster name format
```
