### PR TITLE
Cleanup clustermesh-related deprecated flag and kvstore key

### DIFF
--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -186,7 +186,7 @@ jobs:
             --set=clustermesh.useAPIServer=${{ !matrix.external-kvstore }} \
             --set=clustermesh.maxConnectedClusters=${{ matrix.max-connected-clusters }} \
             --set=clustermesh.config.enabled=true \
-            --set=extraConfig.clustermesh-ip-identities-sync-timeout=10m \
+            --set=extraConfig.clustermesh-sync-timeout=10m \
             --set=clustermesh.apiserver.readinessProbe.periodSeconds=1 \
             --set=clustermesh.apiserver.kvstoremesh.readinessProbe.periodSeconds=1 \
             --set=clustermesh.apiserver.updateStrategy.rollingUpdate.maxSurge=1 `# Use surge update strategy to enable clients to failover` \

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -313,6 +313,9 @@ Annotations:
 Removed Options
 ~~~~~~~~~~~~~~~
 
+* The previously deprecated ``clustermesh-ip-identities-sync-timeout`` flag has
+  been removed in favor of ``clustermesh-sync-timeout``.
+
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~
 

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -238,7 +238,7 @@ func (cm *ClusterMesh) IPIdentitiesSynced(ctx context.Context) error {
 }
 
 func (cm *ClusterMesh) synced(ctx context.Context, toWaitFn func(*remoteCluster) wait.Fn) error {
-	wctx, cancel := context.WithTimeout(ctx, cm.conf.Timeout())
+	wctx, cancel := context.WithTimeout(ctx, cm.conf.ClusterMeshSyncTimeout)
 	defer cancel()
 
 	waiters := make([]wait.Fn, 0)

--- a/pkg/clustermesh/operator/clustermesh.go
+++ b/pkg/clustermesh/operator/clustermesh.go
@@ -188,7 +188,7 @@ func (cm *clusterMesh) ServicesSynced(ctx context.Context) error {
 }
 
 func (cm *clusterMesh) synced(ctx context.Context, toWaitFn func(*remoteCluster) wait.Fn) error {
-	wctx, cancel := context.WithTimeout(ctx, cm.syncTimeoutConfig.Timeout())
+	wctx, cancel := context.WithTimeout(ctx, cm.syncTimeoutConfig.ClusterMeshSyncTimeout)
 	defer cancel()
 
 	waiters := make([]wait.Fn, 0)

--- a/pkg/clustermesh/wait/synced.go
+++ b/pkg/clustermesh/wait/synced.go
@@ -16,36 +16,17 @@ type TimeoutConfig struct {
 	// synchronization from all remote clusters, before triggering the
 	// circuit breaker and possibly disrupting cross-cluster connections.
 	ClusterMeshSyncTimeout time.Duration
-
-	// ClusterMeshIPIdentitiesSyncTimeout is the timeout when waiting for the
-	// initial synchronization of ipcache entries and identities from all remote
-	// clusters before regenerating the local endpoints.
-	// Deprecated in favor of ClusterMeshSyncTimeout.
-	ClusterMeshIPIdentitiesSyncTimeout time.Duration
 }
 
 func (def TimeoutConfig) Flags(flags *pflag.FlagSet) {
 	flags.Duration("clustermesh-sync-timeout", def.ClusterMeshSyncTimeout,
 		"Timeout waiting for the initial synchronization of information from remote clusters")
-
-	flags.Duration("clustermesh-ip-identities-sync-timeout", def.ClusterMeshIPIdentitiesSyncTimeout,
-		"Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration")
-	flags.MarkDeprecated("clustermesh-ip-identities-sync-timeout", "Use --clustermesh-sync-timeout instead")
-}
-
-func (tc TimeoutConfig) Timeout() time.Duration {
-	if tc.ClusterMeshSyncTimeout != TimeoutConfigDefault.ClusterMeshSyncTimeout {
-		return tc.ClusterMeshSyncTimeout
-	}
-
-	return tc.ClusterMeshIPIdentitiesSyncTimeout
 }
 
 var (
 	// TimeoutConfigDefault is the default timeout configuration.
 	TimeoutConfigDefault = TimeoutConfig{
-		ClusterMeshSyncTimeout:             1 * time.Minute,
-		ClusterMeshIPIdentitiesSyncTimeout: 1 * time.Minute,
+		ClusterMeshSyncTimeout: 1 * time.Minute,
 	}
 
 	// ErrRemoteClusterDisconnected is the error returned by wait for sync

--- a/pkg/endpoint/regenerator.go
+++ b/pkg/endpoint/regenerator.go
@@ -50,7 +50,7 @@ func newRegenerator(in struct {
 	return &Regenerator{
 		logger:        in.Logger,
 		cmWaitFn:      waitFn,
-		cmWaitTimeout: in.Config.Timeout(),
+		cmWaitTimeout: in.Config.ClusterMeshSyncTimeout,
 	}
 }
 

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -39,17 +39,6 @@ const (
 	// the heartbeat
 	HeartbeatPath = BaseKeyPrefix + "/.heartbeat"
 
-	// HasClusterConfigPath is the path to the key used to convey that the cluster
-	// configuration will be eventually created, and remote cilium agents shall
-	// wait until it is present. If this key is not set, the cilium configuration
-	// might, or might not, be configured, but the agents will continue regardless,
-	// falling back to the backward compatible behavior. It must be set before that
-	// the agents have the possibility to connect to the kvstore (that is, when
-	// it is not yet exposed). The corresponding values is ignored.
-	// Starting from v1.16, Cilium always expects the cluster configuration to be
-	// present. This key is now deprecated and shall be removed in Cilium v1.17.
-	HasClusterConfigPath = BaseKeyPrefix + "/.has-cluster-config"
-
 	// ClusterConfigPrefix is the kvstore prefix to cluster configuration
 	ClusterConfigPrefix = BaseKeyPrefix + "/cluster-config"
 


### PR DESCRIPTION
Drop the deprecated `clustermesh-ip-identities-sync-timeout` flag (65ece676c95d), and the `.has-cluster-config` etcd key (cc7c27da59dc).

```release-note
Cleanup clustermesh-related deprecated flag and kvstore key
```
