### PR TITLE
helm: allow configuring the clustermesh-apiserver storage medium

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -500,6 +500,10 @@
      - Security context to be added to clustermesh-apiserver etcd containers
      - object
      - ``{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}``
+   * - :spelling:ignore:`clustermesh.apiserver.etcd.storageMedium`
+     - Specifies whether etcd data is stored in a temporary volume backed by the node's default medium, such as disk, SSD or network storage (Disk), or RAM (Memory). The Memory option enables improved etcd read and write performance at the cost of additional memory usage, which counts against the memory limits of the container.
+     - string
+     - ``"Disk"``
    * - :spelling:ignore:`clustermesh.apiserver.extraArgs`
      - Additional clustermesh-apiserver arguments.
      - list

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -175,6 +175,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.etcd.lifecycle | object | `{}` | lifecycle setting for the etcd container |
 | clustermesh.apiserver.etcd.resources | object | `{}` | Specifies the resources for etcd container in the apiserver |
 | clustermesh.apiserver.etcd.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | Security context to be added to clustermesh-apiserver etcd containers |
+| clustermesh.apiserver.etcd.storageMedium | string | `"Disk"` | Specifies whether etcd data is stored in a temporary volume backed by the node's default medium, such as disk, SSD or network storage (Disk), or RAM (Memory). The Memory option enables improved etcd read and write performance at the cost of additional memory usage, which counts against the memory limits of the container. |
 | clustermesh.apiserver.extraArgs | list | `[]` | Additional clustermesh-apiserver arguments. |
 | clustermesh.apiserver.extraEnv | list | `[]` | Additional clustermesh-apiserver environment variables. |
 | clustermesh.apiserver.extraVolumeMounts | list | `[]` | Additional clustermesh-apiserver volumeMounts. |

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -398,7 +398,8 @@ spec:
           defaultMode: 0400
       {{- end }}
       - name: etcd-data-dir
-        emptyDir: {}
+        emptyDir:
+          medium: {{ ternary "Memory" "" (eq .Values.clustermesh.apiserver.etcd.storageMedium "Memory") | quote }}
       {{- if .Values.clustermesh.apiserver.kvstoremesh.enabled }}
       - name: kvstoremesh-secrets
         projected:

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -871,6 +871,12 @@
                     }
                   },
                   "type": "object"
+                },
+                "storageMedium": {
+                  "enum": [
+                    "Disk",
+                    "Memory"
+                  ]
                 }
               },
               "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2985,6 +2985,15 @@ clustermesh:
         extraArgs: []
         # -- Additional environment variables to `clustermesh-apiserver etcdinit`.
         extraEnv: []
+      # @schema
+      # enum: [Disk, Memory]
+      # @schema
+      # -- Specifies whether etcd data is stored in a temporary volume backed by
+      # the node's default medium, such as disk, SSD or network storage (Disk), or
+      # RAM (Memory). The Memory option enables improved etcd read and write
+      # performance at the cost of additional memory usage, which counts against
+      # the memory limits of the container.
+      storageMedium: Disk
     kvstoremesh:
       # -- Enable KVStoreMesh. KVStoreMesh caches the information retrieved
       # from the remote clusters in the local etcd instance.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2995,6 +2995,17 @@ clustermesh:
         extraArgs: []
         # -- Additional environment variables to `clustermesh-apiserver etcdinit`.
         extraEnv: []
+
+      # @schema
+      # enum: [Disk, Memory]
+      # @schema
+      # -- Specifies whether etcd data is stored in a temporary volume backed by
+      # the node's default medium, such as disk, SSD or network storage (Disk), or
+      # RAM (Memory). The Memory option enables improved etcd read and write
+      # performance at the cost of additional memory usage, which counts against
+      # the memory limits of the container.
+      storageMedium: Disk
+
     kvstoremesh:
       # -- Enable KVStoreMesh. KVStoreMesh caches the information retrieved
       # from the remote clusters in the local etcd instance.


### PR DESCRIPTION
The clustermesh-apiserver's etcd sidecar instance is by design stateless, as etcd data is stored in an emptyDir Kubernetes volume and not preserved upon restarts. Yet, let's expose to users the medium config, to allow creating a volume backed by RAM rather than node storage. This allows for greatly improved etcd read and write performance at the cost of additional memory usage, which counts against the memory limits of the container. Additional information is available in the upstream documentation \[1\].

\[1\]: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir

<!-- Description of change -->

```release-note
Allow configuring RAM-backed clustermesh-apiserver's etcd storage for improved performance in high-scale/high-churn environments 
```
