### PR TITLE
envoy/xds: Await until endpoint restoration is done

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -227,7 +227,6 @@ func LaunchAsEndpoint(baseCtx context.Context,
 	mtuConfig mtu.MTU,
 	bigTCPConfig *bigtcp.Configuration,
 	epMgr EndpointAdder,
-	proxy endpoint.EndpointProxy,
 	allocator cache.IdentityAllocator,
 	routingConfig routingConfigurer,
 	sysctl sysctl.Sysctl,
@@ -320,7 +319,7 @@ func LaunchAsEndpoint(baseCtx context.Context,
 	}
 
 	// Create the endpoint
-	ep, err := endpoint.NewEndpointFromChangeModel(baseCtx, owner, policyGetter, ipcache, proxy, allocator, info)
+	ep, err := endpoint.NewEndpointFromChangeModel(baseCtx, owner, policyGetter, ipcache, nil, allocator, info)
 	if err != nil {
 		return nil, fmt.Errorf("Error while creating endpoint model: %w", err)
 	}

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -92,7 +92,6 @@ func (d *Daemon) initHealth(spec *healthApi.Spec, cleaner *daemonCleanup, sysctl
 						d.mtuConfig,
 						d.bigTCPConfig,
 						d.endpointManager,
-						d.l7Proxy,
 						d.identityAllocator,
 						d.healthEndpointRouting,
 						sysctl,

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -15,12 +15,14 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
+	"github.com/cilium/cilium/pkg/endpointstate"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -112,6 +114,7 @@ type xdsServerParams struct {
 
 	Lifecycle          cell.Lifecycle
 	IPCache            *ipcache.IPCache
+	RestorerPromise    promise.Promise[endpointstate.Restorer]
 	LocalEndpointStore *LocalEndpointStore
 
 	EnvoyProxyConfig envoyProxyConfig
@@ -128,6 +131,7 @@ type xdsServerParams struct {
 
 func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 	xdsServer, err := newXDSServer(
+		params.RestorerPromise,
 		params.IPCache,
 		params.LocalEndpointStore,
 		xdsServerConfig{

--- a/pkg/envoy/embedded_envoy_test.go
+++ b/pkg/envoy/embedded_envoy_test.go
@@ -57,7 +57,7 @@ func TestEnvoy(t *testing.T) {
 
 	localEndpointStore := newLocalEndpointStore()
 
-	xdsServer, err := newXDSServer(testipcache.NewMockIPCache(), localEndpointStore,
+	xdsServer, err := newXDSServer(nil, testipcache.NewMockIPCache(), localEndpointStore,
 		xdsServerConfig{
 			envoySocketDir:    testRunDir,
 			proxyGID:          1337,
@@ -162,7 +162,7 @@ func TestEnvoyNACK(t *testing.T) {
 
 	localEndpointStore := newLocalEndpointStore()
 
-	xdsServer, err := newXDSServer(testipcache.NewMockIPCache(), localEndpointStore,
+	xdsServer, err := newXDSServer(nil, testipcache.NewMockIPCache(), localEndpointStore,
 		xdsServerConfig{
 			envoySocketDir:    testRunDir,
 			proxyGID:          1337,

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -30,10 +30,11 @@ var (
 // startXDSGRPCServer starts a gRPC server to serve xDS APIs using the given
 // resource watcher and network listener.
 // Returns a function that stops the GRPC server when called.
-func startXDSGRPCServer(listener net.Listener, config map[string]*xds.ResourceTypeConfiguration) context.CancelFunc {
+func (s *xdsServer) startXDSGRPCServer(listener net.Listener, config map[string]*xds.ResourceTypeConfiguration) context.CancelFunc {
 	grpcServer := grpc.NewServer()
 
-	xdsServer := xds.NewServer(config)
+	// xdsServer optionally pauses serving any resources until endpoints have been restored
+	xdsServer := xds.NewServer(config, s.restorerPromise)
 	dsServer := (*xdsGRPCServer)(xdsServer)
 
 	// TODO: https://github.com/cilium/cilium/issues/5051

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -77,6 +77,9 @@ func newNPHDSCache(ipcache IPCacheEventSource) NPHDSCache {
 
 var observerOnce = sync.Once{}
 
+func (cache *NPHDSCache) MarkRestorePending()   {}
+func (cache *NPHDSCache) MarkRestoreCompleted() {}
+
 // HandleResourceVersionAck is required to implement ResourceVersionAckObserver.
 // We use this to start the IP Cache listener on the first ACK so that we only
 // start the IP Cache listener if there is an Envoy node that uses NPHDS

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -35,6 +35,12 @@ type ResourceVersionAckObserver interface {
 	// has acknowledged having applied the resources.
 	// Calls to this function must not block.
 	HandleResourceVersionAck(ackVersion uint64, nackVersion uint64, nodeIP string, resourceNames []string, typeURL string, detail string)
+
+	// MarkRestorePending informs the observer about a pending state restoration.
+	MarkRestorePending()
+
+	// MarkRestoreCompleted clears the 'restore' state so that updates are acked normally.
+	MarkRestoreCompleted()
 }
 
 // AckingResourceMutatorRevertFunc is a function which reverts the effects of
@@ -102,6 +108,10 @@ type AckingResourceMutatorWrapper struct {
 
 	// pendingCompletions is the list of updates that are pending completion.
 	pendingCompletions map[*completion.Completion]*pendingCompletion
+
+	// restoring controls waiting for acks. When 'true' updates do not wait for acks from the xDS client,
+	// as xDS caches are pre-populated before passing any resources to xDS clients.
+	restoring bool
 }
 
 // pendingCompletion is an update that is pending completion.
@@ -125,6 +135,21 @@ func NewAckingResourceMutatorWrapper(mutator ResourceMutator) *AckingResourceMut
 		ackedVersions:      make(map[string]uint64),
 		pendingCompletions: make(map[*completion.Completion]*pendingCompletion),
 	}
+}
+
+func (m *AckingResourceMutatorWrapper) MarkRestorePending() {
+	m.locker.Lock()
+	defer m.locker.Unlock()
+
+	m.restoring = true
+}
+
+// MarkRestoreCompleted clears the 'restore' state so that updates are acked normally.
+func (m *AckingResourceMutatorWrapper) MarkRestoreCompleted() {
+	m.locker.Lock()
+	defer m.locker.Unlock()
+
+	m.restoring = false
 }
 
 // AddVersionCompletion adds a completion to wait for any ACK for the
@@ -154,6 +179,16 @@ func (m *AckingResourceMutatorWrapper) Upsert(typeURL string, resourceName strin
 	defer m.locker.Unlock()
 
 	wait := wg != nil
+
+	if m.restoring {
+		// Do not wait for acks when restoring state
+		log.WithFields(logrus.Fields{
+			logfields.XDSTypeURL:      typeURL,
+			logfields.XDSResourceName: resourceName,
+		}).Debug("Upsert: Restoring, skipping wait for ACK")
+
+		wait = false
+	}
 
 	var updated bool
 	var revert ResourceMutatorRevertFunc
@@ -238,6 +273,16 @@ func (m *AckingResourceMutatorWrapper) Delete(typeURL string, resourceName strin
 	defer m.locker.Unlock()
 
 	wait := wg != nil
+
+	if m.restoring {
+		// Do not wait for acks when restoring state
+		log.WithFields(logrus.Fields{
+			logfields.XDSTypeURL:      typeURL,
+			logfields.XDSResourceName: resourceName,
+		}).Debug("Delete: Restoring, skipping wait for ACK")
+
+		wait = false
+	}
 
 	// Always delete the resource, even if the completion's context was
 	// canceled before we even started, since we have no way to signal whether

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -68,10 +68,6 @@ type AckingResourceMutator interface {
 	// method call.
 	Upsert(typeURL string, resourceName string, resource proto.Message, nodeIDs []string, wg *completion.WaitGroup, callback func(error)) AckingResourceMutatorRevertFunc
 
-	// UseCurrent inserts a completion that allows the caller to wait for the current
-	// version of the given typeURL to be ACKed.
-	UseCurrent(typeURL string, nodeIDs []string, wg *completion.WaitGroup)
-
 	// DeleteNode frees resources held for the named node
 	DeleteNode(nodeID string)
 
@@ -157,18 +153,22 @@ func (m *AckingResourceMutatorWrapper) Upsert(typeURL string, resourceName strin
 	m.locker.Lock()
 	defer m.locker.Unlock()
 
+	wait := wg != nil
+
 	var updated bool
 	var revert ResourceMutatorRevertFunc
 	m.version, updated, revert = m.mutator.Upsert(typeURL, resourceName, resource)
 
 	if !updated {
-		if wg != nil {
+		if wait {
 			m.useCurrent(typeURL, nodeIDs, wg, callback)
+		} else if callback != nil {
+			callback(nil)
 		}
 		return func(completion *completion.Completion) {}
 	}
 
-	if wg != nil {
+	if wait {
 		// Create a new completion
 		c := wg.AddCompletionWithCallback(callback)
 		if _, found := m.pendingCompletions[c]; found {
@@ -188,6 +188,8 @@ func (m *AckingResourceMutatorWrapper) Upsert(typeURL string, resourceName strin
 			comp.remainingNodesResources[nodeID][resourceName] = struct{}{}
 		}
 		m.pendingCompletions[c] = comp
+	} else if callback != nil {
+		callback(nil)
 	}
 
 	// Returned revert function locks again, so it can NOT be called from 'callback' directly,
@@ -216,16 +218,6 @@ func (m *AckingResourceMutatorWrapper) useCurrent(typeURL string, nodeIDs []stri
 	}
 }
 
-// UseCurrent adds a completion to the WaitGroup if the current
-// version of the cached resource has not been acked yet, allowing the
-// caller to wait for the ACK.
-func (m *AckingResourceMutatorWrapper) UseCurrent(typeURL string, nodeIDs []string, wg *completion.WaitGroup) {
-	m.locker.Lock()
-	defer m.locker.Unlock()
-
-	m.useCurrent(typeURL, nodeIDs, wg, nil)
-}
-
 func (m *AckingResourceMutatorWrapper) currentVersionAcked(nodeIDs []string) bool {
 	for _, node := range nodeIDs {
 		if acked, exists := m.ackedVersions[node]; !exists || acked < m.version {
@@ -245,6 +237,8 @@ func (m *AckingResourceMutatorWrapper) Delete(typeURL string, resourceName strin
 	m.locker.Lock()
 	defer m.locker.Unlock()
 
+	wait := wg != nil
+
 	// Always delete the resource, even if the completion's context was
 	// canceled before we even started, since we have no way to signal whether
 	// the resource is actually deleted.
@@ -258,13 +252,15 @@ func (m *AckingResourceMutatorWrapper) Delete(typeURL string, resourceName strin
 	m.version, updated, revert = m.mutator.Delete(typeURL, resourceName)
 
 	if !updated {
-		if wg != nil {
+		if wait {
 			m.useCurrent(typeURL, nodeIDs, wg, callback)
+		} else if callback != nil {
+			callback(nil)
 		}
 		return func(completion *completion.Completion) {}
 	}
 
-	if wg != nil {
+	if wait {
 		c := wg.AddCompletionWithCallback(callback)
 		if _, found := m.pendingCompletions[c]; found {
 			log.WithFields(logrus.Fields{
@@ -274,6 +270,8 @@ func (m *AckingResourceMutatorWrapper) Delete(typeURL string, resourceName strin
 		}
 
 		m.addVersionCompletion(typeURL, m.version, nodeIDs, c)
+	} else if callback != nil {
+		callback(nil)
 	}
 
 	return func(completion *completion.Completion) {

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -119,6 +119,18 @@ func TestUpsertSingleNode(t *testing.T) {
 	require.Equal(t, uint64(2), acker.ackedVersions[node0])
 }
 
+// UseCurrent adds a completion to the WaitGroup if the current
+// version of the cached resource has not been acked yet, allowing the
+// caller to wait for the ACK.
+func (m *AckingResourceMutatorWrapper) UseCurrent(typeURL string, nodeIDs []string, wg *completion.WaitGroup) {
+	m.locker.Lock()
+	defer m.locker.Unlock()
+
+	if wg != nil {
+		m.useCurrent(typeURL, nodeIDs, wg, nil)
+	}
+}
+
 func TestUseCurrent(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -93,7 +93,7 @@ func TestRequestAllResources(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}})
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
 
 	streamDone := make(chan struct{})
 
@@ -216,7 +216,7 @@ func TestAck(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}})
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
 
 	streamDone := make(chan struct{})
 
@@ -337,7 +337,7 @@ func TestRequestSomeResources(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}})
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
 
 	streamDone := make(chan struct{})
 
@@ -507,7 +507,7 @@ func TestUpdateRequestResources(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}})
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
 
 	streamDone := make(chan struct{})
 
@@ -607,7 +607,7 @@ func TestRequestStaleNonce(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}})
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
 
 	streamDone := make(chan struct{})
 
@@ -733,7 +733,7 @@ func TestNAck(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}})
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
 
 	streamDone := make(chan struct{})
 
@@ -859,7 +859,7 @@ func TestNAckFromTheStart(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}})
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
 
 	streamDone := make(chan struct{})
 
@@ -986,7 +986,7 @@ func TestRequestHighVersionFromTheStart(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}})
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
 
 	streamDone := make(chan struct{})
 

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
+	"github.com/cilium/cilium/pkg/endpointstate"
 	_ "github.com/cilium/cilium/pkg/envoy/resource"
 	"github.com/cilium/cilium/pkg/envoy/xds"
 	"github.com/cilium/cilium/pkg/lock"
@@ -45,6 +46,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -190,6 +192,8 @@ type xdsServer struct {
 	// them to the proxy via NPHDS in the cases described
 	ipCache IPCacheEventSource
 
+	restorerPromise promise.Promise[endpointstate.Restorer]
+
 	localEndpointStore *LocalEndpointStore
 }
 
@@ -216,8 +220,9 @@ type xdsServerConfig struct {
 }
 
 // newXDSServer creates a new xDS GRPC server.
-func newXDSServer(ipCache IPCacheEventSource, localEndpointStore *LocalEndpointStore, config xdsServerConfig) (*xdsServer, error) {
+func newXDSServer(restorerPromise promise.Promise[endpointstate.Restorer], ipCache IPCacheEventSource, localEndpointStore *LocalEndpointStore, config xdsServerConfig) (*xdsServer, error) {
 	return &xdsServer{
+		restorerPromise:    restorerPromise,
 		listeners:          make(map[string]*Listener),
 		ipCache:            ipCache,
 		localEndpointStore: localEndpointStore,
@@ -237,7 +242,7 @@ func (s *xdsServer) start() error {
 
 	resourceConfig := s.initializeXdsConfigs()
 
-	s.stopFunc = startXDSGRPCServer(socketListener, resourceConfig)
+	s.stopFunc = s.startXDSGRPCServer(socketListener, resourceConfig)
 
 	return nil
 }


### PR DESCRIPTION
Wait until endpoint restoration is done before serving any xDS resources to external (daemonset) Envoy on Cilium restart. This reduces Envoy resource churn during agent restart.

Add Cell to xds so that it can depend on the promise directly.

With this we only get one no-op policy update in Envoy:
```
[cilium/network_policy.cc:1175] NetworkPolicyMap::onConfigUpdate(cilium.policymap.10.244.1.193.1.), 3 resources, version: 17
xternal/envoy/source/common/init/watcher_impl.cc:31] init manager NetworkPolicyMap manager for version 16 destroyed
[cilium/network_policy.cc:1200] Received Network Policy for endpoint 1830 in onConfigUpdate() version 17
[cilium/network_policy.cc:1214] New policy is equal to old one, not updating.
[cilium/network_policy.cc:1200] Received Network Policy for endpoint 3283 in onConfigUpdate() version 17
[cilium/network_policy.cc:1214] New policy is equal to old one, not updating.
[cilium/network_policy.cc:1200] Received Network Policy for endpoint 3268 in onConfigUpdate() version 17
[cilium/network_policy.cc:1214] New policy is equal to old one, not updating.
[external/envoy/source/common/init/target_impl.cc:34] target NetworkPolicyMap manager for version 16 destroyed
[cilium/network_policy.cc:1266] Reopening ipcache on new stream
[cilium/ipcache.cc:81] cilium.ipcache: Opened ipcache.
[cilium/network_policy.cc:1273] Skipping empty or duplicate policy update.
```

```release-note
Cilium restart now waits for Envoy resources to stabilize on restart before serving them to daemonset Envoy, reducing policy churn.
```
