### PR TITLE
bpf: s/NODE_MAC/THIS_INTERFACE_MAC

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1005,7 +1005,7 @@ static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx, __u32
 #ifdef ENABLE_L2_ANNOUNCEMENTS
 static __always_inline int handle_l2_announcement(struct __ctx_buff *ctx)
 {
-	union macaddr mac = NODE_MAC;
+	union macaddr mac = THIS_INTERFACE_MAC;
 	union macaddr smac;
 	__be32 sip;
 	__be32 tip;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -388,7 +388,7 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	struct ct_state *ct_state, ct_state_new = {};
 	struct ipv6_ct_tuple *tuple;
 #ifdef ENABLE_ROUTING
-	union macaddr router_mac = NODE_MAC;
+	union macaddr router_mac = THIS_INTERFACE_MAC;
 #endif
 	struct ct_buffer6 *ct_buffer;
 	void *data, *data_end;
@@ -821,7 +821,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	struct ct_state *ct_state, ct_state_new = {};
 	struct ipv4_ct_tuple *tuple;
 #ifdef ENABLE_ROUTING
-	union macaddr router_mac = NODE_MAC;
+	union macaddr router_mac = THIS_INTERFACE_MAC;
 #endif
 	void *data, *data_end;
 	struct iphdr *ip4;
@@ -1411,12 +1411,12 @@ int tail_handle_ipv4(struct __ctx_buff *ctx)
 #ifdef ENABLE_ARP_RESPONDER
 /*
  * ARP responder for ARP requests from container
- * Respond to IPV4_GATEWAY with NODE_MAC
+ * Respond to IPV4_GATEWAY with THIS_INTERFACE_MAC
  */
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_ARP)
 int tail_handle_arp(struct __ctx_buff *ctx)
 {
-	union macaddr mac = NODE_MAC;
+	union macaddr mac = THIS_INTERFACE_MAC;
 	union macaddr smac;
 	__be32 sip;
 	__be32 tip;

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -150,7 +150,7 @@ not_esp:
 #ifdef HOST_IFINDEX
 	if (1) {
 		union macaddr host_mac = HOST_IFINDEX_MAC;
-		union macaddr router_mac = NODE_MAC;
+		union macaddr router_mac = THIS_INTERFACE_MAC;
 
 		ret = ipv6_l3(ctx, ETH_HLEN, (__u8 *)&router_mac.addr,
 			      (__u8 *)&host_mac.addr, METRIC_INGRESS);
@@ -187,7 +187,7 @@ static __always_inline int ipv4_host_delivery(struct __ctx_buff *ctx, struct iph
 #ifdef HOST_IFINDEX
 	if (1) {
 		union macaddr host_mac = HOST_IFINDEX_MAC;
-		union macaddr router_mac = NODE_MAC;
+		union macaddr router_mac = THIS_INTERFACE_MAC;
 		int ret;
 
 		ret = ipv4_l3(ctx, ETH_HLEN, (__u8 *)&router_mac.addr,
@@ -480,7 +480,7 @@ int tail_handle_ipv4(struct __ctx_buff *ctx)
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_ARP)
 int tail_handle_arp(struct __ctx_buff *ctx)
 {
-	union macaddr mac = NODE_MAC;
+	union macaddr mac = THIS_INTERFACE_MAC;
 	union macaddr smac;
 	struct trace_ctx trace = {
 		.reason = TRACE_REASON_CT_REPLY,

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -47,7 +47,7 @@ static __always_inline int icmp6_load_type(struct __ctx_buff *ctx, int l4_off, _
 
 static __always_inline int icmp6_send_reply(struct __ctx_buff *ctx, int nh_off)
 {
-	union macaddr smac, dmac = NODE_MAC;
+	union macaddr smac, dmac = THIS_INTERFACE_MAC;
 	const int csum_off = nh_off + ICMP6_CSUM_OFFSET;
 	union v6addr sip, dip, router_ip;
 	__be32 sum;
@@ -293,7 +293,7 @@ static __always_inline int __icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off)
 {
 	union v6addr target, router;
 	struct endpoint_info *ep;
-	union macaddr router_mac = NODE_MAC;
+	union macaddr router_mac = THIS_INTERFACE_MAC;
 
 	if (ctx_load_bytes(ctx, nh_off + ICMP6_ND_TARGET_OFFSET, target.addr,
 			   sizeof(((struct ipv6hdr *)NULL)->saddr)) < 0)

--- a/bpf/lib/proxy_hairpin.h
+++ b/bpf/lib/proxy_hairpin.h
@@ -29,7 +29,7 @@ ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, struct iphdr *ip4,
 {
 #if defined(ENABLE_IPV4) || defined(ENABLE_IPV6)
 	union macaddr host_mac = HOST_IFINDEX_MAC;
-	union macaddr router_mac = NODE_MAC;
+	union macaddr router_mac = THIS_INTERFACE_MAC;
 #endif
 	int ret = 0;
 

--- a/bpf/lib/static_data.h
+++ b/bpf/lib/static_data.h
@@ -94,7 +94,7 @@
  * ends up in .rodata.config in the ELF and is also inlined by the Go loader,
  * even though it's not handled by ELF variable substitution.
  *
- * Variables relying on this are NODE_MAC, LXC_IP, IPV6_MASQUERADE, ROUTER_IP
+ * Variables relying on this are THIS_INTERFACE_MAC, LXC_IP, IPV6_MASQUERADE, ROUTER_IP
  * and HOST_IP.
  */
 #define DEFINE_IPV6(name, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) \

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -18,9 +18,9 @@
 
 #define CLUSTER_ID 0
 
-#ifndef NODE_MAC
-DEFINE_MAC(NODE_MAC, 0xde, 0xad, 0xbe, 0xef, 0xc0, 0xde);
-#define NODE_MAC fetch_mac(NODE_MAC)
+#ifndef THIS_INTERFACE_MAC
+DEFINE_MAC(THIS_INTERFACE_MAC, 0xde, 0xad, 0xbe, 0xef, 0xc0, 0xde);
+#define THIS_INTERFACE_MAC fetch_mac(THIS_INTERFACE_MAC)
 #endif
 
 #ifndef ROUTER_IP

--- a/bpf/tests/config_replacement.h
+++ b/bpf/tests/config_replacement.h
@@ -88,10 +88,10 @@
 
 #endif /* ___EP_CONFIG____ */
 
-#ifndef NODE_MAC
-#define NODE_MAC_1 (0xde) << 24 | (0xad) << 16 | (0xbe) << 8 | (0xef)
-#define NODE_MAC_2 (0xc0) << 8 | (0xde)
-#define NODE_MAC { { NODE_MAC_1, NODE_MAC_2 } }
+#ifndef THIS_INTERFACE_MAC
+#define THIS_INTERFACE_MAC_1 (0xde) << 24 | (0xad) << 16 | (0xbe) << 8 | (0xef)
+#define THIS_INTERFACE_MAC_2 (0xc0) << 8 | (0xde)
+#define THIS_INTERACE_MAC { { THIS_INTERFACE_MAC_1, THIS_INTERFACE_MAC_2 } }
 #endif
 
 #ifndef ROUTER_IP

--- a/bpf/tests/ipsec_from_lxc_native.c
+++ b/bpf/tests/ipsec_from_lxc_native.c
@@ -3,6 +3,6 @@
 
 #define ENABLE_ROUTING
 
-#define EXPECTED_DEST_MAC (&((union macaddr)NODE_MAC).addr[0])
+#define EXPECTED_DEST_MAC (&((union macaddr)THIS_INTERFACE_MAC).addr[0])
 
 #include "ipsec_from_lxc_generic.h"

--- a/bpf/tests/ipv6_ndp_from_netdev_test.c
+++ b/bpf/tests/ipv6_ndp_from_netdev_test.c
@@ -100,7 +100,7 @@ int ipv6_from_netdev_ns_for_pod_check(const struct __ctx_buff *ctx)
 	if (l2->h_proto != bpf_htons(ETH_P_IPV6))
 		test_fatal("l2 proto hasn't been set to ETH_P_IP");
 
-	union macaddr node_mac = NODE_MAC;
+	union macaddr node_mac = THIS_INTERFACE_MAC;
 
 	if (memcmp(l2->h_source, (__u8 *)&node_mac.addr, ETH_ALEN) != 0)
 		test_fatal("src mac hasn't been set to node mac");

--- a/bpf/tests/tc_l2_announcement.c
+++ b/bpf/tests/tc_l2_announcement.c
@@ -6,8 +6,8 @@
 /* Enable debug output */
 #define DEBUG
 
-/* Set NODE_MAC equal to mac_two */
-#define NODE_MAC { .addr = {0x13, 0x37, 0x13, 0x37, 0x13, 0x37} }
+/* Set THIS_INTERFACE_MAC equal to mac_two */
+#define THIS_INTERFACE_MAC { .addr = {0x13, 0x37, 0x13, 0x37, 0x13, 0x37} }
 
 #define SECCTX_FROM_IPCACHE 1
 

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -1017,7 +1017,7 @@ func (h *HeaderfileWriter) writeStaticData(devices []string, fw io.Writer, e dat
 		fmt.Fprint(fw, defineUint16("LXC_ID", uint16(e.GetID())))
 	}
 
-	fmt.Fprint(fw, defineMAC("NODE_MAC", e.GetNodeMAC()))
+	fmt.Fprint(fw, defineMAC("THIS_INTERFACE_MAC", e.GetNodeMAC()))
 
 	secID := e.GetIdentityLocked().Uint32()
 	fmt.Fprint(fw, defineUint32("SECLABEL", secID))

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -254,7 +254,7 @@ func (l *loader) reinitializeOverlay(ctx context.Context, tunnelConfig tunnel.Co
 	// gather compile options for bpf_overlay.c
 	opts := []string{
 		fmt.Sprintf("-DSECLABEL=%d", identity.ReservedIdentityWorld),
-		fmt.Sprintf("-DNODE_MAC={.addr=%s}", mac.CArrayString(link.Attrs().HardwareAddr)),
+		fmt.Sprintf("-DTHIS_INTERFACE_MAC={.addr=%s}", mac.CArrayString(link.Attrs().HardwareAddr)),
 		fmt.Sprintf("-DCALLS_MAP=cilium_calls_overlay_%d", identity.ReservedIdentityWorld),
 	}
 	if option.Config.EnableNodePort {

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -192,15 +192,15 @@ func (l *loader) patchHostNetdevDatapath(ep datapath.Endpoint, ifName string) (m
 		return nil, nil, err
 	}
 
-	// The NODE_MAC value is specific to each attachment interface.
+	// The THIS_INTERFACE_MAC value is specific to each attachment interface.
 	mac := mac.MAC(iface.Attrs().HardwareAddr)
 	if mac == nil {
 		// L2-less device
 		mac = make([]byte, 6)
 		opts["ETH_HLEN"] = uint64(0)
 	}
-	opts["NODE_MAC_1"] = uint64(sliceToBe32(mac[0:4]))
-	opts["NODE_MAC_2"] = uint64(sliceToBe16(mac[4:6]))
+	opts["THIS_INTERFACE_MAC_1"] = uint64(sliceToBe32(mac[0:4]))
+	opts["THIS_INTERFACE_MAC_2"] = uint64(sliceToBe16(mac[4:6]))
 
 	ifIndex := uint32(iface.Attrs().Index)
 

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -227,8 +227,8 @@ func ELFVariableSubstitutions(ep datapath.Endpoint) map[string]uint64 {
 	}
 
 	mac := ep.GetNodeMAC()
-	result["NODE_MAC_1"] = uint64(sliceToBe32(mac[0:4]))
-	result["NODE_MAC_2"] = uint64(sliceToBe16(mac[4:6]))
+	result["THIS_INTERFACE_MAC_1"] = uint64(sliceToBe32(mac[0:4]))
+	result["THIS_INTERFACE_MAC_2"] = uint64(sliceToBe16(mac[4:6]))
 
 	if ep.IsHost() {
 		if option.Config.EnableNodePort {

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -102,7 +102,7 @@ func xdpCompileArgs(xdpDev string, extraCArgs []string) ([]string, error) {
 
 	args := []string{
 		fmt.Sprintf("-DSECLABEL=%d", identity.ReservedIdentityWorld),
-		fmt.Sprintf("-DNODE_MAC={.addr=%s}", mac.CArrayString(link.Attrs().HardwareAddr)),
+		fmt.Sprintf("-DTHIS_INTERFACE_MAC={.addr=%s}", mac.CArrayString(link.Attrs().HardwareAddr)),
 		"-DCALLS_MAP=cilium_calls_xdp",
 	}
 	args = append(args, extraCArgs...)


### PR DESCRIPTION
This value is *not* some generic, node-wide MAC address. Rather it is the MAC address of the specific interface that the BPF program is attached to.

Align the naming with the THIS_MTU macro.