### PR TITLE
gha: correctly trigger integration tests via ariane commands

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -14,6 +14,7 @@ triggers:
     - conformance-gateway-api.yaml
     - conformance-gke.yaml
     - conformance-ingress.yaml
+    - integration-test.yaml
     - tests-clustermesh-upgrade.yaml
     - tests-l4lb.yaml
     - tests-ipsec-upgrade.yaml
@@ -51,6 +52,9 @@ triggers:
   /ci-ingress:
     workflows:
     - conformance-ingress.yaml
+  /ci-integration:
+    workflows:
+    - integration-test.yaml
   /ci-l4lb:
     workflows:
     - tests-l4lb.yaml
@@ -76,6 +80,8 @@ workflows:
     paths-ignore-regex: (test|Documentation)/
   conformance-ingress.yaml:
     paths-ignore-regex: (test|Documentation)/
+  integration-test.yaml:
+    paths-ignore-regex: Documentation/
   tests-clustermesh-upgrade.yaml:
     paths-ignore-regex: (test|Documentation)/
   tests-l4lb.yaml:


### PR DESCRIPTION
The blamed commit backported the GHA-based integration tests to v1.13. However, it missed registering them into the Ariane configuration, which means that tests are not executed upon /test-backport-1.13, nor by means of the scheduled trigger. Let's fix it.

Fixes: 7531e097d2c2 ("introduce ARM github workflows")