### PR TITLE
[DRAFT] daemon: Move PolicyAdd/PolicyRemove into policy manager cell

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -200,6 +200,10 @@ var (
 		// IPCache, policy.Repository and CachingIdentityAllocator.
 		cell.Provide(newPolicyTrifecta),
 
+		// PolicyManager translates simple add/remove policy requests into the necessary
+		// operations to be done and signals to be generated.
+		cell.Provide(NewPolicyManager),
+
 		// IPAM metadata manager, determines which IPAM pool a pod should allocate from
 		ipamMetadata.Cell,
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -111,6 +111,7 @@ type Daemon struct {
 	rec              *recorder.Recorder
 	policy           *policy.Repository
 	policyUpdater    *policy.Updater
+	policyManager    policy.PolicyManager
 	preFilter        datapath.PreFilter
 
 	statusCollectMutex lock.RWMutex
@@ -431,6 +432,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		ipcache:              params.IPCache,
 		policy:               params.Policy,
 		policyUpdater:        params.PolicyUpdater,
+		policyManager:        params.PolicyManager,
 		egressGatewayManager: params.EgressGatewayManager,
 		ipamMetadata:         params.IPAMMetadataManager,
 		cniConfigManager:     params.CNIConfigManager,
@@ -768,7 +770,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 
 		// Launch the policy K8s watcher
 		if params.PolicyK8sWatcher != nil {
-			params.PolicyK8sWatcher.WatchK8sPolicyResources(d.ctx, &d)
+			params.PolicyK8sWatcher.WatchK8sPolicyResources(d.ctx, d.policyManager)
 		}
 
 		// Launch the K8s watchers in parallel as we continue to process other

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1641,6 +1641,7 @@ type daemonParams struct {
 	IdentityAllocator    CachingIdentityAllocator
 	Policy               *policy.Repository
 	PolicyUpdater        *policy.Updater
+	PolicyManager        policy.PolicyManager
 	IPCache              *ipcache.IPCache
 	PolicyK8sWatcher     *policyK8s.PolicyResourcesWatcher
 	EgressGatewayManager *egressgateway.Manager

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -311,7 +311,7 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 
 	ds.d.envoyXdsServer.RemoveAllNetworkPolicies()
 
-	_, err3 := ds.d.PolicyAdd(rules, policyAddOptions)
+	_, err3 := ds.d.policyManager.PolicyAdd(rules, policyAddOptions)
 	require.Equal(t, nil, err3)
 
 	// Prepare the identities necessary for testing
@@ -497,7 +497,7 @@ func (ds *DaemonSuite) testL4L7Shadowing(t *testing.T) {
 
 	ds.d.envoyXdsServer.RemoveAllNetworkPolicies()
 
-	_, err = ds.d.PolicyAdd(rules, policyAddOptions)
+	_, err = ds.d.policyManager.PolicyAdd(rules, policyAddOptions)
 	require.Equal(t, nil, err)
 
 	// Prepare endpoints
@@ -593,7 +593,7 @@ func (ds *DaemonSuite) testL4L7ShadowingShortCircuit(t *testing.T) {
 
 	ds.d.envoyXdsServer.RemoveAllNetworkPolicies()
 
-	_, err = ds.d.PolicyAdd(rules, policyAddOptions)
+	_, err = ds.d.policyManager.PolicyAdd(rules, policyAddOptions)
 	require.Equal(t, nil, err)
 
 	// Prepare endpoints
@@ -693,7 +693,7 @@ func (ds *DaemonSuite) testL3DependentL7(t *testing.T) {
 
 	ds.d.envoyXdsServer.RemoveAllNetworkPolicies()
 
-	_, err = ds.d.PolicyAdd(rules, policyAddOptions)
+	_, err = ds.d.policyManager.PolicyAdd(rules, policyAddOptions)
 	require.Equal(t, nil, err)
 
 	// Prepare endpoints
@@ -779,7 +779,7 @@ func (ds *DaemonSuite) testReplacePolicy(t *testing.T) {
 		rules[i].Sanitize()
 	}
 
-	_, err := ds.d.PolicyAdd(rules, policyAddOptions)
+	_, err := ds.d.policyManager.PolicyAdd(rules, policyAddOptions)
 	require.Nil(t, err)
 	ds.d.policy.Mutex.RLock()
 	require.Equal(t, 2, len(ds.d.policy.SearchRLocked(lbls)))
@@ -794,7 +794,7 @@ func (ds *DaemonSuite) testReplacePolicy(t *testing.T) {
 			},
 		},
 	}
-	_, err = ds.d.PolicyAdd(rules, &policy.AddOptions{Replace: true})
+	_, err = ds.d.policyManager.PolicyAdd(rules, &policy.AddOptions{Replace: true})
 
 	require.Nil(t, err)
 	ds.d.policy.Mutex.RLock()
@@ -875,7 +875,7 @@ func (ds *DaemonSuite) testRemovePolicy(t *testing.T) {
 
 	ds.d.envoyXdsServer.RemoveAllNetworkPolicies()
 
-	_, err3 := ds.d.PolicyAdd(rules, policyAddOptions)
+	_, err3 := ds.d.policyManager.PolicyAdd(rules, policyAddOptions)
 	require.Equal(t, nil, err3)
 
 	cleanup, err2 := prepareEndpointDirs()
@@ -973,7 +973,7 @@ func (ds *DaemonSuite) testIncrementalPolicy(t *testing.T) {
 
 	ds.d.envoyXdsServer.RemoveAllNetworkPolicies()
 
-	_, err3 := ds.d.PolicyAdd(rules, policyAddOptions)
+	_, err3 := ds.d.policyManager.PolicyAdd(rules, policyAddOptions)
 	require.Equal(t, nil, err3)
 
 	cleanup, err2 := prepareEndpointDirs()
@@ -1385,7 +1385,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 		// Only add policies if we have successfully parsed them. Otherwise, if
 		// parsing fails, `rules` is nil, which would wipe out the repo.
 		if want.err == nil {
-			_, policyImportErr = ds.d.PolicyAdd(rules, &policy.AddOptions{
+			_, policyImportErr = ds.d.policyManager.PolicyAdd(rules, &policy.AddOptions{
 				ReplaceWithLabels: args.cnp.GetIdentityLabels(),
 				Source:            metrics.LabelEventSourceK8s,
 			})

--- a/pkg/policy/k8s/watcher.go
+++ b/pkg/policy/k8s/watcher.go
@@ -18,6 +18,7 @@ import (
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
 )
 
 type policyWatcher struct {
@@ -27,7 +28,7 @@ type policyWatcher struct {
 	k8sResourceSynced *k8sSynced.Resources
 	k8sAPIGroups      *k8sSynced.APIGroups
 
-	policyManager         PolicyManager
+	policyManager         policy.PolicyManager
 	svcCache              serviceCache
 	svcCacheNotifications <-chan k8s.ServiceNotification
 

--- a/pkg/policy/types.go
+++ b/pkg/policy/types.go
@@ -1,0 +1,11 @@
+package policy
+
+import (
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+type PolicyManager interface {
+	PolicyAdd(rules api.Rules, opts *AddOptions) (newRev uint64, err error)
+	PolicyDelete(labels labels.LabelArray, opts *DeleteOptions) (newRev uint64, err error)
+}


### PR DESCRIPTION
The Daemon was the owner of the PolicyAdd/PolicyRemove methods, but at the current level of modularization, there was really no reason for this. This commit moves the same logic into its own cell called PolicyManager.

This allows other cells to depend on the PolicyManager without causing dependency cycles.

Unfortunately we can't move this type into pkg/policy because of the dependency on endpoints which would cause a go import cycle.

