### PR TITLE
iptables: Remove unneeded cell.Health param

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -298,7 +298,6 @@ type params struct {
 	SharedCfg SharedConfig
 
 	JobGroup job.Group
-	Health   cell.Health
 	DB       *statedb.DB
 	Devices  statedb.Table[*tables.Device]
 }


### PR DESCRIPTION
The cell.Health reporter is not needed anymore, since one it is already provided to the job registered in the manager by the JobGroup.
