### PR TITLE
resource: Proof-of-concept Resource[T] StateDB implementation

### DIFF
--- a/pkg/k8s/resource/key.go
+++ b/pkg/k8s/resource/key.go
@@ -9,25 +9,12 @@ import (
 )
 
 // Key of an K8s object, e.g. name and optional namespace.
-type Key struct {
-	// Name is the name of the object
-	Name string
-
-	// Namespace is the namespace, or empty if object is not namespaced.
-	Namespace string
-}
-
-func (k Key) String() string {
-	if len(k.Namespace) > 0 {
-		return k.Namespace + "/" + k.Name
-	}
-	return k.Name
-}
+type Key = cache.ObjectName
 
 func NewKey(obj any) Key {
 	if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		namespace, name, _ := cache.SplitMetaNamespaceKey(d.Key)
-		return Key{name, namespace}
+		return Key{Name: name, Namespace: namespace}
 	}
 
 	meta, err := meta.Accessor(obj)
@@ -35,7 +22,7 @@ func NewKey(obj any) Key {
 		return Key{}
 	}
 	if len(meta.GetNamespace()) > 0 {
-		return Key{meta.GetName(), meta.GetNamespace()}
+		return Key{Name: meta.GetName(), Namespace: meta.GetNamespace()}
 	}
-	return Key{meta.GetName(), ""}
+	return Key{Name: meta.GetName()}
 }

--- a/pkg/k8s/resource/reflector.go
+++ b/pkg/k8s/resource/reflector.go
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resource
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	"github.com/cilium/stream"
+)
+
+type KubernetesConfig[Obj any] struct {
+	BufferSize     int                  // Maximum number of objects to commit in one transaction. Uses default if left zero.
+	BufferWaitTime time.Duration        // The amount of time to wait for the buffer to fill. Uses default if left zero.
+	ListerWatcher  cache.ListerWatcher  // The ListerWatcher to use to retrieve the objects
+	Transform      TransformFunc[Obj]   // Optional function to transform the objects given by the ListerWatcher
+	QueryAll       QueryAllFunc[Obj]    // Optional function to query all objects
+	Table          statedb.RWTable[Obj] // The table to populate
+}
+
+// TransformFunc is an optional function to give to the Kubernetes reflector
+// to transform the object returned by the ListerWatcher to the desired
+// target object. If the function returns false the object is silently
+// skipped.
+type TransformFunc[Obj any] func(any) (obj Obj, ok bool)
+
+// QueryAllFunc is an optional function to give to the Kubernetes reflector
+// to query all objects in the table that are managed by the reflector.
+// It is used to delete all objects when the underlying cache.Reflector needs
+// to Replace() all items for a resync.
+type QueryAllFunc[Obj any] func(statedb.ReadTxn, statedb.Table[Obj]) statedb.Iterator[Obj]
+
+const (
+	// DefaultBufferSize is the maximum number of objects to commit to the table in one write transaction.
+	DefaultBufferSize = 64
+
+	// DefaultBufferWaitTime is the amount of time to wait to fill the buffer before committing objects.
+	DefaultBufferWaitTime = 50 * time.Millisecond
+)
+
+func (cfg KubernetesConfig[Obj]) getBufferSize() int {
+	if cfg.BufferSize == 0 {
+		return DefaultBufferSize
+	}
+	return cfg.BufferSize
+}
+
+func (cfg KubernetesConfig[Obj]) getWaitTime() time.Duration {
+	if cfg.BufferWaitTime == 0 {
+		return DefaultBufferWaitTime
+	}
+	return cfg.BufferWaitTime
+}
+
+// Reflector reflects external data into a statedb table
+type Reflector[Obj any] interface {
+	cell.HookInterface // Can be started and stopped.
+}
+
+func RegisterReflector[Obj any](jobGroup job.Group, db *statedb.DB, cfg KubernetesConfig[Obj]) {
+	tr := &k8sReflector[Obj]{
+		KubernetesConfig: cfg,
+		db:               db,
+	}
+	jobGroup.Add(job.OneShot(
+		fmt.Sprintf("k8s-reflector-[%T]", *new(Obj)),
+		tr.run))
+}
+
+type k8sReflector[Obj any] struct {
+	KubernetesConfig[Obj]
+
+	db *statedb.DB
+}
+
+func (s *k8sReflector[Obj]) run(ctx context.Context, health cell.Health) error {
+	type entry struct {
+		deleted   bool
+		name      string
+		namespace string
+		obj       Obj
+	}
+	type buffer struct {
+		replaceItems []any
+		entries      map[string]entry
+	}
+	bufferSize := s.getBufferSize()
+	waitTime := s.getWaitTime()
+	table := s.Table
+
+	transform := s.Transform
+	if transform == nil {
+		// No provided transform function, use the identity function instead.
+		transform = TransformFunc[Obj](func(obj any) (Obj, bool) { return obj.(Obj), true })
+	}
+
+	queryAll := s.QueryAll
+	if queryAll == nil {
+		// No query function provided, use All()
+		queryAll = QueryAllFunc[Obj](func(txn statedb.ReadTxn, tbl statedb.Table[Obj]) statedb.Iterator[Obj] {
+			iter, _ := tbl.All(txn)
+			return iter
+		})
+	}
+
+	var initDoneOnce sync.Once
+	wtxn := s.db.WriteTxn(table)
+	initDone := table.RegisterInitializer(wtxn)
+	wtxn.Commit()
+
+	// Construct a stream of K8s objects, buffered into chunks every [waitTime] period
+	// and then committed.
+	// This reduces the number of write transactions required and thus the number of times
+	// readers get woken up, which results in much better overall throughput.
+	src := stream.Buffer(
+		k8sEventObservable(s.ListerWatcher),
+		bufferSize,
+		waitTime,
+
+		// Buffer the events into a map, coalescing them by key.
+		func(buf *buffer, ev cacheStoreEvent) *buffer {
+			switch {
+			case ev.Type == cacheStoreReplace:
+				return &buffer{
+					replaceItems: ev.Obj.([]any),
+					entries:      make(map[string]entry, bufferSize), // Forget prior entries
+				}
+			case buf == nil:
+				buf = &buffer{
+					replaceItems: nil,
+					entries:      make(map[string]entry, bufferSize),
+				}
+			}
+
+			var entry entry
+			entry.deleted = ev.Type == cacheStoreDelete
+
+			var key string
+			if d, ok := ev.Obj.(cache.DeletedFinalStateUnknown); ok {
+				key = d.Key
+				var err error
+				entry.namespace, entry.name, err = cache.SplitMetaNamespaceKey(d.Key)
+				if err != nil {
+					panic(fmt.Sprintf("%T internal error: cache.SplitMetaNamespaceKey(%q) failed: %s", s, d.Key, err))
+				}
+				entry.obj, ok = transform(d.Obj)
+				if !ok {
+					return buf
+				}
+			} else {
+				meta, err := meta.Accessor(ev.Obj)
+				if err != nil {
+					panic(fmt.Sprintf("%T internal error: meta.Accessor failed: %s", s, err))
+				}
+				entry.name = meta.GetName()
+				if ns := meta.GetNamespace(); ns != "" {
+					key = ns + "/" + meta.GetName()
+					entry.namespace = ns
+				} else {
+					key = meta.GetName()
+				}
+
+				var ok bool
+				entry.obj, ok = transform(ev.Obj)
+				if !ok {
+					return buf
+				}
+			}
+			buf.entries[key] = entry
+			return buf
+		},
+	)
+
+	commitBuffer := func(buf *buffer) {
+		txn := s.db.WriteTxn(s.Table)
+		defer txn.Commit()
+
+		if buf.replaceItems != nil {
+			iter := queryAll(txn, table)
+			for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+				table.Delete(txn, obj)
+			}
+			for _, item := range buf.replaceItems {
+				if obj, ok := transform(item); ok {
+					table.Insert(txn, obj)
+				}
+			}
+			initDoneOnce.Do(func() {
+				initDone(txn)
+			})
+		}
+
+		for _, entry := range buf.entries {
+			if !entry.deleted {
+				table.Insert(txn, entry.obj)
+			} else {
+				table.Delete(txn, entry.obj)
+			}
+		}
+	}
+
+	errs := make(chan error)
+	src.Observe(
+		ctx,
+		commitBuffer,
+		func(err error) {
+			errs <- err
+			close(errs)
+		},
+	)
+	return <-errs
+}
+
+// k8sEventObservable turns a ListerWatcher into an observable using the client-go's Reflector.
+func k8sEventObservable(lw cache.ListerWatcher) stream.Observable[cacheStoreEvent] {
+	return stream.FuncObservable[cacheStoreEvent](
+		func(ctx context.Context, next func(cacheStoreEvent), complete func(err error)) {
+			store := &cacheStoreListener{
+				onAdd: func(obj any) {
+					next(cacheStoreEvent{cacheStoreAdd, obj})
+				},
+				onUpdate:  func(obj any) { next(cacheStoreEvent{cacheStoreUpdate, obj}) },
+				onDelete:  func(obj any) { next(cacheStoreEvent{cacheStoreDelete, obj}) },
+				onReplace: func(objs []any) { next(cacheStoreEvent{cacheStoreReplace, objs}) },
+			}
+			reflector := cache.NewReflector(lw, nil, store, 0)
+			go func() {
+				reflector.Run(ctx.Done())
+				complete(nil)
+			}()
+		})
+}
+
+const (
+	cacheStoreAdd = iota
+	cacheStoreUpdate
+	cacheStoreDelete
+	cacheStoreReplace
+)
+
+type cacheStoreEvent struct {
+	Type int
+	Obj  any
+}
+
+// cacheStoreListener implements the methods used by the cache reflector and
+// calls the given handlers for added, updated and deleted objects.
+type cacheStoreListener struct {
+	onAdd, onUpdate, onDelete func(any)
+	onReplace                 func([]any)
+}
+
+func (s *cacheStoreListener) Add(obj interface{}) error {
+	s.onAdd(obj)
+	return nil
+}
+
+func (s *cacheStoreListener) Update(obj interface{}) error {
+	s.onUpdate(obj)
+	return nil
+}
+
+func (s *cacheStoreListener) Delete(obj interface{}) error {
+	s.onDelete(obj)
+	return nil
+}
+
+func (s *cacheStoreListener) Replace(items []interface{}, resourceVersion string) error {
+	if items == nil {
+		// Always emit a non-nil slice for replace.
+		items = []interface{}{}
+	}
+	s.onReplace(items)
+	return nil
+}
+
+// These methods are never called by cache.Reflector:
+
+func (*cacheStoreListener) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	panic("unimplemented")
+}
+func (*cacheStoreListener) GetByKey(key string) (item interface{}, exists bool, err error) {
+	panic("unimplemented")
+}
+func (*cacheStoreListener) List() []interface{} { panic("unimplemented") }
+func (*cacheStoreListener) ListKeys() []string  { panic("unimplemented") }
+func (*cacheStoreListener) Resync() error       { panic("unimplemented") }
+
+var _ cache.Store = &cacheStoreListener{}

--- a/pkg/k8s/resource/statedb.go
+++ b/pkg/k8s/resource/statedb.go
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resource
+
+import (
+	"context"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+	"github.com/cilium/stream"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+func newKeyIndex[T runtime.Object]() statedb.Index[T, Key] {
+	return statedb.Index[T, Key]{
+		Name: "key",
+		FromObject: func(obj T) index.KeySet {
+			return index.NewKeySet(index.String(NewKey(obj).String()))
+		},
+		FromKey: index.Stringer[Key],
+		Unique:  true,
+	}
+}
+
+// statedbStore implements cache.Store with a StateDB table for
+// reading.
+type statedbStore[T runtime.Object] struct {
+	db       *statedb.DB
+	table    statedb.RWTable[T]
+	keyIndex statedb.Index[T, Key]
+}
+
+// AddIndexers implements cache.Indexer.
+func (s *statedbStore[T]) AddIndexers(newIndexers cache.Indexers) error {
+	panic("unimplemented")
+}
+
+// ByIndex implements cache.Indexer.
+func (s *statedbStore[T]) ByIndex(indexName string, indexedValue string) ([]interface{}, error) {
+	panic("unimplemented")
+}
+
+// GetIndexers implements cache.Indexer.
+func (s *statedbStore[T]) GetIndexers() cache.Indexers {
+	panic("unimplemented")
+}
+
+// Index implements cache.Indexer.
+func (s *statedbStore[T]) Index(indexName string, obj interface{}) ([]interface{}, error) {
+	panic("unimplemented")
+}
+
+// IndexKeys implements cache.Indexer.
+func (s *statedbStore[T]) IndexKeys(indexName string, indexedValue string) ([]string, error) {
+	panic("unimplemented")
+}
+
+// ListIndexFuncValues implements cache.Indexer.
+func (s *statedbStore[T]) ListIndexFuncValues(indexName string) []string {
+	panic("unimplemented")
+}
+
+// Add implements cache.Store.
+func (s *statedbStore[T]) Add(obj interface{}) error {
+	panic("not supported")
+}
+
+// Delete implements cache.Store.
+func (s *statedbStore[T]) Delete(obj interface{}) error {
+	panic("not supported")
+}
+
+// Get implements cache.Store.
+func (s *statedbStore[T]) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	result, _, exists := s.table.Get(s.db.ReadTxn(), s.keyIndex.QueryFromObject(obj.(T)))
+	return result, exists, nil
+}
+
+// GetByKey implements cache.Store.
+func (s *statedbStore[T]) GetByKey(key string) (item interface{}, exists bool, err error) {
+	objName, err := cache.ParseObjectName(key)
+	if err != nil {
+		return nil, false, err
+	}
+	result, _, exists := s.table.Get(s.db.ReadTxn(), s.keyIndex.Query(objName))
+	return result, exists, nil
+}
+
+// List implements cache.Store.
+func (s *statedbStore[T]) List() []interface{} {
+	txn := s.db.ReadTxn()
+	objs := make([]any, 0, s.table.NumObjects(txn))
+	iter, _ := s.table.All(txn)
+	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+		objs = append(objs, obj)
+	}
+	return objs
+}
+
+// ListKeys implements cache.Store.
+func (s *statedbStore[T]) ListKeys() []string {
+	txn := s.db.ReadTxn()
+	keys := make([]string, 0, s.table.NumObjects(txn))
+	iter, _ := s.table.All(txn)
+	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+		objName, err := cache.ObjectToName(obj)
+		if err == nil {
+			keys = append(keys, objName.String())
+		}
+	}
+	return keys
+}
+
+// Replace implements cache.Store.
+func (s *statedbStore[T]) Replace([]interface{}, string) error {
+	panic("not supported")
+}
+
+// Resync implements cache.Store.
+func (s *statedbStore[T]) Resync() error {
+	panic("not supported")
+}
+
+// Update implements cache.Store.
+func (s *statedbStore[T]) Update(obj interface{}) error {
+	panic("not supported")
+}
+
+var _ cache.Indexer = &statedbStore[*runtime.Unknown]{}
+
+type Params struct {
+	cell.In
+
+	JobGroup job.Group
+	DB       *statedb.DB
+}
+
+func NewTableResource[T runtime.Object](name string, lw cache.ListerWatcher, params Params, opts ...ResourceOption) (statedb.Table[T], statedb.Index[T, Key], Resource[T]) {
+	index := newKeyIndex[T]()
+	table, err := statedb.NewTable(
+		"k8s-"+name,
+		index,
+	)
+	if err != nil {
+		panic(err)
+	}
+	err = params.DB.RegisterTable(table)
+	if err != nil {
+		panic(err)
+	}
+	store := &typedStore[T]{
+		store: &statedbStore[T]{
+			db:       params.DB,
+			table:    table,
+			keyIndex: index,
+		},
+	}
+	RegisterReflector(
+		params.JobGroup,
+		params.DB,
+		KubernetesConfig[T]{
+			BufferSize:     1000,
+			BufferWaitTime: 50 * time.Millisecond,
+			ListerWatcher:  lw,
+			Table:          table,
+		})
+
+	return table, index, &statedbResource[T]{
+		store: store,
+		index: index,
+		table: table,
+		db:    params.DB,
+	}
+}
+
+type statedbResource[T runtime.Object] struct {
+	stream.Observable[Event[T]]
+	store Store[T]
+	index statedb.Index[T, Key]
+	table statedb.Table[T]
+	db    *statedb.DB
+}
+
+// Events implements Resource.
+func (s *statedbResource[T]) Events(ctx context.Context, opts ...EventsOpt) <-chan Event[T] {
+	return stream.ToChannel(ctx, s)
+}
+
+func (s *statedbResource[T]) Observe(ctx context.Context, next func(Event[T]), complete func(error)) {
+	// Start observing the table.
+	go func() {
+		txn := s.db.WriteTxn(s.table)
+		iter, err := s.table.Changes(txn)
+		txn.Commit()
+		if err != nil {
+			complete(err)
+			return
+		}
+		defer iter.Close()
+		defer complete(nil)
+
+		initialized := false
+
+		for {
+			for change, _, ok := iter.Next(); ok; change, _, ok = iter.Next() {
+				key, err := cache.ObjectToName(change.Object)
+				if err != nil {
+					panic(err)
+				}
+				kind := Upsert
+				if change.Deleted {
+					kind = Delete
+				}
+				ev := Event[T]{
+					Kind:   kind,
+					Key:    key,
+					Object: change.Object,
+					Done: func(err error) {
+						if err != nil {
+							panic("statedbResource[T] does not implement workqueue")
+						}
+					},
+				}
+				next(ev)
+			}
+
+			txn := s.db.ReadTxn()
+			watch := iter.Watch(txn)
+			if !initialized {
+				if s.table.Initialized(txn) {
+					initialized = true
+					next(Event[T]{
+						Kind: Sync,
+						Done: func(err error) {},
+					})
+				}
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-watch:
+			}
+		}
+	}()
+}
+
+// Store implements Resource.
+func (s *statedbResource[T]) Store(ctx context.Context) (Store[T], error) {
+	for {
+		txn := s.db.ReadTxn()
+		if s.table.Initialized(txn) {
+			return s.store, nil
+		}
+
+		// Not yet initialized. Watch for any change and then check again.
+		_, watch := s.table.All(txn)
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-watch:
+		}
+	}
+}
+
+// Table implements Resource.
+func (s *statedbResource[T]) Table() (statedb.Index[T, cache.ObjectName], statedb.Table[T]) {
+	return s.index, s.table
+}
+
+var _ Resource[*runtime.Unknown] = &statedbResource[*runtime.Unknown]{}


### PR DESCRIPTION
This implements the Resource[T] API (minus the workqueue / retrying) using StateDB and the client-go Reflector. The objects are only stored in a StateDB table and not in cache.Store.

As a proof-of-concept switch the Resource[CiliumNetworkPolicy] over to this and add a cilium-dbg statedb command for it:

```
root@kind-control-plane:/home/cilium# cilium statedb k8s-cilium-network-policies --watch=100ms
# Namespace   Name              Description   Labels   EndpointSelector   NodeSelector   Status
cilium-test   all-egress-deny                 []       {}                 {}             {map[] map[] [{Valid True 2024-06-03 15:42:39 +0000 UTC  Policy validation succeeded}]}
...
```
---

I don't think this necessarily makes sense as a transitional mechanism after thinking about this for a bit. It's likely better to instead introduce internal data models that are more suitable for StateDB use (smaller, parsed ("netip.Addr" and not string), TableRow() etc.). Especially as many objects can also come from kvstore so it'd be better to have e.g. `Table[Node]` to which both the k8s and kvstore reflectors write directly to.
