### PR TITLE
.github/workflows: fix digests file creation

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -193,7 +193,7 @@ jobs:
           cd image-digest/
           echo "## Docker Manifests" > ../image-digest-output.txt
           echo "" >> ../image-digest-output.txt
-          find -type f -not -name "makefile-digest.txt" | sort | xargs -d '\n' cat >> ../image-digest-output.txt
+          find -type f -regex ".*image-digest .*" -not -name "makefile-digest.txt" | sort | xargs -d '\n' cat >> ../image-digest-output.txt
 
       - name: Image Makefile Digests
         shell: bash


### PR DESCRIPTION
With the introduction of 57db22b2029c, Syft creates the sbom files under the same directory the image digest files are created. This resulted on image-digest-output.txt file to contain all the SBOMs unexpectedly. Thus, using find, we will make sure that only the files that start with the "image-digests" are used to by copied into the image-digest-output.txt file.

Tested in https://github.com/aanm/cilium/actions/runs/9358191181

Fixes: 57db22b2029c ("Generate SBOMs using Syft instead of bom")

@ferozsalam if the Syft PR was backported to all branches then we will need to add the needs-backport to all branches.