### PR TITLE
clustermesh: periodically enforce cilium cluster configuration

### DIFF
--- a/clustermesh-apiserver/clustermesh/root.go
+++ b/clustermesh-apiserver/clustermesh/root.go
@@ -368,7 +368,8 @@ func startServer(
 		},
 	}
 
-	if err := cmutils.SetClusterConfig(context.Background(), cinfo.Name, config, backend); err != nil {
+	_, err := cmutils.EnforceClusterConfig(context.Background(), cinfo.Name, config, backend, log)
+	if err != nil {
 		log.WithError(err).Fatal("Unable to set local cluster config on kvstore")
 	}
 

--- a/pkg/clustermesh/kvstoremesh/remote_cluster.go
+++ b/pkg/clustermesh/kvstoremesh/remote_cluster.go
@@ -73,7 +73,9 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 		},
 	}
 
-	if err := cmutils.SetClusterConfig(ctx, rc.name, dstcfg, rc.localBackend); err != nil {
+	stopAndWait, err := cmutils.EnforceClusterConfig(ctx, rc.name, dstcfg, rc.localBackend, rc.logger)
+	defer stopAndWait()
+	if err != nil {
 		ready <- fmt.Errorf("failed to propagate cluster configuration: %w", err)
 		close(ready)
 		return

--- a/pkg/clustermesh/utils/clustercfg.go
+++ b/pkg/clustermesh/utils/clustercfg.go
@@ -20,7 +20,12 @@ var (
 	ErrClusterConfigNotFound = errors.New("not found")
 )
 
-func SetClusterConfig(ctx context.Context, clusterName string, config cmtypes.CiliumClusterConfig, backend kvstore.BackendOperations) error {
+type ClusterConfigBackend interface {
+	Get(ctx context.Context, key string) ([]byte, error)
+	UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool) (bool, error)
+}
+
+func SetClusterConfig(ctx context.Context, clusterName string, config cmtypes.CiliumClusterConfig, backend ClusterConfigBackend) error {
 	key := path.Join(kvstore.ClusterConfigPrefix, clusterName)
 
 	val, err := json.Marshal(config)
@@ -39,7 +44,7 @@ func SetClusterConfig(ctx context.Context, clusterName string, config cmtypes.Ci
 	return nil
 }
 
-func GetClusterConfig(ctx context.Context, clusterName string, backend kvstore.BackendOperations) (cmtypes.CiliumClusterConfig, error) {
+func GetClusterConfig(ctx context.Context, clusterName string, backend ClusterConfigBackend) (cmtypes.CiliumClusterConfig, error) {
 	var config cmtypes.CiliumClusterConfig
 
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)

--- a/pkg/clustermesh/utils/clustercfg.go
+++ b/pkg/clustermesh/utils/clustercfg.go
@@ -7,10 +7,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"path"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/kvstore"
 )
 
@@ -18,6 +22,12 @@ var (
 	// ErrClusterConfigNotFound is the sentinel error returned by
 	// GetClusterConfig if the cluster configuration is not found.
 	ErrClusterConfigNotFound = errors.New("not found")
+
+	// clusterConfigEnforcerGroup is the group for the controllers enforcing
+	clusterConfigEnforcerGroup = controller.NewGroup("clustermesh-cluster-config-enforcer")
+
+	// runInterval is the cluster configuration enforcement interval
+	runInterval = 5 * time.Minute
 )
 
 type ClusterConfigBackend interface {
@@ -42,6 +52,51 @@ func SetClusterConfig(ctx context.Context, clusterName string, config cmtypes.Ci
 	}
 
 	return nil
+}
+
+// EnforceClusterConfig synchronously writes the cluster configuration, and
+// additionally registers a background task to periodically enforce its presence
+// (e.g., in case the associated lease unexpectedly expired).
+func EnforceClusterConfig(
+	ctx context.Context, clusterName string, config cmtypes.CiliumClusterConfig,
+	backend ClusterConfigBackend, log logrus.FieldLogger,
+) (stopAndWait func(), err error) {
+	var (
+		mgr = controller.NewManager()
+		ch  = make(chan error, 1)
+	)
+
+	mgr.UpdateController(
+		fmt.Sprintf("clustermesh-cluster-config-enforcer-%s", clusterName),
+		controller.ControllerParams{
+			Context:     ctx,
+			Group:       clusterConfigEnforcerGroup,
+			RunInterval: runInterval,
+			DoFunc: func(ctx context.Context) error {
+				err := SetClusterConfig(ctx, clusterName, config, backend)
+				select {
+				case ch <- err:
+					if err != nil {
+						return controller.NewExitReason("initial enforcement failed")
+					}
+					return nil
+
+				default:
+					if err != nil {
+						log.WithError(err).Warning("Failed to write cluster configuration")
+					}
+
+					return err
+				}
+			},
+		},
+	)
+
+	// Wait to the initial synchronous enforcement, and then return.
+	err = <-ch
+	ch = nil
+
+	return mgr.RemoveAllAndWait, err
 }
 
 func GetClusterConfig(ctx context.Context, clusterName string, backend ClusterConfigBackend) (cmtypes.CiliumClusterConfig, error) {

--- a/pkg/clustermesh/utils/clustercfg_test.go
+++ b/pkg/clustermesh/utils/clustercfg_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+var mockerr = errors.New("error")
+
+type mockBackend struct {
+	data   lock.Map[string, []byte]
+	errors lock.Map[string, error]
+}
+
+func (mb *mockBackend) withError(clusterName string) {
+	mb.errors.Store(path.Join(kvstore.ClusterConfigPrefix, clusterName), mockerr)
+}
+
+func (mb *mockBackend) Get(_ context.Context, key string) ([]byte, error) {
+	if err, ok := mb.errors.LoadAndDelete(key); ok {
+		return nil, err
+	}
+
+	value, _ := mb.data.Load(key)
+	return value, nil
+}
+
+func (mb *mockBackend) UpdateIfDifferent(_ context.Context, key string, value []byte, _ bool) (bool, error) {
+	if err, ok := mb.errors.LoadAndDelete(key); ok {
+		return false, err
+	}
+
+	mb.data.Store(key, value)
+	return true, nil
+}
+
+func TestGetSetClusterConfig(t *testing.T) {
+	ctx := context.Background()
+	mb := mockBackend{}
+
+	cfg1 := cmtypes.CiliumClusterConfig{ID: 11, Capabilities: cmtypes.CiliumClusterConfigCapabilities{SyncedCanaries: true}}
+	cfg2 := cmtypes.CiliumClusterConfig{ID: 22, Capabilities: cmtypes.CiliumClusterConfigCapabilities{Cached: true}}
+	cfg3 := cmtypes.CiliumClusterConfig{ID: 33, Capabilities: cmtypes.CiliumClusterConfigCapabilities{Cached: true}}
+
+	require.NoError(t, SetClusterConfig(ctx, "foo", cfg1, &mb), "failed to write cluster configuration")
+	require.NoError(t, SetClusterConfig(ctx, "bar", cfg2, &mb), "failed to write cluster configuration")
+	require.NoError(t, SetClusterConfig(ctx, "bar", cfg3, &mb), "failed to update cluster configuration")
+	require.NoError(t, SetClusterConfig(ctx, "bar", cfg3, &mb), "failed to update cluster configuration (same value)")
+
+	mb.withError("error")
+	require.ErrorIs(t, SetClusterConfig(ctx, "error", cfg1, &mb), mockerr, "kvstore error not propagated correctly")
+
+	got, err := GetClusterConfig(ctx, "foo", &mb)
+	require.NoError(t, err, "failed to read cluster configuration")
+	require.EqualValues(t, got, cfg1, "retrieved configuration does not match expected one")
+
+	got, err = GetClusterConfig(ctx, "bar", &mb)
+	require.NoError(t, err, "failed to read cluster configuration")
+	require.EqualValues(t, got, cfg3, "retrieved configuration does not match expected one")
+
+	_, err = GetClusterConfig(ctx, "not-existing", &mb)
+	require.ErrorIs(t, err, ErrClusterConfigNotFound, "incorrect error for not found configuration")
+
+	mb.withError("error")
+	_, err = GetClusterConfig(ctx, "error", &mb)
+	require.ErrorIs(t, err, mockerr, "kvstore error not propagated correctly")
+
+	// Simulate invalid data stored in the kvstore
+	mb.UpdateIfDifferent(ctx, path.Join(kvstore.ClusterConfigPrefix, "invalid"), []byte("invalid"), true)
+	_, err = GetClusterConfig(ctx, "invalid", &mb)
+	require.ErrorContains(t, err, "invalid character", "unmarshaling error not propagated correctly")
+}

--- a/pkg/clustermesh/utils/clustercfg_test.go
+++ b/pkg/clustermesh/utils/clustercfg_test.go
@@ -8,6 +8,11 @@ import (
 	"errors"
 	"path"
 	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 
 	"github.com/stretchr/testify/require"
 
@@ -17,6 +22,12 @@ import (
 )
 
 var mockerr = errors.New("error")
+
+// Configure a generous timeout to prevent flakes when running in a noisy CI environment.
+var (
+	tick    = 10 * time.Millisecond
+	timeout = 5 * time.Second
+)
 
 type mockBackend struct {
 	data   lock.Map[string, []byte]
@@ -80,4 +91,48 @@ func TestGetSetClusterConfig(t *testing.T) {
 	mb.UpdateIfDifferent(ctx, path.Join(kvstore.ClusterConfigPrefix, "invalid"), []byte("invalid"), true)
 	_, err = GetClusterConfig(ctx, "invalid", &mb)
 	require.ErrorContains(t, err, "invalid character", "unmarshaling error not propagated correctly")
+}
+
+func TestEnforceClusterConfig(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// Configure a short run interval for testing purposes
+	defer func(orig time.Duration) { runInterval = orig }(runInterval)
+	runInterval = 25 * time.Millisecond
+
+	ctx := context.Background()
+	mb := mockBackend{}
+	log := logrus.New()
+
+	cfg1 := cmtypes.CiliumClusterConfig{ID: 11, Capabilities: cmtypes.CiliumClusterConfigCapabilities{SyncedCanaries: true}}
+	cfg2 := cmtypes.CiliumClusterConfig{ID: 22, Capabilities: cmtypes.CiliumClusterConfigCapabilities{Cached: true}}
+
+	stopAndWait1, err := EnforceClusterConfig(ctx, "foo", cfg1, &mb, log)
+	defer stopAndWait1()
+	require.NoError(t, err, "failed to write cluster configuration")
+
+	stopAndWait2, err := EnforceClusterConfig(ctx, "bar", cfg2, &mb, log)
+	defer stopAndWait2()
+	require.NoError(t, err, "failed to write cluster configuration")
+
+	mb.withError("error")
+	stopAndWait3, err := EnforceClusterConfig(ctx, "error", cfg2, &mb, log)
+	defer stopAndWait3()
+	require.ErrorIs(t, err, mockerr, "kvstore error not propagated correctly")
+
+	got, err := GetClusterConfig(ctx, "foo", &mb)
+	require.NoError(t, err, "failed to read cluster configuration")
+	require.EqualValues(t, got, cfg1, "retrieved configuration does not match expected one")
+
+	got, err = GetClusterConfig(ctx, "bar", &mb)
+	require.NoError(t, err, "failed to read cluster configuration")
+	require.EqualValues(t, got, cfg2, "retrieved configuration does not match expected one")
+
+	// Externally mutate the cluster configuration, and assert that it gets eventually reconciled.
+	require.NoError(t, SetClusterConfig(ctx, "bar", cfg1, &mb), "failed to override cluster configuration")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		got, err = GetClusterConfig(ctx, "bar", &mb)
+		assert.NoError(c, err, "failed to read cluster configuration")
+		assert.EqualValues(c, got, cfg2, "retrieved configuration does not match expected one")
+	}, timeout, tick)
 }


### PR DESCRIPTION
Currently, we only write the cluster configuration once, when the clustermesh-apiserver starts and when kvstoremesh connects to a remote cluster. However, the cluster configuration presence is critical, as otherwise remote clusters cannot connect to the given cluster. Hence, let's introduce a periodic enforcement mechanism (every 5 minutes), to ensure that it gets eventually restored in case of external modifications or deletions (e.g., if the associated lease unexpectedly expires).

No changes are performed in the cilium operator, as the configuration is already periodically enforced there.

While being there, let's also add basic unit tests to ensure the correct functioning of the cluster config helper methods.
