### PR TITLE
dnsproxy: Pick up cilium/dns with ID retry logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/bombsimon/logrusr/v4 v4.1.0
 	github.com/cilium/coverbee v0.3.2
 	github.com/cilium/deepequal-gen v0.0.0-20231116094812-0d6c075c335f
-	github.com/cilium/dns v1.1.51-0.20240416134107-d47d0dd702a1
+	github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a
 	github.com/cilium/ebpf v0.15.0
 	github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b
 	github.com/cilium/fake v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/cilium/coverbee v0.3.2 h1:RaJN5OaHf/M8tmeLemHmdO0H5bFUhvtTAoYbStDIX14
 github.com/cilium/coverbee v0.3.2/go.mod h1:p9Q2SRC/sPA0qATNfY19GXBUPdcQP6UVV2LKgOHRIzQ=
 github.com/cilium/deepequal-gen v0.0.0-20231116094812-0d6c075c335f h1:t1A8nGkbZcjLACtNGIkfhfnKgG7V83+Tzr1pMeoPuA8=
 github.com/cilium/deepequal-gen v0.0.0-20231116094812-0d6c075c335f/go.mod h1:O4ERd4TTIfE/EKtiqESR2OQEiLwkDwBTW3zrbcQ4S3M=
-github.com/cilium/dns v1.1.51-0.20240416134107-d47d0dd702a1 h1:IR2iQhLyEVDJ52rPpqYAdRZMwlOSDl1XJqkD5PQJAfs=
-github.com/cilium/dns v1.1.51-0.20240416134107-d47d0dd702a1/go.mod h1:/7LC2GOgyXJ7maupZlaVIumYQiGPIgllSf6mA9sg6RU=
+github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a h1:PRGN7B+72mj3OtLL2DM3F/9jp+ItgqgNS7mecgCmwsQ=
+github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a/go.mod h1:/7LC2GOgyXJ7maupZlaVIumYQiGPIgllSf6mA9sg6RU=
 github.com/cilium/ebpf v0.15.0 h1:7NxJhNiBT3NG8pZJ3c+yfrVdHY8ScgKD27sScgjLMMk=
 github.com/cilium/ebpf v0.15.0/go.mod h1:DHp1WyrLeiBh19Cf/tfiSMhqheEiK8fXFZ4No0P1Hso=
 github.com/cilium/endpointslice v0.29.4-0.20240409195643-982ad68ab7ba h1:Ddc5e+pz0/nY0XiAEW/UcIlvnaHACSuF77ePyMNX510=

--- a/vendor/github.com/cilium/dns/shared_client.go
+++ b/vendor/github.com/cilium/dns/shared_client.go
@@ -232,10 +232,20 @@ func handler(wg *sync.WaitGroup, client *Client, conn *Conn, requests chan reque
 			// Due to birthday paradox and the fact that ID is uint16
 			// it's likely to happen with small number (~200) of concurrent requests
 			// which would result in goroutine leak as we would never close req.ch
-			if _, ok := waitingResponses[req.msg.Id]; ok {
-				req.ch <- sharedClientResponse{nil, 0, fmt.Errorf("duplicate request id %d", req.msg.Id)}
-				close(req.ch)
-				continue
+			if _, duplicate := waitingResponses[req.msg.Id]; duplicate {
+				for n := 0; n < 5; n++ {
+					// Try a new ID
+					id := Id()
+					if _, duplicate = waitingResponses[id]; !duplicate {
+						req.msg.Id = id
+						break
+					}
+				}
+				if duplicate {
+					req.ch <- sharedClientResponse{nil, 0, fmt.Errorf("duplicate request id %d", req.msg.Id)}
+					close(req.ch)
+					continue
+				}
 			}
 
 			err := client.SendContext(req.ctx, req.msg, conn, start)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -203,7 +203,7 @@ github.com/cilium/coverbee/pkg/verifierlog
 ## explicit; go 1.20
 github.com/cilium/deepequal-gen
 github.com/cilium/deepequal-gen/generators
-# github.com/cilium/dns v1.1.51-0.20240416134107-d47d0dd702a1
+# github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a
 ## explicit; go 1.18
 github.com/cilium/dns
 # github.com/cilium/ebpf v0.15.0


### PR DESCRIPTION
Update to cilium/dns with request ID retry logic to reduce the likelihood of failures like this:

  level=error msg="Cannot forward proxied DNS lookup" error="duplicate request id 31372" subsys=fqdn/dnsproxy

```release-note
Cilium dnsproxy now retries forwarded request id allocation before failing for a duplicate request id.
```
