### PR TITLE
bpf: propagate src sec id from ingress bpf_overlay to egress bpf_host

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1357,6 +1357,8 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 
 	if (magic == MARK_MAGIC_HOST || magic == MARK_MAGIC_OVERLAY)
 		src_sec_identity = HOST_ID;
+	else if (magic == MARK_MAGIC_IDENTITY)
+		src_sec_identity = get_identity(ctx);
 
 	/* Filter allowed vlan id's and pass them back to kernel.
 	 */

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -455,6 +455,9 @@ not_esp:
 	/* A packet entering the node from the tunnel and not going to a local
 	 * endpoint has to be going to the local host.
 	 */
+
+	set_identity_mark(ctx, *identity, MARK_MAGIC_IDENTITY);
+
 	return ipv4_host_delivery(ctx, ip4);
 }
 


### PR DESCRIPTION
as in a subsequent change bpf_host will need to access the source identity that was carried over the tunnel