### PR TITLE
Some minor but helpful ipcache performance improvements:

### DIFF
--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -30,19 +30,20 @@ type IPCacheTestSuite struct{}
 var (
 	IPIdentityCache *IPCache
 	PolicyHandler   *mockUpdater
+	Allocator       *testidentity.MockIdentityAllocator
 )
 
 func setupIPCacheTestSuite(tb testing.TB) *IPCacheTestSuite {
 	s := &IPCacheTestSuite{}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	allocator := testidentity.NewMockIdentityAllocator(nil)
+	Allocator = testidentity.NewMockIdentityAllocator(nil)
 	PolicyHandler = &mockUpdater{
 		identities: make(map[identityPkg.NumericIdentity]labels.LabelArray),
 	}
 	IPIdentityCache = NewIPCache(&Configuration{
 		Context:           ctx,
-		IdentityAllocator: allocator,
+		IdentityAllocator: Allocator,
 		PolicyHandler:     PolicyHandler,
 		DatapathHandler:   &mockTriggerer{},
 	})


### PR DESCRIPTION
This tightens up the queued-prefix side of the ipcache asynchronous layer:

(see individual commit messages for more detail)

- Fix a panic when allocation fails. This fixes a nil dereference when allocation fails
- Split queued updates in to chunks. This can prevent identity spikes when a large number of prefixes are queued for updates. This is particularly relevant for prefix down-propagation.
- Don't queue prefixes for updates when metadata is unchanged. When an upsert is a no-op, don't bother queuing prefixes.


