### PR TITLE
gha: Correct skipped test name in GatewayAPI

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -131,13 +131,11 @@ jobs:
         run: |
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
           
-          EXEMPT_FEATURES="GatewayStaticAddresses,HTTPRouteParentRefPort"
+          EXEMPT_FEATURES="GatewayStaticAddresses,HTTPRouteParentRefPort,HTTPRouteResponseHeaderModification"
           if [ ${{ matrix.crd-channel }} == "standard" ]; then
             EXEMPT_FEATURES+=",HTTPRouteDestinationPortMatching,HTTPRouteRequestTimeout,HTTPRouteBackendTimeout"
           fi
 
-          SKIPPED_TESTS="MeshConsumerRoute"
-          
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=kubeProxyReplacement=true \
             --helm-set=gatewayAPI.enabled=true \


### PR DESCRIPTION
Relates: 4121a2f7814f38791f114bca9767e6787a04b5dc

Just a note that I am working on Gateway API 1.1.0 support, so will enable this test again in #32233