### PR TITLE
l2-discovery: fix health reporting for link updater

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -899,13 +899,15 @@ func (m *manager) StartNodeNeighborLinkUpdater(nh datapath.NodeNeighbors) {
 		controller.ControllerParams{
 			Group: neighborTableUpdateControllerGroup,
 			DoFunc: func(ctx context.Context) error {
+				var errs error
 				if m.nodeNeighborQueue.isEmpty() {
 					return nil
 				}
-				var errs error
 				for {
-					e := m.nodeNeighborQueue.pop()
-					if e == nil || e.node == nil {
+					e, ok := m.nodeNeighborQueue.pop()
+					if !ok {
+						break
+					} else if e == nil || e.node == nil {
 						errs = errors.Join(errs, fmt.Errorf("invalid node spec found in queue: %#v", e))
 						break
 					}

--- a/pkg/node/manager/queue.go
+++ b/pkg/node/manager/queue.go
@@ -24,15 +24,15 @@ func (q *queue[T]) isEmpty() bool {
 	return len(q.items) == 0
 }
 
-func (q *queue[T]) pop() *T {
-	if q.isEmpty() {
-		return nil
-	}
-
+func (q *queue[T]) pop() (*T, bool) {
 	q.mx.Lock()
 	defer q.mx.Unlock()
+
+	if len(q.items) == 0 {
+		return nil, false
+	}
 	t := q.items[0]
 	q.items = q.items[1:]
 
-	return t
+	return t, true
 }

--- a/pkg/node/manager/queue_test.go
+++ b/pkg/node/manager/queue_test.go
@@ -29,11 +29,16 @@ func TestQPush(t *testing.T) {
 				q.push(&u.items[i])
 			}
 			for i := 0; i < len(u.items); i++ {
-				v := q.pop()
+				v, ok := q.pop()
+				assert.True(t, ok)
 				assert.Less(t, i, len(u.e))
 				assert.Equal(t, u.e[i], *v)
 			}
 			assert.True(t, q.isEmpty())
+
+			v, ok := q.pop()
+			assert.False(t, ok)
+			assert.Nil(t, v)
 		})
 	}
 }
@@ -57,7 +62,10 @@ func TestQPop(t *testing.T) {
 			for i := range u.items {
 				q.push(&u.items[i])
 			}
-			for q.pop() != nil {
+			for {
+				if _, ok := q.pop(); !ok {
+					break
+				}
 			}
 			assert.True(t, q.isEmpty())
 		})


### PR DESCRIPTION
As-is, when l2 neighbor discovery is enabled, the
node-neighbor-link-updater controller fails with "invalid node spec found in queue". This is due to a bug in the controller's DoFunc, where an empty list is treated the same as an invalid queue entry.

When this controller fails, `cilium status` reports errors for all nodes in the cluster similar to the following:

```
cilium             cilium-mgstt    controller node-neighbor-link-updater is failing since 21s (49x): invalid node spec found in queue: (*manager.nodeQueueEntry)(nil)
```

To differentiate between an empty queue and a nil item, the queue's `pop` method now also returns a bool to indicate whether an element was successfully retrieved from the queue.

Fixes: 8d525fe39113 ("Add node neighbor link updater controller")

```release-note
Fix bug that caused all nodes to report false errors when L2 Neighbor Discovery was enabled
```
