### PR TITLE
clustermesh: drop clustermesh/remoteCluster circular reference

### DIFF
--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -156,13 +156,14 @@ func NewClusterMesh(lifecycle cell.Lifecycle, c Configuration) *ClusterMesh {
 
 func (cm *ClusterMesh) NewRemoteCluster(name string, status common.StatusFunc) common.RemoteCluster {
 	rc := &remoteCluster{
-		name:         name,
-		clusterID:    cmtypes.ClusterIDUnset,
-		mesh:         cm,
-		usedIDs:      cm.conf.ClusterIDsManager,
-		status:       status,
-		storeFactory: cm.conf.StoreFactory,
-		synced:       newSynced(),
+		name:                   name,
+		clusterID:              cmtypes.ClusterIDUnset,
+		clusterConfigValidator: cm.conf.ClusterInfo.ValidateRemoteConfig,
+		usedIDs:                cm.conf.ClusterIDsManager,
+		status:                 status,
+		storeFactory:           cm.conf.StoreFactory,
+		remoteIdentityWatcher:  cm.conf.RemoteIdentityWatcher,
+		synced:                 newSynced(),
 	}
 	rc.remoteNodes = cm.conf.StoreFactory.NewWatchStore(
 		name,


### PR DESCRIPTION
Currently, the remoteCluster struct holds a reference to the clustermesh object, leading to a sort of circular dependency. Let's simplify this by explicitly propagating only the necessary parameters, for improved separation and clarity.