### PR TITLE
Test: fix invalid network policies

### DIFF
--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -1115,7 +1115,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 			},
 			setupWanted: func() wanted {
 				r := policy.NewPolicyRepository(nil, nil, nil)
-				r.AddList(api.Rules{
+				r.MustAddList(api.Rules{
 					api.NewRule().
 						WithEndpointSelector(api.EndpointSelector{
 							LabelSelector: &slim_metav1.LabelSelector{
@@ -1146,7 +1146,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 				r := policy.NewPolicyRepository(nil, nil, nil)
 				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...).Sort()
-				r.AddList(api.Rules{
+				r.MustAddList(api.Rules{
 					{
 						EndpointSelector: api.EndpointSelector{
 							LabelSelector: &slim_metav1.LabelSelector{
@@ -1187,7 +1187,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 			},
 			setupWanted: func() wanted {
 				r := policy.NewPolicyRepository(nil, nil, nil)
-				r.AddList(api.Rules{
+				r.MustAddList(api.Rules{
 					api.NewRule().
 						WithEndpointSelector(api.EndpointSelector{
 							LabelSelector: &slim_metav1.LabelSelector{
@@ -1216,7 +1216,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 			name: "have a rule without user labels and update it with user labels, all other rules should be deleted",
 			setupArgs: func() args {
 				r := policy.NewPolicyRepository(nil, nil, nil)
-				r.AddList(api.Rules{
+				r.MustAddList(api.Rules{
 					{
 						EndpointSelector: api.EndpointSelector{
 							LabelSelector: &slim_metav1.LabelSelector{
@@ -1260,7 +1260,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 				r := policy.NewPolicyRepository(nil, nil, nil)
 				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...).Sort()
-				r.AddList(api.Rules{
+				r.MustAddList(api.Rules{
 					api.NewRule().
 						WithEndpointSelector(api.EndpointSelector{
 							LabelSelector: &slim_metav1.LabelSelector{
@@ -1284,7 +1284,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 			name: "have a rule policy installed with multiple rules and apply an empty spec should delete all rules installed",
 			setupArgs: func() args {
 				r := policy.NewPolicyRepository(nil, nil, nil)
-				r.AddList(api.Rules{
+				r.MustAddList(api.Rules{
 					{
 						EndpointSelector: api.EndpointSelector{
 							LabelSelector: &slim_metav1.LabelSelector{
@@ -1331,7 +1331,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 			},
 			setupWanted: func() wanted {
 				r := policy.NewPolicyRepository(nil, nil, nil)
-				r.AddList(api.Rules{
+				r.MustAddList(api.Rules{
 					{
 						EndpointSelector: api.EndpointSelector{
 							LabelSelector: &slim_metav1.LabelSelector{

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -141,10 +141,7 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 		},
 	}
 
-	_, _, err := repo.Add(*egressDenyRule)
-	if err != nil {
-		t.Fatal(err)
-	}
+	repo.MustAddList(api.Rules{egressDenyRule})
 
 	// Track all IDs we allocate so we can validate later that we never miss any
 	checkMutex := lock.Mutex{}

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -196,7 +196,7 @@ func (s *RedirectSuite) NewTestEndpoint(t *testing.T) *Endpoint {
 }
 
 func (s *RedirectSuite) AddRules(rules api.Rules) {
-	s.do.repo.AddList(rules)
+	s.do.repo.MustAddList(rules)
 }
 
 func (s *RedirectSuite) TearDownTest(t *testing.T) {

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -348,7 +348,6 @@ var (
 		HTTP: []api.PortRuleHTTP{
 			{Method: "GET", Path: "/"},
 		},
-		L7Proto: policy.ParserTypeHTTP.String(),
 	}
 
 	lblsL3DenyFoo = labels.ParseLabelArray("l3-deny")
@@ -557,6 +556,8 @@ func TestRedirectWithPriority(t *testing.T) {
 	s := setupRedirectSuite(t)
 
 	ep := s.NewTestEndpoint(t)
+	api.TestAllowIngressListener = true
+	defer func() { api.TestAllowIngressListener = false }()
 
 	s.AddRules(api.Rules{
 		ruleL4AllowListener1.WithEndpointSelector(selectBar_),
@@ -637,6 +638,8 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 
 	ep := s.NewTestEndpoint(t)
 
+	api.TestAllowIngressListener = true
+	defer func() { api.TestAllowIngressListener = false }()
 	s.AddRules(api.Rules{
 		ruleL4L7AllowListener1Priority1.WithEndpointSelector(selectBar_),
 		ruleL4AllowPort80.WithEndpointSelector(selectBar_),

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -146,7 +146,7 @@ func TestParseNetworkPolicyIngress(t *testing.T) {
 
 	repo := testNewPolicyRepository()
 
-	repo.AddList(rules)
+	repo.MustAddList(rules)
 	require.Equal(t, api.Denied, repo.AllowsIngressRLocked(&ctx))
 
 	epSelector := api.NewESFromLabels(fromEndpoints...)
@@ -273,7 +273,7 @@ func TestParseNetworkPolicyMultipleSelectors(t *testing.T) {
 	require.Equal(t, 1, len(rules))
 
 	repo := testNewPolicyRepository()
-	repo.AddList(rules)
+	repo.MustAddList(rules)
 
 	endpointLabels := labels.LabelArray{
 		labels.NewLabel(k8sConst.PodNamespaceLabel, slim_metav1.NamespaceDefault, labels.LabelSourceK8s),
@@ -473,7 +473,7 @@ func TestParseNetworkPolicyEgress(t *testing.T) {
 	}
 
 	repo := testNewPolicyRepository()
-	repo.AddList(rules)
+	repo.MustAddList(rules)
 	// Because search context did not contain port-specific policy, deny is
 	// expected.
 	require.Equal(t, api.Denied, repo.AllowsEgressRLocked(&ctx))
@@ -525,7 +525,7 @@ func parseAndAddRules(t *testing.T, p *slim_networkingv1.NetworkPolicy) *policy.
 	rules, err := ParseNetworkPolicy(p)
 	require.NoError(t, err)
 	rev := repo.GetRevision()
-	_, id := repo.AddList(rules)
+	_, id := repo.MustAddList(rules)
 	require.Equal(t, rev+1, id)
 
 	return repo
@@ -739,7 +739,7 @@ func TestParseNetworkPolicyEmptyFrom(t *testing.T) {
 	}
 
 	repo := testNewPolicyRepository()
-	repo.AddList(rules)
+	repo.MustAddList(rules)
 	require.Equal(t, api.Allowed, repo.AllowsIngressRLocked(&ctx))
 
 	// Empty From rules, all sources should be allowed
@@ -763,7 +763,7 @@ func TestParseNetworkPolicyEmptyFrom(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(rules))
 	repo = testNewPolicyRepository()
-	repo.AddList(rules)
+	repo.MustAddList(rules)
 	require.Equal(t, api.Allowed, repo.AllowsIngressRLocked(&ctx))
 }
 
@@ -794,7 +794,7 @@ func TestParseNetworkPolicyDenyAll(t *testing.T) {
 	}
 
 	repo := testNewPolicyRepository()
-	repo.AddList(rules)
+	repo.MustAddList(rules)
 	require.Equal(t, api.Denied, repo.AllowsIngressRLocked(&ctx))
 }
 
@@ -905,7 +905,7 @@ func TestNetworkPolicyExamples(t *testing.T) {
 	require.Equal(t, 1, len(rules))
 
 	repo := testNewPolicyRepository()
-	repo.AddList(rules)
+	repo.MustAddList(rules)
 	ctx := policy.SearchContext{
 		From: labels.LabelArray{
 			labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
@@ -1039,7 +1039,7 @@ func TestNetworkPolicyExamples(t *testing.T) {
 	require.Equal(t, 1, len(rules))
 
 	repo = testNewPolicyRepository()
-	repo.AddList(rules)
+	repo.MustAddList(rules)
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
 			labels.NewLabel(k8sConst.PodNamespaceLabel, slim_metav1.NamespaceDefault, labels.LabelSourceK8s),
@@ -1107,7 +1107,7 @@ func TestNetworkPolicyExamples(t *testing.T) {
 	require.Equal(t, 1, len(rules))
 
 	repo = testNewPolicyRepository()
-	repo.AddList(rules)
+	repo.MustAddList(rules)
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
 			labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
@@ -1247,7 +1247,7 @@ func TestNetworkPolicyExamples(t *testing.T) {
 
 	repo = testNewPolicyRepository()
 	// add example 4
-	repo.AddList(rules)
+	repo.MustAddList(rules)
 
 	np = slim_networkingv1.NetworkPolicy{}
 	err = json.Unmarshal(ex2, &np)
@@ -1256,7 +1256,7 @@ func TestNetworkPolicyExamples(t *testing.T) {
 	rules, err = ParseNetworkPolicy(&np)
 	require.NoError(t, err)
 	// add example 2
-	repo.AddList(rules)
+	repo.MustAddList(rules)
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
@@ -1393,7 +1393,7 @@ func TestNetworkPolicyExamples(t *testing.T) {
 	rules, err = ParseNetworkPolicy(&np)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(rules))
-	repo.AddList(rules)
+	repo.MustAddList(rules)
 
 	// A reminder: from the kubernetes network policy spec:
 	// namespaceSelector:

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -394,6 +394,10 @@ func (pr *L7Rules) sanitize(ports []PortProtocol) error {
 	return nil
 }
 
+// It is not allowed to configure an ingress listener, but we still
+// have some unit tests relying on this. So, allow overriding this check in the unit tests.
+var TestAllowIngressListener = false
+
 func (pr *PortRule) sanitize(ingress bool) error {
 	hasDNSRules := pr.Rules != nil && len(pr.Rules.DNS) > 0
 	if ingress && hasDNSRules {
@@ -436,7 +440,7 @@ func (pr *PortRule) sanitize(ingress bool) error {
 		// For now we have only tested custom listener support on the egress path.  TODO
 		// (jrajahalme): Lift this limitation in follow-up work once proper testing has been
 		// done on the ingress path.
-		if ingress {
+		if ingress && !TestAllowIngressListener {
 			return fmt.Errorf("Listener is not allowed on ingress (%s)", listener.Name)
 		}
 		// There is no quarantee that Listener will support Cilium policy enforcement.  Even

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -642,7 +642,7 @@ func Test_MergeL3(t *testing.T) {
 			round++
 
 			repo := newPolicyDistillery(selectorCache)
-			_, _ = repo.AddList(rules)
+			_, _ = repo.MustAddList(rules)
 
 			t.Run(fmt.Sprintf("permutation_%d-%d", tt.test, round), func(t *testing.T) {
 				logBuffer := new(bytes.Buffer)
@@ -1189,7 +1189,7 @@ func Test_MergeRules(t *testing.T) {
 		for _, r := range tt.rules {
 			if r != nil {
 				rule := r.WithEndpointSelector(selectFoo_)
-				_, _ = repo.AddList(api.Rules{rule})
+				_, _ = repo.MustAddList(api.Rules{rule})
 			}
 		}
 		t.Run(fmt.Sprintf("permutation_%d", tt.test), func(t *testing.T) {
@@ -1296,7 +1296,7 @@ func Test_MergeRulesWithNamedPorts(t *testing.T) {
 		for _, r := range tt.rules {
 			if r != nil {
 				rule := r.WithEndpointSelector(selectFoo_)
-				_, _ = repo.AddList(api.Rules{rule})
+				_, _ = repo.MustAddList(api.Rules{rule})
 			}
 		}
 		t.Run(fmt.Sprintf("permutation_%d", tt.test), func(t *testing.T) {
@@ -1341,7 +1341,7 @@ func Test_AllowAll(t *testing.T) {
 		for _, r := range tt.rules {
 			if r != nil {
 				rule := r.WithEndpointSelector(tt.selector)
-				_, _ = repo.AddList(api.Rules{rule})
+				_, _ = repo.MustAddList(api.Rules{rule})
 			}
 		}
 		t.Run(fmt.Sprintf("permutation_%d", tt.test), func(t *testing.T) {
@@ -1733,7 +1733,7 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 		repo := newPolicyDistillery(selectorCache)
 		for _, rule := range tt.rules {
 			if rule != nil {
-				_, _ = repo.AddList(api.Rules{rule})
+				_, _ = repo.MustAddList(api.Rules{rule})
 			}
 		}
 		t.Run(tt.test, func(t *testing.T) {
@@ -1783,7 +1783,7 @@ func Test_EnsureEntitiesSelectableByCIDR(t *testing.T) {
 		repo := newPolicyDistillery(selectorCache)
 		for _, rule := range tt.rules {
 			if rule != nil {
-				_, _ = repo.AddList(api.Rules{rule})
+				_, _ = repo.MustAddList(api.Rules{rule})
 			}
 		}
 		t.Run(tt.test, func(t *testing.T) {

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -180,7 +180,6 @@ var (
 		HTTP: []api.PortRuleHTTP{
 			{Method: "GET", Path: "/"},
 		},
-		L7Proto: ParserTypeHTTP.String(),
 	}
 	// API rule definitions for default-deny, L3, L3L4, L3L4L7, L4, L4L7
 	lbls____NoAllow = labels.ParseLabelArray("no-allow")
@@ -1615,7 +1614,7 @@ var (
 		IngressCommonRule: api.IngressCommonRule{
 			FromCIDR: api.CIDRSlice{worldSubnet},
 		},
-	}})
+	}}).WithEndpointSelector(api.WildcardEndpointSelector)
 	mapKeyL3L4NamedPort8080ProtoTCPWorldSubNetIngress = key(worldSubnetIdentity.Uint32(), 8080, 6, trafficdirection.Ingress.Uint8())
 
 	ruleL3AllowWorldSubnetPortRange = api.NewRule().WithIngressRules([]api.IngressRule{{
@@ -1623,11 +1622,13 @@ var (
 			api.PortRule{
 				Ports: []api.PortProtocol{
 					{
-						Port:     "64-127",
+						Port:     "64",
+						EndPort:  127,
 						Protocol: api.ProtoAny,
 					},
 					{
-						Port:     "5-10",
+						Port:     "5",
+						EndPort:  10,
 						Protocol: api.ProtoAny,
 					},
 				},
@@ -1636,7 +1637,7 @@ var (
 		IngressCommonRule: api.IngressCommonRule{
 			FromCIDR: api.CIDRSlice{worldSubnet},
 		},
-	}})
+	}}).WithEndpointSelector(api.WildcardEndpointSelector)
 	mapKeyL3L4Port64To127ProtoTCPWorldSubNetIngress = keyWithPortMask(worldSubnetIdentity.Uint32(), 64, 0xffc0, 6, trafficdirection.Ingress.Uint8())
 	mapKeyL3L4Port5ProtoTCPWorldSubNetIngress       = key(worldSubnetIdentity.Uint32(), 5, 6, trafficdirection.Ingress.Uint8())
 	mapKeyL3L4Port6To7ProtoTCPWorldSubNetIngress    = keyWithPortMask(worldSubnetIdentity.Uint32(), 6, 0xfffe, 6, trafficdirection.Ingress.Uint8())

--- a/pkg/policy/l4_filter_deny_test.go
+++ b/pkg/policy/l4_filter_deny_test.go
@@ -42,7 +42,7 @@ import (
 func TestMergeDenyAllL3(t *testing.T) {
 	td := newTestData()
 	// Case 1A: Specify WildcardEndpointSelector explicitly.
-	td.repo.AddList(api.Rules{&api.Rule{
+	td.repo.MustAddList(api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
 		IngressDeny: []api.IngressDenyRule{
 			{
@@ -106,7 +106,7 @@ func TestMergeDenyAllL3(t *testing.T) {
 
 	td = newTestData()
 	// Case1B: an empty non-nil FromEndpoints does not select any identity.
-	td.repo.AddList(api.Rules{&api.Rule{
+	td.repo.MustAddList(api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
 		IngressDeny: []api.IngressDenyRule{
 			{

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -164,7 +164,7 @@ func init() {
 func TestMergeAllowAllL3AndAllowAllL7(t *testing.T) {
 	td := newTestData()
 	// Case 1A: Specify WildcardEndpointSelector explicitly.
-	td.repo.AddList(api.Rules{&api.Rule{
+	td.repo.MustAddList(api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
 		Ingress: []api.IngressRule{
 			{
@@ -212,7 +212,7 @@ func TestMergeAllowAllL3AndAllowAllL7(t *testing.T) {
 
 	// Case1B: an empty non-nil FromEndpoints does not select any identity.
 	td = newTestData()
-	td.repo.AddList(api.Rules{&api.Rule{
+	td.repo.MustAddList(api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
 		Ingress: []api.IngressRule{
 			{
@@ -329,7 +329,7 @@ func TestMergeAllowAllL3AndShadowedL7(t *testing.T) {
 	// Case 2B: Flip order of case 2A so that rule being merged with is different
 	// than rule being consumed.
 	td = newTestData()
-	td.repo.AddList(api.Rules{&api.Rule{
+	td.repo.MustAddList(api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
 		Ingress: []api.IngressRule{
 			{

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -400,25 +400,6 @@ func (p *Repository) SearchRLocked(lbls labels.LabelArray) api.Rules {
 	return result
 }
 
-// Add inserts a rule into the policy repository
-// This is just a helper function for unit testing.
-// TODO: this should be in a test_helpers.go file or something similar
-// so we can clearly delineate what helpers are for testing.
-// NOTE: This is only called from unit tests, but from multiple packages.
-func (p *Repository) Add(r api.Rule) (uint64, map[uint16]struct{}, error) {
-	p.Mutex.Lock()
-	defer p.Mutex.Unlock()
-
-	if err := r.Sanitize(); err != nil {
-		return p.GetRevision(), nil, err
-	}
-
-	newList := make([]*api.Rule, 1)
-	newList[0] = &r
-	_, rev := p.AddListLocked(newList)
-	return rev, map[uint16]struct{}{}, nil
-}
-
 // AddListLocked inserts a rule into the policy repository with the repository already locked
 // Expects that the entire rule list has already been sanitized.
 func (p *Repository) AddListLocked(rules api.Rules) (ruleSlice, uint64) {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -540,12 +540,15 @@ func (p *Repository) LocalEndpointIdentityRemoved(identity *identity.Identity) {
 	}()
 }
 
-// AddList inserts a rule into the policy repository. It is used for
-// unit-testing purposes only.
-func (p *Repository) AddList(rules api.Rules) (ruleSlice, uint64) {
+// MustAddList inserts a rule into the policy repository. It is used for
+// unit-testing purposes only. Panics if the rule is invalid
+func (p *Repository) MustAddList(rules api.Rules) (ruleSlice, uint64) {
 	for i := range rules {
 		// FIXME(GH-31162): Many unit tests provide invalid rules
-		_ = rules[i].Sanitize()
+		err := rules[i].Sanitize()
+		if err != nil {
+			panic(err)
+		}
 	}
 	p.Mutex.Lock()
 	defer p.Mutex.Unlock()

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -1415,7 +1415,7 @@ func TestPolicyDenyTrace(t *testing.T) {
 	// Add rules to allow foo=>bar
 	l3rule := buildDenyRule("foo", "bar", "")
 	rules := api.Rules{&l3rule}
-	_, _ = repo.AddList(rules)
+	_, _ = repo.MustAddList(rules)
 
 	// foo=>bar is OK
 	expectedOut := `
@@ -1565,7 +1565,7 @@ Ingress verdict: denied
 
 func TestRemoveIdentityFromRuleDenyCaches(t *testing.T) {
 	td := newTestData()
-	td.repo.AddList(api.Rules{&api.Rule{
+	td.repo.MustAddList(api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
 		IngressDeny: []api.IngressDenyRule{
 			{

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -157,14 +157,14 @@ func TestComputePolicyDenyEnforcementAndRules(t *testing.T) {
 	require.Equal(t, false, egr, genCommentf(false, false))
 	require.EqualValues(t, ruleSlice{}, matchingRules, "returned matching rules did not match")
 
-	_, _, err := repo.Add(fooIngressDenyRule1)
+	_, _, err := repo.mustAdd(fooIngressDenyRule1)
 	require.NoError(t, err, "unable to add rule to policy repository")
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.Equal(t, true, ing, genCommentf(true, true))
 	require.Equal(t, false, egr, genCommentf(false, false))
 	require.EqualValues(t, fooIngressDenyRule1, matchingRules[0].Rule, "returned matching rules did not match")
 
-	_, _, err = repo.Add(fooIngressDenyRule2)
+	_, _, err = repo.mustAdd(fooIngressDenyRule2)
 	require.NoError(t, err, "unable to add rule to policy repository")
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.Equal(t, true, ing, genCommentf(true, true))
@@ -186,7 +186,7 @@ func TestComputePolicyDenyEnforcementAndRules(t *testing.T) {
 	require.Equal(t, false, egr, genCommentf(false, false))
 	require.EqualValues(t, ruleSlice{}, matchingRules, "returned matching rules did not match")
 
-	_, _, err = repo.Add(fooEgressDenyRule1)
+	_, _, err = repo.mustAdd(fooEgressDenyRule1)
 	require.NoError(t, err, "unable to add rule to policy repository")
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.Equal(t, false, ing, genCommentf(true, false))
@@ -195,7 +195,7 @@ func TestComputePolicyDenyEnforcementAndRules(t *testing.T) {
 	_, _, numDeleted = repo.DeleteByLabelsLocked(labels.LabelArray{fooEgressDenyRule1Label})
 	require.Equal(t, 1, numDeleted)
 
-	_, _, err = repo.Add(fooEgressDenyRule2)
+	_, _, err = repo.mustAdd(fooEgressDenyRule2)
 	require.NoError(t, err, "unable to add rule to policy repository")
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.Equal(t, false, ing, genCommentf(true, false))
@@ -205,7 +205,7 @@ func TestComputePolicyDenyEnforcementAndRules(t *testing.T) {
 	_, _, numDeleted = repo.DeleteByLabelsLocked(labels.LabelArray{fooEgressDenyRule2Label})
 	require.Equal(t, 1, numDeleted)
 
-	_, _, err = repo.Add(combinedRule)
+	_, _, err = repo.mustAdd(combinedRule)
 	require.NoError(t, err, "unable to add rule to policy repository")
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.Equal(t, true, ing, genCommentf(true, true))
@@ -222,7 +222,7 @@ func TestComputePolicyDenyEnforcementAndRules(t *testing.T) {
 	require.EqualValues(t, ruleSlice{}, matchingRules, "returned matching rules did not match")
 
 	SetPolicyEnabled(option.NeverEnforce)
-	_, _, err = repo.Add(combinedRule)
+	_, _, err = repo.mustAdd(combinedRule)
 	require.NoError(t, err, "unable to add rule to policy repository")
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.Equal(t, false, ing, genCommentf(true, false))
@@ -304,7 +304,7 @@ func TestGetRulesMatching(t *testing.T) {
 	require.Equal(t, false, egressMatch)
 
 	// When ingress deny policy is applied.
-	_, _, err := repo.Add(ingressDenyRule)
+	_, _, err := repo.mustAdd(ingressDenyRule)
 	require.Nil(t, err)
 	ingressMatch, egressMatch = repo.GetRulesMatching(labels.LabelArray{bar, foo})
 	require.Equal(t, true, ingressMatch)
@@ -314,7 +314,7 @@ func TestGetRulesMatching(t *testing.T) {
 	repo.DeleteByLabels(tag)
 
 	// When egress deny policy is applied.
-	_, _, err = repo.Add(egressDenyRule)
+	_, _, err = repo.mustAdd(egressDenyRule)
 	require.Nil(t, err)
 	ingressMatch, egressMatch = repo.GetRulesMatching(labels.LabelArray{bar, foo})
 	require.Equal(t, false, ingressMatch)
@@ -379,11 +379,11 @@ func TestDeniesIngress(t *testing.T) {
 		Labels: tag1,
 	}
 
-	_, _, err := repo.Add(rule1)
+	_, _, err := repo.mustAdd(rule1)
 	require.Nil(t, err)
-	_, _, err = repo.Add(rule2)
+	_, _, err = repo.mustAdd(rule2)
 	require.Nil(t, err)
-	_, _, err = repo.Add(rule3)
+	_, _, err = repo.mustAdd(rule3)
 	require.Nil(t, err)
 
 	// foo=>bar is not OK
@@ -477,11 +477,11 @@ func TestDeniesEgress(t *testing.T) {
 		},
 		Labels: tag1,
 	}
-	_, _, err := repo.Add(rule1)
+	_, _, err := repo.mustAdd(rule1)
 	require.Nil(t, err)
-	_, _, err = repo.Add(rule2)
+	_, _, err = repo.mustAdd(rule2)
 	require.Nil(t, err)
-	_, _, err = repo.Add(rule3)
+	_, _, err = repo.mustAdd(rule3)
 	require.Nil(t, err)
 
 	// foo=>bar is not OK
@@ -546,7 +546,7 @@ func TestWildcardL3RulesIngressDeny(t *testing.T) {
 		Labels: labelsL3,
 	}
 	l3Rule.Sanitize()
-	_, _, err := repo.Add(l3Rule)
+	_, _, err := repo.mustAdd(l3Rule)
 	require.Nil(t, err)
 
 	ctx := &SearchContext{
@@ -602,7 +602,7 @@ func TestWildcardL4RulesIngressDeny(t *testing.T) {
 		Labels: labelsL4Kafka,
 	}
 	l49092Rule.Sanitize()
-	_, _, err := repo.Add(l49092Rule)
+	_, _, err := repo.mustAdd(l49092Rule)
 	require.Nil(t, err)
 
 	l480Rule := api.Rule{
@@ -622,7 +622,7 @@ func TestWildcardL4RulesIngressDeny(t *testing.T) {
 		Labels: labelsL4HTTP,
 	}
 	l480Rule.Sanitize()
-	_, _, err = repo.Add(l480Rule)
+	_, _, err = repo.mustAdd(l480Rule)
 	require.Nil(t, err)
 
 	ctx := &SearchContext{
@@ -694,7 +694,7 @@ func TestL3DependentL4IngressDenyFromRequires(t *testing.T) {
 		},
 	}
 	l480Rule.Sanitize()
-	_, _, err := repo.Add(l480Rule)
+	_, _, err := repo.mustAdd(l480Rule)
 	require.Nil(t, err)
 
 	ctx := &SearchContext{
@@ -766,7 +766,7 @@ func TestL3DependentL4EgressDenyFromRequires(t *testing.T) {
 		},
 	}
 	l480Rule.Sanitize()
-	_, _, err := repo.Add(l480Rule)
+	_, _, err := repo.mustAdd(l480Rule)
 	require.Nil(t, err)
 
 	ctx := &SearchContext{
@@ -846,7 +846,7 @@ func TestWildcardL3RulesEgressDeny(t *testing.T) {
 		Labels: labelsL4,
 	}
 	l3Rule.Sanitize()
-	_, _, err := repo.Add(l3Rule)
+	_, _, err := repo.mustAdd(l3Rule)
 	require.Nil(t, err)
 
 	icmpV4Type := intstr.FromInt(8)
@@ -869,7 +869,7 @@ func TestWildcardL3RulesEgressDeny(t *testing.T) {
 	err = icmpRule.Sanitize()
 	require.Nil(t, err)
 
-	_, _, err = repo.Add(icmpRule)
+	_, _, err = repo.mustAdd(icmpRule)
 	require.Nil(t, err)
 
 	icmpV6Type := intstr.FromInt(128)
@@ -893,7 +893,7 @@ func TestWildcardL3RulesEgressDeny(t *testing.T) {
 	err = icmpV6Rule.Sanitize()
 	require.Nil(t, err)
 
-	_, _, err = repo.Add(icmpV6Rule)
+	_, _, err = repo.mustAdd(icmpV6Rule)
 	require.Nil(t, err)
 
 	ctx := &SearchContext{
@@ -976,7 +976,7 @@ func TestWildcardL4RulesEgressDeny(t *testing.T) {
 		Labels: labelsL3DNS,
 	}
 	l453Rule.Sanitize()
-	_, _, err := repo.Add(l453Rule)
+	_, _, err := repo.mustAdd(l453Rule)
 	require.Nil(t, err)
 
 	l480Rule := api.Rule{
@@ -996,7 +996,7 @@ func TestWildcardL4RulesEgressDeny(t *testing.T) {
 		Labels: labelsL3HTTP,
 	}
 	l480Rule.Sanitize()
-	_, _, err = repo.Add(l480Rule)
+	_, _, err = repo.mustAdd(l480Rule)
 	require.Nil(t, err)
 
 	ctx := &SearchContext{
@@ -1080,7 +1080,7 @@ func TestWildcardCIDRRulesEgressDeny(t *testing.T) {
 		Labels: labelsHTTP,
 	}
 	l480Get.Sanitize()
-	_, _, err := repo.Add(l480Get)
+	_, _, err := repo.mustAdd(l480Get)
 	require.Nil(t, err)
 
 	l3Rule := api.Rule{
@@ -1095,7 +1095,7 @@ func TestWildcardCIDRRulesEgressDeny(t *testing.T) {
 		Labels: labelsL3,
 	}
 	l3Rule.Sanitize()
-	_, _, err = repo.Add(l3Rule)
+	_, _, err = repo.mustAdd(l3Rule)
 	require.Nil(t, err)
 
 	ctx := &SearchContext{
@@ -1161,7 +1161,7 @@ func TestWildcardL3RulesIngressDenyFromEntities(t *testing.T) {
 		Labels: labelsL3,
 	}
 	l3Rule.Sanitize()
-	_, _, err := repo.Add(l3Rule)
+	_, _, err := repo.mustAdd(l3Rule)
 	require.Nil(t, err)
 
 	ctx := &SearchContext{
@@ -1228,7 +1228,7 @@ func TestWildcardL3RulesEgressDenyToEntities(t *testing.T) {
 		Labels: labelsL3,
 	}
 	l3Rule.Sanitize()
-	_, _, err := repo.Add(l3Rule)
+	_, _, err := repo.mustAdd(l3Rule)
 	require.Nil(t, err)
 
 	ctx := &SearchContext{
@@ -1308,7 +1308,7 @@ func TestMinikubeGettingStartedDeny(t *testing.T) {
 		selFromApp2,
 	}
 
-	_, _, err := repo.Add(api.Rule{
+	_, _, err := repo.mustAdd(api.Rule{
 		EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("id=app1")),
 		IngressDeny: []api.IngressDenyRule{
 			{
@@ -1325,7 +1325,7 @@ func TestMinikubeGettingStartedDeny(t *testing.T) {
 	})
 	require.Nil(t, err)
 
-	_, _, err = repo.Add(api.Rule{
+	_, _, err = repo.mustAdd(api.Rule{
 		EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("id=app1")),
 		IngressDeny: []api.IngressDenyRule{
 			{
@@ -1453,7 +1453,7 @@ Ingress verdict: denied
 
 	// Now, add extra rules to allow specifically baz=>bar on port 80
 	l4rule := buildDenyRule("baz", "bar", "80")
-	_, _, err := repo.Add(l4rule)
+	_, _, err := repo.mustAdd(l4rule)
 	require.Nil(t, err)
 
 	// baz=>bar:80 is OK
@@ -1506,7 +1506,7 @@ Ingress verdict: denied
 			},
 		}},
 	}
-	_, _, err = repo.Add(l3rule)
+	_, _, err = repo.mustAdd(l3rule)
 	require.Nil(t, err)
 
 	// foo=>bar is now denied due to the FromRequires

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -2120,7 +2120,7 @@ func TestPolicyTrace(t *testing.T) {
 	// Add rules to allow foo=>bar
 	l3rule := buildRule("foo", "bar", "")
 	rules := api.Rules{&l3rule}
-	_, _ = repo.AddList(rules)
+	_, _ = repo.MustAddList(rules)
 
 	// foo=>bar is OK
 	expectedOut := `
@@ -2271,7 +2271,7 @@ Ingress verdict: denied
 func TestRemoveIdentityFromRuleCaches(t *testing.T) {
 	td := newTestData()
 
-	td.repo.AddList(api.Rules{&api.Rule{
+	td.repo.MustAddList(api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
 		Ingress: []api.IngressRule{
 			{

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -131,7 +131,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 	}
 
 	rule1.Sanitize()
-	_, _, err := repo.Add(rule1)
+	_, _, err := repo.mustAdd(rule1)
 	require.NoError(t, err)
 
 	repo.Mutex.RLock()
@@ -219,7 +219,7 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 	}
 
 	rule1.Sanitize()
-	_, _, err := repo.Add(rule1)
+	_, _, err := repo.mustAdd(rule1)
 	require.NoError(t, err)
 
 	repo.Mutex.RLock()
@@ -311,7 +311,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	}
 
 	rule1.Sanitize()
-	_, _, err := repo.Add(rule1)
+	_, _, err := repo.mustAdd(rule1)
 	require.NoError(t, err)
 
 	repo.Mutex.RLock()
@@ -433,7 +433,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	}
 
 	rule1.Sanitize()
-	_, _, err := repo.Add(rule1)
+	_, _, err := repo.mustAdd(rule1)
 	require.NoError(t, err)
 
 	repo.Mutex.RLock()

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -214,7 +214,7 @@ func (td *testData) bootstrapRepo(ruleGenFunc func(int) api.Rules, numRules int,
 
 	td.sc.UpdateIdentities(generateNumIdentities(3000), nil, wg)
 	wg.Wait()
-	rulez, _ := td.repo.AddList(ruleGenFunc(numRules))
+	rulez, _ := td.repo.MustAddList(ruleGenFunc(numRules))
 
 	epSet := NewEndpointSet(map[Endpoint]struct{}{
 		&dummyEndpoint{

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -299,7 +299,7 @@ func TestL7WithIngressWildcard(t *testing.T) {
 	}
 
 	rule1.Sanitize()
-	_, _, err := repo.Add(rule1)
+	_, _, err := repo.mustAdd(rule1)
 	require.NoError(t, err)
 
 	repo.Mutex.RLock()
@@ -402,7 +402,7 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 	}
 
 	rule1.Sanitize()
-	_, _, err := repo.Add(rule1)
+	_, _, err := repo.mustAdd(rule1)
 	require.NoError(t, err)
 
 	repo.Mutex.RLock()
@@ -503,7 +503,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 	}
 
 	rule1.Sanitize()
-	_, _, err := repo.Add(rule1)
+	_, _, err := repo.mustAdd(rule1)
 	require.NoError(t, err)
 
 	repo.Mutex.RLock()
@@ -626,7 +626,7 @@ func TestMapStateWithIngress(t *testing.T) {
 	}
 
 	rule1.Sanitize()
-	_, _, err := repo.Add(rule1)
+	_, _, err := repo.mustAdd(rule1)
 	require.NoError(t, err)
 
 	repo.Mutex.RLock()

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1658,7 +1658,7 @@ func checkEgress(t *testing.T, repo *Repository, ctx *SearchContext, verdict api
 func TestIngressAllowAll(t *testing.T) {
 	td := newTestData()
 	repo := td.repo
-	repo.AddList(api.Rules{
+	repo.MustAddList(api.Rules{
 		&api.Rule{
 			EndpointSelector: endpointSelectorC,
 			Ingress: []api.IngressRule{
@@ -1689,7 +1689,7 @@ func TestIngressAllowAll(t *testing.T) {
 func TestIngressAllowAllL4Overlap(t *testing.T) {
 	td := newTestData()
 	repo := td.repo
-	repo.AddList(api.Rules{
+	repo.MustAddList(api.Rules{
 		&api.Rule{
 			EndpointSelector: endpointSelectorC,
 			Ingress: []api.IngressRule{
@@ -1727,7 +1727,7 @@ func TestIngressAllowAllL4Overlap(t *testing.T) {
 func TestIngressAllowAllL4OverlapNamedPort(t *testing.T) {
 	td := newTestData()
 	repo := td.repo
-	repo.AddList(api.Rules{
+	repo.MustAddList(api.Rules{
 		&api.Rule{
 			EndpointSelector: endpointSelectorC,
 			Ingress: []api.IngressRule{
@@ -1765,7 +1765,7 @@ func TestIngressAllowAllL4OverlapNamedPort(t *testing.T) {
 func TestIngressL4AllowAll(t *testing.T) {
 	td := newTestData()
 	repo := td.repo
-	repo.AddList(api.Rules{
+	repo.MustAddList(api.Rules{
 		&api.Rule{
 			EndpointSelector: endpointSelectorC,
 			Ingress: []api.IngressRule{
@@ -1808,7 +1808,7 @@ func TestIngressL4AllowAll(t *testing.T) {
 func TestIngressL4AllowAllNamedPort(t *testing.T) {
 	td := newTestData()
 	repo := td.repo
-	repo.AddList(api.Rules{
+	repo.MustAddList(api.Rules{
 		&api.Rule{
 			EndpointSelector: endpointSelectorC,
 			Ingress: []api.IngressRule{
@@ -1856,7 +1856,7 @@ func TestIngressL4AllowAllNamedPort(t *testing.T) {
 func TestEgressAllowAll(t *testing.T) {
 	td := newTestData()
 	repo := td.repo
-	repo.AddList(api.Rules{
+	repo.MustAddList(api.Rules{
 		&api.Rule{
 			EndpointSelector: endpointSelectorA,
 			Egress: []api.EgressRule{
@@ -1886,7 +1886,7 @@ func TestEgressAllowAll(t *testing.T) {
 func TestEgressL4AllowAll(t *testing.T) {
 	td := newTestData()
 	repo := td.repo
-	repo.AddList(api.Rules{
+	repo.MustAddList(api.Rules{
 		&api.Rule{
 			EndpointSelector: endpointSelectorA,
 			Egress: []api.EgressRule{
@@ -1931,7 +1931,7 @@ func TestEgressL4AllowAll(t *testing.T) {
 func TestEgressL4AllowWorld(t *testing.T) {
 	td := newTestData()
 	repo := td.repo
-	repo.AddList(api.Rules{
+	repo.MustAddList(api.Rules{
 		&api.Rule{
 			EndpointSelector: endpointSelectorA,
 			Egress: []api.EgressRule{
@@ -1988,7 +1988,7 @@ func TestEgressL4AllowWorld(t *testing.T) {
 func TestEgressL4AllowAllEntity(t *testing.T) {
 	td := newTestData()
 	repo := td.repo
-	repo.AddList(api.Rules{
+	repo.MustAddList(api.Rules{
 		&api.Rule{
 			EndpointSelector: endpointSelectorA,
 			Egress: []api.EgressRule{
@@ -2045,7 +2045,7 @@ func TestEgressL4AllowAllEntity(t *testing.T) {
 func TestEgressL3AllowWorld(t *testing.T) {
 	td := newTestData()
 	repo := td.repo
-	repo.AddList(api.Rules{
+	repo.MustAddList(api.Rules{
 		&api.Rule{
 			EndpointSelector: endpointSelectorA,
 			Egress: []api.EgressRule{
@@ -2084,7 +2084,7 @@ func TestEgressL3AllowWorld(t *testing.T) {
 func TestEgressL3AllowAllEntity(t *testing.T) {
 	td := newTestData()
 	repo := td.repo
-	repo.AddList(api.Rules{
+	repo.MustAddList(api.Rules{
 		&api.Rule{
 			EndpointSelector: endpointSelectorA,
 			Egress: []api.EgressRule{
@@ -2131,7 +2131,7 @@ func TestL4WildcardMerge(t *testing.T) {
 	// parts of the L4-L7 rule are useless.
 	td := newTestData()
 	repo := td.repo
-	repo.AddList(api.Rules{&api.Rule{
+	repo.MustAddList(api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
 		Ingress: []api.IngressRule{
 			{
@@ -2259,7 +2259,7 @@ func TestL4WildcardMerge(t *testing.T) {
 	// and L7 metadata exists in the L4Filter we are adding; expect to resolve
 	// to L4-only policy without any L7-metadata.
 	repo = td.resetRepo()
-	repo.AddList(api.Rules{&api.Rule{
+	repo.MustAddList(api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
 		Ingress: []api.IngressRule{
 			{
@@ -2346,7 +2346,7 @@ func TestL4WildcardMerge(t *testing.T) {
 
 	// Second, test the expeicit allow at L3.
 	repo = td.resetRepo()
-	repo.AddList(api.Rules{&api.Rule{
+	repo.MustAddList(api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
 		Ingress: []api.IngressRule{
 			{
@@ -2400,7 +2400,7 @@ func TestL4WildcardMerge(t *testing.T) {
 	// and L7 metadata exists in the L4Filter we are adding; expect to resolve
 	// to L4-only policy without any L7-metadata.
 	repo = td.resetRepo()
-	repo.AddList(api.Rules{&api.Rule{
+	repo.MustAddList(api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
 		Ingress: []api.IngressRule{
 			{
@@ -2463,7 +2463,7 @@ func TestL3L4L7Merge(t *testing.T) {
 	// on "/".
 	td := newTestData()
 	repo := td.repo
-	repo.AddList(api.Rules{&api.Rule{
+	repo.MustAddList(api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
 		Ingress: []api.IngressRule{
 			{
@@ -2532,7 +2532,7 @@ func TestL3L4L7Merge(t *testing.T) {
 	}, filter)
 
 	repo = td.resetRepo()
-	repo.AddList(api.Rules{&api.Rule{
+	repo.MustAddList(api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
 		Ingress: []api.IngressRule{
 			{
@@ -2603,7 +2603,7 @@ func TestL3L4L7Merge(t *testing.T) {
 func TestMatches(t *testing.T) {
 	td := newTestData()
 	repo := td.repo
-	repo.AddList(api.Rules{
+	repo.MustAddList(api.Rules{
 		&api.Rule{
 			EndpointSelector: endpointSelectorA,
 			Ingress: []api.IngressRule{


### PR DESCRIPTION
Due to an oversight, the various test suites submitted invalid policies to the repository. We previously allowed this, but this has gotten us in to trouble.

So, fix all invalid policies and require that all testing policies be valid. Also, un-export some unused testing functions.