### PR TITLE
[v1.14] envoy: Bump envoy version to v1.28.4

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1051,7 +1051,7 @@
    * - :spelling:ignore:`envoy.image`
      - Envoy container image.
      - object
-     - ``{"digest":"sha256:bc8dcc3bc008e3a5aab98edb73a0985e6ef9469bda49d5bb3004c001c995c380","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.28.3-31ec52ec5f2e4d28a8e19a0bfb872fa48cf7a515","useDigest":true}``
+     - ``{"digest":"sha256:b528b291561e459024f66414ac3325b88cdd8f9f4854828a155a11e5b10b78a3","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.28.4-b35188ffa1bbe54d1720d2e392779f7a48e58f6b","useDigest":true}``
    * - :spelling:ignore:`envoy.livenessProbe.failureThreshold`
      - failure threshold of liveness probe
      - int

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:5ad7a4c7b6d9f92d4dc1445f0
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.28.3-31ec52ec5f2e4d28a8e19a0bfb872fa48cf7a515@sha256:bc8dcc3bc008e3a5aab98edb73a0985e6ef9469bda49d5bb3004c001c995c380 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.28.4-b35188ffa1bbe54d1720d2e392779f7a48e58f6b@sha256:b528b291561e459024f66414ac3325b88cdd8f9f4854828a155a11e5b10b78a3 as cilium-envoy
 
 #
 # Hubble CLI

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -312,7 +312,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:bc8dcc3bc008e3a5aab98edb73a0985e6ef9469bda49d5bb3004c001c995c380","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.28.3-31ec52ec5f2e4d28a8e19a0bfb872fa48cf7a515","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:b528b291561e459024f66414ac3325b88cdd8f9f4854828a155a11e5b10b78a3","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.28.4-b35188ffa1bbe54d1720d2e392779f7a48e58f6b","useDigest":true}` | Envoy container image. |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | envoy.log.format | string | `"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"` | The format string to use for laying out the log message metadata of Envoy. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1861,9 +1861,9 @@ envoy:
   image:
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.28.3-31ec52ec5f2e4d28a8e19a0bfb872fa48cf7a515"
+    tag: "v1.28.4-b35188ffa1bbe54d1720d2e392779f7a48e58f6b"
     pullPolicy: "IfNotPresent"
-    digest: "sha256:bc8dcc3bc008e3a5aab98edb73a0985e6ef9469bda49d5bb3004c001c995c380"
+    digest: "sha256:b528b291561e459024f66414ac3325b88cdd8f9f4854828a155a11e5b10b78a3"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1858,9 +1858,9 @@ envoy:
   image:
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.28.3-31ec52ec5f2e4d28a8e19a0bfb872fa48cf7a515"
+    tag: "v1.28.4-b35188ffa1bbe54d1720d2e392779f7a48e58f6b"
     pullPolicy: "${PULL_POLICY}"
-    digest: "sha256:bc8dcc3bc008e3a5aab98edb73a0985e6ef9469bda49d5bb3004c001c995c380"
+    digest: "sha256:b528b291561e459024f66414ac3325b88cdd8f9f4854828a155a11e5b10b78a3"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.


### PR DESCRIPTION
This commit is to bump envoy version to v1.28.4 for below CVEs:

- [CVE-2024-34362: Crash (use-after-free) in EnvoyQuicServerStream](https://togithub.com/envoyproxy/envoy/security/advisories/GHSA-hww5-43gv-35jv)
- [CVE-2024-34363: Crash due to uncaught nlohmann JSON exception](https://togithub.com/envoyproxy/envoy/security/advisories/GHSA-g979-ph9j-5gg4)
- [CVE-2024-34364: Envoy OOM vector from HTTP async client with unbounded response buffer for mirror response, and other components](https://togithub.com/envoyproxy/envoy/security/advisories/GHSA-xcj3-h7vf-fw26)
- [CVE-2024-32974: Crash in EnvoyQuicServerStream::OnInitialHeadersComplete()](https://togithub.com/envoyproxy/envoy/security/advisories/GHSA-mgxp-7hhp-8299)
- [CVE-2024-32975: Crash in QuicheDataReader::PeekVarInt62Length()](https://togithub.com/envoyproxy/envoy/security/advisories/GHSA-g9mq-6v96-cpqc)
- [CVE-2024-32976: Endless loop while decompressing Brotli data with extra input](https://togithub.com/envoyproxy/envoy/security/advisories/GHSA-7wp5-c2vq-4f8m)
- [CVE-2024-23326: Envoy incorrectly accepts HTTP 200 response for entering upgrade mode](https://togithub.com/envoyproxy/envoy/security/advisories/GHSA-vcf8-7238-v74c)

Additionally, this build also includes a couple of Cilium fixes, more details can be found in #786.

Upstream release: https://github.com/envoyproxy/envoy/releases/tag/v1.28.4
Relates: https://github.com/cilium/proxy/pull/786
