### PR TITLE
clustermesh: enable kvstoremesh by default

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -535,7 +535,7 @@
    * - :spelling:ignore:`clustermesh.apiserver.kvstoremesh.enabled`
      - Enable KVStoreMesh. KVStoreMesh caches the information retrieved from the remote clusters in the local etcd instance.
      - bool
-     - ``false``
+     - ``true``
    * - :spelling:ignore:`clustermesh.apiserver.kvstoremesh.extraArgs`
      - Additional KVStoreMesh arguments.
      - list

--- a/Documentation/network/clustermesh/clustermesh.rst
+++ b/Documentation/network/clustermesh/clustermesh.rst
@@ -188,13 +188,13 @@ clusters.
 
 .. note::
 
-   You can additionally opt in to :ref:`kvstoremesh` when enabling
-   Cluster Mesh. Make sure to configure the Cilium CLI in *helm* mode and run:
+   Starting from v1.16 KVStoreMesh is enabled by default.
+   You can opt out of :ref:`kvstoremesh` when enabling the Cluster Mesh.
 
    .. code-block:: shell-session
 
-     cilium clustermesh enable --context $CLUSTER1 --enable-kvstoremesh
-     cilium clustermesh enable --context $CLUSTER2 --enable-kvstoremesh
+     cilium clustermesh enable --context $CLUSTER1 --enable-kvstoremesh=false
+     cilium clustermesh enable --context $CLUSTER2 --enable-kvstoremesh=false
 
 .. important::
 

--- a/Documentation/network/clustermesh/intro.rst
+++ b/Documentation/network/clustermesh/intro.rst
@@ -18,15 +18,17 @@ See :ref:`gs_clustermesh` for instructions on how to set up cluster mesh.
 
 .. _kvstoremesh:
 
-KVStoreMesh (beta)
-==================
-
-.. include:: ../../beta.rst
+KVStoreMesh
+===========
 
 KVStoreMesh is an extension of Cluster Mesh. It caches the information obtained
 from the remote clusters in a local kvstore (such as etcd), to which all local
 Cilium agents connect. This is different from vanilla Cluster Mesh, where each
 agent directly pulls the information from the remote clusters. KVStoreMesh enables
-improved scalability and isolation, and targets large scale Cluster Mesh deployments.
+improved scalability and isolation.
 
-See :ref:`enable_clustermesh` for instructions on how to enable KVStoreMesh.
+.. note::
+
+  Starting from v1.16 KVStoreMesh is enabled by default.
+  If you wish to disable it, please refer to :ref:`enable_clustermesh`
+  for instructions on how to disable KVStoreMesh.

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -368,6 +368,9 @@ Annotations:
   service DNS name. Additionally, Kubernetes service DNS name to ClusterIP
   translation is now automatically enabled for etcd (if necessary); the
   ``etcd.operator`` ``kvstore-opt`` option is now a no-op and has been removed.
+* KVStoreMesh is now enabled by default in Clustermesh.
+  If you want to disable KVStoreMesh, set Helm value ``clustermesh.apiserver.kvstoremesh.enabled=false``
+  explicitly during the upgrade.
 
 Removed Options
 ~~~~~~~~~~~~~~~
@@ -413,6 +416,8 @@ Helm Options
   The option has been replaced by ``ciliumEndpointSlice.enabled``.
 * The Helm option for deploying a managed etcd instance via ``etcd.managed``
   and other related Helm configurations have been removed.
+* The Clustermesh option ``clustermesh.apiserver.kvstoremesh.enabled`` is now set to ``true`` by default.
+  To disable KVStoreMesh, set ``clustermesh.apiserver.kvstoremesh.enabled=false`` explicitly during the upgrade.
 
 Added Metrics
 ~~~~~~~~~~~~~

--- a/Makefile.kind
+++ b/Makefile.kind
@@ -96,7 +96,7 @@ kind-connect-clustermesh: check_deps kind-clustermesh-ready
 	$(CILIUM_CLI) clustermesh status --context kind-clustermesh1 --wait
 	$(CILIUM_CLI) clustermesh status --context kind-clustermesh2 --wait
 
-ENABLE_KVSTOREMESH ?= false
+ENABLE_KVSTOREMESH ?= true
 $(eval $(call KIND_ENV,kind-install-cilium-clustermesh))
 kind-install-cilium-clustermesh: check_deps kind-clustermesh-ready ## Install a local Cilium version into the clustermesh clusters and enable clustermesh.
 	@echo "  INSTALL cilium on clustermesh1 cluster"

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -183,7 +183,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.extraVolumes | list | `[]` | Additional clustermesh-apiserver volumes. |
 | clustermesh.apiserver.healthPort | int | `9880` | TCP port for the clustermesh-apiserver health API. |
 | clustermesh.apiserver.image | object | `{"digest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/clustermesh-apiserver-ci","tag":"latest","useDigest":false}` | Clustermesh API server image. |
-| clustermesh.apiserver.kvstoremesh.enabled | bool | `false` | Enable KVStoreMesh. KVStoreMesh caches the information retrieved from the remote clusters in the local etcd instance. |
+| clustermesh.apiserver.kvstoremesh.enabled | bool | `true` | Enable KVStoreMesh. KVStoreMesh caches the information retrieved from the remote clusters in the local etcd instance. |
 | clustermesh.apiserver.kvstoremesh.extraArgs | list | `[]` | Additional KVStoreMesh arguments. |
 | clustermesh.apiserver.kvstoremesh.extraEnv | list | `[]` | Additional KVStoreMesh environment variables. |
 | clustermesh.apiserver.kvstoremesh.extraVolumeMounts | list | `[]` | Additional KVStoreMesh volumeMounts. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2915,7 +2915,7 @@ clustermesh:
     kvstoremesh:
       # -- Enable KVStoreMesh. KVStoreMesh caches the information retrieved
       # from the remote clusters in the local etcd instance.
-      enabled: false
+      enabled: true
       # -- TCP port for the KVStoreMesh health API.
       healthPort: 9881
       # -- Configuration for the KVStoreMesh readiness probe.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2928,7 +2928,7 @@ clustermesh:
     kvstoremesh:
       # -- Enable KVStoreMesh. KVStoreMesh caches the information retrieved
       # from the remote clusters in the local etcd instance.
-      enabled: false
+      enabled: true
 
       # -- TCP port for the KVStoreMesh health API.
       healthPort: 9881


### PR DESCRIPTION
KVStoreMesh has been introduced in v1.14. We have been running KVStoreMesh tests since then, while also testing upgrade path from "vanilla" Clustermesh to KVStoreMesh and back since then. There has been also a visible adaptation by users in the community.

Let's mark KVStoreMesh as stable and enable it by default.

Note: Once 1.16 is out, we will need to update CI test Cilium Cluster Mesh upgrade (ci-clustermesh)

I am tagging @cilium/sig-clustermesh for visibility and waiting for lazy consensus by EOD 12th June GMT time. 
For now, added the label `dont-merge/discussion` for lazy consensus.


```release-note
KVStoreMesh is now enabled by default in Clustermesh.
```
