### PR TITLE
endpoint: skip unnecessary syncPolicyMaps on first regeneration

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -795,7 +795,10 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 		return nil
 	}
 
+	firstRegen := false
+
 	if e.policyMap == nil {
+		firstRegen = true
 		e.policyMap, err = policymap.OpenOrCreate(e.policyMapPath())
 		if err != nil {
 			return err
@@ -875,11 +878,25 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 		// state with the current program (if it exists) for this endpoint.
 		// GH-3897 would fix this by creating a new map to do an atomic swap
 		// with the old one.
-		stats.mapSync.Start()
-		err = e.syncPolicyMap()
-		stats.mapSync.End(err == nil)
-		if err != nil {
-			return fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %w", err)
+		//
+		// We can skip this step on the first regeneration, as it can lead to spurious
+		// policy drops. During the first regen, at this point, the endpoint is still referencing
+		// the old IPCache's fd and the policy maps refer to those identities.
+		//
+		// Until GH-3897 is resolved, we should mininize the time that maps are skewed
+		// in the event that an IP has flapped identities on restoration. The easiest way to
+		// do this to only call syncPolicyMap once, very close to the end of regeneration,
+		// after the new ipcache is being referenced.
+		//
+		// Once the endpoint has regenerated once, it is safe to call syncPolicyMaps
+		// arbitrarily.
+		if !firstRegen {
+			stats.mapSync.Start()
+			err = e.syncPolicyMap()
+			stats.mapSync.End(err == nil)
+			if err != nil {
+				return fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %w", err)
+			}
 		}
 
 		// At this point, traffic is no longer redirected to the proxy for


### PR DESCRIPTION
Endpoints on first regeneration are in a funny state. They reference an old IPCache (which is recreated on agent restart), but their policy maps are not swapped. This means they may be in a state where IPs map to old identities, but those identities are no longer in the new ipcache.

This is not 100% fixable as long as we do not recreate the BPF PolicyMap, but we can significantly reduce the time we are in this skewed state, by eliding the first syncPolicyMaps() call.

We call syncPolicyMaps twice. Once before compilation, and once after. The first call is to make it safe to clean up stale Envoy resources. However, the first-ever call to syncPolicyMaps will have no stale redirects to clean up regardless. Even worse, it all-but guarantees we are in this skewed state for a partcularly long time, as we will be certainly recompiling the endpoints BPF code.

Fortunately, the fix is easy: we can skip the first syncPolicyMaps, and rely on the second, which occurs very quickly after compliation finishes. This minimizes the potential for spurious policy drops.

```release-note
Fixes a rare cause of policy drops on first endpoint regeneration.
```

Fixes: #28645