### PR TITLE
[1.15-backport] ipsec: Fix unencrypted traffic when IPsec is used with L7 egress proxy

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -396,7 +396,11 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	if (from_proxy && info->tunnel_endpoint && encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
 					 info->sec_identity, true);
-#endif
+
+	if (from_proxy &&
+	    (!info || !identity_is_cluster(info->sec_identity)))
+		ctx->mark = MARK_MAGIC_PROXY_TO_WORLD;
+#endif /* ENABLE_IPSEC && !TUNNEL_MODE */
 
 	return CTX_ACT_OK;
 }
@@ -854,7 +858,11 @@ skip_vtep:
 	if (from_proxy && info->tunnel_endpoint && encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
 					 info->sec_identity, true);
-#endif
+
+	if (from_proxy &&
+	    (!info || !identity_is_cluster(info->sec_identity)))
+		ctx->mark = MARK_MAGIC_PROXY_TO_WORLD;
+#endif /* ENABLE_IPSEC && !TUNNEL_MODE */
 
 	return CTX_ACT_OK;
 }

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -698,6 +698,7 @@ enum metric_dir {
  *    In the IPsec case this becomes the SPI on the wire.
  */
 #define MARK_MAGIC_HOST_MASK		0x0F00
+#define MARK_MAGIC_PROXY_TO_WORLD	0x0800
 #define MARK_MAGIC_PROXY_EGRESS_EPID	0x0900 /* mark carries source endpoint ID */
 #define MARK_MAGIC_PROXY_INGRESS	0x0A00
 #define MARK_MAGIC_PROXY_EGRESS		0x0B00

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -476,11 +476,13 @@ func (m *Manager) inboundProxyRedirectRule(cmd string) []string {
 	//    by ip_early_demux
 	toProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
 	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
+	matchProxyToWorld := fmt.Sprintf("%#08x/%#08x", linux_defaults.MarkProxyToWorld, linux_defaults.RouteMarkMask)
 	return []string{
 		"-t", "mangle",
 		cmd, ciliumPreMangleChain,
 		"-m", "socket", "--transparent",
 		"-m", "mark", "!", "--mark", matchFromIPSecEncrypt,
+		"-m", "mark", "!", "--mark", matchProxyToWorld,
 		"-m", "comment", "--comment", "cilium: any->pod redirect proxied traffic to host proxy",
 		"-j", "MARK",
 		"--set-mark", toProxyMark}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/versioncheck"
@@ -541,6 +542,8 @@ func (m *Manager) installStaticProxyRules() error {
 	matchToProxy := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsToProxy, linux_defaults.MagicMarkHostMask)
 	// proxy return traffic has 0 ID in the mask
 	matchProxyReply := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxy, linux_defaults.MagicMarkProxyNoIDMask)
+	// proxy forward traffic
+	matchProxyForward := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkEgress, linux_defaults.MagicMarkHostMask)
 	// L7 proxy upstream return traffic has Endpoint ID in the mask
 	matchL7ProxyUpstream := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxyEPID, linux_defaults.MagicMarkProxyMask)
 	// match traffic from a proxy (either in forward or in return direction)
@@ -588,6 +591,19 @@ func (m *Manager) installStaticProxyRules() error {
 			"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
 			"-j", "CT", "--notrack"}); err != nil {
 			return err
+		}
+
+		// No conntrack for proxy forward traffic that is heading to cilium_host
+		if option.Config.EnableIPSec {
+			if err := ip4tables.runProg([]string{
+				"-t", "raw",
+				"-A", ciliumOutputRawChain,
+				"-o", defaults.HostDevice,
+				"-m", "mark", "--mark", matchProxyForward,
+				"-m", "comment", "--comment", "cilium: NOTRACK for proxy forward traffic",
+				"-j", "CT", "--notrack"}); err != nil {
+				return err
+			}
 		}
 
 		// No conntrack for proxy upstream traffic that is heading to lxc+

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -31,6 +31,10 @@ const (
 	// table which is between 253-255. See ip-route(8).
 	RouteTableInterfacesOffset = 10
 
+	// MarkProxyToWorld is the default mark to use to indicate that a packet
+	// from proxy needs to be sent to the world.
+	MarkProxyToWorld = 0x800
+
 	// RouteMarkDecrypt is the default route mark to use to indicate datapath
 	// needs to decrypt a packet.
 	RouteMarkDecrypt = 0x0D00

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -420,20 +420,19 @@ func (p *Proxy) SetProxyPort(name string, proxyType types.ProxyType, port uint16
 // ReinstallRoutingRules ensures the presence of routing rules and tables needed
 // to route packets to and from the L7 proxy.
 func (p *Proxy) ReinstallRoutingRules() error {
+	fromIngressProxy, fromEgressProxy := requireFromProxyRoutes()
+
 	if option.Config.EnableIPv4 {
 		if err := installToProxyRoutesIPv4(); err != nil {
 			return err
 		}
 
-		if err := removeFromEgressProxyRoutesIPv4(); err != nil {
-			return err
-		}
-		if requireFromProxyRoutes() {
-			if err := installFromProxyRoutesIPv4(node.GetInternalIPv4Router(), defaults.HostDevice); err != nil {
+		if fromIngressProxy || fromEgressProxy {
+			if err := installFromProxyRoutesIPv4(node.GetInternalIPv4Router(), defaults.HostDevice, fromIngressProxy, fromEgressProxy); err != nil {
 				return err
 			}
 		} else {
-			if err := removeFromIngressProxyRoutesIPv4(); err != nil {
+			if err := removeFromProxyRoutesIPv4(); err != nil {
 				return err
 			}
 		}
@@ -441,7 +440,7 @@ func (p *Proxy) ReinstallRoutingRules() error {
 		if err := removeToProxyRoutesIPv4(); err != nil {
 			return err
 		}
-		if err := removeFromIngressProxyRoutesIPv4(); err != nil {
+		if err := removeFromProxyRoutesIPv4(); err != nil {
 			return err
 		}
 	}
@@ -454,19 +453,16 @@ func (p *Proxy) ReinstallRoutingRules() error {
 			return err
 		}
 
-		if err := removeFromEgressProxyRoutesIPv6(); err != nil {
-			return err
-		}
-		if requireFromProxyRoutes() {
+		if fromIngressProxy || fromEgressProxy {
 			ipv6, err := getCiliumNetIPv6()
 			if err != nil {
 				return err
 			}
-			if err := installFromProxyRoutesIPv6(ipv6, defaults.HostDevice); err != nil {
+			if err := installFromProxyRoutesIPv6(ipv6, defaults.HostDevice, fromIngressProxy, fromEgressProxy); err != nil {
 				return err
 			}
 		} else {
-			if err := removeFromIngressProxyRoutesIPv6(); err != nil {
+			if err := removeFromProxyRoutesIPv6(); err != nil {
 				return err
 			}
 		}
@@ -474,7 +470,7 @@ func (p *Proxy) ReinstallRoutingRules() error {
 		if err := removeToProxyRoutesIPv6(); err != nil {
 			return err
 		}
-		if err := removeFromIngressProxyRoutesIPv6(); err != nil {
+		if err := removeFromProxyRoutesIPv6(); err != nil {
 			return err
 		}
 	}
@@ -485,8 +481,10 @@ func (p *Proxy) ReinstallRoutingRules() error {
 	return nil
 }
 
-func requireFromProxyRoutes() bool {
-	return (option.Config.EnableEnvoyConfig || option.Config.EnableIPSec) && !option.Config.TunnelingEnabled()
+func requireFromProxyRoutes() (fromIngressProxy, fromEgressProxy bool) {
+	fromIngressProxy = (option.Config.EnableEnvoyConfig || option.Config.EnableIPSec) && !option.Config.TunnelingEnabled()
+	fromEgressProxy = option.Config.EnableIPSec && !option.Config.TunnelingEnabled()
+	return
 }
 
 // getCiliumNetIPv6 retrieves the first IPv6 address from the cilium_net device.

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -123,7 +123,7 @@ var (
 
 // installFromProxyRoutesIPv4 configures routes and rules needed to redirect ingress
 // packets from the proxy.
-func installFromProxyRoutesIPv4(ipv4 net.IP, device string) error {
+func installFromProxyRoutesIPv4(ipv4 net.IP, device string, fromIngressProxy, fromEgressProxy bool) error {
 	fromProxyToCiliumHostRoute4 := route.Route{
 		Table: linux_defaults.RouteTableFromProxy,
 		Prefix: net.IPNet{
@@ -141,8 +141,15 @@ func installFromProxyRoutesIPv4(ipv4 net.IP, device string) error {
 		Proto:   linux_defaults.RTProto,
 	}
 
-	if err := route.ReplaceRule(fromIngressProxyRule); err != nil {
-		return fmt.Errorf("inserting ipv4 from ingress proxy routing rule %v: %w", fromIngressProxyRule, err)
+	if fromIngressProxy {
+		if err := route.ReplaceRule(fromIngressProxyRule); err != nil {
+			return fmt.Errorf("inserting ipv4 from ingress proxy routing rule %v: %w", fromIngressProxyRule, err)
+		}
+	}
+	if fromEgressProxy {
+		if err := route.ReplaceRule(fromEgressProxyRule); err != nil {
+			return fmt.Errorf("inserting ipv4 from egress proxy routing rule %v: %w", fromEgressProxyRule, err)
+		}
 	}
 	if err := route.Upsert(fromProxyToCiliumHostRoute4); err != nil {
 		return fmt.Errorf("inserting ipv4 from proxy to cilium_host route %v: %w", fromProxyToCiliumHostRoute4, err)
@@ -154,10 +161,13 @@ func installFromProxyRoutesIPv4(ipv4 net.IP, device string) error {
 	return nil
 }
 
-// removeFromIngressProxyRoutesIPv4 ensures routes and rules for traffic from the proxy are removed.
-func removeFromIngressProxyRoutesIPv4() error {
+// removeFromProxyRoutesIPv4 ensures routes and rules for traffic from the proxy are removed.
+func removeFromProxyRoutesIPv4() error {
 	if err := route.DeleteRule(netlink.FAMILY_V4, fromIngressProxyRule); err != nil && !errors.Is(err, syscall.ENOENT) {
 		return fmt.Errorf("removing ipv4 from ingress proxy routing rule: %w", err)
+	}
+	if err := route.DeleteRule(netlink.FAMILY_V4, fromEgressProxyRule); err != nil && !errors.Is(err, syscall.ENOENT) {
+		return fmt.Errorf("removing ipv4 from egress proxy routing rule: %w", err)
 	}
 	if err := route.DeleteRouteTable(linux_defaults.RouteTableFromProxy, netlink.FAMILY_V4); err != nil {
 		return fmt.Errorf("removing ipv4 from proxy route table: %w", err)
@@ -171,16 +181,9 @@ func removeStaleProxyRulesIPv4() error {
 	return removeProtoUnspecRules(netlink.FAMILY_V4)
 }
 
-func removeFromEgressProxyRoutesIPv4() error {
-	if err := route.DeleteRule(netlink.FAMILY_V4, fromEgressProxyRule); err != nil && !errors.Is(err, syscall.ENOENT) {
-		return fmt.Errorf("removing ipv4 from egress proxy routing rule: %w", err)
-	}
-	return nil
-}
-
 // installFromProxyRoutesIPv6 configures routes and rules needed to redirect ingress
 // packets from the proxy.
-func installFromProxyRoutesIPv6(ipv6 net.IP, device string) error {
+func installFromProxyRoutesIPv6(ipv6 net.IP, device string, fromIngressProxy, fromEgressProxy bool) error {
 	fromProxyToCiliumHostRoute6 := route.Route{
 		Table: linux_defaults.RouteTableFromProxy,
 		Prefix: net.IPNet{
@@ -198,8 +201,15 @@ func installFromProxyRoutesIPv6(ipv6 net.IP, device string) error {
 		Proto:   linux_defaults.RTProto,
 	}
 
-	if err := route.ReplaceRuleIPv6(fromIngressProxyRule); err != nil {
-		return fmt.Errorf("inserting ipv6 from ingress proxy routing rule %v: %w", fromIngressProxyRule, err)
+	if fromIngressProxy {
+		if err := route.ReplaceRuleIPv6(fromIngressProxyRule); err != nil {
+			return fmt.Errorf("inserting ipv6 from ingress proxy routing rule %v: %w", fromIngressProxyRule, err)
+		}
+	}
+	if fromEgressProxy {
+		if err := route.ReplaceRuleIPv6(fromEgressProxyRule); err != nil {
+			return fmt.Errorf("inserting ipv6 from egress proxy routing rule %v: %w", fromEgressProxyRule, err)
+		}
 	}
 	if err := route.Upsert(fromProxyToCiliumHostRoute6); err != nil {
 		return fmt.Errorf("inserting ipv6 from proxy to cilium_host route %v: %w", fromProxyToCiliumHostRoute6, err)
@@ -211,11 +221,16 @@ func installFromProxyRoutesIPv6(ipv6 net.IP, device string) error {
 	return nil
 }
 
-// removeFromIngressProxyRoutesIPv6 ensures routes and rules for traffic from the proxy are removed.
-func removeFromIngressProxyRoutesIPv6() error {
+// removeFromProxyRoutesIPv6 ensures routes and rules for traffic from the proxy are removed.
+func removeFromProxyRoutesIPv6() error {
 	if err := route.DeleteRule(netlink.FAMILY_V6, fromIngressProxyRule); err != nil {
 		if !errors.Is(err, syscall.ENOENT) && !errors.Is(err, syscall.EAFNOSUPPORT) {
 			return fmt.Errorf("removing ipv6 from ingress proxy routing rule: %w", err)
+		}
+	}
+	if err := route.DeleteRule(netlink.FAMILY_V6, fromEgressProxyRule); err != nil {
+		if !errors.Is(err, syscall.ENOENT) && !errors.Is(err, syscall.EAFNOSUPPORT) {
+			return fmt.Errorf("removing ipv6 from egress proxy routing rule: %w", err)
 		}
 	}
 	if err := route.DeleteRouteTable(linux_defaults.RouteTableFromProxy, netlink.FAMILY_V6); err != nil {
@@ -250,15 +265,6 @@ func removeProtoUnspecRules(family int) error {
 			if err := netlink.RuleDel(&r); err != nil && !errors.Is(err, syscall.ENOENT) {
 				return fmt.Errorf("removing proto unspec routing rule: %w", err)
 			}
-		}
-	}
-	return nil
-}
-
-func removeFromEgressProxyRoutesIPv6() error {
-	if err := route.DeleteRule(netlink.FAMILY_V6, fromEgressProxyRule); err != nil {
-		if !errors.Is(err, syscall.ENOENT) && !errors.Is(err, syscall.EAFNOSUPPORT) {
-			return fmt.Errorf("removing ipv6 from egress proxy routing rule: %w", err)
 		}
 	}
 	return nil

--- a/pkg/proxy/routes_test.go
+++ b/pkg/proxy/routes_test.go
@@ -86,7 +86,7 @@ func TestRoutes(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Install routes and rules the first time.
-				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName))
+				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName, true, true))
 
 				rules, err := route.ListRules(netlink.FAMILY_V4, &fromIngressProxyRule)
 				assert.NoError(t, err)
@@ -99,10 +99,10 @@ func TestRoutes(t *testing.T) {
 				assert.Len(t, rt, 2)
 
 				// Ensure idempotence.
-				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName))
+				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName, true, true))
 
 				// Remove routes installed before.
-				assert.NoError(t, removeFromIngressProxyRoutesIPv4())
+				assert.NoError(t, removeFromProxyRoutesIPv4())
 
 				rules, err = route.ListRules(netlink.FAMILY_V4, &fromIngressProxyRule)
 				assert.NoError(t, err)
@@ -185,7 +185,7 @@ func TestRoutes(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Install routes and rules the first time.
-				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName))
+				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName, true, true))
 
 				rules, err := route.ListRules(netlink.FAMILY_V6, &fromIngressProxyRule)
 				assert.NoError(t, err)
@@ -198,10 +198,10 @@ func TestRoutes(t *testing.T) {
 				assert.Len(t, rt, 2)
 
 				// Ensure idempotence.
-				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName))
+				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName, true, true))
 
 				// Remove routes installed before.
-				assert.NoError(t, removeFromIngressProxyRoutesIPv6())
+				assert.NoError(t, removeFromProxyRoutesIPv6())
 
 				rules, err = route.ListRules(netlink.FAMILY_V6, &fromIngressProxyRule)
 				assert.NoError(t, err)


### PR DESCRIPTION
- [x] https://github.com/cilium/cilium/pull/32683 @jschwinger233 


```upstream-prs
 32683
```