### PR TITLE
.github: fix renovate GitHub workflow config

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,15 +1,16 @@
 name: Renovate
 on:
-  # running every hour every working day
-  # running every two hours outside of those hours
   schedule:
+    # Running every hour every working day (Monday to Friday)
     - cron: '0 * * * 1-5'
-    - cron: '0 */2 * * 6-7'
+    # Running every two hours on weekends (Saturday and Sunday)
+    - cron: '0 */2 * * 6,0'
   # allow to manually trigger this workflow
   workflow_dispatch:
     inputs:
       renovate_log_level_debug:
         type: boolean
+        description: "Rune Renovate With Debug Log Levels"
         default: true
 
 jobs:


### PR DESCRIPTION
The renovate config had some errors, as pointed out by GitHub, this commit fixes the errors.

Fixes: 38e90f3f15f0 ("Renovate SPIRE images in makefile values")