### PR TITLE
ipsec-tests: Fix flaky TestUpsertIPSecKeyMissing

### DIFF
--- a/pkg/datapath/linux/ipsec/xfrm_state_cache_test.go
+++ b/pkg/datapath/linux/ipsec/xfrm_state_cache_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/option"
@@ -121,4 +122,29 @@ func TestXfrmStateListCacheDisabled(t *testing.T) {
 
 	// And is still expired
 	require.True(t, xfrmStateCache.isExpired(), "Cache should be stil expired as it's disabled")
+}
+
+func cleanIPSecStatesAndPolicies(t *testing.T) {
+	xfrmStateList, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+	if err != nil {
+		t.Fatalf("Can't list XFRM states: %v", err)
+	}
+
+	for _, s := range xfrmStateList {
+		if err := netlink.XfrmStateDel(&s); err != nil {
+			t.Fatalf("Can't delete XFRM state: %v", err)
+		}
+
+	}
+
+	xfrmPolicyList, err := netlink.XfrmPolicyList(netlink.FAMILY_ALL)
+	if err != nil {
+		t.Fatalf("Can't list XFRM policies: %v", err)
+	}
+
+	for _, p := range xfrmPolicyList {
+		if err := netlink.XfrmPolicyDel(&p); err != nil {
+			t.Fatalf("Can't delete XFRM policy: %v", err)
+		}
+	}
 }


### PR DESCRIPTION
In case previous test failed, it did not clean up ipSecKeysGlobal resulting in failing TestUpsertIPSecKeyMissing too. Let's ensure that global ipsec key is missing before running test.

Related: #32933
