### PR TITLE
ci: l4lb: Don't hang on gathering logs forever

### DIFF
--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -137,7 +137,7 @@ jobs:
         if: ${{ !success() && steps.lb-test.outcome != 'skipped' }}
         run: |
           docker ps -a
-          docker logs -f lb-node
+          docker logs lb-node
           docker inspect lb-node
           docker exec -t lb-node docker ps
 


### PR DESCRIPTION
It doesn't make sense to pass `--follow` when the container is still
running, this will hang forever and fail to complete the remaining steps
in the workflow. Remove the follow flag.

Fixes: 93927457779d ("ci: l4lb: gather more infos about docker-in-docker issues")
Fixes: #32570
