### PR TITLE
Bandwidth map: fix missing table in reconciler config

### DIFF
--- a/pkg/maps/bwmap/cell.go
+++ b/pkg/maps/bwmap/cell.go
@@ -49,6 +49,7 @@ func edtReconcilerConfig(m throttleMap, edts statedb.RWTable[Edt]) reconciler.Co
 	ops := bpf.NewMapOps[Edt](m.Map)
 
 	return reconciler.Config[Edt]{
+		Table:                     edts,
 		FullReconcilationInterval: time.Hour,
 		RetryBackoffMinDuration:   100 * time.Millisecond,
 		RetryBackoffMaxDuration:   time.Minute,


### PR DESCRIPTION
The table wasn't assigned to the reconciler config for the bandwidth map this causes an error on startup when bandwidth manager is enabled. This commit should resolve the issue.

Fixes: #32909

```release-note
Fix bandwidth manager reconciler config
```
