### PR TITLE
clustermesh: fix remote service deletion on endpointslicesync

### DIFF
--- a/pkg/clustermesh/endpointslicesync/endpointslice_meta_controller.go
+++ b/pkg/clustermesh/endpointslicesync/endpointslice_meta_controller.go
@@ -64,7 +64,9 @@ func newEndpointSliceMeshController(
 	factory := informers.NewSharedInformerFactory(meshClient, 12*time.Hour)
 	endpointSliceInformer := factory.Discovery().V1().EndpointSlices()
 
-	meshServiceInformer := newMeshServiceInformer(logger, globalServices, services)
+	meshServiceInformer := newMeshServiceInformer(
+		logger, globalServices, services, meshNodeInformer,
+	)
 
 	controller := endpointslice.NewControllerWithName(
 		ctx, meshPodInformer, meshServiceInformer,

--- a/pkg/clustermesh/endpointslicesync/endpointslice_test.go
+++ b/pkg/clustermesh/endpointslicesync/endpointslice_test.go
@@ -5,22 +5,18 @@ package endpointslicesync
 
 import (
 	"context"
-	"fmt"
-	"reflect"
 	"testing"
 	"time"
-	"unsafe"
 
-	"github.com/cilium/endpointslice-controller/endpointslice"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cache "k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	"github.com/cilium/cilium/operator/k8s"
@@ -41,23 +37,6 @@ const (
 	remoteClusterName string = "cluster-1"
 	globalSvcIP       string = "42.42.42.42"
 )
-
-func getControllerQueue(controller *endpointslice.Controller) workqueue.RateLimitingInterface {
-	return *(*workqueue.RateLimitingInterface)(unsafe.Pointer(
-		reflect.ValueOf(controller).Elem().FieldByName("queue").UnsafeAddr(),
-	))
-}
-
-func waitEmptyQueue(queue workqueue.RateLimitingInterface) error {
-	for i := 0; i < 20; i++ {
-		time.Sleep(time.Millisecond * 10)
-		if queue.Len() == 0 {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("endpointSlice controller queue has not been emptied after 200ms")
-}
 
 func createService(name string) *slim_corev1.Service {
 	return &slim_corev1.Service{
@@ -80,7 +59,7 @@ func createGlobalService(
 	globalService *common.GlobalServiceCache,
 	podInformer *meshPodInformer,
 	svcName string,
-	updateClusterSvc func(*store.ClusterService)) {
+	updateClusterSvc func(*store.ClusterService)) *store.ClusterService {
 	clusterSvc := &store.ClusterService{
 		Cluster:   remoteClusterName,
 		Namespace: svcName,
@@ -97,7 +76,7 @@ func createGlobalService(
 	globalService.OnUpdate(clusterSvc)
 	// We manually call the rest of the informer for convenience
 	podInformer.onClusterServiceUpdate(clusterSvc)
-
+	return clusterSvc
 }
 
 func getEndpointSlice(clientset k8sClient.Clientset, svcName string) (*discovery.EndpointSliceList, error) {
@@ -149,6 +128,9 @@ func Test_meshEndpointSlice_Reconcile(t *testing.T) {
 
 	svcStore, _ := services.Store(context.Background())
 
+	tick := 10 * time.Millisecond
+	timeout := 200 * time.Millisecond
+
 	t.Run("Create service then global service", func(t *testing.T) {
 		svcName := "local-svc-global-svc"
 		hostname := svcName + "-0"
@@ -159,22 +141,28 @@ func Test_meshEndpointSlice_Reconcile(t *testing.T) {
 			clusterSvc.Hostnames = map[string]string{globalSvcIP: hostname}
 		})
 
-		queue := getControllerQueue(controller)
-		require.NoError(t, waitEmptyQueue(queue))
+		var epList *discovery.EndpointSliceList
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			epList, err = getEndpointSlice(&fakeClient, svcName)
+			assert.NoError(c, err)
+			assert.Len(c, epList.Items, 1)
+		}, timeout, tick, "endpointslice is not reconciled correctly")
 
-		epList, err := getEndpointSlice(&fakeClient, svcName)
-		require.NoError(t, err)
-		require.Equal(t, 1, len(epList.Items))
 		require.Equal(t, map[string]string{
 			discovery.LabelServiceName:        svcName,
 			discovery.LabelManagedBy:          utils.EndpointSliceMeshControllerName,
 			mcsapiv1alpha1.LabelSourceCluster: remoteClusterName,
 			corev1.IsHeadlessService:          "",
 		}, epList.Items[0].Labels)
-		require.Equal(t, 1, len(epList.Items[0].Endpoints))
+		require.Len(t, epList.Items[0].Endpoints, 1)
 
-		require.NotNil(t, 1, epList.Items[0].Endpoints[0].Hostname)
-		require.Equal(t, *epList.Items[0].Endpoints[0].Hostname, hostname)
+		require.NotNil(t, epList.Items[0].Endpoints[0].Hostname)
+		require.Equal(t, hostname, *epList.Items[0].Endpoints[0].Hostname)
+
+		require.Len(t, epList.Items[0].OwnerReferences, 1)
+		require.Equal(t, "v1", epList.Items[0].OwnerReferences[0].APIVersion)
+		require.Equal(t, "Service", epList.Items[0].OwnerReferences[0].Kind)
+		require.Equal(t, "local-svc-global-svc", epList.Items[0].OwnerReferences[0].Name)
 	})
 
 	t.Run("Create global service then service", func(t *testing.T) {
@@ -184,44 +172,19 @@ func Test_meshEndpointSlice_Reconcile(t *testing.T) {
 		svcStore.CacheStore().Add(svc1)
 		serviceInformer.refreshAllCluster(svc1)
 
-		queue := getControllerQueue(controller)
-		require.NoError(t, waitEmptyQueue(queue))
+		var epList *discovery.EndpointSliceList
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			epList, err = getEndpointSlice(&fakeClient, svcName)
+			assert.NoError(t, err)
+			assert.Len(t, epList.Items, 1)
+		}, timeout, tick, "endpointslice is not reconciled correctly")
 
-		epList, err := getEndpointSlice(&fakeClient, svcName)
-		require.NoError(t, err)
-		require.Equal(t, 1, len(epList.Items))
 		require.Equal(t, map[string]string{
 			discovery.LabelServiceName:        svcName,
 			discovery.LabelManagedBy:          utils.EndpointSliceMeshControllerName,
 			mcsapiv1alpha1.LabelSourceCluster: remoteClusterName,
 			corev1.IsHeadlessService:          "",
 		}, epList.Items[0].Labels)
-	})
-
-	t.Run("Create service without global service", func(t *testing.T) {
-		svcName := "local-svc-no-global-svc"
-		svc1 := createService(svcName)
-		svcStore.CacheStore().Add(svc1)
-		serviceInformer.refreshAllCluster(svc1)
-
-		queue := getControllerQueue(controller)
-		require.NoError(t, waitEmptyQueue(queue))
-
-		epList, err := getEndpointSlice(&fakeClient, svcName)
-		require.NoError(t, err)
-		require.Zero(t, len(epList.Items))
-	})
-
-	t.Run("Create global service without service", func(t *testing.T) {
-		svcName := "global-svc-no-local-svc"
-		createGlobalService(globalService, podInformer, svcName, nil)
-
-		queue := getControllerQueue(controller)
-		require.NoError(t, waitEmptyQueue(queue))
-
-		epList, err := getEndpointSlice(&fakeClient, svcName)
-		require.NoError(t, err)
-		require.Zero(t, len(epList.Items))
 	})
 
 	t.Run("Create headless service and global service", func(t *testing.T) {
@@ -233,29 +196,11 @@ func Test_meshEndpointSlice_Reconcile(t *testing.T) {
 		serviceInformer.refreshAllCluster(svc1)
 		createGlobalService(globalService, podInformer, svcName, nil)
 
-		queue := getControllerQueue(controller)
-		require.NoError(t, waitEmptyQueue(queue))
-
-		epList, err := getEndpointSlice(&fakeClient, svcName)
-		require.NoError(t, err)
-		require.Equal(t, 1, len(epList.Items))
-	})
-
-	t.Run("Create headless service with endpointslice opt-out and global service", func(t *testing.T) {
-		svcName := "local-svc-headless-opt-out-global-svc"
-		svc1 := createService(svcName)
-		svc1.Spec.ClusterIP = corev1.ClusterIPNone
-		svc1.ObjectMeta.Annotations[annotation.GlobalServiceSyncEndpointSlices] = "false"
-		svcStore.CacheStore().Add(svc1)
-		serviceInformer.refreshAllCluster(svc1)
-		createGlobalService(globalService, podInformer, svcName, nil)
-
-		queue := getControllerQueue(controller)
-		require.NoError(t, waitEmptyQueue(queue))
-
-		epList, err := getEndpointSlice(&fakeClient, svcName)
-		require.NoError(t, err)
-		require.Equal(t, 0, len(epList.Items))
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			epList, err := getEndpointSlice(&fakeClient, svcName)
+			assert.NoError(c, err)
+			assert.Len(c, epList.Items, 1)
+		}, timeout, tick, "endpointslice is not reconciled correctly")
 	})
 
 	t.Run("Create service with global annotation and remove it", func(t *testing.T) {
@@ -265,22 +210,23 @@ func Test_meshEndpointSlice_Reconcile(t *testing.T) {
 		svcStore.CacheStore().Add(svc1)
 		serviceInformer.refreshAllCluster(svc1)
 
-		queue := getControllerQueue(controller)
-		require.NoError(t, waitEmptyQueue(queue))
-
-		// Make sure that we have 1 endpointslice
-		epList, err := getEndpointSlice(&fakeClient, svcName)
-		require.NoError(t, err)
-		require.Equal(t, 1, len(epList.Items))
+		var epList *discovery.EndpointSliceList
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			// Make sure that we have 1 endpointslice
+			epList, err = getEndpointSlice(&fakeClient, svcName)
+			assert.NoError(c, err)
+			assert.Len(c, epList.Items, 1)
+		}, timeout, tick, "endpointslice is not reconciled correctly")
 
 		svc1.Annotations[annotation.GlobalServiceSyncEndpointSlices] = "false"
 		svcStore.CacheStore().Update(svc1)
 		serviceInformer.refreshAllCluster(svc1)
 
-		require.NoError(t, waitEmptyQueue(queue))
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			epList, err := getEndpointSlice(&fakeClient, svcName)
+			assert.NoError(c, err)
+			assert.Len(c, epList.Items, 0)
+		}, timeout, tick, "endpointslice is not reconciled correctly")
 
-		epList, err = getEndpointSlice(&fakeClient, svcName)
-		require.NoError(t, err)
-		require.Zero(t, len(epList.Items))
 	})
 }

--- a/pkg/clustermesh/endpointslicesync/node_informer.go
+++ b/pkg/clustermesh/endpointslicesync/node_informer.go
@@ -56,6 +56,13 @@ func createDummyNode(cluster string) *v1.Node {
 	}
 }
 
+func (i *meshNodeInformer) ListClusters() []string {
+	i.mutex.RLock()
+	defer i.mutex.RUnlock()
+
+	return maps.Keys(i.nodes)
+}
+
 func (i *meshNodeInformer) List(selector labels.Selector) ([]*v1.Node, error) {
 	reqs, _ := selector.Requirements()
 	if !selector.Empty() {


### PR DESCRIPTION
This fixes remote service deletion in endpointslicesync (see second commit).

And it also fixes tests by using EventuallyWithT instead of waiting for the controller queue to be empty. The queue being empty does not signify that the reconciliation is done as the controller pops elements when the reconciliation starts and not when it ends.

cc @giorio94 
Fixes #32931