### PR TITLE
loader: cache parsed CollectionSpec

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -914,10 +914,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		return nil, nil, err
 	}
 
-	if err := d.datapath.Loader().RestoreTemplates(option.Config.StateDir); err != nil {
-		log.WithError(err).Error("Unable to restore previous BPF templates")
-	}
-
 	// Start watcher for endpoint IP --> identity mappings in key-value store.
 	// this needs to be done *after* init() for the daemon in that function,
 	// we populate the IPCache with the host's IP(s).

--- a/pkg/datapath/fake/types/datapath.go
+++ b/pkg/datapath/fake/types/datapath.go
@@ -162,10 +162,6 @@ func (f *FakeLoader) HostDatapathInitialized() <-chan struct{} {
 	return nil
 }
 
-func (f *FakeLoader) RestoreTemplates(stateDir string) error {
-	return nil
-}
-
 func (f *FakeLoader) DetachXDP(ifaceName string, bpffsBase, progName string) error {
 	return nil
 }

--- a/pkg/datapath/loader/cache_test.go
+++ b/pkg/datapath/loader/cache_test.go
@@ -5,10 +5,11 @@ package loader
 
 import (
 	"context"
-	"fmt"
+	"runtime"
+	"sync"
 	"testing"
-	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
@@ -32,126 +33,53 @@ func TestObjectCache(t *testing.T) {
 	dir := getDirs(t)
 
 	// First run should compile and generate the object.
-	_, isNew, err := cache.fetchOrCompile(ctx, &localNodeConfig, &realEP, dir, nil)
+	first, isNew, err := cache.fetchOrCompile(ctx, &localNodeConfig, &realEP, dir, nil)
 	require.NoError(t, err)
-	require.Equal(t, isNew, true)
+	require.True(t, isNew)
 
 	// Same EP should not be compiled twice.
-	_, isNew, err = cache.fetchOrCompile(ctx, &localNodeConfig, &realEP, dir, nil)
+	second, isNew, err := cache.fetchOrCompile(ctx, &localNodeConfig, &realEP, dir, nil)
 	require.NoError(t, err)
-	require.Equal(t, isNew, false)
+	require.False(t, isNew)
+	require.False(t, second == first)
 
 	// Changing the ID should not generate a new object.
 	realEP.Id++
-	_, isNew, err = cache.fetchOrCompile(ctx, &localNodeConfig, &realEP, dir, nil)
+	third, isNew, err := cache.fetchOrCompile(ctx, &localNodeConfig, &realEP, dir, nil)
 	require.NoError(t, err)
-	require.Equal(t, isNew, false)
+	require.False(t, isNew)
+	require.False(t, third == first)
 
 	// Changing a setting on the EP should generate a new object.
 	realEP.Opts.SetBool("foo", true)
-	_, isNew, err = cache.fetchOrCompile(ctx, &localNodeConfig, &realEP, dir, nil)
+	fourth, isNew, err := cache.fetchOrCompile(ctx, &localNodeConfig, &realEP, dir, nil)
 	require.NoError(t, err)
-	require.Equal(t, isNew, true)
-}
-
-type buildResult struct {
-	goroutine int
-	path      string
-	compiled  bool
-	err       error
-}
-
-func receiveResult(t *testing.T, results chan buildResult) (*buildResult, error) {
-	select {
-	case result := <-results:
-		if result.err != nil {
-			return nil, result.err
-		}
-		return &result, nil
-	case <-time.After(contextTimeout):
-		return nil, fmt.Errorf("Timed out waiting for goroutines to return")
-	}
+	require.True(t, isNew)
+	require.False(t, fourth == first)
 }
 
 func TestObjectCacheParallel(t *testing.T) {
 	tmpDir := t.TempDir()
 
+	setupCompilationDirectories(t)
+
 	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
 	defer cancel()
 
-	setupCompilationDirectories(t)
+	cache := newObjectCache(configWriterForTest(t), tmpDir)
+	ep := testutils.NewTestEndpoint()
 
-	tests := []struct {
-		description string
-		builds      int
-		divisor     int
-	}{
-		{
-			description: "One build, multiple blocking goroutines",
-			builds:      8,
-			divisor:     8,
-		},
-		{
-			description: "Eight builds, half compile, half block",
-			builds:      8,
-			divisor:     2,
-		},
-		{
-			description: "Eight unique builds",
-			builds:      8,
-			divisor:     1,
-		},
+	var wg sync.WaitGroup
+	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, err := cache.fetchOrCompile(ctx, &localNodeConfig, &ep, getDirs(t), nil)
+			assert.NoError(t, err)
+		}()
 	}
 
-	for _, test := range tests {
-		t.Logf("  %s", test.description)
-
-		results := make(chan buildResult, test.builds)
-		cache := newObjectCache(configWriterForTest(t), tmpDir)
-		for i := 0; i < test.builds; i++ {
-			go func(i int) {
-				ep := testutils.NewTestEndpoint()
-				opt := fmt.Sprintf("OPT%d", i/test.divisor)
-				ep.Opts.SetBool(opt, true)
-				file, isNew, err := cache.fetchOrCompile(ctx, &localNodeConfig, &ep, getDirs(t), nil)
-				path := ""
-				if file != nil {
-					path = file.Name()
-				}
-				results <- buildResult{
-					goroutine: i,
-					path:      path,
-					compiled:  isNew,
-					err:       err,
-				}
-			}(i)
-		}
-
-		// First result will always be a compilation for the new set of options
-		compiled := make(map[string]int, test.builds)
-		used := make(map[string]int, test.builds)
-		for i := 0; i < test.builds; i++ {
-			result, err := receiveResult(t, results)
-			require.NoError(t, err)
-
-			used[result.path] = used[result.path] + 1
-			if result.compiled {
-				compiled[result.path] = compiled[result.path] + 1
-			}
-		}
-
-		require.Len(t, compiled, test.builds/test.divisor)
-		require.Len(t, used, test.builds/test.divisor)
-		for _, templateCompileCount := range compiled {
-			// Only one goroutine compiles each template
-			require.Equal(t, templateCompileCount, 1)
-		}
-		for _, templateUseCount := range used {
-			// Based on the test parameters, a number of goroutines
-			// may share the same template.
-			require.Equal(t, templateUseCount, test.divisor)
-		}
-	}
+	wg.Wait()
 }
 
 func configWriterForTest(t testing.TB) types.ConfigWriter {

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -577,15 +577,9 @@ func (l *loader) ReloadDatapath(ctx context.Context, ep datapath.Endpoint, stats
 
 	cfg := l.nodeConfig.Load()
 
-	templateFile, _, err := l.templateCache.fetchOrCompile(ctx, cfg, ep, &dirs, stats)
+	spec, _, err := l.templateCache.fetchOrCompile(ctx, cfg, ep, &dirs, stats)
 	if err != nil {
 		return err
-	}
-	defer templateFile.Close()
-
-	spec, err := bpf.LoadCollectionSpec(templateFile.Name())
-	if err != nil {
-		return fmt.Errorf("loading eBPF ELF %s: %w", templateFile.Name(), err)
 	}
 
 	stats.BpfLoadProg.Start()

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/netip"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -104,7 +105,7 @@ type Params struct {
 func newLoader(p Params) *loader {
 	return &loader{
 		cfg:               p.Config,
-		templateCache:     newObjectCache(p.ConfigWriter, option.Config.StateDir),
+		templateCache:     newObjectCache(p.ConfigWriter, filepath.Join(option.Config.StateDir, defaults.TemplatesDir)),
 		sysctl:            p.Sysctl,
 		hostDpInitialized: make(chan struct{}),
 		prefilter:         p.Prefilter,

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -23,7 +23,6 @@ type Loader interface {
 	Unload(ep Endpoint)
 	Reinitialize(ctx context.Context, cfg LocalNodeConfiguration, tunnelConfig tunnel.Config, iptMgr IptablesManager, p Proxy) error
 	HostDatapathInitialized() <-chan struct{}
-	RestoreTemplates(stateDir string) error
 	DetachXDP(iface string, bpffsBase, progName string) error
 
 	WriteEndpointConfig(w io.Writer, cfg EndpointConfiguration) error


### PR DESCRIPTION
loader: evict object cache when datapath config changes

    The object cache currently does no invalidation, which means that we
    accumulate cachedObject in memory and template ELF on disk. Use update of
    the base datapath hash as an opportunity to evict some of that cache.

    In practice this is probably not a big issue: datapath config changes rarely
    if every, and we only have templates for endpoints and host endpoint.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

loader: cache parsed CollectionSpec

    The object cache parses an ELF from disk any time it is asked for a 
    template. This is wasteful since parsing the ELF is quite resource 
    intensive.

    Cache the parsed CollectionSpec instead.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
