### PR TITLE
Proxy persist proxy ports

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -591,6 +591,12 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	if err != nil {
 		log.WithError(err).Error("Unable to read existing endpoints")
 	}
+	// Restore all proxy ports from datapath, if possible
+	// Must be run before d.bootstrapFQDN(), which depends
+	// on the ports having been restored.
+	if d.l7Proxy != nil {
+		d.l7Proxy.RestoreProxyPorts()
+	}
 	bootstrapStats.restore.End(true)
 
 	bootstrapStats.fqdn.Start()

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -93,20 +93,15 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 		return nil
 	}
 
-	// Once we stop returning errors from StartDNSProxy this should live in
-	// StartProxySupport
-	port, err := d.l7Proxy.GetProxyPort(proxytypes.DNSProxyName)
-	if err != nil {
-		return err
-	}
-	if option.Config.ToFQDNsProxyPort != 0 {
-		port = uint16(option.Config.ToFQDNsProxyPort)
-	} else if port == 0 {
-		// Try locate old DNS proxy port number from the datapath, and reuse it if it's not open
-		oldPort := d.datapath.GetProxyPort(proxytypes.DNSProxyName)
-		openLocalPorts := proxy.OpenLocalPorts()
-		if _, alreadyOpen := openLocalPorts[oldPort]; !alreadyOpen {
-			port = oldPort
+	// A configured proxy port takes precedence over using the previous port.
+	port := uint16(option.Config.ToFQDNsProxyPort)
+	if port == 0 {
+		// Try reuse previous DNS proxy port number
+		if oldPort, err := d.l7Proxy.GetProxyPort(proxytypes.DNSProxyName); err == nil {
+			openLocalPorts := proxy.OpenLocalPorts()
+			if _, alreadyOpen := openLocalPorts[oldPort]; !alreadyOpen {
+				port = oldPort
+			}
 		}
 	}
 	if err := re.InitRegexCompileLRU(option.Config.FQDNRegexCompileLRUSize); err != nil {

--- a/pkg/ciliumenvoyconfig/cec_resource_parser.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser.go
@@ -99,7 +99,7 @@ func newCECResourceParser(params parserParams) *cecResourceParser {
 }
 
 type PortAllocator interface {
-	AllocateCRDProxyPort(name string, localOnly bool) (uint16, error)
+	AllocateCRDProxyPort(name string) (uint16, error)
 	AckProxyPort(ctx context.Context, name string) error
 	ReleaseProxyPort(name string) error
 }
@@ -408,7 +408,7 @@ func (r *cecResourceParser) parseResources(cecNamespace string, cecName string, 
 		if !isInternalListener {
 			if listener.GetAddress() == nil {
 				listenerName := listener.Name
-				port, err := r.portAllocator.AllocateCRDProxyPort(listenerName, true)
+				port, err := r.portAllocator.AllocateCRDProxyPort(listenerName)
 				if err != nil || port == 0 {
 					return envoy.Resources{}, fmt.Errorf("listener port allocation for %q failed: %w", listenerName, err)
 				}

--- a/pkg/ciliumenvoyconfig/cec_resource_parser.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser.go
@@ -99,7 +99,7 @@ func newCECResourceParser(params parserParams) *cecResourceParser {
 }
 
 type PortAllocator interface {
-	AllocateProxyPort(name string, ingress, localOnly bool) (uint16, error)
+	AllocateCRDProxyPort(name string, localOnly bool) (uint16, error)
 	AckProxyPort(ctx context.Context, name string) error
 	ReleaseProxyPort(name string) error
 }
@@ -408,7 +408,7 @@ func (r *cecResourceParser) parseResources(cecNamespace string, cecName string, 
 		if !isInternalListener {
 			if listener.GetAddress() == nil {
 				listenerName := listener.Name
-				port, err := r.portAllocator.AllocateProxyPort(listenerName, false, true)
+				port, err := r.portAllocator.AllocateCRDProxyPort(listenerName, true)
 				if err != nil || port == 0 {
 					return envoy.Resources{}, fmt.Errorf("listener port allocation for %q failed: %w", listenerName, err)
 				}

--- a/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
@@ -47,7 +47,7 @@ func NewMockPortAllocator() *MockPortAllocator {
 	}
 }
 
-func (m *MockPortAllocator) AllocateCRDProxyPort(name string, localOnly bool) (uint16, error) {
+func (m *MockPortAllocator) AllocateCRDProxyPort(name string) (uint16, error) {
 	if mp, exists := m.ports[name]; exists {
 		return mp.port, nil
 	}

--- a/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
@@ -47,7 +47,7 @@ func NewMockPortAllocator() *MockPortAllocator {
 	}
 }
 
-func (m *MockPortAllocator) AllocateProxyPort(name string, ingress, localOnly bool) (uint16, error) {
+func (m *MockPortAllocator) AllocateCRDProxyPort(name string, localOnly bool) (uint16, error) {
 	if mp, exists := m.ports[name]; exists {
 		return mp.port, nil
 	}

--- a/pkg/datapath/fake/types/datapath.go
+++ b/pkg/datapath/fake/types/datapath.go
@@ -88,8 +88,8 @@ func (f *FakeDatapath) SupportsOriginalSourceAddr() bool {
 	return false
 }
 
-func (m *FakeDatapath) GetProxyPort(name string) uint16 {
-	return 0
+func (m *FakeDatapath) GetProxyPorts() map[string]uint16 {
+	return nil
 }
 
 func (m *FakeDatapath) InstallNoTrackRules(ip netip.Addr, port uint16) {

--- a/pkg/datapath/fake/types/datapath.go
+++ b/pkg/datapath/fake/types/datapath.go
@@ -81,7 +81,7 @@ func (f *FakeDatapath) WriteEndpointConfig(io.Writer, *datapath.LocalNodeConfigu
 	return nil
 }
 
-func (f *FakeDatapath) InstallProxyRules(uint16, bool, string) {
+func (f *FakeDatapath) InstallProxyRules(uint16, string) {
 }
 
 func (f *FakeDatapath) SupportsOriginalSourceAddr() bool {

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1002,46 +1002,45 @@ func (m *Manager) doInstallProxyRules(proxyPort uint16, name string) error {
 	return nil
 }
 
-// GetProxyPort finds a proxy port used for redirect 'name' installed earlier with InstallProxyRules.
-// By convention "ingress" or "egress" is part of 'name' so it does not need to be specified explicitly.
-// Returns 0 a TPROXY entry with 'name' can not be found.
-func (m *Manager) GetProxyPort(name string) uint16 {
+// GetProxyPorts enumerates all existing TPROXY rules in the datapath installed earlier with
+// InstallProxyRules and returns all proxy ports found.
+func (m *Manager) GetProxyPorts() map[string]uint16 {
 	prog := ip4tables
 	if !m.sharedCfg.EnableIPv4 {
 		prog = ip6tables
 	}
 
-	return m.doGetProxyPort(prog, name)
+	return m.doGetProxyPorts(prog)
 }
 
-func (m *Manager) doGetProxyPort(prog iptablesInterface, name string) uint16 {
+func (m *Manager) doGetProxyPorts(prog iptablesInterface) map[string]uint16 {
+	portMap := make(map[string]uint16)
+
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
 	rules, err := prog.runProgOutput([]string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain})
 	if err != nil {
-		return 0
+		return portMap
 	}
 
 	re := regexp.MustCompile(
-		name + ".*TPROXY redirect " +
+		"(cilium-[^ ]*) proxy.*TPROXY redirect " +
 			"(0.0.0.0|" + ipfamily.IPv4().Localhost +
 			"|::|" + ipfamily.IPv6().Localhost + ")" +
 			":([1-9][0-9]*) mark",
 	)
 	strs := re.FindAllString(rules, -1)
-	if len(strs) == 0 {
-		return 0
+	for _, str := range strs {
+		// Pick the name and port number from each match
+		name := re.ReplaceAllString(str, "$1")
+		portStr := re.ReplaceAllString(str, "$3")
+		portUInt64, err := strconv.ParseUint(portStr, 10, 16)
+		if err == nil {
+			portMap[name] = uint16(portUInt64)
+		}
 	}
-	// Pick the port number from the last match, as rules are appended to the end (-A)
-	portStr := re.ReplaceAllString(strs[len(strs)-1], "$2")
-	portUInt64, err := strconv.ParseUint(portStr, 10, 16)
-	if err != nil {
-		log.WithError(err).Debugf("Port number cannot be parsed: %s", portStr)
-		return 0
-	}
-
-	return uint16(portUInt64)
+	return portMap
 }
 
 func (m *Manager) getDeliveryInterface(ifName string) string {

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -344,7 +344,7 @@ func TestAddProxyRulesv4(t *testing.T) {
 	}
 }
 
-func TestGetProxyPort(t *testing.T) {
+func TestGetProxyPorts(t *testing.T) {
 	mockIp4tables := &mockIptables{t: t, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
 		{
@@ -362,9 +362,9 @@ TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd7a90
 	}
 
 	// Finds the latest port number if multiple rules for the same proxy name
-	port := mockManager.doGetProxyPort(mockIp4tables, "cilium-dns-egress")
-	if port != uint16(43479) {
-		t.Fatalf("expected port number %d, got %d", uint16(43479), port)
+	portMap := mockManager.doGetProxyPorts(mockIp4tables)
+	if len(portMap) != 1 || portMap["cilium-dns-egress"] != uint16(43479) {
+		t.Fatalf("expected port number %d, got %d, portMap: %v", uint16(43479), portMap["cilium-dns-egress"], portMap)
 	}
 	if err := mockIp4tables.checkExpectations(); err != nil {
 		t.Fatal(err)
@@ -379,17 +379,17 @@ TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd7a90
 				`Chain CILIUM_PRE_mangle (1 references)
 target     prot opt source               destination
 MARK       all  --  0.0.0.0/0            0.0.0.0/0            socket --transparent /* cilium: any->pod redirect proxied traffic to host proxy */ MARK set 0x200
-TPROXY     tcp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd5a90200 /* cilium: TPROXY to host cilium-random-proxy proxy */ TPROXY redirect 0.0.0.0:43477 mark 0x200/0xffffffff
-TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd5a90200 /* cilium: TPROXY to host cilium-random-proxy proxy */ TPROXY redirect 0.0.0.0:43477 mark 0x200/0xffffffff
-TPROXY     tcp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd7a90200 /* cilium: TPROXY to host cilium-random-proxy proxy */ TPROXY redirect 0.0.0.0:43479 mark 0x200/0xffffffff
-TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd7a90200 /* cilium: TPROXY to host cilium-random-proxy proxy */ TPROXY redirect 0.0.0.0:43479 mark 0x200/0xffffffff
+TPROXY     tcp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd5a90200 /* cilium: TPROXY to host cilium-random-ingress proxy */ TPROXY redirect 0.0.0.0:43477 mark 0x200/0xffffffff
+TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd5a90200 /* cilium: TPROXY to host cilium-random-ingress proxy */ TPROXY redirect 0.0.0.0:43477 mark 0x200/0xffffffff
+TPROXY     tcp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd7a90200 /* cilium: TPROXY to host cilium-random-ingress proxy */ TPROXY redirect 0.0.0.0:43479 mark 0x200/0xffffffff
+TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd7a90200 /* cilium: TPROXY to host cilium-random-ingress proxy */ TPROXY redirect 0.0.0.0:43479 mark 0x200/0xffffffff
 `),
 		},
 	}
 
-	port = mockManager.doGetProxyPort(mockIp4tables, "cilium-random-proxy")
-	if port != uint16(43479) {
-		t.Fatalf("expected port number %d, got %d", uint16(43479), port)
+	portMap = mockManager.doGetProxyPorts(mockIp4tables)
+	if len(portMap) != 1 || portMap["cilium-random-ingress"] != uint16(43479) {
+		t.Fatalf("expected port number %d, got %d, portMap: %v", uint16(43479), portMap["cilium-random-ingress"], portMap)
 	}
 	if err := mockIp4tables.checkExpectations(); err != nil {
 		t.Fatal(err)

--- a/pkg/datapath/iptables/reconciler.go
+++ b/pkg/datapath/iptables/reconciler.go
@@ -90,9 +90,8 @@ type reconciliationRequest[T any] struct {
 }
 
 type proxyInfo struct {
-	name        string
-	port        uint16
-	isLocalOnly bool
+	name string
+	port uint16
 }
 
 type noTrackPodInfo struct {
@@ -107,7 +106,7 @@ func reconciliationLoop(
 	installIptRules bool,
 	params *reconcilerParams,
 	updateRules func(state desiredState, firstInit bool) error,
-	updateProxyRules func(proxyPort uint16, localOnly bool, name string) error,
+	updateProxyRules func(proxyPort uint16, name string) error,
 	installNoTrackRules func(addr netip.Addr, port uint16) error,
 	removeNoTrackRules func(addr netip.Addr, port uint16) error,
 ) error {
@@ -201,7 +200,7 @@ stop:
 				continue
 			}
 
-			if err := updateProxyRules(req.info.port, req.info.isLocalOnly, req.info.name); err != nil {
+			if err := updateProxyRules(req.info.port, req.info.name); err != nil {
 				if partialLogLimiter.Allow() {
 					log.WithError(err).Error("iptables proxy rules incremental update failed, will retry a full reconciliation")
 				}

--- a/pkg/datapath/iptables/reconciler_test.go
+++ b/pkg/datapath/iptables/reconciler_test.go
@@ -87,13 +87,12 @@ func TestReconciliationLoop(t *testing.T) {
 
 		return nil
 	}
-	updateProxyFunc := func(proxyPort uint16, localOnly bool, name string) error {
+	updateProxyFunc := func(proxyPort uint16, name string) error {
 		mu.Lock()
 		defer mu.Unlock()
 		state.proxies[name] = proxyInfo{
-			name:        name,
-			port:        proxyPort,
-			isLocalOnly: localOnly,
+			name: name,
+			port: proxyPort,
 		}
 		return nil
 	}
@@ -205,9 +204,8 @@ func TestReconciliationLoop(t *testing.T) {
 			action: func() {
 				params.proxies <- reconciliationRequest[proxyInfo]{
 					info: proxyInfo{
-						name:        "proxy-test-1",
-						port:        9090,
-						isLocalOnly: true,
+						name: "proxy-test-1",
+						port: 9090,
 					},
 					updated: make(chan struct{}),
 				}
@@ -222,9 +220,8 @@ func TestReconciliationLoop(t *testing.T) {
 				},
 				proxies: map[string]proxyInfo{
 					"proxy-test-1": {
-						name:        "proxy-test-1",
-						port:        9090,
-						isLocalOnly: true,
+						name: "proxy-test-1",
+						port: 9090,
 					},
 				},
 			},
@@ -234,9 +231,8 @@ func TestReconciliationLoop(t *testing.T) {
 			action: func() {
 				params.proxies <- reconciliationRequest[proxyInfo]{
 					info: proxyInfo{
-						name:        "proxy-test-2",
-						port:        9091,
-						isLocalOnly: false,
+						name: "proxy-test-2",
+						port: 9091,
 					},
 					updated: make(chan struct{}),
 				}
@@ -251,14 +247,12 @@ func TestReconciliationLoop(t *testing.T) {
 				},
 				proxies: map[string]proxyInfo{
 					"proxy-test-1": {
-						name:        "proxy-test-1",
-						port:        9090,
-						isLocalOnly: true,
+						name: "proxy-test-1",
+						port: 9090,
 					},
 					"proxy-test-2": {
-						name:        "proxy-test-2",
-						port:        9091,
-						isLocalOnly: false,
+						name: "proxy-test-2",
+						port: 9091,
 					},
 				},
 			},
@@ -291,14 +285,12 @@ func TestReconciliationLoop(t *testing.T) {
 				},
 				proxies: map[string]proxyInfo{
 					"proxy-test-1": {
-						name:        "proxy-test-1",
-						port:        9090,
-						isLocalOnly: true,
+						name: "proxy-test-1",
+						port: 9090,
 					},
 					"proxy-test-2": {
-						name:        "proxy-test-2",
-						port:        9091,
-						isLocalOnly: false,
+						name: "proxy-test-2",
+						port: 9091,
 					},
 				},
 				noTrackPods: sets.New(
@@ -328,14 +320,12 @@ func TestReconciliationLoop(t *testing.T) {
 				},
 				proxies: map[string]proxyInfo{
 					"proxy-test-1": {
-						name:        "proxy-test-1",
-						port:        9090,
-						isLocalOnly: true,
+						name: "proxy-test-1",
+						port: 9090,
 					},
 					"proxy-test-2": {
-						name:        "proxy-test-2",
-						port:        9091,
-						isLocalOnly: false,
+						name: "proxy-test-2",
+						port: 9091,
 					},
 				},
 				noTrackPods: sets.New(

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -47,7 +47,7 @@ type Proxy interface {
 type IptablesManager interface {
 	// InstallProxyRules creates the necessary datapath config (e.g., iptables
 	// rules for redirecting host proxy traffic on a specific ProxyPort)
-	InstallProxyRules(proxyPort uint16, localOnly bool, name string)
+	InstallProxyRules(proxyPort uint16, name string)
 
 	// SupportsOriginalSourceAddr tells if the datapath supports
 	// use of original source addresses in proxy upstream

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -54,9 +54,9 @@ type IptablesManager interface {
 	// connections.
 	SupportsOriginalSourceAddr() bool
 
-	// GetProxyPort fetches the existing proxy port configured for the
-	// specified listener. Used early in bootstrap to reopen proxy ports.
-	GetProxyPort(listener string) uint16
+	// GetProxyPorts fetches the existing proxy ports configured in the
+	// datapath. Used early in bootstrap to reopen proxy ports.
+	GetProxyPorts() map[string]uint16
 
 	// InstallNoTrackRules is explicitly called when a pod has valid
 	// "policy.cilium.io/no-track-port" annotation.  When

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -33,7 +33,7 @@ type envoyProxyIntegration struct {
 
 // createRedirect creates a redirect with corresponding proxy configuration. This will launch a proxy instance.
 func (p *envoyProxyIntegration) createRedirect(r *Redirect, wg *completion.WaitGroup) (RedirectImplementation, error) {
-	if r.listener.proxyType == types.ProxyTypeCRD {
+	if r.listener.ProxyType == types.ProxyTypeCRD {
 		// CRD Listeners already exist, create a no-op implementation
 		return &CRDRedirect{}, nil
 	}
@@ -49,17 +49,17 @@ func (p *envoyProxyIntegration) changeLogLevel(level logrus.Level) error {
 func (p *envoyProxyIntegration) handleEnvoyRedirect(r *Redirect, wg *completion.WaitGroup) (RedirectImplementation, error) {
 	l := r.listener
 	redirect := &envoyRedirect{
-		listenerName: net.JoinHostPort(r.name, fmt.Sprintf("%d", l.proxyPort)),
+		listenerName: net.JoinHostPort(r.name, fmt.Sprintf("%d", l.ProxyPort)),
 		xdsServer:    p.xdsServer,
 		adminClient:  p.adminClient,
 	}
 
 	mayUseOriginalSourceAddr := p.iptablesManager.SupportsOriginalSourceAddr()
 	// Only use original source address for egress
-	if l.ingress {
+	if l.Ingress {
 		mayUseOriginalSourceAddr = false
 	}
-	p.xdsServer.AddListener(redirect.listenerName, policy.L7ParserType(l.proxyType), l.proxyPort, l.ingress, mayUseOriginalSourceAddr, wg)
+	p.xdsServer.AddListener(redirect.listenerName, policy.L7ParserType(l.ProxyType), l.ProxyPort, l.Ingress, mayUseOriginalSourceAddr, wg)
 
 	return redirect, nil
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -578,6 +578,11 @@ func (p *Proxy) createNewRedirect(
 	scopedLog = scopedLog.
 		WithField("portName", ppName)
 
+	if pp.proxyPort == 0 && pp.rulesPort != 0 {
+		// try first with the previous port
+		pp.proxyPort = pp.rulesPort
+	}
+
 	for nRetry := 0; nRetry < redirectCreationAttempts; nRetry++ {
 		if !pp.configured {
 			if nRetry > 0 {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -64,7 +64,7 @@ type ProxyPort struct {
 	// acknowledged yet. This is reset to false when the underlying proxy listener
 	// is removed.
 	configured bool
-	// rulesPort congains the proxy port value configured to the datapath rules and
+	// rulesPort contains the proxy port value configured to the datapath rules and
 	// is non-zero when a proxy has been successfully created and the
 	// datapath rules have been created.
 	rulesPort uint16
@@ -158,11 +158,11 @@ func defaultProxyPortMap() map[string]*ProxyPort {
 
 // Called with mutex held!
 func (p *Proxy) isPortAvailable(openLocalPorts map[uint16]struct{}, port uint16, reuse bool) bool {
-	if inuse, used := p.allocatedPorts[port]; used && (inuse || !reuse) {
-		return false // port already used
-	}
 	if port == 0 {
 		return false // zero port requested
+	}
+	if inuse, used := p.allocatedPorts[port]; used && (inuse || !reuse) {
+		return false // port already used
 	}
 	// Check that the port is not already open
 	if _, alreadyOpen := openLocalPorts[port]; alreadyOpen {
@@ -581,11 +581,9 @@ func (p *Proxy) createNewRedirect(
 	for nRetry := 0; nRetry < redirectCreationAttempts; nRetry++ {
 		if !pp.configured {
 			if nRetry > 0 {
-				// Retry with a new proxy port in case there was a conflict with the
-				// previous one when the port has not been `configured` yet.
-				// The incremented port number here is just a hint to allocatePort()
-				// below, it will check if it is available for use.
-				pp.proxyPort++
+				// Clear the proxy port on retry so that a random new port will be
+				// tried.
+				pp.proxyPort = 0
 			}
 
 			// Check if pp.proxyPort is available and find another available proxy port if not.
@@ -634,6 +632,15 @@ func (p *Proxy) createNewRedirect(
 		// when reverting. Undo what we have done above.
 		p.mutex.Lock()
 		delete(p.redirects, id)
+
+		// Mark the  port for reuse only if no other ports are available
+		// Discourage the reuse of the same port in future as revert may have been due to
+		// port not being available for bind().
+		p.allocatedPorts[pp.proxyPort] = false
+		// clear proxy port on failure so that a new one will be tried next time
+		pp.proxyPort = 0
+		pp.configured = false
+
 		p.updateRedirectMetrics()
 		p.mutex.Unlock()
 		implFinalizeFunc, _ := redirect.implementation.Close(wg)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -8,7 +8,11 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"net"
+	"os"
+	"path/filepath"
 
+	"github.com/google/renameio/v2"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
@@ -26,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/types"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/trigger"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "proxy")
@@ -39,6 +44,11 @@ const (
 
 	// redirectCreationAttempts is the number of attempts to create a redirect
 	redirectCreationAttempts = 5
+
+	// The filename for the allocated proxy ports. This is periodically
+	// written, and restored on restart.
+	// The full path is, by default, /run/cilium/state/proxy_ports_state.json
+	proxyPortsFile = "proxy_ports_state.json"
 )
 
 type DatapathUpdater interface {
@@ -48,18 +58,18 @@ type DatapathUpdater interface {
 }
 
 type ProxyPort struct {
+	// proxy type this port applies to (immutable)
+	ProxyType types.ProxyType `json:"type"`
+	// 'true' for Ingress, 'false' for egress (immutable)
+	// 'false' for CRD redirects, which are accessed by name only.
+	Ingress bool `json:"ingress"`
+	// ProxyPort is the desired proxy listening port number.
+	ProxyPort uint16 `json:"port"`
 	// isStatic is true when the listener on the proxy port is incapable
 	// of stopping and/or being reconfigured with a new proxy port once it has been
 	// first started. Set 'true' by SetProxyPort(), which is only called for
 	// static listeners (currently only DNS proxy).
 	isStatic bool
-	// proxy type this port applies to (immutable)
-	proxyType types.ProxyType
-	// 'true' for ingress, 'false' for egress (immutable)
-	// 'false' for CRD redirects, which are accessed by name only.
-	ingress bool
-	// ProxyPort is the desired proxy listening port number.
-	proxyPort uint16
 	// nRedirects is the number of redirects using this proxy port
 	nRedirects int
 	// Configured is true when the proxy is (being) configured, but not necessarily
@@ -71,6 +81,8 @@ type ProxyPort struct {
 	// (new, if after restart) datapath rules have been created.
 	rulesPort uint16
 }
+
+type proxyPortsMap map[string]*ProxyPort
 
 // Proxy maintains state about redirects
 type Proxy struct {
@@ -101,7 +113,13 @@ type Proxy struct {
 
 	// proxyPorts defaults to a map of all supported proxy ports.
 	// In addition, it also manages dynamically created proxy ports (e.g. CEC).
-	proxyPorts map[string]*ProxyPort
+	proxyPorts proxyPortsMap
+
+	// path where the set of proxyPorts is persisted on the filesystem for restoration on
+	// restart
+	proxyPortsPath string
+
+	proxyPortsTrigger *trigger.Trigger
 
 	envoyIntegration *envoyProxyIntegration
 	dnsIntegration   *dnsProxyIntegration
@@ -121,32 +139,33 @@ func createProxy(
 		datapathUpdater:  datapathUpdater,
 		allocatedPorts:   make(map[uint16]bool),
 		proxyPorts:       defaultProxyPortMap(),
+		proxyPortsPath:   filepath.Join(option.Config.StateDir, proxyPortsFile),
 		envoyIntegration: envoyIntegration,
 		dnsIntegration:   dnsIntegration,
 	}
 }
 
-func defaultProxyPortMap() map[string]*ProxyPort {
-	return map[string]*ProxyPort{
+func defaultProxyPortMap() proxyPortsMap {
+	return proxyPortsMap{
 		"cilium-http-egress": {
-			proxyType: types.ProxyTypeHTTP,
-			ingress:   false,
+			ProxyType: types.ProxyTypeHTTP,
+			Ingress:   false,
 		},
 		"cilium-http-ingress": {
-			proxyType: types.ProxyTypeHTTP,
-			ingress:   true,
+			ProxyType: types.ProxyTypeHTTP,
+			Ingress:   true,
 		},
 		types.DNSProxyName: {
-			proxyType: types.ProxyTypeDNS,
-			ingress:   false,
+			ProxyType: types.ProxyTypeDNS,
+			Ingress:   false,
 		},
 		"cilium-proxylib-egress": {
-			proxyType: types.ProxyTypeAny,
-			ingress:   false,
+			ProxyType: types.ProxyTypeAny,
+			Ingress:   false,
 		},
 		"cilium-proxylib-ingress": {
-			proxyType: types.ProxyTypeAny,
-			ingress:   true,
+			ProxyType: types.ProxyTypeAny,
+			Ingress:   true,
 		},
 	}
 }
@@ -222,15 +241,18 @@ func (p *Proxy) ackProxyPort(ctx context.Context, name string, pp *ProxyPort) er
 	// if the proxy is not currently configured.
 
 	// Add new rules, if needed
-	if pp.rulesPort != pp.proxyPort {
+	if pp.rulesPort != pp.ProxyPort {
 		// Add rules for the new port
 		// This should always succeed if we have managed to start-up properly
-		scopedLog.Infof("Adding new proxy port rules for %s:%d", name, pp.proxyPort)
-		p.datapathUpdater.InstallProxyRules(pp.proxyPort, name)
-		pp.rulesPort = pp.proxyPort
+		scopedLog.Infof("Adding new proxy port rules for %s:%d", name, pp.ProxyPort)
+		p.datapathUpdater.InstallProxyRules(pp.ProxyPort, name)
+		pp.rulesPort = pp.ProxyPort
+
+		// trigger writing proxy ports to file
+		p.proxyPortsTrigger.Trigger()
 	}
 	pp.nRedirects++
-	scopedLog.Debugf("AckProxyPort: acked proxy port %d (%v)", pp.proxyPort, *pp)
+	scopedLog.Debugf("AckProxyPort: acked proxy port %d (%v)", pp.ProxyPort, *pp)
 	return nil
 }
 
@@ -245,14 +267,14 @@ func (p *Proxy) releaseProxyPort(name string) error {
 	pp.nRedirects--
 	if pp.nRedirects <= 0 {
 		if pp.isStatic {
-			return fmt.Errorf("Can't release proxy port: proxy %s on %d has a static listener", name, pp.proxyPort)
+			return fmt.Errorf("Can't release proxy port: proxy %s on %d has a static listener", name, pp.ProxyPort)
 		}
 
-		log.WithField(fieldProxyRedirectID, name).Debugf("Delayed release of proxy port %d", pp.proxyPort)
+		log.WithField(fieldProxyRedirectID, name).Debugf("Delayed release of proxy port %d", pp.ProxyPort)
 
 		// Allow the port to be reallocated for other use if needed.
-		p.allocatedPorts[pp.proxyPort] = false
-		pp.proxyPort = 0
+		p.allocatedPorts[pp.ProxyPort] = false
+		pp.ProxyPort = 0
 		pp.configured = false
 		pp.nRedirects = 0
 
@@ -272,7 +294,7 @@ func (p *Proxy) findProxyPortByType(l7Type types.ProxyType, listener string, ing
 	case types.ProxyTypeCRD:
 		// CRD proxy ports are dynamically created, look up by name
 		// 'ingress' is always false for CRD type
-		if pp, ok := p.proxyPorts[listener]; ok && pp.proxyType == types.ProxyTypeCRD && !pp.ingress {
+		if pp, ok := p.proxyPorts[listener]; ok && pp.ProxyType == types.ProxyTypeCRD && !pp.Ingress {
 			return listener, pp
 		}
 		log.Debugf("findProxyPortByType: can not find crd listener %s from %v", listener, p.proxyPorts)
@@ -288,7 +310,7 @@ func (p *Proxy) findProxyPortByType(l7Type types.ProxyType, listener string, ing
 	}
 	// proxyPorts is small enough to not bother indexing it.
 	for name, pp := range p.proxyPorts {
-		if pp.proxyType == portType && pp.ingress == ingress {
+		if pp.ProxyType == portType && pp.Ingress == ingress {
 			return name, pp
 		}
 	}
@@ -307,28 +329,110 @@ func proxyNotFoundError(name string) error {
 	return fmt.Errorf("unrecognized proxy: %s", name)
 }
 
-// Exported API
+// must be called with mutex NOT held via p.proxyPortsTrigger
+func (p *Proxy) storeProxyPorts(reasons []string) {
+	if p.proxyPortsPath == "" {
+		return // this is a unit test
+	}
+	log := log.WithField(logfields.Path, p.proxyPortsPath)
 
-// RestoreProxyPorts tries to find earlier port numbers from datapath and use them
+	// use renameio to prevent partial writes
+	out, err := renameio.NewPendingFile(p.proxyPortsPath, renameio.WithExistingPermissions(), renameio.WithPermissions(0o600))
+	if err != nil {
+		log.WithError(err).Error("failed to prepare proxy ports file")
+		return
+	}
+	defer out.Cleanup()
+
+	jw := jsoniter.ConfigFastest.NewEncoder(out)
+
+	portsMap := make(proxyPortsMap)
+	p.mutex.Lock()
+	// only retain acknowledged, non-zero ports
+	for name, pp := range p.proxyPorts {
+		if pp.configured && pp.ProxyPort > 0 {
+			portsMap[name] = pp
+		}
+	}
+	p.mutex.Unlock()
+
+	if err := jw.Encode(portsMap); err != nil {
+		log.WithError(err).Error("failed to marshal proxy ports state")
+		return
+	}
+	if err := out.CloseAtomicallyReplace(); err != nil {
+		log.WithError(err).Error("failed to write proxy ports file")
+		return
+	}
+	log.Debug("Wrote proxy ports state")
+}
+
+// restore proxy ports from file created earlier by stroreProxyPorts
+// must be called with mutex held
+func (p *Proxy) restoreProxyPortsFromFile() error {
+	log := log.WithField(logfields.Path, p.proxyPortsPath)
+
+	// Read in checkpoint file
+	fp, err := os.Open(p.proxyPortsPath)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	jr := jsoniter.ConfigFastest.NewDecoder(fp)
+	var portsMap proxyPortsMap
+	if err := jr.Decode(&portsMap); err != nil {
+		return err
+	}
+
+	for name, pp := range portsMap {
+		p.proxyPorts[name] = pp
+		p.allocatedPorts[pp.ProxyPort] = false
+		log.
+			WithField(fieldProxyRedirectID, name).
+			WithField("proxyPort", pp.ProxyPort).
+			Debugf("RestoreProxyPorts: preallocated proxy port")
+	}
+	return nil
+}
+
+// restoreProxyPortsFromIptables tries to find earlier port numbers from datapath and use them
 // as defaults for proxy ports
-func (p *Proxy) RestoreProxyPorts() {
-	portMap := p.datapathUpdater.GetProxyPorts()
-	for name, port := range portMap {
+// must be called with mutex held
+func (p *Proxy) restoreProxyPortsFromIptables() {
+	// restore proxy ports from the datapath iptables rules
+	portsMap := p.datapathUpdater.GetProxyPorts()
+	for name, port := range portsMap {
 		pp := p.proxyPorts[name]
 		if pp != nil {
-			pp.proxyPort = port
+			pp.ProxyPort = port
 		} else {
 			// Only CRD type proxy ports can be dynamically allocated. Assume a port
 			// from datapath with an unknown name was for a dynamically allocated CRD
 			// proxy and pre-allocate a proxy port for it.
 			// CRD proxy ports always have 'ingress' as 'false'.
-			p.proxyPorts[name] = &ProxyPort{proxyType: types.ProxyTypeCRD, ingress: false, proxyPort: port}
+			p.proxyPorts[name] = &ProxyPort{ProxyType: types.ProxyTypeCRD, Ingress: false, ProxyPort: port}
 		}
 		p.allocatedPorts[port] = false
 		log.
 			WithField(fieldProxyRedirectID, name).
 			WithField("proxyPort", port).
-			Debugf("RestoreProxyPorts: preallocated proxy port")
+			Debugf("RestoreProxyPorts: preallocated proxy port from iptables")
+	}
+}
+
+// Exported API
+
+// RestoreProxyPorts tries to find earlier port numbers from datapath and use them
+// as defaults for proxy ports
+func (p *Proxy) RestoreProxyPorts() {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	err := p.restoreProxyPortsFromFile()
+	if err != nil {
+		log.WithError(err).WithField(logfields.Path, p.proxyPortsPath).Info("No proxy ports file found, falling back to restoring from iptables rules")
+		p.restoreProxyPortsFromIptables()
 	}
 }
 
@@ -339,7 +443,7 @@ func (p *Proxy) GetProxyPort(name string) (uint16, error) {
 	defer p.mutex.RUnlock()
 	pp := p.proxyPorts[name]
 	if pp != nil {
-		return pp.proxyPort, nil
+		return pp.ProxyPort, nil
 	}
 	return 0, proxyNotFoundError(name)
 }
@@ -353,20 +457,20 @@ func (p *Proxy) AllocateCRDProxyPort(name string) (uint16, error) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 	pp := p.proxyPorts[name]
-	if pp == nil || pp.ingress {
-		pp = &ProxyPort{proxyType: types.ProxyTypeCRD, ingress: false}
+	if pp == nil || pp.Ingress {
+		pp = &ProxyPort{ProxyType: types.ProxyTypeCRD, Ingress: false}
 	}
 
 	// Allocate a new port only if a port was never allocated before.
 	// This is required since Envoy may already be listening on the
 	// previously allocated port for this proxy listener.
-	if pp.proxyPort == 0 {
+	if pp.ProxyPort == 0 {
 		var err error
 		// Try to allocate the same port that was previously used on the datapath
 		if pp.rulesPort != 0 && !p.allocatedPorts[pp.rulesPort] {
-			pp.proxyPort = pp.rulesPort
+			pp.ProxyPort = pp.rulesPort
 		} else {
-			pp.proxyPort, err = p.allocatePort(pp.rulesPort, p.rangeMin, p.rangeMax)
+			pp.ProxyPort, err = p.allocatePort(pp.rulesPort, p.rangeMin, p.rangeMax)
 			if err != nil {
 				return 0, err
 			}
@@ -374,13 +478,13 @@ func (p *Proxy) AllocateCRDProxyPort(name string) (uint16, error) {
 	}
 	p.proxyPorts[name] = pp
 	// marks port as reserved
-	p.allocatedPorts[pp.proxyPort] = true
+	p.allocatedPorts[pp.ProxyPort] = true
 	// mark proxy port as configured
 	pp.configured = true
 
-	log.WithField(fieldProxyRedirectID, name).Debugf("AllocateProxyPort: allocated proxy port %d (%v)", pp.proxyPort, *pp)
+	log.WithField(fieldProxyRedirectID, name).Debugf("AllocateProxyPort: allocated proxy port %d (%v)", pp.ProxyPort, *pp)
 
-	return pp.proxyPort, nil
+	return pp.ProxyPort, nil
 }
 
 func (p *Proxy) ReleaseProxyPort(name string) error {
@@ -400,16 +504,16 @@ func (p *Proxy) SetProxyPort(name string, proxyType types.ProxyType, port uint16
 
 	pp := p.proxyPorts[name]
 	if pp == nil {
-		pp = &ProxyPort{proxyType: proxyType, ingress: ingress}
+		pp = &ProxyPort{ProxyType: proxyType, Ingress: ingress}
 		p.proxyPorts[name] = pp
 	}
 	if pp.nRedirects > 0 {
-		return fmt.Errorf("Can't set proxy port to %d: proxy %s is already configured on %d", port, name, pp.proxyPort)
+		return fmt.Errorf("Can't set proxy port to %d: proxy %s is already configured on %d", port, name, pp.ProxyPort)
 	}
-	pp.proxyPort = port
+	pp.ProxyPort = port
 	pp.isStatic = true // prevents release of the proxy port
 	// marks port as reserved
-	p.allocatedPorts[pp.proxyPort] = true
+	p.allocatedPorts[pp.ProxyPort] = true
 	// mark proxy port as configured
 	pp.configured = true
 	return nil
@@ -526,7 +630,7 @@ func (p *Proxy) CreateOrUpdateRedirect(
 		existingRedirect.mutex.Lock()
 
 		// Only consider configured (but not necessarily acked) proxy ports for update
-		if existingRedirect.listener.configured && existingRedirect.listener.proxyType == types.ProxyType(l4.GetL7Parser()) {
+		if existingRedirect.listener.configured && existingRedirect.listener.ProxyType == types.ProxyType(l4.GetL7Parser()) {
 			updateRevertFunc := existingRedirect.updateRules(l4)
 			revertStack.Push(updateRevertFunc)
 			implUpdateRevertFunc, err := existingRedirect.implementation.UpdateRules(wg)
@@ -540,13 +644,13 @@ func (p *Proxy) CreateOrUpdateRedirect(
 
 			scopedLog.
 				WithField(logfields.Object, logfields.Repr(existingRedirect)).
-				WithField("proxyType", existingRedirect.listener.proxyType).
+				WithField("proxyType", existingRedirect.listener.ProxyType).
 				Debug("updated existing proxy instance")
 
 			existingRedirect.mutex.Unlock()
 
 			// Must return the proxy port when successful
-			return existingRedirect.listener.proxyPort, nil, nil, revertStack.Revert
+			return existingRedirect.listener.ProxyPort, nil, nil, revertStack.Revert
 		}
 
 		// Stale or incompatible redirects get removed before a new one is created below
@@ -597,9 +701,9 @@ func (p *Proxy) createNewRedirect(
 	scopedLog = scopedLog.
 		WithField("portName", ppName)
 
-	if pp.proxyPort == 0 && pp.rulesPort != 0 {
+	if pp.ProxyPort == 0 && pp.rulesPort != 0 {
 		// try first with the previous port
-		pp.proxyPort = pp.rulesPort
+		pp.ProxyPort = pp.rulesPort
 	}
 
 	for nRetry := 0; nRetry < redirectCreationAttempts; nRetry++ {
@@ -611,16 +715,16 @@ func (p *Proxy) createNewRedirect(
 		// preallocated port, as in typical case the listener we are about to configure
 		// already exists (daemonset proxy), or can be created on a new proxy with the same
 		// port (embedded Envoy).
-		if !pp.configured && (nRetry > 0 || pp.proxyPort == 0) {
+		if !pp.configured && (nRetry > 0 || pp.ProxyPort == 0) {
 			// Clear the proxy port on retry so that a random new port will be tried.
-			pp.proxyPort = 0
+			pp.ProxyPort = 0
 
 			// Check if pp.proxyPort is available and find another available proxy port if not.
-			proxyPort, err := p.allocatePort(pp.proxyPort, p.rangeMin, p.rangeMax)
+			proxyPort, err := p.allocatePort(pp.ProxyPort, p.rangeMin, p.rangeMax)
 			if err != nil {
 				return 0, fmt.Errorf("failed to allocate port: %w", err), nil, nil
 			}
-			pp.proxyPort = proxyPort
+			pp.ProxyPort = proxyPort
 		}
 
 		if err := p.createRedirectImpl(redirect, l4, wg); err != nil {
@@ -652,7 +756,7 @@ func (p *Proxy) createNewRedirect(
 	// must mark the proxyPort configured while we still hold the lock to prevent racing between two parallel runs
 
 	// marks port as reserved
-	p.allocatedPorts[pp.proxyPort] = true
+	p.allocatedPorts[pp.ProxyPort] = true
 	// mark proxy port as configured
 	pp.configured = true
 
@@ -665,9 +769,9 @@ func (p *Proxy) createNewRedirect(
 		// Mark the  port for reuse only if no other ports are available
 		// Discourage the reuse of the same port in future as revert may have been due to
 		// port not being available for bind().
-		p.allocatedPorts[pp.proxyPort] = false
+		p.allocatedPorts[pp.ProxyPort] = false
 		// clear proxy port on failure so that a new one will be tried next time
-		pp.proxyPort = 0
+		pp.ProxyPort = 0
 		pp.configured = false
 
 		p.updateRedirectMetrics()
@@ -692,7 +796,7 @@ func (p *Proxy) createNewRedirect(
 	}
 
 	// Must return the proxy port when successful
-	return pp.proxyPort, nil, finalizeFunc, revertFunc
+	return pp.ProxyPort, nil, finalizeFunc, revertFunc
 }
 
 func (p *Proxy) createRedirectImpl(redir *Redirect, l4 policy.ProxyPolicy, wg *completion.WaitGroup) error {
@@ -753,7 +857,7 @@ func (p *Proxy) removeRedirect(id string, wg *completion.WaitGroup) (error, reve
 	// Delay the release and reuse of the port number so it is guaranteed to be
 	// safe to listen on the port again. This can't be reverted, so do it in a
 	// FinalizeFunc.
-	proxyPort := r.listener.proxyPort
+	proxyPort := r.listener.ProxyPort
 	listenerName := r.name
 
 	finalizeList.Append(func() {
@@ -840,7 +944,7 @@ func (p *Proxy) GetStatusModel() *models.ProxyStatus {
 func (p *Proxy) updateRedirectMetrics() {
 	result := map[string]int{}
 	for _, redirect := range p.redirects {
-		result[string(redirect.listener.proxyType)]++
+		result[string(redirect.listener.ProxyType)]++
 	}
 	for proto, count := range result {
 		metrics.ProxyRedirects.WithLabelValues(proto).Set(float64(count))

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -42,7 +42,7 @@ const (
 )
 
 type DatapathUpdater interface {
-	InstallProxyRules(proxyPort uint16, localOnly bool, name string)
+	InstallProxyRules(proxyPort uint16, name string)
 	SupportsOriginalSourceAddr() bool
 }
 
@@ -69,8 +69,6 @@ type ProxyPort struct {
 	// is non-zero when a proxy has been successfully created and the
 	// datapath rules have been created.
 	rulesPort uint16
-	// localOnly is true when the proxy port is only accessible from the loopback device
-	localOnly bool
 }
 
 // Proxy maintains state about redirects
@@ -132,27 +130,22 @@ func defaultProxyPortMap() map[string]*ProxyPort {
 		"cilium-http-egress": {
 			proxyType: types.ProxyTypeHTTP,
 			ingress:   false,
-			localOnly: true,
 		},
 		"cilium-http-ingress": {
 			proxyType: types.ProxyTypeHTTP,
 			ingress:   true,
-			localOnly: true,
 		},
 		types.DNSProxyName: {
 			proxyType: types.ProxyTypeDNS,
 			ingress:   false,
-			localOnly: true,
 		},
 		"cilium-proxylib-egress": {
 			proxyType: types.ProxyTypeAny,
 			ingress:   false,
-			localOnly: true,
 		},
 		"cilium-proxylib-ingress": {
 			proxyType: types.ProxyTypeAny,
 			ingress:   true,
-			localOnly: true,
 		},
 	}
 }
@@ -232,7 +225,7 @@ func (p *Proxy) ackProxyPort(ctx context.Context, name string, pp *ProxyPort) er
 		// Add rules for the new port
 		// This should always succeed if we have managed to start-up properly
 		scopedLog.Infof("Adding new proxy port rules for %s:%d", name, pp.proxyPort)
-		p.datapathUpdater.InstallProxyRules(pp.proxyPort, pp.localOnly, name)
+		p.datapathUpdater.InstallProxyRules(pp.proxyPort, name)
 		pp.rulesPort = pp.proxyPort
 	}
 	pp.nRedirects++
@@ -331,13 +324,13 @@ func (p *Proxy) GetProxyPort(name string) (uint16, error) {
 // already allocated.
 // Each call has to be paired with AckProxyPort(name) to update the datapath rules accordingly.
 // Each allocated port must be eventually freed with ReleaseProxyPort().
-func (p *Proxy) AllocateCRDProxyPort(name string, localOnly bool) (uint16, error) {
+func (p *Proxy) AllocateCRDProxyPort(name string) (uint16, error) {
 	// Accessing pp.proxyPort requires the lock
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 	pp := p.proxyPorts[name]
 	if pp == nil || pp.ingress {
-		pp = &ProxyPort{proxyType: types.ProxyTypeCRD, ingress: false, localOnly: localOnly}
+		pp = &ProxyPort{proxyType: types.ProxyTypeCRD, ingress: false}
 	}
 
 	// Allocate a new port only if a port was never allocated before.

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -44,6 +44,7 @@ const (
 type DatapathUpdater interface {
 	InstallProxyRules(proxyPort uint16, name string)
 	SupportsOriginalSourceAddr() bool
+	GetProxyPorts() map[string]uint16
 }
 
 type ProxyPort struct {
@@ -67,7 +68,7 @@ type ProxyPort struct {
 	configured bool
 	// rulesPort contains the proxy port value configured to the datapath rules and
 	// is non-zero when a proxy has been successfully created and the
-	// datapath rules have been created.
+	// (new, if after restart) datapath rules have been created.
 	rulesPort uint16
 }
 
@@ -307,6 +308,29 @@ func proxyNotFoundError(name string) error {
 }
 
 // Exported API
+
+// RestoreProxyPorts tries to find earlier port numbers from datapath and use them
+// as defaults for proxy ports
+func (p *Proxy) RestoreProxyPorts() {
+	portMap := p.datapathUpdater.GetProxyPorts()
+	for name, port := range portMap {
+		pp := p.proxyPorts[name]
+		if pp != nil {
+			pp.proxyPort = port
+		} else {
+			// Only CRD type proxy ports can be dynamically allocated. Assume a port
+			// from datapath with an unknown name was for a dynamically allocated CRD
+			// proxy and pre-allocate a proxy port for it.
+			// CRD proxy ports always have 'ingress' as 'false'.
+			p.proxyPorts[name] = &ProxyPort{proxyType: types.ProxyTypeCRD, ingress: false, proxyPort: port}
+		}
+		p.allocatedPorts[port] = false
+		log.
+			WithField(fieldProxyRedirectID, name).
+			WithField("proxyPort", port).
+			Debugf("RestoreProxyPorts: preallocated proxy port")
+	}
+}
 
 // GetProxyPort() returns the fixed listen port for a proxy, if any.
 func (p *Proxy) GetProxyPort(name string) (uint16, error) {
@@ -579,12 +603,17 @@ func (p *Proxy) createNewRedirect(
 	}
 
 	for nRetry := 0; nRetry < redirectCreationAttempts; nRetry++ {
-		if !pp.configured {
-			if nRetry > 0 {
-				// Clear the proxy port on retry so that a random new port will be
-				// tried.
-				pp.proxyPort = 0
-			}
+		// Reallocate port only if not yet configured and the first try failed, or the port
+		// has not been (pre)allocated yet.
+		// For example, on restart we may have preallocated port that is not configured
+		// yet. The port may already be listening, causing allocatePort() to select another
+		// one, as the port is not available. We should make the first try with the
+		// preallocated port, as in typical case the listener we are about to configure
+		// already exists (daemonset proxy), or can be created on a new proxy with the same
+		// port (embedded Envoy).
+		if !pp.configured && (nRetry > 0 || pp.proxyPort == 0) {
+			// Clear the proxy port on retry so that a random new port will be tried.
+			pp.proxyPort = 0
 
 			// Check if pp.proxyPort is available and find another available proxy port if not.
 			proxyPort, err := p.allocatePort(pp.proxyPort, p.rangeMin, p.rangeMax)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -55,6 +55,7 @@ type ProxyPort struct {
 	// proxy type this port applies to (immutable)
 	proxyType types.ProxyType
 	// 'true' for ingress, 'false' for egress (immutable)
+	// 'false' for CRD redirects, which are accessed by name only.
 	ingress bool
 	// ProxyPort is the desired proxy listening port number.
 	proxyPort uint16
@@ -276,7 +277,8 @@ func (p *Proxy) findProxyPortByType(l7Type types.ProxyType, listener string, ing
 	switch l7Type {
 	case types.ProxyTypeCRD:
 		// CRD proxy ports are dynamically created, look up by name
-		if pp, ok := p.proxyPorts[listener]; ok && pp.proxyType == types.ProxyTypeCRD {
+		// 'ingress' is always false for CRD type
+		if pp, ok := p.proxyPorts[listener]; ok && pp.proxyType == types.ProxyTypeCRD && !pp.ingress {
 			return listener, pp
 		}
 		log.Debugf("findProxyPortByType: can not find crd listener %s from %v", listener, p.proxyPorts)
@@ -325,17 +327,17 @@ func (p *Proxy) GetProxyPort(name string) (uint16, error) {
 	return 0, proxyNotFoundError(name)
 }
 
-// AllocateProxyPort() allocates a new port for listener 'name', or returns the current one if
+// AllocateCRDProxyPort() allocates a new port for listener 'name', or returns the current one if
 // already allocated.
 // Each call has to be paired with AckProxyPort(name) to update the datapath rules accordingly.
 // Each allocated port must be eventually freed with ReleaseProxyPort().
-func (p *Proxy) AllocateProxyPort(name string, ingress, localOnly bool) (uint16, error) {
+func (p *Proxy) AllocateCRDProxyPort(name string, localOnly bool) (uint16, error) {
 	// Accessing pp.proxyPort requires the lock
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 	pp := p.proxyPorts[name]
-	if pp == nil {
-		pp = &ProxyPort{proxyType: types.ProxyTypeCRD, ingress: ingress, localOnly: localOnly}
+	if pp == nil || pp.ingress {
+		pp = &ProxyPort{proxyType: types.ProxyTypeCRD, ingress: false, localOnly: localOnly}
 	}
 
 	// Allocate a new port only if a port was never allocated before.

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -27,6 +27,10 @@ func (m *MockDatapathUpdater) SupportsOriginalSourceAddr() bool {
 	return true
 }
 
+func (m *MockDatapathUpdater) GetProxyPorts() map[string]uint16 {
+	return nil
+}
+
 func TestPortAllocator(t *testing.T) {
 	mockDatapathUpdater := &MockDatapathUpdater{}
 

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -20,7 +20,7 @@ import (
 
 type MockDatapathUpdater struct{}
 
-func (m *MockDatapathUpdater) InstallProxyRules(proxyPort uint16, localOnly bool, name string) {
+func (m *MockDatapathUpdater) InstallProxyRules(proxyPort uint16, name string) {
 }
 
 func (m *MockDatapathUpdater) SupportsOriginalSourceAddr() bool {
@@ -37,7 +37,7 @@ func TestPortAllocator(t *testing.T) {
 
 	p := createProxy(10000, 20000, mockDatapathUpdater, nil, nil)
 
-	port, err := p.AllocateCRDProxyPort("listener1", true)
+	port, err := p.AllocateCRDProxyPort("listener1")
 	require.NoError(t, err)
 	require.NotEqual(t, 0, port)
 
@@ -46,7 +46,7 @@ func TestPortAllocator(t *testing.T) {
 	require.Equal(t, port, port1)
 
 	// Another allocation for the same name gets the same port
-	port1a, err := p.AllocateCRDProxyPort("listener1", true)
+	port1a, err := p.AllocateCRDProxyPort("listener1")
 	require.NoError(t, err)
 	require.Equal(t, port1, port1a)
 
@@ -55,7 +55,6 @@ func TestPortAllocator(t *testing.T) {
 	require.Equal(t, types.ProxyTypeCRD, pp.proxyType)
 	require.Equal(t, port, pp.proxyPort)
 	require.Equal(t, false, pp.ingress)
-	require.Equal(t, true, pp.localOnly)
 	require.Equal(t, true, pp.configured)
 	require.Equal(t, false, pp.isStatic)
 	require.Equal(t, 0, pp.nRedirects)
@@ -76,7 +75,7 @@ func TestPortAllocator(t *testing.T) {
 	require.Equal(t, uint16(0), pp.rulesPort)
 
 	// Allocates a different port (due to port was never acked)
-	port2, err := p.AllocateCRDProxyPort("listener1", true)
+	port2, err := p.AllocateCRDProxyPort("listener1")
 	require.NoError(t, err)
 	require.NotEqual(t, port, port2)
 	name2, pp2 := p.findProxyPortByType(types.ProxyTypeCRD, "listener1", false)
@@ -84,7 +83,6 @@ func TestPortAllocator(t *testing.T) {
 	require.Equal(t, pp2, pp)
 	require.Equal(t, types.ProxyTypeCRD, pp.proxyType)
 	require.Equal(t, false, pp.ingress)
-	require.Equal(t, true, pp.localOnly)
 	require.Equal(t, port2, pp.proxyPort)
 	require.Equal(t, true, pp.configured)
 	require.Equal(t, false, pp.isStatic)
@@ -130,7 +128,7 @@ func TestPortAllocator(t *testing.T) {
 	p.allocatedPorts[port2] = true
 
 	// Allocate again, this time a different port is allocated
-	port3, err := p.AllocateCRDProxyPort("listener1", true)
+	port3, err := p.AllocateCRDProxyPort("listener1")
 	require.NoError(t, err)
 	require.NotEqual(t, uint16(0), port3)
 	require.NotEqual(t, port2, port3)
@@ -140,7 +138,6 @@ func TestPortAllocator(t *testing.T) {
 	require.Equal(t, pp2, pp)
 	require.Equal(t, types.ProxyTypeCRD, pp.proxyType)
 	require.Equal(t, false, pp.ingress)
-	require.Equal(t, true, pp.localOnly)
 	require.Equal(t, port3, pp.proxyPort)
 	require.Equal(t, true, pp.configured)
 	require.Equal(t, false, pp.isStatic)
@@ -166,12 +163,11 @@ func TestPortAllocator(t *testing.T) {
 	require.Equal(t, false, inuse)
 
 	// No-one used the port so next allocation gets the same port again
-	port4, err := p.AllocateCRDProxyPort("listener1", true)
+	port4, err := p.AllocateCRDProxyPort("listener1")
 	require.NoError(t, err)
 	require.Equal(t, port3, port4)
 	require.Equal(t, types.ProxyTypeCRD, pp.proxyType)
 	require.Equal(t, false, pp.ingress)
-	require.Equal(t, true, pp.localOnly)
 	require.Equal(t, port4, pp.proxyPort)
 	require.Equal(t, true, pp.configured)
 	require.Equal(t, false, pp.isStatic)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -37,7 +37,7 @@ func TestPortAllocator(t *testing.T) {
 
 	p := createProxy(10000, 20000, mockDatapathUpdater, nil, nil)
 
-	port, err := p.AllocateProxyPort("listener1", false, true)
+	port, err := p.AllocateCRDProxyPort("listener1", true)
 	require.NoError(t, err)
 	require.NotEqual(t, 0, port)
 
@@ -46,7 +46,7 @@ func TestPortAllocator(t *testing.T) {
 	require.Equal(t, port, port1)
 
 	// Another allocation for the same name gets the same port
-	port1a, err := p.AllocateProxyPort("listener1", false, true)
+	port1a, err := p.AllocateCRDProxyPort("listener1", true)
 	require.NoError(t, err)
 	require.Equal(t, port1, port1a)
 
@@ -76,9 +76,12 @@ func TestPortAllocator(t *testing.T) {
 	require.Equal(t, uint16(0), pp.rulesPort)
 
 	// Allocates a different port (due to port was never acked)
-	port2, err := p.AllocateProxyPort("listener1", true, false)
+	port2, err := p.AllocateCRDProxyPort("listener1", true)
 	require.NoError(t, err)
 	require.NotEqual(t, port, port2)
+	name2, pp2 := p.findProxyPortByType(types.ProxyTypeCRD, "listener1", false)
+	require.Equal(t, name2, name)
+	require.Equal(t, pp2, pp)
 	require.Equal(t, types.ProxyTypeCRD, pp.proxyType)
 	require.Equal(t, false, pp.ingress)
 	require.Equal(t, true, pp.localOnly)
@@ -127,11 +130,14 @@ func TestPortAllocator(t *testing.T) {
 	p.allocatedPorts[port2] = true
 
 	// Allocate again, this time a different port is allocated
-	port3, err := p.AllocateProxyPort("listener1", true, true)
+	port3, err := p.AllocateCRDProxyPort("listener1", true)
 	require.NoError(t, err)
 	require.NotEqual(t, uint16(0), port3)
 	require.NotEqual(t, port2, port3)
 	require.NotEqual(t, port1, port3)
+	name2, pp2 = p.findProxyPortByType(types.ProxyTypeCRD, "listener1", false)
+	require.Equal(t, name2, name)
+	require.Equal(t, pp2, pp)
 	require.Equal(t, types.ProxyTypeCRD, pp.proxyType)
 	require.Equal(t, false, pp.ingress)
 	require.Equal(t, true, pp.localOnly)
@@ -160,7 +166,7 @@ func TestPortAllocator(t *testing.T) {
 	require.Equal(t, false, inuse)
 
 	// No-one used the port so next allocation gets the same port again
-	port4, err := p.AllocateProxyPort("listener1", true, true)
+	port4, err := p.AllocateCRDProxyPort("listener1", true)
 	require.NoError(t, err)
 	require.Equal(t, port3, port4)
 	require.Equal(t, types.ProxyTypeCRD, pp.proxyType)


### PR DESCRIPTION
Persist proxy ports in `/var/run/cilium/state/proxy_ports_state.json` so that proxy ports (including the DNS proxy port) can also be restored when BPF tproxy is used. This file is written each time we would upsert a TPROXY iptables rule and restored on restart. If the file does not exist proxy ports are restored from iptables rules instead. This is needed for upgrade compatibility.

Earlier commits in this series fix related issues in proxy port handling that are mainly meaningful for restoration with daemonset Envoy proxy:
- Clear proxy port on failure so that we'll try another random port next time
- Try previously used ports first when recreating a redirect
- Rename AllocateProxyPort as AllocateCRDProxyPort, simplify prototype
- Remove "localOnly", it is already always `true`

The last two commits introduce the main changes:
- Restore all proxy ports from iptables rules (rather than only DNS proxy port)
- Persist proxy ports in /var/run/cilium/state/proxy_ports_state.json

Since this mainly enhances use of daemonset Envoy proxy by reducing Listener churn on Cilium agent restarts and daemonset Envoy is enabled by default only from Cilium 1.16, there is no need to backport these changes.
