### PR TITLE
clustermesh: extract operator logic into a specific package

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -46,6 +46,7 @@ import (
 	operatorWatchers "github.com/cilium/cilium/operator/watchers"
 	"github.com/cilium/cilium/pkg/clustermesh/endpointslicesync"
 	"github.com/cilium/cilium/pkg/clustermesh/mcsapi"
+	operatorClusterMesh "github.com/cilium/cilium/pkg/clustermesh/operator"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -187,6 +188,7 @@ var (
 			nodeipam.Cell,
 			auth.Cell,
 			store.Cell,
+			operatorClusterMesh.Cell,
 			endpointslicesync.Cell,
 			mcsapi.Cell,
 			legacyCell,

--- a/pkg/clustermesh/endpointslicesync/cell.go
+++ b/pkg/clustermesh/endpointslicesync/cell.go
@@ -7,69 +7,44 @@ import (
 	"time"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
-	"github.com/cilium/cilium/pkg/clustermesh/common"
-	"github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/clustermesh/wait"
-	"github.com/cilium/cilium/pkg/dial"
+	"github.com/cilium/cilium/pkg/clustermesh/operator"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
-	"github.com/cilium/cilium/pkg/kvstore/store"
-	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 )
 
 const subsystem = "clustermesh"
 
-var log = logging.DefaultLogger.WithField(logfields.LogSubsys, subsystem)
-
 // Cell is the cell for the Operator ClusterMesh
 var Cell = cell.Module(
 	"endpointslicesync-clustermesh",
 	"EndpointSlice clustermesh synchronization in the Cilium operator",
-	cell.Config(ClusterMeshConfig{}),
-	cell.Provide(
-		newClusterMesh,
-		newAPIClustersHandler,
-	),
-	// Invoke an empty function which takes a ClusterMesh to force its construction.
-	cell.Invoke(func(ClusterMesh) {}),
-
-	cell.Config(common.Config{}),
-	cell.Config(wait.TimeoutConfigDefault),
+	cell.Config(EndpointSliceSyncConfig{}),
+	cell.Invoke(registerEndpointSliceSync),
 
 	metrics.Metric(NewMetrics),
-	metrics.Metric(common.MetricsProvider(subsystem)),
 )
 
-type clusterMeshParams struct {
+type endpointSliceSyncParams struct {
 	cell.In
 
-	common.Config
-	wait.TimeoutConfig
-	Cfg ClusterMeshConfig
+	operator.ClusterMeshConfig
+	EndpointSliceSyncConfig
+	Logger   logrus.FieldLogger
+	JobGroup job.Group
 
-	// ClusterInfo is the id/name of the local cluster. This is used for logging and metrics
-	ClusterInfo types.ClusterInfo
-
-	Clientset k8sClient.Clientset
-	Services  resource.Resource[*slim_corev1.Service]
-
-	Metrics       Metrics
-	CommonMetrics common.Metrics
-	StoreFactory  store.Factory
-
-	// ServiceResolver, if not nil, is used to create a custom dialer for service resolution.
-	ServiceResolver *dial.ServiceResolver
+	Clientset   k8sClient.Clientset
+	Services    resource.Resource[*slim_corev1.Service]
+	ClusterMesh operator.ClusterMesh
 }
 
-// ClusterMeshConfig contains the configuration for ClusterMesh inside the operator.
-type ClusterMeshConfig struct {
-	// ClusterMeshEnableEndpointSync enables the EndpointSlice Cluster Mesh synchronization
-	ClusterMeshEnableEndpointSync bool `mapstructure:"clustermesh-enable-endpoint-sync"`
+// EndpointSliceSyncConfig contains the configuration for endpointSliceSync inside the operator.
+type EndpointSliceSyncConfig struct {
 	// ClusterMeshConcurrentEndpointSync the number of service endpoint syncing operations
 	// that will be done concurrently by the EndpointSlice Cluster Mesh controller.
 	ClusterMeshConcurrentEndpointSync int `mapstructure:"clustermesh-concurrent-service-endpoint-syncs"`
@@ -84,12 +59,7 @@ type ClusterMeshConfig struct {
 }
 
 // Flags adds the flags used by ClientConfig.
-func (cfg ClusterMeshConfig) Flags(flags *pflag.FlagSet) {
-	flags.BoolVar(&cfg.ClusterMeshEnableEndpointSync,
-		"clustermesh-enable-endpoint-sync",
-		false,
-		"Whether or not the endpoint slice cluster mesh synchronization is enabled.",
-	)
+func (cfg EndpointSliceSyncConfig) Flags(flags *pflag.FlagSet) {
 	flags.IntVar(&cfg.ClusterMeshConcurrentEndpointSync,
 		"clustermesh-concurrent-service-endpoint-syncs",
 		5, // This currently mirrors the same default value as the endpointslice Kubernetes controller https://github.com/kubernetes/kubernetes/blob/v1.29.0/cmd/kube-controller-manager/app/options/endpointslicecontroller.go#L45

--- a/pkg/clustermesh/endpointslicesync/dummy_informer.go
+++ b/pkg/clustermesh/endpointslicesync/dummy_informer.go
@@ -6,53 +6,55 @@ package endpointslicesync
 import (
 	"time"
 
+	"github.com/sirupsen/logrus"
 	cache "k8s.io/client-go/tools/cache"
 )
 
 type dummyInformer struct {
-	name string
+	name   string
+	logger logrus.FieldLogger
 }
 
 func (i *dummyInformer) AddIndexers(indexers cache.Indexers) error {
-	log.Errorf("called not implemented function %s.AddIndexers", i.name)
+	i.logger.Errorf("called not implemented function %s.AddIndexers", i.name)
 	return nil
 }
 func (i *dummyInformer) GetIndexer() cache.Indexer {
-	log.Errorf("called not implemented function %s.GetIndexer", i.name)
+	i.logger.Errorf("called not implemented function %s.GetIndexer", i.name)
 	return nil
 }
 func (i *dummyInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
-	log.Errorf("called not implemented function %s.AddEventHandlerWithResyncPeriod", i.name)
+	i.logger.Errorf("called not implemented function %s.AddEventHandlerWithResyncPeriod", i.name)
 	return nil, nil
 }
 func (i *dummyInformer) RemoveEventHandler(handle cache.ResourceEventHandlerRegistration) error {
-	log.Errorf("called not implemented function %s.RemoveEventHandler", i.name)
+	i.logger.Errorf("called not implemented function %s.RemoveEventHandler", i.name)
 	return nil
 }
 func (i *dummyInformer) GetStore() cache.Store {
-	log.Errorf("called not implemented function %s.GetStore", i.name)
+	i.logger.Errorf("called not implemented function %s.GetStore", i.name)
 	return nil
 }
 func (i *dummyInformer) GetController() cache.Controller {
-	log.Errorf("called not implemented function %s.GetController", i.name)
+	i.logger.Errorf("called not implemented function %s.GetController", i.name)
 	return nil
 }
 func (i *dummyInformer) Run(stopCh <-chan struct{}) {
-	log.Errorf("called not implemented function %s.Run", i.name)
+	i.logger.Errorf("called not implemented function %s.Run", i.name)
 }
 func (i *dummyInformer) LastSyncResourceVersion() string {
-	log.Errorf("called not implemented function %s.LastSyncResourceVersion", i.name)
+	i.logger.Errorf("called not implemented function %s.LastSyncResourceVersion", i.name)
 	return ""
 }
 func (i *dummyInformer) SetWatchErrorHandler(handler cache.WatchErrorHandler) error {
-	log.Errorf("called not implemented function %s.SetWatchErrorHandler", i.name)
+	i.logger.Errorf("called not implemented function %s.SetWatchErrorHandler", i.name)
 	return nil
 }
 func (i *dummyInformer) SetTransform(handler cache.TransformFunc) error {
-	log.Errorf("called not implemented function %s.SetTransform", i.name)
+	i.logger.Errorf("called not implemented function %s.SetTransform", i.name)
 	return nil
 }
 func (i *dummyInformer) IsStopped() bool {
-	log.Errorf("called not implemented function %s.IsStopped", i.name)
+	i.logger.Errorf("called not implemented function %s.IsStopped", i.name)
 	return false
 }

--- a/pkg/clustermesh/endpointslicesync/endpointslicesync.go
+++ b/pkg/clustermesh/endpointslicesync/endpointslicesync.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpointslicesync
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	cache "k8s.io/client-go/tools/cache"
+)
+
+func registerEndpointSliceSync(_ cell.Lifecycle, params endpointSliceSyncParams) {
+	if !params.Clientset.IsEnabled() || params.ClusterMesh == nil || !params.ClusterMeshEnableEndpointSync {
+		return
+	}
+
+	params.Logger.Info("Endpoint Slice Cluster Mesh synchronization enabled")
+
+	meshPodInformer := newMeshPodInformer(params.Logger, params.ClusterMesh.GlobalServices())
+	params.ClusterMesh.RegisterClusterServiceUpdateHook(meshPodInformer.onClusterServiceUpdate)
+	params.ClusterMesh.RegisterClusterServiceDeleteHook(meshPodInformer.onClusterServiceDelete)
+	meshNodeInformer := newMeshNodeInformer(params.Logger)
+	params.ClusterMesh.RegisterClusterAddHook(meshNodeInformer.onClusterAdd)
+	params.ClusterMesh.RegisterClusterDeleteHook(meshNodeInformer.onClusterDelete)
+	params.JobGroup.Add(job.OneShot("endpointslicesync-main", func(ctx context.Context, health cell.Health) error {
+		params.Logger.Info("Bootstrap clustermesh EndpointSlice controller")
+
+		endpointSliceMeshController, meshServiceInformer, endpointSliceInformerFactory := newEndpointSliceMeshController(
+			ctx, params.Logger, params.EndpointSliceSyncConfig, meshPodInformer,
+			meshNodeInformer, params.Clientset,
+			params.Services, params.ClusterMesh.GlobalServices(),
+		)
+
+		endpointSliceInformerFactory.Start(ctx.Done())
+		if err := meshServiceInformer.Start(ctx); err != nil {
+			return err
+		}
+		endpointSliceInformerFactory.WaitForCacheSync(ctx.Done())
+
+		if !cache.WaitForCacheSync(ctx.Done(), meshServiceInformer.HasSynced) {
+			return fmt.Errorf("waitForCacheSync on service informer not successful")
+		}
+
+		if err := params.ClusterMesh.ServicesSynced(ctx); err != nil {
+			return nil // The parent context expired, and we are already terminating
+		}
+		endpointSliceMeshController.Run(ctx, params.ClusterMeshConcurrentEndpointSync)
+		return nil
+	}))
+}

--- a/pkg/clustermesh/endpointslicesync/metrics.go
+++ b/pkg/clustermesh/endpointslicesync/metrics.go
@@ -16,8 +16,6 @@ import (
 )
 
 type Metrics struct {
-	// TotalGlobalServices tracks the total number of global services.
-	TotalGlobalServices metric.Vec[metric.Gauge]
 	// EndpointsAddedPerSync tracks the number of endpoints added on each
 	// Service sync.
 	EndpointsAddedPerSync metric.Vec[metric.Observer]
@@ -170,13 +168,6 @@ func NewMetrics() Metrics {
 	linkCounterVec(endpointslicemetrics.EndpointSliceSyncs, endpointSliceSyncs)
 
 	return Metrics{
-		TotalGlobalServices: metric.NewGaugeVec(metric.GaugeOpts{
-			Namespace: metrics.CiliumOperatorNamespace,
-			Subsystem: subsystem,
-			Name:      "global_services",
-			Help:      "The total number of global services in the cluster mesh",
-		}, []string{metrics.LabelSourceCluster}),
-
 		EndpointsAddedPerSync:        endpointsAddedPerSync,
 		EndpointsRemovedPerSync:      endpointsRemovedPerSync,
 		EndpointsDesired:             endpointsDesired,

--- a/pkg/clustermesh/endpointslicesync/node_informer.go
+++ b/pkg/clustermesh/endpointslicesync/node_informer.go
@@ -6,6 +6,7 @@ package endpointslicesync
 import (
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -29,9 +30,9 @@ type meshNodeInformer struct {
 	mutex   lock.RWMutex
 }
 
-func newMeshNodeInformer() *meshNodeInformer {
+func newMeshNodeInformer(logger logrus.FieldLogger) *meshNodeInformer {
 	return &meshNodeInformer{
-		dummyInformer: dummyInformer{"meshNodeInformer"},
+		dummyInformer: dummyInformer{name: "meshNodeInformer", logger: logger},
 		nodes:         map[string]*v1.Node{},
 	}
 }

--- a/pkg/clustermesh/endpointslicesync/pod_informer.go
+++ b/pkg/clustermesh/endpointslicesync/pod_informer.go
@@ -6,6 +6,7 @@ package endpointslicesync
 import (
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -24,13 +25,14 @@ import (
 type meshPodInformer struct {
 	dummyInformer
 
+	logger             logrus.FieldLogger
 	globalServiceCache *common.GlobalServiceCache
 	handler            cache.ResourceEventHandler
 }
 
-func newMeshPodInformer(globalServiceCache *common.GlobalServiceCache) *meshPodInformer {
+func newMeshPodInformer(logger logrus.FieldLogger, globalServiceCache *common.GlobalServiceCache) *meshPodInformer {
 	return &meshPodInformer{
-		dummyInformer:      dummyInformer{"meshPodInformer"},
+		dummyInformer:      dummyInformer{name: "meshPodInformer", logger: logger},
 		globalServiceCache: globalServiceCache,
 	}
 }
@@ -190,10 +192,10 @@ func (i *meshPodInformer) Lister() listersv1.PodLister {
 }
 
 func (i meshPodLister) Get(name string) (*v1.Pod, error) {
-	log.Error("called not implemented function meshPodLister.Get")
+	i.informer.logger.Error("called not implemented function meshPodLister.Get")
 	return nil, nil
 }
 func (i meshPodInformer) List(selector labels.Selector) ([]*v1.Pod, error) {
-	log.Error("called not implemented function meshPodInformer.Get")
+	i.logger.Error("called not implemented function meshPodInformer.Get")
 	return nil, nil
 }

--- a/pkg/clustermesh/operator/api.go
+++ b/pkg/clustermesh/operator/api.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package endpointslicesync
+package operator
 
 import (
 	"github.com/go-openapi/runtime/middleware"

--- a/pkg/clustermesh/operator/cell.go
+++ b/pkg/clustermesh/operator/cell.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package operator
+
+import (
+	"github.com/cilium/hive/cell"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/clustermesh/common"
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/clustermesh/wait"
+	"github.com/cilium/cilium/pkg/dial"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/metrics"
+)
+
+const subsystem = "clustermesh"
+
+// Cell is the cell for the Operator ClusterMesh
+var Cell = cell.Module(
+	"clustermesh",
+	"Cell providing clustermesh capabilities in the operator",
+	cell.Config(ClusterMeshConfig{}),
+	cell.Provide(
+		newClusterMesh,
+		newAPIClustersHandler,
+	),
+
+	cell.Config(common.Config{}),
+	cell.Config(wait.TimeoutConfigDefault),
+
+	metrics.Metric(NewMetrics),
+	metrics.Metric(common.MetricsProvider(subsystem)),
+)
+
+type clusterMeshParams struct {
+	cell.In
+
+	common.Config
+	wait.TimeoutConfig
+	Cfg    ClusterMeshConfig
+	Logger logrus.FieldLogger
+
+	// ClusterInfo is the id/name of the local cluster. This is used for logging and metrics
+	ClusterInfo types.ClusterInfo
+
+	Metrics       Metrics
+	CommonMetrics common.Metrics
+	StoreFactory  store.Factory
+
+	// ServiceResolver, if not nil, is used to create a custom dialer for service resolution.
+	ServiceResolver *dial.ServiceResolver
+}
+
+// ClusterMeshConfig contains the configuration for ClusterMesh inside the operator.
+type ClusterMeshConfig struct {
+	// ClusterMeshEnableEndpointSync enables the EndpointSlice Cluster Mesh synchronization
+	ClusterMeshEnableEndpointSync bool `mapstructure:"clustermesh-enable-endpoint-sync"`
+}
+
+// Flags adds the flags used by ClientConfig.
+func (cfg ClusterMeshConfig) Flags(flags *pflag.FlagSet) {
+	flags.BoolVar(&cfg.ClusterMeshEnableEndpointSync,
+		"clustermesh-enable-endpoint-sync",
+		false,
+		"Whether or not the endpoint slice cluster mesh synchronization is enabled.",
+	)
+}

--- a/pkg/clustermesh/operator/metrics.go
+++ b/pkg/clustermesh/operator/metrics.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package operator
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+type Metrics struct {
+	// TotalGlobalServices tracks the total number of global services.
+	TotalGlobalServices metric.Vec[metric.Gauge]
+}
+
+func NewMetrics() Metrics {
+	return Metrics{
+		TotalGlobalServices: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Subsystem: subsystem,
+			Name:      "global_services",
+			Help:      "The total number of global services in the cluster mesh",
+		}, []string{metrics.LabelSourceCluster}),
+	}
+}

--- a/pkg/clustermesh/operator/remote_cluster.go
+++ b/pkg/clustermesh/operator/remote_cluster.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package endpointslicesync
+package operator
 
 import (
 	"context"


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

This commit extracts all the clustermesh specific code into a package called operator. The aim of this is to provide clustermesh specific features to other package launched in the operator. The first user for this besides endpointslicesync would be the mcsapi package.

Related to #32712

```release-note
Extract clustermesh logic in the operator in a generic package
```
