### PR TITLE
Wait for CEC and CCEC resources before restoring endpoints.

### DIFF
--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/heartbeat"
 	"github.com/cilium/cilium/pkg/kvstore/store"
@@ -54,6 +55,18 @@ var Cell = cell.Module(
 		}
 	}),
 	store.Cell,
+
+	// Shared synchronization structures for waiting on K8s resources to
+	// be synced
+	synced.Cell,
+
+	// Provide CRD resource names for 'synced.CRDSyncCell' below.
+	cell.Provide(func() synced.CRDSyncResourceNames { return synced.ClusterMeshAPIServerResourceNames() }),
+
+	// CRDSyncCell provides a promise that is resolved as soon as CRDs used by the
+	// clustermesh-apiserver have synced.
+	// Allows cells to wait for CRDs before trying to list Cilium resources.
+	synced.CRDSyncCell,
 
 	heartbeat.Cell,
 	HealthAPIEndpointsCell,

--- a/clustermesh-apiserver/clustermesh/k8s/resource_ctors.go
+++ b/clustermesh-apiserver/clustermesh/k8s/resource_ctors.go
@@ -4,43 +4,41 @@
 package k8s
 
 import (
-	"github.com/cilium/hive/cell"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 )
 
-func CiliumSlimEndpointResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*types.CiliumEndpoint], error) {
-	if !cs.IsEnabled() {
+func CiliumSlimEndpointResource(params k8s.CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*types.CiliumEndpoint], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumEndpointList](cs.CiliumV2().CiliumEndpoints(slim_corev1.NamespaceAll)),
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumEndpointList](params.ClientSet.CiliumV2().CiliumEndpoints(slim_corev1.NamespaceAll)),
 		opts...,
 	)
-	return resource.New[*types.CiliumEndpoint](lc, lw,
+	return resource.New[*types.CiliumEndpoint](params.Lifecycle, lw,
 		resource.WithLazyTransform(func() runtime.Object {
 			return &cilium_api_v2.CiliumEndpoint{}
-		}, k8s.TransformToCiliumEndpoint),
+		}, k8s.TransformToCiliumEndpoint), resource.WithCRDSync(params.CRDSyncPromise),
 	), nil
 }
 
-func CiliumNodeResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumNode], error) {
-	if !cs.IsEnabled() {
+func CiliumNodeResource(params k8s.CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumNode], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](cs.CiliumV2().CiliumNodes()),
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](params.ClientSet.CiliumV2().CiliumNodes()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumNode](lc, lw,
-		resource.WithMetric("CiliumNode"),
+	return resource.New[*cilium_api_v2.CiliumNode](params.Lifecycle, lw,
+		resource.WithMetric("CiliumNode"), resource.WithCRDSync(params.CRDSyncPromise),
 	), nil
 }

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -115,6 +115,14 @@ var (
 		// Store cell provides factory for creating watchStore/syncStore/storeManager
 		// useful for synchronizing data from/to kvstore.
 		store.Cell,
+
+		// Provide CRD resource names for 'k8sSynced.CRDSyncCell' below.
+		cell.Provide(func() k8sSynced.CRDSyncResourceNames { return k8sSynced.AgentCRDResourceNames() }),
+		// CRDSyncCell provides a promise that is resolved as soon as CRDs used by the
+		// agent have k8sSynced.
+		// Allows cells to wait for CRDs before trying to list Cilium resources.
+		// This is separate from k8sSynced.Cell as this one needs to be mocked for tests.
+		k8sSynced.CRDSyncCell,
 	)
 
 	// ControlPlane implement the per-node control functions. These are pure

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -222,7 +222,8 @@ var (
 		// ServiceCache holds the list of known services correlated with the matching endpoints.
 		k8s.ServiceCacheCell,
 
-		// K8s policy resource watcher cell.
+		// K8s policy resource watcher cell. It depends on the half-initialized daemon which is
+		// resolved by newDaemonPromise()
 		policyK8s.Cell,
 
 		// Directory policy watcher cell.

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -601,7 +601,8 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		// context deadline or if the context has been cancelled, the context's
 		// error will be returned. Otherwise, it succeeded.
 		if !option.Config.DryMode {
-			if err := d.k8sWatcher.WaitForCRDsToRegister(d.ctx); err != nil {
+			_, err := params.CRDSyncPromise.Await(d.ctx)
+			if err != nil {
 				return nil, restoredEndpoints, err
 			}
 		}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -721,11 +721,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	if params.Clientset.IsEnabled() {
 		bootstrapStats.k8sInit.Start()
 
-		// Launch the policy K8s watcher
-		if params.PolicyK8sWatcher != nil {
-			params.PolicyK8sWatcher.WatchK8sPolicyResources(d.ctx, &d)
-		}
-
 		// Launch the K8s watchers in parallel as we continue to process other
 		// daemon options.
 		d.k8sWatcher.InitK8sSubsystem(d.ctx, params.CacheStatus)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1612,7 +1612,6 @@ var daemonCell = cell.Module(
 	cell.Provide(
 		newDaemonPromise,
 		promise.New[endpointstate.Restorer],
-		func() k8s.CacheStatus { return make(k8s.CacheStatus) },
 		newSyncHostIPs,
 	),
 	// Provide a read-only copy of the current daemon settings to be consumed
@@ -1633,9 +1632,9 @@ type daemonParams struct {
 	LocalNodeStore         *node.LocalNodeStore
 	Shutdowner             hive.Shutdowner
 	Resources              agentK8s.Resources
-	CacheStatus            k8s.CacheStatus
 	K8sWatcher             *watchers.K8sWatcher
 	K8sSvcCache            *k8s.ServiceCache
+	CacheStatus            k8sSynced.CacheStatus
 	K8sResourceSynced      *k8sSynced.Resources
 	K8sAPIGroups           *k8sSynced.APIGroups
 	NodeManager            nodeManager.NodeManager

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1686,6 +1686,7 @@ type daemonParams struct {
 	ServiceResolver     *dial.ServiceResolver
 	Recorder            *recorder.Recorder
 	IPAM                *ipam.IPAM
+	CRDSyncPromise      promise.Promise[k8sSynced.CRDSync]
 }
 
 func newDaemonPromise(params daemonParams) (promise.Promise[*Daemon], promise.Promise[*option.DaemonConfig]) {

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/hive"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/labelsfilter"
@@ -127,6 +128,7 @@ func setupDaemonSuite(tb testing.TB) *DaemonSuite {
 			func() *option.DaemonConfig { return option.Config },
 			func() cnicell.CNIConfigManager { return &fakecni.FakeCNIConfigManager{} },
 			func() ctmapgc.Enabler { return ctmapgc.NewFake() },
+			k8sSynced.RejectedCRDSyncPromise,
 		),
 		fakeDatapath.Cell,
 		prefilter.Cell,

--- a/daemon/cmd/local_node_sync_test.go
+++ b/daemon/cmd/local_node_sync_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	"github.com/cilium/cilium/pkg/node/types"
@@ -84,6 +85,7 @@ func TestLocalNodeSync(t *testing.T) {
 		fln  = newFakeLocalNode()
 		sync = newLocalNodeSynchronizer(localNodeSynchronizerParams{
 			Config: &option.DaemonConfig{
+				ConfigPatchMutex:           new(lock.RWMutex),
 				IPv4NodeAddr:               "1.2.3.4",
 				IPv6NodeAddr:               "fd00::1",
 				NodeEncryptionOptOutLabels: k8sLabels.Nothing(),
@@ -133,6 +135,7 @@ func TestInitLocalNode_initFromK8s(t *testing.T) {
 	lni := &localNodeSynchronizer{
 		localNodeSynchronizerParams: localNodeSynchronizerParams{
 			Config: &option.DaemonConfig{
+				ConfigPatchMutex:             new(lock.RWMutex),
 				IPv4NodeAddr:                 "auto",
 				IPv6NodeAddr:                 "auto",
 				IPv6ClusterAllocCIDRBase:     "fd00::",

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -31,7 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
-	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -72,7 +72,7 @@ type policyParams struct {
 	EndpointManager endpointmanager.EndpointManager
 	CertManager     certificatemanager.CertificateManager
 	SecretManager   certificatemanager.SecretManager
-	CacheStatus     k8s.CacheStatus
+	CacheStatus     synced.CacheStatus
 	ClusterInfo     cmtypes.ClusterInfo
 }
 

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/daemon/cmd/cni/fake"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node/manager"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/nodediscovery"
@@ -26,9 +27,10 @@ type GetNodesSuite struct {
 }
 
 var fakeConfig = &option.DaemonConfig{
-	RoutingMode: option.RoutingModeTunnel,
-	EnableIPSec: true,
-	EncryptNode: true,
+	ConfigPatchMutex: new(lock.RWMutex),
+	RoutingMode:      option.RoutingModeTunnel,
+	EnableIPSec:      true,
+	EncryptNode:      true,
 }
 
 func setupGetNodesSuite(tb testing.TB) *GetNodesSuite {

--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -66,9 +66,9 @@ var (
 					},
 				)
 			},
-			func(lc cell.Lifecycle, cs client.Clientset) (LocalCiliumNodeResource, error) {
+			func(params k8s.CiliumResourceParams) (LocalCiliumNodeResource, error) {
 				return k8s.CiliumNodeResource(
-					lc, cs,
+					params,
 					func(opts *metav1.ListOptions) {
 						opts.FieldSelector = fields.ParseSelectorOrDie("metadata.name=" + nodeTypes.GetName()).String()
 					},

--- a/operator/cmd/ccnp_event.go
+++ b/operator/cmd/ccnp_event.go
@@ -44,7 +44,7 @@ func enableCCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sCli
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				k8sEventMetric(resources.MetricCCNP, resources.MetricCreate)
-				if cnp := k8s.CastInformerEvent[types.SlimCNP](obj); cnp != nil {
+				if cnp := informer.CastInformerEvent[types.SlimCNP](obj); cnp != nil {
 					// We need to deepcopy this structure because we are writing
 					// fields.
 					// See https://github.com/cilium/cilium/blob/27fee207f5422c95479422162e9ea0d2f2b6c770/pkg/policy/api/ingress.go#L112-L134
@@ -55,8 +55,8 @@ func enableCCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sCli
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				k8sEventMetric(resources.MetricCCNP, resources.MetricUpdate)
-				if oldCNP := k8s.CastInformerEvent[types.SlimCNP](oldObj); oldCNP != nil {
-					if newCNP := k8s.CastInformerEvent[types.SlimCNP](newObj); newCNP != nil {
+				if oldCNP := informer.CastInformerEvent[types.SlimCNP](oldObj); oldCNP != nil {
+					if newCNP := informer.CastInformerEvent[types.SlimCNP](newObj); newCNP != nil {
 						if oldCNP.DeepEqual(newCNP) {
 							return
 						}
@@ -73,7 +73,7 @@ func enableCCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sCli
 			},
 			DeleteFunc: func(obj interface{}) {
 				k8sEventMetric(resources.MetricCCNP, resources.MetricDelete)
-				cnp := k8s.CastInformerEvent[types.SlimCNP](obj)
+				cnp := informer.CastInformerEvent[types.SlimCNP](obj)
 				if cnp == nil {
 					return
 				}

--- a/operator/cmd/cilium_node.go
+++ b/operator/cmd/cilium_node.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/ipam/allocator"
-	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/informer"
@@ -174,8 +173,8 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup) 
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				if oldNode := k8s.CastInformerEvent[cilium_v2.CiliumNode](oldObj); oldNode != nil {
-					if newNode := k8s.CastInformerEvent[cilium_v2.CiliumNode](newObj); newNode != nil {
+				if oldNode := informer.CastInformerEvent[cilium_v2.CiliumNode](oldObj); oldNode != nil {
+					if newNode := informer.CastInformerEvent[cilium_v2.CiliumNode](newObj); newNode != nil {
 						if oldNode.DeepEqual(newNode) {
 							return
 						}

--- a/operator/cmd/cnp_event.go
+++ b/operator/cmd/cnp_event.go
@@ -45,7 +45,7 @@ func enableCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sClie
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				k8sEventMetric(resources.MetricCNP, resources.MetricCreate)
-				if cnp := k8s.CastInformerEvent[types.SlimCNP](obj); cnp != nil {
+				if cnp := informer.CastInformerEvent[types.SlimCNP](obj); cnp != nil {
 					// We need to deepcopy this structure because we are writing
 					// fields.
 					// See https://github.com/cilium/cilium/blob/27fee207f5422c95479422162e9ea0d2f2b6c770/pkg/policy/api/ingress.go#L112-L134
@@ -56,8 +56,8 @@ func enableCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sClie
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				k8sEventMetric(resources.MetricCNP, resources.MetricUpdate)
-				if oldCNP := k8s.CastInformerEvent[types.SlimCNP](oldObj); oldCNP != nil {
-					if newCNP := k8s.CastInformerEvent[types.SlimCNP](newObj); newCNP != nil {
+				if oldCNP := informer.CastInformerEvent[types.SlimCNP](oldObj); oldCNP != nil {
+					if newCNP := informer.CastInformerEvent[types.SlimCNP](newObj); newCNP != nil {
 						if oldCNP.DeepEqual(newCNP) {
 							return
 						}
@@ -74,7 +74,7 @@ func enableCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sClie
 			},
 			DeleteFunc: func(obj interface{}) {
 				k8sEventMetric(resources.MetricCNP, resources.MetricDelete)
-				cnp := k8s.CastInformerEvent[types.SlimCNP](obj)
+				cnp := informer.CastInformerEvent[types.SlimCNP](obj)
 				if cnp == nil {
 					return
 				}

--- a/operator/pkg/bgpv2/fixture_test.go
+++ b/operator/pkg/bgpv2/fixture_test.go
@@ -20,6 +20,7 @@ import (
 	cilium_client_v2alpha1 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -125,6 +126,7 @@ func newFixture(ctx context.Context, req *require.Assertions) (*fixture, func())
 
 		cell.Provide(func() *option.DaemonConfig {
 			return &option.DaemonConfig{
+				ConfigPatchMutex:      new(lock.RWMutex),
 				EnableBGPControlPlane: true,
 				Debug:                 true,
 			}

--- a/pkg/ciliumenvoyconfig/cec_reconciler_test.go
+++ b/pkg/ciliumenvoyconfig/cec_reconciler_test.go
@@ -316,7 +316,7 @@ func executeForConfigType[T k8sRuntime.Object](t *testing.T,
 				shouldFailFor: tc.shouldFailFor,
 			}
 
-			reconciler := newCiliumEnvoyConfigReconciler(logger, manager)
+			reconciler := newCiliumEnvoyConfigReconciler(reconcilerParams{Logger: logger, Manager: manager})
 
 			// init current state
 			configs := map[resource.Key]*config{}
@@ -536,7 +536,7 @@ func TestReconcileExistingConfigs(t *testing.T) {
 				shouldFailFor: tc.failFor,
 			}
 
-			reconciler := newCiliumEnvoyConfigReconciler(logger, manager)
+			reconciler := newCiliumEnvoyConfigReconciler(reconcilerParams{Logger: logger, Manager: manager})
 
 			// init current state
 			reconciler.configs = make(map[resource.Key]*config, len(tc.configs))
@@ -673,7 +673,7 @@ func TestHandleLocalNodeLabels(t *testing.T) {
 				shouldFailFor: tc.failFor,
 			}
 
-			reconciler := newCiliumEnvoyConfigReconciler(logger, manager)
+			reconciler := newCiliumEnvoyConfigReconciler(reconcilerParams{Logger: logger, Manager: manager})
 
 			// init current state
 			reconciler.configs = make(map[resource.Key]*config, len(tc.configs))

--- a/pkg/datapath/tables/node_address_test.go
+++ b/pkg/datapath/tables/node_address_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -567,7 +568,8 @@ func fixture(t *testing.T, addressScopeMax int, beforeStart func(*hive.Hive)) (*
 		// in a follow-up PR.
 		cell.Provide(func() *option.DaemonConfig {
 			return &option.DaemonConfig{
-				AddressScopeMax: addressScopeMax,
+				ConfigPatchMutex: new(lock.RWMutex),
+				AddressScopeMax:  addressScopeMax,
 			}
 		}),
 	)

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -27,6 +27,7 @@ import (
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -125,7 +126,7 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 	k.manager, err = newEgressGatewayManager(Params{
 		Lifecycle:         lc,
 		Config:            Config{1 * time.Millisecond},
-		DaemonConfig:      &option.DaemonConfig{},
+		DaemonConfig:      &option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)},
 		IdentityAllocator: identityAllocator,
 		PolicyMap:         policyMap,
 		Policies:          k.policies,

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -27,7 +27,8 @@ import (
 )
 
 var fakeConfig = &option.DaemonConfig{
-	K8sNamespace: "kube-system",
+	ConfigPatchMutex: new(lock.RWMutex),
+	K8sNamespace:     "kube-system",
 }
 
 func TestAllocateIdentityReserved(t *testing.T) {

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -17,6 +17,7 @@ import (
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/trigger"
@@ -59,6 +60,7 @@ func TestIPNotAvailableInPoolError(t *testing.T) {
 }
 
 var testConfigurationCRD = &option.DaemonConfig{
+	ConfigPatchMutex:        new(lock.RWMutex),
 	EnableIPv4:              true,
 	EnableIPv6:              false,
 	EnableHealthChecking:    true,

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -15,6 +15,7 @@ import (
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -28,6 +29,7 @@ func fakeIPv6AllocCIDRIP(fakeAddressing types.NodeAddressing) netip.Addr {
 }
 
 var testConfiguration = &option.DaemonConfig{
+	ConfigPatchMutex:        new(lock.RWMutex),
 	EnableIPv4:              true,
 	EnableIPv6:              true,
 	EnableHealthChecking:    true,

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
-	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -85,7 +85,7 @@ type Configuration struct {
 	cache.IdentityAllocator
 	ipcacheTypes.PolicyHandler
 	ipcacheTypes.DatapathHandler
-	k8s.CacheStatus
+	synced.CacheStatus
 }
 
 // IPCache is a collection of mappings:

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -15,31 +15,7 @@ import (
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/types"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 )
-
-// CastInformerEvent tries to cast obj to type typ, directly
-// or by DeletedFinalStateUnknown type. It returns nil and logs
-// an error if obj doesn't contain type typ.
-func CastInformerEvent[typ any](obj interface{}) *typ {
-	k8sObj, ok := obj.(*typ)
-	if ok {
-		return k8sObj
-	}
-	deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
-	if ok {
-		// Delete was not observed by the watcher but is
-		// removed from kube-apiserver. This is the last
-		// known state and the object no longer exists.
-		k8sObj, ok := deletedObj.Obj.(*typ)
-		if ok {
-			return k8sObj
-		}
-	}
-	log.WithField(logfields.Object, logfields.Repr(obj)).
-		Warnf("Ignoring invalid type, expected: %T", new(typ))
-	return nil
-}
 
 // AnnotationsEqual returns whether the annotation with any key in
 // relevantAnnotations is equal in anno1 and anno2.

--- a/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
+++ b/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/annotation"
-	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 
 	"github.com/cilium/cilium/pkg/k8s/informer"
@@ -430,8 +429,8 @@ func benchmarkInformer(ctx context.Context, nCycles int, newInformer bool, b *te
 			cache.ResourceEventHandlerFuncs{
 				AddFunc: func(obj interface{}) {},
 				UpdateFunc: func(oldObj, newObj interface{}) {
-					if oldK8sNP := k8s.CastInformerEvent[slim_corev1.Node](oldObj); oldK8sNP != nil {
-						if newK8sNP := k8s.CastInformerEvent[slim_corev1.Node](newObj); newK8sNP != nil {
+					if oldK8sNP := informer.CastInformerEvent[slim_corev1.Node](oldObj); oldK8sNP != nil {
+						if newK8sNP := informer.CastInformerEvent[slim_corev1.Node](newObj); newK8sNP != nil {
 							if reflect.DeepEqual(oldK8sNP, newK8sNP) {
 								return
 							}
@@ -439,7 +438,7 @@ func benchmarkInformer(ctx context.Context, nCycles int, newInformer bool, b *te
 					}
 				},
 				DeleteFunc: func(obj interface{}) {
-					k8sNP := k8s.CastInformerEvent[slim_corev1.Node](obj)
+					k8sNP := informer.CastInformerEvent[slim_corev1.Node](obj)
 					if k8sNP == nil {
 						deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
 						if !ok {
@@ -448,7 +447,7 @@ func benchmarkInformer(ctx context.Context, nCycles int, newInformer bool, b *te
 						// Delete was not observed by the watcher but is
 						// removed from kube-apiserver. This is the last
 						// known state and the object no longer exists.
-						k8sNP = k8s.CastInformerEvent[slim_corev1.Node](deletedObj.Obj)
+						k8sNP = informer.CastInformerEvent[slim_corev1.Node](deletedObj.Obj)
 						if k8sNP == nil {
 							return
 						}

--- a/pkg/k8s/informer/cast.go
+++ b/pkg/k8s/informer/cast.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package informer
+
+import (
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// CastInformerEvent tries to cast obj to type typ, directly
+// or by DeletedFinalStateUnknown type. It returns nil and logs
+// an error if obj doesn't contain type typ.
+func CastInformerEvent[typ any](obj interface{}) *typ {
+	k8sObj, ok := obj.(*typ)
+	if ok {
+		return k8sObj
+	}
+	deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
+	if ok {
+		// Delete was not observed by the watcher but is
+		// removed from kube-apiserver. This is the last
+		// known state and the object no longer exists.
+		k8sObj, ok := deletedObj.Obj.(*typ)
+		if ok {
+			return k8sObj
+		}
+	}
+	log.WithField(logfields.Object, logfields.Repr(obj)).
+		Warnf("Ignoring invalid type, expected: %T", new(typ))
+	return nil
+}

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -22,10 +22,12 @@ import (
 	slim_discoveryv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
 	slim_discoveryv1beta1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1beta1"
 	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
+	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/promise"
 )
 
 // Config defines the configuration options for k8s resources.
@@ -65,6 +67,19 @@ func namespaceIndexFunc(obj any) ([]string, error) {
 	return []string{object.GetNamespace()}, nil
 }
 
+// Dependencies for Cilium resources that may be used by Cilium Agent.
+// When CRDSyncPromise is provided, watchers of resources using this
+// will block until all CRDs used by the agent have been registered.
+// Agent will fail to start if Cilium Operator does not register all
+// the CRDs in time.
+type CiliumResourceParams struct {
+	cell.In
+
+	Lifecycle      cell.Lifecycle
+	ClientSet      client.Clientset
+	CRDSyncPromise promise.Promise[synced.CRDSync] `optional:"true"`
+}
+
 // ServiceResource builds the Resource[Service] object.
 func ServiceResource(lc cell.Lifecycle, cfg Config, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*slim_corev1.Service], error) {
 	if !cs.IsEnabled() {
@@ -99,17 +114,18 @@ func NodeResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.L
 	return resource.New[*slim_corev1.Node](lc, lw, resource.WithMetric("Node")), nil
 }
 
-func CiliumNodeResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumNode], error) {
-	if !cs.IsEnabled() {
+func CiliumNodeResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumNode], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](cs.CiliumV2().CiliumNodes()),
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](params.ClientSet.CiliumV2().CiliumNodes()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumNode](lc, lw,
+	return resource.New[*cilium_api_v2.CiliumNode](params.Lifecycle, lw,
 		resource.WithMetric("CiliumNode"),
 		resource.WithStoppableInformer(),
+		resource.WithCRDSync(params.CRDSyncPromise), // optional, can be nil
 	), nil
 }
 
@@ -135,26 +151,26 @@ func NamespaceResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*met
 	return resource.New[*slim_corev1.Namespace](lc, lw, resource.WithMetric("Namespace")), nil
 }
 
-func LBIPPoolsResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool], error) {
-	if !cs.IsEnabled() {
+func LBIPPoolsResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumLoadBalancerIPPoolList](cs.CiliumV2alpha1().CiliumLoadBalancerIPPools()),
+		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumLoadBalancerIPPoolList](params.ClientSet.CiliumV2alpha1().CiliumLoadBalancerIPPools()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool](lc, lw, resource.WithMetric("CiliumLoadBalancerIPPool")), nil
+	return resource.New[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool](params.Lifecycle, lw, resource.WithMetric("CiliumLoadBalancerIPPool"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
-func CiliumIdentityResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumIdentity], error) {
-	if !cs.IsEnabled() {
+func CiliumIdentityResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumIdentity], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumIdentityList](cs.CiliumV2().CiliumIdentities()),
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumIdentityList](params.ClientSet.CiliumV2().CiliumIdentities()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumIdentity](lc, lw, resource.WithMetric("CiliumIdentityList")), nil
+	return resource.New[*cilium_api_v2.CiliumIdentity](params.Lifecycle, lw, resource.WithMetric("CiliumIdentityList"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
 func NetworkPolicyResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*slim_networkingv1.NetworkPolicy], error) {
@@ -168,96 +184,96 @@ func NetworkPolicyResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(
 	return resource.New[*slim_networkingv1.NetworkPolicy](lc, lw, resource.WithMetric("NetworkPolicy")), nil
 }
 
-func CiliumNetworkPolicyResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumNetworkPolicy], error) {
-	if !cs.IsEnabled() {
+func CiliumNetworkPolicyResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumNetworkPolicy], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNetworkPolicyList](cs.CiliumV2().CiliumNetworkPolicies("")),
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNetworkPolicyList](params.ClientSet.CiliumV2().CiliumNetworkPolicies("")),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumNetworkPolicy](lc, lw, resource.WithMetric("CiliumNetworkPolicy")), nil
+	return resource.New[*cilium_api_v2.CiliumNetworkPolicy](params.Lifecycle, lw, resource.WithMetric("CiliumNetworkPolicy"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
-func CiliumClusterwideNetworkPolicyResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumClusterwideNetworkPolicy], error) {
-	if !cs.IsEnabled() {
+func CiliumClusterwideNetworkPolicyResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumClusterwideNetworkPolicy], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumClusterwideNetworkPolicyList](cs.CiliumV2().CiliumClusterwideNetworkPolicies()),
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumClusterwideNetworkPolicyList](params.ClientSet.CiliumV2().CiliumClusterwideNetworkPolicies()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumClusterwideNetworkPolicy](lc, lw, resource.WithMetric("CiliumClusterwideNetworkPolicy")), nil
+	return resource.New[*cilium_api_v2.CiliumClusterwideNetworkPolicy](params.Lifecycle, lw, resource.WithMetric("CiliumClusterwideNetworkPolicy"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
-func CiliumCIDRGroupResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumCIDRGroup], error) {
-	if !cs.IsEnabled() {
+func CiliumCIDRGroupResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumCIDRGroup], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumCIDRGroupList](cs.CiliumV2alpha1().CiliumCIDRGroups()),
+		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumCIDRGroupList](params.ClientSet.CiliumV2alpha1().CiliumCIDRGroups()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2alpha1.CiliumCIDRGroup](lc, lw, resource.WithMetric("CiliumCIDRGroup")), nil
+	return resource.New[*cilium_api_v2alpha1.CiliumCIDRGroup](params.Lifecycle, lw, resource.WithMetric("CiliumCIDRGroup"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
-func CiliumPodIPPoolResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumPodIPPool], error) {
-	if !cs.IsEnabled() {
+func CiliumPodIPPoolResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumPodIPPool], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumPodIPPoolList](cs.CiliumV2alpha1().CiliumPodIPPools()),
+		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumPodIPPoolList](params.ClientSet.CiliumV2alpha1().CiliumPodIPPools()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2alpha1.CiliumPodIPPool](lc, lw, resource.WithMetric("CiliumPodIPPool")), nil
+	return resource.New[*cilium_api_v2alpha1.CiliumPodIPPool](params.Lifecycle, lw, resource.WithMetric("CiliumPodIPPool"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
-func CiliumBGPPeeringPolicyResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumBGPPeeringPolicy], error) {
-	if !cs.IsEnabled() {
+func CiliumBGPPeeringPolicyResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumBGPPeeringPolicy], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumBGPPeeringPolicyList](cs.CiliumV2alpha1().CiliumBGPPeeringPolicies()),
+		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumBGPPeeringPolicyList](params.ClientSet.CiliumV2alpha1().CiliumBGPPeeringPolicies()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2alpha1.CiliumBGPPeeringPolicy](lc, lw, resource.WithMetric("CiliumBGPPeeringPolicies")), nil
+	return resource.New[*cilium_api_v2alpha1.CiliumBGPPeeringPolicy](params.Lifecycle, lw, resource.WithMetric("CiliumBGPPeeringPolicies"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
-func CiliumBGPNodeConfigResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumBGPNodeConfig], error) {
-	if !cs.IsEnabled() {
+func CiliumBGPNodeConfigResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumBGPNodeConfig], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumBGPNodeConfigList](cs.CiliumV2alpha1().CiliumBGPNodeConfigs()),
+		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumBGPNodeConfigList](params.ClientSet.CiliumV2alpha1().CiliumBGPNodeConfigs()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2alpha1.CiliumBGPNodeConfig](lc, lw, resource.WithMetric("CiliumBGPNodeConfig")), nil
+	return resource.New[*cilium_api_v2alpha1.CiliumBGPNodeConfig](params.Lifecycle, lw, resource.WithMetric("CiliumBGPNodeConfig"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
-func CiliumBGPAdvertisementResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumBGPAdvertisement], error) {
-	if !cs.IsEnabled() {
+func CiliumBGPAdvertisementResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumBGPAdvertisement], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumBGPAdvertisementList](cs.CiliumV2alpha1().CiliumBGPAdvertisements()),
+		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumBGPAdvertisementList](params.ClientSet.CiliumV2alpha1().CiliumBGPAdvertisements()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2alpha1.CiliumBGPAdvertisement](lc, lw, resource.WithMetric("CiliumBGPAdvertisement")), nil
+	return resource.New[*cilium_api_v2alpha1.CiliumBGPAdvertisement](params.Lifecycle, lw, resource.WithMetric("CiliumBGPAdvertisement"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
-func CiliumBGPPeerConfigResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumBGPPeerConfig], error) {
-	if !cs.IsEnabled() {
+func CiliumBGPPeerConfigResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumBGPPeerConfig], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumBGPPeerConfigList](cs.CiliumV2alpha1().CiliumBGPPeerConfigs()),
+		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumBGPPeerConfigList](params.ClientSet.CiliumV2alpha1().CiliumBGPPeerConfigs()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2alpha1.CiliumBGPPeerConfig](lc, lw, resource.WithMetric("CiliumBGPPeerConfig")), nil
+	return resource.New[*cilium_api_v2alpha1.CiliumBGPPeerConfig](params.Lifecycle, lw, resource.WithMetric("CiliumBGPPeerConfig"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
 func EndpointsResource(lc cell.Lifecycle, cfg Config, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*Endpoints], error) {
@@ -363,24 +379,25 @@ func transformEndpoint(obj any) (any, error) {
 // to initialize it before the first access.
 // To reflect this, the node.LocalNodeStore dependency is explicitly requested in the function
 // signature.
-func CiliumSlimEndpointResource(lc cell.Lifecycle, cs client.Clientset, _ *node.LocalNodeStore, opts ...func(*metav1.ListOptions)) (resource.Resource[*types.CiliumEndpoint], error) {
-	if !cs.IsEnabled() {
+func CiliumSlimEndpointResource(params CiliumResourceParams, _ *node.LocalNodeStore, opts ...func(*metav1.ListOptions)) (resource.Resource[*types.CiliumEndpoint], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumEndpointList](cs.CiliumV2().CiliumEndpoints(slim_corev1.NamespaceAll)),
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumEndpointList](params.ClientSet.CiliumV2().CiliumEndpoints(slim_corev1.NamespaceAll)),
 		opts...,
 	)
 	indexers := cache.Indexers{
 		"localNode": ciliumEndpointLocalPodIndexFunc,
 	}
-	return resource.New[*types.CiliumEndpoint](lc, lw,
+	return resource.New[*types.CiliumEndpoint](params.Lifecycle, lw,
 		resource.WithLazyTransform(func() k8sRuntime.Object {
 			return &cilium_api_v2.CiliumEndpoint{}
 		}, TransformToCiliumEndpoint),
 		resource.WithMetric("CiliumEndpoint"),
 		resource.WithIndexers(indexers),
 		resource.WithStoppableInformer(),
+		resource.WithCRDSync(params.CRDSyncPromise),
 	), nil
 }
 
@@ -408,21 +425,22 @@ func ciliumEndpointLocalPodIndexFunc(obj any) ([]string, error) {
 // to initialize it before the first access.
 // To reflect this, the node.LocalNodeStore dependency is explicitly requested in the function
 // signature.
-func CiliumEndpointSliceResource(lc cell.Lifecycle, cs client.Clientset, _ *node.LocalNodeStore, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice], error) {
-	if !cs.IsEnabled() {
+func CiliumEndpointSliceResource(params CiliumResourceParams, _ *node.LocalNodeStore, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumEndpointSliceList](cs.CiliumV2alpha1().CiliumEndpointSlices()),
+		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumEndpointSliceList](params.ClientSet.CiliumV2alpha1().CiliumEndpointSlices()),
 		opts...,
 	)
 	indexers := cache.Indexers{
 		"localNode": ciliumEndpointSliceLocalPodIndexFunc,
 	}
-	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](lc, lw,
+	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](params.Lifecycle, lw,
 		resource.WithMetric("CiliumEndpointSlice"),
 		resource.WithIndexers(indexers),
 		resource.WithStoppableInformer(),
+		resource.WithCRDSync(params.CRDSyncPromise),
 	), nil
 }
 
@@ -443,35 +461,35 @@ func ciliumEndpointSliceLocalPodIndexFunc(obj any) ([]string, error) {
 	return indices, nil
 }
 
-func CiliumExternalWorkloads(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumExternalWorkload], error) {
-	if !cs.IsEnabled() {
+func CiliumExternalWorkloads(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumExternalWorkload], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumExternalWorkloadList](cs.CiliumV2().CiliumExternalWorkloads()),
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumExternalWorkloadList](params.ClientSet.CiliumV2().CiliumExternalWorkloads()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumExternalWorkload](lc, lw, resource.WithMetric("CiliumExternalWorkloads")), nil
+	return resource.New[*cilium_api_v2.CiliumExternalWorkload](params.Lifecycle, lw, resource.WithMetric("CiliumExternalWorkloads"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
-func CiliumEnvoyConfigResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumEnvoyConfig], error) {
-	if !cs.IsEnabled() {
+func CiliumEnvoyConfigResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumEnvoyConfig], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumEnvoyConfigList](cs.CiliumV2().CiliumEnvoyConfigs("")),
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumEnvoyConfigList](params.ClientSet.CiliumV2().CiliumEnvoyConfigs("")),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumEnvoyConfig](lc, lw, resource.WithMetric("CiliumEnvoyConfig")), nil
+	return resource.New[*cilium_api_v2.CiliumEnvoyConfig](params.Lifecycle, lw, resource.WithMetric("CiliumEnvoyConfig"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
-func CiliumClusterwideEnvoyConfigResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumClusterwideEnvoyConfig], error) {
-	if !cs.IsEnabled() {
+func CiliumClusterwideEnvoyConfigResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumClusterwideEnvoyConfig], error) {
+	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
 	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumClusterwideEnvoyConfigList](cs.CiliumV2().CiliumClusterwideEnvoyConfigs()),
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumClusterwideEnvoyConfigList](params.ClientSet.CiliumV2().CiliumClusterwideEnvoyConfigs()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumClusterwideEnvoyConfig](lc, lw, resource.WithMetric("CiliumClusterwideEnvoyConfig")), nil
+	return resource.New[*cilium_api_v2.CiliumClusterwideEnvoyConfig](params.Lifecycle, lw, resource.WithMetric("CiliumClusterwideEnvoyConfig"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }

--- a/pkg/k8s/synced/cache_status.go
+++ b/pkg/k8s/synced/cache_status.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package k8s
+package synced
 
 // CacheStatus allows waiting for k8s caches to synchronize.
 type CacheStatus chan struct{}

--- a/pkg/k8s/synced/cell.go
+++ b/pkg/k8s/synced/cell.go
@@ -15,6 +15,12 @@ import (
 	"github.com/cilium/cilium/pkg/promise"
 )
 
+type syncedParams struct {
+	cell.In
+
+	CacheStatus CacheStatus
+}
+
 var Cell = cell.Module(
 	"k8s-synced",
 	"Provides types for internal K8s resource synchronization",
@@ -23,8 +29,14 @@ var Cell = cell.Module(
 		return new(APIGroups)
 	}),
 
-	cell.Provide(func() *Resources {
-		return new(Resources)
+	cell.Provide(func(params syncedParams) *Resources {
+		return &Resources{
+			CacheStatus: params.CacheStatus,
+		}
+	}),
+
+	cell.Provide(func() CacheStatus {
+		return make(CacheStatus)
 	}),
 )
 

--- a/pkg/k8s/synced/cell.go
+++ b/pkg/k8s/synced/cell.go
@@ -4,7 +4,15 @@
 package synced
 
 import (
+	"context"
+	"errors"
+
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/promise"
 )
 
 var Cell = cell.Module(
@@ -19,3 +27,60 @@ var Cell = cell.Module(
 		return new(Resources)
 	}),
 )
+
+var CRDSyncCell = cell.Module(
+	"k8s-synced-crdsync",
+	"Provides promise for waiting for CRD to have been synchronized",
+
+	cell.Provide(newCRDSyncPromise),
+)
+
+// CRDSync is an empty type used for promise.Promise. If SyncCRDs() fails, the error is passed via
+// promise Reject to the result of the promise Await() call.
+type CRDSync struct{}
+
+// CRDSyncResourceNames is a slice of CRD resource names CRDSync promise waits for
+type CRDSyncResourceNames []string
+
+var ErrCRDSyncDisabled = errors.New("CRDSync promise is disabled")
+
+// RejectedCRDSyncPromise can be used in hives that do not provide the CRDSync promise.
+var RejectedCRDSyncPromise = func() promise.Promise[CRDSync] {
+	crdSyncResolver, crdSyncPromise := promise.New[CRDSync]()
+	crdSyncResolver.Reject(ErrCRDSyncDisabled)
+	return crdSyncPromise
+}
+
+type syncCRDsPromiseParams struct {
+	cell.In
+
+	Lifecycle     cell.Lifecycle
+	Jobs          job.Registry
+	Health        cell.Health
+	Clientset     client.Clientset
+	Resources     *Resources
+	APIGroups     *APIGroups
+	ResourceNames CRDSyncResourceNames
+}
+
+func newCRDSyncPromise(params syncCRDsPromiseParams) promise.Promise[CRDSync] {
+	crdSyncResolver, crdSyncPromise := promise.New[CRDSync]()
+	if !params.Clientset.IsEnabled() || option.Config.DryMode {
+		crdSyncResolver.Reject(ErrCRDSyncDisabled)
+		return crdSyncPromise
+	}
+
+	g := params.Jobs.NewGroup(params.Health)
+	g.Add(job.OneShot("sync-crds", func(ctx context.Context, health cell.Health) error {
+		err := SyncCRDs(ctx, params.Clientset, params.ResourceNames, params.Resources, params.APIGroups)
+		if err != nil {
+			crdSyncResolver.Reject(err)
+		} else {
+			crdSyncResolver.Resolve(struct{}{})
+		}
+		return err
+	}))
+	params.Lifecycle.Append(g)
+
+	return crdSyncPromise
+}

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/cilium/cilium/pkg/k8s"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -206,7 +205,7 @@ func SyncCRDs(ctx context.Context, clientset client.Clientset, crdNames []string
 }
 
 func (s *crdState) add(obj interface{}) {
-	if pom := k8s.CastInformerEvent[slim_metav1.PartialObjectMetadata](obj); pom != nil {
+	if pom := informer.CastInformerEvent[slim_metav1.PartialObjectMetadata](obj); pom != nil {
 		s.Lock()
 		s.m[CRDResourceName(pom.GetName())] = true
 		s.Unlock()
@@ -214,7 +213,7 @@ func (s *crdState) add(obj interface{}) {
 }
 
 func (s *crdState) remove(obj interface{}) {
-	if pom := k8s.CastInformerEvent[slim_metav1.PartialObjectMetadata](obj); pom != nil {
+	if pom := informer.CastInformerEvent[slim_metav1.PartialObjectMetadata](obj); pom != nil {
 		s.Lock()
 		s.m[CRDResourceName(pom.GetName())] = false
 		s.Unlock()

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -179,6 +179,7 @@ func SyncCRDs(ctx context.Context, clientset client.Clientset, crdNames []string
 	log.Info("Waiting until all Cilium CRDs are available")
 
 	ticker := time.NewTicker(50 * time.Millisecond)
+	count := 0
 	for {
 		select {
 		case <-ctx.Done():
@@ -199,6 +200,11 @@ func SyncCRDs(ctx context.Context, clientset client.Clientset, crdNames []string
 				ticker.Stop()
 				log.Info("All Cilium CRDs have been found and are available")
 				return nil
+			}
+			count++
+			if count == 20 {
+				count = 0
+				log.Infof("Still waiting for Cilium Operator to register the following CRDs: %v", crds.unSynced())
 			}
 		}
 	}

--- a/pkg/k8s/synced/resources_test.go
+++ b/pkg/k8s/synced/resources_test.go
@@ -91,7 +91,7 @@ func TestWaitForCacheSyncWithTimeout(t *testing.T) {
 				t.Parallel()
 
 				assert := assert.New(t)
-				r := &Resources{}
+				r := &Resources{CacheStatus: make(CacheStatus)}
 				stop := make(chan struct{})
 				swg := lock.NewStoppableWaitGroup()
 				start := time.Now()

--- a/pkg/k8s/watchers/cilium_local_redirect_policy.go
+++ b/pkg/k8s/watchers/cilium_local_redirect_policy.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/informer"
@@ -75,7 +74,7 @@ func (k *K8sCiliumLRPWatcher) ciliumLocalRedirectPolicyInit() {
 				defer func() {
 					k.k8sEventReporter.K8sEventReceived(apiGroup, metricCLRP, resources.MetricCreate, valid, equal)
 				}()
-				if cLRP := k8s.CastInformerEvent[cilium_v2.CiliumLocalRedirectPolicy](obj); cLRP != nil {
+				if cLRP := informer.CastInformerEvent[cilium_v2.CiliumLocalRedirectPolicy](obj); cLRP != nil {
 					valid = true
 					err := k.addCiliumLocalRedirectPolicy(cLRP)
 					k.k8sEventReporter.K8sEventProcessed(metricCLRP, resources.MetricCreate, err == nil)
@@ -89,7 +88,7 @@ func (k *K8sCiliumLRPWatcher) ciliumLocalRedirectPolicyInit() {
 				defer func() {
 					k.k8sEventReporter.K8sEventReceived(apiGroup, metricCLRP, resources.MetricDelete, valid, equal)
 				}()
-				cLRP := k8s.CastInformerEvent[cilium_v2.CiliumLocalRedirectPolicy](obj)
+				cLRP := informer.CastInformerEvent[cilium_v2.CiliumLocalRedirectPolicy](obj)
 				if cLRP == nil {
 					return
 				}

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -166,7 +166,7 @@ func (k *K8sPodWatcher) createAllPodsController(slimClient slimclientset.Interfa
 		0,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				if pod := k8s.CastInformerEvent[slim_corev1.Pod](obj); pod != nil {
+				if pod := informer.CastInformerEvent[slim_corev1.Pod](obj); pod != nil {
 					err := k.addK8sPodV1(pod)
 					k.k8sEventReporter.K8sEventProcessed(metricPod, resources.MetricCreate, err == nil)
 					k.k8sEventReporter.K8sEventReceived(podApiGroup, metricPod, resources.MetricCreate, true, false)
@@ -175,8 +175,8 @@ func (k *K8sPodWatcher) createAllPodsController(slimClient slimclientset.Interfa
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				if oldPod := k8s.CastInformerEvent[slim_corev1.Pod](oldObj); oldPod != nil {
-					if newPod := k8s.CastInformerEvent[slim_corev1.Pod](newObj); newPod != nil {
+				if oldPod := informer.CastInformerEvent[slim_corev1.Pod](oldObj); oldPod != nil {
+					if newPod := informer.CastInformerEvent[slim_corev1.Pod](newObj); newPod != nil {
 						if oldPod.DeepEqual(newPod) {
 							k.k8sEventReporter.K8sEventReceived(podApiGroup, metricPod, resources.MetricUpdate, false, true)
 						} else {
@@ -190,7 +190,7 @@ func (k *K8sPodWatcher) createAllPodsController(slimClient slimclientset.Interfa
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
-				if pod := k8s.CastInformerEvent[slim_corev1.Pod](obj); pod != nil {
+				if pod := informer.CastInformerEvent[slim_corev1.Pod](obj); pod != nil {
 					err := k.deleteK8sPodV1(pod)
 					k.k8sEventReporter.K8sEventProcessed(metricPod, resources.MetricDelete, err == nil)
 					k.k8sEventReporter.K8sEventReceived(podApiGroup, metricPod, resources.MetricDelete, true, false)

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -43,6 +43,8 @@ const (
 	k8sAPIGroupCiliumEndpointV2                 = "cilium/v2::CiliumEndpoint"
 	k8sAPIGroupCiliumLocalRedirectPolicyV2      = "cilium/v2::CiliumLocalRedirectPolicy"
 	k8sAPIGroupCiliumEndpointSliceV2Alpha1      = "cilium/v2alpha1::CiliumEndpointSlice"
+	k8sAPIGroupCiliumEnvoyConfigV2              = "cilium/v2::CiliumEnvoyConfig"
+	k8sAPIGroupCiliumClusterwideEnvoyConfigV2   = "cilium/v2::CiliumClusterwideEnvoyConfig"
 
 	metricCLRP = "CiliumLocalRedirectPolicy"
 	metricPod  = "Pod"
@@ -224,16 +226,16 @@ var ciliumResourceToGroupMapping = map[string]watcherInfo{
 	synced.CRDResourceName(cilium_v2.CEWName):           {skip, ""}, // Handled in clustermesh-apiserver/
 	synced.CRDResourceName(cilium_v2.CEGPName):          {skip, ""}, // Handled via Resource[T].
 	synced.CRDResourceName(v2alpha1.CESName):            {start, k8sAPIGroupCiliumEndpointSliceV2Alpha1},
-	synced.CRDResourceName(cilium_v2.CCECName):          {skip, ""}, // Handled via CiliumEnvoyConfig watcher via Resource[T]
-	synced.CRDResourceName(cilium_v2.CECName):           {skip, ""}, // Handled via CiliumEnvoyConfig watcher via Resource[T]
-	synced.CRDResourceName(v2alpha1.BGPPName):           {skip, ""}, // Handled in BGP control plane
-	synced.CRDResourceName(v2alpha1.BGPCCName):          {skip, ""}, // Handled in BGP control plane
-	synced.CRDResourceName(v2alpha1.BGPAName):           {skip, ""}, // Handled in BGP control plane
-	synced.CRDResourceName(v2alpha1.BGPPCName):          {skip, ""}, // Handled in BGP control plane
-	synced.CRDResourceName(v2alpha1.BGPNCName):          {skip, ""}, // Handled in BGP control plane
-	synced.CRDResourceName(v2alpha1.BGPNCOName):         {skip, ""}, // Handled in BGP control plane
-	synced.CRDResourceName(v2alpha1.LBIPPoolName):       {skip, ""}, // Handled in LB IPAM
-	synced.CRDResourceName(v2alpha1.CNCName):            {skip, ""}, // Handled by init directly
+	synced.CRDResourceName(cilium_v2.CCECName):          {waitOnly, k8sAPIGroupCiliumClusterwideEnvoyConfigV2}, // Handled in pkg/ciliumenvoyconfig/
+	synced.CRDResourceName(cilium_v2.CECName):           {waitOnly, k8sAPIGroupCiliumEnvoyConfigV2},            // Handled in pkg/ciliumenvoyconfig/
+	synced.CRDResourceName(v2alpha1.BGPPName):           {skip, ""},                                            // Handled in BGP control plane
+	synced.CRDResourceName(v2alpha1.BGPCCName):          {skip, ""},                                            // Handled in BGP control plane
+	synced.CRDResourceName(v2alpha1.BGPAName):           {skip, ""},                                            // Handled in BGP control plane
+	synced.CRDResourceName(v2alpha1.BGPPCName):          {skip, ""},                                            // Handled in BGP control plane
+	synced.CRDResourceName(v2alpha1.BGPNCName):          {skip, ""},                                            // Handled in BGP control plane
+	synced.CRDResourceName(v2alpha1.BGPNCOName):         {skip, ""},                                            // Handled in BGP control plane
+	synced.CRDResourceName(v2alpha1.LBIPPoolName):       {skip, ""},                                            // Handled in LB IPAM
+	synced.CRDResourceName(v2alpha1.CNCName):            {skip, ""},                                            // Handled by init directly
 	synced.CRDResourceName(v2alpha1.CCGName):            {waitOnly, k8sAPIGroupCiliumCIDRGroupV2Alpha1},
 	synced.CRDResourceName(v2alpha1.L2AnnouncementName): {skip, ""}, // Handled by L2 announcement directly
 	synced.CRDResourceName(v2alpha1.CPIPName):           {skip, ""}, // Handled by multi-pool IPAM allocator

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -35,7 +35,7 @@ func Test_No_Resources_InitK8sSubsystem(t *testing.T) {
 		nil,
 		nil,
 		nil,
-		&synced.Resources{},
+		&synced.Resources{CacheStatus: make(synced.CacheStatus)},
 		nil,
 		&fakeK8sWatcherConfiguration{},
 	)

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -74,6 +75,7 @@ func newFixture(t testing.TB) *fixture {
 		Lifecycle: &cell.DefaultLifecycle{},
 		Health:    h,
 		DaemonConfig: &option.DaemonConfig{
+			ConfigPatchMutex:         new(lock.RWMutex),
 			K8sNamespace:             "kube_system",
 			EnableL2Announcements:    true,
 			L2AnnouncerLeaseDuration: 15 * time.Second,
@@ -1183,6 +1185,7 @@ func TestL2AnnouncerLifecycle(t *testing.T) {
 		cell.Invoke(statedb.RegisterTable[*tables.Device]),
 		cell.Provide(func() *option.DaemonConfig {
 			return &option.DaemonConfig{
+				ConfigPatchMutex:      new(lock.RWMutex),
 				EnableL2Announcements: true,
 			}
 		}),

--- a/pkg/maps/nat/cell.go
+++ b/pkg/maps/nat/cell.go
@@ -49,11 +49,15 @@ var Cell = cell.Module(
 				ipv4Nat, ipv6Nat = GlobalMaps(cfg.EnableIPv4,
 					cfg.EnableIPv6, true)
 
-				// Maps are still created in daemon.initMaps(...) under the same circumstances
+				// Maps are still created before DaemonConfig promise is resolved in
+				// daemon.initMaps(...) under the same circumstances
 				// so we just open them here so they can be provided to hive.
 				//
 				// TODO: Refactor ctmap gc Enable() such that it can use the map descriptors from
 				// here so we can move all nat map creation logic into here.
+				// NOTE: This code runs concurrently with startDaemon(), so if any dependency to
+				// daemon having finished endpoint restore, for example, is added, we should
+				// await for an appropriate promise.
 				if cfg.EnableIPv4 {
 					if err := ipv4Nat.Open(); err != nil {
 						return fmt.Errorf("open IPv4 nat map: %w", err)

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -26,7 +27,7 @@ func TestGaugeWithThreshold(t *testing.T) {
 	)
 
 	reg := NewRegistry(RegistryParams{
-		DaemonConfig: &option.DaemonConfig{},
+		DaemonConfig: &option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)},
 	})
 
 	metrics, err := reg.inner.Gather()

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -238,7 +239,7 @@ func TestNodeLifecycle(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 
@@ -313,7 +314,7 @@ func TestMultipleSources(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -396,7 +397,7 @@ func BenchmarkUpdateAndDeleteCycle(b *testing.B) {
 	ipcacheMock := newIPcacheMock()
 	dp := fakeTypes.NewNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	require.NoError(b, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -420,7 +421,7 @@ func TestClusterSizeDependantInterval(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	dp := fakeTypes.NewNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -445,7 +446,7 @@ func TestBackgroundSync(t *testing.T) {
 	signalNodeHandler.EnableNodeValidateImplementationEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	mngr.Subscribe(signalNodeHandler)
 	require.NoError(t, err)
 	defer mngr.Stop(context.TODO())
@@ -494,7 +495,7 @@ func TestIpcache(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -571,7 +572,7 @@ func TestIpcacheHealthIP(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -650,7 +651,11 @@ func TestNodeEncryption(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{EncryptNode: true, EnableIPSec: true}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{
+		ConfigPatchMutex: new(lock.RWMutex),
+		EncryptNode:      true,
+		EnableIPSec:      true,
+	}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -743,7 +748,7 @@ func TestNode(t *testing.T) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -893,7 +898,7 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 		<-done
 	}
 	ipcacheMock := newIPcacheMock()
-	config := &option.DaemonConfig{}
+	config := &option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}
 	err := hive.New(
 		cell.Provide(func() testParams {
 			return testParams{
@@ -944,7 +949,10 @@ func TestNodeWithSameInternalIP(t *testing.T) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{LocalRouterIPv4: "169.254.4.6"}, ipcache, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{
+		ConfigPatchMutex: new(lock.RWMutex),
+		LocalRouterIPv4:  "169.254.4.6",
+	}, ipcache, newIPSetMock(), nil, NewNodeMetrics(), h)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -1042,6 +1050,7 @@ func TestNodeIpset(t *testing.T) {
 	filter := func(no *nodeTypes.Node) bool { return no.Name != "node1" }
 	h, _ := cell.NewSimpleHealth()
 	mngr, err := New(&option.DaemonConfig{
+		ConfigPatchMutex:     new(lock.RWMutex),
 		RoutingMode:          option.RoutingModeNative,
 		EnableIPv4Masquerade: true,
 	}, newIPcacheMock(), newIPSetMock(), filter, NewNodeMetrics(), h)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -5,6 +5,8 @@ package option
 
 import (
 	"bytes"
+	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,7 +21,11 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/mackerelio/go-osstat/memory"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cast"
@@ -1380,6 +1386,10 @@ func LogRegisteredOptions(vp *viper.Viper, entry *logrus.Entry) {
 
 // DaemonConfig is the configuration used by Daemon.
 type DaemonConfig struct {
+	// Private sum of the config written to file. Used to check that the config is not changed
+	// after.
+	shaSum [32]byte
+
 	CreationTime        time.Time
 	BpfDir              string   // BPF template files directory
 	LibDir              string   // Cilium library files directory
@@ -3960,16 +3970,17 @@ func (c *DaemonConfig) KubeProxyReplacementFullyEnabled() bool {
 		c.EnableSessionAffinity
 }
 
+var backupFileNames []string = []string{
+	"agent-runtime-config.json",
+	"agent-runtime-config-1.json",
+	"agent-runtime-config-2.json",
+}
+
 // StoreInFile stores the configuration in a the given directory under the file
 // name 'daemon-config.json'. If this file already exists, it is renamed to
 // 'daemon-config-1.json', if 'daemon-config-1.json' also exists,
 // 'daemon-config-1.json' is renamed to 'daemon-config-2.json'
 func (c *DaemonConfig) StoreInFile(dir string) error {
-	backupFileNames := []string{
-		"agent-runtime-config.json",
-		"agent-runtime-config-1.json",
-		"agent-runtime-config-2.json",
-	}
 	backupFiles(dir, backupFileNames)
 	f, err := os.Create(backupFileNames[0])
 	if err != nil {
@@ -3978,7 +3989,85 @@ func (c *DaemonConfig) StoreInFile(dir string) error {
 	defer f.Close()
 	e := json.NewEncoder(f)
 	e.SetIndent("", " ")
-	return e.Encode(c)
+
+	// Exclude concurrent modification of fields protected by c.ConfigPatchMutex
+	// we store the file
+	c.ConfigPatchMutex.RLock()
+	err = e.Encode(c)
+	c.shaSum = c.checksum()
+	c.ConfigPatchMutex.RUnlock()
+
+	return err
+}
+
+func (c *DaemonConfig) checksum() [32]byte {
+	// take a shallow copy for summing
+	sumConfig := *c
+	// Ignore variable parts
+	sumConfig.Opts = nil
+	cBytes, err := json.Marshal(&sumConfig)
+	if err != nil {
+		return [32]byte{}
+	}
+	return sha256.Sum256(cBytes)
+}
+
+// ValidateUnchanged takes a context that is unused so that it can be used as a doFunc in a
+// controller
+func (c *DaemonConfig) ValidateUnchanged(context.Context) error {
+	// Exclude concurrent modification of fields protected by c.ConfigPatchMutex
+	// we store the file
+	c.ConfigPatchMutex.RLock()
+	sum := c.checksum()
+	c.ConfigPatchMutex.RUnlock()
+
+	if sum != c.shaSum {
+		return c.diffFromFile()
+	}
+	return nil
+}
+
+func (c *DaemonConfig) diffFromFile() error {
+	f, err := os.Open(backupFileNames[0])
+	if err != nil {
+		return err
+	}
+
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	fileBytes := make([]byte, fi.Size())
+	count, err := f.Read(fileBytes)
+	if err != nil {
+		return err
+	}
+	fileBytes = fileBytes[:count]
+
+	var config DaemonConfig
+	err = json.Unmarshal(fileBytes, &config)
+
+	var diff string
+	if err != nil {
+		diff = fmt.Errorf("unmarshal failed %q: %w", string(fileBytes), err).Error()
+	} else {
+		// Ignore all unexported fields during Diff.
+		// from https://github.com/google/go-cmp/issues/313#issuecomment-1315651560
+		opts := cmp.FilterPath(func(p cmp.Path) bool {
+			sf, ok := p.Index(-1).(cmp.StructField)
+			if !ok {
+				return false
+			}
+			r, _ := utf8.DecodeRuneInString(sf.Name())
+			return !unicode.IsUpper(r)
+		}, cmp.Ignore())
+
+		diff = cmp.Diff(&config, c, opts,
+			cmpopts.IgnoreTypes(&IntOptions{}),
+			cmpopts.IgnoreTypes(&OptionLibrary{}))
+	}
+	return fmt.Errorf("Config differs:\n%s", diff)
 }
 
 func (c *DaemonConfig) BGPControlPlaneEnabled() bool {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1421,7 +1421,7 @@ type DaemonConfig struct {
 	Opts *IntOptions
 
 	// Mutex for serializing configuration updates to the daemon.
-	ConfigPatchMutex lock.RWMutex
+	ConfigPatchMutex *lock.RWMutex
 
 	// Monitor contains the configuration for the node monitor.
 	Monitor *models.MonitorStatus
@@ -2403,6 +2403,7 @@ var (
 	Config = &DaemonConfig{
 		CreationTime:                    time.Now(),
 		Opts:                            NewIntOptions(&DaemonOptionLibrary),
+		ConfigPatchMutex:                new(lock.RWMutex),
 		Monitor:                         &models.MonitorStatus{Cpus: int64(runtime.NumCPU()), Npages: 64, Pagesize: int64(os.Getpagesize()), Lost: 0, Unknown: 0},
 		IPv6ClusterAllocCIDR:            defaults.IPv6ClusterAllocCIDR,
 		IPv6ClusterAllocCIDRBase:        defaults.IPv6ClusterAllocCIDRBase,

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -21,28 +21,46 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/lock"
 )
 
 func TestValidateIPv6ClusterAllocCIDR(t *testing.T) {
-	valid1 := &DaemonConfig{IPv6ClusterAllocCIDR: "fdfd::/64"}
+	valid1 := &DaemonConfig{
+		ConfigPatchMutex:     new(lock.RWMutex),
+		IPv6ClusterAllocCIDR: "fdfd::/64",
+	}
 
 	require.Nil(t, valid1.validateIPv6ClusterAllocCIDR())
 	require.Equal(t, "fdfd::", valid1.IPv6ClusterAllocCIDRBase)
 
-	valid2 := &DaemonConfig{IPv6ClusterAllocCIDR: "fdfd:fdfd:fdfd:fdfd:aaaa::/64"}
+	valid2 := &DaemonConfig{
+		ConfigPatchMutex:     new(lock.RWMutex),
+		IPv6ClusterAllocCIDR: "fdfd:fdfd:fdfd:fdfd:aaaa::/64",
+	}
 	require.Nil(t, valid2.validateIPv6ClusterAllocCIDR())
 	require.Equal(t, "fdfd:fdfd:fdfd:fdfd::", valid2.IPv6ClusterAllocCIDRBase)
 
-	invalid1 := &DaemonConfig{IPv6ClusterAllocCIDR: "foo"}
+	invalid1 := &DaemonConfig{
+		ConfigPatchMutex:     new(lock.RWMutex),
+		IPv6ClusterAllocCIDR: "foo",
+	}
 	require.NotNil(t, invalid1.validateIPv6ClusterAllocCIDR())
 
-	invalid2 := &DaemonConfig{IPv6ClusterAllocCIDR: "fdfd"}
+	invalid2 := &DaemonConfig{
+		ConfigPatchMutex:     new(lock.RWMutex),
+		IPv6ClusterAllocCIDR: "fdfd",
+	}
 	require.NotNil(t, invalid2.validateIPv6ClusterAllocCIDR())
 
-	invalid3 := &DaemonConfig{IPv6ClusterAllocCIDR: "fdfd::/32"}
+	invalid3 := &DaemonConfig{
+		ConfigPatchMutex:     new(lock.RWMutex),
+		IPv6ClusterAllocCIDR: "fdfd::/32",
+	}
 	require.NotNil(t, invalid3.validateIPv6ClusterAllocCIDR())
 
-	invalid4 := &DaemonConfig{}
+	invalid4 := &DaemonConfig{
+		ConfigPatchMutex: new(lock.RWMutex),
+	}
 	require.NotNil(t, invalid4.validateIPv6ClusterAllocCIDR())
 }
 
@@ -206,30 +224,44 @@ func TestBindEnv(t *testing.T) {
 }
 
 func TestEnabledFunctions(t *testing.T) {
-	d := &DaemonConfig{}
+	d := &DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}
 	assert.False(t, d.IPv4Enabled())
 	assert.False(t, d.IPv6Enabled())
 	assert.False(t, d.SCTPEnabled())
-	d = &DaemonConfig{EnableIPv4: true}
+	d = &DaemonConfig{
+		ConfigPatchMutex: new(lock.RWMutex),
+		EnableIPv4:       true,
+	}
 	assert.True(t, d.IPv4Enabled())
 	assert.False(t, d.IPv6Enabled())
 	assert.False(t, d.SCTPEnabled())
-	d = &DaemonConfig{EnableIPv6: true}
+	d = &DaemonConfig{
+		ConfigPatchMutex: new(lock.RWMutex),
+		EnableIPv6:       true,
+	}
 	assert.False(t, d.IPv4Enabled())
 	assert.True(t, d.IPv6Enabled())
 	assert.False(t, d.SCTPEnabled())
-	d = &DaemonConfig{EnableSCTP: true}
+	d = &DaemonConfig{
+		ConfigPatchMutex: new(lock.RWMutex),
+		EnableSCTP:       true,
+	}
 	assert.False(t, d.IPv4Enabled())
 	assert.False(t, d.IPv6Enabled())
 	assert.True(t, d.SCTPEnabled())
-	d = &DaemonConfig{}
+	d = &DaemonConfig{
+		ConfigPatchMutex: new(lock.RWMutex),
+	}
 	require.Empty(t, d.IPAMMode())
-	d = &DaemonConfig{IPAM: ipamOption.IPAMENI}
+	d = &DaemonConfig{
+		ConfigPatchMutex: new(lock.RWMutex),
+		IPAM:             ipamOption.IPAMENI,
+	}
 	require.Equal(t, ipamOption.IPAMENI, d.IPAMMode())
 }
 
 func TestLocalAddressExclusion(t *testing.T) {
-	d := &DaemonConfig{}
+	d := &DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}
 	err := d.parseExcludedLocalAddresses([]string{"1.1.1.1/32", "3.3.3.0/24", "f00d::1/128"})
 	require.NoError(t, err)
 
@@ -261,6 +293,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "default map sizes",
 			d: &DaemonConfig{
+				ConfigPatchMutex:      new(lock.RWMutex),
 				AuthMapEntries:        AuthMapEntriesDefault,
 				CTMapEntriesGlobalTCP: CTMapEntriesGlobalTCPDefault,
 				CTMapEntriesGlobalAny: CTMapEntriesGlobalAnyDefault,
@@ -287,6 +320,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "arbitrary map sizes within range",
 			d: &DaemonConfig{
+				ConfigPatchMutex:      new(lock.RWMutex),
 				AuthMapEntries:        20000,
 				CTMapEntriesGlobalTCP: 20000,
 				CTMapEntriesGlobalAny: 18000,
@@ -311,7 +345,8 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "Auth map size below range",
 			d: &DaemonConfig{
-				AuthMapEntries: AuthMapEntriesMin - 1,
+				ConfigPatchMutex: new(lock.RWMutex),
+				AuthMapEntries:   AuthMapEntriesMin - 1,
 			},
 			want: sizes{
 				AuthMapEntries: AuthMapEntriesMin - 1,
@@ -321,7 +356,8 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "Auth map size above range",
 			d: &DaemonConfig{
-				AuthMapEntries: AuthMapEntriesMax + 1,
+				ConfigPatchMutex: new(lock.RWMutex),
+				AuthMapEntries:   AuthMapEntriesMax + 1,
 			},
 			want: sizes{
 				AuthMapEntries: AuthMapEntriesMax + 1,
@@ -331,6 +367,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "CT TCP map size below range",
 			d: &DaemonConfig{
+				ConfigPatchMutex:      new(lock.RWMutex),
 				CTMapEntriesGlobalTCP: LimitTableMin - 1,
 			},
 			want: sizes{
@@ -341,6 +378,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "CT TCP map size above range",
 			d: &DaemonConfig{
+				ConfigPatchMutex:      new(lock.RWMutex),
 				CTMapEntriesGlobalTCP: LimitTableMax + 1,
 			},
 			want: sizes{
@@ -351,6 +389,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "CT Any map size below range",
 			d: &DaemonConfig{
+				ConfigPatchMutex:      new(lock.RWMutex),
 				CTMapEntriesGlobalAny: LimitTableMin - 1,
 			},
 			want: sizes{
@@ -361,6 +400,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "CT Any map size above range",
 			d: &DaemonConfig{
+				ConfigPatchMutex:      new(lock.RWMutex),
 				CTMapEntriesGlobalAny: LimitTableMax + 1,
 			},
 			want: sizes{
@@ -371,6 +411,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "NAT map size below range",
 			d: &DaemonConfig{
+				ConfigPatchMutex:    new(lock.RWMutex),
 				NATMapEntriesGlobal: LimitTableMin - 1,
 			},
 			want: sizes{
@@ -381,6 +422,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "NAT map size above range",
 			d: &DaemonConfig{
+				ConfigPatchMutex:    new(lock.RWMutex),
 				NATMapEntriesGlobal: LimitTableMax + 1,
 			},
 			want: sizes{
@@ -391,6 +433,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "NAT map auto sizing with default size",
 			d: &DaemonConfig{
+				ConfigPatchMutex:      new(lock.RWMutex),
 				AuthMapEntries:        AuthMapEntriesDefault,
 				CTMapEntriesGlobalTCP: 2048,
 				CTMapEntriesGlobalAny: 4096,
@@ -415,6 +458,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "NAT map auto sizing outside of range",
 			d: &DaemonConfig{
+				ConfigPatchMutex:      new(lock.RWMutex),
 				CTMapEntriesGlobalTCP: 2048,
 				CTMapEntriesGlobalAny: 4096,
 				NATMapEntriesGlobal:   8192,
@@ -429,6 +473,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "Policy map size below range",
 			d: &DaemonConfig{
+				ConfigPatchMutex: new(lock.RWMutex),
 				PolicyMapEntries: PolicyMapMin - 1,
 			},
 			want: sizes{
@@ -439,6 +484,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "Policy map size above range",
 			d: &DaemonConfig{
+				ConfigPatchMutex: new(lock.RWMutex),
 				PolicyMapEntries: PolicyMapMax + 1,
 			},
 			want: sizes{
@@ -449,6 +495,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "Fragments map size below range",
 			d: &DaemonConfig{
+				ConfigPatchMutex:    new(lock.RWMutex),
 				FragmentsMapEntries: FragmentsMapMin - 1,
 			},
 			want: sizes{
@@ -459,6 +506,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "Fragments map size above range",
 			d: &DaemonConfig{
+				ConfigPatchMutex:    new(lock.RWMutex),
 				FragmentsMapEntries: FragmentsMapMax + 1,
 			},
 			want: sizes{
@@ -504,6 +552,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 		{
 			name: "with native routing cidr",
 			d: &DaemonConfig{
+				ConfigPatchMutex:      new(lock.RWMutex),
 				EnableIPv4Masquerade:  true,
 				EnableIPv6Masquerade:  true,
 				RoutingMode:           RoutingModeNative,
@@ -516,6 +565,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 		{
 			name: "without native routing cidr and no masquerade",
 			d: &DaemonConfig{
+				ConfigPatchMutex:     new(lock.RWMutex),
 				EnableIPv4Masquerade: false,
 				EnableIPv6Masquerade: false,
 				RoutingMode:          RoutingModeNative,
@@ -527,6 +577,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 		{
 			name: "without native routing cidr and tunnel enabled",
 			d: &DaemonConfig{
+				ConfigPatchMutex:     new(lock.RWMutex),
 				EnableIPv4Masquerade: true,
 				EnableIPv6Masquerade: true,
 				RoutingMode:          RoutingModeTunnel,
@@ -538,6 +589,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 		{
 			name: "without native routing cidr and tunnel disabled",
 			d: &DaemonConfig{
+				ConfigPatchMutex:     new(lock.RWMutex),
 				EnableIPv4Masquerade: true,
 				EnableIPv6Masquerade: true,
 				RoutingMode:          RoutingModeNative,
@@ -549,6 +601,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 		{
 			name: "without native routing cidr and with masquerade and tunnel disabled and ipam not eni",
 			d: &DaemonConfig{
+				ConfigPatchMutex:     new(lock.RWMutex),
 				EnableIPv4Masquerade: true,
 				EnableIPv6Masquerade: true,
 				RoutingMode:          RoutingModeNative,
@@ -560,6 +613,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 		{
 			name: "without native routing cidr and tunnel disabled, but ipmasq-agent",
 			d: &DaemonConfig{
+				ConfigPatchMutex:     new(lock.RWMutex),
 				EnableIPv4Masquerade: true,
 				EnableIPv6Masquerade: true,
 				RoutingMode:          RoutingModeNative,
@@ -593,6 +647,7 @@ func TestCheckIPv6NativeRoutingCIDR(t *testing.T) {
 		{
 			name: "with native routing cidr",
 			d: &DaemonConfig{
+				ConfigPatchMutex:      new(lock.RWMutex),
 				EnableIPv4Masquerade:  true,
 				EnableIPv6Masquerade:  true,
 				RoutingMode:           RoutingModeNative,
@@ -604,6 +659,7 @@ func TestCheckIPv6NativeRoutingCIDR(t *testing.T) {
 		{
 			name: "without native routing cidr and no masquerade",
 			d: &DaemonConfig{
+				ConfigPatchMutex:     new(lock.RWMutex),
 				EnableIPv4Masquerade: false,
 				EnableIPv6Masquerade: false,
 				RoutingMode:          RoutingModeNative,
@@ -614,6 +670,7 @@ func TestCheckIPv6NativeRoutingCIDR(t *testing.T) {
 		{
 			name: "without native routing cidr and tunnel enabled",
 			d: &DaemonConfig{
+				ConfigPatchMutex:     new(lock.RWMutex),
 				EnableIPv4Masquerade: true,
 				EnableIPv6Masquerade: true,
 				RoutingMode:          RoutingModeTunnel,
@@ -624,6 +681,7 @@ func TestCheckIPv6NativeRoutingCIDR(t *testing.T) {
 		{
 			name: "without native routing cidr and tunnel disabled",
 			d: &DaemonConfig{
+				ConfigPatchMutex:     new(lock.RWMutex),
 				EnableIPv4Masquerade: true,
 				EnableIPv6Masquerade: true,
 				RoutingMode:          RoutingModeNative,
@@ -634,6 +692,7 @@ func TestCheckIPv6NativeRoutingCIDR(t *testing.T) {
 		{
 			name: "without native routing cidr and tunnel disabled, but ipmasq-agent",
 			d: &DaemonConfig{
+				ConfigPatchMutex:     new(lock.RWMutex),
 				EnableIPv4Masquerade: true,
 				EnableIPv6Masquerade: true,
 				RoutingMode:          RoutingModeNative,
@@ -666,24 +725,27 @@ func TestCheckIPAMDelegatedPlugin(t *testing.T) {
 		{
 			name: "IPAMDelegatedPlugin with local router IPv4 set and endpoint health checking disabled",
 			d: &DaemonConfig{
-				IPAM:            ipamOption.IPAMDelegatedPlugin,
-				EnableIPv4:      true,
-				LocalRouterIPv4: "169.254.0.0",
+				ConfigPatchMutex: new(lock.RWMutex),
+				IPAM:             ipamOption.IPAMDelegatedPlugin,
+				EnableIPv4:       true,
+				LocalRouterIPv4:  "169.254.0.0",
 			},
 			expectErr: nil,
 		},
 		{
 			name: "IPAMDelegatedPlugin with local router IPv6 set and endpoint health checking disabled",
 			d: &DaemonConfig{
-				IPAM:            ipamOption.IPAMDelegatedPlugin,
-				EnableIPv6:      true,
-				LocalRouterIPv6: "fe80::1",
+				ConfigPatchMutex: new(lock.RWMutex),
+				IPAM:             ipamOption.IPAMDelegatedPlugin,
+				EnableIPv6:       true,
+				LocalRouterIPv6:  "fe80::1",
 			},
 			expectErr: nil,
 		},
 		{
 			name: "IPAMDelegatedPlugin with health checking enabled",
 			d: &DaemonConfig{
+				ConfigPatchMutex:             new(lock.RWMutex),
 				IPAM:                         ipamOption.IPAMDelegatedPlugin,
 				EnableHealthChecking:         true,
 				EnableEndpointHealthChecking: true,
@@ -693,22 +755,25 @@ func TestCheckIPAMDelegatedPlugin(t *testing.T) {
 		{
 			name: "IPAMDelegatedPlugin without local router IPv4",
 			d: &DaemonConfig{
-				IPAM:       ipamOption.IPAMDelegatedPlugin,
-				EnableIPv4: true,
+				ConfigPatchMutex: new(lock.RWMutex),
+				IPAM:             ipamOption.IPAMDelegatedPlugin,
+				EnableIPv4:       true,
 			},
 			expectErr: fmt.Errorf("--local-router-ipv4 must be provided when IPv4 is enabled with --ipam=delegated-plugin"),
 		},
 		{
 			name: "IPAMDelegatedPlugin without local router IPv6",
 			d: &DaemonConfig{
-				IPAM:       ipamOption.IPAMDelegatedPlugin,
-				EnableIPv6: true,
+				ConfigPatchMutex: new(lock.RWMutex),
+				IPAM:             ipamOption.IPAMDelegatedPlugin,
+				EnableIPv6:       true,
 			},
 			expectErr: fmt.Errorf("--local-router-ipv6 must be provided when IPv6 is enabled with --ipam=delegated-plugin"),
 		},
 		{
 			name: "IPAMDelegatedPlugin with envoy config enabled",
 			d: &DaemonConfig{
+				ConfigPatchMutex:  new(lock.RWMutex),
 				IPAM:              ipamOption.IPAMDelegatedPlugin,
 				EnableEnvoyConfig: true,
 			},
@@ -1108,6 +1173,7 @@ func TestBPFMapSizeCalculation(t *testing.T) {
 			}
 
 			d := &DaemonConfig{
+				ConfigPatchMutex:      new(lock.RWMutex),
 				CTMapEntriesGlobalTCP: vp.GetInt(CTMapEntriesGlobalTCPName),
 				CTMapEntriesGlobalAny: vp.GetInt(CTMapEntriesGlobalAnyName),
 				NATMapEntriesGlobal:   vp.GetInt(NATMapEntriesGlobalName),

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -4,11 +4,13 @@
 package option
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -1357,4 +1359,38 @@ func TestDaemonConfig_validateContainerIPLocalReservedPorts(t *testing.T) {
 			tt.wantErr(t, c.validateContainerIPLocalReservedPorts(), "validateContainerIPLocalReservedPorts()")
 		})
 	}
+}
+
+func TestDaemonConfig_StoreInFile(t *testing.T) {
+	err := Config.StoreInFile(".")
+	assert.NoError(t, err)
+
+	err = Config.ValidateUnchanged(context.Background())
+	assert.NoError(t, err)
+
+	// minor change
+	Config.DryMode = true
+	err = Config.ValidateUnchanged(context.Background())
+	assert.Error(t, err)
+	strErr := strings.ReplaceAll(err.Error(), "\u00a0", " ")
+	assert.Equal(t, strErr, `Config differs:
+  &option.DaemonConfig{
+  	... // 1 ignored and 15 identical fields
+  	DatapathMode: "",
+  	RoutingMode:  "",
+- 	DryMode:      false,
++ 	DryMode:      true,
+  	RestoreState: false,
+  	KeepConfig:   false,
+  	... // 5 ignored and 312 identical fields
+  }
+`)
+	Config.DryMode = false
+
+	// IntOptions changes are ignored
+	assert.False(t, Config.Opts.IsEnabled("unit-test-key-only")) // make sure not used
+	Config.Opts.SetBool("unit-test-key-only", true)
+	err = Config.ValidateUnchanged(context.Background())
+	assert.NoError(t, err)
+	Config.Opts.Delete("unit-test-key-only")
 }

--- a/pkg/policy/k8s/cell.go
+++ b/pkg/policy/k8s/cell.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/promise"
 )
 
 const (
@@ -31,7 +32,7 @@ const (
 	k8sAPIGroupCiliumCIDRGroupV2Alpha1          = "cilium/v2alpha1::CiliumCIDRGroup"
 )
 
-// Cell provides the K8s policy watcher. The K8s policy watcher watches all
+// Cell starts the K8s policy watcher. The K8s policy watcher watches all
 // policy related K8s resources (Kubernetes NetworkPolicy (KNP),
 // CiliumNetworkPolicy (CNP), ClusterwideCiliumNetworkPolicy (CCNP),
 // and CiliumCIDRGroup (CCG)), translates them to Cilium's own
@@ -41,7 +42,7 @@ var Cell = cell.Module(
 	"policy-k8s-watcher",
 	"Watches K8s policy related objects",
 
-	cell.Provide(newPolicyResourcesWatcher),
+	cell.Invoke(startK8sPolicyWatcher),
 )
 
 type PolicyManager interface {
@@ -65,7 +66,8 @@ type PolicyWatcherParams struct {
 	K8sResourceSynced *synced.Resources
 	K8sAPIGroups      *synced.APIGroups
 
-	ServiceCache *k8s.ServiceCache
+	PolicyManager promise.Promise[PolicyManager]
+	ServiceCache  *k8s.ServiceCache
 
 	CiliumNetworkPolicies            resource.Resource[*cilium_v2.CiliumNetworkPolicy]
 	CiliumClusterwideNetworkPolicies resource.Resource[*cilium_v2.CiliumClusterwideNetworkPolicy]
@@ -73,54 +75,28 @@ type PolicyWatcherParams struct {
 	NetworkPolicies                  resource.Resource[*slim_networking_v1.NetworkPolicy]
 }
 
-type PolicyResourcesWatcher struct {
-	params PolicyWatcherParams
-}
-
-func newPolicyResourcesWatcher(p PolicyWatcherParams) *PolicyResourcesWatcher {
-	if !p.ClientSet.IsEnabled() {
-		return nil // skip watcher if K8s is not enabled
+func startK8sPolicyWatcher(params PolicyWatcherParams) {
+	if !params.ClientSet.IsEnabled() {
+		return // skip watcher if K8s is not enabled
 	}
 
-	return &PolicyResourcesWatcher{
-		params: p,
-	}
-}
+	// We want to subscribe before the start hook is invoked in order to not miss
+	// any events
+	ctx, cancel := context.WithCancel(context.Background())
+	svcCacheNotifications := stream.ToChannel(ctx, params.ServiceCache.Notifications(),
+		stream.WithBufferSize(int(params.Config.K8sServiceCacheSize)))
 
-// WatchK8sPolicyResources starts watching Kubernetes policy resources.
-// Needs to be called before K8sWatcher.InitK8sSubsystem.
-func (p *PolicyResourcesWatcher) WatchK8sPolicyResources(ctx context.Context, policyManager PolicyManager) {
-	w := newPolicyWatcher(ctx, policyManager, p)
-	w.watchResources(ctx)
-}
-
-// newPolicyWatcher constructs a new policy watcher. Needs to be constructed
-// before K8sWatcher.InitK8sSubsystem is executed.
-// This constructor unfortunately cannot be started via the Hive lifecycle as
-// there exists a circular dependency between this watcher and the Daemon:
-// The constructor newDaemon cannot complete before all pre-existing
-// K8s policy resources have been added via the PolicyManager
-// (i.e. watchResources has observed the Sync event for CNP/CCNP/KNP).
-// Because the PolicyManager interface itself is implemented by the Daemon
-// struct, we have a circular dependency.
-func newPolicyWatcher(ctx context.Context, policyManager PolicyManager, p *PolicyResourcesWatcher) *policyWatcher {
-	// In order to not miss any service events, we register a subscriber here,
-	// before the call to K8sWatcher.InitK8sSubsystem.
-	svcCacheNotifications := stream.ToChannel(ctx, p.params.ServiceCache.Notifications(),
-		stream.WithBufferSize(int(p.params.Config.K8sServiceCacheSize)))
-
-	w := &policyWatcher{
-		log:                              p.params.Logger,
-		config:                           p.params.Config,
-		k8sResourceSynced:                p.params.K8sResourceSynced,
-		k8sAPIGroups:                     p.params.K8sAPIGroups,
-		svcCache:                         p.params.ServiceCache,
+	p := &policyWatcher{
+		log:                              params.Logger,
+		config:                           params.Config,
+		k8sResourceSynced:                params.K8sResourceSynced,
+		k8sAPIGroups:                     params.K8sAPIGroups,
+		svcCache:                         params.ServiceCache,
 		svcCacheNotifications:            svcCacheNotifications,
-		policyManager:                    policyManager,
-		ciliumNetworkPolicies:            p.params.CiliumNetworkPolicies,
-		ciliumClusterwideNetworkPolicies: p.params.CiliumClusterwideNetworkPolicies,
-		ciliumCIDRGroups:                 p.params.CiliumCIDRGroups,
-		networkPolicies:                  p.params.NetworkPolicies,
+		ciliumNetworkPolicies:            params.CiliumNetworkPolicies,
+		ciliumClusterwideNetworkPolicies: params.CiliumClusterwideNetworkPolicies,
+		ciliumCIDRGroups:                 params.CiliumCIDRGroups,
+		networkPolicies:                  params.NetworkPolicies,
 
 		cnpCache:          make(map[resource.Key]*types.SlimCNP),
 		cidrGroupCache:    make(map[string]*cilium_v2_alpha1.CiliumCIDRGroup),
@@ -129,5 +105,37 @@ func newPolicyWatcher(ctx context.Context, policyManager PolicyManager, p *Polic
 		toServicesPolicies: make(map[resource.Key]struct{}),
 		cnpByServiceID:     make(map[k8s.ServiceID]map[resource.Key]struct{}),
 	}
-	return w
+
+	params.Lifecycle.Append(cell.Hook{
+		OnStart: func(startCtx cell.HookContext) error {
+			policyManager, err := params.PolicyManager.Await(startCtx)
+			if err != nil {
+				return err
+			}
+			p.policyManager = policyManager
+			p.watchResources(ctx)
+			return nil
+		},
+		OnStop: func(cell.HookContext) error {
+			if cancel != nil {
+				cancel()
+			}
+			return nil
+		},
+	})
+
+	if params.Config.EnableK8sNetworkPolicy {
+		p.registerResourceWithSyncFn(ctx, k8sAPIGroupNetworkingV1Core, func() bool {
+			return p.knpSynced.Load()
+		})
+	}
+	p.registerResourceWithSyncFn(ctx, k8sAPIGroupCiliumNetworkPolicyV2, func() bool {
+		return p.cnpSynced.Load() && p.cidrGroupSynced.Load()
+	})
+	p.registerResourceWithSyncFn(ctx, k8sAPIGroupCiliumClusterwideNetworkPolicyV2, func() bool {
+		return p.ccnpSynced.Load() && p.cidrGroupSynced.Load()
+	})
+	p.registerResourceWithSyncFn(ctx, k8sAPIGroupCiliumCIDRGroupV2Alpha1, func() bool {
+		return p.cidrGroupSynced.Load()
+	})
 }

--- a/pkg/policy/k8s/service_test.go
+++ b/pkg/policy/k8s/service_test.go
@@ -252,7 +252,7 @@ func TestPolicyWatcher_updateToServicesPolicies(t *testing.T) {
 	p := &policyWatcher{
 		log:                logrus.NewEntry(logger),
 		config:             &option.DaemonConfig{},
-		k8sResourceSynced:  &k8sSynced.Resources{},
+		k8sResourceSynced:  &k8sSynced.Resources{CacheStatus: make(k8sSynced.CacheStatus)},
 		k8sAPIGroups:       &k8sSynced.APIGroups{},
 		policyManager:      policyManager,
 		svcCache:           svcCache,

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/maps/ctmap/gc"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -74,6 +75,7 @@ func (h *agentHandle) setupCiliumAgentHive(clientset k8sClient.Clientset, extraC
 			func() *option.DaemonConfig { return option.Config },
 			func() cnicell.CNIConfigManager { return &fakecni.FakeCNIConfigManager{} },
 			func() gc.Enabler { return gc.NewFake() },
+			k8sSynced.RejectedCRDSyncPromise,
 		),
 		fakeDatapath.Cell,
 		prefilter.Cell,


### PR DESCRIPTION
Just like we are currently waiting for policy CRDs before generating endpoints for the first time after restoring them during an agent restart, it is also beneficial to wait for CEC and CCEC resources as well. This is mainly due to possible policy redirections to CEC/CCEC listeners, but also for the possibility of L7 LB service annotations, as well as east/west Ingress and Gateway API, which are implemented via CEC/CCEC resources.

In order to achieve this we first break up potentially blocking parts of daemon lifecycle start hook to run in a goroutine, so that the hive may run concurrently with the daemon bootstrap. This is necessary as start hooks are executed in the order in which they are appended to the hive lifecycle, and the next start hook can only run when the previous one has returned.

startDeamon() blocks waiting for a subset of k8s resources to have been synchronized, and as we add CEC and CCEC resources to that subset, we want to be able to use the hive lifecycle to start running the resource watchers for these resources. This becomes possible by making sure daemon start hooks do not block for this purpose. Similarly, any start hook that needs to await for the daemon promise needs to perform that Await call in a goroutine. This allows the hive to run all the needed start hooks while startDaemon() is waiting for the resources to have been synchronized.

This change also allows reverting the change in k8s policy watchers introduced in https://github.com/cilium/cilium/pull/32028, as now the hive is not stalled by the daemon waiting for the k8s resources to synchronize.

During testing there were spurious error and warning logs from the vendored k8s code when Cilium resources were requested before the corresponding CRDs had been registered. This is resolved by providing a new CRDSync promise to the hive, and then awaiting for that promise before requesting any Cilium resources. This eliminates the error and warning logs seen for CiliumNode, CiliumEnvoyConfig, and CIliumClusterwideEnvoyConfig resources. The CRDSync promise is optional so that it can be ignored for other than the agent hive.