### PR TITLE
logging: Pass debug to slog as well

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -166,6 +166,9 @@ func SetupLogging(loggers []string, logOpts LogOptions, tag string, debug bool) 
 	// background goroutines that are not cleaned up.
 	initializeKLog()
 
+	if debug {
+		logOpts[LevelOpt] = "debug"
+	}
 	initializeSlog(logOpts, len(loggers) == 0)
 
 	// Updating the default log format


### PR DESCRIPTION
Pass agent debug option to slog so that we get debug logging from hive as well. This enables diagnosis of error cases where a start hook hangs and thus prevents further start hooks from running, for example.