### PR TITLE
clustermesh: drain all known entries upon cluster ID change

### DIFF
--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -121,6 +122,7 @@ func TestClusterMesh(t *testing.T) {
 		Metrics:               NewMetrics(),
 		CommonMetrics:         common.MetricsProvider(subsystem)(),
 		StoreFactory:          storeFactory,
+		Logger:                logrus.New(),
 	})
 	require.NotNil(t, cm, "Failed to initialize clustermesh")
 	// cluster2 is the cluster which is tested with sync canaries

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/statedb"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -131,6 +132,7 @@ func setup(tb testing.TB) *ClusterMeshServicesTestSuite {
 		Metrics:               NewMetrics(),
 		CommonMetrics:         common.MetricsProvider(subsystem)(),
 		StoreFactory:          store,
+		Logger:                logrus.New(),
 	})
 	require.NotNil(tb, s.mesh)
 


### PR DESCRIPTION
Recent changes (#32749, #32785) introduced improved validation to ensure that the information retrieved from remote clusters matches the advertised cluster ID, and discard it otherwise. Let's additionally fully drain all previously known entries upon cluster ID change. Indeed, although synthetic deletion events would be generated in any case upon initial listing (as the entries with the incorrect cluster ID would not pass validation), that would leave a window of time in which there would still be stale entries for a cluster ID that has already been released, potentially leading to inconsistencies if the same ID is acquired again in the meanwhile by a different cluster.