### PR TITLE
bgpv2: Allow empty advertisement

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpadvertisements.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpadvertisements.yaml
@@ -223,7 +223,6 @@ spec:
                   required:
                   - advertisementType
                   type: object
-                minItems: 1
                 type: array
             required:
             - advertisements

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.29.8"
+	CustomResourceDefinitionSchemaVersion = "1.29.9"
 )

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_advert_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_advert_types.go
@@ -91,7 +91,6 @@ type CiliumBGPAdvertisementSpec struct {
 	// Advertisements is a list of BGP advertisements.
 	//
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MinItems=1
 	Advertisements []BGPAdvertisement `json:"advertisements"`
 }
 


### PR DESCRIPTION
Remove unnecessary restriction.

```release-note
bgpv2: Allow empty advertisement
```
