### PR TITLE
renovate: prevent upgrading certgen to v0.2 in stable branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -309,15 +309,6 @@
       ]
     },
     {
-      "matchPackageNames": [
-        "gcr.io/etcd-development/etcd"
-      ],
-      "allowedVersions": "<3.16",
-      "matchBaseBranches": [
-        "v1.15"
-      ]
-    },
-    {
       "matchDepNames": [
         "golang.zx2c4.com/wireguard"
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -309,6 +309,17 @@
       ]
     },
     {
+      "matchPackageNames": [
+        "quay.io/cilium/certgen",
+      ],
+      "allowedVersions": "<0.2.0",
+      "matchBaseBranches": [
+        "v1.15",
+        "v1.14",
+        "v1.13"
+      ]
+    },
+    {
       "matchDepNames": [
         "golang.zx2c4.com/wireguard"
       ],


### PR DESCRIPTION
certgen v0.2 is going to introduce breaking changes. Hence, let's introduce a new renovate rule to prevent it from being upgraded in stable Cilium version. While being there, let's also drop an apparently unnecessary etcd-releated constaint introduced in a recent refactoring of the renovate configuration.

Related: https://github.com/cilium/certgen/pull/220