### PR TITLE
Fix #32587 concurrent hubble dynamic exporter stop and reload

### DIFF
--- a/pkg/hubble/exporter/dynamic_exporter.go
+++ b/pkg/hubble/exporter/dynamic_exporter.go
@@ -52,10 +52,10 @@ func (d *DynamicExporter) OnDecodedEvent(ctx context.Context, event *v1.Event) (
 
 // Stop stops configuration watcher  and all managed flow log exporters.
 func (d *DynamicExporter) Stop() error {
+	d.watcher.Stop()
+
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
-
-	d.watcher.Stop()
 
 	var errs error
 	for _, me := range d.managedExporters {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.

In rare cases when dynamic exporter lifecycle Stop() function is called during config reload it may cause deadlock on mutex. This change stops config watcher ticker before locking the mutex, as mutex lock is effectively needed only to terminate configured exporters, not for terminating config watcher itself.

Fixes: #32587

```release-note
Fix #32587 concurrent hubble dynamic exporter stop and reload
```
