### PR TITLE
ci: fix cluster name in CI tests

### DIFF
--- a/.github/workflows/fqdn-perf.yaml
+++ b/.github/workflows/fqdn-perf.yaml
@@ -58,9 +58,7 @@ env:
   # renovate: datasource=golang-version depName=go
   go_version: 1.22.4
   test_name: perf-fqdn
-  # Adding k8s.local to the end makes kops happy-
-  # has stricter DNS naming requirements.
-  cluster_base_name: ${{ github.run_id }}-${{ github.run_attempt }}.k8s.local
+  cluster_name: ${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
   echo-inputs:
@@ -108,6 +106,7 @@ jobs:
             --set pprof.enabled=true \
             --helm-set=prometheus.enabled=true \
             --helm-set=dnsProxy.proxyResponseMaxDelay=100s \
+            --helm-set=cluster.name=${{ env.cluster_name }} \
             --wait=false"
 
           # only add SHA to the image tags if it was set
@@ -128,7 +127,9 @@ jobs:
             --helm-set=hubble.relay.image.useDigest=false"
           fi
 
-          CLUSTER_NAME="${{ env.test_name }}-${{ env.cluster_base_name }}"
+          # Adding k8s.local to the end makes kops happy
+          # has stricter DNS naming requirements.
+          CLUSTER_NAME="${{ env.test_name }}-${{ env.cluster_name }}.k8s.local"
 
           echo SHA=${SHA} >> $GITHUB_OUTPUT
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -40,7 +40,7 @@ env:
   # Adding k8s.local to the end makes kops happy-
   # has stricter DNS naming requirements.
   test_name: scale-100
-  cluster_base_name: ${{ github.run_id }}-${{ github.run_attempt }}.k8s.local
+  cluster_name: ${{ github.run_id }}-${{ github.run_attempt }}
   # renovate: datasource=docker depName=google/cloud-sdk
   gcloud_version: 478.0.0
 
@@ -71,6 +71,7 @@ jobs:
           CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
             --set pprof.enabled=true \
             --helm-set=prometheus.enabled=true \
+            --helm-set=cluster.name=${{ env.cluster_name }} \
             --wait=false"
 
           # only add SHA to the image tags if it was set
@@ -91,7 +92,9 @@ jobs:
             --helm-set=hubble.relay.image.useDigest=false"
           fi
 
-          CLUSTER_NAME="${{ env.test_name }}-${{ env.cluster_base_name }}"
+          # Adding k8s.local to the end makes kops happy
+          # has stricter DNS naming requirements.
+          CLUSTER_NAME="${{ env.test_name }}-${{ env.cluster_name }}.k8s.local"
 
           echo SHA=${SHA} >> $GITHUB_OUTPUT
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT

--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -40,7 +40,7 @@ env:
   # Adding k8s.local to the end makes kops happy-
   # has stricter DNS naming requirements.
   test_name: node-throughput
-  cluster_base_name: ${{ github.run_id }}-${{ github.run_attempt }}.k8s.local
+  cluster_name: ${{ github.run_id }}-${{ github.run_attempt }}
   GCP_PERF_RESULTS_BUCKET: gs://cilium-scale-results
   # renovate: datasource=docker depName=google/cloud-sdk
   gcloud_version: 478.0.0
@@ -73,9 +73,12 @@ jobs:
 
           # Setup Cilium install options
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
+            --helm-set=cluster.name=${{ env.cluster_name }} \
             --wait=false"
 
-          CLUSTER_NAME="${{ env.test_name }}-${{ env.cluster_base_name }}"
+          # Adding k8s.local to the end makes kops happy
+          # has stricter DNS naming requirements.
+          CLUSTER_NAME="${{ env.test_name }}-${{ env.cluster_name }}.k8s.local"
 
           echo SHA=${SHA} >> $GITHUB_OUTPUT
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT


### PR DESCRIPTION
In these workflows, we used a specific cluster name for kops. Cilium-cli fetched the cluster name from context resulting in a validation error.
