### PR TITLE
cilium, netkit: Add CI e2e coverage

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -81,7 +81,7 @@ jobs:
       job_name: 'Setup & Test'
     strategy:
       fail-fast: false
-      max-parallel: 16
+      max-parallel: 22
       matrix:
         include:
           # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -269,6 +269,68 @@ jobs:
             host-fw: 'true'
             ciliumendpointslice: 'true'
             ingress-controller: 'true'
+
+          - name: '17'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: 'bpf-20240610.092500'
+            misc: 'bpf.datapathMode=netkit,bpf.masquerade=true,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
+            kube-proxy: 'none'
+            kpr: 'true'
+            ipv6: 'true'
+            tunnel: 'disabled'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
+
+          - name: '18'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: 'bpf-20240610.092500'
+            misc: 'bpf.datapathMode=netkit-l2,bpf.masquerade=true,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
+            kube-proxy: 'none'
+            kpr: 'true'
+            ipv6: 'true'
+            tunnel: 'disabled'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
+
+          - name: '19'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: 'bpf-20240610.092500'
+            misc: 'bpf.datapathMode=netkit,bpf.masquerade=true'
+            kube-proxy: 'none'
+            kpr: 'true'
+            tunnel: 'vxlan'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
+
+          - name: '20'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: 'bpf-20240610.092500'
+            misc: 'bpf.datapathMode=netkit-l2,bpf.masquerade=true'
+            kube-proxy: 'none'
+            kpr: 'true'
+            tunnel: 'vxlan'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
+
+          - name: '21'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: 'bpf-20240610.092500'
+            misc: 'bpf.datapathMode=netkit,bpf.masquerade=true'
+            kube-proxy: 'none'
+            kpr: 'true'
+            tunnel: 'geneve'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
+
+          - name: '22'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: 'bpf-20240610.092500'
+            misc: 'bpf.datapathMode=netkit-l2,bpf.masquerade=true'
+            kube-proxy: 'none'
+            kpr: 'true'
+            tunnel: 'geneve'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
 
     timeout-minutes: 60
     steps:

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -81,7 +81,7 @@ jobs:
       job_name: 'Setup & Test'
     strategy:
       fail-fast: false
-      max-parallel: 16
+      max-parallel: 22
       matrix:
         include:
           # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -275,6 +275,70 @@ jobs:
             encryption-node: 'false'
             host-fw: 'true'
             ciliumendpointslice: 'true'
+
+          # Disable until 1.17 has been released, so that 1.16 to 1.17 upgrade
+          # can be tested with netkit.
+          # - name: '17'
+          #  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+          #  kernel: 'bpf-20240610.092500'
+          #  misc: 'bpf.datapathMode=netkit,bpf.masquerade=true,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
+          #  kube-proxy: 'none'
+          #  kpr: 'true'
+          #  ipv6: 'true'
+          #  tunnel: 'disabled'
+          #  devices: '{eth0,eth1}'
+          #  secondary-network: 'true'
+          #
+          # - name: '18'
+          #  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+          #  kernel: 'bpf-20240610.092500'
+          #  misc: 'bpf.datapathMode=netkit-l2,bpf.masquerade=true,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
+          #  kube-proxy: 'none'
+          #  kpr: 'true'
+          #  ipv6: 'true'
+          #  tunnel: 'disabled'
+          #  devices: '{eth0,eth1}'
+          #  secondary-network: 'true'
+          #
+          # - name: '19'
+          #  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+          #  kernel: 'bpf-20240610.092500'
+          #  misc: 'bpf.datapathMode=netkit,bpf.masquerade=true'
+          #  kube-proxy: 'none'
+          #  kpr: 'true'
+          #  tunnel: 'vxlan'
+          #  devices: '{eth0,eth1}'
+          #  secondary-network: 'true'
+          #
+          # - name: '20'
+          #  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+          #  kernel: 'bpf-20240610.092500'
+          #  misc: 'bpf.datapathMode=netkit-l2,bpf.masquerade=true'
+          #  kube-proxy: 'none'
+          #  kpr: 'true'
+          #  tunnel: 'vxlan'
+          #  devices: '{eth0,eth1}'
+          #  secondary-network: 'true'
+          #
+          # - name: '21'
+          #  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+          #  kernel: 'bpf-20240610.092500'
+          #  misc: 'bpf.datapathMode=netkit,bpf.masquerade=true'
+          #  kube-proxy: 'none'
+          #  kpr: 'true'
+          #  tunnel: 'geneve'
+          #  devices: '{eth0,eth1}'
+          #  secondary-network: 'true'
+          #
+          # - name: '22'
+          #  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+          #  kernel: 'bpf-20240610.092500'
+          #  misc: 'bpf.datapathMode=netkit-l2,bpf.masquerade=true'
+          #  kube-proxy: 'none'
+          #  kpr: 'true'
+          #  tunnel: 'geneve'
+          #  devices: '{eth0,eth1}'
+          #  secondary-network: 'true'
 
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Add various netkit and netkit-l2 test coverage to CI:

 - netkit/netkit-l2 with recommended performance profile (https://docs.cilium.io/en/latest/operations/performance/tuning/)
 - netkit/netkit-l2 with vxlan/geneve

Closes: https://github.com/cilium/cilium/issues/32939

Related LVH changes:
- bpf tree support: https://github.com/cilium/little-vm-helper-images/pull/525
- build for CI: https://github.com/cilium/little-vm-helper-images/pull/527