### PR TITLE
endpoint: Place endpoints without bpf to endpoints map

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -75,10 +75,12 @@ const (
 
 	// PropertyWithouteBPFDatapath marks the endpoint that doesn't contain a
 	// eBPF datapath program.
+	// Endpoint is still placed in the endpoints map so that ARP and ND work.
 	PropertyWithouteBPFDatapath = "property-without-bpf-endpoint"
 
 	// PropertySkipBPFPolicy will mark the endpoint to skip ebpf
 	// policy regeneration.
+	// Endpoint is still placed in the endpoints map  so that ARP and ND work.
 	PropertySkipBPFPolicy = "property-skip-bpf-policy"
 
 	// PropertySkipBPFRegeneration will mark the endpoint to skip ebpf


### PR DESCRIPTION
Even endpoints without bpf programs or policy need ARP and IPv6 ND to work so that traffic can reach them. Place such endpoints in the bpf endpoints map (aka lxcmap).

This fixes missing IPv6 ND responses for the Ingress IPs.

Fixes: #32980
```release-note
IPv6 ND responses are enabled for Ingress IPs.
```
