### PR TITLE
pkg/k8s: Add required resources for Operator managing CIDs

### DIFF
--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -44,6 +44,7 @@ var (
 			CiliumEndpointSliceResource,
 			CiliumNodeResource,
 			k8s.PodResource,
+			k8s.NamespaceResource,
 			k8s.CiliumNetworkPolicyResource,
 			k8s.CiliumClusterwideNetworkPolicyResource,
 		),
@@ -63,4 +64,5 @@ type Resources struct {
 	CiliumEndpointSlices resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice]
 	CiliumNodes          resource.Resource[*cilium_api_v2.CiliumNode]
 	Pods                 resource.Resource[*slim_corev1.Pod]
+	Namespaces           resource.Resource[*slim_corev1.Namespace]
 }

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -43,7 +43,7 @@ var (
 			CiliumEndpointResource,
 			CiliumEndpointSliceResource,
 			CiliumNodeResource,
-			k8s.PodResource,
+			PodResource,
 			k8s.NamespaceResource,
 			k8s.CiliumNetworkPolicyResource,
 			k8s.CiliumClusterwideNetworkPolicyResource,


### PR DESCRIPTION
The PR contains multiple parts split by commits but related to the same feature, Operator Managing CIDs. The PR mostly adds indexes and additional resources to be watched by Operator.

- pkg/k8s: Index Pod resources by namespace 
  - The Pod resource will be used by Operator Managing CIDs to reconcile all
the pods in a namespace when the namespace labels are added or removed.

- operator/k8s: Add Namespace resource to operator resources cell
  - The Namespace resource will be used by Operator Managing CIDs to fetch
relevant labels to create CIDs.

- pkg/k8s: Add indexer for CiliumIdentity objects based on security labels 
  - Add indexer for CiliumIdentity objects based on security labels to enable efficient lookup of existing CIDs for reuse during allocation when Cilium Operator manages Cilium Identities.



Related: https://github.com/cilium/cilium/issues/27752
Draft full implementation: https://github.com/cilium/cilium/pull/33204