### PR TITLE
helm/certgen: use namespaced RBAC for hubble certs generation

### DIFF
--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/role.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/role.yaml
@@ -1,8 +1,9 @@
 {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") .Values.serviceAccounts.hubblecertgen.create .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: hubble-generate-certs
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/rolebinding.yaml
@@ -1,8 +1,9 @@
 {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") .Values.serviceAccounts.hubblecertgen.create .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: hubble-generate-certs
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -11,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: hubble-generate-certs
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
Convert the ClusterRole/ClusterRoleBinding to Role/RoleBinding to reduce the overall permissions considering that certgen only needs to access the secrets in the local namespace, based on the current configuration. This also aligns it with the equivalent permissions used for clustermesh.

<!-- Description of change -->

```release-note
Switch the RBAC used for hubble certificate generation in `cronJob` mode to namespace-scoped.
```
