### PR TITLE
CODEOWNERS: Move devcontainer to cilium/ci

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -226,7 +226,7 @@
 /CONTRIBUTING.md @cilium/contributing
 /.authors.aux @cilium/contributing
 /.clomonitor.yml @cilium/contributing
-/.devcontainer @cilium/contributing
+/.devcontainer @cilium/ci-structure
 /.gitattributes @cilium/contributing
 /.github/ @cilium/contributing
 /.github/ariane-config.yaml @cilium/github-sec @cilium/ci-structure


### PR DESCRIPTION
When updating the builder image, this file gets updated, then pulls in
@cilium/contributing as a codeowner. Move it over to cilium/ci to reduce
the number of touchpoints for builder update PRs.
