### PR TITLE
docs: Deprecate support for podnetwork etcd

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -358,6 +358,11 @@ Annotations:
 * Certain invalid CiliumNetworkPolicies that have always been ignored will now be rejected by the apiserver.
   Specifically, policies with multiple L7 protocols on the same port, over 40 port rules, or over
   40 ICMP rules will now have server-side validation.
+* Cilium could previously be run in a configuration where the Etcd instances
+  that distribute Cilium state between nodes would be managed in pod network by
+  Cilium itself. This support was complicated and error prone, so the support
+  is now deprecated. The following guide provides alternatives for running
+  Cilium with Etcd: :ref:`k8s_install_etcd`.
 
 Removed Options
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Running Etcd in podnetwork to distribute state between Cilium instances
introduces a range of challenges to bootstrapping and ensuring reliable
connectivity within the cluster. We've deprecated in-built support in
the Helm charts for this sort of configuration for several releases, and
documented suggested alternatives. If we deprecate this feature then we
can simplify some of the operations inside the cilium-agent.

For alternative installation steps, see https://docs.cilium.io/en/stable/installation/k8s-install-external-etcd/#admin-install-daemonset .

Related: https://github.com/cilium/cilium/pull/15464