### PR TITLE
doc: Listed L2LB LB class to LB IPAM doc

### DIFF
--- a/Documentation/network/lb-ipam.rst
+++ b/Documentation/network/lb-ipam.rst
@@ -388,6 +388,8 @@ for allocation (if the feature is enabled):
 loadBalancerClass               Feature
 ------------------------------- ------------------------
 ``io.cilium/bgp-control-plane`` :ref:`bgp_control_plane`
+------------------------------- ------------------------
+``io.cilium/l2-announcer``      :ref:`l2_announcements`
 =============================== ========================
 
 If the ``.spec.loadBalancerClass`` is set to a class which isn't handled by Cilium's LB IPAM, 


### PR DESCRIPTION
Added the L2LB LoadBalancerClass `io.cilium/l2-announcer` to the LB IPAM documentation page.

```release-note
doc: List L2LB LB class to LB IPAM doc
```
