### PR TITLE
BGPv1 and BGPv2 - Reject all inbound BGP advertisements

### DIFF
--- a/pkg/bgpv1/gobgp/server_test.go
+++ b/pkg/bgpv1/gobgp/server_test.go
@@ -5,6 +5,7 @@ package gobgp
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	gobgp "github.com/osrg/gobgp/v3/api"
@@ -20,6 +21,56 @@ var testServerParameters = types.ServerParameters{
 		RouterID:   "127.0.0.1",
 		ListenPort: -1,
 	},
+}
+
+// TestGlobalImportPolicy verifies the presence of a global import policy. This is configured
+// internally by Cilium at startup.
+func TestGlobalImportPolicy(t *testing.T) {
+	router, err := NewGoBGPServer(context.Background(), log, testServerParameters)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		router.Stop()
+	})
+
+	gobgpServer := router.(*GoBGPServer).server
+	request := &gobgp.ListPolicyAssignmentRequest{
+		Name:      "global",
+		Direction: gobgp.PolicyDirection_IMPORT,
+	}
+	response := []*gobgp.PolicyAssignment{}
+
+	// For this test, we must call the underlying GoBGP server directly.
+	// router.GetRoutePolicies() returns only the sub-policy for local routes.
+	err = gobgpServer.ListPolicyAssignment(context.Background(), request, func(policyAssignment *gobgp.PolicyAssignment) {
+		response = append(response, policyAssignment)
+	})
+	require.NoError(t, err)
+
+	// check that retrieved policy matches the expected
+	require.Len(t, response, 1)
+
+	if response[0].Name != globalPolicyAssignmentName {
+		t.Errorf("expected %s but got %s", globalPolicyAssignmentName, response[0].Name)
+	}
+
+	expected := []*gobgp.Policy{
+		{
+			Name: globalAllowLocalPolicyName,
+			Statements: []*gobgp.Statement{
+				{
+					Name: fmt.Sprintf("%s_stmt0", globalAllowLocalPolicyName),
+					Conditions: &gobgp.Conditions{
+						RouteType:  gobgp.Conditions_ROUTE_TYPE_LOCAL,
+						RpkiResult: -1,
+					},
+
+					Actions: &gobgp.Actions{RouteAction: gobgp.RouteAction_ACCEPT}},
+			},
+		},
+	}
+
+	require.EqualValues(t, expected, response[0].Policies)
 }
 
 func TestAddRemoveRoutePolicy(t *testing.T) {
@@ -47,6 +98,16 @@ func TestAddRemoveRoutePolicy(t *testing.T) {
 			pResp, err := router.GetRoutePolicies(context.Background())
 			require.NoError(t, err)
 
+			// ignore the global policy that is configured when starting GoBGP
+			filteredPolicies := []*types.RoutePolicy{}
+			for _, policy := range pResp.Policies {
+				if policy.Name == globalAllowLocalPolicyName {
+					continue
+				}
+				filteredPolicies = append(filteredPolicies, policy)
+			}
+			pResp.Policies = filteredPolicies
+
 			// check that retrieved policy matches the expected
 			require.Len(t, pResp.Policies, 1)
 			require.EqualValues(t, tt.Policy, pResp.Policies[0])
@@ -64,6 +125,10 @@ func checkPoliciesCleanedUp(t *testing.T, gobgpServer *server.BgpServer) {
 	// check that polies were removed
 	cnt := 0
 	err := gobgpServer.ListPolicy(context.Background(), &gobgp.ListPolicyRequest{}, func(p *gobgp.Policy) {
+		// ignore the global policy that is configured when starting GoBGP
+		if p.Name == globalAllowLocalPolicyName {
+			return
+		}
 		cnt++
 	})
 	require.NoError(t, err)
@@ -72,6 +137,12 @@ func checkPoliciesCleanedUp(t *testing.T, gobgpServer *server.BgpServer) {
 	// check that policy assignments were removed
 	cnt = 0
 	err = gobgpServer.ListPolicyAssignment(context.Background(), &gobgp.ListPolicyAssignmentRequest{}, func(a *gobgp.PolicyAssignment) {
+		// ignore the global policy that is configured when starting GoBGP
+		for _, policy := range a.Policies {
+			if policy.Name == globalAllowLocalPolicyName {
+				return
+			}
+		}
 		cnt += len(a.Policies)
 	})
 	require.NoError(t, err)

--- a/pkg/bgpv1/manager/reconciler/route_policy.go
+++ b/pkg/bgpv1/manager/reconciler/route_policy.go
@@ -85,15 +85,16 @@ func (r *RoutePolicyReconciler) Reconcile(ctx context.Context, params ReconcileP
 	currentPolicies := r.getMetadata(params.CurrentServer)
 
 	// compile set of desired policies
+	// note: only per-neighbor export policies are supported at this time
 	desiredPolicies := make(map[string]*types.RoutePolicy)
 	for _, n := range params.DesiredConfig.Neighbors {
 		for _, routeAttrs := range n.AdvertisedPathAttributes {
-			policy, err := r.pathAttributesToPolicy(routeAttrs, n.PeerAddress, params)
+			exportPolicy, err := r.pathAttributesToPolicy(routeAttrs, n.PeerAddress, params)
 			if err != nil {
 				return fmt.Errorf("failed to convert BGP PathAttributes to a RoutePolicy: %w", err)
 			}
-			if len(policy.Statements) > 0 {
-				desiredPolicies[policy.Name] = policy
+			if len(exportPolicy.Statements) > 0 {
+				desiredPolicies[exportPolicy.Name] = exportPolicy
 			}
 		}
 	}
@@ -189,6 +190,7 @@ func (r *RoutePolicyReconciler) storeMetadata(sc *instance.ServerWithConfig, met
 	sc.ReconcilerMetadata[r.Name()] = meta
 }
 
+// pathAttributesToPolicy prepares an export policy configured by CRD using the Advertised Path Attributes feature
 func (r *RoutePolicyReconciler) pathAttributesToPolicy(attrs v2alpha1api.CiliumBGPPathAttributes, neighborAddress string, params ReconcileParams) (*types.RoutePolicy, error) {
 	var v4Prefixes, v6Prefixes types.PolicyPrefixMatchList
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

# BGPv1 and BGPv2 - Reject all inbound BGP advertisements

# Overview

Cilium's BGPv1 and BGPv2 Control Planes accepts all BGP Paths advertised to it.  However, these paths do not program the datapath. This PR modifies Cilium's BGP implementation to reject all inbound BGP advertisements.

The desire for this change is:
1) To reduce confusion by administrators of a Cilium installation.  When viewing `cilium bgp routes`, the current output, which shows all received BGP paths, gives the impression that these paths/routes are being used for routing by the CNI (programmed into the dataplane).  For Cilium, this is not true and they are simply ignored.

2) To move a potential failure point in Cilium's BGP stack.  In the BGPv[1|2] implementation, a [GoBGP](https://github.com/osrg/gobgp) server is instantiated by Cilium's directly in Go.  It does not run as an external process.  If GoBGP experiences a memory leak or panic, it has the potential to disrupt Cilium as well.  One point of failure that I've seen in the past is when using GoBGP in environments containing millions of BGP paths.  While it's an unlikely use case for a CNI, the potential exists that one could try to pass full Internet tables into their CNI.  As these are unused, it would be ideal to drop them.

# Description
This PR configures a global `IMPORT` routing policy just after starting Cilium's internal [GoBGP](https://github.com/osrg/gobgp/tree/master) instance.  The policy rejects all paths.  Due to GoBGP specifics, the global import policy configured includes "permit local routes" sub-policy (see this PR's comment thread).  That was required because early testing of the change without the local route exception resulted in filtering ALL announcements, including Cilium's own outbound announcements.

* In `pkg/bgpv1/gobgp/server.go`, a top-level variable named `allowLocalPolicy` was added.  This defines a sub-policy containing the local route exception described above.
* In `pkg/bgpv1/gobgp/server.go`,  at approximately line 113, just after calling `StartBgp()`, the internal GoBGP server's `AddPolicy()` is called to configure the sub-policy containing the local route exception described above.
* In `pkg/bgpv1/gobgp/server.go`,  at approximately line 117, the internal GoBGP server's `SetPolicyAssignment()` is called to configure the global import policy.

During testing, it was observed that calling `SetPolicyAssignment()` prior to calling  `StartBgp()` resulted in a deadlock.  The call never returned.

# Testing

## Manual Testing - Setup

For testing of this change, I first referenced https://docs.cilium.io/en/latest/contributing/development/bgp_cplane/ to bring up a local Kind K8s cluster with Cilium.  The exact steps were:

```
make kind-bgp-v4

KIND_CLUSTER_NAME=bgp-cplane-dev-v4 make kind-image
cilium install --chart-directory install/kubernetes/cilium -f contrib/containerlab/bgp-cplane-dev-v4/values.yaml --set image.override="localhost:5000/cilium/cilium-dev:local" --set image.pullPolicy=Never --set operator.image.override="localhost:5000/cilium/operator-generic:local" --set operator.image.pullPolicy=Never
```

Next, I brought up a "hello world" service using:
```
kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.39 -- /agnhost netexec --http-port=8080

kubectl expose deployment hello-node --type=LoadBalancer --port=8080
```

## Manual Testing - BGPv1

The following configuration (`bgpp.yaml`) was applied to configure BGP peers using Cilium's BGPv1 Control Plane:

```
---
apiVersion: cilium.io/v2alpha1
kind: CiliumBGPPeeringPolicy
metadata:
  name: control-plane
spec:
  nodeSelector:
    matchLabels:
      kubernetes.io/hostname: bgp-cplane-dev-v4-control-plane
  virtualRouters:
  - localASN: 65001
    neighbors:
    - peerASN: 65000
      peerAddress: 10.0.1.1/32
---
apiVersion: cilium.io/v2alpha1
kind: CiliumBGPPeeringPolicy
metadata:
  name: worker
spec:
  nodeSelector:
    matchLabels:
      kubernetes.io/hostname: bgp-cplane-dev-v4-worker
  virtualRouters:
  - localASN: 65002
    #exportPodCIDR: true
    serviceSelector:
      #matchLabels:
      #  name: hello-node
      matchExpressions:
       - { key: app, operator: In, values: [hello-node, hello-node2, hello-node3] }
    serviceAdvertisements:
      - LoadBalancerIP # <-- default
      #- ClusterIP      # <-- options
      #- ExternalIP     # <-- options
    neighbors:
    - peerASN: 65000
      peerAddress: 10.0.2.1/32
      #holdTimeSeconds: 180
      #keepAliveTimeSeconds: 60
      #eBGPMultihopTTL: 1
      gracefulRestart:
        enabled: true
        restartTimeSeconds: 60
      advertisedPathAttributes:
      - selectorType: CiliumLoadBalancerIPPool
        selector:
          matchLabels:
            environment: mgmt
        communities:
          standard:
          - 65002:100
          large:
          - 65002:100:1
---
apiVersion: "cilium.io/v2alpha1"
kind: CiliumLoadBalancerIPPool
metadata:
  name: "mgmt"
  labels:
    environment: mgmt
spec:
  blocks:
    - cidr: "100.64.8.0/22"
  cidrs:
    - cidr: "100.64.12.0/22"
  #serviceSelector:
  #  matchExpressions:
  #    - {key: app, operator: In, values: [hello-node]}
---
```

Then, in the FRR container (`clab-bgp-cplane-dev-v4-router0`), I added additional routes and advertised those into BGP using:
```

docker exec -ti clab-bgp-cplane-dev-v4-router0 bash

bash-5.1# ip route add 100.100.100.0/24 dev lo
bash-5.1# ip route add 100.100.110.0/24 dev lo
bash-5.1# ip route add 100.100.120.0/24 dev lo
bash-5.1# ip route add 100.100.130.0/24 dev lo
bash-5.1# ip route add 100.100.140.0/24 dev lo

bash-5.1# vtysh

Hello, this is FRRouting (version 8.4_git).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

router0# conf t
router0(config)# router bgp 65000
router0(config-router)# network 100.100.100.0/24
router0(config-router)# network 100.100.110.0/24
router0(config-router)# network 100.100.120.0/24
router0(config-router)# network 100.100.130.0/24
router0(config-router)# network 100.100.140.0/24
```

These were observed in:
```
router0# show ip bgp
...
   Network          Next Hop            Metric LocPrf Weight Path
*> 100.64.12.1/32   10.0.2.2                               0 65002 i
*> 100.100.100.0/24 0.0.0.0                  0         32768 i
*> 100.100.110.0/24 0.0.0.0                  0         32768 i
*> 100.100.120.0/24 0.0.0.0                  0         32768 i
*> 100.100.130.0/24 0.0.0.0                  0         32768 i
*> 100.100.140.0/24 0.0.0.0                  0         32768 i
```

[**BEFORE**] On Cilium's side, before this PR, these were observed in:
```
$  cilium bgp peers
Node                              Local AS   Peer AS   Peer Address   Session State   Uptime   Family         Received   Advertised
bgp-cplane-dev-v4-control-plane   65001      65000     10.0.1.1       established     7m42s    ipv4/unicast   6          0
                                                                                               ipv6/unicast   0          0
bgp-cplane-dev-v4-worker          65002      65000     10.0.2.1       established     7m40s    ipv4/unicast   6          2
                                                                                               ipv6/unicast   0          1


$  cilium bgp routes
(Defaulting to vailable ipv4 unicastroutes, please see help for more options)

Node                              VRouter   Prefix             NextHop    Age     Attrs
bgp-cplane-dev-v4-control-plane   65001     100.100.100.0/24   10.0.1.1   4m19s   [{Origin: i} {AsPath: 65000} {Nexthop: 10.0.1.1} {Med: 0}]
                                  65001     100.100.110.0/24   10.0.1.1   4m16s   [{Origin: i} {AsPath: 65000} {Nexthop: 10.0.1.1} {Med: 0}]
                                  65001     100.100.120.0/24   10.0.1.1   4m15s   [{Origin: i} {AsPath: 65000} {Nexthop: 10.0.1.1} {Med: 0}]
                                  65001     100.100.130.0/24   10.0.1.1   3m15s   [{Origin: i} {AsPath: 65000} {Nexthop: 10.0.1.1} {Med: 0}]
                                  65001     100.100.140.0/24   10.0.1.1   3m29s   [{Origin: i} {AsPath: 65000} {Nexthop: 10.0.1.1} {Med: 0}]
                                  65001     100.64.12.1/32     10.0.1.1   7m38s   [{Origin: i} {AsPath: 65000 65002} {Nexthop: 10.0.1.1} {Communities: 65002:100} {LargeCommunity: [ 65002:100:1]}]
bgp-cplane-dev-v4-worker          65002     100.100.100.0/24   10.0.2.1   4m19s   [{Origin: i} {AsPath: 65000} {Nexthop: 10.0.2.1} {Med: 0}]
                                  65002     100.100.110.0/24   10.0.2.1   4m16s   [{Origin: i} {AsPath: 65000} {Nexthop: 10.0.2.1} {Med: 0}]
                                  65002     100.100.120.0/24   10.0.2.1   4m15s   [{Origin: i} {AsPath: 65000} {Nexthop: 10.0.2.1} {Med: 0}]
                                  65002     100.100.130.0/24   10.0.2.1   3m15s   [{Origin: i} {AsPath: 65000} {Nexthop: 10.0.2.1} {Med: 0}]
                                  65002     100.100.140.0/24   10.0.2.1   3m29s   [{Origin: i} {AsPath: 65000} {Nexthop: 10.0.2.1} {Med: 0}]
                                  65002     100.64.12.1/32     0.0.0.0    7m38s   [{Origin: i} {Nexthop: 0.0.0.0}]
```


[**AFTER**] On Cilium's side with this PR, I saw:
```
$  cilium bgp routes
(Defaulting to `available ipv4 unicast` routes, please see help for more options)

Node                       VRouter   Prefix           NextHop   Age     Attrs
bgp-cplane-dev-v4-worker   65002     100.64.12.1/32   0.0.0.0   2m34s   [{Origin: i} {Nexthop: 0.0.0.0}]
```

**Inspecting Cilium using `cilium-dbg` on `bgp-cplane-dev-v4-worker`:**
```
root@bgp-cplane-dev-v4-worker:/home/cilium# cilium-dbg bgp peers
Local AS   Peer AS   Peer Address   Session       Uptime   Family         Received   Advertised
65002      65000     10.0.2.1:179   established   4m13s    ipv4/unicast   6          2
                                                           ipv6/unicast   0          1

root@bgp-cplane-dev-v4-worker:/home/cilium# cilium-dbg bgp route-policies
VRouter   Policy Name                                   Type     Match Peers   Match Prefixes (Min..Max Len)                        RIB Action   Path Actions
65002     10.0.2.1/32-CiliumLoadBalancerIPPool-cae...   export   10.0.2.1/32   {100.64.8.0/22 (32..32)} {100.64.12.0/22 (32..32)}   none         {AddCommunities: [65002:100]} {AddLargeCommunities: [65002:100:1]}
65002     10.0.2.1/32-import                            import   10.0.2.1/32                                                        reject

root@bgp-cplane-dev-v4-worker:/home/cilium# cilium-dbg bgp routes
(Defaulting to `available ipv4 unicast` routes, please see help for more options)

VRouter   Prefix           NextHop   Age     Attrs
65002     100.64.12.1/32   0.0.0.0   4m25s   [{Origin: i} {Nexthop: 0.0.0.0}]
```

**Inspecting Cilium using `cilium-dbg` on `bgp-cplane-dev-v4-control-plane`:**
```
$  k exec cilium-lrmbw -n kube-system bash -ti
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.

root@bgp-cplane-dev-v4-control-plane:/home/cilium# cilium bgp peers
Local AS   Peer AS   Peer Address   Session       Uptime   Family         Received   Advertised
65001      65000     10.0.1.1:179   established   4m56s    ipv4/unicast   6          0
                                                           ipv6/unicast   0          0

root@bgp-cplane-dev-v4-control-plane:/home/cilium# cilium bgp route-policies
VRouter   Policy Name          Type     Match Peers   Match Prefixes (Min..Max Len)   RIB Action   Path Actions
65001     10.0.1.1/32-import   import   10.0.1.1/32                                   reject
root@bgp-cplane-dev-v4-control-plane:/home/cilium# cilium bgp routes
(Defaulting to `available ipv4 unicast` routes, please see help for more options)

VRouter   Prefix   NextHop   Age   Attrs
```

[**AFTER**] Inspecting Cilium's advertised BGP route on the FRR container:
```
router0# show ip bgp
BGP table version is 6, local router ID is 10.0.0.1, vrf id 0
Default local pref 100, local AS 65000
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          Next Hop            Metric LocPrf Weight Path
*> 100.64.12.1/32   10.0.2.2                               0 65002 i
*> 100.100.100.0/24 0.0.0.0                  0         32768 i
*> 100.100.110.0/24 0.0.0.0                  0         32768 i
*> 100.100.120.0/24 0.0.0.0                  0         32768 i
*> 100.100.130.0/24 0.0.0.0                  0         32768 i
*> 100.100.140.0/24 0.0.0.0                  0         32768 i

Displayed  6 routes and 6 total paths
router0# show ip bgp 100.64.12.1/32
BGP routing table entry for 100.64.12.1/32, version 1
Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  10.0.1.2 10.0.2.2
  65002
    10.0.2.2 from 10.0.2.2 (10.0.2.2)
      Origin IGP, valid, external, best (First path received)
      Community: 65002:100
      Large Community: 65002:100:1
      Last update: Tue Jun 11 02:09:53 2024
```

## Manual Testing - BGPv2

For testing BGPv2, I nuked the test environment.  Then, I applied the following `bgpp.yaml`:

```
$  cat bgppv2.yaml
apiVersion: cilium.io/v2alpha1
kind: CiliumBGPClusterConfig
metadata:
  name: cilium-bgp
spec:
  nodeSelector:
    matchLabels:
      kubernetes.io/hostname: bgp-cplane-dev-v4-control-plane
  bgpInstances:
  - name: "control-plane"
    localASN: 65001
    peers:
    - name: "frr"
      peerASN: 65000
      peerAddress: 10.0.1.1
      peerConfigRef:
        name: "cilium-cp-frr-peer"
---
apiVersion: cilium.io/v2alpha1
kind: CiliumBGPPeerConfig
metadata:
  name: "cilium-cp-frr-peer"
spec:
  transport:
    localPort: 179
    peerPort: 179
  #timers:
  #  connectRetryTimeSeconds: 12
  #  holdTimeSeconds: 9
  #  keepAliveTimeSeconds: 3
  #authSecretRef: bgp-auth-secret
  gracefulRestart:
    enabled: true
    restartTimeSeconds: 15
  families:
    - afi: ipv4
      safi: unicast
      advertisements:
        matchLabels:
          advertise: "bgp"
---
apiVersion: cilium.io/v2alpha1
kind: CiliumBGPAdvertisement
metadata:
  name: "bgp-advertisements"
  labels:
    advertise: "bgp"
spec:
  advertisements:
    #- advertisementType: "LoadBalancerIP"
    - advertisementType: "PodCIDR"
      #serviceSelector:
      #matchLabels:
      #  name: hello-node
      #  matchExpressions:
      #  - { key: app, operator: In, values: [hello-node, hello-node2, hello-node3] }
      attributes:
        communities:
          standard: [ "65001:100" ]
        localPreference: 99
---
apiVersion: "cilium.io/v2alpha1"
kind: CiliumLoadBalancerIPPool
metadata:
  name: "mgmt"
  labels:
    environment: mgmt
spec:
  blocks:
    - cidr: "100.64.8.0/22"
  cidrs:
    - cidr: "100.64.12.0/22"
---
```

**Testing with a local build of cilium-dbg**
```
root@bgp-cplane-dev-v4-control-plane:/home/cilium# /tmp/cilium-dbg bgp peers
Local AS   Peer AS   Peer Address   Session       Uptime   Family         Received   Accepted   Advertised
65001      65000     10.0.1.1:179   established   4m48s    ipv4/unicast   11         10         2


root@bgp-cplane-dev-v4-control-plane:/home/cilium# /tmp/cilium-dbg bgp routes
(Defaulting to `available ipv4 unicast` routes, please see help for more options)

VRouter   Prefix        NextHop   Age     Attrs
65001     10.1.0.0/24   0.0.0.0   4m59s   [{Origin: i} {Nexthop: 0.0.0.0}]
```

**Testing with cilium CLI**
```
$  cilium bgp peers
Node                              Local AS   Peer AS   Peer Address   Session State   Uptime   Family         Received   Advertised
bgp-cplane-dev-v4-control-plane   65001      65000     10.0.1.1       established     11m19s   ipv4/unicast   11         2

$  cilium bgp routes
(Defaulting to `available ipv4 unicast` routes, please see help for more options)

Node                              VRouter   Prefix        NextHop   Age      Attrs
bgp-cplane-dev-v4-control-plane   65001     10.1.0.0/24   0.0.0.0   11m30s   [{Origin: i} {Nexthop: 0.0.0.0}]
```

**Inspecting the FRR container**
```
router0# show ip bgp
BGP table version is 11, local router ID is 10.0.0.1, vrf id 0
Default local pref 100, local AS 65000
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          Next Hop            Metric LocPrf Weight Path
*> 10.1.0.0/24      10.0.1.2                               0 65001 i
*> 100.100.100.0/24 0.0.0.0                  0         32768 i
*> 100.100.110.0/24 0.0.0.0                  0         32768 i
*> 100.100.120.0/24 0.0.0.0                  0         32768 i
*> 100.100.130.0/24 0.0.0.0                  0         32768 i
*> 100.100.140.0/24 0.0.0.0                  0         32768 i
*> 200.200.200.0/24 0.0.0.0                  0         32768 i
*> 200.200.210.0/24 0.0.0.0                  0         32768 i
*> 200.200.220.0/24 0.0.0.0                  0         32768 i
*> 200.200.230.0/24 0.0.0.0                  0         32768 i
*> 200.200.240.0/24 0.0.0.0                  0         32768 i

Displayed  11 routes and 11 total paths
router0# show ip bgp 10.1.0.0/24
BGP routing table entry for 10.1.0.0/24, version 1
Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  10.0.1.2
  65001
    10.0.1.2 from 10.0.1.2 (10.0.1.2)
      Origin IGP, valid, external, best (First path received)
      Community: 65001:100
      Last update: Sat Jun 15 00:10:53 2024
```

The configuration applied to the FRR container to inject 10 additional routes was:
```
ip route add 100.100.100.0/24 dev lo
ip route add 100.100.110.0/24 dev lo
ip route add 100.100.120.0/24 dev lo
ip route add 100.100.130.0/24 dev lo
ip route add 100.100.140.0/24 dev lo
ip route add 200.200.200.0/24 dev lo
ip route add 200.200.210.0/24 dev lo
ip route add 200.200.220.0/24 dev lo
ip route add 200.200.230.0/24 dev lo
ip route add 200.200.240.0/24 dev lo

vtysh
conf t
router bgp 65000
network 100.100.100.0/24
network 100.100.110.0/24
network 100.100.120.0/24
network 100.100.130.0/24
network 100.100.140.0/24
network 200.200.200.0/24
network 200.200.210.0/24
network 200.200.220.0/24
network 200.200.230.0/24
network 200.200.240.0/24
exit
exit
```

## Unit Tests

* Existing tests from `pkg/bgpv1/gobgp/server_test.go` were updated to exclude the global import policy when evaluating results.
* A new test named `TestGlobalImportPolicy()` was added to verify the global import policy.  This test calls the internal GoBGP server directly, instead of `router.GetRoutePolicies()` which returns only the sub-policy for local routes.

Fixes: #32826


```release-note
BGPv1 and BGPv2 - Reject all inbound BGP advertisements
```
