### PR TITLE
Fix CiliumEnvoyConfig Nodeport handling

### DIFF
--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -72,12 +72,6 @@ func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 	cec.Name = cecName
 
 	dedicatedService := d.getService(sourceResource, modelService)
-	if dedicatedService.Spec.Type == corev1.ServiceTypeNodePort {
-		// clear out the CEC Port field for NodePort services.
-		for i := range cec.Spec.Services {
-			cec.Spec.Services[i].Ports = nil
-		}
-	}
 
 	return cec, dedicatedService, getEndpoints(sourceResource), err
 }

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
@@ -1568,6 +1568,7 @@ var complexNodePortIngressCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-ingress-dummy-ingress",
 				Namespace: "dummy-namespace",
+				Ports:     []uint16{80, 443},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{

--- a/pkg/ciliumenvoyconfig/cec_manager.go
+++ b/pkg/ciliumenvoyconfig/cec_manager.go
@@ -136,6 +136,13 @@ func (r *cecManager) addK8sServiceRedirects(resourceName service.L7LBResourceNam
 			return fmt.Errorf("listener %q not found in resources", svc.Listener)
 		}
 
+		// Add any relevant Nodeport values into the list of Ports to redirect.
+		nodePorts, err := r.getServiceNodeports(svc.Name, svc.Namespace, svc.Ports)
+		if err != nil {
+			return err
+		}
+		svc.Ports = append(svc.Ports, nodePorts...)
+
 		// Tell service manager to redirect the service to the port
 		serviceName := getServiceName(resourceName, svc.Name, svc.Namespace, true)
 		if err := r.serviceManager.RegisterL7LBServiceRedirect(serviceName, resourceName, proxyPort, svc.Ports); err != nil {
@@ -186,6 +193,29 @@ func (r *cecManager) syncCiliumEnvoyConfigService(name string, namespace string,
 		}
 	}
 	return nil
+}
+
+// getServiceNodeports returns any relevant Nodeport numbers for the provided
+// Service ports. If the provided servicePorts do not have any nodeports set, returns
+// an empty list.
+func (r *cecManager) getServiceNodeports(name, namespace string, servicePorts []uint16) ([]uint16, error) {
+	var nodePorts []uint16
+	kSvc, err := r.getK8sService(name, namespace)
+	if err != nil {
+		return nodePorts, fmt.Errorf("could not retrieve service details for service %s/%s", namespace, name)
+	}
+
+	for _, servicePort := range servicePorts {
+		for _, port := range kSvc.Spec.Ports {
+			if servicePort == uint16(port.Port) {
+				if port.NodePort != 0 {
+					nodePorts = append(nodePorts, uint16(port.NodePort))
+				}
+			}
+		}
+	}
+
+	return nodePorts, nil
 }
 
 // getK8sService retrieves k8s service from the store

--- a/pkg/ciliumenvoyconfig/cec_manager.go
+++ b/pkg/ciliumenvoyconfig/cec_manager.go
@@ -91,7 +91,7 @@ func (r *cecManager) addCiliumEnvoyConfig(cecObjectMeta metav1.ObjectMeta, cecSp
 
 	name := service.L7LBResourceName{Name: cecObjectMeta.Name, Namespace: cecObjectMeta.Namespace}
 	if err := r.addK8sServiceRedirects(name, cecSpec, resources); err != nil {
-		return fmt.Errorf("failed to redirect k8s services to Envoy: %w", err)
+		return fmt.Errorf("failed to redirect k8s services to Envoy in CEC Add: %w", err)
 	}
 
 	if len(resources.Listeners) > 0 {
@@ -203,6 +203,11 @@ func (r *cecManager) getServiceNodeports(name, namespace string, servicePorts []
 	kSvc, err := r.getK8sService(name, namespace)
 	if err != nil {
 		return nodePorts, fmt.Errorf("could not retrieve service details for service %s/%s", namespace, name)
+	}
+
+	if kSvc == nil {
+		r.logger.Debugf("Retrieved nil service details for service %s/%s, ignoring Nodeports for this service in this update", namespace, name)
+		return nodePorts, nil
 	}
 
 	for _, servicePort := range servicePorts {
@@ -340,7 +345,7 @@ func (r *cecManager) updateCiliumEnvoyConfig(
 	}
 
 	if err := r.addK8sServiceRedirects(name, newCECSpec, newResources); err != nil {
-		return fmt.Errorf("failed to redirect k8s services to Envoy: %w", err)
+		return fmt.Errorf("failed to redirect k8s services to Envoy in CEC Update: %w", err)
 	}
 
 	if oldResources.ListenersAddedOrDeleted(&newResources) {


### PR DESCRIPTION
Adds additional service redirect handling for Services with Nodeports set, which will automatically include the Nodeport in the set of redirected ports if ports to redirect are specified.

Also removes a hack in the Dedicated Ingress code that was introduced to solve this problem previously.

