### PR TITLE
gateway-api:  Supports Addresses provided by the Gateway API specification

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -122,7 +122,7 @@ jobs:
         run: |
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
 
-          EXEMPT_FEATURES="GatewayStaticAddresses,HTTPRouteParentRefPort,MeshConsumerRoute"
+          EXEMPT_FEATURES="HTTPRouteParentRefPort,MeshConsumerRoute"
           if [ ${{ matrix.crd-channel }} == "standard" ]; then
             EXEMPT_FEATURES+=",HTTPRouteDestinationPortMatching,HTTPRouteRequestTimeout,HTTPRouteBackendTimeout,GatewayInfrastructurePropagation"
           fi
@@ -260,8 +260,17 @@ jobs:
       - name: Run Gateway API conformance test
         timeout-minutes: 30
         run: |
+          KIND_NET_CIDR=$(docker network inspect kind -f '{{json .IPAM.Config}}' | jq -r '.[] | select(.Subnet | test("^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+")) | .Subnet')
+          echo "KIND_NET_CIDR: $KIND_NET_CIDR"
+          GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES=$(echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.206@")
+          GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES=$(echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.216@")
+          echo "GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES: $GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES"
+          echo "GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES: $GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES"
           if [ ${{ matrix.conformance-profile }} == "true" ]; then
-            GATEWAY_API_CONFORMANCE_TESTS=1 go test \
+            GATEWAY_API_CONFORMANCE_TESTS=1 \
+            GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES=$GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES  \
+            GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES=$GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES \
+            go test \
               -p 4 \
               -v ./operator/pkg/gateway-api \
               --gateway-class cilium \
@@ -279,7 +288,10 @@ jobs:
               -json \
             | tparse -progress
           else
-            GATEWAY_API_CONFORMANCE_TESTS=1 go test \
+            GATEWAY_API_CONFORMANCE_TESTS=1 \
+            GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES=$GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES  \
+            GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES=$GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES \
+            go test \
               -p 4 \
               -v ./operator/pkg/gateway-api \
               --gateway-class cilium \

--- a/operator/pkg/gateway-api/conformance_test.go
+++ b/operator/pkg/gateway-api/conformance_test.go
@@ -4,11 +4,21 @@
 package gateway_api
 
 import (
+	"os"
+	"strings"
 	"testing"
 
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance"
+	"sigs.k8s.io/gateway-api/pkg/features"
 
 	"github.com/cilium/cilium/pkg/testutils"
+)
+
+var (
+	usableNetworkAddressesEnv   = "GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES"
+	unusableNetworkAddressesEnv = "GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES"
 )
 
 // TestConformance runs the conformance tests for Gateway API
@@ -32,6 +42,38 @@ import (
 //		--debug -test.run "TestConformance/HTTPRouteDisallowedKind"
 func TestConformance(t *testing.T) {
 	testutils.GatewayAPIConformanceTest(t)
-
-	conformance.RunConformance(t)
+	var skipTests []string
+	options := conformance.DefaultOptions(t)
+	var usableNetworkAddresses []v1beta1.GatewayAddress
+	var unusableNetworkAddresses []v1beta1.GatewayAddress
+	usableAddresses := os.Getenv(usableNetworkAddressesEnv)
+	if usableAddresses == "" {
+		t.Logf("Set %s to run this test", features.SupportGatewayStaticAddresses)
+		skipTests = append(skipTests, string(features.SupportGatewayStaticAddresses))
+	} else {
+		var addressType = v1.IPAddressType
+		for _, value := range strings.Split(usableAddresses, ",") {
+			usableNetworkAddresses = append(usableNetworkAddresses, v1beta1.GatewayAddress{
+				Type:  &addressType,
+				Value: value,
+			})
+		}
+	}
+	unusableAddresses := os.Getenv(unusableNetworkAddressesEnv)
+	if unusableAddresses == "" {
+		t.Logf("Set %s to run this test", features.SupportGatewayStaticAddresses)
+		skipTests = append(skipTests, string(features.SupportGatewayStaticAddresses))
+	} else {
+		var addressType = v1.IPAddressType
+		for _, value := range strings.Split(usableAddresses, ",") {
+			unusableNetworkAddresses = append(unusableNetworkAddresses, v1beta1.GatewayAddress{
+				Type:  &addressType,
+				Value: value,
+			})
+		}
+	}
+	options.UnusableNetworkAddresses = unusableNetworkAddresses
+	options.UsableNetworkAddresses = usableNetworkAddresses
+	options.SkipTests = append(options.SkipTests, skipTests...)
+	conformance.RunConformanceWithOptions(t, options)
 }

--- a/operator/pkg/gateway-api/gateway_status.go
+++ b/operator/pkg/gateway-api/gateway_status.go
@@ -11,24 +11,24 @@ import (
 )
 
 // setGatewayAccepted inserts or updates the Accepted condition for the provided Gateway resource.
-func setGatewayAccepted(gw *gatewayv1.Gateway, accepted bool, msg string) *gatewayv1.Gateway {
-	gw.Status.Conditions = merge(gw.Status.Conditions, gatewayStatusAcceptedCondition(gw, accepted, msg))
+func setGatewayAccepted(gw *gatewayv1.Gateway, accepted bool, msg string, reason gatewayv1.GatewayConditionReason) *gatewayv1.Gateway {
+	gw.Status.Conditions = merge(gw.Status.Conditions, gatewayStatusAcceptedCondition(gw, accepted, msg, reason))
 	return gw
 }
 
 // setGatewayProgrammed inserts or updates the Programmed condition for the provided Gateway resource.
-func setGatewayProgrammed(gw *gatewayv1.Gateway, ready bool, msg string) *gatewayv1.Gateway {
-	gw.Status.Conditions = merge(gw.Status.Conditions, gatewayStatusProgrammedCondition(gw, ready, msg))
+func setGatewayProgrammed(gw *gatewayv1.Gateway, ready bool, msg string, reason gatewayv1.GatewayConditionReason) *gatewayv1.Gateway {
+	gw.Status.Conditions = merge(gw.Status.Conditions, gatewayStatusProgrammedCondition(gw, ready, msg, reason))
 	return gw
 }
 
-func gatewayStatusAcceptedCondition(gw *gatewayv1.Gateway, accepted bool, msg string) metav1.Condition {
+func gatewayStatusAcceptedCondition(gw *gatewayv1.Gateway, accepted bool, msg string, reason gatewayv1.GatewayConditionReason) metav1.Condition {
 	switch accepted {
 	case true:
 		return metav1.Condition{
 			Type:               string(gatewayv1.GatewayConditionAccepted),
 			Status:             metav1.ConditionTrue,
-			Reason:             string(gatewayv1.GatewayConditionAccepted),
+			Reason:             string(reason),
 			Message:            msg,
 			ObservedGeneration: gw.GetGeneration(),
 			LastTransitionTime: metav1.NewTime(time.Now()),
@@ -37,7 +37,7 @@ func gatewayStatusAcceptedCondition(gw *gatewayv1.Gateway, accepted bool, msg st
 		return metav1.Condition{
 			Type:               string(gatewayv1.GatewayConditionAccepted),
 			Status:             metav1.ConditionFalse,
-			Reason:             string(gatewayv1.GatewayReasonNoResources),
+			Reason:             string(reason),
 			Message:            msg,
 			ObservedGeneration: gw.GetGeneration(),
 			LastTransitionTime: metav1.NewTime(time.Now()),
@@ -45,22 +45,24 @@ func gatewayStatusAcceptedCondition(gw *gatewayv1.Gateway, accepted bool, msg st
 	}
 }
 
-func gatewayStatusProgrammedCondition(gw *gatewayv1.Gateway, scheduled bool, msg string) metav1.Condition {
+func gatewayStatusProgrammedCondition(gw *gatewayv1.Gateway, scheduled bool, msg string, reason gatewayv1.GatewayConditionReason) metav1.Condition {
 	switch scheduled {
 	case true:
 		return metav1.Condition{
-			Type:               string(gatewayv1.GatewayConditionProgrammed),
-			Status:             metav1.ConditionTrue,
-			Reason:             string(gatewayv1.GatewayReasonProgrammed),
+			Type:   string(gatewayv1.GatewayConditionProgrammed),
+			Status: metav1.ConditionTrue,
+			//Reason:             string(gatewayv1.GatewayReasonProgrammed),
+			Reason:             string(reason),
 			Message:            msg,
 			ObservedGeneration: gw.GetGeneration(),
 			LastTransitionTime: metav1.NewTime(time.Now()),
 		}
 	default:
 		return metav1.Condition{
-			Type:               string(gatewayv1.GatewayConditionProgrammed),
-			Status:             metav1.ConditionFalse,
-			Reason:             string(gatewayv1.GatewayReasonListenersNotReady),
+			Type:   string(gatewayv1.GatewayConditionProgrammed),
+			Status: metav1.ConditionFalse,
+			//Reason:             string(gatewayv1.GatewayReasonListenersNotReady),
+			Reason:             string(reason),
 			Message:            msg,
 			ObservedGeneration: gw.GetGeneration(),
 			LastTransitionTime: metav1.NewTime(time.Now()),

--- a/operator/pkg/gateway-api/gateway_status_test.go
+++ b/operator/pkg/gateway-api/gateway_status_test.go
@@ -18,6 +18,7 @@ func Test_gatewayStatusScheduledCondition(t *testing.T) {
 		gw        *gatewayv1.Gateway
 		scheduled bool
 		msg       string
+		reason    gatewayv1.GatewayConditionReason
 	}
 	tests := []struct {
 		name string
@@ -32,6 +33,7 @@ func Test_gatewayStatusScheduledCondition(t *testing.T) {
 						Generation: 100,
 					},
 				},
+				reason:    gatewayv1.GatewayReasonAccepted,
 				scheduled: true,
 				msg:       "Scheduled Gateway",
 			},
@@ -52,6 +54,7 @@ func Test_gatewayStatusScheduledCondition(t *testing.T) {
 					},
 				},
 				scheduled: false,
+				reason:    gatewayv1.GatewayReasonNoResources,
 				msg:       "Invalid Gateway",
 			},
 			want: metav1.Condition{
@@ -65,7 +68,7 @@ func Test_gatewayStatusScheduledCondition(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := gatewayStatusAcceptedCondition(tt.args.gw, tt.args.scheduled, tt.args.msg)
+			got := gatewayStatusAcceptedCondition(tt.args.gw, tt.args.scheduled, tt.args.msg, tt.args.reason)
 			assert.True(t, cmp.Equal(got, tt.want, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")), "gatewayStatusAcceptedCondition() = %v, want %v", got, tt.want)
 		})
 	}

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/model"
+	"github.com/cilium/cilium/pkg/annotation"
 )
 
 const (
@@ -40,14 +41,25 @@ func GatewayAPI(input Input) ([]model.HTTPListener, []model.TLSPassthroughListen
 	var resHTTP []model.HTTPListener
 	var resTLSPassthrough []model.TLSPassthroughListener
 
-	var labels, annotations map[string]string
+	labels := make(map[string]string)
+	annotations := make(map[string]string)
 	if input.Gateway.Spec.Infrastructure != nil {
 		labels = toMapString(input.Gateway.Spec.Infrastructure.Labels)
 		annotations = toMapString(input.Gateway.Spec.Infrastructure.Annotations)
 	}
-
+	ips := make([]string, 0, len(input.Gateway.Spec.Addresses))
+	for _, address := range input.Gateway.Spec.Addresses {
+		if address.Type == nil || *address.Type == gatewayv1.IPAddressType {
+			ips = append(ips, address.Value)
+		}
+	}
+	// If already use the LBIPAMIPKeyAlias to specify the IP, don't overwrite it.
+	// At a future date this annotation will be removed if no spec.addresses are set.
+	if len(ips) != 0 && annotations[annotation.LBIPAMIPKeyAlias] == "" {
+		annotations[annotation.LBIPAMIPKeyAlias] = strings.Join(ips, ",")
+	}
 	var infra *model.Infrastructure
-	if labels != nil || annotations != nil {
+	if len(labels) != 0 || len(annotations) != 0 {
 		infra = &model.Infrastructure{
 			Labels:      labels,
 			Annotations: annotations,


### PR DESCRIPTION
Fixes: #32865

Cilium Gateway supports Addresses provided by the Gateway API specification https://gateway-api.sigs.k8s.io/api-types/gateway/?h=addresses



```release-note
Cilium Gateway supports Addresses provided by the Gateway API specification
```
