### PR TITLE
bgpv2: Remove node selector check from v2 PodCIDRReconciler

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
@@ -14,8 +14,6 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
-	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -194,17 +192,6 @@ func (r *PodCIDRReconciler) getDesiredRoutePolicies(p ReconcileParams, desiredPe
 			fam := types.ToAgentFamily(family)
 
 			for _, advert := range adverts {
-				labelSelector, err := slim_metav1.LabelSelectorAsSelector(advert.Selector)
-				if err != nil {
-					return nil, fmt.Errorf("failed constructing LabelSelector: %w", err)
-				}
-
-				// if there is a label selector in advertisement, check if it matches cilium node label.
-				// No selector means it matches the node.
-				if advert.Selector != nil && !labelSelector.Matches(labels.Set(p.CiliumNode.Labels)) {
-					continue
-				}
-
 				var v4Prefixes, v6Prefixes types.PolicyPrefixMatchList
 				for _, prefix := range desiredPrefixes {
 					match := &types.RoutePolicyPrefixMatch{CIDR: prefix, PrefixLenMin: prefix.Bits(), PrefixLenMax: prefix.Bits()}


### PR DESCRIPTION
Removes unnecessary CiliumNode label selector check for PodCIDR advertisements in the BGPv2 PodCIDRReconciler. 

This check was reflected from the BGPv1 code, but for BGPv2 we would like to avoid it, as this behavior is inconsistent with other advertisement types (other advertisement types advertise the paths for selected resources, but PodCIDR only applies to the local node).

This only affects yet unreleased BGPv2 codebase, and as we would like clean this up before releasing it, marking this as a v1.16 release-blocker.