### PR TITLE
gateway-api: Check for matching controller name

### DIFF
--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -59,7 +59,7 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch GatewayClass resources, which are linked to Gateway
 		Watches(&gatewayv1.GatewayClass{},
 			r.enqueueRequestForOwningGatewayClass(),
-			builder.WithPredicates(predicate.NewPredicateFuncs(hasMatchingControllerFn))).
+			builder.WithPredicates(predicate.NewPredicateFuncs(matchesControllerName(controllerName)))).
 		// Watch related LB service for status
 		Watches(&corev1.Service{},
 			r.enqueueRequestForOwningResource(),

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -67,12 +67,13 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		scopedLog.WithField(gatewayClass, gw.Spec.GatewayClassName).
 			WithError(err).
 			Error("Unable to get GatewayClass")
-		if k8serrors.IsNotFound(err) {
-			setGatewayAccepted(gw, false, "GatewayClass does not exist")
-			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
-		}
-		setGatewayAccepted(gw, false, "Unable to get GatewayClass")
-		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		// Doing nothing till the GatewayClass is available and matching controller name
+		return controllerruntime.Success()
+	}
+
+	if string(gwc.Spec.ControllerName) != controllerName {
+		scopedLog.Debug("GatewayClass does not have matching controller name, doing nothing")
+		return controllerruntime.Success()
 	}
 
 	httpRouteList := &gatewayv1.HTTPRouteList{}

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -332,18 +332,8 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 			NamespacedName: key,
 		})
 
-		require.Error(t, err)
-		require.Equal(t, "gatewayclasses.gateway.networking.k8s.io \"non-existent-gateway-class\" not found", err.Error())
-		require.Equal(t, ctrl.Result{}, result)
-
-		gw := &gatewayv1.Gateway{}
-		err = c.Get(context.Background(), key, gw)
 		require.NoError(t, err)
-		require.Len(t, gw.Status.Conditions, 1)
-		require.Equal(t, "Accepted", gw.Status.Conditions[0].Type)
-		require.Equal(t, metav1.ConditionFalse, gw.Status.Conditions[0].Status)
-		require.Equal(t, "NoResources", gw.Status.Conditions[0].Reason)
-		require.Equal(t, "GatewayClass does not exist", gw.Status.Conditions[0].Message)
+		require.Equal(t, ctrl.Result{}, result)
 	})
 
 	t.Run("valid http gateway", func(t *testing.T) {


### PR DESCRIPTION
Basically, we should do nothing for a given Gateway resource, till it's confirmed that its GatewayClass is managed by Cilium. Just a note that other watched and owned resources can by-pass the predicate function NewPredicateFuncs(hasMatchingControllerFn), the explicit check in reconcile method is required.

This commit is to perform the controller name check for Gateway resource to avoid unnecessary and wrong reconciliation.

Fixes: #31978

