### PR TITLE
linux/node: reallocate nodeID upon conflict

### DIFF
--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -56,8 +56,27 @@ func (n *linuxNodeHandler) allocateIDForNode(node *nodeTypes.Node) uint16 {
 
 	for _, addr := range node.IPAddresses {
 		ip := addr.IP.String()
-		if _, exists := n.nodeIDsByIPs[ip]; exists {
+		if id, exists := n.nodeIDsByIPs[ip]; exists && id == nodeID {
 			continue
+		} else if exists && id != nodeID {
+			// The map is in an inconsistent state. This can occur when a node
+			// is deleted while the agent is down and its IPs are reused.
+			log.WithFields(logrus.Fields{
+				logfields.IPAddr:   ip,
+				"mapped-to-nodeID": id,
+				"expected-nodeID":  nodeID,
+			}).Error("BUG: IPs of one node map to multiple node IDs. Reallocating a fresh nodeID.")
+
+			// To allocate a fresh ID, unmap the IPs of this node, and try again.
+			for _, addr := range node.IPAddresses {
+				if err := n.unmapNodeID(addr.IP.String()); err != nil {
+					log.WithError(err).WithFields(logrus.Fields{
+						logfields.IPAddr: ip,
+					}).Error("Failed to unmap stale nodeID mapping")
+				}
+			}
+
+			return n.allocateIDForNode(node)
 		}
 		if err := n.mapNodeID(ip, nodeID); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{


### PR DESCRIPTION
NodeIDs and IPsec state suffer from a lack of reconciliation. If the agent misses a node deletion event, stale state is never cleaned up. This is somewhat known (#29822, #26298), but was generally considered not of huge consequence. Stale XFRM states/policies can accumulate, but will not match traffic - the effect is mostly slowing down processing in agent and kernel. nodeIDs can eventually run out if too many node deletions are missed, but the rate at which these are missed is expected to be low.

Unfortunately, there are large clusters with high node churn in which rare events become common, and hence the following sequence of events is probable enough to actually observe:

1. a node is deleted while the agent is down (e.g. due to being upgraded)
2. a new node joins the cluster, which is observed by the agent _in partial fashion_: that is, the agent receives an update which contains _only_ the k8s node internal IP, but not a cilium internal IP.
3. this new node then receives a cilium internal IP _which was previously used_.

Alternatively, if the new node arrives in a full update, but _both_ the NodeInternalIP and the CiliumInternalIP are recycled _from nodes which we missed the delete for_, we arrive at the same point.

If this occurs, the agent can have a partioned view of what nodeID this node should have - in the BPF map, the k8s internal IP will map to a different nodeID than the cilium internal ip. This breaks IPsec traffic towards this node, as BPF applies a mark based on the BPF map nodeID of the tunnnel endpoint, but the xfrm states expect to match the mark based on the cilium internal IP. The result is traffic which doesn't match any xfrm state/policy, falling back to the catch all block policy.

To work around this, we enforce that all IPs of a node get the same nodeID - even if an IP was already pointing to an existing nodeID. Since this node update is more current than whatever state we had held, it seems more correct to ensure all IPs point to the same nodeID than avoiding a BPF map write. We do so by forcing the allocation of a new nodeID (and logging an error).


cc @rgo3 
