### PR TITLE
k8s: remove unused method NewStandaloneClientset

### DIFF
--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -42,7 +41,6 @@ import (
 	slim_clientset "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned"
 	slim_fake "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/fake"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/version"
 )
@@ -501,24 +499,6 @@ func NewFakeClientset() (*FakeClientset, Clientset) {
 	}
 	client.clientsetGetters = clientsetGetters{&client}
 	return &client, &client
-}
-
-// NewStandaloneClientset creates a clientset outside hive. To be removed once
-// remaining uses of k8s.Init()/k8s.Client()/etc. have been converted.
-func NewStandaloneClientset(cfg Config) (Clientset, error) {
-	log := logging.DefaultLogger
-	lc := &cell.DefaultLifecycle{}
-
-	clientset, err := newClientset(lc, log, cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := lc.Start(slog.Default(), context.Background()); err != nil {
-		return nil, err
-	}
-
-	return clientset, err
 }
 
 type ClientBuilderFunc func(name string) (Clientset, error)


### PR DESCRIPTION
This commit removes the deprecated and now unused method `NewStandaloneClientset`.

In the meantime, all usages have been moved to use the Hive Cell dependency directly.