### PR TITLE
docs: ipsec: mention dependency on transparent mode for DNS proxy

### DIFF
--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -98,6 +98,12 @@ Enable Encryption in Cilium
 At this point the Cilium managed nodes will be using IPsec for all traffic. For further
 information on Cilium's transparent encryption, see :ref:`ebpf_datapath`.
 
+Dependencies
+============
+
+When L7 proxy support is enabled (``--enable-l7-proxy=true``), IPsec requires that the
+DNS proxy operates in transparent mode (``--dnsproxy-enable-transparent-mode=true``).
+
 Encryption interface
 --------------------
 


### PR DESCRIPTION
For connections that are established by the DNS proxy, this is required to detect the original source IP and apply IPsec policy accordingly. The agent fatals if IPsec and L7 proxy are enabled, but the DNS proxy is not set to transparent mode.