### PR TITLE
docs: egressgw: remove kernel requirement

### DIFF
--- a/Documentation/network/egress-gateway.rst
+++ b/Documentation/network/egress-gateway.rst
@@ -10,10 +10,6 @@
 Egress Gateway
 **************
 
-.. note::
-
-    Egress Gateway requires a 5.2 or more recent kernel.
-
 The egress gateway feature routes all IPv4 connections originating from pods and
 destined to specific cluster-external CIDRs through particular nodes, from now
 on called "gateway nodes".


### PR DESCRIPTION
We already require a 5.4 kernel
(https://github.com/cilium/cilium/pull/30869). We also explicitly check for HAVE_LARGE_INSN_LIMIT (https://github.com/cilium/cilium/pull/30896), which afaik was the main reason for the 5.2 kernel requirement.