### PR TITLE
fqdn: Pre-allocate ToFQDN selector identities

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -62,6 +62,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 		Cache:               fqdn.NewDNSCache(option.Config.ToFQDNsMinTTL),
 		GetEndpointsDNSInfo: d.getEndpointsDNSInfo,
 		IPCache:             ipcache,
+		IdentityAllocator:   d.identityAllocator,
 	}
 	// Disable cleanup tracking on the default DNS cache. This cache simply
 	// tracks which api.FQDNSelector are present in policy which apply to

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -4,7 +4,11 @@
 package fqdn
 
 import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/labels"
 )
 
 // Config is a simple configuration structure to set how pkg/fqdn subcomponents
@@ -24,6 +28,10 @@ type Config struct {
 	GetEndpointsDNSInfo func(endpointID string) []EndpointDNSInfo
 
 	IPCache IPCache
+
+	// IdentityAllocator will be used to pre-allocate identities when a new selector
+	// is registered
+	IdentityAllocator IdentityAllocator
 }
 
 type EndpointDNSInfo struct {
@@ -37,4 +45,9 @@ type IPCache interface {
 	UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64)
 	RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64)
 	WaitForRevision(rev uint64)
+}
+
+type IdentityAllocator interface {
+	AllocateLocalIdentity(lbls labels.Labels, notifyOwner bool, oldNID identity.NumericIdentity) (id *identity.Identity, allocated bool, err error)
+	Release(ctx context.Context, id *identity.Identity, notifyOwner bool) (released bool, err error)
 }

--- a/pkg/fqdn/identities.go
+++ b/pkg/fqdn/identities.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package fqdn
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/trigger"
+)
+
+const (
+	identityAllocationTriggerName     = "fqdn-selector-identity-pre-allocation"
+	identityAllocationTriggerInterval = 100 * time.Millisecond
+)
+
+// newIdentityAllocationQueue creates a new queue to asynchronously allocate
+// and release identities for FQDNSelectors. This is done asynchronously to
+// avoid deadlocks:
+// We must not hold the NameManager lock when calling AllocateLocalIdentity
+// with notifyOwner=true, as the owner is the SelectorCache which can call
+// into NameManager (via RegisterFQDNSelector or UnregisterFQDNSelector),
+// thus creating a cyclic lock dependency which would lead to deadlocks.
+func newIdentityAllocationQueue(allocator IdentityAllocator) *identityQueue {
+	a := newIdentityPreAllocator(allocator)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	q := &identityQueue{}
+	q.trigger, _ = trigger.NewTrigger(trigger.Parameters{
+		Name:        identityAllocationTriggerName,
+		MinInterval: identityAllocationTriggerInterval,
+		TriggerFunc: func(reasons []string) {
+			for _, item := range q.drain() {
+				if item.allocate {
+					if err := a.allocate(item.selector); err != nil {
+						log.WithError(err).WithField(logfields.Selector, item.selector).
+							Error("Failed to pre-allocate identity")
+					}
+				} else {
+					if err := a.release(ctx, item.selector); err != nil {
+						log.WithError(err).WithField(logfields.Selector, item.selector).
+							Error("Failed to release pre-allocated identity")
+					}
+				}
+			}
+		},
+		ShutdownFunc: cancel,
+	})
+
+	return q
+}
+
+// identityPreAllocator wraps the real IdentityAllocator and stores
+// the pre-allocated identities for easier release
+type identityPreAllocator struct {
+	preAllocatedIdentities map[api.FQDNSelector][]*identity.Identity
+	backend                IdentityAllocator
+}
+
+func newIdentityPreAllocator(allocator IdentityAllocator) *identityPreAllocator {
+	return &identityPreAllocator{
+		preAllocatedIdentities: make(map[api.FQDNSelector][]*identity.Identity),
+		backend:                allocator,
+	}
+}
+
+// identitiesForFQDNSelector returns a slice of identity labels we want to
+// pre-allocate for this selector. If we are running in dual-stack mode, we
+// want to allocate one identity for IPv4 and IPv6 each, otherwise we only
+// need to allocate a single identity
+func identitiesForFQDNSelector(selector api.FQDNSelector) []labels.Labels {
+	selectorLbl := selector.IdentityLabel()
+	if option.Config.IsDualStack() {
+		return []labels.Labels{
+			labels.FromSlice([]labels.Label{selectorLbl, labels.WorldLabelV4}),
+			labels.FromSlice([]labels.Label{selectorLbl, labels.WorldLabelV6}),
+		}
+	} else {
+		return []labels.Labels{
+			labels.FromSlice([]labels.Label{selectorLbl, labels.WorldLabelNonDualStack}),
+		}
+	}
+}
+
+func (a *identityPreAllocator) allocate(selector api.FQDNSelector) (err error) {
+	_, ok := a.preAllocatedIdentities[selector]
+	if ok {
+		return errors.New("attempted to pre-allocate already pre-allocated identity")
+	}
+
+	requiredIdentities := identitiesForFQDNSelector(selector)
+	allocatedIdentities := make([]*identity.Identity, 0, len(requiredIdentities))
+	for _, lbls := range requiredIdentities {
+		id, _, allocErr := a.backend.AllocateLocalIdentity(lbls, true, identity.IdentityUnknown)
+		if allocErr != nil {
+			// This should never happen, unless we ran out of local identities.
+			// Since this is pre-allocation only (which is an optimization
+			// and not needed for correctness), we don't retry here.
+			// There is still a chance that the system recovers by itself
+			// if identities are released as part of the IPCache label
+			// injection triggered by updateMetadata.
+			err = errors.Join(err, allocErr)
+			// In case the previous allocation succeeded, we still want to
+			// add it to preAllocatedIdentities in order to release it later
+			continue
+		}
+		allocatedIdentities = append(allocatedIdentities, id)
+	}
+
+	if len(allocatedIdentities) > 0 {
+		a.preAllocatedIdentities[selector] = allocatedIdentities
+	}
+	return err
+}
+
+func (a *identityPreAllocator) release(ctx context.Context, selector api.FQDNSelector) (err error) {
+	identities, ok := a.preAllocatedIdentities[selector]
+	if !ok {
+		return errors.New("attempted to release non-allocated identity")
+	}
+
+	// Always delete the bookkeeping for pre-allocated identity even if release
+	// fails, as release basically only fails if we have a bug in our code.
+	// No point in re-trying in such a case.
+	delete(a.preAllocatedIdentities, selector)
+
+	for _, id := range identities {
+		_, releaseErr := a.backend.Release(ctx, id, true)
+		if releaseErr != nil {
+			err = errors.Join(err, releaseErr)
+		}
+	}
+
+	return nil
+}
+
+type identityQueueItem struct {
+	selector api.FQDNSelector
+	allocate bool // true -> allocate, false -> release
+}
+
+type identityQueue struct {
+	lock    lock.Mutex
+	queue   []identityQueueItem
+	trigger *trigger.Trigger
+}
+
+func (q *identityQueue) drain() (items []identityQueueItem) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	items, q.queue = q.queue, []identityQueueItem{}
+	return items
+}
+
+func (q *identityQueue) enqueueItem(item identityQueueItem) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	// Note that we enqueue items in sequence, thereby preserving the order of
+	// allocate and release events emitted by the NameManager. This ensures we
+	// are not releasing identities before they are allocated.
+	q.queue = append(q.queue, item)
+	q.trigger.Trigger()
+}
+
+func (q *identityQueue) enqueueAllocation(selector api.FQDNSelector) {
+	q.enqueueItem(identityQueueItem{
+		selector: selector,
+		allocate: true,
+	})
+}
+
+func (q *identityQueue) enqueueRelease(selector api.FQDNSelector) {
+	q.enqueueItem(identityQueueItem{
+		selector: selector,
+		allocate: false,
+	})
+}

--- a/pkg/fqdn/identities_test.go
+++ b/pkg/fqdn/identities_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package fqdn
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+type mockIdentityAllocator struct {
+	allocations chan labels.Labels
+	releases    chan labels.Labels
+}
+
+func newMockIdentityAllocator() *mockIdentityAllocator {
+	return &mockIdentityAllocator{
+		allocations: make(chan labels.Labels),
+		releases:    make(chan labels.Labels),
+	}
+}
+
+func (m *mockIdentityAllocator) AllocateLocalIdentity(lbls labels.Labels, notifyOwner bool, oldNID identity.NumericIdentity) (id *identity.Identity, allocated bool, err error) {
+	m.allocations <- lbls
+	return &identity.Identity{ID: oldNID, Labels: lbls}, false, nil
+}
+
+func (m *mockIdentityAllocator) Release(ctx context.Context, id *identity.Identity, notifyOwner bool) (released bool, err error) {
+	m.releases <- id.Labels
+	return false, nil
+}
+
+func TestNameManagerIdentityPreAllocation(t *testing.T) {
+	ipc := newMockIPCache()
+	ida := newMockIdentityAllocator()
+	nameManager := NewNameManager(Config{
+		MinTTL:            1,
+		Cache:             NewDNSCache(0),
+		IPCache:           ipc,
+		IdentityAllocator: ida,
+	})
+	t.Cleanup(nameManager.identityQueue.trigger.Shutdown)
+
+	// Register three selectors in sequence. This also tests that allocation
+	// happens asynchronously as our the mock identity allocator blocks
+	// until we read its channel
+	nameManager.RegisterFQDNSelector(ciliumIOSel)
+	nameManager.RegisterFQDNSelector(ciliumIOSelMatchPattern)
+	nameManager.RegisterFQDNSelector(githubSel)
+	for _, lbls := range identitiesForFQDNSelector(ciliumIOSel) {
+		require.Equal(t, lbls, <-ida.allocations)
+	}
+	for _, lbls := range identitiesForFQDNSelector(ciliumIOSelMatchPattern) {
+		require.Equal(t, lbls, <-ida.allocations)
+	}
+	for _, lbls := range identitiesForFQDNSelector(githubSel) {
+		require.Equal(t, lbls, <-ida.allocations)
+	}
+
+	// Bad cases: Unregister a selector which does not exist, and register a
+	// selector twice.
+	// Note: We check that these did not cause any allocation releases below,
+	// after the "Unregistering in sequence" block - as we're certain that the
+	// trigger has run after we've observed all legitimate releases
+	nameManager.RegisterFQDNSelector(ciliumIOSel)
+	nameManager.UnregisterFQDNSelector(api.FQDNSelector{
+		MatchName: "does.not.exist",
+	})
+
+	// Unregistering in sequence
+	nameManager.UnregisterFQDNSelector(ciliumIOSel)
+	nameManager.UnregisterFQDNSelector(githubSel)
+	nameManager.UnregisterFQDNSelector(ciliumIOSelMatchPattern)
+	for _, lbls := range identitiesForFQDNSelector(ciliumIOSel) {
+		require.Equal(t, lbls, <-ida.releases)
+	}
+	for _, lbls := range identitiesForFQDNSelector(githubSel) {
+		require.Equal(t, lbls, <-ida.releases)
+	}
+	for _, lbls := range identitiesForFQDNSelector(ciliumIOSelMatchPattern) {
+		require.Equal(t, lbls, <-ida.releases)
+	}
+
+	// Check that the "bad cases" did not trigger any actions
+	require.Empty(t, ida.allocations)
+	require.Empty(t, ida.releases)
+}

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -117,6 +117,12 @@ type IdentityAllocator interface {
 	// previous numeric identity exists.
 	AllocateIdentity(context.Context, labels.Labels, bool, identity.NumericIdentity) (*identity.Identity, bool, error)
 
+	// AllocateLocalIdentity works the same as AllocateIdentity, but it guarantees
+	// that the allocated identity will be local-only.
+	// If the provided set of labels does not map to a local identity scope,
+	// this will return an error.
+	AllocateLocalIdentity(lbls labels.Labels, notifyOwner bool, oldNID identity.NumericIdentity) (id *identity.Identity, allocated bool, err error)
+
 	// Release is the reverse operation of AllocateIdentity() and releases the
 	// specified identity.
 	Release(context.Context, *identity.Identity, bool) (released bool, err error)

--- a/pkg/labels/cidr.go
+++ b/pkg/labels/cidr.go
@@ -13,9 +13,9 @@ import (
 )
 
 var (
-	worldLabelNonDualStack = Label{Key: IDNameWorld, Source: LabelSourceReserved}
-	worldLabelV4           = Label{Source: LabelSourceReserved, Key: IDNameWorldIPv4}
-	worldLabelV6           = Label{Source: LabelSourceReserved, Key: IDNameWorldIPv6}
+	WorldLabelNonDualStack = Label{Key: IDNameWorld, Source: LabelSourceReserved}
+	WorldLabelV4           = Label{Source: LabelSourceReserved, Key: IDNameWorldIPv4}
+	WorldLabelV6           = Label{Source: LabelSourceReserved, Key: IDNameWorldIPv6}
 )
 
 // maskedIPToLabelString is the base method for serializing an IP + prefix into
@@ -101,11 +101,11 @@ func GetCIDRLabels(prefix netip.Prefix) Labels {
 func AddWorldLabel(addr netip.Addr, lbls Labels) {
 	switch {
 	case !option.Config.IsDualStack():
-		lbls[worldLabelNonDualStack.Key] = worldLabelNonDualStack
+		lbls[WorldLabelNonDualStack.Key] = WorldLabelNonDualStack
 	case addr.Is4():
-		lbls[worldLabelV4.Key] = worldLabelV4
+		lbls[WorldLabelV4.Key] = WorldLabelV4
 	default:
-		lbls[worldLabelV6.Key] = worldLabelV6
+		lbls[WorldLabelV6.Key] = WorldLabelV6
 	}
 }
 

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -130,6 +130,14 @@ func (f *MockIdentityAllocator) AllocateIdentity(_ context.Context, lbls labels.
 	return realID, true, nil
 }
 
+func (f *MockIdentityAllocator) AllocateLocalIdentity(lbls labels.Labels, notifyOwner bool, oldNID identity.NumericIdentity) (*identity.Identity, bool, error) {
+	if identity.ScopeForLabels(lbls) == identity.IdentityScopeGlobal {
+		return nil, false, cache.ErrNonLocalIdentity
+	}
+
+	return f.AllocateIdentity(context.Background(), lbls, notifyOwner, oldNID)
+}
+
 // Release releases a fake identity. It is meant to generally mock the
 // canonical identity release logic.
 func (f *MockIdentityAllocator) Release(_ context.Context, id *identity.Identity, _ bool) (released bool, err error) {


### PR DESCRIPTION
This PR contains a further performance improvement for https://github.com/cilium/cilium/pull/32769, namely pre-allocation for selector identities as proposed in [CFP-28427](https://github.com/cilium/design-cfps/blob/fe6dd4faf9c03626428e63536d0f5c5ec6e82ef1/cilium/CFP-28427-fqdn-selectors.md#fqdn-identity-pre-allocation).

The basic idea is that we pre-allocate a matching identity whenever a new ToFQDN selector is added by the policy engine. This reduces critical path latency for DNS lookups, as no policy maps need to be updated when the first DNS lookup occurs.

See commit messages for details