### PR TITLE
Fix release build SBOM generation

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -120,7 +120,8 @@ jobs:
         with:
           artifact-name: sbom_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
           output-file: ./sbom_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
-          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
+          image: quay.io/${{ env.QUAY_ORGANIZATION }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
+          upload-release-assets: false
 
       - name: Attach SBOM to container images
         run: |


### PR DESCRIPTION
- Use the correct image to generate SBOMs
- Stop release asset uploads, which can require extra permissions (that this workflow doesn't have) and that we don't need.
