### PR TITLE
endpoint: remove unused parameter from Add/NewEndpoint functions

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -211,7 +211,7 @@ func CleanupEndpoint() {
 
 // EndpointAdder is any type which adds an endpoint to be managed by Cilium.
 type EndpointAdder interface {
-	AddEndpoint(owner regeneration.Owner, ep *endpoint.Endpoint, reason string) error
+	AddEndpoint(owner regeneration.Owner, ep *endpoint.Endpoint) error
 }
 
 // LaunchAsEndpoint launches the cilium-health agent in a nested network
@@ -363,7 +363,7 @@ func LaunchAsEndpoint(baseCtx context.Context,
 		}
 	}
 
-	if err := epMgr.AddEndpoint(owner, ep, "Create cilium-health endpoint"); err != nil {
+	if err := epMgr.AddEndpoint(owner, ep); err != nil {
 		return nil, fmt.Errorf("Error while adding endpoint: %w", err)
 	}
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -90,7 +90,6 @@ import (
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node"
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
-	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pidfile"
@@ -1778,8 +1777,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 	} else {
 		log.Info("Creating host endpoint")
 		err := d.endpointManager.AddHostEndpoint(
-			d.ctx, d, d, d.ipcache, d.l7Proxy, d.identityAllocator,
-			"Create host endpoint", nodeTypes.GetName())
+			d.ctx, d, d, d.ipcache, d.l7Proxy, d.identityAllocator)
 		if err != nil {
 			return fmt.Errorf("unable to create host endpoint: %w", err)
 		}
@@ -1795,8 +1793,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 			} else {
 				log.Info("Creating ingress endpoint")
 				err := d.endpointManager.AddIngressEndpoint(
-					d.ctx, d, d, d.ipcache, d.l7Proxy, d.identityAllocator,
-					"Create ingress endpoint")
+					d.ctx, d, d, d.ipcache, d.l7Proxy, d.identityAllocator)
 				if err != nil {
 					return fmt.Errorf("unable to create ingress endpoint: %w", err)
 				}

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -518,7 +518,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 	}
 
 	// e.ID assigned here
-	err = d.endpointManager.AddEndpoint(owner, ep, "Create endpoint from API PUT")
+	err = d.endpointManager.AddEndpoint(owner, ep)
 	if err != nil {
 		return d.errorDuringCreation(ep, fmt.Errorf("unable to insert endpoint into manager: %w", err))
 	}

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -87,7 +87,7 @@ type EndpointsLookup interface {
 
 type EndpointsModify interface {
 	// AddEndpoint takes the prepared endpoint object and starts managing it.
-	AddEndpoint(owner regeneration.Owner, ep *endpoint.Endpoint, reason string) (err error)
+	AddEndpoint(owner regeneration.Owner, ep *endpoint.Endpoint) (err error)
 
 	// AddIngressEndpoint creates an Endpoint representing Cilium Ingress on this node without a
 	// corresponding container necessarily existing. This is needed to be able to ingest and
@@ -99,7 +99,6 @@ type EndpointsModify interface {
 		ipcache *ipcache.IPCache,
 		proxy endpoint.EndpointProxy,
 		allocator cache.IdentityAllocator,
-		reason string,
 	) error
 
 	AddHostEndpoint(
@@ -109,7 +108,6 @@ type EndpointsModify interface {
 		ipcache *ipcache.IPCache,
 		proxy endpoint.EndpointProxy,
 		allocator cache.IdentityAllocator,
-		reason, nodeName string,
 	) error
 
 	// RestoreEndpoint exposes the specified endpoint to other subsystems via the

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -648,7 +648,7 @@ func (mgr *endpointManager) RestoreEndpoint(ep *endpoint.Endpoint) error {
 }
 
 // AddEndpoint takes the prepared endpoint object and starts managing it.
-func (mgr *endpointManager) AddEndpoint(owner regeneration.Owner, ep *endpoint.Endpoint, reason string) (err error) {
+func (mgr *endpointManager) AddEndpoint(owner regeneration.Owner, ep *endpoint.Endpoint) (err error) {
 	if ep.ID != 0 {
 		return fmt.Errorf("Endpoint ID is already set to %d", ep.ID)
 	}
@@ -686,14 +686,13 @@ func (mgr *endpointManager) AddIngressEndpoint(
 	ipcache *ipcache.IPCache,
 	proxy endpoint.EndpointProxy,
 	allocator cache.IdentityAllocator,
-	reason string,
 ) error {
 	ep, err := endpoint.CreateIngressEndpoint(owner, policyGetter, ipcache, proxy, allocator)
 	if err != nil {
 		return err
 	}
 
-	if err := mgr.AddEndpoint(owner, ep, reason); err != nil {
+	if err := mgr.AddEndpoint(owner, ep); err != nil {
 		return err
 	}
 
@@ -709,14 +708,13 @@ func (mgr *endpointManager) AddHostEndpoint(
 	ipcache *ipcache.IPCache,
 	proxy endpoint.EndpointProxy,
 	allocator cache.IdentityAllocator,
-	reason, nodeName string,
 ) error {
 	ep, err := endpoint.CreateHostEndpoint(owner, policyGetter, ipcache, proxy, allocator)
 	if err != nil {
 		return err
 	}
 
-	if err := mgr.AddEndpoint(owner, ep, reason); err != nil {
+	if err := mgr.AddEndpoint(owner, ep); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This commit removes unused parameters from the functions `Add*Endpoint` and `New*Endpoint` from the EndpointManager.

- `reason`
- `nodeName`
