### PR TITLE
[v1.15] Disable release SBOM asset uploads

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -7,8 +7,6 @@ on:
       - v1.15.[0-9]+-rc.[0-9]+
 
 permissions:
-  # To be able to read SBOMs (see https://github.com/anchore/sbom-action/issues/468)
-  actions: read
   # To be able to access the repository with `actions/checkout`
   contents: read
   # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
@@ -123,6 +121,7 @@ jobs:
           artifact-name: sbom_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
           output-file: ./sbom_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
           image: quay.io/${{ env.QUAY_ORGANIZATION }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
+          upload-release-assets: false
 
       - name: Attach SBOM to container images
         run: |


### PR DESCRIPTION
We are not using this feature, and it requires extra workflow permissions.
