### PR TITLE
[v1.14] Disable release SBOM asset uploads

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -116,6 +116,7 @@ jobs:
           artifact-name: sbom_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
           output-file: ./sbom_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
           image: quay.io/${{ env.QUAY_ORGANIZATION }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
+          upload-release-assets: false
 
       - name: Attach SBOM to container images
         run: |


### PR DESCRIPTION
We are not using this feature, and it requires extra workflow permissions.
