### PR TITLE
bgpv2: pass types.Router in path and policy reconcilers

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
@@ -110,7 +110,7 @@ func (r *PodCIDRReconciler) reconcilePaths(ctx context.Context, p ReconcileParam
 	updatedAFPaths, err := ReconcileAFPaths(&ReconcileAFPathsParams{
 		Logger:       r.logger.WithField(types.InstanceLogField, p.DesiredConfig.Name),
 		Ctx:          ctx,
-		Instance:     p.BGPInstance,
+		Router:       p.BGPInstance.Router,
 		DesiredPaths: desiredFamilyAdverts,
 		CurrentPaths: metadata.AFPaths,
 	})
@@ -133,7 +133,7 @@ func (r *PodCIDRReconciler) reconcileRoutePolicies(ctx context.Context, p Reconc
 	updatedPolicies, err := ReconcileRoutePolicies(&ReconcileRoutePoliciesParams{
 		Logger:          r.logger.WithField(types.InstanceLogField, p.DesiredConfig.Name),
 		Ctx:             ctx,
-		Instance:        p.BGPInstance,
+		Router:          p.BGPInstance.Router,
 		DesiredPolicies: desiredRoutePolicies,
 		CurrentPolicies: r.getMetadata(p.BGPInstance).RoutePolicies,
 	})

--- a/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool.go
@@ -121,7 +121,7 @@ func (r *PodIPPoolReconciler) reconcilePaths(ctx context.Context, p ReconcilePar
 					types.PodIPPoolLogField: poolKey,
 				}),
 			Ctx:          ctx,
-			Instance:     p.BGPInstance,
+			Router:       p.BGPInstance.Router,
 			DesiredPaths: desiredPoolAFPaths,
 			CurrentPaths: currentPoolAFPaths,
 		})
@@ -197,7 +197,7 @@ func (r *PodIPPoolReconciler) reconcileRoutePolicies(ctx context.Context, p Reco
 					types.PodIPPoolLogField: poolKey,
 				}),
 			Ctx:             ctx,
-			Instance:        p.BGPInstance,
+			Router:          p.BGPInstance.Router,
 			DesiredPolicies: desiredRPs,
 			CurrentPolicies: currentRPs,
 		})

--- a/pkg/bgpv1/manager/reconcilerv2/policies.go
+++ b/pkg/bgpv1/manager/reconcilerv2/policies.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -36,7 +35,7 @@ type RoutePolicyMap map[string]*types.RoutePolicy
 type ReconcileRoutePoliciesParams struct {
 	Logger          logrus.FieldLogger
 	Ctx             context.Context
-	Instance        *instance.BGPInstance
+	Router          types.Router
 	DesiredPolicies RoutePolicyMap
 	CurrentPolicies RoutePolicyMap
 }
@@ -73,7 +72,7 @@ func ReconcileRoutePolicies(rp *ReconcileRoutePoliciesParams) (RoutePolicyMap, e
 			types.PolicyLogField: p.Name,
 		}).Debug("Adding route policy")
 
-		err := rp.Instance.Router.AddRoutePolicy(rp.Ctx, types.RoutePolicyRequest{
+		err := rp.Router.AddRoutePolicy(rp.Ctx, types.RoutePolicyRequest{
 			DefaultExportAction: types.RoutePolicyActionReject, // do not advertise routes by default
 			Policy:              p,
 		})
@@ -94,13 +93,13 @@ func ReconcileRoutePolicies(rp *ReconcileRoutePoliciesParams) (RoutePolicyMap, e
 		}).Debug("Updating (re-creating) route policy")
 
 		existing := rp.CurrentPolicies[p.Name]
-		err := rp.Instance.Router.RemoveRoutePolicy(rp.Ctx, types.RoutePolicyRequest{Policy: existing})
+		err := rp.Router.RemoveRoutePolicy(rp.Ctx, types.RoutePolicyRequest{Policy: existing})
 		if err != nil {
 			return runningPolicies, err
 		}
 		delete(runningPolicies, existing.Name)
 
-		err = rp.Instance.Router.AddRoutePolicy(rp.Ctx, types.RoutePolicyRequest{
+		err = rp.Router.AddRoutePolicy(rp.Ctx, types.RoutePolicyRequest{
 			DefaultExportAction: types.RoutePolicyActionReject, // do not advertise routes by default
 			Policy:              p,
 		})
@@ -118,7 +117,7 @@ func ReconcileRoutePolicies(rp *ReconcileRoutePoliciesParams) (RoutePolicyMap, e
 			types.PolicyLogField: p.Name,
 		}).Debug("Removing route policy")
 
-		err := rp.Instance.Router.RemoveRoutePolicy(rp.Ctx, types.RoutePolicyRequest{Policy: p})
+		err := rp.Router.RemoveRoutePolicy(rp.Ctx, types.RoutePolicyRequest{Policy: p})
 		if err != nil {
 			return runningPolicies, err
 		}
@@ -143,7 +142,7 @@ func ReconcileRoutePolicies(rp *ReconcileRoutePoliciesParams) (RoutePolicyMap, e
 			SoftResetDirection: types.SoftResetDirectionOut, // we are using only export policies
 		}
 
-		err = rp.Instance.Router.ResetNeighbor(rp.Ctx, req)
+		err = rp.Router.ResetNeighbor(rp.Ctx, req)
 		if err != nil {
 			// non-fatal error (may happen if the neighbor is not up), just log it
 			rp.Logger.WithFields(logrus.Fields{

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -202,7 +202,7 @@ func (r *ServiceReconciler) reconcileLBIPPoolRoutePolicies(ctx context.Context, 
 		updatedLBPoolRoutePolicies, rErr := ReconcileRoutePolicies(&ReconcileRoutePoliciesParams{
 			Logger:          r.logger.WithField(types.InstanceLogField, p.DesiredConfig.Name),
 			Ctx:             ctx,
-			Instance:        p.BGPInstance,
+			Router:          p.BGPInstance.Router,
 			DesiredPolicies: desiredLBPoolRoutePolicies,
 			CurrentPolicies: currentLBPoolRoutePolicies,
 		})
@@ -273,7 +273,7 @@ func (r *ServiceReconciler) reconcileSvcRoutePolicies(ctx context.Context, p Rec
 		updatedSvcRoutePolicies, rErr := ReconcileRoutePolicies(&ReconcileRoutePoliciesParams{
 			Logger:          r.logger.WithField(types.InstanceLogField, p.DesiredConfig.Name),
 			Ctx:             ctx,
-			Instance:        p.BGPInstance,
+			Router:          p.BGPInstance.Router,
 			DesiredPolicies: desiredSvcRoutePolicies,
 			CurrentPolicies: currentSvcRoutePolicies,
 		})
@@ -393,7 +393,7 @@ func (r *ServiceReconciler) reconcilePaths(ctx context.Context, p ReconcileParam
 		updatedAFPaths, rErr := ReconcileAFPaths(&ReconcileAFPathsParams{
 			Logger:       r.logger.WithField(types.InstanceLogField, p.DesiredConfig.Name),
 			Ctx:          ctx,
-			Instance:     p.BGPInstance,
+			Router:       p.BGPInstance.Router,
 			DesiredPaths: desiredAFPaths,
 			CurrentPaths: currentAFPaths,
 		})


### PR DESCRIPTION
This change passes only required field to Policy and Path reconcilers. Instead of passing BGPInstance, we pass only the Router interface which is required by underlying implementation.
