### PR TITLE
[1.13] Instruct users to manually clean stale routing rules after downgrade

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -406,11 +406,13 @@ jobs:
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium status
 
           # 1.12 is EOL, we have to run commands manually to clean up stale routing rules
-          cilium_pods=$(kubectl -nkube-system get po -l k8s-app=cilium --no-headers -o custom-columns=":metadata.name")
-          for cilium_pod in $cilium_pods; do
-            kubectl -nkube-system exec $cilium_pod -- ip -4 rule delete fwmark 0xB00/0xF00 lookup 2005 2>/dev/null || true
-            kubectl -nkube-system exec $cilium_pod -- ip -6 rule delete fwmark 0xB00/0xF00 lookup 2005 2>/dev/null || true
-          done
+          if [ "${{ matrix.mode }}" = "minor" ]; then
+            cilium_pods=$(kubectl -nkube-system get po -l k8s-app=cilium --no-headers -o custom-columns=":metadata.name")
+            for cilium_pod in $cilium_pods; do
+              kubectl -nkube-system exec $cilium_pod -- ip -4 rule delete fwmark 0xB00/0xF00 lookup 2005 2>/dev/null || true
+              kubectl -nkube-system exec $cilium_pod -- ip -6 rule delete fwmark 0xB00/0xF00 lookup 2005 2>/dev/null || true
+            done
+          fi
 
       - name: Check conn-disrupt-test after downgrading
         if: ${{ steps.vars.outputs.downgrade_version != '' }}

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -306,6 +306,20 @@ Annotations:
 
 .. _1.13_upgrade_notes:
 
+1.13.18 Upgrade Notes
+---------------------
+
+* For IPsec users, in case of a downgrade to v1.12 or earlier, please run
+  commands after downgrade completes to ensure connectivity via L7/DNS proxy:
+
+.. code-block:: shell-session
+
+    cilium_pods=$(kubectl -nkube-system get po -l k8s-app=cilium --no-headers -o custom-columns=":metadata.name")
+    for cilium_pod in $cilium_pods; do
+        kubectl -nkube-system exec $cilium_pod -- ip -4 rule delete fwmark 0xB00/0xF00 lookup 2005 2>/dev/null || true
+        kubectl -nkube-system exec $cilium_pod -- ip -6 rule delete fwmark 0xB00/0xF00 lookup 2005 2>/dev/null || true
+    done
+
 1.13.7 Upgrade Notes
 --------------------
 

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -199,6 +199,25 @@ to all clusters in the mesh. You might need to increase the transition time to
 allow for the new keys to be deployed and applied across all clusters,
 which you can do with the agent flag ``ipsec-key-rotation-duration``.
 
+Downgrade
+=========
+
+.. attention::
+
+   This is a v1.13-only requirement. In v1.14 and later, the Cilium agent can
+   automatically remove stale routing rules.
+
+To ensure connectivity via L7/DNS proxy after downgrade, please run commands
+after downgrade completes:
+
+.. code-block:: shell-session
+
+    cilium_pods=$(kubectl -nkube-system get po -l k8s-app=cilium --no-headers -o custom-columns=":metadata.name")
+    for cilium_pod in $cilium_pods; do
+        kubectl -nkube-system exec $cilium_pod -- ip -4 rule delete fwmark 0xB00/0xF00 lookup 2005 2>/dev/null || true
+        kubectl -nkube-system exec $cilium_pod -- ip -6 rule delete fwmark 0xB00/0xF00 lookup 2005 2>/dev/null || true
+    done
+
 Troubleshooting
 ===============
 


### PR DESCRIPTION
Downgrade from 1.13 to 1.12 (EOL) requires manual cleanups, this PR adds the upgrade and downgrade notes in Documentation.

This PR also makes sure the manual cleanups are only run for minor downgrade in ci-ipsec-upgrade.