### PR TITLE
bpf: host: use security identities in to-netdev's trace notifications

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1364,12 +1364,13 @@ __section_entry
 int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 {
 	__u32 magic = ctx->mark & MARK_MAGIC_HOST_MASK;
+	__u32 dst_sec_identity = UNKNOWN_ID;
+	__u32 src_sec_identity = UNKNOWN_ID;
 	struct trace_ctx trace = {
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = 0,
 	};
 	__u32 __maybe_unused vlan_id;
-	__u32 src_sec_identity = 0;
 	int ret = CTX_ACT_OK;
 	__s8 ext_err = 0;
 #if defined(ENABLE_HOST_FIREWALL) || defined(ENABLE_EGRESS_GATEWAY_COMMON)
@@ -1466,7 +1467,8 @@ skip_host_firewall:
 			/* we are redirecting back into the stack, so TRACE_TO_STACK
 			 * for tracepoint
 			 */
-			send_trace_notify(ctx, TRACE_TO_STACK, UNKNOWN_ID, UNKNOWN_ID,
+			send_trace_notify(ctx, TRACE_TO_STACK, src_sec_identity,
+					  dst_sec_identity,
 					  TRACE_EP_ID_UNKNOWN, TRACE_IFINDEX_UNKNOWN,
 					  TRACE_REASON_ENCRYPT_OVERLAY, 0);
 			return ret;
@@ -1529,7 +1531,6 @@ skip_host_firewall:
 		int l4_off;
 		struct remote_endpoint_info *info;
 		struct endpoint_info *src_ep;
-		__u32 dst_sec_identity = UNKNOWN_ID;
 
 		if (!validate_ethertype(ctx, &proto) || proto != bpf_htons(ETH_P_IP))
 			goto skip_egress_gateway;
@@ -1605,7 +1606,7 @@ exit:
 	if (IS_ERR(ret))
 		goto drop_err;
 
-	send_trace_notify(ctx, TRACE_TO_NETWORK, UNKNOWN_ID, UNKNOWN_ID,
+	send_trace_notify(ctx, TRACE_TO_NETWORK, src_sec_identity, dst_sec_identity,
 			  TRACE_EP_ID_UNKNOWN,
 			  TRACE_IFINDEX_UNKNOWN, trace.reason, trace.monitor);
 


### PR DESCRIPTION
For some types of traffic, to-netdev derives precise security identities. Consistently use these values in the trace notifications.