### PR TITLE
Introduce granular etcd permissions to access KVstoreMesh cached data

### DIFF
--- a/Documentation/operations/troubleshooting_clustermesh.rst
+++ b/Documentation/operations/troubleshooting_clustermesh.rst
@@ -101,6 +101,10 @@ you may perform the following steps to troubleshoot ClusterMesh issues.
       optionally the kvstoremesh container in the clustermesh-apiserver deployment,
       to authenticate against remote etcd instances (either internal or external).
 
+    * ``clustermesh-apiserver-local-cert``, which is used by Cilium agents to
+      authenticate against the local etcd instance. Only applicable if KVStoreMesh
+      is enabled.
+
  #. Validate that the configuration for remote clusters is picked up correctly.
     For each remote cluster, an info log message ``New remote cluster
     configuration`` along with the remote cluster name must be logged in the

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -904,6 +904,29 @@ spec:
               - key: {{ .Values.tls.caBundle.key }}
                 path: common-etcd-client-ca.crt
           {{- end }}
+          # note: we configure the volume for the kvstoremesh-specific certificate
+          # regardless of whether KVStoreMesh is enabled or not, so that it can be
+          # automatically mounted in case KVStoreMesh gets subsequently enabled,
+          # without requiring an agent restart.
+          - secret:
+              name: clustermesh-apiserver-local-cert
+              optional: true
+              items:
+              - key: tls.key
+                path: local-etcd-client.key
+              - key: tls.crt
+                path: local-etcd-client.crt
+          {{- if not .Values.tls.caBundle.enabled }}
+              - key: ca.crt
+                path: local-etcd-client-ca.crt
+          {{- else }}
+          - {{ .Values.tls.caBundle.useSecret | ternary "secret" "configMap" }}:
+              name: {{ .Values.tls.caBundle.name }}
+              optional: true
+              items:
+              - key: {{ .Values.tls.caBundle.key }}
+                path: local-etcd-client-ca.crt
+          {{- end }}
       {{- if and .Values.ipMasqAgent .Values.ipMasqAgent.enabled }}
       - name: ip-masq-agent
         configMap:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/_helpers.tpl
@@ -2,6 +2,10 @@
 admin-{{ .Values.cluster.name }}
 {{- end -}}
 
+{{- define "clustermesh-apiserver-generate-certs.local-common-name" -}}
+local-{{ .Values.cluster.name }}
+{{- end -}}
+
 {{- define "clustermesh-apiserver-generate-certs.remote-common-name" -}}
 {{- if eq .Values.clustermesh.apiserver.tls.authMode "cluster" -}}
 remote-{{ .Values.cluster.name }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/local-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/local-secret.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: clustermesh-apiserver-local-cert
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.clustermesh.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  issuerRef:
+    {{- toYaml .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef | nindent 4 }}
+  secretName: clustermesh-apiserver-local-cert
+  commonName: {{ include "clustermesh-apiserver-generate-certs.local-common-name" . }}
+  duration: {{ printf "%dh0m0s" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
@@ -66,6 +66,16 @@ spec:
                   - client auth
                   validity: {{ $certValidityStr }}
                 {{- end }}
+                {{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled }}
+                - name: clustermesh-apiserver-local-cert
+                  namespace: {{ .Release.Namespace }}
+                  commonName: {{ include "clustermesh-apiserver-generate-certs.local-common-name" . | quote }}
+                  usage:
+                  - signing
+                  - key encipherment
+                  - client auth
+                  validity: {{ $certValidityStr }}
+                {{- end }}
                 {{- if .Values.externalWorkloads.enabled }}
                 - name: clustermesh-apiserver-client-cert
                   namespace: {{ .Release.Namespace }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/role.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/role.yaml
@@ -34,6 +34,7 @@ rules:
       - clustermesh-apiserver-server-cert
       - clustermesh-apiserver-admin-cert
       - clustermesh-apiserver-remote-cert
+      - clustermesh-apiserver-local-cert
       - clustermesh-apiserver-client-cert
     verbs:
       - update

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/local-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/local-secret.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "helm") }}
+{{- $_ := include "cilium.ca.setup" . -}}
+{{- $cn := include "clustermesh-apiserver-generate-certs.local-common-name" . -}}
+{{- $cert := genSignedCert $cn nil nil (.Values.clustermesh.apiserver.tls.auto.certValidityDuration | int) .commonCA -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: clustermesh-apiserver-local-cert
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.clustermesh.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  ca.crt:  {{ .commonCA.Cert | b64enc }}
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key  | b64enc }}
+{{- end }}

--- a/pkg/kvstore/etcdinit/init.go
+++ b/pkg/kvstore/etcdinit/init.go
@@ -6,6 +6,7 @@ package init
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -62,7 +63,7 @@ func ClusterMeshEtcdInit(ctx context.Context, log *logrus.Entry, client *clientv
 	}
 
 	// Admin user
-	adminUsername := adminUsernameForClusterName(ciliumClusterName)
+	adminUsername := usernameForClusterName("admin", ciliumClusterName)
 	log.WithField("etcdUsername", adminUsername).
 		Info("Configuring admin user")
 	err = ic.addNoPasswordUser(ctx, adminUsername)
@@ -104,7 +105,31 @@ func ClusterMeshEtcdInit(ctx context.Context, log *logrus.Entry, client *clientv
 		return err
 	}
 
-	// Remote user
+	// Local user (i.e., local agents accessing information cached by KVStoreMesh)
+	localUsername := usernameForClusterName("local", ciliumClusterName)
+	log.WithField("etcdUsername", localUsername).
+		Info("Configuring local user")
+	localRolename := rolename("local")
+	err = ic.addNoPasswordUser(ctx, localUsername)
+	if err != nil {
+		return err
+	}
+	err = ic.addRole(ctx, localRolename)
+	if err != nil {
+		return err
+	}
+	err = ic.grantRoleToUser(ctx, localRolename, localUsername)
+	if err != nil {
+		return err
+	}
+	for _, keyRange := range rangesForLocalRole() {
+		err = ic.grantPermissionToRole(ctx, readOnly, keyRange, localRolename)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Remote user (i.e., remote clusters accessing state information)
 	remoteUsername := username("remote")
 	log.WithField("etcdUsername", remoteUsername).
 		Info("Configuring remote user")
@@ -121,9 +146,11 @@ func ClusterMeshEtcdInit(ctx context.Context, log *logrus.Entry, client *clientv
 	if err != nil {
 		return err
 	}
-	err = ic.grantPermissionToRole(ctx, readOnly, allKeysRange, remoteRolename)
-	if err != nil {
-		return err
+	for _, keyRange := range rangesForRemoteRole(ciliumClusterName) {
+		err = ic.grantPermissionToRole(ctx, readOnly, keyRange, remoteRolename)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Post setup
@@ -136,13 +163,13 @@ func ClusterMeshEtcdInit(ctx context.Context, log *logrus.Entry, client *clientv
 	return nil
 }
 
-// adminUsernameForClusterName generates the admin account username for a given clusterName. This handles the edge case
+// usernameForClusterName generates the account username for a given clusterName. This handles the edge case
 // where the clusterName is blank, ensuring we don't have a username with a trailing hyphen.
-func adminUsernameForClusterName(clusterName string) username {
+func usernameForClusterName(base, clusterName string) username {
 	if clusterName == "" {
-		return "admin"
+		return username(base)
 	}
-	return username(fmt.Sprintf("admin-%s", clusterName))
+	return username(fmt.Sprintf("%s-%s", base, clusterName))
 }
 
 // initClient is a thin wrapper around the etcd client library that provides functions with more useful error messages,
@@ -226,6 +253,11 @@ type keyRange struct {
 	end   string
 }
 
+// rangeForKey generates a keyRange for a given key. Differently from rangeForPrefix, it does not enforce a trailing /
+func rangeForKey(key string) keyRange {
+	return keyRange{key, clientv3.GetPrefixRangeEnd(key)}
+}
+
 // rangeForPrefix generates a keyRange for a given prefix. This is a wrapper around the client's GetPrefixRangeEnd
 // function.
 func rangeForPrefix(prefix string) keyRange {
@@ -235,10 +267,7 @@ func rangeForPrefix(prefix string) keyRange {
 	if !strings.HasSuffix(prefix, "/") {
 		prefix += "/"
 	}
-	return keyRange{
-		prefix,
-		clientv3.GetPrefixRangeEnd(prefix),
-	}
+	return rangeForKey(prefix)
 }
 
 // allKeysRange is the range over all keys in etcd. Granting permissions on this range is the same as granting global
@@ -283,4 +312,31 @@ func (ic initClient) enableAuth(ctx context.Context) error {
 		return fmt.Errorf("enabling authentication on etcd: %w", err)
 	}
 	return nil
+}
+
+// rangesForLocalRole returns the set of etcd key ranges allowed to be accessed by the local user.
+func rangesForLocalRole() []keyRange {
+	return []keyRange{
+		rangeForKey(kvstore.HeartbeatPath),
+		rangeForKey(kvstore.HasClusterConfigPath),
+		rangeForPrefix(kvstore.CachePrefix),
+		rangeForPrefix(kvstore.ClusterConfigPrefix),
+		rangeForPrefix(kvstore.SyncedPrefix),
+	}
+}
+
+// rangesForLocalUser returns the set of etcd key ranges allowed to be accessed by the remote user.
+func rangesForRemoteRole(clusterName string) []keyRange {
+	return []keyRange{
+		rangeForKey(kvstore.HeartbeatPath),
+		rangeForKey(kvstore.HasClusterConfigPath),
+		rangeForPrefix(kvstore.StatePrefix),
+		rangeForKey(path.Join(kvstore.ClusterConfigPrefix, clusterName)),
+		rangeForPrefix(path.Join(kvstore.SyncedPrefix, clusterName)),
+
+		// kvstoremesh-specific prefixes still allowed for backward compatibility
+		rangeForPrefix(kvstore.CachePrefix),
+		rangeForPrefix(kvstore.ClusterConfigPrefix),
+		rangeForPrefix(kvstore.SyncedPrefix),
+	}
 }

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -25,6 +25,13 @@ const (
 	// BaseKeyPrefix is the base prefix that should be used for all keys
 	BaseKeyPrefix = "cilium"
 
+	// StatePrefix is the kvstore prefix used to store the Cilium's state.
+	StatePrefix = BaseKeyPrefix + "/state"
+
+	// CachePrefix is the kvstore prefix used to store the information retrieved
+	// from a remote cluster and cached locally by KVStoreMesh.
+	CachePrefix = BaseKeyPrefix + "/cache"
+
 	// InitLockPath is the path to the init lock to test quorum
 	InitLockPath = BaseKeyPrefix + "/.initlock"
 
@@ -59,8 +66,8 @@ const (
 // (holding the cilium state) to the corresponding one holding cached information
 // from another kvstore (that is, "cilium/cache").
 func StateToCachePrefix(prefix string) string {
-	if strings.HasPrefix(prefix, "cilium/state") {
-		return strings.Replace(prefix, "cilium/state", "cilium/cache", 1)
+	if strings.HasPrefix(prefix, StatePrefix) {
+		return strings.Replace(prefix, StatePrefix, CachePrefix, 1)
 	}
 	return prefix
 }


### PR DESCRIPTION
Currently, the same etcd user (i.e., remote) is granted permissions to read the whole content of the clustermesh-apiserver's sidecar etcd instance, including also the data cached by kvstoremesh, when enabled. In an effort to harden the overall clustermesh posture, let's introduce a separate and dedicated user for local access, to ensure that remote clusters cannot access cached data, as it may include information that they would not normally have access to.
    
Specifically, the remote user is intended to have access only to the information regarding the local cluster, while the local user can access cached data about remote clusters only. Still, for backward compatibility purposes, the remote user still retains access to cached data as well in this release. The reason being that there would otherwise be a time window upon upgrade in which Cilium Agents would lose access to the kvstoremesh data (especially in large clusters). Indeed, the new certificate would be mounted by the agents only upon rollout, but the configuration would be immediately reloaded (thus   targeting the new, not yet mounted, certificate), hence breaking the access to the information cached by kvstoremesh.

Please review commit by commit, and refer to the individual descriptions for additional details. 
