### PR TITLE
bpf: encap: fix ifindex in TO_OVERLAY trace notification

### DIFF
--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -36,11 +36,17 @@ __encap_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 
 	cilium_dbg(ctx, DBG_ENCAP, node_id, seclabel);
 
+#if __ctx_is == __ctx_skb
+	*ifindex = ENCAP_IFINDEX;
+#else
+	*ifindex = 0;
+#endif
+
 	send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, dstid, TRACE_EP_ID_UNKNOWN,
 			  *ifindex, ct_reason, monitor);
 
 	return ctx_set_encap_info(ctx, src_ip, src_port, node_id, seclabel, vni,
-				  NULL, 0, ifindex);
+				  NULL, 0);
 }
 
 static __always_inline int
@@ -223,11 +229,17 @@ __encap_with_nodeid_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 
 	cilium_dbg(ctx, DBG_ENCAP, node_id, seclabel);
 
+#if __ctx_is == __ctx_skb
+	*ifindex = ENCAP_IFINDEX;
+#else
+	*ifindex = 0;
+#endif
+
 	send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, dstid, TRACE_EP_ID_UNKNOWN,
 			  *ifindex, ct_reason, monitor);
 
 	return ctx_set_encap_info(ctx, src_ip, src_port, node_id, seclabel, vni, opt,
-				  opt_len, ifindex);
+				  opt_len);
 }
 
 static __always_inline void

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -268,7 +268,7 @@ static __always_inline __maybe_unused int
 ctx_set_encap_info(struct __sk_buff *ctx, __u32 src_ip,
 		   __be16 src_port __maybe_unused, __u32 node_id,
 		   __u32 seclabel, __u32 vni __maybe_unused,
-		   void *opt, __u32 opt_len, int *ifindex)
+		   void *opt, __u32 opt_len)
 {
 	struct bpf_tunnel_key key = {};
 	__u32 key_size = TUNNEL_KEY_WITHOUT_SRC_IP;
@@ -297,8 +297,6 @@ ctx_set_encap_info(struct __sk_buff *ctx, __u32 src_ip,
 		if (unlikely(ret < 0))
 			return DROP_WRITE_ERROR;
 	}
-
-	*ifindex = ENCAP_IFINDEX;
 
 	return CTX_ACT_REDIRECT;
 }

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -158,7 +158,7 @@ static __always_inline bool ctx_snat_done(struct xdp_md *ctx)
 static __always_inline __maybe_unused int
 ctx_set_encap_info(struct xdp_md *ctx, __u32 src_ip, __be16 src_port,
 		   __u32 daddr, __u32 seclabel __maybe_unused,
-		   __u32 vni __maybe_unused, void *opt, __u32 opt_len, int *ifindex)
+		   __u32 vni __maybe_unused, void *opt, __u32 opt_len)
 {
 	__u32 inner_len = ctx_full_len(ctx);
 	__u32 tunnel_hdr_len = 8; /* geneve / vxlan */
@@ -234,8 +234,6 @@ ctx_set_encap_info(struct xdp_md *ctx, __u32 src_ip, __be16 src_port,
 	ip4->check = csum_fold(csum_diff(NULL, 0, ip4, sizeof(*ip4), 0));
 
 	eth->h_proto = bpf_htons(ETH_P_IP);
-
-	*ifindex = 0;
 
 	return CTX_ACT_REDIRECT;
 }


### PR DESCRIPTION
The encap helpers were meant to abstract from differences between TC and XDP. Therefore ctx_set_encap_info() provides the ifindex for TC, and setting the ifindex also indicates that a redirect to encap interface is possible (rather than manually adding the overlay headers + FIB lookup).

The downside is that __encap_with_nodeid() for TC currently emits a trace notification without the ifindex set to ENCAP_IFINDEX.

Fix this up manually by moving the `ifindex` initialization up.