### PR TITLE
fqdn: Exit go routines early if datapath update times out

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1758,7 +1758,9 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 	// After K8s caches have been synced, IPCache can start label injection.
 	// Ensure that the initial labels are injected before we regenerate endpoints
 	log.Debug("Waiting for initial IPCache revision")
-	d.ipcache.WaitForRevision(1)
+	if err := d.ipcache.WaitForRevision(d.ctx, 1); err != nil {
+		log.WithError(err).Error("Failed to wait for initial IPCache revision")
+	}
 
 	d.initRestore(restoredEndpoints, params.EndpointRegenerator)
 

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -4,6 +4,8 @@
 package fqdn
 
 import (
+	"context"
+
 	"github.com/cilium/cilium/pkg/ipcache"
 )
 
@@ -36,5 +38,5 @@ type EndpointDNSInfo struct {
 type IPCache interface {
 	UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64)
 	RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64)
-	WaitForRevision(rev uint64)
+	WaitForRevision(ctx context.Context, rev uint64) error
 }

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -11,10 +11,10 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
-	"sync"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -252,7 +252,7 @@ func NewNameManager(config Config) *NameManager {
 
 // UpdateGenerateDNS inserts the new DNS information into the cache. If the IPs
 // have changed for a name they will be reflected in updatedDNSIPs.
-func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) *sync.WaitGroup {
+func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) *errgroup.Group {
 	n.RWMutex.Lock()
 	defer n.RWMutex.Unlock()
 
@@ -265,14 +265,11 @@ func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Tim
 		}).Debug("Updated FQDN with new IPs")
 	}
 
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		if err := n.config.IPCache.WaitForRevision(ctx, ipcacheRevision); err == nil {
-			wg.Done()
-		}
-	}()
-	return wg
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		return n.config.IPCache.WaitForRevision(ctx, ipcacheRevision)
+	})
+	return g
 }
 
 func (n *NameManager) CompleteBootstrap() {

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -268,8 +268,9 @@ func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Tim
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		n.config.IPCache.WaitForRevision(ipcacheRevision)
-		wg.Done()
+		if err := n.config.IPCache.WaitForRevision(ctx, ipcacheRevision); err == nil {
+			wg.Done()
+		}
 	}()
 	return wg
 }

--- a/pkg/fqdn/name_manager_test.go
+++ b/pkg/fqdn/name_manager_test.go
@@ -75,8 +75,8 @@ func (m *mockIPCache) RemoveMetadataBatch(updates ...ipcache.MU) (revision uint6
 	return 0
 }
 
-func (m *mockIPCache) WaitForRevision(rev uint64) {
-	// no-op
+func (m *mockIPCache) WaitForRevision(ctx context.Context, rev uint64) error {
+	return nil
 }
 
 func ipsFromPrefixes(t *testing.T, prefixes ...netip.Prefix) (ips []net.IP) {

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -603,15 +603,17 @@ func (ipc *IPCache) RemoveIdentityOverride(cidr netip.Prefix, identityLabels lab
 // metadata updates. Thus, the sequence
 //
 //	rev := UpsertMetadataBatch(prefix1, metadata, ...)
-//	WaitForRevision(rev)
+//	WaitForRevision(ctx, rev)
 //
 // means that prefix1 has had at least one call to InjectLabels with the supplied
 // metadata. It does not guarantee that the metadata matches exactly what was
 // passed to UpsertMetadata, as other callers may have also queued modifications.
 //
 // Note that the revision number should be treated as an opaque identifier.
-func (ipc *IPCache) WaitForRevision(desired uint64) {
-	ipc.metadata.waitForRevision(desired)
+// Returns a non-nil error if the provided context was cancelled before the
+// desired revision was reached.
+func (ipc *IPCache) WaitForRevision(ctx context.Context, desired uint64) error {
+	return ipc.metadata.waitForRevision(ctx, desired)
 }
 
 // DumpToListenerLocked dumps the entire contents of the IPCache by triggering

--- a/pkg/testutils/ipcache/ipcache.go
+++ b/pkg/testutils/ipcache/ipcache.go
@@ -4,6 +4,7 @@
 package testipcache
 
 import (
+	"context"
 	"net"
 	"net/netip"
 
@@ -66,7 +67,9 @@ func (m *MockIPCache) RemoveMetadataBatch(updates ...ipcache.MU) (revision uint6
 	return 0
 }
 
-func (m *MockIPCache) WaitForRevision(rev uint64) {}
+func (m *MockIPCache) WaitForRevision(ctx context.Context, rev uint64) error {
+	return nil
+}
 
 func NewMockIPCache() *MockIPCache {
 	return &MockIPCache{}


### PR DESCRIPTION
This PR optimizes the time FQDN Go routines linger around when waiting on datapath updates. Before this PR, they would wait until the datapath update finished, even though the parent already decided to moved on without waiting on the datpath update.

See commit messages and https://github.com/cilium/cilium/pull/32769#discussion_r1626356945 for further details