### PR TITLE
bpf: move feature-specific maps into their header files

### DIFF
--- a/bpf/lib/edt.h
+++ b/bpf/lib/edt.h
@@ -7,12 +7,20 @@
 
 #include "common.h"
 #include "time.h"
-#include "maps.h"
 
 /* From XDP layer, we neither go through an egress hook nor qdisc
  * from here, hence nothing to be set.
  */
 #if defined(ENABLE_BANDWIDTH_MANAGER) && __ctx_is == __ctx_skb
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, struct edt_id);
+	__type(value, struct edt_info);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, THROTTLE_MAP_SIZE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} THROTTLE_MAP __section_maps_btf;
+
 static __always_inline void edt_set_aggregate(struct __ctx_buff *ctx,
 					      __u32 aggregate)
 {

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -8,7 +8,6 @@
 #include "lib/overloadable.h"
 
 #include "encap.h"
-#include "maps.h"
 
 #ifdef ENABLE_EGRESS_GATEWAY_COMMON
 
@@ -57,6 +56,15 @@ int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, 
 }
 
 #ifdef ENABLE_EGRESS_GATEWAY
+struct {
+	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
+	__type(key, struct egress_gw_policy_key);
+	__type(value, struct egress_gw_policy_entry);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, EGRESS_POLICY_MAP_SIZE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} EGRESS_POLICY_MAP __section_maps_btf;
+
 static __always_inline
 struct egress_gw_policy_entry *lookup_ip4_egress_gw_policy(__be32 saddr, __be32 daddr)
 {

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -17,6 +17,15 @@
 #include "high_scale_ipcache.h"
 
 #ifdef HAVE_ENCAP
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, struct tunnel_key);
+	__type(value, struct tunnel_value);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, TUNNEL_ENDPOINT_MAP_SIZE);
+	__uint(map_flags, CONDITIONAL_PREALLOC);
+} TUNNEL_MAP __section_maps_btf;
+
 static __always_inline int
 __encap_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 		    __be32 tunnel_endpoint,

--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -78,17 +78,6 @@ tail_call_egress_policy(struct __ctx_buff *ctx, __u16 endpoint_id)
 
 #endif
 
-#ifdef ENABLE_BANDWIDTH_MANAGER
-struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__type(key, struct edt_id);
-	__type(value, struct edt_info);
-	__uint(pinning, LIBBPF_PIN_BY_NAME);
-	__uint(max_entries, THROTTLE_MAP_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
-} THROTTLE_MAP __section_maps_btf;
-#endif /* ENABLE_BANDWIDTH_MANAGER */
-
 #ifdef POLICY_MAP
 /* Per-endpoint policy enforcement map */
 struct {

--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -129,19 +129,6 @@ struct bpf_elf_map __section_maps CALLS_MAP = {
 };
 #endif /* SKIP_CALLS_MAP */
 
-#ifdef HAVE_ENCAP
-
-struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__type(key, struct tunnel_key);
-	__type(value, struct tunnel_value);
-	__uint(pinning, LIBBPF_PIN_BY_NAME);
-	__uint(max_entries, TUNNEL_ENDPOINT_MAP_SIZE);
-	__uint(map_flags, CONDITIONAL_PREALLOC);
-} TUNNEL_MAP __section_maps_btf;
-
-#endif
-
 #if defined(ENABLE_CUSTOM_CALLS) && defined(CUSTOM_CALLS_MAP)
 /* Private per-EP map for tail calls to user-defined programs.
  * CUSTOM_CALLS_MAP is a per-EP map name, only defined for programs that need

--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -242,17 +242,6 @@ struct {
 	__uint(map_flags, BPF_F_NO_PREALLOC);
 } L2_RESPONDER_MAP4 __section_maps_btf;
 
-#ifdef ENABLE_EGRESS_GATEWAY
-struct {
-	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
-	__type(key, struct egress_gw_policy_key);
-	__type(value, struct egress_gw_policy_entry);
-	__uint(pinning, LIBBPF_PIN_BY_NAME);
-	__uint(max_entries, EGRESS_POLICY_MAP_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
-} EGRESS_POLICY_MAP __section_maps_btf;
-#endif /* ENABLE_EGRESS_GATEWAY */
-
 #ifdef ENABLE_SRV6
 # define SRV6_VRF_MAP(IP_FAMILY)				\
 struct {						\


### PR DESCRIPTION
Clean up the global `maps.h` header a bit, and co-locate the maps with the rest of the relevant code.
