### PR TITLE
bpf: clean up some unneeded includes

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -32,7 +32,6 @@
 #include "lib/identity.h"
 #include "lib/nodeport.h"
 #include "lib/clustermesh.h"
-#include "lib/wireguard.h"
 #include "lib/egress_gateway.h"
 
 #ifdef ENABLE_VTEP

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -7,11 +7,9 @@
 #include "dbg.h"
 #include "hash.h"
 #include "trace.h"
-#include "l3.h"
 
 #if __ctx_is == __ctx_skb
 #include "encrypt.h"
-#include "wireguard.h"
 #endif /* __ctx_is == __ctx_skb */
 
 #include "high_scale_ipcache.h"

--- a/bpf/lib/high_scale_ipcache.h
+++ b/bpf/lib/high_scale_ipcache.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "ipv4.h"
+#include "l4.h"
 #include "maps.h"
 
 #ifdef ENABLE_HIGH_SCALE_IPCACHE


### PR DESCRIPTION
Motivated by trimming down the `wireguard.h` usage.