### PR TITLE
ipam: cell for IPAM and IPAMRestAPIHandler

### DIFF
--- a/daemon/cmd/api_handlers.go
+++ b/daemon/cmd/api_handlers.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/api/v1/server/restapi/endpoint"
-	"github.com/cilium/cilium/api/v1/server/restapi/ipam"
 	"github.com/cilium/cilium/api/v1/server/restapi/metrics"
 	"github.com/cilium/cilium/api/v1/server/restapi/policy"
 	"github.com/cilium/cilium/api/v1/server/restapi/service"
@@ -48,10 +47,6 @@ type handlersOut struct {
 	EndpointPatchEndpointIDHandler       endpoint.PatchEndpointIDHandler
 	EndpointPatchEndpointIDLabelsHandler endpoint.PatchEndpointIDLabelsHandler
 	EndpointPutEndpointIDHandler         endpoint.PutEndpointIDHandler
-
-	IpamDeleteIpamIPHandler ipam.DeleteIpamIPHandler
-	IpamPostIpamHandler     ipam.PostIpamHandler
-	IpamPostIpamIPHandler   ipam.PostIpamIPHandler
 
 	MetricsGetMetricsHandler metrics.GetMetricsHandler
 
@@ -166,13 +161,6 @@ func ciliumAPIHandlers(dp promise.Promise[*Daemon], cfg *option.DaemonConfig, _ 
 
 	// /service/
 	out.ServiceGetServiceHandler = wrapAPIHandler(dp, getServiceHandler)
-
-	if option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
-		// /ipam/{ip}/
-		out.IpamPostIpamHandler = wrapAPIHandler(dp, postIPAMHandler)
-		out.IpamPostIpamIPHandler = wrapAPIHandler(dp, postIPAMIPHandler)
-		out.IpamDeleteIpamIPHandler = wrapAPIHandler(dp, deleteIPAMIPHandler)
-	}
 
 	// /debuginfo
 	out.DaemonGetDebuginfoHandler = wrapAPIHandler(dp, getDebugInfoHandler)

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/gops"
 	ipamcell "github.com/cilium/cilium/pkg/ipam/cell"
-	ipamMetadata "github.com/cilium/cilium/pkg/ipam/metadata"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
@@ -208,9 +207,6 @@ var (
 
 		// IPAM provides IP address management.
 		ipamcell.Cell,
-
-		// IPAM metadata manager, determines which IPAM pool a pod should allocate from
-		ipamMetadata.Cell,
 
 		// Egress Gateway allows originating traffic from specific IPv4 addresses.
 		egressgateway.Cell,

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/gops"
+	ipamcell "github.com/cilium/cilium/pkg/ipam/cell"
 	ipamMetadata "github.com/cilium/cilium/pkg/ipam/metadata"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -204,6 +205,9 @@ var (
 
 		// IPCache, policy.Repository and CachingIdentityAllocator.
 		cell.Provide(newPolicyTrifecta),
+
+		// IPAM provides IP address management.
+		ipamcell.Cell,
 
 		// IPAM metadata manager, determines which IPAM pool a pod should allocate from
 		ipamMetadata.Cell,

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -51,7 +51,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/ipam"
-	ipamMetadata "github.com/cilium/cilium/pkg/ipam/metadata"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -171,8 +170,6 @@ type Daemon struct {
 	endpointCreations *endpointCreationManager
 
 	cgroupManager manager.CGroupManager
-
-	ipamMetadata *ipamMetadata.Manager
 
 	apiLimiterSet *rate.APILimiterSet
 
@@ -410,7 +407,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		identityAllocator: params.IdentityAllocator,
 		ipcache:           params.IPCache,
 		policy:            params.Policy,
-		ipamMetadata:      params.IPAMMetadataManager,
 		cniConfigManager:  params.CNIConfigManager,
 		clusterInfo:       params.ClusterInfo,
 		clustermesh:       params.ClusterMesh,
@@ -428,6 +424,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		k8sWatcher:        params.K8sWatcher,
 		k8sSvcCache:       params.K8sSvcCache,
 		rec:               params.Recorder,
+		ipam:              params.IPAM,
 	}
 
 	d.configModifyQueue = eventqueue.NewEventQueueBuffered("config-modify-queue", ConfigModifyQueueSize)
@@ -798,7 +795,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	}
 
 	// Start IPAM
-	d.startIPAM(params.Resources.LocalCiliumNode)
+	d.startIPAM()
 
 	bootstrapStats.restore.Start()
 	// restore endpoints before any IPs are allocated to avoid eventual IP

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -62,7 +62,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/exporter/exporteroption"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/identity"
-	ipamMetadata "github.com/cilium/cilium/pkg/ipam/metadata"
+	"github.com/cilium/cilium/pkg/ipam"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/ipmasq"
@@ -1647,7 +1647,6 @@ type daemonParams struct {
 	PolicyK8sWatcher       *policyK8s.PolicyResourcesWatcher
 	DirectoryPolicyWatcher *policyDirectory.PolicyResourcesWatcher
 	DirReadStatus          policyDirectory.DirectoryWatcherReadStatus
-	IPAMMetadataManager    *ipamMetadata.Manager
 	CNIConfigManager       cni.CNIConfigManager
 	SwaggerSpec            *server.Spec
 	HealthAPISpec          *healthApi.Spec
@@ -1685,6 +1684,7 @@ type daemonParams struct {
 	CGroupManager       cgroup.CGroupManager
 	ServiceResolver     *dial.ServiceResolver
 	Recorder            *recorder.Recorder
+	IPAM                *ipam.IPAM
 }
 
 func newDaemonPromise(params daemonParams) (promise.Promise[*Daemon], promise.Promise[*option.DaemonConfig]) {

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	ipamapi "github.com/cilium/cilium/api/v1/server/restapi/ipam"
-	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/cidr"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
@@ -616,14 +615,11 @@ func (d *Daemon) configureIPAM() {
 	}
 }
 
-func (d *Daemon) startIPAM(node agentK8s.LocalCiliumNodeResource) {
+func (d *Daemon) startIPAM() {
 	bootstrapStats.ipam.Start()
 	log.Info("Initializing node addressing")
 	// Set up ipam conf after init() because we might be running d.conf.KVStoreIPv4Registration
-	d.ipam = ipam.NewIPAM(d.datapath.LocalNodeAddressing(), option.Config, d.nodeDiscovery, d.nodeLocalStore, d.k8sWatcher, node, d.mtuConfig, d.clientset)
-	if d.ipamMetadata != nil {
-		d.ipam.WithMetadata(d.ipamMetadata)
-	}
+	d.ipam.ConfigureAllocator()
 	bootstrapStats.ipam.End(true)
 }
 

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -31,10 +31,6 @@ var (
 )
 
 func (ipam *IPAM) determineIPAMPool(owner string, family Family) (Pool, error) {
-	if ipam.metadata == nil {
-		return PoolDefault(), nil
-	}
-
 	pool, err := ipam.metadata.GetIPPoolForPod(owner, family)
 	if err != nil {
 		return "", fmt.Errorf("unable to determine IPAM pool for owner %q: %w", owner, err)

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -23,6 +23,7 @@ type ownerMock struct{}
 
 func (o *ownerMock) K8sEventReceived(resourceApiGroup, scope string, action string, valid, equal bool) {
 }
+
 func (o *ownerMock) K8sEventProcessed(scope string, action string, status bool) {}
 
 func (o *ownerMock) UpdateCiliumNodeResource() {}
@@ -46,6 +47,7 @@ func TestAllocatedIPDump(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	ipam.ConfigureAllocator()
 
 	allocv4, allocv6, status := ipam.Dump()
 	require.NotEqual(t, "", status)
@@ -66,6 +68,7 @@ func TestExpirationTimer(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	ipam.ConfigureAllocator()
 
 	err := ipam.AllocateIP(ip, "foo", PoolDefault())
 	require.Nil(t, err)
@@ -132,6 +135,7 @@ func TestAllocateNextWithExpiration(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	ipam.ConfigureAllocator()
 
 	// Allocate IPs and test expiration timer. 'pool' is empty in order to test
 	// that the allocated pool is passed to StartExpirationTimer

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -46,7 +46,7 @@ var mtuMock = mtu.NewConfiguration(0, false, false, false, false, 1500, nil)
 func TestAllocatedIPDump(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil)
 	ipam.ConfigureAllocator()
 
 	allocv4, allocv6, status := ipam.Dump()
@@ -67,7 +67,7 @@ func TestExpirationTimer(t *testing.T) {
 
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil)
 	ipam.ConfigureAllocator()
 
 	err := ipam.AllocateIP(ip, "foo", PoolDefault())
@@ -134,7 +134,8 @@ func TestAllocateNextWithExpiration(t *testing.T) {
 
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	fakeMetadata := fakeMetadataFunc(func(owner string, family Family) (pool string, err error) { return "some-pool", nil })
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, fakeMetadata)
 	ipam.ConfigureAllocator()
 
 	// Allocate IPs and test expiration timer. 'pool' is empty in order to test

--- a/pkg/ipam/api/ipam_api_handler.go
+++ b/pkg/ipam/api/ipam_api_handler.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipamapi
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/swag"
+
+	"github.com/cilium/cilium/api/v1/models"
+	ipamapi "github.com/cilium/cilium/api/v1/server/restapi/ipam"
+	"github.com/cilium/cilium/pkg/api"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/ipam"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type IpamDeleteIpamIPHandler struct {
+	IPAM            *ipam.IPAM
+	EndpointManager endpointmanager.EndpointManager
+}
+
+type IpamPostIpamHandler struct {
+	IPAM *ipam.IPAM
+}
+
+type IpamPostIpamIPHandler struct {
+	IPAM *ipam.IPAM
+}
+
+func (r *IpamPostIpamHandler) Handle(params ipamapi.PostIpamParams) middleware.Responder {
+	family := strings.ToLower(swag.StringValue(params.Family))
+	owner := swag.StringValue(params.Owner)
+	pool := ipam.Pool(swag.StringValue(params.Pool))
+	var expirationTimeout time.Duration
+	if swag.BoolValue(params.Expiration) {
+		expirationTimeout = defaults.IPAMExpiration
+	}
+	ipv4Result, ipv6Result, err := r.IPAM.AllocateNextWithExpiration(family, owner, pool, expirationTimeout)
+	if err != nil {
+		return api.Error(ipamapi.PostIpamFailureCode, err)
+	}
+
+	resp := &models.IPAMResponse{
+		HostAddressing: node.GetNodeAddressing(),
+		Address:        &models.AddressPair{},
+	}
+
+	if ipv4Result != nil {
+		resp.Address.IPV4 = ipv4Result.IP.String()
+		resp.Address.IPV4PoolName = ipv4Result.IPPoolName.String()
+		resp.IPV4 = &models.IPAMAddressResponse{
+			Cidrs:           ipv4Result.CIDRs,
+			IP:              ipv4Result.IP.String(),
+			MasterMac:       ipv4Result.PrimaryMAC,
+			Gateway:         ipv4Result.GatewayIP,
+			ExpirationUUID:  ipv4Result.ExpirationUUID,
+			InterfaceNumber: ipv4Result.InterfaceNumber,
+		}
+	}
+
+	if ipv6Result != nil {
+		resp.Address.IPV6 = ipv6Result.IP.String()
+		resp.Address.IPV6PoolName = ipv6Result.IPPoolName.String()
+		resp.IPV6 = &models.IPAMAddressResponse{
+			Cidrs:           ipv6Result.CIDRs,
+			IP:              ipv6Result.IP.String(),
+			MasterMac:       ipv6Result.PrimaryMAC,
+			Gateway:         ipv6Result.GatewayIP,
+			ExpirationUUID:  ipv6Result.ExpirationUUID,
+			InterfaceNumber: ipv6Result.InterfaceNumber,
+		}
+	}
+
+	return ipamapi.NewPostIpamCreated().WithPayload(resp)
+}
+
+// Handle incoming requests address allocation requests for the daemon.
+func (r *IpamPostIpamIPHandler) Handle(params ipamapi.PostIpamIPParams) middleware.Responder {
+	owner := swag.StringValue(params.Owner)
+	pool := ipam.Pool(swag.StringValue(params.Pool))
+	if err := r.IPAM.AllocateIPString(params.IP, owner, pool); err != nil {
+		return api.Error(ipamapi.PostIpamIPFailureCode, err)
+	}
+
+	return ipamapi.NewPostIpamIPOK()
+}
+
+func (r *IpamDeleteIpamIPHandler) Handle(params ipamapi.DeleteIpamIPParams) middleware.Responder {
+	// Release of an IP that is in use is not allowed
+	if ep := r.EndpointManager.LookupIPv4(params.IP); ep != nil {
+		return api.Error(ipamapi.DeleteIpamIPFailureCode, fmt.Errorf("IP is in use by endpoint %d", ep.ID))
+	}
+	if ep := r.EndpointManager.LookupIPv6(params.IP); ep != nil {
+		return api.Error(ipamapi.DeleteIpamIPFailureCode, fmt.Errorf("IP is in use by endpoint %d", ep.ID))
+	}
+
+	ip := net.ParseIP(params.IP)
+	if ip == nil {
+		return api.Error(ipamapi.DeleteIpamIPInvalidCode, fmt.Errorf("Invalid IP address: %s", params.IP))
+	}
+
+	pool := ipam.Pool(swag.StringValue(params.Pool))
+	if err := r.IPAM.ReleaseIP(ip, pool); err != nil {
+		return api.Error(ipamapi.DeleteIpamIPFailureCode, err)
+	}
+
+	return ipamapi.NewDeleteIpamIPOK()
+}

--- a/pkg/ipam/cell/cell.go
+++ b/pkg/ipam/cell/cell.go
@@ -29,6 +29,9 @@ var Cell = cell.Module(
 
 	cell.Provide(newIPAddressManager),
 	cell.Provide(newIPAMAPIHandler),
+
+	// IPAM metadata manager, determines which IPAM pool a pod should allocate from
+	ipamMetadata.Cell,
 )
 
 type ipamParams struct {

--- a/pkg/ipam/cell/cell.go
+++ b/pkg/ipam/cell/cell.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipamcell
+
+import (
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/daemon/k8s"
+	datapathTypes "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/ipam"
+	ipamMetadata "github.com/cilium/cilium/pkg/ipam/metadata"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/watchers"
+	"github.com/cilium/cilium/pkg/mtu"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/nodediscovery"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// Cell provides access to the IP address management
+var Cell = cell.Module(
+	"ipam",
+	"IP Address Management",
+
+	cell.Provide(newIPAddressManager),
+)
+
+type ipamParams struct {
+	cell.In
+
+	AgentConfig *option.DaemonConfig
+
+	NodeAddressing      datapathTypes.NodeAddressing
+	LocalNodeStore      *node.LocalNodeStore
+	K8sEventReporter    *watchers.K8sEventReporter
+	NodeResource        k8s.LocalCiliumNodeResource
+	MTU                 mtu.MTU
+	Clientset           k8sClient.Clientset
+	IPAMMetadataManager *ipamMetadata.Manager
+	NodeDiscovery       *nodediscovery.NodeDiscovery
+}
+
+func newIPAddressManager(params ipamParams) *ipam.IPAM {
+	ipam := ipam.NewIPAM(params.NodeAddressing, params.AgentConfig, params.NodeDiscovery, params.LocalNodeStore, params.K8sEventReporter, params.NodeResource, params.MTU, params.Clientset)
+
+	if params.IPAMMetadataManager != nil {
+		ipam.WithMetadata(params.IPAMMetadataManager)
+	}
+
+	return ipam
+}

--- a/pkg/ipam/cell/cell.go
+++ b/pkg/ipam/cell/cell.go
@@ -45,18 +45,12 @@ type ipamParams struct {
 	NodeResource        k8s.LocalCiliumNodeResource
 	MTU                 mtu.MTU
 	Clientset           k8sClient.Clientset
-	IPAMMetadataManager *ipamMetadata.Manager
+	IPAMMetadataManager ipamMetadata.Manager
 	NodeDiscovery       *nodediscovery.NodeDiscovery
 }
 
 func newIPAddressManager(params ipamParams) *ipam.IPAM {
-	ipam := ipam.NewIPAM(params.NodeAddressing, params.AgentConfig, params.NodeDiscovery, params.LocalNodeStore, params.K8sEventReporter, params.NodeResource, params.MTU, params.Clientset)
-
-	if params.IPAMMetadataManager != nil {
-		ipam.WithMetadata(params.IPAMMetadataManager)
-	}
-
-	return ipam
+	return ipam.NewIPAM(params.NodeAddressing, params.AgentConfig, params.NodeDiscovery, params.LocalNodeStore, params.K8sEventReporter, params.NodeResource, params.MTU, params.Clientset, params.IPAMMetadataManager)
 }
 
 type ipamAPIHandlerParams struct {

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -98,7 +98,7 @@ func TestMarkForReleaseNoAllocate(t *testing.T) {
 		sharedNodeStore.ownNode = cn
 	})
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(fakeAddressing, conf, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	ipam := NewIPAM(fakeAddressing, conf, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil)
 	ipam.ConfigureAllocator()
 	sharedNodeStore.updateLocalNodeResource(cn)
 

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -99,6 +99,7 @@ func TestMarkForReleaseNoAllocate(t *testing.T) {
 	})
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	ipam := NewIPAM(fakeAddressing, conf, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	ipam.ConfigureAllocator()
 	sharedNodeStore.updateLocalNodeResource(cn)
 
 	// Allocate the first 3 IPs

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -67,7 +67,7 @@ type Metadata interface {
 }
 
 // NewIPAM returns a new IP address manager
-func NewIPAM(nodeAddressing types.NodeAddressing, c *option.DaemonConfig, nodeDiscovery Owner, localNodeStore *node.LocalNodeStore, k8sEventReg K8sEventRegister, node agentK8s.LocalCiliumNodeResource, mtuConfig MtuConfiguration, clientset client.Clientset) *IPAM {
+func NewIPAM(nodeAddressing types.NodeAddressing, c *option.DaemonConfig, nodeDiscovery Owner, localNodeStore *node.LocalNodeStore, k8sEventReg K8sEventRegister, node agentK8s.LocalCiliumNodeResource, mtuConfig MtuConfiguration, clientset client.Clientset, metadata Metadata) *IPAM {
 	return &IPAM{
 		nodeAddressing:   nodeAddressing,
 		config:           c,
@@ -81,6 +81,7 @@ func NewIPAM(nodeAddressing types.NodeAddressing, c *option.DaemonConfig, nodeDi
 		mtuConfig:      mtuConfig,
 		clientset:      clientset,
 		nodeDiscovery:  nodeDiscovery,
+		metadata:       metadata,
 	}
 }
 
@@ -132,12 +133,6 @@ func (ipam *IPAM) ConfigureAllocator() {
 	default:
 		log.Fatalf("Unknown IPAM backend %s", ipam.config.IPAMMode())
 	}
-}
-
-// WithMetadata sets an optional Metadata provider, which IPAM will use to
-// determine what IPAM pool an IP owner should allocate its IP from
-func (ipam *IPAM) WithMetadata(m Metadata) {
-	ipam.metadata = m
 }
 
 // getIPOwner returns the owner for an IP in a particular pool or the empty

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -18,9 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 )
 
-var (
-	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ipam")
-)
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ipam")
 
 // Family is the type describing all address families support by the IP
 // allocation manager
@@ -69,61 +67,71 @@ type Metadata interface {
 }
 
 // NewIPAM returns a new IP address manager
-func NewIPAM(nodeAddressing types.NodeAddressing, c *option.DaemonConfig, owner Owner, localNodeStore *node.LocalNodeStore, k8sEventReg K8sEventRegister, node agentK8s.LocalCiliumNodeResource, mtuConfig MtuConfiguration, clientset client.Clientset) *IPAM {
-	ipam := &IPAM{
+func NewIPAM(nodeAddressing types.NodeAddressing, c *option.DaemonConfig, nodeDiscovery Owner, localNodeStore *node.LocalNodeStore, k8sEventReg K8sEventRegister, node agentK8s.LocalCiliumNodeResource, mtuConfig MtuConfiguration, clientset client.Clientset) *IPAM {
+	return &IPAM{
 		nodeAddressing:   nodeAddressing,
 		config:           c,
 		owner:            map[Pool]map[string]string{},
 		expirationTimers: map[timerKey]expirationTimer{},
 		excludedIPs:      map[string]string{},
-	}
 
-	switch c.IPAMMode() {
+		k8sEventReg:    k8sEventReg,
+		localNodeStore: localNodeStore,
+		nodeResource:   node,
+		mtuConfig:      mtuConfig,
+		clientset:      clientset,
+		nodeDiscovery:  nodeDiscovery,
+	}
+}
+
+// ConfigureAllocator initializes the IPAM allocator according to the configuration.
+// As a precondition, the NodeAddressing must be fully initialized - therefore the method
+// must be called after Daemon.WaitForNodeInformation.
+func (ipam *IPAM) ConfigureAllocator() {
+	switch ipam.config.IPAMMode() {
 	case ipamOption.IPAMKubernetes, ipamOption.IPAMClusterPool:
 		log.WithFields(logrus.Fields{
-			logfields.V4Prefix: nodeAddressing.IPv4().AllocationCIDR(),
-			logfields.V6Prefix: nodeAddressing.IPv6().AllocationCIDR(),
-		}).Infof("Initializing %s IPAM", c.IPAMMode())
+			logfields.V4Prefix: ipam.nodeAddressing.IPv4().AllocationCIDR(),
+			logfields.V6Prefix: ipam.nodeAddressing.IPv6().AllocationCIDR(),
+		}).Infof("Initializing %s IPAM", ipam.config.IPAMMode())
 
-		if c.IPv6Enabled() {
-			ipam.IPv6Allocator = newHostScopeAllocator(nodeAddressing.IPv6().AllocationCIDR().IPNet)
+		if ipam.config.IPv6Enabled() {
+			ipam.IPv6Allocator = newHostScopeAllocator(ipam.nodeAddressing.IPv6().AllocationCIDR().IPNet)
 		}
 
-		if c.IPv4Enabled() {
-			ipam.IPv4Allocator = newHostScopeAllocator(nodeAddressing.IPv4().AllocationCIDR().IPNet)
+		if ipam.config.IPv4Enabled() {
+			ipam.IPv4Allocator = newHostScopeAllocator(ipam.nodeAddressing.IPv4().AllocationCIDR().IPNet)
 		}
 	case ipamOption.IPAMMultiPool:
 		log.Info("Initializing MultiPool IPAM")
-		manager := newMultiPoolManager(c, node, owner, clientset.CiliumV2().CiliumNodes())
+		manager := newMultiPoolManager(ipam.config, ipam.nodeResource, ipam.nodeDiscovery, ipam.clientset.CiliumV2().CiliumNodes())
 
-		if c.IPv6Enabled() {
+		if ipam.config.IPv6Enabled() {
 			ipam.IPv6Allocator = manager.Allocator(IPv6)
 		}
-		if c.IPv4Enabled() {
+		if ipam.config.IPv4Enabled() {
 			ipam.IPv4Allocator = manager.Allocator(IPv4)
 		}
 	case ipamOption.IPAMCRD, ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
 		log.Info("Initializing CRD-based IPAM")
-		if c.IPv6Enabled() {
-			ipam.IPv6Allocator = newCRDAllocator(IPv6, c, owner, localNodeStore, clientset, k8sEventReg, mtuConfig)
+		if ipam.config.IPv6Enabled() {
+			ipam.IPv6Allocator = newCRDAllocator(IPv6, ipam.config, ipam.nodeDiscovery, ipam.localNodeStore, ipam.clientset, ipam.k8sEventReg, ipam.mtuConfig)
 		}
 
-		if c.IPv4Enabled() {
-			ipam.IPv4Allocator = newCRDAllocator(IPv4, c, owner, localNodeStore, clientset, k8sEventReg, mtuConfig)
+		if ipam.config.IPv4Enabled() {
+			ipam.IPv4Allocator = newCRDAllocator(IPv4, ipam.config, ipam.nodeDiscovery, ipam.localNodeStore, ipam.clientset, ipam.k8sEventReg, ipam.mtuConfig)
 		}
 	case ipamOption.IPAMDelegatedPlugin:
 		log.Info("Initializing no-op IPAM since we're using a CNI delegated plugin")
-		if c.IPv6Enabled() {
+		if ipam.config.IPv6Enabled() {
 			ipam.IPv6Allocator = &noOpAllocator{}
 		}
-		if c.IPv4Enabled() {
+		if ipam.config.IPv4Enabled() {
 			ipam.IPv4Allocator = &noOpAllocator{}
 		}
 	default:
-		log.Fatalf("Unknown IPAM backend %s", c.IPAMMode())
+		log.Fatalf("Unknown IPAM backend %s", ipam.config.IPAMMode())
 	}
-
-	return ipam
 }
 
 // WithMetadata sets an optional Metadata provider, which IPAM will use to

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -123,6 +123,7 @@ func TestLock(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	ipam.ConfigureAllocator()
 
 	// Since the IPs we have allocated to the endpoints might or might not
 	// be in the allocrange specified in cilium, we need to specify them
@@ -146,6 +147,7 @@ func TestExcludeIP(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	ipam.ConfigureAllocator()
 
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
 	ipv4 = ipv4.Next()
@@ -178,6 +180,7 @@ func TestIPAMMetadata(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	ipam.ConfigureAllocator()
 	ipam.IPv4Allocator = newFakePoolAllocator(map[string]string{
 		"default": "10.10.0.0/16",
 		"test":    "192.168.178.0/24",
@@ -256,6 +259,7 @@ func TestLegacyAllocatorIPAMMetadata(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	ipam.ConfigureAllocator()
 	ipam.WithMetadata(fakeMetadataFunc(func(owner string, family Family) (pool string, err error) {
 		return "some-pool", nil
 	}))

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -122,7 +122,7 @@ func (f fakePoolAllocator) RestoreFinished() {}
 func TestLock(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil)
 	ipam.ConfigureAllocator()
 
 	// Since the IPs we have allocated to the endpoints might or might not
@@ -146,7 +146,7 @@ func TestLock(t *testing.T) {
 func TestExcludeIP(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil)
 	ipam.ConfigureAllocator()
 
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
@@ -179,26 +179,7 @@ func TestDeriveFamily(t *testing.T) {
 func TestIPAMMetadata(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
-	ipam.ConfigureAllocator()
-	ipam.IPv4Allocator = newFakePoolAllocator(map[string]string{
-		"default": "10.10.0.0/16",
-		"test":    "192.168.178.0/24",
-		"special": "172.18.19.0/24",
-	})
-	ipam.IPv6Allocator = newFakePoolAllocator(map[string]string{
-		"default": "fd00:100::/80",
-		"test":    "fc00:100::/96",
-		"special": "fe00:100::/80",
-	})
-
-	// Without metadata, should always return PoolDefault()
-	resIPv4, resIPv6, err := ipam.AllocateNext("", "test/some-pod", "")
-	require.Nil(t, err)
-	require.Equal(t, PoolDefault(), resIPv4.IPPoolName)
-	require.Equal(t, PoolDefault(), resIPv6.IPPoolName)
-
-	ipam.WithMetadata(fakeMetadataFunc(func(owner string, family Family) (pool string, err error) {
+	fakeMetadata := fakeMetadataFunc(func(owner string, family Family) (pool string, err error) {
 		// use namespace to determine pool name
 		namespace, _, _ := strings.Cut(owner, "/")
 		switch namespace {
@@ -211,13 +192,26 @@ func TestIPAMMetadata(t *testing.T) {
 		default:
 			return PoolDefault().String(), nil
 		}
-	}))
+	})
+
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, fakeMetadata)
+	ipam.ConfigureAllocator()
+	ipam.IPv4Allocator = newFakePoolAllocator(map[string]string{
+		"default": "10.10.0.0/16",
+		"test":    "192.168.178.0/24",
+		"special": "172.18.19.0/24",
+	})
+	ipam.IPv6Allocator = newFakePoolAllocator(map[string]string{
+		"default": "fd00:100::/80",
+		"test":    "fc00:100::/96",
+		"special": "fe00:100::/80",
+	})
 
 	// Checks AllocateIP
 	specialIP := net.ParseIP("172.18.19.20")
-	_, err = ipam.AllocateIPWithoutSyncUpstream(specialIP, "special/wants-special-ip", "")
+	_, err := ipam.AllocateIPWithoutSyncUpstream(specialIP, "special/wants-special-ip", "")
 	require.NotNil(t, err) // pool required
-	resIPv4, err = ipam.AllocateIPWithoutSyncUpstream(specialIP, "special/wants-special-ip", "special")
+	resIPv4, err := ipam.AllocateIPWithoutSyncUpstream(specialIP, "special/wants-special-ip", "special")
 	require.Nil(t, err)
 	require.Equal(t, Pool("special"), resIPv4.IPPoolName)
 	require.Equal(t, true, resIPv4.IP.Equal(specialIP))
@@ -229,7 +223,7 @@ func TestIPAMMetadata(t *testing.T) {
 	require.Nil(t, err)
 
 	// Checks if pool metadata is used if pool is empty
-	resIPv4, resIPv6, err = ipam.AllocateNext("", "test/some-other-pod", "")
+	resIPv4, resIPv6, err := ipam.AllocateNext("", "test/some-other-pod", "")
 	require.Nil(t, err)
 	require.Equal(t, Pool("test"), resIPv4.IPPoolName)
 	require.Equal(t, Pool("test"), resIPv6.IPPoolName)
@@ -258,11 +252,9 @@ func TestLegacyAllocatorIPAMMetadata(t *testing.T) {
 	// pool
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
+	fakeMetadata := fakeMetadataFunc(func(owner string, family Family) (pool string, err error) { return "some-pool", nil })
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, fakeMetadata)
 	ipam.ConfigureAllocator()
-	ipam.WithMetadata(fakeMetadataFunc(func(owner string, family Family) (pool string, err error) {
-		return "some-pool", nil
-	}))
 
 	// AllocateIP requires explicit pool
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)

--- a/pkg/ipam/metadata/manager.go
+++ b/pkg/ipam/metadata/manager.go
@@ -19,9 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
-var (
-	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ipam-metadata-manager")
-)
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ipam-metadata-manager")
 
 type ManagerStoppedError struct{}
 
@@ -54,14 +52,18 @@ func (r *ResourceNotFound) Is(target error) bool {
 	return true
 }
 
-type Manager struct {
+type Manager interface {
+	GetIPPoolForPod(owner string, family ipam.Family) (pool string, err error)
+}
+
+type manager struct {
 	namespaceResource resource.Resource[*slim_core_v1.Namespace]
 	namespaceStore    resource.Store[*slim_core_v1.Namespace]
 	podResource       k8s.LocalPodResource
 	podStore          resource.Store[*slim_core_v1.Pod]
 }
 
-func (m *Manager) Start(ctx cell.HookContext) (err error) {
+func (m *manager) Start(ctx cell.HookContext) (err error) {
 	m.namespaceStore, err = m.namespaceResource.Store(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to obtain namespace store: %w", err)
@@ -75,7 +77,7 @@ func (m *Manager) Start(ctx cell.HookContext) (err error) {
 	return nil
 }
 
-func (m *Manager) Stop(ctx cell.HookContext) error {
+func (m *manager) Stop(ctx cell.HookContext) error {
 	m.namespaceStore = nil
 	m.podStore = nil
 	return nil
@@ -114,7 +116,7 @@ func determinePoolByAnnotations(annotations map[string]string, family ipam.Famil
 	return "", false
 }
 
-func (m *Manager) GetIPPoolForPod(owner string, family ipam.Family) (pool string, err error) {
+func (m *manager) GetIPPoolForPod(owner string, family ipam.Family) (pool string, err error) {
 	if m.namespaceStore == nil || m.podStore == nil {
 		return "", &ManagerStoppedError{}
 	}

--- a/pkg/ipam/metadata/manager_test.go
+++ b/pkg/ipam/metadata/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/annotation"
@@ -65,7 +66,7 @@ func namespaceKey(name string) resource.Key {
 }
 
 func TestManager_GetIPPoolForPod(t *testing.T) {
-	m := &Manager{
+	m := &manager{
 		namespaceStore: mockStore[*slim_core_v1.Namespace]{
 			namespaceKey("default"): &slim_core_v1.Namespace{},
 			namespaceKey("special"): &slim_core_v1.Namespace{
@@ -236,4 +237,16 @@ func TestManager_GetIPPoolForPod(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDefaultManager_DefaultPool(t *testing.T) {
+	defaultPoolManager := defaultIPPoolManager{}
+
+	ipv4Pool, err := defaultPoolManager.GetIPPoolForPod("", ipam.IPv4)
+	require.Nil(t, err)
+	require.Equal(t, ipam.PoolDefault(), ipam.Pool(ipv4Pool))
+
+	ipv6Pool, err := defaultPoolManager.GetIPPoolForPod("", ipam.IPv6)
+	require.Nil(t, err)
+	require.Equal(t, ipam.PoolDefault(), ipam.Pool(ipv6Pool))
 }

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -120,12 +120,12 @@ type IPAM struct {
 // DebugStatus implements debug.StatusObject to provide debug status collection
 // ability
 func (ipam *IPAM) DebugStatus() string {
-	if ipam == nil {
-		return "<nil>"
-	}
-
 	ipam.allocatorMutex.RLock()
-	str := spew.Sdump(ipam)
+	str := spew.Sdump(
+		"owners", ipam.owner,
+		"expiration timers", ipam.expirationTimers,
+		"excluded ips", ipam.excludedIPs,
+	)
 	ipam.allocatorMutex.RUnlock()
 	return str
 }

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -8,8 +8,11 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 
+	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -106,6 +109,13 @@ type IPAM struct {
 	// excludedIPS contains excluded IPs and their respective owners per pool. The key is a
 	// combination pool:ip to avoid having to maintain a map of maps.
 	excludedIPs map[string]string
+
+	localNodeStore *node.LocalNodeStore
+	k8sEventReg    K8sEventRegister
+	nodeResource   agentK8s.LocalCiliumNodeResource
+	mtuConfig      MtuConfiguration
+	clientset      client.Clientset
+	nodeDiscovery  Owner
 }
 
 // DebugStatus implements debug.StatusObject to provide debug status collection

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -92,7 +92,6 @@ type IPAM struct {
 	IPv4Allocator Allocator
 
 	// metadata provides information about a particular IP owner.
-	// May be nil.
 	metadata Metadata
 
 	// owner maps an IP to the owner per pool.

--- a/pkg/k8s/watchers/cell.go
+++ b/pkg/k8s/watchers/cell.go
@@ -24,7 +24,7 @@ var Cell = cell.Module(
 	cell.ProvidePrivate(newK8sEndpointsWatcher),
 	cell.ProvidePrivate(newK8sCiliumLRPWatcher),
 	cell.ProvidePrivate(newK8sCiliumEndpointsWatcher),
-	cell.ProvidePrivate(newK8sEventReporter),
+	cell.Provide(newK8sEventReporter),
 )
 
 type k8sWatcherParams struct {


### PR DESCRIPTION
This PR introduces an initial version of the IPAM Hive Cell

* Initializes and provides the struct `IPAM` (lifecycle aspects are kept in the daemon setup for the time being - due to lifecycle dependencies)
* Provides the IPAM Rest API handlers
* Embeds the existing cell for IPAM metadata manager

The main goal is to enable modularization of IPAM dependent components and free up the daemon init logic.

Further steps could be

* Modularize the inner parts (e.g. allocators) into cells
* Extract the "infra" IPAM parts (allocating IPs for Ingress, Health, ...) of the daemon. I thought about this, but thought that this might be better for a separate PR. It's kind of sitting between IPAM (core) and the Daemon 