### PR TITLE
ci: make runtime privileged tests not run in parallel

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -232,7 +232,7 @@ jobs:
           - focus: "datapath"
             cliFocus: "RuntimeDatapathConntrackInVethModeTest|RuntimeDatapathMonitorTest"
 
-    timeout-minutes: 40
+    timeout-minutes: 50
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
@@ -380,7 +380,7 @@ jobs:
 
       - name: Runtime privileged tests
         if: ${{ matrix.focus == 'privileged' }}
-        timeout-minutes: 30
+        timeout-minutes: 40
         uses: cilium/little-vm-helper@3c748d6fc9d6c44a433de85a66f70e8f7043be04 # v0.0.18
         with:
           provision: 'false'

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ $(SUBDIRS): force ## Execute default make target(make all) for the provided subd
 
 tests-privileged: ## Run Go tests including ones that require elevated privileges.
 	@$(ECHO_CHECK) running privileged tests...
-	PRIVILEGED_TESTS=true PATH=$(PATH):$(ROOT_DIR)/bpf $(GO_TEST) $(TEST_LDFLAGS) \
+	PRIVILEGED_TESTS=true PATH=$(PATH):$(ROOT_DIR)/bpf $(GO_TEST) -p 1 $(TEST_LDFLAGS) \
 		$(TESTPKGS) $(GOTEST_BASE) $(GOTEST_COVER_OPTS) | $(GOTEST_FORMATTER)
 	$(MAKE) generate-cov
 


### PR DESCRIPTION
There was a significant flakiness of IPSec-related privileged tests due to the fact that tests in different packages were modifying xfrm states/policies concurrently.

While increasing timeout for test and making it last longer is non-ideal, less flaky tests outweigh it.
The observed increase in time of test: from ~20 minutes to ~30 minutes.

Related: https://github.com/cilium/cilium/issues/32902
Related: https://github.com/cilium/cilium/pull/32954
