### PR TITLE
gha: Only retrieve IPv4 CIDR from docker network

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -217,8 +217,10 @@ jobs:
       - name: Install Cilium LB IPPool and L2 Announcement Policy
         timeout-minutes: 10
         run: |
-          KIND_NET_CIDR=$(docker network inspect kind -f '{{(index .IPAM.Config 0).Subnet}}')
+          KIND_NET_CIDR=$(docker network inspect kind -f '{{json .IPAM.Config}}' | jq -r '.[] | select(.Subnet | test("^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+")) | .Subnet')
+          echo "KIND_NET_CIDR: $KIND_NET_CIDR"
           LB_CIDR=$(echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.200/28@")
+          echo "LB_CIDR: $LB_CIDR"
 
           echo "Deploying LB-IPAM Pool..."
           cat << EOF > pool.yaml
@@ -230,6 +232,7 @@ jobs:
             cidrs:
               - cidr: "$LB_CIDR"
           EOF
+          cat pool.yaml
           kubectl apply -f pool.yaml
           
           echo "Deploying L2-Announcement Policy..."
@@ -247,6 +250,7 @@ jobs:
                 - key: node-role.kubernetes.io/control-plane
                   operator: DoesNotExist
           EOF
+          cat l2policy.yaml
           kubectl apply -f l2policy.yaml
 
       - name: Run Gateway API conformance test

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -223,9 +223,10 @@ jobs:
       - name: Install Cilium LB IPPool and L2 Announcement Policy
         timeout-minutes: 10
         run: |
-          KIND_NET_CIDR=$(docker network inspect kind -f '{{(index .IPAM.Config 0).Subnet}}')
+          KIND_NET_CIDR=$(docker network inspect kind -f '{{json .IPAM.Config}}' | jq -r '.[] | select(.Subnet | test("^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+")) | .Subnet')
+          echo "KIND_NET_CIDR: $KIND_NET_CIDR"
           LB_CIDR=$(echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.200/28@")
-
+          echo "LB_CIDR: $LB_CIDR"
           echo "Deploying LB-IPAM Pool..."
           cat << EOF > pool.yaml
           apiVersion: "cilium.io/v2alpha1"
@@ -236,6 +237,7 @@ jobs:
             cidrs:
               - cidr: "$LB_CIDR"
           EOF
+          cat pool.yaml
           kubectl apply -f pool.yaml
           
           echo "Deploying L2-Announcement Policy..."
@@ -253,6 +255,7 @@ jobs:
                 - key: node-role.kubernetes.io/control-plane
                   operator: DoesNotExist
           EOF
+          cat l2policy.yaml
           kubectl apply -f l2policy.yaml
 
       - name: Create sample workload


### PR DESCRIPTION
It seems like github runner is enabled with docker dual stack, so the
current docker network inspect command might return IPv6 instead of
IPv4 CIDR, which breaks LB IPPool configuration. Sample output of
`docker network inspect kind` command can be found as per below.

This commit is to make sure that we only retrieve IPv4 CIDR in docker
network inspect command. Additionally, some echo/cat statement are added
to make similar issue more visible in the future.

```
[
    {
        "Name": "kind",
        "Id": "43e3b3267092150f5f2e6f2053157d912ad6b5a4ce20f700e1e9be547a437f75",
        "Created": "2024-06-12T14:18:17.733107881Z",
        "Scope": "local",
        "Driver": "bridge",
        "EnableIPv6": true,
        "IPAM": {
            "Driver": "default",
            "Options": {},
            "Config": [
                {
                    "Subnet": "fc00:f853:ccd:e793::/64"
                },
                {
                    "Subnet": "172.18.0.0/16",
                    "Gateway": "172.18.0.1"
                }
            ]
        },
        "Internal": false,
        "Attachable": false,
        "Ingress": false,
        "ConfigFrom": {
            "Network": ""
        },
        "ConfigOnly": false,
        "Containers": {
            "748d7161857ca5e610f196299828eacafcbdb069d38c00e4e6c14cdeefada9c5": {
                "Name": "chart-testing-control-plane",
                "EndpointID": "0f1a5bbeb14929200ed13cb289afd6bf5f9f455d4ed75bb3a26e167e67bf7784",
                "MacAddress": "02:42:ac:12:00:02",
                "IPv4Address": "172.18.0.2/16",
                "IPv6Address": "fc00:f853:ccd:e793::2/64"
            },
            "c2030425e24a11ea208b87c5d70e194b0f51eee133f09b67404fd2bf97410f13": {
                "Name": "chart-testing-worker",
                "EndpointID": "81489bd101e483be7270e2b5dd7e0bf3a0163b89650d7ef69cc4ce43454479e3",
                "MacAddress": "02:42:ac:12:00:03",
                "IPv4Address": "172.18.0.3/16",
                "IPv6Address": "fc00:f853:ccd:e793::3/64"
            }
        },
        "Options": {
            "com.docker.network.bridge.enable_ip_masquerade": "true",
            "com.docker.network.driver.mtu": "1500"
        },
        "Labels": {}
    }
]
```