### PR TITLE
Surface Active Connection Metrics

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -402,6 +402,7 @@ Makefile* @cilium/build
 /operator/pkg/networkpolicy @cilium/sig-policy
 /operator/pkg/secretsync @cilium/sig-servicemesh
 /operator/watchers/bgp.go @cilium/sig-bgp
+/pkg/act/ @cilium/sig-datapath @cilium/metrics
 /pkg/annotation @cilium/sig-k8s
 /pkg/alibabacloud/ @cilium/alibabacloud
 /pkg/alignchecker/ @cilium/sig-datapath @cilium/loader

--- a/pkg/act/act.go
+++ b/pkg/act/act.go
@@ -170,6 +170,16 @@ func (a *ACT) callback(key *act.ActiveConnectionTrackerKey, value *act.ActiveCon
 
 	entry, ok := a.tracker[key.Zone][key.SvcID]
 	if !ok {
+		if count := a.trackerLen(); count >= metricsCountHardLimit {
+			// Consider replacing with metrics, as this can spam logs.
+			a.log.Warn("Refusing to add new metrics. There are too many!",
+				"limit", metricsCountHardLimit,
+				"count", count,
+				"svc", key.SvcID,
+				"zone", key.Zone,
+			)
+			return
+		}
 		zone, svc, err := a.keyToStrings(key)
 		if err != nil {
 			a.log.Debug("Failed to construct metrics map key in callback", "from-key", key.String())

--- a/pkg/act/act.go
+++ b/pkg/act/act.go
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package act
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+
+	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/maps/act"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/maps/lbmap"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/service"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+const (
+	// metricsUpdateInterval is a time interval for between ACT map reads.
+	// The number of new connections is calculated by comparing values between reads.
+	metricsUpdateInterval = 15 * time.Second
+	// metricsTimeout specifies when a stale entry will be removed from the metrics endpoint
+	// (it will be no longer available to scrape).
+	metricsTimeout = 10 * time.Minute
+	// metricsCountSoftLimit specifies when metric series will be deleted more aggresively.
+	metricsCountSoftLimit = 300
+	// metricsCountHardLimit specifies when new metrics series won't be allocated.
+	metricsCountHardLimit = 500
+)
+
+var Cell = cell.Module(
+	"act-metrics",
+	"Metrics with counts of new and active connections for each service-zone pair",
+
+	metrics.Metric(NewActiveConnectionTrackingMetrics),
+	cell.Invoke(NewACT),
+)
+
+type ActiveConnectionTrackingMetrics struct {
+	New, Active, Failed metric.DeletableVec[metric.Gauge]
+	ProcessingTime      metric.Histogram
+}
+
+func NewActiveConnectionTrackingMetrics() ActiveConnectionTrackingMetrics {
+	return ActiveConnectionTrackingMetrics{
+		New: metric.NewGaugeVec(metric.GaugeOpts{
+			ConfigName: metrics.Namespace + "_act_new_connections_total",
+			Subsystem:  "act",
+			Namespace:  metrics.Namespace,
+			Name:       "new_connections_total",
+		}, []string{"zone", "service"}),
+		Active: metric.NewGaugeVec(metric.GaugeOpts{
+			ConfigName: metrics.Namespace + "_act_active_connections_total",
+			Subsystem:  "act",
+			Namespace:  metrics.Namespace,
+			Name:       "active_connections_total",
+		}, []string{"zone", "service"}),
+		Failed: metric.NewGaugeVec(metric.GaugeOpts{
+			ConfigName: metrics.Namespace + "_act_failed_connections_total",
+			Subsystem:  "act",
+			Namespace:  metrics.Namespace,
+			Name:       "failed_connections_total",
+			Help:       "number of service connections purged from conntrack table",
+		}, []string{"zone", "service"}),
+		ProcessingTime: metric.NewHistogram(metric.HistogramOpts{
+			ConfigName: metrics.Namespace + "_act_processing_time_seconds",
+			Subsystem:  "act",
+			Namespace:  metrics.Namespace,
+			Name:       "processing_time_seconds",
+			Help:       "time to go over ACT map and update the metrics",
+		}),
+	}
+}
+
+type actMetric struct {
+	opened, closed    uint64
+	newFailed, failed uint64
+	updated           time.Time
+	labelValues       []string
+}
+
+type ACT struct {
+	log     *slog.Logger
+	src     act.ActiveConnectionTrackingMap
+	metrics ActiveConnectionTrackingMetrics
+
+	// keyToStrings converts (svc, zone) pair to their string versions
+	keyToStrings func(key *act.ActiveConnectionTrackerKey) (zone string, svc string, err error)
+
+	// mux protects tracker map
+	mux *lock.Mutex
+	// tracker is a map[zone][svc]metric
+	tracker map[uint8]map[uint16]*actMetric
+}
+
+func NewACT(in struct {
+	cell.In
+
+	Conf      act.Config
+	Log       *slog.Logger
+	Lifecycle cell.Lifecycle
+	Jobs      job.Group
+	Source    act.ActiveConnectionTrackingMap
+	Metrics   ActiveConnectionTrackingMetrics
+}) *ACT {
+	if !in.Conf.EnableActiveConnectionTracking {
+		// Active Connection Tracking is disabled.
+		return nil
+	}
+	a := newAct(in.Log, in.Source, in.Metrics, option.Config)
+
+	in.Jobs.Add(job.Timer("act-metrics-update", a.update, metricsUpdateInterval))
+	in.Jobs.Add(job.Timer("act-metrics-cleanup", a.cleanup, metricsTimeout))
+	in.Lifecycle.Append(in.Jobs)
+	ctmap.ACT = a
+	return a
+}
+
+func newAct(log *slog.Logger, src act.ActiveConnectionTrackingMap, metrics ActiveConnectionTrackingMetrics, opts *option.DaemonConfig) *ACT {
+	tracker := make(map[uint8]map[uint16]*actMetric, len(opts.FixedZoneMapping))
+	for zone := range opts.ReverseFixedZoneMapping {
+		tracker[zone] = make(map[uint16]*actMetric)
+	}
+	kts := func(key *act.ActiveConnectionTrackerKey) (zone string, svc string, err error) {
+		zone = opts.GetZone(key.Zone)
+		if zone == "" {
+			return "", "", fmt.Errorf("resolve zone id: %w", err)
+		}
+
+		ref, err := service.GetID(uint32(byteorder.NetworkToHost16(key.SvcID)))
+		if err != nil || ref == nil {
+			return "", "", fmt.Errorf("resolve svc id: %w", err)
+		}
+		svc = ref.String()
+		return
+	}
+	return &ACT{
+		log:          log,
+		src:          src,
+		metrics:      metrics,
+		keyToStrings: kts,
+		mux:          new(lock.Mutex),
+		tracker:      tracker,
+	}
+}
+
+// callback processes an ACT map entry.
+//
+// It will create the new metrics series if needed. In this case metrics won't
+// be presented as the number of new connections can't be calculated yet.
+func (a *ACT) callback(key *act.ActiveConnectionTrackerKey, value *act.ActiveConnectionTrackerValue) {
+	a.mux.Lock()
+	defer a.mux.Unlock()
+
+	entry, ok := a.tracker[key.Zone][key.SvcID]
+	if !ok {
+		zone, svc, err := a.keyToStrings(key)
+		if err != nil {
+			a.log.Debug("Failed to construct metrics map key in callback", "from-key", key.String())
+			return
+		}
+		a.tracker[key.Zone][key.SvcID] = &actMetric{
+			opened:      uint64(value.Opened),
+			closed:      uint64(value.Closed),
+			labelValues: []string{zone, svc},
+		}
+		return
+	}
+
+	opened, closed := uint64(value.Opened), uint64(value.Closed)
+	if opened == entry.opened && closed == entry.closed && entry.newFailed == 0 {
+		a.metrics.New.WithLabelValues(entry.labelValues...).Set(0)
+		a.metrics.Failed.WithLabelValues(entry.labelValues...).Set(0)
+		return
+	}
+	scopedLog := a.log.With("svc", key.SvcID, "zone", key.Zone)
+
+	// Opened/Closed are 32-bit values, so they can roll-over. Adjust
+	if opened < entry.opened {
+		opened += math.MaxUint32
+	}
+	if closed < entry.closed {
+		closed += math.MaxUint32
+	}
+
+	entry.failed += entry.newFailed
+	a.metrics.Failed.WithLabelValues(entry.labelValues...).Set(float64(entry.newFailed))
+
+	active := opened - (closed + entry.failed)
+	if sumClosed := (closed + entry.failed); sumClosed > opened {
+		scopedLog.Error("Unexpected closed+failed", "got", sumClosed, "want", opened)
+		opened = closed + entry.failed
+	}
+	a.metrics.Active.WithLabelValues(entry.labelValues...).Set(float64(active))
+
+	new := opened - entry.opened
+	a.metrics.New.WithLabelValues(entry.labelValues...).Set(float64(new))
+
+	entry.opened = opened
+	entry.closed = closed
+	entry.newFailed = 0
+	entry.updated = time.Now()
+}
+
+func (a *ACT) update(ctx context.Context) error {
+	start := time.Now()
+	err := a.src.IterateWithCallback(ctx, a.callback)
+	if err != nil {
+		return fmt.Errorf("iterate over %q: %w", act.ActiveConnectionTrackingMapName, err)
+	}
+	a.metrics.ProcessingTime.Observe(time.Since(start).Seconds())
+	return nil
+}
+
+func (a *ACT) dropEntry(zone uint8, svc uint16) {
+	entry := a.tracker[zone][svc]
+	a.metrics.New.DeleteLabelValues(entry.labelValues...)
+	a.metrics.Active.DeleteLabelValues(entry.labelValues...)
+	a.metrics.Failed.DeleteLabelValues(entry.labelValues...)
+
+	mapKey := &act.ActiveConnectionTrackerKey{SvcID: svc, Zone: zone}
+	err := a.src.Delete(mapKey)
+	if err != nil {
+		a.log.Debug("Failed to delete ACT map entry", "key", mapKey.String())
+	}
+	delete(a.tracker[zone], svc)
+}
+
+func (a *ACT) _cleanup(ctx context.Context, cutoff time.Time) error {
+	a.mux.Lock()
+	defer a.mux.Unlock()
+
+	for zone, services := range a.tracker {
+		for svc, entry := range services {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			if entry.updated.IsZero() || entry.updated.Before(cutoff) {
+				a.log.Debug("delete", "svc", svc, "zone", zone)
+				a.dropEntry(zone, svc)
+			}
+		}
+	}
+	return nil
+}
+
+func (a *ACT) cleanup(ctx context.Context) error {
+	cutoff := time.Now().Add(-metricsTimeout)
+	return a._cleanup(ctx, cutoff)
+}
+
+// CountFailed4 increments a counter of new failed connections
+// for a given (svc, backend) pair.
+func (a *ACT) CountFailed4(svc uint16, backend uint32) {
+	key := lbmap.NewBackend4KeyV3(loadbalancer.BackendID(backend))
+	a.countFailed(svc, key)
+}
+
+// CountFailed6 increments a counter of new failed connections
+// for a given (svc, backend) pair.
+func (a *ACT) CountFailed6(svc uint16, backend uint32) {
+	key := lbmap.NewBackend6KeyV3(loadbalancer.BackendID(backend))
+	a.countFailed(svc, key)
+}
+
+// countFailed looks up zone information in the backend map and then increments
+// a counter of new failed connection for a constructed (svc, zone) pair.
+func (a *ACT) countFailed(svc uint16, key lbmap.BackendKey) {
+	scopedLog := a.log.With("svc", byteorder.NetworkToHost16(svc), "backend", key.GetID())
+
+	val, err := key.Map().Lookup(key)
+	if err != nil {
+		scopedLog.Error("Failed to lookup backend of purged CT entry", "key", key.String(), "err", err)
+		return
+	}
+	zone := val.(lbmap.BackendValue).GetZone()
+	if zone == 0 {
+		scopedLog.Debug("Ignoring backend without zone")
+		return
+	}
+
+	a.mux.Lock()
+	defer a.mux.Unlock()
+
+	old, ok := a.tracker[zone][svc]
+	if !ok {
+		scopedLog.Debug("Missing ACT entry for purged CT")
+		return
+	}
+	old.newFailed++
+}

--- a/pkg/act/act_test.go
+++ b/pkg/act/act_test.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package act
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/maps/act"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func TestCell(t *testing.T) {
+	err := hive.New(act.Cell, Cell).Populate(hivetest.Logger(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+type mapMock struct {
+	deletedKeys []act.ActiveConnectionTrackerKey
+}
+
+func (*mapMock) IterateWithCallback(context.Context, act.ActiveConnectionTrackingIterateCallback) error {
+	return nil
+}
+
+func (m *mapMock) Delete(key *act.ActiveConnectionTrackerKey) error {
+	m.deletedKeys = append(m.deletedKeys, *key)
+	return nil
+}
+
+func TestCallback(t *testing.T) {
+	opts := &option.DaemonConfig{
+		FixedZoneMapping: map[string]uint8{
+			"zone-a": 123,
+			"zone-b": 234,
+		},
+		ReverseFixedZoneMapping: map[uint8]string{
+			123: "zone-a",
+			234: "zone-b",
+		},
+	}
+	a := newAct(hivetest.Logger(t), new(mapMock), NewActiveConnectionTrackingMetrics(), opts)
+
+	// Initialize
+	a.keyToStrings = func(key *act.ActiveConnectionTrackerKey) (zone string, svc string, err error) {
+		return "zone-a", "svc-a", nil
+	}
+	key := &act.ActiveConnectionTrackerKey{SvcID: 1, Zone: 123}
+	value := &act.ActiveConnectionTrackerValue{Opened: 2, Closed: 1}
+	a.callback(key, value)
+	require.Equal(t, 0.0, a.metrics.Active.WithLabelValues("zone-a", "svc-a").Get())
+	require.Equal(t, 0.0, a.metrics.New.WithLabelValues("zone-a", "svc-a").Get())
+	require.Equal(t, 0.0, a.metrics.Failed.WithLabelValues("zone-a", "svc-a").Get())
+
+	// Update
+	key = &act.ActiveConnectionTrackerKey{SvcID: 1, Zone: 123}
+	value = &act.ActiveConnectionTrackerValue{Opened: 3, Closed: 1}
+	a.callback(key, value)
+	require.Equal(t, 2.0, a.metrics.Active.WithLabelValues("zone-a", "svc-a").Get())
+	require.Equal(t, 1.0, a.metrics.New.WithLabelValues("zone-a", "svc-a").Get())
+	require.Equal(t, 0.0, a.metrics.Failed.WithLabelValues("zone-a", "svc-a").Get())
+
+	// Roll-over
+	a.keyToStrings = func(key *act.ActiveConnectionTrackerKey) (zone string, svc string, err error) {
+		return "zone-a", "svc-b", nil
+	}
+	key = &act.ActiveConnectionTrackerKey{SvcID: 2, Zone: 123}
+	value = &act.ActiveConnectionTrackerValue{Opened: math.MaxInt32, Closed: math.MaxInt32}
+	a.callback(key, value)
+	value = &act.ActiveConnectionTrackerValue{Opened: 1, Closed: 1}
+	a.callback(key, value)
+	require.Equal(t, 0.0, a.metrics.Active.WithLabelValues("zone-a", "svc-b").Get())
+	require.Equal(t, math.MaxInt32+2.0, a.metrics.New.WithLabelValues("zone-a", "svc-b").Get())
+	require.Equal(t, 0.0, a.metrics.Failed.WithLabelValues("zone-a", "svc-b").Get())
+
+	t.Run("invalid_zone", func(t *testing.T) {
+		// Ignore invalid zones
+		a.keyToStrings = func(key *act.ActiveConnectionTrackerKey) (zone string, svc string, err error) {
+			return "", "", fmt.Errorf("invalid zone")
+		}
+		key = &act.ActiveConnectionTrackerKey{SvcID: 1, Zone: 101}
+		value = &act.ActiveConnectionTrackerValue{Opened: 101, Closed: 98}
+		a.callback(key, value)
+		a.callback(key, value)
+		require.Empty(t, a.metrics.Active.WithLabelValues("", "svc-a").Get())
+		require.Empty(t, a.metrics.New.WithLabelValues("", "svc-a").Get())
+		require.Empty(t, a.metrics.Failed.WithLabelValues("", "svc-a").Get())
+		require.Equal(t, 2.0, a.metrics.Active.WithLabelValues("zone-a", "svc-a").Get())
+		require.Equal(t, 1.0, a.metrics.New.WithLabelValues("zone-a", "svc-a").Get())
+		require.Equal(t, 0.0, a.metrics.Failed.WithLabelValues("zone-a", "svc-a").Get())
+	})
+
+	t.Run("count_failed", func(t *testing.T) {
+		// Mark failure
+		a.keyToStrings = func(key *act.ActiveConnectionTrackerKey) (zone string, svc string, err error) {
+			return "zone-b", "svc-b", nil
+		}
+		key = &act.ActiveConnectionTrackerKey{SvcID: 2, Zone: 234}
+		value = &act.ActiveConnectionTrackerValue{Opened: 101, Closed: 101}
+		a.callback(key, value)
+		a.tracker[234][2].newFailed++
+		value = &act.ActiveConnectionTrackerValue{Opened: 151, Closed: 140}
+		a.callback(key, value)
+		require.Equal(t, 10.0, a.metrics.Active.WithLabelValues("zone-b", "svc-b").Get())
+		require.Equal(t, 50.0, a.metrics.New.WithLabelValues("zone-b", "svc-b").Get())
+		require.Equal(t, 1.0, a.metrics.Failed.WithLabelValues("zone-b", "svc-b").Get())
+		require.EqualValues(t, 0, a.tracker[234][2].newFailed)
+		require.EqualValues(t, 1, a.tracker[234][2].failed)
+
+		// Count failure only once
+		value = &act.ActiveConnectionTrackerValue{Opened: 161, Closed: 150}
+		a.callback(key, value)
+		require.Equal(t, 10.0, a.metrics.Active.WithLabelValues("zone-b", "svc-b").Get())
+		require.Equal(t, 10.0, a.metrics.New.WithLabelValues("zone-b", "svc-b").Get())
+		require.Equal(t, 0.0, a.metrics.Failed.WithLabelValues("zone-b", "svc-b").Get())
+		require.EqualValues(t, 0, a.tracker[234][2].newFailed)
+		require.EqualValues(t, 1, a.tracker[234][2].failed)
+	})
+}
+
+func TestCleanup(t *testing.T) {
+	opts := &option.DaemonConfig{
+		FixedZoneMapping: map[string]uint8{
+			"zone-a": 123,
+			"zone-b": 234,
+		},
+		ReverseFixedZoneMapping: map[uint8]string{
+			123: "zone-a",
+			234: "zone-b",
+		},
+	}
+	m := new(mapMock)
+	a := newAct(hivetest.Logger(t), m, NewActiveConnectionTrackingMetrics(), opts)
+
+	// Initialize entry with updates
+	a.keyToStrings = func(key *act.ActiveConnectionTrackerKey) (zone string, svc string, err error) {
+		return "zone-a", "svc-a", nil
+	}
+	key := &act.ActiveConnectionTrackerKey{SvcID: 1, Zone: 123}
+	value := &act.ActiveConnectionTrackerValue{Opened: 2, Closed: 1}
+	a.callback(key, value)
+	value = &act.ActiveConnectionTrackerValue{Opened: 4, Closed: 1}
+	a.tracker[123][1].newFailed++
+	a.callback(key, value)
+	require.Equal(t, 2.0, a.metrics.Active.WithLabelValues("zone-a", "svc-a").Get())
+	require.Equal(t, 2.0, a.metrics.New.WithLabelValues("zone-a", "svc-a").Get())
+	require.Equal(t, 1.0, a.metrics.Failed.WithLabelValues("zone-a", "svc-a").Get())
+
+	// Initialize entry without updates
+	a.keyToStrings = func(key *act.ActiveConnectionTrackerKey) (zone string, svc string, err error) {
+		return "zone-a", "svc-b", nil
+	}
+	key = &act.ActiveConnectionTrackerKey{SvcID: 2, Zone: 123}
+	value = &act.ActiveConnectionTrackerValue{Opened: 10, Closed: 5}
+	a.callback(key, value)
+	require.Equal(t, 0.0, a.metrics.Active.WithLabelValues("zone-a", "svc-b").Get())
+	require.Equal(t, 0.0, a.metrics.New.WithLabelValues("zone-a", "svc-b").Get())
+	require.Equal(t, 0.0, a.metrics.Failed.WithLabelValues("zone-a", "svc-b").Get())
+
+	// Initialize entry created before cutoff but with updates later
+	a.keyToStrings = func(key *act.ActiveConnectionTrackerKey) (zone string, svc string, err error) {
+		return "zone-b", "svc-b", nil
+	}
+	key = &act.ActiveConnectionTrackerKey{SvcID: 2, Zone: 234}
+	value = &act.ActiveConnectionTrackerValue{Opened: 1, Closed: 1}
+	a.callback(key, value)
+
+	cutoff := time.Now()
+
+	// Initialize entry without updates after cutoff
+	a.keyToStrings = func(key *act.ActiveConnectionTrackerKey) (zone string, svc string, err error) {
+		return "zone-b", "svc-a", nil
+	}
+	key = &act.ActiveConnectionTrackerKey{SvcID: 1, Zone: 234}
+	value = &act.ActiveConnectionTrackerValue{Opened: 100, Closed: 50}
+	a.callback(key, value)
+	require.Equal(t, 0.0, a.metrics.Active.WithLabelValues("zone-b", "svc-a").Get())
+	require.Equal(t, 0.0, a.metrics.New.WithLabelValues("zone-b", "svc-a").Get())
+	require.Equal(t, 0.0, a.metrics.Failed.WithLabelValues("zone-b", "svc-a").Get())
+
+	// later updates
+	key = &act.ActiveConnectionTrackerKey{SvcID: 2, Zone: 234}
+	value = &act.ActiveConnectionTrackerValue{Opened: 3, Closed: 2}
+	a.callback(key, value)
+	require.Equal(t, 1.0, a.metrics.Active.WithLabelValues("zone-b", "svc-b").Get())
+	require.Equal(t, 2.0, a.metrics.New.WithLabelValues("zone-b", "svc-b").Get())
+	require.Equal(t, 0.0, a.metrics.Failed.WithLabelValues("zone-b", "svc-b").Get())
+
+	a._cleanup(context.Background(), cutoff)
+	require.Empty(t, a.tracker[123])
+	expected := []act.ActiveConnectionTrackerKey{
+		{Zone: 123, SvcID: 1},
+		{Zone: 123, SvcID: 2},
+		{Zone: 234, SvcID: 1},
+	}
+	require.ElementsMatch(t, expected, m.deletedKeys)
+	require.Len(t, a.tracker[234], 1)
+	// Only "zone-b", "svc-b" has updates after cut-off
+	require.NotEmpty(t, a.tracker[234][2])
+	require.Equal(t, 1.0, a.metrics.Active.WithLabelValues("zone-b", "svc-b").Get())
+	require.Equal(t, 2.0, a.metrics.New.WithLabelValues("zone-b", "svc-b").Get())
+	require.Equal(t, 0.0, a.metrics.Failed.WithLabelValues("zone-b", "svc-b").Get())
+
+	// Confirm no metrics for other pairs
+	require.Equal(t, 0.0, a.metrics.Active.WithLabelValues("zone-b", "svc-a").Get())
+	require.Equal(t, 0.0, a.metrics.New.WithLabelValues("zone-b", "svc-a").Get())
+	require.Equal(t, 0.0, a.metrics.Failed.WithLabelValues("zone-b", "svc-a").Get())
+	require.Equal(t, 0.0, a.metrics.Active.WithLabelValues("zone-a", "svc-b").Get())
+	require.Equal(t, 0.0, a.metrics.New.WithLabelValues("zone-a", "svc-b").Get())
+	require.Equal(t, 0.0, a.metrics.Failed.WithLabelValues("zone-a", "svc-b").Get())
+	require.Equal(t, 0.0, a.metrics.Active.WithLabelValues("zone-a", "svc-a").Get())
+	require.Equal(t, 0.0, a.metrics.New.WithLabelValues("zone-a", "svc-a").Get())
+	require.Equal(t, 0.0, a.metrics.Failed.WithLabelValues("zone-a", "svc-a").Get())
+}

--- a/pkg/act/gc.go
+++ b/pkg/act/gc.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package act
+
+type gcEntry struct {
+	unix int64
+	svc  uint16
+	zone uint8
+}
+
+type gcHeap []gcEntry
+
+func (h gcHeap) Len() int           { return len(h) }
+func (h gcHeap) Less(i, j int) bool { return h[i].unix > h[j].unix }
+func (h gcHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+
+func (h *gcHeap) Push(x any) {
+	*h = append(*h, x.(gcEntry))
+}
+
+func (h *gcHeap) Pop() any {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
 
+	"github.com/cilium/cilium/pkg/act"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/agentliveness"
 	"github.com/cilium/cilium/pkg/datapath/garp"
@@ -130,6 +131,11 @@ var Cell = cell.Module(
 
 	// Provides node handler, which handles node events.
 	cell.Provide(linuxdatapath.NewNodeHandler),
+
+	// Provides Active Connection Tracking metrics based on counts of
+	// opened (from BPF ACT map), closed (from BPF ACT map), and failed
+	// connections (from ctmap's GC).
+	act.Cell,
 )
 
 func newWireguardAgent(lc cell.Lifecycle, sysctl sysctl.Sysctl) *wg.Agent {

--- a/pkg/maps/act/act.go
+++ b/pkg/maps/act/act.go
@@ -63,13 +63,18 @@ func newActiveConnectionTrackingMap(in struct {
 
 	bpf.MapOut[ActiveConnectionTrackingMap]
 	defines.NodeOut
-}) {
+}, err error) {
 	if !in.Conf.EnableActiveConnectionTracking {
 		return
 	}
-	size := option.Config.LBServiceMapEntries * len(option.Config.FixedZoneMapping)
+	svcSize := option.Config.LBMapEntries
+	if option.Config.LBServiceMapEntries > 0 {
+		svcSize = option.Config.LBServiceMapEntries
+	}
+	zoneSize := len(option.Config.FixedZoneMapping)
+	size := svcSize * zoneSize
 	if size == 0 {
-		return
+		return out, fmt.Errorf("unexpected map size: %d = svc[%d] * zones[%d]", size, svcSize, zoneSize)
 	}
 
 	out.NodeDefines = map[string]string{

--- a/pkg/maps/ctmap/gc/cell.go
+++ b/pkg/maps/ctmap/gc/cell.go
@@ -17,6 +17,7 @@ var Cell = cell.Module(
 		// Provide the interface uses to start the GC logic. This hack
 		// should be removed once all dependencies have been modularized,
 		// and we can start the GC through a Start hook.
+		// TODO: GH-33557: Add a hook for purge events to replace ctmap.PurgeHook.
 		func(gc *GC) Enabler { return gc },
 	),
 


### PR DESCRIPTION
As described in https://github.com/cilium/design-cfps/pull/31, this is part of https://github.com/cilium/cilium/issues/31752

Example configuration (in `cilium-config`) for KIND cluster:
```
  fixed-zone-mapping: zone-a=123,zone-b=129
  enable-active-connection-tracking: "true"
```
where topology labels were set on the nodes:
```
kubectl label node kind-control-plane topology.kubernetes.io/zone=zone-a
kubectl label node kind-worker topology.kubernetes.io/zone=zone-b
```

Zone mapping can be verified with `cilium map get cilium_lb4_backends_v3`:
```
Key   Value                        State   Error
16    ANY://10.244.1.74[zone-b]    sync
17    ANY://10.244.1.74[zone-b]    sync
18    ANY://10.244.1.202[zone-b]   sync
19    ANY://10.244.1.202[zone-b]   sync
13    ANY://192.168.11.2[zone-b]   sync
14    ANY://10.244.0.178[zone-a]   sync
15    ANY://10.244.0.178[zone-a]   sync
```

LRS accounting can be verified with `cilium map get cilium_lb_act`:
```
Key                       Value     State   Error
10.96.138.80:80[zone-b]   +72 -72
10.96.138.80:80[zone-a]   +28 -28
```

Or by querying prometheus endpoint:
```
# HELP cilium_act_active_connections_total
# TYPE cilium_act_active_connections_total gauge
cilium_act_active_connections_total{service="10.96.43.108:443",zone="zone-a"} 0
cilium_act_active_connections_total{service="10.96.43.108:443",zone="zone-b"} 0
cilium_act_active_connections_total{service="10.96.43.108:80",zone="zone-a"} 12
cilium_act_active_connections_total{service="10.96.43.108:80",zone="zone-b"} 38
# HELP cilium_act_failed_connections_total
# TYPE cilium_act_failed_connections_total gauge
cilium_act_failed_connections_total{service="10.96.43.108:443",zone="zone-a"} 32
cilium_act_failed_connections_total{service="10.96.43.108:443",zone="zone-b"} 68
# HELP cilium_act_new_connections_total
# TYPE cilium_act_new_connections_total gauge
cilium_act_new_connections_total{service="10.96.43.108:443",zone="zone-a"} 0
cilium_act_new_connections_total{service="10.96.43.108:443",zone="zone-b"} 0
cilium_act_new_connections_total{service="10.96.43.108:80",zone="zone-a"} 24
cilium_act_new_connections_total{service="10.96.43.108:80",zone="zone-b"} 76
```

```release-note
Add cilium_act_{new,active,failed}_connections_total metrics with service and zone labels
```
