### PR TITLE
gh: e2e-upgrade: disable config 7

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -151,20 +151,22 @@ jobs:
             # has been resolved.
             # ingress-controller: 'true'
 
-          - name: '7'
-            # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: 'bpf-next-20240529.013128'
-            kube-proxy: 'none'
-            kpr: 'true'
-            devices: '{eth0,eth1}'
-            secondary-network: 'true'
-            tunnel: 'disabled'
-            lb-mode: 'snat'
-            egress-gateway: 'true'
-            lb-acceleration: 'testing-only'
-            # Disable until https://github.com/cilium/cilium/issues/30717
-            # has been resolved.
-            # ingress-controller: 'true'
+#          Disable until https://github.com/cilium/cilium/issues/32689
+#          is resolved.
+#          - name: '7'
+#            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+#            kernel: 'bpf-next-20240529.013128'
+#            kube-proxy: 'none'
+#            kpr: 'true'
+#            devices: '{eth0,eth1}'
+#            secondary-network: 'true'
+#            tunnel: 'disabled'
+#            lb-mode: 'snat'
+#            egress-gateway: 'true'
+#            lb-acceleration: 'testing-only'
+#            # Disable until https://github.com/cilium/cilium/issues/30717
+#            # has been resolved.
+#            # ingress-controller: 'true'
 
           - name: '8'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind


### PR DESCRIPTION
The config is reliably failing [0]. Stabilize the workflow so that we can make it required.

[0] https://github.com/cilium/cilium/issues/32689