### PR TITLE
lrp: move api handler from daemon to lrp hive cell

### DIFF
--- a/daemon/cmd/api_handlers.go
+++ b/daemon/cmd/api_handlers.go
@@ -81,7 +81,6 @@ type handlersOut struct {
 	RecorderPutRecorderIDHandler    recorder.PutRecorderIDHandler
 
 	ServiceDeleteServiceIDHandler service.DeleteServiceIDHandler
-	ServiceGetLrpHandler          service.GetLrpHandler
 	ServiceGetServiceHandler      service.GetServiceHandler
 	ServiceGetServiceIDHandler    service.GetServiceIDHandler
 	ServicePutServiceIDHandler    service.PutServiceIDHandler
@@ -170,9 +169,6 @@ func ciliumAPIHandlers(dp promise.Promise[*Daemon], cfg *option.DaemonConfig, _ 
 		out.PolicyPutPolicyHandler = wrapAPIHandler(dp, putPolicyHandler)
 		out.PolicyDeletePolicyHandler = wrapAPIHandler(dp, deletePolicyHandler)
 		out.PolicyGetPolicySelectorsHandler = wrapAPIHandler(dp, getPolicySelectorsHandler)
-
-		// /lrp/
-		out.ServiceGetLrpHandler = wrapAPIHandler(dp, getLRPHandler)
 	}
 
 	// /service/{id}/

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -79,7 +79,6 @@ import (
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/recorder"
-	"github.com/cilium/cilium/pkg/redirectpolicy"
 	"github.com/cilium/cilium/pkg/resiliency"
 	"github.com/cilium/cilium/pkg/service"
 	serviceStore "github.com/cilium/cilium/pkg/service/store"
@@ -171,8 +170,6 @@ type Daemon struct {
 	// endpointCreations is a map of all currently ongoing endpoint
 	// creation events
 	endpointCreations *endpointCreationManager
-
-	lrpManager *redirectpolicy.Manager
 
 	cgroupManager manager.CGroupManager
 
@@ -432,7 +429,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		bigTCPConfig:      params.BigTCPConfig,
 		tunnelConfig:      params.TunnelConfig,
 		bwManager:         params.BandwidthManager,
-		lrpManager:        params.LRPManager,
 		cgroupManager:     params.CGroupManager,
 		preFilter:         params.Prefilter,
 		endpointManager:   params.EndpointManager,

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -99,7 +99,6 @@ import (
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/rate"
-	"github.com/cilium/cilium/pkg/redirectpolicy"
 	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/version"
@@ -1676,7 +1675,6 @@ type daemonParams struct {
 	MTU                 mtu.MTU
 	Sysctl              sysctl.Sysctl
 	SyncHostIPs         *syncHostIPs
-	LRPManager          *redirectpolicy.Manager
 	NodeDiscovery       *nodediscovery.NodeDiscovery
 	Prefilter           datapath.PreFilter
 	CompilationLock     datapath.CompilationLock

--- a/pkg/redirectpolicy/api.go
+++ b/pkg/redirectpolicy/api.go
@@ -1,23 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package cmd
+package redirectpolicy
 
 import (
 	"github.com/go-openapi/runtime/middleware"
 
 	"github.com/cilium/cilium/api/v1/models"
-	. "github.com/cilium/cilium/api/v1/server/restapi/service"
+	"github.com/cilium/cilium/api/v1/server/restapi/service"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/redirectpolicy"
 )
 
-func getLRPHandler(d *Daemon, params GetLrpParams) middleware.Responder {
-	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /lrp request")
-	return NewGetLrpOK().WithPayload(getLRPs(d.lrpManager))
+type getLrpHandler struct {
+	lrpManager *Manager
 }
 
-func getLRPs(rpm *redirectpolicy.Manager) []*models.LRPSpec {
+func (h *getLrpHandler) Handle(params service.GetLrpParams) middleware.Responder {
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /lrp request")
+	return service.NewGetLrpOK().WithPayload(getLRPs(h.lrpManager))
+}
+
+func getLRPs(rpm *Manager) []*models.LRPSpec {
 	lrps := rpm.GetLRPs()
 	list := make([]*models.LRPSpec, 0, len(lrps))
 	for _, v := range lrps {

--- a/pkg/redirectpolicy/cell.go
+++ b/pkg/redirectpolicy/cell.go
@@ -6,6 +6,7 @@ package redirectpolicy
 import (
 	"github.com/cilium/hive/cell"
 
+	serviceapi "github.com/cilium/cilium/api/v1/server/restapi/service"
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -18,6 +19,7 @@ var Cell = cell.Module(
 	"LRP Manager",
 
 	cell.Provide(newLRPManager),
+	cell.Provide(newLRPApiHandler),
 )
 
 type lrpManagerParams struct {
@@ -31,4 +33,10 @@ type lrpManagerParams struct {
 
 func newLRPManager(params lrpManagerParams) *Manager {
 	return NewRedirectPolicyManager(params.Svc, params.SvcCache, params.Lpr, params.Ep)
+}
+
+func newLRPApiHandler(lrpManager *Manager) serviceapi.GetLrpHandler {
+	return &getLrpHandler{
+		lrpManager: lrpManager,
+	}
 }


### PR DESCRIPTION
Currently, the daemon implements the LRP API handler. With it comes the last dependency to the LRP manager from the daemon.

Therefore, this commit moves the LRP API handler from the daemon to the existing LRP hive cell and removes the dependency from the daemon to the LRP manager.