### PR TITLE
daemon: remove unnecessary method DebugEnabled

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -211,11 +211,6 @@ func (d *Daemon) GetPolicyRepository() *policy.Repository {
 	return d.policy
 }
 
-// DebugEnabled returns if debug mode is enabled.
-func (d *Daemon) DebugEnabled() bool {
-	return option.Config.Opts.IsEnabled(option.Debug)
-}
-
 // GetCompilationLock returns the mutex responsible for synchronizing compilation
 // of BPF programs.
 func (d *Daemon) GetCompilationLock() datapath.CompilationLock {
@@ -979,7 +974,7 @@ func changedOption(key string, value option.OptionSetting, data interface{}) {
 	d := data.(*Daemon)
 	if key == option.Debug {
 		// Set the debug toggle (this can be a no-op)
-		if d.DebugEnabled() {
+		if option.Config.Opts.IsEnabled(option.Debug) {
 			logging.SetLogLevelToDebug()
 		}
 		// Reflect log level change to proxies

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -233,7 +233,6 @@ func (d *Daemon) launchHubble() {
 	observerOpts = append(observerOpts,
 		observeroption.WithMaxFlows(maxFlows),
 		observeroption.WithMonitorBuffer(option.Config.HubbleEventQueueSize),
-		observeroption.WithCiliumDaemon(d),
 	)
 	if option.Config.HubbleExportFilePath != "" {
 		exporterOpts := []exporteroption.Option{

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -487,21 +487,9 @@ func TestLocalObserverServer_GetFlows_Follow_Since(t *testing.T) {
 	assert.Equal(t, err, io.EOF)
 }
 
-type fakeCiliumDaemon struct{}
-
-func (f *fakeCiliumDaemon) DebugEnabled() bool {
-	return true
-}
-
 func TestHooks(t *testing.T) {
 	numFlows := 10
 	queueSize := 0
-
-	ciliumDaemon := &fakeCiliumDaemon{}
-	onServerInit := func(srv observeroption.Server) error {
-		assert.Equal(t, srv.GetOptions().CiliumDaemon, ciliumDaemon)
-		return nil
-	}
 
 	seenFlows := int64(0)
 	skipEveryNFlows := int64(2)
@@ -531,8 +519,6 @@ func TestHooks(t *testing.T) {
 	s, err := NewLocalServer(pp, nsManager, log,
 		observeroption.WithMaxFlows(container.Capacity15),
 		observeroption.WithMonitorBuffer(queueSize),
-		observeroption.WithCiliumDaemon(ciliumDaemon),
-		observeroption.WithOnServerInitFunc(onServerInit),
 		observeroption.WithOnMonitorEventFunc(onMonitorEventFirst),
 		observeroption.WithOnMonitorEventFunc(onMonitorEventSecond),
 		observeroption.WithOnDecodedFlowFunc(onDecodedFlow),

--- a/pkg/hubble/observer/observeroption/option.go
+++ b/pkg/hubble/observer/observeroption/option.go
@@ -16,11 +16,6 @@ import (
 	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
 )
 
-// CiliumDaemon is a reference to the Cilium's Daemon when running inside Cilium
-type CiliumDaemon interface {
-	DebugEnabled() bool
-}
-
 // Server gives access to the Hubble server
 type Server interface {
 	GetOptions() Options
@@ -31,8 +26,6 @@ type Server interface {
 type Options struct {
 	MaxFlows      container.Capacity // max number of flows that can be stored in the ring buffer
 	MonitorBuffer int                // buffer size for monitor payload
-
-	CiliumDaemon CiliumDaemon // when running inside Cilium, contains a reference to the daemon
 
 	OnServerInit   []OnServerInit          // invoked when the hubble server is initialized
 	OnMonitorEvent []OnMonitorEvent        // invoked before an event is decoded
@@ -142,14 +135,6 @@ func WithMonitorBuffer(size int) Option {
 func WithMaxFlows(capacity container.Capacity) Option {
 	return func(o *Options) error {
 		o.MaxFlows = capacity
-		return nil
-	}
-}
-
-// WithCiliumDaemon provides access to the Cilium daemon via downcast
-func WithCiliumDaemon(daemon CiliumDaemon) Option {
-	return func(o *Options) error {
-		o.CiliumDaemon = daemon
 		return nil
 	}
 }


### PR DESCRIPTION
The method `Daemon.DebugEnabled` is used in two cases.

1. In an optionChanged callback that can directly access the config property
2. As hubble observer option that is actually no longer used

Therefore, this commit removes the unnecessary method from the daemon.