### PR TITLE
v1.13 Backports 2024-06-13

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -182,7 +182,8 @@ jobs:
       - name: Install metallb for LB service
         timeout-minutes: 10
         run: |
-          KIND_NET_CIDR=$(docker network inspect kind -f '{{(index .IPAM.Config 0).Subnet}}')
+          KIND_NET_CIDR=$(docker network inspect kind -f '{{json .IPAM.Config}}' | jq -r '.[] | select(.Subnet | test("^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+")) | .Subnet')
+          echo "KIND_NET_CIDR: $KIND_NET_CIDR"
           METALLB_IP_START=$(echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.200@")
           METALLB_IP_END=$(echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.250@")
           METALLB_IP_RANGE="${METALLB_IP_START}-${METALLB_IP_END}"
@@ -197,7 +198,8 @@ jobs:
           psp:
             create: false
           EOF
-          
+          cat metallb_values.yaml
+
           helm install --namespace metallb-system \
             --create-namespace \
             --repo https://metallb.github.io/metallb metallb metallb \

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -193,7 +193,8 @@ jobs:
       - name: Install metallb for LB service
         timeout-minutes: 10
         run: |
-          KIND_NET_CIDR=$(docker network inspect kind -f '{{(index .IPAM.Config 0).Subnet}}')
+          KIND_NET_CIDR=$(docker network inspect kind -f '{{json .IPAM.Config}}' | jq -r '.[] | select(.Subnet | test("^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+")) | .Subnet')
+          echo "KIND_NET_CIDR: $KIND_NET_CIDR"
           METALLB_IP_START=$(echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.200@")
           METALLB_IP_END=$(echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.250@")
           METALLB_IP_RANGE="${METALLB_IP_START}-${METALLB_IP_END}"
@@ -208,7 +209,8 @@ jobs:
           psp:
             create: false
           EOF
-          
+          cat metallb_values.yaml
+
           helm install --namespace metallb-system \
             --create-namespace \
             --repo https://metallb.github.io/metallb metallb metallb \


### PR DESCRIPTION
 * [x] #33093 (@sayboras) :warning: resolved conflicts
    * ℹ️ Hit conflicts due to the usage of MetalLB rather than Cilium LB. Preserved the main hunk, and adapted the debug output.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 33093
```
