### PR TITLE
bpf: fix skip_tunnel_nodeport_revnat

### DIFF
--- a/bpf/tests/skip_tunnel_nodeport_revnat.c
+++ b/bpf/tests/skip_tunnel_nodeport_revnat.c
@@ -192,8 +192,8 @@ setup(struct __ctx_buff *ctx, bool v4, bool flag_skip_tunnel)
 		 */
 		struct ipv4_nat_target target = {
 			.addr = NODEPORT_IPV4,
-			.min_port = NODEPORT_NAT_PORT,
-			.max_port = NODEPORT_NAT_PORT,
+			.min_port = __bpf_ntohs(NODEPORT_NAT_PORT),
+			.max_port = __bpf_ntohs(NODEPORT_NAT_PORT) + 1,
 		};
 
 		void *map = get_cluster_snat_map_v4(0);
@@ -234,8 +234,8 @@ setup(struct __ctx_buff *ctx, bool v4, bool flag_skip_tunnel)
 		};
 		struct ipv6_nat_target target = {
 			.addr = *((union v6addr *)NODEPORT_IPV6),
-			.min_port = NODEPORT_NAT_PORT,
-			.max_port = NODEPORT_NAT_PORT,
+			.min_port = __bpf_ntohs(NODEPORT_NAT_PORT),
+			.max_port = __bpf_ntohs(NODEPORT_NAT_PORT) + 1,
 		};
 
 		struct ipv6_nat_entry state;


### PR DESCRIPTION
bpf: fix skip_tunnel_nodeport_revnat

    The test contains a bug since it passes min_port and max_port in struct
    ip{4,6}_nat_target in network instead of host byte order. It doesn't fail
    because of a series of "fortunate" circumstances, which boil down to
    invoking the following function

        __u16 __snat_try_keep_port(__u16 start, __u16 end, __u16 val)
       {
           return val >= start && val <= end ? val :
                __snat_clamp_port_range(start, end, (__u16)get_prandom_u32());
       }

    with the following arguments:

        __snat_try_keep_port(htons(port), htons(port), port)

    since htons(port) <= port <= htons(port) is (almost) never true, we end up
    invoking

        __u16 __snat_clamp_port_range(__u16 start, __u16 end,  __u16 val)
       {
           return (val % (__u16)(end - start)) + start;
       }

    Since start == end, we end up executing val % 0. This seems to cause UB
    which somehow leads to the code just using val. Of course, this all comes
    crashing down when trying to modify any of the code in this path. Fix the
    test by converting to host byte order as appropriate.

    Fixes: c1761f75ec ("bpf: Implement handling of flag_skip_tunnel for revNAT
    nodeport traffic") Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
