### PR TITLE
bpf: extract ethertype in to-netdev / to-overlay just once

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1348,12 +1348,10 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = 0,
 	};
+	__be16 __maybe_unused proto = 0;
 	__u32 __maybe_unused vlan_id;
 	int ret = CTX_ACT_OK;
 	__s8 ext_err = 0;
-#if defined(ENABLE_HOST_FIREWALL) || defined(ENABLE_EGRESS_GATEWAY_COMMON)
-	__u16 proto = 0;
-#endif
 
 	if (magic == MARK_MAGIC_HOST || magic == MARK_MAGIC_OVERLAY)
 		src_sec_identity = HOST_ID;
@@ -1383,6 +1381,9 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 	}
 #endif
 
+	/* Load the ethertype just once: */
+	validate_ethertype(ctx, &proto);
+
 #ifdef ENABLE_HOST_FIREWALL
 	/* This was initially added for Egress GW. There it's no longer needed,
 	 * but it potentially also helps other paths (LB-to-remote-backend ?).
@@ -1390,7 +1391,7 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 	if (ctx_snat_done(ctx))
 		goto skip_host_firewall;
 
-	if (!validate_ethertype(ctx, &proto)) {
+	if (!eth_is_supported_ethertype(proto)) {
 		ret = DROP_UNSUPPORTED_L2;
 		goto drop_err;
 	}
@@ -1432,7 +1433,7 @@ skip_host_firewall:
 		goto drop_err;
 
 #if defined(ENABLE_BANDWIDTH_MANAGER)
-	ret = edt_sched_departure(ctx);
+	ret = edt_sched_departure(ctx, proto);
 	/* No send_drop_notify_error() here given we're rate-limiting. */
 	if (ret == CTX_ACT_DROP) {
 		update_metrics(ctx_full_len(ctx), METRIC_EGRESS,
@@ -1483,7 +1484,7 @@ skip_host_firewall:
 	 * is set before the redirect.
 	 */
 	if ((ctx->mark & MARK_MAGIC_WG_ENCRYPTED) != MARK_MAGIC_WG_ENCRYPTED) {
-		ret = wg_maybe_redirect_to_encrypt(ctx);
+		ret = wg_maybe_redirect_to_encrypt(ctx, proto);
 		if (ret == CTX_ACT_REDIRECT)
 			return ret;
 		else if (IS_ERR(ret))
@@ -1491,7 +1492,7 @@ skip_host_firewall:
 	}
 
 #if defined(ENCRYPTION_STRICT_MODE)
-	if (!strict_allow(ctx)) {
+	if (!strict_allow(ctx, proto)) {
 		ret = DROP_UNENCRYPTED_TRAFFIC;
 		goto drop_err;
 	}
@@ -1499,7 +1500,7 @@ skip_host_firewall:
 #endif /* ENABLE_WIREGUARD */
 
 #ifdef ENABLE_HEALTH_CHECK
-	ret = lb_handle_health(ctx);
+	ret = lb_handle_health(ctx, proto);
 	if (ret != CTX_ACT_OK)
 		goto exit;
 #endif
@@ -1519,7 +1520,7 @@ skip_host_firewall:
 		if (src_sec_identity == HOST_ID)
 			goto skip_egress_gateway;
 
-		if (!validate_ethertype(ctx, &proto) || proto != bpf_htons(ETH_P_IP))
+		if (proto != bpf_htons(ETH_P_IP))
 			goto skip_egress_gateway;
 
 		if (ctx_egw_done(ctx))
@@ -1581,7 +1582,7 @@ skip_egress_gateway:
 		 * handle_nat_fwd tail calls in the majority of cases,
 		 * so control might never return to this program.
 		 */
-		ret = handle_nat_fwd(ctx, 0, &trace, &ext_err);
+		ret = handle_nat_fwd(ctx, 0, proto, &trace, &ext_err);
 		if (ret == CTX_ACT_REDIRECT)
 			return ret;
 	}

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -748,7 +748,11 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 	__u32 src_sec_identity = UNKNOWN_ID;
 	int ret = TC_ACT_OK;
 	__u32 cluster_id __maybe_unused = 0;
+	__be16 __maybe_unused proto = 0;
 	__s8 ext_err = 0;
+
+	/* Load the ethertype just once: */
+	validate_ethertype(ctx, &proto);
 
 #ifdef ENABLE_BANDWIDTH_MANAGER
 	/* In tunneling mode, we should do this as close as possible to the
@@ -757,7 +761,7 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 	 * timestamp already here. The tunnel dev has noqueue qdisc, so as
 	 * tradeoff it's close enough.
 	 */
-	ret = edt_sched_departure(ctx);
+	ret = edt_sched_departure(ctx, proto);
 	/* No send_drop_notify_error() here given we're rate-limiting. */
 	if (ret == CTX_ACT_DROP) {
 		update_metrics(ctx_full_len(ctx), METRIC_EGRESS,
@@ -789,7 +793,7 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 		goto out;
 	}
 
-	ret = handle_nat_fwd(ctx, cluster_id, &trace, &ext_err);
+	ret = handle_nat_fwd(ctx, cluster_id, proto, &trace, &ext_err);
 out:
 #endif
 	if (IS_ERR(ret))

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -11,8 +11,8 @@
 #include <linux/in.h>
 #include <linux/socket.h>
 
-#include "eth.h"
 #include "endian.h"
+#include "eth.h"
 #include "mono.h"
 #include "config.h"
 #include "tunnel.h"
@@ -177,10 +177,8 @@ static __always_inline bool validate_ethertype_l2_off(struct __ctx_buff *ctx,
 	eth = data + l2_off;
 
 	*proto = eth->h_proto;
-	if (bpf_ntohs(*proto) < ETH_P_802_3_MIN)
-		return false; /* non-Ethernet II unsupported */
 
-	return true;
+	return eth_is_supported_ethertype(*proto);
 }
 
 static __always_inline bool validate_ethertype(struct __ctx_buff *ctx,

--- a/bpf/lib/edt.h
+++ b/bpf/lib/edt.h
@@ -40,14 +40,14 @@ static __always_inline __u32 edt_get_aggregate(struct __ctx_buff *ctx)
 	return aggregate;
 }
 
-static __always_inline int edt_sched_departure(struct __ctx_buff *ctx)
+static __always_inline int
+edt_sched_departure(struct __ctx_buff *ctx, __be16 proto)
 {
 	__u64 delay, now, t, t_next;
 	struct edt_id aggregate;
 	struct edt_info *info;
-	__u16 proto;
 
-	if (!validate_ethertype(ctx, &proto))
+	if (!eth_is_supported_ethertype(proto))
 		return CTX_ACT_OK;
 	if (proto != bpf_htons(ETH_P_IP) &&
 	    proto != bpf_htons(ETH_P_IPV6))

--- a/bpf/lib/eth.h
+++ b/bpf/lib/eth.h
@@ -46,6 +46,12 @@ static __always_inline int eth_is_bcast(const union macaddr *a)
 		return 0;
 }
 
+static __always_inline bool eth_is_supported_ethertype(__be16 proto)
+{
+	/* non-Ethernet II unsupported */
+	return proto >= bpf_htons(ETH_P_802_3_MIN);
+}
+
 static __always_inline int eth_load_saddr(struct __ctx_buff *ctx, __u8 *mac,
 					  int off)
 {

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -3268,17 +3268,16 @@ health_encap_v6(struct __ctx_buff *ctx, const union v6addr *tunnel_ep,
 }
 
 static __always_inline int
-lb_handle_health(struct __ctx_buff *ctx __maybe_unused)
+lb_handle_health(struct __ctx_buff *ctx __maybe_unused, __be16 proto)
 {
 	void *data __maybe_unused, *data_end __maybe_unused;
 	__sock_cookie key __maybe_unused;
 	int ret __maybe_unused;
-	__u16 proto = 0;
 
 	if ((ctx->mark & MARK_MAGIC_HEALTH_IPIP_DONE) ==
 	    MARK_MAGIC_HEALTH_IPIP_DONE)
 		return CTX_ACT_OK;
-	validate_ethertype(ctx, &proto);
+
 	switch (proto) {
 #if defined(ENABLE_IPV4) && DSR_ENCAP_MODE == DSR_ENCAP_IPIP
 	case bpf_htons(ETH_P_IP): {
@@ -3317,17 +3316,14 @@ lb_handle_health(struct __ctx_buff *ctx __maybe_unused)
 #endif /* ENABLE_HEALTH_CHECK */
 
 static __always_inline int
-handle_nat_fwd(struct __ctx_buff *ctx, __u32 cluster_id,
+handle_nat_fwd(struct __ctx_buff *ctx, __u32 cluster_id, __be16 proto,
 	       struct trace_ctx *trace __maybe_unused,
 	       __s8 *ext_err __maybe_unused)
 {
 	int ret = CTX_ACT_OK;
-	__u16 proto;
 
 	ctx_store_meta(ctx, CB_CLUSTER_ID_EGRESS, cluster_id);
 
-	if (!validate_ethertype(ctx, &proto))
-		return CTX_ACT_OK;
 	switch (proto) {
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -16,18 +16,17 @@
 #include "lib/proxy.h"
 
 static __always_inline int
-wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
+wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 {
 	struct remote_endpoint_info *dst = NULL;
 	struct remote_endpoint_info __maybe_unused *src = NULL;
 	void *data, *data_end;
-	__u16 proto = 0;
 	struct ipv6hdr __maybe_unused *ip6;
 	struct iphdr __maybe_unused *ip4;
 	bool from_tunnel __maybe_unused = false;
 	__u32 magic __maybe_unused = 0;
 
-	if (!validate_ethertype(ctx, &proto))
+	if (!eth_is_supported_ethertype(proto))
 		return DROP_UNSUPPORTED_L2;
 
 	switch (proto) {
@@ -165,17 +164,13 @@ out:
 
 /* strict_allow checks whether the packet is allowed to pass through the strict mode. */
 static __always_inline bool
-strict_allow(struct __ctx_buff *ctx) {
+strict_allow(struct __ctx_buff *ctx, __be16 proto) {
 	struct remote_endpoint_info __maybe_unused *dest_info, __maybe_unused *src_info;
 	bool __maybe_unused in_strict_cidr = false;
 	void *data, *data_end;
 #ifdef ENABLE_IPV4
 	struct iphdr *ip4;
 #endif
-	__u16 proto = 0;
-
-	if (!validate_ethertype(ctx, &proto))
-		return true;
 
 	switch (proto) {
 #ifdef ENABLE_IPV4


### PR DESCRIPTION
See the second patch description for details.