### PR TITLE
dummy testing

### DIFF
--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -72,12 +72,6 @@ func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 	cec.Name = cecName
 
 	dedicatedService := d.getService(sourceResource, modelService)
-	if dedicatedService.Spec.Type == corev1.ServiceTypeNodePort {
-		// clear out the CEC Port field for NodePort services.
-		for i := range cec.Spec.Services {
-			cec.Spec.Services[i].Ports = nil
-		}
-	}
 
 	return cec, dedicatedService, getEndpoints(sourceResource), err
 }

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
@@ -1568,6 +1568,7 @@ var complexNodePortIngressCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-ingress-dummy-ingress",
 				Namespace: "dummy-namespace",
+				Ports:     []uint16{80, 443},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{

--- a/pkg/ciliumenvoyconfig/cec_manager.go
+++ b/pkg/ciliumenvoyconfig/cec_manager.go
@@ -136,6 +136,13 @@ func (r *cecManager) addK8sServiceRedirects(resourceName service.L7LBResourceNam
 			return fmt.Errorf("listener %q not found in resources", svc.Listener)
 		}
 
+		// Add any relevant Nodeport values into the list of Ports to redirect.
+		nodePorts, err := r.getServiceNodeports(svc.Name, svc.Namespace, svc.Ports)
+		if err != nil {
+			return err
+		}
+		svc.Ports = append(svc.Ports, nodePorts...)
+
 		// Tell service manager to redirect the service to the port
 		serviceName := getServiceName(resourceName, svc.Name, svc.Namespace, true)
 		if err := r.serviceManager.RegisterL7LBServiceRedirect(serviceName, resourceName, proxyPort, svc.Ports); err != nil {
@@ -186,6 +193,34 @@ func (r *cecManager) syncCiliumEnvoyConfigService(name string, namespace string,
 		}
 	}
 	return nil
+}
+
+// getServiceNodeports returns any relevant Nodeport numbers for the provided
+// Service ports. If the provided servicePorts do not have any nodeports set, returns
+// an empty list.
+func (r *cecManager) getServiceNodeports(name, namespace string, servicePorts []uint16) ([]uint16, error) {
+	var nodePorts []uint16
+	kSvc, err := r.getK8sService(name, namespace)
+	if err != nil {
+		return nodePorts, fmt.Errorf("could not retrieve service details for service %s/%s", namespace, name)
+	}
+
+	if kSvc == nil {
+		return nil, nil
+	}
+
+	for _, servicePort := range servicePorts {
+		for _, port := range kSvc.Spec.Ports {
+			if servicePort != uint16(port.Port) {
+				continue
+			}
+			if port.NodePort != 0 {
+				nodePorts = append(nodePorts, uint16(port.NodePort))
+			}
+		}
+	}
+
+	return nodePorts, nil
 }
 
 // getK8sService retrieves k8s service from the store

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -213,7 +213,7 @@ type L7LBInfo struct {
 // 'ports' is typically short for no point optimizing the search.
 func (i *L7LBInfo) isProtoAndPortMatch(fe *lb.L4Addr) bool {
 	// L7 LB redirect is only supported for TCP frontends
-	if fe.Protocol != lb.TCP {
+	if fe.Protocol == lb.UDP || fe.Protocol == lb.SCTP {
 		return false
 	}
 


### PR DESCRIPTION
Adds additional service redirect handling for Services with Nodeports set, which will automatically include the Nodeport in the set of redirected ports if ports to redirect are specified.

Also removes a hack in the Dedicated Ingress code that was introduced to solve this problem previously.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
