### PR TITLE
ipcache: Fix orphaned ipcache entries when mixing Upsert and Inject

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -307,6 +307,9 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 		// entriesToReplace stores the identity to replace in the ipcache.
 		entriesToReplace = make(map[netip.Prefix]ipcacheEntry)
 		entriesToDelete  = make(map[netip.Prefix]Identity)
+		// unmanagedPrefixes is the set of prefixes for which we no longer have
+		// any metadata, but were created by a call directly to Upsert()
+		unmanagedPrefixes = make(map[netip.Prefix]Identity)
 	)
 
 	ipc.metadata.RLock()
@@ -407,8 +410,16 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 			// and the existing IPCache entry was never touched by any other
 			// subsystem using the old Upsert API, then we can safely remove
 			// the IPCache entry associated with this prefix.
-			if prefixInfo == nil && oldID.createdFromMetadata {
-				entriesToDelete[prefix] = oldID
+			if prefixInfo == nil {
+				if oldID.createdFromMetadata {
+					entriesToDelete[prefix] = oldID
+				} else {
+					// If, on the other hand, this prefix *was* touched by
+					// another, Upsert-based system, flag this prefix as
+					// potentially eligible for deletion if all references
+					// are removed.
+					unmanagedPrefixes[prefix] = oldID
+				}
 			}
 		}
 
@@ -472,7 +483,7 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 		}
 	}
 
-	for _, id := range previouslyAllocatedIdentities {
+	for prefix, id := range previouslyAllocatedIdentities {
 		realID := ipc.IdentityAllocator.LookupIdentityByID(ctx, id.ID)
 		if realID == nil {
 			continue
@@ -494,6 +505,16 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 		// removed reference to the identity.
 		if released {
 			idsToDelete[id.ID] = nil // SelectorCache removal
+
+			// Corner case: This prefix + identity was initially created by a direct Upsert(),
+			// but all identity references have been released. We should then delete this prefix.
+			if oldID, unmanaged := unmanagedPrefixes[prefix]; unmanaged && oldID.ID == id.ID {
+				entriesToDelete[prefix] = oldID
+				log.WithFields(logrus.Fields{
+					logfields.IPAddr:   prefix,
+					logfields.Identity: id,
+				}).Debug("Force-removing released prefix from the ipcache.")
+			}
 		}
 	}
 	if len(idsToDelete) > 0 {


### PR DESCRIPTION
Note: v1.16 does not have this problem, though the code paths are still extant. So, I filed this PR against `main` rather than against v1.15 directly.

When a prefix is initially created by the synchronous Upsert() API, it is flagged as such so that InjectLabels() knows it is shared. However, this flag is not removed if the legacy caller releases all references to this prefix.

Thus, the timeline

1. AllocateCIDRs("1.1.1.1/32") --> refcount == 1
2. UpsertPrefixes("1.1.1.1/32") --> refcount == 2
3. ReleaseCIDRIdentities("1.1.1.1/32") --> refcount == 1
4. RemovePrefixes("1.1.1.1/32") --> refcount == 0

leaves us with the prefix still in the ipcache, but the identity fully released. This leads to traffic drops, as the identity is unknown to the policy system and thus not present in the BPF policymaps.

The fix is to forcibly remove the prefix if the identity reference reaches zero and the prefix is not in the metadata layer.
