### PR TITLE
[v1.14] - remove tracking of backports with MLH

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -1,5 +1,3 @@
-project: "https://github.com/cilium/cilium/projects/285"
-column: "In progress"
 auto-label:
   - "kind/backports"
   - "backport/1.14"


### PR DESCRIPTION
With the sunset of GH projects by GH [1], we will now create
organization-projects to track which PR is available on which release
after a CHANGELOG of a release is performed. Thus, we can also sunset
this feature from MLH.

[1] https://github.blog/changelog/2024-05-23-sunset-notice-projects-classic/

Signed-off-by: André Martins <andre@cilium.io>
