### PR TITLE
Miscellaneous fixes in the usage of Makefile.override and build modifiers

### DIFF
--- a/cilium-dbg/Makefile
+++ b/cilium-dbg/Makefile
@@ -1,6 +1,8 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
+.DEFAULT_GOAL := all
+
 ROOT_DIR := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
 
 include ${ROOT_DIR}/../Makefile.defs

--- a/cilium-dbg/Makefile
+++ b/cilium-dbg/Makefile
@@ -9,7 +9,6 @@ include ${ROOT_DIR}/../Makefile.defs
 # ROOT_DIR changes to repo root after including Makefile.defs
 -include ${ROOT_DIR}/Makefile.override
 
-$(warning $(OTHERTEST))
 TARGET := cilium-dbg
 TARGET_OLD := cilium
 

--- a/cilium-health/Makefile
+++ b/cilium-health/Makefile
@@ -1,6 +1,8 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
+.DEFAULT_GOAL := all
+
 include ../Makefile.defs
 
 # Add the ability to override variables

--- a/clustermesh-apiserver/Makefile
+++ b/clustermesh-apiserver/Makefile
@@ -1,6 +1,8 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
+.DEFAULT_GOAL := all
+
 ROOT_DIR := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
 
 include ${ROOT_DIR}/../Makefile.defs

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -1,6 +1,8 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
+.DEFAULT_GOAL := all
+
 ROOT_DIR := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
 
 include ${ROOT_DIR}/../Makefile.defs

--- a/hubble-relay/Makefile
+++ b/hubble-relay/Makefile
@@ -1,6 +1,8 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
+.DEFAULT_GOAL := all
+
 ROOT_DIR := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
 
 include ${ROOT_DIR}/../Makefile.defs

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -25,8 +25,8 @@ WORKDIR /go/src/github.com/cilium/cilium
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
     --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/go/pkg \
-    make GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} \
-    DESTDIR=/out/${TARGETOS}/${TARGETARCH} build-container-${OPERATOR_VARIANT} install-container-binary-${OPERATOR_VARIANT}
+    make GOARCH=${TARGETARCH} DESTDIR=/out/${TARGETOS}/${TARGETARCH} ${MODIFIERS} \
+    build-container-${OPERATOR_VARIANT} install-container-binary-${OPERATOR_VARIANT}
 
 # licenses-all is a "script" that executes "go run" so its ARCH should be set
 # to the same ARCH specified in the base image of this Docker stage (BUILDARCH)

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,6 +1,8 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
+.DEFAULT_GOAL := all
+
 ROOT_DIR := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
 
 include ${ROOT_DIR}/../Makefile.defs


### PR DESCRIPTION
Please review commit by commit, and refer to the individual descriptions for additional details.

<!-- Description of change -->

Fixes: https://github.com/cilium/cilium/pull/32660

```release-note
Miscellaneous fixes in the usage of Makefile.override and build modifiers
```
