### PR TITLE
clustermesh: switch to the "local" user to access kvstoremesh data

### DIFF
--- a/Documentation/operations/troubleshooting_clustermesh.rst
+++ b/Documentation/operations/troubleshooting_clustermesh.rst
@@ -99,9 +99,9 @@ you may perform the following steps to troubleshoot ClusterMesh issues.
       containers in the clustermesh-apiserver deployment, to authenticate against the
       sidecar etcd instance. Not applicable if an external etcd cluster is used.
 
-    * ``clustermesh-apiserver-remote-cert``, which is used by Cilium agents, and
-      optionally the kvstoremesh container in the clustermesh-apiserver deployment,
-      to authenticate against remote etcd instances (either internal or external).
+    * ``clustermesh-apiserver-remote-cert``, which is used by Cilium agents, or
+      the kvstoremesh container in the clustermesh-apiserver deployment when
+      KVStoreMesh is enabled, to authenticate against remote etcd instances.
 
     * ``clustermesh-apiserver-local-cert``, which is used by Cilium agents to
       authenticate against the local etcd instance. Only applicable if KVStoreMesh

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
@@ -17,10 +17,6 @@ metadata:
 data:
   users.yaml: |
     users:
-    {{- if .Values.clustermesh.apiserver.kvstoremesh.enabled }}
-    - name: remote-{{ .Values.cluster.name }}
-      role: remote
-    {{- end }}
     {{- range .Values.clustermesh.config.clusters }}
     - name: remote-{{ .name }}
       role: remote

--- a/pkg/kvstore/etcdinit/init.go
+++ b/pkg/kvstore/etcdinit/init.go
@@ -311,10 +311,5 @@ func rangesForRemoteRole(clusterName string) []keyRange {
 		rangeForPrefix(kvstore.StatePrefix),
 		rangeForKey(path.Join(kvstore.ClusterConfigPrefix, clusterName)),
 		rangeForPrefix(path.Join(kvstore.SyncedPrefix, clusterName)),
-
-		// kvstoremesh-specific prefixes still allowed for backward compatibility
-		rangeForPrefix(kvstore.CachePrefix),
-		rangeForPrefix(kvstore.ClusterConfigPrefix),
-		rangeForPrefix(kvstore.SyncedPrefix),
 	}
 }


### PR DESCRIPTION
Now that the support for the "local" etcd user has been available for one version \[1\], and Cilium agents are mounting the corresponding certificate \[2\], let's switch the agents to actually use it, rather than the remote one, to access cached data. Additionally, let's strip down the permissions of the remote user, as remote clusters don't need to access cached data.

\[1\]: cb6a58bef00b ("clustermesh: granular etcd permissions for kvstoremesh cached data")
\[2\]: c464e66620a4 ("helm: mount kvstoremesh-specific certificate into cilium agents")

<!-- Description of change -->

```release-note
clustermesh: switch to the "local" user to access kvstoremesh data
```
