### PR TITLE
ImmSet optimisation for multi inserts or multi deletions

### DIFF
--- a/pkg/container/immset_test.go
+++ b/pkg/container/immset_test.go
@@ -135,7 +135,7 @@ func BenchmarkImmSetInsert_100(b *testing.B)   { benchmarkImmSetInsert(b, 100) }
 func BenchmarkImmSetInsert_1000(b *testing.B)  { benchmarkImmSetInsert(b, 1000) }
 func BenchmarkImmSetInsert_10000(b *testing.B) { benchmarkImmSetInsert(b, 10000) }
 
-func benchmarkImmSetInsertMany(b *testing.B, numItems int, ins func(s ImmSet[int], xs ...int) ImmSet[int]) {
+func benchmarkImmSetInsertMany(b *testing.B, numItems int) {
 	a1 := make([]int, numItems)
 	a2 := make([]int, numItems)
 	for i := 0; i < numItems; i++ {
@@ -145,34 +145,18 @@ func benchmarkImmSetInsertMany(b *testing.B, numItems int, ins func(s ImmSet[int
 	s := NewImmSet(a1...)
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		ins(s, a2...)
+		s.Insert(a2...)
 	}
 }
 
 func BenchmarkImmSetInsertMany_100(b *testing.B) {
-	benchmarkImmSetInsertMany(b, 100, ImmSet[int].Insert)
+	benchmarkImmSetInsertMany(b, 100)
 }
 func BenchmarkImmSetInsertMany_1000(b *testing.B) {
-	benchmarkImmSetInsertMany(b, 1000, ImmSet[int].Insert)
+	benchmarkImmSetInsertMany(b, 1000)
 }
 func BenchmarkImmSetInsertMany_10000(b *testing.B) {
-	benchmarkImmSetInsertMany(b, 10000, ImmSet[int].Insert)
-}
-func BenchmarkImmSetInsertMany_100000(b *testing.B) {
-	benchmarkImmSetInsertMany(b, 100000, ImmSet[int].Insert)
-}
-
-func BenchmarkNewImmSetInsertMany_100(b *testing.B) {
-	benchmarkImmSetInsertMany(b, 100, ImmSet[int].InsertNew)
-}
-func BenchmarkNewImmSetInsertMany_1000(b *testing.B) {
-	benchmarkImmSetInsertMany(b, 1000, ImmSet[int].InsertNew)
-}
-func BenchmarkNewImmSetInsertMany_10000(b *testing.B) {
-	benchmarkImmSetInsertMany(b, 10000, ImmSet[int].InsertNew)
-}
-func BenchmarkNewImmSetInsertMany_100000(b *testing.B) {
-	benchmarkImmSetInsertMany(b, 100000, ImmSet[int].InsertNew)
+	benchmarkImmSetInsertMany(b, 10000)
 }
 
 func benchmarkImmSetDelete(b *testing.B, numItems int) {
@@ -192,7 +176,7 @@ func BenchmarkImmSetDelete_100(b *testing.B)   { benchmarkImmSetDelete(b, 100) }
 func BenchmarkImmSetDelete_1000(b *testing.B)  { benchmarkImmSetDelete(b, 1000) }
 func BenchmarkImmSetDelete_10000(b *testing.B) { benchmarkImmSetDelete(b, 10000) }
 
-func benchmarkImmSetDeleteMany(b *testing.B, numItems int, del func(s ImmSet[int], xs ...int) ImmSet[int]) {
+func benchmarkImmSetDeleteMany(b *testing.B, numItems int) {
 	s := NewImmSet[int]()
 	a := make([]int, 0, numItems)
 	for i := 0; i < numItems; i++ {
@@ -202,31 +186,21 @@ func benchmarkImmSetDeleteMany(b *testing.B, numItems int, del func(s ImmSet[int
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		del(s, a...)
+		s.Delete(a...)
 	}
 }
 
 func BenchmarkImmSetDeleteMany_100(b *testing.B) {
-	benchmarkImmSetDeleteMany(b, 100, ImmSet[int].Delete)
+	benchmarkImmSetDeleteMany(b, 100)
 }
 func BenchmarkImmSetDeleteMany_1000(b *testing.B) {
-	benchmarkImmSetDeleteMany(b, 1000, ImmSet[int].Delete)
+	benchmarkImmSetDeleteMany(b, 1000)
 }
 func BenchmarkImmSetDeleteMany_10000(b *testing.B) {
-	benchmarkImmSetDeleteMany(b, 10000, ImmSet[int].Delete)
+	benchmarkImmSetDeleteMany(b, 10000)
 }
 
-func BenchmarkNewImmSetDeleteMany_100(b *testing.B) {
-	benchmarkImmSetDeleteMany(b, 100, ImmSet[int].DeleteNew)
-}
-func BenchmarkNewImmSetDeleteMany_1000(b *testing.B) {
-	benchmarkImmSetDeleteMany(b, 1000, ImmSet[int].DeleteNew)
-}
-func BenchmarkNewImmSetDeleteMany_10000(b *testing.B) {
-	benchmarkImmSetDeleteMany(b, 10000, ImmSet[int].DeleteNew)
-}
-
-func benchmarkImmSetDifference(b *testing.B, numItems int, diff func(s1 ImmSet[int], s2 ImmSet[int]) ImmSet[int]) {
+func benchmarkImmSetDifference(b *testing.B, numItems int) {
 	s1 := NewImmSet[int]()
 	s2 := NewImmSet[int]()
 	for i := 0; i < numItems; i++ {
@@ -236,37 +210,21 @@ func benchmarkImmSetDifference(b *testing.B, numItems int, diff func(s1 ImmSet[i
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		diff(s1, s2)
+		s1.Difference(s2)
 	}
 }
 
 func BenchmarkImmSetDifference_100(b *testing.B) {
-	benchmarkImmSetDifference(b, 100, ImmSet[int].Difference)
+	benchmarkImmSetDifference(b, 100)
 }
 func BenchmarkImmSetDifference_1000(b *testing.B) {
-	benchmarkImmSetDifference(b, 1000, ImmSet[int].Difference)
+	benchmarkImmSetDifference(b, 1000)
 }
 func BenchmarkImmSetDifference_10000(b *testing.B) {
-	benchmarkImmSetDifference(b, 10000, ImmSet[int].Difference)
-}
-func BenchmarkImmSetDifference_100000(b *testing.B) {
-	benchmarkImmSetDifference(b, 100000, ImmSet[int].Difference)
+	benchmarkImmSetDifference(b, 10000)
 }
 
-func BenchmarkNewImmSetDifference_100(b *testing.B) {
-	benchmarkImmSetDifference(b, 100, ImmSet[int].DifferenceNew)
-}
-func BenchmarkNewImmSetDifference_1000(b *testing.B) {
-	benchmarkImmSetDifference(b, 1000, ImmSet[int].DifferenceNew)
-}
-func BenchmarkNewImmSetDifference_10000(b *testing.B) {
-	benchmarkImmSetDifference(b, 10000, ImmSet[int].DifferenceNew)
-}
-func BenchmarkNewImmSetDifference_100000(b *testing.B) {
-	benchmarkImmSetDifference(b, 100000, ImmSet[int].DifferenceNew)
-}
-
-func benchmarkImmSetUnion(b *testing.B, numItems int, uni func(s1 ImmSet[int], s2 ImmSet[int]) ImmSet[int]) {
+func benchmarkImmSetUnion(b *testing.B, numItems int) {
 	a1 := make([]int, numItems)
 	a2 := make([]int, numItems)
 	for i := 0; i < numItems; i++ {
@@ -277,16 +235,10 @@ func benchmarkImmSetUnion(b *testing.B, numItems int, uni func(s1 ImmSet[int], s
 	s2 := NewImmSet(a2...)
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		uni(s1, s2)
+		s1.Union(s2)
 	}
 }
 
-func BenchmarkImmSetUnion_100(b *testing.B)   { benchmarkImmSetUnion(b, 100, ImmSet[int].Union) }
-func BenchmarkImmSetUnion_1000(b *testing.B)  { benchmarkImmSetUnion(b, 1000, ImmSet[int].Union) }
-func BenchmarkImmSetUnion_10000(b *testing.B) { benchmarkImmSetUnion(b, 10000, ImmSet[int].Union) }
-
-func BenchmarkNewImmSetUnion_100(b *testing.B)  { benchmarkImmSetUnion(b, 100, ImmSet[int].UnionNew) }
-func BenchmarkNewImmSetUnion_1000(b *testing.B) { benchmarkImmSetUnion(b, 1000, ImmSet[int].UnionNew) }
-func BenchmarkNewImmSetUnion_10000(b *testing.B) {
-	benchmarkImmSetUnion(b, 10000, ImmSet[int].UnionNew)
-}
+func BenchmarkImmSetUnion_100(b *testing.B)   { benchmarkImmSetUnion(b, 100) }
+func BenchmarkImmSetUnion_1000(b *testing.B)  { benchmarkImmSetUnion(b, 1000) }
+func BenchmarkImmSetUnion_10000(b *testing.B) { benchmarkImmSetUnion(b, 10000) }

--- a/pkg/container/immset_test.go
+++ b/pkg/container/immset_test.go
@@ -135,6 +135,46 @@ func BenchmarkImmSetInsert_100(b *testing.B)   { benchmarkImmSetInsert(b, 100) }
 func BenchmarkImmSetInsert_1000(b *testing.B)  { benchmarkImmSetInsert(b, 1000) }
 func BenchmarkImmSetInsert_10000(b *testing.B) { benchmarkImmSetInsert(b, 10000) }
 
+func benchmarkImmSetInsertMany(b *testing.B, numItems int, ins func(s ImmSet[int], xs ...int) ImmSet[int]) {
+	a1 := make([]int, numItems)
+	a2 := make([]int, numItems)
+	for i := 0; i < numItems; i++ {
+		a1[i] = int(rand.IntN(numItems))
+		a2[i] = int(rand.IntN(numItems))
+	}
+	s := NewImmSet(a1...)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		ins(s, a2...)
+	}
+}
+
+func BenchmarkImmSetInsertMany_100(b *testing.B) {
+	benchmarkImmSetInsertMany(b, 100, ImmSet[int].Insert)
+}
+func BenchmarkImmSetInsertMany_1000(b *testing.B) {
+	benchmarkImmSetInsertMany(b, 1000, ImmSet[int].Insert)
+}
+func BenchmarkImmSetInsertMany_10000(b *testing.B) {
+	benchmarkImmSetInsertMany(b, 10000, ImmSet[int].Insert)
+}
+func BenchmarkImmSetInsertMany_100000(b *testing.B) {
+	benchmarkImmSetInsertMany(b, 100000, ImmSet[int].Insert)
+}
+
+func BenchmarkNewImmSetInsertMany_100(b *testing.B) {
+	benchmarkImmSetInsertMany(b, 100, ImmSet[int].InsertNew)
+}
+func BenchmarkNewImmSetInsertMany_1000(b *testing.B) {
+	benchmarkImmSetInsertMany(b, 1000, ImmSet[int].InsertNew)
+}
+func BenchmarkNewImmSetInsertMany_10000(b *testing.B) {
+	benchmarkImmSetInsertMany(b, 10000, ImmSet[int].InsertNew)
+}
+func BenchmarkNewImmSetInsertMany_100000(b *testing.B) {
+	benchmarkImmSetInsertMany(b, 100000, ImmSet[int].InsertNew)
+}
+
 func benchmarkImmSetDelete(b *testing.B, numItems int) {
 	s := NewImmSet[int]()
 	for i := 0; i < numItems; i++ {
@@ -151,3 +191,102 @@ func benchmarkImmSetDelete(b *testing.B, numItems int) {
 func BenchmarkImmSetDelete_100(b *testing.B)   { benchmarkImmSetDelete(b, 100) }
 func BenchmarkImmSetDelete_1000(b *testing.B)  { benchmarkImmSetDelete(b, 1000) }
 func BenchmarkImmSetDelete_10000(b *testing.B) { benchmarkImmSetDelete(b, 10000) }
+
+func benchmarkImmSetDeleteMany(b *testing.B, numItems int, del func(s ImmSet[int], xs ...int) ImmSet[int]) {
+	s := NewImmSet[int]()
+	a := make([]int, 0, numItems)
+	for i := 0; i < numItems; i++ {
+		s = s.Insert(int(rand.IntN(numItems)))
+		a = append(a, int(rand.IntN(numItems)))
+	}
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		del(s, a...)
+	}
+}
+
+func BenchmarkImmSetDeleteMany_100(b *testing.B) {
+	benchmarkImmSetDeleteMany(b, 100, ImmSet[int].Delete)
+}
+func BenchmarkImmSetDeleteMany_1000(b *testing.B) {
+	benchmarkImmSetDeleteMany(b, 1000, ImmSet[int].Delete)
+}
+func BenchmarkImmSetDeleteMany_10000(b *testing.B) {
+	benchmarkImmSetDeleteMany(b, 10000, ImmSet[int].Delete)
+}
+
+func BenchmarkNewImmSetDeleteMany_100(b *testing.B) {
+	benchmarkImmSetDeleteMany(b, 100, ImmSet[int].DeleteNew)
+}
+func BenchmarkNewImmSetDeleteMany_1000(b *testing.B) {
+	benchmarkImmSetDeleteMany(b, 1000, ImmSet[int].DeleteNew)
+}
+func BenchmarkNewImmSetDeleteMany_10000(b *testing.B) {
+	benchmarkImmSetDeleteMany(b, 10000, ImmSet[int].DeleteNew)
+}
+
+func benchmarkImmSetDifference(b *testing.B, numItems int, diff func(s1 ImmSet[int], s2 ImmSet[int]) ImmSet[int]) {
+	s1 := NewImmSet[int]()
+	s2 := NewImmSet[int]()
+	for i := 0; i < numItems; i++ {
+		s1 = s1.Insert(int(rand.IntN(numItems)))
+		s2 = s2.Insert(int(rand.IntN(numItems)))
+	}
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		diff(s1, s2)
+	}
+}
+
+func BenchmarkImmSetDifference_100(b *testing.B) {
+	benchmarkImmSetDifference(b, 100, ImmSet[int].Difference)
+}
+func BenchmarkImmSetDifference_1000(b *testing.B) {
+	benchmarkImmSetDifference(b, 1000, ImmSet[int].Difference)
+}
+func BenchmarkImmSetDifference_10000(b *testing.B) {
+	benchmarkImmSetDifference(b, 10000, ImmSet[int].Difference)
+}
+func BenchmarkImmSetDifference_100000(b *testing.B) {
+	benchmarkImmSetDifference(b, 100000, ImmSet[int].Difference)
+}
+
+func BenchmarkNewImmSetDifference_100(b *testing.B) {
+	benchmarkImmSetDifference(b, 100, ImmSet[int].DifferenceNew)
+}
+func BenchmarkNewImmSetDifference_1000(b *testing.B) {
+	benchmarkImmSetDifference(b, 1000, ImmSet[int].DifferenceNew)
+}
+func BenchmarkNewImmSetDifference_10000(b *testing.B) {
+	benchmarkImmSetDifference(b, 10000, ImmSet[int].DifferenceNew)
+}
+func BenchmarkNewImmSetDifference_100000(b *testing.B) {
+	benchmarkImmSetDifference(b, 100000, ImmSet[int].DifferenceNew)
+}
+
+func benchmarkImmSetUnion(b *testing.B, numItems int, uni func(s1 ImmSet[int], s2 ImmSet[int]) ImmSet[int]) {
+	a1 := make([]int, numItems)
+	a2 := make([]int, numItems)
+	for i := 0; i < numItems; i++ {
+		a1[i] = int(rand.IntN(numItems))
+		a2[i] = int(rand.IntN(numItems))
+	}
+	s1 := NewImmSet(a1...)
+	s2 := NewImmSet(a2...)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		uni(s1, s2)
+	}
+}
+
+func BenchmarkImmSetUnion_100(b *testing.B)   { benchmarkImmSetUnion(b, 100, ImmSet[int].Union) }
+func BenchmarkImmSetUnion_1000(b *testing.B)  { benchmarkImmSetUnion(b, 1000, ImmSet[int].Union) }
+func BenchmarkImmSetUnion_10000(b *testing.B) { benchmarkImmSetUnion(b, 10000, ImmSet[int].Union) }
+
+func BenchmarkNewImmSetUnion_100(b *testing.B)  { benchmarkImmSetUnion(b, 100, ImmSet[int].UnionNew) }
+func BenchmarkNewImmSetUnion_1000(b *testing.B) { benchmarkImmSetUnion(b, 1000, ImmSet[int].UnionNew) }
+func BenchmarkNewImmSetUnion_10000(b *testing.B) {
+	benchmarkImmSetUnion(b, 10000, ImmSet[int].UnionNew)
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

This PR proposes new implementations with lower computational complexity of the following methods of `ImmSet` :
 * `func (s ImmSet[T]) Insert(xs ...T) ImmSet[T]`,
 * `func (s ImmSet[T]) Delete(xs ...T) ImmSet[T]`,
 * `func (s ImmSet[T]) Difference(s2 ImmSet[T]) ImmSet[T]`,
 * `func (s ImmSet[T]) Union(s2 ImmSet[T]) ImmSet[T]`.

The first commit of the PR contains benchmarking comparing the existing and the new implementation. For me, the results were as follows:
 * for `Insert`, the proposed method becomes faster already with the container of size 1000, and then it performed _10x_ faster for size 10,000 and _100x_ faster for size 100,000;
 * for `Delete`, the proposed method becomes faster already with the container of size 1000, and then it performed _~5x_ faster for size 10,000;
 * for `Difference`, the proposed method was already _4x_ faster for size 100, and then it performed _7x_ faster for size 1000, _35x_ times faster for size 10,000, and _193x_ faster for size 100,000;
 * for `Union`, the proposed method performs slightly faster, but gains do not visibly grow with increasing size.

The proposed implementation has improved computational complexity, lowering the complexity of `Insert`, `Delete`, and `Difference` _from quadratic to linear_:
 * the complexity of `Insert` is `O(len(s.xs)*len(xs))`, and the complexity of `InsertNew` is `O(len(s.xs)+len(xs))`;
 * the complexity of `Delete` is `O(len(s.xs)*len(xs))`, and the complexity of `DeleteNew` is `O(len(s.xs)+len(xs))`;
 * the complexity of `Difference` is `O(len(s.xs)*len(s2.xs))` because it uses `Delete` internally, and the complexity of `DifferenceNew` is `O(len(s.xs)+len(s2.xs))`;
 * the complexity of `Union` is harder to estimate: it involves sorting a slice of size `n:=len(s.xs)+len(s2.xs)`, but this slice is a concatenation of two sorted slices, so most likely this does not lead to the usual `O(n*log(n))` complexity; of course, it is at least `O(n)`; the complexity of `UnionNew` is `O(n)`.

**EDIT:** I see no obvious impact of changes applied after code review on the benchmarking results.