### PR TITLE
k8s: Fix usage of assert in TestWaitForCacheSyncWithTimeout

### DIFF
--- a/pkg/k8s/synced/resources_test.go
+++ b/pkg/k8s/synced/resources_test.go
@@ -34,7 +34,6 @@ type waitForCacheTest struct {
 
 func TestWaitForCacheSyncWithTimeout(t *testing.T) {
 	unit := func(d int) time.Duration { return syncedPollPeriod * time.Duration(d) }
-	assert := assert.New(t)
 	for msg, test := range map[string]waitForCacheTest{
 		"Should complete due to event causing timeout to be extended past initial timeout": {
 			timeout: unit(5),
@@ -90,6 +89,8 @@ func TestWaitForCacheSyncWithTimeout(t *testing.T) {
 		func(test waitForCacheTest) {
 			t.Run(msg, func(t *testing.T) {
 				t.Parallel()
+
+				assert := assert.New(t)
 				r := &Resources{}
 				stop := make(chan struct{})
 				swg := lock.NewStoppableWaitGroup()


### PR DESCRIPTION
TestWaitForCacheSyncWithTimeout is relying on subtests, so a new assert object should be derived from each subtest testing.T, in order to report the failing one correctly.

Temporarily changing the code to force a failure in the `Not invoking BlockWaitGroupToSyncResources should cause wait to succeed immediately` case, it can be seen that no subtest is reported as failing:

```
--- FAIL: TestWaitForCacheSyncWithTimeout (0.00s)
    --- PASS: TestWaitForCacheSyncWithTimeout/Waiting_for_no_resources_should_always_sync (0.00s)
    --- PASS: TestWaitForCacheSyncWithTimeout/Not_invoking_BlockWaitGroupToSyncResources_should_cause_wait_to_succeed_immediately (0.00s)
    --- PASS: TestWaitForCacheSyncWithTimeout/Should_timeout_due_to_watched_resource_exceeding_timeout (0.20s)
    --- PASS: TestWaitForCacheSyncWithTimeout/Any_one_timeout_should_cause_error (0.60s)
    --- PASS: TestWaitForCacheSyncWithTimeout/Should_complete_due_to_event_causing_timeout_to_be_extended_past_initial_timeout (0.70s)
```

While after this change the expected subtest is correctly reported as the offending one:

```
--- FAIL: TestWaitForCacheSyncWithTimeout (0.00s)
    --- PASS: TestWaitForCacheSyncWithTimeout/Waiting_for_no_resources_should_always_sync (0.00s)
    --- FAIL: TestWaitForCacheSyncWithTimeout/Not_invoking_BlockWaitGroupToSyncResources_should_cause_wait_to_succeed_immediately (0.00s)
    --- PASS: TestWaitForCacheSyncWithTimeout/Should_timeout_due_to_watched_resource_exceeding_timeout (0.20s)
    --- PASS: TestWaitForCacheSyncWithTimeout/Any_one_timeout_should_cause_error (0.60s)
    --- PASS: TestWaitForCacheSyncWithTimeout/Should_complete_due_to_event_causing_timeout_to_be_extended_past_initial_timeout (0.70s)
```