### PR TITLE
endpoint: Fix Policy Sync Method

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1305,34 +1305,51 @@ func (e *Endpoint) syncPolicyMapsWith(realized policy.MapState, withDiffs bool) 
 	errors := 0
 
 	// Add policy map entries before deleting to avoid transient drops
-
+	var adds []policy.MapChange
 	e.desiredPolicy.GetPolicyMap().ForEach(func(keyToAdd policy.Key, entry policy.MapStateEntry) bool {
 		if oldEntry, ok := realized.Get(keyToAdd); !ok || !oldEntry.DatapathEqual(&entry) {
-			if !e.addPolicyKey(keyToAdd, entry, false) {
+			adds = append(adds, policy.MapChange{
+				Add:   true,
+				Key:   keyToAdd,
+				Value: entry,
+			})
+		}
+		return true
+	})
+	for _, add := range adds {
+		if oldEntry, ok := realized.Get(add.Key); !ok || !oldEntry.DatapathEqual(&add.Value) {
+			if !e.addPolicyKey(add.Key, add.Value, false) {
 				errors++
 			}
 			diffCount++
 			if withDiffs {
-				diffs = append(diffs, policy.MapChange{Add: true, Key: keyToAdd, Value: entry})
+				diffs = append(diffs, add)
 			}
 		}
-		return true
-	})
-
+	}
+	var deletes []policy.MapChange
 	// Delete policy keys present in the realized state, but not present in the desired state
 	realized.ForEach(func(keyToDelete policy.Key, _ policy.MapStateEntry) bool {
 		// If key that is in realized state is not in desired state, just remove it.
 		if entry, ok := e.desiredPolicy.GetPolicyMap().Get(keyToDelete); !ok {
-			if !e.deletePolicyKey(keyToDelete, false) {
+			deletes = append(deletes, policy.MapChange{
+				Key:   keyToDelete,
+				Value: entry,
+			})
+		}
+		return true
+	})
+	for _, del := range deletes {
+		if _, ok := e.desiredPolicy.GetPolicyMap().Get(del.Key); !ok {
+			if !e.deletePolicyKey(del.Key, false) {
 				errors++
 			}
 			diffCount++
 			if withDiffs {
-				diffs = append(diffs, policy.MapChange{Add: false, Key: keyToDelete, Value: entry})
+				diffs = append(diffs, del)
 			}
 		}
-		return true
-	})
+	}
 
 	if errors > 0 {
 		err = fmt.Errorf("syncPolicyMap failed")


### PR DESCRIPTION
The endpoint package had the last code in the Cilium repository that updated mapstate during iteration. Updating the map state during iteration will sometimes result in corrupting the map state.

Fixes: #32959

