### PR TITLE
[v1.15] ipcache: Fix orphaned ipcache entries when mixing Upsert and Inject

### DIFF
--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -460,6 +460,9 @@ func TestInjectWithLegacyAPIOverlap(t *testing.T) {
 	// Assert that ipcache has released its final reference to the identity
 	realID = IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.Background(), id.ID)
 	assert.True(t, realID == nil)
+
+	_, ok = IPIdentityCache.LookupByIP(prefix.String())
+	assert.False(t, ok)
 }
 
 // This test ensures that the ipcache does the right thing when legacy and new


### PR DESCRIPTION
 * [ ] #33120 (@squeed)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 33120
```
