### PR TITLE
kvstoremesh: correctly remove cached data upon cluster disconnection

### DIFF
--- a/pkg/clustermesh/common/clustermesh_test.go
+++ b/pkg/clustermesh/common/clustermesh_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/clustermesh/utils"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestClusterMeshMultipleAddRemove(t *testing.T) {
+	testutils.IntegrationTest(t)
+	kvstore.SetupDummy(t, "etcd")
+
+	baseDir := t.TempDir()
+	path := func(name string) string { return filepath.Join(baseDir, name) }
+
+	for i, cluster := range []string{"cluster1", "cluster2", "cluster3"} {
+		writeFile(t, path(cluster), fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
+		cfg := types.CiliumClusterConfig{ID: uint32(i + 1)}
+		require.NoError(t, utils.SetClusterConfig(context.Background(), cluster, cfg, kvstore.Client()))
+	}
+
+	var ready lock.Map[string, bool]
+	isReady := func(name string) bool {
+		rdy, _ := ready.Load(name)
+		return rdy
+	}
+
+	var blockRemoval lock.Map[string, chan struct{}]
+	blockRemoval.Store("cluster1", make(chan struct{}))
+	blockRemoval.Store("cluster2", make(chan struct{}))
+	blockRemoval.Store("cluster3", make(chan struct{}))
+
+	gcm := NewClusterMesh(Configuration{
+		Config:      Config{ClusterMeshConfig: baseDir},
+		ClusterInfo: types.ClusterInfo{ID: 255, Name: "local"},
+		NewRemoteCluster: func(name string, _ StatusFunc) RemoteCluster {
+			return &fakeRemoteCluster{
+				onRun: func() { ready.Store(name, true) },
+				onRemove: func() {
+					wait, _ := blockRemoval.Load(name)
+					<-wait
+				},
+			}
+		},
+		Metrics: MetricsProvider("clustermesh")(),
+	})
+	hivetest.Lifecycle(t).Append(gcm)
+	cm := gcm.(*clusterMesh)
+
+	// Directly call the add/remove methods, rather than creating/removing the
+	// files to prevent race conditions due to the interplay with the watcher.
+	cm.add("cluster1", path("cluster1"))
+	require.EventuallyWithT(t, func(c *assert.CollectT) { assert.True(c, isReady("cluster1")) }, timeout, tick, "Cluster1 is not ready")
+
+	// A blocked cluster removal operation should not block parallel cluster additions
+	cm.remove("cluster1")
+
+	cm.add("cluster2", path("cluster2"))
+	cm.add("cluster3", path("cluster3"))
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) { assert.True(c, isReady("cluster2")) }, timeout, tick, "Cluster2 is not ready")
+	require.EventuallyWithT(t, func(c *assert.CollectT) { assert.True(c, isReady("cluster3")) }, timeout, tick, "Cluster3 is not ready")
+
+	// Unblock the cluster removal
+	block, _ := blockRemoval.Load("cluster1")
+	close(block)
+
+	// Multiple removals and additions, ending with an addition should lead to a ready cluster
+	ready.Store("cluster2", false)
+	cm.remove("cluster2")
+	cm.add("cluster2", path("cluster2"))
+	cm.remove("cluster2")
+	cm.add("cluster2", path("cluster2"))
+
+	require.False(t, isReady("cluster2"), "Cluster2 is ready, although it shouldn't")
+
+	// Unblock the cluster removal
+	block, _ = blockRemoval.Load("cluster2")
+	close(block)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) { assert.True(c, isReady("cluster2")) }, timeout, tick, "Cluster2 is not ready")
+
+	// Multiple removals and additions, ending with a removal should lead to a non-ready cluster
+	ready.Store("cluster3", false)
+	cm.remove("cluster3")
+	cm.add("cluster3", path("cluster3"))
+	cm.remove("cluster3")
+	cm.add("cluster3", path("cluster3"))
+	cm.remove("cluster3")
+
+	require.False(t, isReady("cluster3"), "Cluster3 is ready, although it shouldn't")
+
+	// Unblock the cluster removal
+	block, _ = blockRemoval.Load("cluster3")
+	close(block)
+
+	// Make sure that the deletion go routine terminated before checking
+	cm.wg.Wait()
+	require.False(t, isReady("cluster3"), "Cluster3 is ready, although it shouldn't")
+}

--- a/pkg/clustermesh/common/config_test.go
+++ b/pkg/clustermesh/common/config_test.go
@@ -31,22 +31,22 @@ var (
 	timeout = 5 * time.Second
 )
 
-type fakeRemoteCluster struct{ onRun, onStop, onRemove func() }
+type fakeRemoteCluster struct{ onRun, onStop, onRemove func(context.Context) }
 
-func (f *fakeRemoteCluster) Run(_ context.Context, _ kvstore.BackendOperations, _ types.CiliumClusterConfig, ready chan<- error) {
+func (f *fakeRemoteCluster) Run(ctx context.Context, _ kvstore.BackendOperations, _ types.CiliumClusterConfig, ready chan<- error) {
 	if f.onRun != nil {
-		f.onRun()
+		f.onRun(ctx)
 	}
 	close(ready)
 }
 func (f *fakeRemoteCluster) Stop() {
 	if f.onStop != nil {
-		f.onStop()
+		f.onStop(context.Background())
 	}
 }
-func (f *fakeRemoteCluster) Remove() {
+func (f *fakeRemoteCluster) Remove(ctx context.Context) {
 	if f.onRemove != nil {
-		f.onRemove()
+		f.onRemove(ctx)
 	}
 }
 

--- a/pkg/clustermesh/common/config_test.go
+++ b/pkg/clustermesh/common/config_test.go
@@ -31,13 +31,24 @@ var (
 	timeout = 5 * time.Second
 )
 
-type fakeRemoteCluster struct{}
+type fakeRemoteCluster struct{ onRun, onStop, onRemove func() }
 
-func (*fakeRemoteCluster) Run(_ context.Context, _ kvstore.BackendOperations, _ types.CiliumClusterConfig, ready chan<- error) {
+func (f *fakeRemoteCluster) Run(_ context.Context, _ kvstore.BackendOperations, _ types.CiliumClusterConfig, ready chan<- error) {
+	if f.onRun != nil {
+		f.onRun()
+	}
 	close(ready)
 }
-func (*fakeRemoteCluster) Stop()   {}
-func (*fakeRemoteCluster) Remove() {}
+func (f *fakeRemoteCluster) Stop() {
+	if f.onStop != nil {
+		f.onStop()
+	}
+}
+func (f *fakeRemoteCluster) Remove() {
+	if f.onRemove != nil {
+		f.onRemove()
+	}
+}
 
 func writeFile(t *testing.T, name, content string) {
 	t.Helper()

--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -38,7 +38,7 @@ type RemoteCluster interface {
 	Run(ctx context.Context, backend kvstore.BackendOperations, config types.CiliumClusterConfig, ready chan<- error)
 
 	Stop()
-	Remove()
+	Remove(ctx context.Context)
 }
 
 // remoteCluster represents another cluster other than the cluster the agent is
@@ -385,9 +385,9 @@ func (rc *remoteCluster) onStop() {
 // (i.e., its configuration is removed). In this case, we need to drain
 // all known entries, to properly cleanup the status without requiring to
 // restart the agent.
-func (rc *remoteCluster) onRemove() {
+func (rc *remoteCluster) onRemove(ctx context.Context) {
 	rc.onStop()
-	rc.Remove()
+	rc.Remove(ctx)
 
 	rc.logger.Info("Remote cluster disconnected")
 }

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
@@ -5,26 +5,35 @@ package kvstoremesh
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	baseclocktest "k8s.io/utils/clock/testing"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/clustermesh-apiserver/syncstate"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/clustermesh/utils"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -85,6 +94,24 @@ func (w *remoteEtcdClientWrapper) ListAndWatch(ctx context.Context, prefix strin
 	}()
 
 	return &kvstore.Watcher{Events: events}
+}
+
+func clockAdvance(t assert.TestingT, fc *baseclocktest.FakeClock, d time.Duration) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	timer, stop := inctimer.New()
+	defer stop()
+
+	for !fc.HasWaiters() {
+		select {
+		case <-ctx.Done():
+			assert.FailNow(t, "Could not advance clock within expected timeout")
+		case <-timer.After(1 * time.Millisecond):
+		}
+	}
+
+	fc.Step(d)
 }
 
 func TestRemoteClusterRun(t *testing.T) {
@@ -202,8 +229,10 @@ func TestRemoteClusterRun(t *testing.T) {
 				cached:            tt.srccfg.Capabilities.Cached,
 				kvs:               tt.kvs,
 			}
+
 			st := store.NewFactory(store.MetricsProvider())
-			km := KVStoreMesh{backend: kvstore.Client(), storeFactory: st, logger: logrus.New()}
+			fakeclock := baseclocktest.NewFakeClock(time.Now())
+			km := KVStoreMesh{backend: kvstore.Client(), storeFactory: st, logger: logrus.New(), clock: fakeclock}
 
 			rc := km.newRemoteCluster("foo", nil)
 			ready := make(chan error)
@@ -254,8 +283,284 @@ func TestRemoteClusterRun(t *testing.T) {
 
 			// Assert that synced canaries have been watched if expected
 			require.Equal(t, tt.srccfg.Capabilities.SyncedCanaries, remoteClient.syncedCanariesWatched)
+
+			cancel()
+			wg.Wait()
+
+			// rc.Remove waits for a 3 minutes grace period before proceeding
+			// with the deletion. Let's handle that by advancing the fake time.
+			go clockAdvance(t, fakeclock, 3*time.Minute)
+
+			// Assert that Remove() removes all keys previously created
+			rc.Remove(context.Background())
+
+			pairs, err := kvstore.Client().ListPrefix(context.Background(), kvstore.BaseKeyPrefix)
+			require.NoError(t, err, "Failed to retrieve kvstore keys")
+			require.Empty(t, pairs, "Cached keys not correctly removed")
 		})
 	}
+}
+
+type localClientWrapper struct {
+	kvstore.BackendOperations
+	errors map[string]uint
+}
+
+func (lcw *localClientWrapper) Delete(ctx context.Context, key string) error {
+	if cnt := lcw.errors[key]; cnt > 0 {
+		lcw.errors[key] = cnt - 1
+		return errors.New("fake error")
+	}
+
+	return lcw.BackendOperations.Delete(ctx, key)
+}
+
+func (lcw *localClientWrapper) DeletePrefix(ctx context.Context, path string) error {
+	if cnt := lcw.errors[path]; cnt > 0 {
+		lcw.errors[path] = cnt - 1
+		return errors.New("fake error")
+	}
+
+	return lcw.BackendOperations.DeletePrefix(ctx, path)
+}
+
+func TestRemoteClusterRemove(t *testing.T) {
+	testutils.IntegrationTest(t)
+
+	ctx := context.Background()
+	kvstore.SetupDummyWithConfigOpts(t, "etcd",
+		// Explicitly set higher QPS than the default to speedup the test
+		map[string]string{kvstore.EtcdRateLimitOption: "100"},
+	)
+
+	keys := func(name string) []string {
+		return []string{
+			fmt.Sprintf("cilium/cluster-config/%s", name),
+			fmt.Sprintf("cilium/synced/%s/cilium/cache/nodes/v1", name),
+			fmt.Sprintf("cilium/synced/%s/cilium/cache/services/v1", name),
+			fmt.Sprintf("cilium/synced/%s/cilium/cache/identities/v1", name),
+			fmt.Sprintf("cilium/synced/%s/cilium/cache/ip/v1", name),
+			fmt.Sprintf("cilium/cache/nodes/v1/%s/bar", name),
+			fmt.Sprintf("cilium/cache/services/v1/%s/bar", name),
+			fmt.Sprintf("cilium/cache/identities/v1/%s/bar", name),
+			fmt.Sprintf("cilium/cache/ip/v1/%s/bar", name),
+		}
+	}
+
+	wrapper := &localClientWrapper{
+		BackendOperations: kvstore.Client(),
+		errors: map[string]uint{
+			"cilium/cache/identities/v1/foobar/": 1,
+			"cilium/cluster-config/baz":          10,
+		},
+	}
+
+	st := store.NewFactory(store.MetricsProvider())
+	fakeclock := baseclocktest.NewFakeClock(time.Now())
+	km := KVStoreMesh{backend: wrapper, storeFactory: st, logger: logrus.New(), clock: fakeclock}
+	rcs := make(map[string]*remoteCluster)
+	for _, cluster := range []string{"foo", "foobar", "baz"} {
+		rcs[cluster] = km.newRemoteCluster(cluster, nil).(*remoteCluster)
+		rcs[cluster].Stop()
+	}
+
+	for _, rc := range rcs {
+		for _, key := range keys(rc.name) {
+			require.NoError(t, kvstore.Client().Update(ctx, key, []byte("value"), false))
+		}
+	}
+
+	var wg sync.WaitGroup
+	bgrun := func(ctx context.Context, fn func(context.Context)) {
+		wg.Add(1)
+		go func() {
+			fn(ctx)
+			wg.Done()
+		}()
+	}
+
+	assertDeleted := func(t assert.TestingT, ctx context.Context, key string) {
+		value, err := kvstore.Client().Get(ctx, key)
+		assert.NoError(t, err, "Failed to retrieve kvstore key %s", key)
+		assert.Empty(t, string(value), "Key %s has not been deleted", key)
+	}
+
+	assertNotDeleted := func(t assert.TestingT, ctx context.Context, key string) {
+		value, err := kvstore.Client().Get(ctx, key)
+		assert.NoError(t, err, "Failed to retrieve kvstore key %s", key)
+		assert.NotEmpty(t, string(value), "Key %s has been incorrectly deleted", key)
+	}
+
+	// Remove should only delete the cluster config key before grace period expiration
+	bgrun(ctx, rcs["foo"].Remove)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assertDeleted(c, ctx, keys("foo")[0])
+		for _, key := range keys("foo")[1:] {
+			assertNotDeleted(c, ctx, key)
+		}
+	}, timeout, tick)
+
+	clockAdvance(t, fakeclock, 3*time.Minute-1*time.Millisecond)
+
+	// Grace period should still not have expired
+	time.Sleep(tick)
+	for _, key := range keys("foo")[1:] {
+		assertNotDeleted(t, ctx, key)
+	}
+
+	clockAdvance(t, fakeclock, 1*time.Millisecond)
+	wg.Wait()
+
+	// Grace period expired, all keys should now have been deleted
+	for _, key := range keys("foo") {
+		assertDeleted(t, ctx, key)
+	}
+
+	// Keys of other clusters should not have been touched
+	for _, cluster := range []string{"foobar", "baz"} {
+		for _, key := range keys(cluster) {
+			assertNotDeleted(t, ctx, key)
+		}
+	}
+
+	// Simulate the failure of one of the delete calls
+	bgrun(ctx, rcs["foobar"].Remove)
+
+	clockAdvance(t, fakeclock, 3*time.Minute)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		// Only the keys up to the erroring one should have been deleted
+		for _, key := range keys("foobar")[0:7] {
+			assertDeleted(c, ctx, key)
+		}
+		for _, key := range keys("foobar")[7:] {
+			assertNotDeleted(c, ctx, key)
+		}
+	}, timeout, tick)
+
+	clockAdvance(t, fakeclock, 2*time.Second-1*time.Millisecond)
+	time.Sleep(tick)
+	for _, key := range keys("foobar")[7:] {
+		// Backoff should not have expired yet
+		assertNotDeleted(t, ctx, key)
+	}
+
+	clockAdvance(t, fakeclock, 1*time.Millisecond)
+	wg.Wait()
+
+	for _, key := range keys("foobar") {
+		// Backoff expired, all keys should have been deleted
+		assertDeleted(t, ctx, key)
+	}
+
+	// Simulate the persistent failure of one of the delete calls
+	bgrun(ctx, rcs["baz"].Remove)
+
+	clockAdvance(t, fakeclock, 2*time.Second)  // First retry
+	clockAdvance(t, fakeclock, 4*time.Second)  // Second retry
+	clockAdvance(t, fakeclock, 8*time.Second)  // Third retry
+	clockAdvance(t, fakeclock, 16*time.Second) // Forth retry
+
+	// Fifth and last retry
+	clockAdvance(t, fakeclock, 32*time.Second-1*time.Millisecond)
+
+	// Make sure that Remove() is still actually waiting. If it weren't,
+	// clockAdvance couldn't complete successfully.
+	clockAdvance(t, fakeclock, 1*time.Millisecond)
+	wg.Wait()
+
+	for _, key := range keys("baz") {
+		// All keys should not have been deleted due to the persistent error
+		assertNotDeleted(t, ctx, key)
+	}
+
+	// The context expired during grace period
+	cctx, cancel := context.WithCancel(context.Background())
+	bgrun(cctx, rcs["foo"].Remove)
+	clockAdvance(t, fakeclock, 1*time.Minute)
+	cancel()
+	wg.Wait()
+
+	// Remove the existing waiter that we didn't clean-up due to context termination.
+	if fakeclock.HasWaiters() {
+		fakeclock.Step(5 * time.Minute)
+	}
+
+	// The context expired during backoff
+	cctx, cancel = context.WithCancel(context.Background())
+	bgrun(cctx, rcs["baz"].Remove)
+	clockAdvance(t, fakeclock, 1*time.Minute)
+	cancel()
+	wg.Wait()
+
+	// Remove the existing waiter that we didn't clean-up due to context termination.
+	if fakeclock.HasWaiters() {
+		fakeclock.Step(5 * time.Minute)
+	}
+}
+
+func TestRemoteClusterRemoveShutdown(t *testing.T) {
+	// Test that KVStoreMesh shutdown process is not blocked by possible
+	// in-progress remote cluster removals.
+	testutils.IntegrationTest(t)
+
+	ctx := context.Background()
+	kvstore.SetupDummyWithConfigOpts(t, "etcd",
+		// Explicitly set higher QPS than the default to speedup the test
+		map[string]string{kvstore.EtcdRateLimitOption: "100"},
+	)
+
+	dir := t.TempDir()
+	cfg := []byte(fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "remote"), cfg, 0644))
+
+	// Let's manually create a fake cluster configuration for the remote cluster,
+	// because we are using the same kvstore. This will be used as a synchronization
+	// point to stop the hive while blocked waiting for the grace period.
+	require.NoError(t, utils.SetClusterConfig(ctx, "remote", types.CiliumClusterConfig{ID: 20}, kvstore.Client()))
+
+	var km *KVStoreMesh
+	h := hive.New(
+		Cell,
+
+		cell.Provide(
+			func() types.ClusterInfo { return types.ClusterInfo{ID: 10, Name: "local"} },
+			func() Config { return Config{} },
+			func() promise.Promise[kvstore.BackendOperations] {
+				clr, clp := promise.New[kvstore.BackendOperations]()
+				clr.Resolve(kvstore.Client())
+				return clp
+			},
+		),
+
+		cell.Invoke(func(km_ *KVStoreMesh) { km = km_ }),
+	)
+	hive.AddConfigOverride(h, func(cfg *common.Config) { cfg.ClusterMeshConfig = dir })
+
+	tlog := hivetest.Logger(t)
+	require.NoError(t, h.Start(tlog, ctx), "Failed to start the hive")
+
+	// Wait until the connection has been successfully established, before disconnecting.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		status := km.status()
+		if assert.Len(c, status, 1) {
+			assert.True(c, status[0].Ready)
+		}
+	}, timeout, tick, "Failed to connect to the remote cluster")
+
+	require.NoError(t, os.Remove(filepath.Join(dir, "remote")))
+
+	// Wait until the cluster config key has been removed, to ensure that we are
+	// actually waiting for the grace period expiration.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		key := path.Join(kvstore.ClusterConfigPrefix, "remote")
+		value, err := kvstore.Client().Get(ctx, key)
+		assert.NoError(c, err, "Failed to retrieve kvstore key %s", key)
+		assert.Empty(c, string(value), "Key %s has not been deleted", key)
+	}, timeout, tick)
+
+	sctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	require.NoError(t, h.Stop(tlog, sctx), "Failed to stop the hive")
 }
 
 func TestRemoteClusterStatus(t *testing.T) {

--- a/pkg/clustermesh/kvstoremesh/remote_cluster.go
+++ b/pkg/clustermesh/kvstoremesh/remote_cluster.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/utils/clock"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
@@ -22,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
 	serviceStore "github.com/cilium/cilium/pkg/service/store"
 )
@@ -52,7 +54,12 @@ type remoteCluster struct {
 	// before removing the cluster from readiness checks.
 	readyTimeout time.Duration
 
+	// disableDrainOnDisconnection disables the removal of cached data upon
+	// cluster disconnection.
+	disableDrainOnDisconnection bool
+
 	logger logrus.FieldLogger
+	clock  clock.Clock
 }
 
 func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperations, srccfg types.CiliumClusterConfig, ready chan<- error) {
@@ -129,9 +136,93 @@ func (rc *remoteCluster) Stop() {
 	rc.wg.Wait()
 }
 
-func (rc *remoteCluster) Remove(context.Context) {
-	// Cluster specific keys are not explicitly removed, but they will be
-	// disappear once the associated lease expires.
+func (rc *remoteCluster) Remove(ctx context.Context) {
+	if rc.disableDrainOnDisconnection {
+		rc.logger.Warning("Remote cluster disconnected, but cached data removal is disabled. " +
+			"Reconnecting to the same cluster without first restarting KVStoreMesh may lead to inconsistencies")
+		return
+	}
+
+	const retries = 5
+	var (
+		retry   = 0
+		backoff = 2 * time.Second
+	)
+
+	rc.logger.Info("Remote cluster disconnected: draining cached data")
+	for {
+		err := rc.drain(ctx, retry == 0)
+		switch {
+		case err == nil:
+			rc.logger.Info("Successfully removed all cached data from kvstore")
+			return
+		case ctx.Err() != nil:
+			return
+		case retry == retries:
+			rc.logger.WithError(err).Error(
+				"Failed to remove cached data from kvstore, despite retries. Reconnecting to the " +
+					"same cluster without first restarting KVStoreMesh may lead to inconsistencies")
+			return
+		}
+
+		rc.logger.WithError(err).Warning("Failed to remove cached data from kvstore, retrying")
+		select {
+		case <-rc.clock.After(backoff):
+			retry++
+			backoff *= 2
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// drain drains the cached data from the local kvstore. The cluster configuration
+// is removed as first step, to prevent bootstrapping agents from connecting while
+// removing the rest of the cached data. Indeed, there's no point in retrieving
+// incomplete data, and it is expected that agents will be disconnecting as well.
+func (rc *remoteCluster) drain(ctx context.Context, withGracePeriod bool) (err error) {
+	keys := []string{
+		path.Join(kvstore.ClusterConfigPrefix, rc.name),
+	}
+	prefixes := []string{
+		path.Join(kvstore.SyncedPrefix, rc.name),
+		path.Join(kvstore.StateToCachePrefix(nodeStore.NodeStorePrefix), rc.name),
+		path.Join(kvstore.StateToCachePrefix(serviceStore.ServiceStorePrefix), rc.name),
+		path.Join(kvstore.StateToCachePrefix(identityCache.IdentitiesPath), rc.name),
+		path.Join(kvstore.StateToCachePrefix(ipcache.IPIdentitiesPath), rc.name),
+	}
+
+	for _, key := range keys {
+		if err = rc.localBackend.Delete(ctx, key); err != nil {
+			return fmt.Errorf("deleting key %q: %w", key, err)
+		}
+	}
+
+	if withGracePeriod {
+		// Wait for the grace period before deleting all the cached data. This
+		// allows Cilium agents to disconnect in the meanwhile, to reduce the
+		// overhead on etcd and prevent issues in case KVStoreMesh is disabled
+		// (as the removal of the configurations would cause the draining as
+		// well). The cluster configuration is deleted before waiting to prevent
+		// new agents from connecting in this time window.
+		const drainGracePeriod = 3 * time.Minute
+		rc.logger.WithField(logfields.Duration, drainGracePeriod).
+			Info("Waiting before removing cached data from kvstore, to allow Cilium agents to disconnect")
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-rc.clock.After(drainGracePeriod):
+			rc.logger.Info("Finished waiting before removing cached data from kvstore")
+		}
+	}
+
+	for _, prefix := range prefixes {
+		if err = rc.localBackend.DeletePrefix(ctx, prefix+"/"); err != nil {
+			return fmt.Errorf("deleting prefix %q: %w", prefix+"/", err)
+		}
+	}
+
+	return nil
 }
 
 // waitForConnection waits for a connection to be established to the remote cluster.

--- a/pkg/clustermesh/kvstoremesh/remote_cluster.go
+++ b/pkg/clustermesh/kvstoremesh/remote_cluster.go
@@ -129,7 +129,7 @@ func (rc *remoteCluster) Stop() {
 	rc.wg.Wait()
 }
 
-func (rc *remoteCluster) Remove() {
+func (rc *remoteCluster) Remove(context.Context) {
 	// Cluster specific keys are not explicitly removed, but they will be
 	// disappear once the associated lease expires.
 }

--- a/pkg/clustermesh/operator/remote_cluster.go
+++ b/pkg/clustermesh/operator/remote_cluster.go
@@ -68,7 +68,7 @@ func (rc *remoteCluster) Stop() {
 	rc.synced.Stop()
 }
 
-func (rc *remoteCluster) Remove() {
+func (rc *remoteCluster) Remove(context.Context) {
 	for _, clusterDeleteHook := range rc.clusterDeleteHooks {
 		clusterDeleteHook(rc.name)
 	}

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -135,7 +135,7 @@ func (rc *remoteCluster) Stop() {
 	rc.synced.Stop()
 }
 
-func (rc *remoteCluster) Remove() {
+func (rc *remoteCluster) Remove(context.Context) {
 	// Draining shall occur only when the configuration for the remote cluster
 	// is removed, and not in case the agent is shutting down, otherwise we
 	// would break existing connections on restart.


### PR DESCRIPTION
Currently, a comment attached to the Remove method claims that the cached data would have disappeared due to lease expiration. However, the lease is never expected to expire, as we use a single local client for all remote clusters. Additionally, depending on lease expiration would leave a significantly long race condition window in which stale data would still be present if the same cluster were to be reconnected.

In most cases, stale cached data is not a problem, as the etcd instance is stateless. However, it can create problems if the same cluster is first disconnected and then subsequently reconnected, without restarting the clustermesh-apiserver pod in between. Indeed, in this case we would have leftover entries that would not be cleaned up before reconnecting.

Let's address this issue by explicitly deleting the cached data upon cluster disconnection. This operation is performed synchronously (i.e., blocking other connection/disconnection operations) to prevent race conditions causing the deletion of incorrect data. Yet, to avoid blocking forever in case of errors, we only allow a limited number of retries, and give up with a loud error if they all fail.

<!-- Description of change -->

Fixes: #issue-number

```release-note
Correctly remove data cached by KVStoreMesh for a given cluster when disconnecting from such cluster
```
