### PR TITLE
nodemap: Move v1Map init to Start hook

### DIFF
--- a/pkg/maps/nodemap/cell.go
+++ b/pkg/maps/nodemap/cell.go
@@ -53,6 +53,9 @@ func newNodeMap(lifecycle cell.Lifecycle, conf Config) (bpf.MapOut[MapV2], error
 			}
 
 			// do v1 to v2 map migration if necessary
+			if err := nodeMap.v1Map.init(); err != nil {
+				return fmt.Errorf("failed to init v1 node map: %w", err)
+			}
 			return nodeMap.migrateV1(MapName, encrypt.MapName)
 		},
 		OnStop: func(context cell.HookContext) error {

--- a/pkg/maps/nodemap/node_map_v2.go
+++ b/pkg/maps/nodemap/node_map_v2.go
@@ -53,16 +53,9 @@ type nodeMapV2 struct {
 }
 
 func newMapV2(mapName string, v1MapName string, conf Config) *nodeMapV2 {
-	v1Map := newMap(v1MapName, conf)
-
-	if err := v1Map.init(); err != nil {
-		log.WithError(err).Error("failed to init v1 node map")
-		return nil
-	}
-
 	return &nodeMapV2{
 		conf:  conf,
-		v1Map: v1Map,
+		v1Map: newMap(v1MapName, conf),
 		bpfMap: ebpf.NewMap(&ebpf.MapSpec{
 			Name:       mapName,
 			Type:       ebpf.Hash,

--- a/pkg/maps/nodemap/node_map_v2_privileged_test.go
+++ b/pkg/maps/nodemap/node_map_v2_privileged_test.go
@@ -31,6 +31,10 @@ func TestNodeMapV2(t *testing.T) {
 	})
 	err := nodeMap.init()
 	require.Nil(t, err)
+
+	err = nodeMap.v1Map.init()
+	require.Nil(t, err)
+
 	defer nodeMap.bpfMap.Unpin()
 
 	bpfNodeIDMap := map[uint16]string{}
@@ -108,6 +112,9 @@ func TestNodeMapMigration(t *testing.T) {
 	nodeMapV2 := newMapV2(name2, name1, Config{
 		NodeMapMax: 1024,
 	})
+	err = nodeMapV2.v1Map.init()
+	require.Nil(t, err)
+
 	err = nodeMapV2.init()
 	require.Nil(t, err)
 	defer nodeMapV2.bpfMap.Unpin()


### PR DESCRIPTION
The v1Map was initialized from the object constructor causing this log error when running "go run ./daemon hive":
```
  time="2024-06-14T16:42:14+02:00" level=error msg="failed to init v1 node map"
  error="failed to init bpf map: unable to create map: creating map: load pinned map: permission denied" subsys=NodeMap
```
