### PR TITLE
Reconcile qdiscs accurately when using BW manager

### DIFF
--- a/pkg/datapath/linux/bandwidth/ops.go
+++ b/pkg/datapath/linux/bandwidth/ops.go
@@ -57,19 +57,36 @@ func (ops *ops) Update(ctx context.Context, txn statedb.ReadTxn, q *tables.Bandw
 	if err != nil {
 		return fmt.Errorf("QdiscList: %w", err)
 	}
-	if len(qdiscs) > 0 {
-		ok := qdiscs[0].Type() == "mq"
-		if qdiscs[0].Type() == "fq" {
-			fq, _ := qdiscs[0].(*netlink.Fq)
+	updatedQdiscs := 0
+	// Update numEgressQdiscs to only include egress qdiscs while iterating
+	numEgressQdiscs := len(qdiscs)
+	for _, qdisc := range qdiscs {
+		switch qdisc.Attrs().Parent {
+		// Update egress qdisc count by excluding clsact and ingress qdiscs.
+		// clsact and ingress have the same handle.
+		case netlink.HANDLE_CLSACT:
+			numEgressQdiscs--
+		case netlink.HANDLE_ROOT:
+			if qdisc.Type() == "mq" {
+				updatedQdiscs++
+			}
+		default:
+			if qdisc.Type() == "fq" {
+				fq, _ := qdisc.(*netlink.Fq)
 
-			// If it's "fq" and with our parameters, then assume this was
-			// already set up and there wasn't any MQ support.
-			ok = fq.Horizon == uint32(q.FqHorizon.Microseconds()) &&
-				fq.Buckets == q.FqBuckets
+				// If it's "fq" and with our parameters, then assume this was
+				// already set up and there wasn't any MQ support.
+				ok := fq.Horizon == uint32(q.FqHorizon.Microseconds()) &&
+					fq.Buckets == q.FqBuckets
+				if ok {
+					updatedQdiscs++
+				}
+			}
+
 		}
-		if ok {
-			return nil
-		}
+	}
+	if updatedQdiscs == numEgressQdiscs {
+		return nil
 	}
 
 	// We strictly want to avoid a down/up cycle on the device at


### PR DESCRIPTION
Current logic bails out without updating leaf qdiscs when first item in the qdisc list is of type mq. Other qdiscs could be pfifo_fast for example. Encountered the following in my local testing, the second qdisc was never replaced with fq.

```
qdisc mq 0: dev enX0 root
qdisc pfifo_fast 0: dev enX0 parent :1 bands 3 priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
```