### PR TITLE
Do not assign option.Config.Opts after init

### DIFF
--- a/cilium-dbg/cmd/endpoint_config.go
+++ b/cilium-dbg/cmd/endpoint_config.go
@@ -70,7 +70,7 @@ func configEndpoint(cmd *cobra.Command, args []string) {
 	// modify the configuration we fetched directly since we don't need it
 	modifiedOptsCfg := cfg.Realized
 	for k := range opts {
-		name, value, err := option.ParseOption(opts[k], &endpointMutableOptionLibrary)
+		name, value, err := endpointMutableOptionLibrary.ParseOption(opts[k])
 		if err != nil {
 			Fatalf("Cannot parse option %s: %s", opts[k], err)
 		}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1977,7 +1977,11 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 		controller.ControllerParams{
 			Group:  cfgGroup,
 			Health: params.Health,
-			DoFunc: option.Config.ValidateUnchanged,
+			DoFunc: func(context.Context) error {
+				// Validate that Daemon config has not changed, ignoring 'Opts'
+				// that may be modified via config patch events.
+				return option.Config.ValidateUnchanged()
+			},
 			// avoid synhronized run with other
 			// controllers started at same time
 			RunInterval: 61 * time.Second,

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -456,7 +456,7 @@ func (d *Daemon) allocateIPs(ctx context.Context, router restoredIPs) error {
 	if option.Config.EnableIPv6 {
 		log.Infof("  IPv6 allocation prefix: %s", node.GetIPv6AllocRange())
 
-		if c := option.Config.GetIPv6NativeRoutingCIDR(); c != nil {
+		if c := option.Config.IPv6NativeRoutingCIDR; c != nil {
 			log.Infof("  IPv6 native routing prefix: %s", c.String())
 		}
 
@@ -476,7 +476,7 @@ func (d *Daemon) allocateIPs(ctx context.Context, router restoredIPs) error {
 	if option.Config.EnableIPv4 {
 		log.Infof("  IPv4 allocation prefix: %s", node.GetIPv4AllocRange())
 
-		if c := option.Config.GetIPv4NativeRoutingCIDR(); c != nil {
+		if c := option.Config.IPv4NativeRoutingCIDR; c != nil {
 			log.Infof("  IPv4 native routing prefix: %s", c.String())
 		}
 

--- a/daemon/cmd/local_node_sync_test.go
+++ b/daemon/cmd/local_node_sync_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	"github.com/cilium/cilium/pkg/node/types"
@@ -85,7 +84,6 @@ func TestLocalNodeSync(t *testing.T) {
 		fln  = newFakeLocalNode()
 		sync = newLocalNodeSynchronizer(localNodeSynchronizerParams{
 			Config: &option.DaemonConfig{
-				ConfigPatchMutex:           new(lock.RWMutex),
 				IPv4NodeAddr:               "1.2.3.4",
 				IPv6NodeAddr:               "fd00::1",
 				NodeEncryptionOptOutLabels: k8sLabels.Nothing(),
@@ -135,7 +133,6 @@ func TestInitLocalNode_initFromK8s(t *testing.T) {
 	lni := &localNodeSynchronizer{
 		localNodeSynchronizerParams: localNodeSynchronizerParams{
 			Config: &option.DaemonConfig{
-				ConfigPatchMutex:             new(lock.RWMutex),
 				IPv4NodeAddr:                 "auto",
 				IPv6NodeAddr:                 "auto",
 				IPv6ClusterAllocCIDRBase:     "fd00::",

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -771,10 +771,7 @@ func (d *Daemon) startStatusCollector(cleaner *daemonCleanup) {
 		{
 			Name: "check-locks",
 			Probe: func(ctx context.Context) (interface{}, error) {
-				// Try to acquire a couple of global locks to have the status API fail
-				// in case of a deadlock on these locks
-				option.Config.ConfigPatchMutex.Lock()
-				option.Config.ConfigPatchMutex.Unlock()
+				// nothing to do any more.
 				return nil, nil
 			},
 			OnStatusUpdate: func(status status.Status) {

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -15,7 +15,6 @@ import (
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/daemon/cmd/cni/fake"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node/manager"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/nodediscovery"
@@ -27,10 +26,9 @@ type GetNodesSuite struct {
 }
 
 var fakeConfig = &option.DaemonConfig{
-	ConfigPatchMutex: new(lock.RWMutex),
-	RoutingMode:      option.RoutingModeTunnel,
-	EnableIPSec:      true,
-	EncryptNode:      true,
+	RoutingMode: option.RoutingModeTunnel,
+	EnableIPSec: true,
+	EncryptNode: true,
 }
 
 func setupGetNodesSuite(tb testing.TB) *GetNodesSuite {

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -181,7 +181,7 @@ func (h *ConfigModifyEventHandler) datapathRegen(reasons []string) {
 func (h *ConfigModifyEventHandler) configModify(params daemonapi.PatchConfigParams, resChan chan interface{}) {
 	cfgSpec := params.Configuration
 
-	om, err := option.Config.Opts.Library.ValidateConfigurationMap(cfgSpec.Options)
+	om, err := option.Config.Opts.ValidateConfigurationMap(cfgSpec.Options)
 	if err != nil {
 		msg := fmt.Errorf("invalid configuration option: %w", err)
 		resChan <- api.Error(daemonapi.PatchConfigBadRequestCode, msg)
@@ -195,7 +195,7 @@ func (h *ConfigModifyEventHandler) configModify(params daemonapi.PatchConfigPara
 	oldEnforcementValue := policy.GetPolicyEnabled()
 	oldConfigOpts := make(option.OptionMap, len(om))
 	for k := range om {
-		oldConfigOpts[k] = option.Config.Opts.Opts[k]
+		oldConfigOpts[k] = option.Config.Opts.GetValue(k)
 	}
 
 	// Only update if value provided for PolicyEnforcement.

--- a/operator/pkg/bgpv2/fixture_test.go
+++ b/operator/pkg/bgpv2/fixture_test.go
@@ -20,7 +20,6 @@ import (
 	cilium_client_v2alpha1 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/k8s/utils"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -126,7 +125,6 @@ func newFixture(ctx context.Context, req *require.Assertions) (*fixture, func())
 
 		cell.Provide(func() *option.DaemonConfig {
 			return &option.DaemonConfig{
-				ConfigPatchMutex:      new(lock.RWMutex),
 				EnableBGPControlPlane: true,
 				Debug:                 true,
 			}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -637,7 +637,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 					cDefinesMap["IP_MASQ_AGENT_IPV4"] = ipmasq.MapNameIPv4
 
 					// native-routing-cidr is optional with ip-masq-agent and may be nil
-					excludeCIDR = option.Config.GetIPv4NativeRoutingCIDR()
+					excludeCIDR = option.Config.IPv4NativeRoutingCIDR
 				} else {
 					excludeCIDR = datapath.RemoteSNATDstAddrExclusionCIDRv4()
 				}
@@ -657,7 +657,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 					cDefinesMap["ENABLE_IP_MASQ_AGENT_IPV6"] = "1"
 					cDefinesMap["IP_MASQ_AGENT_IPV6"] = ipmasq.MapNameIPv6
 
-					excludeCIDR = option.Config.GetIPv6NativeRoutingCIDR()
+					excludeCIDR = option.Config.IPv6NativeRoutingCIDR
 				} else {
 					excludeCIDR = datapath.RemoteSNATDstAddrExclusionCIDRv6()
 				}

--- a/pkg/datapath/types/config.go
+++ b/pkg/datapath/types/config.go
@@ -118,7 +118,7 @@ type ConfigWriter interface {
 // packet sent from a local endpoint to an IP address belonging to the CIDR
 // should not be SNAT'd.
 func RemoteSNATDstAddrExclusionCIDRv4() *cidr.CIDR {
-	if c := option.Config.GetIPv4NativeRoutingCIDR(); c != nil {
+	if c := option.Config.IPv4NativeRoutingCIDR; c != nil {
 		// ipv4-native-routing-cidr is set, so use it
 		return c
 	}
@@ -130,7 +130,7 @@ func RemoteSNATDstAddrExclusionCIDRv4() *cidr.CIDR {
 // packet sent from a local endpoint to an IP address belonging to the CIDR
 // should not be SNAT'd.
 func RemoteSNATDstAddrExclusionCIDRv6() *cidr.CIDR {
-	if c := option.Config.GetIPv6NativeRoutingCIDR(); c != nil {
+	if c := option.Config.IPv6NativeRoutingCIDR; c != nil {
 		// ipv6-native-routing-cidr is set, so use it
 		return c
 	}

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -27,7 +27,6 @@ import (
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -126,7 +125,7 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 	k.manager, err = newEgressGatewayManager(Params{
 		Lifecycle:         lc,
 		Config:            Config{1 * time.Millisecond},
-		DaemonConfig:      &option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)},
+		DaemonConfig:      &option.DaemonConfig{},
 		IdentityAllocator: identityAllocator,
 		PolicyMap:         policyMap,
 		Policies:          k.policies,

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -571,6 +571,7 @@ func createEndpoint(owner regeneration.Owner, policyGetter policyRepoGetter, nam
 		proxy:            proxy,
 		ifName:           ifName,
 		OpLabels:         labels.NewOpLabels(),
+		Options:          option.NewIntOptions(&EndpointMutableOptionLibrary),
 		DNSRules:         nil,
 		DNSRulesV2:       nil,
 		DNSHistory:       fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
@@ -833,25 +834,15 @@ func (e *Endpoint) forcePolicyComputation() {
 	e.forcePolicyCompute = true
 }
 
-// SetDefaultOpts initializes the endpoint Options and configures the specified
-// options.
+// SetDefaultOpts configures all options for the endpoint, getting the values from 'opts'.
 func (e *Endpoint) SetDefaultOpts(opts *option.IntOptions) {
-	if e.Options == nil {
-		e.Options = option.NewIntOptions(&EndpointMutableOptionLibrary)
-	}
-	if e.Options.Library == nil {
-		e.Options.Library = &EndpointMutableOptionLibrary
-	}
-	if e.Options.Opts == nil {
-		e.Options.Opts = option.OptionMap{}
-	}
-
 	if opts != nil {
-		epOptLib := option.GetEndpointMutableOptionLibrary()
-		for k := range epOptLib {
+		for k := range EndpointMutableOptionLibrary {
 			e.Options.SetValidated(k, opts.GetValue(k))
 		}
 	}
+	// Always set DebugPolicy if Debug is configured, possibly overriding this setting in
+	// 'opts'
 	if option.Config.Debug {
 		e.Options.SetValidated(option.DebugPolicy, option.OptionEnabled)
 	}
@@ -1691,7 +1682,7 @@ func (e *Endpoint) APICanModifyConfig(n models.ConfigurationMap) error {
 	}
 	for config, val := range n {
 		if optionSetting, err := option.NormalizeBool(val); err == nil {
-			if e.Options.Opts[config] == optionSetting {
+			if e.Options.GetValue(config) == optionSetting {
 				// The option won't be changed.
 				continue
 			}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -909,8 +909,9 @@ func parseEndpoint(ctx context.Context, owner regeneration.Owner, policyGetter p
 
 	ep.initDNSHistoryTrigger()
 
-	// Validate the options that were parsed
-	ep.SetDefaultOpts(ep.Options)
+	// Set default options, unsupported options were already dropped by
+	// ep.Options.UnmarshalJSON
+	ep.SetDefaultOpts(nil)
 
 	// Initialize fields to values which are non-nil that are not serialized.
 	ep.hasBPFProgram = make(chan struct{})

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -532,6 +532,7 @@ func (ep *Endpoint) UnmarshalJSON(raw []byte) error {
 	// translation from serializableEndpoint --> Endpoint.
 	restoredEp := &serializableEndpoint{
 		OpLabels:   labels.NewOpLabels(),
+		Options:    option.NewIntOptions(&EndpointMutableOptionLibrary),
 		DNSHistory: fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
 		DNSZombies: fqdn.NewDNSZombieMappings(option.Config.ToFQDNsMaxDeferredConnectionDeletes, option.Config.ToFQDNsMaxIPsPerHost),
 	}

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -627,7 +627,6 @@ func (mgr *endpointManager) expose(ep *endpoint.Endpoint) error {
 // RestoreEndpoint exposes the specified endpoint to other subsystems via the
 // manager.
 func (mgr *endpointManager) RestoreEndpoint(ep *endpoint.Endpoint) error {
-	ep.SetDefaultConfiguration()
 	err := mgr.expose(ep)
 	if err != nil {
 		return err

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 var fakeConfig = &option.DaemonConfig{
-	ConfigPatchMutex: new(lock.RWMutex),
-	K8sNamespace:     "kube-system",
+	K8sNamespace: "kube-system",
 }
 
 func TestAllocateIdentityReserved(t *testing.T) {

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -247,7 +247,7 @@ func deriveVpcCIDRs(node *ciliumv2.CiliumNode) (primaryCIDR *cidr.CIDR, secondar
 func (n *nodeStore) autoDetectIPv4NativeRoutingCIDR(localNodeStore *node.LocalNodeStore) bool {
 	if primaryCIDR, secondaryCIDRs := deriveVpcCIDRs(n.ownNode); primaryCIDR != nil {
 		allCIDRs := append([]*cidr.CIDR{primaryCIDR}, secondaryCIDRs...)
-		if nativeCIDR := n.conf.GetIPv4NativeRoutingCIDR(); nativeCIDR != nil {
+		if nativeCIDR := n.conf.IPv4NativeRoutingCIDR; nativeCIDR != nil {
 			found := false
 			for _, vpcCIDR := range allCIDRs {
 				logFields := logrus.Fields{
@@ -686,8 +686,8 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 				result.CIDRs = []string{eni.VPC.PrimaryCIDR}
 				result.CIDRs = append(result.CIDRs, eni.VPC.CIDRs...)
 				// Add manually configured Native Routing CIDR
-				if a.conf.GetIPv4NativeRoutingCIDR() != nil {
-					result.CIDRs = append(result.CIDRs, a.conf.GetIPv4NativeRoutingCIDR().String())
+				if a.conf.IPv4NativeRoutingCIDR != nil {
+					result.CIDRs = append(result.CIDRs, a.conf.IPv4NativeRoutingCIDR.String())
 				}
 				if eni.Subnet.CIDR != "" {
 					// The gateway for a subnet and VPC is always x.x.x.1

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -17,7 +17,6 @@ import (
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/trigger"
@@ -60,7 +59,6 @@ func TestIPNotAvailableInPoolError(t *testing.T) {
 }
 
 var testConfigurationCRD = &option.DaemonConfig{
-	ConfigPatchMutex:        new(lock.RWMutex),
 	EnableIPv4:              true,
 	EnableIPv6:              false,
 	EnableHealthChecking:    true,

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -15,7 +15,6 @@ import (
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -29,7 +28,6 @@ func fakeIPv6AllocCIDRIP(fakeAddressing types.NodeAddressing) netip.Addr {
 }
 
 var testConfiguration = &option.DaemonConfig{
-	ConfigPatchMutex:        new(lock.RWMutex),
 	EnableIPv4:              true,
 	EnableIPv6:              true,
 	EnableHealthChecking:    true,

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -75,7 +74,6 @@ func newFixture(t testing.TB) *fixture {
 		Lifecycle: &cell.DefaultLifecycle{},
 		Health:    h,
 		DaemonConfig: &option.DaemonConfig{
-			ConfigPatchMutex:         new(lock.RWMutex),
 			K8sNamespace:             "kube_system",
 			EnableL2Announcements:    true,
 			L2AnnouncerLeaseDuration: 15 * time.Second,
@@ -1185,7 +1183,6 @@ func TestL2AnnouncerLifecycle(t *testing.T) {
 		cell.Invoke(statedb.RegisterTable[*tables.Device]),
 		cell.Provide(func() *option.DaemonConfig {
 			return &option.DaemonConfig{
-				ConfigPatchMutex:      new(lock.RWMutex),
 				EnableL2Announcements: true,
 			}
 		}),

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -27,7 +26,7 @@ func TestGaugeWithThreshold(t *testing.T) {
 	)
 
 	reg := NewRegistry(RegistryParams{
-		DaemonConfig: &option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)},
+		DaemonConfig: &option.DaemonConfig{},
 	})
 
 	metrics, err := reg.inner.Gather()

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -243,7 +242,7 @@ func TestNodeLifecycle(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 
@@ -318,7 +317,7 @@ func TestMultipleSources(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -401,7 +400,7 @@ func BenchmarkUpdateAndDeleteCycle(b *testing.B) {
 	ipcacheMock := newIPcacheMock()
 	dp := fakeTypes.NewNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	require.NoError(b, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -425,7 +424,7 @@ func TestClusterSizeDependantInterval(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	dp := fakeTypes.NewNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -450,7 +449,7 @@ func TestBackgroundSync(t *testing.T) {
 	signalNodeHandler.EnableNodeValidateImplementationEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	mngr.Subscribe(signalNodeHandler)
 	require.NoError(t, err)
 	defer mngr.Stop(context.TODO())
@@ -499,7 +498,7 @@ func TestIpcache(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -576,7 +575,7 @@ func TestIpcacheHealthIP(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -656,9 +655,8 @@ func TestNodeEncryption(t *testing.T) {
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
 	mngr, err := New(&option.DaemonConfig{
-		ConfigPatchMutex: new(lock.RWMutex),
-		EncryptNode:      true,
-		EnableIPSec:      true,
+		EncryptNode: true,
+		EnableIPSec: true,
 	}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
@@ -752,7 +750,7 @@ func TestNode(t *testing.T) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -902,7 +900,7 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 		<-done
 	}
 	ipcacheMock := newIPcacheMock()
-	config := &option.DaemonConfig{ConfigPatchMutex: new(lock.RWMutex)}
+	config := &option.DaemonConfig{}
 	err := hive.New(
 		cell.Provide(func() testParams {
 			return testParams{
@@ -954,8 +952,7 @@ func TestNodeWithSameInternalIP(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	h, _ := cell.NewSimpleHealth()
 	mngr, err := New(&option.DaemonConfig{
-		ConfigPatchMutex: new(lock.RWMutex),
-		LocalRouterIPv4:  "169.254.4.6",
+		LocalRouterIPv4: "169.254.4.6",
 	}, ipcache, newIPSetMock(), nil, NewNodeMetrics(), h)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
@@ -1054,7 +1051,6 @@ func TestNodeIpset(t *testing.T) {
 	filter := func(no *nodeTypes.Node) bool { return no.Name != "node1" }
 	h, _ := cell.NewSimpleHealth()
 	mngr, err := New(&option.DaemonConfig{
-		ConfigPatchMutex:     new(lock.RWMutex),
 		RoutingMode:          option.RoutingModeNative,
 		EnableIPv4Masquerade: true,
 	}, newIPcacheMock(), newIPSetMock(), filter, NewNodeMetrics(), h)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2525,36 +2525,6 @@ var (
 	}
 )
 
-// GetIPv4NativeRoutingCIDR returns the native routing CIDR if configured
-func (c *DaemonConfig) GetIPv4NativeRoutingCIDR() (cidr *cidr.CIDR) {
-	c.ConfigPatchMutex.RLock()
-	cidr = c.IPv4NativeRoutingCIDR
-	c.ConfigPatchMutex.RUnlock()
-	return
-}
-
-// SetIPv4NativeRoutingCIDR sets the native routing CIDR
-func (c *DaemonConfig) SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR) {
-	c.ConfigPatchMutex.Lock()
-	c.IPv4NativeRoutingCIDR = cidr
-	c.ConfigPatchMutex.Unlock()
-}
-
-// GetIPv6NativeRoutingCIDR returns the native routing CIDR if configured
-func (c *DaemonConfig) GetIPv6NativeRoutingCIDR() (cidr *cidr.CIDR) {
-	c.ConfigPatchMutex.RLock()
-	cidr = c.IPv6NativeRoutingCIDR
-	c.ConfigPatchMutex.RUnlock()
-	return
-}
-
-// SetIPv6NativeRoutingCIDR sets the native routing CIDR
-func (c *DaemonConfig) SetIPv6NativeRoutingCIDR(cidr *cidr.CIDR) {
-	c.ConfigPatchMutex.Lock()
-	c.IPv6NativeRoutingCIDR = cidr
-	c.ConfigPatchMutex.Unlock()
-}
-
 // IsExcludedLocalAddress returns true if the specified IP matches one of the
 // excluded local IP ranges
 func (c *DaemonConfig) IsExcludedLocalAddress(ip net.IP) bool {
@@ -3761,7 +3731,7 @@ func (c *DaemonConfig) checkMapSizeLimits() error {
 }
 
 func (c *DaemonConfig) checkIPv4NativeRoutingCIDR() error {
-	if c.GetIPv4NativeRoutingCIDR() != nil {
+	if c.IPv4NativeRoutingCIDR != nil {
 		return nil
 	}
 	if !c.EnableIPv4 || !c.EnableIPv4Masquerade {
@@ -3788,7 +3758,7 @@ func (c *DaemonConfig) checkIPv4NativeRoutingCIDR() error {
 }
 
 func (c *DaemonConfig) checkIPv6NativeRoutingCIDR() error {
-	if c.GetIPv6NativeRoutingCIDR() != nil {
+	if c.IPv6NativeRoutingCIDR != nil {
 		return nil
 	}
 	if !c.EnableIPv6 || !c.EnableIPv6Masquerade {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -5,7 +5,6 @@ package option
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
@@ -42,7 +41,6 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
@@ -1461,9 +1459,6 @@ type DaemonConfig struct {
 	// Options changeable at runtime
 	Opts *IntOptions
 
-	// Mutex for serializing configuration updates to the daemon.
-	ConfigPatchMutex *lock.RWMutex
-
 	// Monitor contains the configuration for the node monitor.
 	Monitor *models.MonitorStatus
 
@@ -2474,7 +2469,6 @@ var (
 	Config = &DaemonConfig{
 		CreationTime:                    time.Now(),
 		Opts:                            NewIntOptions(&DaemonOptionLibrary),
-		ConfigPatchMutex:                new(lock.RWMutex),
 		Monitor:                         &models.MonitorStatus{Cpus: int64(runtime.NumCPU()), Npages: 64, Pagesize: int64(os.Getpagesize()), Lost: 0, Unknown: 0},
 		IPv6ClusterAllocCIDR:            defaults.IPv6ClusterAllocCIDR,
 		IPv6ClusterAllocCIDRBase:        defaults.IPv6ClusterAllocCIDRBase,
@@ -4026,6 +4020,7 @@ var backupFileNames []string = []string{
 // name 'daemon-config.json'. If this file already exists, it is renamed to
 // 'daemon-config-1.json', if 'daemon-config-1.json' also exists,
 // 'daemon-config-1.json' is renamed to 'daemon-config-2.json'
+// Caller is responsible for blocking concurrent changes.
 func (c *DaemonConfig) StoreInFile(dir string) error {
 	backupFiles(dir, backupFileNames)
 	f, err := os.Create(backupFileNames[0])
@@ -4036,12 +4031,8 @@ func (c *DaemonConfig) StoreInFile(dir string) error {
 	e := json.NewEncoder(f)
 	e.SetIndent("", " ")
 
-	// Exclude concurrent modification of fields protected by c.ConfigPatchMutex
-	// we store the file
-	c.ConfigPatchMutex.RLock()
 	err = e.Encode(c)
 	c.shaSum = c.checksum()
-	c.ConfigPatchMutex.RUnlock()
 
 	return err
 }
@@ -4058,15 +4049,10 @@ func (c *DaemonConfig) checksum() [32]byte {
 	return sha256.Sum256(cBytes)
 }
 
-// ValidateUnchanged takes a context that is unused so that it can be used as a doFunc in a
-// controller
-func (c *DaemonConfig) ValidateUnchanged(context.Context) error {
-	// Exclude concurrent modification of fields protected by c.ConfigPatchMutex
-	// we store the file
-	c.ConfigPatchMutex.RLock()
+// ValidateUnchanged checks that invariable parts of the config have not changed since init.
+// Caller is responsible for blocking concurrent changes.
+func (c *DaemonConfig) ValidateUnchanged() error {
 	sum := c.checksum()
-	c.ConfigPatchMutex.RUnlock()
-
 	if sum != c.shaSum {
 		return c.diffFromFile()
 	}

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -1312,6 +1312,10 @@ func TestDaemonConfig_validateContainerIPLocalReservedPorts(t *testing.T) {
 }
 
 func TestDaemonConfig_StoreInFile(t *testing.T) {
+	// Set an IntOption so that they are also stored in file
+	assert.False(t, Config.Opts.IsEnabled("unit-test-key-only")) // make sure not used
+	Config.Opts.SetBool("unit-test-key-only", true)
+
 	err := Config.StoreInFile(".")
 	assert.NoError(t, err)
 
@@ -1326,8 +1330,7 @@ func TestDaemonConfig_StoreInFile(t *testing.T) {
 	Config.DryMode = false
 
 	// IntOptions changes are ignored
-	assert.False(t, Config.Opts.IsEnabled("unit-test-key-only")) // make sure not used
-	Config.Opts.SetBool("unit-test-key-only", true)
+	Config.Opts.SetBool("unit-test-key-only", false)
 	err = Config.ValidateUnchanged()
 	assert.NoError(t, err)
 	Config.Opts.Delete("unit-test-key-only")

--- a/pkg/option/daemon.go
+++ b/pkg/option/daemon.go
@@ -38,5 +38,5 @@ func init() {
 
 // ParseDaemonOption parses a string as daemon option
 func ParseDaemonOption(opt string) (string, OptionSetting, error) {
-	return ParseOption(opt, &DaemonOptionLibrary)
+	return DaemonOptionLibrary.ParseOption(opt)
 }

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -178,9 +178,20 @@ func (o *IntOptions) MarshalJSON() ([]byte, error) {
 func (o *IntOptions) UnmarshalJSON(b []byte) error {
 	o.optsMU.Lock()
 	defer o.optsMU.Unlock()
-	return json.Unmarshal(b, &intOptions{
+	err := json.Unmarshal(b, &intOptions{
 		Opts: o.opts,
 	})
+	if err != nil {
+		return err
+	}
+	// Silently discard unsupported options
+	for k := range o.opts {
+		key, _ := o.library.Lookup(k)
+		if key == "" {
+			delete(o.opts, k)
+		}
+	}
+	return nil
 }
 
 // GetImmutableModel returns the set of immutable options as a ConfigurationMap API model.

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -104,7 +104,7 @@ func NormalizeBool(value string) (OptionSetting, error) {
 func (l *OptionLibrary) ValidateConfigurationMap(n models.ConfigurationMap) (OptionMap, error) {
 	o := make(OptionMap)
 	for k, v := range n {
-		_, newVal, err := ParseKeyValue(l, k, v)
+		_, newVal, err := l.parseKeyValue(k, v)
 		if err != nil {
 			return nil, err
 		}
@@ -291,7 +291,7 @@ func (o *IntOptions) InheritDefault(parent *IntOptions, key string) {
 	o.optsMU.RUnlock()
 }
 
-func ParseOption(arg string, lib *OptionLibrary) (string, OptionSetting, error) {
+func (l *OptionLibrary) ParseOption(arg string) (string, OptionSetting, error) {
 	result := OptionEnabled
 
 	if arg[0] == '!' {
@@ -306,16 +306,16 @@ func ParseOption(arg string, lib *OptionLibrary) (string, OptionSetting, error) 
 			return "", OptionDisabled, fmt.Errorf("invalid boolean format")
 		}
 
-		return ParseKeyValue(lib, arg, optionSplit[1])
+		return l.parseKeyValue(arg, optionSplit[1])
 	}
 
 	return "", OptionDisabled, fmt.Errorf("invalid option format")
 }
 
-func ParseKeyValue(lib *OptionLibrary, arg, value string) (string, OptionSetting, error) {
+func (l *OptionLibrary) parseKeyValue(arg, value string) (string, OptionSetting, error) {
 	var result OptionSetting
 
-	key, spec := lib.Lookup(arg)
+	key, spec := l.Lookup(arg)
 	if key == "" {
 		return "", OptionDisabled, fmt.Errorf("unknown option %q", arg)
 	}
@@ -408,7 +408,7 @@ func (o *IntOptions) Validate(n models.ConfigurationMap) error {
 	o.optsMU.RLock()
 	defer o.optsMU.RUnlock()
 	for k, v := range n {
-		_, newVal, err := ParseKeyValue(o.library, k, v)
+		_, newVal, err := o.library.parseKeyValue(k, v)
 		if err != nil {
 			return err
 		}

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -4,6 +4,7 @@
 package option
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -148,9 +149,38 @@ func (om OptionMap) DeepCopy() OptionMap {
 // locking by the caller, while functions with internal access presume
 // the caller to have taken care of any locking needed.
 type IntOptions struct {
-	optsMU  lock.RWMutex   // Protects all variables from this structure below this line
-	Opts    OptionMap      `json:"map"`
-	Library *OptionLibrary `json:"-"`
+	optsMU  lock.RWMutex // Protects all variables from this structure below this line
+	opts    OptionMap
+	library *OptionLibrary
+}
+
+// intOptions is only used for JSON
+type intOptions struct {
+	Opts OptionMap `json:"map"`
+}
+
+// ValidateConfigurationMap validates a given configuration map based on the
+// option library
+func (o *IntOptions) ValidateConfigurationMap(n models.ConfigurationMap) (OptionMap, error) {
+	return o.library.ValidateConfigurationMap(n)
+}
+
+// Custom json marshal for unexported 'opts' while holding a read lock
+func (o *IntOptions) MarshalJSON() ([]byte, error) {
+	o.optsMU.RLock()
+	defer o.optsMU.RUnlock()
+	return json.Marshal(&intOptions{
+		Opts: o.opts,
+	})
+}
+
+// Custom json unmarshal for unexported 'opts' while holding a write lock
+func (o *IntOptions) UnmarshalJSON(b []byte) error {
+	o.optsMU.Lock()
+	defer o.optsMU.Unlock()
+	return json.Unmarshal(b, &intOptions{
+		Opts: o.opts,
+	})
 }
 
 // GetImmutableModel returns the set of immutable options as a ConfigurationMap API model.
@@ -163,8 +193,8 @@ func (o *IntOptions) GetImmutableModel() *models.ConfigurationMap {
 func (o *IntOptions) GetMutableModel() *models.ConfigurationMap {
 	mutableCfg := make(models.ConfigurationMap)
 	o.optsMU.RLock()
-	for k, v := range o.Opts {
-		_, config := o.Library.Lookup(k)
+	for k, v := range o.opts {
+		_, config := o.library.Lookup(k)
 
 		// It's possible that an option has since been removed and thus has
 		// no corresponding configuration; need to check if configuration is
@@ -189,8 +219,8 @@ func (o *IntOptions) GetMutableModel() *models.ConfigurationMap {
 func (o *IntOptions) DeepCopy() *IntOptions {
 	o.optsMU.RLock()
 	cpy := &IntOptions{
-		Opts:    o.Opts.DeepCopy(),
-		Library: o.Library,
+		opts:    o.opts.DeepCopy(),
+		library: o.library,
 	}
 	o.optsMU.RUnlock()
 	return cpy
@@ -198,13 +228,13 @@ func (o *IntOptions) DeepCopy() *IntOptions {
 
 func NewIntOptions(lib *OptionLibrary) *IntOptions {
 	return &IntOptions{
-		Opts:    OptionMap{},
-		Library: lib,
+		opts:    OptionMap{},
+		library: lib,
 	}
 }
 
 func (o *IntOptions) getValue(key string) OptionSetting {
-	value, exists := o.Opts[key]
+	value, exists := o.opts[key]
 	if !exists {
 		return OptionDisabled
 	}
@@ -226,7 +256,7 @@ func (o *IntOptions) IsEnabled(key string) bool {
 // expected to have validated the input to this function.
 func (o *IntOptions) SetValidated(key string, value OptionSetting) {
 	o.optsMU.Lock()
-	o.Opts[key] = value
+	o.opts[key] = value
 	o.optsMU.Unlock()
 }
 
@@ -237,27 +267,27 @@ func (o *IntOptions) SetBool(key string, value bool) {
 		intValue = OptionEnabled
 	}
 	o.optsMU.Lock()
-	o.Opts[key] = intValue
+	o.opts[key] = intValue
 	o.optsMU.Unlock()
 }
 
 func (o *IntOptions) Delete(key string) {
 	o.optsMU.Lock()
-	delete(o.Opts, key)
+	delete(o.opts, key)
 	o.optsMU.Unlock()
 }
 
 func (o *IntOptions) SetIfUnset(key string, value OptionSetting) {
 	o.optsMU.Lock()
-	if _, exists := o.Opts[key]; !exists {
-		o.Opts[key] = value
+	if _, exists := o.opts[key]; !exists {
+		o.opts[key] = value
 	}
 	o.optsMU.Unlock()
 }
 
 func (o *IntOptions) InheritDefault(parent *IntOptions, key string) {
 	o.optsMU.RLock()
-	o.Opts[key] = parent.GetValue(key)
+	o.opts[key] = parent.GetValue(key)
 	o.optsMU.RUnlock()
 }
 
@@ -310,24 +340,24 @@ func ParseKeyValue(lib *OptionLibrary, arg, value string) (string, OptionSetting
 // getFmtOpt returns #define name if option exists and is set to true in endpoint's Opts
 // map or #undef name if option does not exist or exists but is set to false
 func (o *IntOptions) getFmtOpt(name string) string {
-	define := o.Library.Define(name)
+	define := o.library.Define(name)
 	if define == "" {
 		return ""
 	}
 
 	value := o.getValue(name)
 	if value != OptionDisabled {
-		return fmt.Sprintf("#define %s %d", o.Library.Define(name), value)
+		return fmt.Sprintf("#define %s %d", o.library.Define(name), value)
 	}
-	return "#undef " + o.Library.Define(name)
+	return "#undef " + o.library.Define(name)
 }
 
 func (o *IntOptions) GetFmtList() string {
 	txt := ""
 
 	o.optsMU.RLock()
-	opts := make([]string, 0, len(o.Opts))
-	for k := range o.Opts {
+	opts := make([]string, 0, len(o.opts))
+	for k := range o.opts {
 		opts = append(opts, k)
 	}
 	sort.Strings(opts)
@@ -349,23 +379,23 @@ func (o *IntOptions) Dump() {
 	}
 
 	o.optsMU.RLock()
-	opts := make([]string, 0, len(o.Opts))
-	for k := range o.Opts {
+	opts := make([]string, 0, len(o.opts))
+	for k := range o.opts {
 		opts = append(opts, k)
 	}
 	sort.Strings(opts)
 
 	for _, k := range opts {
 		var text string
-		_, option := o.Library.Lookup(k)
+		_, option := o.library.Lookup(k)
 		if option == nil || option.Format == nil {
-			if o.Opts[k] == OptionDisabled {
+			if o.opts[k] == OptionDisabled {
 				text = "Disabled"
 			} else {
 				text = "Enabled"
 			}
 		} else {
-			text = option.Format(o.Opts[k])
+			text = option.Format(o.opts[k])
 		}
 
 		fmt.Printf("%-24s %s\n", k, text)
@@ -378,17 +408,17 @@ func (o *IntOptions) Validate(n models.ConfigurationMap) error {
 	o.optsMU.RLock()
 	defer o.optsMU.RUnlock()
 	for k, v := range n {
-		_, newVal, err := ParseKeyValue(o.Library, k, v)
+		_, newVal, err := ParseKeyValue(o.library, k, v)
 		if err != nil {
 			return err
 		}
 
 		// Ignore validation if value is identical
-		if oldVal, ok := o.Opts[k]; ok && oldVal == newVal {
+		if oldVal, ok := o.opts[k]; ok && oldVal == newVal {
 			continue
 		}
 
-		if err := o.Library.Validate(k, v); err != nil {
+		if err := o.library.Validate(k, v); err != nil {
 			return err
 		}
 	}
@@ -401,35 +431,35 @@ type ChangedFunc func(key string, value OptionSetting, data interface{})
 
 // enable enables the option `name` with all its dependencies
 func (o *IntOptions) enable(name string) {
-	if o.Library != nil {
-		if _, opt := o.Library.Lookup(name); opt != nil {
+	if o.library != nil {
+		if _, opt := o.library.Lookup(name); opt != nil {
 			for _, dependency := range opt.Requires {
 				o.enable(dependency)
 			}
 		}
 	}
 
-	o.Opts[name] = OptionEnabled
+	o.opts[name] = OptionEnabled
 }
 
 // set enables the option `name` with all its dependencies, and sets the
 // integer level of the option to `value`.
 func (o *IntOptions) set(name string, value OptionSetting) {
 	o.enable(name)
-	o.Opts[name] = value
+	o.opts[name] = value
 }
 
 // disable disables the option `name`. All options which depend on the option
 // to be disabled will be disabled. Options which have previously been enabled
 // as a dependency will not be automatically disabled.
 func (o *IntOptions) disable(name string) {
-	o.Opts[name] = OptionDisabled
+	o.opts[name] = OptionDisabled
 
-	if o.Library != nil {
+	if o.library != nil {
 		// Disable all options which have a dependency on the option
 		// that was just disabled
-		for key, opt := range *o.Library {
-			if opt.RequiresOption(name) && o.Opts[key] != OptionDisabled {
+		for key, opt := range *o.library {
+			if opt.RequiresOption(name) && o.opts[key] != OptionDisabled {
 				o.disable(key)
 			}
 		}
@@ -453,7 +483,7 @@ func (o *IntOptions) ApplyValidated(n OptionMap, changed ChangedFunc, data inter
 
 	o.optsMU.Lock()
 	for k, optVal := range n {
-		val, ok := o.Opts[k]
+		val, ok := o.opts[k]
 
 		if optVal == OptionDisabled {
 			/* Only disable if enabled already */

--- a/pkg/option/option_test.go
+++ b/pkg/option/option_test.go
@@ -17,7 +17,7 @@ func TestGetValue(t *testing.T) {
 	v1 := OptionSetting(7)
 
 	o := IntOptions{
-		Opts: OptionMap{
+		opts: OptionMap{
 			k1: v1,
 			k2: OptionEnabled,
 		},
@@ -32,7 +32,7 @@ func TestIsEnabled(t *testing.T) {
 	k1, k2 := "foo", "bar"
 
 	o := IntOptions{
-		Opts: OptionMap{
+		opts: OptionMap{
 			k1: OptionEnabled,
 			k2: OptionDisabled,
 		},
@@ -47,7 +47,7 @@ func TestSetValidated(t *testing.T) {
 	k1, k2 := "foo", "bar"
 
 	o := IntOptions{
-		Opts: OptionMap{
+		opts: OptionMap{
 			k1: OptionEnabled,
 		},
 	}
@@ -65,7 +65,7 @@ func TestSetBool(t *testing.T) {
 	k1, k2, k3 := "foo", "bar", "baz"
 
 	o := IntOptions{
-		Opts: OptionMap{
+		opts: OptionMap{
 			k1: OptionEnabled,
 			k2: OptionDisabled,
 		},
@@ -83,7 +83,7 @@ func TestDelete(t *testing.T) {
 	k1, k2 := "foo", "bar"
 
 	o := IntOptions{
-		Opts: OptionMap{
+		opts: OptionMap{
 			k1: OptionEnabled,
 			k2: OptionEnabled,
 		},
@@ -99,7 +99,7 @@ func TestSetIfUnset(t *testing.T) {
 	k1, k2 := "foo", "bar"
 
 	o := IntOptions{
-		Opts: OptionMap{
+		opts: OptionMap{
 			k1: OptionDisabled,
 		},
 	}
@@ -115,10 +115,10 @@ func TestInheritDefault(t *testing.T) {
 	k := "foo"
 
 	o := IntOptions{
-		Opts: OptionMap{},
+		opts: OptionMap{},
 	}
 	parent := IntOptions{
-		Opts: OptionMap{
+		opts: OptionMap{
 			k: OptionEnabled,
 		},
 	}
@@ -205,13 +205,13 @@ func TestGetFmtOpts(t *testing.T) {
 	}
 
 	o := IntOptions{
-		Opts: OptionMap{
+		opts: OptionMap{
 			"test": OptionEnabled,
 			"BAR":  OptionDisabled,
 			"foo":  OptionEnabled,
 			"bar":  OptionDisabled,
 		},
-		Library: &OptionLibrary{
+		library: &OptionLibrary{
 			"test": &OptionTest,
 		},
 	}
@@ -223,13 +223,13 @@ func TestGetFmtOpts(t *testing.T) {
 	require.Equal(t, fmtList, fmtList2)
 
 	o2 := IntOptions{
-		Opts: OptionMap{
+		opts: OptionMap{
 			"foo":  OptionEnabled,
 			"BAR":  OptionDisabled,
 			"bar":  OptionDisabled,
 			"test": OptionEnabled,
 		},
-		Library: &OptionLibrary{
+		library: &OptionLibrary{
 			"test": &OptionTest,
 		},
 	}
@@ -248,12 +248,12 @@ func TestGetFmtOpt(t *testing.T) {
 	}
 
 	o := IntOptions{
-		Opts: OptionMap{
+		opts: OptionMap{
 			"test":  OptionEnabled,
 			"BAR":   OptionDisabled,
 			"alice": 2,
 		},
-		Library: &OptionLibrary{
+		library: &OptionLibrary{
 			"test":  &OptionTest,
 			"alice": &OptionTest,
 		},
@@ -275,10 +275,10 @@ func TestGetImmutableModel(t *testing.T) {
 	}
 
 	o := IntOptions{
-		Opts: OptionMap{
+		opts: OptionMap{
 			k: OptionEnabled,
 		},
-		Library: &OptionLibrary{
+		library: &OptionLibrary{
 			k: &OptionTest,
 		},
 	}
@@ -304,12 +304,12 @@ func TestGetMutableModel(t *testing.T) {
 	}
 
 	o := IntOptions{
-		Opts: OptionMap{
+		opts: OptionMap{
 			k1: OptionEnabled,
 			k2: OptionDisabled,
 			k3: OptionEnabled,
 		},
-		Library: &OptionLibrary{
+		library: &OptionLibrary{
 			k1: &OptionDefaultFormat,
 			k2: &OptionDefaultFormat,
 			k3: &OptionCustomFormat,
@@ -352,13 +352,13 @@ func TestValidate(t *testing.T) {
 	}
 
 	o := IntOptions{
-		Opts: OptionMap{
+		opts: OptionMap{
 			k1: OptionEnabled,
 			k2: OptionEnabled,
 			k3: OptionDisabled,
 			k4: OptionEnabled,
 		},
-		Library: &OptionLibrary{
+		library: &OptionLibrary{
 			k1: &OptionTest,
 			k2: &OptionCustomVerify,
 			k3: &OptionCustomVerify,
@@ -392,14 +392,14 @@ func TestApplyValidated(t *testing.T) {
 	}
 
 	o := IntOptions{
-		Opts: OptionMap{
+		opts: OptionMap{
 			k1: OptionEnabled,
 			k2: OptionEnabled,
 			k3: OptionDisabled,
 			k4: OptionDisabled,
 			k5: OptionDisabled,
 		},
-		Library: &OptionLibrary{
+		library: &OptionLibrary{
 			k1: &OptionDefault,
 			k2: &Option2,
 			k3: &Option3,
@@ -428,7 +428,7 @@ func TestApplyValidated(t *testing.T) {
 		actualChanges[key] = value
 	}
 
-	om, err := o.Library.ValidateConfigurationMap(cfg)
+	om, err := o.library.ValidateConfigurationMap(cfg)
 	require.NoError(t, err)
 	require.Equal(t, len(expectedChanges), o.ApplyValidated(om, changed, &cfg))
 	require.Equal(t, expectedChanges, actualChanges)

--- a/pkg/option/option_test.go
+++ b/pkg/option/option_test.go
@@ -137,7 +137,7 @@ func TestParseKeyValueWithDefaultParseFunc(t *testing.T) {
 		},
 	}
 
-	_, res, err := ParseKeyValue(&l, k, "on")
+	_, res, err := l.parseKeyValue(k, "on")
 	require.Nil(t, err)
 	require.Equal(t, OptionEnabled, res)
 }
@@ -158,14 +158,14 @@ func TestParseKeyValue(t *testing.T) {
 		},
 	}
 
-	_, _, err := ParseKeyValue(&l, k, "true")
+	_, _, err := l.parseKeyValue(k, "true")
 	require.NotNil(t, err)
 
-	_, res, err := ParseKeyValue(&l, k, "yes")
+	_, res, err := l.parseKeyValue(k, "yes")
 	require.Nil(t, err)
 	require.Equal(t, OptionEnabled, res)
 
-	_, _, err = ParseKeyValue(&l, "unknown", "yes")
+	_, _, err = l.parseKeyValue("unknown", "yes")
 	require.NotNil(t, err)
 }
 
@@ -182,18 +182,18 @@ func TestParseOption(t *testing.T) {
 		k: &OptionTest,
 	}
 
-	_, _, err := ParseOption(k+":enabled", &l)
+	_, _, err := l.ParseOption(k + ":enabled")
 	require.NotNil(t, err)
 
-	_, res, err := ParseOption(arg, &l)
+	_, res, err := l.ParseOption(arg)
 	require.Nil(t, err)
 	require.Equal(t, OptionEnabled, res)
 
-	_, _, err = ParseOption("!"+arg, &l)
+	_, _, err = l.ParseOption("!" + arg)
 	require.NotNil(t, err)
 
 	OptionTest.Immutable = true
-	_, _, err = ParseOption(arg, &l)
+	_, _, err = l.ParseOption(arg)
 	require.NotNil(t, err)
 	OptionTest.Immutable = false
 }


### PR DESCRIPTION
Access to `option.Config.Opts` is not protected against the pointer changing after init. Fix by removing pointer change on config change revert.

Clean up `ConfigPatchMutex` use by removing unused setters and unnecessary getters.

Now that `ConfigPatchMutex` is only used to guard patching of `Opts` by the daemon, we can remove `ConfigPatchMutex` altogether, as daemon config events are already serialized via an event queue.
This simplifies testing `option.DaemonConfig` by removing the need to initialize the mutex pointer.

Finally, unexport `IntOptions` fields (`option.DaemonConfig.Opts`) to protect against accidental bypass of the mutex within.
