### PR TITLE
renovate: run post upgrade tasks on Makefile.values

### DIFF
--- a/.github/actions/renovate/entrypoint.sh
+++ b/.github/actions/renovate/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+apt update
+
+apt install -y gettext
+
+ls -lah /var/run/docker.sock
+
+# Add the group of /var/run/docker.sock to ubuntu user
+GROUP_ID=$(stat -c '%g' /var/run/docker.sock)
+GROUP_NAME=$(getent group "$GROUP_ID" | cut -d: -f1)
+
+if [ -z "$GROUP_NAME" ]; then
+  GROUP_NAME="docker_group"
+  groupadd -g "$GROUP_ID" "$GROUP_NAME"
+fi
+
+usermod -aG "$GROUP_NAME" ubuntu
+
+runuser -u ubuntu renovate

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -81,17 +81,6 @@
     "^make -C install/kubernetes$",
     "^make -C Documentation update-helm-values$",
   ],
-  "postUpgradeTasks": {
-    "commands": [
-      "make -C install/kubernetes",
-      "make -C Documentation update-helm-values"
-    ],
-    "fileFilters": [
-      "VERSION",
-      "install/kubernetes/**"
-    ],
-    "executionMode": "update"
-  },
   "packageRules": [
     {
       // Try to group all updates for all dependencies in a single PR. More
@@ -220,7 +209,6 @@
       ],
     },
     {
-      "groupName": "spire-images",
       "matchFiles": [
         "install/kubernetes/Makefile.values"
       ],
@@ -234,7 +222,6 @@
       "allowedVersions": ">1.6",
     },
     {
-      "groupName": "spire-images",
       "matchFiles": [
         "install/kubernetes/Makefile.values"
       ],
@@ -454,6 +441,24 @@
         "quay.io/cilium/kindest-node"
       ],
       "ignoreUnstable": false
+    },
+    {
+      "matchFiles": [
+        "install/kubernetes/Makefile.values"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "make -C install/kubernetes",
+          "make -C Documentation update-helm-values"
+        ],
+        "fileFilters": [
+          "install/kubernetes/Makefile.values",
+          "install/kubernetes/cilium/README.md",
+          "install/kubernetes/cilium/values.yaml",
+          "Documentation/helm-values.rst"
+        ],
+        "executionMode": "update"
+      }
     }
   ],
   "kubernetes": {

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -39,6 +39,8 @@ jobs:
           # default to DEBUG log level, this is always useful
           LOG_LEVEL: ${{ github.event.inputs.renovate_log_level_debug == 'false' && 'INFO' || 'DEBUG' }}
         with:
+          docker-user: root
+          docker-cmd-file: .github/actions/renovate/entrypoint.sh
           configurationFile: .github/renovate.json5
           token: '${{ steps.get_token.outputs.app_token }}'
           mount-docker-socket: true


### PR DESCRIPTION
Run postUpgradeTasks after modifying install/kubernetes/Makefile.values file.

Tested in https://github.com/aanm/cilium/pull/661