### PR TITLE
doc: Update doc for CRD CiliumNodeConfig from v2alpha1 to v2

### DIFF
--- a/Documentation/configuration/per-node-config.rst
+++ b/Documentation/configuration/per-node-config.rst
@@ -10,8 +10,6 @@
 Per-node configuration
 **********************
 
-.. include:: ../beta.rst
-
 The Cilium agent process (a.k.a. DaemonSet) supports setting configuration
 on a per-node basis. This allows overriding :ref:`cilium-config-configmap`
 for a node or set of nodes. It is managed by CiliumNodeConfig objects.
@@ -45,7 +43,7 @@ hardware, one would label the relevant nodes and override their configuration.
 
 .. code-block:: yaml
 
-    apiVersion: cilium.io/v2alpha1
+    apiVersion: cilium.io/v2
     kind: CiliumNodeConfig
     metadata:
       namespace: kube-system
@@ -83,7 +81,7 @@ nodes with ``io.cilium.migration/kube-proxy-replacement: true``
     .. code-block:: shell-session
 
         cat <<EOF | kubectl apply --server-side -f -
-        apiVersion: cilium.io/v2alpha1
+        apiVersion: cilium.io/v2
         kind: CiliumNodeConfig
         metadata:
           namespace: kube-system

--- a/Documentation/installation/k8s-install-migration.rst
+++ b/Documentation/installation/k8s-install-migration.rst
@@ -219,7 +219,7 @@ Preparation
     .. code-block:: shell-session
 
         cat <<EOF | kubectl apply --server-side -f -
-        apiVersion: cilium.io/v2alpha1
+        apiVersion: cilium.io/v2
         kind: CiliumNodeConfig
         metadata:
           namespace: kube-system


### PR DESCRIPTION
Update documentation after moving CRD `CiliumNodeConfig` from v2 to v2alpha1.

```release-note
doc: Update doc for CRD CiliumNodeConfig from v2alpha1 to v2
```