### PR TITLE
.github/workflows: pin renovate version

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -39,6 +39,8 @@ jobs:
           # default to DEBUG log level, this is always useful
           LOG_LEVEL: ${{ github.event.inputs.renovate_log_level_debug == 'false' && 'INFO' || 'DEBUG' }}
         with:
+          # renovate: datasource=github-releases depName=renovatebot/renovate
+          renovate-version: 37.409.0
           docker-user: root
           docker-cmd-file: .github/actions/renovate/entrypoint.sh
           configurationFile: .github/renovate.json5


### PR DESCRIPTION
To avoid unwanted breakages from renovate, we should also pin renovate version and let it be updated on a weekly basis like the other dependencies.

Tested in https://github.com/aanm/cilium/pull/662