### PR TITLE
bpf: host: sanitize whole skb->cb in to-netdev

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1352,6 +1352,8 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 	int ret = CTX_ACT_OK;
 	__s8 ext_err = 0;
 
+	bpf_clear_meta(ctx);
+
 	if (magic == MARK_MAGIC_HOST || magic == MARK_MAGIC_OVERLAY)
 		src_sec_identity = HOST_ID;
 	else if (magic == MARK_MAGIC_IDENTITY)
@@ -1394,8 +1396,6 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 		ret = DROP_UNSUPPORTED_L2;
 		goto drop_err;
 	}
-
-	policy_clear_mark(ctx);
 
 	switch (proto) {
 # if defined ENABLE_ARP_PASSTHROUGH || defined ENABLE_ARP_RESPONDER


### PR DESCRIPTION
We can't trust the cb if a packet passed through the network stack. Instead of selectively clearing cb slots, just clear the whole array.