### PR TITLE
vendor: pin StateDB to version v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/cilium/linters v0.0.0-20240611134452-310e8a3d60a5
 	github.com/cilium/lumberjack/v2 v2.3.0
 	github.com/cilium/proxy v0.0.0-20240418093727-2c7164c53e26
-	github.com/cilium/statedb v0.0.0-20240604111733-b27b7794ffac
+	github.com/cilium/statedb v0.1.0
 	github.com/cilium/stream v0.0.0-20240226091623-f979d32855f8
 	github.com/cilium/workerpool v1.2.0
 	github.com/containernetworking/cni v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7 h1:ocC6/1Gz6LJd0X
 github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7/go.mod h1:8nydvUTW+/9nVywCQ9bE/YGzb4EISALP4lKNpK3fFqo=
 github.com/cilium/proxy v0.0.0-20240418093727-2c7164c53e26 h1:wzm/nEkcMO6oGSySoqe3/bMcF1sxrxI2ByidN3gg30A=
 github.com/cilium/proxy v0.0.0-20240418093727-2c7164c53e26/go.mod h1:jzAmtWhlyR3kx+AwYdQvGM04lmHwsWhq1ySfAVpY/SA=
-github.com/cilium/statedb v0.0.0-20240604111733-b27b7794ffac h1:khBWgt+O0ym72mbnPRbWzSvALbXOLoyIrbSOyY1QXVE=
-github.com/cilium/statedb v0.0.0-20240604111733-b27b7794ffac/go.mod h1:KPwsudjhZ90zoBguYMtssKpstR74jVKd/D+73PZy+sg=
+github.com/cilium/statedb v0.1.0 h1:ljSPEKnPutaJZazGKGRCs9v4sgJChqOE6RUhu/eZxts=
+github.com/cilium/statedb v0.1.0/go.mod h1:KPwsudjhZ90zoBguYMtssKpstR74jVKd/D+73PZy+sg=
 github.com/cilium/stream v0.0.0-20240226091623-f979d32855f8 h1:j6VF1s6gz3etRH5ObCr0UUyJblP9cK5fbgkQTz8fTRA=
 github.com/cilium/stream v0.0.0-20240226091623-f979d32855f8/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.2.0 h1:Wc2iOPTvCgWKQXeq4L5tnx4QFEI+z5q1+bSpSS0cnAY=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -501,7 +501,7 @@ github.com/cilium/proxy/go/envoy/type/tracing/v3
 github.com/cilium/proxy/go/envoy/type/v3
 github.com/cilium/proxy/go/envoy/watchdog/v3
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.0.0-20240604111733-b27b7794ffac
+# github.com/cilium/statedb v0.1.0
 ## explicit; go 1.22.0
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
Time to introduce versioning to StateDB as there's some API cleanups coming and we want to control when renovate tries to bump StateDB.
