### PR TITLE
helm: drop IDENTITY_ALLOCATION_MODE environment variable from clustermesh-apiserver

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -207,11 +207,6 @@ spec:
               name: cilium-config
               key: cluster-id
               optional: true
-        - name: IDENTITY_ALLOCATION_MODE
-          valueFrom:
-            configMapKeyRef:
-              name: cilium-config
-              key: identity-allocation-mode
         - name: ENABLE_K8S_ENDPOINT_SLICE
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
The associated flag is no longer configurable since 26d08a888d8a ("clustermesh-apiserver: extract external workloads in a separate cell"), because the clustermesh-apiserver cannot be enabled in combination with kvstore identity allocation mode.
