### PR TITLE
gha: Grant write status permission

### DIFF
--- a/.github/workflows/tests-ces-migrate.yaml
+++ b/.github/workflows/tests-ces-migrate.yaml
@@ -8,7 +8,17 @@ on:
     - main
     - ft/main/**
 
-permissions: read-all
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # To read actions state with catchpoint/workflow-telemetry-action
+  actions: read
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # To be able to set commit status
+  statuses: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}


### PR DESCRIPTION
This is to fix the below issue when the step is trying to update status.

> Error: Resource not accessible by integration

Sample run with failure https://github.com/cilium/cilium/actions/runs/9534715391/job/26279677470?pr=33092

