### PR TITLE
datapath/node: avoid fatal on daemon init when node routes fail.

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1306,7 +1306,11 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 		}
 	}
 
-	return errs
+	if errs != nil {
+		n.log.Warn("node configuration changed but was unable to update node datapath configuration", errs)
+	}
+
+	return nil
 }
 
 func filterL2Devices(devices []string) ([]string, error) {


### PR DESCRIPTION
Prior to 9486e7b731903eb949cb2fcd70f08e1da386dc5d the call to reconcile the node (i.e. nodeUpdated) did not have errors handled. This meant that (*linuxNodeManager).NodeConfigurationChanged(...) would not return an error if there the underlying node reconciliation failed.

This was the assumption prior to v1.15 that node reconciliation tasks log errors in-line and continue exection without returning early. Following these changes, the call to NodeConfigurationChanged will now return an error if the underlying nodeUpdated call fails.

Issue #31843 is a result of the now incorrect dependency on not terminating execution in case of nodeUpdated failure where in cases where (unreachable) node routes for remote nodes failing was previously silently logged - will now cause the agent to terminate on init if this fails. There may be other such regressions built on these expectations.

This reverts to behavior found in v1.14 where this will log nodeUpdated failures and continue execution.

Fixes: #31843
