### PR TITLE
bandwidth-manager: introduce ecn marking to prevent bufferbloat

### DIFF
--- a/bpf/include/bpf/ctx/skb.h
+++ b/bpf/include/bpf/ctx/skb.h
@@ -52,6 +52,8 @@
 
 #define ctx_event_output	skb_event_output
 
+#define ctx_ecn_set_ce		skb_ecn_set_ce
+
 #define ctx_adjust_meta		({ -ENOTSUPP; })
 
 /* Avoid expensive calls into the kernel flow dissector if it's not an L4

--- a/bpf/include/bpf/helpers_skb.h
+++ b/bpf/include/bpf/helpers_skb.h
@@ -42,6 +42,8 @@ static int BPF_FUNC(skb_change_head, struct __sk_buff *skb, __u32 head_room,
 
 static int BPF_FUNC(skb_pull_data, struct __sk_buff *skb, __u32 len);
 
+static int BPF_FUNC(skb_ecn_set_ce, struct __sk_buff *skb);
+
 /* Packet tunnel encap/decap */
 static int BPF_FUNC(skb_get_tunnel_key, struct __sk_buff *skb,
 		    struct bpf_tunnel_key *to, __u32 size, __u32 flags);

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -347,7 +347,7 @@ struct edt_info {
 	__u64		bps;
 	__u64		t_last;
 	__u64		t_horizon_drop;
-	__u64		pad[4];
+	__u64		t_horizon_ecn;
 };
 
 struct remote_endpoint_info {

--- a/bpf/lib/edt.h
+++ b/bpf/lib/edt.h
@@ -80,6 +80,12 @@ edt_sched_departure(struct __ctx_buff *ctx, __be16 proto)
 		return CTX_ACT_DROP;
 	WRITE_ONCE(info->t_last, t_next);
 	ctx->tstamp = t_next;
+
+	if (t_next - now >= info->t_horizon_ecn) {
+		/* This can fail if ECN is not enabled */
+		ctx_ecn_set_ce(ctx);
+	}
+
 	return CTX_ACT_OK;
 }
 #else

--- a/pkg/maps/bwmap/bwmap.go
+++ b/pkg/maps/bwmap/bwmap.go
@@ -25,6 +25,14 @@ const (
 	// from user space this is a limit to prevent buggy applications
 	// to fill the FQ qdisc.
 	DefaultDropHorizon = 2 * time.Second
+
+	// DefaultEcnHorizon represents threshold for ECN marking.
+	// Though single TCP connection can have TSQ limit, we can
+	// have multiple connections from same Pod, which can results
+	// in many packets queuing up in the host. With ECN marking,
+	// we can prevent queueing up and hence reduce the latency.
+	// To enable this, we need ECN marking for TCP connections.
+	DefaultEcnHorizon = 1 * time.Millisecond
 )
 
 type EdtId struct {
@@ -35,10 +43,10 @@ func (k *EdtId) String() string  { return fmt.Sprintf("%d", int(k.Id)) }
 func (k *EdtId) New() bpf.MapKey { return &EdtId{} }
 
 type EdtInfo struct {
-	Bps             uint64    `align:"bps"`
-	TimeLast        uint64    `align:"t_last"`
-	TimeHorizonDrop uint64    `align:"t_horizon_drop"`
-	Pad             [4]uint64 `align:"pad"`
+	Bps             uint64 `align:"bps"`
+	TimeLast        uint64 `align:"t_last"`
+	TimeHorizonDrop uint64 `align:"t_horizon_drop"`
+	TimeHorizonEcn  uint64 `align:"t_horizon_ecn"`
 }
 
 func (v *EdtInfo) String() string    { return fmt.Sprintf("%d", int(v.Bps)) }

--- a/pkg/maps/bwmap/table.go
+++ b/pkg/maps/bwmap/table.go
@@ -33,6 +33,9 @@ type Edt struct {
 	// delta in future.
 	TimeHorizonDrop uint64
 
+	// TimeHorizonEcn is the threshold for ECN marking.
+	TimeHorizonEcn uint64
+
 	// Status is the BPF map reconciliation status of this throttle entry.
 	Status reconciler.Status
 }
@@ -51,6 +54,7 @@ func NewEdt(endpointID uint16, bytesPerSecond uint64) Edt {
 		EndpointID:      endpointID,
 		BytesPerSecond:  bytesPerSecond,
 		TimeHorizonDrop: uint64(DefaultDropHorizon),
+		TimeHorizonEcn:  uint64(DefaultEcnHorizon),
 		Status:          reconciler.StatusPending(),
 	}
 }
@@ -72,6 +76,7 @@ func (e Edt) BinaryValue() encoding.BinaryMarshaler {
 		Bps:             e.BytesPerSecond,
 		TimeLast:        0, // Used on the BPF-side
 		TimeHorizonDrop: e.TimeHorizonDrop,
+		TimeHorizonEcn:  e.TimeHorizonEcn,
 	}
 	return bpf.StructBinaryMarshaler{Target: &v}
 }
@@ -81,6 +86,7 @@ func (e Edt) TableHeader() []string {
 		"EndpointID",
 		"BitsPerSecond",
 		"TimeHorizonDrop",
+		"TimeHorizonEcn",
 		"Status",
 	}
 }
@@ -93,6 +99,7 @@ func (e Edt) TableRow() []string {
 		strconv.FormatUint(uint64(e.EndpointID), 10),
 		quantity.String(),
 		strconv.FormatUint(e.TimeHorizonDrop, 10),
+		strconv.FormatUint(e.TimeHorizonEcn, 10),
 		e.Status.String(),
 	}
 }


### PR DESCRIPTION
Currently the bandwidth manager is enforcing a rate limit for flows in one pod, and the flows in one pod are sharing one same queue. It's using tail drop policy with threshold as 2 seconds. This can cause bufferbloat and 2-second queuing latency when there are many tcp connections.

Here we introduce ecn marking to solve the issue, by default, the marking threshold is set to 1ms.

For tests, we had a pod with 100Mbps egress limit, and there are 128 TCP connections in the pod as background traffic, and we compare the TCP_RR latency

Method		| Avg Latency
with-ECN	| 3.1ms
without-ECN	| 2247.3ms

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #29083

```release-note
bandwidth-manager: introduce ecn marking to prevent bufferbloat
```
