### PR TITLE
bpf: recreate CT entry if proxy_redirect is stale for non-tcp

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -544,6 +544,11 @@ ct_recreate6:
 		/* Did we end up at a stale non-service entry? Recreate if so. */
 		if (unlikely(ct_state->rev_nat_index != ct_state_new.rev_nat_index))
 			goto ct_recreate6;
+
+		/* See comment in handle_ipv4_from_lxc(). */
+		ct_state_new.proxy_redirect = proxy_port > 0;
+		if (unlikely(ct_state->proxy_redirect != ct_state_new.proxy_redirect))
+			goto ct_recreate6;
 		break;
 
 	case CT_RELATED:
@@ -994,6 +999,20 @@ ct_recreate4:
 	case CT_ESTABLISHED:
 		/* Did we end up at a stale non-service entry? Recreate if so. */
 		if (unlikely(ct_state->rev_nat_index != ct_state_new.rev_nat_index))
+			goto ct_recreate4;
+
+		/* Recreate the CT entry if the proxy_redirect flag is stale.
+		 * Otherwise, the return packet will be erroneously redirected (or not)
+		 * This check assumes the case where non-TCP packets hit the stale
+		 * CT entry with the proxy_redirect flag, or active TCP connection
+		 * suddenly comes into the scope of an L7 policy. Recreating the entry
+		 * updates the proxy_redirect flag properly.
+		 *
+		 * if the packet hits a closing stale entry, ct_lookup returns CT_NEW and
+		 * caller recreates the entry.
+		 */
+		ct_state_new.proxy_redirect = proxy_port > 0;
+		if (unlikely(ct_state->proxy_redirect != ct_state_new.proxy_redirect))
 			goto ct_recreate4;
 		break;
 


### PR DESCRIPTION
This commit fixes the issue that datapath erroneously redirects (or doesn't redirect) the reply packets to the proxy if the packet hits the stale CT entry.

The PR #32653 fixed the issue for TCP by having __ct_lookup return CT_NEW if the packet hits a closing stale entry so that the caller can recreate an entry to update the proxy_redirect flag.

This commit lets datapath recreate an entry for non-TCP in the similar case to update the proxy_redirect flag.

This problem can occur, for example, when using dns-proxy.

```
kubectl -n cilium-test exec client3-7557dd665c-csxh6 -- curl --silent --fail --show-error --connect-timeout 2 --max-time 10 -4 http://echo-external-node.cilium-test.svc.cluster.local:8080/client-ip
curl: (28) Resolving timed out after 2001 milliseconds
command terminated with exit code 28

// The reply packet from core-dns is dropped
kubectl exec debug-8sx77 -- tcpdump -nl -i any udp and host 10.244.1.159 and port 53
listening on any, link-type LINUX_SLL2 (Linux cooked v2), snapshot length 262144 bytes
03:43:28.350752 lxc7273688205e1 In  IP 10.244.1.159.34716 > 10.244.0.36.53: 1292+ A? echo-external-node.cilium-test.svc.cluster.local.cilium-test.svc.cluster.local. (96)
03:43:28.350883 cilium_vxlan Out IP 10.244.1.159.34716 > 10.244.0.36.53: 1292+ A? echo-external-node.cilium-test.svc.cluster.local.cilium-test.svc.cluster.local. (96)
03:43:28.351919 cilium_vxlan P   IP 10.244.0.36.53 > 10.244.1.159.34716: 1292 NXDomain*- 0/1/0 (189)
03:43:28.352224 lxc7273688205e1 In  IP 10.244.1.159.48844 > 10.244.0.108.53: 51484+ A? echo-external-node.cilium-test.svc.cluster.local.svc.cluster.local. (84)
03:43:28.352295 cilium_vxlan Out IP 10.244.1.159.48844 > 10.244.0.108.53: 51484+ A? echo-external-node.cilium-test.svc.cluster.local.svc.cluster.local. (84)
03:43:28.353106 cilium_vxlan P   IP 10.244.0.108.53 > 10.244.1.159.48844: 51484 NXDomain*- 0/1/0 (177)

// Stale CT entry with ProxyRedirect flag
kubectl -n kube-system exec cilium-f65hc -- cilium bpf ct list global 
UDP OUT 10.244.1.159:34716 -> 10.244.0.36:53 expires=1165307 Packets=0 Bytes=0 RxFlagsSeen=0x00 LastRxReport=1165247 TxFlagsSeen=0x00 LastTxReport=1165247 Flags=0x0000 [ ] RevNAT=0 SourceSecurityID=5242 IfIndex=0 
UDP OUT 10.244.1.159:48844 -> 10.244.0.108:53 expires=1165307 Packets=0 Bytes=0 RxFlagsSeen=0x00 LastRxReport=1165247 TxFlagsSeen=0x00 LastTxReport=1165247 Flags=0x0040 [ ProxyRedirect ] RevNAT=0 SourceSecurityID=5242 IfIndex=0 
```


```release-note
Recreate CT entries for non-TCP to fix L7 proxy redirect failures.
```
