### PR TITLE
bpf: ct: return actual error from CT lookup

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -885,6 +885,9 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 	/* See lb4_local comments re svc endpoint lookup process */
 	ret = ct_lazy_lookup6(map, tuple, ctx, l4_off, CT_SERVICE,
 			      SCOPE_REVERSE, CT_ENTRY_SVC, state, &monitor);
+	if (ret < 0)
+		goto drop_err;
+
 	switch (ret) {
 	case CT_NEW:
 		if (unlikely(svc->count == 0))
@@ -1535,6 +1538,9 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 
 	ret = ct_lazy_lookup4(map, tuple, ctx, is_fragment, l4_off, has_l4_header,
 			      CT_SERVICE, SCOPE_REVERSE, CT_ENTRY_SVC, state, &monitor);
+	if (ret < 0)
+		goto drop_err;
+
 	switch (ret) {
 	case CT_NEW:
 		if (unlikely(svc->count == 0))

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -762,6 +762,9 @@ nodeport_dsr_ingress_ipv6(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 	ret = ct_lazy_lookup6(get_ct_map6(tuple), tuple, ctx, l4_off,
 			      CT_EGRESS, SCOPE_FORWARD, CT_ENTRY_DSR,
 			      NULL, &monitor);
+	if (ret < 0)
+		return ret;
+
 	switch (ret) {
 	case CT_NEW:
 create_ct:
@@ -1316,6 +1319,9 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 		ret = ct_lazy_lookup6(get_ct_map6(tuple), tuple, ctx, l4_off,
 				      CT_EGRESS, SCOPE_FORWARD, CT_ENTRY_NODEPORT,
 				      &ct_state, &monitor);
+		if (ret < 0)
+			return ret;
+
 		switch (ret) {
 		case CT_NEW:
 			ct_state.src_sec_id = WORLD_IPV6_ID;
@@ -2295,6 +2301,9 @@ nodeport_dsr_ingress_ipv4(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 	ret = ct_lazy_lookup4(get_ct_map4(tuple), tuple, ctx, ipv4_is_fragment(ip4),
 			      l4_off, has_l4_header, CT_EGRESS, SCOPE_FORWARD,
 			      CT_ENTRY_DSR, NULL, &monitor);
+	if (ret < 0)
+		return ret;
+
 	switch (ret) {
 	case CT_NEW:
 create_ct:
@@ -2858,6 +2867,9 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 		ret = ct_lazy_lookup4(get_ct_map4(tuple), tuple, ctx, is_fragment,
 				      l4_off, has_l4_header, CT_EGRESS, SCOPE_FORWARD,
 				      CT_ENTRY_NODEPORT, &ct_state, &monitor);
+		if (ret < 0)
+			return ret;
+
 		switch (ret) {
 		case CT_NEW:
 			ct_state.src_sec_id = src_sec_identity;


### PR DESCRIPTION
The CT lookup potentially returns an error (with some DROP_* value). But there are a few code paths that currently handle such an error as part of their `default` case for the `switch(ct_result)` statement,  and just return DROP_UNKNOWN_CT. Fix them up to return the actual error.