### PR TITLE
cilium-agent: remove unused permissions for CNP/CCNP status

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -148,8 +148,6 @@ rules:
 - apiGroups:
   - cilium.io
   resources:
-  - ciliumnetworkpolicies/status
-  - ciliumclusterwidenetworkpolicies/status
   - ciliumendpoints/status
   - ciliumendpoints
   - ciliuml2announcementpolicies/status

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -148,8 +148,6 @@ rules:
 - apiGroups:
   - cilium.io
   resources:
-  - ciliumnetworkpolicies/status
-  - ciliumclusterwidenetworkpolicies/status
   - ciliumendpoints/status
   - ciliumendpoints
   - ciliuml2announcementpolicies/status


### PR DESCRIPTION
CNP/CCNP node statuses have been removed in #24503 Currently, only the operator is updating CNP/CCNP status for derived policies.

Related #29590

```release-note
Removed cilium-agent permissions to update CiliumNetworkPolicy and CiliumClusterWideNetworkPolicy statuses
```
