### PR TITLE
fqdn: Skip "open ports" check for statically configured ports

### DIFF
--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -61,7 +61,7 @@ func TestPortAllocator(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, 0, port)
 
-	port1, err := p.GetProxyPort("listener1")
+	port1, _, err := p.GetProxyPort("listener1")
 	require.NoError(t, err)
 	require.Equal(t, port, port1)
 
@@ -84,7 +84,7 @@ func TestPortAllocator(t *testing.T) {
 	require.NoError(t, err)
 
 	// ProxyPort lingers and can still be found, but it's port is zeroed
-	port1b, err := p.GetProxyPort("listener1")
+	port1b, _, err := p.GetProxyPort("listener1")
 	require.NoError(t, err)
 	require.Equal(t, uint16(0), port1b)
 	require.Equal(t, uint16(0), pp.ProxyPort)


### PR DESCRIPTION
When restoring the previous DNS proxy port, we check if the port is
already in-use. However, if the port we retreived from `GetProxyPort`
was previously set via `SetProxyPort`, then we want to use it
unconditionally. We rely on `isStatic` for this, as as static ports
cannot change and the open port may be open with `SO_REUSEPORT` (which
`proxy.OpenLocalPorts()` does not check). Restored ports never have
`isStatic` set to true, so this does retain the "open ports" check if
the port was restored.

In addition, when restoring ports we want to make sure
that previous calls to `SetProxyPort` are also not overwritten, thus
this commit also only restores the port if it wasn't explicitly set.

This is the same behavior we had previously, which did not check the
returned port of `d.l7Proxy.GetProxyPort` against the list of open
ports.

Fixes: d11e4d261279 ("proxy: Reuse proxy ports from datapath on restart")
