### PR TITLE
toFQDNs: Add documention and metrics for `fqdn` identities

### DIFF
--- a/Documentation/contributing/development/debugging.rst
+++ b/Documentation/contributing/development/debugging.rst
@@ -286,10 +286,10 @@ allocated Security Identities. These can be listed with:
                k8s:io.kubernetes.pod.namespace=default
                k8s:org=alliance
     ...
-    16777217   cidr:104.198.14.52/32
+    16777217   fqdn:*
                reserved:world
 
-Note that CIDR identities are allocated locally on the node and have a high-bit set so they are often in the 16-million range.
+Note that FQDN identities are allocated locally on the node and have a high-bit set so they are often in the 16-million range.
 Note that this is the identity in the monitor output for the HTTP connection.
 
 In cases where there is no matching identity for an IP in the fqdn cache it may
@@ -348,8 +348,7 @@ The L7 DNS rule has an implicit L3 allow-all because it defines only L4 and L7
 sections. This is the second selector in the list, and includes all possible L3
 identities known in the system. In contrast, the first selector, which
 corresponds to the ``toFQDNS: matchName: "*"`` rule would list all identities
-for IPs that came from the DNS Proxy. Other CIDR identities would not be
-included.
+for IPs that came from the DNS Proxy.
 
 Unintended DNS Policy Drops
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -381,10 +380,10 @@ Datapath Plumbing
 ~~~~~~~~~~~~~~~~~
 
 For a policy to be fully realized the datapath for an Endpoint must be updated.
-In the case of a new DNS-source IP, the CIDR identity associated with it must
+In the case of a new DNS-source IP, the FQDN identity associated with it must
 propagate from the selectors to the Endpoint specific policy. Unless a new
 policy is being added, this often only involves updating the Policy Map of the
-Endpoint with the new CIDR Identity of the IP. This can be verified:
+Endpoint with the new FQDN Identity of the IP. This can be verified:
 
 .. code-block:: shell-session
 
@@ -394,7 +393,7 @@ Endpoint with the new CIDR Identity of the IP. This can be verified:
     Ingress     reserved:host                 ANY          NONE         0       0
     Egress      reserved:unknown              53/TCP       36447        0       0
     Egress      reserved:unknown              53/UDP       36447        138     2
-    Egress      cidr:104.198.14.52/32         ANY          NONE         477     6
+    Egress      fqdn:*                        ANY          NONE         477     6
                 reserved:world 
 
 Note that the labels for identities are resolved here. This can be skipped, or

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -546,6 +546,7 @@ Name                               Labels                           Default     
 ``fqdn_active_names``              ``endpoint``                     Disabled     Number of domains inside the DNS cache that have not expired (by TTL), per endpoint
 ``fqdn_active_ips``                ``endpoint``                     Disabled     Number of IPs inside the DNS cache associated with a domain that has not expired (by TTL), per endpoint
 ``fqdn_alive_zombie_connections``  ``endpoint``                     Disabled     Number of IPs associated with domains that have expired (by TTL) yet still associated with an active connection (aka zombie), per endpoint
+``fqdn_selectors``                                                  Enabled      Number of registered ToFQDN selectors
 ================================== ================================ ============ ========================================================
 
 Jobs

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -418,6 +418,7 @@ Identity
 Name                                     Labels                                             Default    Description
 ======================================== ================================================== ========== ========================================================
 ``identity``                             ``type``                                           Enabled    Number of identities currently allocated
+``identity_label_sources``               ``source``                                         Enabled    Number of identities which contain at least one label from the given label source
 ``ipcache_errors_total``                 ``type``, ``error``                                Enabled    Number of errors interacting with the ipcache
 ``ipcache_events_total``                 ``type``                                           Enabled    Number of events interacting with the ipcache
 ======================================== ================================================== ========== ========================================================

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -316,6 +316,19 @@ Annotations:
   If your current setup has third-party old-style tc BPF users, then this option should be
   disabled via Helm through ``bpf.enableTCX=false`` in order to continue in old-style tc BPF
   attachment mode as before.
+* The implementation of ``toFQDNs`` selectors in policies has been overhauled to improve
+  performance when many different IPs are observed for a selector: Instead of creating
+  ``cidr`` identities for each allowed IP, IPs observed in DNS lookups are now labeled
+  with the selectors ``toFQDNs`` matching them. This reduces tail latency significantly for
+  FQDNs with a highly dynamic set of IPs, such as e.g. content delivery networks and
+  cloud object storage services.
+  Cilium automatically migrates its internal state for ``toFQDNs`` policy entries upon
+  upgrade or downgrade. To avoid drops during upgrades in clusters with ``toFQDNs`` policies,
+  it is required to run Cilium v1.15.6 or newer before upgrading to Cilium v1.16. If upgrading
+  from an older Cilium version, temporary packet drops for connections allowed by ``toFQDNs``
+  policies may occur during the initial endpoint regeneration on Cilium v1.16.
+  Similarly, when downgrading from v1.16 to v1.15 or older, temporary drops may occur for
+  such connections as well during initial endpoint regeneration on the downgraded version.
 * The ``cilium-dbg status --verbose`` command health data may now show health reported on a non-leaf
   component under a leaf named ``reporter``. Health data tree branches will now also be sorted by
   the fully qualified health status identifier.
@@ -432,7 +445,12 @@ Helm Options
 Added Metrics
 ~~~~~~~~~~~~~
 
-* TBD
+* ``cilium_identity_label_sources`` is a new metric which counts the number of
+  identities with per label source. This is particularly useful to further break
+  down the source of local identities by having separate metrics for ``fqdn``
+  and ``cidr`` labels.
+* ``cilium_fqdn_selectors`` is a new metric counting the number of ingested
+  ``toFQDNs`` selectors.
 
 Removed Metrics
 ~~~~~~~~~~~~~~~

--- a/Documentation/security/policy/troubleshooting.rst
+++ b/Documentation/security/policy/troubleshooting.rst
@@ -195,3 +195,19 @@ the state of applying FQDN policy in multiple layers of the daemon:
       # cilium-dbg ip list | grep -A 1 140.82.121.6
       140.82.121.6/32                 fqdn:api.github.com
                                       reserved:world
+
+Monitoring ``toFQDNs`` identity usage
+-------------------------------------
+
+When using ``toFQDNs`` selectors, every IP observed by a matching DNS lookup
+will be labeled with that selector. As a DNS name might be matched by multiple
+selectors, and because an IP might map to multiple names, an IP might be labeled
+by multiple selectors. As with regular cluster identities, every unique combination
+of labels will allocate its own numeric security identity. This can lead to many
+different identities being allocated, as described in :ref:`identity-relevant-labels`.
+
+To detect potential identity exhaustion for ``toFQDNs`` identities, the number
+allocated FQDN identities can be monitored using the ``identity_label_sources{type="fqdn"}``
+metric. As a comparative reference the ``fqdn_selectors`` metric monitors the number
+of registered ``toFQDNs`` selectors. For more details on metrics, please
+refer to :ref:`metrics`.

--- a/Documentation/security/policy/troubleshooting.rst
+++ b/Documentation/security/policy/troubleshooting.rst
@@ -188,10 +188,10 @@ the state of applying FQDN policy in multiple layers of the daemon:
 
 
 #. If the traffic is allowed, then these IPs should have corresponding local identities via
-   ``cilium-dbg identity list | grep <IP>``:
+   ``cilium-dbg ip list | grep <IP>``:
 
    .. code-block:: shell-session
 
-      # cilium-dbg identity list | grep -A 1 140.82.121.6
-      16777230   cidr:140.82.121.6/32
-           reserved:world
+      # cilium-dbg ip list | grep -A 1 140.82.121.6
+      140.82.121.6/32                 fqdn:api.github.com
+                                      reserved:world

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -384,6 +384,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 
 	identity.IterateReservedIdentities(func(_ identity.NumericIdentity, _ *identity.Identity) {
 		metrics.Identity.WithLabelValues(identity.ReservedIdentityType).Inc()
+		metrics.IdentityLabelSources.WithLabelValues(labels.LabelSourceReserved).Inc()
 	})
 
 	d := Daemon{

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -100,6 +100,11 @@ func newPolicyTrifecta(params policyParams) (policyOut, error) {
 		// Must be done before calling policy.NewPolicyRepository() below.
 		num := identity.InitWellKnownIdentities(option.Config, params.ClusterInfo)
 		metrics.Identity.WithLabelValues(identity.WellKnownIdentityType).Add(float64(num))
+		identity.WellKnown.ForEach(func(i *identity.Identity) {
+			for labelSource := range i.Labels.CollectSources() {
+				metrics.IdentityLabelSources.WithLabelValues(labelSource).Inc()
+			}
+		})
 	}
 
 	// policy repository: maintains list of active Rules and their subject

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/source"
@@ -196,6 +197,9 @@ func (n *NameManager) RegisterFQDNSelector(selector api.FQDNSelector) {
 		}
 
 		n.allSelectors[selector] = regex
+		if metrics.FQDNSelectors.IsEnabled() {
+			metrics.FQDNSelectors.Set(float64(len(n.allSelectors)))
+		}
 	}
 
 	// The newly added FQDN selector could match DNS Names in the cache. If
@@ -215,6 +219,9 @@ func (n *NameManager) UnregisterFQDNSelector(selector api.FQDNSelector) {
 
 	// Remove selector
 	delete(n.allSelectors, selector)
+	if metrics.FQDNSelectors.IsEnabled() {
+		metrics.FQDNSelectors.Set(float64(len(n.allSelectors)))
+	}
 
 	// Re-compute labels for affected names and IPs
 	selectedNamesAndIPs := n.mapSelectorsToNamesLocked(selector)

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -394,6 +394,10 @@ func (m *CachingIdentityAllocator) AllocateLocalIdentity(lbls labels.Labels, not
 
 	if allocated {
 		metrics.Identity.WithLabelValues(metricLabel).Inc()
+		for labelSource := range lbls.CollectSources() {
+			metrics.IdentityLabelSources.WithLabelValues(labelSource).Inc()
+		}
+
 		if m.checkpointTrigger != nil {
 			m.checkpointTrigger.Trigger()
 		}
@@ -470,6 +474,9 @@ func (m *CachingIdentityAllocator) AllocateIdentity(ctx context.Context, lbls la
 
 	if allocated || isNewLocally {
 		metrics.Identity.WithLabelValues(identity.ClusterLocalIdentityType).Inc()
+		for labelSource := range lbls.CollectSources() {
+			metrics.IdentityLabelSources.WithLabelValues(labelSource).Inc()
+		}
 	}
 
 	// Notify the owner of the newly added identities so that the
@@ -678,6 +685,9 @@ func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Ide
 			}
 			if metricVal != identity.ClusterLocalIdentityType && m.checkpointTrigger != nil {
 				m.checkpointTrigger.Trigger()
+			}
+			for labelSource := range id.Labels.CollectSources() {
+				metrics.IdentityLabelSources.WithLabelValues(labelSource).Dec()
 			}
 			metrics.Identity.WithLabelValues(metricVal).Dec()
 		}

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -222,6 +222,12 @@ func (w wellKnownIdentities) LookupByLabels(lbls labels.Labels) *Identity {
 	return nil
 }
 
+func (w wellKnownIdentities) ForEach(yield func(*Identity)) {
+	for _, id := range w {
+		yield(id.identity)
+	}
+}
+
 func (w wellKnownIdentities) lookupByNumericIdentity(identity NumericIdentity) *Identity {
 	wki, ok := w[identity]
 	if !ok {

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -670,6 +670,15 @@ func (l Labels) HasSource(source string) bool {
 	return false
 }
 
+// CollectSources returns all distinct label sources found in l
+func (l Labels) CollectSources() map[string]struct{} {
+	sources := make(map[string]struct{})
+	for _, lbl := range l {
+		sources[lbl.Source] = struct{}{}
+	}
+	return sources
+}
+
 // parseSource returns the parsed source of the given str. It also returns the next piece
 // of text that is after the source.
 // Example:

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -355,6 +355,11 @@ var (
 	// Identity is the number of identities currently in use on the node by type
 	Identity = NoOpGaugeVec
 
+	// IdentityLabelSources is the number of identities in use on the node with
+	// have a particular label source. Note that an identity may contain labels
+	// from multiple sources and thus might be counted in multiple buckets
+	IdentityLabelSources = NoOpGaugeVec
+
 	// Events
 
 	// EventTS is the time in seconds since epoch that we last received an
@@ -665,6 +670,7 @@ type LegacyMetrics struct {
 	CIDRGroupsReferenced             metric.Gauge
 	CIDRGroupTranslationTimeStats    metric.Histogram
 	Identity                         metric.Vec[metric.Gauge]
+	IdentityLabelSources             metric.Vec[metric.Gauge]
 	EventTS                          metric.Vec[metric.Gauge]
 	EventLagK8s                      metric.Gauge
 	ProxyRedirects                   metric.Vec[metric.Gauge]
@@ -861,6 +867,14 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Name:      "identity",
 			Help:      "Number of identities currently allocated",
 		}, []string{LabelType}),
+
+		IdentityLabelSources: metric.NewGaugeVec(metric.GaugeOpts{
+			ConfigName: Namespace + "_identity_label_sources",
+
+			Namespace: Namespace,
+			Name:      "identity_label_sources",
+			Help:      "Number of identities which contain at least one label of the given label source",
+		}, []string{LabelSource}),
 
 		EventTS: metric.NewGaugeVec(metric.GaugeOpts{
 			ConfigName: Namespace + "_event_ts",
@@ -1368,6 +1382,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 	CIDRGroupsReferenced = lm.CIDRGroupsReferenced
 	CIDRGroupTranslationTimeStats = lm.CIDRGroupTranslationTimeStats
 	Identity = lm.Identity
+	IdentityLabelSources = lm.IdentityLabelSources
 	EventTS = lm.EventTS
 	EventLagK8s = lm.EventLagK8s
 	ProxyRedirects = lm.ProxyRedirects

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -508,6 +508,9 @@ var (
 	// connection (aka zombie), per endpoint.
 	FQDNAliveZombieConnections = NoOpGaugeVec
 
+	// FQDNSelectors is the total number of registered ToFQDN selectors
+	FQDNSelectors = NoOpGauge
+
 	// FQDNSemaphoreRejectedTotal is the total number of DNS requests rejected
 	// by the DNS proxy because too many requests were in flight, as enforced by
 	// the admission semaphore.
@@ -706,6 +709,7 @@ type LegacyMetrics struct {
 	FQDNActiveNames                  metric.Vec[metric.Gauge]
 	FQDNActiveIPs                    metric.Vec[metric.Gauge]
 	FQDNAliveZombieConnections       metric.Vec[metric.Gauge]
+	FQDNSelectors                    metric.Gauge
 	FQDNSemaphoreRejectedTotal       metric.Counter
 	IPCacheErrorsTotal               metric.Vec[metric.Counter]
 	IPCacheEventsTotal               metric.Vec[metric.Counter]
@@ -1179,6 +1183,14 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Help:       "Number of IPs associated with domains that have expired (by TTL) yet still associated with an active connection (aka zombie), per endpoint",
 		}, []string{LabelPeerEndpoint}),
 
+		FQDNSelectors: metric.NewGauge(metric.GaugeOpts{
+			ConfigName: Namespace + "_" + SubsystemFQDN + "_selectors",
+			Namespace:  Namespace,
+			Subsystem:  SubsystemFQDN,
+			Name:       "selectors",
+			Help:       "Number of registered ToFQDN selectors",
+		}),
+
 		FQDNSemaphoreRejectedTotal: metric.NewCounter(metric.CounterOpts{
 			ConfigName: Namespace + "_" + SubsystemFQDN + "_semaphore_rejected_total",
 			Disabled:   true,
@@ -1418,6 +1430,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 	FQDNActiveNames = lm.FQDNActiveNames
 	FQDNActiveIPs = lm.FQDNActiveIPs
 	FQDNAliveZombieConnections = lm.FQDNAliveZombieConnections
+	FQDNSelectors = lm.FQDNSelectors
 	FQDNSemaphoreRejectedTotal = lm.FQDNSemaphoreRejectedTotal
 	IPCacheErrorsTotal = lm.IPCacheErrorsTotal
 	IPCacheEventsTotal = lm.IPCacheEventsTotal


### PR DESCRIPTION
This PR:

 - Adds two metrics allowing users to track the identities created by the new `toFQDNs` implementation  https://github.com/cilium/cilium/pull/32769)
 - Updates the troubleshooting guide to use the new identity system in the examples
 - Mentions the upgrade impact in the upgrade notes section