### PR TITLE
bpf: rename UINT8_MAX to UINT16_max and fix cluster_id casts

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1189,12 +1189,12 @@ skip_vtep:
 	if (!skip_tunnel) {
 		struct tunnel_key key = {};
 
-		if (cluster_id > UINT8_MAX)
+		if (cluster_id > UINT16_MAX)
 			return DROP_INVALID_CLUSTER_ID;
 
 		key.ip4 = ip4->daddr & IPV4_MASK;
 		key.family = ENDPOINT_KEY_IPV4;
-		key.cluster_id = (__u8)cluster_id;
+		key.cluster_id = (__u16)cluster_id;
 
 #if !defined(ENABLE_NODEPORT) && defined(ENABLE_HOST_FIREWALL)
 		/*

--- a/bpf/include/bpf/types_mapper.h
+++ b/bpf/include/bpf/types_mapper.h
@@ -32,4 +32,4 @@ typedef __u64 __aligned_u64;
 typedef __u64 __net_cookie;
 typedef __u64 __sock_cookie;
 
-#define UINT8_MAX 0xffff
+#define UINT16_MAX 0xffff

--- a/bpf/lib/eps.h
+++ b/bpf/lib/eps.h
@@ -61,10 +61,10 @@ ipcache_lookup6(const void *map, const union v6addr *addr,
 	};
 
 	/* Check overflow */
-	if (cluster_id > UINT8_MAX)
+	if (cluster_id > UINT16_MAX)
 		return NULL;
 
-	key.cluster_id = (__u8)cluster_id;
+	key.cluster_id = (__u16)cluster_id;
 
 	ipv6_addr_clear_suffix(&key.ip6, prefix);
 	return map_lookup_elem(map, &key);
@@ -82,10 +82,10 @@ ipcache_lookup4(const void *map, __be32 addr, __u32 prefix, __u32 cluster_id)
 	};
 
 	/* Check overflow */
-	if (cluster_id > UINT8_MAX)
+	if (cluster_id > UINT16_MAX)
 		return NULL;
 
-	key.cluster_id = (__u8)cluster_id;
+	key.cluster_id = (__u16)cluster_id;
 
 	key.ip4 &= GET_PREFIX(prefix);
 	return map_lookup_elem(map, &key);


### PR DESCRIPTION
The UINT8_MAX macro is defined as the 16bit value 0xFFFF. Regardless of its originally intended use, since cluster_id is now a uint16 to allow for extended Cluster Mesh, this renames the macro to UINT16_MAX, rather than changing the value.

Lingering casts of cluster_id as a uint8 have also been corrected to ensure it is properly handled as uint16.

Fixes: e8752ec125fc ("bpf: Define UINT8_MAX")
