### PR TITLE
option/resolver: Avoid falling back to v2alpha1 CNC if v2 found

### DIFF
--- a/pkg/option/resolver/resolver.go
+++ b/pkg/option/resolver/resolver.go
@@ -50,7 +50,7 @@ func (cs *ConfigSource) String() string {
 
 func ResolveConfigurations(ctx context.Context, client client.Clientset, nodeName string, sources []ConfigSource, allowConfigKeys, denyConfigKeys []string) (map[string]string, error) {
 	config := map[string]string{}
-	sourceDescriptions := []string{} // We want to keep track of which sources we actually use
+	sourceDescriptions := []string{} // We want to keep track of which sources we actually use; this is a sorted list
 
 	// matchKeys is a set of keys that are either allowed or denied
 	var matchKeys sets.Set[string]

--- a/pkg/option/resolver/resolver.go
+++ b/pkg/option/resolver/resolver.go
@@ -238,12 +238,12 @@ func readNodeConfigsAllVersions(ctx context.Context, client client.Clientset, no
 
 	nodeConfigv2, descv2, errv2 := readNodeConfigs(ctx, client, nodeName, namespace, name)
 	if errv2 != nil {
-		log.WithFields(logrus.Fields{logfields.Node: nodeName}).Errorf("CiliumNodeConfig v2 not found: %s", errv2)
+		log.WithError(errv2).WithFields(logrus.Fields{logfields.Node: nodeName}).Error("CiliumNodeConfig v2 not found when reading configuration")
 	}
 
 	nodeConfigv2alpha1, descv2alpha1, errv2alpha1 := readNodeConfigsv2alpha1(ctx, client, nodeName, namespace, name)
 	if errv2alpha1 != nil {
-		log.WithFields(logrus.Fields{logfields.Node: nodeName}).Errorf("CiliumNodeConfig v2alpha1 not found: %s", errv2alpha1)
+		log.WithError(errv2alpha1).WithFields(logrus.Fields{logfields.Node: nodeName}).Errorf("CiliumNodeConfig v2alpha1 not found when reading configuration")
 		// return the errors for the two versions
 		if errv2 != nil {
 			msg := fmt.Sprintf("CiliumNodeConfig v2 and v2alpha1 not found: %s and %s\n", errv2, errv2alpha1)

--- a/pkg/option/resolver/resolver_test.go
+++ b/pkg/option/resolver/resolver_test.go
@@ -174,11 +174,9 @@ func TestResolveConfigurations(t *testing.T) {
 	g.Expect(config).To(gomega.Equal(map[string]string{
 		"cm-key":         "cm-val",
 		"anno-key":       "anno-val",
-		"cnc-key":        "cnc-val",
-		"cnc-key-2":      "cnc-val-2",
 		"cnc-key-v2":     "cnc-val-v2",
 		"cnc-key-2-v2":   "cnc-val-2-v2",
-		"config-sources": "cilium-node-config:test-ns/specific,cilium-node-config:test-ns/specific-v2,cilium-node-config:test-ns/test-1,cilium-node-config:test-ns/test-1-v2,config-map:test-ns/cm,node:nodename",
+		"config-sources": "cilium-node-config:test-ns/specific-v2,cilium-node-config:test-ns/test-1-v2,config-map:test-ns/cm,node:nodename",
 	}))
 }
 
@@ -372,7 +370,7 @@ func TestReadNodeConfigs(t *testing.T) {
 				g.Expect(err).To(gomega.BeNil())
 			}
 
-			configs, _, err := readNodeConfigsAllVersions(context.Background(), clients, tc.name, testNS, "")
+			configs, _, _, err := readNodeConfigsAllVersions(context.Background(), clients, tc.name, testNS, "")
 			g.Expect(err).To(gomega.BeNil())
 
 			g.Expect(configs).To(gomega.Equal(tc.expected))
@@ -487,7 +485,7 @@ func TestReadNodeConfigsAlpha(t *testing.T) {
 				g.Expect(err).To(gomega.BeNil())
 			}
 
-			configs, _, err := readNodeConfigsAllVersions(context.Background(), clients, tc.name, testNS, "")
+			configs, _, _, err := readNodeConfigsAllVersions(context.Background(), clients, tc.name, testNS, "")
 			g.Expect(err).To(gomega.BeNil())
 
 			g.Expect(configs).To(gomega.Equal(tc.expected))


### PR DESCRIPTION
- **option/resolver: Use structured logging for errors**
- **option,resolver: Sort config sources descriptions**
- **option/resolver: Avoid falling back to v2alpha1 CNC if v2 found**

Fixes: https://github.com/cilium/cilium/pull/31721