### PR TITLE
clustermesh: fix spurious cluster configuration add event

### DIFF
--- a/pkg/clustermesh/common/config.go
+++ b/pkg/clustermesh/common/config.go
@@ -112,6 +112,7 @@ func (cdw *configDirectoryWatcher) handle(abspath string) {
 			// watcher (except for NotFound) to prevent an infinite loop if
 			// something wrong happened.
 			cdw.handle(abspath)
+			return
 		}
 	}
 


### PR DESCRIPTION
In order to prevent possible race conditions when watching clustermesh config file changes, once we receive a file change notification, we first add that path to the list of watched ones and, if it wasn't already registered, recurse again. This prevents missing possible updates that could have happened in the time window between the reading of the file and the registration of the watcher.

However, the previous implementation was lacking a return statement, hence causing the add notification to be actually triggered twice, if the two iterations read two different versions of the file. Practically speaking, this is extremely unlikely to lead to actual issues, unless multiple back-to-back changes are performed in sequence (as we do in the unit tests).

Regardless, let's fix it by adding the missing return statement.

Fixes: 106d0981ee35 ("clustermesh: fix config watcher race condition with back-to-back changes")

<!-- Description of change -->

```release-note
Fix rare spurious double reconnection upon clustermesh configuration change for remote cluster
```
