### PR TITLE
Miscellaneous improvements about closing kvstore client.

### DIFF
--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -129,7 +129,7 @@ func (rc *remoteCluster) releaseOldConnection() {
 	// condition.
 	go func() {
 		if backend != nil {
-			backend.Close(context.Background())
+			backend.Close()
 		}
 	}()
 }
@@ -162,7 +162,7 @@ func (rc *remoteCluster) restartRemoteConnection() {
 
 				if err != nil {
 					if backend != nil {
-						backend.Close(ctx)
+						backend.Close()
 					}
 					rc.logger.WithError(err).Warning("Unable to establish etcd connection to remote cluster")
 					return err

--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -124,14 +124,9 @@ func (rc *remoteCluster) releaseOldConnection() {
 	rc.etcdClusterID = ""
 	rc.mutex.Unlock()
 
-	// Release resources asynchronously in the background. Many of these
-	// operations may time out if the connection was closed due to an error
-	// condition.
-	go func() {
-		if backend != nil {
-			backend.Close()
-		}
-	}()
+	if backend != nil {
+		backend.Close()
+	}
 }
 
 func (rc *remoteCluster) restartRemoteConnection() {

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -191,7 +191,7 @@ type BackendOperations interface {
 	ListPrefixIfLocked(ctx context.Context, prefix string, lock KVLocker) (KeyValuePairs, error)
 
 	// Close closes the kvstore client
-	Close(ctx context.Context)
+	Close()
 
 	// Encodes a binary slice into a character set that the backend
 	// supports

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -647,7 +647,7 @@ func (c *consulClient) listPrefix(ctx context.Context, prefix string) (KeyValueP
 }
 
 // Close closes the consul session
-func (c *consulClient) Close(ctx context.Context) {
+func (c *consulClient) Close() {
 	close(c.statusCheckErrors)
 	if c.controllers != nil {
 		c.controllers.RemoveAll()

--- a/pkg/kvstore/dummy.go
+++ b/pkg/kvstore/dummy.go
@@ -49,7 +49,7 @@ func SetupDummyWithConfigOpts(tb testing.TB, dummyBackend string, opts map[strin
 			tb.Fatalf("Unable to delete all kvstore keys: %v", err)
 		}
 
-		Client().Close(context.Background())
+		Client().Close()
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1527,7 +1527,7 @@ func (e *etcdClient) ListPrefix(ctx context.Context, prefix string) (v KeyValueP
 }
 
 // Close closes the etcd session
-func (e *etcdClient) Close(ctx context.Context) {
+func (e *etcdClient) Close() {
 	close(e.stopStatusChecker)
 
 	if err := e.client.Close(); err != nil {


### PR DESCRIPTION
Please refer to the individual commit messages for additional details:
* kvstore: drop context from the Close() signature
* clustermesh: synchronously close backend on reconnection