### PR TITLE
pkg/endpoint: store template hash in template.txt

### DIFF
--- a/pkg/datapath/fake/types/datapath.go
+++ b/pkg/datapath/fake/types/datapath.go
@@ -130,7 +130,7 @@ func (f *FakeLoader) CompileOrLoad(ctx context.Context, ep datapath.Endpoint, st
 	panic("implement me")
 }
 
-func (f *FakeLoader) ReloadDatapath(ctx context.Context, ep datapath.Endpoint, stats *metrics.SpanStat) error {
+func (f *FakeLoader) ReloadDatapath(ctx context.Context, ep datapath.Endpoint, stats *metrics.SpanStat) (string, error) {
 	panic("implement me")
 }
 

--- a/pkg/datapath/loader/cache_test.go
+++ b/pkg/datapath/loader/cache_test.go
@@ -33,28 +33,28 @@ func TestObjectCache(t *testing.T) {
 	dir := getDirs(t)
 
 	// First run should compile and generate the object.
-	first, isNew, err := cache.fetchOrCompile(ctx, &localNodeConfig, &realEP, dir, nil)
+	first, hash, err := cache.fetchOrCompile(ctx, &localNodeConfig, &realEP, dir, nil)
 	require.NoError(t, err)
-	require.True(t, isNew)
+	require.NotEmpty(t, hash)
 
 	// Same EP should not be compiled twice.
-	second, isNew, err := cache.fetchOrCompile(ctx, &localNodeConfig, &realEP, dir, nil)
+	second, hash2, err := cache.fetchOrCompile(ctx, &localNodeConfig, &realEP, dir, nil)
 	require.NoError(t, err)
-	require.False(t, isNew)
+	require.Equal(t, hash, hash2)
 	require.False(t, second == first)
 
 	// Changing the ID should not generate a new object.
 	realEP.Id++
-	third, isNew, err := cache.fetchOrCompile(ctx, &localNodeConfig, &realEP, dir, nil)
+	third, hash3, err := cache.fetchOrCompile(ctx, &localNodeConfig, &realEP, dir, nil)
 	require.NoError(t, err)
-	require.False(t, isNew)
+	require.Equal(t, hash, hash3)
 	require.False(t, third == first)
 
 	// Changing a setting on the EP should generate a new object.
 	realEP.Opts.SetBool("foo", true)
-	fourth, isNew, err := cache.fetchOrCompile(ctx, &localNodeConfig, &realEP, dir, nil)
+	fourth, hash4, err := cache.fetchOrCompile(ctx, &localNodeConfig, &realEP, dir, nil)
 	require.NoError(t, err)
-	require.True(t, isNew)
+	require.NotEqual(t, hash, hash4)
 	require.False(t, fourth == first)
 }
 

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -576,7 +576,7 @@ func (l *loader) replaceOverlayDatapath(ctx context.Context, cArgs []string, ifa
 // CompileOrLoad with the same configuration parameters. When the first
 // goroutine completes compilation of the template, all other CompileOrLoad
 // invocations will be released.
-func (l *loader) ReloadDatapath(ctx context.Context, ep datapath.Endpoint, stats *metrics.SpanStat) (err error) {
+func (l *loader) ReloadDatapath(ctx context.Context, ep datapath.Endpoint, stats *metrics.SpanStat) (hash string, err error) {
 	dirs := directoryInfo{
 		Library: option.Config.BpfDir,
 		Runtime: option.Config.StateDir,
@@ -586,15 +586,15 @@ func (l *loader) ReloadDatapath(ctx context.Context, ep datapath.Endpoint, stats
 
 	cfg := l.nodeConfig.Load()
 
-	spec, _, err := l.templateCache.fetchOrCompile(ctx, cfg, ep, &dirs, stats)
+	spec, hash, err := l.templateCache.fetchOrCompile(ctx, cfg, ep, &dirs, stats)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	stats.BpfLoadProg.Start()
 	err = l.reloadDatapath(ep, spec)
 	stats.BpfLoadProg.End(err == nil)
-	return err
+	return hash, err
 }
 
 // Unload removes the datapath specific program aspects

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -90,7 +90,7 @@ func testReloadDatapath(t *testing.T, ep *testutils.TestEndpoint) {
 	stats := &metrics.SpanStat{}
 
 	l := newTestLoader(t)
-	err := l.ReloadDatapath(ctx, ep, stats)
+	_, err := l.ReloadDatapath(ctx, ep, stats)
 	require.NoError(t, err)
 }
 
@@ -171,7 +171,7 @@ func testCompileFailure(t *testing.T, ep *testutils.TestEndpoint) {
 	var err error
 	stats := &metrics.SpanStat{}
 	for err == nil && time.Now().Before(timeout) {
-		err = l.ReloadDatapath(ctx, ep, stats)
+		_, err = l.ReloadDatapath(ctx, ep, stats)
 	}
 	require.Error(t, err)
 }

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -17,7 +17,7 @@ import (
 type Loader interface {
 	CallsMapPath(id uint16) string
 	CustomCallsMapPath(id uint16) string
-	ReloadDatapath(ctx context.Context, ep Endpoint, stats *metrics.SpanStat) error
+	ReloadDatapath(ctx context.Context, ep Endpoint, stats *metrics.SpanStat) (string, error)
 	ReinitializeXDP(ctx context.Context, extraCArgs []string) error
 	EndpointHash(cfg EndpointConfiguration) (string, error)
 	Unload(ep Endpoint)


### PR DESCRIPTION
The loader uses two subtly different hashes to identify endpoint configuration. The endpoint hash is unique for each endpoint and is used to detect when configuration changes. The template hash is shared between multiple endpoints and is used as a cache key of sorts.

When I rewrote the loader to not fiddle with the endpoint state directory anymore I made the mistake of persisting the endpoint hash into template.txt. This means that it is not possible to correlate an endpoint state directory with a template cache entry.

Fix this by returning the template hash as a sort of ID from ReloadDatapath and writing that into template.txt.

Fixes: 76ca09a108 ("loader: stop linking template.o into ep.StateDir()")