### PR TITLE
[v1.13] health: only launch /hello after host datapath is ready

### DIFF
--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -27,7 +27,7 @@ const (
 func (d *Daemon) initHealth(cleaner *daemonCleanup) {
 	// Launch cilium-health in the same process (and namespace) as cilium.
 	log.Info("Launching Cilium health daemon")
-	if ch, err := health.Launch(); err != nil {
+	if ch, err := health.Launch(d.datapath.Loader().HostDatapathInitialized()); err != nil {
 		log.WithError(err).Fatal("Failed to launch cilium-health")
 	} else {
 		d.ciliumHealth = ch

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -154,3 +154,7 @@ func (f *fakeLoader) CustomCallsMapPath(id uint16) string {
 func (f *fakeLoader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
 	return nil
 }
+
+func (f *fakeLoader) HostDatapathInitialized() <-chan struct{} {
+	return nil
+}

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -22,6 +22,7 @@ type Loader interface {
 	EndpointHash(cfg EndpointConfiguration) (string, error)
 	Unload(ep Endpoint)
 	Reinitialize(ctx context.Context, o BaseProgramOwner, deviceMTU int, iptMgr IptablesManager, p Proxy) error
+	HostDatapathInitialized() <-chan struct{}
 }
 
 // BaseProgramOwner is any type for which a loader is building base programs.

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -65,11 +65,14 @@ type Loader struct {
 	templateCache *objectCache
 
 	ipsecMu lock.Mutex // guards reinitializeIPSec
+
+	hostDpInitializedOnce sync.Once
+	hostDpInitialized     chan struct{}
 }
 
 // NewLoader returns a new loader.
 func NewLoader() *Loader {
-	return &Loader{}
+	return &Loader{hostDpInitialized: make(chan struct{})}
 }
 
 // Init initializes the datapath cache with base program hashes derived from
@@ -292,6 +295,10 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 		defer finalize()
 	}
 
+	l.hostDpInitializedOnce.Do(func() {
+		close(l.hostDpInitialized)
+	})
+
 	return nil
 }
 
@@ -508,4 +515,10 @@ func (l *Loader) CallsMapPath(id uint16) string {
 // specified ID.
 func (l *Loader) CustomCallsMapPath(id uint16) string {
 	return bpf.LocalMapPath(callsmap.CustomCallsMapName, id)
+}
+
+// HostDatapathInitialized returns a channel which is closed when the
+// host datapath has been loaded for the first time.
+func (l *Loader) HostDatapathInitialized() <-chan struct{} {
+	return l.hostDpInitialized
 }

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -149,7 +149,7 @@ func (s *LoaderTestSuite) testCompileAndLoad(c *C, ep *testutils.TestEndpoint) {
 	defer cancel()
 	stats := &metrics.SpanStat{}
 
-	l := &Loader{}
+	l := NewLoader()
 	err := l.compileAndLoad(ctx, ep, dirInfo, stats)
 	c.Assert(err, IsNil)
 }
@@ -216,7 +216,7 @@ func (s *LoaderTestSuite) testCompileFailure(c *C, ep *testutils.TestEndpoint) {
 		}
 	}()
 
-	l := &Loader{}
+	l := NewLoader()
 	timeout := time.Now().Add(contextTimeout)
 	var err error
 	stats := &metrics.SpanStat{}
@@ -257,7 +257,7 @@ func BenchmarkCompileAndLoad(b *testing.B) {
 	ctx, cancel := context.WithTimeout(context.Background(), benchTimeout)
 	defer cancel()
 
-	l := &Loader{}
+	l := NewLoader()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -332,7 +332,7 @@ func BenchmarkCompileOrLoad(b *testing.B) {
 	}
 	defer os.RemoveAll(epDir)
 
-	l := &Loader{}
+	l := NewLoader()
 	l.templateCache = newObjectCache(&config.HeaderfileWriter{}, nil, tmpDir)
 	if err := l.CompileOrLoad(ctx, &ep, nil); err != nil {
 		log.Warningf("Failure in %s: %s", tmpDir, err)

--- a/pkg/endpoint/directory.go
+++ b/pkg/endpoint/directory.go
@@ -66,7 +66,9 @@ func moveNewFilesTo(oldDir, newDir string) error {
 			}
 		}
 		if !exists {
-			os.Rename(filepath.Join(oldDir, oldFile.Name()), filepath.Join(newDir, oldFile.Name()))
+			if err := os.Link(filepath.Join(oldDir, oldFile.Name()), filepath.Join(newDir, oldFile.Name())); err != nil {
+				return fmt.Errorf("failed to move endpoint state file: %w", err)
+			}
 		}
 	}
 	return nil

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -57,15 +57,6 @@ func getCiliumVersionString(epCHeaderFilePath string) ([]byte, error) {
 	}
 }
 
-// hostObjFileName is the name of the host object file.
-const hostObjFileName = "bpf_host.o"
-
-func hasHostObjectFile(epDir string) bool {
-	hostObjFilepath := filepath.Join(epDir, hostObjFileName)
-	_, err := os.Stat(hostObjFilepath)
-	return err == nil
-}
-
 // ReadEPsFromDirNames returns a mapping of endpoint ID to endpoint of endpoints
 // from a list of directory names that can possible contain an endpoint.
 func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, policyGetter policyRepoGetter,
@@ -89,7 +80,6 @@ func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, policyGe
 	possibleEPs := map[uint16]*Endpoint{}
 	for _, epDirName := range completeEPDirNames {
 		epDir := filepath.Join(basePath, epDirName)
-		isHost := hasHostObjectFile(epDir)
 
 		cHeaderFile := filepath.Join(epDir, common.CHeaderFileName)
 		scopedLog := log.WithFields(logrus.Fields{
@@ -157,7 +147,7 @@ func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, policyGe
 
 		// We need to save the host endpoint ID as we'll need it to regenerate
 		// other endpoints.
-		if isHost {
+		if ep.IsHost() {
 			node.SetEndpointID(ep.GetID())
 		}
 	}

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -218,7 +218,7 @@ func (r *Recorder) orderedMaskSets() ([]*RecMask, []*RecMask) {
 
 func (r *Recorder) triggerDatapathRegenerate() error {
 	var masks4, masks6 string
-	l := &loader.Loader{}
+	l := loader.NewLoader()
 	extraCArgs := []string{}
 	if len(r.recMask) == 0 {
 		extraCArgs = append(extraCArgs, "-Dcapture_enabled=0")


### PR DESCRIPTION
Backporting some host endpoint-related fixes to hopefully address `HOST_EP_ID 65535` being rendered into bpf_lxc's ep_config.h.

- https://github.com/cilium/cilium/pull/27392
- https://github.com/cilium/cilium/pull/32521
- https://github.com/cilium/cilium/pull/32439

```upstream-prs
 27392 32521 32439
```