### PR TITLE
Revert "Fix CiliumEnvoyConfig Nodeport handling"

### DIFF
--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -72,6 +72,12 @@ func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 	cec.Name = cecName
 
 	dedicatedService := d.getService(sourceResource, modelService)
+	if dedicatedService.Spec.Type == corev1.ServiceTypeNodePort {
+		// clear out the CEC Port field for NodePort services.
+		for i := range cec.Spec.Services {
+			cec.Spec.Services[i].Ports = nil
+		}
+	}
 
 	return cec, dedicatedService, getEndpoints(sourceResource), err
 }

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
@@ -1568,7 +1568,6 @@ var complexNodePortIngressCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				Name:      "cilium-ingress-dummy-ingress",
 				Namespace: "dummy-namespace",
-				Ports:     []uint16{80, 443},
 			},
 		},
 		BackendServices: []*ciliumv2.Service{

--- a/pkg/ciliumenvoyconfig/cec_manager.go
+++ b/pkg/ciliumenvoyconfig/cec_manager.go
@@ -91,7 +91,7 @@ func (r *cecManager) addCiliumEnvoyConfig(cecObjectMeta metav1.ObjectMeta, cecSp
 
 	name := service.L7LBResourceName{Name: cecObjectMeta.Name, Namespace: cecObjectMeta.Namespace}
 	if err := r.addK8sServiceRedirects(name, cecSpec, resources); err != nil {
-		return fmt.Errorf("failed to redirect k8s services to Envoy in CEC Add: %w", err)
+		return fmt.Errorf("failed to redirect k8s services to Envoy: %w", err)
 	}
 
 	if len(resources.Listeners) > 0 {
@@ -203,11 +203,6 @@ func (r *cecManager) getServiceNodeports(name, namespace string, servicePorts []
 	kSvc, err := r.getK8sService(name, namespace)
 	if err != nil {
 		return nodePorts, fmt.Errorf("could not retrieve service details for service %s/%s", namespace, name)
-	}
-
-	if kSvc == nil {
-		r.logger.Debugf("Retrieved nil service details for service %s/%s, ignoring Nodeports for this service in this update", namespace, name)
-		return nodePorts, nil
 	}
 
 	for _, servicePort := range servicePorts {
@@ -345,7 +340,7 @@ func (r *cecManager) updateCiliumEnvoyConfig(
 	}
 
 	if err := r.addK8sServiceRedirects(name, newCECSpec, newResources); err != nil {
-		return fmt.Errorf("failed to redirect k8s services to Envoy in CEC Update: %w", err)
+		return fmt.Errorf("failed to redirect k8s services to Envoy: %w", err)
 	}
 
 	if oldResources.ListenersAddedOrDeleted(&newResources) {


### PR DESCRIPTION
Reverts cilium/cilium#33040

Reverting due to being the likely cause for the flakes on `ci-e2e` first observed here: https://github.com/cilium/cilium/actions/runs/9559266646