### PR TITLE
use CiliumEndpoint watcher to remove pod metrics across all nodes

### DIFF
--- a/pkg/hubble/metrics/api/api.go
+++ b/pkg/hubble/metrics/api/api.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
-	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -126,13 +126,13 @@ func (h Handlers) ProcessFlow(ctx context.Context, flow *pb.Flow) error {
 	return errs
 }
 
-// ProcessPodDeletion queries all handlers for a list of MetricVec and removes
-// metrics directly associated to deleted pod.
-func (h Handlers) ProcessPodDeletion(pod *slim_corev1.Pod) {
+// ProcessCiliumEndpointDeletion queries all handlers for a list of MetricVec and removes
+// metrics directly associated to pod of the deleted cilium endpoint.
+func (h Handlers) ProcessCiliumEndpointDeletion(endpoint *types.CiliumEndpoint) {
 	for _, h := range h.handlers {
 		for _, mv := range h.ListMetricVec() {
 			if ctx := h.Context(); ctx != nil {
-				ctx.DeleteMetricsAssociatedWithPod(pod.GetName(), pod.GetNamespace(), mv)
+				ctx.DeleteMetricsAssociatedWithPod(endpoint.GetName(), endpoint.GetNamespace(), mv)
 			}
 		}
 	}

--- a/pkg/hubble/metrics/api/registry_test.go
+++ b/pkg/hubble/metrics/api/registry_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
-	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/k8s/types"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
 
@@ -120,7 +120,7 @@ func TestRegister(t *testing.T) {
 
 		verifyMetricSeriesExists(t, promRegistry, 2)
 
-		handlers.ProcessPodDeletion(&slim_corev1.Pod{
+		handlers.ProcessCiliumEndpointDeletion(&types.CiliumEndpoint{
 			ObjectMeta: slim_metav1.ObjectMeta{
 				Name:      "foo-123",
 				Namespace: "foo",
@@ -130,7 +130,7 @@ func TestRegister(t *testing.T) {
 
 		verifyMetricSeriesExists(t, promRegistry, 1)
 
-		handlers.ProcessPodDeletion(&slim_corev1.Pod{
+		handlers.ProcessCiliumEndpointDeletion(&types.CiliumEndpoint{
 			ObjectMeta: slim_metav1.ObjectMeta{
 				Name:      "bar-123",
 				Namespace: "bar",
@@ -153,7 +153,7 @@ func TestRegister(t *testing.T) {
 
 		verifyMetricSeriesExists(t, promRegistry, 1)
 
-		handlers.ProcessPodDeletion(&slim_corev1.Pod{
+		handlers.ProcessCiliumEndpointDeletion(&types.CiliumEndpoint{
 			ObjectMeta: slim_metav1.ObjectMeta{
 				Name:      "foo-123",
 				Namespace: "foo",
@@ -163,7 +163,7 @@ func TestRegister(t *testing.T) {
 
 		verifyMetricSeriesExists(t, promRegistry, 1)
 
-		handlers.ProcessPodDeletion(&slim_corev1.Pod{
+		handlers.ProcessCiliumEndpointDeletion(&types.CiliumEndpoint{
 			ObjectMeta: slim_metav1.ObjectMeta{
 				Name:      "bar-123",
 				Namespace: "bar",
@@ -186,7 +186,7 @@ func TestRegister(t *testing.T) {
 
 		verifyMetricSeriesExists(t, promRegistry, 2)
 
-		handlers.ProcessPodDeletion(&slim_corev1.Pod{
+		handlers.ProcessCiliumEndpointDeletion(&types.CiliumEndpoint{
 			ObjectMeta: slim_metav1.ObjectMeta{
 				Name:      "foo-123",
 				Namespace: "foo",
@@ -196,7 +196,7 @@ func TestRegister(t *testing.T) {
 
 		verifyMetricSeriesExists(t, promRegistry, 1)
 
-		handlers.ProcessPodDeletion(&slim_corev1.Pod{
+		handlers.ProcessCiliumEndpointDeletion(&types.CiliumEndpoint{
 			ObjectMeta: slim_metav1.ObjectMeta{
 				Name:      "bar-123",
 				Namespace: "bar",
@@ -219,7 +219,7 @@ func TestRegister(t *testing.T) {
 
 		verifyMetricSeriesExists(t, promRegistry, 2)
 
-		handlers.ProcessPodDeletion(&slim_corev1.Pod{
+		handlers.ProcessCiliumEndpointDeletion(&types.CiliumEndpoint{
 			ObjectMeta: slim_metav1.ObjectMeta{
 				Name:      "foo-123",
 				Namespace: "foo",
@@ -229,7 +229,7 @@ func TestRegister(t *testing.T) {
 
 		verifyMetricSeriesExists(t, promRegistry, 2)
 
-		handlers.ProcessPodDeletion(&slim_corev1.Pod{
+		handlers.ProcessCiliumEndpointDeletion(&types.CiliumEndpoint{
 			ObjectMeta: slim_metav1.ObjectMeta{
 				Name:      "bar-123",
 				Namespace: "bar",

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -14,6 +14,7 @@ import (
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	hubblemetrics "github.com/cilium/cilium/pkg/hubble/metrics"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -284,4 +285,5 @@ func (k *K8sCiliumEndpointsWatcher) endpointDeleted(endpoint *types.CiliumEndpoi
 			k.policyManager.TriggerPolicyUpdates(true, "Named ports deleted")
 		}
 	}
+	hubblemetrics.ProcessCiliumEndpointDeletion(endpoint)
 }

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
-	hubblemetrics "github.com/cilium/cilium/pkg/hubble/metrics"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -615,7 +614,6 @@ func (k *K8sPodWatcher) deleteK8sPodV1(pod *slim_corev1.Pod) error {
 	if option.Config.EnableLocalRedirectPolicy {
 		k.redirectPolicyManager.OnDeletePod(pod)
 	}
-	hubblemetrics.ProcessPodDeletion(pod)
 
 	k.cgroupManager.OnDeletePod(pod)
 


### PR DESCRIPTION
Fixes #31889 by using the CiliumEndpoints watcher to drive metrics deletion instead of the Pod watcher. Metrics deletion was being handled by the pod watcher when a pod was deleted so to were all the metrics associated with it. However, if a cilium agent is configured with CiliumEndpointCRD enabled, it will only watch for pods on the current node. This leads to a leak where metrics would never be reaped up on nodes where the pod was not running.

Every node watches all the CiliumEndpoints and the endpoint resources contains contain enough information to trigger the deletion of the metrics. This change moves the deletion to the CiliumEndpoint watcher and uses the endpoint name and namespace to delete the metric when the endpoint is deleted.

Signed-off-by: Steve Gargan steve.gargan@gmail.com

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!



```release-note
Fix hubble metrics leak by using CiliumEndpoint watcher to remove stale metrics.
```
