### PR TITLE
bgpv1: reorder neighbor creation and deletion steps

### DIFF
--- a/pkg/bgpv1/manager/reconciler/neighbor.go
+++ b/pkg/bgpv1/manager/reconciler/neighbor.go
@@ -147,17 +147,13 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 		}
 	}
 
-	// create new neighbors
-	for _, n := range toCreate {
-		l.Infof("Adding peer %v %v to local ASN %v", n.PeerAddress, n.PeerASN, p.DesiredConfig.LocalASN)
-		tcpPassword, err := r.fetchPeerPassword(p.CurrentServer, n)
-		if err != nil {
-			return fmt.Errorf("failed fetching password for neighbor %v %v: %w", n.PeerAddress, n.PeerASN, err)
-		}
-		if err := p.CurrentServer.Server.AddNeighbor(ctx, types.NeighborRequest{Neighbor: n, Password: tcpPassword}); err != nil {
+	// remove neighbors
+	for _, n := range toRemove {
+		l.Infof("Removing peer %v %v from local ASN %v", n.PeerAddress, n.PeerASN, p.DesiredConfig.LocalASN)
+		if err := p.CurrentServer.Server.RemoveNeighbor(ctx, types.NeighborRequest{Neighbor: n}); err != nil {
 			return fmt.Errorf("failed while reconciling neighbor %v %v: %w", n.PeerAddress, n.PeerASN, err)
 		}
-		r.updateMetadata(p.CurrentServer, n, tcpPassword)
+		r.deleteMetadata(p.CurrentServer, n)
 	}
 
 	// update neighbors
@@ -173,13 +169,17 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 		r.updateMetadata(p.CurrentServer, n, tcpPassword)
 	}
 
-	// remove neighbors
-	for _, n := range toRemove {
-		l.Infof("Removing peer %v %v from local ASN %v", n.PeerAddress, n.PeerASN, p.DesiredConfig.LocalASN)
-		if err := p.CurrentServer.Server.RemoveNeighbor(ctx, types.NeighborRequest{Neighbor: n}); err != nil {
+	// create new neighbors
+	for _, n := range toCreate {
+		l.Infof("Adding peer %v %v to local ASN %v", n.PeerAddress, n.PeerASN, p.DesiredConfig.LocalASN)
+		tcpPassword, err := r.fetchPeerPassword(p.CurrentServer, n)
+		if err != nil {
+			return fmt.Errorf("failed fetching password for neighbor %v %v: %w", n.PeerAddress, n.PeerASN, err)
+		}
+		if err := p.CurrentServer.Server.AddNeighbor(ctx, types.NeighborRequest{Neighbor: n, Password: tcpPassword}); err != nil {
 			return fmt.Errorf("failed while reconciling neighbor %v %v: %w", n.PeerAddress, n.PeerASN, err)
 		}
-		r.deleteMetadata(p.CurrentServer, n)
+		r.updateMetadata(p.CurrentServer, n, tcpPassword)
 	}
 
 	return nil

--- a/pkg/bgpv1/manager/reconciler/neighbor_test.go
+++ b/pkg/bgpv1/manager/reconciler/neighbor_test.go
@@ -78,6 +78,18 @@ func TestNeighborReconciler(t *testing.T) {
 			err: nil,
 		},
 		{
+			name: "change peer ASN",
+			neighbors: []v2alpha1api.CiliumBGPNeighbor{
+				{PeerASN: 64124, PeerAddress: "192.168.0.1/32"},
+				{PeerASN: 64124, PeerAddress: "192.168.0.2/32"},
+			},
+			newNeighbors: []v2alpha1api.CiliumBGPNeighbor{
+				{PeerASN: 64125, PeerAddress: "192.168.0.1/32", PeerPort: ptr.To[int32](v2alpha1api.DefaultBGPPeerPort)},
+				{PeerASN: 64125, PeerAddress: "192.168.0.2/32", PeerPort: ptr.To[int32](v2alpha1api.DefaultBGPPeerPort)},
+			},
+			err: nil,
+		},
+		{
 			name: "neighbor with peer port",
 			neighbors: []v2alpha1api.CiliumBGPNeighbor{
 				{PeerASN: 64124, PeerAddress: "192.168.0.1/32", PeerPort: ptr.To[int32](42424)},


### PR DESCRIPTION
This change reorders the peer creation and deletion order in neighbor reconciler. If the peer ASN or address is modified, we need to delete the old peer and then add a new one.

Fixes: #33163
