### PR TITLE
bgpv2: use peer asn and address in the key

### DIFF
--- a/pkg/bgpv1/gobgp/peer.go
+++ b/pkg/bgpv1/gobgp/peer.go
@@ -247,9 +247,8 @@ func (g *GoBGPServer) setPeerTransport(peer, existingPeer *gobgp.Peer, peerAddr 
 		peer.Transport = &gobgp.Transport{}
 	}
 
-	if localPort > 0 {
-		peer.Transport.LocalPort = localPort
-	}
+	// update local port, 0 is fine as well. In which case, linux will assign a random port.
+	peer.Transport.LocalPort = localPort
 
 	if peerPort > 0 {
 		peer.Transport.RemotePort = peerPort

--- a/pkg/bgpv1/manager/reconcilerv2/neighbor_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/neighbor_test.go
@@ -68,6 +68,17 @@ var (
 		},
 	}
 
+	peer2UpdatedASN = func() PeerData {
+		peer2Copy := PeerData{
+			Peer:     peer2.Peer.DeepCopy(),
+			Config:   peer2.Config.DeepCopy(),
+			Password: peer2.Password,
+		}
+
+		peer2Copy.Peer.PeerASN = ptr.To[int64](64125)
+		return peer2Copy
+	}()
+
 	peer2UpdatedTimers = func() PeerData {
 		peer2Copy := PeerData{
 			Peer:     peer2.Peer.DeepCopy(),
@@ -170,6 +181,12 @@ func TestNeighborReconciler(t *testing.T) {
 			name:         "remove peers",
 			neighbors:    []PeerData{peer1, peer2},
 			newNeighbors: []PeerData{peer1},
+			err:          nil,
+		},
+		{
+			name:         "update config : ASN",
+			neighbors:    []PeerData{peer1, peer2},
+			newNeighbors: []PeerData{peer1, peer2UpdatedASN},
 			err:          nil,
 		},
 		{


### PR DESCRIPTION
This change adds the ASN and address to the peer's key along with the name.

Secondly, the order of peer changes is now deleted, updated, and added. This is done because adding an old peer before deleting it will fail when changing the peer ASN or address.

This change also allows setting the local peer port to 0 (random port selection from the kernel). This is required when setting the local port from some value back to 0.

Fixes: #33163
