### PR TITLE
[v1.14] ipcache: Fix orphaned ipcache entries when mixing Upsert and Inject 

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -205,6 +205,9 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 		// entriesToReplace stores the identity to replace in the ipcache.
 		entriesToReplace = make(map[netip.Prefix]ipcacheEntry)
 		entriesToDelete  = make(map[netip.Prefix]Identity)
+		// unmanagedPrefixes is the set of prefixes for which we no longer have
+		// any metadata, but were created by a call directly to Upsert()
+		unmanagedPrefixes = make(map[netip.Prefix]Identity)
 	)
 
 	ipc.metadata.RLock()
@@ -308,8 +311,16 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 			// and the existing IPCache entry was never touched by any other
 			// subsystem using the old Upsert API, then we can safely remove
 			// the IPCache entry associated with this prefix.
-			if prefixInfo == nil && oldID.createdFromMetadata {
-				entriesToDelete[prefix] = oldID
+			if prefixInfo == nil {
+				if oldID.createdFromMetadata {
+					entriesToDelete[prefix] = oldID
+				} else {
+					// If, on the other hand, this prefix *was* touched by
+					// another, Upsert-based system, flag this prefix as
+					// potentially eligible for deletion if all references
+					// are removed.
+					unmanagedPrefixes[prefix] = oldID
+				}
 			}
 		}
 
@@ -373,7 +384,7 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 		}
 	}
 
-	for _, id := range previouslyAllocatedIdentities {
+	for prefix, id := range previouslyAllocatedIdentities {
 		realID := ipc.IdentityAllocator.LookupIdentityByID(ctx, id.ID)
 		if realID == nil {
 			continue
@@ -397,6 +408,16 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 		// logic for handling the removal of these identities.
 		if released {
 			idsToDelete[id.ID] = nil // SelectorCache removal
+
+			// Corner case: This prefix + identity was initially created by a direct Upsert(),
+			// but all identity references have been released. We should then delete this prefix.
+			if oldID, unmanaged := unmanagedPrefixes[prefix]; unmanaged && oldID.ID == id.ID {
+				entriesToDelete[prefix] = oldID
+				log.WithFields(logrus.Fields{
+					logfields.IPAddr:   prefix,
+					logfields.Identity: id,
+				}).Debug("Force-removing released prefix from the ipcache.")
+			}
 		}
 	}
 	if len(idsToDelete) > 0 {

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -346,6 +346,9 @@ func TestInjectWithLegacyAPIOverlap(t *testing.T) {
 	// Assert that ipcache has released its final reference to the identity
 	realID = IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.Background(), id.ID)
 	assert.True(t, realID == nil)
+
+	_, ok = IPIdentityCache.LookupByIP(prefix.String())
+	assert.False(t, ok)
 }
 
 func TestFilterMetadataByLabels(t *testing.T) {


### PR DESCRIPTION
 * [x] #33120 (@squeed)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 33120
```
