### PR TITLE
identity: Ensure checkpoint runs on shutdown 

### DIFF
--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -499,7 +499,8 @@ func TestCheckpointRestore(t *testing.T) {
 	modelBefore := mgr.GetIdentities()
 
 	// Explicitly checkpoint, to ensure we get the latest data
-	mgr.checkpoint(nil)
+	err := mgr.checkpoint(context.TODO())
+	require.NoError(t, err)
 
 	newMgr := NewCachingIdentityAllocator(owner)
 	defer newMgr.Close()

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/allocator"
+	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/idpool"
@@ -237,11 +238,23 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 // The CachingIdentityAllocator is used in multiple places, but we only want to
 // checkpoint the "primary" allocator
 func (m *CachingIdentityAllocator) EnableCheckpointing() {
+	controllerManager := controller.NewManager()
+	controllerGroup := controller.NewGroup("identity-allocator")
+	controllerName := "local-identity-checkpoint"
 	triggerDone := make(chan struct{})
 	t, _ := trigger.NewTrigger(trigger.Parameters{
-		MinInterval:  10 * time.Second,
-		TriggerFunc:  m.checkpoint,
-		ShutdownFunc: func() { close(triggerDone) },
+		MinInterval: 10 * time.Second,
+		TriggerFunc: func(reasons []string) {
+			controllerManager.UpdateController(controllerName, controller.ControllerParams{
+				Group:    controllerGroup,
+				DoFunc:   m.checkpoint,
+				StopFunc: m.checkpoint, // perform one last checkpoint when the controller is removed
+			})
+		},
+		ShutdownFunc: func() {
+			controllerManager.RemoveControllerAndWait(controllerName) // waits for StopFunc
+			close(triggerDone)
+		},
 	})
 
 	m.checkpointTrigger = t
@@ -495,9 +508,9 @@ func (m *CachingIdentityAllocator) UnwithholdLocalIdentities(nids []identity.Num
 // to ensure that numeric identities are, as much as possible, stable across agent restarts.
 //
 // Do not call this directly, rather, use m.checkpointTrigger.Trigger()
-func (m *CachingIdentityAllocator) checkpoint(reasons []string) {
+func (m *CachingIdentityAllocator) checkpoint(ctx context.Context) error {
 	if m.checkpointPath == "" {
-		return // this is a unit test
+		return nil // this is a unit test
 	}
 	log := log.WithField(logfields.Path, m.checkpointPath)
 
@@ -509,20 +522,21 @@ func (m *CachingIdentityAllocator) checkpoint(reasons []string) {
 	out, err := renameio.NewPendingFile(m.checkpointPath, renameio.WithExistingPermissions(), renameio.WithPermissions(0o600))
 	if err != nil {
 		log.WithError(err).Error("failed to prepare checkpoint file")
-		return
+		return err
 	}
 	defer out.Cleanup()
 
 	jw := jsoniter.ConfigFastest.NewEncoder(out)
 	if err := jw.Encode(ids); err != nil {
 		log.WithError(err).Error("failed to marshal identity checkpoint state")
-		return
+		return err
 	}
 	if err := out.CloseAtomicallyReplace(); err != nil {
 		log.WithError(err).Error("failed to write identity checkpoint file")
-		return
+		return err
 	}
 	log.Debug("Wrote local identity allocator checkpoint")
+	return nil
 }
 
 // RestoreLocalIdentities reads in the checkpointed local allocator state

--- a/test/provision/docker-run-cilium.sh
+++ b/test/provision/docker-run-cilium.sh
@@ -21,6 +21,7 @@ fi
 if [ "$1" = "uninstall" ] ; then
     if [ -n "$(${SUDO} docker ps -a -q -f label=app=cilium)" ]; then
         echo "Shutting down running Cilium agent"
+        ${SUDO} docker stop cilium || true
         ${SUDO} docker rm -f cilium || true
     fi
     if [ -f /usr/bin/cilium ] ; then

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -1094,6 +1094,7 @@ var _ = Describe("RuntimeAgentFQDNPolicies", func() {
 			vm.WaitEndpointsReady()
 		}()
 
+		fullIdentitiesListBefore := vm.Exec("cilium-dbg identity list").OutputPrettyPrint()
 		idsBefore := vm.SelectedIdentities("cilium.test")
 		Expect(idsBefore).NotTo(HaveLen(0))
 		GinkgoPrint("cilium.test selectors before restart: " + idsBefore)
@@ -1134,9 +1135,13 @@ var _ = Describe("RuntimeAgentFQDNPolicies", func() {
 
 		expectFQDNSareApplied("cilium.test", 0)
 
+		fullIdentitiesListAfter := vm.Exec("cilium-dbg identity list").OutputPrettyPrint()
 		idsAfter := vm.SelectedIdentities("cilium.test")
 		GinkgoPrint("cilium.test selectors after restart: " + idsAfter)
-		Expect(idsAfter).To(Equal(idsBefore))
+		Expect(idsAfter).To(Equal(idsBefore),
+			fmt.Sprintf("cilium.test selector identities changed.\n Before:\n%s\n\nAfter:\n%s",
+				fullIdentitiesListBefore,
+				fullIdentitiesListAfter))
 
 		By("Dumping IP cache after the DNS policy is imported after restart")
 		ipcacheAfterDNSPolicy, err := vm.BpfIPCacheList(true)


### PR DESCRIPTION
This PR improves the identity checkpointing mechanism required for dropless restarts with the new FQDN identities (c.f. #32769). It does this by ensuring a final checkpoint is performed during shutdown (see commit message of first commit).

This PR thereby also fixes a CI flake in `ci-runtime: DNS proxy policy works if Cilium stops`, which checks that numeric identities don't change after a restart. For the fix to take effect in ci-runtime, we need to ensure SIGTERM is sent rather than SIGKILL when stopping Cilium, which the second commit does. Sending SIGTERM mirrors the behavior in K8s tests.

The third commit adds some additional test output in case this fix is somehow not sufficient (though in local testing it was very successful) and we need to further debug the test.

Fixes: #33249