### PR TITLE
bpf: ensure test objects are compiled before tests are run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -559,7 +559,7 @@ force :;
 
 run_bpf_tests: ## Build and run the BPF unit tests using the cilium-builder container image.
 	DOCKER_ARGS=--privileged contrib/scripts/builder.sh \
-		"make" "-j$(shell nproc)" "-C" "bpf/tests/" "all" "run"
+		"make" "-j$(shell nproc)" "-C" "bpf/tests/" "run"
 
 run-builder: ## Drop into a shell inside a container running the cilium-builder image.
 	DOCKER_ARGS=-it contrib/scripts/builder.sh bash

--- a/bpf/tests/Makefile
+++ b/bpf/tests/Makefile
@@ -79,7 +79,7 @@ ifdef DUMPCTX
     BPF_TEST_FLAGS += -dump-ctx
 endif
 
-run:
+run: $(TEST_OBJECTS)
 	$(QUIET)$(GO) test ./bpftest -bpf-test-path $(ROOT_DIR)/bpf/tests $(BPF_TEST_FLAGS)
 
 -include $(TEST_OBJECTS:.o=.d)


### PR DESCRIPTION
The run target doesn't have a prerequisite on the .o files it ends up testing, so an invocation like make -j2 run has an undefined order. The go test may be invoked before all objects have been compiled.