### PR TITLE
ctmap: Stop GC handler if signal map is closed

### DIFF
--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -187,7 +187,11 @@ func (gc *GC) Enable() {
 			triggeredBySignal = false
 			gc.signalHandler.UnmuteSignals()
 			select {
-			case x := <-gc.signalHandler.Signals():
+			case x, ok := <-gc.signalHandler.Signals():
+				if !ok {
+					gc.logger.Info("Signal handler closed. Stopping conntrack garbage collector")
+					return
+				}
 				// mute before draining so that no more wakeups are queued just
 				// after we have drained
 				gc.signalHandler.MuteSignals()


### PR DESCRIPTION
When Cilium receives a SIGTERM, the signal manager (`pkg/signal`) cell stop hook is invoked, which in turn informs all signal handlers that the manager has been closed (by passing in a `nil` reader). This causes handlers such as `ChannelHandler` to close their respective channels too.

This means that the CT GC (which uses a `ChannelHandler`) needs to deal with the case where its channel is closed during cilium-agent shutdown. This commit addresses that by stopping the GC go routine if the signals channel is closed. Previously, the GC go routine interpreted the closed channel as a signal to run GC and started do back to back GC in a busy loop, resulting in wasted CPU cycles during shutdown. This was also visibly by the following log lines being repeated many times during shutdown:

```
level=info msg="Starting initial GC of connection tracking" subsys=ct-nat-map-gc
level=debug msg="Registered BPF map" path=/sys/fs/bpf/tc/globals/cilium_ct4_global subsys=bpf
level=debug msg="Registered BPF map" path=/sys/fs/bpf/tc/globals/cilium_ct_any4_global subsys=bpf
level=debug msg="Unregistered BPF map" path=/sys/fs/bpf/tc/globals/cilium_ct_any4_global subsys=bpf
level=debug msg="Unregistered BPF map" path=/sys/fs/bpf/tc/globals/cilium_ct4_global subsys=bpf
```

With this commit applied, the GC go routine exits properly, emitting a log line while doing so.
