### PR TITLE
daemon/ipam: don't swallow parse error of CIDR

### DIFF
--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -95,10 +95,13 @@ func (d *Daemon) allocateRouterIPv6(family types.NodeAddressingFamily, fromK8s, 
 }
 
 // Coalesce CIDRS when allocating the DatapathIPs and healthIPs. GH #18868
-func coalesceCIDRs(rCIDRs []string) (result []string) {
+func coalesceCIDRs(rCIDRs []string) (result []string, err error) {
 	cidrs := make([]*net.IPNet, 0, len(rCIDRs))
 	for _, k := range rCIDRs {
-		ip, mask, _ := net.ParseCIDR(k)
+		ip, mask, err := net.ParseCIDR(k)
+		if err != nil {
+			return nil, err
+		}
 		cidrs = append(cidrs, &net.IPNet{IP: ip, Mask: mask.Mask})
 	}
 	ipv4cidr, ipv6cidr := iputil.CoalesceCIDRs(cidrs)
@@ -191,7 +194,10 @@ func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily, fromK8s,
 		option.Config.IPAM == ipamOption.IPAMENI &&
 		result != nil &&
 		len(result.CIDRs) > 0 {
-		result.CIDRs = coalesceCIDRs(result.CIDRs)
+		result.CIDRs, err = coalesceCIDRs(result.CIDRs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to coalesce CIDRs: %w", err)
+		}
 	}
 
 	if (option.Config.IPAM == ipamOption.IPAMENI ||
@@ -251,7 +257,10 @@ func (d *Daemon) allocateHealthIPs() error {
 			option.Config.IPAM == ipamOption.IPAMENI &&
 			result != nil &&
 			len(result.CIDRs) > 0 {
-			result.CIDRs = coalesceCIDRs(result.CIDRs)
+			result.CIDRs, err = coalesceCIDRs(result.CIDRs)
+			if err != nil {
+				return fmt.Errorf("failed to coalesce CIDRs: %w", err)
+			}
 		}
 
 		log.Debugf("IPv4 health endpoint address: %s", result.IP)
@@ -326,7 +335,10 @@ func (d *Daemon) allocateIngressIPs() error {
 				option.Config.IPAM == ipamOption.IPAMENI &&
 				result != nil &&
 				len(result.CIDRs) > 0 {
-				result.CIDRs = coalesceCIDRs(result.CIDRs)
+				result.CIDRs, err = coalesceCIDRs(result.CIDRs)
+				if err != nil {
+					return fmt.Errorf("failed to coalesce CIDRs: %w", err)
+				}
 			}
 
 			node.SetIngressIPv4(result.IP)
@@ -384,7 +396,10 @@ func (d *Daemon) allocateIngressIPs() error {
 				option.Config.IPAM == ipamOption.IPAMENI &&
 				result != nil &&
 				len(result.CIDRs) > 0 {
-				result.CIDRs = coalesceCIDRs(result.CIDRs)
+				result.CIDRs, err = coalesceCIDRs(result.CIDRs)
+				if err != nil {
+					return fmt.Errorf("failed to coalesce CIDRs: %w", err)
+				}
 			}
 
 			node.SetIngressIPv6(result.IP)

--- a/daemon/cmd/ipam_test.go
+++ b/daemon/cmd/ipam_test.go
@@ -19,58 +19,58 @@ import (
 func TestCoalesceCIDRs(t *testing.T) {
 	CIDR := []string{"10.0.0.0/8"}
 	expectedCIDR := []string{"10.0.0.0/8"}
-	newCIDR := coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err := coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"10.105.0.0/16", "10.0.0.0/8"}
 	expectedCIDR = []string{"10.0.0.0/8"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"10.105.0.0/16", "10.104.0.0/19", "10.0.0.0/8"}
 	expectedCIDR = []string{"10.0.0.0/8"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24"}
 	expectedCIDR = []string{"10.105.0.0/16", "192.168.1.0/24"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8"}
 	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8", "f00d::a0f:0:0:0/96"}
 	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24", "f00d::a0f:0:0:0/96"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"f00d::a0f:0:0:0/96", "10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8"}
 	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24", "f00d::a0f:0:0:0/96"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"f00d::a0f:0:0:0/96"}
 	expectedCIDR = []string{"f00d::a0f:0:0:0/96"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 }
 


### PR DESCRIPTION
It's possible that an invalid CIDR is passed to coalesceCIDRs, so we should not swallow the error of parsing it.

Related: #32855
