### PR TITLE
hubble: deflake TestLocalObserverServer_NodeLabels

### DIFF
--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -148,7 +148,11 @@ func (d *Daemon) launchHubble() {
 
 	// fill in the local node information after the dropEventEmitter logique,
 	// but before anything else (e.g. metrics).
-	localNodeWatcher := observer.NewLocalNodeWatcher(d.ctx, d.nodeLocalStore)
+	localNodeWatcher, err := observer.NewLocalNodeWatcher(d.ctx, d.nodeLocalStore)
+	if err != nil {
+		logger.WithError(err).Error("Failed to retrieve local node information")
+		return
+	}
 	observerOpts = append(observerOpts, observeroption.WithOnDecodedFlow(localNodeWatcher))
 
 	grpcMetrics := grpc_prometheus.NewServerMetrics()

--- a/pkg/hubble/observer/local_node_watcher.go
+++ b/pkg/hubble/observer/local_node_watcher.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"slices"
 
-	"github.com/cilium/stream"
-
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node"
@@ -17,9 +15,8 @@ import (
 // LocalNodeWatcher populate Hubble flows local node related fields (currently
 // only labels).
 type LocalNodeWatcher struct {
-	mu      lock.Mutex
-	updated int // update counter
-	cache   struct {
+	mu    lock.Mutex
+	cache struct {
 		// labels are represented as a Go map in node.LocalNode, but we need a
 		// key=val slice for Hubble flows.
 		labels []string
@@ -27,21 +24,29 @@ type LocalNodeWatcher struct {
 }
 
 // NewLocalNodeWatcher return a new LocalNodeWatcher. The given context control
-// whether the LocalNodeWatcher gets updated by the localNodeStream. It is safe
+// whether the LocalNodeWatcher gets updated by the localNodeStore. It is safe
 // to use the returned LocalNodeWatcher once the context is cancelled, but its
 // information might be out-of-date.
-func NewLocalNodeWatcher(ctx context.Context, localNodeStream stream.Observable[node.LocalNode]) *LocalNodeWatcher {
+func NewLocalNodeWatcher(ctx context.Context, localNodeStore *node.LocalNodeStore) (*LocalNodeWatcher, error) {
 	watcher := LocalNodeWatcher{}
-	localNodeStream.Observe(ctx, watcher.update, watcher.complete)
-	return &watcher
+	// fetch the initial local node
+	n, err := localNodeStore.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	watcher.update(n)
+	// subscribe to local node changes.
+	localNodeStore.Observe(ctx, watcher.update, watcher.complete)
+
+	return &watcher, nil
 }
 
 // OnDecodedFlow implements OnDecodedFlow for LocalNodeWatcher. The
 // LocalNodeWatcher populate the flow's node_labels field.
 func (w *LocalNodeWatcher) OnDecodedFlow(_ context.Context, flow *flowpb.Flow) (bool, error) {
 	w.mu.Lock()
+	defer w.mu.Unlock()
 	flow.NodeLabels = w.cache.labels
-	w.mu.Unlock()
 	return false, nil
 }
 
@@ -49,24 +54,15 @@ func (w *LocalNodeWatcher) OnDecodedFlow(_ context.Context, flow *flowpb.Flow) (
 func (w *LocalNodeWatcher) update(n node.LocalNode) {
 	labels := sortedLabelSlice(n.Labels)
 	w.mu.Lock()
-	w.cache.labels = labels
-	w.updated++
-	w.mu.Unlock()
-}
-
-// generation return this watcher update counter.
-func (w *LocalNodeWatcher) generation() int {
-	w.mu.Lock()
 	defer w.mu.Unlock()
-	return w.updated
+	w.cache.labels = labels
 }
 
 // complete clears the LocalNodeWatcher cache.
 func (w *LocalNodeWatcher) complete(error) {
 	w.mu.Lock()
+	defer w.mu.Unlock()
 	w.cache.labels = nil
-	w.updated++
-	w.mu.Unlock()
 }
 
 // sortedLabelSlice convert a given map of key/val labels, and return a sorted

--- a/pkg/hubble/observer/local_node_watcher_test.go
+++ b/pkg/hubble/observer/local_node_watcher_test.go
@@ -6,7 +6,6 @@ package observer
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -57,11 +56,10 @@ func Test_LocalNodeWatcher(t *testing.T) {
 	var watcher *LocalNodeWatcher
 
 	t.Run("NewLocalNodeWatcher", func(t *testing.T) {
-		watcher = NewLocalNodeWatcher(ctx, node.NewTestLocalNodeStore(localNode))
+		var err error
+		watcher, err = NewLocalNodeWatcher(ctx, node.NewTestLocalNodeStore(localNode))
+		require.NoError(t, err)
 		require.NotNil(t, watcher)
-		require.Eventually(t, func() bool {
-			return watcher.generation() > 0
-		}, time.Second, 10*time.Millisecond)
 	})
 
 	t.Run("OnDecodedFlow", func(t *testing.T) {


### PR DESCRIPTION
Before this patch, `TestLocalObserverServer_NodeLabels` was flaky because it didn't wait on the `localNodeWatcher` to have been updated at least once before using it.

This commit makes `NewLocalNodeWatcher` retrieve the local node info so that the returned `LocalNodeWatcher` is usable right away. This means that the Hubble startup will block until the `LocalNodeStore` is ready with local node info, which in practice should not be an issue.

fix #33273