### PR TITLE
Add auto-merge for renovate for trusted dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -83,6 +83,44 @@
   ],
   "packageRules": [
     {
+      "matchPackageNames": [
+        "go", // golang version directive upgrade in go.mod
+        "grpc-ecosystem/grpc-health-probe", // Grpc ecosystem
+        "kindest/node", // official kindest images
+        "kubernetes-sigs/kind", // official kind dependencies
+        "renovatebot/github-action", // Renovate's GH action
+        "renovatebot/renovate", // Renovate's bot name
+      ],
+      "matchPackagePrefixes": [
+        "actions/", // GitHub official's GH actions
+        "cilium/", // Cilium's GH actions
+        "docker.io/library/", // official Docker images
+        "gcr.io/distroless", // official distroless images
+        "gcr.io/etcd-development/etcd", // etcd
+        "ghcr.io/spiffe/", // Spiffe's official images
+        "github.com/actions/", // GitHub official's GH actions
+        "github.com/aws/", // Amazon's dependencies
+        "github.com/Azure/", // Azure's dependencies
+        "github.com/cilium/", // Any Cilium dependency
+        "github.com/docker/", // Docker official org
+        "github.com/golang/", // Golang official org
+        "github.com/google/", // Google official org
+        "github.com/go-openapi/", // Open API official org
+        "github.com/hashicorp/", // Hashicorp's official org
+        "github.com/prometheus/", // Prometheu's official org
+        "go.etcd.io/etcd/", // etcd's official org
+        "golang.org/x/", // Golang official experimental org
+        "google.golang.org/", // Google official repo for api/genproto/grpc/protobuf
+        "k8s.io/", // Kubernetes official repo
+        "quay.io/cilium/", // LVH images
+        "quay.io/lvh-images/", // LVH images
+        "sigs.k8s.io/", // Kubernetes official SIG repo
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "groupName": "auto-merge-trusted-deps"
+    },
+    {
       // Try to group all updates for all dependencies in a single PR. More
       // specific packageRules are followed by this one.
       "matchUpdateTypes": [

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -17,6 +17,9 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
+  push:
+    branches:
+      - 'renovate/**'
   # Run every 6 hours
   schedule:
     - cron:  '0 0/6 * * *'

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -17,6 +17,9 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
+  push:
+    branches:
+      - 'renovate/**'
   # Run every 6 hours
   schedule:
     - cron:  '30 0/6 * * *'

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -22,6 +22,7 @@ on:
     branches:
       - main
       - ft/main/**
+      - 'renovate/**'
     paths-ignore:
       - 'Documentation/**'
 

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -17,6 +17,9 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
+  push:
+    branches:
+      - 'renovate/**'
   # Run every 6 hours
   schedule:
     - cron:  '0 5/6 * * *'

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -17,6 +17,9 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
+  push:
+    branches:
+      - 'renovate/**'
   # Run every 6 hours
   schedule:
     - cron:  '0 1/6 * * *'

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -17,6 +17,9 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
+  push:
+    branches:
+      - 'renovate/**'
   # Run every 6 hours
   schedule:
     - cron:  '0 4/6 * * *'

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -22,6 +22,7 @@ on:
     branches:
       - main
       - ft/main/**
+      - 'renovate/**'
     paths-ignore:
       - 'Documentation/**'
       - 'test/**'

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -17,6 +17,9 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
+  push:
+    branches:
+      - 'renovate/**'
   # Run every 6 hours
   schedule:
     - cron:  '0 1/6 * * *'

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -17,6 +17,9 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
+  push:
+    branches:
+      - 'renovate/**'
   # Run every 6 hours
   schedule:
     - cron:  '0 2/6 * * *'

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -21,6 +21,7 @@ on:
     branches:
       - main
       - ft/main/**
+      - 'renovate/**'
     paths-ignore:
       - 'Documentation/**'
       - 'test/**'

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -17,6 +17,9 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
+  push:
+    branches:
+      - 'renovate/**'
   # Run every 6 hours
   schedule:
     - cron:  '0 5/6 * * *'

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -22,6 +22,7 @@ on:
     branches:
       - main
       - ft/main/**
+      - 'renovate/**'
     paths-ignore:
       - 'Documentation/**'
 

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -21,6 +21,7 @@ on:
     branches:
       - main
       - ft/main/**
+      - 'renovate/**'
     paths-ignore:
       - 'Documentation/**'
 

--- a/.github/workflows/fqdn-perf.yaml
+++ b/.github/workflows/fqdn-perf.yaml
@@ -19,6 +19,9 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
+  push:
+    branches:
+      - 'renovate/**'
 
 # For testing uncomment following lines:
 #  push:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -21,6 +21,7 @@ on:
     branches:
     - main
     - ft/main/**
+    - 'renovate/**'
     paths-ignore:
     - 'Documentation/**'
 

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -22,6 +22,7 @@ on:
     branches:
       - main
       - ft/main/**
+      - 'renovate/**'
     paths-ignore:
       - 'Documentation/**'
 

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -17,6 +17,9 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
+  push:
+    branches:
+      - 'renovate/**'
   # Run every 6 hours
   schedule:
     - cron:  '0 5/6 * * *'

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -17,6 +17,9 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
+  push:
+    branches:
+      - 'renovate/**'
   # Run every 6 hours
   schedule:
     - cron:  '0 5/6 * * *'

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -17,6 +17,9 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
+  push:
+    branches:
+      - 'renovate/**'
   # Run every 6 hours
   schedule:
     - cron:  '0 5/6 * * *'

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -22,6 +22,7 @@ on:
     branches:
       - main
       - ft/main/**
+      - 'renovate/**'
     paths-ignore:
       - 'Documentation/**'
 


### PR DESCRIPTION
Besides these changes we will also need to add cilium-renovate to the `Allow specified actors to bypass required pull requests` as documented by renovate documentation:

> let Renovate bypass the mandatory Pull Request reviews using the "[Allow specified actors to bypass required pull requests](https://github.blog/changelog/2021-11-19-allow-bypassing-required-pull-requests/)" option in your branch protection rules.