### PR TITLE
docs: Add deprecation warning in Ginkgo E2E docs

### DIFF
--- a/Documentation/contributing/testing/e2e_legacy.rst
+++ b/Documentation/contributing/testing/e2e_legacy.rst
@@ -9,6 +9,12 @@
 End-To-End Testing Framework (Legacy)
 =====================================
 
+.. warning::
+   The Ginkgo end-to-end testing framework is deprecated. New end-to-end
+   tests should be implemented using the `cilium-cli
+   <https://github.com/cilium/cilium-cli/#connectivity-check>`_ connectivity
+   testing framework. For more information, see :ref:`testsuite`.
+
 Introduction
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

This commit adds a warning at the top of the Ginkgo-based E2E testing documentation, making it explicitly clear that the framework is deprecated. The Ginkgo-based E2E testing documentation is already marked with a "legacy" note in the title of the page, so the goal of this commit is to extend this note and make it clear that the cilium-cli framework should be used moving forward.

```release-note
Add explicit deprecation notice in the Ginkgo-based E2E testing documentation
```
