### PR TITLE
fix(cgroups): PodMetadata.IPs as low level net.IP

### DIFF
--- a/daemon/cmd/cgroup_dump_metadata.go
+++ b/daemon/cmd/cgroup_dump_metadata.go
@@ -23,11 +23,17 @@ func getCgroupDumpMetadataHandler(d *Daemon, params restapi.GetCgroupDumpMetadat
 			}
 			respCms = append(respCms, respCm)
 		}
+
+		ips := make([]string, 0, len(pm.IPs))
+		for i := range pm.IPs {
+			ips = append(ips, pm.IPs[i].String())
+		}
+
 		respPm := &models.CgroupPodMetadata{
 			Name:       pm.Name,
 			Namespace:  pm.Namespace,
 			Containers: respCms,
-			Ips:        pm.IPs,
+			Ips:        ips,
 		}
 		resp.PodMetadatas = append(resp.PodMetadatas, respPm)
 	}

--- a/pkg/hubble/parser/sock/parser.go
+++ b/pkg/hubble/parser/sock/parser.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -143,16 +142,11 @@ func (p *Parser) decodeEndpointIP(cgroupId uint64, ipVersion flowpb.IPVersion) (
 			})
 
 			for _, podIP := range m.IPs {
-				isIPv6 := strings.Contains(podIP, ":")
+				isIPv6 := len(podIP) == net.IPv6len
 				if isIPv6 && ipVersion == flowpb.IPVersion_IPv6 ||
 					!isIPv6 && ipVersion == flowpb.IPVersion_IPv4 {
-					ip = net.ParseIP(podIP)
-					if ip == nil {
-						scopedLog.WithField(logfields.IPAddr, podIP).Debug("failed to parse pod IP")
-						return nil, false
-					}
 
-					return ip, true
+					return podIP, true
 				}
 			}
 			scopedLog.Debug("no matching IP for pod")

--- a/pkg/hubble/parser/sock/parser_test.go
+++ b/pkg/hubble/parser/sock/parser_test.go
@@ -187,7 +187,7 @@ func TestDecodeSockEvent(t *testing.T) {
 				return &cgroupManager.PodMetadata{
 					Name:      xwingPodName,
 					Namespace: xwingPodNamespace,
-					IPs:       []string{xwingIPv4, xwingIPv6},
+					IPs:       []net.IP{net.ParseIP(xwingIPv4), net.ParseIP(xwingIPv6)},
 				}
 			}
 			return nil


### PR DESCRIPTION
We are currently working on finding what happen on #33063, and during the debug logging analysis and the code reading i found that pod metadata fetch on our very busy clusters is done very very very often, hundreds of time per second, because it's done per socket creation.

Each time we retrieve those metadata we currently parse string adresses we copy over the metadata store to the caller through channels and we parse it on each metadata call.

With this change, we parse it on the store directly, once and we can directly play with it on the callers without converting each time we call it. This will reduce CPU cycles each time we create a socket, and also the memory of the metadata store because we use a raw 4 bytes instead of 15 bytes (for IPv4) string

```release-note
Reduce memory footprint for cgroup PodMetadata tracing & CPU usage on each socket creation.
```

note: it's totally backportable on 1.15 branch
