### PR TITLE
ci: Fix CES Migration workflow failing when skipped

### DIFF
--- a/.github/workflows/tests-ces-migrate.yaml
+++ b/.github/workflows/tests-ces-migrate.yaml
@@ -199,15 +199,3 @@ jobs:
         uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
         with:
           junit-directory: "cilium-junits"
-
-  commit-status-final:
-    if: ${{ always() }}
-    name: Commit Status Final
-    needs: setup-and-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
-        with:
-          sha: ${{ github.sha }}
-          status: ${{ needs.setup-and-test.result }}


### PR DESCRIPTION
The CES migration workflow was recently modified in commit ffb8443 to only execute if the changes in the tested commit are relevant to the tests executed in the workflow. If the setup-and-test job is skipped based on this precondition, the commit-status-final job will fail to execute properly. This is because the status of the setup-and-test job is piped directly into the status parameter of the set-commit-status action, which does not support the value "skipped".

This commit removes the commit-status-final job from the workflow, as this job is only needed if the workflow is executed via a workflow_dispatch trigger that takes a SHA as an input. Additionally, the workflow does not contain a corresponding commit-status-start job, indicating that the commit-status-final job may not be needed.

An example failure can be found here:
https://github.com/cilium/cilium/actions/runs/9601333957/job/26479710471?pr=33288. The logs for the failed commit-status-final job are:

```
Error: state must be one of "error", "failure", "pending", "success"
```

```release-note
Fix bug in CES migration workflow causing it to fail when it should be skipped.
```
