### PR TITLE
examples: Fix subject selector in ingress policy

### DIFF
--- a/examples/kubernetes/servicemesh/policy/allow-ingress-cidr.yaml
+++ b/examples/kubernetes/servicemesh/policy/allow-ingress-cidr.yaml
@@ -4,7 +4,10 @@ metadata:
   name: "allow-cidr"
 spec:
   description: "Allow all the traffic originating from a specific CIDR"
-  endpointSelector: {}
+  endpointSelector:
+    matchExpressions:
+    - key: reserved:ingress
+      operator: Exists
   ingress:
   - fromCIDRSet:
     # Please update the CIDR to match your environment


### PR DESCRIPTION
This policy example selected *all* Endpoints rather than just the
Ingress Endpoint. Since the policy is intended to allow traffic to the
Ingress and not other managed Endpoints, restrict the selector.

Fixes: b68cf99c3bb5 ("ingress: Update docs with network policy example")
Fixes: #31060