### PR TITLE
Attach hubble packet drop events on egress to source pod

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -109,6 +109,9 @@ issues:
     - path: "pkg/ipam/(cidrset|service)/.+\\.go"
       linters:
         - goheader
+    - path: "pkg/hubble/dropeventemitter/fake_recorder.go"
+      linters:
+        - goheader
 
 linters:
   disable-all: true

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -133,6 +133,7 @@ func (d *Daemon) launchHubble() {
 			option.Config.HubbleDropEventsInterval,
 			option.Config.HubbleDropEventsReasons,
 			d.clientset,
+			d.k8sWatcher,
 		)
 
 		observerOpts = append(observerOpts,

--- a/pkg/hubble/dropeventemitter/fake_recorder.go
+++ b/pkg/hubble/dropeventemitter/fake_recorder.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2015 The Kubernetes Authors.
+
+package dropeventemitter
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+)
+
+// FakeRecorder is used as a fake during tests. It is thread safe. It is usable
+// when created manually and not by NewFakeRecorder, however all events may be
+// thrown away in this case.
+type FakeRecorder struct {
+	Events chan string
+
+	IncludeObject bool
+}
+
+func objectString(object runtime.Object, includeObject bool) string {
+	if !includeObject {
+		return ""
+	}
+	return fmt.Sprintf(" involvedObject{kind=%s,apiVersion=%s}",
+		object.GetObjectKind().GroupVersionKind().Kind,
+		object.GetObjectKind().GroupVersionKind().GroupVersion(),
+	)
+}
+
+func annotationsString(annotations map[string]string) string {
+	if len(annotations) == 0 {
+		return ""
+	} else {
+		return " " + fmt.Sprint(annotations)
+	}
+}
+
+func (f *FakeRecorder) writeEvent(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	if f.Events != nil {
+		f.Events <- fmt.Sprintf(eventtype+" "+reason+" "+messageFmt, args...) +
+			objectString(object, f.IncludeObject) + annotationsString(annotations)
+	}
+}
+
+func (f *FakeRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	f.writeEvent(object, nil, eventtype, reason, "%s", message)
+}
+
+func (f *FakeRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	f.writeEvent(object, nil, eventtype, reason, messageFmt, args...)
+}
+
+func (f *FakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	f.writeEvent(object, annotations, eventtype, reason, messageFmt, args...)
+}
+
+func (f *FakeRecorder) WithLogger(logger klog.Logger) record.EventRecorderLogger {
+	return f
+}
+
+// NewFakeRecorder creates new fake event recorder with event channel with
+// buffer of given size.
+func NewFakeRecorder(bufferSize int) *FakeRecorder {
+	return &FakeRecorder{
+		Events: make(chan string, bufferSize),
+	}
+}

--- a/pkg/hubble/dropeventemitter/fake_recorder.go
+++ b/pkg/hubble/dropeventemitter/fake_recorder.go
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2015 The Kubernetes Authors.
 
+// Copy of client-go/tools/record/fake.go
+// Duplicated this since there's no easy way to access UID from client-go's fake recorder
+
 package dropeventemitter
 
 import (
@@ -21,12 +24,18 @@ type FakeRecorder struct {
 }
 
 func objectString(object runtime.Object, includeObject bool) string {
+	var uid string
+	uo, err := runtime.DefaultUnstructuredConverter.ToUnstructured(object)
+	if err != nil && uo["metadata"] != nil && uo["metadata"].(map[string]interface{})["uid"] != nil {
+		uid = uo["metadata"].(map[string]interface{})["uid"].(string)
+	}
 	if !includeObject {
 		return ""
 	}
-	return fmt.Sprintf(" involvedObject{kind=%s,apiVersion=%s}",
+	return fmt.Sprintf(" involvedObject{kind=%s,apiVersion=%s,uid=%s}",
 		object.GetObjectKind().GroupVersionKind().Kind,
 		object.GetObjectKind().GroupVersionKind().GroupVersion(),
+		uid,
 	)
 }
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -107,6 +107,11 @@ type cgroupManager interface {
 	OnDeletePod(pod *slim_corev1.Pod)
 }
 
+type CacheAccessK8SWatcher interface {
+	GetCachedNamespace(namespace string) (*slim_corev1.Namespace, error)
+	GetCachedPod(namespace, name string) (*slim_corev1.Pod, error)
+}
+
 type ipcacheManager interface {
 	// GH-21142: Re-evaluate the need for these APIs
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (namedPortsChanged bool, err error)


### PR DESCRIPTION
 Currently k8s events generated from agent based on hubble drop events
 aren't associated with pods generating the packets. Attaching UID of the
 source pod to k8s event would provider a better UX for debugging packet
 drops.

 This can also be extended in future to attach packets drops on ingress
 to pods. This is however, a lot more involved since the agent's cache
 does not have access to remote pod UIDs in all scenarios.
 
 ```
$ kubectl describe pod/xwing | tail -4
Events:
  Type     Reason      Age                 From    Message
  ----     ------      ----                ----    -------
  Warning  PacketDrop  57s (x29 over 13d)  cilium  Outgoing packet dropped (policy_denied) to world-ipv4 (3.161.82.97) TCP/80
 ```

See commits for more details.

Open question : Is there a better way to extend client-go's fake recorder to return UID info ?

Thanks to @EricMountain for the suggestion.

```release-note
Kubernetes events generated for packet drops are now associated with source pod
```
