### PR TITLE
cni: Revert "cni: Use correct route MTU for various cloud cidrs"

### DIFF
--- a/plugins/cilium-cni/cmd/interface.go
+++ b/plugins/cilium-cni/cmd/interface.go
@@ -58,7 +58,7 @@ func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, 
 
 	if err := routingInfo.Configure(
 		ipConfig.Address.IP,
-		int(conf.RouteMTU),
+		int(conf.DeviceMTU),
 		conf.EgressMultiHomeIPRuleCompat,
 		false,
 	); err != nil {


### PR DESCRIPTION
The PR #32244, that was merged with commit 29a340e, was intended to fix IP fragmentation with WireGuard deployments, causing poor network throughput and increased network latency. Unfortunately, after this PR was merged, users began reporting issues with Cilium modifying the MTU of the default interface of the node. This commit reverts the blamed commit in an attempt to fix said issues.

The surfaced side-effect is tracked in issue #33303.

Fixes: #33258

```release-note
Revert PR #32244 which caused unintended side-effects that negatively impacted network performance.
```
