### PR TITLE
operator: Remove deprecated CES sync errors metric

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -686,7 +686,6 @@ Name                                           Labels                           
 ============================================== ================================ ========================================================
 ``number_of_ceps_per_ces``                                                      The number of CEPs batched in a CES
 ``number_of_cep_changes_per_ces``              ``opcode``                       The number of changed CEPs in each CES update
-``ces_sync_errors_total``                                                       Number of CES sync errors
 ``ces_sync_total``                             ``outcome``                      The number of completed CES syncs by outcome
 ``ces_queueing_delay_seconds``                                                  CiliumEndpointSlice queueing delay in seconds
 ============================================== ================================ ========================================================

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -439,7 +439,7 @@ Removed Metrics
 
 The following deprecated metrics were removed:
 
-* TBD
+* ``cilium_ces_sync_errors_total``
 
 Changed Metrics
 ~~~~~~~~~~~~~~~

--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -260,9 +260,6 @@ func (c *Controller) handleErr(err error, key CESName) {
 		return
 	}
 
-	// Increment error count for sync errors
-	c.metrics.CiliumEndpointSliceSyncErrors.Inc()
-
 	if c.queue.NumRequeues(key) < maxRetries {
 		c.queue.AddRateLimited(key)
 		return

--- a/operator/pkg/ciliumendpointslice/metrics.go
+++ b/operator/pkg/ciliumendpointslice/metrics.go
@@ -47,12 +47,6 @@ func NewMetrics() *Metrics {
 			Help:      "The number of changed CEPs in each CES update",
 		}, []string{LabelOpcode}),
 
-		CiliumEndpointSliceSyncErrors: metric.NewCounter(metric.CounterOpts{
-			Namespace: metrics.CiliumOperatorNamespace,
-			Name:      "ces_sync_errors_total",
-			Help:      "Number of CES sync errors",
-		}),
-
 		CiliumEndpointSliceSyncTotal: metric.NewCounterVec(metric.CounterOpts{
 			Namespace: metrics.CiliumOperatorNamespace,
 			Name:      "ces_sync_total",
@@ -79,11 +73,6 @@ type Metrics struct {
 
 	// CiliumEndpointSliceSyncTotal indicates the total number of completed CES syncs with k8s-apiserver by success/fail outcome.
 	CiliumEndpointSliceSyncTotal metric.Vec[metric.Counter]
-
-	// CiliumEndpointSliceSyncErrors used to track the total number of errors occurred during syncing CES with k8s-apiserver.
-	// This metric is going to be deprecated in Cilium 1.14 and removed in 1.15.
-	// It is replaced by CiliumEndpointSliceSyncTotal metric.
-	CiliumEndpointSliceSyncErrors metric.Counter
 
 	// CiliumEndpointSliceQueueDelay measures the time spent by CES's in the workqueue. This measures time difference between
 	// CES insert in the workqueue and removal from workqueue.


### PR DESCRIPTION
Deprecated in v1.14 so we can remove it in v1.16.

Fixes: https://github.com/cilium/cilium/issues/23747

Signed-off-by: Chris Tarazi <chris@isovalent.com>
