### PR TITLE
fix: trigger host endpoint regeneration only when required

### DIFF
--- a/pkg/endpointmanager/host.go
+++ b/pkg/endpointmanager/host.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/node"
 )
 
@@ -31,7 +32,10 @@ func (mgr *endpointManager) HostEndpointExists() bool {
 
 func (mgr *endpointManager) startNodeLabelsObserver(old map[string]string) {
 	mgr.localNodeStore.Observe(context.Background(), func(ln node.LocalNode) {
-		if maps.Equal(old, ln.Labels) {
+		oldIdtyLabels, _ := labelsfilter.Filter(labels.Map2Labels(old, labels.LabelSourceK8s))
+		newIdtyLabels, _ := labelsfilter.Filter(labels.Map2Labels(ln.Labels, labels.LabelSourceK8s))
+		if maps.Equal(oldIdtyLabels.K8sStringMap(), newIdtyLabels.K8sStringMap()) {
+			log.Debug("Host endpoint identity labels unchanged, skipping labels update")
 			return
 		}
 

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/node"
@@ -990,4 +991,122 @@ func TestMissingNodeLabelsUpdate(t *testing.T) {
 	require.EqualValues(t, ok, true)
 	got := hostEP.OpLabels.IdentityLabels().K8sStringMap()
 	require.EqualValues(t, map[string]string{"k2": "v2"}, got)
+}
+
+func TestUpdateHostEndpointLabels(t *testing.T) {
+	// Initialize label filter config.
+	labelsfilter.ParseLabelPrefixCfg([]string{"k8s:!ignore1", "k8s:!ignore2"}, nil, "")
+	s := setupEndpointManagerSuite(t)
+	mgr := New(&dummyEpSyncher{}, nil, nil)
+	hostEPID := uint16(17)
+	type args struct {
+		oldLabels, newLabels map[string]string
+	}
+	type want struct {
+		labels      map[string]string
+		labelsCheck assert.ComparisonAssertionFunc
+	}
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWant   func() want
+		preTestRun  func()
+		postTestRun func()
+	}{
+		{
+			name: "Add labels",
+			preTestRun: func() {
+				ep := endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep.SetIsHost(true)
+				ep.ID = hostEPID
+				require.Nil(t, mgr.expose(ep))
+			},
+			setupArgs: func() args {
+				return args{
+					newLabels: map[string]string{"k1": "v1"},
+				}
+			},
+			setupWant: func() want {
+				return want{
+					labels:      map[string]string{"k1": "v1"},
+					labelsCheck: assert.EqualValues,
+				}
+			},
+			postTestRun: func() {
+				if hostEP, ok := mgr.endpoints[hostEPID]; ok {
+					mgr.WaitEndpointRemoved(hostEP)
+				}
+			},
+		},
+		{
+			name: "Update labels",
+			preTestRun: func() {
+				ep := endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep.SetIsHost(true)
+				ep.ID = hostEPID
+				ep.OpLabels.Custom = labels.Labels{"k1": labels.NewLabel("k1", "v1", labels.LabelSourceK8s)}
+				require.Nil(t, mgr.expose(ep))
+			},
+			setupArgs: func() args {
+				return args{
+					oldLabels: map[string]string{"k1": "v1"},
+					newLabels: map[string]string{"k2": "v2"},
+				}
+			},
+			setupWant: func() want {
+				return want{
+					labels:      map[string]string{"k2": "v2"},
+					labelsCheck: assert.EqualValues,
+				}
+			},
+			postTestRun: func() {
+				if hostEP, ok := mgr.endpoints[hostEPID]; ok {
+					mgr.WaitEndpointRemoved(hostEP)
+				}
+			},
+		},
+		{
+			name: "Ignore labels",
+			preTestRun: func() {
+				ep := endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep.SetIsHost(true)
+				ep.ID = hostEPID
+				ep.OpLabels.Custom = labels.Labels{"k1": labels.NewLabel("k1", "v1", labels.LabelSourceK8s)}
+				require.Nil(t, mgr.expose(ep))
+			},
+			setupArgs: func() args {
+				return args{
+					oldLabels: map[string]string{"k1": "v1"},
+					newLabels: map[string]string{"k1": "v1", "ignore1": "v2", "ignore2": "v2"},
+				}
+			},
+			setupWant: func() want {
+				return want{
+					labels:      map[string]string{"k1": "v1"},
+					labelsCheck: assert.EqualValues,
+				}
+			},
+			postTestRun: func() {
+				if hostEP, ok := mgr.endpoints[hostEPID]; ok {
+					mgr.WaitEndpointRemoved(hostEP)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt.preTestRun()
+		args := tt.setupArgs()
+		want := tt.setupWant()
+		mgr.localNodeStore = node.NewTestLocalNodeStore(node.LocalNode{Node: types.Node{
+			Labels: args.oldLabels,
+		}})
+		mgr.startNodeLabelsObserver(args.oldLabels)
+		mgr.localNodeStore.Update(func(ln *node.LocalNode) { ln.Labels = args.newLabels })
+
+		hostEP, ok := mgr.endpoints[hostEPID]
+		require.EqualValues(t, ok, true)
+		got := hostEP.OpLabels.IdentityLabels().K8sStringMap()
+		want.labelsCheck(t, want.labels, got, "Test Name: %s", tt.name)
+		tt.postTestRun()
+	}
 }


### PR DESCRIPTION
Explicitly check if host endpoint's identity labels are changed before calling endpoint.UpdateLabelsFrom function. Without this change, host endpoint is regenerated even if the old and new identity labels are the same.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Host endpoint is regenerated even when the identity labels are unchanged. If a node label changes frequently (in our env every 1-2 seconds), the host endpoint is regenerated unnecessarily. These regenerations overwhelmed the cilium agent logs. 

For pod endpoints, we explicitly check if the labels are changed:

https://github.com/cilium/cilium/blob/3fc57b38abe6179ac4c8fc21dd515c038ab45226/pkg/k8s/watchers/pod.go#L475-L479

This change checks the node endpoint labels to avoid unnecessary endpoint regenerations. 

```release-note
Skip regenerating host endpoint on k8s node labels update if identity labels are unchanged
```
