### PR TITLE
docs: BGPv2 CP documentation update

### DIFF
--- a/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
@@ -84,10 +84,10 @@ resource.
 
 The ``CiliumBGPPeerConfig`` resource contains configuration options for:
 
-- :ref:`Transport <bgp_peer_configuration_transport>`
 - :ref:`MD5 Password <bgp_peer_configuration_password>`
 - :ref:`Timers <bgp_peer_configuration_timers>`
 - :ref:`Graceful Restart <bgp_peer_configuration_graceful_restart>`
+- :ref:`Transport <bgp_peer_configuration_transport>`
 - :ref:`Address Families <bgp_peer_configuration_afi>`
 
 Here is an example configuration of the ``CiliumBGPPeerConfig`` resource. In the next
@@ -100,11 +100,7 @@ section, we will go over each configuration option.
     metadata:
       name: cilium-peer
     spec:
-      transport:
-        localPort: 179
-        peerPort: 179
       timers:
-        connectRetryTimeSeconds: 12
         holdTimeSeconds: 9
         keepAliveTimeSeconds: 3
       authSecretRef: bgp-auth-secret
@@ -117,31 +113,6 @@ section, we will go over each configuration option.
           advertisements:
             matchLabels:
               advertise: "bgp"
-
-.. _bgp_peer_configuration_transport:
-
-Transport
----------
-
-The transport section of ``CiliumBGPPeerConfig`` can be used to configure custom source and
-destination ports for the BGP session with the peer. ``LocalPort`` and ``PeerPort`` fields are used to
-configure the source and destination ports, respectively.
-
-By default, when BGP is operating in `active mode <https://datatracker.ietf.org/doc/html/rfc4271#section-8.2.1>`_
-( with the Cilium agent initiating the TCP connection), destination port is 179 and source port is dynamic.
-
-Here is an example of setting the transport configuration:
-
-.. code-block:: yaml
-
-    apiVersion: cilium.io/v2alpha1
-    kind: CiliumBGPPeerConfig
-    metadata:
-      name: cilium-peer
-    spec:
-      transport:
-        localPort: 179
-        peerPort: 179
 
 
 .. _bgp_peer_configuration_password:
@@ -275,6 +246,31 @@ Default value of ``RestartTime`` is 120 seconds. More details on graceful restar
 
 .. _RFC-4724 : https://www.rfc-editor.org/rfc/rfc4724.html
 .. _RFC-8538 : https://www.rfc-editor.org/rfc/rfc8538.html
+
+
+.. _bgp_peer_configuration_transport:
+
+Transport
+---------
+
+The transport section of ``CiliumBGPPeerConfig`` can be used to configure a custom
+destination port for a peer's BGP session.
+
+By default, when BGP is operating in `active mode <https://datatracker.ietf.org/doc/html/rfc4271#section-8.2.1>`_
+(with the Cilium agent initiating the TCP connection), the destination port is 179 and the source port is ephemeral.
+
+Here is an example of setting the transport configuration:
+
+.. code-block:: yaml
+
+    apiVersion: cilium.io/v2alpha1
+    kind: CiliumBGPPeerConfig
+    metadata:
+      name: cilium-peer
+    spec:
+      transport:
+        peerPort: 179
+
 
 .. _bgp_peer_configuration_afi:
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->
This PR updates Cilium's documentation for the BGPv2 Control Plane.  In specific, it adds a caution note for the transport section.

This update was prompted by https://cilium.slack.com/archives/C53TG4J4R/p1718753533112889.  In that, I had started a thread regarding extremely slow convergence after a neighbor reset event.  In my testing, I observed a 2+ minute delay before Cilium's BGP session re-established with a remote BGP speaker after issuing a hard reset of the session from the remote speaker's side.

After removing:
```
spec:
  transport:
    localPort: 179
    peerPort: 179
```

From my `CiliumBGPPeerConfig`, what previously took 2+ minutes was now less than 10 seconds.

```release-note
Documentation update for BGPv2 transport configuration
```

## Testing

For testing, I ran `make html` from the Documentation directory.  Then I opened the modified HTML file from `_build/`.  A screenshot is shown below.
<img width="1033" alt="Screenshot 2024-06-20 at 5 06 10 PM" src="https://github.com/cilium/cilium/assets/167127161/c88a39d7-c130-46c8-a842-3d02971013d9">
