### PR TITLE
policy: Do not scan all entries when adding new ones

### DIFF
--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -394,7 +394,7 @@ func combineL4L7(l4 []api.PortRule, l7 *api.L7Rules) []api.PortRule {
 }
 
 func (s *RedirectSuite) testMapState(initMap map[policy.Key]policy.MapStateEntry) policy.MapState {
-	return policy.NewMapState().WithState(initMap)
+	return policy.NewMapState().WithState(initMap, s.do.repo.GetSelectorCache())
 }
 
 func TestRedirectWithDeny(t *testing.T) {

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -393,6 +393,10 @@ func combineL4L7(l4 []api.PortRule, l7 *api.L7Rules) []api.PortRule {
 	return result
 }
 
+func (s *RedirectSuite) testMapState(initMap map[policy.Key]policy.MapStateEntry) policy.MapState {
+	return policy.NewMapState().WithState(initMap)
+}
+
 func TestRedirectWithDeny(t *testing.T) {
 	s := setupRedirectSuite(t)
 	ep := s.NewTestEndpoint(t)
@@ -408,7 +412,7 @@ func TestRedirectWithDeny(t *testing.T) {
 	err = ep.setDesiredPolicy(res)
 	require.Nil(t, err)
 
-	expected := policy.NewMapState(map[policy.Key]policy.MapStateEntry{
+	expected := s.testMapState(map[policy.Key]policy.MapStateEntry{
 		mapKeyAllowAllE: {
 			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
 		},
@@ -437,7 +441,7 @@ func TestRedirectWithDeny(t *testing.T) {
 	// entries and make any conclusions from it.
 	require.Equal(t, 1, len(desiredRedirects))
 
-	expected2 := policy.NewMapState(map[policy.Key]policy.MapStateEntry{
+	expected2 := s.testMapState(map[policy.Key]policy.MapStateEntry{
 		mapKeyAllowAllE: {
 			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
 		},
@@ -571,7 +575,7 @@ func TestRedirectWithPriority(t *testing.T) {
 	err = ep.setDesiredPolicy(res)
 	require.Nil(t, err)
 
-	expected := policy.NewMapState(map[policy.Key]policy.MapStateEntry{
+	expected := s.testMapState(map[policy.Key]policy.MapStateEntry{
 		mapKeyAllowAllE: {
 			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
 		},
@@ -598,7 +602,7 @@ func TestRedirectWithPriority(t *testing.T) {
 	require.Equal(t, crd1Port, desiredRedirects["12345:ingress:TCP:80:/cec1/listener1"])
 	require.Equal(t, 2, len(desiredRedirects))
 
-	expected2 := policy.NewMapState(map[policy.Key]policy.MapStateEntry{
+	expected2 := s.testMapState(map[policy.Key]policy.MapStateEntry{
 		mapKeyAllowAllE: {
 			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
 		},
@@ -652,7 +656,7 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 	err = ep.setDesiredPolicy(res)
 	require.Nil(t, err)
 
-	expected := policy.NewMapState(map[policy.Key]policy.MapStateEntry{
+	expected := s.testMapState(map[policy.Key]policy.MapStateEntry{
 		mapKeyAllowAllE: {
 			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
 		},
@@ -679,7 +683,7 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 	require.Equal(t, crd1Port, desiredRedirects["12345:ingress:TCP:80:/cec1/listener1"])
 	require.Equal(t, 2, len(desiredRedirects))
 
-	expected2 := policy.NewMapState(map[policy.Key]policy.MapStateEntry{
+	expected2 := s.testMapState(map[policy.Key]policy.MapStateEntry{
 		mapKeyAllowAllE: {
 			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
 		},

--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -116,3 +116,23 @@ func NetsContainsAny(a, b []*net.IPNet) bool {
 	}
 	return false
 }
+
+// PrefixesContainsAny checks that any subnet in the `a` subnet group *fully*
+// contains any of the subnets in the `b` subnet group.
+func PrefixesContainsAny(a, b []netip.Prefix) bool {
+	for _, an := range a {
+		aMask := an.Bits()
+		aIsIPv4 := an.Addr().Is4()
+		for _, bn := range b {
+			bIsIPv4 := bn.Addr().Is4()
+			isSameFamily := aIsIPv4 == bIsIPv4
+			if isSameFamily {
+				bMask := bn.Bits()
+				if bMask >= aMask && an.Contains(bn.Addr()) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -116,23 +116,3 @@ func NetsContainsAny(a, b []*net.IPNet) bool {
 	}
 	return false
 }
-
-// PrefixesContainsAny checks that any subnet in the `a` subnet group *fully*
-// contains any of the subnets in the `b` subnet group.
-func PrefixesContainsAny(a, b []netip.Prefix) bool {
-	for _, an := range a {
-		aMask := an.Bits()
-		aIsIPv4 := an.Addr().Is4()
-		for _, bn := range b {
-			bIsIPv4 := bn.Addr().Is4()
-			isSameFamily := aIsIPv4 == bIsIPv4
-			if isSameFamily {
-				bMask := bn.Bits()
-				if bMask >= aMask && an.Contains(bn.Addr()) {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -435,7 +435,7 @@ func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.Labe
 	// because this test suite doesn't have a notion of traffic direction, so
 	// the extra egress allow-all is technically correct, but omitted from the
 	// expected output that's asserted against for the sake of brevity.
-	epp.policyMapState.delete(mapKeyAllowAllE_)
+	epp.policyMapState.delete(mapKeyAllowAllE_, nil)
 
 	return epp.policyMapState, nil
 }
@@ -488,7 +488,7 @@ func Test_MergeL3(t *testing.T) {
 	selectorCache := testNewSelectorCache(identityCache)
 
 	testMapState := func(initMap map[Key]MapStateEntry) MapState {
-		return newMapState().WithState(initMap)
+		return newMapState().WithState(initMap, selectorCache)
 	}
 
 	type authResult map[identity.NumericIdentity]AuthTypes
@@ -758,16 +758,16 @@ func parseTable(test string) generatedBPFKey {
 // function and non unit-test code should be seen as coincidental.
 // The algorithm represented in this function should be the source of truth
 // of our expectations when enforcing multiple types of policies.
-func testCaseToMapState(t generatedBPFKey) MapState {
+func testCaseToMapState(t generatedBPFKey, identities Identities) MapState {
 	m := newMapState()
 
 	if t.L3Key.L3 != nil {
 		if t.L3Key.Deny != nil && *t.L3Key.Deny {
-			m.denies.upsert(mapKeyDeny_Foo__, mapEntryL7Deny_())
+			m.denies.upsert(mapKeyDeny_Foo__, mapEntryL7Deny_(), identities)
 		} else {
 			// If L7 is not set or if it explicitly set but it's false
 			if t.L3Key.L7 == nil || !*t.L3Key.L7 {
-				m.allows.upsert(mapKeyAllowFoo__, mapEntryL7None_())
+				m.allows.upsert(mapKeyAllowFoo__, mapEntryL7None_(), identities)
 			}
 			// there's no "else" because we don't support L3L7 policies, i.e.,
 			// a L4 port needs to be specified.
@@ -775,31 +775,31 @@ func testCaseToMapState(t generatedBPFKey) MapState {
 	}
 	if t.L4Key.L3 != nil {
 		if t.L4Key.Deny != nil && *t.L4Key.Deny {
-			m.denies.upsert(mapKeyDeny____L4, mapEntryL7Deny_())
+			m.denies.upsert(mapKeyDeny____L4, mapEntryL7Deny_(), identities)
 		} else {
 			// If L7 is not set or if it explicitly set but it's false
 			if t.L4Key.L7 == nil || !*t.L4Key.L7 {
-				m.allows.upsert(mapKeyAllow___L4, mapEntryL7None_())
+				m.allows.upsert(mapKeyAllow___L4, mapEntryL7None_(), identities)
 			} else {
 				// L7 is set and it's true then we should expected a mapEntry
 				// with L7 redirection.
-				m.allows.upsert(mapKeyAllow___L4, mapEntryL7Proxy())
+				m.allows.upsert(mapKeyAllow___L4, mapEntryL7Proxy(), identities)
 			}
 		}
 	}
 	if t.L3L4Key.L3 != nil {
 		if t.L3L4Key.Deny != nil && *t.L3L4Key.Deny {
-			m.denies.upsert(mapKeyDeny_FooL4, mapEntryL7Deny_())
+			m.denies.upsert(mapKeyDeny_FooL4, mapEntryL7Deny_(), identities)
 		} else {
 			// If L7 is not set or if it explicitly set but it's false
 			if t.L3L4Key.L7 == nil || !*t.L3L4Key.L7 {
-				m.allows.upsert(mapKeyAllowFooL4, mapEntryL7None_())
+				m.allows.upsert(mapKeyAllowFooL4, mapEntryL7None_(), identities)
 			} else {
 				// L7 is set and it's true then we should expected a mapEntry
 				// with L7 redirection only if we haven't set it already
 				// for an existing L4-only.
 				if t.L4Key.L7 == nil || !*t.L4Key.L7 {
-					m.allows.upsert(mapKeyAllowFooL4, mapEntryL7Proxy())
+					m.allows.upsert(mapKeyAllowFooL4, mapEntryL7Proxy(), identities)
 				}
 			}
 		}
@@ -810,12 +810,12 @@ func testCaseToMapState(t generatedBPFKey) MapState {
 	denyL3L4, denyL3L4exists := m.denies.Lookup(mapKeyDeny_FooL4)
 	allowL4, allowL4exists := m.allows.Lookup(mapKeyAllow___L4)
 	if allowL4exists && !allowL4.IsDeny && denyL3exists && denyL3.IsDeny && denyL3L4exists && denyL3L4.IsDeny {
-		m.AddDependent(mapKeyDeny_Foo__, mapKeyDeny_FooL4, ChangeState{})
+		m.AddDependent(mapKeyDeny_Foo__, mapKeyDeny_FooL4, identities, ChangeState{})
 	}
 	return m
 }
 
-func generateMapStates() []MapState {
+func generateMapStates(identities Identities) []MapState {
 	rawTestTable := []string{
 		"X	X	X	X	X	X	X	X	X	X	X	X", // 0
 		"X	X	X	X	X	X	X	X	1	0	0	0",
@@ -1084,7 +1084,7 @@ func generateMapStates() []MapState {
 	mapStates := make([]MapState, 0, len(rawTestTable))
 	for _, rawTest := range rawTestTable {
 		testCase := parseTable(rawTest)
-		mapState := testCaseToMapState(testCase)
+		mapState := testCaseToMapState(testCase, identities)
 		mapStates = append(mapStates, mapState)
 	}
 
@@ -1133,7 +1133,7 @@ func Test_MergeRules(t *testing.T) {
 	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
 	testMapState := func(initMap map[Key]MapStateEntry) MapState {
-		return newMapState().WithState(initMap)
+		return newMapState().WithState(initMap, selectorCache)
 	}
 
 	tests := []struct {
@@ -1179,7 +1179,7 @@ func Test_MergeRules(t *testing.T) {
 		{31, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
 	}
 
-	expectedMapState := generateMapStates()
+	expectedMapState := generateMapStates(selectorCache)
 	// Add the auto generated test cases for the deny policies
 	generatedIdx := 32
 	for i := generatedIdx; i < 256; i++ {
@@ -1230,7 +1230,7 @@ func Test_MergeRules(t *testing.T) {
 					return true
 				}
 				v.DerivedFromRules = labels.LabelArrayList(nil).Sort()
-				mapstate.insert(k, v)
+				mapstate.insert(k, v, selectorCache)
 				return true
 			})
 			if equal := assert.EqualExportedValues(t, expectedMapState[tt.test], mapstate); !equal {
@@ -1262,7 +1262,7 @@ func Test_MergeRulesWithNamedPorts(t *testing.T) {
 	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
 	testMapState := func(initMap map[Key]MapStateEntry) MapState {
-		return newMapState().WithState(initMap)
+		return newMapState().WithState(initMap, selectorCache)
 	}
 
 	tests := []struct {
@@ -1344,7 +1344,7 @@ func Test_AllowAll(t *testing.T) {
 	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
 	testMapState := func(initMap map[Key]MapStateEntry) MapState {
-		return newMapState().WithState(initMap)
+		return newMapState().WithState(initMap, selectorCache)
 	}
 
 	tests := []struct {
@@ -1675,7 +1675,7 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
 	testMapState := func(initMap map[Key]MapStateEntry) MapState {
-		return newMapState().WithState(initMap)
+		return newMapState().WithState(initMap, selectorCache)
 	}
 
 	tests := []struct {
@@ -1796,7 +1796,7 @@ func Test_EnsureEntitiesSelectableByCIDR(t *testing.T) {
 	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
 	testMapState := func(initMap map[Key]MapStateEntry) MapState {
-		return newMapState().WithState(initMap)
+		return newMapState().WithState(initMap, selectorCache)
 	}
 
 	tests := []struct {

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -487,6 +487,10 @@ func Test_MergeL3(t *testing.T) {
 	}
 	selectorCache := testNewSelectorCache(identityCache)
 
+	testMapState := func(initMap map[Key]MapStateEntry) MapState {
+		return newMapState().WithState(initMap)
+	}
+
 	type authResult map[identity.NumericIdentity]AuthTypes
 	tests := []struct {
 		test   int
@@ -497,7 +501,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			0,
 			api.Rules{ruleL3__AllowFoo, ruleL3__AllowBar},
-			NewMapState(map[Key]MapStateEntry{
+			testMapState(map[Key]MapStateEntry{
 				mapKeyAllowFoo__: mapEntryL7None_(lblsL3__AllowFoo),
 				mapKeyAllowBar__: mapEntryL7None_(lblsL3__AllowBar),
 			}),
@@ -509,7 +513,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			1,
 			api.Rules{ruleL3__AllowFoo, ruleL3L4__Allow},
-			NewMapState(map[Key]MapStateEntry{
+			testMapState(map[Key]MapStateEntry{
 				mapKeyAllowFoo__: mapEntryL7None_(lblsL3__AllowFoo),
 				mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow),
 			}),
@@ -521,7 +525,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			2,
 			api.Rules{ruleL3__AllowFoo, ruleL3__AllowBarAuth},
-			NewMapState(map[Key]MapStateEntry{
+			testMapState(map[Key]MapStateEntry{
 				mapKeyAllowFoo__: mapEntryL7None_(lblsL3__AllowFoo),
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
 			}),
@@ -533,7 +537,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			3,
 			api.Rules{ruleL3__AllowFoo, ruleL3__AllowBarAuth, rule__L4__AllowAuth},
-			NewMapState(map[Key]MapStateEntry{
+			testMapState(map[Key]MapStateEntry{
 				mapKeyAllow___L4: mapEntryL7Auth_(AuthTypeSpire, lbls__L4__Allow),
 				mapKeyAllowFoo__: mapEntryL7None_(lblsL3__AllowFoo),
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
@@ -546,7 +550,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			4,
 			api.Rules{rule____AllowAll, ruleL3__AllowBarAuth},
-			NewMapState(map[Key]MapStateEntry{
+			testMapState(map[Key]MapStateEntry{
 				mapKeyAllowAll__: mapEntryL7None_(lbls____AllowAll),
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
 			}),
@@ -558,7 +562,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			5,
 			api.Rules{rule____AllowAllAuth, ruleL3__AllowBar},
-			NewMapState(map[Key]MapStateEntry{
+			testMapState(map[Key]MapStateEntry{
 				mapKeyAllowAll__: mapEntryL7Auth_(AuthTypeSpire, lbls____AllowAll),
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeSpire, lblsL3__AllowBar),
 			}),
@@ -570,7 +574,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			6,
 			api.Rules{rule____AllowAllAuth, rule__L4__Allow},
-			NewMapState(map[Key]MapStateEntry{
+			testMapState(map[Key]MapStateEntry{
 				mapKeyAllowAll__: mapEntryL7Auth_(AuthTypeSpire, lbls____AllowAll),
 				mapKeyAllow___L4: mapEntryL7Auth_(AuthTypeSpire, lbls__L4__Allow),
 			}),
@@ -582,7 +586,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			7,
 			api.Rules{rule____AllowAllAuth, ruleL3__AllowBar, rule__L4__Allow},
-			NewMapState(map[Key]MapStateEntry{
+			testMapState(map[Key]MapStateEntry{
 				mapKeyAllowAll__: mapEntryL7Auth_(AuthTypeSpire, lbls____AllowAll),
 				mapKeyAllow___L4: mapEntryL7Auth_(AuthTypeSpire, lbls__L4__Allow),
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeSpire, lblsL3__AllowBar),
@@ -595,7 +599,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			8,
 			api.Rules{rule____AllowAll, ruleL3__AllowBar, rule__L4__Allow},
-			NewMapState(map[Key]MapStateEntry{
+			testMapState(map[Key]MapStateEntry{
 				mapKeyAllowAll__: mapEntryL7Auth_(AuthTypeDisabled, lbls____AllowAll),
 				mapKeyAllow___L4: mapEntryL7Auth_(AuthTypeDisabled, lbls__L4__Allow),
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeDisabled, lblsL3__AllowBar),
@@ -608,7 +612,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			9,
 			api.Rules{rule____AllowAll, rule__L4__Allow, ruleL3__AllowBarAuth},
-			NewMapState(map[Key]MapStateEntry{
+			testMapState(map[Key]MapStateEntry{
 				mapKeyAllowAll__: mapEntryL7Auth_(AuthTypeDisabled, lbls____AllowAll),
 				mapKeyAllow___L4: mapEntryL7Auth_(AuthTypeDisabled, lbls__L4__Allow),
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
@@ -622,7 +626,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			10, // Same as 9, but the L3L4 entry is created by an explicit rule.
 			api.Rules{rule____AllowAll, rule__L4__Allow, ruleL3__AllowBarAuth, ruleL3L4AllowBarAuth},
-			NewMapState(map[Key]MapStateEntry{
+			testMapState(map[Key]MapStateEntry{
 				mapKeyAllowAll__: mapEntryL7Auth_(AuthTypeDisabled, lbls____AllowAll),
 				mapKeyAllow___L4: mapEntryL7Auth_(AuthTypeDisabled, lbls__L4__Allow),
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
@@ -755,7 +759,7 @@ func parseTable(test string) generatedBPFKey {
 // The algorithm represented in this function should be the source of truth
 // of our expectations when enforcing multiple types of policies.
 func testCaseToMapState(t generatedBPFKey) MapState {
-	m := newMapState(nil)
+	m := newMapState()
 
 	if t.L3Key.L3 != nil {
 		if t.L3Key.Deny != nil && *t.L3Key.Deny {
@@ -1128,6 +1132,10 @@ func Test_MergeRules(t *testing.T) {
 	selectorCache := testNewSelectorCache(identityCache)
 	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
+	testMapState := func(initMap map[Key]MapStateEntry) MapState {
+		return newMapState().WithState(initMap)
+	}
+
 	tests := []struct {
 		test     int
 		rules    api.Rules
@@ -1137,38 +1145,38 @@ func Test_MergeRules(t *testing.T) {
 		// https://docs.google.com/spreadsheets/d/1WANIoZGB48nryylQjjOw6lKjI80eVgPShrdMTMalLEw/edit?usp=sharing
 		//
 		//  Rule 0                   | Rule 1         | Rule 2         | Rule 3         | Rule 4         | Rule 5         | Rule 6         | Rule 7         | Desired BPF map state
-		{0, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, newMapState(nil)},
-		{1, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{2, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
-		{3, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{4, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow)})},
-		{5, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{6, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
-		{7, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
-		{8, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},
-		{9, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{10, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},
-		{11, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{12, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                      // L3L4 entry suppressed to allow L4-only entry to redirect
-		{13, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                  // L3L4 entry suppressed to allow L4-only entry to redirect
-		{14, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                     // L3L4 entry suppressed to allow L4-only entry to redirect
-		{15, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // L3L4 entry suppressed to allow L4-only entry to redirect
-		{16, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow)})},
-		{17, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{18, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
-		{19, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{20, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow)})},
-		{21, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{22, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
-		{23, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{24, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                      // identical L3L4 entry suppressed
-		{25, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                  // identical L3L4 entry suppressed
-		{26, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
-		{27, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
-		{28, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                      // identical L3L4 entry suppressed
-		{29, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                  // identical L3L4 entry suppressed
-		{30, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
-		{31, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
+		{0, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(nil)},
+		{1, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{2, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{3, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{4, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow)})},
+		{5, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{6, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
+		{7, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
+		{8, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},
+		{9, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{10, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},
+		{11, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{12, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                      // L3L4 entry suppressed to allow L4-only entry to redirect
+		{13, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                  // L3L4 entry suppressed to allow L4-only entry to redirect
+		{14, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                     // L3L4 entry suppressed to allow L4-only entry to redirect
+		{15, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // L3L4 entry suppressed to allow L4-only entry to redirect
+		{16, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow)})},
+		{17, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{18, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{19, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{20, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow)})},
+		{21, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{22, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{23, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{24, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                      // identical L3L4 entry suppressed
+		{25, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                  // identical L3L4 entry suppressed
+		{26, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
+		{27, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
+		{28, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                      // identical L3L4 entry suppressed
+		{29, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                  // identical L3L4 entry suppressed
+		{30, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
+		{31, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
 	}
 
 	expectedMapState := generateMapStates()
@@ -1253,6 +1261,10 @@ func Test_MergeRulesWithNamedPorts(t *testing.T) {
 	selectorCache := testNewSelectorCache(identityCache)
 	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
+	testMapState := func(initMap map[Key]MapStateEntry) MapState {
+		return newMapState().WithState(initMap)
+	}
+
 	tests := []struct {
 		test     int
 		rules    api.Rules
@@ -1262,38 +1274,38 @@ func Test_MergeRulesWithNamedPorts(t *testing.T) {
 		// https://docs.google.com/spreadsheets/d/1WANIoZGB48nryylQjjOw6lKjI80eVgPShrdMTMalLEw/edit?usp=sharing
 		//
 		//  Rule 0                   | Rule 1         | Rule 2         | Rule 3         | Rule 4         | Rule 5         | Rule 6         | Rule 7         | Desired BPF map state
-		{0, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, newMapState(nil)},
-		{1, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{2, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
-		{3, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{4, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow)})},
-		{5, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{6, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
-		{7, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
-		{8, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},
-		{9, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{10, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},
-		{11, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{12, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                        // L3L4 entry suppressed to allow L4-only entry to redirect
-		{13, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                    // L3L4 entry suppressed to allow L4-only entry to redirect
-		{14, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                     // L3L4 entry suppressed to allow L4-only entry to redirect
-		{15, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // L3L4 entry suppressed to allow L4-only entry to redirect
-		{16, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow)})},
-		{17, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{18, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
-		{19, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{20, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow)})},
-		{21, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{22, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
-		{23, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{24, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                          // identical L3L4 entry suppressed
-		{25, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                      // identical L3L4 entry suppressed
-		{26, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                       // identical L3L4 entry suppressed
-		{27, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},   // identical L3L4 entry suppressed
-		{28, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                        // identical L3L4 entry suppressed
-		{29, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                    // identical L3L4 entry suppressed
-		{30, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
-		{31, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
+		{0, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(nil)},
+		{1, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{2, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{3, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{4, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow)})},
+		{5, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{6, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
+		{7, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
+		{8, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},
+		{9, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{10, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},
+		{11, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{12, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                        // L3L4 entry suppressed to allow L4-only entry to redirect
+		{13, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                    // L3L4 entry suppressed to allow L4-only entry to redirect
+		{14, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                     // L3L4 entry suppressed to allow L4-only entry to redirect
+		{15, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // L3L4 entry suppressed to allow L4-only entry to redirect
+		{16, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow)})},
+		{17, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{18, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{19, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{20, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow)})},
+		{21, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{22, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{23, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{24, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                          // identical L3L4 entry suppressed
+		{25, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                      // identical L3L4 entry suppressed
+		{26, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                       // identical L3L4 entry suppressed
+		{27, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},   // identical L3L4 entry suppressed
+		{28, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                        // identical L3L4 entry suppressed
+		{29, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                    // identical L3L4 entry suppressed
+		{30, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
+		{31, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, testMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
 	}
 	for _, tt := range tests {
 		repo := newPolicyDistillery(selectorCache)
@@ -1331,14 +1343,18 @@ func Test_AllowAll(t *testing.T) {
 	selectorCache := testNewSelectorCache(identityCache)
 	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
+	testMapState := func(initMap map[Key]MapStateEntry) MapState {
+		return newMapState().WithState(initMap)
+	}
+
 	tests := []struct {
 		test     int
 		selector api.EndpointSelector
 		rules    api.Rules
 		expected MapState
 	}{
-		{0, api.EndpointSelectorNone, api.Rules{rule____AllowAll}, NewMapState(map[Key]MapStateEntry{mapKeyAllowAll__: mapEntryL7None_(lblsAllowAllIngress)})},
-		{1, api.WildcardEndpointSelector, api.Rules{rule____AllowAll}, NewMapState(map[Key]MapStateEntry{mapKeyAllowAll__: mapEntryL7None_(lbls____AllowAll)})},
+		{0, api.EndpointSelectorNone, api.Rules{rule____AllowAll}, testMapState(map[Key]MapStateEntry{mapKeyAllowAll__: mapEntryL7None_(lblsAllowAllIngress)})},
+		{1, api.WildcardEndpointSelector, api.Rules{rule____AllowAll}, testMapState(map[Key]MapStateEntry{mapKeyAllowAll__: mapEntryL7None_(lbls____AllowAll)})},
 	}
 
 	for _, tt := range tests {
@@ -1658,32 +1674,36 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 	selectorCache := testNewSelectorCache(identityCache)
 	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
+	testMapState := func(initMap map[Key]MapStateEntry) MapState {
+		return newMapState().WithState(initMap)
+	}
+
 	tests := []struct {
 		test     string
 		rules    api.Rules
 		expected MapState
 	}{
-		{"deny_world_no_labels", api.Rules{ruleL3DenyWorld, ruleL3AllowWorldIP}, newMapState(map[Key]MapStateEntry{
+		{"deny_world_no_labels", api.Rules{ruleL3DenyWorld, ruleL3AllowWorldIP}, testMapState(map[Key]MapStateEntry{
 			mapKeyL3WorldIngress:  mapEntryDeny,
 			mapKeyL3WorldEgress:   mapEntryDeny,
 			mapKeyL3SubnetIngress: mapEntryDeny,
 			mapKeyL3SubnetEgress:  mapEntryDeny,
-		})}, {"deny_world_with_labels", api.Rules{ruleL3DenyWorldWithLabels, ruleL3AllowWorldIP}, newMapState(map[Key]MapStateEntry{
+		})}, {"deny_world_with_labels", api.Rules{ruleL3DenyWorldWithLabels, ruleL3AllowWorldIP}, testMapState(map[Key]MapStateEntry{
 			mapKeyL3WorldIngress:  mapEntryWorldDenyWithLabels,
 			mapKeyL3WorldEgress:   mapEntryWorldDenyWithLabels,
 			mapKeyL3SubnetIngress: mapEntryDeny,
 			mapKeyL3SubnetEgress:  mapEntryDeny,
-		})}, {"deny_one_ip_with_a_larger_subnet", api.Rules{ruleL3DenySubnet, ruleL3AllowWorldIP}, newMapState(map[Key]MapStateEntry{
+		})}, {"deny_one_ip_with_a_larger_subnet", api.Rules{ruleL3DenySubnet, ruleL3AllowWorldIP}, testMapState(map[Key]MapStateEntry{
 			mapKeyL3SubnetIngress:        mapEntryDeny,
 			mapKeyL3SubnetEgress:         mapEntryDeny,
 			mapKeyL3SmallerSubnetIngress: mapEntryDeny,
 			mapKeyL3SmallerSubnetEgress:  mapEntryDeny,
-		})}, {"deny_part_of_a_subnet_with_an_ip", api.Rules{ruleL3DenySmallerSubnet, ruleL3AllowLargerSubnet}, newMapState(map[Key]MapStateEntry{
+		})}, {"deny_part_of_a_subnet_with_an_ip", api.Rules{ruleL3DenySmallerSubnet, ruleL3AllowLargerSubnet}, testMapState(map[Key]MapStateEntry{
 			mapKeyL3SmallerSubnetIngress: mapEntryDeny,
 			mapKeyL3SmallerSubnetEgress:  mapEntryDeny,
 			mapKeyL3SubnetIngress:        mapEntryAllow,
 			mapKeyL3SubnetEgress:         mapEntryAllow,
-		})}, {"broad_cidr_deny_is_a_portproto_subset_of_a_specific_cidr_allow", api.Rules{ruleL3L4Port8080ProtoAnyDenyWorld, ruleL3AllowWorldIP}, newMapState(map[Key]MapStateEntry{
+		})}, {"broad_cidr_deny_is_a_portproto_subset_of_a_specific_cidr_allow", api.Rules{ruleL3L4Port8080ProtoAnyDenyWorld, ruleL3AllowWorldIP}, testMapState(map[Key]MapStateEntry{
 			mapKeyL3L4Port8080ProtoTCPWorldIngress:    mapEntryDeny,
 			mapKeyL3L4Port8080ProtoTCPWorldEgress:     mapEntryDeny,
 			mapKeyL3L4Port8080ProtoUDPWorldIngress:    mapEntryDeny,
@@ -1698,7 +1718,7 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 			mapKeyL3L4Port8080ProtoSCTPWorldSNEgress:  mapEntryDeny,
 			mapKeyL3SmallerSubnetIngress:              mapEntryAllow,
 			mapKeyL3SmallerSubnetEgress:               mapEntryAllow,
-		})}, {"broad_cidr_allow_is_a_portproto_subset_of_a_specific_cidr_deny", api.Rules{ruleL3AllowWorldSubnet, ruleL3DenyWorldIP}, newMapState(map[Key]MapStateEntry{
+		})}, {"broad_cidr_allow_is_a_portproto_subset_of_a_specific_cidr_deny", api.Rules{ruleL3AllowWorldSubnet, ruleL3DenyWorldIP}, testMapState(map[Key]MapStateEntry{
 			mapKeyL3L4Port8080ProtoTCPWorldSNIngress:  mapEntryAllow,
 			mapKeyL3L4Port8080ProtoTCPWorldSNEgress:   mapEntryAllow,
 			mapKeyL3L4Port8080ProtoUDPWorldSNIngress:  mapEntryAllow,
@@ -1713,10 +1733,10 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 			mapKeyL4Port8080ProtoUDPWorldIPEgress:     mapEntryDeny,
 			mapKeyL4Port8080ProtoSCTPWorldIPIngress:   mapEntryDeny,
 			mapKeyL4Port8080ProtoSCTPWorldIPEgress:    mapEntryDeny,
-		})}, {"named_port_world_subnet", api.Rules{ruleL3AllowWorldSubnetNamedPort}, newMapState(map[Key]MapStateEntry{
+		})}, {"named_port_world_subnet", api.Rules{ruleL3AllowWorldSubnetNamedPort}, testMapState(map[Key]MapStateEntry{
 			mapKeyL3L4NamedPortHTTPProtoTCPWorldSubNetIngress: mapEntryAllow,
 			mapKeyL3L4NamedPortHTTPProtoTCPWorldIPIngress:     mapEntryAllow,
-		})}, {"port_range_world_subnet", api.Rules{ruleL3AllowWorldSubnetPortRange}, newMapState(map[Key]MapStateEntry{
+		})}, {"port_range_world_subnet", api.Rules{ruleL3AllowWorldSubnetPortRange}, testMapState(map[Key]MapStateEntry{
 			mapKeyL3L4Port64To127ProtoTCPWorldSubNetIngress: mapEntryAllow,
 			mapKeyL3L4Port5ProtoTCPWorldSubNetIngress:       mapEntryAllow,
 			mapKeyL3L4Port6To7ProtoTCPWorldSubNetIngress:    mapEntryAllow,
@@ -1775,12 +1795,16 @@ func Test_EnsureEntitiesSelectableByCIDR(t *testing.T) {
 	selectorCache := testNewSelectorCache(identityCache)
 	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
+	testMapState := func(initMap map[Key]MapStateEntry) MapState {
+		return newMapState().WithState(initMap)
+	}
+
 	tests := []struct {
 		test     string
 		rules    api.Rules
 		expected MapState
 	}{
-		{"host_cidr_select", api.Rules{ruleL3AllowHostEgress}, newMapState(map[Key]MapStateEntry{
+		{"host_cidr_select", api.Rules{ruleL3AllowHostEgress}, testMapState(map[Key]MapStateEntry{
 			mapKeyL3UnknownIngress: mapEntryL3UnknownIngress,
 			mapKeyL3HostEgress:     mapEntryAllow,
 		})},

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -435,7 +435,7 @@ func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.Labe
 	// because this test suite doesn't have a notion of traffic direction, so
 	// the extra egress allow-all is technically correct, but omitted from the
 	// expected output that's asserted against for the sake of brevity.
-	epp.policyMapState.Delete(mapKeyAllowAllE_)
+	epp.policyMapState.delete(mapKeyAllowAllE_)
 
 	return epp.policyMapState, nil
 }
@@ -759,11 +759,11 @@ func testCaseToMapState(t generatedBPFKey) MapState {
 
 	if t.L3Key.L3 != nil {
 		if t.L3Key.Deny != nil && *t.L3Key.Deny {
-			m.denies.Upsert(mapKeyDeny_Foo__, mapEntryL7Deny_())
+			m.denies.upsert(mapKeyDeny_Foo__, mapEntryL7Deny_())
 		} else {
 			// If L7 is not set or if it explicitly set but it's false
 			if t.L3Key.L7 == nil || !*t.L3Key.L7 {
-				m.allows.Upsert(mapKeyAllowFoo__, mapEntryL7None_())
+				m.allows.upsert(mapKeyAllowFoo__, mapEntryL7None_())
 			}
 			// there's no "else" because we don't support L3L7 policies, i.e.,
 			// a L4 port needs to be specified.
@@ -771,31 +771,31 @@ func testCaseToMapState(t generatedBPFKey) MapState {
 	}
 	if t.L4Key.L3 != nil {
 		if t.L4Key.Deny != nil && *t.L4Key.Deny {
-			m.denies.Upsert(mapKeyDeny____L4, mapEntryL7Deny_())
+			m.denies.upsert(mapKeyDeny____L4, mapEntryL7Deny_())
 		} else {
 			// If L7 is not set or if it explicitly set but it's false
 			if t.L4Key.L7 == nil || !*t.L4Key.L7 {
-				m.allows.Upsert(mapKeyAllow___L4, mapEntryL7None_())
+				m.allows.upsert(mapKeyAllow___L4, mapEntryL7None_())
 			} else {
 				// L7 is set and it's true then we should expected a mapEntry
 				// with L7 redirection.
-				m.allows.Upsert(mapKeyAllow___L4, mapEntryL7Proxy())
+				m.allows.upsert(mapKeyAllow___L4, mapEntryL7Proxy())
 			}
 		}
 	}
 	if t.L3L4Key.L3 != nil {
 		if t.L3L4Key.Deny != nil && *t.L3L4Key.Deny {
-			m.denies.Upsert(mapKeyDeny_FooL4, mapEntryL7Deny_())
+			m.denies.upsert(mapKeyDeny_FooL4, mapEntryL7Deny_())
 		} else {
 			// If L7 is not set or if it explicitly set but it's false
 			if t.L3L4Key.L7 == nil || !*t.L3L4Key.L7 {
-				m.allows.Upsert(mapKeyAllowFooL4, mapEntryL7None_())
+				m.allows.upsert(mapKeyAllowFooL4, mapEntryL7None_())
 			} else {
 				// L7 is set and it's true then we should expected a mapEntry
 				// with L7 redirection only if we haven't set it already
 				// for an existing L4-only.
 				if t.L4Key.L7 == nil || !*t.L4Key.L7 {
-					m.allows.Upsert(mapKeyAllowFooL4, mapEntryL7Proxy())
+					m.allows.upsert(mapKeyAllowFooL4, mapEntryL7Proxy())
 				}
 			}
 		}
@@ -1222,7 +1222,7 @@ func Test_MergeRules(t *testing.T) {
 					return true
 				}
 				v.DerivedFromRules = labels.LabelArrayList(nil).Sort()
-				mapstate.Insert(k, v)
+				mapstate.insert(k, v)
 				return true
 			})
 			if equal := assert.EqualExportedValues(t, expectedMapState[tt.test], mapstate); !equal {

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -41,7 +41,7 @@ func FuzzResolveEgressPolicy(f *testing.F) {
 
 func FuzzDenyPreferredInsert(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		keys := newMapState(nil)
+		keys := newMapState()
 		key := Key{}
 		entry := MapStateEntry{}
 		ff := fuzz.NewConsumer(data)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -541,7 +541,8 @@ type ChangeState struct {
 // 'p.PolicyMapState' using denyPreferredInsertWithChanges().
 // Keys and old values of any added or deleted entries are added to 'changes'.
 // 'redirects' is the map of currently realized redirects, it is used to find the proxy port for any redirects.
-// SelectorCache is also in read-locked state during this call.
+// p.SelectorCache is used as Identities interface during this call, which only has GetPrefix() that
+// needs no lock.
 func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redirects map[string]uint16, changes ChangeState) {
 	port := l4.Port
 	proto := uint8(l4.U8Proto)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -813,6 +813,7 @@ func createL4Filter(policyCtx PolicyContext, peerEndpoints api.EndpointSelectorS
 	}
 
 	// already validated via L4Proto.Validate(), never "ANY"
+	// NOTE: "ANY" for wildcarded port/proto!
 	u8p, _ := u8proto.ParseProtocol(string(protocol))
 
 	l4 := &L4Filter{

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -875,10 +875,8 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 					// and it has a more specific port-protocol than the new-entry
 					// then an additional copy of the new-entry with the more
 					// specific port-protocol of the iterated-allow-entry must be inserted.
-					newKeyCpy := newKey
-					newKeyCpy.DestPort = k.DestPort
-					newKeyCpy.InvertedPortMask = k.InvertedPortMask
-					newKeyCpy.Nexthdr = k.Nexthdr
+					newKeyCpy := k
+					newKeyCpy.Identity = newKey.Identity
 					l3l4DenyEntry := NewMapStateEntry(newKey, newEntry.DerivedFromRules, 0, "", 0, true, DefaultAuthType, AuthTypeDisabled)
 					updates = append(updates, MapChange{
 						Add:   true,
@@ -983,10 +981,8 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 					// iterated-deny-entry then an additional copy of the iterated-deny-entry
 					// with the more specific port-porotocol of the new-entry must
 					// be added.
-					denyKeyCpy := k
-					denyKeyCpy.DestPort = newKey.DestPort
-					denyKeyCpy.InvertedPortMask = newKey.InvertedPortMask
-					denyKeyCpy.Nexthdr = newKey.Nexthdr
+					denyKeyCpy := newKey
+					denyKeyCpy.Identity = k.Identity
 					l3l4DenyEntry := NewMapStateEntry(k, v.DerivedFromRules, 0, "", 0, true, DefaultAuthType, AuthTypeDisabled)
 					updates = append(updates, MapChange{
 						Add:   true,
@@ -1129,10 +1125,8 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, feat
 					// overridden by a more generic entry and 'max_specificity >
 					// 0' after the loop.
 					if k.Identity != 0 && k.Nexthdr == 0 && newKey.Identity == 0 && newKey.Nexthdr != 0 {
-						newKeyCpy := k
-						newKeyCpy.DestPort = newKey.DestPort
-						newKeyCpy.InvertedPortMask = newKey.InvertedPortMask
-						newKeyCpy.Nexthdr = newKey.Nexthdr
+						newKeyCpy := newKey
+						newKeyCpy.Identity = k.Identity
 						l3l4AuthEntry := NewMapStateEntry(k, v.DerivedFromRules, 0, newEntry.Listener, newEntry.priority, false, DefaultAuthType, v.AuthType)
 						l3l4AuthEntry.DerivedFromRules.MergeSorted(newEntry.DerivedFromRules)
 						l3l4State.allows.upsert(newKeyCpy, l3l4AuthEntry)
@@ -1183,10 +1177,8 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, feat
 					// only override the AuthType for the L3 & L4 combination,
 					// not L4 in general.
 					if newKey.Identity != 0 && newKey.Nexthdr == 0 && k.Identity == 0 && k.Nexthdr != 0 {
-						newKeyCpy := newKey
-						newKeyCpy.DestPort = k.DestPort
-						newKeyCpy.InvertedPortMask = k.InvertedPortMask
-						newKeyCpy.Nexthdr = k.Nexthdr
+						newKeyCpy := k
+						newKeyCpy.Identity = newKey.Identity
 						l3l4AuthEntry := NewMapStateEntry(newKey, newEntry.DerivedFromRules, 0, v.Listener, v.priority, false, DefaultAuthType, newEntry.AuthType)
 						l3l4AuthEntry.DerivedFromRules.MergeSorted(v.DerivedFromRules)
 						ms.addKeyWithChanges(newKeyCpy, l3l4AuthEntry, changes)
@@ -1372,10 +1364,8 @@ func (ms *mapState) addVisibilityKeys(e PolicyOwner, redirectPort uint16, visMet
 			//
 			// Wildcarded L4, i.e., L3-only
 			//
-			k2 := k
-			k2.DestPort = key.DestPort
-			k2.InvertedPortMask = key.InvertedPortMask
-			k2.Nexthdr = key.Nexthdr
+			k2 := key
+			k2.Identity = k.Identity
 			if !v.IsDeny && !haveL4OnlyKey && !addL4OnlyKey {
 				// 4. For each L3-only ALLOW key add the corresponding L3/L4
 				//    ALLOW redirect if no L3/L4 key already exists and no

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -96,8 +96,8 @@ type MapState interface {
 
 // mapState is a state of a policy map.
 type mapState struct {
-	allows *mapStateMap
-	denies *mapStateMap
+	allows mapStateMap
+	denies mapStateMap
 }
 
 // Identities is a convenience interface for looking up CIDRs
@@ -352,8 +352,8 @@ func NewMapState(initMap map[Key]MapStateEntry) MapState {
 
 func newMapState(initMap map[Key]MapStateEntry) *mapState {
 	m := &mapState{
-		allows: &mapStateMap{bitlpm.NewTrie[Key, map[identity.NumericIdentity]MapStateEntry](policyTypes.MapStatePrefixLen), 0},
-		denies: &mapStateMap{bitlpm.NewTrie[Key, map[identity.NumericIdentity]MapStateEntry](policyTypes.MapStatePrefixLen), 0},
+		allows: mapStateMap{bitlpm.NewTrie[Key, map[identity.NumericIdentity]MapStateEntry](policyTypes.MapStatePrefixLen), 0},
+		denies: mapStateMap{bitlpm.NewTrie[Key, map[identity.NumericIdentity]MapStateEntry](policyTypes.MapStatePrefixLen), 0},
 	}
 	for k, v := range initMap {
 		m.Insert(k, v)

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -67,8 +67,6 @@ const (
 // MapState is a map interface for policy maps
 type MapState interface {
 	Get(Key) (MapStateEntry, bool)
-	Insert(Key, MapStateEntry)
-	Delete(Key)
 
 	// ForEach allows iteration over the MapStateEntries. It returns true if
 	// the iteration was not stopped early by the callback.
@@ -79,13 +77,21 @@ type MapState interface {
 	ForEachDeny(func(Key, MapStateEntry) (cont bool)) (complete bool)
 	GetIdentities(*logrus.Logger) ([]int64, []int64)
 	GetDenyIdentities(*logrus.Logger) ([]int64, []int64)
-	RevertChanges(ChangeState)
-	AddVisibilityKeys(PolicyOwner, uint16, *VisibilityMetadata, ChangeState)
 	Len() int
 
+	// private accessors
+	deniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool
+
+	//
+	// modifiers are private
+	//
+	delete(Key)
+	insert(Key, MapStateEntry)
+	revertChanges(ChangeState)
+
+	addVisibilityKeys(PolicyOwner, uint16, *VisibilityMetadata, ChangeState)
 	allowAllIdentities(ingress, egress bool)
 	determineAllowLocalhostIngress()
-	deniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool
 	denyPreferredInsertWithChanges(newKey Key, newEntry MapStateEntry, identities Identities, features policyFeatures, changes ChangeState)
 	deleteKeyWithChanges(key Key, owner MapStateOwner, changes ChangeState)
 
@@ -136,7 +142,7 @@ func (msm *mapStateMap) Lookup(k Key) (MapStateEntry, bool) {
 	return v, ok
 }
 
-func (msm *mapStateMap) Upsert(k Key, e MapStateEntry) {
+func (msm *mapStateMap) upsert(k Key, e MapStateEntry) {
 	id := identity.NumericIdentity(k.Identity)
 	_, exists := msm.entries[k]
 
@@ -157,7 +163,7 @@ func (msm *mapStateMap) Upsert(k Key, e MapStateEntry) {
 	}
 }
 
-func (msm *mapStateMap) Delete(k Key) {
+func (msm *mapStateMap) delete(k Key) {
 	_, exists := msm.entries[k]
 	if exists {
 		delete(msm.entries, k)
@@ -350,7 +356,7 @@ func newMapState(initMap map[Key]MapStateEntry) *mapState {
 		},
 	}
 	for k, v := range initMap {
-		m.Insert(k, v)
+		m.insert(k, v)
 	}
 	return m
 }
@@ -368,26 +374,26 @@ func (ms *mapState) Get(k Key) (MapStateEntry, bool) {
 	return ms.allows.Lookup(k)
 }
 
-// Insert the Key and matcthing MapStateEntry into the
+// insert the Key and matcthing MapStateEntry into the
 // MapState
-func (ms *mapState) Insert(k Key, v MapStateEntry) {
+func (ms *mapState) insert(k Key, v MapStateEntry) {
 	if k.DestPort == 0 && k.InvertedPortMask != 0xffff {
 		stacktrace := hclog.Stacktrace()
-		log.Errorf("mapState.Insert: invalid wildcard port with non-zero mask: %v. Stacktrace: %s", k, stacktrace)
+		log.Errorf("mapState.insert: invalid wildcard port with non-zero mask: %v. Stacktrace: %s", k, stacktrace)
 	}
 	if v.IsDeny {
-		ms.allows.Delete(k)
-		ms.denies.Upsert(k, v)
+		ms.allows.delete(k)
+		ms.denies.upsert(k, v)
 	} else {
-		ms.denies.Delete(k)
-		ms.allows.Upsert(k, v)
+		ms.denies.delete(k)
+		ms.allows.upsert(k, v)
 	}
 }
 
 // Delete removes the Key an related MapStateEntry.
-func (ms *mapState) Delete(k Key) {
-	ms.allows.Delete(k)
-	ms.denies.Delete(k)
+func (ms *mapState) delete(k Key) {
+	ms.allows.delete(k)
+	ms.denies.delete(k)
 }
 
 // ForEach iterates over every Key MapStateEntry and stops when the function
@@ -466,7 +472,7 @@ func (ms *mapState) addDependentOnEntry(owner Key, e MapStateEntry, dependent Ke
 			changes.Old[owner] = e
 		}
 		e.AddDependent(dependent)
-		ms.Insert(owner, e)
+		ms.insert(owner, e)
 	}
 }
 
@@ -477,15 +483,15 @@ func (ms *mapState) RemoveDependent(owner Key, dependent Key, changes ChangeStat
 	if e, exists := ms.allows.Lookup(owner); exists {
 		changes.insertOldIfNotExists(owner, e)
 		e.RemoveDependent(dependent)
-		ms.denies.Delete(owner)
-		ms.allows.Upsert(owner, e)
+		ms.denies.delete(owner)
+		ms.allows.upsert(owner, e)
 		return
 	}
 	if e, exists := ms.denies.Lookup(owner); exists {
 		changes.insertOldIfNotExists(owner, e)
 		e.RemoveDependent(dependent)
-		ms.allows.Delete(owner)
-		ms.denies.Upsert(owner, e)
+		ms.allows.delete(owner)
+		ms.denies.upsert(owner, e)
 	}
 }
 
@@ -656,14 +662,14 @@ func (ms *mapState) addKeyWithChanges(key Key, entry MapStateEntry, changes Chan
 		// place!
 		datapathEqual = oldEntry.DatapathEqual(&entry)
 		oldEntry.Merge(&entry)
-		ms.Insert(key, oldEntry)
+		ms.insert(key, oldEntry)
 	} else {
 		// Newly inserted entries must have their own containers, so that they
 		// remain separate when new owners/dependents are added to existing entries
 		entry.DerivedFromRules = slices.Clone(entry.DerivedFromRules)
 		entry.owners = maps.Clone(entry.owners)
 		entry.dependents = maps.Clone(entry.dependents)
-		ms.Insert(key, entry)
+		ms.insert(key, entry)
 	}
 
 	// Record an incremental Add if desired and entry is new or changed
@@ -728,8 +734,8 @@ func (ms *mapState) deleteKeyWithChanges(key Key, owner MapStateOwner, changes C
 			}
 		}
 
-		ms.allows.Delete(key)
-		ms.denies.Delete(key)
+		ms.allows.delete(key)
+		ms.denies.delete(key)
 	}
 }
 
@@ -810,14 +816,14 @@ func protocolsMatch(a, b Key) bool {
 
 // RevertChanges undoes changes to 'keys' as indicated by 'changes.adds' and 'changes.old' collected via
 // denyPreferredInsertWithChanges().
-func (ms *mapState) RevertChanges(changes ChangeState) {
+func (ms *mapState) revertChanges(changes ChangeState) {
 	for k := range changes.Adds {
-		ms.allows.Delete(k)
-		ms.denies.Delete(k)
+		ms.allows.delete(k)
+		ms.denies.delete(k)
 	}
 	// 'old' contains all the original values of both modified and deleted entries
 	for k, v := range changes.Old {
-		ms.Insert(k, v)
+		ms.insert(k, v)
 	}
 }
 
@@ -1120,7 +1126,7 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, feat
 						newKeyCpy.Nexthdr = newKey.Nexthdr
 						l3l4AuthEntry := NewMapStateEntry(k, v.DerivedFromRules, 0, newEntry.Listener, newEntry.priority, false, DefaultAuthType, v.AuthType)
 						l3l4AuthEntry.DerivedFromRules.MergeSorted(newEntry.DerivedFromRules)
-						l3l4State.allows.Upsert(newKeyCpy, l3l4AuthEntry)
+						l3l4State.allows.upsert(newKeyCpy, l3l4AuthEntry)
 					}
 				}
 				return true
@@ -1232,7 +1238,7 @@ func (changes *ChangeState) insertOldIfNotExists(key Key, entry MapStateEntry) b
 	return false
 }
 
-// AddVisibilityKeys adjusts and expands PolicyMapState keys
+// addVisibilityKeys adjusts and expands PolicyMapState keys
 // and values to redirect for visibility on the port of the visibility
 // annotation while still denying traffic on this port for identities
 // for which the traffic is denied.
@@ -1276,7 +1282,7 @@ func (changes *ChangeState) insertOldIfNotExists(key Key, entry MapStateEntry) b
 // 'adds' and 'oldValues' are updated with the changes made. 'adds' contains both the added and
 // changed keys. 'oldValues' contains the old values for changed keys. This function does not
 // delete any keys.
-func (ms *mapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMeta *VisibilityMetadata, changes ChangeState) {
+func (ms *mapState) addVisibilityKeys(e PolicyOwner, redirectPort uint16, visMeta *VisibilityMetadata, changes ChangeState) {
 	direction := trafficdirection.Egress
 	if visMeta.Ingress {
 		direction = trafficdirection.Ingress
@@ -1304,7 +1310,7 @@ func (ms *mapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMet
 		e.PolicyDebug(logrus.Fields{
 			logfields.BPFMapKey:   key,
 			logfields.BPFMapValue: entry,
-		}, "AddVisibilityKeys: Changing L4-only ALLOW key for visibility redirect")
+		}, "addVisibilityKeys: Changing L4-only ALLOW key for visibility redirect")
 		ms.addKeyWithChanges(key, entry, changes)
 	}
 	if haveAllowAllKey && !haveL4OnlyKey {
@@ -1313,7 +1319,7 @@ func (ms *mapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMet
 		e.PolicyDebug(logrus.Fields{
 			logfields.BPFMapKey:   key,
 			logfields.BPFMapValue: entry,
-		}, "AddVisibilityKeys: Adding L4-only ALLOW key for visibility redirect")
+		}, "addVisibilityKeys: Adding L4-only ALLOW key for visibility redirect")
 		addL4OnlyKey = true
 		ms.addKeyWithChanges(key, entry, changes)
 	}
@@ -1346,7 +1352,7 @@ func (ms *mapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMet
 				e.PolicyDebug(logrus.Fields{
 					logfields.BPFMapKey:   k,
 					logfields.BPFMapValue: v,
-				}, "AddVisibilityKeys: Changing L3/L4 ALLOW key for visibility redirect")
+				}, "addVisibilityKeys: Changing L3/L4 ALLOW key for visibility redirect")
 				updates = append(updates, MapChange{
 					Add:   true,
 					Key:   k,
@@ -1372,7 +1378,7 @@ func (ms *mapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMet
 					e.PolicyDebug(logrus.Fields{
 						logfields.BPFMapKey:   k2,
 						logfields.BPFMapValue: v2,
-					}, "AddVisibilityKeys: Extending L3-only ALLOW key to L3/L4 key for visibility redirect")
+					}, "addVisibilityKeys: Extending L3-only ALLOW key to L3/L4 key for visibility redirect")
 					updates = append(updates, MapChange{
 						Add:   true,
 						Key:   k2,
@@ -1390,7 +1396,7 @@ func (ms *mapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMet
 					e.PolicyDebug(logrus.Fields{
 						logfields.BPFMapKey:   k2,
 						logfields.BPFMapValue: v2,
-					}, "AddVisibilityKeys: Extending L3-only DENY key to L3/L4 key to deny a port with visibility annotation")
+					}, "addVisibilityKeys: Extending L3-only DENY key to L3/L4 key to deny a port with visibility annotation")
 					updates = append(updates, MapChange{
 						Add:   true,
 						Key:   k2,
@@ -1435,7 +1441,7 @@ func (ms *mapState) allowAllIdentities(ingress, egress bool) {
 				labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowAnyIngress, labels.LabelSourceReserved),
 			},
 		}
-		ms.allows.Upsert(allKey[trafficdirection.Ingress], NewMapStateEntry(nil, derivedFrom, 0, "", 0, false, ExplicitAuthType, AuthTypeDisabled))
+		ms.allows.upsert(allKey[trafficdirection.Ingress], NewMapStateEntry(nil, derivedFrom, 0, "", 0, false, ExplicitAuthType, AuthTypeDisabled))
 	}
 	if egress {
 		derivedFrom := labels.LabelArrayList{
@@ -1443,7 +1449,7 @@ func (ms *mapState) allowAllIdentities(ingress, egress bool) {
 				labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowAnyEgress, labels.LabelSourceReserved),
 			},
 		}
-		ms.allows.Upsert(allKey[trafficdirection.Egress], NewMapStateEntry(nil, derivedFrom, 0, "", 0, false, ExplicitAuthType, AuthTypeDisabled))
+		ms.allows.upsert(allKey[trafficdirection.Egress], NewMapStateEntry(nil, derivedFrom, 0, "", 0, false, ExplicitAuthType, AuthTypeDisabled))
 	}
 }
 

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -70,10 +70,6 @@ type MapState interface {
 	// ForEach allows iteration over the MapStateEntries. It returns true if
 	// the iteration was not stopped early by the callback.
 	ForEach(func(Key, MapStateEntry) (cont bool)) (complete bool)
-	// ForEachAllow behaves like ForEach, but only iterates MapStateEntries which are not denies.
-	ForEachAllow(func(Key, MapStateEntry) (cont bool)) (complete bool)
-	// ForEachDeny behaves like ForEach, but only iterates MapStateEntries which are denies.
-	ForEachDeny(func(Key, MapStateEntry) (cont bool)) (complete bool)
 	GetIdentities(*logrus.Logger) ([]int64, []int64)
 	GetDenyIdentities(*logrus.Logger) ([]int64, []int64)
 	Len() int
@@ -747,19 +743,7 @@ func (ms *mapState) delete(k Key, identities Identities) {
 // ForEach iterates over every Key MapStateEntry and stops when the function
 // argument returns false. It returns false iff the iteration was cut short.
 func (ms *mapState) ForEach(f func(Key, MapStateEntry) (cont bool)) (complete bool) {
-	return ms.ForEachAllow(f) && ms.ForEachDeny(f)
-}
-
-// ForEachAllow iterates over every Key MapStateEntry that isn't a deny and
-// stops when the function argument returns false
-func (ms *mapState) ForEachAllow(f func(Key, MapStateEntry) (cont bool)) (complete bool) {
-	return ms.allows.ForEach(f)
-}
-
-// ForEachDeny iterates over every Key MapStateEntry that is a deny and
-// stops when the function argument returns false
-func (ms *mapState) ForEachDeny(f func(Key, MapStateEntry) (cont bool)) (complete bool) {
-	return ms.denies.ForEach(f)
+	return ms.allows.ForEach(f) && ms.denies.ForEach(f)
 }
 
 // Len returns the length of the map
@@ -769,6 +753,7 @@ func (ms *mapState) Len() int {
 
 // Equals determines if this MapState is equal to the
 // argument MapState
+// Only used for testing, but also from the endpoint package!
 func (msA *mapState) Equals(msB MapState) bool {
 	if msA.Len() != msB.Len() {
 		return false

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -187,6 +187,10 @@ func (ms *mapState) validatePortProto(t *testing.T) {
 }
 
 func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
+	testMapState := func(initMap map[Key]MapStateEntry) *mapState {
+		return newMapState().withState(initMap)
+	}
+
 	type args struct {
 		key   Key
 		entry MapStateEntry
@@ -200,7 +204,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 	}{
 		{
 			name: "test-1 - no KV added, map should remain the same",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         0,
 					DestPort:         0,
@@ -219,7 +223,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				},
 				entry: MapStateEntry{},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         0,
 					DestPort:         0,
@@ -238,7 +242,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-2a - L3 allow KV should not overwrite deny entry",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -264,7 +268,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           false,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         0,
@@ -301,7 +305,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-2b - L3 port-range allow KV should not overwrite deny entry",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -327,7 +331,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           false,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         64,
@@ -364,7 +368,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-3a - L3-L4 allow KV should not overwrite deny entry",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -389,7 +393,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           false,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -407,7 +411,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-3b - L3-L4 port-range allow KV should not overwrite deny entry",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         64,
@@ -434,7 +438,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           false,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         64,
@@ -453,7 +457,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-4a - L3-L4 deny KV should overwrite allow entry",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -478,7 +482,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           true,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -514,7 +518,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-4b - L3-L4 port-range deny KV should overwrite allow entry",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -540,7 +544,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           true,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         64,
@@ -585,7 +589,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-5a - L3 deny KV should overwrite all L3-L4 allow and L3 allow entries for the same L3",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -643,7 +647,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           true,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         0,
@@ -720,7 +724,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-5b - L3 port-range deny KV should overwrite all L3-L4 allow and L3 allow entries for the same L3",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -778,7 +782,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           true,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         64,
@@ -855,7 +859,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-6a - L3 egress deny KV should not overwrite any existing ingress allow",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -913,7 +917,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           true,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -982,7 +986,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-6b - L3 egress port-range deny KV should not overwrite any existing ingress allow",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -1040,7 +1044,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           true,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -1109,7 +1113,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-7a - L3 ingress deny KV should not be overwritten by a L3-L4 ingress allow",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         0,
@@ -1135,7 +1139,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           false,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         0,
@@ -1154,7 +1158,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-7b - L3 ingress deny KV should not be overwritten by a L3-L4 port-range ingress allow",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         0,
@@ -1181,7 +1185,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           false,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         0,
@@ -1200,7 +1204,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-8a - L3 ingress deny KV should not be overwritten by a L3-L4-L7 ingress allow",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         0,
@@ -1227,7 +1231,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           false,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         0,
@@ -1246,7 +1250,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-8b - L3 ingress deny KV should not be overwritten by a L3-L4-L7 port-range ingress allow",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         0,
@@ -1274,7 +1278,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           false,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         0,
@@ -1293,7 +1297,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-9a - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -1320,7 +1324,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           true,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         0,
@@ -1366,7 +1370,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-9b - L3 ingress deny KV should overwrite a L3-L4-L7 port-range ingress allow",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         64,
@@ -1394,7 +1398,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           true,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         0,
@@ -1442,7 +1446,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-10a - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow and a L3-L4 deny",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -1479,7 +1483,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           true,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         0,
@@ -1541,7 +1545,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-10b - L3 ingress deny KV should overwrite a L3-L4-L7 port-range ingress allow and a L3-L4 port-range deny",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         64,
@@ -1580,7 +1584,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           true,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         0,
@@ -1646,7 +1650,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-11a - L3 ingress allow should not be allowed if there is a L3 'all' deny",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -1684,7 +1688,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           false,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -1714,7 +1718,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-11b - L3 ingress allow should not be allowed if there is a L3 'all' deny",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         64,
@@ -1753,7 +1757,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           false,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         64,
@@ -1784,7 +1788,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-12a - inserting a L3 'all' deny should delete all entries for that direction",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -1833,7 +1837,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           true,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         0,
 					DestPort:         0,
@@ -1907,7 +1911,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-12b - inserting a L3 'all' deny should delete all entries for that direction (including port ranges)",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         64,
@@ -1959,7 +1963,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           true,
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         0,
 					DestPort:         0,
@@ -2038,7 +2042,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-13a - L3-L4-L7 ingress allow should overwrite a L3-L4-L7 ingress allow due to lower priority",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -2063,7 +2067,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					Listener:  "listener2",
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -2099,7 +2103,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-13b - L3-L4-L7 port-range ingress allow should overwrite a L3-L4-L7 port-range ingress allow due to lower priority",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         64,
@@ -2126,7 +2130,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					Listener:  "listener2",
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         64,
@@ -2165,7 +2169,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-14a - L4-L7 ingress allow should overwrite a L3-L4-L7 ingress allow due to lower priority on the same port",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -2190,7 +2194,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					Listener:  "listener1",
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -2219,7 +2223,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-14b - L4-L7 port-range ingress allow should overwrite a L3-L4-L7 port-range ingress allow due to lower priority on the same port",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         64,
@@ -2246,7 +2250,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					Listener:  "listener1",
 				},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				{
 					Identity:         1,
 					DestPort:         64,
@@ -2283,7 +2287,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			Old:     make(map[Key]MapStateEntry),
 		}
 		// copy the starting point
-		ms := newMapState(make(map[Key]MapStateEntry, tt.ms.Len()))
+		ms := testMapState(make(map[Key]MapStateEntry, tt.ms.Len()))
 		tt.ms.ForEach(func(k Key, v MapStateEntry) bool {
 			ms.insert(k, v)
 			return true
@@ -2390,6 +2394,10 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 	csFoo := newTestCachedSelector("Foo", false)
 	csBar := newTestCachedSelector("Bar", false)
 
+	testMapState := func(initMap map[Key]MapStateEntry) *mapState {
+		return newMapState().withState(initMap)
+	}
+
 	type args struct {
 		cs       *testCachedSelector
 		adds     []int
@@ -2410,14 +2418,14 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		deletes   Keys
 	}{{
 		name: "test-1a - Adding L3-deny to an existing allow-all with L4-only allow redirect map state entries",
-		setup: newMapState(map[Key]MapStateEntry{
+		setup: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():   allowEntry(0),
 			HttpIngressKey(0): allowEntry(12345, nil),
 		}),
 		args: []args{
 			{cs: csFoo, adds: []int{41}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():          allowEntry(0),
 			testIngressKey(41, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(41)),
 			HttpIngressKey(0):        allowEntry(12345, nil),
@@ -2434,7 +2442,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{42}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():          allowEntry(0),
 			testIngressKey(41, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(41)),
 			testIngressKey(42, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(42)),
@@ -2453,7 +2461,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: nil, deletes: []int{42}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():          allowEntry(0),
 			testIngressKey(41, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(41)),
 			HttpIngressKey(0):        allowEntry(12345, nil),
@@ -2469,7 +2477,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			HttpIngressKey(42): denyEntry(0, csFoo),
 			HttpIngressKey(43): denyEntry(0, csFoo),
 		}),
@@ -2484,7 +2492,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csBar, adds: []int{42, 44}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			HttpIngressKey(42): denyEntry(0, csFoo, csBar),
 			HttpIngressKey(43): denyEntry(0, csFoo),
 			HttpIngressKey(44): denyEntry(0, csBar),
@@ -2499,7 +2507,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			HttpIngressKey(42): denyEntry(0, csBar),
 			HttpIngressKey(43): denyEntry(0, csFoo),
 			HttpIngressKey(44): denyEntry(0, csBar),
@@ -2512,7 +2520,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			HttpIngressKey(42): denyEntry(0, csBar),
 			HttpIngressKey(43): denyEntry(0, csFoo),
 			HttpIngressKey(44): denyEntry(0, csBar),
@@ -2525,7 +2533,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csBar, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			HttpIngressKey(43): denyEntry(0, csFoo),
 			HttpIngressKey(44): denyEntry(0, csBar),
 		}),
@@ -2539,7 +2547,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csBar, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			HttpIngressKey(43): denyEntry(0, csFoo),
 			HttpIngressKey(44): denyEntry(0, csBar),
 		}),
@@ -2548,7 +2556,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 	}, {
 		continued: false,
 		name:      "test-3a - egress allow with deny-L3",
-		setup: newMapState(map[Key]MapStateEntry{
+		setup: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
@@ -2557,7 +2565,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
@@ -2571,7 +2579,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 			{cs: csBar, adds: []int{43}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
 			{cs: csBar, adds: []int{43}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
@@ -2589,7 +2597,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
@@ -2604,7 +2612,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 	}, {
 		continued: false,
 		name:      "test-4a - Add L7 skipped due to covering L3 deny",
-		setup: newMapState(map[Key]MapStateEntry{
+		setup: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
@@ -2612,7 +2620,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{42}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
@@ -2626,7 +2634,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 			{cs: csFoo, adds: []int{42}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
@@ -2635,13 +2643,13 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		deletes: Keys{},
 	}, {
 		name: "test-5 - Adding L3-deny to an existing allow-all",
-		setup: newMapState(map[Key]MapStateEntry{
+		setup: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey(): allowEntry(0),
 		}),
 		args: []args{
 			{cs: csFoo, adds: []int{41}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():          allowEntry(0),
 			testIngressKey(41, 0, 0): denyEntry(0, csFoo),
 		}),
@@ -2651,7 +2659,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		deletes: Keys{},
 	}, {
 		name: "test-6 - Multiple dependent entries",
-		setup: newMapState(map[Key]MapStateEntry{
+		setup: testMapState(map[Key]MapStateEntry{
 			AnyEgressKey():     allowEntry(0),
 			HttpEgressKey(0):   allowEntry(12345, nil),
 			DNSUDPEgressKey(0): allowEntry(12346, nil),
@@ -2659,7 +2667,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{41}, deletes: []int{}, port: 0, proto: 0, ingress: false, redirect: false, deny: true},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			AnyEgressKey():          allowEntry(0),
 			testEgressKey(41, 0, 0): denyEntry(0, csFoo).WithDependents(HttpEgressKey(41), DNSUDPEgressKey(41)),
 			HttpEgressKey(0):        allowEntry(12345, nil),
@@ -2679,7 +2687,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args:      []args{
 			//{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: newMapState(nil),
+		state: newMapState(),
 		adds:  Keys{
 			//HttpIngressKey(42): allowEntry(0),
 		},
@@ -2689,7 +2697,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 	},
 	}
 
-	policyMapState := newMapState(nil)
+	policyMapState := newMapState()
 
 	for _, tt := range tests {
 		policyMaps := MapChanges{}
@@ -2697,7 +2705,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 			if tt.setup != nil {
 				policyMapState = tt.setup
 			} else {
-				policyMapState = newMapState(nil)
+				policyMapState = newMapState()
 			}
 		}
 		for _, x := range tt.args {
@@ -2735,6 +2743,10 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 	csFoo := newTestCachedSelector("Foo", false)
 	csBar := newTestCachedSelector("Bar", false)
 
+	testMapState := func(initMap map[Key]MapStateEntry) *mapState {
+		return newMapState().withState(initMap)
+	}
+
 	type args struct {
 		cs       *testCachedSelector
 		adds     []int
@@ -2759,7 +2771,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			HttpIngressKey(42): allowEntry(0, csFoo),
 			HttpIngressKey(43): allowEntry(0, csFoo),
 		}),
@@ -2774,7 +2786,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		args: []args{
 			{cs: csBar, adds: []int{42, 44}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			HttpIngressKey(42): allowEntry(0, csFoo, csBar),
 			HttpIngressKey(43): allowEntry(0, csFoo),
 			HttpIngressKey(44): allowEntry(0, csBar),
@@ -2789,7 +2801,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			HttpIngressKey(42): allowEntry(0, csBar),
 			HttpIngressKey(43): allowEntry(0, csFoo),
 			HttpIngressKey(44): allowEntry(0, csBar),
@@ -2802,7 +2814,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			HttpIngressKey(42): allowEntry(0, csBar),
 			HttpIngressKey(43): allowEntry(0, csFoo),
 			HttpIngressKey(44): allowEntry(0, csBar),
@@ -2815,7 +2827,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		args: []args{
 			{cs: csBar, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			HttpIngressKey(43): allowEntry(0, csFoo),
 			HttpIngressKey(44): allowEntry(0, csBar),
 		}),
@@ -2829,7 +2841,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		args: []args{
 			{cs: csBar, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			HttpIngressKey(43): allowEntry(0, csFoo),
 			HttpIngressKey(44): allowEntry(0, csBar),
 		}),
@@ -2844,7 +2856,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():     allowEntry(0, nil),
 			HostIngressKey():    allowEntry(0, nil),
 			DNSUDPEgressKey(42): allowEntry(0, csBar),
@@ -2863,7 +2875,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():     allowEntry(0, nil),
 			HostIngressKey():    allowEntry(0, nil),
 			DNSUDPEgressKey(42): allowEntry(0, csBar),
@@ -2881,7 +2893,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{cs: csFoo, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 			{cs: csFoo, adds: []int{}, deletes: []int{44}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: newMapState(nil),
+		state: newMapState(),
 		adds:  Keys{},
 		deletes: Keys{
 			// Delete of the key is recoded as the key may have existed already in the (bpf) map
@@ -2895,7 +2907,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{cs: csFoo, adds: []int{}, deletes: []int{44}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 			{cs: csFoo, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			HttpEgressKey(44): allowEntry(1, csFoo),
 		}),
 		adds: Keys{
@@ -2908,7 +2920,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		args:      []args{
 			//{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: newMapState(nil),
+		state: newMapState(),
 		adds:  Keys{
 			//HttpIngressKey(42): allowEntry(0),
 		},
@@ -2918,12 +2930,12 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 	},
 	}
 
-	policyMapState := newMapState(nil)
+	policyMapState := newMapState()
 
 	for _, tt := range tests {
 		policyMaps := MapChanges{}
 		if !tt.continued {
-			policyMapState = newMapState(nil)
+			policyMapState = newMapState()
 		}
 		for _, x := range tt.args {
 			dir := trafficdirection.Egress
@@ -2964,6 +2976,10 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 	csFoo := newTestCachedSelector("Foo", false)
 	csBar := newTestCachedSelector("Bar", false)
 
+	testMapState := func(initMap map[Key]MapStateEntry) *mapState {
+		return newMapState().withState(initMap)
+	}
+
 	type args struct {
 		redirectPort uint16
 		visMeta      VisibilityMetadata
@@ -2975,83 +2991,83 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 	}{
 		{
 			name: "test-1 - Add HTTP ingress visibility - allow-all",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				AnyIngressKey(): allowEntry(0),
 			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				AnyIngressKey():   allowEntry(0),
 				HttpIngressKey(0): allowEntryD(12345, visibilityDerivedFrom, nil),
 			}),
 		},
 		{
 			name: "test-2 - Add HTTP ingress visibility - no allow-all",
-			ms:   newMapState(nil),
+			ms:   newMapState(),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: newMapState(nil),
+			want: newMapState(),
 		},
 		{
 			name: "test-3 - Add HTTP ingress visibility - L4-allow",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				HttpIngressKey(0): allowEntryD(0, labels.LabelArrayList{testLabels}),
 			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				HttpIngressKey(0): allowEntryD(12345, labels.LabelArrayList{visibilityDerivedFromLabels, testLabels}, nil),
 			}),
 		},
 		{
 			name: "test-4 - Add HTTP ingress visibility - L3/L4-allow",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				HttpIngressKey(123): allowEntryD(0, labels.LabelArrayList{testLabels}, csBar),
 			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				HttpIngressKey(123): allowEntryD(12345, labels.LabelArrayList{visibilityDerivedFromLabels, testLabels}, csBar),
 			}),
 		},
 		{
 			name: "test-5 - Add HTTP ingress visibility - L3-allow (host)",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				HostIngressKey(): allowEntry(0),
 			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				HostIngressKey():  allowEntry(0).WithDependents(HttpIngressKey(1)),
 				HttpIngressKey(1): allowEntryD(12345, labels.LabelArrayList{visibilityDerivedFromLabels}).WithOwners(HostIngressKey()),
 			}),
 		},
 		{
 			name: "test-6 - Add HTTP ingress visibility - L3/L4-allow on different port",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				testIngressKey(123, 88, 6): allowEntryD(0, labels.LabelArrayList{testLabels}, csBar),
 			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				testIngressKey(123, 88, 6): allowEntryD(0, labels.LabelArrayList{testLabels}, csBar),
 			}),
 		},
 		{
 			name: "test-7 - Add HTTP ingress visibility - allow-all + L4-deny (no change)",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				AnyIngressKey():   allowEntry(0),
 				HttpIngressKey(0): denyEntry(0),
 			}),
@@ -3059,14 +3075,14 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				AnyIngressKey():   allowEntry(0),
 				HttpIngressKey(0): denyEntry(0),
 			}),
 		},
 		{
 			name: "test-8 - Add HTTP ingress visibility - allow-all + L3-deny",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				AnyIngressKey():           allowEntry(0),
 				testIngressKey(234, 0, 0): denyEntry(0, csFoo),
 			}),
@@ -3074,7 +3090,7 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				AnyIngressKey():           allowEntry(0),
 				testIngressKey(234, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(234)),
 				HttpIngressKey(0):         allowEntryD(12345, visibilityDerivedFrom, nil),
@@ -3083,7 +3099,7 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 		},
 		{
 			name: "test-9 - Add HTTP ingress visibility - allow-all + L3/L4-deny",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				AnyIngressKey():     allowEntry(0),
 				HttpIngressKey(132): denyEntry(0, csBar),
 			}),
@@ -3091,7 +3107,7 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				AnyIngressKey():     allowEntry(0),
 				HttpIngressKey(132): denyEntry(0, csBar),
 				HttpIngressKey(0):   allowEntryD(12345, visibilityDerivedFrom, nil),
@@ -3099,14 +3115,14 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 		},
 		{
 			name: "test-10 - Add HTTP egress visibility",
-			ms: newMapState(map[Key]MapStateEntry{
+			ms: testMapState(map[Key]MapStateEntry{
 				AnyEgressKey(): allowEntry(0),
 			}),
 			args: args{
 				redirectPort: 12346,
 				visMeta:      VisibilityMetadata{Ingress: false, Port: 80, Proto: u8proto.TCP},
 			},
-			want: newMapState(map[Key]MapStateEntry{
+			want: testMapState(map[Key]MapStateEntry{
 				AnyEgressKey():   allowEntry(0),
 				HttpEgressKey(0): allowEntryD(12346, visibilityDerivedFrom, nil),
 			}),
@@ -3158,6 +3174,10 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 	csFoo := newTestCachedSelector("Foo", false)
 	csBar := newTestCachedSelector("Bar", false)
 
+	testMapState := func(initMap map[Key]MapStateEntry) *mapState {
+		return newMapState().withState(initMap)
+	}
+
 	type args struct {
 		cs       *testCachedSelector
 		adds     []int
@@ -3185,7 +3205,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 		deletes   Keys
 	}{{
 		name: "test-1a - Adding identity to deny with visibilty",
-		setup: newMapState(map[Key]MapStateEntry{
+		setup: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():           allowEntry(0),
 			testIngressKey(234, 0, 0): denyEntry(0, csFoo),
 		}),
@@ -3203,7 +3223,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{235}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():           allowEntry(0),
 			testIngressKey(234, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(234)),
 			testIngressKey(235, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(235)),
@@ -3222,7 +3242,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: nil, deletes: []int{235}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():           allowEntry(0),
 			testIngressKey(234, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(234)),
 			HttpIngressKey(0):         allowEntryD(12345, visibilityDerivedFrom, nil),
@@ -3242,7 +3262,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Parser: ParserTypeHTTP, Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			testIngressKey(235, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(235)),
 			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
 			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(235, 0, 0)),
@@ -3268,7 +3288,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Parser: ParserTypeHTTP, Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			testIngressKey(235, 0, 0): allowEntry(0, csFoo, csBar).WithDependents(HttpIngressKey(235)),
 			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
 			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(235, 0, 0)),
@@ -3293,7 +3313,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Parser: ParserTypeHTTP, Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			testIngressKey(235, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(235)),
 			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
 			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(235, 0, 0)),
@@ -3313,7 +3333,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Parser: ParserTypeHTTP, Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			testIngressKey(235, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(235)),
 			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
 			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(235, 0, 0)),
@@ -3333,7 +3353,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Parser: ParserTypeHTTP, Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
 			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
 			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
@@ -3354,7 +3374,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Parser: ParserTypeHTTP, Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
 			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
 			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
@@ -3365,7 +3385,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 	}, {
 		continued: false,
 		name:      "test-3a - egress HTTP proxy (setup)",
-		setup: newMapState(map[Key]MapStateEntry{
+		setup: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():  allowEntry(0),
 			HostIngressKey(): allowEntry(0),
 			HttpEgressKey(0): allowEntry(0),
@@ -3396,7 +3416,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():  allowEntry(0),
 			HostIngressKey(): allowEntry(0),
 			// Entry added solely due to visibility annotation has a 'nil' owner
@@ -3431,7 +3451,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 				visMeta:      VisibilityMetadata{Parser: ParserTypeHTTP, Ingress: false, Port: 53, Proto: u8proto.UDP},
 			},
 		},
-		state: newMapState(map[Key]MapStateEntry{
+		state: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():     allowEntry(0),
 			HostIngressKey():    allowEntry(0),
 			HttpIngressKey(0):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(nil),
@@ -3451,7 +3471,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 		args:      []args{
 			//{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: newMapState(nil),
+		state: newMapState(),
 		adds:  Keys{
 			//HttpIngressKey(42): {},
 		},
@@ -3461,7 +3481,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 	},
 	}
 
-	policyMapState := newMapState(nil)
+	policyMapState := newMapState()
 
 	for _, tt := range tests {
 		// Allow omit empty maps
@@ -3482,7 +3502,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			if tt.setup != nil {
 				policyMapState = tt.setup
 			} else {
-				policyMapState = newMapState(nil)
+				policyMapState = newMapState()
 			}
 		}
 		changes := ChangeState{
@@ -3620,7 +3640,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		aEntry := MapStateEntry{IsDeny: tt.aIsDeny}
 		bKey := key(tt.bIdentity, tt.bPort, tt.bProto, 0)
 		bEntry := MapStateEntry{IsDeny: tt.bIsDeny}
-		expectedKeys := newMapState(nil)
+		expectedKeys := newMapState()
 		if tt.outcome&insertA > 0 {
 			if tt.aIsDeny {
 				expectedKeys.denies.upsert(aKey, aEntry)
@@ -3661,7 +3681,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 				expectedKeys.allows.upsert(bKeyWithBProto, bEntryCpy)
 			}
 		}
-		outcomeKeys := newMapState(nil)
+		outcomeKeys := newMapState()
 		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
 		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
 		outcomeKeys.validatePortProto(t)
@@ -3675,7 +3695,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		aEntry := MapStateEntry{IsDeny: tt.aIsDeny}
 		bKey := key(tt.bIdentity, tt.bPort, tt.bProto, 1)
 		bEntry := MapStateEntry{IsDeny: tt.bIsDeny}
-		expectedKeys := newMapState(nil)
+		expectedKeys := newMapState()
 		if tt.aIsDeny {
 			expectedKeys.denies.upsert(aKey, aEntry)
 		} else {
@@ -3686,7 +3706,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		} else {
 			expectedKeys.allows.upsert(bKey, bEntry)
 		}
-		outcomeKeys := newMapState(nil)
+		outcomeKeys := newMapState()
 		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
 		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
 		outcomeKeys.validatePortProto(t)
@@ -3695,7 +3715,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 }
 
 func TestMapState_Get_stacktrace(t *testing.T) {
-	ms := newMapState(nil)
+	ms := newMapState()
 	// This should produce a stacktrace in the error log. It is not validated here but can be
 	// observed manually.
 	// Example log (with newlines expanded):

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -5,6 +5,7 @@ package policy
 
 import (
 	"fmt"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -2297,7 +2298,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			return true
 		})
 
-		ms.denyPreferredInsertWithChanges(tt.args.key, tt.args.entry, nil, denyRules, changes)
+		ms.denyPreferredInsertWithChanges(tt.args.key, tt.args.entry, selectorCache, denyRules, changes)
 		ms.validatePortProto(t)
 		require.Truef(t, ms.Equals(tt.want), "%s: MapState mismatch:\n%s", tt.name, ms.Diff(tt.want))
 		require.EqualValuesf(t, tt.wantAdds, changes.Adds, "%s: Adds mismatch", tt.name)
@@ -2305,7 +2306,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		require.EqualValuesf(t, tt.wantOld, changes.Old, "%s: OldValues mismatch allows", tt.name)
 
 		// Revert changes and check that we get the original mapstate
-		ms.revertChanges(nil, changes)
+		ms.revertChanges(selectorCache, changes)
 		require.Truef(t, ms.Equals(tt.ms), "%s: MapState mismatch:\n%s", tt.name, ms.Diff(tt.ms))
 	}
 }
@@ -3559,7 +3560,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			value := NewMapStateEntry(cs, nil, proxyPort, "", 0, x.deny, DefaultAuthType, AuthTypeDisabled)
 			policyMaps.AccumulateMapChanges(cs, adds, deletes, []Key{key}, value)
 		}
-		adds, deletes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, nil, denyRules)
+		adds, deletes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, selectorCache, denyRules)
 		changes = ChangeState{
 			Adds:    adds,
 			Deletes: deletes,
@@ -3750,4 +3751,170 @@ func TestMapState_Get_stacktrace(t *testing.T) {
 	// go/src/testing/testing.go:1689" subsys=policy
 	_, ok := ms.Get(Key{})
 	assert.False(t, ok)
+}
+
+type validator struct{}
+
+// prefixesContainsAny checks that any subnet in the `a` subnet group *fully*
+// contains any of the subnets in the `b` subnet group.
+func prefixesContainsAny(a, b []netip.Prefix) bool {
+	for _, an := range a {
+		aMask := an.Bits()
+		aIsIPv4 := an.Addr().Is4()
+		for _, bn := range b {
+			bIsIPv4 := bn.Addr().Is4()
+			isSameFamily := aIsIPv4 == bIsIPv4
+			if isSameFamily {
+				bMask := bn.Bits()
+				if bMask >= aMask && an.Contains(bn.Addr()) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// identityIsSupersetOf compares two entries and keys to see if the primary identity contains
+// the compared identity. This means that either that primary identity is 0 (i.e. it is a superset
+// of every other identity), or one of the subnets of the primary identity fully contains or is
+// equal to one of the subnets in the compared identity (note:this covers cases like "reserved:world").
+func identityIsSupersetOf(primaryIdentity, compareIdentity uint32, identities Identities) bool {
+	// If the identities are equal then neither is a superset (for the purposes of our business logic).
+	if primaryIdentity == compareIdentity {
+		return false
+	}
+
+	// Consider an identity that selects a broader CIDR as a superset of
+	// an identity that selects a narrower CIDR. For instance, an identity
+	// corresponding to 192.0.0.0/16 is a superset of the identity that
+	// corresponds to 192.0.2.3/32.
+	//
+	// The reasons we need to do this are surprisingly complex, taking into
+	// consideration design decisions around the handling of ToFQDNs policy
+	// and how L4PolicyMap/L4Filter structures cache the policies with
+	// respect to specific CIDRs. More specifically:
+	// - At the time of initial L4Filter creation, it is not known which
+	//   specific CIDRs (or corresponding identities) are selected by a
+	//   toFQDNs rule in the policy engine.
+	// - It is possible to have a CIDR deny rule that should deny peers
+	//   that are allowed by a ToFQDNs statement. The precedence rules in
+	//   the API for such policy conflicts define that the deny should take
+	//   precedence.
+	// - Consider a case where there is a deny rule for 192.0.0.0/16 with
+	//   an allow rule for cilium.io, and one of the IP addresses for
+	//   cilium.io is 192.0.2.3.
+	// - If the IP for cilium.io was known at initial policy computation
+	//   time, then we would calculate the MapState from the L4Filters and
+	//   immediately determine that there is a conflict between the
+	//   L4Filter that denies 192.0.0.0/16 vs. the allow for 192.0.2.3.
+	//   From this we could immediately discard the "allow to 192.0.2.3"
+	//   policymap entry during policy calculation. This would satisfy the
+	//   API constraint that deny rules take precedence over allow rules.
+	//   However, this is not the case for ToFQDNs -- the IPs are not known
+	//   until DNS resolution time by the selected application / endpoint.
+	// - In order to make ToFQDNs policy implementation efficient, it uses
+	//   a shorter incremental policy computation path that attempts to
+	//   directly implement the ToFQDNs allow into a MapState entry without
+	//   reaching back up to the L4Filter layer to iterate all selectors
+	//   to determine traffic reachability for this newly learned IP.
+	// - As such, when the new ToFQDNs allow for the 192.0.2.3 IP address
+	//   is implemented, we must iterate back through all existing MapState
+	//   entries to determine whether any of the other map entries already
+	//   denies this traffic by virtue of the IP prefix being a superset of
+	//   this new allow. This allows us to ensure that the broader CIDR
+	//   deny semantics are correctly applied when there is a combination
+	//   of CIDR deny rules and ToFQDNs allow rules.
+	//
+	// An alternative to this approach might be to change the ToFQDNs
+	// policy calculation layer to reference back to the L4Filter layer,
+	// and perhaps introduce additional CIDR caching somewhere there so
+	// that this policy computation can be efficient while handling DNS
+	// responses. As of the writing of this message, such there is no
+	// active proposal to implement this proposal. As a result, any time
+	// there is an incremental policy update for a new map entry, we must
+	// iterate through all entries in the map and re-evaluate superset
+	// relationships for deny entries to ensure that policy precedence is
+	// correctly implemented between the new and old entries, taking into
+	// account whether the identities may represent CIDRs that have a
+	// superset relationship.
+	return primaryIdentity == 0 && compareIdentity != 0 ||
+		prefixesContainsAny(getNets(identities, primaryIdentity),
+			getNets(identities, compareIdentity))
+}
+
+func (v *validator) isSupersetOf(a, d Key, identities Identities) {
+	if a.TrafficDirection != d.TrafficDirection {
+		panic("TrafficDirection mismatch")
+	}
+	if !identityIsSupersetOf(a.Identity, d.Identity, identities) {
+		panic(fmt.Sprintf("superset mismatch %s !> %s",
+			identities.GetPrefix(identity.NumericIdentity(a.Identity)).String(),
+			identities.GetPrefix(identity.NumericIdentity(d.Identity)).String()))
+	}
+}
+
+func (v *validator) isSupersetOrSame(a, d Key, identities Identities) {
+	if a.TrafficDirection != d.TrafficDirection {
+		panic("TrafficDirection mismatch")
+	}
+	if !(a.Identity == d.Identity ||
+		identityIsSupersetOf(a.Identity, d.Identity, identities)) {
+		panic(fmt.Sprintf("superset or equal mismatch %s !>= %s",
+			identities.GetPrefix(identity.NumericIdentity(a.Identity)).String(),
+			identities.GetPrefix(identity.NumericIdentity(d.Identity)).String()))
+	}
+}
+
+func (v *validator) isBroader(a, d Key) {
+	if a.TrafficDirection != d.TrafficDirection {
+		panic("TrafficDirection mismatch")
+	}
+
+	// Do not consider non-matching protocols
+	if !protocolsMatch(a, d) || !a.PortProtoIsBroader(d) {
+		panic(fmt.Sprintf("descendant (%v) is not narrower than ancestor (%v)", d, a))
+	}
+}
+
+func (v *validator) isBroaderOrEqual(a, d Key) {
+	if a.TrafficDirection != d.TrafficDirection {
+		panic("TrafficDirection mismatch")
+	}
+
+	// Do not consider non-matching protocols
+	if !protocolsMatch(a, d) || !(a.PortProtoIsBroader(d) || a.PortProtoIsEqual(d)) {
+		panic(fmt.Sprintf("descendant (%v) is not narrower than ancestor (%v)", d, a))
+	}
+}
+
+func TestDenyPreferredInsertLogic(t *testing.T) {
+	td := newTestData()
+	td.bootstrapRepo(GenerateCIDRDenyRules, 1000, t)
+	p, _ := td.repo.resolvePolicyLocked(fooIdentity)
+
+	mapState := newMapState()
+	mapState.validator = &validator{} // insert validator
+
+	// This is DistillPolicy, but with MapState validator injected
+	epPolicy := &EndpointPolicy{
+		selectorPolicy: p,
+		policyMapState: mapState,
+		PolicyOwner:    DummyOwner{},
+	}
+
+	if !p.IngressPolicyEnabled || !p.EgressPolicyEnabled {
+		epPolicy.policyMapState.allowAllIdentities(
+			!p.IngressPolicyEnabled, !p.EgressPolicyEnabled)
+	}
+	p.insertUser(epPolicy)
+
+	p.SelectorCache.mutex.RLock()
+	epPolicy.toMapState()
+	epPolicy.policyMapState.determineAllowLocalhostIngress()
+	p.SelectorCache.mutex.RUnlock()
+
+	n := epPolicy.policyMapState.Len()
+	p.Detach()
+	assert.True(t, n > 0)
 }

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -162,6 +162,33 @@ func (p *EndpointPolicy) Detach() {
 	p.selectorPolicy.removeUser(p)
 }
 
+// NewMapStateWithInsert returns a new MapState and an insert function that can be used to populate
+// it. We keep general insert functions private so that the caller can only insert to this specific
+// map.
+func NewMapStateWithInsert() (MapState, func(k Key, e MapStateEntry)) {
+	currentMap := NewMapState(nil)
+
+	return currentMap, func(k Key, e MapStateEntry) {
+		currentMap.insert(k, e)
+	}
+}
+
+func (p *EndpointPolicy) InsertMapState(key Key, entry MapStateEntry) {
+	p.policyMapState.insert(key, entry)
+}
+
+func (p *EndpointPolicy) DeleteMapState(key Key) {
+	p.policyMapState.delete(key)
+}
+
+func (p *EndpointPolicy) RevertChanges(changes ChangeState) {
+	p.policyMapState.revertChanges(changes)
+}
+
+func (p *EndpointPolicy) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMeta *VisibilityMetadata, changes ChangeState) {
+	p.policyMapState.addVisibilityKeys(e, redirectPort, visMeta, changes)
+}
+
 // toMapState transforms the EndpointPolicy.L4Policy into
 // the datapath-friendly format inside EndpointPolicy.PolicyMapState.
 // Called with selectorcache locked for reading.

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -106,7 +106,7 @@ func (p *selectorPolicy) Detach() {
 func (p *selectorPolicy) DistillPolicy(policyOwner PolicyOwner, isHost bool) *EndpointPolicy {
 	calculatedPolicy := &EndpointPolicy{
 		selectorPolicy: p,
-		policyMapState: NewMapState(nil),
+		policyMapState: NewMapState(),
 		PolicyOwner:    policyOwner,
 	}
 
@@ -149,7 +149,7 @@ func (p *EndpointPolicy) GetPolicyMap() MapState {
 // will initialize a new MapState object for the caller.
 func (p *EndpointPolicy) SetPolicyMap(ms MapState) {
 	if ms == nil {
-		p.policyMapState = NewMapState(nil)
+		p.policyMapState = NewMapState()
 		return
 	}
 	p.policyMapState = ms
@@ -166,7 +166,7 @@ func (p *EndpointPolicy) Detach() {
 // it. We keep general insert functions private so that the caller can only insert to this specific
 // map.
 func NewMapStateWithInsert() (MapState, func(k Key, e MapStateEntry)) {
-	currentMap := NewMapState(nil)
+	currentMap := NewMapState()
 
 	return currentMap, func(k Key, e MapStateEntry) {
 		currentMap.insert(k, e)
@@ -262,6 +262,6 @@ func (p *EndpointPolicy) ConsumeMapChanges() (adds, deletes Keys) {
 func NewEndpointPolicy(repo *Repository) *EndpointPolicy {
 	return &EndpointPolicy{
 		selectorPolicy: newSelectorPolicy(repo.GetSelectorCache()),
-		policyMapState: NewMapState(nil),
+		policyMapState: NewMapState(),
 	}
 }

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -42,68 +42,6 @@ func GenerateL3IngressDenyRules(numRules int) api.Rules {
 	return rules
 }
 
-func GenerateL3EgressDenyRules(numRules int) api.Rules {
-	parseFooLabel := labels.ParseSelectLabel("k8s:foo")
-	fooSelector := api.NewESFromLabels(parseFooLabel)
-	barSelector := api.NewESFromLabels(labels.ParseSelectLabel("bar"))
-
-	// Change ingRule and rule in the for-loop below to change what type of rules
-	// are added into the policy repository.
-	egDenyRule := api.EgressDenyRule{
-		EgressCommonRule: api.EgressCommonRule{
-			ToEndpoints: []api.EndpointSelector{barSelector},
-		},
-	}
-
-	rules := make(api.Rules, 0, numRules)
-	for i := 1; i <= numRules; i++ {
-		rule := api.Rule{
-			EndpointSelector: fooSelector,
-			EgressDeny:       []api.EgressDenyRule{egDenyRule},
-		}
-		rule.Sanitize()
-		rules = append(rules, &rule)
-	}
-	return rules
-}
-
-func GenerateCIDRDenyRules(numRules int) api.Rules {
-	parseFooLabel := labels.ParseSelectLabel("k8s:foo")
-	fooSelector := api.NewESFromLabels(parseFooLabel)
-	//barSelector := api.NewESFromLabels(labels.ParseSelectLabel("bar"))
-
-	// Change ingRule and rule in the for-loop below to change what type of rules
-	// are added into the policy repository.
-	egDenyRule := api.EgressDenyRule{
-		EgressCommonRule: api.EgressCommonRule{
-			ToCIDR: []api.CIDR{api.CIDR("10.2.3.0/24"), api.CIDR("ff02::/64")},
-		},
-		/*ToRequires:  []api.EndpointSelector{barSelector},
-		ToPorts: []api.PortRule{
-			{
-				Ports: []api.PortProtocol{
-					{
-						Port:     "8080",
-						Protocol: api.ProtoTCP,
-					},
-				},
-			},
-		},*/
-	}
-
-	var rules api.Rules
-	for i := 1; i <= numRules; i++ {
-
-		rule := api.Rule{
-			EndpointSelector: fooSelector,
-			EgressDeny:       []api.EgressDenyRule{egDenyRule},
-		}
-		rule.Sanitize()
-		rules = append(rules, &rule)
-	}
-	return rules
-}
-
 func TestL3WithIngressDenyWildcard(t *testing.T) {
 	td := newTestData()
 	repo := td.repo

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 )
 
-func GenerateL3IngressDenyRules(numRules int) api.Rules {
+func GenerateL3IngressDenyRules(numRules int) (api.Rules, identity.IdentityMap) {
 	parseFooLabel := labels.ParseSelectLabel("k8s:foo")
 	fooSelector := api.NewESFromLabels(parseFooLabel)
 	barSelector := api.NewESFromLabels(labels.ParseSelectLabel("bar"))
@@ -39,7 +39,8 @@ func GenerateL3IngressDenyRules(numRules int) api.Rules {
 		rule.Sanitize()
 		rules = append(rules, &rule)
 	}
-	return rules
+
+	return rules, generateNumIdentities(3000)
 }
 
 func TestL3WithIngressDenyWildcard(t *testing.T) {

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -455,7 +455,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 			IngressPolicyEnabled: true,
 		},
 		PolicyOwner: DummyOwner{},
-		policyMapState: newMapState(map[Key]MapStateEntry{
+		policyMapState: newMapState().withState(map[Key]MapStateEntry{
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
 			{TrafficDirection: trafficdirection.Egress.Uint8(), InvertedPortMask: 0xffff /* This is a wildcard */}: allowEgressMapStateEntry,
@@ -616,7 +616,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 			IngressPolicyEnabled: true,
 		},
 		PolicyOwner: DummyOwner{},
-		policyMapState: newMapState(map[Key]MapStateEntry{
+		policyMapState: newMapState().withState(map[Key]MapStateEntry{
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
 			{TrafficDirection: trafficdirection.Egress.Uint8(), InvertedPortMask: 0xffff /* This is a wildcard */}: allowEgressMapStateEntry,

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -460,7 +460,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 			// will still allow egress to world.
 			{TrafficDirection: trafficdirection.Egress.Uint8(), InvertedPortMask: 0xffff /* This is a wildcard */}: allowEgressMapStateEntry,
 			{DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
-		}),
+		}, td.sc),
 	}
 
 	// Add new identity to test accumulation of MapChanges
@@ -625,7 +625,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 			{Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, Nexthdr: 6}:                       rule1MapStateEntry.WithOwners(cachedSelectorWorldV6, cachedSelectorWorld),
 			{Identity: 192, DestPort: 80, Nexthdr: 6}:                                                              rule1MapStateEntry,
 			{Identity: 194, DestPort: 80, Nexthdr: 6}:                                                              rule1MapStateEntry,
-		}),
+		}, td.sc),
 	}
 
 	adds, deletes := policy.ConsumeMapChanges()

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -550,7 +550,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 		policyMapState: newMapState().withState(map[Key]MapStateEntry{
 			{TrafficDirection: trafficdirection.Egress.Uint8(), InvertedPortMask: 0xffff}: allowEgressMapStateEntry,
 			{DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
-		}),
+		}, td.sc),
 	}
 
 	// Add new identity to test accumulation of MapChanges
@@ -723,7 +723,7 @@ func TestMapStateWithIngress(t *testing.T) {
 			{Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, Nexthdr: 6}:                     rule1MapStateEntry.WithOwners(cachedSelectorWorld, cachedSelectorWorldV6),
 			{Identity: 192, DestPort: 80, Nexthdr: 6}:                                                            rule1MapStateEntry.WithAuthType(AuthTypeDisabled),
 			{Identity: 194, DestPort: 80, Nexthdr: 6}:                                                            rule1MapStateEntry.WithAuthType(AuthTypeDisabled),
-		}),
+		}, td.sc),
 	}
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop
@@ -789,7 +789,9 @@ func (p *EndpointPolicy) allowsIdentity(identity identity.NumericIdentity) (ingr
 	return ingress, egress
 }
 
-func TestEndpointPolicy_allowsIdentity(t *testing.T) {
+func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
+	td := newTestData()
+
 	type fields struct {
 		selectorPolicy *selectorPolicy
 		PolicyMapState *mapState
@@ -849,7 +851,7 @@ func TestEndpointPolicy_allowsIdentity(t *testing.T) {
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Ingress.Uint8(),
 					}: {},
-				}),
+				}, td.sc),
 			},
 			args: args{
 				identity: 0,
@@ -872,7 +874,7 @@ func TestEndpointPolicy_allowsIdentity(t *testing.T) {
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Egress.Uint8(),
 					}: {},
-				}),
+				}, td.sc),
 			},
 			args: args{
 				identity: 0,
@@ -895,7 +897,7 @@ func TestEndpointPolicy_allowsIdentity(t *testing.T) {
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Ingress.Uint8(),
 					}: {IsDeny: true},
-				}),
+				}, td.sc),
 			},
 			args: args{
 				identity: 0,
@@ -918,7 +920,7 @@ func TestEndpointPolicy_allowsIdentity(t *testing.T) {
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Ingress.Uint8(),
 					}: {IsDeny: true},
-				}),
+				}, td.sc),
 			},
 			args: args{
 				identity: 0,
@@ -941,7 +943,7 @@ func TestEndpointPolicy_allowsIdentity(t *testing.T) {
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Egress.Uint8(),
 					}: {IsDeny: true},
-				}),
+				}, td.sc),
 			},
 			args: args{
 				identity: 0,
@@ -964,7 +966,7 @@ func TestEndpointPolicy_allowsIdentity(t *testing.T) {
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Egress.Uint8(),
 					}: {IsDeny: true},
-				}),
+				}, td.sc),
 			},
 			args: args{
 				identity: 0,

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -547,7 +547,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 			EgressPolicyEnabled:  false,
 		},
 		PolicyOwner: DummyOwner{},
-		policyMapState: newMapState(map[Key]MapStateEntry{
+		policyMapState: newMapState().withState(map[Key]MapStateEntry{
 			{TrafficDirection: trafficdirection.Egress.Uint8(), InvertedPortMask: 0xffff}: allowEgressMapStateEntry,
 			{DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
 		}),
@@ -716,7 +716,7 @@ func TestMapStateWithIngress(t *testing.T) {
 			EgressPolicyEnabled:  false,
 		},
 		PolicyOwner: DummyOwner{},
-		policyMapState: newMapState(map[Key]MapStateEntry{
+		policyMapState: newMapState().withState(map[Key]MapStateEntry{
 			{TrafficDirection: trafficdirection.Egress.Uint8(), InvertedPortMask: 0xffff /*This is a wildcard*/}: allowEgressMapStateEntry,
 			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}:                         rule1MapStateEntry.WithOwners(cachedSelectorWorld),
 			{Identity: uint32(identity.ReservedIdentityWorldIPv4), DestPort: 80, Nexthdr: 6}:                     rule1MapStateEntry.WithOwners(cachedSelectorWorld, cachedSelectorWorldV4),
@@ -811,7 +811,7 @@ func TestEndpointPolicy_allowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: false,
 					EgressPolicyEnabled:  false,
 				},
-				PolicyMapState: newMapState(nil),
+				PolicyMapState: newMapState(),
 			},
 			args: args{
 				identity: 0,
@@ -826,7 +826,7 @@ func TestEndpointPolicy_allowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: newMapState(nil),
+				PolicyMapState: newMapState(),
 			},
 			args: args{
 				identity: 0,
@@ -841,7 +841,7 @@ func TestEndpointPolicy_allowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: newMapState(map[Key]MapStateEntry{
+				PolicyMapState: newMapState().withState(map[Key]MapStateEntry{
 					{
 						Identity:         0,
 						DestPort:         0,
@@ -864,7 +864,7 @@ func TestEndpointPolicy_allowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: newMapState(map[Key]MapStateEntry{
+				PolicyMapState: newMapState().withState(map[Key]MapStateEntry{
 					{
 						Identity:         0,
 						DestPort:         0,
@@ -887,7 +887,7 @@ func TestEndpointPolicy_allowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: newMapState(map[Key]MapStateEntry{
+				PolicyMapState: newMapState().withState(map[Key]MapStateEntry{
 					{
 						Identity:         0,
 						DestPort:         0,
@@ -910,7 +910,7 @@ func TestEndpointPolicy_allowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: false,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: newMapState(map[Key]MapStateEntry{
+				PolicyMapState: newMapState().withState(map[Key]MapStateEntry{
 					{
 						Identity:         0,
 						DestPort:         0,
@@ -933,7 +933,7 @@ func TestEndpointPolicy_allowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: newMapState(map[Key]MapStateEntry{
+				PolicyMapState: newMapState().withState(map[Key]MapStateEntry{
 					{
 						Identity:         0,
 						DestPort:         0,
@@ -956,7 +956,7 @@ func TestEndpointPolicy_allowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  false,
 				},
-				PolicyMapState: newMapState(map[Key]MapStateEntry{
+				PolicyMapState: newMapState().withState(map[Key]MapStateEntry{
 					{
 						Identity:         0,
 						DestPort:         0,


### PR DESCRIPTION
Hold MapStateEntries in `entries` map, `trie` and `cidr` within the `trie` are additional indices for the same MapStateEntries. `cidr` only indexes keys with CIDR identities, while `trie` indexes keys by traffic direction, protocol, destination port and mask.

Use the `trie` and the new `cidr` index when adding entries to MapState with deny entries, and the existing `trie` index when adding entries to MapState with auth entries. Likewise, use the `trie` index when adding visibility entries. With this we no longer scan through all entries in MapState when adding new entries.

MapState now contains an optional validator interface that can be set in unit tests to add calls to validation code for the new ancestor/descendants code. This is currently enabled only for the `denyPreferredInsertWithChanges`.

On local benchmarking for generating MapState for an egress policy with 1000 deny and 1000 allow CIDR rules:

Before:
```
Number of MapState entries: 117515
goos: linux
goarch: arm64
pkg: github.com/cilium/cilium/pkg/policy
BenchmarkRegenerateCIDRDenyPolicyRules-12    	       1	763361909494 ns/op
PASS
ok  	github.com/cilium/cilium/pkg/policy	763.696s
```
After:
```
Number of MapState entries: 117515
goos: linux
goarch: arm64
pkg: github.com/cilium/cilium/pkg/policy
BenchmarkRegenerateCIDRDenyPolicyRules-12    	Number of MapState entries: 117515
Number of MapState entries: 117515
       3	 418981451 ns/op
PASS
ok  	github.com/cilium/cilium/pkg/policy	3.434s
```
This is a 1820x speedup :-)

Using the PortProto `trie` in addition to the new `cidr` trie as suggested by @nathanjsweet made this 8x faster for this specific test case.

```release-note
Deny rule processing has been improved to run faster, especially on larger policies.
```
