### PR TITLE
Revert "Policy catch invalid port wildcard"

### DIFF
--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -119,9 +119,6 @@ func (k *PolicyKey) GetDestPort() uint16 {
 
 // GetPortMask returns the port mask of the key
 func (k *PolicyKey) GetPortMask() uint16 {
-	if k.DestPortNetwork == 0 {
-		return 0
-	}
 	return 0xffff
 }
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -127,11 +127,7 @@ func TestCachePopulation(t *testing.T) {
 
 // Distillery integration tests
 func key(id uint32, port uint16, hdr uint8, dir uint8) Key {
-	mask := uint16(0xffff)
-	if port == 0 {
-		mask = 0
-	}
-	return keyWithPortMask(id, port, mask, hdr, dir)
+	return keyWithPortMask(id, port, 0xffff, hdr, dir)
 }
 
 // keyWithPortMask returns a key with a specific port mask.
@@ -359,16 +355,16 @@ var (
 	dirIngress = trafficdirection.Ingress.Uint8()
 	dirEgress  = trafficdirection.Egress.Uint8()
 	// Desired map keys for L3, L3-dependent L4, L4
-	mapKeyAllowFoo__ = key(identityFoo, 0, 0, dirIngress)
-	mapKeyAllowBar__ = key(identityBar, 0, 0, dirIngress)
+	mapKeyAllowFoo__ = keyWithPortMask(identityFoo, 0, 0, 0, dirIngress)
+	mapKeyAllowBar__ = keyWithPortMask(identityBar, 0, 0, 0, dirIngress)
 	mapKeyAllowBarL4 = key(identityBar, 80, 6, dirIngress)
 	mapKeyAllowFooL4 = key(identityFoo, 80, 6, dirIngress)
 	mapKeyDeny_Foo__ = mapKeyAllowFoo__
 	mapKeyDeny_FooL4 = mapKeyAllowFooL4
 	mapKeyAllow___L4 = key(0, 80, 6, dirIngress)
 	mapKeyDeny____L4 = mapKeyAllow___L4
-	mapKeyAllowAll__ = key(0, 0, 0, dirIngress)
-	mapKeyAllowAllE_ = key(0, 0, 0, dirEgress)
+	mapKeyAllowAll__ = keyWithPortMask(0, 0, 0, 0, dirIngress)
+	mapKeyAllowAllE_ = keyWithPortMask(0, 0, 0, 0, dirEgress)
 	// Desired map entries for no L7 redirect / redirect to Proxy
 	mapEntryL7None_ = func(lbls ...labels.LabelArray) MapStateEntry {
 		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), 0, "", 0, false, DefaultAuthType, AuthTypeDisabled).WithOwners()
@@ -1379,8 +1375,8 @@ var (
 	cpyRule                   = *ruleL3DenyWorld
 	ruleL3DenyWorldWithLabels = (&cpyRule).WithLabels(labels.LabelWorld.LabelArray())
 	worldReservedID           = identity.ReservedIdentityWorld.Uint32()
-	mapKeyL3WorldIngress      = key(worldReservedID, 0, 0, trafficdirection.Ingress.Uint8())
-	mapKeyL3WorldEgress       = key(worldReservedID, 0, 0, trafficdirection.Egress.Uint8())
+	mapKeyL3WorldIngress      = keyWithPortMask(worldReservedID, 0, 0, 0, trafficdirection.Ingress.Uint8())
+	mapKeyL3WorldEgress       = keyWithPortMask(worldReservedID, 0, 0, 0, trafficdirection.Egress.Uint8())
 	mapEntryDeny              = MapStateEntry{
 		ProxyPort:        0,
 		DerivedFromRules: labels.LabelArrayList{nil},
@@ -1433,8 +1429,8 @@ var (
 			ToCIDRSet: api.CIDRRuleSlice{worldSubnetRule},
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
-	mapKeyL3SubnetIngress = key(worldSubnetIdentity.Uint32(), 0, 0, trafficdirection.Ingress.Uint8())
-	mapKeyL3SubnetEgress  = key(worldSubnetIdentity.Uint32(), 0, 0, trafficdirection.Egress.Uint8())
+	mapKeyL3SubnetIngress = keyWithPortMask(worldSubnetIdentity.Uint32(), 0, 0, 0, trafficdirection.Ingress.Uint8())
+	mapKeyL3SubnetEgress  = keyWithPortMask(worldSubnetIdentity.Uint32(), 0, 0, 0, trafficdirection.Egress.Uint8())
 
 	ruleL3DenySmallerSubnet = api.NewRule().WithIngressDenyRules([]api.IngressDenyRule{{
 		IngressCommonRule: api.IngressCommonRule{
@@ -1456,8 +1452,8 @@ var (
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
 
-	mapKeyL3SmallerSubnetIngress = key(worldIPIdentity.Uint32(), 0, 0, trafficdirection.Ingress.Uint8())
-	mapKeyL3SmallerSubnetEgress  = key(worldIPIdentity.Uint32(), 0, 0, trafficdirection.Egress.Uint8())
+	mapKeyL3SmallerSubnetIngress = keyWithPortMask(worldIPIdentity.Uint32(), 0, 0, 0, trafficdirection.Ingress.Uint8())
+	mapKeyL3SmallerSubnetEgress  = keyWithPortMask(worldIPIdentity.Uint32(), 0, 0, 0, trafficdirection.Egress.Uint8())
 
 	ruleL3AllowHostEgress = api.NewRule().WithEgressRules([]api.EgressRule{{
 		EgressCommonRule: api.EgressCommonRule{
@@ -1465,14 +1461,14 @@ var (
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
 
-	mapKeyL3UnknownIngress = key(identity.IdentityUnknown.Uint32(), 0, 0, trafficdirection.Ingress.Uint8())
+	mapKeyL3UnknownIngress = keyWithPortMask(identity.IdentityUnknown.Uint32(), 0, 0, 0, trafficdirection.Ingress.Uint8())
 	derivedFrom            = labels.LabelArrayList{
 		labels.LabelArray{
 			labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowAnyIngress, labels.LabelSourceReserved),
 		},
 	}
 	mapEntryL3UnknownIngress          = NewMapStateEntry(nil, derivedFrom, 0, "", 0, false, ExplicitAuthType, AuthTypeDisabled)
-	mapKeyL3HostEgress                = key(identity.ReservedIdentityHost.Uint32(), 0, 0, trafficdirection.Egress.Uint8())
+	mapKeyL3HostEgress                = keyWithPortMask(identity.ReservedIdentityHost.Uint32(), 0, 0, 0, trafficdirection.Egress.Uint8())
 	ruleL3L4Port8080ProtoAnyDenyWorld = api.NewRule().WithIngressDenyRules([]api.IngressDenyRule{
 		{
 			ToPorts: api.PortDenyRules{
@@ -1559,8 +1555,8 @@ var (
 			ToCIDR: api.CIDRSlice{worldIPCIDR},
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
-	mapKeyL4AnyPortProtoWorldIPIngress      = key(worldIPIdentity.Uint32(), 0, 0, trafficdirection.Ingress.Uint8())
-	mapKeyL4AnyPortProtoWorldIPEgress       = key(worldIPIdentity.Uint32(), 0, 0, trafficdirection.Egress.Uint8())
+	mapKeyL4AnyPortProtoWorldIPIngress      = keyWithPortMask(worldIPIdentity.Uint32(), 0, 0, 0, trafficdirection.Ingress.Uint8())
+	mapKeyL4AnyPortProtoWorldIPEgress       = keyWithPortMask(worldIPIdentity.Uint32(), 0, 0, 0, trafficdirection.Egress.Uint8())
 	mapKeyL4Port8080ProtoTCPWorldIPIngress  = key(worldIPIdentity.Uint32(), 8080, 6, trafficdirection.Ingress.Uint8())
 	mapKeyL4Port8080ProtoTCPWorldIPEgress   = key(worldIPIdentity.Uint32(), 8080, 6, trafficdirection.Egress.Uint8())
 	mapKeyL4Port8080ProtoUDPWorldIPIngress  = key(worldIPIdentity.Uint32(), 8080, 17, trafficdirection.Ingress.Uint8())

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -350,9 +350,6 @@ func newMapState(initMap map[Key]MapStateEntry) *mapState {
 
 // Get the MapStateEntry that matches the Key.
 func (ms *mapState) Get(k Key) (MapStateEntry, bool) {
-	if k.DestPort == 0 && k.InvertedPortMask != 0xffff {
-		panic("invalid wildcard port with non-zero mask")
-	}
 	v, ok := ms.denies.Lookup(k)
 	if ok {
 		return v, ok
@@ -363,9 +360,6 @@ func (ms *mapState) Get(k Key) (MapStateEntry, bool) {
 // Insert the Key and matcthing MapStateEntry into the
 // MapState
 func (ms *mapState) Insert(k Key, v MapStateEntry) {
-	if k.DestPort == 0 && k.InvertedPortMask != 0xffff {
-		panic("invalid wildcard port with non-zero mask")
-	}
 	if v.IsDeny {
 		ms.allows.Delete(k)
 		ms.denies.Upsert(k, v)
@@ -1449,7 +1443,6 @@ func (ms *mapState) allowAllIdentities(ingress, egress bool) {
 		keyToAdd := Key{
 			Identity:         0,
 			DestPort:         0,
-			InvertedPortMask: 0xffff, // This is a wildcard
 			Nexthdr:          0,
 			TrafficDirection: trafficdirection.Egress.Uint8(),
 		}
@@ -1483,7 +1476,6 @@ func (ms *mapState) deniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
 	anyKey := Key{
 		Identity:         0,
 		DestPort:         0,
-		InvertedPortMask: 0xffff,
 		Nexthdr:          0,
 		TrafficDirection: dir,
 	}

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -22,12 +22,12 @@ func Test_IsSuperSetOf(t *testing.T) {
 		subSet   Key
 		res      int
 	}{
-		{key(0, 0, 0, 0), key(0, 0, 0, 0), 0},
-		{key(0, 0, 0, 0), key(42, 0, 6, 0), 1},
-		{key(0, 0, 0, 0), key(42, 80, 6, 0), 1},
-		{key(0, 0, 0, 0), key(42, 0, 0, 0), 1},
-		{key(0, 0, 6, 0), key(42, 0, 6, 0), 3}, // port is the same
-		{key(0, 0, 6, 0), key(42, 80, 6, 0), 2},
+		{keyWithPortMask(0, 0, 0, 0, 0), keyWithPortMask(0, 0, 0, 0, 0), 0},
+		{keyWithPortMask(0, 0, 0, 0, 0), keyWithPortMask(42, 0, 0, 6, 0), 1},
+		{keyWithPortMask(0, 0, 0, 0, 0), key(42, 80, 6, 0), 1},
+		{keyWithPortMask(0, 0, 0, 0, 0), keyWithPortMask(42, 0, 0, 0, 0), 1},
+		{keyWithPortMask(0, 0, 0, 6, 0), keyWithPortMask(42, 0, 0, 6, 0), 3}, // port is the same
+		{keyWithPortMask(0, 0, 0, 6, 0), key(42, 80, 6, 0), 2},
 		{keyWithPortMask(0, 64, 0xffc0, 6, 0), key(42, 80, 6, 0), 2}, // port range 64-127,80
 		{key(0, 80, 6, 0), key(42, 80, 6, 0), 3},
 		{keyWithPortMask(0, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 3}, // port ranges are the same
@@ -35,17 +35,17 @@ func Test_IsSuperSetOf(t *testing.T) {
 		{key(2, 80, 6, 0), key(42, 80, 6, 0), 0},                                         // id is different
 		{key(0, 8080, 6, 0), key(42, 80, 6, 0), 0},                                       // port is different
 		{keyWithPortMask(0, 64, 0xffc0, 6, 0), key(42, 8080, 6, 0), 0},                   // port range is different from port
-		{key(42, 0, 0, 0), key(42, 0, 0, 0), 0},                                          // same key
-		{key(42, 0, 0, 0), key(42, 0, 6, 0), 4},
-		{key(42, 0, 0, 0), key(42, 80, 6, 0), 4},
+		{keyWithPortMask(42, 0, 0, 0, 0), keyWithPortMask(42, 0, 0, 0, 0), 0},            // same key
+		{keyWithPortMask(42, 0, 0, 0, 0), keyWithPortMask(42, 0, 0, 6, 0), 4},
+		{keyWithPortMask(42, 0, 0, 0, 0), key(42, 80, 6, 0), 4},
 		{keyWithPortMask(42, 64, 0xffc0, 0, 0), key(42, 80, 6, 0), 4}, // port range 64-127,80
-		{key(42, 0, 0, 0), key(42, 0, 17, 0), 4},
-		{key(42, 0, 0, 0), key(42, 80, 17, 0), 4},
+		{keyWithPortMask(42, 0, 0, 0, 0), keyWithPortMask(42, 0, 0, 17, 0), 4},
+		{keyWithPortMask(42, 0, 0, 0, 0), key(42, 80, 17, 0), 4},
 		{keyWithPortMask(42, 64, 0xffc0, 0, 0), key(42, 80, 17, 0), 4},
-		{key(42, 0, 6, 0), key(42, 0, 6, 0), 0}, // same key
-		{key(42, 0, 6, 0), key(42, 80, 6, 0), 5},
+		{keyWithPortMask(42, 0, 0, 6, 0), keyWithPortMask(42, 0, 0, 6, 0), 0}, // same key
+		{keyWithPortMask(42, 0, 0, 6, 0), key(42, 80, 6, 0), 5},
 		{keyWithPortMask(42, 64, 0xffc0, 6, 0), key(42, 80, 6, 0), 5},
-		{key(42, 0, 6, 0), key(42, 8080, 6, 0), 5},
+		{keyWithPortMask(42, 0, 0, 6, 0), key(42, 8080, 6, 0), 5},
 		{key(42, 80, 6, 0), key(42, 80, 6, 0), 0},                                          // same key
 		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 0},  // same key
 		{key(42, 80, 6, 0), key(42, 8080, 6, 0), 0},                                        // different port
@@ -54,69 +54,69 @@ func Test_IsSuperSetOf(t *testing.T) {
 		{key(42, 80, 6, 0), key(42, 8080, 17, 0), 0},                                       // different port and proto
 
 		// increasing specificity for a L3/L4 key
-		{key(0, 0, 0, 0), key(42, 80, 6, 0), 1},
+		{keyWithPortMask(0, 0, 0, 0, 0), key(42, 80, 6, 0), 1},
 		{keyWithPortMask(0, 64, 0xffc0, 0, 0), key(42, 80, 6, 0), 1},
-		{key(0, 0, 6, 0), key(42, 80, 6, 0), 2},
+		{keyWithPortMask(0, 0, 0, 6, 0), key(42, 80, 6, 0), 2},
 		{keyWithPortMask(0, 64, 0xffc0, 6, 0), key(42, 80, 6, 0), 2},
 		{key(0, 80, 6, 0), key(42, 80, 6, 0), 3},
 		{keyWithPortMask(0, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 3},
-		{key(42, 0, 0, 0), key(42, 80, 6, 0), 4},
+		{keyWithPortMask(42, 0, 0, 0, 0), key(42, 80, 6, 0), 4},
 		{keyWithPortMask(42, 64, 0xffc0, 0, 0), key(42, 80, 6, 0), 4},
-		{key(42, 0, 6, 0), key(42, 80, 6, 0), 5},
+		{keyWithPortMask(42, 0, 0, 6, 0), key(42, 80, 6, 0), 5},
 		{keyWithPortMask(42, 64, 0xffc0, 6, 0), key(42, 80, 6, 0), 5},
 		{key(42, 80, 6, 0), key(42, 80, 6, 0), 0},                                         // same key
 		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 0}, // same key
 
 		// increasing specificity for a L3-only key
-		{key(0, 0, 0, 0), key(42, 0, 0, 0), 1},
-		{keyWithPortMask(0, 64, 0xffc0, 0, 0), key(42, 0, 0, 0), 1},
-		{key(0, 0, 6, 0), key(42, 0, 0, 0), 0},                                            // not a superset
-		{key(0, 80, 6, 0), key(42, 0, 0, 0), 0},                                           // not a superset
-		{keyWithPortMask(0, 64, 0xffc0, 6, 0), key(42, 0, 0, 0), 0},                       // not a superset
-		{key(42, 0, 0, 0), key(42, 0, 0, 0), 0},                                           // same key
-		{key(42, 0, 6, 0), key(42, 0, 0, 0), 0},                                           // not a superset
+		{keyWithPortMask(0, 0, 0, 0, 0), keyWithPortMask(42, 0, 0, 0, 0), 1},
+		{keyWithPortMask(0, 64, 0xffc0, 0, 0), keyWithPortMask(42, 0, 0, 0, 0), 1},
+		{keyWithPortMask(0, 0, 0, 6, 0), keyWithPortMask(42, 0, 0, 0, 0), 0},              // not a superset
+		{key(0, 80, 6, 0), keyWithPortMask(42, 0, 0, 0, 0), 0},                            // not a superset
+		{keyWithPortMask(0, 64, 0xffc0, 6, 0), keyWithPortMask(42, 0, 0, 0, 0), 0},        // not a superset
+		{keyWithPortMask(42, 0, 0, 0, 0), keyWithPortMask(42, 0, 0, 0, 0), 0},             // same key
+		{keyWithPortMask(42, 0, 0, 6, 0), keyWithPortMask(42, 0, 0, 0, 0), 0},             // not a superset
 		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 0, 0), 0}, // not a superset
-		{key(42, 80, 6, 0), key(42, 0, 0, 0), 0},                                          // not a superset
-		{keyWithPortMask(42, 64, 0xffc0, 6, 0), key(42, 0, 0, 0), 0},                      // not a superset
+		{key(42, 80, 6, 0), keyWithPortMask(42, 0, 0, 0, 0), 0},                           // not a superset
+		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(42, 0, 0, 0, 0), 0},       // not a superset
 
 		// increasing specificity for a L3/proto key
-		{key(0, 0, 0, 0), key(42, 0, 6, 0), 1}, // wildcard
+		{keyWithPortMask(0, 0, 0, 0, 0), keyWithPortMask(42, 0, 0, 6, 0), 1}, // wildcard
 		{keyWithPortMask(0, 64, 0xffc0, 0, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 1},
-		{key(0, 0, 6, 0), key(42, 0, 6, 0), 3},                                           // ports are the same
+		{keyWithPortMask(0, 0, 0, 6, 0), keyWithPortMask(42, 0, 0, 6, 0), 3},             // ports are the same
 		{keyWithPortMask(0, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 3}, // port ranges are the same
-		{key(0, 80, 6, 0), key(42, 0, 6, 0), 0},                                          // not a superset
+		{key(0, 80, 6, 0), keyWithPortMask(42, 0, 0, 6, 0), 0},                           // not a superset
 		{key(0, 80, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 0},                     // not a superset
-		{key(42, 0, 0, 0), key(42, 0, 6, 0), 4},
+		{keyWithPortMask(42, 0, 0, 0, 0), keyWithPortMask(42, 0, 0, 6, 0), 4},
 		{keyWithPortMask(42, 64, 0xffc0, 0, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 4},
-		{key(42, 0, 6, 0), key(42, 0, 6, 0), 0},                                           // same key
+		{keyWithPortMask(42, 0, 0, 6, 0), keyWithPortMask(42, 0, 0, 6, 0), 0},             // same key
 		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 0}, // same key
-		{key(42, 80, 6, 0), key(42, 0, 6, 0), 0},                                          // not a superset
+		{key(42, 80, 6, 0), keyWithPortMask(42, 0, 0, 6, 0), 0},                           // not a superset
 		{key(42, 80, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 0},                     // not a superset
 
 		// increasing specificity for a proto-only key
-		{key(0, 0, 0, 0), key(0, 0, 6, 0), 1},
+		{keyWithPortMask(0, 0, 0, 0, 0), keyWithPortMask(0, 0, 0, 6, 0), 1},
 		{keyWithPortMask(0, 64, 0xffc0, 0, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 1},
-		{key(0, 0, 6, 0), key(0, 0, 6, 0), 0},                                            // same key
+		{keyWithPortMask(0, 0, 0, 6, 0), keyWithPortMask(0, 0, 0, 6, 0), 0},              // same key
 		{keyWithPortMask(0, 64, 0xffc0, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0},  // same key
-		{key(0, 80, 6, 0), key(0, 0, 6, 0), 0},                                           // not a superset
+		{key(0, 80, 6, 0), keyWithPortMask(0, 0, 0, 6, 0), 0},                            // not a superset
 		{key(0, 80, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0},                      // not a superset
-		{key(42, 0, 0, 0), key(0, 0, 6, 0), 0},                                           // not a superset
+		{keyWithPortMask(42, 0, 0, 0, 0), keyWithPortMask(0, 0, 0, 6, 0), 0},             // not a superset
 		{keyWithPortMask(42, 64, 0xffc0, 0, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0}, // not a superset
-		{key(42, 0, 6, 0), key(0, 0, 6, 0), 0},                                           // not a superset
+		{keyWithPortMask(42, 0, 0, 6, 0), keyWithPortMask(0, 0, 0, 6, 0), 0},             // not a superset
 		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0}, // not a superset
-		{key(42, 80, 6, 0), key(0, 0, 6, 0), 0},                                          // not a superset
+		{key(42, 80, 6, 0), keyWithPortMask(0, 0, 0, 6, 0), 0},                           // not a superset
 		{key(42, 80, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0},                     // not a superset
 
 		// increasing specificity for a L4-only key
-		{key(0, 0, 0, 0), key(0, 80, 6, 0), 1},
+		{keyWithPortMask(0, 0, 0, 0, 0), key(0, 80, 6, 0), 1},
 		{keyWithPortMask(0, 64, 0xffc0, 0, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 1},
-		{key(0, 0, 6, 0), key(0, 80, 6, 0), 2},
+		{keyWithPortMask(0, 0, 0, 6, 0), key(0, 80, 6, 0), 2},
 		{keyWithPortMask(0, 64, 0xffc0, 6, 0), key(0, 80, 6, 0), 2},
 		{key(0, 80, 6, 0), key(0, 80, 6, 0), 0},                                          // same key
 		{keyWithPortMask(0, 64, 0xffc0, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0},  // same key
-		{key(42, 0, 0, 0), key(0, 80, 6, 0), 0},                                          // not a superset
+		{keyWithPortMask(42, 0, 0, 0, 0), key(0, 80, 6, 0), 0},                           // not a superset
 		{keyWithPortMask(42, 64, 0xffc0, 0, 0), key(0, 80, 6, 0), 0},                     // not a superset
-		{key(42, 0, 6, 0), key(0, 80, 6, 0), 0},                                          // not a superset
+		{keyWithPortMask(42, 0, 0, 6, 0), key(0, 80, 6, 0), 0},                           // not a superset
 		{keyWithPortMask(42, 64, 0xffc0, 6, 0), key(0, 80, 6, 0), 0},                     // not a superset
 		{key(42, 80, 6, 0), key(0, 80, 6, 0), 0},                                         // not a superset
 		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0}, // not a superset
@@ -3583,7 +3583,11 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 			}
 		}
 		if tt.outcome&insertAWithBProto > 0 {
-			aKeyWithBProto := key(tt.aIdentity, tt.bPort, tt.bProto, 0)
+			var invertedPortMask uint16
+			if tt.bPort == 0 {
+				invertedPortMask = 0xffff // this is a wildcard
+			}
+			aKeyWithBProto := Key{Identity: tt.aIdentity, DestPort: tt.bPort, InvertedPortMask: invertedPortMask, Nexthdr: tt.bProto}
 			aEntryCpy := MapStateEntry{IsDeny: tt.aIsDeny}
 			aEntryCpy.owners = map[MapStateOwner]struct{}{aKey: {}}
 			aEntry.AddDependent(aKeyWithBProto)
@@ -3596,7 +3600,11 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 			}
 		}
 		if tt.outcome&insertBWithAProto > 0 {
-			bKeyWithBProto := key(tt.bIdentity, tt.aPort, tt.aProto, 0)
+			var invertedPortMask uint16
+			if tt.aPort == 0 {
+				invertedPortMask = 0xffff
+			}
+			bKeyWithBProto := Key{Identity: tt.bIdentity, DestPort: tt.aPort, InvertedPortMask: invertedPortMask, Nexthdr: tt.aProto}
 			bEntryCpy := MapStateEntry{IsDeny: tt.bIsDeny}
 			bEntryCpy.owners = map[MapStateOwner]struct{}{bKey: {}}
 			bEntry.AddDependent(bKeyWithBProto)
@@ -3618,9 +3626,16 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 	// This should result in both entries being inserted with
 	// no changes, as they do not affect one another anymore.
 	for _, tt := range tests {
-		aKey := key(tt.aIdentity, tt.aPort, tt.aProto, 0)
+		var aInvertedMask, bInvertedMask uint16
+		if tt.aPort == 0 {
+			aInvertedMask = 0xffff
+		}
+		if tt.bPort == 0 {
+			bInvertedMask = 0xffff
+		}
+		aKey := Key{Identity: tt.aIdentity, DestPort: tt.aPort, InvertedPortMask: aInvertedMask, Nexthdr: tt.aProto}
 		aEntry := MapStateEntry{IsDeny: tt.aIsDeny}
-		bKey := key(tt.bIdentity, tt.bPort, tt.bProto, 1)
+		bKey := Key{Identity: tt.bIdentity, DestPort: tt.bPort, InvertedPortMask: bInvertedMask, Nexthdr: tt.bProto, TrafficDirection: 1}
 		bEntry := MapStateEntry{IsDeny: tt.bIsDeny}
 		expectedKeys := newMapState(nil)
 		if tt.aIsDeny {

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -204,7 +204,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         0,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: 0,
 				}: {
@@ -214,16 +213,13 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				},
 			}),
 			args: args{
-				key: Key{
-					InvertedPortMask: 0xffff,
-				},
+				key:   Key{},
 				entry: MapStateEntry{},
 			},
 			want: newMapState(map[Key]MapStateEntry{
 				{
 					Identity:         0,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: 0,
 				}: {
@@ -254,7 +250,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				},
@@ -268,7 +263,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -291,7 +285,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				Key{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
@@ -599,7 +592,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -620,7 +612,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         2,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -633,7 +624,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				},
@@ -647,7 +637,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -668,7 +657,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         2,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -681,7 +669,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				Key{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
@@ -698,7 +685,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -869,7 +855,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -890,7 +875,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         2,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -903,7 +887,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Egress.Uint8(),
 				},
@@ -927,7 +910,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -938,7 +920,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Egress.Uint8(),
 				}: {
@@ -959,7 +940,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         2,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -972,7 +952,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				Key{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Egress.Uint8(),
 				}: struct{}{},
@@ -1113,7 +1092,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1139,7 +1117,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1158,7 +1135,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1185,7 +1161,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1204,7 +1179,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1231,7 +1205,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1250,7 +1223,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1278,7 +1250,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1310,7 +1281,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				},
@@ -1324,7 +1294,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1337,7 +1306,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				Key{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
@@ -1384,7 +1352,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				},
@@ -1398,7 +1365,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1411,7 +1377,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				Key{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
@@ -1469,7 +1434,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				},
@@ -1483,7 +1447,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1496,7 +1459,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				Key{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
@@ -1570,7 +1532,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				},
@@ -1584,7 +1545,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1597,7 +1557,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				Key{
 					Identity:         1,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
@@ -1661,7 +1620,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         0,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1674,7 +1632,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         100,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				},
@@ -1699,7 +1656,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         0,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1730,7 +1686,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         0,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1743,7 +1698,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         100,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				},
@@ -1769,7 +1723,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         0,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1823,7 +1776,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         0,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				},
@@ -1837,7 +1789,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         0,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1861,7 +1812,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				Key{
 					Identity:         0,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
@@ -1949,7 +1899,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: Key{
 					Identity:         0,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				},
@@ -1963,7 +1912,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				{
 					Identity:         0,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: {
@@ -1988,7 +1936,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				Key{
 					Identity:         0,
 					DestPort:         0,
-					InvertedPortMask: 0xffff,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
@@ -3616,9 +3563,9 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		// allow-allow insertions do not need tests as their affect on one another does not matter.
 	}
 	for _, tt := range tests {
-		aKey := key(tt.aIdentity, tt.aPort, tt.aProto, 0)
+		aKey := Key{Identity: tt.aIdentity, DestPort: tt.aPort, Nexthdr: tt.aProto}
 		aEntry := MapStateEntry{IsDeny: tt.aIsDeny}
-		bKey := key(tt.bIdentity, tt.bPort, tt.bProto, 0)
+		bKey := Key{Identity: tt.bIdentity, DestPort: tt.bPort, Nexthdr: tt.bProto}
 		bEntry := MapStateEntry{IsDeny: tt.bIsDeny}
 		expectedKeys := newMapState(nil)
 		if tt.outcome&insertA > 0 {

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -5,6 +5,9 @@ package policy
 
 import (
 	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 )
 
 // selectorPolicy is a structure which contains the resolved policy for a
@@ -233,6 +236,37 @@ func (p *EndpointPolicy) ConsumeMapChanges() (adds, deletes Keys) {
 	defer p.selectorPolicy.SelectorCache.mutex.Unlock()
 	features := p.selectorPolicy.L4Policy.Ingress.features | p.selectorPolicy.L4Policy.Egress.features
 	return p.policyMapChanges.consumeMapChanges(p.PolicyOwner, p.policyMapState, features, p.SelectorCache)
+}
+
+// AllowsIdentity returns whether the specified policy allows
+// ingress and egress traffic for the specified numeric security identity.
+// If the 'secID' is zero, it will check if all traffic is allowed.
+//
+// Returning true for either return value indicates all traffic is allowed.
+func (p *EndpointPolicy) AllowsIdentity(identity identity.NumericIdentity) (ingress, egress bool) {
+	key := Key{
+		Identity: uint32(identity),
+	}
+
+	if !p.IngressPolicyEnabled {
+		ingress = true
+	} else {
+		key.TrafficDirection = trafficdirection.Ingress.Uint8()
+		if v, exists := p.policyMapState.Get(key); exists && !v.IsDeny {
+			ingress = true
+		}
+	}
+
+	if !p.EgressPolicyEnabled {
+		egress = true
+	} else {
+		key.TrafficDirection = trafficdirection.Egress.Uint8()
+		if v, exists := p.policyMapState.Get(key); exists && !v.IsDeny {
+			egress = true
+		}
+	}
+
+	return ingress, egress
 }
 
 // NewEndpointPolicy returns an empty EndpointPolicy stub.

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -756,39 +756,7 @@ func TestMapStateWithIngress(t *testing.T) {
 	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
 }
 
-// allowsIdentity returns whether the specified policy allows
-// ingress and egress traffic for the specified numeric security identity.
-// If the 'secID' is zero, it will check if all traffic is allowed.
-//
-// Returning true for either return value indicates all traffic is allowed.
-func (p *EndpointPolicy) allowsIdentity(identity identity.NumericIdentity) (ingress, egress bool) {
-	key := Key{
-		Identity:         uint32(identity),
-		InvertedPortMask: 0xffff, // wildcard port
-	}
-
-	if !p.IngressPolicyEnabled {
-		ingress = true
-	} else {
-		key.TrafficDirection = trafficdirection.Ingress.Uint8()
-		if v, exists := p.policyMapState.Get(key); exists && !v.IsDeny {
-			ingress = true
-		}
-	}
-
-	if !p.EgressPolicyEnabled {
-		egress = true
-	} else {
-		key.TrafficDirection = trafficdirection.Egress.Uint8()
-		if v, exists := p.policyMapState.Get(key); exists && !v.IsDeny {
-			egress = true
-		}
-	}
-
-	return ingress, egress
-}
-
-func TestEndpointPolicy_allowsIdentity(t *testing.T) {
+func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 	type fields struct {
 		selectorPolicy *selectorPolicy
 		PolicyMapState *mapState
@@ -978,12 +946,12 @@ func TestEndpointPolicy_allowsIdentity(t *testing.T) {
 				selectorPolicy: tt.fields.selectorPolicy,
 				policyMapState: tt.fields.PolicyMapState,
 			}
-			gotIngress, gotEgress := p.allowsIdentity(tt.args.identity)
+			gotIngress, gotEgress := p.AllowsIdentity(tt.args.identity)
 			if gotIngress != tt.wantIngress {
-				t.Errorf("allowsIdentity() gotIngress = %v, want %v", gotIngress, tt.wantIngress)
+				t.Errorf("AllowsIdentity() gotIngress = %v, want %v", gotIngress, tt.wantIngress)
 			}
 			if gotEgress != tt.wantEgress {
-				t.Errorf("allowsIdentity() gotEgress = %v, want %v", gotEgress, tt.wantEgress)
+				t.Errorf("AllowsIdentity() gotEgress = %v, want %v", gotEgress, tt.wantEgress)
 			}
 		})
 	}

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -547,8 +547,8 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 		},
 		PolicyOwner: DummyOwner{},
 		policyMapState: newMapState(map[Key]MapStateEntry{
-			{TrafficDirection: trafficdirection.Egress.Uint8(), InvertedPortMask: 0xffff}: allowEgressMapStateEntry,
-			{DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
+			{TrafficDirection: trafficdirection.Egress.Uint8()}: allowEgressMapStateEntry,
+			{DestPort: 80, Nexthdr: 6}:                          rule1MapStateEntry,
 		}),
 	}
 


### PR DESCRIPTION
`panic` is not acceptable in production code.

Reverts cilium/cilium#33302