### PR TITLE
policy: Replace panics with error logs with stacktrace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/consul/api v1.29.1
+	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jeremywohl/flatten v1.0.1
@@ -197,7 +198,6 @@ require (
 	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-msgpack v1.1.5 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 
@@ -351,7 +352,8 @@ func newMapState(initMap map[Key]MapStateEntry) *mapState {
 // Get the MapStateEntry that matches the Key.
 func (ms *mapState) Get(k Key) (MapStateEntry, bool) {
 	if k.DestPort == 0 && k.InvertedPortMask != 0xffff {
-		panic("invalid wildcard port with non-zero mask")
+		stacktrace := hclog.Stacktrace()
+		log.Errorf("mapState.Get: invalid wildcard port with non-zero mask: %v. Stacktrace: %s", k, stacktrace)
 	}
 	v, ok := ms.denies.Lookup(k)
 	if ok {
@@ -364,7 +366,8 @@ func (ms *mapState) Get(k Key) (MapStateEntry, bool) {
 // MapState
 func (ms *mapState) Insert(k Key, v MapStateEntry) {
 	if k.DestPort == 0 && k.InvertedPortMask != 0xffff {
-		panic("invalid wildcard port with non-zero mask")
+		stacktrace := hclog.Stacktrace()
+		log.Errorf("mapState.Insert: invalid wildcard port with non-zero mask: %v. Stacktrace: %s", k, stacktrace)
 	}
 	if v.IsDeny {
 		ms.allows.Delete(k)

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -3693,3 +3693,21 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		require.EqualValuesf(t, expectedKeys, outcomeKeys, "different traffic directions %s", tt.name)
 	}
 }
+
+func TestMapState_Get_stacktrace(t *testing.T) {
+	ms := newMapState(nil)
+	// This should produce a stacktrace in the error log. It is not validated here but can be
+	// observed manually.
+	// Example log (with newlines expanded):
+	// time="2024-06-22T23:21:27+03:00" level=error msg="mapState.Get: invalid wildcard port with non-zero mask: Identity=0,DestPort=0,Nexthdr=0,TrafficDirection=0. Stacktrace:
+	// github.com/hashicorp/go-hclog.Stacktrace
+	// 	github.com/cilium/cilium/vendor/github.com/hashicorp/go-hclog/stacktrace.go:51
+	// github.com/cilium/cilium/pkg/policy.(*mapState).Get
+	// 	github.com/cilium/cilium/pkg/policy/mapstate.go:355
+	// github.com/cilium/cilium/pkg/policy.TestMapState_Get_stacktrace
+	// 	github.com/cilium/cilium/pkg/policy/mapstate_test.go:3699
+	// testing.tRunner
+	// go/src/testing/testing.go:1689" subsys=policy
+	_, ok := ms.Get(Key{})
+	assert.False(t, ok)
+}


### PR DESCRIPTION
Production code should not panic on a subsystem error. Log an error instead and include a stacktrace in the error log message.

github.com/hashicorp/go-hclog was already (indirectly) vendored, so this is not adding a new dependency to the project.

Fixes: #33302
