### PR TITLE
bpf,tests: Add IPv4 checsum validation

### DIFF
--- a/bpf/tests/hairpin_sctp_flow.c
+++ b/bpf/tests/hairpin_sctp_flow.c
@@ -139,6 +139,9 @@ int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l3->daddr != v4_pod_one)
 		test_fatal("dest IP hasn't been changed to the pod IP");
 
+	if (l3->check != bpf_htons(0xb09c))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	l4 = (void *)l3 + sizeof(struct iphdr);
 
 	if ((void *)l4 + sizeof(struct sctphdr) > data_end)
@@ -226,6 +229,9 @@ int hairpin_flow_forward_ingress_check(__maybe_unused const struct __ctx_buff *c
 
 	if (l3->daddr != v4_pod_one)
 		test_fatal("dest IP changed");
+
+	if (l3->check != bpf_htons(0xaf9c))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 
@@ -395,6 +401,9 @@ int hairpin_sctp_flow_4_reverse_ingress_v4_check(const struct __ctx_buff *ctx)
 
 	if (l3->daddr != v4_pod_one)
 		test_fatal("dest IP hasn't been NAT'ed to the original source IP");
+
+	if (l3->check != bpf_htons(0x3a0))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
@@ -213,6 +213,9 @@ int overlay_to_lxc_syn_check(struct __ctx_buff *ctx)
 	if (l3->daddr != BACKEND_IP)
 		test_fatal("dst IP has changed");
 
+	if (l3->check != bpf_htons(0x4111))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source != CLIENT_INTER_CLUSTER_SNAT_PORT)
 		test_fatal("src port has changed");
 
@@ -303,6 +306,9 @@ int lxc_to_overlay_ack_check(struct __ctx_buff *ctx)
 
 	if (l3->daddr != CLIENT_NODE_IP)
 		test_fatal("dst IP has changed");
+
+	if (l3->check != bpf_htons(0x4111))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	if (l4->source != BACKEND_PORT)
 		test_fatal("src port has changed");
@@ -396,6 +402,9 @@ int overlay_to_lxc_ack_check(struct __ctx_buff *ctx)
 
 	if (l3->daddr != BACKEND_IP)
 		test_fatal("dst IP has changed");
+
+	if (l3->check != bpf_htons(0x4111))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	if (l4->source != CLIENT_INTER_CLUSTER_SNAT_PORT)
 		test_fatal("src port has changed");

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
@@ -249,6 +249,9 @@ int from_overlay_syn_check(struct __ctx_buff *ctx)
 	if (l3->daddr != BACKEND_IP)
 		test_fatal("dst IP has changed");
 
+	if (l3->check != bpf_htons(0x4212))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source != CLIENT_INTER_CLUSTER_SNAT_PORT)
 		test_fatal("src port has changed");
 
@@ -337,6 +340,9 @@ int to_overlay_synack_check(struct __ctx_buff *ctx)
 	if (l3->daddr != CLIENT_NODE_IP)
 		test_fatal("dst IP has changed");
 
+	if (l3->check != bpf_htons(0x4112))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source != BACKEND_PORT)
 		test_fatal("src port has changed");
 
@@ -405,6 +411,9 @@ int from_overlay_ack_check(struct __ctx_buff *ctx)
 
 	if (l3->daddr != BACKEND_IP)
 		test_fatal("dst IP has changed");
+
+	if (l3->check != bpf_htons(0x4212))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	if (l4->source != CLIENT_INTER_CLUSTER_SNAT_PORT)
 		test_fatal("src port has changed");

--- a/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
@@ -214,6 +214,9 @@ int lxc_to_overlay_syn_check(struct __ctx_buff *ctx)
 	if (l3->daddr != BACKEND_IP)
 		test_fatal("dst IP hasn't been NATed to remote backend IP");
 
+	if (l3->check != bpf_htons(0xf968))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");
 
@@ -318,6 +321,9 @@ int overlay_to_lxc_synack_check(struct __ctx_buff *ctx)
 	if (l3->daddr != CLIENT_IP)
 		test_fatal("dst IP is not client IP");
 
+	if (l3->check != bpf_htons(0x402))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source != FRONTEND_PORT)
 		test_fatal("src port is not service frontend port");
 
@@ -402,6 +408,9 @@ int lxc_to_overlay_ack_check(struct __ctx_buff *ctx)
 
 	if (l3->daddr != BACKEND_IP)
 		test_fatal("dst IP hasn't been NATed to remote backend IP");
+
+	if (l3->check != bpf_htons(0xf968))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");

--- a/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
@@ -246,6 +246,9 @@ int to_overlay_syn_check(struct __ctx_buff *ctx)
 	if (l3->daddr != BACKEND_IP)
 		test_fatal("dst IP has changed");
 
+	if (l3->check != bpf_htons(0x4111))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source != CLIENT_INTER_CLUSTER_SNAT_PORT)
 		test_fatal("src port hasn't been SNATed for inter-cluster communication");
 
@@ -343,6 +346,9 @@ int from_overlay_synack_check(struct __ctx_buff *ctx)
 	if (l3->daddr != CLIENT_IP)
 		test_fatal("dst IP hasn't been RevSNATed to client IP");
 
+	if (l3->check != bpf_htons(0xfa68))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source != BACKEND_PORT)
 		test_fatal("src port has changed");
 
@@ -434,6 +440,9 @@ int to_overlay_ack_check(struct __ctx_buff *ctx)
 
 	if (l3->daddr != BACKEND_IP)
 		test_fatal("dst IP has changed");
+
+	if (l3->check != bpf_htons(0x4111))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	if (l4->source != CLIENT_INTER_CLUSTER_SNAT_PORT)
 		test_fatal("src port hasn't been SNATed for inter-cluster communication");

--- a/bpf/tests/ipsec_from_host_generic.h
+++ b/bpf/tests/ipsec_from_host_generic.h
@@ -165,6 +165,9 @@ int ipv4_ipsec_from_host_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l3->daddr != v4_pod_two)
 		test_fatal("dest IP was changed");
 
+	if (l3->check != bpf_htons(0xf948))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	l4 = (void *)l3 + sizeof(struct iphdr);
 
 	if ((void *)l4 + sizeof(struct ip_esp_hdr) > data_end)

--- a/bpf/tests/ipsec_from_network_generic.h
+++ b/bpf/tests/ipsec_from_network_generic.h
@@ -159,6 +159,9 @@ int ipv4_not_decrypted_ipsec_from_network_check(__maybe_unused const struct __ct
 	if (l3->daddr != v4_pod_two)
 		test_fatal("dest IP was changed");
 
+	if (l3->check != bpf_htons(0xf948))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	l4 = (void *)l3 + sizeof(struct iphdr);
 
 	if ((void *)l4 + sizeof(struct ip_esp_hdr) > data_end)
@@ -395,6 +398,9 @@ int ipv4_decrypted_ipsec_from_network_check(__maybe_unused const struct __ctx_bu
 
 	if (l3->daddr != v4_pod_two)
 		test_fatal("dest IP was changed");
+
+	if (l3->check != bpf_htons(0xf968))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 

--- a/bpf/tests/ipsec_from_overlay_generic.h
+++ b/bpf/tests/ipsec_from_overlay_generic.h
@@ -192,6 +192,9 @@ int ipv4_not_decrypted_ipsec_from_overlay_check(__maybe_unused const struct __ct
 	if (l3->daddr != v4_pod_two)
 		test_fatal("dest IP was changed");
 
+	if (l3->check != bpf_htons(0xf948))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	l4 = (void *)l3 + sizeof(struct iphdr);
 
 	if ((void *)l4 + sizeof(struct ip_esp_hdr) > data_end)
@@ -428,6 +431,9 @@ int ipv4_decrypted_ipsec_from_overlay_check(__maybe_unused const struct __ctx_bu
 
 	if (l3->daddr != v4_pod_two)
 		test_fatal("dest IP was changed");
+
+	if (l3->check != bpf_htons(0xfa68))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 

--- a/bpf/tests/l4lb_ipip_health_check_host.c
+++ b/bpf/tests/l4lb_ipip_health_check_host.c
@@ -181,6 +181,9 @@ int l4lb_health_check_host_check(const struct __ctx_buff *ctx)
 	if (l3->daddr != FRONTEND_IP)
 		test_fatal("dst IP has changed");
 
+	if (l3->check != bpf_htons(0x402))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");
 

--- a/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
+++ b/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
@@ -207,6 +207,9 @@ int nodeport_geneve_dsr_lb_xdp1_local_backend_check(const struct __ctx_buff *ctx
 	if (l3->daddr != BACKEND_IP_LOCAL)
 		test_fatal("dst IP hasn't been NATed to local backend IP");
 
+	if (l3->check != bpf_htons(0x4112))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");
 
@@ -341,6 +344,9 @@ int nodeport_geneve_dsr_lb_xdp_fwd_check(__maybe_unused const struct __ctx_buff 
 	if (l3->daddr != BACKEND_NODE_IP)
 		test_fatal("outerDstIP is not correct");
 
+	if (l3->check != bpf_htons(0x5371))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (udp->dest != bpf_htons(TUNNEL_PORT))
 		test_fatal("outerDstPort is not tunnel port");
 
@@ -375,6 +381,9 @@ int nodeport_geneve_dsr_lb_xdp_fwd_check(__maybe_unused const struct __ctx_buff 
 
 	if (inner_l3->daddr != BACKEND_IP_REMOTE)
 		test_fatal("innerDstIP hasn't been NATed to remote backend IP");
+
+	if (inner_l3->check != bpf_htons(0x4111))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(inner_l3->check));
 
 	if (tcp_inner->source != CLIENT_PORT)
 		test_fatal("innerSrcPort has changed");

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -824,6 +824,7 @@ static __always_inline void pktgen__finish_ipv4(const struct pktgen *builder, in
 	v4len = (__be16)(builder->cur_off - builder->layer_offsets[i]);
 	/* Calculate total length, which is IPv4 hdr + all layers after it */
 	ipv4_layer->tot_len = __bpf_htons(v4len);
+	ipv4_layer->check = csum_fold(csum_diff(NULL, 0, ipv4_layer, sizeof(struct iphdr), 0));
 }
 
 static __always_inline void pktgen__finish_ipv6(const struct pktgen *builder, int i)

--- a/bpf/tests/skip_tunnel_from_host.c
+++ b/bpf/tests/skip_tunnel_from_host.c
@@ -210,6 +210,9 @@ check_ctx(const struct __ctx_buff *ctx, __u32 expected_result, bool v4)
 		if (l3->daddr != DST_IPV4)
 			test_fatal("dest IP was changed");
 
+		if (l3->check != bpf_htons(0xa611))
+			test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 		l4 = (void *)l3 + sizeof(struct iphdr);
 	} else {
 		struct ipv6hdr *l3;

--- a/bpf/tests/skip_tunnel_from_lxc.c
+++ b/bpf/tests/skip_tunnel_from_lxc.c
@@ -191,6 +191,9 @@ check_ctx(const struct __ctx_buff *ctx, __u32 expected_result, bool v4)
 		if (l3->daddr != DST_IPV4)
 			test_fatal("dest IP was changed");
 
+		if (l3->check != bpf_htons(0xf968))
+			test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 		l4 = (void *)l3 + sizeof(struct iphdr);
 	} else {
 		struct ipv6hdr *l3;

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -227,6 +227,9 @@ int egressgw_skip_excluded_cidr_snat_check(const struct __ctx_buff *ctx)
 	if ((void *)l3 + sizeof(struct iphdr) > data_end)
 		test_fatal("l3 out of bounds");
 
+	if (l3->check != bpf_htons(0x4112))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	l4 = (void *)l3 + sizeof(struct iphdr);
 	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
 		test_fatal("l4 out of bounds");

--- a/bpf/tests/tc_host_encrypted_overlay.c
+++ b/bpf/tests/tc_host_encrypted_overlay.c
@@ -172,6 +172,9 @@ int tc_host_encrypted_overlay_01_check(const struct __ctx_buff *ctx)
 	if (l3->daddr != NODE2_IP)
 		test_fatal("dst IP has changed");
 
+	if (l3->check != bpf_htons(0x7da4))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source != NODE1_TUNNEL_SPORT)
 		test_fatal("src port has changed");
 

--- a/bpf/tests/tc_lxc_lb4_no_backend.c
+++ b/bpf/tests/tc_lxc_lb4_no_backend.c
@@ -129,6 +129,9 @@ int lxc_no_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 	assert(l3->ttl == 64);
 	assert(l3->protocol == IPPROTO_ICMP);
 
+	if (l3->check != bpf_htons(0x4b8e))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	l4 = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct iphdr);
 	if ((void *) l4 + sizeof(struct icmphdr) > data_end)
 		test_fatal("l4 header out of bounds");
@@ -140,7 +143,7 @@ int lxc_no_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 	 * context with the runner option and importing the packet into
 	 * wireshark
 	 */
-	assert(l4->checksum == bpf_htons(0x7990));
+	assert(l4->checksum == bpf_htons(0x2de7));
 
 	test_finish();
 }

--- a/bpf/tests/tc_nodeport_l3_dev.c
+++ b/bpf/tests/tc_nodeport_l3_dev.c
@@ -174,6 +174,9 @@ int ipv4_l3_to_l2_fast_redirect_check(__maybe_unused const struct __ctx_buff *ct
 	if (l3->daddr != TEST_IP_LOCAL)
 		test_fatal("dest IP was changed");
 
+	if (l3->check != bpf_htons(0xfa68))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	l4 = (void *)l3 + sizeof(struct iphdr);
 
 	if ((void *)l4 + sizeof(struct tcphdr) > data_end)

--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -227,6 +227,9 @@ int nodeport_dsr_backend_check(struct __ctx_buff *ctx)
 	if (l3->daddr != BACKEND_IP)
 		test_fatal("dst IP has changed");
 
+	if (l3->check != bpf_htons(0x400a))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (opt->type != DSR_IPV4_OPT_TYPE)
 		test_fatal("type in DSR IP option has changed")
 	if (opt->len != 8)
@@ -343,6 +346,9 @@ static __always_inline int check_reply(const struct __ctx_buff *ctx)
 
 	if (l3->daddr != CLIENT_IP)
 		test_fatal("dst IP has changed");
+
+	if (l3->check != bpf_htons(0x4baa))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	if (l4->source != FRONTEND_PORT)
 		test_fatal("src port hasn't been RevNATed to frontend port");
@@ -490,6 +496,9 @@ int nodeport_dsr_backend_redirect_check(struct __ctx_buff *ctx)
 	if (l3->daddr != BACKEND_IP)
 		test_fatal("dst IP has changed");
 
+	if (l3->check != bpf_htons(0x3509))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (opt->type != DSR_IPV4_OPT_TYPE)
 		test_fatal("type in DSR IP option has changed")
 	if (opt->len != 8)
@@ -620,6 +629,9 @@ int nodeport_dsr_backend_redirect_reply_check(struct __ctx_buff *ctx)
 
 	if (l3->daddr != CLIENT_IP_2)
 		test_fatal("dst IP has changed");
+
+	if (l3->check != bpf_htons(0x3611))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	if (l4->source != BACKEND_PORT)
 		test_fatal("src port has changed");

--- a/bpf/tests/tc_nodeport_lb4_dsr_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_lb.c
@@ -176,6 +176,9 @@ int nodeport_dsr_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l3->daddr != BACKEND_IP)
 		test_fatal("dst IP hasn't been NATed to remote backend IP");
 
+	if (l3->check != bpf_htons(0x434a))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (opt->type != DSR_IPV4_OPT_TYPE)
 		test_fatal("type in DSR IP option is bad")
 	if (opt->len != 8)

--- a/bpf/tests/tc_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_backend.c
@@ -153,6 +153,9 @@ int nodeport_nat_backend_check(const struct __ctx_buff *ctx)
 	if (l3->daddr != BACKEND_IP)
 		test_fatal("dst IP has changed");
 
+	if (l3->check != bpf_htons(0xa712))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source != LB_PORT)
 		test_fatal("src port has changed");
 

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -240,6 +240,9 @@ int nodeport_local_backend_check(const struct __ctx_buff *ctx)
 	if (l3->daddr != BACKEND_IP_LOCAL)
 		test_fatal("dst IP hasn't been NATed to local backend IP");
 
+	if (l3->check != bpf_htons(0x4212))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");
 
@@ -329,6 +332,9 @@ int nodeport_local_backend_reply_check(const struct __ctx_buff *ctx)
 
 	if (l3->daddr != CLIENT_IP)
 		test_fatal("dst IP has changed");
+
+	if (l3->check != bpf_htons(0x4baa))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	if (l4->source != FRONTEND_PORT)
 		test_fatal("src port hasn't been revNATed to frontend port");
@@ -422,6 +428,9 @@ int nodeport_local_backend_redirect_check(const struct __ctx_buff *ctx)
 	if (l3->daddr != BACKEND_IP_LOCAL)
 		test_fatal("dst IP hasn't been NATed to local backend IP");
 
+	if (l3->check != bpf_htons(0x3711))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");
 
@@ -513,6 +522,9 @@ int nodeport_local_backend_redirect_reply_check(const struct __ctx_buff *ctx)
 
 	if (l3->daddr != CLIENT_IP_2)
 		test_fatal("dst IP has changed");
+
+	if (l3->check != bpf_htons(0x3611))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	if (l4->source != BACKEND_PORT)
 		test_fatal("src port has changed");
@@ -612,6 +624,9 @@ int nodeport_udp_local_backend_check(const struct __ctx_buff *ctx)
 
 	if (l3->daddr != BACKEND_IP_LOCAL)
 		test_fatal("dst IP hasn't been NATed to local backend IP");
+
+	if (l3->check != bpf_htons(0x4213))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");
@@ -714,6 +729,9 @@ int nodeport_nat_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	if (l3->daddr != BACKEND_IP_REMOTE)
 		test_fatal("dst IP hasn't been NATed to remote backend IP");
+
+	if (l3->check != bpf_htons(0xa711))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	if (l4->source == CLIENT_PORT)
 		test_fatal("src port hasn't been NATed");

--- a/bpf/tests/tc_nodeport_lb4_no_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_no_backend.c
@@ -133,6 +133,9 @@ int nodeport_no_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 	assert(l3->ttl == 64);
 	assert(l3->protocol == IPPROTO_ICMP);
 
+	if (l3->check != bpf_htons(0x4b8e))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	l4 = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct iphdr);
 	if ((void *) l4 + sizeof(struct icmphdr) > data_end)
 		test_fatal("l4 header out of bounds");
@@ -144,7 +147,7 @@ int nodeport_no_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 	 * context with the runner option and importing the packet into
 	 * wireshark
 	 */
-	assert(l4->checksum == bpf_htons(0x7990));
+	assert(l4->checksum == bpf_htons(0x2de7));
 
 	test_finish();
 }

--- a/bpf/tests/tc_nodeport_lb_terminating_backend.c
+++ b/bpf/tests/tc_nodeport_lb_terminating_backend.c
@@ -182,6 +182,9 @@ int tc_nodeport_lb_terminating_backend_0_check(const struct __ctx_buff *ctx)
 	if (l3->daddr != BACKEND_IP_LOCAL)
 		test_fatal("dst IP hasn't been NATed to local backend IP");
 
+	if (l3->check != bpf_htons(0x4213))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");
 
@@ -282,6 +285,9 @@ int tc_nodeport_lb_terminating_backend_1_check(const struct __ctx_buff *ctx)
 
 	if (l3->daddr != BACKEND_IP_LOCAL)
 		test_fatal("dst IP hasn't been NATed to local backend IP");
+
+	if (l3->check != bpf_htons(0x4213))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -148,6 +148,9 @@ int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l3->daddr != v4_pod_one)
 		test_fatal("dest IP hasn't been changed to the pod IP");
 
+	if (l3->check != bpf_htons(-0x4f02))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	l4 = (void *)l3 + sizeof(struct iphdr);
 
 	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
@@ -269,6 +272,9 @@ int hairpin_flow_forward_ingress_check(__maybe_unused const struct __ctx_buff *c
 
 	if (l3->daddr != v4_pod_one)
 		test_fatal("dest IP changed");
+
+	if (l3->check != bpf_htons(-0x5002))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 
@@ -464,6 +470,9 @@ int hairpin_flow_reverse_ingress_check(const struct __ctx_buff *ctx)
 
 	if (l3->daddr != v4_pod_one)
 		test_fatal("dest IP hasn't been NAT'ed to the original source IP");
+
+	if (l3->check != bpf_htons(0x402))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 

--- a/bpf/tests/xdp_egressgw_reply.c
+++ b/bpf/tests/xdp_egressgw_reply.c
@@ -205,6 +205,9 @@ int egressgw_reply_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l3->protocol != IPPROTO_UDP)
 		test_fatal("outer IP doesn't have correct L4 protocol")
 
+	if (l3->check != bpf_htons(0x527e))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l3->saddr != IPV4_DIRECT_ROUTING)
 		test_fatal("outerSrcIP is not correct")
 
@@ -225,6 +228,9 @@ int egressgw_reply_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	if (inner_l3->daddr != CLIENT_IP)
 		test_fatal("innerDstIP hasn't been revNATed to the client IP");
+
+	if (inner_l3->check != bpf_htons(0x4212))
+		test_fatal("inner L3 checksum is invalid: %d", bpf_htons(inner_l3->check));
 
 	if (inner_l4->source != EXTERNAL_SVC_PORT)
 		test_fatal("innerSrcPort is not the external SVC port");

--- a/bpf/tests/xdp_nodeport_lb4_dsr_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_dsr_lb.c
@@ -172,6 +172,9 @@ int nodeport_dsr_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l3->daddr != BACKEND_IP)
 		test_fatal("dst IP hasn't been NATed to remote backend IP");
 
+	if (l3->check != bpf_htons(0x434a))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (opt->type != DSR_IPV4_OPT_TYPE)
 		test_fatal("type in DSR IP option is bad")
 	if (opt->len != 8)

--- a/bpf/tests/xdp_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_backend.c
@@ -153,6 +153,9 @@ int nodeport_nat_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l3->daddr != BACKEND_IP)
 		test_fatal("dst IP has changed");
 
+	if (l3->check != bpf_htons(0xa612))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source != LB_PORT)
 		test_fatal("src port has changed");
 

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -204,6 +204,9 @@ int nodeport_local_backend_check(const struct __ctx_buff *ctx)
 	if (l3->daddr != BACKEND_IP_LOCAL)
 		test_fatal("dst IP hasn't been NATed to local backend IP");
 
+	if (l3->check != bpf_htons(0x4112))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");
 
@@ -306,6 +309,9 @@ int nodeport_nat_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l3->daddr != BACKEND_IP_REMOTE)
 		test_fatal("dst IP hasn't been NATed to remote backend IP");
 
+	if (l3->check != bpf_htons(0xa711))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
 	if (l4->source == CLIENT_PORT)
 		test_fatal("src port hasn't been NATed");
 
@@ -395,6 +401,9 @@ static __always_inline int check_reply(const struct __ctx_buff *ctx)
 
 	if (l3->daddr != CLIENT_IP)
 		test_fatal("dst IP hasn't been RevNATed to client IP");
+
+	if (l3->check != bpf_htons(0x4ca9))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
 
 	if (l4->source != FRONTEND_PORT)
 		test_fatal("src port hasn't been RevNATed to frontend port");


### PR DESCRIPTION
The PR adds eBPF tests IPv4 checksum calculation and check.

Relate issue: https://github.com/cilium/cilium/issues/29504

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
