### PR TITLE
policy: take SelectorCache read lock when applying incremental changes

### DIFF
--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -229,8 +229,8 @@ func (l4policy L4DirectionPolicy) updateRedirects(p *EndpointPolicy, createRedir
 // have completed.
 // PolicyOwner (aka Endpoint) is also locked during this call.
 func (p *EndpointPolicy) ConsumeMapChanges() (adds, deletes Keys) {
-	p.selectorPolicy.SelectorCache.mutex.Lock()
-	defer p.selectorPolicy.SelectorCache.mutex.Unlock()
+	p.selectorPolicy.SelectorCache.mutex.RLock()
+	defer p.selectorPolicy.SelectorCache.mutex.RUnlock()
 	features := p.selectorPolicy.L4Policy.Ingress.features | p.selectorPolicy.L4Policy.Egress.features
 	return p.policyMapChanges.consumeMapChanges(p.PolicyOwner, p.policyMapState, features, p.SelectorCache)
 }


### PR DESCRIPTION
We need to take a lock on the SelectorCache for a subtle reason: deny insertion needs the ability to convert a numerical ID to a CIDR, and the SelectorCache provides this functionality.

Accordingly, we must lock the SelectorCache while applying changes. Most trees that lead to this take a RLock() of the SelectorCache. This call was an oversight. It does not modify the SelectorCache and thus may safely take an RLock as well.
