### PR TITLE
[v1.15] .github: add workflow for renovate to build base images

### DIFF
--- a/.github/workflows/build-images-base-renovate.yaml
+++ b/.github/workflows/build-images-base-renovate.yaml
@@ -1,0 +1,30 @@
+name: Base Image Release Build - Renovate
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  push:
+    branches:
+      - "renovate/v1.15-**"
+    paths:
+      - images/runtime/**
+      - images/builder/**
+
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-base-images-from-renovate:
+    name: "Build Base Images From Renovate"
+    uses: ./.github/workflows/build-images-base.yaml
+    secrets: inherit
+    with:
+      # Build the base images from this environment which is set up specifically
+      # for renovate.
+      environment: release-base-images-renovate

--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -10,6 +10,24 @@ on:
     paths:
       - images/runtime/**
       - images/builder/**
+  # This workflow can be reused so that renovate can execute this workflow_dispatch:
+  # run from a different environment than 'release-base-images'. See
+  # build-images-base-renovate.yaml
+  workflow_call:
+    secrets:
+      QUAY_BASE_RELEASE_USERNAME:
+        required: true
+      QUAY_BASE_RELEASE_PASSWORD:
+        required: true
+      AUTO_COMMITTER_PEM:
+        required: true
+      AUTO_COMMITTER_APP_ID:
+        required: true
+    inputs:
+      environment:
+        required: true
+        type: string
+        default: "release-base-images"
 
 permissions:
   # To be able to access the repository with `actions/checkout`
@@ -23,9 +41,11 @@ concurrency:
 
 jobs:
   build-and-push:
+    # Skip this workflow for branches that are created by renovate
+    if: "!startsWith(github.head_ref, 'renovate/')"
     name: Build and Push Images
     timeout-minutes: 45
-    environment: release-base-images
+    environment: ${{ inputs.environment || 'release-base-images' }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout default branch (trusted)


### PR DESCRIPTION
[ upstream commit f054f94b24b9c242611b956ba3f3698e8394c884 ]

As renovate can automate a lot of our dependency updates it will also be possible for it to trigger the workflow to build base images. For this to happen we need to create a new workflow that reuses the existing workflow by using a different environment. This environment is protected to only be executed on the branches that are created by renovate.

```upstream-prs
 33326
```