### PR TITLE
vendor: Update statedb to v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/cilium/linters v0.0.0-20240611134452-310e8a3d60a5
 	github.com/cilium/lumberjack/v2 v2.3.0
 	github.com/cilium/proxy v0.0.0-20240418093727-2c7164c53e26
-	github.com/cilium/statedb v0.1.0
+	github.com/cilium/statedb v0.1.1
 	github.com/cilium/stream v0.0.0-20240226091623-f979d32855f8
 	github.com/cilium/workerpool v1.2.0
 	github.com/containernetworking/cni v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7 h1:ocC6/1Gz6LJd0X
 github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7/go.mod h1:8nydvUTW+/9nVywCQ9bE/YGzb4EISALP4lKNpK3fFqo=
 github.com/cilium/proxy v0.0.0-20240418093727-2c7164c53e26 h1:wzm/nEkcMO6oGSySoqe3/bMcF1sxrxI2ByidN3gg30A=
 github.com/cilium/proxy v0.0.0-20240418093727-2c7164c53e26/go.mod h1:jzAmtWhlyR3kx+AwYdQvGM04lmHwsWhq1ySfAVpY/SA=
-github.com/cilium/statedb v0.1.0 h1:ljSPEKnPutaJZazGKGRCs9v4sgJChqOE6RUhu/eZxts=
-github.com/cilium/statedb v0.1.0/go.mod h1:KPwsudjhZ90zoBguYMtssKpstR74jVKd/D+73PZy+sg=
+github.com/cilium/statedb v0.1.1 h1:jtkB3aguIMQwZH0UzjpJQu50LmB3/QN1j5LqGl8rjys=
+github.com/cilium/statedb v0.1.1/go.mod h1:KPwsudjhZ90zoBguYMtssKpstR74jVKd/D+73PZy+sg=
 github.com/cilium/stream v0.0.0-20240226091623-f979d32855f8 h1:j6VF1s6gz3etRH5ObCr0UUyJblP9cK5fbgkQTz8fTRA=
 github.com/cilium/stream v0.0.0-20240226091623-f979d32855f8/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.2.0 h1:Wc2iOPTvCgWKQXeq4L5tnx4QFEI+z5q1+bSpSS0cnAY=

--- a/pkg/hive/reconciler_metrics.go
+++ b/pkg/hive/reconciler_metrics.go
@@ -148,12 +148,12 @@ func (m *reconcilerMetricsImpl) IncrementalReconciliationDuration(moduleID cell.
 }
 
 // IncrementalReconciliationErrors implements reconciler.Metrics.
-func (m *reconcilerMetricsImpl) IncrementalReconciliationErrors(moduleID cell.FullModuleID, errs []error) {
+func (m *reconcilerMetricsImpl) IncrementalReconciliationErrors(moduleID cell.FullModuleID, newErrors, currentErrors int) {
 	if m.m.IncrementalReconciliationCurrentErrors.IsEnabled() {
-		m.m.IncrementalReconciliationCurrentErrors.WithLabelValues(LabelModuleId, moduleID.String()).Set(float64(len(errs)))
+		m.m.IncrementalReconciliationCurrentErrors.WithLabelValues(LabelModuleId, moduleID.String()).Set(float64(currentErrors))
 	}
 	if m.m.IncrementalReconciliationTotalErrors.IsEnabled() {
-		m.m.IncrementalReconciliationCurrentErrors.WithLabelValues(LabelModuleId, moduleID.String()).Add(float64(len(errs)))
+		m.m.IncrementalReconciliationTotalErrors.WithLabelValues(LabelModuleId, moduleID.String()).Add(float64(newErrors))
 	}
 }
 

--- a/vendor/github.com/cilium/statedb/reconciler/incremental.go
+++ b/vendor/github.com/cilium/statedb/reconciler/incremental.go
@@ -5,6 +5,7 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cilium/hive/cell"
@@ -35,8 +36,13 @@ type incrementalRound[Obj comparable] struct {
 	// not lock the table while reconciling. If an object has changed in the meanwhile
 	// the stale reconciliation result for that object is dropped.
 	results map[Obj]opResult
+}
 
-	errs []error
+// opResult is the outcome from reconciling a single object
+type opResult struct {
+	original any              // the original object
+	rev      statedb.Revision // revision of the object
+	err      error
 }
 
 func (r *reconciler[Obj]) incremental(ctx context.Context, txn statedb.ReadTxn, changes statedb.ChangeIterator[Obj]) []error {
@@ -65,11 +71,14 @@ func (r *reconciler[Obj]) incremental(ctx context.Context, txn statedb.ReadTxn, 
 	round.processRetries()
 
 	// Finally commit the status updates.
-	round.commitStatus()
+	newErrors := round.commitStatus()
 
-	r.metrics.IncrementalReconciliationErrors(r.ModuleID, round.errs)
-
-	return round.errs
+	// Since all failures are retried, we can return the errors from the retry
+	// queue which includes both errors occurred in this round and the old
+	// errors.
+	errs := round.retries.errors()
+	round.metrics.IncrementalReconciliationErrors(r.ModuleID, newErrors, len(errs))
+	return errs
 }
 
 func (round *incrementalRound[Obj]) single(changes statedb.ChangeIterator[Obj]) {
@@ -88,10 +97,7 @@ func (round *incrementalRound[Obj]) single(changes statedb.ChangeIterator[Obj]) 
 		// Clear retries as the object has changed.
 		round.retries.Clear(obj)
 
-		err := round.processSingle(obj, change.Revision, change.Deleted)
-		if err != nil {
-			round.errs = append(round.errs, err)
-		}
+		round.processSingle(obj, change.Revision, change.Deleted)
 		round.numReconciled++
 		if round.numReconciled >= round.config.IncrementalRoundSize {
 			break
@@ -119,12 +125,13 @@ func (round *incrementalRound[Obj]) batch(changes statedb.ChangeIterator[Obj]) {
 		round.retries.Clear(obj)
 
 		// Clone the object so we or the operations can mutate it.
+		orig := obj
 		obj = round.config.CloneObject(obj)
 
 		if change.Deleted {
-			deleteBatch = append(deleteBatch, BatchEntry[Obj]{Object: obj, Revision: rev})
+			deleteBatch = append(deleteBatch, BatchEntry[Obj]{Object: obj, Revision: rev, original: orig})
 		} else {
-			updateBatch = append(updateBatch, BatchEntry[Obj]{Object: obj, Revision: rev})
+			updateBatch = append(updateBatch, BatchEntry[Obj]{Object: obj, Revision: rev, original: orig})
 		}
 
 		round.numReconciled++
@@ -145,8 +152,7 @@ func (round *incrementalRound[Obj]) batch(changes statedb.ChangeIterator[Obj]) {
 		for _, entry := range deleteBatch {
 			if entry.Result != nil {
 				// Delete failed, queue a retry for it.
-				round.errs = append(round.errs, entry.Result)
-				round.retries.Add(entry.Object)
+				round.retries.Add(entry.original, entry.Revision, true, entry.Result)
 			}
 		}
 	}
@@ -163,13 +169,9 @@ func (round *incrementalRound[Obj]) batch(changes statedb.ChangeIterator[Obj]) {
 
 		for _, entry := range updateBatch {
 			if entry.Result == nil {
-				// Reconciling succeeded, so clear the retries.
 				round.retries.Clear(entry.Object)
-				round.results[entry.Object] = opResult{rev: entry.Revision, status: StatusDone()}
-			} else {
-				round.errs = append(round.errs, entry.Result)
-				round.results[entry.Object] = opResult{rev: entry.Revision, status: StatusError(entry.Result)}
 			}
+			round.results[entry.Object] = opResult{rev: entry.Revision, err: entry.Result, original: entry.original}
 		}
 	}
 }
@@ -177,32 +179,17 @@ func (round *incrementalRound[Obj]) batch(changes statedb.ChangeIterator[Obj]) {
 func (round *incrementalRound[Obj]) processRetries() {
 	now := time.Now()
 	for round.numReconciled < round.config.IncrementalRoundSize {
-		robj, retryAt, ok := round.retries.Top()
-		if !ok || retryAt.After(now) {
+		item, ok := round.retries.Top()
+		if !ok || item.retryAt.After(now) {
 			break
 		}
 		round.retries.Pop()
-
-		obj, rev, found := round.table.Get(round.txn, round.primaryIndexer.QueryFromObject(robj.(Obj)))
-		if found {
-			status := round.config.GetObjectStatus(obj)
-			if status.Kind != StatusKindError {
-				continue
-			}
-		} else {
-			obj = robj.(Obj)
-		}
-
-		err := round.processSingle(obj, rev, !found)
-		if err != nil {
-			round.errs = append(round.errs, err)
-		}
-
+		round.processSingle(item.object.(Obj), item.rev, item.delete)
 		round.numReconciled++
 	}
 }
 
-func (round *incrementalRound[Obj]) processSingle(obj Obj, rev statedb.Revision, delete bool) error {
+func (round *incrementalRound[Obj]) processSingle(obj Obj, rev statedb.Revision, delete bool) {
 	start := time.Now()
 
 	var (
@@ -214,31 +201,24 @@ func (round *incrementalRound[Obj]) processSingle(obj Obj, rev statedb.Revision,
 		err = round.config.Operations.Delete(round.ctx, round.txn, obj)
 		if err != nil {
 			// Deletion failed. Retry again later.
-			round.retries.Add(obj)
+			round.retries.Add(obj, rev, true, err)
 		}
 	} else {
 		// Clone the object so it can be mutated by Update()
+		orig := obj
 		obj = round.config.CloneObject(obj)
 		op = OpUpdate
 		err = round.config.Operations.Update(round.ctx, round.txn, obj)
-		if err == nil {
-			round.results[obj] = opResult{rev: rev, status: StatusDone()}
-		} else {
-			round.results[obj] = opResult{rev: rev, status: StatusError(err)}
-		}
+		round.results[obj] = opResult{original: orig, rev: rev, err: err}
 	}
 	round.metrics.IncrementalReconciliationDuration(round.moduleID, op, time.Since(start))
 
 	if err == nil {
-		// Reconciling succeeded, so clear the object.
 		round.retries.Clear(obj)
 	}
-
-	return err
-
 }
 
-func (round *incrementalRound[Obj]) commitStatus() {
+func (round *incrementalRound[Obj]) commitStatus() (numErrors int) {
 	if len(round.results) == 0 {
 		// Nothing to commit.
 		return
@@ -252,12 +232,24 @@ func (round *incrementalRound[Obj]) commitStatus() {
 		// Update the object if it is unchanged. It may happen that the object has
 		// been updated in the meanwhile, in which case we ignore the status as the
 		// update will be picked up by next reconciliation round.
-		round.table.CompareAndSwap(wtxn, result.rev, round.config.SetObjectStatus(obj, result.status))
+		var status Status
+		if result.err == nil {
+			status = StatusDone()
+		} else {
+			status = StatusError(result.err)
+			numErrors++
+		}
+		_, _, err := round.table.CompareAndSwap(wtxn, result.rev,
+			round.config.SetObjectStatus(obj, status))
 
-		if result.status.Kind == StatusKindError {
-			// Reconciling the object failed, so add it to be retried now that its
-			// status is updated.
-			round.retries.Add(obj)
+		if result.err != nil && err == nil {
+			// Reconciliation of the object had failed and the status was updated
+			// successfully (object had not changed). Queue the retry for the object.
+			newRevision := round.table.Revision(wtxn)
+			round.retries.Add(result.original.(Obj), newRevision, false, result.err)
+		} else if result.err != nil && err != nil {
+			fmt.Printf("FAIL queued %v for retry due to %s ! %s\n", result.original, result.err, err)
 		}
 	}
+	return
 }

--- a/vendor/github.com/cilium/statedb/reconciler/metrics.go
+++ b/vendor/github.com/cilium/statedb/reconciler/metrics.go
@@ -12,7 +12,7 @@ import (
 
 type Metrics interface {
 	IncrementalReconciliationDuration(moduleID cell.FullModuleID, operation string, duration time.Duration)
-	IncrementalReconciliationErrors(moduleID cell.FullModuleID, errs []error)
+	IncrementalReconciliationErrors(moduleID cell.FullModuleID, newErrors, currentErrors int)
 
 	FullReconciliationErrors(moduleID cell.FullModuleID, errs []error)
 	FullReconciliationDuration(moduleID cell.FullModuleID, operation string, duration time.Duration)
@@ -53,12 +53,12 @@ func (m *ExpVarMetrics) IncrementalReconciliationDuration(moduleID cell.FullModu
 	m.IncrementalReconciliationDurationVar.AddFloat(moduleID.String()+"/"+operation, duration.Seconds())
 }
 
-func (m *ExpVarMetrics) IncrementalReconciliationErrors(moduleID cell.FullModuleID, errs []error) {
+func (m *ExpVarMetrics) IncrementalReconciliationErrors(moduleID cell.FullModuleID, newErrors, currentErrors int) {
 	m.IncrementalReconciliationCountVar.Add(moduleID.String(), 1)
-	m.IncrementalReconciliationTotalErrorsVar.Add(moduleID.String(), int64(len(errs)))
+	m.IncrementalReconciliationTotalErrorsVar.Add(moduleID.String(), int64(newErrors))
 
 	var intVar expvar.Int
-	intVar.Set(int64(len(errs)))
+	intVar.Set(int64(currentErrors))
 	m.IncrementalReconciliationCurrentErrorsVar.Set(moduleID.String(), &intVar)
 }
 

--- a/vendor/github.com/cilium/statedb/reconciler/reconciler.go
+++ b/vendor/github.com/cilium/statedb/reconciler/reconciler.go
@@ -180,7 +180,7 @@ func (r *reconciler[Obj]) loop(ctx context.Context, health cell.Health) error {
 				fmt.Sprintf("OK, %d objects", r.Config.Table.NumObjects(txn)))
 		} else {
 			health.Degraded(
-				fmt.Sprintf("%d failure(s)", len(errs)),
+				fmt.Sprintf("%d error(s)", len(errs)),
 				joinErrors(errs))
 		}
 	}

--- a/vendor/github.com/cilium/statedb/reconciler/types.go
+++ b/vendor/github.com/cilium/statedb/reconciler/types.go
@@ -157,6 +157,8 @@ type BatchEntry[Obj any] struct {
 	Object   Obj
 	Revision statedb.Revision
 	Result   error
+
+	original Obj
 }
 
 type BatchOperations[Obj any] interface {
@@ -254,10 +256,4 @@ func StatusError(err error) Status {
 		UpdatedAt: time.Now(),
 		Error:     err.Error(),
 	}
-}
-
-// opResult is the outcome from reconciling a single object
-type opResult struct {
-	rev    statedb.Revision // revision of the object
-	status Status           // the status to commit
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -501,7 +501,7 @@ github.com/cilium/proxy/go/envoy/type/tracing/v3
 github.com/cilium/proxy/go/envoy/type/v3
 github.com/cilium/proxy/go/envoy/watchdog/v3
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.1.0
+# github.com/cilium/statedb v0.1.1
 ## explicit; go 1.22.0
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
This commit updates the statedb vendored module to v0.1.1. This version contains a few improvements and bug fixes. This commit also updates the reconciler_metrics.go file since there was a minor API change.