### PR TITLE
LB-IPAM: Add flag to ignore services without LBClass set

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -93,6 +93,7 @@ cilium-operator-alibabacloud [flags]
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
       --kvstore string                                       Key-value store type
       --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
+      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -69,6 +69,7 @@ cilium-operator-alibabacloud hive [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -74,6 +74,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -101,6 +101,7 @@ cilium-operator-aws [flags]
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
       --kvstore string                                       Key-value store type
       --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
+      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -69,6 +69,7 @@ cilium-operator-aws hive [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -74,6 +74,7 @@ cilium-operator-aws hive dot-graph [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -96,6 +96,7 @@ cilium-operator-azure [flags]
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
       --kvstore string                                       Key-value store type
       --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
+      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -69,6 +69,7 @@ cilium-operator-azure hive [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -74,6 +74,7 @@ cilium-operator-azure hive dot-graph [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -92,6 +92,7 @@ cilium-operator-generic [flags]
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
       --kvstore string                                       Key-value store type
       --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
+      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -69,6 +69,7 @@ cilium-operator-generic hive [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -74,6 +74,7 @@ cilium-operator-generic hive dot-graph [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -106,6 +106,7 @@ cilium-operator [flags]
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
       --kvstore string                                       Key-value store type
       --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
+      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -69,6 +69,7 @@ cilium-operator hive [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -74,6 +74,7 @@ cilium-operator hive dot-graph [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
+      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -12,6 +12,10 @@
      - Description
      - Type
      - Default
+   * - :spelling:ignore:`LBIPAM.requireLBClass`
+     - requireLBClass tells LB-IPAM to only allocate IPs to services with a specific LoadBalancer class. ref: https://docs.cilium.io/en/stable/network/lb-ipam/#loadbalancerclass
+     - bool
+     - ``false``
    * - :spelling:ignore:`MTU`
      - Configure the underlying network MTU to overwrite auto-detected MTU. This value doesn't change the host network interface MTU i.e. eth0 or ens0. It changes the MTU for cilium_net@cilium_host, cilium_host@cilium_net, cilium_vxlan and lxc_health interfaces.
      - int

--- a/Documentation/network/lb-ipam.rst
+++ b/Documentation/network/lb-ipam.rst
@@ -395,6 +395,27 @@ loadBalancerClass               Feature
 If the ``.spec.loadBalancerClass`` is set to a class which isn't handled by Cilium's LB IPAM, 
 then Cilium's LB IPAM will ignore the service entirely, not even setting a condition in the status. 
 
+By default, if the ``.spec.loadBalancerClass`` field is not set, Cilium's LB IPAM will assume it can 
+allocate IPs for the service from its configured pools. If this isn't the desired behavior, you can 
+configure LB-IPAM to only allocate IPs for services from its configured pools when it has a recognized 
+load balancer class by setting the following configuration in the Helm chart or ConfigMap:
+
+.. tabs::
+    .. group-tab:: Helm
+
+        .. parsed-literal::
+
+            $ helm upgrade cilium |CHART_RELEASE| \\
+               --namespace kube-system \\
+               --reuse-values \\
+               --set LBIPAM.requireLBClass=true
+
+    .. group-tab:: ConfigMap
+
+        .. code-block:: yaml
+
+            lbipam-require-lb-class: true
+
 Requesting IPs
 --------------
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -637,6 +637,7 @@ repo
 repos
 reproducibility
 requireIPv
+requireLBClass
 resync
 retpoline
 retransmission

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -53,6 +53,7 @@ contributors across the globe, there is almost always someone available to help.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| LBIPAM.requireLBClass | bool | `false` | requireLBClass tells LB-IPAM to only allocate IPs to services with a specific LoadBalancer class. ref: https://docs.cilium.io/en/stable/network/lb-ipam/#loadbalancerclass |
 | MTU | int | `0` | Configure the underlying network MTU to overwrite auto-detected MTU. This value doesn't change the host network interface MTU i.e. eth0 or ens0. It changes the MTU for cilium_net@cilium_host, cilium_host@cilium_net, cilium_vxlan and lxc_health interfaces. |
 | affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-agent. |
 | agent | bool | `true` | Install the cilium agent resources. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1038,6 +1038,10 @@ data:
   enable-node-ipam: "true"
 {{- end }}
 
+{{- if .Values.LBIPAM.requireLBClass }}
+  lbipam-require-lb-class: "true"
+{{- end }}
+
 {{- if .Values.apiRateLimit }}
   api-rate-limit: {{ .Values.apiRateLimit | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1,5 +1,13 @@
 {
   "properties": {
+    "LBIPAM": {
+      "properties": {
+        "requireLBClass": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "MTU": {
       "type": "integer"
     },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1781,6 +1781,10 @@ nodeIPAM:
   # -- Configure Node IPAM
   # ref: https://docs.cilium.io/en/stable/network/node-ipam/
   enabled: false
+LBIPAM:
+  # -- requireLBClass tells LB-IPAM to only allocate IPs to services with a specific LoadBalancer class.
+  # ref: https://docs.cilium.io/en/stable/network/lb-ipam/#loadbalancerclass
+  requireLBClass: false
 # @schema
 # type: [null, string]
 # @schema

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1786,6 +1786,10 @@ nodeIPAM:
   # -- Configure Node IPAM
   # ref: https://docs.cilium.io/en/stable/network/node-ipam/
   enabled: false
+LBIPAM:
+  # -- requireLBClass tells LB-IPAM to only allocate IPs to services with a specific LoadBalancer class.
+  # ref: https://docs.cilium.io/en/stable/network/lb-ipam/#loadbalancerclass
+  requireLBClass: false
 # @schema
 # type: [null, string]
 # @schema

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -82,6 +82,8 @@ type lbIPAMParams struct {
 	jobGroup job.Group
 
 	metrics *ipamMetrics
+
+	config lbipamConfig
 }
 
 func newLBIPAM(params lbIPAMParams) *LBIPAM {
@@ -1135,10 +1137,10 @@ func (ipam *LBIPAM) isResponsibleForSVC(svc *slim_core_v1.Service) bool {
 		return false
 	}
 
-	// We will assume that we are the default LB, LB-IPAM shouldn't be enabled clusters that don't support LBClasses
-	// and have multiple LBs.
+	// If no load balancer class is specified, we will assume that we are responsible for the service
+	// unless we have been configured to require a load balancer class.
 	if svc.Spec.LoadBalancerClass == nil {
-		return true
+		return !ipam.lbIPAMParams.config.LBIPAMRequireLBClass
 	}
 
 	if !slices.Contains(ipam.lbClasses, *svc.Spec.LoadBalancerClass) {


### PR DESCRIPTION
The existing behavior of LB-IPAM was to assume LB-IPAM is responsible for services without an LBClass set. This made sense since LB-IPAM is aimed at environments where traditional LB controllers are not available and there were still supported k8s deployments that did not support LBClass.

All supported k8s deployments now support LBClass, and users have reported situations where the default LB controller has to be assigned to a controller other than LB-IPAM due to the other controller not respecting LBClasses. Therefor, it is advantages to have the option to tell LB-IPAM to ignore services without an LBClass set and only manage services with an LBClass that we own.

This PR adds this functionality, by default we still have the old behavior, but the `--lbipam-require-lb-class` flag / `lbIPAM.requireLBClass` helm option can be set to `true` to make LB-IPAM ignore services without an LBClass set.

Fixes: #33319

```release-note
Add a flag that instruct LB-IPAM to only allocate IPs for services with .Spec.LoadBalancerClass specified
```
