### PR TITLE
build-images-base: cancel github runs based on branch name

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -36,7 +36,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
With the introduction of workflow_call by f054f94b24b9, the concurrency group started to cancel jobs based on the workflow name alone which has caused workflow runs created by this workflow were canceled even if they were opened from different branches.

Fixes: f054f94b24b9 (".github: add workflow for renovate to build base images")