### PR TITLE
Revert "CI: bump default FQDN datapath timeout from 100 to 250ms"

### DIFF
--- a/.github/actions/helm-default/action.yaml
+++ b/.github/actions/helm-default/action.yaml
@@ -31,7 +31,6 @@ runs:
           --helm-set=debug.enabled=true \
           --helm-set=debug.verbose=envoy \
           --helm-set=bpf.monitorAggregation=none \
-          --helm-set=dnsProxy.proxyResponseMaxDelay=250ms \
           --helm-set=hubble.relay.retryTimeout=5s"
 
         # only add SHA to the image tags if it was set


### PR DESCRIPTION
This reverts commit 34caeb233b0d47a0e4f9553fbd7ac532e0c1a5f8.

Thanks to [recent improvements on `main`](https://github.com/cilium/cilium/pull/32769), P99 latency for Cilium DNS in the fqdn-perf workflow has dropped from ~100ms to ~15ms. This should allow us to fall back to the default FQDN timeout to 100ms.

Note that in contrast to the above commit, this commit here should not be backported to older branches, as the performance fixes are not backported either.
