### PR TITLE
contrib,tool: exclude slice cleanup

### DIFF
--- a/tools/legacyhguardcheck/main.go
+++ b/tools/legacyhguardcheck/main.go
@@ -68,7 +68,6 @@ func checkDir(dirPath string) (bool, error) {
 var ifndefRegex = regexp.MustCompile(`#ifndef\s+([A-Za-z0-9_]+)\s*\n#define ([A-Za-z0-9_]+)`)
 
 var exclude = []string{
-	"bpf/tests/config_replacement.h",
 	"bpf/node_config.h",
 	"bpf/lib/clustermesh.h",
 	"bpf/include/linux/byteorder/big_endian.h",


### PR DESCRIPTION
The config_replacement.h was removed. So we no
longer need in the exclude slice.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
