### PR TITLE
build-images-base: push to branch if pull request ref doesn't exist

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -286,7 +286,7 @@ jobs:
 
       - name: Push changes into PR
         env:
-          REF: ${{ github.event.pull_request.head.ref }}
+          REF: ${{ github.event.pull_request.head.ref || github.ref }}
         if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' || steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
         run: |
           git diff HEAD^


### PR DESCRIPTION
With the introduction of workflow_call by f054f94b24b9, pushing changes to the branch was not possible when the event was type "workflow_call" as the github.event.pull_request.head.ref does not exist.

Fixes: f054f94b24b9 (".github: add workflow for renovate to build base images")