### PR TITLE
.github: fix workflows for on push

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -17,10 +17,12 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
+  push:
+    branches:
+      - 'renovate/v1.14-**'
   # Run every 6 hours
   schedule:
     - cron: '0 3/6 * * *'
-      - 'renovate/v1.14-**'
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -17,10 +17,12 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
+  push:
+    branches:
+      - 'renovate/v1.14-**'
   # Run every 6 hours
   schedule:
     - cron:  '0 3/6 * * *'
-      - 'renovate/v1.14-**'
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -17,10 +17,12 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
+  push:
+    branches:
+      - 'renovate/v1.14-**'
   # Run every 6 hours
   schedule:
     - cron:  '0 5/6 * * *'
-      - 'renovate/v1.14-**'
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.


### PR DESCRIPTION
Due to a bad backport from 75e043b3efa7 the workflows got badly configured which prevented their execution. This commit adds the push event on the right place.

Fixes: 75e043b3efa7 ("run CI automatically for renovate")

I wonder how it was not caught by CI in https://github.com/cilium/cilium/pull/33316 :thinking: 
