### PR TITLE
hive: Fixed copy-paste error in reconciler.Metrics implementation

### DIFF
--- a/pkg/hive/reconciler_metrics.go
+++ b/pkg/hive/reconciler_metrics.go
@@ -153,7 +153,7 @@ func (m *reconcilerMetricsImpl) IncrementalReconciliationErrors(moduleID cell.Fu
 		m.m.IncrementalReconciliationCurrentErrors.WithLabelValues(LabelModuleId, moduleID.String()).Set(float64(currentErrors))
 	}
 	if m.m.IncrementalReconciliationTotalErrors.IsEnabled() {
-		m.m.IncrementalReconciliationCurrentErrors.WithLabelValues(LabelModuleId, moduleID.String()).Add(float64(newErrors))
+		m.m.IncrementalReconciliationTotalErrors.WithLabelValues(LabelModuleId, moduleID.String()).Add(float64(newErrors))
 	}
 }
 


### PR DESCRIPTION
The code checked if `IncrementalReconciliationTotalErrors` was enabled but then modified `IncrementalReconciliationCurrentErrors`. Seems like a copy-paste error from the case above, fixed it.

