### PR TITLE
Fix log message when instance limits are unavailable

### DIFF
--- a/pkg/alibabacloud/eni/node.go
+++ b/pkg/alibabacloud/eni/node.go
@@ -189,7 +189,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (available ipamTypes.AllocationMap, stats stats.InterfaceStats, err error) {
 	limits, limitsAvailable := n.getLimits()
 	if !limitsAvailable {
-		return nil, stats, fmt.Errorf(errUnableToDetermineLimits)
+		return nil, stats, ipam.LimitsNotFound{}
 	}
 
 	// During preparation of IP allocations, the primary NIC is not considered

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -542,7 +542,7 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Ent
 	err error) {
 	limits, limitsAvailable := n.getLimits()
 	if !limitsAvailable {
-		return nil, stats, fmt.Errorf(errUnableToDetermineLimits)
+		return nil, stats, ipam.LimitsNotFound{}
 	}
 
 	// n.node does not need to be protected by n.mutex as it is only written to

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -7,6 +7,7 @@ package ipam
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -458,7 +459,13 @@ func (n *Node) recalculate() {
 	defer n.mutex.Unlock()
 
 	if err != nil {
-		scopedLog.Warning("Instance not found! Please delete corresponding ciliumnode if instance has already been deleted.")
+		var limitsNotFound LimitsNotFound
+		ok := errors.As(err, &limitsNotFound)
+		if ok {
+			scopedLog.WithError(err).Warning("Instance limits not found.")
+		} else {
+			scopedLog.WithError(err).Warning("Instance not found! Please delete corresponding ciliumnode if instance has already been deleted.")
+		}
 		// Avoid any further action
 		n.stats.IPv4.NeededIPs = 0
 		n.stats.IPv4.ExcessIPs = 0

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -146,3 +146,11 @@ type expirationTimer struct {
 	uuid string
 	stop chan<- struct{}
 }
+
+// LimitsNotFound is an error that signals lack of limits for given instance type
+type LimitsNotFound struct{}
+
+// Error implements error interface
+func (_ LimitsNotFound) Error() string {
+	return "Limits not found"
+}


### PR DESCRIPTION
This PR adds a different log message in handling `ResyncInterfacesAndIPs` error if it was caused by an issue with getting instance limits. Previous log message was confusing and didn't indicate that limits were the issue.

```release-note
Fix log message when instance limits are unavailable 
``` 