### PR TITLE
operator/ciliumidentity: Add CID time trackers

### DIFF
--- a/operator/pkg/ciliumidentity/cache.go
+++ b/operator/pkg/ciliumidentity/cache.go
@@ -4,12 +4,13 @@
 package ciliumidentity
 
 import (
-	"errors"
+	"log/slog"
 	"strconv"
 
 	"github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 // SecIDs is used to handle duplicate CIDs. Operator itself will not generate
@@ -26,12 +27,14 @@ type CIDState struct {
 	// Maps label string generated from GlobalIdentity.GetKey() to CID name.
 	labelsToID map[string]*SecIDs
 	mu         lock.RWMutex
+	logger     *slog.Logger
 }
 
-func NewCIDState() *CIDState {
+func NewCIDState(logger *slog.Logger) *CIDState {
 	cidState := &CIDState{
 		idToLabels: make(map[string]*key.GlobalIdentity),
 		labelsToID: make(map[string]*SecIDs),
+		logger:     logger,
 	}
 
 	return cidState
@@ -49,6 +52,7 @@ func (c *CIDState) Upsert(id string, k *key.GlobalIdentity) {
 		return
 	}
 
+	c.logger.Debug("Upsert internal mapping between", logfields.CIDName, id, "labels", k.Labels().String())
 	c.idToLabels[id] = k
 
 	keyStr := k.GetKey()
@@ -76,6 +80,8 @@ func (c *CIDState) Remove(id string) {
 	if !exists {
 		return
 	}
+
+	c.logger.Debug("Remove internal mapping between", logfields.CIDName, id, "labels", k.Labels().String())
 
 	delete(c.idToLabels, id)
 
@@ -162,31 +168,20 @@ func (c *CIDUsageInPods) AssignCIDToPod(podName, cidName string) (string, int) {
 
 // RemovePod removes the pod from the pod to CID map, decrements the CID usage
 // and returns the CID name and its usage count after decrementing the usage.
+// If the pod does not exist in the pod to CID map it returns empty values.
 // The return values are used to track when old CIDs are no longer used.
-func (c *CIDUsageInPods) RemovePod(podName string) (string, int, error) {
+func (c *CIDUsageInPods) RemovePod(podName string) (string, int, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	cidName, exists := c.podToCID[podName]
 	if !exists {
-		return "", 0, errors.New("cilium identity not found in pods usage cache")
+		return "", 0, false
 	}
 	count := c.decrementUsage(cidName)
 	delete(c.podToCID, podName)
 
-	return cidName, count, nil
-}
-
-func (c *CIDUsageInPods) CIDUsedByPod(podName string) (string, bool) {
-	if len(podName) == 0 {
-		return "", false
-	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	cidName, exists := c.podToCID[podName]
-	return cidName, exists
+	return cidName, count, true
 }
 
 func (c *CIDUsageInPods) CIDUsageCount(cidName string) int {

--- a/operator/pkg/ciliumidentity/cache_test.go
+++ b/operator/pkg/ciliumidentity/cache_test.go
@@ -5,14 +5,16 @@ package ciliumidentity
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"reflect"
 	"sync"
 	"testing"
 
-	"github.com/cilium/cilium/pkg/labels"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging"
 
 	cestest "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
 	"github.com/cilium/cilium/pkg/identity/key"
@@ -34,9 +36,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestCIDState(t *testing.T) {
+	logger := slog.New(logging.SlogNopHandler)
 	// The subtests below share the same state to serially test insert, lookup and
 	// remove operations of CIDState.
-	state := NewCIDState()
+	state := NewCIDState(logger)
 	k1 := key.GetCIDKeyFromLabels(k8sLables_A, labels.LabelSourceK8s)
 	k2 := key.GetCIDKeyFromLabels(k8sLables_B, labels.LabelSourceK8s)
 	k3 := key.GetCIDKeyFromLabels(k8sLables_B_duplicate, labels.LabelSourceK8s)
@@ -142,9 +145,11 @@ func TestCIDState(t *testing.T) {
 }
 
 func TestCIDStateThreadSafety(t *testing.T) {
+	logger := slog.New(logging.SlogNopHandler)
+
 	// This test ensures that no changes to the CID state break its thread safety.
 	// Multiple go routines in parallel continuously keep using CIDState.
-	state := NewCIDState()
+	state := NewCIDState(logger)
 
 	k := key.GetCIDKeyFromLabels(k8sLables_A, labels.LabelSourceK8s)
 	k2 := key.GetCIDKeyFromLabels(k8sLables_B, labels.LabelSourceK8s)
@@ -191,12 +196,12 @@ func TestCIDUsageInPods(t *testing.T) {
 	podName1 := "pod1"
 	assert.Equal(t, 0, state.CIDUsageCount(cidName1), assertTxt)
 
-	usedCID, exists := state.CIDUsedByPod(podName1)
+	usedCID, exists := state.podToCID[podName1]
 	assert.Equal(t, false, exists, assertTxt)
 	assert.Equal(t, "", usedCID, assertTxt)
 
-	prevCID, count, err := state.RemovePod(podName1)
-	assert.Error(t, err)
+	prevCID, count, exists := state.RemovePod(podName1)
+	assert.Equal(t, false, exists)
 	assert.Equal(t, "", prevCID, assertTxt)
 	assert.Equal(t, 0, count, assertTxt)
 
@@ -206,7 +211,7 @@ func TestCIDUsageInPods(t *testing.T) {
 	assert.Equal(t, 0, count, assertTxt)
 	assert.Equal(t, 1, state.CIDUsageCount(cidName1), assertTxt)
 
-	usedCID, exists = state.CIDUsedByPod(podName1)
+	usedCID, exists = state.podToCID[podName1]
 	assert.Equal(t, true, exists, assertTxt)
 	assert.Equal(t, cidName1, usedCID, assertTxt)
 
@@ -217,7 +222,7 @@ func TestCIDUsageInPods(t *testing.T) {
 	assert.Equal(t, 0, count, assertTxt)
 	assert.Equal(t, 2, state.CIDUsageCount(cidName1), assertTxt)
 
-	usedCID, exists = state.CIDUsedByPod(podName2)
+	usedCID, exists = state.podToCID[podName2]
 	assert.Equal(t, true, exists, assertTxt)
 	assert.Equal(t, cidName1, usedCID, assertTxt)
 
@@ -228,7 +233,7 @@ func TestCIDUsageInPods(t *testing.T) {
 	assert.Equal(t, 1, count, assertTxt)
 	assert.Equal(t, 1, state.CIDUsageCount(cidName2), assertTxt)
 
-	usedCID, exists = state.CIDUsedByPod(podName2)
+	usedCID, exists = state.podToCID[podName2]
 	assert.Equal(t, true, exists, assertTxt)
 	assert.Equal(t, cidName2, usedCID, assertTxt)
 
@@ -239,7 +244,7 @@ func TestCIDUsageInPods(t *testing.T) {
 	assert.Equal(t, 2, state.CIDUsageCount(cidName2), assertTxt)
 	assert.Equal(t, 0, state.CIDUsageCount(cidName1), assertTxt)
 
-	usedCID, exists = state.CIDUsedByPod(podName1)
+	usedCID, exists = state.podToCID[podName1]
 	assert.Equal(t, true, exists, assertTxt)
 	assert.Equal(t, cidName2, usedCID, assertTxt)
 
@@ -251,24 +256,24 @@ func TestCIDUsageInPods(t *testing.T) {
 	assert.Equal(t, 0, state.CIDUsageCount(cidName1), assertTxt)
 
 	assertTxt = "Remove Pod 1"
-	prevCID, count, err = state.RemovePod(podName1)
-	assert.NoError(t, err)
+	prevCID, count, exists = state.RemovePod(podName1)
+	assert.Equal(t, true, exists)
 	assert.Equal(t, cidName2, prevCID, assertTxt)
 	assert.Equal(t, 1, count, assertTxt)
 	assert.Equal(t, 1, state.CIDUsageCount(cidName2), assertTxt)
 
-	usedCID, exists = state.CIDUsedByPod(podName1)
+	usedCID, exists = state.podToCID[podName1]
 	assert.Equal(t, false, exists, assertTxt)
 	assert.Equal(t, "", usedCID, assertTxt)
 
 	assertTxt = "Remove Pod 2"
-	prevCID, count, err = state.RemovePod(podName2)
-	assert.NoError(t, err)
+	prevCID, count, exists = state.RemovePod(podName2)
+	assert.Equal(t, true, exists)
 	assert.Equal(t, cidName2, prevCID, assertTxt)
 	assert.Equal(t, 0, count, assertTxt)
 	assert.Equal(t, 0, state.CIDUsageCount(cidName2), assertTxt)
 
-	usedCID, exists = state.CIDUsedByPod(podName2)
+	usedCID, exists = state.podToCID[podName2]
 	assert.Equal(t, false, exists, assertTxt)
 	assert.Equal(t, "", usedCID, assertTxt)
 }

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -677,6 +677,9 @@ const (
 	// CEPUID is the UID of the CiliumEndpoint.
 	CEPUID = "ciliumEndpointUID"
 
+	// CIDName is the name of the CiliumIdentity.
+	CIDName = "ciliumIdentityName"
+
 	// CESName is the name of the CiliumEndpointSlice.
 	CESName = "ciliumEndpointSliceName"
 


### PR DESCRIPTION
Add `EnqueueTimeTracker` and `CIDDeletionTracker` structures to manage enqueuing times and track CID deletion marks. This feature will be used by Operator Managing CIDs. 

`EnqueueTimeTracker` is only used for metrics to meter the duration from enqueuing the reconciliation until the CID reconciliation is completed. 
`CIDDeletionTracker` is used to handle CID deletion when the CID is no longer needed, this is only used by operator. The deletion tracker allows us to implement a `cidDeleteDelay` which is the delay to enqueue another CID event to be reconciled after CID is marked for deletion. This is required for simultaneous CID management by both cilium-operator and cilium-agent. Without the delay, operator might immediately clean up CIDs created by agent, before agent can finish CEP creation. The deletion tracker is not used in cilium-agent and is only used to enforce the delay for deletion by operator.



Related CFP #27752

Draft full implementation: https://github.com/cilium/cilium/pull/33204