### PR TITLE
operator/identitygc: Disable identitygc when Operator manages CID

### DIFF
--- a/operator/identitygc/cell.go
+++ b/operator/identitygc/cell.go
@@ -81,4 +81,8 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 type SharedConfig struct {
 	// IdentityAllocationMode specifies what mode to use for identity allocation
 	IdentityAllocationMode string
+	// EnableOperatorManageCIDs enables operator to manage CID by
+	// running a CID controller. If enabled, Identity GC cell is
+	// then disabled because CID controller takes care of garbage collection.
+	EnableOperatorManageCIDs bool
 }

--- a/operator/identitygc/gc.go
+++ b/operator/identitygc/gc.go
@@ -88,7 +88,7 @@ type GC struct {
 }
 
 func registerGC(p params) {
-	if !p.Clientset.IsEnabled() {
+	if !p.Clientset.IsEnabled() || p.SharedCfg.EnableOperatorManageCIDs {
 		return
 	}
 


### PR DESCRIPTION
`EnableOperatorManageCIDs` enables operator to manage CID by running a CID controller. If enabled, Identity GC cell is then disabled because CID controller takes care of garbage collection.

Related https://github.com/cilium/cilium/issues/27752

Draft full implementation: https://github.com/cilium/cilium/pull/33204