### PR TITLE
docs: Improve note on kube-apiserver entity limitations

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -364,9 +364,12 @@ all
     The all entity represents the combination of all known clusters as well
     world and whitelists all communication.
 
-.. note:: The ``kube-apiserver`` entity is unavailable in some Kubernetes 
-   distributions, such as Azure AKS and GCP GKE for ingress traffic. You could still use ``cluster`` which
-   is broader.
+.. note:: The ``kube-apiserver`` entity may not work for *ingress traffic* in some Kubernetes
+   distributions, such as Azure AKS and GCP GKE. This is due to the fact that ingress
+   control-plane traffic is being tunneled through worker nodes, which does not preserve
+   the original source IP. You may be able to use a broader ``fromEntities: cluster`` rule
+   instead. Restricting *egress traffic* via ``toEntities: kube-apiserver`` however is expected
+   to work on these Kubernetes distributions.
 
 Access to/from kube-apiserver
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
In the previous wording it was easy to overlook that this limitation only applies to ingress traffic.

Fixes: https://github.com/cilium/cilium/pull/32464