### PR TITLE
pkg/ciliumidentity: Add Cilium Identity Controller Operator hive cell

### DIFF
--- a/operator/identitygc/crd_gc.go
+++ b/operator/identitygc/crd_gc.go
@@ -12,7 +12,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	operatorK8s "github.com/cilium/cilium/operator/k8s"
+	"github.com/cilium/cilium/operator/k8s"
 	"github.com/cilium/cilium/pkg/controller"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -102,7 +102,7 @@ func (igc *GC) gc(ctx context.Context) error {
 			_, foundInCES = idsInCESs[identity.Name]
 		}
 		// The identity is definitely alive if there's a CE or CES using it.
-		alive := foundInCES || hasCEWithIdentity(cepStore, identity.Name)
+		alive := foundInCES || k8s.HasCEWithIdentity(cepStore, identity.Name)
 
 		if alive {
 			igc.heartbeatStore.markAlive(identity.Name, timeNow)
@@ -228,11 +228,6 @@ func (igc *GC) updateIdentity(ctx context.Context, identity *v2.CiliumIdentity) 
 	log.WithField(logfields.Identity, identity.GetName()).Debug("Updated identity")
 
 	return nil
-}
-
-func hasCEWithIdentity(cepStore resource.Store[*v2.CiliumEndpoint], identity string) bool {
-	ces, _ := cepStore.IndexKeys(operatorK8s.CiliumEndpointIndexIdentity, identity)
-	return len(ces) != 0
 }
 
 func usedIdentitiesInCESs(cesStore resource.Store[*v2alpha1.CiliumEndpointSlice]) map[string]bool {

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -69,8 +69,6 @@ type Resources struct {
 
 // HasCEWithIdentity returns true or false if the Cilium Endpoint store has
 // the given identity.
-// Once the CiliumEndpoint is migrated to use resources
-// the cepStore can be removed and used the local store.
 func HasCEWithIdentity(cepStore resource.Store[*cilium_api_v2.CiliumEndpoint], identity string) bool {
 	if cepStore == nil {
 		return false

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -66,3 +66,16 @@ type Resources struct {
 	Pods                 resource.Resource[*slim_corev1.Pod]
 	Namespaces           resource.Resource[*slim_corev1.Namespace]
 }
+
+// HasCEWithIdentity returns true or false if the Cilium Endpoint store has
+// the given identity.
+// Once the CiliumEndpoint is migrated to use resources
+// the cepStore can be removed and used the local store.
+func HasCEWithIdentity(cepStore resource.Store[*cilium_api_v2.CiliumEndpoint], identity string) bool {
+	if cepStore == nil {
+		return false
+	}
+	ces, _ := cepStore.IndexKeys(CiliumEndpointIndexIdentity, identity)
+
+	return len(ces) != 0
+}

--- a/operator/pkg/ciliumidentity/cache.go
+++ b/operator/pkg/ciliumidentity/cache.go
@@ -177,18 +177,6 @@ func (c *CIDUsageInPods) RemovePod(podName string) (string, int, error) {
 	return cidName, count, nil
 }
 
-func (c *CIDUsageInPods) CIDUsedByPod(podName string) (string, bool) {
-	if len(podName) == 0 {
-		return "", false
-	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	cidName, exists := c.podToCID[podName]
-	return cidName, exists
-}
-
 func (c *CIDUsageInPods) CIDUsageCount(cidName string) int {
 	if len(cidName) == 0 {
 		return 0

--- a/operator/pkg/ciliumidentity/cache_test.go
+++ b/operator/pkg/ciliumidentity/cache_test.go
@@ -5,19 +5,20 @@ package ciliumidentity
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"reflect"
 	"sync"
 	"testing"
-
-	"github.com/cilium/cilium/pkg/labels"
 
 	"github.com/stretchr/testify/assert"
 
 	cestest "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
 	"github.com/cilium/cilium/pkg/identity/key"
 	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
+	"github.com/cilium/cilium/pkg/logging"
 )
 
 var (
@@ -34,9 +35,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestCIDState(t *testing.T) {
+	logger := slog.New(logging.SlogNopHandler)
 	// The subtests below share the same state to serially test insert, lookup and
 	// remove operations of CIDState.
-	state := NewCIDState()
+	state := NewCIDState(logger)
 	k1 := key.GetCIDKeyFromLabels(k8sLables_A, labels.LabelSourceK8s)
 	k2 := key.GetCIDKeyFromLabels(k8sLables_B, labels.LabelSourceK8s)
 	k3 := key.GetCIDKeyFromLabels(k8sLables_B_duplicate, labels.LabelSourceK8s)
@@ -142,9 +144,11 @@ func TestCIDState(t *testing.T) {
 }
 
 func TestCIDStateThreadSafety(t *testing.T) {
+	logger := slog.New(logging.SlogNopHandler)
+
 	// This test ensures that no changes to the CID state break its thread safety.
 	// Multiple go routines in parallel continuously keep using CIDState.
-	state := NewCIDState()
+	state := NewCIDState(logger)
 
 	k := key.GetCIDKeyFromLabels(k8sLables_A, labels.LabelSourceK8s)
 	k2 := key.GetCIDKeyFromLabels(k8sLables_B, labels.LabelSourceK8s)

--- a/operator/pkg/ciliumidentity/cache_test.go
+++ b/operator/pkg/ciliumidentity/cache_test.go
@@ -199,8 +199,8 @@ func TestCIDUsageInPods(t *testing.T) {
 	assert.Equal(t, false, exists, assertTxt)
 	assert.Equal(t, "", usedCID, assertTxt)
 
-	prevCID, count, err := state.RemovePod(podName1)
-	assert.Error(t, err)
+	prevCID, count, exists := state.RemovePod(podName1)
+	assert.Equal(t, false, exists)
 	assert.Equal(t, "", prevCID, assertTxt)
 	assert.Equal(t, 0, count, assertTxt)
 
@@ -255,8 +255,8 @@ func TestCIDUsageInPods(t *testing.T) {
 	assert.Equal(t, 0, state.CIDUsageCount(cidName1), assertTxt)
 
 	assertTxt = "Remove Pod 1"
-	prevCID, count, err = state.RemovePod(podName1)
-	assert.NoError(t, err)
+	prevCID, count, exists = state.RemovePod(podName1)
+	assert.Equal(t, true, exists)
 	assert.Equal(t, cidName2, prevCID, assertTxt)
 	assert.Equal(t, 1, count, assertTxt)
 	assert.Equal(t, 1, state.CIDUsageCount(cidName2), assertTxt)
@@ -266,8 +266,8 @@ func TestCIDUsageInPods(t *testing.T) {
 	assert.Equal(t, "", usedCID, assertTxt)
 
 	assertTxt = "Remove Pod 2"
-	prevCID, count, err = state.RemovePod(podName2)
-	assert.NoError(t, err)
+	prevCID, count, exists = state.RemovePod(podName2)
+	assert.Equal(t, true, exists)
 	assert.Equal(t, cidName2, prevCID, assertTxt)
 	assert.Equal(t, 0, count, assertTxt)
 	assert.Equal(t, 0, state.CIDUsageCount(cidName2), assertTxt)

--- a/operator/pkg/ciliumidentity/cache_test.go
+++ b/operator/pkg/ciliumidentity/cache_test.go
@@ -191,7 +191,7 @@ func TestCIDUsageInPods(t *testing.T) {
 	podName1 := "pod1"
 	assert.Equal(t, 0, state.CIDUsageCount(cidName1), assertTxt)
 
-	usedCID, exists := state.CIDUsedByPod(podName1)
+	usedCID, exists := state.podToCID[podName1]
 	assert.Equal(t, false, exists, assertTxt)
 	assert.Equal(t, "", usedCID, assertTxt)
 
@@ -206,7 +206,7 @@ func TestCIDUsageInPods(t *testing.T) {
 	assert.Equal(t, 0, count, assertTxt)
 	assert.Equal(t, 1, state.CIDUsageCount(cidName1), assertTxt)
 
-	usedCID, exists = state.CIDUsedByPod(podName1)
+	usedCID, exists = state.podToCID[podName1]
 	assert.Equal(t, true, exists, assertTxt)
 	assert.Equal(t, cidName1, usedCID, assertTxt)
 
@@ -217,7 +217,7 @@ func TestCIDUsageInPods(t *testing.T) {
 	assert.Equal(t, 0, count, assertTxt)
 	assert.Equal(t, 2, state.CIDUsageCount(cidName1), assertTxt)
 
-	usedCID, exists = state.CIDUsedByPod(podName2)
+	usedCID, exists = state.podToCID[podName2]
 	assert.Equal(t, true, exists, assertTxt)
 	assert.Equal(t, cidName1, usedCID, assertTxt)
 
@@ -228,7 +228,7 @@ func TestCIDUsageInPods(t *testing.T) {
 	assert.Equal(t, 1, count, assertTxt)
 	assert.Equal(t, 1, state.CIDUsageCount(cidName2), assertTxt)
 
-	usedCID, exists = state.CIDUsedByPod(podName2)
+	usedCID, exists = state.podToCID[podName2]
 	assert.Equal(t, true, exists, assertTxt)
 	assert.Equal(t, cidName2, usedCID, assertTxt)
 
@@ -239,7 +239,7 @@ func TestCIDUsageInPods(t *testing.T) {
 	assert.Equal(t, 2, state.CIDUsageCount(cidName2), assertTxt)
 	assert.Equal(t, 0, state.CIDUsageCount(cidName1), assertTxt)
 
-	usedCID, exists = state.CIDUsedByPod(podName1)
+	usedCID, exists = state.podToCID[podName1]
 	assert.Equal(t, true, exists, assertTxt)
 	assert.Equal(t, cidName2, usedCID, assertTxt)
 
@@ -257,7 +257,7 @@ func TestCIDUsageInPods(t *testing.T) {
 	assert.Equal(t, 1, count, assertTxt)
 	assert.Equal(t, 1, state.CIDUsageCount(cidName2), assertTxt)
 
-	usedCID, exists = state.CIDUsedByPod(podName1)
+	usedCID, exists = state.podToCID[podName1]
 	assert.Equal(t, false, exists, assertTxt)
 	assert.Equal(t, "", usedCID, assertTxt)
 
@@ -268,7 +268,7 @@ func TestCIDUsageInPods(t *testing.T) {
 	assert.Equal(t, 0, count, assertTxt)
 	assert.Equal(t, 0, state.CIDUsageCount(cidName2), assertTxt)
 
-	usedCID, exists = state.CIDUsedByPod(podName2)
+	usedCID, exists = state.podToCID[podName2]
 	assert.Equal(t, false, exists, assertTxt)
 	assert.Equal(t, "", usedCID, assertTxt)
 }

--- a/operator/pkg/ciliumidentity/cell.go
+++ b/operator/pkg/ciliumidentity/cell.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import (
+	"github.com/cilium/hive/cell"
+)
+
+// Cell implements the CID Controller. It subscribes to CID, CES, Pods
+// and Namespace events and reconciles the state of CID in the cluster.
+var Cell = cell.Module(
+	"k8s-cid-controller",
+	"Cilium Identity Controller Operator",
+	cell.Invoke(registerController),
+)
+
+// SharedConfig contains the configuration that is shared between
+// this module and others.
+// It is a temporary solution meant to avoid polluting this module with a direct
+// dependency on global operator and daemon configurations.
+type SharedConfig struct {
+	// EnableOperatorManageCIDs enables operator to manage Cilium Identities by
+	// running a Cilium Identity controller.
+	EnableOperatorManageCIDs bool
+
+	// EnableCiliumEndpointSlice indicates if the Cilium Endpoint Slice feature is
+	// enabled.
+	EnableCiliumEndpointSlice bool
+}

--- a/operator/pkg/ciliumidentity/controller.go
+++ b/operator/pkg/ciliumidentity/controller.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+type queueOperations interface {
+	enqueueCIDReconciliation(cidKey resource.Key, delay time.Duration)
+	enqueuePodReconciliation(podKey resource.Key, delay time.Duration)
+}
+
+type params struct {
+	cell.In
+
+	Logger              *slog.Logger
+	Lifecycle           cell.Lifecycle
+	Clientset           k8sClient.Clientset
+	SharedCfg           SharedConfig
+	Namespace           resource.Resource[*slim_corev1.Namespace]
+	Pod                 resource.Resource[*slim_corev1.Pod]
+	CiliumIdentity      resource.Resource[*cilium_api_v2.CiliumIdentity]
+	CiliumEndpoint      resource.Resource[*cilium_api_v2.CiliumEndpoint]
+	CiliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice]
+}
+
+type Controller struct {
+	logger              *slog.Logger
+	context             context.Context
+	contextCancel       context.CancelFunc
+	clientset           k8sClient.Clientset
+	reconciler          *reconciler
+	namespace           resource.Resource[*slim_corev1.Namespace]
+	pod                 resource.Resource[*slim_corev1.Pod]
+	ciliumIdentity      resource.Resource[*cilium_api_v2.CiliumIdentity]
+	ciliumEndpoint      resource.Resource[*cilium_api_v2.CiliumEndpoint]
+	ciliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice]
+
+	cesEnabled bool
+
+	// oldNSSecurityLabels is a map between namespace, and it's security labels.
+	// It's used to track previous state of labels, to detect when labels changed.
+	oldNSSecurityLabels map[string]labels.Labels
+}
+
+func registerController(p params) {
+	if !p.Clientset.IsEnabled() || !p.SharedCfg.EnableOperatorManageCIDs {
+		return
+	}
+
+	cidController := &Controller{
+		logger:              p.Logger,
+		clientset:           p.Clientset,
+		namespace:           p.Namespace,
+		pod:                 p.Pod,
+		ciliumIdentity:      p.CiliumIdentity,
+		ciliumEndpoint:      p.CiliumEndpoint,
+		ciliumEndpointSlice: p.CiliumEndpointSlice,
+		oldNSSecurityLabels: make(map[string]labels.Labels),
+		cesEnabled:          p.SharedCfg.EnableCiliumEndpointSlice,
+	}
+
+	p.Lifecycle.Append(cidController)
+}
+
+func (c *Controller) Start(_ cell.HookContext) error {
+	c.logger.Info("Starting CID controller Operator")
+	defer utilruntime.HandleCrash()
+
+	var err error
+	c.context, c.contextCancel = context.WithCancel(context.Background())
+	c.reconciler, err = newReconciler(
+		c.context,
+		c.logger,
+		c.clientset,
+		c.namespace,
+		c.pod,
+		c.ciliumIdentity,
+		c.ciliumEndpoint,
+		c.ciliumEndpointSlice,
+		c.cesEnabled,
+		c,
+	)
+
+	if err != nil {
+		return fmt.Errorf("cid reconciler failed to init: %w", err)
+	}
+
+	c.logger.Info("Starting CID controller reconciler")
+
+	// The desired state needs to be calculated before the events are processed.
+	if err := c.reconciler.calcDesiredStateOnStartup(); err != nil {
+		return fmt.Errorf("cid controller failed to calculate the desired state: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Controller) enqueueCIDReconciliation(cidKey resource.Key, delay time.Duration) {
+}
+
+func (c *Controller) enqueuePodReconciliation(podKey resource.Key, delay time.Duration) {
+}
+
+func (c *Controller) Stop(hookContext cell.HookContext) error {
+	return nil
+}

--- a/operator/pkg/ciliumidentity/identity.go
+++ b/operator/pkg/ciliumidentity/identity.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import "github.com/cilium/cilium/pkg/k8s/resource"
+
+func cidResourceKey(cidName string) resource.Key {
+	return resource.Key{Name: cidName}
+}

--- a/operator/pkg/ciliumidentity/namespace.go
+++ b/operator/pkg/ciliumidentity/namespace.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import "github.com/cilium/cilium/pkg/k8s/resource"
+
+func nsResourceKey(namespace string) resource.Key {
+	return resource.Key{Name: namespace}
+}

--- a/operator/pkg/ciliumidentity/pod.go
+++ b/operator/pkg/ciliumidentity/pod.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import "github.com/cilium/cilium/pkg/k8s/resource"
+
+func podResourceKey(podName, podNamespace string) resource.Key {
+	return resource.Key{Name: podName, Namespace: podNamespace}
+}

--- a/operator/pkg/ciliumidentity/reconciler.go
+++ b/operator/pkg/ciliumidentity/reconciler.go
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	operator_k8s "github.com/cilium/cilium/operator/k8s"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/basicallocator"
+	"github.com/cilium/cilium/pkg/identity/key"
+	"github.com/cilium/cilium/pkg/idpool"
+	"github.com/cilium/cilium/pkg/k8s"
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/identitybackend"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+type reconciler struct {
+	logger          *slog.Logger
+	ctx             context.Context
+	clientset       k8sClient.Clientset
+	idAllocator     *basicallocator.BasicIDAllocator
+	desiredCIDState *CIDState
+	cidUsageInPods  *CIDUsageInPods
+	cidUsageInCES   *CIDUsageInCES
+	// Ensures no CID duplicates are created while allocating CIDs in parallel,
+	// (that is, when processing a pod event and a CID event concurrently).
+	cidCreateLock lock.RWMutex
+	cesEnabled    bool
+	queueOps      queueOperations
+
+	nsStore  resource.Store[*slim_corev1.Namespace]
+	podStore resource.Store[*slim_corev1.Pod]
+	cidStore resource.Store[*cilium_api_v2.CiliumIdentity]
+	cepStore resource.Store[*cilium_api_v2.CiliumEndpoint]
+	cesStore resource.Store[*v2alpha1.CiliumEndpointSlice]
+}
+
+func newReconciler(
+	ctx context.Context,
+	logger *slog.Logger,
+	clientset k8sClient.Clientset,
+	namespace resource.Resource[*slim_corev1.Namespace],
+	pod resource.Resource[*slim_corev1.Pod],
+	ciliumIdentity resource.Resource[*cilium_api_v2.CiliumIdentity],
+	ciliumEndpoint resource.Resource[*cilium_api_v2.CiliumEndpoint],
+	ciliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice],
+	cesEnabled bool,
+	queueOps queueOperations,
+) (*reconciler, error) {
+	logger.Info("Creating CID controller Operator reconciler")
+
+	minIDValue := idpool.ID(identity.GetMinimalAllocationIdentity(option.Config.ClusterID))
+	maxIDValue := idpool.ID(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))
+	idAllocator := basicallocator.NewBasicIDAllocator(minIDValue, maxIDValue)
+
+	nsStore, err := namespace.Store(ctx)
+	if err != nil {
+		return nil, err
+	}
+	podStore, err := pod.Store(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cidStore, err := ciliumIdentity.Store(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cepStore, err := ciliumEndpoint.Store(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cesStore, err := ciliumEndpointSlice.Store(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &reconciler{
+		logger:          logger,
+		ctx:             ctx,
+		clientset:       clientset,
+		idAllocator:     idAllocator,
+		desiredCIDState: NewCIDState(logger),
+		cidUsageInPods:  NewCIDUsageInPods(),
+		cidUsageInCES:   NewCIDUsageInCES(),
+		queueOps:        queueOps,
+		nsStore:         nsStore,
+		podStore:        podStore,
+		cidStore:        cidStore,
+		cepStore:        cepStore,
+		cesStore:        cesStore,
+		cesEnabled:      cesEnabled,
+	}
+
+	return r, nil
+}
+
+// syncCESsOnStartup updates the cache of CID usage in CES for all the
+// existing CESs.
+func (r *reconciler) calcDesiredStateOnStartup() error {
+	r.syncCESsOnStartup()
+	return r.syncPodsOnStartup()
+}
+
+func (r *reconciler) syncCESsOnStartup() {
+	if !r.cesEnabled {
+		return
+	}
+
+	for _, ces := range r.cesStore.List() {
+		r.cidUsageInCES.ProcessCESUpsert(ces.Name, ces.Endpoints)
+	}
+}
+
+// syncPodsOnStartup ensures that all pods have a CID for their labels.
+func (r *reconciler) syncPodsOnStartup() error {
+	var lastError error
+
+	for _, pod := range r.podStore.List() {
+		if err := r.reconcilePod(podResourceKey(pod.Name, pod.Namespace)); err != nil {
+			lastError = err
+		}
+	}
+
+	return lastError
+}
+
+// reconcileCID ensures that the desired state for the CID is reached, by
+// comparing the CID in desired state cache and watcher's store and doing one of
+// the following:
+// 1. Nothing - If CID doesn't exist in both desired state cache and watcher's
+// store.
+// 2. Creates CID - If CID only exists in the desired state cache.
+// 3. Updates CID - If CIDs in the desired state cache and watcher's store are
+// not the same.
+// Currently, the CID deletion is handled by the operator/identitygc
+func (r *reconciler) reconcileCID(cidResourceKey resource.Key) error {
+	cidName := cidResourceKey.Name
+	storeCID, existsInStore, err := r.cidStore.GetByKey(cidResourceKey)
+
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+
+	cidKey, existsInDesiredState := r.desiredCIDState.LookupByID(cidName)
+	if !existsInDesiredState && !existsInStore {
+		err := r.makeIDAvailable(cidName)
+		r.logger.Warn("Failed to return CID to pool",
+			logfields.CIDName, cidName,
+			logfields.Error, err)
+		return nil
+	}
+
+	cidIsUsed := r.cidIsUsedInPods(cidName) || r.cidIsUsedInCEPOrCES(cidName)
+
+	if !existsInDesiredState {
+		if !cidIsUsed {
+			return nil
+		}
+
+		r.cidCreateLock.Lock()
+		defer r.cidCreateLock.Unlock()
+
+		id, err := r.idAllocator.ValidateIDString(cidName)
+		if err != nil {
+			return err
+		}
+		return r.idAllocator.Allocate(idpool.ID(id))
+	}
+
+	if !existsInStore {
+		if cidIsUsed {
+			return r.createCID(cidName, cidKey)
+		} else {
+			r.desiredCIDState.Remove(cidName)
+			return nil
+		}
+	}
+
+	storeCIDKey := key.GetCIDKeyFromLabels(storeCID.SecurityLabels, "")
+	if cidKey.Equals(storeCIDKey.LabelArray) {
+		return nil
+	}
+
+	return r.updateCID(storeCID, cidKey)
+}
+
+func (r *reconciler) createCID(cidName string, cidKey *key.GlobalIdentity) error {
+	cidLabels := cidKey.GetAsMap()
+	selectedLabels, skippedLabels := identitybackend.SanitizeK8sLabels(cidLabels)
+	r.logger.Debug("Skipped non-kubernetes labels when labelling CID. All labels will still be used in identity determination", logfields.Labels, skippedLabels)
+
+	cid := &cilium_api_v2.CiliumIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   cidName,
+			Labels: selectedLabels,
+		},
+		SecurityLabels: cidLabels,
+	}
+
+	r.logger.Info("Creating CID", "labels", cidLabels, logfields.CIDName, cidName)
+
+	_, err := r.clientset.CiliumV2().CiliumIdentities().Create(r.ctx, cid, metav1.CreateOptions{})
+	return err
+}
+
+func (r *reconciler) updateCID(cid *cilium_api_v2.CiliumIdentity, cidKey *key.GlobalIdentity) error {
+	cidLabels := cidKey.GetAsMap()
+	selectedLabels, skippedLabels := identitybackend.SanitizeK8sLabels(cidLabels)
+	r.logger.Debug("Skipped non-kubernetes labels when labelling CID. All labels will still be used in identity determination", logfields.Labels, skippedLabels)
+
+	cid.Labels = selectedLabels
+	cid.SecurityLabels = cidLabels
+
+	r.logger.Info("Updating CID", logfields.CIDName, cid.Name)
+
+	_, err := r.clientset.CiliumV2().CiliumIdentities().Update(r.ctx, cid, metav1.UpdateOptions{})
+	return err
+}
+
+func (r *reconciler) makeIDAvailable(cidName string) error {
+	cidNum, err := strconv.Atoi(cidName)
+	if err != nil {
+		return err
+	}
+	return r.idAllocator.ReturnToAvailablePool(idpool.ID(cidNum))
+}
+
+func (r *reconciler) upsertDesiredState(cidName string, cidKey *key.GlobalIdentity) error {
+	if cidKey == nil || len(cidName) == 0 {
+		return fmt.Errorf("invalid CID, name: %q, key: %v", cidName, cidKey)
+	}
+
+	cachedCIDKey, exists := r.desiredCIDState.LookupByID(cidName)
+	if exists && cidKey.Equals(cachedCIDKey.LabelArray) {
+		return nil
+	}
+
+	id, err := r.idAllocator.ValidateIDString(cidName)
+	if err != nil {
+		return err
+	}
+
+	err = r.idAllocator.Allocate(idpool.ID(id))
+	if err != nil {
+		return err
+	}
+	r.desiredCIDState.Upsert(cidName, cidKey)
+
+	return nil
+}
+
+// reconcilePod ensures that there is a CID that matches the pod. CIDs are
+// created for new unique label sets.
+func (r *reconciler) reconcilePod(podKey resource.Key) error {
+	pod, exists, err := r.podStore.GetByKey(podKey)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+	// When a pod is not found in the pod store, it means it's deleted.
+	if !exists {
+		_, _, _ = r.cidUsageInPods.RemovePod(podKey.String())
+		return nil
+	}
+
+	return r.allocateCIDForPod(pod)
+}
+
+func (r *reconciler) cidIsUsedInPods(cidName string) bool {
+	return r.cidUsageInPods.CIDUsageCount(cidName) > 0
+}
+
+func (r *reconciler) cidIsUsedInCEPOrCES(cidName string) bool {
+	if !r.cesEnabled {
+		return operator_k8s.HasCEWithIdentity(r.cepStore, cidName)
+	}
+
+	cidUsageCount := r.cidUsageInCES.CIDUsageCount(cidName)
+	return cidUsageCount > 0
+}
+
+// allocateCIDForPod gets pod and namespace labels that are relevant to security
+// identities, and ensures that a CID exists for that label set.
+// 1. CID exists: No action.
+// 2. CID doesn't exist: Create CID.
+func (r *reconciler) allocateCIDForPod(pod *slim_corev1.Pod) error {
+	k8sLabels, err := r.getRelevantLabelsForPod(pod)
+	if err != nil {
+		return fmt.Errorf("failed to get relevant labels for pod: %w", err)
+	}
+	cidKey := key.GetCIDKeyFromLabels(k8sLabels, labels.LabelSourceK8s)
+
+	r.cidCreateLock.Lock()
+	defer r.cidCreateLock.Unlock()
+
+	cidName, isNewCID, err := r.allocateCID(cidKey)
+	if err != nil {
+		return fmt.Errorf("failed to allocate CID: %w", err)
+	}
+
+	r.desiredCIDState.Upsert(cidName, cidKey)
+
+	podName := podResourceKey(pod.Name, pod.Namespace).String()
+	prevCIDName, _ := r.cidUsageInPods.AssignCIDToPod(podName, cidName)
+
+	r.logger.Info("CID allocated for pod",
+		logfields.K8sPodName, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
+		logfields.CIDName, cidName,
+		logfields.OldIdentity, prevCIDName,
+		logfields.Labels, k8sLabels)
+
+	if isNewCID {
+		r.queueOps.enqueueCIDReconciliation(cidResourceKey(cidName), 0)
+	}
+
+	return nil
+}
+
+func (r *reconciler) allocateCID(cidKey *key.GlobalIdentity) (string, bool, error) {
+	cidName, exists := r.desiredCIDState.LookupByKey(cidKey)
+	if exists {
+		return cidName, false, nil
+	}
+
+	storeCIDs, err := r.cidStore.ByIndex(k8s.ByKeyIndex, cidKey.GetKey())
+	if err != nil {
+		return "", false, err
+	}
+
+	// If CIDs that match labels are found in CID store but not in the desired cache,
+	// they need to be added to the desired cache and used instead of creating a new
+	// CID for these labels.
+	if len(storeCIDs) > 0 {
+		// Return the assignment from the CID store, otherwise allocates a new identity
+		cidName, err = r.handleStoreCIDMatch(storeCIDs)
+		if err != nil {
+			r.logger.Error("Failed to access CID store", logfields.Error, err)
+		} else {
+			return cidName, false, nil
+		}
+	}
+
+	allocatedID, err := r.idAllocator.AllocateRandom()
+	if err != nil {
+		return "", false, err
+	}
+
+	return allocatedID.String(), true, nil
+}
+
+func (r *reconciler) getRelevantLabelsForPod(pod *slim_corev1.Pod) (map[string]string, error) {
+	ns, err := r.getNamespace(pod.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	_, labelsMap, _, err := k8s.GetPodMetadata(ns, pod)
+	if err != nil {
+		return nil, err
+	}
+
+	return labelsMap, nil
+}
+
+func (r *reconciler) getNamespace(namespace string) (*slim_corev1.Namespace, error) {
+	ns, exists, err := r.nsStore.GetByKey(resource.Key{Name: namespace})
+	if err != nil {
+		return nil, fmt.Errorf("unable to get namespace %q, error: %w", namespace, err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("namespace %q not found in store", namespace)
+	}
+
+	return ns, nil
+}
+
+func (r *reconciler) handleStoreCIDMatch(storeCIDs []*cilium_api_v2.CiliumIdentity) (string, error) {
+	// Deduplication: The first cid will be added to the desired cache
+	cid := storeCIDs[0]
+	cidKey := key.GetCIDKeyFromLabels(cid.SecurityLabels, "")
+
+	if err := r.upsertDesiredState(cid.Name, cidKey); err != nil {
+		r.logger.Warn("Failed to add CID to cache",
+			logfields.CIDName, cid.Name,
+			logfields.Error, err)
+		return "", err
+	} else {
+		return cid.Name, nil
+	}
+}
+
+// reconcileNamespace enqueues all pods in the namespace to be reconciled by the CID
+// controller.
+func (r *reconciler) reconcileNamespace(nsKey resource.Key) error {
+	if err := r.updateAllPodsInNamespace(nsKey.Name); err != nil {
+		return fmt.Errorf("reconcile namespace %s change: %w", nsKey.Name, err)
+	}
+	return nil
+}
+
+func (r *reconciler) updateAllPodsInNamespace(namespace string) error {
+	r.logger.Info("Reconcile all pods in namespace", logfields.K8sNamespace, namespace)
+
+	if r.podStore == nil {
+		return fmt.Errorf("pod store is not initialized")
+	}
+	podList, err := r.podStore.ByIndex(cache.NamespaceIndex, namespace)
+	if err != nil {
+		return err
+	}
+
+	var lastErr error
+
+	for _, pod := range podList {
+		r.queueOps.enqueuePodReconciliation(podResourceKey(pod.Name, pod.Namespace), 0)
+	}
+
+	return lastErr
+}

--- a/operator/pkg/ciliumidentity/reconciler_test.go
+++ b/operator/pkg/ciliumidentity/reconciler_test.go
@@ -1,0 +1,705 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sTesting "k8s.io/client-go/testing"
+
+	"github.com/cilium/cilium/operator/k8s"
+	cestest "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/identity/key"
+	capi_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	idbackend "github.com/cilium/cilium/pkg/k8s/identitybackend"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+var (
+	testLbsA = map[string]string{"key-a": "val-1"}
+	testLbsB = map[string]string{"key-b": "val-2"}
+	testLbsC = map[string]string{"key-c": "val-3"}
+)
+
+type testQueueOps struct {
+	fakeWorkQueue map[string]bool
+}
+
+func (t testQueueOps) enqueueCIDReconciliation(cidKey resource.Key, _ time.Duration) {
+	t.fakeWorkQueue[cidKey.String()] = true
+}
+
+func (t testQueueOps) enqueuePodReconciliation(cidKey resource.Key, _ time.Duration) {
+	t.fakeWorkQueue[cidKey.String()] = true
+}
+
+func testNewReconciler(t *testing.T, ctx context.Context, enableCES bool) (*reconciler, *testQueueOps, k8sClient.FakeClientset, func()) {
+	var namespace resource.Resource[*slim_corev1.Namespace]
+	var pod resource.Resource[*slim_corev1.Pod]
+	var ciliumIdentity resource.Resource[*capi_v2.CiliumIdentity]
+	var ciliumEndpoint resource.Resource[*capi_v2.CiliumEndpoint]
+	var ciliumEndpointSlice resource.Resource[*capi_v2a1.CiliumEndpointSlice]
+	var fakeClient k8sClient.FakeClientset
+
+	h := hive.New(
+		k8sClient.FakeClientCell,
+		k8s.ResourcesCell,
+		cell.Invoke(func(
+			c *k8sClient.FakeClientset,
+			nsResource resource.Resource[*slim_corev1.Namespace],
+			podResource resource.Resource[*slim_corev1.Pod],
+			cidResource resource.Resource[*capi_v2.CiliumIdentity],
+			cepResource resource.Resource[*capi_v2.CiliumEndpoint],
+			cesResource resource.Resource[*capi_v2a1.CiliumEndpointSlice],
+		) error {
+			fakeClient = *c
+			namespace = nsResource
+			pod = podResource
+			ciliumIdentity = cidResource
+			ciliumEndpoint = cepResource
+			ciliumEndpointSlice = cesResource
+			return nil
+		}),
+	)
+	tlog := hivetest.Logger(t)
+	_ = h.Start(tlog, ctx)
+	cleanupFunc := func() {
+		_ = h.Stop(tlog, ctx)
+	}
+
+	queueOps := &testQueueOps{fakeWorkQueue: make(map[string]bool)}
+	reconciler, _ := newReconciler(
+		ctx,
+		tlog,
+		fakeClient.Clientset,
+		namespace,
+		pod,
+		ciliumIdentity,
+		ciliumEndpoint,
+		ciliumEndpointSlice,
+		enableCES,
+		queueOps,
+	)
+	return reconciler, queueOps, fakeClient, cleanupFunc
+}
+
+func testCreateCIDObj(id string, lbs map[string]string) *capi_v2.CiliumIdentity {
+	secLbs := make(map[string]string)
+	for k, v := range lbs {
+		secLbs[k] = v
+	}
+
+	k := key.GetCIDKeyFromLabels(secLbs, labels.LabelSourceK8s)
+	secLbs = k.GetAsMap()
+
+	selectedLabels, _ := idbackend.SanitizeK8sLabels(secLbs)
+
+	return &capi_v2.CiliumIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   id,
+			Labels: selectedLabels,
+		},
+		SecurityLabels: secLbs,
+	}
+}
+
+func testCreateCIDObjNs(id string, pod *slim_corev1.Pod, namespace *slim_corev1.Namespace) *capi_v2.CiliumIdentity {
+	lbs := k8sUtils.SanitizePodLabels(pod.ObjectMeta.Labels, namespace, "", "")
+	secLbs := key.GetCIDKeyFromLabels(lbs, labels.LabelSourceK8s).GetAsMap()
+	selectedLabels, _ := idbackend.SanitizeK8sLabels(secLbs)
+
+	return &capi_v2.CiliumIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   id,
+			Labels: selectedLabels,
+		},
+		SecurityLabels: secLbs,
+	}
+}
+
+func testCreatePodObj(name, namespace string, lbs, annotations map[string]string) *slim_corev1.Pod {
+	return &slim_corev1.Pod{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      lbs,
+			Annotations: annotations,
+		},
+	}
+}
+
+func testCreateNSObj(name string, lbs map[string]string) *slim_corev1.Namespace {
+	if lbs == nil {
+		lbs = make(map[string]string)
+	}
+
+	lbs["kubernetes.io/metadata.name"] = name
+
+	return &slim_corev1.Namespace{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:   name,
+			Labels: lbs,
+		},
+	}
+}
+
+func testVerifyCIDUsageInPods(t *testing.T, usage *CIDUsageInPods, expectedCIDs, expectedPods int) {
+	if expectedCIDs != len(usage.cidUsageCount) {
+		t.Errorf("Unexpected number of unique CIDs. Expected: %d, Got: %d", expectedCIDs, len(usage.cidUsageCount))
+	}
+	if expectedPods != len(usage.podToCID) {
+		t.Errorf("Unexpected number of pods. Expected: %d, Got: %d", expectedPods, len(usage.podToCID))
+	}
+
+	totalUsedCIDs := 0
+	for _, count := range usage.cidUsageCount {
+		totalUsedCIDs += count
+	}
+
+	if expectedPods != totalUsedCIDs {
+		t.Errorf("Total CID usage does not match expected pod count. Expected: %d, Got: %d", expectedPods, totalUsedCIDs)
+	}
+}
+
+func TestSyncCESsOnStartup(t *testing.T) {
+	testCases := []struct {
+		name          string
+		cesEnabled    bool
+		endpointSlice *capi_v2a1.CiliumEndpointSlice
+		expectedCIDs  map[int64]int
+	}{
+		{
+			name:       "ces_disabled",
+			cesEnabled: false,
+			endpointSlice: cestest.CreateStoreEndpointSlice("ces", "ns",
+				[]capi_v2a1.CoreCiliumEndpoint{
+					cestest.CreateManagerEndpoint("cep1", 1000),
+					cestest.CreateManagerEndpoint("cep2", 1000),
+					cestest.CreateManagerEndpoint("cep3", 2000),
+					cestest.CreateManagerEndpoint("cep4", 2000)}),
+			expectedCIDs: map[int64]int{},
+		},
+		{
+			name:       "ces_enabled",
+			cesEnabled: true,
+			endpointSlice: cestest.CreateStoreEndpointSlice("ces", "ns",
+				[]capi_v2a1.CoreCiliumEndpoint{
+					cestest.CreateManagerEndpoint("cep1", 1000),
+					cestest.CreateManagerEndpoint("cep2", 1000),
+					cestest.CreateManagerEndpoint("cep3", 2000),
+				}),
+			expectedCIDs: map[int64]int{
+				1000: 2,
+				2000: 1,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			reconciler, _, _, cleanupFunc := testNewReconciler(t, ctx, tc.cesEnabled)
+			defer cleanupFunc()
+
+			if err := reconciler.cesStore.CacheStore().Add(tc.endpointSlice); err != nil {
+				t.Errorf("Error adding CiliumEndpointSlice to cache store: %v", err)
+			}
+
+			reconciler.syncCESsOnStartup()
+
+			if !reflect.DeepEqual(reconciler.cidUsageInCES.cidUsageCount, tc.expectedCIDs) {
+				t.Errorf("Expected CID usage count map to be %v, but got %v", tc.expectedCIDs, reconciler.cidUsageInCES.cidUsageCount)
+			}
+		})
+	}
+}
+
+func TestSyncPodsOnStartup(t *testing.T) {
+	ns1 := testCreateNSObj("ns1", nil)
+	ns2 := testCreateNSObj("ns2", nil)
+
+	pod1 := testCreatePodObj("pod1", ns1.Name, testLbsA, nil)
+	pod2 := testCreatePodObj("pod2", ns1.Name, testLbsB, nil)
+	pod3 := testCreatePodObj("pod3", ns2.Name, testLbsC, nil)
+
+	testCases := []struct {
+		name          string
+		pods          []*slim_corev1.Pod
+		existingCIDs  []*capi_v2.CiliumIdentity
+		expectedQSize int // Expected size of the queue after sync
+	}{
+		{
+			name: "new_pods",
+			pods: []*slim_corev1.Pod{
+				pod1,
+				pod2,
+				pod3,
+			},
+			expectedQSize: 3,
+		},
+		{
+			name: "cid_with_new_pod",
+			pods: []*slim_corev1.Pod{
+				pod1,
+				pod2,
+				pod3, // new pod
+			},
+			existingCIDs: []*capi_v2.CiliumIdentity{
+				testCreateCIDObjNs("1000", pod1, ns1),
+				testCreateCIDObjNs("2000", pod2, ns1),
+			},
+			expectedQSize: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			reconciler, queueOps, _, cleanupFunc := testNewReconciler(t, ctx, false)
+			defer cleanupFunc()
+
+			for _, pod := range tc.pods {
+				_ = reconciler.nsStore.CacheStore().Add(testCreateNSObj(pod.Namespace, nil))
+				_ = reconciler.podStore.CacheStore().Add(pod)
+			}
+			for _, cid := range tc.existingCIDs {
+				_ = reconciler.cidStore.CacheStore().Add(cid)
+			}
+
+			if err := reconciler.syncPodsOnStartup(); err != nil {
+				t.Errorf("Error syncing pods on startup: %v", err)
+			}
+
+			if len(queueOps.fakeWorkQueue) != tc.expectedQSize {
+				t.Errorf("Expected queue size to be %d, but got %d", tc.expectedQSize, len(queueOps.fakeWorkQueue))
+			}
+		})
+	}
+}
+
+func TestReconcileCID(t *testing.T) {
+	cidName := "1000"
+
+	testCases := []struct {
+		name                string
+		cidKey              resource.Key
+		initialStoreState   *capi_v2.CiliumIdentity // CID initially in the store
+		desiredState        map[string]string       // Desired CID labels
+		usedInPods          bool
+		errorDuringDeletion bool
+		expectedCreate      *capi_v2.CiliumIdentity
+		expectedUpdate      *capi_v2.CiliumIdentity
+		expectedDelete      string // Name of the CID to be deleted
+		expectedQueueSize   int
+	}{
+		{
+			name:              "default",
+			cidKey:            cidResourceKey(cidName),
+			initialStoreState: testCreateCIDObj(cidName, testLbsA),
+			usedInPods:        false,
+			expectedQueueSize: 0, // TODO queue size should be 1 if OP deletes CID
+		},
+		{
+			name:           "cid_only_in_desired",
+			cidKey:         cidResourceKey(cidName),
+			desiredState:   testLbsA,
+			usedInPods:     true,
+			expectedCreate: testCreateCIDObj(cidName, testLbsA), // CID is created
+		},
+		{
+			name:              "cid_in_desired_and_store",
+			cidKey:            cidResourceKey(cidName),
+			initialStoreState: testCreateCIDObj(cidName, testLbsA),
+			desiredState:      testLbsA,
+			usedInPods:        true,
+		},
+		{
+			name:              "cid_store_different_labels_than_desired",
+			cidKey:            cidResourceKey(cidName),
+			initialStoreState: testCreateCIDObj(cidName, testLbsB),
+			desiredState:      testLbsA,
+			usedInPods:        true,
+			expectedUpdate:    testCreateCIDObj(cidName, testLbsA),
+		},
+		{
+			name:   "cid_not_in_store",
+			cidKey: cidResourceKey(cidName),
+		},
+		{
+			name:              "cid_used_in_pods_no_desired",
+			cidKey:            cidResourceKey(cidName),
+			initialStoreState: testCreateCIDObj(cidName, testLbsA),
+			usedInPods:        true,
+		},
+		{
+			name:              "cid_in_store_not_used",
+			cidKey:            cidResourceKey(cidName),
+			initialStoreState: testCreateCIDObj(cidName, testLbsA),
+			usedInPods:        false,
+			desiredState:      testLbsA,
+			expectedQueueSize: 0, // TODO queue size should be 1 if OP deletes CID
+		},
+		{
+			name:         "cid_in_desired_not_used",
+			cidKey:       cidResourceKey(cidName),
+			usedInPods:   false,
+			desiredState: testLbsA,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			reconciler, queueOps, _, cleanupFunc := testNewReconciler(t, ctx, false)
+			defer cleanupFunc()
+
+			cs := reconciler.clientset.(*k8sClient.FakeClientset)
+			var createCID, updateCID *capi_v2.CiliumIdentity
+			var deleteCIDName string
+			cs.CiliumFakeClientset.PrependReactor("create", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+				pa := action.(k8sTesting.CreateAction)
+				createCID = pa.GetObject().(*capi_v2.CiliumIdentity)
+				return true, nil, nil
+			})
+			cs.CiliumFakeClientset.PrependReactor("update", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+				pa := action.(k8sTesting.UpdateAction)
+				updateCID = pa.GetObject().(*capi_v2.CiliumIdentity)
+				return true, nil, nil
+			})
+			cs.CiliumFakeClientset.PrependReactor("delete", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+				if tc.errorDuringDeletion {
+					return false, nil, fmt.Errorf("forced error on deletion")
+				}
+				pa := action.(k8sTesting.DeleteAction)
+				deleteCIDName = pa.GetName()
+				return true, nil, nil
+			})
+
+			if tc.initialStoreState != nil {
+				if err := reconciler.cidStore.CacheStore().Add(tc.initialStoreState); err != nil {
+					t.Errorf("Error adding CID to cache store: %v", err)
+				}
+			}
+
+			if tc.desiredState != nil {
+				if err := reconciler.upsertDesiredState(tc.cidKey.Name, key.GetCIDKeyFromLabels(tc.desiredState, labels.LabelSourceK8s)); err != nil {
+					t.Errorf("Unexpected error upserting desired state: %v", err)
+				}
+			}
+
+			if tc.usedInPods {
+				reconciler.cidUsageInPods.cidUsageCount[tc.cidKey.Name] = 1
+			}
+
+			if err := reconciler.reconcileCID(tc.cidKey); err != nil {
+				t.Errorf("Unexpected error during reconciliation: %v", err)
+			}
+
+			if !reflect.DeepEqual(createCID, tc.expectedCreate) {
+				t.Errorf("Unexpected createCID result: got %v, want %v", createCID, tc.expectedCreate)
+			}
+			if !reflect.DeepEqual(updateCID, tc.expectedUpdate) {
+				t.Errorf("Unexpected updateCID result: got %v, want %v", updateCID, tc.expectedUpdate)
+			}
+			if deleteCIDName != tc.expectedDelete {
+				t.Errorf("Unexpected deleteCIDName result: got %v, want %v", deleteCIDName, tc.expectedDelete)
+			}
+			if len(queueOps.fakeWorkQueue) != tc.expectedQueueSize {
+				t.Errorf("Unexpected fakeWorkQueue size: got %v, want %v", len(queueOps.fakeWorkQueue), tc.expectedQueueSize)
+			}
+
+			// TODO check for CID deletion too, adapt once we decide how to handle CID deletion
+			// See https://github.com/cilium/cilium/pull/33380
+		})
+	}
+}
+
+func TestReconcilePod(t *testing.T) {
+	ns1 := testCreateNSObj("ns1", nil)
+
+	pod1 := testCreatePodObj("pod1", ns1.Name, testLbsA, nil)
+	pod2 := testCreatePodObj("pod2", ns1.Name, testLbsA, nil)
+
+	cidName := "1000"
+
+	type expectedState struct {
+		queueSize           int
+		existsInQueue       []string
+		numDesiredCIDLabels int
+		expectedCIDs        int
+		expectedPods        int
+		expectedCID         string
+	}
+
+	testCases := []struct {
+		name            string
+		newPod          *slim_corev1.Pod
+		existingPods    []*slim_corev1.Pod
+		existingCIDs    []*capi_v2.CiliumIdentity
+		initialPodToCID map[resource.Key]string
+		expected        expectedState
+		expectError     bool
+	}{
+		{
+			name:     "pod_not_in_store_or_mapping",
+			newPod:   pod1,
+			expected: expectedState{},
+		},
+		{
+			name:         "new_pod_with_no_cid",
+			newPod:       pod1,
+			existingPods: []*slim_corev1.Pod{pod1},
+			expected: expectedState{
+				queueSize:           1,
+				numDesiredCIDLabels: 1,
+				expectedPods:        1,
+				expectedCIDs:        1,
+			},
+		},
+		{
+			name:         "pod_in_store_with_cid_not_in_mapping",
+			newPod:       pod1,
+			existingPods: []*slim_corev1.Pod{pod1},
+			existingCIDs: []*capi_v2.CiliumIdentity{testCreateCIDObjNs(cidName, pod1, ns1)},
+			expected: expectedState{
+				queueSize:           0,
+				numDesiredCIDLabels: 1,
+				expectedPods:        1,
+				expectedCIDs:        1,
+				expectedCID:         cidName,
+			},
+		},
+		{
+			name:            "pod_in_store_with_cid_and_mapping",
+			newPod:          pod1,
+			existingPods:    []*slim_corev1.Pod{pod1},
+			existingCIDs:    []*capi_v2.CiliumIdentity{testCreateCIDObjNs(cidName, pod1, ns1)},
+			initialPodToCID: map[resource.Key]string{podResourceKey(pod1.Name, ns1.Name): cidName},
+			expected: expectedState{
+				queueSize:           0,
+				numDesiredCIDLabels: 1,
+				expectedPods:        1,
+				expectedCIDs:        1,
+				expectedCID:         cidName,
+			},
+		},
+		{
+			name:            "multiple_pods_same_cid",
+			newPod:          pod2,
+			existingPods:    []*slim_corev1.Pod{pod1, pod2},
+			existingCIDs:    []*capi_v2.CiliumIdentity{testCreateCIDObjNs(cidName, pod1, ns1)},
+			initialPodToCID: map[resource.Key]string{podResourceKey(pod1.Name, ns1.Name): cidName},
+			expected: expectedState{
+				queueSize:           0,
+				numDesiredCIDLabels: 1,
+				expectedPods:        2,
+				expectedCIDs:        1,
+				expectedCID:         cidName,
+			},
+		},
+		{
+			name:            "pod_with_different_labels",
+			newPod:          testCreatePodObj("pod1", ns1.Name, testLbsB, nil),
+			existingPods:    []*slim_corev1.Pod{testCreatePodObj("pod1", ns1.Name, testLbsB, nil)},
+			existingCIDs:    []*capi_v2.CiliumIdentity{testCreateCIDObjNs(cidName, pod1, ns1)},
+			initialPodToCID: map[resource.Key]string{podResourceKey(pod1.Name, ns1.Name): cidName},
+			expected: expectedState{
+				queueSize:           1, // TODO queue size should be 2 if OP deletes CID
+				numDesiredCIDLabels: 1,
+				expectedPods:        1,
+				expectedCIDs:        1,
+			},
+		},
+		{
+			name:            "pod_in_store_with_cid_and_different_mapping",
+			newPod:          pod1,
+			existingPods:    []*slim_corev1.Pod{pod1},
+			existingCIDs:    []*capi_v2.CiliumIdentity{testCreateCIDObjNs(cidName, pod1, ns1)},
+			initialPodToCID: map[resource.Key]string{podResourceKey(pod1.Name, ns1.Name): "2000"},
+			expected: expectedState{
+				queueSize:           0, // TODO queue size should be 1 if OP deletes CID
+				numDesiredCIDLabels: 1,
+				expectedPods:        1,
+				expectedCIDs:        1,
+				expectedCID:         cidName,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			reconciler, queueOps, _, cleanupFunc := testNewReconciler(t, ctx, false)
+			defer cleanupFunc()
+
+			for _, pod := range tc.existingPods {
+				_ = reconciler.nsStore.CacheStore().Add(testCreateNSObj(pod.GetNamespace(), nil))
+				_ = reconciler.podStore.CacheStore().Add(pod)
+			}
+			for _, cid := range tc.existingCIDs {
+				_ = reconciler.cidStore.CacheStore().Add(cid)
+			}
+			for podKey, cidName := range tc.initialPodToCID {
+				reconciler.cidUsageInPods.AssignCIDToPod(podKey.String(), cidName)
+			}
+
+			if err := reconciler.reconcilePod(podResourceKey(tc.newPod.Name, tc.newPod.Namespace)); err != nil {
+				t.Errorf("Unexpected error behavior: got error %v", err)
+			}
+
+			if tc.expected.queueSize != len(queueOps.fakeWorkQueue) {
+				t.Errorf("Queue size mismatch: expected %d, got %d", tc.expected.queueSize, len(queueOps.fakeWorkQueue))
+			}
+
+			for _, k := range tc.expected.existsInQueue {
+				if _, exists := queueOps.fakeWorkQueue[k]; !exists {
+					t.Errorf("Item missing from fake work queue: expected key '%s'", k)
+				}
+			}
+			if tc.expected.numDesiredCIDLabels != len(reconciler.desiredCIDState.idToLabels) {
+				t.Errorf("Number of desired CID labels mismatch: expected %d, got %d", tc.expected.numDesiredCIDLabels, len(reconciler.desiredCIDState.idToLabels))
+			}
+
+			testVerifyCIDUsageInPods(t, reconciler.cidUsageInPods, tc.expected.expectedCIDs, tc.expected.expectedPods)
+
+			if len(tc.expected.expectedCID) > 0 {
+				lbs, exists := reconciler.desiredCIDState.LookupByID(cidName)
+				if !exists {
+					t.Errorf("Expected CID %s not found in desiredCIDState", cidName)
+				}
+
+				expectedLbs := key.GetCIDKeyFromLabels(
+					k8sUtils.SanitizePodLabels(tc.newPod.ObjectMeta.Labels, ns1, "", ""),
+					labels.LabelSourceK8s,
+				).GetAsMap()
+
+				if diff := cmp.Diff(lbs.GetAsMap(), expectedLbs); diff != "" {
+					t.Errorf("Labels differ:\n%s", diff)
+				}
+			}
+
+		})
+	}
+}
+
+func TestReconcileNS(t *testing.T) {
+	ns1 := testCreateNSObj("ns1", nil)
+
+	pod1 := testCreatePodObj("pod1", ns1.Name, testLbsA, nil)
+	pod2 := testCreatePodObj("pod2", ns1.Name, testLbsA, nil)
+
+	testCases := []struct {
+		name              string
+		nsName            string
+		pods              []*slim_corev1.Pod
+		expectedQueueSize int
+	}{{
+		name:              "empty_ns",
+		nsName:            "ns1",
+		pods:              []*slim_corev1.Pod{},
+		expectedQueueSize: 0,
+	},
+		{
+			name:   "unrelated_ns",
+			nsName: "ns2",
+			pods: []*slim_corev1.Pod{
+				pod1,
+			},
+			expectedQueueSize: 0,
+		},
+		{
+			name:   "multiple_pods",
+			nsName: ns1.Name,
+			pods: []*slim_corev1.Pod{
+				pod1,
+				pod2,
+			},
+			expectedQueueSize: 2,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			reconciler, queueOps, _, cleanupFunc := testNewReconciler(t, ctx, false)
+			defer cleanupFunc()
+
+			if err := reconciler.nsStore.CacheStore().Add(testCreateNSObj(tc.nsName, nil)); err != nil {
+				t.Errorf("Unexpected error behavior: got error %v", err)
+			}
+
+			for _, pod := range tc.pods {
+				if err := reconciler.podStore.CacheStore().Add(pod); err != nil {
+					t.Errorf("Unexpected error behavior: got error %v", err)
+				}
+			}
+
+			err := reconciler.reconcileNamespace(nsResourceKey(tc.nsName))
+
+			if err != nil {
+				t.Errorf("Unexpected error behavior: got error %v", err)
+			}
+			if tc.expectedQueueSize != len(queueOps.fakeWorkQueue) {
+				t.Errorf("Expected queue size %d, but got %d", tc.expectedQueueSize, len(queueOps.fakeWorkQueue))
+			}
+		})
+	}
+}
+
+func TestHandleStoreCIDMatch(t *testing.T) {
+	testCases := []struct {
+		name        string
+		cidList     []*capi_v2.CiliumIdentity
+		expectedCID string
+	}{
+		{
+			name: "one_item",
+			cidList: []*capi_v2.CiliumIdentity{
+				{ObjectMeta: metav1.ObjectMeta{Name: "1000"}},
+			},
+			expectedCID: "1000",
+		},
+		{
+			name: "three_items",
+			cidList: []*capi_v2.CiliumIdentity{
+				{ObjectMeta: metav1.ObjectMeta{Name: "1000"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "2000"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "3000"}},
+			},
+			expectedCID: "1000",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			reconciler, _, _, cleanupFunc := testNewReconciler(t, ctx, false)
+			defer cleanupFunc()
+
+			cid, err := reconciler.handleStoreCIDMatch(tc.cidList)
+
+			if err != nil {
+				t.Errorf("Expected no error, got: %v", err)
+			}
+
+			if tc.expectedCID != cid {
+				t.Errorf("Expected CID %v, but got %v", tc.expectedCID, cid)
+			}
+		})
+	}
+}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -677,6 +677,9 @@ const (
 	// CEPUID is the UID of the CiliumEndpoint.
 	CEPUID = "ciliumEndpointUID"
 
+	// CIDName is the name of the CiliumIdentity.
+	CIDName = "ciliumIdentityName"
+
 	// CESName is the name of the CiliumEndpointSlice.
 	CESName = "ciliumEndpointSliceName"
 


### PR DESCRIPTION
Add the reconciler logic for reconciling CIDs, Pods, Namespaces.

The Cilium Identity API objects will be managed by the cilium-operator instead of the cilium-agent. The desired state for Cilium Identities is determined by the cilium-operator based on monitored events for Cilium Identities, Pods, Namespaces, and Cilium Endpoint Slices (if enabled). When pod updates occur for a unique label set derived from pod and namespace labels, the cilium-operator creates Cilium Identities.

Related CFP #27752
Draft full implementation: https://github.com/cilium/cilium/pull/33204