### PR TITLE
envoy: Enable DaemonSet only for new installation

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1169,9 +1169,9 @@
      - string
      - ``nil``
    * - :spelling:ignore:`envoy.enabled`
-     - Enable Envoy Proxy in standalone DaemonSet.
-     - bool
-     - ``true``
+     - Enable Envoy Proxy in standalone DaemonSet. This field is enabled by default for new installation.
+     - string
+     - ``true`` for new installation
    * - :spelling:ignore:`envoy.extraArgs`
      - Additional envoy container arguments.
      - list

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -306,11 +306,11 @@ Annotations:
 1.16 Upgrade Notes
 ------------------
 
-* Cilium Envoy DaemonSet is now enabled by default, and existing in-container installs
-  will be changed to DaemonSet mode unless specifically opted out of. This can be done by
-  disabling it manually by setting ``envoy.enabled=false`` accordingly. This change adds
-  one additional Pod per Node, therefore Nodes at maximum Pod capacity will face an
-  eviction of a single non-system critical Pod after upgrading.
+* Cilium Envoy DaemonSet is now enabled by default for new installation if the helm attribute
+  ``envoy.enabled`` is not specified, for existing cluster, please set ``upgradeCompatibility``
+  to 1.15 or earlier to keep the previous behavior. This change adds one additional Pod per Node,
+  therefore Nodes at maximum Pod capacity will face an eviction of a single non-system critical
+  Pod after upgrading.
 * For Linux kernels of version 6.6 or newer, Cilium by default switches to tcx BPF links for
   attaching its tc BPF programs in the core datapath for better resiliency and performance.
   If your current setup has third-party old-style tc BPF users, then this option should be

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -342,7 +342,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.debug.admin.enabled | bool | `false` | Enable admin interface for cilium-envoy. This is useful for debugging and should not be enabled in production. |
 | envoy.debug.admin.port | int | `9901` | Port number (bound to loopback interface). kubectl port-forward can be used to access the admin interface. |
 | envoy.dnsPolicy | string | `nil` | DNS policy for Cilium envoy pods. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
-| envoy.enabled | bool | `true` | Enable Envoy Proxy in standalone DaemonSet. |
+| envoy.enabled | string | `true` for new installation | Enable Envoy Proxy in standalone DaemonSet. This field is enabled by default for new installation. |
 | envoy.extraArgs | list | `[]` | Additional envoy container arguments. |
 | envoy.extraContainers | list | `[]` | Additional containers added to the cilium Envoy DaemonSet. |
 | envoy.extraEnv | list | `[]` | Additional envoy container environment variables. |

--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -141,3 +141,17 @@ Enable automatic lookup of k8sServicePort from the cluster-info ConfigMap (kubea
   {{- end }}
 {{- end }}
 
+{{/*
+Return user specify envoy.enabled or default value based on the upgradeCompatibility
+*/}}
+{{- define "envoyDaemonSetEnabled" }}
+  {{- if (not (kindIs "invalid" .Values.envoy.enabled)) }}
+    {{- .Values.envoy.enabled }}
+  {{- else }}
+    {{- if semverCompare ">=1.16" (default "1.16" .Values.upgradeCompatibility) }}
+      {{- true }}
+    {{- else }}
+      {{- false }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -9,6 +9,7 @@
 {{- end -}}
 
 {{- $kubeProxyReplacement := (coalesce .Values.kubeProxyReplacement "false") -}}
+{{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
 
 ---
 apiVersion: apps/v1
@@ -236,13 +237,13 @@ spec:
           containerPort: {{ .Values.prometheus.port }}
           hostPort: {{ .Values.prometheus.port }}
           protocol: TCP
-        {{- if and .Values.envoy.prometheus.enabled (not .Values.envoy.enabled) }}
+        {{- if and .Values.envoy.prometheus.enabled (not $envoyDS) }}
         - name: envoy-metrics
           containerPort: {{ .Values.envoy.prometheus.port }}
           hostPort: {{ .Values.envoy.prometheus.port }}
           protocol: TCP
         {{- end }}
-        {{- if and .Values.envoy.debug.admin.port (not .Values.envoy.enabled) }}
+        {{- if and .Values.envoy.debug.admin.port (not $envoyDS) }}
         - name: envoy-admin
           containerPort: {{ .Values.envoy.debug.admin.port }}
           hostPort: {{ .Values.envoy.debug.admin.port }}
@@ -279,7 +280,7 @@ spec:
           mountPath: {{ dir .Values.authentication.mutual.spire.adminSocketPath }}
           readOnly: false
         {{- end }}
-        {{- if .Values.envoy.enabled }}
+        {{- if $envoyDS }}
         - name: envoy-sockets
           mountPath: /var/run/cilium/envoy/sockets
           readOnly: false
@@ -833,7 +834,7 @@ spec:
           path: {{ dir .Values.authentication.mutual.spire.adminSocketPath }}
           type: DirectoryOrCreate
       {{- end }}
-      {{- if .Values.envoy.enabled }}
+      {{- if $envoyDS }}
       # Sharing socket with Cilium Envoy on the same node by using a host path
       - name: envoy-sockets
         hostPath:

--- a/install/kubernetes/cilium/templates/cilium-agent/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/service.yaml
@@ -1,3 +1,4 @@
+{{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
 {{- if and .Values.agent (not .Values.preflight.enabled) .Values.prometheus.enabled }}
 {{- if .Values.prometheus.serviceMonitor.enabled }}
 apiVersion: v1
@@ -23,13 +24,13 @@ spec:
     port: {{ .Values.prometheus.port }}
     protocol: TCP
     targetPort: prometheus
-  {{- if not .Values.envoy.enabled }}
+  {{- if not $envoyDS }}
   - name: envoy-metrics
     port: {{ .Values.envoy.prometheus.port }}
     protocol: TCP
     targetPort: envoy-metrics
   {{- end }}
-{{- else if and .Values.envoy.prometheus.enabled (not .Values.envoy.enabled) }}
+{{- else if and .Values.envoy.prometheus.enabled (not $envoyDS) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -15,6 +15,7 @@
 {{- $defaultK8sClientQPS := 5 -}}
 {{- $defaultK8sClientBurst := 10 -}}
 {{- $defaultDNSProxyEnableTransparentMode := "false" -}}
+{{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
 
 {{- /* Default values when 1.8 was initially deployed */ -}}
 {{- if semverCompare ">=1.8" (default "1.8" .Values.upgradeCompatibility) -}}
@@ -213,7 +214,7 @@ data:
   {{- end }}
 {{- end }}
 
-{{- if not .Values.envoy.enabled }}
+{{- if not $envoyDS }}
   # Port to expose Envoy metrics (e.g. "9964"). Envoy metrics listener will be disabled if this
   # field is not set.
   {{- if .Values.envoy.prometheus.enabled }}
@@ -1264,7 +1265,7 @@ data:
   proxy-max-connection-duration-seconds: {{ .Values.envoy.maxConnectionDurationSeconds | quote }}
   proxy-idle-timeout-seconds: {{ .Values.envoy.idleTimeoutDurationSeconds | quote }}
 
-  external-envoy-proxy: {{ .Values.envoy.enabled | quote }}
+  external-envoy-proxy: {{ include "envoyDaemonSetEnabled" . | quote }}
   envoy-base-id: {{ .Values.envoy.baseID | quote }}
 
 {{- if .Values.envoy.log.path }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/configmap.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.envoy.enabled (not .Values.preflight.enabled) }}
+{{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
+{{- if and $envoyDS (not .Values.preflight.enabled) }}
 
 ---
 apiVersion: v1

--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -1,5 +1,5 @@
-{{- if and .Values.envoy.enabled (not .Values.preflight.enabled) }}
-
+{{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
+{{- if (and $envoyDS (not .Values.preflight.enabled)) }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/install/kubernetes/cilium/templates/cilium-envoy/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/service.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.envoy.enabled (not .Values.preflight.enabled) .Values.envoy.prometheus.enabled }}
+{{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
+{{- if and $envoyDS (not .Values.preflight.enabled) .Values.envoy.prometheus.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/install/kubernetes/cilium/templates/cilium-envoy/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/serviceaccount.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.envoy.enabled (not .Values.preflight.enabled) .Values.serviceAccounts.envoy.create }}
+{{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
+{{- if and $envoyDS (not .Values.preflight.enabled) .Values.serviceAccounts.envoy.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/install/kubernetes/cilium/templates/cilium-envoy/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/servicemonitor.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.envoy.enabled (not .Values.preflight.enabled) .Values.envoy.prometheus.enabled .Values.envoy.prometheus.serviceMonitor.enabled }}
+{{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
+{{- if and $envoyDS (not .Values.preflight.enabled) .Values.envoy.prometheus.enabled .Values.envoy.prometheus.serviceMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1886,7 +1886,10 @@
           ]
         },
         "enabled": {
-          "type": "boolean"
+          "type": [
+            "null",
+            "boolean"
+          ]
         },
         "extraArgs": {
           "items": {},

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2081,8 +2081,13 @@ dashboards:
   annotations: {}
 # Configure Cilium Envoy options.
 envoy:
+  # @schema
+  # type: [null, boolean]
+  # @schema
   # -- Enable Envoy Proxy in standalone DaemonSet.
-  enabled: true
+  # This field is enabled by default for new installation.
+  # @default -- `true` for new installation
+  enabled: ~
   # -- (int)
   # Set Envoy'--base-id' to use when allocating shared memory regions.
   # Only needs to be changed if multiple Envoy instances will run on the same node and may have conflicts. Supported values: 0 - 4294967295. Defaults to '0'

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2087,8 +2087,13 @@ dashboards:
   annotations: {}
 # Configure Cilium Envoy options.
 envoy:
+  # @schema
+  # type: [null, boolean]
+  # @schema
   # -- Enable Envoy Proxy in standalone DaemonSet.
-  enabled: true
+  # This field is enabled by default for new installation.
+  # @default -- `true` for new installation
+  enabled: ~
   # -- (int)
   # Set Envoy'--base-id' to use when allocating shared memory regions.
   # Only needs to be changed if multiple Envoy instances will run on the same node and may have conflicts. Supported values: 0 - 4294967295. Defaults to '0'


### PR DESCRIPTION
### Description

This commit is to _only_ enable Envoy DS for new installation. The
existing cilium installation can opt in by setting upgradeCompatibility
value as per recommended upgrade guide.

One user-defined function (e.g envoyDeamonSetEnabled) is added to avoid
code duplication. Another point worth noting is the usage of eq function
to enforce boolean data type for inline variable

Relates: https://github.com/cilium/cilium/pull/30034, https://github.com/cilium/cilium/issues/33261
Signed-off-by: Tam Mach <tam.mach@cilium.io>

### Testing

Testing was done with `helm template` command as per below

```shell
# New installation -> should install envoy deamonset by default
$ helm template cilium /home/tammach/go/src/github.com/cilium/cilium/install/kubernetes/cilium | grep cilium-envoy/daemonset   
# Source: cilium/templates/cilium-envoy/daemonset.yaml

# Manual set envoy.enabled flags
$ helm template cilium /home/tammach/go/src/github.com/cilium/cilium/install/kubernetes/cilium --set envoy.enabled=true | grep cilium-envoy/daemonset
# Source: cilium/templates/cilium-envoy/daemonset.yaml
$ helm template cilium /home/tammach/go/src/github.com/cilium/cilium/install/kubernetes/cilium --set envoy.enabled=false | grep cilium-envoy/daemonset

# Manual set upgradeCompatibility value 
$ helm template cilium /home/tammach/go/src/github.com/cilium/cilium/install/kubernetes/cilium --set upgradeCompatibility=1.16 | grep cilium-envoy/daemonset
# Source: cilium/templates/cilium-envoy/daemonset.yaml
$ helm template cilium /home/tammach/go/src/github.com/cilium/cilium/install/kubernetes/cilium --set upgradeCompatibility=1.15 | grep cilium-envoy/daemonset

```