### PR TITLE
pkg/ciliumidentity: Add Cilium Identity Controller Operator reconciler 

### DIFF
--- a/operator/identitygc/crd_gc.go
+++ b/operator/identitygc/crd_gc.go
@@ -8,11 +8,12 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/cilium/cilium/operator/k8s"
+
 	"github.com/sirupsen/logrus"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	operatorK8s "github.com/cilium/cilium/operator/k8s"
 	"github.com/cilium/cilium/pkg/controller"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -102,7 +103,7 @@ func (igc *GC) gc(ctx context.Context) error {
 			_, foundInCES = idsInCESs[identity.Name]
 		}
 		// The identity is definitely alive if there's a CE or CES using it.
-		alive := foundInCES || hasCEWithIdentity(cepStore, identity.Name)
+		alive := foundInCES || k8s.HasCEWithIdentity(cepStore, identity.Name)
 
 		if alive {
 			igc.heartbeatStore.markAlive(identity.Name, timeNow)
@@ -226,11 +227,6 @@ func (igc *GC) updateIdentity(ctx context.Context, identity *v2.CiliumIdentity) 
 	log.WithField(logfields.Identity, identity.GetName()).Debug("Updated identity")
 
 	return nil
-}
-
-func hasCEWithIdentity(cepStore resource.Store[*v2.CiliumEndpoint], identity string) bool {
-	ces, _ := cepStore.IndexKeys(operatorK8s.CiliumEndpointIndexIdentity, identity)
-	return len(ces) != 0
 }
 
 func usedIdentitiesInCESs(cesStore resource.Store[*v2alpha1.CiliumEndpointSlice]) map[string]bool {

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -66,3 +66,16 @@ type Resources struct {
 	Pods                 resource.Resource[*slim_corev1.Pod]
 	Namespaces           resource.Resource[*slim_corev1.Namespace]
 }
+
+// HasCEWithIdentity returns true or false if the Cilium Endpoint store has
+// the given identity.
+// Once the CiliumEndpoint is migrated to use resources
+// the cepStore can be removed and used the local store.
+func HasCEWithIdentity(cepStore resource.Store[*cilium_api_v2.CiliumEndpoint], identity string) bool {
+	if cepStore == nil {
+		return false
+	}
+	ces, _ := cepStore.IndexKeys(CiliumEndpointIndexIdentity, identity)
+
+	return len(ces) != 0
+}

--- a/operator/pkg/ciliumidentity/cell.go
+++ b/operator/pkg/ciliumidentity/cell.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import (
+	"github.com/cilium/hive/cell"
+)
+
+// Cell implements the CID Controller. It subscribes to CID, CES, Pods
+// and Namespace events and reconciles the state of CID in the cluster.
+var Cell = cell.Module(
+	"k8s-cid-controller",
+	"Cilium Identity Controller Operator",
+	cell.Invoke(registerController),
+)
+
+// SharedConfig contains the configuration that is shared between
+// this module and others.
+// It is a temporary solution meant to avoid polluting this module with a direct
+// dependency on global operator and daemon configurations.
+type SharedConfig struct {
+	// EnableOperatorManageCIDs enables operator to manage Cilium Identities by
+	// running a Cilium Identity controller.
+	EnableOperatorManageCIDs bool
+
+	// EnableCiliumEndpointSlice indicates if the Cilium Endpoint Slice feature is
+	// enabled.
+	EnableCiliumEndpointSlice bool
+}

--- a/operator/pkg/ciliumidentity/controller.go
+++ b/operator/pkg/ciliumidentity/controller.go
@@ -20,6 +20,20 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 )
 
+var (
+	// cidDeleteDelay is the delay to enqueue another CID event to be reconciled
+	// after CID is marked for deletion. This is required for simultaneous CID
+	// management by both cilium-operator and cilium-agent. Without the delay,
+	// operator might immediately clean up CIDs created by agent, before agent can
+	// finish CEP creation.
+	cidDeleteDelay = 30 * time.Second
+)
+
+type queueOperations interface {
+	enqueueCIDReconciliation(cidKey resource.Key, delay time.Duration)
+	enqueuePodReconciliation(podKey resource.Key, delay time.Duration)
+}
+
 type params struct {
 	cell.In
 

--- a/operator/pkg/ciliumidentity/controller.go
+++ b/operator/pkg/ciliumidentity/controller.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import (
+	"context"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/workerpool"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/util/workqueue"
+
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+type params struct {
+	cell.In
+
+	Logger              logrus.FieldLogger
+	Lifecycle           cell.Lifecycle
+	Clientset           k8sClient.Clientset
+	SharedCfg           SharedConfig
+	Namespace           resource.Resource[*slim_corev1.Namespace]
+	Pod                 resource.Resource[*slim_corev1.Pod]
+	CiliumIdentity      resource.Resource[*cilium_api_v2.CiliumIdentity]
+	CiliumEndpoint      resource.Resource[*cilium_api_v2.CiliumEndpoint]
+	CiliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice]
+}
+
+type Controller struct {
+	logger              logrus.FieldLogger
+	context             context.Context
+	contextCancel       context.CancelFunc
+	clientset           k8sClient.Clientset
+	reconciler          *reconciler
+	namespace           resource.Resource[*slim_corev1.Namespace]
+	pod                 resource.Resource[*slim_corev1.Pod]
+	ciliumIdentity      resource.Resource[*cilium_api_v2.CiliumIdentity]
+	ciliumEndpoint      resource.Resource[*cilium_api_v2.CiliumEndpoint]
+	ciliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice]
+
+	// Work queues are used to sync resources with the api-server.
+	// Work queues will rate-limit requests going to api-server. Ensures a single
+	// resource key will not be processed multiple times concurrently, and if
+	// a resource key is added multiple times before it can be processed, this
+	// will only be processed once.
+	cidQueue      workqueue.RateLimitingInterface
+	podQueue      workqueue.RateLimitingInterface
+	cidEnqueuedAt *EnqueueTimeTracker
+	podEnqueuedAt *EnqueueTimeTracker
+
+	wp         *workerpool.WorkerPool
+	cesEnabled bool
+
+	// oldNSSecurityLabels is a map between namespace, and it's security labels.
+	// It's used to track previous state of labels, to detect when labels changed.
+	oldNSSecurityLabels map[string]labels.Labels
+}
+
+func registerController(p params) {
+	if !p.Clientset.IsEnabled() || !p.SharedCfg.EnableOperatorManageCIDs {
+		return
+	}
+
+	cidController := &Controller{
+		logger:              p.Logger,
+		clientset:           p.Clientset,
+		namespace:           p.Namespace,
+		pod:                 p.Pod,
+		ciliumIdentity:      p.CiliumIdentity,
+		ciliumEndpoint:      p.CiliumEndpoint,
+		ciliumEndpointSlice: p.CiliumEndpointSlice,
+		cidEnqueuedAt:       &EnqueueTimeTracker{enqueuedAt: make(map[string]time.Time)},
+		podEnqueuedAt:       &EnqueueTimeTracker{enqueuedAt: make(map[string]time.Time)},
+		oldNSSecurityLabels: make(map[string]labels.Labels),
+		cesEnabled:          p.SharedCfg.EnableCiliumEndpointSlice,
+	}
+
+	p.Lifecycle.Append(cidController)
+}
+
+func (c *Controller) Start(hookContext cell.HookContext) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *Controller) Stop(hookContext cell.HookContext) error {
+	//TODO implement me
+	panic("implement me")
+}

--- a/operator/pkg/ciliumidentity/identity.go
+++ b/operator/pkg/ciliumidentity/identity.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import "github.com/cilium/cilium/pkg/k8s/resource"
+
+func cidResourceKey(cidName string) resource.Key {
+	return resource.Key{Name: cidName}
+}

--- a/operator/pkg/ciliumidentity/namespace.go
+++ b/operator/pkg/ciliumidentity/namespace.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import "github.com/cilium/cilium/pkg/k8s/resource"
+
+func nsResourceKey(namespace string) resource.Key {
+	return resource.Key{Name: namespace}
+}

--- a/operator/pkg/ciliumidentity/pod.go
+++ b/operator/pkg/ciliumidentity/pod.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import "github.com/cilium/cilium/pkg/k8s/resource"
+
+func podResourceKey(podName, podNamespace string) resource.Key {
+	return resource.Key{Name: podName, Namespace: podNamespace}
+}

--- a/operator/pkg/ciliumidentity/reconciler.go
+++ b/operator/pkg/ciliumidentity/reconciler.go
@@ -1,0 +1,33 @@
+package ciliumidentity
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/identity/basicallocator"
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+type reconciler struct {
+	logger             logrus.FieldLogger
+	clientset          k8sClient.Clientset
+	idAllocator        *basicallocator.BasicIDAllocator
+	desiredCIDState    *CIDState
+	cidUsageInPods     *CIDUsageInPods
+	cidUsageInCES      *CIDUsageInCES
+	cidDeletionTracker *CIDDeletionTracker
+	// Ensures no CID duplicates are created while allocating CIDs in parallel,
+	// and avoids race conditions when CIDs are being deleted.
+	cidCreateLock lock.RWMutex
+	cesEnabled    bool
+
+	nsStore  resource.Store[*slim_corev1.Namespace]
+	podStore resource.Store[*slim_corev1.Pod]
+	cidStore resource.Store[*cilium_api_v2.CiliumIdentity]
+	cepStore resource.Store[*cilium_api_v2.CiliumEndpoint]
+	cesStore resource.Store[*v2alpha1.CiliumEndpointSlice]
+}

--- a/operator/pkg/ciliumidentity/reconciler.go
+++ b/operator/pkg/ciliumidentity/reconciler.go
@@ -1,15 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
 package ciliumidentity
 
 import (
-	"github.com/sirupsen/logrus"
+	"context"
+	"fmt"
+	"strconv"
+	"time"
 
+	"github.com/cilium/cilium/pkg/option"
+
+	"github.com/cilium/cilium/pkg/labels"
+
+	"github.com/sirupsen/logrus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	operator_k8s "github.com/cilium/cilium/operator/k8s"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/basicallocator"
+	"github.com/cilium/cilium/pkg/identity/key"
+	"github.com/cilium/cilium/pkg/idpool"
+	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/identitybackend"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 type reconciler struct {
@@ -24,10 +47,468 @@ type reconciler struct {
 	// and avoids race conditions when CIDs are being deleted.
 	cidCreateLock lock.RWMutex
 	cesEnabled    bool
+	queueOps      queueOperations
 
 	nsStore  resource.Store[*slim_corev1.Namespace]
 	podStore resource.Store[*slim_corev1.Pod]
 	cidStore resource.Store[*cilium_api_v2.CiliumIdentity]
 	cepStore resource.Store[*cilium_api_v2.CiliumEndpoint]
 	cesStore resource.Store[*v2alpha1.CiliumEndpointSlice]
+}
+
+func newReconciler(
+	ctx context.Context,
+	logger logrus.FieldLogger,
+	clientset k8sClient.Clientset,
+	namespace resource.Resource[*slim_corev1.Namespace],
+	pod resource.Resource[*slim_corev1.Pod],
+	ciliumIdentity resource.Resource[*cilium_api_v2.CiliumIdentity],
+	ciliumEndpoint resource.Resource[*cilium_api_v2.CiliumEndpoint],
+	ciliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice],
+	cesEnabled bool,
+	queueOps queueOperations,
+) *reconciler {
+	logger.Info("Creating CID controller Operator reconciler")
+
+	minIDValue := idpool.ID(identity.GetMinimalAllocationIdentity(option.Config.ClusterID))
+	maxIDValue := idpool.ID(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))
+	idAllocator := basicallocator.NewBasicIDAllocator(minIDValue, maxIDValue)
+
+	nsStore, _ := namespace.Store(ctx)
+	podStore, _ := pod.Store(ctx)
+	cidStore, _ := ciliumIdentity.Store(ctx)
+	cepStore, _ := ciliumEndpoint.Store(ctx)
+	cesStore, _ := ciliumEndpointSlice.Store(ctx)
+
+	r := &reconciler{
+		logger:             logger,
+		clientset:          clientset,
+		idAllocator:        idAllocator,
+		desiredCIDState:    NewCIDState(logger),
+		cidUsageInPods:     NewCIDUsageInPods(),
+		cidUsageInCES:      NewCIDUsageInCES(),
+		cidDeletionTracker: NewCIDDeletionTracker(logger),
+		queueOps:           queueOps,
+		nsStore:            nsStore,
+		podStore:           podStore,
+		cidStore:           cidStore,
+		cepStore:           cepStore,
+		cesStore:           cesStore,
+		cesEnabled:         cesEnabled,
+	}
+
+	return r
+}
+
+// syncCESsOnStartup updates the cache of CID usage in CES for all the
+// existing CESs.
+func (r *reconciler) calcDesiredStateOnStartup() error {
+	r.syncCESsOnStartup()
+	return r.syncPodsOnStartup()
+}
+
+func (r *reconciler) syncCESsOnStartup() {
+	if !r.cesEnabled {
+		return
+	}
+
+	for _, ces := range r.cesStore.List() {
+		r.cidUsageInCES.ProcessCESUpsert(ces.Name, ces.Endpoints)
+	}
+}
+
+// syncPodsOnStartup ensures that all pods have a CID for their labels, and that
+// all non-used CIDs are deleted. Non used CIDs are those that aren't in use by
+// any of the pods and also don't exist in CESs (if CES is enabled).
+func (r *reconciler) syncPodsOnStartup() error {
+	var lastError error
+
+	for _, pod := range r.podStore.List() {
+		if err := r.reconcilePod(podResourceKey(pod.Name, pod.Namespace)); err != nil {
+			lastError = err
+		}
+	}
+
+	return lastError
+}
+
+// reconcileCID ensures that the desired state for the CID is reached, by
+// comparing the CID in desired state cache and watcher's store and doing one of
+// the following:
+// 1. Nothing - If CID doesn't exist in both desired state cache and watcher's
+// store.
+// 2. Deletes CID - If CID only exists in the watcher's store, and it isn't used.
+// 3. Creates CID - If CID only exists in the desired state cache.
+// 4. Updates CID - If CIDs in the desired state cache and watcher's store are
+// not the same.
+func (r *reconciler) reconcileCID(cidResourceKey resource.Key) error {
+	cidName := cidResourceKey.Name
+	storeCIDObj, existsInStore, err := r.cidStore.CacheStore().GetByKey(cidResourceKey.Name)
+
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+
+	var storeCID *cilium_api_v2.CiliumIdentity
+	if existsInStore {
+		var ok bool
+		storeCID, ok = storeCIDObj.(*cilium_api_v2.CiliumIdentity)
+		if !ok {
+			return fmt.Errorf("wrong type (%T) of object when getting CID %q from the CID store", storeCIDObj, cidName)
+		}
+	}
+
+	cidKey, existsInDesiredState := r.desiredCIDState.LookupByID(cidName)
+	if !existsInDesiredState && !existsInStore {
+		_ = r.makeIDAvailable(cidName)
+		return nil
+	}
+
+	cidIsUsed := r.cidIsUsedInPods(cidName) || r.cidIsUsedInCEPOrCES(cidName)
+	if !existsInDesiredState {
+		if cidIsUsed {
+			return nil
+		}
+		r.cidCreateLock.Lock()
+		defer r.cidCreateLock.Unlock()
+		return r.handleCIDDeletion(cidName)
+	}
+
+	if !cidIsUsed {
+		if existsInStore {
+			r.cidCreateLock.Lock()
+			defer r.cidCreateLock.Unlock()
+			return r.handleCIDDeletion(cidName)
+		}
+
+		r.desiredCIDState.Remove(cidName)
+		return nil
+	}
+
+	if !existsInStore {
+		return r.createCID(cidName, cidKey)
+	}
+
+	storeCIDKey := key.GetCIDKeyFromLabels(storeCID.SecurityLabels, "")
+	if cidKey.Equals(storeCIDKey.LabelArray) {
+		return nil
+	}
+
+	return r.updateCID(storeCID, cidKey)
+}
+
+func (r *reconciler) createCID(cidName string, cidKey *key.GlobalIdentity) error {
+	cidLabels := cidKey.GetAsMap()
+	selectedLabels, skippedLabels := identitybackend.SanitizeK8sLabels(cidLabels)
+	r.logger.WithField(logfields.Labels, skippedLabels).Debug("Skipped non-kubernetes labels when labelling CID. All labels will still be used in identity determination")
+
+	cid := &cilium_api_v2.CiliumIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   cidName,
+			Labels: selectedLabels,
+		},
+		SecurityLabels: cidLabels,
+	}
+
+	r.logger.WithField(logfields.CIDName, cidName).Infof("Creating a CID for security labels: %+v", cidLabels)
+
+	_, err := r.clientset.CiliumV2().CiliumIdentities().Create(context.TODO(), cid, metav1.CreateOptions{})
+	return err
+}
+
+func (r *reconciler) updateCID(cid *cilium_api_v2.CiliumIdentity, cidKey *key.GlobalIdentity) error {
+	cidLabels := cidKey.GetAsMap()
+	selectedLabels, skippedLabels := identitybackend.SanitizeK8sLabels(cidLabels)
+	r.logger.WithField(logfields.Labels, skippedLabels).Debug("Skipped non-kubernetes labels when labelling CID. All labels will still be used in identity determination")
+
+	cid.Labels = selectedLabels
+	cid.SecurityLabels = cidLabels
+
+	r.logger.WithField(logfields.CIDName, cid.Name).Info("Updating a CID")
+
+	_, err := r.clientset.CiliumV2().CiliumIdentities().Update(context.TODO(), cid, metav1.UpdateOptions{})
+	return err
+}
+
+func (r *reconciler) deleteCID(cidName string) error {
+	r.logger.WithField(logfields.CIDName, cidName).Info("Deleting a CID")
+
+	err := r.clientset.CiliumV2().CiliumIdentities().Delete(context.TODO(), cidName, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// handleCIDDeletion marks or deletes already marked CID.
+// Requires to be called with cidCreateLock locked because it modifies the
+// internal state of CID.
+func (r *reconciler) handleCIDDeletion(cidName string) error {
+	markedTime, isMarked := r.cidDeletionTracker.MarkedTime(cidName)
+	if !isMarked {
+		r.cidDeletionTracker.Mark(cidName)
+		r.queueOps.enqueueCIDReconciliation(cidResourceKey(cidName), cidDeleteDelay)
+		return nil
+	}
+
+	durationSinceMarked := time.Since(markedTime)
+	if durationSinceMarked >= cidDeleteDelay {
+		if err := r.deleteCID(cidName); err != nil {
+			r.logger.WithField(logfields.CIDName, cidName).Errorf("Deleting CID failed, will retry, error: %v", err)
+			r.queueOps.enqueueCIDReconciliation(cidResourceKey(cidName), 0)
+			return fmt.Errorf("failed to delete CID: %w", err)
+		}
+
+		r.cidDeletionTracker.Unmark(cidName)
+		r.desiredCIDState.Remove(cidName)
+		r.makeIDAvailable(cidName)
+		return nil
+	}
+
+	r.queueOps.enqueueCIDReconciliation(cidResourceKey(cidName), cidDeleteDelay)
+	return nil
+}
+
+func (r *reconciler) makeIDAvailable(cidName string) error {
+	cidNum, err := strconv.Atoi(cidName)
+	if err != nil {
+		return err
+	}
+	return r.idAllocator.ReturnToAvailablePool(idpool.ID(cidNum))
+}
+
+func (r *reconciler) upsertDesiredState(cidName string, cidKey *key.GlobalIdentity) error {
+	if cidKey == nil || len(cidName) == 0 {
+		return fmt.Errorf("invalid CID, name: %q, key: %v", cidName, cidKey)
+	}
+
+	cachedCIDKey, exists := r.desiredCIDState.LookupByID(cidName)
+	if exists && cidKey.Equals(cachedCIDKey.LabelArray) {
+		return nil
+	}
+
+	id, err := r.idAllocator.ValidateIDString(cidName)
+	if err != nil {
+		return err
+	}
+
+	err = r.idAllocator.Allocate(idpool.ID(id))
+	if err != nil {
+		return err
+	}
+	r.desiredCIDState.Upsert(cidName, cidKey)
+
+	return nil
+}
+
+// reconcilePod ensures that there is a CID that matches the pod. CIDs are
+// created for new unique label sets, and potentially deleted when pods are
+// deleted, if no other pods match the CID labels.
+func (r *reconciler) reconcilePod(podKey resource.Key) error {
+	pod, exists, err := r.podStore.GetByKey(podKey)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+	// When a pod is not found in the pod store, it means it's deleted.
+	if !exists {
+		prevCIDName, count, found := r.cidUsageInPods.RemovePod(podKey.String())
+		if found && count == 0 && !r.cidIsUsedInCEPOrCES(prevCIDName) {
+			r.cidCreateLock.Lock()
+			defer r.cidCreateLock.Unlock()
+			if err := r.handleCIDDeletion(prevCIDName); err != nil {
+				r.logger.WithFields(
+					logrus.Fields{
+						logfields.CIDName:    prevCIDName,
+						logfields.K8sPodName: podKey.String(),
+					},
+				).WithError(err).Error("CID deletion failed when reconciling pod deletion")
+			}
+		}
+		return nil
+	}
+
+	return r.allocateCIDForPod(pod)
+}
+
+func (r *reconciler) cidIsUsedInPods(cidName string) bool {
+	return r.cidUsageInPods.CIDUsageCount(cidName) > 0
+}
+
+func (r *reconciler) cidIsUsedInCEPOrCES(cidName string) bool {
+	if !r.cesEnabled {
+		return operator_k8s.HasCEWithIdentity(r.cepStore, cidName)
+	}
+
+	cidUsageCount := r.cidUsageInCES.CIDUsageCount(cidName)
+	return cidUsageCount > 0
+}
+
+// allocateCIDForPod gets pod and namespace labels that are relevant to security
+// identities, and ensures that a CID exists for that label set.
+// 1. CID exists: No action.
+// 2. CID doesn't exist: Create CID.
+func (r *reconciler) allocateCIDForPod(pod *slim_corev1.Pod) error {
+	k8sLabels, err := r.getRelevantLabelsForPod(pod)
+	if err != nil {
+		return fmt.Errorf("failed to get relevant labels for pod: %w", err)
+	}
+	cidKey := key.GetCIDKeyFromLabels(k8sLabels, labels.LabelSourceK8s)
+
+	r.cidCreateLock.Lock()
+	defer r.cidCreateLock.Unlock()
+
+	cidName, isNewCID, err := r.allocateCID(cidKey)
+	if err != nil {
+		return fmt.Errorf("failed to allocate CID: %w", err)
+	}
+
+	r.desiredCIDState.Upsert(cidName, cidKey)
+
+	podName := podResourceKey(pod.Name, pod.Namespace).String()
+	prevCIDName, count := r.cidUsageInPods.AssignCIDToPod(podName, cidName)
+
+	r.logger.WithFields(
+		logrus.Fields{
+			logfields.K8sPodName:  fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
+			logfields.CIDName:     cidName,
+			logfields.OldIdentity: prevCIDName,
+			logfields.Labels:      k8sLabels,
+		},
+	).Infof("CID allocated for a pod")
+
+	if len(prevCIDName) > 0 && count == 0 && !r.cidIsUsedInCEPOrCES(prevCIDName) {
+		r.handleCIDDeletion(prevCIDName)
+	}
+
+	if isNewCID {
+		r.queueOps.enqueueCIDReconciliation(cidResourceKey(cidName), 0)
+	}
+
+	return nil
+}
+
+func (r *reconciler) allocateCID(cidKey *key.GlobalIdentity) (string, bool, error) {
+	cidName, exists := r.desiredCIDState.LookupByKey(cidKey)
+	if exists {
+		r.cidDeletionTracker.Unmark(cidName)
+		return cidName, false, nil
+	}
+
+	storeCIDs, err := r.cidStore.ByIndex(k8s.ByKeyIndex, cidKey.GetKey())
+	if err != nil {
+		return "", false, err
+	}
+
+	// If CIDs that match labels are found in CID store but not in the desired cache,
+	// they need to be added to the desired cache and used instead of creating a new
+	// CID for these labels.
+	if len(storeCIDs) > 0 {
+		// Return the assignment from the CID store, otherwise allocates a new identity
+		cidName, err = r.handleStoreCIDMatch(storeCIDs)
+		if err != nil {
+			r.logger.Error(err)
+		} else {
+			r.cidDeletionTracker.Unmark(cidName)
+			return cidName, false, nil
+		}
+	}
+
+	allocatedID, err := r.idAllocator.AllocateRandom()
+	if err != nil {
+		return "", false, err
+	}
+
+	return allocatedID.String(), true, nil
+}
+
+func (r *reconciler) getRelevantLabelsForPod(pod *slim_corev1.Pod) (map[string]string, error) {
+	ns, err := r.getNamespace(pod.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	_, labelsMap, _, err := k8s.GetPodMetadata(ns, pod)
+	if err != nil {
+		return nil, err
+	}
+
+	return labelsMap, nil
+}
+
+func (r *reconciler) getNamespace(namespace string) (*slim_corev1.Namespace, error) {
+	nsLookupObj := &slim_corev1.Namespace{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+
+	ns, exists, err := r.nsStore.Get(nsLookupObj)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get namespace %q, error: %w", namespace, err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("namespace %q not found in store", namespace)
+	}
+
+	return ns, nil
+}
+
+func (r *reconciler) handleStoreCIDMatch(storeCIDs []*cilium_api_v2.CiliumIdentity) (string, error) {
+	if len(storeCIDs) == 0 {
+		return "", fmt.Errorf("store CIDs list is empty")
+	}
+
+	var selectedCIDName string
+
+	// Deduplication: Reconcile all CID. The first will be added to the desired
+	// cache and the rest will be deleted, because they are not used.
+	for _, cid := range storeCIDs {
+		toDelete := true
+
+		if len(selectedCIDName) == 0 {
+			cidKey := key.GetCIDKeyFromLabels(cid.SecurityLabels, "")
+			if err := r.upsertDesiredState(cid.Name, cidKey); err != nil {
+				r.logger.Warningf("Failed to add CID %s to cache: %v", cid.Name, err)
+			} else {
+				toDelete = false
+				selectedCIDName = cid.Name
+			}
+		}
+
+		if toDelete {
+			r.queueOps.enqueueCIDReconciliation(cidResourceKey(cid.Name), 0)
+		}
+	}
+
+	return selectedCIDName, nil
+}
+
+// reconcileNamespace enqueues all pods in the namespace to be reconciled by the CID
+// controller.
+func (r *reconciler) reconcileNamespace(nsKey resource.Key) error {
+	if err := r.updateAllPodsInNamespace(nsKey.Name); err != nil {
+		return fmt.Errorf("failed to reconcile namespace %s change: %w", nsKey.Name, err)
+	}
+	return nil
+}
+
+func (r *reconciler) updateAllPodsInNamespace(namespace string) error {
+	r.logger.Infof("Reconciling all pods in ns: %s", namespace)
+
+	if r.podStore == nil {
+		return fmt.Errorf("pod store is not initialized")
+	}
+	podList, err := r.podStore.ByIndex(cache.NamespaceIndex, namespace)
+	if err != nil {
+		return err
+	}
+
+	var lastErr error
+
+	for _, pod := range podList {
+		r.queueOps.enqueuePodReconciliation(podResourceKey(pod.Name, pod.Namespace), 0)
+	}
+
+	return lastErr
 }

--- a/operator/pkg/ciliumidentity/reconciler_test.go
+++ b/operator/pkg/ciliumidentity/reconciler_test.go
@@ -1,0 +1,751 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sTesting "k8s.io/client-go/testing"
+
+	"github.com/cilium/cilium/operator/k8s"
+	cestest "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/identity/key"
+	capi_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	idbackend "github.com/cilium/cilium/pkg/k8s/identitybackend"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "cid-controller")
+
+	testLbsA = map[string]string{"key-a": "val-1"}
+	testLbsB = map[string]string{"key-b": "val-2"}
+	testLbsC = map[string]string{"key-c": "val-3"}
+)
+
+type testQueueOps struct {
+	fakeWorkQueue map[string]bool
+}
+
+func (t testQueueOps) enqueueCIDReconciliation(cidKey resource.Key, _ time.Duration) {
+	t.fakeWorkQueue[cidKey.String()] = true
+}
+
+func (t testQueueOps) enqueuePodReconciliation(cidKey resource.Key, _ time.Duration) {
+	t.fakeWorkQueue[cidKey.String()] = true
+}
+
+func testNewReconciler(t *testing.T, ctx context.Context, enableCES bool) (*reconciler, *testQueueOps, k8sClient.FakeClientset, func()) {
+	var namespace resource.Resource[*slim_corev1.Namespace]
+	var pod resource.Resource[*slim_corev1.Pod]
+	var ciliumIdentity resource.Resource[*capi_v2.CiliumIdentity]
+	var ciliumEndpoint resource.Resource[*capi_v2.CiliumEndpoint]
+	var ciliumEndpointSlice resource.Resource[*capi_v2a1.CiliumEndpointSlice]
+	var fakeClient k8sClient.FakeClientset
+
+	h := hive.New(
+		k8sClient.FakeClientCell,
+		k8s.ResourcesCell,
+		cell.Invoke(func(
+			c *k8sClient.FakeClientset,
+			nsResource resource.Resource[*slim_corev1.Namespace],
+			podResource resource.Resource[*slim_corev1.Pod],
+			cidResource resource.Resource[*capi_v2.CiliumIdentity],
+			cepResource resource.Resource[*capi_v2.CiliumEndpoint],
+			cesResource resource.Resource[*capi_v2a1.CiliumEndpointSlice],
+		) error {
+			fakeClient = *c
+			namespace = nsResource
+			pod = podResource
+			ciliumIdentity = cidResource
+			ciliumEndpoint = cepResource
+			ciliumEndpointSlice = cesResource
+			return nil
+		}),
+	)
+	tlog := hivetest.Logger(t)
+	_ = h.Start(tlog, ctx)
+	cleanupFunc := func() {
+		_ = h.Stop(tlog, ctx)
+	}
+
+	queueOps := &testQueueOps{fakeWorkQueue: make(map[string]bool)}
+	reconciler := newReconciler(
+		ctx,
+		log,
+		fakeClient.Clientset,
+		namespace,
+		pod,
+		ciliumIdentity,
+		ciliumEndpoint,
+		ciliumEndpointSlice,
+		enableCES,
+		queueOps,
+	)
+	return reconciler, queueOps, fakeClient, cleanupFunc
+}
+
+func testCreateCIDObj(id string, lbs map[string]string) *capi_v2.CiliumIdentity {
+	secLbs := make(map[string]string)
+	for k, v := range lbs {
+		secLbs[k] = v
+	}
+
+	k := key.GetCIDKeyFromLabels(secLbs, labels.LabelSourceK8s)
+	secLbs = k.GetAsMap()
+
+	selectedLabels, _ := idbackend.SanitizeK8sLabels(secLbs)
+
+	return &capi_v2.CiliumIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   id,
+			Labels: selectedLabels,
+		},
+		SecurityLabels: secLbs,
+	}
+}
+
+func testCreateCIDObjNs(id string, pod *slim_corev1.Pod, namespace *slim_corev1.Namespace) *capi_v2.CiliumIdentity {
+	lbs := k8sUtils.SanitizePodLabels(pod.ObjectMeta.Labels, namespace, "", "")
+	secLbs := key.GetCIDKeyFromLabels(lbs, labels.LabelSourceK8s).GetAsMap()
+	selectedLabels, _ := idbackend.SanitizeK8sLabels(secLbs)
+
+	return &capi_v2.CiliumIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   id,
+			Labels: selectedLabels,
+		},
+		SecurityLabels: secLbs,
+	}
+}
+
+func testCreatePodObj(name, namespace string, lbs, annotations map[string]string) *slim_corev1.Pod {
+	return &slim_corev1.Pod{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      lbs,
+			Annotations: annotations,
+		},
+	}
+}
+
+func testCreateNSObj(name string, lbs map[string]string) *slim_corev1.Namespace {
+	if lbs == nil {
+		lbs = make(map[string]string)
+	}
+
+	lbs["kubernetes.io/metadata.name"] = name
+
+	return &slim_corev1.Namespace{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:   name,
+			Labels: lbs,
+		},
+	}
+}
+
+func testVerifyCIDUsageInPods(t *testing.T, usage *CIDUsageInPods, expectedCIDs, expectedPods int) {
+	if expectedCIDs != len(usage.cidUsageCount) {
+		t.Errorf("Unexpected number of unique CIDs. Expected: %d, Got: %d", expectedCIDs, len(usage.cidUsageCount))
+	}
+	if expectedPods != len(usage.podToCID) {
+		t.Errorf("Unexpected number of pods. Expected: %d, Got: %d", expectedPods, len(usage.podToCID))
+	}
+
+	totalUsedCIDs := 0
+	for _, count := range usage.cidUsageCount {
+		totalUsedCIDs += count
+	}
+
+	if expectedPods != totalUsedCIDs {
+		t.Errorf("Total CID usage does not match expected pod count. Expected: %d, Got: %d", expectedPods, totalUsedCIDs)
+	}
+}
+
+func TestSyncCESsOnStartup(t *testing.T) {
+	testCases := []struct {
+		name          string
+		cesEnabled    bool
+		endpointSlice *capi_v2a1.CiliumEndpointSlice
+		expectedCIDs  map[int64]int
+	}{
+		{
+			name:       "CES disabled",
+			cesEnabled: false,
+			endpointSlice: cestest.CreateStoreEndpointSlice("ces1", "ns",
+				[]capi_v2a1.CoreCiliumEndpoint{
+					cestest.CreateManagerEndpoint("cep1", 1000),
+					cestest.CreateManagerEndpoint("cep2", 1000),
+					cestest.CreateManagerEndpoint("cep3", 2000),
+					cestest.CreateManagerEndpoint("cep4", 2000)}),
+			expectedCIDs: nil,
+		},
+		{
+			name:       "CES enabled",
+			cesEnabled: true,
+			endpointSlice: cestest.CreateStoreEndpointSlice("ces2", "ns",
+				[]capi_v2a1.CoreCiliumEndpoint{
+					cestest.CreateManagerEndpoint("cep1", 1000),
+					cestest.CreateManagerEndpoint("cep2", 1000),
+					cestest.CreateManagerEndpoint("cep3", 2000),
+				}),
+			expectedCIDs: map[int64]int{1000: 2, 2000: 1},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			reconciler, _, _, cleanupFunc := testNewReconciler(t, ctx, tc.cesEnabled)
+			defer cleanupFunc()
+
+			if err := reconciler.cesStore.CacheStore().Add(tc.endpointSlice); err != nil {
+				t.Errorf("Error adding CiliumEndpointSlice to cache store: %v", err)
+			}
+
+			reconciler.syncCESsOnStartup()
+
+			if tc.cesEnabled {
+				for cid, expectedCount := range tc.expectedCIDs {
+					actualCount := reconciler.cidUsageInCES.cidUsageCount[cid]
+					if actualCount != expectedCount {
+						t.Errorf("Expected CID %d usage count to be %d, but got %d", cid, expectedCount, actualCount)
+					}
+				}
+			} else {
+				if len(reconciler.cidUsageInCES.cidUsageCount) != 0 {
+					t.Errorf("Expected no CIDs to be used when CES is disabled, but found %d", len(reconciler.cidUsageInCES.cidUsageCount))
+				}
+			}
+		})
+	}
+}
+
+func TestSyncPodsOnStartup(t *testing.T) {
+	ns1 := testCreateNSObj("ns1", nil)
+	ns2 := testCreateNSObj("ns2", nil)
+
+	pod1 := testCreatePodObj("pod1", ns1.Name, testLbsA, nil)
+	pod2 := testCreatePodObj("pod2", ns1.Name, testLbsB, nil)
+	pod3 := testCreatePodObj("pod3", ns2.Name, testLbsC, nil)
+
+	testCases := []struct {
+		name          string
+		pods          []*slim_corev1.Pod
+		existingCIDs  []*capi_v2.CiliumIdentity
+		expectedQSize int // Expected size of the queue after sync
+	}{
+		{
+			name: "New pods",
+			pods: []*slim_corev1.Pod{
+				pod1,
+				pod2,
+				pod3,
+			},
+			expectedQSize: 3,
+		},
+		{
+			name: "Existing CIDs with new pod",
+			pods: []*slim_corev1.Pod{
+				pod1,
+				pod2,
+				pod3, // new pod
+			},
+			existingCIDs: []*capi_v2.CiliumIdentity{
+				testCreateCIDObjNs("1000", pod1, ns1),
+				testCreateCIDObjNs("2000", pod2, ns1),
+			},
+			expectedQSize: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			reconciler, queueOps, _, cleanupFunc := testNewReconciler(t, ctx, false)
+			defer cleanupFunc()
+
+			for _, pod := range tc.pods {
+				_ = reconciler.nsStore.CacheStore().Add(testCreateNSObj(pod.Namespace, nil))
+				_ = reconciler.podStore.CacheStore().Add(pod)
+			}
+			for _, cid := range tc.existingCIDs {
+				_ = reconciler.cidStore.CacheStore().Add(cid)
+			}
+
+			if err := reconciler.syncPodsOnStartup(); err != nil {
+				t.Errorf("Error syncing pods on startup: %v", err)
+			}
+
+			if len(queueOps.fakeWorkQueue) != tc.expectedQSize {
+				t.Errorf("Expected queue size to be %d, but got %d", tc.expectedQSize, len(queueOps.fakeWorkQueue))
+			}
+		})
+	}
+}
+
+func TestReconcileCID(t *testing.T) {
+	cidName := "1000"
+
+	testCases := []struct {
+		name                string
+		cidKey              resource.Key
+		initialStoreState   *capi_v2.CiliumIdentity // CID initially in the store
+		desiredState        map[string]string       // Desired CID labels
+		usedInPods          bool
+		errorDuringDeletion bool
+		expectedCreate      *capi_v2.CiliumIdentity
+		expectedUpdate      *capi_v2.CiliumIdentity
+		expectedDelete      string // Name of the CID to be deleted
+		expectedQueueSize   int
+	}{
+		{
+			name:              "default",
+			cidKey:            cidResourceKey(cidName),
+			initialStoreState: testCreateCIDObj(cidName, testLbsA),
+			usedInPods:        false,
+			expectedQueueSize: 1,
+		},
+		{
+			name:           "CID only in desired",
+			cidKey:         cidResourceKey(cidName),
+			desiredState:   testLbsA,
+			usedInPods:     true,
+			expectedCreate: testCreateCIDObj(cidName, testLbsA), // CID is created
+		},
+		{
+			name:              "CID in desired and store",
+			cidKey:            cidResourceKey(cidName),
+			initialStoreState: testCreateCIDObj(cidName, testLbsA),
+			desiredState:      testLbsA,
+			usedInPods:        true,
+		},
+		{
+			name:              "CID only in store",
+			cidKey:            cidResourceKey(cidName),
+			initialStoreState: testCreateCIDObj(cidName, testLbsA),
+			expectedDelete:    cidName,
+		},
+		{
+			name:                "failed deletion",
+			cidKey:              cidResourceKey(cidName),
+			initialStoreState:   testCreateCIDObj(cidName, testLbsA),
+			errorDuringDeletion: true,
+			expectedQueueSize:   1,
+		},
+		{
+			name:              "CID in store with different labels than desired",
+			cidKey:            cidResourceKey(cidName),
+			initialStoreState: testCreateCIDObj(cidName, testLbsB),
+			desiredState:      testLbsA,
+			usedInPods:        true,
+			expectedUpdate:    testCreateCIDObj(cidName, testLbsA),
+		},
+		{
+			name:   "CID not in store",
+			cidKey: cidResourceKey(cidName),
+		},
+		{
+			name:              "CID used in pods no desired",
+			cidKey:            cidResourceKey(cidName),
+			initialStoreState: testCreateCIDObj(cidName, testLbsA),
+			usedInPods:        true,
+		},
+		{
+			name:              "CID in store not used",
+			cidKey:            cidResourceKey(cidName),
+			initialStoreState: testCreateCIDObj(cidName, testLbsA),
+			usedInPods:        false,
+			desiredState:      testLbsA,
+			expectedQueueSize: 1,
+		},
+		{
+			name:         "CID in desired not used",
+			cidKey:       cidResourceKey(cidName),
+			usedInPods:   false,
+			desiredState: testLbsA,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			reconciler, queueOps, _, cleanupFunc := testNewReconciler(t, ctx, false)
+			defer cleanupFunc()
+
+			cs := reconciler.clientset.(*k8sClient.FakeClientset)
+			var createCID, updateCID *capi_v2.CiliumIdentity
+			var deleteCIDName string
+			cs.CiliumFakeClientset.PrependReactor("create", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+				pa := action.(k8sTesting.CreateAction)
+				createCID = pa.GetObject().(*capi_v2.CiliumIdentity)
+				return true, nil, nil
+			})
+			cs.CiliumFakeClientset.PrependReactor("update", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+				pa := action.(k8sTesting.UpdateAction)
+				updateCID = pa.GetObject().(*capi_v2.CiliumIdentity)
+				return true, nil, nil
+			})
+			cs.CiliumFakeClientset.PrependReactor("delete", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+				if tc.errorDuringDeletion {
+					return false, nil, fmt.Errorf("forced error on deletion")
+				}
+				pa := action.(k8sTesting.DeleteAction)
+				deleteCIDName = pa.GetName()
+				return true, nil, nil
+			})
+
+			if tc.initialStoreState != nil {
+				if err := reconciler.cidStore.CacheStore().Add(tc.initialStoreState); err != nil {
+					t.Errorf("Error adding CID to cache store: %v", err)
+				}
+			}
+
+			if tc.desiredState != nil {
+				if err := reconciler.upsertDesiredState(tc.cidKey.Name, key.GetCIDKeyFromLabels(tc.desiredState, labels.LabelSourceK8s)); err != nil {
+					t.Errorf("Unexpected error upserting desired state: %v", err)
+				}
+			}
+
+			if tc.usedInPods {
+				reconciler.cidUsageInPods.cidUsageCount[tc.cidKey.Name] = 1
+			}
+
+			if tc.expectedDelete != "" {
+				reconciler.cidDeletionTracker.markedForDeletion[tc.cidKey.Name] = time.Now().Add(-cidDeleteDelay)
+			}
+
+			if err := reconciler.reconcileCID(tc.cidKey); err != nil {
+				t.Errorf("Unexpected error during reconciliation: %v", err)
+			}
+
+			if !reflect.DeepEqual(createCID, tc.expectedCreate) {
+				t.Errorf("Unexpected createCID result: got %v, want %v", createCID, tc.expectedCreate)
+			}
+			if !reflect.DeepEqual(updateCID, tc.expectedUpdate) {
+				t.Errorf("Unexpected updateCID result: got %v, want %v", updateCID, tc.expectedUpdate)
+			}
+			if deleteCIDName != tc.expectedDelete {
+				t.Errorf("Unexpected deleteCIDName result: got %v, want %v", deleteCIDName, tc.expectedDelete)
+			}
+			if len(queueOps.fakeWorkQueue) != tc.expectedQueueSize {
+				t.Errorf("Unexpected fakeWorkQueue size: got %v, want %v", len(queueOps.fakeWorkQueue), tc.expectedQueueSize)
+			}
+			if _, isMarked := reconciler.cidDeletionTracker.MarkedTime(tc.cidKey.Name); tc.errorDuringDeletion && isMarked != tc.errorDuringDeletion {
+				t.Errorf("CID deletion state mismatch: CID{%s} - expected to be marked as deleted, found isMarked=%t, errorDuringDeletion=%t", tc.cidKey.Name, isMarked, tc.errorDuringDeletion)
+			}
+		})
+	}
+}
+
+func TestReconcilePod(t *testing.T) {
+	ns1 := testCreateNSObj("ns1", nil)
+
+	pod1 := testCreatePodObj("pod1", ns1.Name, testLbsA, nil)
+	pod2 := testCreatePodObj("pod2", ns1.Name, testLbsA, nil)
+
+	cidName := "1000"
+
+	type expectedState struct {
+		queueSize           int
+		existsInQueue       []string
+		numDesiredCIDLabels int
+		expectedCIDs        int
+		expectedPods        int
+		expectedCID         string
+	}
+
+	testCases := []struct {
+		name            string
+		newPod          *slim_corev1.Pod
+		existingPods    []*slim_corev1.Pod
+		existingCIDs    []*capi_v2.CiliumIdentity
+		initialPodToCID map[resource.Key]string
+		expected        expectedState
+		expectError     bool
+	}{
+		{
+			name:     "Pod not in store or mapping",
+			newPod:   pod1,
+			expected: expectedState{},
+		},
+		{
+			name:            "Pod not in store but in mapping",
+			newPod:          pod1,
+			initialPodToCID: map[resource.Key]string{podResourceKey(pod1.Name, ns1.Name): cidName},
+			expected: expectedState{
+				queueSize:     1,
+				existsInQueue: []string{cidName},
+			},
+		},
+		{
+			name:         "New pod with no CID",
+			newPod:       pod1,
+			existingPods: []*slim_corev1.Pod{pod1},
+			expected: expectedState{
+				queueSize:           1,
+				numDesiredCIDLabels: 1,
+				expectedPods:        1,
+				expectedCIDs:        1,
+			},
+		},
+		{
+			name:         "Pod in store with CID not in mapping",
+			newPod:       pod1,
+			existingPods: []*slim_corev1.Pod{pod1},
+			existingCIDs: []*capi_v2.CiliumIdentity{testCreateCIDObjNs(cidName, pod1, ns1)},
+			expected: expectedState{
+				queueSize:           0,
+				numDesiredCIDLabels: 1,
+				expectedPods:        1,
+				expectedCIDs:        1,
+				expectedCID:         cidName,
+			},
+		},
+		{
+			name:            "Pod in store with CID and mapping",
+			newPod:          pod1,
+			existingPods:    []*slim_corev1.Pod{pod1},
+			existingCIDs:    []*capi_v2.CiliumIdentity{testCreateCIDObjNs(cidName, pod1, ns1)},
+			initialPodToCID: map[resource.Key]string{podResourceKey(pod1.Name, ns1.Name): cidName},
+			expected: expectedState{
+				queueSize:           0,
+				numDesiredCIDLabels: 1,
+				expectedPods:        1,
+				expectedCIDs:        1,
+				expectedCID:         cidName,
+			},
+		},
+		{
+			name:            "Multiple pods same CIDs",
+			newPod:          pod2,
+			existingPods:    []*slim_corev1.Pod{pod1, pod2},
+			existingCIDs:    []*capi_v2.CiliumIdentity{testCreateCIDObjNs(cidName, pod1, ns1)},
+			initialPodToCID: map[resource.Key]string{podResourceKey(pod1.Name, ns1.Name): cidName},
+			expected: expectedState{
+				queueSize:           0,
+				numDesiredCIDLabels: 1,
+				expectedPods:        2,
+				expectedCIDs:        1,
+				expectedCID:         cidName,
+			},
+		},
+		{
+			name:            "Pod with different labels",
+			newPod:          testCreatePodObj("pod1", ns1.Name, testLbsB, nil),
+			existingPods:    []*slim_corev1.Pod{testCreatePodObj("pod1", ns1.Name, testLbsB, nil)},
+			existingCIDs:    []*capi_v2.CiliumIdentity{testCreateCIDObjNs(cidName, pod1, ns1)},
+			initialPodToCID: map[resource.Key]string{podResourceKey(pod1.Name, ns1.Name): cidName},
+			expected: expectedState{
+				queueSize:           2,
+				numDesiredCIDLabels: 1,
+				expectedPods:        1,
+				expectedCIDs:        1,
+			},
+		},
+		{
+			name:            "Pod in store with CID and different mapping",
+			newPod:          pod1,
+			existingPods:    []*slim_corev1.Pod{pod1},
+			existingCIDs:    []*capi_v2.CiliumIdentity{testCreateCIDObjNs(cidName, pod1, ns1)},
+			initialPodToCID: map[resource.Key]string{podResourceKey(pod1.Name, ns1.Name): "2000"},
+			expected: expectedState{
+				queueSize:           1,
+				numDesiredCIDLabels: 1,
+				expectedPods:        1,
+				expectedCIDs:        1,
+				expectedCID:         cidName,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			reconciler, queueOps, _, cleanupFunc := testNewReconciler(t, ctx, false)
+			defer cleanupFunc()
+
+			for _, pod := range tc.existingPods {
+				_ = reconciler.nsStore.CacheStore().Add(testCreateNSObj(pod.GetNamespace(), nil))
+				_ = reconciler.podStore.CacheStore().Add(pod)
+			}
+			for _, cid := range tc.existingCIDs {
+				_ = reconciler.cidStore.CacheStore().Add(cid)
+			}
+			for podKey, cidName := range tc.initialPodToCID {
+				reconciler.cidUsageInPods.AssignCIDToPod(podKey.String(), cidName)
+			}
+
+			if err := reconciler.reconcilePod(podResourceKey(tc.newPod.Name, tc.newPod.Namespace)); err != nil {
+				t.Errorf("Unexpected error behavior: got error %v", err)
+			}
+
+			if tc.expected.queueSize != len(queueOps.fakeWorkQueue) {
+				t.Errorf("Queue size mismatch: expected %d, got %d", tc.expected.queueSize, len(queueOps.fakeWorkQueue))
+			}
+
+			for _, k := range tc.expected.existsInQueue {
+				if _, exists := queueOps.fakeWorkQueue[k]; !exists {
+					t.Errorf("Item missing from fake work queue: expected key '%s'", k)
+				}
+			}
+			if tc.expected.numDesiredCIDLabels != len(reconciler.desiredCIDState.idToLabels) {
+				t.Errorf("Number of desired CID labels mismatch: expected %d, got %d", tc.expected.numDesiredCIDLabels, len(reconciler.desiredCIDState.idToLabels))
+			}
+
+			testVerifyCIDUsageInPods(t, reconciler.cidUsageInPods, tc.expected.expectedCIDs, tc.expected.expectedPods)
+
+			if len(tc.expected.expectedCID) > 0 {
+				lbs, exists := reconciler.desiredCIDState.LookupByID(cidName)
+				if !exists {
+					t.Errorf("Expected CID %s not found in desiredCIDState", cidName)
+				}
+
+				expectedLbs := key.GetCIDKeyFromLabels(
+					k8sUtils.SanitizePodLabels(tc.newPod.ObjectMeta.Labels, ns1, "", ""),
+					labels.LabelSourceK8s,
+				).GetAsMap()
+
+				if diff := cmp.Diff(lbs.GetAsMap(), expectedLbs); diff != "" {
+					t.Errorf("Labels differ:\n%s", diff)
+				}
+			}
+
+		})
+	}
+}
+
+func TestReconcileNS(t *testing.T) {
+	ns1 := testCreateNSObj("ns1", nil)
+
+	pod1 := testCreatePodObj("pod1", ns1.Name, testLbsA, nil)
+	pod2 := testCreatePodObj("pod2", ns1.Name, testLbsA, nil)
+
+	testCases := []struct {
+		name              string
+		nsName            string
+		pods              []*slim_corev1.Pod
+		expectedQueueSize int
+	}{{
+		name:              "Empty NS",
+		nsName:            "ns1",
+		pods:              []*slim_corev1.Pod{},
+		expectedQueueSize: 0,
+	},
+		{
+			name:   "Unrelated NS",
+			nsName: "ns2",
+			pods: []*slim_corev1.Pod{
+				pod1,
+			},
+			expectedQueueSize: 0,
+		},
+		{
+			name:   "Multiple Pods",
+			nsName: ns1.Name,
+			pods: []*slim_corev1.Pod{
+				pod1,
+				pod2,
+			},
+			expectedQueueSize: 2,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			reconciler, queueOps, _, cleanupFunc := testNewReconciler(t, ctx, false)
+			defer cleanupFunc()
+
+			if err := reconciler.nsStore.CacheStore().Add(testCreateNSObj(tc.nsName, nil)); err != nil {
+				t.Errorf("Unexpected error behavior: got error %v", err)
+			}
+
+			for _, pod := range tc.pods {
+				if err := reconciler.podStore.CacheStore().Add(pod); err != nil {
+					t.Errorf("Unexpected error behavior: got error %v", err)
+				}
+			}
+
+			err := reconciler.reconcileNamespace(nsResourceKey(tc.nsName))
+
+			if err != nil {
+				t.Errorf("Unexpected error behavior: got error %v", err)
+			}
+			if tc.expectedQueueSize != len(queueOps.fakeWorkQueue) {
+				t.Errorf("Expected queue size %d, but got %d", tc.expectedQueueSize, len(queueOps.fakeWorkQueue))
+			}
+		})
+	}
+}
+
+func TestHandleStoreCIDMatch(t *testing.T) {
+	testCases := []struct {
+		name          string
+		cidList       []*capi_v2.CiliumIdentity
+		expectedCID   string
+		expectedError bool
+	}{
+		{
+			name:          "nil list",
+			cidList:       nil,
+			expectedCID:   "",
+			expectedError: true,
+		},
+		{
+			name:          "empty list",
+			cidList:       []*capi_v2.CiliumIdentity{},
+			expectedCID:   "",
+			expectedError: true,
+		},
+		{
+			name: "1 item in list",
+			cidList: []*capi_v2.CiliumIdentity{
+				{ObjectMeta: metav1.ObjectMeta{Name: "1000"}},
+			},
+			expectedCID:   "1000",
+			expectedError: false,
+		},
+		{
+			name: "3 items in list",
+			cidList: []*capi_v2.CiliumIdentity{
+				{ObjectMeta: metav1.ObjectMeta{Name: "1000"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "2000"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "3000"}},
+			},
+			expectedCID:   "1000",
+			expectedError: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			reconciler, _, _, cleanupFunc := testNewReconciler(t, ctx, false)
+			defer cleanupFunc()
+
+			cid, err := reconciler.handleStoreCIDMatch(tc.cidList)
+			assert.Equal(t, tc.expectedError, err != nil)
+			assert.Equal(t, tc.expectedCID, cid)
+		})
+	}
+}


### PR DESCRIPTION
Add the reconciler logic for reconciling CIDs, Pods, Namespaces when operator manages CIDs.

This changes are based on:
* https://github.com/cilium/cilium/pull/33383 which adds `Clium Identity Controller Operator hive cell`

-- The first commit can be ignored as it would bee reviewed and merged in the previous PR

Related https://github.com/cilium/cilium/issues/27752
Draft full implementation: https://github.com/cilium/cilium/pull/33204