### PR TITLE
operator: include CRD categories when applying cilium CRDs

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/register.go
+++ b/pkg/k8s/apis/cilium.io/client/register.go
@@ -401,6 +401,7 @@ func constructV1CRD(
 				Plural:     template.Spec.Names.Plural,
 				ShortNames: template.Spec.Names.ShortNames,
 				Singular:   template.Spec.Names.Singular,
+				Categories: template.Spec.Names.Categories,
 			},
 			Scope:      template.Spec.Scope,
 			Versions:   template.Spec.Versions,


### PR DESCRIPTION
Currently, when the Cilium Operator applies the Cilium CRDs to the cluster, the categories of the CRD aren't configured. This prevents listing all resources by category.

This commit fixes this by including the categories when applying the CRDs.