### PR TITLE
helm: Cleanup default values for old Cilium versions

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -1,12 +1,7 @@
 {{- if and .Values.agent (not .Values.preflight.enabled) }}
 
 {{- /*  Default values with backwards compatibility */ -}}
-{{- $defaultKeepDeprecatedProbes := true -}}
-
-{{- /* Default values when 1.8 was initially deployed */ -}}
-{{- if semverCompare ">=1.8" (default "1.8" .Values.upgradeCompatibility) -}}
-  {{- $defaultKeepDeprecatedProbes = false -}}
-{{- end -}}
+{{- $defaultKeepDeprecatedProbes := false -}}
 
 {{- $kubeProxyReplacement := (coalesce .Values.kubeProxyReplacement "false") -}}
 {{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1,7 +1,7 @@
 {{- if and ( or (.Values.agent) (.Values.operator.enabled) .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) (not .Values.preflight.enabled) }}
 {{- /*  Default values with backwards compatibility */ -}}
 {{- $defaultBpfMapDynamicSizeRatio := 0.0025 -}}
-{{- $defaultBpfMasquerade := "true" -}}
+{{- $defaultBpfMasquerade := "false" -}}
 {{- $defaultBpfClockProbe := "true" -}}
 {{- $defaultBpfTProxy := "false" -}}
 {{- $defaultIPAM := "cluster-pool" -}}
@@ -22,12 +22,6 @@
 {{- else -}}
   {{- $defaultOperatorApiServeAddr = "[::1]:9234" -}}
 {{- end }}
-
-{{- /* Default values when 1.10 was initially deployed */ -}}
-{{- if semverCompare ">=1.10" (default "1.10" .Values.upgradeCompatibility) -}}
-  {{- /* Needs to be explicitly disabled because it was enabled on all versions >=v1.8 above. */ -}}
-  {{- $defaultBpfMasquerade = "false" -}}
-{{- end -}}
 
 {{- /* Default values when 1.12 was initially deployed */ -}}
 {{- if semverCompare ">=1.12" (default "1.12" .Values.upgradeCompatibility) -}}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -30,12 +30,6 @@
   {{- end }}
   {{- $defaultBpfCtTcpMax = 0 -}}
   {{- $defaultBpfCtAnyMax = 0 -}}
-  {{- $defaultKubeProxyReplacement = "probe" -}}
-{{- end -}}
-
-{{- /* Default values when 1.9 was initially deployed */ -}}
-{{- if semverCompare ">=1.9" (default "1.9" .Values.upgradeCompatibility) -}}
-  {{- $defaultKubeProxyReplacement = "probe" -}}
 {{- end -}}
 
 {{- /* Default values when 1.10 was initially deployed */ -}}
@@ -49,14 +43,7 @@
   {{- if .Values.azure.enabled }}
       {{- $azureUsePrimaryAddress = "false" -}}
   {{- end }}
-  {{- $defaultKubeProxyReplacement = "disabled" -}}
   {{- $defaultDNSProxyEnableTransparentMode = "true" -}}
-{{- end -}}
-
-{{- /* Default values when 1.14 was initially deployed */ -}}
-{{- if semverCompare ">=1.14" (default "1.14" .Values.upgradeCompatibility) -}}
-  {{- /* KPR default for 1.14 needed to override earlier version defaults set above when upgradeCompatibility is not specified */ -}}
-  {{- $defaultKubeProxyReplacement = "false" -}}
 {{- end -}}
 
 {{- $ipam := (coalesce .Values.ipam.mode $defaultIPAM) -}}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -14,7 +14,7 @@
 {{- $azureUsePrimaryAddress := "true" -}}
 {{- $defaultK8sClientQPS := 5 -}}
 {{- $defaultK8sClientBurst := 10 -}}
-{{- $defaultDNSProxyEnableTransparentMode := "false" -}}
+{{- $defaultDNSProxyEnableTransparentMode := "true" -}}
 {{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
 
 {{- if .Values.ipv4.enabled }}
@@ -23,13 +23,9 @@
   {{- $defaultOperatorApiServeAddr = "[::1]:9234" -}}
 {{- end }}
 
-{{- /* Default values when 1.12 was initially deployed */ -}}
-{{- if semverCompare ">=1.12" (default "1.12" .Values.upgradeCompatibility) -}}
-  {{- if .Values.azure.enabled }}
-      {{- $azureUsePrimaryAddress = "false" -}}
-  {{- end }}
-  {{- $defaultDNSProxyEnableTransparentMode = "true" -}}
-{{- end -}}
+{{- if .Values.azure.enabled }}
+    {{- $azureUsePrimaryAddress = "false" -}}
+{{- end }}
 
 {{- $ipam := (coalesce .Values.ipam.mode $defaultIPAM) -}}
 {{- $bpfCtTcpMax := (coalesce .Values.bpf.ctTcpMax $defaultBpfCtTcpMax) -}}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1,13 +1,13 @@
 {{- if and ( or (.Values.agent) (.Values.operator.enabled) .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) (not .Values.preflight.enabled) }}
 {{- /*  Default values with backwards compatibility */ -}}
-{{- $defaultBpfMapDynamicSizeRatio := 0.0 -}}
-{{- $defaultBpfMasquerade := "false" -}}
-{{- $defaultBpfClockProbe := "false" -}}
+{{- $defaultBpfMapDynamicSizeRatio := 0.0025 -}}
+{{- $defaultBpfMasquerade := "true" -}}
+{{- $defaultBpfClockProbe := "true" -}}
 {{- $defaultBpfTProxy := "false" -}}
 {{- $defaultIPAM := "cluster-pool" -}}
 {{- $defaultOperatorApiServeAddr := "localhost:9234" -}}
-{{- $defaultBpfCtTcpMax := 524288 -}}
-{{- $defaultBpfCtAnyMax := 262144 -}}
+{{- $defaultBpfCtTcpMax := 0 -}}
+{{- $defaultBpfCtAnyMax := 0 -}}
 {{- $enableIdentityMark := "true" -}}
 {{- $fragmentTracking := "true" -}}
 {{- $defaultKubeProxyReplacement := "false" -}}
@@ -17,20 +17,11 @@
 {{- $defaultDNSProxyEnableTransparentMode := "false" -}}
 {{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
 
-{{- /* Default values when 1.8 was initially deployed */ -}}
-{{- if semverCompare ">=1.8" (default "1.8" .Values.upgradeCompatibility) -}}
-  {{- $defaultBpfMapDynamicSizeRatio = 0.0025 -}}
-  {{- $defaultBpfMasquerade = "true" -}}
-  {{- $defaultBpfClockProbe = "true" -}}
-  {{- $defaultIPAM = "cluster-pool" -}}
-  {{- if .Values.ipv4.enabled }}
-    {{- $defaultOperatorApiServeAddr = "127.0.0.1:9234" -}}
-  {{- else -}}
-    {{- $defaultOperatorApiServeAddr = "[::1]:9234" -}}
-  {{- end }}
-  {{- $defaultBpfCtTcpMax = 0 -}}
-  {{- $defaultBpfCtAnyMax = 0 -}}
-{{- end -}}
+{{- if .Values.ipv4.enabled }}
+  {{- $defaultOperatorApiServeAddr = "127.0.0.1:9234" -}}
+{{- else -}}
+  {{- $defaultOperatorApiServeAddr = "[::1]:9234" -}}
+{{- end }}
 
 {{- /* Default values when 1.10 was initially deployed */ -}}
 {{- if semverCompare ">=1.10" (default "1.10" .Values.upgradeCompatibility) -}}


### PR DESCRIPTION
Please refer to individual commit for more details, basically, the goal is to clean up old default values based for old upgradeCompatibility versions.