### PR TITLE
docs: Add Port Range Information

### DIFF
--- a/Documentation/network/kubernetes/policy.rst
+++ b/Documentation/network/kubernetes/policy.rst
@@ -52,8 +52,6 @@ Known missing features for Kubernetes Network Policy:
 +-------------------------------+-------------------+
 | SCTP                          | :gh-issue:`5719`  |
 +-------------------------------+-------------------+
-| Port ranges (endPort)         | :gh-issue:`16622` |
-+-------------------------------+-------------------+
 
 As of v1.15, ``ipBlock`` can now optionally select :ref:`node IPs <cidr_select_nodes>`. Previously,
 nodes were excluded from ``ipBlock``; see :gh-issue:`20550`.

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -719,10 +719,15 @@ which is defined as follows:
 
         // PortProtocol specifies an L4 port with an optional transport protocol
         type PortProtocol struct {
-                // Port is an L4 port number. For now the string will be strictly
-                // parsed as a single uint16. In the future, this field may support
-                // ranges in the form "1024-2048"
+                // Port can be an L4 port number, or a name in the form of "http"
+                // or "http-8080". EndPort is ignored if Port is a named port.
                 Port string `json:"port"`
+
+                // EndPort can only be an L4 port number. It is ignored when
+                // Port is a named port.
+                //
+                // +optional
+                EndPort int32 `json:"endPort,omitempty"`
 
                 // Protocol is the L4 protocol. If omitted or empty, any protocol
                 // matches. Accepted values: "TCP", "UDP", ""/"ANY"
@@ -752,6 +757,27 @@ only be able to emit packets using TCP on port 80, to any layer 3 destination:
 .. only:: epub or latex
 
         .. literalinclude:: ../../../examples/policies/l4/l4.json
+
+Example Port Ranges
+~~~~~~~~~~~~~~~~~~~
+
+The following rule limits all endpoints with the label ``app=myService`` to
+only be able to emit packets using TCP on ports 80-444, to any layer 3 destination:
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../../examples/policies/l4/l4_port_range.yaml
+     .. group-tab:: JSON
+
+        .. literalinclude:: ../../../examples/policies/l4/l4_port_range.json
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../../../examples/policies/l4/l4_port_range.json
+
 
 Labels-dependent Layer 4 rule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -928,6 +954,8 @@ latter rule will have no effect.
           protocol specific access denied message is crafted and returned, e.g.
           an *HTTP 403 access denied* is sent back for HTTP requests which
           violate the policy, or a *DNS REFUSED* response for DNS requests.
+
+.. note:: Layer 7 rules do not currently support port ranges.
 
 .. note:: There is currently a max limit of 40 ports with layer 7 policies per
           endpoint. This might change in the future when support for ranges is

--- a/examples/policies/l4/l4_port_range.json
+++ b/examples/policies/l4/l4_port_range.json
@@ -1,0 +1,9 @@
+[{
+    "labels": [{"key": "name", "value": "l4-rule"}],
+    "endpointSelector": {"matchLabels":{"app":"myService"}},
+    "egress": [{
+        "toPorts": [
+          {"ports":[ {"port": "80", "endPort": 444, "protocol": "TCP"}]}
+        ]
+    }]
+}]

--- a/examples/policies/l4/l4_port_range.yaml
+++ b/examples/policies/l4/l4_port_range.yaml
@@ -1,0 +1,14 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "l4-port-range-rule"
+spec:
+  endpointSelector:
+    matchLabels:
+      app: myService
+  egress:
+    - toPorts:
+      - ports:
+        - port: "80"
+          endPort: 444
+          protocol: TCP


### PR DESCRIPTION
~- SCTP and Port Ranges are now supported, both are removed from the unsupported features table.~
- DNS rules and L7 rules do not support port ranges yet. Notes are added to call attention to this.
- Add a Port Range example.

**Edit:**
- SCTP support will be addressed in a different PR.