### PR TITLE
clustermesh-apiserver: Document and warn against potential connectivity issue

### DIFF
--- a/Documentation/operations/troubleshooting_clustermesh.rst
+++ b/Documentation/operations/troubleshooting_clustermesh.rst
@@ -171,6 +171,22 @@ you may perform the following steps to troubleshoot ClusterMesh issues.
     * A firewall between the local cluster and the remote cluster may drop the
       control plane connection. Ensure that port 2379/TCP is allowed.
 
+    * The connection may fail to establish when all the following conditions
+      are met:
+
+      * tunneling is enabled,
+      * WireGuard encryption is enabled,
+      * any of the Host Firewall or node-to-node encryption is enabled, and
+      * a NodePort (and not a LoadBalancer) service is used to expose the clustermesh-apiserver
+
+      In this configuration, the connection may fail to establish because the
+      use of the Host Firewall causes traffic asymmetry (using native routing
+      device in one way, and encapsulation in the other way). If the setup for
+      WireGuard keys does not happen in a synchronous way for the nodes in the
+      different clusters, this asymmetry causes the connection's source node to
+      drop encrypted replies that it cannot process. For more details, see
+      :gh-issue:`31209`.
+
 State Propagation
 -----------------
 

--- a/Documentation/security/network/encryption-wireguard.rst
+++ b/Documentation/security/network/encryption-wireguard.rst
@@ -216,6 +216,19 @@ have WireGuard encryption enabled, i.e. mixed mode is currently not supported.
 In addition, UDP traffic between nodes of different clusters on port ``51871``
 must be allowed.
 
+Known limitations
+-----------------
+
+- When using WireGuard with the ``clustermesh-apiserver``, the following
+  combination of options is not supported:
+
+  - tunneling enabled,
+  - any of the Host Firewall or node-to-node encryption enabled, and
+  - the clustermesh-apiserver being exposed as a NodePort service.
+
+  This combination may result in a failure to establish the connection to the
+  ``clustermesh-apiserver``. For details, refer to :gh-issue:`31209`.
+
 .. _node-node-wg:
 
 Node-to-Node Encryption (beta)

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -1438,12 +1438,12 @@ Host Policies known issues
   supported:
 
   - Cilium operating in CRD mode (as opposed to KVstore mode),
-  - Host Policies enabled,
   - tunneling enabled,
-  - kube-proxy-replacement enabled, and
-  - WireGuard enabled.
+  - WireGuard enabled,
+  - Host Policies enabled or node-to-node encryption enabled, and
+  - the clustermesh-apiserver being exposed as a NodePort service.
 
-  This combination results in a failure to connect to the
+  This combination may result in a failure to connect to the
   clustermesh-apiserver. For details, refer to :gh-issue:`31209`.
 
 - Host Policies do not work on host WireGuard interfaces. For details, see

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -115,6 +115,9 @@
   {{- if .Values.disableEndpointCRD }}
     {{ fail "The clustermesh-apiserver cannot be enabled in combination with .Values.disableEndpointCRD=true" }}
   {{- end }}
+  {{- if and (or (eq .Values.routingMode "") (eq .Values.routingMode "tunnel")) (and .Values.encryption.enabled (eq .Values.encryption.type "wireguard")) (or .Values.hostFirewall.enabled .Values.encryption.nodeEncryption) (eq .Values.clustermesh.apiserver.service.type "NodePort") }}
+    {{ fail "The clustermesh-apiserver cannot be exposed as a NodePort service when used in combination with tunneling, WireGuard encryption, and any of the Host Firewall or node-to-node encryption. For details, refer to https://github.com/cilium/cilium/issues/31209." }}
+  {{- end }}
 {{- end }}
 {{- if .Values.externalWorkloads.enabled }}
   {{- if ne .Values.identityAllocationMode "crd" }}


### PR DESCRIPTION
- **docs: List clustermesh-apiserver limitation in troubleshooting section**
- **helm: Add check for clustermesh-apiserver + KPR/tunnel/WireGuard/HFW**

Relates to: https://github.com/cilium/cilium/issues/31209
