### PR TITLE
bgpv2: Fix defaulting of BGP peer config

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/peer_advertisements.go
+++ b/pkg/bgpv1/manager/reconcilerv2/peer_advertisements.go
@@ -65,6 +65,10 @@ func (p *CiliumPeerAdvertisement) GetConfiguredAdvertisements(conf *v2alpha1.Cil
 	for _, peer := range conf.Peers {
 		lp := l.WithField(types.PeerLogField, peer.Name)
 
+		if peer.PeerConfigRef == nil || peer.PeerConfigRef.Name == "" {
+			lp.Debug("Peer config not specified, skipping advertisement check")
+			continue
+		}
 		peerConfig, exist, err := p.peerConfig.GetByKey(resource.Key{Name: peer.PeerConfigRef.Name})
 		if err != nil {
 			if errors.Is(err, store.ErrStoreUninitialized) {
@@ -72,7 +76,6 @@ func (p *CiliumPeerAdvertisement) GetConfiguredAdvertisements(conf *v2alpha1.Cil
 			}
 			return nil, err
 		}
-
 		if !exist {
 			lp.Debug("Peer config not found, skipping advertisement check")
 			continue


### PR DESCRIPTION
Fixes a crash when PeerConfigRef is not specified & uses the default peer config only when PeerConfigRef is not specified in `CiliumBGPClusterConfig` / `CiliumBGPNodeConfig`. If it is specified but not existing, skips the peer configuration instead of using the default values.

This avoids unnecessary session reset during session setup when both `CiliumBGPClusterConfig` and `CiliumBGPPeerConfig` are configured in a single batch, but PeerConfig does not exist yet at the time of processing the ClusterConfig / NodeConfig.

It also makes it more obvious for the users if they misspell the peer config name in the `PeerConfigRef` (peer will not be configured instead of configuring it with the default config).

```release-note
bgpv2: Fix defaulting of BGP peer config, use the default peer config only when PeerConfigRef is not specified in CiliumBGPClusterConfig.
```
