### PR TITLE
Revert "IPAM: Adds AWS IPv6 Prefix Delegation Config Option"

### DIFF
--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -132,12 +132,9 @@ const (
 	// Defaults to 180 secs
 	ExcessIPReleaseDelay = "excess-ip-release-delay"
 
-	// AWSEnablePrefixDelegation allows operator to allocate IPv4 prefixes to ENIs on nitro instances instead of individual
+	// AWSEnablePrefixDelegation allows operator to allocate prefixes to ENIs on nitro instances instead of individual
 	// IP addresses. Allows for increased pod density on nodes.
 	AWSEnablePrefixDelegation = "aws-enable-prefix-delegation"
-
-	// AWSEnableIPv6PrefixDelegation allows operator to allocate IPv6 prefixes to ENIs on nitro instances.
-	AWSEnableIPv6PrefixDelegation = "aws-enable-ipv6-prefix-delegation"
 
 	// ENITags are the tags that will be added to every ENI created by the
 	// AWS ENI IPAM.
@@ -347,12 +344,9 @@ type OperatorConfig struct {
 	// the number of API calls to AWS EC2 service.
 	AWSReleaseExcessIPs bool
 
-	// AWSEnablePrefixDelegation allows operator to allocate IPv4 prefixes to ENIs on nitro instances instead of individual
+	// AWSEnablePrefixDelegation allows operator to allocate prefixes to ENIs on nitro instances instead of individual
 	// IP addresses. Allows for increased pod density on nodes.
 	AWSEnablePrefixDelegation bool
-
-	// AWSEnablePrefixDelegation allows operator to allocate IPv6 prefixes to ENIs on nitro instances.
-	AWSEnableIPv6PrefixDelegation bool
 
 	// AWSUsePrimaryAddress specifies whether an interface's primary address should be available for allocations on
 	// node
@@ -483,7 +477,6 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 
 	c.AWSReleaseExcessIPs = vp.GetBool(AWSReleaseExcessIPs)
 	c.AWSEnablePrefixDelegation = vp.GetBool(AWSEnablePrefixDelegation)
-	c.AWSEnableIPv6PrefixDelegation = vp.GetBool(AWSEnableIPv6PrefixDelegation)
 	c.AWSUsePrimaryAddress = vp.GetBool(AWSUsePrimaryAddress)
 	c.UpdateEC2AdapterLimitViaAPI = vp.GetBool(UpdateEC2AdapterLimitViaAPI)
 	c.EC2APIEndpoint = vp.GetString(EC2APIEndpoint)

--- a/pkg/alibabacloud/eni/node_test.go
+++ b/pkg/alibabacloud/eni/node_test.go
@@ -66,7 +66,7 @@ func TestCreateInterface(t *testing.T) {
 	alibabaAPI.UpdateENIs(primaryENIs)
 	instances.Resync(context.TODO())
 
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -119,7 +119,7 @@ func TestCandidateAndEmptyInterfaces(t *testing.T) {
 	alibabaAPI.UpdateENIs(primaryENIs)
 	instances.Resync(context.TODO())
 
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 	// Set PreAllocate as 1
@@ -150,7 +150,7 @@ func TestPrepareIPAllocation(t *testing.T) {
 	alibabaAPI.UpdateENIs(primaryENIs)
 	instances.Resync(context.TODO())
 
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 	mngr.SetInstancesAPIReadiness(false) // to avoid the manager background jobs starting and racing us.

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -67,7 +67,7 @@ func TestGetNodeNames(t *testing.T) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
 	require.NotNil(t, instances)
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -96,7 +96,7 @@ func TestNodeManagerGet(t *testing.T) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
 	require.NotNil(t, instances)
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -131,7 +131,7 @@ func TestNodeManagerDefaultAllocation(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -176,7 +176,7 @@ func TestNodeManagerPrefixDelegation(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, true, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, true)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -245,7 +245,7 @@ func TestNodeManagerENIWithSGTags(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -305,7 +305,7 @@ func TestNodeManagerMinAllocate20(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -361,7 +361,7 @@ func TestNodeManagerMinAllocateAndPreallocate(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -426,7 +426,7 @@ func TestNodeManagerReleaseAddress(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, true, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, true, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -533,7 +533,7 @@ func TestNodeManagerENIExcludeInterfaceTags(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -596,7 +596,7 @@ func TestNodeManagerExceedENICapacity(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -654,7 +654,7 @@ func TestInterfaceCreatedInInitialSubnet(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -712,7 +712,7 @@ func TestNodeManagerManyNodes(t *testing.T) {
 
 	ec2api := ec2mock.NewAPI(subnets, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instancesManager := NewInstancesManager(ec2api)
-	mngr, err := ipam.NewNodeManager(instancesManager, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instancesManager, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -787,7 +787,7 @@ func TestNodeManagerInstanceNotRunning(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	ec2api.SetMockError(ec2mock.AttachNetworkInterface, errors.New("foo is not 'running' foo"))
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -836,7 +836,7 @@ func TestInstanceBeenDeleted(t *testing.T) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 1, instanceID, eniID2)
 	require.NoError(t, err)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -881,7 +881,7 @@ func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rate
 	ec2api.SetLimiter(rateLimit, burst)
 	instances := NewInstancesManager(ec2api)
 	require.NotNil(b, instances)
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(b, err)
 	require.NotNil(b, mngr)
 

--- a/pkg/azure/ipam/ipam_test.go
+++ b/pkg/azure/ipam/ipam_test.go
@@ -171,7 +171,7 @@ func TestIpamPreAllocate8(t *testing.T) {
 	instances.Resync(context.TODO())
 
 	k8sapi := newK8sMock()
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsmock.NewMockMetrics(), 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -233,7 +233,7 @@ func TestIpamMinAllocate10(t *testing.T) {
 	instances.Resync(context.TODO())
 
 	k8sapi := newK8sMock()
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsmock.NewMockMetrics(), 10, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -296,7 +296,7 @@ func TestIpamManyNodes(t *testing.T) {
 
 			k8sapi := newK8sMock()
 			metrics := metricsmock.NewMockMetrics()
-			mngr, err := ipam.NewNodeManager(instances, k8sapi, metrics, int64(test.concurrency), false, false, false)
+			mngr, err := ipam.NewNodeManager(instances, k8sapi, metrics, int64(test.concurrency), false, false)
 			require.NoError(t, err)
 			require.NotNil(t, mngr)
 
@@ -371,7 +371,7 @@ func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rate
 
 	k8sapi := newK8sMock()
 	metrics := metricsmock.NewMockMetrics()
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metrics, workers, false, false, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metrics, workers, false, false)
 	require.NoError(b, err)
 	require.NotNil(b, mngr)
 

--- a/pkg/ipam/allocator/alibabacloud/alibabacloud.go
+++ b/pkg/ipam/allocator/alibabacloud/alibabacloud.go
@@ -101,7 +101,7 @@ func (a *AllocatorAlibabaCloud) Start(ctx context.Context, getterUpdater ipam.Ci
 	}
 	instances := eni.NewInstancesManager(a.client)
 	nodeManager, err := ipam.NewNodeManager(instances, getterUpdater, iMetrics,
-		operatorOption.Config.ParallelAllocWorkers, operatorOption.Config.AlibabaCloudReleaseExcessIPs, false, false)
+		operatorOption.Config.ParallelAllocWorkers, operatorOption.Config.AlibabaCloudReleaseExcessIPs, false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize AlibabaCloud node manager: %w", err)
 	}

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -123,7 +123,7 @@ func (a *AllocatorAWS) Start(ctx context.Context, getterUpdater ipam.CiliumNodeG
 	instances := eni.NewInstancesManager(a.client)
 	nodeManager, err := ipam.NewNodeManager(instances, getterUpdater, iMetrics,
 		operatorOption.Config.ParallelAllocWorkers, operatorOption.Config.AWSReleaseExcessIPs,
-		operatorOption.Config.AWSEnablePrefixDelegation, operatorOption.Config.AWSEnableIPv6PrefixDelegation)
+		operatorOption.Config.AWSEnablePrefixDelegation)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize ENI node manager: %w", err)
 	}

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -79,7 +79,7 @@ func (*AllocatorAzure) Start(ctx context.Context, getterUpdater ipam.CiliumNodeG
 		return nil, fmt.Errorf("unable to create Azure client: %w", err)
 	}
 	instances := azureIPAM.NewInstancesManager(azureClient)
-	nodeManager, err := ipam.NewNodeManager(instances, getterUpdater, iMetrics, operatorOption.Config.ParallelAllocWorkers, false, false, false)
+	nodeManager, err := ipam.NewNodeManager(instances, getterUpdater, iMetrics, operatorOption.Config.ParallelAllocWorkers, false, false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize Azure node manager: %w", err)
 	}

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -86,8 +86,7 @@ type Node struct {
 	// ipv4Alloc represents IPv4-specific allocation attributes for this node
 	ipv4Alloc ipAllocAttrs
 
-	// ipv6Alloc represents IPv6-specific allocation attributes for this node
-	ipv6Alloc ipAllocAttrs
+	// TODO: Add support for IPv6 allocation: https://github.com/cilium/cilium/issues/19251
 
 	// resyncNeeded is set to the current time when a resync with the EC2
 	// API is required. The timestamp is required to ensure that this is

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -165,16 +165,15 @@ type nodeMap map[string]*Node
 
 // NodeManager manages all nodes with ENIs
 type NodeManager struct {
-	mutex                lock.RWMutex
-	nodes                nodeMap
-	instancesAPI         AllocationImplementation
-	k8sAPI               CiliumNodeGetterUpdater
-	metricsAPI           MetricsAPI
-	parallelWorkers      int64
-	releaseExcessIPs     bool
-	stableInstancesAPI   bool
-	prefixDelegation     bool
-	ipv6PrefixDelegation bool
+	mutex              lock.RWMutex
+	nodes              nodeMap
+	instancesAPI       AllocationImplementation
+	k8sAPI             CiliumNodeGetterUpdater
+	metricsAPI         MetricsAPI
+	parallelWorkers    int64
+	releaseExcessIPs   bool
+	stableInstancesAPI bool
+	prefixDelegation   bool
 }
 
 func (n *NodeManager) ClusterSizeDependantInterval(baseInterval time.Duration) time.Duration {
@@ -187,20 +186,19 @@ func (n *NodeManager) ClusterSizeDependantInterval(baseInterval time.Duration) t
 
 // NewNodeManager returns a new NodeManager
 func NewNodeManager(instancesAPI AllocationImplementation, k8sAPI CiliumNodeGetterUpdater, metrics MetricsAPI,
-	parallelWorkers int64, releaseExcessIPs bool, prefixDelegation, ipv6prefixDelegation bool) (*NodeManager, error) {
+	parallelWorkers int64, releaseExcessIPs bool, prefixDelegation bool) (*NodeManager, error) {
 	if parallelWorkers < 1 {
 		parallelWorkers = 1
 	}
 
 	mngr := &NodeManager{
-		nodes:                nodeMap{},
-		instancesAPI:         instancesAPI,
-		k8sAPI:               k8sAPI,
-		metricsAPI:           metrics,
-		parallelWorkers:      parallelWorkers,
-		releaseExcessIPs:     releaseExcessIPs,
-		prefixDelegation:     prefixDelegation,
-		ipv6PrefixDelegation: ipv6prefixDelegation,
+		nodes:            nodeMap{},
+		instancesAPI:     instancesAPI,
+		k8sAPI:           k8sAPI,
+		metricsAPI:       metrics,
+		parallelWorkers:  parallelWorkers,
+		releaseExcessIPs: releaseExcessIPs,
+		prefixDelegation: prefixDelegation,
 	}
 
 	// Assume readiness, the initial blocking resync in Start() will update
@@ -290,13 +288,6 @@ func (n *NodeManager) Upsert(resource *v2.CiliumNode) {
 				ipsMarkedForRelease: make(map[string]time.Time),
 				ipReleaseStatus:     make(map[string]string),
 			},
-		}
-
-		if n.ipv6PrefixDelegation {
-			node.ipv6Alloc = ipAllocAttrs{
-				ipsMarkedForRelease: make(map[string]time.Time),
-				ipReleaseStatus:     make(map[string]string),
-			}
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -432,7 +423,7 @@ func (n *NodeManager) Get(nodeName string) *Node {
 	return node
 }
 
-// GetNodesByIPWatermarkLocked returns all nodes that require IPv4 addresses to be
+// GetNodesByIPWatermarkLocked returns all nodes that require addresses to be
 // allocated or released, sorted by the number of addresses needed to be operated
 // in descending order. Number of addresses to be released is negative value
 // so that nodes with IP deficit are resolved first

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -181,7 +181,7 @@ func (n *nodeOperationsMock) IsPrefixDelegated() bool {
 func TestGetNodeNames(t *testing.T) {
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
-	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -207,7 +207,7 @@ func TestGetNodeNames(t *testing.T) {
 func TestNodeManagerGet(t *testing.T) {
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
-	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -226,7 +226,7 @@ func TestNodeManagerDelete(t *testing.T) {
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
 	metrics := metricsmock.NewMockMetrics()
-	mngr, err := NewNodeManager(am, k8sapi, metrics, 10, false, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metrics, 10, false, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -325,7 +325,7 @@ func reachedAddressesNeeded(mngr *NodeManager, nodeName string, needed int) (suc
 func TestNodeManagerDefaultAllocation(t *testing.T) {
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
-	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -356,7 +356,7 @@ func TestNodeManagerDefaultAllocation(t *testing.T) {
 func TestNodeManagerMinAllocate20(t *testing.T) {
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
-	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -396,7 +396,7 @@ func TestNodeManagerMinAllocate20(t *testing.T) {
 func TestNodeManagerMinAllocateAndPreallocate(t *testing.T) {
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
-	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -445,7 +445,7 @@ func TestNodeManagerReleaseAddress(t *testing.T) {
 	operatorOption.Config.ExcessIPReleaseDelay = 2
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
-	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, true, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, true, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -516,7 +516,7 @@ func TestNodeManagerAbortRelease(t *testing.T) {
 	operatorOption.Config.ExcessIPReleaseDelay = 2
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
-	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, true, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, true, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -603,7 +603,7 @@ func TestNodeManagerManyNodes(t *testing.T) {
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
 	metricsapi := metricsmock.NewMockMetrics()
-	mngr, err := NewNodeManager(am, k8sapi, metricsapi, 10, false, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsapi, 10, false, false)
 	require.Nil(t, err)
 	require.NotNil(t, mngr)
 
@@ -647,7 +647,7 @@ func TestNodeManagerManyNodes(t *testing.T) {
 func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rateLimit float64, burst int) {
 	am := newAllocationImplementationMock()
 	require.NotNil(b, am)
-	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false, false)
+	mngr, err := NewNodeManager(am, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
 	require.Nil(b, err)
 	require.NotNil(b, mngr)
 


### PR DESCRIPTION
Reverts cilium/cilium#31145 due to https://github.com/cilium/cilium/pull/32352 not landing in time for v1.16.0.