### PR TITLE
fix edge case in cidrGroupRefs

### DIFF
--- a/pkg/policy/k8s/cilium_cidr_group.go
+++ b/pkg/policy/k8s/cilium_cidr_group.go
@@ -222,16 +222,34 @@ func translateCIDRGroupRefs(cnp *types.SlimCNP, cidrsSets map[string][]api.CIDR)
 
 func translateSpec(spec *api.Rule, cidrsSets map[string][]api.CIDR) {
 	for i := range spec.Ingress {
-		spec.Ingress[i].FromCIDRSet = translateCIDRRuleSlice(spec.Ingress[i].FromCIDRSet, cidrsSets)
+		cidrSet := translateCIDRRuleSlice(spec.Ingress[i].FromCIDRSet, cidrsSets)
+		// Careful to distinguish between nil (unset, selecting everything) and
+		// empty list (selecting nothing), hence this overly explicit code.
+		if cidrSet == nil {
+			cidrSet = make([]api.CIDRRule, 0)
+		}
+		spec.Ingress[i].FromCIDRSet = cidrSet
 	}
 	for i := range spec.IngressDeny {
-		spec.IngressDeny[i].FromCIDRSet = translateCIDRRuleSlice(spec.IngressDeny[i].FromCIDRSet, cidrsSets)
+		cidrSet := translateCIDRRuleSlice(spec.IngressDeny[i].FromCIDRSet, cidrsSets)
+		if cidrSet == nil {
+			cidrSet = make([]api.CIDRRule, 0)
+		}
+		spec.IngressDeny[i].FromCIDRSet = cidrSet
 	}
 	for i := range spec.Egress {
-		spec.Egress[i].ToCIDRSet = translateCIDRRuleSlice(spec.Egress[i].ToCIDRSet, cidrsSets)
+		cidrSet := translateCIDRRuleSlice(spec.Egress[i].ToCIDRSet, cidrsSets)
+		if cidrSet == nil {
+			cidrSet = make([]api.CIDRRule, 0)
+		}
+		spec.Egress[i].ToCIDRSet = cidrSet
 	}
 	for i := range spec.EgressDeny {
-		spec.EgressDeny[i].ToCIDRSet = translateCIDRRuleSlice(spec.EgressDeny[i].ToCIDRSet, cidrsSets)
+		cidrSet := translateCIDRRuleSlice(spec.EgressDeny[i].ToCIDRSet, cidrsSets)
+		if cidrSet == nil {
+			cidrSet = make([]api.CIDRRule, 0)
+		}
+		spec.EgressDeny[i].ToCIDRSet = cidrSet
 	}
 }
 

--- a/pkg/policy/k8s/cilium_cidr_group_test.go
+++ b/pkg/policy/k8s/cilium_cidr_group_test.go
@@ -1091,13 +1091,35 @@ func TestCIDRGroupRefsToCIDRsSets(t *testing.T) {
 		refs     []string
 		cache    map[string]*cilium_v2_alpha1.CiliumCIDRGroup
 		expected map[string][]api.CIDR
-		err      error
+		err      string
 	}{
 		{
 			name:     "nil refs",
 			refs:     nil,
 			cache:    map[string]*cilium_v2_alpha1.CiliumCIDRGroup{},
 			expected: map[string][]api.CIDR{},
+		},
+		{
+			name: "missing refs",
+			err:  "cidr group \"missing\" not found, skipping translation",
+			refs: []string{"missing", "cidr-group-1"},
+			cache: map[string]*cilium_v2_alpha1.CiliumCIDRGroup{
+				"cidr-group-1": {
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2alpha1",
+						Kind:       "CiliumCIDRGroup",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cidr-group-1",
+					},
+					Spec: cilium_v2_alpha1.CiliumCIDRGroupSpec{
+						ExternalCIDRs: []api.CIDR{api.CIDR("1.1.1.1/32"), api.CIDR("2.2.2.2/32")},
+					},
+				},
+			},
+			expected: map[string][]api.CIDR{
+				"cidr-group-1": {"1.1.1.1/32", "2.2.2.2/32"},
+			},
 		},
 		{
 			name: "with refs",
@@ -1139,8 +1161,10 @@ func TestCIDRGroupRefsToCIDRsSets(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			p := &policyWatcher{cidrGroupCache: tc.cache}
 			got, err := p.cidrGroupRefsToCIDRsSets(tc.refs)
-			if err != nil {
+			if err != nil && tc.err == "" {
 				t.Fatalf("unexpected error from cidrGroupRefsToCIDRsSets: %s", err)
+			} else if err != nil && err.Error() != tc.err {
+				t.Fatalf("unexpected error divergence from cidrGroupRefsToCIDRsSets: %s != %s", err, tc.err)
 			}
 			if !reflect.DeepEqual(got, tc.expected) {
 				t.Fatalf("expected cidr sets to be %v, got %v", tc.expected, got)

--- a/pkg/policy/k8s/cilium_cidr_group_test.go
+++ b/pkg/policy/k8s/cilium_cidr_group_test.go
@@ -1538,7 +1538,7 @@ func TestCIDRGroupRefsTranslate(t *testing.T) {
 								},
 								{
 									IngressCommonRule: api.IngressCommonRule{
-										FromCIDRSet: nil,
+										FromCIDRSet: []api.CIDRRule{}, // Empty list, not nil!
 									},
 								},
 							},
@@ -1560,7 +1560,7 @@ func TestCIDRGroupRefsTranslate(t *testing.T) {
 								},
 								{
 									EgressCommonRule: api.EgressCommonRule{
-										ToCIDRSet: nil,
+										ToCIDRSet: []api.CIDRRule{}, // Empty list, not nil!
 									},
 								},
 							},
@@ -1671,7 +1671,7 @@ func TestCIDRGroupRefsTranslate(t *testing.T) {
 								},
 								{
 									IngressCommonRule: api.IngressCommonRule{
-										FromCIDRSet: nil,
+										FromCIDRSet: []api.CIDRRule{}, // Empty list, not nil!
 									},
 								},
 							},
@@ -1782,7 +1782,7 @@ func TestCIDRGroupRefsTranslate(t *testing.T) {
 								},
 								{
 									EgressCommonRule: api.EgressCommonRule{
-										ToCIDRSet: nil,
+										ToCIDRSet: []api.CIDRRule{}, // Empty list, not nil!
 									},
 								},
 							},


### PR DESCRIPTION
relevant, second commit msg reproduced for convenience, first commit simply adds a missing test.

```
When current code translates a CNP with _only_ a dangling cidrGroupRef,
it fails distinguish between nil (meaning an unset selector, selecting
everything) and the empty list (selecting nothing). This leads to
bizarre situations, such as the following. With "dangling" pointing to a
non-existant cidrGroup, the CNP below allowed egress traffic to port 80
instead of denying it.

  egress:
  - toCIDRSet: [{cidrGroupRef: dangling}]
    toPorts: ( ... 80 ... )

To fix this, transform the nil to an empty list in an overly explicit
manner to make clear why this is necessary. It's somewhat subtle as in
Go, most of the time, nil and empty list are equivalent, hence be
explicit to avoid an easy refactor breaking this again. In addition, of
course, adapt the tests so that they would catch it too.
```

Fixes: #32735 

```release-note
Cilium now correctly handles the case when a to/fromCIDRSet policy _only_ contains a cidrGroupRef to a non-existent cidrGroup by denying traffic.
```
