### PR TITLE
Extend the check-ipsec-leak bpftrace script to capture additional details of leaked packets

### DIFF
--- a/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
@@ -83,11 +83,12 @@ kprobe:br_forward
         @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol];
 
     if (($src_is_pod && $dst_is_pod) || ($trace_override && ($src_is_pod || $dst_is_pod))) {
-      printf("[%s] %s:%d -> %s:%d (proto: %d, ifindex: %d, netns: %x)\n",
+      printf("[%s] %s:%d -> %s:%d (proto: %d, encap: %d, ifindex: %d, netns: %x)\n",
         strftime("%H:%M:%S:%f", nsecs),
         ntop($ip4h->saddr), bswap($udph->source),
         ntop($ip4h->daddr), bswap($udph->dest),
         $ip4h->protocol,
+        $skb->encapsulation,
         $skb->dev->ifindex,
         $skb->dev->nd_net.net->ns.inum);
     }
@@ -102,11 +103,12 @@ kprobe:br_forward
         @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr];
 
     if (($src_is_pod && $dst_is_pod) || ($trace_override && ($src_is_pod || $dst_is_pod))) {
-      printf("[%s] %s:%d -> %s:%d (proto: %d, ifindex: %d, netns: %x)\n",
+      printf("[%s] %s:%d -> %s:%d (proto: %d, encap: %d, ifindex: %d, netns: %x)\n",
         strftime("%H:%M:%S:%f", nsecs),
         ntop($ip6h->saddr.in6_u.u6_addr8), bswap($udph->source),
         ntop($ip6h->daddr.in6_u.u6_addr8), bswap($udph->dest),
         $ip6h->nexthdr,
+        $skb->encapsulation,
         $skb->dev->ifindex,
         $skb->dev->nd_net.net->ns.inum);
     }

--- a/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
@@ -27,6 +27,14 @@
 #define TYPE_PROXY_DNS_IP4 3
 #define TYPE_PROXY_DNS_IP6 4
 
+// Character literals don't appear be supported, hence this hack.
+// https://github.com/bpftrace/bpftrace/issues/3278
+#define CH_A 0x41   // 'A'
+#define CH_F 0x46   // 'F'
+#define CH_R 0x52   // 'R'
+#define CH_S 0x53   // 'S'
+#define CH_DOT 0x2E // '.'
+
 struct dnshdr {
   u16 id;
   u16 flags;
@@ -92,11 +100,16 @@ kprobe:br_forward
         @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol];
 
     if (($src_is_pod && $dst_is_pod) || ($trace_override && ($src_is_pod || $dst_is_pod))) {
-      printf("[%s] %s:%d -> %s:%d (proto: %d, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
+      $tcph = (struct tcphdr*)$udph;
+      printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
         strftime("%H:%M:%S:%f", nsecs),
         ntop($ip4h->saddr), bswap($udph->source),
         ntop($ip4h->daddr), bswap($udph->dest),
         $ip4h->protocol,
+        $ip4h->protocol == PROTO_TCP && $tcph->syn ? CH_S : CH_DOT,
+        $ip4h->protocol == PROTO_TCP && $tcph->ack ? CH_A : CH_DOT,
+        $ip4h->protocol == PROTO_TCP && $tcph->fin ? CH_F : CH_DOT,
+        $ip4h->protocol == PROTO_TCP && $tcph->rst ? CH_R : CH_DOT,
         $skb->encapsulation,
         $skb->dev->ifindex,
         $skb->dev->nd_net.net->ns.inum,
@@ -123,11 +136,16 @@ kprobe:br_forward
         @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr];
 
     if (($src_is_pod && $dst_is_pod) || ($trace_override && ($src_is_pod || $dst_is_pod))) {
-      printf("[%s] %s:%d -> %s:%d (proto: %d, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
+      $tcph = (struct tcphdr*)$udph;
+      printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
         strftime("%H:%M:%S:%f", nsecs),
         ntop($ip6h->saddr.in6_u.u6_addr8), bswap($udph->source),
         ntop($ip6h->daddr.in6_u.u6_addr8), bswap($udph->dest),
         $ip6h->nexthdr,
+        $ip6h->nexthdr == PROTO_TCP && $tcph->syn ? CH_S : CH_DOT,
+        $ip6h->nexthdr == PROTO_TCP && $tcph->ack ? CH_A : CH_DOT,
+        $ip6h->nexthdr == PROTO_TCP && $tcph->fin ? CH_F : CH_DOT,
+        $ip6h->nexthdr == PROTO_TCP && $tcph->rst ? CH_R : CH_DOT,
         $skb->encapsulation,
         $skb->dev->ifindex,
         $skb->dev->nd_net.net->ns.inum,

--- a/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
@@ -27,6 +27,15 @@
 #define TYPE_PROXY_DNS_IP4 3
 #define TYPE_PROXY_DNS_IP6 4
 
+struct dnshdr {
+  u16 id;
+  u16 flags;
+  u16 qdcount;
+  u16 ancount;
+  u16 nscount;
+  u16 arcount;
+}
+
 kprobe:br_forward
 {
   $skb = ((struct sk_buff *) arg1);
@@ -91,6 +100,16 @@ kprobe:br_forward
         $skb->encapsulation,
         $skb->dev->ifindex,
         $skb->dev->nd_net.net->ns.inum);
+
+      if ($ip4h->protocol == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
+        $dns = (struct dnshdr*)($udph + 1);
+        $query = (uint8 *)($dns + 1);
+        printf("[%s] Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
+          strftime("%H:%M:%S:%f", nsecs),
+          bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
+          bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
+          str(kptr($query)));
+      }
     }
   }
 
@@ -111,6 +130,16 @@ kprobe:br_forward
         $skb->encapsulation,
         $skb->dev->ifindex,
         $skb->dev->nd_net.net->ns.inum);
+
+      if ($ip6h->nexthdr == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
+        $dns = (struct dnshdr*)($udph + 1);
+        $query = (uint8 *)($dns + 1);
+        printf("[%s] Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
+          strftime("%H:%M:%S:%f", nsecs),
+          bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
+          bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
+          str(kptr($query)));
+      }
     }
   }
 }

--- a/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
@@ -92,14 +92,15 @@ kprobe:br_forward
         @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol];
 
     if (($src_is_pod && $dst_is_pod) || ($trace_override && ($src_is_pod || $dst_is_pod))) {
-      printf("[%s] %s:%d -> %s:%d (proto: %d, encap: %d, ifindex: %d, netns: %x)\n",
+      printf("[%s] %s:%d -> %s:%d (proto: %d, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
         strftime("%H:%M:%S:%f", nsecs),
         ntop($ip4h->saddr), bswap($udph->source),
         ntop($ip4h->daddr), bswap($udph->dest),
         $ip4h->protocol,
         $skb->encapsulation,
         $skb->dev->ifindex,
-        $skb->dev->nd_net.net->ns.inum);
+        $skb->dev->nd_net.net->ns.inum,
+        $trace_override);
 
       if ($ip4h->protocol == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
         $dns = (struct dnshdr*)($udph + 1);
@@ -122,14 +123,15 @@ kprobe:br_forward
         @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr];
 
     if (($src_is_pod && $dst_is_pod) || ($trace_override && ($src_is_pod || $dst_is_pod))) {
-      printf("[%s] %s:%d -> %s:%d (proto: %d, encap: %d, ifindex: %d, netns: %x)\n",
+      printf("[%s] %s:%d -> %s:%d (proto: %d, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
         strftime("%H:%M:%S:%f", nsecs),
         ntop($ip6h->saddr.in6_u.u6_addr8), bswap($udph->source),
         ntop($ip6h->daddr.in6_u.u6_addr8), bswap($udph->dest),
         $ip6h->nexthdr,
         $skb->encapsulation,
         $skb->dev->ifindex,
-        $skb->dev->nd_net.net->ns.inum);
+        $skb->dev->nd_net.net->ns.inum,
+        $trace_override);
 
       if ($ip6h->nexthdr == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
         $dns = (struct dnshdr*)($udph + 1);


### PR DESCRIPTION
We have been recently witnessing a few [conformance ipsec runs reporting leaked packets](https://github.com/cilium/cilium/issues/33084), with some referring to DNS answers from a coredns pod to a CiliumInternalIP. In order to simplify troubleshooting these issues, and figure out whether they are legitimate or flakes, let's additionally print whether the detected packet was encapsulated or not, and whether it matched a "trace_override". Moreover, let's output information about the DNS message itself, so that we can trace down which component performed the request. Similatly, let's also print the TCP flags.
    
The output is along the lines of:

```    
[15:54:36:823373] 10.244.1.188:57010 -> 10.244.2.76:53 (proto: 17, TCP flags: ...., encap: 1, ifindex: 53, netns: f0000000, override: 0)
[15:54:36:823373] Detected DNS message, ID: 4391, flags 0100, QD: 1, AN: 0, NS: 0, AR: 0, query podinfodefaultsvcclusterlocal
[15:54:36:823534] 10.244.2.76:53 -> 10.244.1.188:57010 (proto: 17, TCP flags: ...., encap: 1, ifindex: 49, netns: f0000000, override: 0)
[15:54:36:823536] Detected DNS message, ID: 4391, flags 8500, QD: 1, AN: 1, NS: 0, AR: 0, query podinfodefaultsvcclusterlocal
[15:54:36:823631] 10.244.2.76:53 -> 10.244.1.188:57010 (proto: 17, TCP flags: ...., encap: 1, ifindex: 49, netns: f0000000, override: 0)
[15:54:36:823632] Detected DNS message, ID: 42f7, flags 8500, QD: 1, AN: 1, NS: 0, AR: 0, query podinfodefaultsvcclusterlocal
[15:54:36:823767] fd00:10:244:1::eb5b:35708 -> fd00:10:244:2::b2fb:9898 (proto: 6, TCP flags: S..., encap: 1, ifindex: 53, netns: f0000000, override: 0)
[15:54:36:823811] fd00:10:244:2::b2fb:9898 -> fd00:10:244:1::eb5b:35708 (proto: 6, TCP flags: SA.., encap: 1, ifindex: 49, netns: f0000000, override: 0)
```