### PR TITLE
envoy: Avoid short circuit backend filtering

### DIFF
--- a/pkg/ciliumenvoyconfig/envoy_l7lb_backend_syncer.go
+++ b/pkg/ciliumenvoyconfig/envoy_l7lb_backend_syncer.go
@@ -199,12 +199,11 @@ func filterServiceBackends(svc *loadbalancer.SVC, onlyPorts []string) map[string
 	for _, port := range onlyPorts {
 		// check for port number
 		if port == strconv.Itoa(int(svc.Frontend.Port)) {
-			return map[string][]*loadbalancer.Backend{
-				port: preferredBackends,
-			}
+			res[port] = preferredBackends
 		}
 
-		// check for either named port
+		// Continue checking for either named port as the same service
+		// can be used with multiple port types together
 		for _, backend := range preferredBackends {
 			if port == backend.FEPortName {
 				res[port] = append(res[port], backend)
@@ -218,9 +217,9 @@ func filterServiceBackends(svc *loadbalancer.SVC, onlyPorts []string) map[string
 // filterPreferredBackends returns the slice of backends which are preferred for the given service.
 // If there is no preferred backend, it returns the slice of all backends.
 func filterPreferredBackends(backends []*loadbalancer.Backend) []*loadbalancer.Backend {
-	res := []*loadbalancer.Backend{}
+	var res []*loadbalancer.Backend
 	for _, backend := range backends {
-		if backend.Preferred == loadbalancer.Preferred(true) {
+		if backend.Preferred {
 			res = append(res, backend)
 		}
 	}
@@ -233,7 +232,7 @@ func filterPreferredBackends(backends []*loadbalancer.Backend) []*loadbalancer.B
 
 type backendSyncInfo struct {
 	// Names of the L7 LB resources (e.g. CEC) that need this service's backends to be
-	// synced to to an L7 Loadbalancer.
+	// synced to an L7 Loadbalancer.
 	backendRefs map[service.L7LBResourceName]backendSyncCECInfo
 }
 

--- a/pkg/ciliumenvoyconfig/envoy_l7lb_backend_syncer_test.go
+++ b/pkg/ciliumenvoyconfig/envoy_l7lb_backend_syncer_test.go
@@ -49,6 +49,12 @@ func Test_filterServiceBackends(t *testing.T) {
 			assert.Len(t, backends, 1)
 			assert.Len(t, backends["8080"], 1)
 		})
+		t.Run("named and number ports", func(t *testing.T) {
+			backends := filterServiceBackends(svc, []string{"8080", "http"})
+			assert.Len(t, backends, 2)
+			assert.Len(t, backends["8080"], 1)
+			assert.Len(t, backends["http"], 1)
+		})
 		t.Run("no match", func(t *testing.T) {
 			backends := filterServiceBackends(svc, []string{"8000"})
 			assert.Len(t, backends, 0)


### PR DESCRIPTION
### Description 

The same service can be used with multiple port types (e.g number and name), so we should continue matching port values for both.

Reported-by: Philip Schmid <phisch@cisco.com>

### Testing

The below manifest is used for testing (before and after the changes).

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: echo
spec:
  ingressClassName: cilium
  rules:
    - http:
        paths:
          - backend:
              service:
                name: echo
                port:
                  name: http
            path: /named
            pathType: Prefix
    - http:
        paths:
          - backend:
              service:
                name: echo
                port:
                  number: 80
            path: /number
            pathType: Prefix
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: server
  name: server
spec:
  replicas: 1
  selector:
    matchLabels:
      app: server
  template:
    metadata:
      labels:
        app: server
    spec:
      containers:
        - env:
            - name: NODE
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: spec.nodeName
            - name: PRINT_HTTP_REQUEST_HEADERS
              value: "true"
            - name: PORT
              value: "80"
          image: ghcr.io/philipschmid/echo-app:v0.4
          imagePullPolicy: IfNotPresent
          name: server
          ports:
            - containerPort: 80
              name: http
              protocol: TCP
---
apiVersion: v1
kind: Service
metadata:
  name: echo
spec:
  ports:
    - name: http
      port: 80
      protocol: TCP
      targetPort: 80
  selector:
    app: server
```

<details>

<summary>Before the changes, traffic to /named is returning 503</summary>

```shell
$ lb=$(kubectl get ingress echo -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
$ curl -v http://$lb/named
*   Trying 10.98.35.245:80...
* Connected to 10.98.35.245 (10.98.35.245) port 80
> GET /named HTTP/1.1
> Host: 10.98.35.245
> User-Agent: curl/8.8.0
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 503 Service Unavailable
< content-length: 19
< content-type: text/plain
< date: Wed, 26 Jun 2024 10:10:28 GMT
< server: envoy
< 
* Connection #0 to host 10.98.35.245 left intact
no healthy upstream%   
```

</details>

<details>
<summary>After the changes</summary>

```shell
$ lb=$(kubectl get ingress echo -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
$ curl -v http://$lb/number
*   Trying 10.96.175.210:80...
* Connected to 10.96.175.210 (10.96.175.210) port 80
> GET /number HTTP/1.1
> Host: 10.96.175.210
> User-Agent: curl/8.8.0
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< content-type: application/json
< date: Wed, 26 Jun 2024 10:27:42 GMT
< content-length: 327
< x-envoy-upstream-service-time: 0
< server: envoy
< 
{"timestamp":"2024-06-26T10:27:42.213Z","source_ip":"10.244.0.93","hostname":"server-866c4fc4c7-g5l7n","node":"minikube","headers":{"Accept":["*/*"],"User-Agent":["curl/8.8.0"],"X-Envoy-Internal":["true"],"X-Forwarded-For":["192.168.49.1"],"X-Forwarded-Proto":["http"],"X-Request-Id":["87612d4e-b85e-4daf-b1d4-3b50936913c9"]}}
* Connection #0 to host 10.96.175.210 left intact

$ curl -v http://$lb/named 
*   Trying 10.96.175.210:80...
* Connected to 10.96.175.210 (10.96.175.210) port 80
> GET /named HTTP/1.1
> Host: 10.96.175.210
> User-Agent: curl/8.8.0
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< content-type: application/json
< date: Wed, 26 Jun 2024 10:27:45 GMT
< content-length: 327
< x-envoy-upstream-service-time: 0
< server: envoy
< 
{"timestamp":"2024-06-26T10:27:45.681Z","source_ip":"10.244.0.93","hostname":"server-866c4fc4c7-g5l7n","node":"minikube","headers":{"Accept":["*/*"],"User-Agent":["curl/8.8.0"],"X-Envoy-Internal":["true"],"X-Forwarded-For":["192.168.49.1"],"X-Forwarded-Proto":["http"],"X-Request-Id":["4bc965fa-6399-4b34-8af1-3d5f3946d729"]}}
* Connection #0 to host 10.96.175.210 left intact
```

</details>