### PR TITLE
[WIP] Fix missing health endpoint in upgrade tests

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -155,22 +155,20 @@ jobs:
             # has been resolved.
             # ingress-controller: 'true'
 
-#          Disable until https://github.com/cilium/cilium/issues/32689
-#          is resolved.
-#          - name: '7'
-#            # renovate: datasource=docker depName=quay.io/lvh-images/kind
-#            kernel: 'bpf-next-20240624.013140'
-#            kube-proxy: 'none'
-#            kpr: 'true'
-#            devices: '{eth0,eth1}'
-#            secondary-network: 'true'
-#            tunnel: 'disabled'
-#            lb-mode: 'snat'
-#            egress-gateway: 'true'
-#            lb-acceleration: 'testing-only'
-#            # Disable until https://github.com/cilium/cilium/issues/30717
-#            # has been resolved.
-#            # ingress-controller: 'true'
+          - name: '7'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: 'bpf-next-20240624.013140'
+            kube-proxy: 'none'
+            kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
+            tunnel: 'disabled'
+            lb-mode: 'snat'
+            egress-gateway: 'true'
+            lb-acceleration: 'testing-only'
+            # Disable until https://github.com/cilium/cilium/issues/30717
+            # has been resolved.
+            # ingress-controller: 'true'
 
           - name: '8'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -117,8 +117,7 @@ func (d *Daemon) initHealth(spec *healthApi.Spec, cleaner *daemonCleanup, sysctl
 	)
 
 	// Make sure to clean up the endpoint namespace when cilium-agent terminates
-	cleaner.cleanupFuncs.Add(health.KillEndpoint)
-	cleaner.cleanupFuncs.Add(health.CleanupEndpoint)
+	cleaner.cleanupFuncs.Add(d.cleanupHealthEndpoint)
 }
 
 func (d *Daemon) cleanupHealthEndpoint() {


### PR DESCRIPTION
Currently on shutdown we don't remove the health endpoint from the
endpoint but do remove the corresponding netlink interface. On restart
this can lead to a race where the loader tries to attach a bpf program
to the health endpoint but fails because the netlink interface is not
recreated yet. This commit makes sure we do remove the health endpoint
properly from the endpoint manager when the agent shuts down.

Fixes: #32689 
