### PR TITLE
Updating the header file with DNS rules during policy updates

### DIFF
--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -48,6 +48,8 @@ func (dr *dnsRedirect) setRules(wg *completion.WaitGroup, newRules policy.L7Data
 	}
 	dr.currentRules = copyRules(dr.redirect.rules)
 
+	log.Infof("Updating the DNS rules for endpoint %d", dr.redirect.endpointID)
+	dr.redirect.localEndpoint.SyncEndpointHeaderFile()
 	return nil
 }
 
@@ -68,6 +70,7 @@ func (dr *dnsRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, rev
 	return func() {
 		dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPortProto, nil)
 		dr.redirect.localEndpoint.OnDNSPolicyUpdateLocked(nil)
+		dr.redirect.localEndpoint.SyncEndpointHeaderFile()
 		dr.currentRules = nil
 	}, nil
 }

--- a/pkg/proxy/endpoint/endpoint.go
+++ b/pkg/proxy/endpoint/endpoint.go
@@ -24,6 +24,10 @@ type EndpointInfoSource interface {
 type EndpointUpdater interface {
 	EndpointInfoSource
 
+	// SyncEndpointHeaderFile is called when we are setting the dns rules for
+	// an endpoint redirect.
+	SyncEndpointHeaderFile()
+
 	// OnProxyPolicyUpdate is called when the proxy acknowledges that it
 	// has applied a policy.
 	OnProxyPolicyUpdate(policyRevision uint64)

--- a/pkg/proxy/endpoint/test/updater_mock.go
+++ b/pkg/proxy/endpoint/test/updater_mock.go
@@ -24,6 +24,8 @@ func (m *ProxyUpdaterMock) GetNamedPort(bool, string, uint8) uint16 { return 0 }
 
 func (m *ProxyUpdaterMock) ConntrackNameLocked() string { return "global" }
 
+func (m *ProxyUpdaterMock) SyncEndpointHeaderFile() {}
+
 func (m *ProxyUpdaterMock) OnProxyPolicyUpdate(policyRevision uint64) {}
 
 func (m *ProxyUpdaterMock) UpdateProxyStatistics(proxyTypet, l4Protocol string, port, proxyPort uint16, ingress, request bool,


### PR DESCRIPTION
Writing the DNS rules to the endpoint header/json file as we apply the policy changes, This keeps the `ep_config.json` and `ep_config.h` in sync with the current rules being applied the policy.
