### PR TITLE
gha: expose cmapisrv both via NodePort and LB in conformance-clustermesh

### DIFF
--- a/.github/actions/set-env-variables/action.yml
+++ b/.github/actions/set-env-variables/action.yml
@@ -19,10 +19,14 @@ runs:
 
         # renovate: datasource=github-releases depName=kubernetes-sigs/kind
         KIND_VERSION="v0.23.0"
+        # renovate: datasource=github-releases depName=kubernetes-sigs/cloud-provider-kind
+        KIND_KCP_VERSION="v0.3.0"
+
         # renovate: datasource=docker
         KIND_K8S_IMAGE="kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e"
         KIND_K8S_VERSION=$(echo "$KIND_K8S_IMAGE" | sed -r 's|.+:(v[0-9a-z.-]+)(@.+)?|\1|')
 
         echo "KIND_VERSION=$KIND_VERSION" >> $GITHUB_ENV
+        echo "KIND_KCP_VERSION=$KIND_KCP_VERSION" >> $GITHUB_ENV
         echo "KIND_K8S_IMAGE=$KIND_K8S_IMAGE" >> $GITHUB_ENV
         echo "KIND_K8S_VERSION=$KIND_K8S_VERSION" >> $GITHUB_ENV

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -238,7 +238,7 @@ jobs:
         id: default_vars
         uses: ./.github/actions/helm-default
         with:
-          image-tag: ${{ inputs.SHA }}
+          image-tag: af4ebb7b3e5247bb4466865d719978df0e1d3127
           chart-dir: ./untrusted/install/kubernetes/cilium
 
       - name: Set up job variables for GHA environment
@@ -599,7 +599,7 @@ jobs:
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
       - name: Post-test information gathering
-        if: ${{ !success() && steps.install-cilium-cluster1.outcome != 'skipped' }}
+        if: ${{ always() }}
         run: |
           cilium --context ${{ env.contextName1 }} status
           cilium --context ${{ env.contextName1 }} clustermesh status

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -382,6 +382,24 @@ jobs:
           config: ./.github/kind-config-cluster2.yaml
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
+      - name: Start the Kubernetes Cloud Provider for Kind
+        run: |
+          BASE_URL=https://github.com/kubernetes-sigs/cloud-provider-kind/releases/download/${KIND_KCP_VERSION}
+          curl -LO "${BASE_URL}/cloud-provider-kind_${KIND_KCP_VERSION/v/}_linux_amd64.tar.gz"
+          curl -LO "${BASE_URL}/cloud-provider-kind_${KIND_KCP_VERSION/v/}_checksums.txt"
+          grep cloud-provider-kind_${KIND_KCP_VERSION/v/}_linux_amd64.tar.gz cloud-provider-kind_${KIND_KCP_VERSION/v/}_checksums.txt | sha256sum --check
+          tar xvf cloud-provider-kind_${KIND_KCP_VERSION/v/}_linux_amd64.tar.gz cloud-provider-kind
+
+          ./cloud-provider-kind &> cloud-provider-kind.log &
+
+          kubectl --context ${{ env.contextName1 }} label node \
+            -l node.kubernetes.io/exclude-from-external-load-balancers \
+            node.kubernetes.io/exclude-from-external-load-balancers-
+
+          kubectl --context ${{ env.contextName2 }} label node \
+            -l node.kubernetes.io/exclude-from-external-load-balancers \
+            node.kubernetes.io/exclude-from-external-load-balancers-
+
       - name: Label one of the nodes as external to the cluster
         run: |
           kubectl --context ${{ env.contextName1 }} label node \
@@ -504,7 +522,7 @@ jobs:
             ${{ steps.vars.outputs.cilium_install_defaults }} \
             --helm-set cluster.name=${{ env.ciliumClusterName1 }} \
             --helm-set cluster.id=1 \
-            --helm-set clustermesh.apiserver.service.nodePort=32379 \
+            --helm-set clustermesh.apiserver.service.type=LoadBalancer \
             --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.cm-auth-mode-1 }} \
             ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
             ${{ steps.clustermesh-vars.outputs.cilium_install_clustermesh }} \
@@ -526,6 +544,7 @@ jobs:
             ${{ steps.vars.outputs.cilium_install_defaults }} \
             --helm-set cluster.name=${{ env.ciliumClusterName2 }} \
             --helm-set cluster.id=${{ matrix.maxConnectedClusters }} \
+            --helm-set clustermesh.apiserver.service.type=NodePort \
             --helm-set clustermesh.apiserver.service.nodePort=32380 \
             --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.cm-auth-mode-2 }} \
             ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
@@ -605,6 +624,8 @@ jobs:
               docker logs kvstore$i
             done
           fi
+
+          cat cloud-provider-kind.log
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload artifacts


### PR DESCRIPTION
Currently, all clustermesh-related tests expose the clustermesh-apiserver with a NodePort service, for the sake of convenience. However, LoadBalancer services are the suggested approach for production environments, as they are not bound to a specific node. Hence, let's modify the conformance clustermesh GHA workflow to expose the clustermesh-apiserver in one cluster with a NodePort service, and the other with a LoadBalancer service, so that we cover both cases. We leverage the recently introduced Kubernetes Cloud Provider for Kind to provide the LoadBalancer implementation.