### PR TITLE
datapath: Fix redirect from from L3 netdev to tunnel

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1195,6 +1195,17 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 	if (tunnel_endpoint) {
 		__be16 src_port;
 
+#if __ctx_is == __ctx_skb
+		{
+			/* See the corresponding v4 path for details */
+			bool l2_hdr_required = false;
+
+			ret = maybe_add_l2_hdr(ctx, ENCAP_IFINDEX, &l2_hdr_required);
+			if (ret != 0)
+				goto drop_err;
+		}
+#endif
+
 		src_port = tunnel_gen_src_port_v6(&tuple);
 
 		ret = nodeport_add_tunnel_encap(ctx,
@@ -2721,6 +2732,20 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 #ifdef TUNNEL_MODE
 	if (tunnel_endpoint) {
 		__be16 src_port;
+
+#if __ctx_is == __ctx_skb
+		{
+			/* Append L2 hdr before redirecting to tunnel netdev.
+			 * Otherwise, the kernel will drop such request in
+			 * https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/core/filter.c?h=v6.7.4#n2147
+			 */
+			bool l2_hdr_required = false;
+
+			ret = maybe_add_l2_hdr(ctx, ENCAP_IFINDEX, &l2_hdr_required);
+			if (ret != 0)
+				goto drop_err;
+		}
+#endif
 
 		src_port = tunnel_gen_src_port_v4(&tuple);
 

--- a/bpf/tests/tc_nodeport_l3_dev_to_tunnel.c
+++ b/bpf/tests/tc_nodeport_l3_dev_to_tunnel.c
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+
+#define ETH_HLEN		0
+#define SECCTX_FROM_IPCACHE	1
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define TUNNEL_MODE	1
+#define ENCAP_IFINDEX	42
+#define ENABLE_NODEPORT	1
+
+#define TEST_IP_LOCAL		v4_pod_one
+#define TEST_IP_REMOTE		v4_pod_two
+#define TEST_IPV6_LOCAL		v6_pod_one
+
+#define CLIENT_IP		v4_ext_one
+#define CLIENT_IPV6		{ .addr = { 0x1, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+#define CLIENT_PORT		__bpf_htons(111)
+
+#define FRONTEND_IP		v4_svc_one
+#define FRONTEND_IPV6		{ .addr = { 0x5, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+#define FRONTEND_PORT		tcp_svc_one
+
+#define BACKEND_IP		v4_pod_one
+#define BACKEND_IPV6		{ .addr = { 0x3, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+#define BACKEND_PORT		__bpf_htons(8080)
+
+#include "bpf_host.c"
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+
+static volatile const __u8 *node_mac = mac_two;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 2);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[0] = &cil_from_netdev,
+	},
+};
+
+PKTGEN("tc", "ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel")
+int ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* We are building an L3 skb which doesn't have L2 header, so in theory
+	 * we need to skip L2 header and set ctx->protocol = bpf_ntohs(ETH_P_IP),
+	 * but bpf verifier doesn't allow us to do so, and kernel also doesn't
+	 * handle an L3 skb properly (see https://elixir.bootlin.com/linux/v6.2.1/source/net/bpf/test_run.c#L1156).
+	 * Therefore we workaround the issue by pushing L2 header in the PKTGEN
+	 * and stripping it in the SETUP.
+	 */
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)node_mac, (__u8 *)node_mac,
+					  CLIENT_IP, FRONTEND_IP,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel")
+int ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel_setup(struct __ctx_buff *ctx)
+{
+	void *data = (void *)(long)ctx->data;
+	void *data_end = (void *)(long)ctx->data_end;
+	__u64 flags = BPF_F_ADJ_ROOM_FIXED_GSO;
+
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, 1, 1);
+	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, 1, 124,
+			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, TEST_IP_REMOTE, 0);
+
+	/* As commented in PKTGEN, now we strip the L2 header. Bpf helper
+	 * skb_adjust_room will use L2 header to overwrite L3 header, so we play
+	 * a trick to memcpy(ethhdr, iphdr, ETH_HLEN) ahead of skb_adjust_room
+	 * so as to guarantee L3 header keeps intact.
+	 */
+	if ((void *)data + __ETH_HLEN + __ETH_HLEN <= data_end)
+		memcpy(data, data + __ETH_HLEN, __ETH_HLEN);
+
+	skb_adjust_room(ctx, -__ETH_HLEN, BPF_ADJ_ROOM_MAC, flags);
+
+	tail_call_static(ctx, entry_call_map, 0);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel")
+int ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel_check(__maybe_unused
+							   const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	/* Check that LB request got redirected (to a tunnel iface) */
+	assert(*status_code == TC_ACT_REDIRECT);
+
+	/* Check that L2 hdr was added */
+	l2 = data + sizeof(__u32);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IP))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	test_finish();
+}
+
+PKTGEN("tc", "ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel")
+int ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel(struct __ctx_buff *ctx)
+{
+	union v6addr frontend_ip = FRONTEND_IPV6;
+	union v6addr client_ip = CLIENT_IPV6;
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* We are building an L3 skb which doesn't have L2 header, so in theory
+	 * we need to skip L2 header and set ctx->protocol = bpf_ntohs(ETH_P_IP),
+	 * but bpf verifier doesn't allow us to do so, and kernel also doesn't
+	 * handle an L3 skb properly (see https://elixir.bootlin.com/linux/v6.2.1/source/net/bpf/test_run.c#L1156).
+	 * Therefore we workaround the issue by pushing L2 header in the PKTGEN
+	 * and stripping it in the SETUP.
+	 */
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)node_mac, (__u8 *)node_mac,
+					  (__u8 *)&client_ip, (__u8 *)&frontend_ip,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel")
+int ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel_setup(struct __ctx_buff *ctx)
+{
+	union v6addr frontend_ip = FRONTEND_IPV6;
+	union v6addr backend_ip = BACKEND_IPV6;
+	void *data = (void *)(long)ctx->data;
+	void *data_end = (void *)(long)ctx->data_end;
+	__u64 flags = BPF_F_ADJ_ROOM_FIXED_GSO;
+
+	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, 1, 1);
+	lb_v6_add_backend(&frontend_ip, FRONTEND_PORT, 1, 124,
+			  &backend_ip, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	ipcache_v6_add_entry(&backend_ip, 0, 112233, TEST_IP_REMOTE, 0);
+
+	/* As commented in PKTGEN, now we strip the L2 header. Bpf helper
+	 * skb_adjust_room will use L2 header to overwrite L3 header, so we play
+	 * a trick to memcpy(ethhdr, iphdr, ETH_HLEN) ahead of skb_adjust_room
+	 * so as to guarantee L3 header keeps intact.
+	 */
+	if ((void *)data + __ETH_HLEN + __ETH_HLEN <= data_end)
+		memcpy(data, data + __ETH_HLEN, __ETH_HLEN);
+
+	skb_adjust_room(ctx, -__ETH_HLEN, BPF_ADJ_ROOM_MAC, flags);
+
+	tail_call_static(ctx, entry_call_map, 0);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel")
+int ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel_check(__maybe_unused
+							   const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	/* Check that LB request got redirected (to a tunnel iface) */
+	assert(*status_code == TC_ACT_REDIRECT);
+
+	/* Check that L2 hdr was added */
+	l2 = data + sizeof(__u32);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IPV6))
+		test_fatal("l2 proto hasn't been set to ETH_P_IPV6");
+
+	test_finish();
+}


### PR DESCRIPTION
Previously, the redirect from L3 netdev (in nodeport.h) to Cilium's tunnel device failed due to the bpf_redirect returning -ERANGE \[1\].

Further investigation revealed the following values for the troublesome skb:
```
        skb->len = 60
        skb->data = 0x000000009566a77e
        skb->head = 0x000000001a70ff88
        skb->network_header = 64
```

"skb->data" was set to a weird location when compared to "skb->head", and thus made the check to fail.

Adding the L2 hdr before redirecting to the tunnel device resolved the issue.

\[1\]: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/core/filter.c?h=v6.7.4#n2147

Fix #26847

cc @jspaleta 
