### PR TITLE
envoy: Add renovate configuration for cilium-proxy image

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -578,6 +578,23 @@
         "quay.io/cilium/cilium-envoy"
       ],
       "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-.*$",
+      "allowedVersions": "<1.29",
+      "matchBaseBranches": [
+        "v1.15",
+        "v1.14",
+        "v1.13"
+      ]
+    },
+    {
+      "matchDepNames": [
+        "quay.io/cilium/cilium-envoy"
+      ],
+      "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-.*$",
+      "allowedVersions": "<1.30",
+      "matchBaseBranches": [
+        "v1.16",
+        "main",
+      ]
     },
     {
       "matchDepNames": [


### PR DESCRIPTION
This is to make sure that we don't unintentionally bump the minor
version for stable branches.