### PR TITLE
helm: ensure that envoy daemonset is installed only when needed

### DIFF
--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -145,7 +145,9 @@ Enable automatic lookup of k8sServicePort from the cluster-info ConfigMap (kubea
 Return user specify envoy.enabled or default value based on the upgradeCompatibility
 */}}
 {{- define "envoyDaemonSetEnabled" }}
-  {{- if (not (kindIs "invalid" .Values.envoy.enabled)) }}
+  {{- if not .Values.l7Proxy }}
+    {{- false }}
+  {{- else if (not (kindIs "invalid" .Values.envoy.enabled)) }}
     {{- .Values.envoy.enabled }}
   {{- else }}
     {{- if semverCompare ">=1.16" (default "1.16" .Values.upgradeCompatibility) }}


### PR DESCRIPTION
As `.Values.ingressController.enabled` and `.Values.gatewayAPI.enabled` require `.Values.l7Proxy` to be set it's sufficient to just perform a check on that value.

<!-- Description of change -->

Fixes https://github.com/cilium/cilium/issues/33430

No backport necessary as this only affects 1.16

```release-note
helm: ensure that envoy daemonset is installed only when needed
```
