### PR TITLE
gateway-api: Bump version to latest upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -129,7 +129,7 @@ require (
 	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0
 	sigs.k8s.io/controller-runtime v0.18.4
 	sigs.k8s.io/controller-tools v0.15.0
-	sigs.k8s.io/gateway-api v1.1.0
+	sigs.k8s.io/gateway-api v1.1.1-0.20240625203242-cb5bf1541fa7
 	sigs.k8s.io/mcs-api v0.1.1-0.20240624222831-d7001fe1d21c
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1020,8 +1020,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.29.0 h1:/U5vjBbQn3RCh
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.29.0/go.mod h1:z7+wmGM2dfIiLRfrC6jb5kV2Mq/sK1ZP303cxzkV5Y4=
 sigs.k8s.io/controller-runtime v0.18.4 h1:87+guW1zhvuPLh1PHybKdYFLU0YJp4FhJRmiHvm5BZw=
 sigs.k8s.io/controller-runtime v0.18.4/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
-sigs.k8s.io/gateway-api v1.1.0 h1:DsLDXCi6jR+Xz8/xd0Z1PYl2Pn0TyaFMOPPZIj4inDM=
-sigs.k8s.io/gateway-api v1.1.0/go.mod h1:ZH4lHrL2sDi0FHZ9jjneb8kKnGzFWyrTya35sWUTrRs=
+sigs.k8s.io/gateway-api v1.1.1-0.20240625203242-cb5bf1541fa7 h1:udSMkvcUfzNYdPIbvUUR1F084KEvAIhcsmADAwAab6c=
+sigs.k8s.io/gateway-api v1.1.1-0.20240625203242-cb5bf1541fa7/go.mod h1:ZH4lHrL2sDi0FHZ9jjneb8kKnGzFWyrTya35sWUTrRs=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kind v0.23.0 h1:8fyDGWbWTeCcCTwA04v4Nfr45KKxbSPH1WO9K+jVrBg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2264,7 +2264,7 @@ sigs.k8s.io/controller-tools/pkg/schemapatcher
 sigs.k8s.io/controller-tools/pkg/schemapatcher/internal/yaml
 sigs.k8s.io/controller-tools/pkg/version
 sigs.k8s.io/controller-tools/pkg/webhook
-# sigs.k8s.io/gateway-api v1.1.0
+# sigs.k8s.io/gateway-api v1.1.1-0.20240625203242-cb5bf1541fa7
 ## explicit; go 1.22.0
 sigs.k8s.io/gateway-api/apis/v1
 sigs.k8s.io/gateway-api/apis/v1alpha2

--- a/vendor/sigs.k8s.io/gateway-api/apis/v1/gatewayclass_types.go
+++ b/vendor/sigs.k8s.io/gateway-api/apis/v1/gatewayclass_types.go
@@ -93,8 +93,10 @@ type GatewayClassSpec struct {
 	// or an implementation-specific custom resource. The resource can be
 	// cluster-scoped or namespace-scoped.
 	//
-	// If the referent cannot be found, the GatewayClass's "InvalidParameters"
-	// status condition will be true.
+	// If the referent cannot be found, refers to an unsupported kind, or when
+	// the data within that resource is malformed, the GatewayClass SHOULD be
+	// rejected with the "Accepted" status condition set to "False" and an
+	// "InvalidParameters" reason.
 	//
 	// A Gateway for this GatewayClass may provide its own `parametersRef`. When both are specified,
 	// the merging behavior is implementation specific.
@@ -162,6 +164,7 @@ const (
 	// Possible reasons for this condition to be False are:
 	//
 	// * "InvalidParameters"
+	// * "Unsupported"
 	// * "UnsupportedVersion"
 	//
 	// Possible reasons for this condition to be Unknown are:
@@ -176,9 +179,10 @@ const (
 	// true.
 	GatewayClassReasonAccepted GatewayClassConditionReason = "Accepted"
 
-	// This reason is used with the "Accepted" condition when the
-	// GatewayClass was not accepted because the parametersRef field
-	// was invalid, with more detail in the message.
+	// This reason is used with the "Accepted" condition when the GatewayClass
+	// was not accepted because the parametersRef field refers to a nonexistent
+	// or unsupported resource or kind, or when the data within that resource is
+	// malformed.
 	GatewayClassReasonInvalidParameters GatewayClassConditionReason = "InvalidParameters"
 
 	// This reason is used with the "Accepted" condition when the
@@ -186,6 +190,11 @@ const (
 	// to admit the GatewayClass. It is the default Reason on a new
 	// GatewayClass.
 	GatewayClassReasonPending GatewayClassConditionReason = "Pending"
+
+	// This reason is used with the "Accepted" condition when the GatewayClass
+	// was not accepted because the implementation does not support a
+	// user-defined GatewayClass.
+	GatewayClassReasonUnsupported GatewayClassConditionReason = "Unsupported"
 
 	// Deprecated: Use "Pending" instead.
 	GatewayClassReasonWaiting GatewayClassConditionReason = "Waiting"

--- a/vendor/sigs.k8s.io/gateway-api/apis/v1beta1/httproute_types.go
+++ b/vendor/sigs.k8s.io/gateway-api/apis/v1beta1/httproute_types.go
@@ -111,7 +111,7 @@ type HeaderMatchType = v1.HeaderMatchType
 //
 // * "/invalid" - "/" is an invalid character
 // +k8s:deepcopy-gen=false
-type HTTPHeaderName = v1.HeaderName
+type HTTPHeaderName = v1.HTTPHeaderName
 
 // HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
 // headers.

--- a/vendor/sigs.k8s.io/gateway-api/conformance/apis/v1/groupversion.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/apis/v1/groupversion.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+const (
+	// Group is the API group for the Conformance Report API.
+	Group = "gateway.networking.k8s.io"
+
+	// Version is the API version for the Conformance Report API.
+	Version = "v1"
+)
+
+// GroupVersion is the API group and version for the Conformance Report API.
+var GroupVersion = schema.GroupVersion{Group: Group, Version: Version}

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/grpcroute-exact-method-matching.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/grpcroute-exact-method-matching.go
@@ -69,7 +69,7 @@ var GRPCExactMethodMatching = suite.ConformanceTest{
 			tc := testCases[i]
 			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
 				t.Parallel()
-				grpc.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.TimeoutConfig, gwAddr, tc)
+				grpc.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.GRPCClient, suite.TimeoutConfig, gwAddr, tc)
 			})
 		}
 	},

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/grpcroute-header-matching.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/grpcroute-header-matching.go
@@ -130,7 +130,7 @@ var GRPCRouteHeaderMatching = suite.ConformanceTest{
 			tc := testCases[i]
 			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
 				t.Parallel()
-				grpc.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.TimeoutConfig, gwAddr, tc)
+				grpc.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.GRPCClient, suite.TimeoutConfig, gwAddr, tc)
 			})
 		}
 	},

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/grpcroute-listener-hostname-matching.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/grpcroute-listener-hostname-matching.go
@@ -126,7 +126,7 @@ var GRPCRouteListenerHostnameMatching = suite.ConformanceTest{
 			tc := testCases[i]
 			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
 				t.Parallel()
-				grpc.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.TimeoutConfig, gwAddr, tc)
+				grpc.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.GRPCClient, suite.TimeoutConfig, gwAddr, tc)
 			})
 		}
 	},

--- a/vendor/sigs.k8s.io/gateway-api/pkg/consts/consts.go
+++ b/vendor/sigs.k8s.io/gateway-api/pkg/consts/consts.go
@@ -27,7 +27,7 @@ const (
 
 	// BundleVersion is the value used for the "gateway.networking.k8s.io/bundle-version" annotation.
 	// These value must be updated during the release process.
-	BundleVersion = "v1.1.0"
+	BundleVersion = "v1.2.0-dev"
 
 	// ApprovalLink is the value used for the "api-approved.kubernetes.io" annotation.
 	// These value must be updated during the release process.

--- a/vendor/sigs.k8s.io/gateway-api/pkg/features/features.go
+++ b/vendor/sigs.k8s.io/gateway-api/pkg/features/features.go
@@ -144,6 +144,12 @@ const (
 
 	// This option indicates support for HTTPRoute parentRef port (extended conformance).
 	SupportHTTPRouteParentRefPort SupportedFeature = "HTTPRouteParentRefPort"
+
+	// This option indicates support for HTTPRoute with a backendref with an appProtocol 'kubernetes.io/h2c' (extended conformance)
+	SupportHTTPRouteBackendProtocolH2C SupportedFeature = "HTTPRouteBackendProtocolH2C"
+
+	// This option indicates support for HTTPRoute with a backendref with an appProtoocol 'kubernetes.io/ws' (extended conformance)
+	SupportHTTPRouteBackendProtocolWebSocket SupportedFeature = "HTTPRouteBackendProtocolWebSocket"
 )
 
 // HTTPRouteExtendedFeatures includes all extended features for HTTPRoute
@@ -164,6 +170,8 @@ var HTTPRouteExtendedFeatures = sets.New(
 	SupportHTTPRouteBackendTimeout,
 	SupportHTTPRouteParentRefPort,
 	SupportHTTPRouteBackendRequestHeaderModification,
+	SupportHTTPRouteBackendProtocolH2C,
+	SupportHTTPRouteBackendProtocolWebSocket,
 )
 
 // -----------------------------------------------------------------------------
@@ -173,12 +181,6 @@ var HTTPRouteExtendedFeatures = sets.New(
 const (
 	// This option indicates support for Destination Port matching.
 	SupportHTTPRouteDestinationPortMatching SupportedFeature = "HTTPRouteDestinationPortMatching"
-
-	// This option indicates support for HTTPRoute with a backendref with an appProtocol 'kubernetes.io/h2c'
-	SupportHTTPRouteBackendProtocolH2C SupportedFeature = "HTTPRouteBackendProtocolH2C"
-
-	// This option indicates support for HTTPRoute with a backendref with an appProtoocol 'kubernetes.io/ws'
-	SupportHTTPRouteBackendProtocolWebSocket SupportedFeature = "HTTPRouteBackendProtocolWebSocket"
 )
 
 // HTTPRouteExperimentalFeatures includes all the supported experimental features, currently only
@@ -186,8 +188,6 @@ const (
 // Implementations have the flexibility to opt-in for either specific features or the entire set.
 var HTTPRouteExperimentalFeatures = sets.New(
 	SupportHTTPRouteDestinationPortMatching,
-	SupportHTTPRouteBackendProtocolH2C,
-	SupportHTTPRouteBackendProtocolWebSocket,
 )
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
This is mainly to pick up new conformance tests for GRPCRoute such as exact method matching, listener hostname, etc.
