### PR TITLE
bgpv2: deprecate local port setting in transport config

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeerconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeerconfigs.yaml
@@ -221,9 +221,11 @@ spec:
                   used."
                 properties:
                   localPort:
-                    default: 179
-                    description: "LocalPort is the local port to be used for the BGP
-                      session. \n If not specified, defaults to TCP port 179."
+                    description: "Deprecated LocalPort is the local port to be used
+                      for the BGP session. \n If not specified, ephemeral port will
+                      be picked to initiate a connection. \n This field is deprecated
+                      and will be removed in a future release. Local port configuration
+                      is unnecessary and is not recommended."
                     format: int32
                     maximum: 65535
                     minimum: 1

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_peer_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_peer_types.go
@@ -124,14 +124,17 @@ type CiliumBGPFamilyWithAdverts struct {
 
 // CiliumBGPTransport defines the BGP transport parameters for the peer.
 type CiliumBGPTransport struct {
+	// Deprecated
 	// LocalPort is the local port to be used for the BGP session.
 	//
-	// If not specified, defaults to TCP port 179.
+	// If not specified, ephemeral port will be picked to initiate a connection.
+	//
+	// This field is deprecated and will be removed in a future release.
+	// Local port configuration is unnecessary and is not recommended.
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
-	// +kubebuilder:default=179
 	LocalPort *int32 `json:"localPort,omitempty"`
 
 	// PeerPort is the peer port to be used for the BGP session.


### PR DESCRIPTION
Deprecate setting the local port for BGP peer transport configuration. Setting the local port from the user's perspective is unnecessary; it should be an ephemeral port picked by the kernel when establishing a TCP connection.


Related discussion : https://github.com/cilium/cilium/pull/33307#issuecomment-2188904924 
