### PR TITLE
Fix bug that skips other selectors if ToEndpoints is empty

### DIFF
--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -298,7 +298,7 @@ func (e *EgressCommonRule) getDestinationEndpointSelectorsWithRequirements(
 	// explicitly check for empty non-nil slices, it should not result in any identity being selected.
 	if e.aggregatedSelectors == nil || (e.ToEndpoints != nil && len(e.ToEndpoints) == 0) ||
 		(e.ToNodes != nil && len(e.ToNodes) == 0) {
-		return nil
+		return e.aggregatedSelectors
 	}
 
 	res := make(EndpointSelectorSlice, 0, len(e.ToEndpoints)+len(e.aggregatedSelectors)+len(e.ToNodes))

--- a/pkg/policy/api/ingress.go
+++ b/pkg/policy/api/ingress.go
@@ -225,7 +225,7 @@ func (i *IngressCommonRule) GetSourceEndpointSelectorsWithRequirements(requireme
 	// explicitly check for empty non-nil slices, it should not result in any identity being selected.
 	if i.aggregatedSelectors == nil || (i.FromEndpoints != nil && len(i.FromEndpoints) == 0) ||
 		(i.FromNodes != nil && len(i.FromNodes) == 0) {
-		return nil
+		return i.aggregatedSelectors
 	}
 
 	res := make(EndpointSelectorSlice, 0, len(i.FromEndpoints)+len(i.aggregatedSelectors)+len(i.FromNodes))


### PR DESCRIPTION
- **policy: Add test for non-empty ToCIDR and empty ToEndpoints**
- **policy/api: Fix bug that skips other selectors if ToEndpoints is empty**

---

Second commit for convenience:

> 
> policy/api: Fix bug that skips other selectors if ToEndpoints is empty
> ```
> As reported in GH-33432, do not skip other selectors in the case
> ToEndpoints is empty. For example, if the user defined a ToCIDR with an
> empty ToEndpoints, then
> getDestinationEndpointSelectorsWithRequirements() /
> GetSourceEndpointSelectorsWithRequirements() returns nil, causing the
> ToCIDRs section to be skipped. Instead, return the aggregated selectors,
> which aggregates selectors such as ToCIDRs, prior to the call to the
> aforementioned functions inside SetAggregatedSelectors().
> 
> Fixes: e97df7badd ("policy: Do not select any identity with ingress empty slices")
> Fixes: 6ccd044b05 ("policy: Do not select any identity with egress empty slices")
> Fixes: https://github.com/cilium/cilium/pull/29608
> ```

Fixes: https://github.com/cilium/cilium/pull/29608

cc @pippolo84 