### PR TITLE
Fix container/bitlpm traversal

### DIFF
--- a/pkg/container/bitlpm/trie.go
+++ b/pkg/container/bitlpm/trie.go
@@ -112,21 +112,18 @@ type node[K, T any] struct {
 //
 // Note: If the prefix argument exceeds the Trie's maximum
 // prefix, it will be set to the Trie's maximum prefix.
-func (t *trie[K, T]) ExactLookup(prefixLen uint, k Key[K]) (T, bool) {
+func (t *trie[K, T]) ExactLookup(prefixLen uint, k Key[K]) (ret T, found bool) {
 	prefixLen = min(prefixLen, t.maxPrefix)
-	var (
-		empty, ret  T
-		matchPrefix uint
-	)
-	t.traverse(t.maxPrefix, k, func(currentNode *node[K, T], matchLen uint) bool {
-		ret = currentNode.value
-		matchPrefix = matchLen
+	t.traverse(prefixLen, k, func(currentNode *node[K, T], matchLen uint) bool {
+		// Only copy node value if exact prefix length is found
+		if matchLen == prefixLen {
+			ret = currentNode.value
+			found = true
+			return false // no need to continue
+		}
 		return true
 	})
-	if matchPrefix != prefixLen {
-		return empty, false
-	}
-	return ret, true
+	return ret, found
 }
 
 // LongestPrefixMatch returns the value for the key with the

--- a/pkg/container/bitlpm/trie.go
+++ b/pkg/container/bitlpm/trie.go
@@ -185,6 +185,10 @@ func (t *trie[K, T]) Descendants(prefixLen uint, k Key[K], fn func(prefix uint, 
 			currentNode.forEach(fn)
 			return
 		}
+		// currentNode is a leaf and has no children. Calling k.BitValueAt may overrun the key storage.
+		if currentNode.prefixLen >= t.maxPrefix {
+			return
+		}
 		currentNode = currentNode.children[k.BitValueAt(currentNode.prefixLen)]
 	}
 }


### PR DESCRIPTION
Fix two bugs in container/bitlpm traversal:
- avoid accessing key past its length
- stop traversal when the sought after prefix length has been found
