### PR TITLE
policy: Fix `mapstate.Diff()` used in tests

### DIFF
--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -419,7 +419,7 @@ func TestRedirectWithDeny(t *testing.T) {
 	})
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(t, expected))
+			ep.desiredPolicy.GetPolicyMap().Diff(expected))
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -460,7 +460,7 @@ func TestRedirectWithDeny(t *testing.T) {
 	// that port, as it is shadowed by the deny rule
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected2) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(t, expected2))
+			ep.desiredPolicy.GetPolicyMap().Diff(expected2))
 	}
 
 	// Keep only desired redirects
@@ -476,7 +476,7 @@ func TestRedirectWithDeny(t *testing.T) {
 	// Check that the state before addRedirects is restored
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(t, expected))
+			ep.desiredPolicy.GetPolicyMap().Diff(expected))
 	}
 	require.Equal(t, 2, ep.desiredPolicy.GetPolicyMap().Len())
 }
@@ -581,7 +581,7 @@ func TestRedirectWithPriority(t *testing.T) {
 	})
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(t, expected))
+			ep.desiredPolicy.GetPolicyMap().Diff(expected))
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -613,7 +613,7 @@ func TestRedirectWithPriority(t *testing.T) {
 	})
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected2) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(t, expected2))
+			ep.desiredPolicy.GetPolicyMap().Diff(expected2))
 	}
 
 	// Keep only desired redirects
@@ -629,7 +629,7 @@ func TestRedirectWithPriority(t *testing.T) {
 	// Check that the state before addRedirects is restored
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(t, expected))
+			ep.desiredPolicy.GetPolicyMap().Diff(expected))
 	}
 	require.Equal(t, 2, ep.desiredPolicy.GetPolicyMap().Len())
 }
@@ -662,7 +662,7 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 	})
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(t, expected))
+			ep.desiredPolicy.GetPolicyMap().Diff(expected))
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -694,7 +694,7 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 	})
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected2) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(t, expected2))
+			ep.desiredPolicy.GetPolicyMap().Diff(expected2))
 	}
 
 	// Keep only desired redirects
@@ -710,7 +710,7 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 	// Check that the state before addRedirects is restored
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(t, expected))
+			ep.desiredPolicy.GetPolicyMap().Diff(expected))
 	}
 	require.Equal(t, 2, ep.desiredPolicy.GetPolicyMap().Len())
 }

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -655,7 +655,7 @@ func Test_MergeL3(t *testing.T) {
 				if err != nil {
 					t.Errorf("Policy resolution failure: %s", err)
 				}
-				if equal := assert.True(t, mapstate.Equals(tt.result), mapstate.Diff(t, tt.result)); !equal {
+				if equal := assert.True(t, mapstate.Equals(tt.result), mapstate.Diff(tt.result)); !equal {
 					t.Logf("Rules:\n%s\n\n", api.Rules(rules).String())
 					t.Logf("Policy Trace: \n%s\n", logBuffer.String())
 					t.Errorf("Policy obtained didn't match expected for endpoint %s:\nObtained: %v\nExpected: %v", labelsFoo, mapstate, tt.result)
@@ -1206,7 +1206,7 @@ func Test_MergeRules(t *testing.T) {
 			// Ignore generated rules as they lap LabelArrayList which would
 			// make the tests fail.
 			if i < generatedIdx {
-				if equal := assert.True(t, mapstate.Equals(tt.expected), mapstate.Diff(t, tt.expected)); !equal {
+				if equal := assert.True(t, mapstate.Equals(tt.expected), mapstate.Diff(tt.expected)); !equal {
 					require.EqualExportedValuesf(t, tt.expected, mapstate, "Policy obtained didn't match expected for endpoint %s", labelsFoo)
 					t.Logf("Rules:\n%s\n\n", tt.rules.String())
 					t.Logf("Policy Trace: \n%s\n", logBuffer.String())
@@ -1311,7 +1311,7 @@ func Test_MergeRulesWithNamedPorts(t *testing.T) {
 				t.Errorf("Policy resolution failure: %s", err)
 			}
 			require.Truef(t, mapstate.Equals(tt.expected),
-				"Policy obtained didn't match expected for endpoint %s:\n%s", labelsFoo, mapstate.Diff(t, tt.expected))
+				"Policy obtained didn't match expected for endpoint %s:\n%s", labelsFoo, mapstate.Diff(tt.expected))
 		})
 	}
 }
@@ -1356,7 +1356,7 @@ func Test_AllowAll(t *testing.T) {
 			if err != nil {
 				t.Errorf("Policy resolution failure: %s", err)
 			}
-			if equal := assert.True(t, mapstate.Equals(tt.expected), mapstate.Diff(t, tt.expected)); !equal {
+			if equal := assert.True(t, mapstate.Equals(tt.expected), mapstate.Diff(tt.expected)); !equal {
 				t.Logf("Rules:\n%s\n\n", tt.rules.String())
 				t.Logf("Policy Trace: \n%s\n", logBuffer.String())
 				t.Errorf("Policy obtained didn't match expected for endpoint %s", labelsFoo)
@@ -1750,7 +1750,7 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 			if err != nil {
 				t.Errorf("Policy resolution failure: %s", err)
 			}
-			if equal := assert.True(t, mapstate.Equals(tt.expected), mapstate.Diff(t, tt.expected)); !equal {
+			if equal := assert.True(t, mapstate.Equals(tt.expected), mapstate.Diff(tt.expected)); !equal {
 				t.Logf("Policy Trace: \n%s\n", logBuffer.String())
 				t.Errorf("Policy test, %q, obtained didn't match expected for endpoint %s", tt.test, labelsFoo)
 			}
@@ -1800,7 +1800,7 @@ func Test_EnsureEntitiesSelectableByCIDR(t *testing.T) {
 			if err != nil {
 				t.Errorf("Policy resolution failure: %s", err)
 			}
-			if equal := assert.True(t, mapstate.Equals(tt.expected), mapstate.Diff(t, tt.expected)); !equal {
+			if equal := assert.True(t, mapstate.Equals(tt.expected), mapstate.Diff(tt.expected)); !equal {
 				t.Logf("Policy Trace: \n%s\n", logBuffer.String())
 				t.Errorf("Policy test, %q, obtained didn't match expected for endpoint %s", tt.test, labelsFoo)
 			}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"slices"
 	"strconv"
-	"testing"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/sirupsen/logrus"
@@ -77,14 +76,16 @@ type MapState interface {
 	RevertChanges(ChangeState)
 	AddVisibilityKeys(PolicyOwner, uint16, *VisibilityMetadata, ChangeState)
 	Len() int
-	Equals(MapState) bool
-	Diff(t *testing.T, expected MapState) string
 
 	allowAllIdentities(ingress, egress bool)
 	determineAllowLocalhostIngress()
 	deniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool
 	denyPreferredInsertWithChanges(newKey Key, newEntry MapStateEntry, identities Identities, features policyFeatures, changes ChangeState)
 	deleteKeyWithChanges(key Key, owner MapStateOwner, changes ChangeState)
+
+	// For testing from other packages only
+	Equals(MapState) bool
+	Diff(expected MapState) string
 }
 
 // mapState is a state of a policy map.
@@ -422,7 +423,7 @@ func (msA *mapState) Equals(msB MapState) bool {
 // Diff returns the string of differences between 'obtained' and 'expected' prefixed with
 // '+ ' or '- ' for obtaining something unexpected, or not obtaining the expected, respectively.
 // For use in debugging.
-func (obtained *mapState) Diff(_ *testing.T, expected MapState) (res string) {
+func (obtained *mapState) Diff(expected MapState) (res string) {
 	res += "Missing (-), Unexpected (+):\n"
 	expected.ForEach(func(kE Key, vE MapStateEntry) bool {
 		if vO, ok := obtained.Get(kE); ok {
@@ -436,8 +437,8 @@ func (obtained *mapState) Diff(_ *testing.T, expected MapState) (res string) {
 		return true
 	})
 	obtained.ForEach(func(kE Key, vE MapStateEntry) bool {
-		if vO, ok := expected.Get(kE); !ok {
-			res += "+ " + kE.String() + ": " + vO.String() + "\n"
+		if _, ok := expected.Get(kE); !ok {
+			res += "+ " + kE.String() + ": " + vE.String() + "\n"
 		}
 		return true
 	})

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -2291,14 +2291,14 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 
 		ms.denyPreferredInsertWithChanges(tt.args.key, tt.args.entry, nil, denyRules, changes)
 		ms.validatePortProto(t)
-		require.Truef(t, ms.Equals(tt.want), "%s: MapState mismatch:\n%s", tt.name, ms.Diff(nil, tt.want))
+		require.Truef(t, ms.Equals(tt.want), "%s: MapState mismatch:\n%s", tt.name, ms.Diff(tt.want))
 		require.EqualValuesf(t, tt.wantAdds, changes.Adds, "%s: Adds mismatch", tt.name)
 		require.EqualValuesf(t, tt.wantDeletes, changes.Deletes, "%s: Deletes mismatch", tt.name)
 		require.EqualValuesf(t, tt.wantOld, changes.Old, "%s: OldValues mismatch allows", tt.name)
 
 		// Revert changes and check that we get the original mapstate
 		ms.RevertChanges(changes)
-		require.Truef(t, ms.Equals(tt.ms), "%s: MapState mismatch:\n%s", tt.name, ms.Diff(nil, tt.ms))
+		require.Truef(t, ms.Equals(tt.ms), "%s: MapState mismatch:\n%s", tt.name, ms.Diff(tt.ms))
 	}
 }
 
@@ -2725,7 +2725,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		}
 		adds, deletes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, denyRules, nil)
 		policyMapState.validatePortProto(t)
-		require.True(t, policyMapState.Equals(tt.state), "%s (MapState):\n%s", tt.name, policyMapState.Diff(nil, tt.state))
+		require.True(t, policyMapState.Equals(tt.state), "%s (MapState):\n%s", tt.name, policyMapState.Diff(tt.state))
 		require.EqualValues(t, tt.adds, adds, tt.name+" (adds)")
 		require.EqualValues(t, tt.deletes, deletes, tt.name+" (deletes)")
 	}
@@ -2950,7 +2950,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		}
 		adds, deletes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, policyFeatures(0), nil)
 		policyMapState.validatePortProto(t)
-		require.True(t, policyMapState.Equals(tt.state), tt.name+"%s (MapState):\n%s", policyMapState.Diff(nil, tt.state))
+		require.True(t, policyMapState.Equals(tt.state), tt.name+"%s (MapState):\n%s", policyMapState.Diff(tt.state))
 		require.EqualValues(t, tt.adds, adds, tt.name+" (adds)")
 		require.EqualValues(t, tt.deletes, deletes, tt.name+" (deletes)")
 	}
@@ -3126,7 +3126,7 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 		}
 		tt.ms.AddVisibilityKeys(DummyOwner{}, tt.args.redirectPort, &tt.args.visMeta, changes)
 		tt.ms.validatePortProto(t)
-		require.True(t, tt.ms.Equals(tt.want), "%s:\n%s", tt.name, tt.ms.Diff(nil, tt.want))
+		require.True(t, tt.ms.Equals(tt.want), "%s:\n%s", tt.name, tt.ms.Diff(tt.want))
 		// Find new and updated entries
 		wantAdds := make(Keys)
 		wantOld := make(map[Key]MapStateEntry)
@@ -3534,7 +3534,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			changes.Deletes[k] = struct{}{}
 		}
 		policyMapState.validatePortProto(t)
-		require.True(t, tt.state.Equals(policyMapState), "%s (MapState):\n%s", tt.name, policyMapState.Diff(nil, tt.state))
+		require.True(t, tt.state.Equals(policyMapState), "%s (MapState):\n%s", tt.name, policyMapState.Diff(tt.state))
 		require.EqualValues(t, tt.adds, changes.Adds, tt.name+" (adds)")
 		require.EqualValues(t, tt.deletes, changes.Deletes, tt.name+" (deletes)")
 	}
@@ -3665,7 +3665,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
 		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
 		outcomeKeys.validatePortProto(t)
-		require.True(t, expectedKeys.Equals(outcomeKeys), "%s (MapState):\n%s", tt.name, outcomeKeys.Diff(nil, expectedKeys))
+		require.True(t, expectedKeys.Equals(outcomeKeys), "%s (MapState):\n%s", tt.name, outcomeKeys.Diff(expectedKeys))
 	}
 	// Now test all cases with different traffic directions.
 	// This should result in both entries being inserted with

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -181,7 +181,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState))
+		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, policy, &expectedEndpointPolicy)
@@ -274,7 +274,7 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState))
+		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, policy, &expectedEndpointPolicy)
@@ -380,7 +380,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState))
+		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, policy, &expectedEndpointPolicy)
@@ -550,7 +550,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState))
+		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, policy, &expectedEndpointPolicy)

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -359,7 +359,7 @@ func TestL7WithIngressWildcard(t *testing.T) {
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState))
+		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, policy, &expectedEndpointPolicy)
@@ -466,7 +466,7 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState))
+		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, policy, &expectedEndpointPolicy)
@@ -569,7 +569,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState))
+		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, policy, &expectedEndpointPolicy)
@@ -750,7 +750,7 @@ func TestMapStateWithIngress(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.Diff(nil, expectedEndpointPolicy.policyMapState))
+		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)


### PR DESCRIPTION
Use the actual unexpected value, rather then the one that was not found.

Remove the import of unused "testing" from production code.

Fixes: #29162
