### PR TITLE
bgpv2/contrib: update cilium version in labs and minor fixes

### DIFF
--- a/contrib/containerlab/bgpv2/multi-homing/Makefile
+++ b/contrib/containerlab/bgpv2/multi-homing/Makefile
@@ -1,6 +1,5 @@
 # version of cilium to deploy
-HELM_CHART ?= oci://quay.io/cilium-charts-dev/cilium
-VERSION ?= 1.16.0-dev-dev.247-main-8c97a2119d
+VERSION ?= v1.16.0-rc.0
 
 deploy:
 	kind create cluster --config cluster.yaml
@@ -8,7 +7,7 @@ deploy:
 	# create secret for bgp
 	kubectl -n kube-system create secret generic --type=string bgp-auth-secret --from-literal=password=cilium123
 	# install cilium
-	helm install cilium -n kube-system $(HELM_CHART) --version $(VERSION) -f values.yaml
+	helm install cilium -n kube-system cilium/cilium --version $(VERSION) -f values.yaml
 	cilium status --wait --namespace kube-system
 
 destroy:

--- a/contrib/containerlab/bgpv2/multi-homing/README.md
+++ b/contrib/containerlab/bgpv2/multi-homing/README.md
@@ -23,12 +23,12 @@ CiliumBGPPeerConfig resource with name `cilium-peer`.
     peers:
     - name: "65000"
       peerASN: 65000
-      peerAddress: fd00:10:0:1::1
+      peerAddress: fd00:10::1
       peerConfigRef:
         name: "cilium-peer"
     - name: "65011"
       peerASN: 65011
-      peerAddress: fd00:11:0:1::1
+      peerAddress: fd00:11::1
       peerConfigRef:
         name: "cilium-peer"
 ```
@@ -66,18 +66,46 @@ Snippet of 'PodCIDR' advertisement is defined below. BGP control plane will adve
           wellKnown: [ "no-export" ]
 ```
 
+**BGP node configuration override**
+
+In below example, router ID is configured manually for each node. Name of the CiliumBGPNodeConfigOverride resource matches the node name on which this 
+configuration will be applied.
+
+```yaml
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPNodeConfigOverride
+metadata:
+  name: bgpv2-cplane-dev-multi-homing-control-plane
+spec:
+  bgpInstances:
+    - name: "65001"
+      routerID: "1.2.3.4"
+
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPNodeConfigOverride
+metadata:
+  name: bgpv2-cplane-dev-multi-homing-worker
+spec:
+  bgpInstances:
+    - name: "65001"
+      routerID: "5.6.7.8"
+```
+
 Verification
 ------------
 
 **BGP Peering**
 
 ```
-cilium# cilium bgp peers
-Local AS   Peer AS   Peer Address         Session       Uptime   Family         Received   Advertised
-65001      65000     fd00:10:0:1::1:179   established   8s       ipv4/unicast   0          2
-                                                                 ipv6/unicast   0          2
-65001      65011     fd00:11:0:1::1:179   established   9s       ipv4/unicast   0          2
-                                                                 ipv6/unicast   0          2
+root@bgpv2-cplane-dev-multi-homing-worker:/home/cilium# cilium bgp peers
+Local AS   Peer AS   Peer Address     Session       Uptime   Family         Received   Advertised
+65001      65000     fd00:10::1:179   established   4m45s    ipv4/unicast   0          2
+                                                             ipv6/unicast   0          2
+65001      65011     fd00:11::1:179   established   4m47s    ipv4/unicast   0          2
+                                                             ipv6/unicast   0          2
+
 ```
 
 **BGP Routes**
@@ -85,38 +113,38 @@ Local AS   Peer AS   Peer Address         Session       Uptime   Family         
 PodCIDR is 10.1.1.0 on this node, which is advertised with communities attribute 'no-export'.
 
 ```
-cilium# cilium bgp routes advertised ipv4 unicast
-VRouter   Peer             Prefix        NextHop          Age     Attrs
-65001     fd00:10:0:1::1   10.1.1.0/24   fd00:10:0:2::2   1m37s   [{Origin: i} {AsPath: 65001} {Communities: no-export} {MpReach(ipv4-unicast): {Nexthop: fd00:10:0:2::2, NLRIs: [10.1.1.0/24]}}]
-65001     fd00:11:0:1::1   10.1.1.0/24   fd00:11:0:2::2   1m37s   [{Origin: i} {AsPath: 65001} {Communities: no-export} {MpReach(ipv4-unicast): {Nexthop: fd00:11:0:2::2, NLRIs: [10.1.1.0/24]}}]
+root@bgpv2-cplane-dev-multi-homing-worker:/home/cilium# cilium bgp routes advertised ipv4 unicast
+VRouter   Peer         Prefix        NextHop          Age     Attrs
+65001     fd00:10::1   10.1.1.0/24   fd00:10:0:2::2   5m35s   [{Origin: i} {AsPath: 65001} {Communities: no-export} {MpReach(ipv4-unicast): {Nexthop: fd00:10:0:2::2, NLRIs: [10.1.1.0/24]}}]
+65001     fd00:11::1   10.1.1.0/24   fd00:11:0:2::2   5m35s   [{Origin: i} {AsPath: 65001} {Communities: no-export} {MpReach(ipv4-unicast): {Nexthop: fd00:11:0:2::2, NLRIs: [10.1.1.0/24]}}]
 ```
 
-On peering routers we can see 10.1.1.0/24 prefix with appropriate route attributes.
+On peering routers we can see 10.1.1.0/24 prefix with appropriate route attributes and configured router ID.
 
 **FRR Router0**
 
 ```
-docker exec -it clab-bgpv2-cplane-dev-multi-homing-router0 vtysh -c 'sh bgp ipv4 10.1.1.0'
-BGP routing table entry for 10.1.1.0/24, version 5
+ docker exec -it clab-bgpv2-cplane-dev-multi-homing-router0 vtysh -c 'sh bgp ipv4 10.1.1.0'
+BGP routing table entry for 10.1.1.0/24, version 2
 Paths: (1 available, best #1, table default, not advertised to EBGP peer)
   Not advertised to any peer
   65001
-    fd00:10:0:2::2 from fd00:10:0:2::2 (10.0.2.2)
+    fd00:10:0:2::2 from fd00:10:0:2::2 (5.6.7.8)               <<<<<<<<< Router ID
       Origin IGP, valid, external, best (First path received)
-      Community: no-export
-      Last update: Thu May 16 16:10:52 2024
+      Community: no-export                                     <<<<<<<<< Community
+      Last update: Fri Jun 28 15:30:33 2024
 ```
 
 **FRR Router1**
 
 ```
 docker exec -it clab-bgpv2-cplane-dev-multi-homing-router1 vtysh -c 'sh bgp ipv4 10.1.1.0'
-BGP routing table entry for 10.1.1.0/24, version 5
+BGP routing table entry for 10.1.1.0/24, version 1
 Paths: (1 available, best #1, table default, not advertised to EBGP peer)
   Not advertised to any peer
   65001
-    fd00:11:0:2::2 from fd00:11:0:2::2 (10.0.2.2)
+    fd00:11:0:2::2 from fd00:11:0:2::2 (5.6.7.8)
       Origin IGP, valid, external, best (First path received)
       Community: no-export
-      Last update: Thu May 16 16:10:49 2024
+      Last update: Fri Jun 28 15:30:31 2024
 ```

--- a/contrib/containerlab/bgpv2/multi-homing/bgp.yaml
+++ b/contrib/containerlab/bgpv2/multi-homing/bgp.yaml
@@ -13,12 +13,12 @@ spec:
     peers:
     - name: "65000"
       peerASN: 65000
-      peerAddress: fd00:10:0:0::1
+      peerAddress: fd00:10::1
       peerConfigRef:
         name: "cilium-peer"
     - name: "65011"
       peerASN: 65011
-      peerAddress: fd00:11:0:0::1
+      peerAddress: fd00:11::1
       peerConfigRef:
         name: "cilium-peer"
 
@@ -67,11 +67,6 @@ spec:
   bgpInstances:
     - name: "65001"
       routerID: "1.2.3.4"
-      peers:
-        - name: "65000"
-          localAddress: fd00:10:0:1::2
-        - name: "65011"
-          localAddress: fd00:11:0:1::2
 
 ---
 apiVersion: cilium.io/v2alpha1
@@ -82,8 +77,3 @@ spec:
   bgpInstances:
     - name: "65001"
       routerID: "5.6.7.8"
-      peers:
-        - name: "65000"
-          localAddress: fd00:10:0:2::2
-        - name: "65011"
-          localAddress: fd00:11:0:2::2

--- a/contrib/containerlab/bgpv2/multi-homing/values.yaml
+++ b/contrib/containerlab/bgpv2/multi-homing/values.yaml
@@ -8,7 +8,6 @@ ipv6:
 
 bgpControlPlane:
   enabled: true
-  v2Enabled: true
 
 ipv4NativeRoutingCIDR: 10.0.0.0/8
 ipv6NativeRoutingCIDR: fd00::/16

--- a/contrib/containerlab/bgpv2/pod-ip-pool/Makefile
+++ b/contrib/containerlab/bgpv2/pod-ip-pool/Makefile
@@ -1,6 +1,5 @@
 # version of cilium to deploy
-HELM_CHART ?= oci://quay.io/cilium-charts-dev/cilium
-VERSION ?= 1.16.0-dev-dev.247-main-8c97a2119d
+VERSION ?= v1.16.0-rc.0
 
 deploy:
 	kind create cluster --config cluster.yaml
@@ -10,7 +9,7 @@ deploy:
 	# create secret for bgp
 	kubectl -n kube-system create secret generic --type=string bgp-auth-secret --from-literal=password=cilium123
 	# install cilium
-	helm install cilium -n kube-system $(HELM_CHART) --version $(VERSION) -f values.yaml
+	helm install cilium -n kube-system cilium/cilium --version $(VERSION) -f values.yaml
 
 destroy:
 	sudo containerlab -t topo.yaml destroy -c

--- a/contrib/containerlab/bgpv2/pod-ip-pool/README.md
+++ b/contrib/containerlab/bgpv2/pod-ip-pool/README.md
@@ -36,7 +36,7 @@ Single BGP peer is defined in the BGP cluster configuration. This will be applie
     peers:
     - name: "65000"
       peerASN: 65000
-      peerAddress: fd00:10:0:1::1
+      peerAddress: fd00:10::1
       peerConfigRef:
         name: "cilium-peer"
 ```
@@ -91,14 +91,14 @@ Verification
 
 ```
 root@bgpv2-cplane-dev-pod-ip-pool-worker:/home/cilium# cilium bgp routes advertised ipv4 unicast
-VRouter   Peer             Prefix          NextHop          Age     Attrs
-65001     fd00:10:0:1::1   10.100.1.0/24   fd00:10:0:2::2   1m28s   [{Origin: i} {AsPath: 65001} {Communities: 65000:100} {MpReach(ipv4-unicast): {Nexthop: fd00:10:0:2::2, NLRIs: [10.100.1.0/24]}}]
-65001     fd00:10:0:1::1   10.200.0.0/24   fd00:10:0:2::2   1m12s   [{Origin: i} {AsPath: 65001} {Communities: 65000:200} {MpReach(ipv4-unicast): {Nexthop: fd00:10:0:2::2, NLRIs: [10.200.0.0/24]}}]
+VRouter   Peer         Prefix          NextHop          Age     Attrs
+65001     fd00:10::1   10.100.1.0/24   fd00:10:0:2::2   4m14s   [{Origin: i} {AsPath: 65001} {Communities: 65000:100} {MpReach(ipv4-unicast): {Nexthop: fd00:10:0:2::2, NLRIs: [10.100.1.0/24]}}]
+65001     fd00:10::1   10.200.0.0/24   fd00:10:0:2::2   3m57s   [{Origin: i} {AsPath: 65001} {Communities: 65000:200} {MpReach(ipv4-unicast): {Nexthop: fd00:10:0:2::2, NLRIs: [10.200.0.0/24]}}]
 
 root@bgpv2-cplane-dev-pod-ip-pool-worker:/home/cilium# cilium bgp routes advertised ipv6 unicast
-VRouter   Peer             Prefix              NextHop          Age     Attrs
-65001     fd00:10:0:1::1   fd00:100:1:1::/64   fd00:10:0:2::2   1m33s   [{Origin: i} {AsPath: 65001} {Communities: 65000:100} {MpReach(ipv6-unicast): {Nexthop: fd00:10:0:2::2, NLRIs: [fd00:100:1:1::/64]}}]
-65001     fd00:10:0:1::1   fd00:200:1:2::/64   fd00:10:0:2::2   1m2s    [{Origin: i} {AsPath: 65001} {Communities: 65000:200} {MpReach(ipv6-unicast): {Nexthop: fd00:10:0:2::2, NLRIs: [fd00:200:1:2::/64]}}]
+VRouter   Peer         Prefix              NextHop          Age     Attrs
+65001     fd00:10::1   fd00:100:1:1::/64   fd00:10:0:2::2   4m43s   [{Origin: i} {AsPath: 65001} {Communities: 65000:100} {MpReach(ipv6-unicast): {Nexthop: fd00:10:0:2::2, NLRIs: [fd00:100:1:1::/64]}}]
+65001     fd00:10::1   fd00:200:1:2::/64   fd00:10:0:2::2   4m11s   [{Origin: i} {AsPath: 65001} {Communities: 65000:200} {MpReach(ipv6-unicast): {Nexthop: fd00:10:0:2::2, NLRIs: [fd00:200:1:2::/64]}}]
 ```
 
 **Router0**
@@ -130,7 +130,7 @@ Paths: (1 available, best #1, table default)
     fd00:10:0:1::2 from fd00:10:0:1::2 (10.0.1.2)
       Origin IGP, valid, external, best (First path received)
       Community: 65000:100
-      Last update: Thu May 16 17:47:20 2024
+      Last update: Fri Jun 28 15:55:08 2024
 
 docker exec -it clab-bgpv2-cplane-dev-pod-ip-pool-router0 vtysh -c 'sh bgp ipv4 10.200.0.0'
 BGP routing table entry for 10.200.0.0/24, version 3
@@ -141,5 +141,5 @@ Paths: (1 available, best #1, table default)
     fd00:10:0:2::2 from fd00:10:0:2::2 (10.0.2.2)
       Origin IGP, valid, external, best (First path received)
       Community: 65000:200
-      Last update: Thu May 16 17:47:13 2024
+      Last update: Fri Jun 28 15:54:59 2024
 ```

--- a/contrib/containerlab/bgpv2/pod-ip-pool/bgp.yaml
+++ b/contrib/containerlab/bgpv2/pod-ip-pool/bgp.yaml
@@ -44,7 +44,7 @@ spec:
     peers:
     - name: "65000"
       peerASN: 65000
-      peerAddress: fd00:10:0:1::1
+      peerAddress: fd00:10::1
       peerConfigRef:
         name: "cilium-peer"
 

--- a/contrib/containerlab/bgpv2/pod-ip-pool/topo.yaml
+++ b/contrib/containerlab/bgpv2/pod-ip-pool/topo.yaml
@@ -11,6 +11,9 @@ topology:
       - ip addr add 10.0.2.1/24 dev net1
       - ip addr add 10.0.3.1/24 dev net2
       - sysctl net.ipv6.conf.all.forwarding=1
+      - ip link add name loopback type dummy
+      - ip link set dev loopback up
+      - ip addr add fd00:10:0:0::1/128 dev loopback
       - ip addr add fd00:10:0:1::1/64 dev net0
       - ip addr add fd00:10:0:2::1/64 dev net1
       - ip addr add fd00:10:0:3::1/64 dev net2
@@ -59,6 +62,7 @@ topology:
       - ip addr add 10.0.2.2/24 dev net0
       - ip addr add fd00:10:0:2::2/64 dev net0
       # These static routes are needed because Cilium cannot import routes currently.
+      - ip route add fd00:10:0:0::1/128 via fd00:10:0:1::1 dev net0 # loopback of router0
       - ip route add 10.0.0.0/8 via 10.0.2.1 dev net0
       - ip route add fd00::/16 via fd00:10:0:2::1 dev net0
     # Server without Cilium. Useful for testing connectivity.

--- a/contrib/containerlab/bgpv2/pod-ip-pool/values.yaml
+++ b/contrib/containerlab/bgpv2/pod-ip-pool/values.yaml
@@ -10,7 +10,6 @@ ipv6:
 
 bgpControlPlane:
   enabled: true
-  v2Enabled: true
 
 ipv4NativeRoutingCIDR: 10.0.0.0/8
 ipv6NativeRoutingCIDR: fd00::/16

--- a/contrib/containerlab/bgpv2/service/Makefile
+++ b/contrib/containerlab/bgpv2/service/Makefile
@@ -1,5 +1,4 @@
-HELM_REPO ?= oci://quay.io/cilium-charts-dev/cilium
-VERSION ?= 1.16.0-dev-dev.247-main-8c97a2119d
+VERSION ?= v1.16.0-rc.0
 
 deploy:
 	kind create cluster --config cluster.yaml
@@ -9,7 +8,7 @@ deploy:
 	# create secret for bgp
 	kubectl -n kube-system create secret generic --type=string bgp-auth-secret --from-literal=password=cilium123
 	# install cilium
-	helm install cilium -n kube-system $(HELM_REPO) --version $(VERSION) -f values.yaml
+	helm install cilium -n kube-system cilium/cilium --version $(VERSION) -f values.yaml
 	cilium status --wait --namespace kube-system
 
 destroy:

--- a/contrib/containerlab/bgpv2/service/bgp.yaml
+++ b/contrib/containerlab/bgpv2/service/bgp.yaml
@@ -24,7 +24,7 @@ spec:
     peers:
     - name: "65000"
       peerASN: 65000
-      peerAddress: fd00:10:0:1::1
+      peerAddress: fd00:10::1
       peerConfigRef:
         name: "cilium-peer"
 

--- a/contrib/containerlab/bgpv2/service/topo.yaml
+++ b/contrib/containerlab/bgpv2/service/topo.yaml
@@ -11,6 +11,9 @@ topology:
       - ip addr add 10.0.2.1/24 dev net1
       - ip addr add 10.0.3.1/24 dev net2
       - sysctl net.ipv6.conf.all.forwarding=1
+      - ip link add name loopback type dummy
+      - ip link set dev loopback up
+      - ip addr add fd00:10:0:0::1/128 dev loopback
       - ip addr add fd00:10:0:1::1/64 dev net0
       - ip addr add fd00:10:0:2::1/64 dev net1
       - ip addr add fd00:10:0:3::1/64 dev net2
@@ -59,6 +62,7 @@ topology:
       - ip addr add 10.0.2.2/24 dev net0
       - ip addr add fd00:10:0:2::2/64 dev net0
       # These static routes are needed because Cilium cannot import routes currently.
+      - ip route add fd00:10:0:0::1/128 via fd00:10:0:1::1 dev net0 # loopback of router0
       - ip route add 10.0.0.0/8 via 10.0.2.1 dev net0
       - ip route add fd00::/16 via fd00:10:0:2::1 dev net0
     # Server without Cilium. Useful for testing connectivity.

--- a/contrib/containerlab/bgpv2/service/values.yaml
+++ b/contrib/containerlab/bgpv2/service/values.yaml
@@ -8,7 +8,6 @@ ipv6:
 
 bgpControlPlane:
   enabled: true
-  v2Enabled: true
 
 ipv4NativeRoutingCIDR: 10.0.0.0/8
 ipv6NativeRoutingCIDR: fd00::/16


### PR DESCRIPTION
Updating the cilium version to v1.16.0-rc.0 for lab deployments. Removed the bgpv2Enable flag; it is no longer required.

This change also modifies peering to loopback instead of the link address, making sure that multiple Cilium nodes can use the same BGP peer address in a cluster configuration.
