### PR TITLE
socket-LB: Terminate pod netns connections to deleted service backends

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1637,14 +1637,10 @@ Limitations
       device changes.
     * When socket-LB feature is enabled, pods sending (connected) UDP traffic to services
       can continue to send traffic to a service backend even after it's deleted. Cilium agent
-      handles such scenarios by forcefully terminating pod sockets in the host network
-      namespace that are connected to deleted backends, so that the pods can be
-      load-balanced to active backends. This functionality requires these
-      kernel configs to be enabled: ``CONFIG_INET_DIAG``, ``CONFIG_INET_UDP_DIAG``
-      and ``CONFIG_INET_DIAG_DESTROY``. If you have application pods (not deployed in the
-      host network namespace) making long-lived connections using (connected) UDP,
-      you can enable ``bpf-lb-sock-hostns-only`` in order to enable the socket-LB
-      feature only in the host network namespace.
+      handles such scenarios by forcefully terminating application sockets that are connected
+      to deleted backends, so that the applications can be load-balanced to active backends.
+      This functionality requires these kernel configs to be enabled:
+      ``CONFIG_INET_DIAG``, ``CONFIG_INET_UDP_DIAG`` and ``CONFIG_INET_DIAG_DESTROY``.
     * Cilium's BPF-based masquerading is recommended over iptables when using the
       BPF-based NodePort. Otherwise, there is a risk for port collisions between
       BPF and iptables SNAT, which might result in dropped NodePort

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -345,6 +345,10 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableSocketLB, false, "Enable socket-based LB for E/W traffic")
 	option.BindEnv(vp, option.EnableSocketLB)
 
+	flags.Bool(option.EnableSocketLBPodConnectionTermination, true, "Enable terminating connections to deleted service backends when socket-LB is enabled")
+	flags.MarkHidden(option.EnableSocketLBPodConnectionTermination)
+	option.BindEnv(vp, option.EnableSocketLBPodConnectionTermination)
+
 	flags.Bool(option.EnableSocketLBTracing, true, "Enable tracing for socket-based LB")
 	option.BindEnv(vp, option.EnableSocketLBTracing)
 
@@ -1384,6 +1388,7 @@ func initEnv(vp *viper.Viper) {
 		option.Config.KubeProxyReplacement = option.KubeProxyReplacementFalse
 		option.Config.EnableSocketLB = true
 		option.Config.EnableSocketLBTracing = true
+		option.Config.EnableSocketLBPodConnectionTermination = true
 		option.Config.EnableHostPort = false
 		option.Config.EnableNodePort = true
 		option.Config.EnableExternalIPs = true

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -314,6 +314,7 @@ func probeKubeProxyReplacementOptions(sysctl sysctl.Sysctl) error {
 		}
 	} else {
 		option.Config.EnableSocketLBTracing = false
+		option.Config.EnableSocketLBPodConnectionTermination = false
 	}
 
 	if option.Config.EnableSessionAffinity && option.Config.EnableSocketLB {

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -315,6 +315,13 @@ spec:
         {{- end}}
         - name: cilium-run
           mountPath: /var/run/cilium
+        {{- /* mount the directory if socketLB.enabled is true and socketLB.terminatePodConnections is not explicitly set to false */ -}}
+        {{- if or (and (kindIs "invalid" .Values.socketLB.terminatePodConnections) .Values.socketLB.enabled)
+                  (and .Values.socketLB.enabled .Values.socketLB.terminatePodConnections)  }}
+        - name: cilium-netns
+          mountPath: /var/run/cilium/netns
+          mountPropagation: HostToContainer
+        {{- end}}
         - name: etc-cni-netd
           mountPath: {{ .Values.cni.hostConfDirMountPath }}
         {{- if .Values.etcd.enabled }}
@@ -790,6 +797,14 @@ spec:
         hostPath:
           path: {{ .Values.daemon.runPath }}
           type: DirectoryOrCreate
+      {{- if or (and (kindIs "invalid" .Values.socketLB.terminatePodConnections) .Values.socketLB.enabled)
+                (and .Values.socketLB.enabled .Values.socketLB.terminatePodConnections)  }}
+        # To exec into pod network namespaces
+      - name: cilium-netns
+        hostPath:
+          path: /var/run/netns
+          type: DirectoryOrCreate
+      {{- end }}
       {{- if .Values.bpf.autoMount.enabled }}
         # To keep state between restarts / upgrades for bpf maps
       - name: bpf-maps

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -719,9 +719,13 @@ data:
 {{- if $socketLB }}
 {{- if hasKey $socketLB "enabled" }}
   bpf-lb-sock: {{ $socketLB.enabled | quote }}
+  bpf-lb-sock-terminate-pod-connections: {{ $socketLB.enabled | quote }}
 {{- end }}
 {{- if hasKey $socketLB "hostNamespaceOnly" }}
   bpf-lb-sock-hostns-only: {{ $socketLB.hostNamespaceOnly | quote }}
+{{- end }}
+{{- if hasKey $socketLB "terminatePodConnections" }}
+  bpf-lb-sock-terminate-pod-connections: {{ $socketLB.terminatePodConnections | quote }}
 {{- end }}
 {{- end }}
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1023,6 +1023,8 @@ socketLB:
   enabled: false
   # -- Disable socket lb for non-root ns. This is used to enable Istio routing rules.
   # hostNamespaceOnly: false
+  # -- Enable terminating pod connections to deleted service backends.
+  # terminatePodConnections: true
 # -- Configure certificate generation for Hubble integration.
 # If hubble.tls.auto.method=cronJob, these values are used
 # for the Kubernetes CronJob which will be scheduled regularly to

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -262,6 +262,7 @@ securityContext:
       - IPC_LOCK
       # Used in iptables. Consider removing once we are iptables-free
       - SYS_MODULE
+      # Needed to switch network namespaces (used for health endpoint, socket-LB).
       # We need it for now but might not need it for >= 5.11 specially
       # for the 'SYS_RESOURCE'.
       # In >= 5.8 there's already BPF and PERMON capabilities

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -260,6 +260,7 @@ securityContext:
       - IPC_LOCK
       # Used in iptables. Consider removing once we are iptables-free
       - SYS_MODULE
+      # Needed to switch network namespaces (used for health endpoint, socket-LB).
       # We need it for now but might not need it for >= 5.11 specially
       # for the 'SYS_RESOURCE'.
       # In >= 5.8 there's already BPF and PERMON capabilities

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1029,6 +1029,8 @@ socketLB:
   enabled: false
   # -- Disable socket lb for non-root ns. This is used to enable Istio routing rules.
   # hostNamespaceOnly: false
+  # -- Enable terminating pod connections to deleted service backends.
+  # terminatePodConnections: true
 # -- Configure certificate generation for Hubble integration.
 # If hubble.tls.auto.method=cronJob, these values are used
 # for the Kubernetes CronJob which will be scheduled regularly to

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -594,6 +594,9 @@ const (
 
 	// EnableEnvoyConfig is the default value for option.EnableEnvoyConfig
 	EnableEnvoyConfig = false
+
+	// NetNsPath is the default path to the mounted network namespaces directory
+	NetNsPath = "/var/run/cilium/netns"
 )
 
 var (

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -501,6 +501,10 @@ const (
 	// BPFSocketLBHostnsOnly is the name of the BPFSocketLBHostnsOnly option
 	BPFSocketLBHostnsOnly = "bpf-lb-sock-hostns-only"
 
+	// EnableSocketLBPodConnectionTermination enables termination of pod connections
+	// to deleted service backends when socket-LB is enabled.
+	EnableSocketLBPodConnectionTermination = "bpf-lb-sock-terminate-pod-connections"
+
 	// RoutingMode is the name of the option to choose between native routing and tunneling mode
 	RoutingMode = "routing-mode"
 
@@ -2467,6 +2471,10 @@ type DaemonConfig struct {
 	// NodeLabels is the list of label prefixes used to determine identity of a node (requires enabling of
 	// EnableNodeSelectorLabels)
 	NodeLabels []string
+
+	// EnableSocketLBPodConnectionTermination enables the termination of connections from pods
+	// to deleted service backends when socket-LB is enabled
+	EnableSocketLBPodConnectionTermination bool
 }
 
 var (
@@ -3054,6 +3062,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.BPFSocketLBHostnsOnly = vp.GetBool(BPFSocketLBHostnsOnly)
 	c.EnableSocketLB = vp.GetBool(EnableSocketLB)
 	c.EnableSocketLBTracing = vp.GetBool(EnableSocketLBTracing)
+	c.EnableSocketLBPodConnectionTermination = vp.GetBool(EnableSocketLBPodConnectionTermination)
 	c.EnableBPFTProxy = vp.GetBool(EnableBPFTProxy)
 	c.EnableXTSocketFallback = vp.GetBool(EnableXTSocketFallbackName)
 	c.EnableAutoDirectRouting = vp.GetBool(EnableAutoDirectRoutingName)


### PR DESCRIPTION
Extension of https://github.com/cilium/cilium/pull/25169 to terminate connections to deleted service backends in pod network namespaces.

Testing:

Manually tested with starting a pair of UDP server and pod applications, and deleted the service backend.

```
$ k get pods -o wide
NAME          READY   STATUS    RESTARTS   AGE    IP             NODE          NOMINATED NODE   READINESS GATES
client        1/1     Running   0          163m   10.244.1.228   kind-worker   <none>           <none>

$ kubectl exec -it server -- iperf3 -s -p  5010
-----------------------------------------------------------
Server listening on 5010 (test #1)
-----------------------------------------------------------
Accepted connection from 10.244.1.228, port 42620
[  5] local 10.244.1.204 port 5010 connected to 10.244.1.228 port 35150

```

```
time="2024-06-28T20:53:54Z" level=debug msg="handling udp connections to deleted backend 10.244.1.204:5010" subsys=service
time="2024-06-28T20:53:54Z" level=info msg="socket {35150 5010 10.244.1.228 10.244.1.204 0 [297562409 0]}" subsys=datapath-sockets
time="2024-06-28T20:53:54Z" level=debug msg="Destroyed socket: {35150 5010 10.244.1.228 10.244.1.204 0 [297562409 0]}" subsys=datapath-sockets
time="2024-06-28T20:53:54Z" level=info msg="Forcefully terminated sockets" errors="<nil>" failed=0 filter="{10.244.1.204 5010 2 17 0x4584220}" subsys=datapath-sockets success=1
```

Fixes: https://github.com/cilium/cilium/issues/27300

```release-note
Forcefully terminate stale connections in pod network namespaces that are connected to deleted service backends when socket-lb is enabled, and allow pod applications to re-connect to active backends.
```