### PR TITLE
Update IPsec to handle larger PSK values when using per-tunnel PSK

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -184,8 +185,16 @@ func computeNodeIPsecKey(globalKey, srcNodeIP, dstNodeIP, srcBootID, dstBootID [
 	input = append(input, dstNodeIP...)
 	input = append(input, srcBootID[:36]...)
 	input = append(input, dstBootID[:36]...)
-	output := sha256.Sum256(input)
-	return output[:len(globalKey)]
+
+	var hash []byte
+	if len(globalKey) <= 32 {
+		h := sha256.Sum256(input)
+		hash = h[:]
+	} else {
+		h := sha512.Sum512(input)
+		hash = h[:]
+	}
+	return hash[:len(globalKey)]
 }
 
 // canonicalIP returns a canonical IPv4 address (4 bytes)

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -42,6 +42,7 @@ var (
 	path           = "ipsec_keys_test"
 	keysDat        = []byte("1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef foobar\n1 digest_null \"\" cipher_null \"\"\n")
 	keysAeadDat    = []byte("6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
+	keysAeadDat256 = []byte("6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f144434241343332312423222114131211 128\n")
 	invalidKeysDat = []byte("1 test abcdefghijklmnopqrstuvwzyzABCDEF test abcdefghijklmnopqrstuvwzyzABCDEF\n")
 )
 
@@ -71,16 +72,14 @@ func TestInvalidLoadKeys(t *testing.T) {
 func TestLoadKeys(t *testing.T) {
 	log := setupIPSecSuitePrivileged(t)
 
-	keys := bytes.NewReader(keysDat)
-	_, spi, err := LoadIPSecKeys(log, keys)
-	require.NoError(t, err)
-	err = SetIPSecSPI(log, spi)
-	require.NoError(t, err)
-	keys = bytes.NewReader(keysAeadDat)
-	_, spi, err = LoadIPSecKeys(log, keys)
-	require.NoError(t, err)
-	err = SetIPSecSPI(log, spi)
-	require.NoError(t, err)
+	testCases := [][]byte{keysDat, keysAeadDat, keysAeadDat256}
+	for _, testCase := range testCases {
+		keys := bytes.NewReader(testCase)
+		_, spi, err := LoadIPSecKeys(log, keys)
+		require.NoError(t, err)
+		err = SetIPSecSPI(log, spi)
+		require.NoError(t, err)
+	}
 }
 
 func TestParseSPI(t *testing.T) {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

For PSK values <= 32 bytes use SHA256 to compute the node key.  Otherwise use SHA512. This is needed to support GCM-256-AES since a PSK for this would require 36 bytes as per RFC 4106.

Fixes: #33457


