### PR TITLE
envoy: Update envoy 1.28.x to v1.28.5

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:408dd9633bf6f96af4efb86b7
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.28.4-b35188ffa1bbe54d1720d2e392779f7a48e58f6b@sha256:b528b291561e459024f66414ac3325b88cdd8f9f4854828a155a11e5b10b78a3 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.28.5-1e0a902a90fa02ca3efa88abf36d145f224e19d9@sha256:87eb5c1bf0888af4871d8bb2827ffb0b81b789e571a163530cc44ec7c45b84c3 as cilium-envoy
 
 #
 # Hubble CLI


### PR DESCRIPTION
This is mainly to pick up the below CVE fix from the upstream.

Related CVE: https://github.com/envoyproxy/envoy/security/advisories/GHSA-fp35-g349-h66f
Relates: https://github.com/cilium/proxy/pull/819
Relates: https://github.com/envoyproxy/envoy/releases/tag/v1.28.5
