### PR TITLE
[v1.15] bpf: ct: return actual error from CT lookup (fixup)

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1402,6 +1402,9 @@ skip_service_lookup:
 		ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
 				      CT_EGRESS, SCOPE_FORWARD, CT_ENTRY_NODEPORT,
 				      &ct_state, &monitor);
+		if (ret < 0)
+			return ret;
+
 		switch (ret) {
 		case CT_NEW:
 redo:
@@ -2948,6 +2951,9 @@ skip_service_lookup:
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, is_fragment,
 				      l4_off, has_l4_header, CT_EGRESS, SCOPE_FORWARD,
 				      CT_ENTRY_NODEPORT, &ct_state, &monitor);
+		if (ret < 0)
+			return ret;
+
 		switch (ret) {
 		case CT_NEW:
 redo:


### PR DESCRIPTION
Bring some changes from https://github.com/cilium/cilium/pull/33225 back, that got lost in https://github.com/cilium/cilium/pull/33378.