### PR TITLE
daemon: add agent-runtime-config backup files to gitignore

### DIFF
--- a/pkg/option/.gitignore
+++ b/pkg/option/.gitignore
@@ -1,0 +1,1 @@
+agent-runtime-config*.json


### PR DESCRIPTION
Executing the unit tests in `pkg/option` generates `agent-runtime-config.json` backup files.

```
❯ go test ./pkg/option/...
ok      github.com/cilium/cilium/pkg/option     0.236s
ok      github.com/cilium/cilium/pkg/option/resolver    (cached)

❯ git status
On branch main
Your branch is up to date with 'origin/main'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        pkg/option/agent-runtime-config.json

nothing added to commit but untracked files present (use "git add" to track)
```

This commit adds the config files to the gitignore file to prevent them from being added to version control.

Note: At a second look it seems that the config backup files are never stored into the Cilium StateDir. Writing, reading and validating the config files directly operators on the working directory. And the whole backup file rotation doesn't seem to work as expected as this one is working on the statedir directory where no backup files exists :thinking: But this PR fixes the issue that these config files shouldn't be added to version control (even though it would be nicer to be able to use a temp test dir - but this would require to change the config logic)

Fixes: https://github.com/cilium/cilium/pull/32981