### PR TITLE
ci: enable BGP Control Plane in e2e tests

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -58,6 +58,9 @@ inputs:
   local-redirect-policy:
     description: 'Enable local redirect policy'
     default: 'false'
+  bgp-control-plane:
+    description: 'Enable BGP Control Plane'
+    default: 'false'
 outputs:
   config:
     description: 'Cilium installation config'
@@ -170,5 +173,10 @@ runs:
             LOCAL_REDIRECT_POLICY="--helm-set=localRedirectPolicy=true"
           fi
 
-          CONFIG="${DEFAULTS} ${IMAGE} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION} ${INGRESS_CONTROLLER} ${CILIUMENDPOINTSLICE} ${LOCAL_REDIRECT_POLICY}"
+          BGP_CONTROL_PLANE=""
+          if [ "${{ inputs.bgp-control-plane }}" == "true" ]; then
+            BGP_CONTROL_PLANE="${{ env.BGP_CONTROL_PLANE_HELM_VALUES }}"
+          fi
+
+          CONFIG="${DEFAULTS} ${IMAGE} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION} ${INGRESS_CONTROLLER} ${CILIUMENDPOINTSLICE} ${LOCAL_REDIRECT_POLICY} ${BGP_CONTROL_PLANE}"
           echo "config=${CONFIG}" >> $GITHUB_OUTPUT

--- a/.github/actions/set-env-variables/action.yml
+++ b/.github/actions/set-env-variables/action.yml
@@ -10,6 +10,7 @@ runs:
         # no prod yet
         echo "QUAY_CHARTS_ORGANIZATION_DEV=cilium-charts-dev" >> $GITHUB_ENV
         echo "EGRESS_GATEWAY_HELM_VALUES=--helm-set=egressGateway.enabled=true" >> $GITHUB_ENV
+        echo "BGP_CONTROL_PLANE_HELM_VALUES=--helm-set=bgpControlPlane.enabled=true" >> $GITHUB_ENV
         echo "CILIUM_CLI_RELEASE_REPO=cilium/cilium-cli" >> $GITHUB_ENV
         # renovate: datasource=github-releases depName=cilium/cilium-cli
         CILIUM_CLI_VERSION="v0.16.13"

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -153,6 +153,7 @@ jobs:
             host-fw: 'true'
             lb-acceleration: 'testing-only'
             ingress-controller: 'true'
+            bgp-control-plane: 'true'
 
           - name: '7'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -390,6 +391,7 @@ jobs:
           misc: ${{ matrix.misc }}
           ciliumendpointslice: ${{ matrix.ciliumendpointslice }}
           local-redirect-policy: ${{ matrix.local-redirect-policy }}
+          bgp-control-plane: ${{ matrix.bgp-control-plane }}
 
       - name: Set Kind params
         id: kind-params

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -154,6 +154,7 @@ jobs:
             # Disable until https://github.com/cilium/cilium/issues/30717
             # has been resolved.
             # ingress-controller: 'true'
+            bgp-control-plane: 'true'
 
 #          Disable until https://github.com/cilium/cilium/issues/32689
 #          is resolved.
@@ -395,6 +396,7 @@ jobs:
           ingress-controller: ${{ matrix.ingress-controller }}
           misc: ${{ matrix.misc || 'bpfClockProbe=false,cni.uninstall=false' }}
           ciliumendpointslice: ${{ matrix.ciliumendpointslice }}
+          bgp-control-plane: ${{ matrix.bgp-control-plane }}
 
       - name: Derive newest Cilium installation config
         id: cilium-newest-config
@@ -417,6 +419,7 @@ jobs:
           ingress-controller: ${{ matrix.ingress-controller }}
           misc: ${{ matrix.misc || 'bpfClockProbe=false,cni.uninstall=false' }}
           ciliumendpointslice: ${{ matrix.ciliumendpointslice }}
+          bgp-control-plane: ${{ matrix.bgp-control-plane }}
 
       - name: Set Kind params
         id: kind-params


### PR DESCRIPTION
Enables BGP Control Plane tests introduced by https://github.com/cilium/cilium-cli/pull/2649 in e2e test workflows. Allows for parametrization of BGP CP helm values.

Note: it is not really important on which matrix item we enable the BGP tests.