### PR TITLE
ipsec: Remove deprecated secret parsing code

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -60,8 +60,7 @@ const (
 	offsetAuthKey  = 2
 	offsetEncAlgo  = 3
 	offsetEncKey   = 4
-	offsetIP       = 5
-	maxOffset      = offsetIP
+	maxOffset      = offsetEncKey
 
 	defaultDropPriority      = 100
 	oldXFRMOutPolicyPriority = 50
@@ -1201,19 +1200,10 @@ func LoadIPSecKeys(log *slog.Logger, r io.Reader) (int, uint8, error) {
 		ipSecKey.Spi = spi
 		ipSecKey.ESN = esn
 
-		if len(s) == offsetBase+offsetIP+1 {
-			// The IPsec secret has the optional IP address field at the end.
-			log.Warn("IPsec secrets with an IP address as the last argument are deprecated and will be unsupported in v1.13.")
-			if ipSecKeysGlobal[s[offsetBase+offsetIP]] != nil {
-				oldSpi = ipSecKeysGlobal[s[offsetBase+offsetIP]].Spi
-			}
-			ipSecKeysGlobal[s[offsetBase+offsetIP]] = ipSecKey
-		} else {
-			if ipSecKeysGlobal[""] != nil {
-				oldSpi = ipSecKeysGlobal[""].Spi
-			}
-			ipSecKeysGlobal[""] = ipSecKey
+		if ipSecKeysGlobal[""] != nil {
+			oldSpi = ipSecKeysGlobal[""].Spi
 		}
+		ipSecKeysGlobal[""] = ipSecKey
 
 		ipSecKeysRemovalTime[oldSpi] = time.Now()
 		ipSecCurrentKeySPI = spi
@@ -1229,10 +1219,7 @@ func parseSPI(log *slog.Logger, spiStr string) (uint8, int, bool, error) {
 	}
 	spi, err := strconv.Atoi(spiStr)
 	if err != nil {
-		// If no version info is provided assume using key format without
-		// versioning and assign SPI.
-		log.Warn("IPsec secrets without an SPI as the first argument are deprecated and will be unsupported in v1.13.")
-		return 1, -1, esn, nil
+		return 0, 0, false, fmt.Errorf("the first argument of the IPsec secret is not a number. Attempted %q", spiStr)
 	}
 	if spi > linux_defaults.IPsecMaxKeyVersion {
 		return 0, 0, false, fmt.Errorf("encryption key space exhausted. ID must be nonzero and less than %d. Attempted %q", linux_defaults.IPsecMaxKeyVersion+1, spiStr)

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -40,7 +40,7 @@ func setupIPSecSuitePrivileged(tb testing.TB) *slog.Logger {
 
 var (
 	path           = "ipsec_keys_test"
-	keysDat        = []byte("1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef foobar\n1 digest_null \"\" cipher_null \"\"\n")
+	keysDat        = []byte("1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n1 digest_null \"\" cipher_null \"\"\n")
 	keysAeadDat    = []byte("6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
 	invalidKeysDat = []byte("1 test abcdefghijklmnopqrstuvwzyzABCDEF test abcdefghijklmnopqrstuvwzyzABCDEF\n")
 )
@@ -96,7 +96,7 @@ func TestParseSPI(t *testing.T) {
 		{"254", 0, 0, false, true},
 		{"15", 15, 0, false, false},
 		{"3+", 3, 0, true, false},
-		{"abc", 1, -1, false, false},
+		{"abc", 0, 0, false, true},
 		{"0", 0, 0, false, true},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
These format options for the IPsec secret were never documented and have been deprecated since v1.12. We postpone the removal since a lot was going on in IPsec land, but it's now time to remove it.