### PR TITLE
bpf: lxc: loopback cleanups

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1901,13 +1901,9 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, int ifindex, __u32 src_la
 	 * connection. Populate
 	 * - .loopback, so that policy enforcement is bypassed, and
 	 * - .rev_nat_index, so that replies can be RevNATed.
-	 *
-	 * TODO: in v1.17, remove the rev_nat_index part. We're no longer driving
-	 * RevNAT from this CT entry.
 	 */
 	if (ret == CT_NEW && ip4->saddr == IPV4_LOOPBACK &&
-	    ct_has_loopback_egress_entry4(get_ct_map4(tuple), tuple,
-					  &ct_state_new.rev_nat_index)) {
+	    ct_has_loopback_egress_entry4(get_ct_map4(tuple), tuple)) {
 		ct_state_new.loopback = true;
 		goto skip_policy_enforcement;
 	}

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -571,9 +571,6 @@ ct_recreate6:
 		return DROP_UNKNOWN_CT;
 	}
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
-		return DROP_INVALID;
-
 #ifdef ENABLE_SRV6
 	{
 		__u32 *vrf_id;

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -1059,8 +1059,7 @@ err_ct_fill_up:
 
 #ifndef DISABLE_LOOPBACK_LB
 static __always_inline bool
-ct_has_loopback_egress_entry4(const void *map, struct ipv4_ct_tuple *tuple,
-			      __u16 *rev_nat_index)
+ct_has_loopback_egress_entry4(const void *map, struct ipv4_ct_tuple *tuple)
 {
 	__u8 flags = tuple->flags;
 	struct ct_entry *entry;
@@ -1069,12 +1068,7 @@ ct_has_loopback_egress_entry4(const void *map, struct ipv4_ct_tuple *tuple,
 	entry = map_lookup_elem(map, tuple);
 	tuple->flags = flags;
 
-	if (entry && entry->lb_loopback) {
-		*rev_nat_index = entry->rev_nat_index;
-		return true;
-	}
-
-	return false;
+	return entry && entry->lb_loopback;
 }
 #endif
 


### PR DESCRIPTION
Apply two minor cleanups related to loopback handling in bpf_lxc.

Fixes: #33154