### PR TITLE
ipsec: Deprecate global IPsec keys

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -1240,6 +1240,9 @@ func parseSPI(log *slog.Logger, spiStr string) (uint8, int, bool, error) {
 	if spi == 0 {
 		return 0, 0, false, fmt.Errorf("zero is not a valid key ID. ID must be nonzero and less than %d. Attempted %q", linux_defaults.IPsecMaxKeyVersion+1, spiStr)
 	}
+	if !esn {
+		log.Warn(fmt.Sprintf("global IPsec keys are deprecated and will be removed in v1.17. Use per-tunnel keys instead by adding a '+' sign after the SPI (%d+ in your case).", spi))
+	}
 	return uint8(spi), 0, esn, nil
 }
 


### PR DESCRIPTION
Using a single IPsec key for all IPsec tunnels is insecure. It was only preserved to allow for a smooth switch to per-tunnel keys. Per-tunnel keys have been released in v1.13, v1.14, and v1.15, so we can now deprecate the insecure alternative for v1.16.