### PR TITLE
gh: ipsec: clarify check for leaked proxy traffic during key rotation

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -349,6 +349,8 @@ jobs:
         uses: ./.github/actions/bpftrace/start
         with:
           script: ./.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
+          # As we are not testing with proxy connections during key rotation,
+          # disable the check for proxy traffic.
           args: ${{ steps.bpftrace-params.outputs.params }} "false"
 
       - name: Setup conn-disrupt-test before rotating (${{ join(matrix.*, ', ') }})


### PR DESCRIPTION
Add a comment to explain why we need to disable the check for proxy traffic when running the bpftrace leak detection during key rotation.