### PR TITLE
fix: Track node labels propagated to the endpoint manager correctly

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -506,6 +506,11 @@ func (e *Endpoint) IsHost() bool {
 	return e.isHost
 }
 
+// SetIsHost is a convenient method to create host endpoints for testing.
+func (ep *Endpoint) SetIsHost(isHost bool) {
+	ep.isHost = isHost
+}
+
 // closeBPFProgramChannel closes the channel that signals whether the endpoint
 // has had its BPF program compiled. If the channel is already closed, this is
 // a no-op.


### PR DESCRIPTION
This fixes a race condition during agent startup that causes the k8s node label updates to not get propagated to the host endpoint.

The current endpoint label update logic rejects a request if any of the labels on the old node are not present in the endpoint manager state.

For host endpoints, the k8s node label add/update events may be missed if the k8s node watcher initializes before the host endpoint is created. As a result, the host endpoint labels are outdated, and all subsequent node label updates are rejected due to the aforementioned precondition check.

To resolve the issue, this commit updates the old labels only if the current node label update is successfully propagated to the endpoint manager.

Fixes cilium#29649

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Fixes a race condition during agent startup that causes the k8s node label updates to not get propagated to the host endpoint.
```
