### PR TITLE
Documentation: accept ORG and REPO

### DIFF
--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -8,7 +8,7 @@ if [ ! -e "$dst_file" ]; then
 fi
 
 . "${dir}/../contrib/backporting/common.sh"
-remote="$(get_remote)"
+remote="$(get_remote "${ORG:-}" "${REPO:-}")"
 
 set -e
 set -o nounset


### PR DESCRIPTION
By default, the check-crd-compat-table script will get the remote from cilium/cilium. This script won't work if there isn't a remote under these names. As a workaround, and to avoid many refactoring, the script will detect if ORG and / or REPO environment variables are set and use those as inputs to get the remote name.