### PR TITLE
bpf: lxc: use THIS_INTERFACE_IFINDEX instead of CB_IFINDEX

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1667,7 +1667,8 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 #endif /* !ENABLE_ROUTING && !ENABLE_NODEPORT */
 
 		if (ifindex)
-			ret = redirect_ep(ctx, ifindex, from_host, from_tunnel);
+			ret = redirect_ep(ctx, THIS_INTERFACE_IFINDEX, from_host,
+					  from_tunnel);
 		break;
 	default:
 		break;
@@ -2018,7 +2019,8 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 #endif /* !ENABLE_ROUTING && !ENABLE_NODEPORT */
 
 		if (ifindex)
-			ret = redirect_ep(ctx, ifindex, from_host, from_tunnel);
+			ret = redirect_ep(ctx, THIS_INTERFACE_IFINDEX, from_host,
+					  from_tunnel);
 		break;
 	default:
 		break;

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -109,6 +109,9 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 
 	/* Jumps to destination pod's BPF program to enforce ingress policies. */
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);
+	/* With v1.17+, the actual ifindex is unused and this can be just a
+	 * "needs redirect" boolean flag:
+	 */
 	ctx_store_meta(ctx, CB_IFINDEX, ep->ifindex);
 	ctx_store_meta(ctx, CB_FROM_HOST, from_host ? 1 : 0);
 	ctx_store_meta(ctx, CB_FROM_TUNNEL, from_tunnel ? 1 : 0);


### PR DESCRIPTION
When bpf_lxc's ingress path is called via the policy tailcall map, it takes a CB_IFINDEX parameter. This is used to redirect the packet into the endpoint, after applying policy.

But now that we bake the endpoint's ifindex into the bpf_lxc program, this can be replaced by THIS_INTERFACE_IFINDEX. Allowing us to eventually condense all the boolean flags (CB_IFINDEX / CB_FROM_HOST / CB_FROM_TUNNEL) into a single skb->cb slot.