### PR TITLE
bgpv2: Skip reconcile while BGPNodeConfig is not initialized

### DIFF
--- a/pkg/bgpv1/agent/controller.go
+++ b/pkg/bgpv1/agent/controller.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/cilium/hive/cell"
@@ -233,6 +234,10 @@ func (c *Controller) Reconcile(ctx context.Context) error {
 		Name: c.LocalCiliumNode.Name,
 	})
 	if err != nil {
+		if errors.Is(err, store.ErrStoreUninitialized) {
+			log.Debug("BGPNodeConfig store not yet initialized")
+			return nil // skip the reconciliation - once the store is initialized, it will trigger new reconcile event
+		}
 		log.WithError(err).Error("failed to get BGPNodeConfig")
 		return err
 	}


### PR DESCRIPTION
At the moment, these errors are logged most of the time during the agent startup:
```
time="2024-07-01T14:23:32Z" level=error msg="failed to get BGPNodeConfig" error="the store has not initialized yet" subsys=bgp-control-plane
time="2024-07-01T14:23:32Z" level=error msg="Encountered error during reconciliation" component=Controller.Run error="the store has not initialized yet" subsys=bgp-control-plane
```
(usually logged multiple times thanks to retries and many reconcile events during the startup)

The reason for this is that `CiliumBGPPeerConfig` store is created [asynchronously in a job of BGPCPResourceStore](https://github.com/cilium/cilium/blob/b1ea3e32ebf78c1b4cde863ec86d21ee2e028dd3/pkg/bgpv1/manager/store/resource_store.go#L66), and the BGP Agent's Controller does not wait with starting the reconciliation loop until it is created.

As another reconcile event will be triggered when this store is initialized (e.g. upon Sync event [here](https://github.com/cilium/cilium/blob/b1ea3e32ebf78c1b4cde863ec86d21ee2e028dd3/pkg/bgpv1/manager/store/resource_store.go#L71)), it is safe to skip reconciliation attempts while it is not initialized.