### PR TITLE
Fix renovate's concurrency group

### DIFF
--- a/.github/workflows/build-images-base-renovate.yaml
+++ b/.github/workflows/build-images-base-renovate.yaml
@@ -15,10 +15,6 @@ permissions:
   # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
   id-token: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build-base-images-from-renovate:
     name: "Build Base Images From Renovate"


### PR DESCRIPTION
The "Base Image Release Build - Renovate" workflow doesn't need a concurrency group has it will use the concurrency group of the workflow that it uses, the "./.github/workflows/build-images-base.yaml". Using the concurrency groups on both workflows will result in the following error:

Canceling since a deadlock for concurrency group 'Base Image Release Build - Renovate-refs/heads/renovate/main-all-dependencies' was detected between 'top level workflow' and 'build-base-images-from-renovate'
