### PR TITLE
v1.15 Backports 2024-07-01

### DIFF
--- a/.github/actions/set-env-variables/action.yml
+++ b/.github/actions/set-env-variables/action.yml
@@ -12,7 +12,7 @@ runs:
         echo "EGRESS_GATEWAY_HELM_VALUES=--helm-set=egressGateway.enabled=true" >> $GITHUB_ENV
         echo "CILIUM_CLI_RELEASE_REPO=cilium/cilium-cli" >> $GITHUB_ENV
         # renovate: datasource=github-releases depName=cilium/cilium-cli
-        CILIUM_CLI_VERSION="v0.16.10"
+        CILIUM_CLI_VERSION="v0.16.11"
         echo "CILIUM_CLI_VERSION=$CILIUM_CLI_VERSION" >> $GITHUB_ENV
         echo "PUSH_TO_DOCKER_HUB=true" >> $GITHUB_ENV
         echo "GCP_PERF_RESULTS_BUCKET=gs://cilium-scale-results" >> $GITHUB_ENV

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -300,12 +300,18 @@ jobs:
         run: |
           mkdir -p cilium-junits
 
+          TEST=""
+          if [ "${{ matrix.key-one }}" = "gcm(aes)" ] && [ "${{ matrix.key-two }}" = "cbc(aes)" ]; then
+            # Until https://github.com/cilium/cilium/issues/29480 is resolved
+            TEST='--test "!pod-to-pod-no-frag"'
+          fi
+
           ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
             --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-            --flush-ct
+            --flush-ct $TEST
 
       - name: Assert that no unencrypted packets are leaked
         uses: ./.github/actions/bpftrace/check

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2395,7 +2395,7 @@
    * - :spelling:ignore:`nodeinit.image`
      - node-init image.
      - object
-     - ``{"digest":"sha256:820155cb3b7f00c8d61c1cffa68c44440906cb046bdbad8ff544f5deb1103456","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/startup-script","tag":"19fb149fb3d5c7a37d3edfaf10a2be3ab7386661","useDigest":true}``
+     - ``{"digest":"sha256:8d7b41c4ca45860254b3c19e20210462ef89479bb6331d6760c4e609d651b29c","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/startup-script","tag":"c54c7edeab7fde4da68e59acd319ab24af242c3f","useDigest":true}``
    * - :spelling:ignore:`nodeinit.nodeSelector`
      - Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
      - object

--- a/Documentation/network/kubernetes/local-redirect-policy.rst
+++ b/Documentation/network/kubernetes/local-redirect-policy.rst
@@ -160,9 +160,9 @@ in Cilium pod running on the same node as ``lrp-pod``.
 .. code-block:: shell-session
 
     $ kubectl exec -it -n kube-system cilium-5ngzd -- cilium-dbg service list
-    ID   Frontend               Service Type   Backend
+    ID   Frontend               Service Type       Backend
     [...]
-    4    172.20.0.51:80         ClusterIP      1 => 10.16.70.187:80
+    4    172.20.0.51:80         LocalRedirect      1 => 10.16.70.187:80
 
 Invoke a curl command from the client pod to the IP address and port
 configuration specified in the ``lrp-addr`` custom resource above.

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -361,9 +361,12 @@ all
     The all entity represents the combination of all known clusters as well
     world and whitelists all communication.
 
-.. note:: The ``kube-apiserver`` entity is unavailable in some Kubernetes 
-   distributions, such as Azure AKS and GCP GKE for ingress traffic. You could still use ``cluster`` which
-   is broader.
+.. note:: The ``kube-apiserver`` entity may not work for *ingress traffic* in some Kubernetes
+   distributions, such as Azure AKS and GCP GKE. This is due to the fact that ingress
+   control-plane traffic is being tunneled through worker nodes, which does not preserve
+   the original source IP. You may be able to use a broader ``fromEntities: cluster`` rule
+   instead. Restricting *egress traffic* via ``toEntities: kube-apiserver`` however is expected
+   to work on these Kubernetes distributions.
 
 Access to/from kube-apiserver
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1218,6 +1218,17 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 	if (tunnel_endpoint) {
 		__be16 src_port;
 
+#if __ctx_is == __ctx_skb
+		{
+			/* See the corresponding v4 path for details */
+			bool l2_hdr_required = false;
+
+			ret = maybe_add_l2_hdr(ctx, ENCAP_IFINDEX, &l2_hdr_required);
+			if (ret != 0)
+				goto drop_err;
+		}
+#endif
+
 		src_port = tunnel_gen_src_port_v6(&tuple);
 
 		ret = nodeport_add_tunnel_encap(ctx,
@@ -2734,6 +2745,20 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 #ifdef TUNNEL_MODE
 	if (tunnel_endpoint) {
 		__be16 src_port;
+
+#if __ctx_is == __ctx_skb
+		{
+			/* Append L2 hdr before redirecting to tunnel netdev.
+			 * Otherwise, the kernel will drop such request in
+			 * https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/core/filter.c?h=v6.7.4#n2147
+			 */
+			bool l2_hdr_required = false;
+
+			ret = maybe_add_l2_hdr(ctx, ENCAP_IFINDEX, &l2_hdr_required);
+			if (ret != 0)
+				goto drop_err;
+		}
+#endif
 
 		src_port = tunnel_gen_src_port_v4(&tuple);
 

--- a/bpf/tests/tc_nodeport_l3_dev_to_tunnel.c
+++ b/bpf/tests/tc_nodeport_l3_dev_to_tunnel.c
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+
+#define ETH_HLEN		0
+#define SECCTX_FROM_IPCACHE	1
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define TUNNEL_MODE	1
+#define ENCAP_IFINDEX	42
+#define ENABLE_NODEPORT	1
+
+#define TEST_IP_LOCAL		v4_pod_one
+#define TEST_IP_REMOTE		v4_pod_two
+#define TEST_IPV6_LOCAL		v6_pod_one
+
+#define CLIENT_IP		v4_ext_one
+#define CLIENT_IPV6		{ .addr = { 0x1, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+#define CLIENT_PORT		__bpf_htons(111)
+
+#define FRONTEND_IP		v4_svc_one
+#define FRONTEND_IPV6		{ .addr = { 0x5, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+#define FRONTEND_PORT		tcp_svc_one
+
+#define BACKEND_IP		v4_pod_one
+#define BACKEND_IPV6		{ .addr = { 0x3, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+#define BACKEND_PORT		__bpf_htons(8080)
+
+#include "bpf_host.c"
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+
+static volatile const __u8 *node_mac = mac_two;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 2);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[0] = &cil_from_netdev,
+	},
+};
+
+PKTGEN("tc", "ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel")
+int ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* We are building an L3 skb which doesn't have L2 header, so in theory
+	 * we need to skip L2 header and set ctx->protocol = bpf_ntohs(ETH_P_IP),
+	 * but bpf verifier doesn't allow us to do so, and kernel also doesn't
+	 * handle an L3 skb properly (see https://elixir.bootlin.com/linux/v6.2.1/source/net/bpf/test_run.c#L1156).
+	 * Therefore we workaround the issue by pushing L2 header in the PKTGEN
+	 * and stripping it in the SETUP.
+	 */
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)node_mac, (__u8 *)node_mac,
+					  CLIENT_IP, FRONTEND_IP,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel")
+int ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel_setup(struct __ctx_buff *ctx)
+{
+	void *data = (void *)(long)ctx->data;
+	void *data_end = (void *)(long)ctx->data_end;
+	__u64 flags = BPF_F_ADJ_ROOM_FIXED_GSO;
+
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, 1, 1);
+	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, 1, 124,
+			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, TEST_IP_REMOTE, 0);
+
+	/* As commented in PKTGEN, now we strip the L2 header. Bpf helper
+	 * skb_adjust_room will use L2 header to overwrite L3 header, so we play
+	 * a trick to memcpy(ethhdr, iphdr, ETH_HLEN) ahead of skb_adjust_room
+	 * so as to guarantee L3 header keeps intact.
+	 */
+	if ((void *)data + __ETH_HLEN + __ETH_HLEN <= data_end)
+		memcpy(data, data + __ETH_HLEN, __ETH_HLEN);
+
+	skb_adjust_room(ctx, -__ETH_HLEN, BPF_ADJ_ROOM_MAC, flags);
+
+	tail_call_static(ctx, entry_call_map, 0);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel")
+int ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel_check(__maybe_unused
+							   const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	/* Check that LB request got redirected (to a tunnel iface) */
+	assert(*status_code == TC_ACT_REDIRECT);
+
+	/* Check that L2 hdr was added */
+	l2 = data + sizeof(__u32);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IP))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	test_finish();
+}
+
+PKTGEN("tc", "ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel")
+int ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel(struct __ctx_buff *ctx)
+{
+	union v6addr frontend_ip = FRONTEND_IPV6;
+	union v6addr client_ip = CLIENT_IPV6;
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* We are building an L3 skb which doesn't have L2 header, so in theory
+	 * we need to skip L2 header and set ctx->protocol = bpf_ntohs(ETH_P_IP),
+	 * but bpf verifier doesn't allow us to do so, and kernel also doesn't
+	 * handle an L3 skb properly (see https://elixir.bootlin.com/linux/v6.2.1/source/net/bpf/test_run.c#L1156).
+	 * Therefore we workaround the issue by pushing L2 header in the PKTGEN
+	 * and stripping it in the SETUP.
+	 */
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)node_mac, (__u8 *)node_mac,
+					  (__u8 *)&client_ip, (__u8 *)&frontend_ip,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel")
+int ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel_setup(struct __ctx_buff *ctx)
+{
+	union v6addr frontend_ip = FRONTEND_IPV6;
+	union v6addr backend_ip = BACKEND_IPV6;
+	void *data = (void *)(long)ctx->data;
+	void *data_end = (void *)(long)ctx->data_end;
+	__u64 flags = BPF_F_ADJ_ROOM_FIXED_GSO;
+
+	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, 1, 1);
+	lb_v6_add_backend(&frontend_ip, FRONTEND_PORT, 1, 124,
+			  &backend_ip, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	ipcache_v6_add_entry(&backend_ip, 0, 112233, TEST_IP_REMOTE, 0);
+
+	/* As commented in PKTGEN, now we strip the L2 header. Bpf helper
+	 * skb_adjust_room will use L2 header to overwrite L3 header, so we play
+	 * a trick to memcpy(ethhdr, iphdr, ETH_HLEN) ahead of skb_adjust_room
+	 * so as to guarantee L3 header keeps intact.
+	 */
+	if ((void *)data + __ETH_HLEN + __ETH_HLEN <= data_end)
+		memcpy(data, data + __ETH_HLEN, __ETH_HLEN);
+
+	skb_adjust_room(ctx, -__ETH_HLEN, BPF_ADJ_ROOM_MAC, flags);
+
+	tail_call_static(ctx, entry_call_map, 0);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel")
+int ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel_check(__maybe_unused
+							   const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	/* Check that LB request got redirected (to a tunnel iface) */
+	assert(*status_code == TC_ACT_REDIRECT);
+
+	/* Check that L2 hdr was added */
+	l2 = data + sizeof(__u32);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IPV6))
+		test_fatal("l2 proto hasn't been set to ETH_P_IPV6");
+
+	test_finish();
+}

--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -44,8 +44,8 @@ export CILIUM_ETCD_OPERATOR_DIGEST:=sha256:04b8327f7f992693c2cb483b999041ed8f92e
 
 # renovate: datasource=docker
 export CILIUM_NODEINIT_REPO:=quay.io/cilium/startup-script
-export CILIUM_NODEINIT_VERSION:=19fb149fb3d5c7a37d3edfaf10a2be3ab7386661
-export CILIUM_NODEINIT_DIGEST:=sha256:820155cb3b7f00c8d61c1cffa68c44440906cb046bdbad8ff544f5deb1103456
+export CILIUM_NODEINIT_VERSION:=c54c7edeab7fde4da68e59acd319ab24af242c3f
+export CILIUM_NODEINIT_DIGEST:=sha256:8d7b41c4ca45860254b3c19e20210462ef89479bb6331d6760c4e609d651b29c
 
 # renovate: datasource=docker
 export CILIUM_ENVOY_REPO:=quay.io/cilium/cilium-envoy

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -648,7 +648,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.extraEnv | list | `[]` | Additional nodeinit environment variables. |
 | nodeinit.extraVolumeMounts | list | `[]` | Additional nodeinit volumeMounts. |
 | nodeinit.extraVolumes | list | `[]` | Additional nodeinit volumes. |
-| nodeinit.image | object | `{"digest":"sha256:820155cb3b7f00c8d61c1cffa68c44440906cb046bdbad8ff544f5deb1103456","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/startup-script","tag":"19fb149fb3d5c7a37d3edfaf10a2be3ab7386661","useDigest":true}` | node-init image. |
+| nodeinit.image | object | `{"digest":"sha256:8d7b41c4ca45860254b3c19e20210462ef89479bb6331d6760c4e609d651b29c","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/startup-script","tag":"c54c7edeab7fde4da68e59acd319ab24af242c3f","useDigest":true}` | node-init image. |
 | nodeinit.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | nodeinit.podAnnotations | object | `{}` | Annotations to be added to node-init pods. |
 | nodeinit.podLabels | object | `{}` | Labels to be added to node-init pods. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2706,8 +2706,8 @@ nodeinit:
   image:
     override: ~
     repository: "quay.io/cilium/startup-script"
-    tag: "19fb149fb3d5c7a37d3edfaf10a2be3ab7386661"
-    digest: "sha256:820155cb3b7f00c8d61c1cffa68c44440906cb046bdbad8ff544f5deb1103456"
+    tag: "c54c7edeab7fde4da68e59acd319ab24af242c3f"
+    digest: "sha256:8d7b41c4ca45860254b3c19e20210462ef89479bb6331d6760c4e609d651b29c"
     useDigest: true
     pullPolicy: "IfNotPresent"
 

--- a/pkg/egressgateway/endpoint.go
+++ b/pkg/egressgateway/endpoint.go
@@ -53,10 +53,6 @@ func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint, identityLabels label
 		}
 	}
 
-	if endpoint.Identity == nil {
-		return nil, fmt.Errorf("endpoint has no identity metadata")
-	}
-
 	data := &endpointMetadata{
 		ips:    addrs,
 		labels: identityLabels.K8sStringMap(),

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -458,6 +458,11 @@ func (manager *Manager) addEndpoint(endpoint *k8sTypes.CiliumEndpoint) error {
 		logfields.K8sUID:          endpoint.UID,
 	})
 
+	if endpoint.Identity == nil {
+		logger.Warning("Endpoint is missing identity metadata, skipping update to egress policy.")
+		return nil
+	}
+
 	if identityLabels, err = manager.getIdentityLabels(uint32(endpoint.Identity.ID)); err != nil {
 		logger.WithError(err).
 			Warning("Failed to get identity labels for endpoint")

--- a/pkg/hubble/metrics/api/api.go
+++ b/pkg/hubble/metrics/api/api.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
-	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -126,13 +126,13 @@ func (h Handlers) ProcessFlow(ctx context.Context, flow *pb.Flow) error {
 	return errs
 }
 
-// ProcessPodDeletion queries all handlers for a list of MetricVec and removes
-// metrics directly associated to deleted pod.
-func (h Handlers) ProcessPodDeletion(pod *slim_corev1.Pod) {
+// ProcessCiliumEndpointDeletion queries all handlers for a list of MetricVec and removes
+// metrics directly associated to pod of the deleted cilium endpoint.
+func (h Handlers) ProcessCiliumEndpointDeletion(endpoint *types.CiliumEndpoint) {
 	for _, h := range h.handlers {
 		for _, mv := range h.ListMetricVec() {
 			if ctx := h.Context(); ctx != nil {
-				ctx.DeleteMetricsAssociatedWithPod(pod.GetName(), pod.GetNamespace(), mv)
+				ctx.DeleteMetricsAssociatedWithPod(endpoint.GetName(), endpoint.GetNamespace(), mv)
 			}
 		}
 	}

--- a/pkg/hubble/metrics/api/registry_test.go
+++ b/pkg/hubble/metrics/api/registry_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
-	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/k8s/types"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
 
@@ -120,7 +120,7 @@ func TestRegister(t *testing.T) {
 
 		verifyMetricSeriesExists(t, promRegistry, 2)
 
-		handlers.ProcessPodDeletion(&slim_corev1.Pod{
+		handlers.ProcessCiliumEndpointDeletion(&types.CiliumEndpoint{
 			ObjectMeta: slim_metav1.ObjectMeta{
 				Name:      "foo-123",
 				Namespace: "foo",
@@ -130,7 +130,7 @@ func TestRegister(t *testing.T) {
 
 		verifyMetricSeriesExists(t, promRegistry, 1)
 
-		handlers.ProcessPodDeletion(&slim_corev1.Pod{
+		handlers.ProcessCiliumEndpointDeletion(&types.CiliumEndpoint{
 			ObjectMeta: slim_metav1.ObjectMeta{
 				Name:      "bar-123",
 				Namespace: "bar",
@@ -153,7 +153,7 @@ func TestRegister(t *testing.T) {
 
 		verifyMetricSeriesExists(t, promRegistry, 1)
 
-		handlers.ProcessPodDeletion(&slim_corev1.Pod{
+		handlers.ProcessCiliumEndpointDeletion(&types.CiliumEndpoint{
 			ObjectMeta: slim_metav1.ObjectMeta{
 				Name:      "foo-123",
 				Namespace: "foo",
@@ -163,7 +163,7 @@ func TestRegister(t *testing.T) {
 
 		verifyMetricSeriesExists(t, promRegistry, 1)
 
-		handlers.ProcessPodDeletion(&slim_corev1.Pod{
+		handlers.ProcessCiliumEndpointDeletion(&types.CiliumEndpoint{
 			ObjectMeta: slim_metav1.ObjectMeta{
 				Name:      "bar-123",
 				Namespace: "bar",
@@ -186,7 +186,7 @@ func TestRegister(t *testing.T) {
 
 		verifyMetricSeriesExists(t, promRegistry, 2)
 
-		handlers.ProcessPodDeletion(&slim_corev1.Pod{
+		handlers.ProcessCiliumEndpointDeletion(&types.CiliumEndpoint{
 			ObjectMeta: slim_metav1.ObjectMeta{
 				Name:      "foo-123",
 				Namespace: "foo",
@@ -196,7 +196,7 @@ func TestRegister(t *testing.T) {
 
 		verifyMetricSeriesExists(t, promRegistry, 1)
 
-		handlers.ProcessPodDeletion(&slim_corev1.Pod{
+		handlers.ProcessCiliumEndpointDeletion(&types.CiliumEndpoint{
 			ObjectMeta: slim_metav1.ObjectMeta{
 				Name:      "bar-123",
 				Namespace: "bar",
@@ -219,7 +219,7 @@ func TestRegister(t *testing.T) {
 
 		verifyMetricSeriesExists(t, promRegistry, 2)
 
-		handlers.ProcessPodDeletion(&slim_corev1.Pod{
+		handlers.ProcessCiliumEndpointDeletion(&types.CiliumEndpoint{
 			ObjectMeta: slim_metav1.ObjectMeta{
 				Name:      "foo-123",
 				Namespace: "foo",
@@ -229,7 +229,7 @@ func TestRegister(t *testing.T) {
 
 		verifyMetricSeriesExists(t, promRegistry, 2)
 
-		handlers.ProcessPodDeletion(&slim_corev1.Pod{
+		handlers.ProcessCiliumEndpointDeletion(&types.CiliumEndpoint{
 			ObjectMeta: slim_metav1.ObjectMeta{
 				Name:      "bar-123",
 				Namespace: "bar",

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	hubblemetrics "github.com/cilium/cilium/pkg/hubble/metrics"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -226,4 +227,5 @@ func (k *K8sWatcher) endpointDeleted(endpoint *types.CiliumEndpoint) {
 			k.policyManager.TriggerPolicyUpdates(true, "Named ports deleted")
 		}
 	}
+	hubblemetrics.ProcessCiliumEndpointDeletion(endpoint)
 }

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
-	hubblemetrics "github.com/cilium/cilium/pkg/hubble/metrics"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -538,7 +537,6 @@ func (k *K8sWatcher) deleteK8sPodV1(pod *slim_corev1.Pod) error {
 	if option.Config.EnableLocalRedirectPolicy {
 		k.redirectPolicyManager.OnDeletePod(pod)
 	}
-	hubblemetrics.ProcessPodDeletion(pod)
 
 	k.cgroupManager.OnDeletePod(pod)
 

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -6,6 +6,7 @@ package policy
 import (
 	"net"
 	"net/netip"
+	"strings"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -45,13 +46,15 @@ func newIdentity(nid identity.NumericIdentity, lbls labels.LabelArray) scIdentit
 // getLocalScopeNets returns the most specific CIDR for a local scope identity.
 func getLocalScopeNets(id identity.NumericIdentity, lbls labels.LabelArray) []*net.IPNet {
 	if id.HasLocalScope() {
-		var (
-			maskSize         int
-			mostSpecificCidr *net.IPNet
-		)
+		var mostSpecificCidr *net.IPNet
+		maskSize := -1 // allow for 0-length prefix (e.g., "0.0.0.0/0")
 		for _, lbl := range lbls {
 			if lbl.Source == labels.LabelSourceCIDR {
-				_, netIP, err := net.ParseCIDR(lbl.Key)
+				// Reverse the transformation done in labels.maskedIPToLabel()
+				// as ':' is not allowed within a k8s label, colons are represented
+				// with '-'.
+				cidr := strings.ReplaceAll(lbl.Key, "-", ":")
+				_, netIP, err := net.ParseCIDR(cidr)
 				if err == nil {
 					if ms, _ := netIP.Mask.Size(); ms > maskSize {
 						mostSpecificCidr = netIP

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -708,10 +708,6 @@ func (s *Service) upsertService(params *lb.SVC) (bool, lb.ID, error) {
 		backendsCopy = append(backendsCopy, b.DeepCopy())
 	}
 
-	// TODO (Aditi) When we filter backends for LocalRedirect service, there
-	// might be some backend pods with active connections. We may need to
-	// defer filtering the backends list (thereby defer redirecting traffic)
-	// in such cases. GH #12859
 	// Update backends cache and allocate/release backend IDs
 	newBackends, obsoleteBackends, obsoleteSVCBackendIDs, err :=
 		s.updateBackendsCacheLocked(svc, backendsCopy)


### PR DESCRIPTION
 * [x] #33260 (@sgargan) :warning: resolved conflicts
 * [x] #33382 (@gandro)
 * [x] #33421 (@brb)
 * [x] #33311 (@pippolo84)
 * [x] #33427 (@marseel) :warning: resolved conflicts
 * [x] #33448 (@jrajahalme) :warning: resolved conflicts
 * [x] #33442 (@aditighag) :warning: resolved conflicts
 * [x] #33444 (@brb) :warning: resolved conflicts

PRs skipped due to conflicts:

 * #33403 (@sayboras) :x: Dropped because there is no `pkg/ciliumenvoyconfig/envoy_l7lb_backend_syncer.go` in v1.15

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 33260 33382 33421 33311 33427 33448 33442 33444
```
