### PR TITLE
v1.14 Backports 2024-07-02

### DIFF
--- a/.github/actions/set-env-variables/action.yml
+++ b/.github/actions/set-env-variables/action.yml
@@ -10,7 +10,7 @@ runs:
         # no prod yet
         echo "QUAY_CHARTS_ORGANIZATION_DEV=cilium-charts-dev" >> $GITHUB_ENV
         # renovate: datasource=github-releases depName=cilium/cilium-cli
-        CILIUM_CLI_VERSION="v0.16.10"
+        CILIUM_CLI_VERSION="v0.16.11"
         echo "CILIUM_CLI_VERSION=$CILIUM_CLI_VERSION" >> $GITHUB_ENV
         echo "GCP_PERF_RESULTS_BUCKET=gs://cilium-scale-results" >> $GITHUB_ENV
 

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -316,12 +316,18 @@ jobs:
         run: |
           mkdir -p cilium-junits
 
+          TEST=""
+          if [ "${{ matrix.key-one }}" = "gcm(aes)" ] && [ "${{ matrix.key-two }}" = "cbc(aes)" ]; then
+            # Until https://github.com/cilium/cilium/issues/29480 is resolved
+            TEST='--test "!pod-to-pod-no-frag"'
+          fi
+
           ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
             --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-            --flush-ct
+            --flush-ct $TEST
 
       - name: Assert that no unencrypted packets are leaked during tests
         uses: ./.github/actions/bpftrace/check

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -8,7 +8,7 @@ if [ ! -e "$dst_file" ]; then
 fi
 
 . "${dir}/../contrib/backporting/common.sh"
-remote="$(get_remote)"
+remote="$(get_remote "${ORG:-}" "${REPO:-}")"
 
 set -e
 set -o nounset

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2195,7 +2195,7 @@
    * - :spelling:ignore:`nodeinit.image`
      - node-init image.
      - object
-     - ``{"digest":"sha256:820155cb3b7f00c8d61c1cffa68c44440906cb046bdbad8ff544f5deb1103456","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/startup-script","tag":"19fb149fb3d5c7a37d3edfaf10a2be3ab7386661","useDigest":true}``
+     - ``{"digest":"sha256:8d7b41c4ca45860254b3c19e20210462ef89479bb6331d6760c4e609d651b29c","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/startup-script","tag":"c54c7edeab7fde4da68e59acd319ab24af242c3f","useDigest":true}``
    * - :spelling:ignore:`nodeinit.nodeSelector`
      - Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
      - object

--- a/Documentation/network/kubernetes/local-redirect-policy.rst
+++ b/Documentation/network/kubernetes/local-redirect-policy.rst
@@ -160,9 +160,9 @@ in Cilium pod running on the same node as ``lrp-pod``.
 .. code-block:: shell-session
 
     $ kubectl exec -it -n kube-system cilium-5ngzd -- cilium service list
-    ID   Frontend               Service Type   Backend
+    ID   Frontend               Service Type       Backend
     [...]
-    4    172.20.0.51:80         ClusterIP      1 => 10.16.70.187:80
+    4    172.20.0.51:80         LocalRedirect      1 => 10.16.70.187:80
 
 Invoke a curl command from the client pod to the IP address and port
 configuration specified in the ``lrp-addr`` custom resource above.

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -361,9 +361,12 @@ all
     The all entity represents the combination of all known clusters as well
     world and whitelists all communication.
 
-.. note:: The ``kube-apiserver`` entity is unavailable in some Kubernetes 
-   distributions, such as Azure AKS and GCP GKE for ingress traffic. You could still use ``cluster`` which
-   is broader.
+.. note:: The ``kube-apiserver`` entity may not work for *ingress traffic* in some Kubernetes
+   distributions, such as Azure AKS and GCP GKE. This is due to the fact that ingress
+   control-plane traffic is being tunneled through worker nodes, which does not preserve
+   the original source IP. You may be able to use a broader ``fromEntities: cluster`` rule
+   instead. Restricting *egress traffic* via ``toEntities: kube-apiserver`` however is expected
+   to work on these Kubernetes distributions.
 
 Access to/from local host
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -909,6 +909,10 @@ func initializeFlags() {
 	flags.Bool(option.DNSProxyEnableTransparentMode, defaults.DNSProxyEnableTransparentMode, "Enable DNS proxy transparent mode")
 	option.BindEnv(Vp, option.DNSProxyEnableTransparentMode)
 
+	flags.Bool(option.DNSProxyInsecureSkipTransparentModeCheck, false, "Allows DNS proxy transparent mode to be disabled even if encryption is enabled. Enabling this flag and disabling DNS proxy transparent mode will cause proxied DNS traffic to leave the node unencrypted.")
+	flags.MarkHidden(option.DNSProxyInsecureSkipTransparentModeCheck)
+	option.BindEnv(Vp, option.DNSProxyInsecureSkipTransparentModeCheck)
+
 	flags.Int(option.PolicyQueueSize, defaults.PolicyQueueSize, "Size of queues for policy-related events")
 	option.BindEnv(Vp, option.PolicyQueueSize)
 
@@ -1373,8 +1377,10 @@ func initEnv() {
 		log.Fatal("L7 proxy requires iptables rules (--install-iptables-rules=\"true\")")
 	}
 
-	if option.Config.EnableIPSec && option.Config.EnableL7Proxy && !option.Config.DNSProxyEnableTransparentMode {
-		log.Fatal("IPSec requires DNS proxy transparent mode to be enabled (--dnsproxy-enable-transparent-mode=\"true\")")
+	if !option.Config.DNSProxyInsecureSkipTransparentModeCheck {
+		if option.Config.EnableIPSec && option.Config.EnableL7Proxy && !option.Config.DNSProxyEnableTransparentMode {
+			log.Fatal("IPSec requires DNS proxy transparent mode to be enabled (--dnsproxy-enable-transparent-mode=\"true\")")
+		}
 	}
 
 	if option.Config.EnableIPSec && !option.Config.EnableIPv4 {

--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -46,8 +46,8 @@ export CILIUM_ETCD_OPERATOR_DIGEST:=sha256:04b8327f7f992693c2cb483b999041ed8f92e
 
 # renovate: datasource=docker
 export CILIUM_NODEINIT_REPO:=quay.io/cilium/startup-script
-export CILIUM_NODEINIT_VERSION:=19fb149fb3d5c7a37d3edfaf10a2be3ab7386661
-export CILIUM_NODEINIT_DIGEST:=sha256:820155cb3b7f00c8d61c1cffa68c44440906cb046bdbad8ff544f5deb1103456
+export CILIUM_NODEINIT_VERSION:=c54c7edeab7fde4da68e59acd319ab24af242c3f
+export CILIUM_NODEINIT_DIGEST:=sha256:8d7b41c4ca45860254b3c19e20210462ef89479bb6331d6760c4e609d651b29c
 
 # renovate: datasource=docker
 export ETCD_REPO:=quay.io/coreos/etcd

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -598,7 +598,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.extraEnv | list | `[]` | Additional nodeinit environment variables. |
 | nodeinit.extraVolumeMounts | list | `[]` | Additional nodeinit volumeMounts. |
 | nodeinit.extraVolumes | list | `[]` | Additional nodeinit volumes. |
-| nodeinit.image | object | `{"digest":"sha256:820155cb3b7f00c8d61c1cffa68c44440906cb046bdbad8ff544f5deb1103456","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/startup-script","tag":"19fb149fb3d5c7a37d3edfaf10a2be3ab7386661","useDigest":true}` | node-init image. |
+| nodeinit.image | object | `{"digest":"sha256:8d7b41c4ca45860254b3c19e20210462ef89479bb6331d6760c4e609d651b29c","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/startup-script","tag":"c54c7edeab7fde4da68e59acd319ab24af242c3f","useDigest":true}` | node-init image. |
 | nodeinit.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | nodeinit.podAnnotations | object | `{}` | Annotations to be added to node-init pods. |
 | nodeinit.podLabels | object | `{}` | Labels to be added to node-init pods. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2475,8 +2475,8 @@ nodeinit:
   image:
     override: ~
     repository: "quay.io/cilium/startup-script"
-    tag: "19fb149fb3d5c7a37d3edfaf10a2be3ab7386661"
-    digest: "sha256:820155cb3b7f00c8d61c1cffa68c44440906cb046bdbad8ff544f5deb1103456"
+    tag: "c54c7edeab7fde4da68e59acd319ab24af242c3f"
+    digest: "sha256:8d7b41c4ca45860254b3c19e20210462ef89479bb6331d6760c4e609d651b29c"
     useDigest: true
     pullPolicy: "IfNotPresent"
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -505,6 +505,10 @@ const (
 	// DNSProxyEnableTransparentMode enables transparent mode for the DNS proxy.
 	DNSProxyEnableTransparentMode = "dnsproxy-enable-transparent-mode"
 
+	// DNSProxyInsecureSkipTransparentModeCheck is a hidden flag that allows users
+	// to disable transparent mode even if IPSec is enabled
+	DNSProxyInsecureSkipTransparentModeCheck = "dnsproxy-insecure-skip-transparent-mode-check"
+
 	// MTUName is the name of the MTU option
 	MTUName = "mtu"
 
@@ -1887,6 +1891,10 @@ type DaemonConfig struct {
 
 	// DNSProxyEnableTransparentMode enables transparent mode for the DNS proxy.
 	DNSProxyEnableTransparentMode bool
+
+	// DNSProxyInsecureSkipTransparentModeCheck is a hidden flag that allows users
+	// to disable transparent mode even if IPSec is enabled
+	DNSProxyInsecureSkipTransparentModeCheck bool
 
 	// DNSProxyLockCount is the array size containing mutexes which protect
 	// against parallel handling of DNS response IPs.
@@ -3358,6 +3366,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.DNSProxyConcurrencyLimit = vp.GetInt(DNSProxyConcurrencyLimit)
 	c.DNSProxyConcurrencyProcessingGracePeriod = vp.GetDuration(DNSProxyConcurrencyProcessingGracePeriod)
 	c.DNSProxyEnableTransparentMode = vp.GetBool(DNSProxyEnableTransparentMode)
+	c.DNSProxyInsecureSkipTransparentModeCheck = vp.GetBool(DNSProxyInsecureSkipTransparentModeCheck)
 	c.DNSProxyLockCount = vp.GetInt(DNSProxyLockCount)
 	c.DNSProxyLockTimeout = vp.GetDuration(DNSProxyLockTimeout)
 	c.FQDNRejectResponse = vp.GetString(FQDNRejectResponseCode)

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -182,13 +182,15 @@ func newIdentity(nid identity.NumericIdentity, lbls labels.LabelArray) scIdentit
 // getLocalScopeNets returns the most specific CIDR for a local scope identity.
 func getLocalScopeNets(id identity.NumericIdentity, lbls labels.LabelArray) []*net.IPNet {
 	if id.HasLocalScope() {
-		var (
-			maskSize         int
-			mostSpecificCidr *net.IPNet
-		)
+		var mostSpecificCidr *net.IPNet
+		maskSize := -1 // allow for 0-length prefix (e.g., "0.0.0.0/0")
 		for _, lbl := range lbls {
 			if lbl.Source == labels.LabelSourceCIDR {
-				_, netIP, err := net.ParseCIDR(lbl.Key)
+				// Reverse the transformation done in labels.maskedIPToLabel()
+				// as ':' is not allowed within a k8s label, colons are represented
+				// with '-'.
+				cidr := strings.ReplaceAll(lbl.Key, "-", ":")
+				_, netIP, err := net.ParseCIDR(cidr)
 				if err == nil {
 					if ms, _ := netIP.Mask.Size(); ms > maskSize {
 						mostSpecificCidr = netIP

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -4,9 +4,12 @@
 package policy
 
 import (
+	"net"
 	"sync"
+	"testing"
 
 	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
@@ -629,4 +632,32 @@ func testNewSelectorCache(ids cache.IdentityCache) *SelectorCache {
 	sc := NewSelectorCache(testidentity.NewMockIdentityAllocator(ids), ids)
 	sc.SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 	return sc
+}
+
+func Test_getLocalScopeNets(t *testing.T) {
+	nets := getLocalScopeNets(identity.ReservedIdentityWorld, nil)
+	require.Len(t, nets, 0)
+
+	nets = getLocalScopeNets(identity.ReservedIdentityWorld, labels.LabelArray{labels.Label{Source: labels.LabelSourceCIDR, Key: "0.0.0.0/0"}})
+	require.Len(t, nets, 0)
+
+	nets = getLocalScopeNets(identity.LocalIdentityFlag, labels.LabelArray{labels.Label{Source: labels.LabelSourceCIDR, Key: "0.0.0.0/0"}})
+	require.Len(t, nets, 1)
+	require.Equal(t, &net.IPNet{IP: make(net.IP, 4), Mask: make(net.IPMask, 4)}, nets[0])
+
+	nets = getLocalScopeNets(identity.LocalIdentityFlag, labels.LabelArray{labels.Label{Source: labels.LabelSourceCIDR, Key: "::/0"}})
+	require.Len(t, nets, 1)
+	require.Equal(t, &net.IPNet{IP: make(net.IP, 16), Mask: make(net.IPMask, 16)}, nets[0])
+
+	nets = getLocalScopeNets(identity.LocalIdentityFlag, labels.LabelArray{labels.Label{Source: labels.LabelSourceCIDR, Key: "--/0"}})
+	require.Len(t, nets, 1)
+	require.Equal(t, &net.IPNet{IP: make(net.IP, 16), Mask: make(net.IPMask, 16)}, nets[0])
+
+	nets = getLocalScopeNets(identity.LocalIdentityFlag, labels.LabelArray{
+		labels.Label{Source: labels.LabelSourceCIDR, Key: "ff--/8"},
+		labels.Label{Source: labels.LabelSourceCIDR, Key: "--/0"},
+		labels.Label{Source: labels.LabelSourceCIDR, Key: "--1/128"},
+	})
+	require.Len(t, nets, 1)
+	require.Equal(t, &net.IPNet{IP: net.IPv6loopback, Mask: net.CIDRMask(128, 128)}, nets[0])
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -670,10 +670,6 @@ func (s *Service) upsertService(params *lb.SVC) (bool, lb.ID, error) {
 		backendsCopy = append(backendsCopy, b.DeepCopy())
 	}
 
-	// TODO (Aditi) When we filter backends for LocalRedirect service, there
-	// might be some backend pods with active connections. We may need to
-	// defer filtering the backends list (thereby defer redirecting traffic)
-	// in such cases. GH #12859
 	// Update backends cache and allocate/release backend IDs
 	newBackends, obsoleteBackendIDs, obsoleteSVCBackendIDs, err :=
 		s.updateBackendsCacheLocked(svc, backendsCopy)


### PR DESCRIPTION
 * [x] #33382 (@gandro)
 * [x] #33427 (@marseel) :warning: resolved conflicts
 * [x] #33448 (@jrajahalme) :warning: resolved conflicts
 * [x] #33442 (@aditighag) :warning: resolved conflicts
 * [x] #33444 (@brb)
 * [x] #33514 (@aanm)
 * [x] #33420 (@gandro) :warning: resolved conflicts

PRs skipped due to conflicts:

 * #33403 (@sayboras) :x: Dropped because there is no `pkg/ciliumenvoyconfig/envoy_l7lb_backend_syncer.go` in v1.15
 * #33421 (@brb) :x: Dropped because I was unable to adapt the test to v1.14 (e.g: missing `lib/ipcache.h` header)
 
Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 33382 33427 33448 33442 33444 33514 33420
```
