### PR TITLE
bgpv2: Fix description of Selector behavior in CiliumBGPAdvertisement CRD

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpadvertisements.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpadvertisements.yaml
@@ -144,7 +144,7 @@ spec:
                     selector:
                       description: Selector is a label selector to select objects
                         of the type specified by AdvertisementType. If not specified,
-                        all objects of the type specified by AdvertisementType are
+                        no objects of the type specified by AdvertisementType are
                         selected for advertisement.
                       properties:
                         matchExpressions:

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_advert_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_advert_types.go
@@ -108,7 +108,7 @@ type BGPAdvertisement struct {
 	Service *BGPServiceOptions `json:"service,omitempty"`
 
 	// Selector is a label selector to select objects of the type specified by AdvertisementType.
-	// If not specified, all objects of the type specified by AdvertisementType are selected for advertisement.
+	// If not specified, no objects of the type specified by AdvertisementType are selected for advertisement.
 	//
 	// +kubebuilder:validation:Optional
 	Selector *slimv1.LabelSelector `json:"selector,omitempty"`


### PR DESCRIPTION
Fixes documentation bug in the `CiliumBGPAdvertisement` CRD: the actual implementation as well as the intention is to not advertise any prefixes if the `Selector` in `CiliumBGPAdvertisement` CRD is not specified.
