### PR TITLE
bpf: wireguard: use overlay mark to detect tunnel traffic

### DIFF
--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -64,33 +64,18 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 		if (!revalidate_data(ctx, &data, &data_end, &ip4))
 			return DROP_INVALID;
 # if defined(HAVE_ENCAP)
-		/* A rudimentary check (inspired by is_enap()) whether a pkt
-		 * is coming from tunnel device. In tunneling mode WG needs to
-		 * encrypt such pkts, so that src sec ID can be transferred.
+		/* In tunneling mode WG needs to encrypt tunnel traffic,
+		 * so that src sec ID can be transferred.
 		 *
 		 * This also handles IPv6, as IPv6 pkts are encapsulated w/
 		 * IPv4 tunneling.
-		 *
-		 * TODO: in v1.17, we can trust that to-overlay will mark all
-		 * traffic. Then replace this with ctx_is_overlay().
 		 */
-		if (ip4->protocol == IPPROTO_UDP) {
-			int l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
-			__be16 dport;
-
-			if (l4_load_port(ctx, l4_off + UDP_DPORT_OFF, &dport) < 0) {
-				/* IP fragmentation is not expected after the
-				 * encap. So this is non-Cilium's pkt.
-				 */
-				break;
-			}
-
-			if (dport == bpf_htons(TUNNEL_PORT)) {
-				from_tunnel = true;
-				break;
-			}
+		if (ctx_is_overlay(ctx)) {
+			from_tunnel = true;
+			break;
 		}
 # endif /* HAVE_ENCAP */
+
 		dst = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 		src = lookup_ip4_remote_endpoint(ip4->saddr, 0);
 		break;

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -23,7 +23,6 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 	void *data, *data_end;
 	struct ipv6hdr __maybe_unused *ip6;
 	struct iphdr __maybe_unused *ip4;
-	bool from_tunnel __maybe_unused = false;
 	__u32 magic __maybe_unused = 0;
 
 	if (!eth_is_supported_ethertype(proto))
@@ -70,10 +69,8 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 		 * This also handles IPv6, as IPv6 pkts are encapsulated w/
 		 * IPv4 tunneling.
 		 */
-		if (ctx_is_overlay(ctx)) {
-			from_tunnel = true;
-			break;
-		}
+		if (ctx_is_overlay(ctx))
+			goto encrypt;
 # endif /* HAVE_ENCAP */
 
 		dst = lookup_ip4_remote_endpoint(ip4->daddr, 0);
@@ -83,11 +80,6 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 	default:
 		goto out;
 	}
-
-#if defined(HAVE_ENCAP)
-	if (from_tunnel)
-		goto encrypt;
-#endif /* HAVE_ENCAP */
 
 #ifndef ENABLE_NODE_ENCRYPTION
 	/* A pkt coming from L7 proxy (i.e., Envoy or the DNS proxy on behalf of


### PR DESCRIPTION
Instead of peeking into the packet headers, rely on the mark that is set
by to-overlay.

https://github.com/cilium/cilium/pull/31082 landed in v1.16, so for v1.17
it's safe to assume that all overlay traffic is marked accordingly.

Fixes: #31780