### PR TITLE
gha: Remove CRD mismatch flag for Gateway API conformance

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -282,7 +282,6 @@ jobs:
               --gateway-class cilium \
               --all-features \
               --exempt-features "${{ steps.vars.outputs.exempt-features }}" \
-              --allow-crds-mismatch \
               -test.run "TestConformance" \
               -test.skip "${{ steps.vars.outputs.skipped_tests }}" \
               -json \


### PR DESCRIPTION
Relates: https://github.com/cilium/cilium/pull/33536#pullrequestreview-2154199974
Suggested-by: Marco Hofstetter <marco.hofstetter@isovalent.com>

