### PR TITLE
bpf: lxc: fix up reporting of drop reason in drop_for_direction()

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -220,7 +220,7 @@ select_ct_map4(struct __ctx_buff *ctx __maybe_unused, int dir __maybe_unused,
 
 #if defined ENABLE_IPV4 || defined ENABLE_IPV6
 static __always_inline int drop_for_direction(struct __ctx_buff *ctx,
-					      enum ct_dir dir, __u32 reason,
+					      enum ct_dir dir, int reason,
 					      __s8 ext_err)
 {
 	__u32 dst = 0;


### PR DESCRIPTION
DROP_* reasons are negative values.

Reported-by: Nikita V. Shirokov <tehnerd@tehnerd.com>
Relates: https://github.com/cilium/cilium/issues/32473

```release-note
Report the correct drop reason when a packet is dropped by the bpf_lxc program.
```
