### PR TITLE
renovate: do not update major golang in v1.16 branch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -323,9 +323,18 @@
         "docker.io/library/golang",
         "go"
       ],
+      "allowedVersions": "<1.23",
+      "matchBaseBranches": [
+        "v1.16"
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "docker.io/library/golang",
+        "go"
+      ],
       "allowedVersions": "<1.22",
       "matchBaseBranches": [
-        "v1.16",
         "v1.15"
       ]
     },


### PR DESCRIPTION
Similar to other stable branches we shouldn't update golang to major versions automatically.

Fixes: da63c10eb308 ("Prepare for v1.17 development cycle")