### PR TITLE
Introduce ClusterMesh scale tests

### DIFF
--- a/.github/actions/cl2-modules/clustermesh/config.yaml
+++ b/.github/actions/cl2-modules/clustermesh/config.yaml
@@ -1,0 +1,107 @@
+{{$sleepDuration := DefaultParam .CL2_SLEEP_DURATION "5m"}}
+{{$replicasPerNode := DefaultParam .CL2_REPLICAS_PER_NODE 90}}
+{{$totalReplicas := MultiplyInt .Nodes $replicasPerNode}}
+{{$latencyPodImage := DefaultParam .CL2_LATENCY_POD_IMAGE "registry.k8s.io/pause:3.9"}}
+
+name: load
+namespace:
+  number: 1
+
+tuningSets:
+- name: Uniform5QPS
+  qpsLoad:
+    qps: 5
+
+steps:
+- name: Gather resources
+  measurements:
+  - Identifier: ResourceUsageSummary
+    Method: ResourceUsageSummary
+    Params:
+      action: start
+
+- module:
+    path: modules/metrics.yaml
+    params:
+      action: start
+
+- module:
+    path: ../cilium-agent-pprofs.yaml
+    params:
+      action: start
+
+- name: Start latency pod measurements
+  measurements:
+    - Identifier: PodStartupLatency
+      Method: PodStartupLatency
+      Params:
+        action: start
+        labelSelector: group = latency
+        threshold: 5s
+
+- name: Create pods
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: {{$totalReplicas}}
+    tuningSet: Uniform5QPS
+    objectBundle:
+    - basename: pod-throughput
+      objectTemplatePath: pod.yaml
+      templateFillMap:
+        Image: {{$latencyPodImage}}
+        Group: latency
+        SingleIdentity: true
+
+- name: Wait for pods to be created
+  measurements:
+  - Identifier: WaitForPods
+    Method: WaitForRunningPods
+    Params:
+      action: gather
+      timeout: 10m
+      desiredPodCount: {{$totalReplicas}}
+      labelSelector: group = latency
+
+- name: Collect pod startup latency
+  measurements:
+    - Identifier: PodStartupLatency
+      Method: PodStartupLatency
+      Params:
+        action: gather
+
+- name: Wait for Cluster Mesh API Server Mock Churn
+  measurements:
+  - Identifier: Sleep
+    Method: Sleep
+    Params:
+      duration: {{$sleepDuration}}
+
+- name: Delete scheduler throughput pods
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: 0
+    tuningSet: Uniform5QPS
+    objectBundle:
+    - basename: pod-throughput
+      objectTemplatePath: pod.yaml
+
+- module:
+    path: ../cilium-agent-pprofs.yaml
+    params:
+      action: gather
+
+- module:
+    path: modules/metrics.yaml
+    params:
+      action: gather
+
+- name: Gather resources
+  measurements:
+  - Identifier: ResourceUsageSummary
+    Method: ResourceUsageSummary
+    Params:
+      action: gather

--- a/.github/actions/cl2-modules/clustermesh/modules/metrics.yaml
+++ b/.github/actions/cl2-modules/clustermesh/modules/metrics.yaml
@@ -1,0 +1,175 @@
+# Valid actions: "start", "gather"
+{{$action := .action}}
+
+steps:
+- name: "{{$action}}ing measurements"
+  measurements:
+
+  - Identifier: BPFMapPressure
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: BPF Map Pressure
+      metricVersion: v1
+      unit: "%"
+      queries:
+      - name: BPF Map Pressure (Max)
+        query: max_over_time(max(cilium_bpf_map_pressure)[%v:]) * 100
+        threshold: 90
+
+  - Identifier: WarningErrorLogs
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: Warning and Error Logs
+      metricVersion: v1
+      unit: count
+      queries:
+      - name: Warnings
+        query: sum(cilium_errors_warnings_total{level="warning"})
+        threshold: 10
+      - name: Errors
+        query: sum(cilium_errors_warnings_total{level="error"})
+        threshold: 10
+
+  - Identifier: ClusterMeshReconnections
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: ClusterMesh Reconnections
+      metricVersion: v1
+      unit: count
+      queries:
+      - name: Agents
+        query: sum(cilium_clustermesh_remote_cluster_failures)
+        threshold: 0
+      - name: KVStoreMesh
+        query: sum(cilium_kvstoremesh_remote_cluster_failures)
+        threshold: 0
+
+  - Identifier: KVStoreMeshDataSynchronization
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: KVStoreMesh Data Synchronization
+      metricVersion: v1
+      unit: count
+      queries:
+      - name: Sync Queue Size
+        query: max_over_time(sum(cilium_kvstoremesh_kvstore_sync_queue_size)[%v:])
+        threshold: 1000
+      - name: Sync Errors
+        query: sum(cilium_kvstoremesh_kvstore_sync_errors_total)
+        threshold: 0
+
+  - Identifier: KVStoreMeshBootstrap
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: KVStoreMesh Bootstrap
+      metricVersion: v1
+      unit: s
+      queries:
+      - name: Bootstrap Time
+        query: sum(cilium_kvstoremesh_bootstrap_seconds)
+        threshold: 60
+
+  - Identifier: KVStoreOperationsDurations
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: KVStore Operations Durations (KVStoreMesh)
+      metricVersion: v1
+      unit: s
+      queries:
+      - name: Upserts - Perc 50
+        query: histogram_quantile(0.5, sum(rate(cilium_kvstoremesh_kvstore_operations_duration_seconds_bucket{action="Update"}[%v])) by (le))
+      - name: Upserts - Perc 90
+        query: histogram_quantile(0.9, sum(rate(cilium_kvstoremesh_kvstore_operations_duration_seconds_bucket{action="Update"}[%v])) by (le))
+      - name: Upserts - Perc 99
+        query: histogram_quantile(0.99, sum(rate(cilium_kvstoremesh_kvstore_operations_duration_seconds_bucket{action="Update"}[%v])) by (le))
+      - name: Deletes - Perc 50
+        query: histogram_quantile(0.5, sum(rate(cilium_kvstoremesh_kvstore_operations_duration_seconds_bucket{action="Delete"}[%v])) by (le))
+      - name: Deletes - Perc 90
+        query: histogram_quantile(0.9, sum(rate(cilium_kvstoremesh_kvstore_operations_duration_seconds_bucket{action="Delete"}[%v])) by (le))
+      - name: Deletes - Perc 99
+        query: histogram_quantile(0.99, sum(rate(cilium_kvstoremesh_kvstore_operations_duration_seconds_bucket{action="Delete"}[%v])) by (le))
+
+  - Identifier: KVStoreEventsQueueTime
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: KVStore Events Queue Time (Agents)
+      metricVersion: v1
+      unit: s
+      queries:
+      - name: Nodes - Perc50
+        query: histogram_quantile(0.5, sum(rate(cilium_kvstore_events_queue_seconds_bucket{scope="nodes/v1"}[%v])) by (le))
+      - name: Nodes - Perc90
+        query: histogram_quantile(0.9, sum(rate(cilium_kvstore_events_queue_seconds_bucket{scope="nodes/v1"}[%v])) by (le))
+      - name: Nodes - Perc99
+        query: histogram_quantile(0.99, sum(rate(cilium_kvstore_events_queue_seconds_bucket{scope="nodes/v1"}[%v])) by (le))
+      - name: Endpoints - Perc50
+        query: histogram_quantile(0.5, sum(rate(cilium_kvstore_events_queue_seconds_bucket{scope="ip/v1"}[%v])) by (le))
+      - name: Endpoints - Perc90
+        query: histogram_quantile(0.9, sum(rate(cilium_kvstore_events_queue_seconds_bucket{scope="ip/v1"}[%v])) by (le))
+      - name: Endpoints - Perc99
+        query: histogram_quantile(0.99, sum(rate(cilium_kvstore_events_queue_seconds_bucket{scope="ip/v1"}[%v])) by (le))
+      - name: Identities - Perc50
+        query: histogram_quantile(0.5, sum(rate(cilium_kvstore_events_queue_seconds_bucket{scope="identities/v1"}[%v])) by (le))
+      - name: Identities - Perc90
+        query: histogram_quantile(0.9, sum(rate(cilium_kvstore_events_queue_seconds_bucket{scope="identities/v1"}[%v])) by (le))
+      - name: Identities - Perc99
+        query: histogram_quantile(0.99, sum(rate(cilium_kvstore_events_queue_seconds_bucket{scope="identities/v1"}[%v])) by (le))
+
+  - Identifier: EtcdResources
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: Etcd Resources
+      metricVersion: v1
+      unit: MB
+      queries:
+      - name: DB Size (Mocker)
+        query: max_over_time(sum(etcd_mvcc_db_total_size_in_bytes{job="cmapisrv-mock-metrics", container="etcd"})[%v:]) / 1e6
+      - name: Process resident set (Mocker)
+        query: max_over_time(sum(process_resident_memory_bytes{job="cmapisrv-mock-metrics", container="etcd"})[%v:]) / 1e6
+      - name: DB Size (KVStoreMesh)
+        query: max_over_time(sum(etcd_mvcc_db_total_size_in_bytes{job="clustermesh-apiserver-metrics", container="etcd"})[%v:]) / 1e6
+      - name: Process resident set (KVStoreMesh)
+        query: max_over_time(sum(process_resident_memory_bytes{job="clustermesh-apiserver-metrics", container="etcd"})[%v:]) / 1e6
+
+  - Identifier: EtcdWatchers
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: Etcd Watchers
+      metricVersion: v1
+      unit: count
+      queries:
+      - name: Total watch streams (Mocker)
+        query: max_over_time(sum(etcd_debugging_mvcc_watch_stream_total{job="cmapisrv-mock-metrics", container="etcd"})[%v:])
+      - name: Total watchers (Mocker)
+        query: max_over_time(sum(etcd_debugging_mvcc_watcher_total{job="cmapisrv-mock-metrics", container="etcd"})[%v:])
+      - name: Total slow watchers (Mocker)
+        query: max_over_time(sum(etcd_debugging_mvcc_slow_watcher_total{job="cmapisrv-mock-metrics", container="etcd"})[%v:])
+      - name: Total watch streams (KVStoreMesh)
+        query: max_over_time(sum(etcd_debugging_mvcc_watch_stream_total{job="clustermesh-apiserver-metrics", container="etcd"})[%v:])
+      - name: Total watchers (KVStoreMesh)
+        query: max_over_time(sum(etcd_debugging_mvcc_watcher_total{job="clustermesh-apiserver-metrics", container="etcd"})[%v:])
+      - name: Total slow watchers (KVStoreMesh)
+        query: max_over_time(sum(etcd_debugging_mvcc_slow_watcher_total{job="clustermesh-apiserver-metrics", container="etcd"})[%v:])
+
+  # For debugging cardinality of metrics, fetch prometheus snapshot and use
+  # following query to get the cardinality of metrics:
+  # topk(10, count by (__name__)({__name__=~"cilium_.+"}))
+  - Identifier: CiliumMetricsCardinality
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: Metrics Cardinality
+      metricVersion: v1
+      unit: count
+      queries:
+      - name: Max
+        query: max_over_time(count({__name__=~"cilium_.+"})[%v:])

--- a/.github/actions/cl2-modules/clustermesh/pod.yaml
+++ b/.github/actions/cl2-modules/clustermesh/pod.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{.Name}}
+  labels:
+    group: {{.Group}}
+{{if not .SingleIdentity}}
+    instance: {{.Name}}
+{{end}}
+spec:
+  containers:
+  - image: {{.Image}}
+    name: pause

--- a/.github/actions/cl2-modules/clustermesh/setup.yaml
+++ b/.github/actions/cl2-modules/clustermesh/setup.yaml
@@ -1,0 +1,10 @@
+name: setup
+steps:
+# ClusterLoader2 requires at least one step, although here
+# we only care about the setting up Prometheus.
+- name: Sleep
+  measurements:
+  - Identifier: Sleep
+    Method: Sleep
+    Params:
+      duration: 1s

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -84,6 +84,9 @@ triggers:
   /scale-100:
     workflows:
     - scale-test-100-gce.yaml
+  /scale-clustermesh:
+    workflows:
+    - scale-test-clustermesh.yaml
   /net-perf-gke:
     workflows:
     - net-perf-gke.yaml

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -630,7 +630,8 @@
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+kernel: '(?<currentValue>.*)'",
         '# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*)\\s+.+kernel: "(?<currentValue>.*)@(?<currentDigest>sha256:[a-f0-9]+)"',
         '# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*)\\s+.+image-version: "(?<currentValue>.*)@(?<currentDigest>sha256:[a-f0-9]+)"',
-        '# renovate: datasource=(?<datasource>.*?)\\s+.+kube-image: "(?<depName>.*):(?<currentValue>.*)@(?<currentDigest>sha256:[a-f0-9]+)"'
+        '# renovate: datasource=(?<datasource>.*?)\\s+.+kube-image: "(?<depName>.*):(?<currentValue>.*)@(?<currentDigest>sha256:[a-f0-9]+)"',
+        '# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?) branch=(?<currentValue>.*?)\\s+.+_ref: (?<currentDigest>.*)'
       ]
     },
     {

--- a/.github/workflows/scale-test-clustermesh.yaml
+++ b/.github/workflows/scale-test-clustermesh.yaml
@@ -1,0 +1,398 @@
+name: Cluster Mesh Scale Test (scale-clustermesh)
+
+on:
+  schedule:
+    - cron: '39 12 * * 1-5'
+
+  workflow_dispatch:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: true
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: true
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: true
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        default: '{}'
+
+# For testing uncomment following lines:
+#  push:
+#    branches:
+#      - your_branch_name
+
+permissions:
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To be able to request the JWT from GitHub's OIDC provider
+  id-token: write
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # To be able to set commit status
+  statuses: write
+
+concurrency:
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - workflow_dispatch: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing, such that re-runs will cancel the previous run.
+  group: |
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+    }}
+  cancel-in-progress: true
+
+env:
+  # renovate: datasource=golang-version depName=go
+  go_version: 1.22.4
+  # renovate: datasource=docker depName=google/cloud-sdk
+  gcloud_version: 482.0.0
+  # renovate: datasource=git-refs depName=https://github.com/cilium/scaffolding branch=main
+  cmapisrv_mock_ref: 27a265b63e7635f093b3e1e70d0c56e57ae72c33
+
+  test_name: scale-clustermesh
+  cluster_name: ${{ github.run_id }}-${{ github.run_attempt }}
+  mock_clusters: 250
+
+jobs:
+  echo-inputs:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    name: Echo Workflow Dispatch Inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo Workflow Dispatch Inputs
+        run: |
+          echo '${{ tojson(inputs) }}'
+
+  commit-status-start:
+    name: Commit Status Start
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set initial commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+
+  install-and-test:
+    runs-on: ubuntu-latest
+    name: Install and Cluster Mesh Scale Test
+    timeout-minutes: 60
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up job variables
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] ; then
+            SHA="${{ inputs.SHA }}"
+          else
+            SHA="${{ github.sha }}"
+          fi
+
+          # Adding k8s.local to the end makes kops happy
+          # has stricter DNS naming requirements.
+          CLUSTER_NAME="${{ env.test_name }}-${{ env.cluster_name }}.k8s.local"
+
+          echo SHA=${SHA} >> $GITHUB_OUTPUT
+          echo CLUSTER_NAME=${CLUSTER_NAME} >> $GITHUB_OUTPUT
+
+      - name: Wait for images to be available
+        timeout-minutes: 30
+        shell: bash
+        run: |
+          for image in cilium-ci operator-generic-ci clustermesh-apiserver-ci ; do
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.SHA }} &> /dev/null; do sleep 45s; done
+          done
+
+      - name: Install Go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: ${{ env.go_version }}
+
+      - name: Install Cilium CLI
+        uses: cilium/cilium-cli@9d071f99ae32af95cb15c3e0a280d222b569a1cf # v0.16.11
+        with:
+          repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
+          release-version: ${{ env.CILIUM_CLI_VERSION }}
+
+      - name: Install Kops
+        uses: cilium/scale-tests-action/install-kops@318a068b7fb62548bd252eecc8123c704b5f0493 # main
+
+      - name: Setup gcloud credentials
+        uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_PERF_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_PERF_SA }}
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
+        with:
+          project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
+          version: ${{ env.gcloud_version }}
+
+      - name: Clone ClusterLoader2
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: kubernetes/perf-tests
+          # Avoid using renovate to update this dependency because: (1)
+          # perf-tests does not tag or release, so renovate will pull
+          # all updates to the default branch and (2) continually
+          # updating CL2 may impact the stability of the scale test
+          # results.
+          ref: 6eb52ac89d5de15a0ad13cfeb2b2026e57ce4f64
+          persist-credentials: false
+          sparse-checkout: clusterloader2
+          path: perf-tests
+
+      - name: Clone the Cluster Mesh API Server Mock
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: cilium/scaffolding
+          ref: ${{ env.cmapisrv_mock_ref }}
+          persist-credentials: false
+          sparse-checkout: cmapisrv-mock
+          path: scaffolding
+
+      - name: Display version info of installed tools
+        run: |
+          echo "--- go ---"
+          go version
+          echo "--- cilium-cli ---"
+          cilium version --client
+          echo "--- kops ---"
+          ./kops version
+          echo "--- gcloud ---"
+          gcloud version
+
+      - name: Deploy cluster
+        id: deploy-cluster
+        uses: cilium/scale-tests-action/create-cluster@318a068b7fb62548bd252eecc8123c704b5f0493 # main
+        timeout-minutes: 30
+        with:
+          cluster_name: ${{ steps.vars.outputs.CLUSTER_NAME }}
+          control_plane_size: n2-standard-8
+          control_plane_count: 1
+          node_size: n2-standard-8
+          node_count: 1
+          node_cidr: 100.0.0.0/16
+          kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
+          project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
+          kube_proxy_enabled: false
+
+      - name: Setup firewall rules
+        uses: cilium/scale-tests-action/setup-firewall@318a068b7fb62548bd252eecc8123c704b5f0493 # main
+        with:
+          cluster_name: ${{ steps.vars.outputs.CLUSTER_NAME }}
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ steps.vars.outputs.SHA }}
+          persist-credentials: false
+          path: untrusted
+          sparse-checkout: |
+            install/kubernetes/cilium
+
+      - name: Install Cilium
+        run: |
+          # * Increase the node BPF map size to account for the total number of nodes.
+          # * Disable health checking, as mocked nodes are unreachable.
+          cilium install \
+            --chart-directory=untrusted/install/kubernetes/cilium \
+            --set image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci:${{ steps.vars.outputs.SHA }} \
+            --set operator.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator-generic-ci:${{ steps.vars.outputs.SHA }} \
+            --set clustermesh.apiserver.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci:${{ steps.vars.outputs.SHA }} \
+            --set ipam.mode=kubernetes \
+            --set kubeProxyReplacement=true \
+            --set k8sServiceHost=api.internal.${{ steps.vars.outputs.CLUSTER_NAME }} \
+            --set k8sServicePort=443 \
+            --set pprof.enabled=true \
+            --set prometheus.enabled=true \
+            --set cluster.name=${{ env.test_name }}-${{ env.cluster_name }} \
+            --set cluster.id=255 \
+            --set operator.replicas=1 \
+            --set operator.nodeSelector.node-role\\.kubernetes\\.io/control-plane= \
+            --set bpf.nodeMapMax=65536 \
+            --set healthChecking=false \
+            --set endpointHealthChecking.enabled=false
+
+      # This step must be run after installing Cilium, as it requires
+      # system pods (e.g., coredns) to be running.
+      - name: Wait for cluster to be ready
+        uses: cilium/scale-tests-action/validate-cluster@318a068b7fb62548bd252eecc8123c704b5f0493 # main
+        timeout-minutes: 20
+        with:
+          cluster_name: ${{ steps.vars.outputs.CLUSTER_NAME }}
+          kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
+
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
+
+      - name: Setup CL2
+        run: |
+          # CL2 needs ssh access to control plane nodes
+          gcloud compute config-ssh
+
+          # Copy the custom configs to the folder where CL2 expects them.
+          cp -r .github/actions/cl2-modules ./perf-tests/clusterloader2/testing/custom
+
+      - name: Run CL2 to setup prometheus
+        working-directory: ./perf-tests/clusterloader2
+        env:
+          CL2_PROMETHEUS_PVC_ENABLED: "false"
+          CL2_PROMETHEUS_SCRAPE_CILIUM_OPERATOR: "true"
+          CL2_PROMETHEUS_SCRAPE_CILIUM_AGENT: "true"
+          CL2_PROMETHEUS_MEMORY_SCALE_FACTOR: 4.0
+        timeout-minutes: 10
+        run: |
+          # Don't run any tasks at this point, just setup the monitoring stack
+          go run ./cmd/clusterloader.go \
+            -v=2 \
+            --testconfig=./testing/custom/clustermesh/setup.yaml \
+            --testoverrides=./testing/prometheus/not-scrape-kube-proxy.yaml \
+            --provider=gce \
+            --enable-prometheus-server \
+            --tear-down-prometheus-server=false \
+            --kubeconfig=$HOME/.kube/config \
+            2>&1 | tee cl2-setup.txt
+
+      - name: Deploy the Cluster Mesh API Server Mock
+        run: |
+          helm install cmapisrv-mock \
+            ./scaffolding/cmapisrv-mock/deploy/cmapisrv-mock \
+            --namespace kube-system \
+            --set image.repository=quay.io/cilium/cmapisrv-mock \
+            --set image.tag=${{ env.cmapisrv_mock_ref }} \
+            --set nodeSelector.node-role\\.kubernetes\\.io/control-plane= \
+            --set tolerations[0].key=node-role.kubernetes.io/control-plane \
+            --set tolerations[0].operator=Exists \
+            --set config.ipv6=false \
+            --set config.clusters=${{ env.mock_clusters }} \
+            --set config.nodes=100 \
+            --set config.nodesQPS=0.1 \
+            --set config.identities=100 \
+            --set config.identitiesQPS=0.2 \
+            --set config.endpoints=1000 \
+            --set config.endpointsQPS=1 \
+            --set config.services=0 \
+            --set config.servicesQPS=0 \
+            --set serviceMonitor=true
+
+          kubectl -n kube-system wait --for=condition=Ready pod \
+            -l app.kubernetes.io/name=cmapisrv-mock --timeout=300s
+
+      - name: Enable KVStoreMesh and configure Cilium to connect to the Cluster Mesh API Server Mock
+        run: |
+          cat<<EOF > values-clustermesh-config.yaml
+          clustermesh:
+            config:
+              enabled: true
+              clusters:
+          EOF
+
+          for i in $(seq 1 ${{ env.mock_clusters }}); do
+            printf "    - name: cluster-%03d\n" ${i}
+            printf "      address: cmapisrv-mock.kube-system.svc\n"
+            printf "      port: 2379\n"
+          done >> values-clustermesh-config.yaml
+
+          # * We enable KVStoreMesh only at this point to leverage the bootstrap QPS
+          #   and speed-up the overall bootstrap process.
+          # * Increase the KVStoreMesh QPS to match the ones of the cmapisrv-mock,
+          #   as not a problem considering the limited number of watchers.
+          # * Store etcd data directly in memory, for improved performance.
+          cilium upgrade --reuse-values \
+            --chart-directory=untrusted/install/kubernetes/cilium \
+            --set clustermesh.useAPIServer=true \
+            --set clustermesh.apiserver.etcd.storageMedium=Memory \
+            --set clustermesh.apiserver.kvstoremesh.enabled=true \
+            --set clustermesh.apiserver.kvstoremesh.extraArgs[0]=--kvstore-opt=etcd.qps=1000 \
+            --set clustermesh.apiserver.nodeSelector.node-role\\.kubernetes\\.io/control-plane= \
+            --set clustermesh.apiserver.tolerations[0].key=node-role.kubernetes.io/control-plane \
+            --set clustermesh.apiserver.tolerations[0].operator=Exists \
+            --set clustermesh.apiserver.metrics.serviceMonitor.enabled=true \
+            --values values-clustermesh-config.yaml
+
+          cilium status --wait
+          cilium clustermesh status --wait --wait-duration=5m
+
+      - name: Run CL2
+        id: run-cl2
+        working-directory: ./perf-tests/clusterloader2
+        env:
+          CL2_PROMETHEUS_PVC_ENABLED: "false"
+          CL2_PROMETHEUS_SCRAPE_CILIUM_OPERATOR: "true"
+          CL2_PROMETHEUS_SCRAPE_CILIUM_AGENT: "true"
+          CL2_PROMETHEUS_MEMORY_SCALE_FACTOR: 4.0
+        timeout-minutes: 30
+        run: |
+          go run ./cmd/clusterloader.go \
+            -v=2 \
+            --testconfig=./testing/custom/clustermesh/config.yaml \
+            --testoverrides=./testing/prometheus/not-scrape-kube-proxy.yaml \
+            --provider=gce \
+            --nodes=1 \
+            --enable-prometheus-server \
+            --tear-down-prometheus-server=false \
+            --report-dir=./report \
+            --experimental-prometheus-snapshot-to-report-dir=true \
+            --kubeconfig=$HOME/.kube/config \
+            2>&1 | tee cl2-output.txt
+
+      - name: Get sysdump
+        if: ${{ always() && steps.run-cl2.outcome != 'skipped' && steps.run-cl2.outcome != 'cancelled' }}
+        run: |
+          cilium status
+          cilium sysdump --output-filename cilium-sysdump-final
+
+      - name: Cleanup cluster
+        if: ${{ always() && steps.deploy-cluster.outcome != 'skipped' }}
+        uses: cilium/scale-tests-action/cleanup-cluster@318a068b7fb62548bd252eecc8123c704b5f0493 # main
+        with:
+          cluster_name: ${{ steps.vars.outputs.CLUSTER_NAME }}
+          kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
+
+      - name: Export results and sysdump to GS bucket
+        if: ${{ always() && steps.run-cl2.outcome != 'skipped' && steps.run-cl2.outcome != 'cancelled' }}
+        uses: cilium/scale-tests-action/export-results@318a068b7fb62548bd252eecc8123c704b5f0493 # main
+        with:
+          test_name: ${{ env.test_name }}
+          results_bucket: ${{ env.GCP_PERF_RESULTS_BUCKET }}
+          artifacts: ./perf-tests/clusterloader2/report/*
+          other_files: cilium-sysdump-final.zip ./perf-tests/clusterloader2/cl2-output.txt
+
+  commit-status-final:
+    if: ${{ always() }}
+    name: Commit Status Final
+    needs: install-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set final commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+          status: ${{ needs.install-and-test.result }}


### PR DESCRIPTION
Introduce a new GitHub Actions Workflow to exercise clustermesh, and thus Cilium, at high scale. The workflow mimics other scale-related tests and deploys a Kubernetes cluster hosted on GCP leveraging Kops. In this case, the cluster is composed of a single control-plane node and a single worker node. Additionally, we leverage cmapisrv-mock \[1\] to mock an arbitrary number of remote clusters, each composed of a given number of nodes, endpoints, and identities, and associated churn rate. The cmapisrv-mock is always scheduled on the control plane node, and is currently configured to mock 250 clusters, encompassing a total of 25k nodes, 250k endpoints and 25k identities. Additionally, for each cluster, the configured churn rates are nodes: 0.1 QPS, endpoints: 1 QPS and identities: 0.2 QPS, for a total of ~325 QPS.
    
Similarly to other scale-related workflows, we leverage ClusterLoader2 [2] to setup the monitoring stack, run the tests and gather the results in the appropriate format to then plot them using perfdash [3]. Specifically, we run it once to setup the monitoring stack, then configure Cilium to connect to the mocked clusters, and then run it a second time to execute the actual tests and gather the results. Currently, the test is composed of a first step starting a given number of pods scheduled on the worker nodes (with 5 QPS) and measuring the startup latency, to observe possible slow-downs when a large number of nodes, endpoints and identities has already been injected. Subsequently, the test sleeps for 5 minutes to observe the effects of the remote clusters churn, and eventually tears down the pods and gathers the results.

\[1\]: https://github.com/cilium/scaffolding/tree/main/cmapisrv-mock
\[2\]: https://github.com/kubernetes/perf-tests/tree/master/clusterloader2
\[3\]: https://github.com/kubernetes/perf-tests/tree/master/perfdash