### PR TITLE
docs: Document plus sign in IPsec secret

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -398,6 +398,9 @@ Annotations:
   ``CiliumLoadBalancerIPPool.spec.blocks``. As of v1.15 both fields have the same behavior. The
   ``cidrs`` field will be removed in v1.16. Please update your IP pool configurations to use
   ``blocks`` instead of ``cidrs`` before upgrading.
+* For IPsec, the use of per-tunnel keys is mandatory, via the use of the ``+``
+  sign in the secret. See the :ref:`encryption_ipsec` guide for more
+  information.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -47,6 +47,14 @@ following command:
     $ kubectl create -n kube-system secret generic cilium-ipsec-keys \
         --from-literal=keys="3+ rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 
+.. attention::
+
+    The ``+`` sign in the secret is mandatory since v1.16. It will force the
+    use of per-tunnel IPsec keys. The former global IPsec keys are considered
+    insecure (cf. `GHSA-pwqm-x5x6-5586`_).
+
+.. _GHSA-pwqm-x5x6-5586: https://github.com/cilium/cilium/security/advisories/GHSA-pwqm-x5x6-5586
+
 The secret can be seen with ``kubectl -n kube-system get secrets`` and will be
 listed as ``cilium-ipsec-keys``.
 


### PR DESCRIPTION
The plus sign in the IPsec secret forces the use of per-tunnel keys. It will be mandatory from version 1.16.