### PR TITLE
Add kernel version limitation to multicast Doc

### DIFF
--- a/Documentation/network/multicast.rst
+++ b/Documentation/network/multicast.rst
@@ -30,6 +30,8 @@ information. If unsure, run ``cilium status`` and validate that Cilium is up
 and running. This guide also assumes Cilium is configured with vxlan mode,
 which is required when using multicast capability.
 
+Multicast only works on kernels >= 5.10 for AMD64, and on kernels >= 6.0 for AArch64.
+
 
 Enable Multicast Feature
 ========================

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -274,7 +274,9 @@ BPF-based proxy redirection                            >= 5.7
 Socket-level LB bypass in pod netns                    >= 5.7
 L3 devices                                             >= 5.8
 BPF-based host routing                                 >= 5.10
+:ref:`enable_multicast` (AMD64)                        >= 5.10
 IPv6 BIG TCP support                                   >= 5.19
+:ref:`enable_multicast` (AArch64)                      >= 6.0
 IPv4 BIG TCP support                                   >= 6.3
 ====================================================== ===============================
 


### PR DESCRIPTION
The kernel version that can enable multicast is different between AMD64 and AArch64 due to the different times when the tail-call in eBPF sub-program was enabled.
I wrote about it in the document.

As we discuss in [below issue](https://github.com/cilium/cilium/issues/33408), to resolve this issue completely, we have to think more.
I think there are two ways :
- Fix as an eBPF program issue
- Add a feature probe helper in the cilium/ebpf library and use it when initializing multicast in cilium-agent


ref : The commit which allow for tailcalls in BPF subprogram in each architecture are below
AMD64:
https://github.com/torvalds/linux/commit/e411901c0b775
This commit is reflected to version 5.10 or newer kernel

AArch64:
https://github.com/torvalds/linux/commit/d4609a5d8c70d21b4a3f801cf896a3c16c613fe1
This commit is reflected to 6.0 or newer kernel


This PR is a little part of the solution of https://github.com/cilium/cilium/issues/33408
