### PR TITLE
option: Fix merge conflict in test expectations

### DIFF
--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -1382,7 +1382,7 @@ func TestDaemonConfig_StoreInFile(t *testing.T) {
 + 	DryMode:      true,
   	RestoreState: false,
   	KeepConfig:   false,
-  	... // 5 ignored and 313 identical fields
+  	... // 5 ignored and 315 identical fields
   }
 `)
 	Config.DryMode = false


### PR DESCRIPTION
Commit 369e927307 ("daemon: Check that DaemonConfig is not changed after being published") added a new test case that needs to be updated when adding new configs.

Commit b7a26eb8a2 ("Add rate limiting on BPF events map") added new configs but the pull request branch didn't include commit 369e927307, thus tests passed in the pull request CI and started failing once the pull request was merged.

This pull request fixes it by updating the test expected output.

cc @siwiutki