### PR TITLE
dev: support for an additional kind values file

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -278,6 +278,10 @@ define KIND_VALUES_FILES
 --helm-values=$(ROOT_DIR)/contrib/testing/kind-values.yaml
 endef
 
+ifdef ADDITIONAL_KIND_VALUES_FILE
+	KIND_VALUES_FILES := $(KIND_VALUES_FILES) --helm-values=$(ROOT_DIR)/$(ADDITIONAL_KIND_VALUES_FILE)
+endif
+
 ifneq ("$(wildcard $(ROOT_DIR)/contrib/testing/kind-custom.yaml)","")
 	KIND_VALUES_FILES := $(KIND_VALUES_FILES) --helm-values=$(ROOT_DIR)/contrib/testing/kind-custom.yaml
 endif


### PR DESCRIPTION
Currently the Cilium Helm values that are used for all of the Make `kind-*` targets are provided by static values files or an optional `kind-custom.yaml` file that is under git ignore (for local dev purposes).

This commit introduces the possibilility to pass an additional values file as make argument.

```
ADDITIONAL_KIND_VALUES_FILE=contrib/testing/kind-feature-x.yaml make kind-debug
```

This provides the possibility to use feature-specific values files during development and reduces the need for a specific make target.