### PR TITLE
renovate: stop wireguard updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -390,6 +390,8 @@
       ]
     },
     {
+      // It's returning 500s for git clones.
+      "enabled": false,
       "matchDepNames": [
         "golang.zx2c4.com/wireguard"
       ],


### PR DESCRIPTION
Renovate has been failing recently to check for the wireguard updates. Also this dependency hasn't received updates for months so it's safe to ignore it temporarily.g