### PR TITLE
ipsec: Clean old upgrade logic

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -843,10 +843,6 @@ enum {
 #define	CB_ENCRYPT_IDENTITY	CB_CT_STATE	/* Alias, non-overlapping,
 						 * Not used by xfrm.
 						 */
-#define	CB_ENCRYPT_DST		CB_CT_STATE	/* Alias, non-overlapping,
-						 * Not used by xfrm.
-						 * Can be removed in v1.15.
-						 */
 #define	CB_CUSTOM_CALLS		CB_CT_STATE	/* Alias, non-overlapping */
 #define	CB_SRV6_VRF_ID		CB_CT_STATE	/* Alias, non-overlapping */
 #define	CB_FROM_TUNNEL		CB_CT_STATE	/* Alias, non-overlapping */

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -183,24 +183,6 @@ static __always_inline __u32 inherit_identity_from_host(struct __ctx_buff *ctx, 
 		*identity = HOST_ID;
 	} else if (magic == MARK_MAGIC_ENCRYPT) {
 		*identity = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);
-
-		/* Special case needed to handle upgrades. Can be removed in v1.15.
-		 * Before the upgrade, bpf_lxc will write the tunnel endpoint in
-		 * skb->cb[4]. After the upgrade, it will write the security identity.
-		 * For the upgrade to happen without drops, bpf_host thus needs to
-		 * handle both cases.
-		 * We can distinguish between the two cases by looking at the first
-		 * byte. Identities are on 24-bits so the first byte will be zero;
-		 * conversely, tunnel endpoint addresses within the range 0.0.0.0/8
-		 * (first byte is zero) are impossible because special purpose
-		 * (RFC6890).
-		 */
-		if ((*identity & 0xFF000000) != 0) {
-			/* skb->cb[4] was actually carrying the tunnel endpoint and the
-			 * security identity is in the mark.
-			 */
-			*identity = get_identity(ctx);
-		}
 #if defined(ENABLE_L7_LB)
 	} else if (magic == MARK_MAGIC_PROXY_EGRESS_EPID) {
 		*identity = get_epid(ctx); /* endpoint identity, not security identity! */

--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -172,13 +172,7 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, nodeID uint1
 	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "default-drop IPv4", wildcardCIDR, wildcardCIDR, spi, 0))
 
 	if newNode.IsLocal() {
-		if n.subnetEncryption() {
-			// FIXME: Remove the following four lines in Cilium v1.16
-			if localCIDR := n.nodeConfig.AllocCIDRIPv4; localCIDR != nil {
-				// This removes a bogus route that Cilium installed prior to v1.15
-				_ = route.Delete(n.createNodeIPSecInRoute(localCIDR.IPNet))
-			}
-		} else {
+		if !n.subnetEncryption() {
 			localCIDR := n.nodeConfig.AllocCIDRIPv4.IPNet
 			errs = errors.Join(errs, n.replaceNodeIPSecInRoute(localCIDR))
 		}
@@ -316,13 +310,7 @@ func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, nodeID uint1
 	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "default-drop IPv6", wildcardCIDR, wildcardCIDR, spi, 0))
 
 	if newNode.IsLocal() {
-		if n.subnetEncryption() {
-			// FIXME: Remove the following four lines in Cilium v1.16
-			if localCIDR := n.nodeConfig.AllocCIDRIPv6; localCIDR != nil {
-				// This removes a bogus route that Cilium installed prior to v1.15
-				_ = route.Delete(n.createNodeIPSecInRoute(localCIDR.IPNet))
-			}
-		} else {
+		if !n.subnetEncryption() {
 			localCIDR := n.nodeConfig.AllocCIDRIPv6.IPNet
 			errs = errors.Join(errs, n.replaceNodeIPSecInRoute(localCIDR))
 		}

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -127,7 +127,7 @@ const (
 	IPsecMarkBitMask = 0x0F00
 
 	// IPsecOldMarkMaskOut is the mask that was previously used. It can be
-	// removed in Cilium v1.15.
+	// removed in Cilium v1.17.
 	IPsecOldMarkMaskOut = 0xFF00
 
 	// IPsecMarkMask is the mask required for the IPsec SPI, node ID, and encrypt/decrypt bits


### PR DESCRIPTION
Each commit removes a bit of special logic that was added to handle upgrades to v1.15 and previous versions. This logic was necessary because those versions had a lot of changes to address https://github.com/cilium/cilium/security/advisories/GHSA-pwqm-x5x6-5586.