### PR TITLE
Fix EC2 API endpoint when using a proxy for the metadata service

### DIFF
--- a/pkg/aws/endpoints/resolver.go
+++ b/pkg/aws/endpoints/resolver.go
@@ -5,6 +5,7 @@ package endpoints
 
 import (
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/logging"
@@ -16,7 +17,7 @@ var (
 )
 
 func Resolver(service, region string) (aws.Endpoint, error) {
-	if ep := operatorOption.Config.EC2APIEndpoint; len(ep) > 0 && service == "ec2" {
+	if ep := operatorOption.Config.EC2APIEndpoint; len(ep) > 0 && service == ec2.ServiceID {
 		log.Debugf("Using custom API endpoint %s for service %s in region %s", ep, service, region)
 		// See https://docs.aws.amazon.com/sdk-for-go/v2/api/aws/endpoints/#hdr-Using_Custom_Endpoints
 		return aws.Endpoint{


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #33597

We have setup proxy for aws service and need to set customized aws endpoint for cilium.

We set the **_ec2-api-endpoint: ec2.custom.com_** in cilium config, but get error in cilium log:

_level=fatal msg="Unable to init eni allocator" error="unable to update instance type to adapter limits from EC2 API: operation error EC2: DescribeInstanceTypes, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: request send failed, Post "https://ec2.us-east-1.amazonaws.com/": EOF" subsys=cilium-operator_


This patch fix the ec2 endpoint resolver issue by using correct serviceID by calling _ec2.serviceID_ (which now  returns **_EC2_** not **_ec2_**`)

```release-note
Fix issue where `ec2-api-endpoint` config would use the incorrect API endpoint.
```
