### PR TITLE
socketlb: tolerate cgroupv1 when detaching bpf programs

### DIFF
--- a/pkg/socketlb/cgroup.go
+++ b/pkg/socketlb/cgroup.go
@@ -198,6 +198,12 @@ func detachAll(attach ebpf.AttachType, cgroupRoot string) error {
 	if errors.Is(err, unix.EINVAL) {
 		err = fmt.Errorf("%w: %w", err, link.ErrNotSupported)
 	}
+	// Even though the cgroup exists, QueryPrograms will return EBADF
+	// on a cgroupv1.
+	if errors.Is(err, unix.EBADF) {
+		log.Debug("The cgroup exists but is a cgroupv1. No detachment necessary")
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("query cgroup %s for type %s: %w", cgroupRoot, attach, err)
 	}


### PR DESCRIPTION
This fixes a regression where Cilium fails to start because it fails to detach socketlb progs from a cgroupv1. This happens because QueryPrograms will fail with EBADF on a cgroupv1. To cleanup remaining programs from socketlb, we always try to remove these programs from the root cgroup. This commit ensures we don't fail to detach socketlb programs from a cgroupv1, as we would never succeed to attach any programs here in the first place.