### PR TITLE
ingress: Set active backend number for Local ETP

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -65,7 +65,7 @@ func (e *ErrLocalRedirectServiceExists) Is(target error) bool {
 	return e.frontend.DeepEqual(&t.frontend) && e.name == t.name
 }
 
-// healthServer is used to manage HealtCheckNodePort listeners
+// healthServer is used to manage HealthCheckNodePort listeners
 type healthServer interface {
 	UpsertService(svcID lb.ID, svcNS, svcName string, localEndpoints int, port uint16)
 	DeleteService(svcID lb.ID)
@@ -847,13 +847,23 @@ func (s *Service) upsertService(params *lb.SVC) (bool, lb.ID, error) {
 			// HealthCheckNodePort is used by external systems to poll the state of the Service,
 			// it should never take into consideration Terminating backends, even when there are only
 			// Terminating backends.
+			//
+			// There is one special case is L7 proxy service, which never have any
+			// backends because the traffic will be redirected.
 			activeBackends := 0
-			for _, b := range backendsCopy {
-				if b.State == lb.BackendStateActive {
-					activeBackends++
+			if params.L7LBProxyPort != 0 {
+				// Set this to 1 because Envoy will be running in this case.
+				getScopedLog().WithField(logfields.ServiceHealthCheckNodePort, svc.svcHealthCheckNodePort).
+					Debug("L7 service with HealthcheckNodePort enabled")
+				activeBackends = 1
+			} else {
+				for _, b := range backendsCopy {
+					if b.State == lb.BackendStateActive {
+						activeBackends++
+					}
 				}
 			}
-			s.healthServer.UpsertService(lb.ID(svc.frontend.ID), svc.svcName.Namespace, svc.svcName.Name,
+			s.healthServer.UpsertService(svc.frontend.ID, svc.svcName.Namespace, svc.svcName.Name,
 				activeBackends, svc.svcHealthCheckNodePort)
 
 			if err = s.upsertNodePortHealthService(svc, &nodeMetaCollector{}); err != nil {


### PR DESCRIPTION
### Description 

This commit is to set number of active local endpoints for L7 service,
which is used by CiliumEnvoyConfig (directly) and Ingress/GatewayAPI
(indirectly). As the proxy port is available, it's most likely that
Envoy listener is up and running, just a note that there might be a
chance that the resources in CEC are problematic and not working as
expected, however, it's out of scope for HealthCheckNodePort for the
underlying L7 service.

Relates: #33547, #32873

### Testing

Testing was done locally with the below manifest, just a note that service-external-traffic-policy annotation is set as `Local`

```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: basic-ingress
  namespace: default
  annotations:
    "ingress.cilium.io/service-external-traffic-policy": Local
spec:
  ingressClassName: cilium
  rules:
    - http:
        paths:
          - backend:
              service:
                name: details
                port:
                  number: 9080
            path: /details
            pathType: Prefix
          - backend:
              service:
                name: productpage
                port:
                  number: 9080
            path: /
            pathType: Prefix

```

The `/healthz` endpoint for related healthCheckNodePort is returning 503 with 0 local endpoints before. With this path, this endpoint is returning 200 as expected.

```
# Before the patch
root@kind-worker:/# curl -v http://localhost:32267/healthz
*   Trying 127.0.0.1:32267...
* Connected to localhost (127.0.0.1) port 32267 (#0)
> GET /healthz HTTP/1.1
> Host: localhost:32267
> User-Agent: curl/7.88.1
> Accept: */*
> 
< HTTP/1.1 503 Service Unavailable
< Content-Type: application/json
< X-Content-Type-Options: nosniff
< X-Load-Balancing-Endpoint-Weight: 0
< Date: Fri, 05 Jul 2024 07:12:00 GMT
< Content-Length: 93
< 
{"service":{"namespace":"default","name":"cilium-ingress-basic-ingress"},"localEndpoints":0}
* Connection #0 to host localhost left intact

# After the patch
root@kind-worker:/# curl -v http://localhost:32267/healthz
*   Trying 127.0.0.1:32267...
* Connected to localhost (127.0.0.1) port 32267 (#0)
> GET /healthz HTTP/1.1
> Host: localhost:32267
> User-Agent: curl/7.88.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Type: application/json
< X-Content-Type-Options: nosniff
< X-Load-Balancing-Endpoint-Weight: 1
< Date: Fri, 05 Jul 2024 07:12:36 GMT
< Content-Length: 93
< 
{"service":{"namespace":"default","name":"cilium-ingress-basic-ingress"},"localEndpoints":1}
* Connection #0 to host localhost left intact
```

