### PR TITLE
renovate: add auto-approve bot for renovate PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -131,7 +131,11 @@
       ],
       "automerge": true,
       "automergeType": "pr",
-      "groupName": "auto-merge-trusted-deps"
+      "groupName": "auto-merge-trusted-deps",
+      // Replace the list of reviewers with just ciliumbot
+      "reviewers":[
+        "ciliumbot",
+      ]
     },
     {
       // Try to group all updates for all dependencies in a single PR. More

--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -1,0 +1,53 @@
+name: Approve Renovate PR
+
+on:
+  pull_request:
+    types:
+    - review_requested
+
+jobs:
+  pre-approve:
+    # Avoid running the 'auto-approve' environment if we don't need to.
+    name: Pre-Approve
+    runs-on: ubuntu-latest
+    if: ${{
+         github.event.pull_request.user.login == 'cilium-renovate[bot]' &&
+         github.triggering_actor == 'cilium-renovate[bot]' &&
+         github.event.requested_reviewer.login == 'ciliumbot'
+        }}
+    steps:
+    - name: Debug
+      run: |
+        echo ${{ github.event.pull_request.user.login }}
+        echo ${{ github.triggering_actor }}
+        echo ${{ github.event.requested_reviewer.login }}
+
+  approve:
+    name: Approve
+    needs: pre-approve
+    environment: auto-approve
+    runs-on: ubuntu-latest
+    steps:
+    - name: Debug
+      run: |
+        echo ${{ github.event.pull_request.user.login }}
+        echo ${{ github.triggering_actor }}
+        echo ${{ github.event.requested_reviewer.login }}
+
+    - name: Approve PR
+      # Approve the PR if all the following conditions are true:
+      # - the PR review was requested by renovate bot and
+      # - the PR was also created by renovate bot
+      # - the requested reviewer was the trusted 'ciliumbot'
+      if: ${{
+           github.event.pull_request.user.login == 'cilium-renovate[bot]' &&
+           github.triggering_actor == 'cilium-renovate[bot]' &&
+           github.event.requested_reviewer.login == 'ciliumbot'
+          }}
+      env:
+        TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        echo ${TOKEN} | gh auth login --with-token
+        gh -R ${GITHUB_REPOSITORY} pr review ${PULL_REQUEST_NUMBER} --approve

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -234,6 +234,7 @@
 /.github/actions/ @cilium/github-sec @cilium/ci-structure
 /.github/actions/kvstore/ @cilium/sig-clustermesh @cilium/kvstore @cilium/github-sec @cilium/ci-structure
 /.github/workflows/ @cilium/github-sec @cilium/ci-structure
+/.github/workflows/auto-approve.yaml @cilium/cilium-maintainers
 /.github/workflows/*clustermesh*.yaml @cilium/sig-clustermesh @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*datapath*.yaml @cilium/sig-datapath @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*gateway-api*.yaml @cilium/sig-servicemesh @cilium/github-sec @cilium/ci-structure


### PR DESCRIPTION
Enable the GitHub "auto-merge" feature in the repository settings at `https://github.com/<org>/<repo>/settings`. If Renovate detects this feature, it allows PRs to be auto-merged by GitHub.

GitHub will auto-merge a PR if all required checks pass and CODEOWNERS have reviewed it. If these conditions are unmet, GitHub won't merge the PR.

To allow Renovate to auto-approve its own PRs, configure Renovate to request a review from the bot `ciliumbot` for PRs with trusted dependencies. The `reviewers` configuration in Renovate will ensure `ciliumbot` is the sole reviewer of Renovate's PRs.

Create a GitHub Action triggered by a review request event, ensuring the PR review was requested by the Renovate bot, the PR was created by Renovate, and the review request is for `ciliumbot`.

Ensure `ciliumbot` belongs to some teams of the CODEOWNERS file but is not auto-assigned reviews by GitHub. This setup allows `ciliumbot` to provide the necessary approvals without manual intervention, enabling seamless integration of Renovate to auto-approve PRs.

The teams that `ciliumbot` will belong to are the ones that usually are selected to review renovate PRs when a trusted dependency is updated.