### PR TITLE
cert: Adding H2 Protocol Support when Get gRPC Config For Client

### DIFF
--- a/pkg/crypto/certloader/server.go
+++ b/pkg/crypto/certloader/server.go
@@ -11,6 +11,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var alpnProtocolH2 = "h2"
+
 // ServerConfigBuilder creates tls.Config to be used as TLS server.
 type ServerConfigBuilder interface {
 	IsMutualTLS() bool
@@ -106,6 +108,7 @@ func (c *WatchedServerConfig) ServerConfig(base *tls.Config) *tls.Config {
 			keypair, caCertPool := c.KeypairAndCACertPool()
 			tlsConfig := base.Clone()
 			tlsConfig.Certificates = []tls.Certificate{*keypair}
+			tlsConfig.NextProtos = constructWithH2ProtoIfNeed(tlsConfig.NextProtos)
 			if c.IsMutualTLS() {
 				// We've been configured to serve mTLS, so setup the ClientCAs
 				// accordingly.
@@ -133,4 +136,16 @@ func (c *WatchedServerConfig) ServerConfig(base *tls.Config) *tls.Config {
 		// MinVersion must be set by the provided base TLS configuration.
 		MinVersion: tls.VersionTLS13,
 	}
+}
+
+// constructWithH2ProtoIfNeed constructs a new slice of protocols with h2
+func constructWithH2ProtoIfNeed(existingProtocols []string) []string {
+	for _, p := range existingProtocols {
+		if p == alpnProtocolH2 {
+			return existingProtocols
+		}
+	}
+	ret := make([]string, 0, len(existingProtocols)+1)
+	ret = append(ret, existingProtocols...)
+	return append(ret, alpnProtocolH2)
 }

--- a/pkg/crypto/certloader/server_test.go
+++ b/pkg/crypto/certloader/server_test.go
@@ -126,6 +126,8 @@ func TestNewWatchedServerConfig(t *testing.T) {
 	assert.Equal(t, tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
 	// Check that our base option is honored.
 	assert.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MinVersion)
+	// check that the ALPN protocol is set.
+	assert.Contains(t, tlsConfig.NextProtos, alpnProtocolH2)
 }
 
 func TestWatchedServerConfigRotation(t *testing.T) {
@@ -175,4 +177,6 @@ func TestWatchedServerConfigRotation(t *testing.T) {
 	assert.Equal(t, tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
 	// Check that our base option is honored.
 	assert.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MinVersion)
+	// check that the ALPN protocol is set.
+	assert.Contains(t, tlsConfig.NextProtos, alpnProtocolH2)
 }


### PR DESCRIPTION
Following the https://github.com/cilium/cilium/pull/33335, Here is a clear commit history about the PR, from more context as follows:

I am currently attempting to use a Java client to [read Peer addresses](https://github.com/cilium/cilium/blob/main/api/v1/peer/peer.proto#L16) and [read Flow data](https://github.com/cilium/cilium/blob/main/api/v1/observer/observer.proto#L21) from Hubble via gRPC. While everything works fine with plain text, I encountered an error when enabling TLS in Cilium according to the official documentation: [Hubble Configure TLS Certs](https://docs.cilium.io/en/latest/gettingstarted/hubble-configuration/#hubble-configure-tls-certs).

Upon investigation and referencing a [gRPC Java issue](https://github.com/grpc/grpc-java/issues/7201#issuecomment-656944061), I discovered that the problem arises because Hubble lacks the `NextProtocol` setting in the server configuration when using `GetConfigForClient`. This omission prevents gRPC Java from supporting HTTP/2, which is essential for data transmission.

Notably, this issue does not occur when the server does not use `GetConfigForClient` for dynamic TLS configuration, as gRPC [defaults to the HTTP/2 protocol during initialization](https://github.com/grpc/grpc-go/blob/master/credentials/tls.go#L204). However, because Cilium requires dynamic TLS updates, using GetConfigForClient is unavoidable.

In this PR, I propose adding the `NextProtocol` setting to include HTTP/2 in the server configuration, thus resolving the issue.