### PR TITLE
renovate: Only update patch version for statedb

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -390,6 +390,24 @@
       ]
     },
     {
+      // Avoid updating patch version for statedb as it might contain breaking changes
+      "enabled": false,
+      "matchPackageNames": [
+        "github.com/cilium/statedb",
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "pin",
+        "pinDigest",
+        "digest",
+        "lockFileMaintenance",
+        "rollback",
+        "bump",
+        "replacement",
+      ],
+    },
+    {
       // It's returning 500s for git clones.
       "enabled": false,
       "matchDepNames": [


### PR DESCRIPTION
For example, the version v0.2.x contains a couple of breaking changes in APIs.
