### PR TITLE
bpf: nodeport: clear EDT info for "Port unreachable" ICMP reply

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1304,9 +1304,11 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 			skip_l3_xlate, ext_err);
 
 #ifdef SERVICE_NO_BACKEND_RESPONSE
-	if (ret == DROP_NO_SERVICE)
+	if (ret == DROP_NO_SERVICE) {
+		edt_set_aggregate(ctx, 0);
 		ret = tail_call_internal(ctx, CILIUM_CALL_IPV6_NO_SERVICE,
 					 ext_err);
+	}
 #endif
 
 	if (IS_ERR(ret))
@@ -2843,9 +2845,12 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 				has_l4_header, skip_l3_xlate, &cluster_id,
 				ext_err);
 #ifdef SERVICE_NO_BACKEND_RESPONSE
-		if (ret == DROP_NO_SERVICE)
+		if (ret == DROP_NO_SERVICE) {
+			/* Packet is TX'ed back out, avoid EDT false-positives: */
+			edt_set_aggregate(ctx, 0);
 			ret = tail_call_internal(ctx, CILIUM_CALL_IPV4_NO_SERVICE,
 						 ext_err);
+		}
 #endif
 	}
 	if (IS_ERR(ret))


### PR DESCRIPTION
The EDT ID for pod-egressing traffic is stored in skb->queue_mapping, and checked by the Bandwidth Manager code in to-netdev.

When the N/S LB responds to a service request with a "Port unreachable" ICMP message, it rebuilds the initial request and redirects it back out (passing through to-netdev). As the NIC driver potentially filled the skb->queue_mapping field on RX, we need to clear it to avoid aliasing with genuine EDT marking.

This is in line with what the nodeport code does when forwarding LB'ed requests to a remote backend.

Fixes: 2c2c5ae08e7e ("bpf: Send ICMP unreachable when no service backends are available")

```release-note
When the Bandwidth Manager feature is enabled, don't apply Egress rate-limiting to "Port unreachable" ICMP replies by Cilium's North-South Loadbalancer.
```
