### PR TITLE
docs: remove mention of outdated clustermesh + L7 policies + tunnel limitation

### DIFF
--- a/Documentation/network/clustermesh/policy.rst
+++ b/Documentation/network/clustermesh/policy.rst
@@ -45,12 +45,3 @@ between two clusters. The cluster name refers to the name given via the
         - matchLabels:
             name: rebel-base
             io.cilium.k8s.policy.cluster: cluster2
-
-Limitations
-###########
-
- * L7 security policies currently only work across multiple clusters if worker
-   nodes have routes installed allowing to route pod IPs of all clusters. This
-   is obtained when running in direct routing mode by running a routing daemon or
-   ``--auto-direct-node-routes`` but won't work automatically when using
-   tunnel/encapsulation mode.


### PR DESCRIPTION
The mention of this limitation appears to have been introduced as part of an early clustermesh documentation version [1], more than 5 years ago. However, since then, the limitation must have been lifted, as we have been successfully testing this combination of features in CI for quite some time. Hence, let's remove this outdated mention from the docs.

\[1\]: 23a71f242a63 ("doc: Update ClusterMesh documentation for 1.4")