### PR TITLE
pkg/hive: Add FeatureLifecycle

### DIFF
--- a/pkg/hive/feature_lifecycle.go
+++ b/pkg/hive/feature_lifecycle.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package hive
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"golang.org/x/exp/maps"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+type FeatureLifecycleInterface interface {
+	Append(Feature, cell.Hook) error
+	Start(Feature, context.Context, *slog.Logger) error
+	Stop(Feature, context.Context, *slog.Logger) error
+
+	IsRunning(Feature) bool
+	List() []Feature
+}
+
+type Feature string
+type FeatureLifecycle struct {
+	mu     lock.Mutex
+	hooks  map[Feature][]cell.Hook
+	status map[Feature]bool
+}
+
+func NewFeatureLifecycle() *FeatureLifecycle {
+	return &FeatureLifecycle{
+		hooks:  make(map[Feature][]cell.Hook),
+		status: make(map[Feature]bool),
+	}
+}
+
+// Append adds a hook to the feature hooks, marking the feature as not running.
+// It returns an error if the feature is already running.
+func (fl *FeatureLifecycle) Append(f Feature, h cell.Hook) error {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+
+	if status, ok := fl.status[f]; ok && status {
+		return fmt.Errorf("cannot add hooks to a running feature: %s", f)
+	}
+
+	fl.hooks[f] = append(fl.hooks[f], h)
+	fl.status[f] = false
+
+	return nil
+}
+
+// Start attempts to start a feature by executing its associated hooks.
+// It returns an error if the feature is already running
+// or if any hook fails to start.
+func (fl *FeatureLifecycle) Start(f Feature, c context.Context, l *slog.Logger) error {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+
+	if status, ok := fl.status[f]; ok && status {
+		return fmt.Errorf("feature %s is already running", f)
+	}
+
+	l.Debug("Starting hooks for", "feature", f)
+	for _, hook := range fl.hooks[f] {
+		if err := hook.Start(c); err != nil {
+			l.Error("Start hook failed", "error", err)
+			return fmt.Errorf("starting hook for feature %s: %w", f, err)
+		}
+	}
+
+	fl.status[f] = true
+
+	return nil
+}
+
+// Stop attempts to stop a feature by stopping its associated hooks.
+// It returns an error if the feature is already stopped.
+// If any hook encounters an error during stopping it aggregates into return error
+func (fl *FeatureLifecycle) Stop(f Feature, c context.Context, l *slog.Logger) error {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+
+	if status, ok := fl.status[f]; ok && !status {
+		return fmt.Errorf("feature %s is already stopped", f)
+	}
+
+	var errs error
+
+	l.Debug("Stopping hooks for", "feature", f)
+
+	for i := len(fl.hooks[f]) - 1; i >= 0; i-- {
+		hook := fl.hooks[f][i]
+		if err := hook.Stop(c); err != nil {
+			l.Error("Stop hook failed", "error", err)
+			errs = errors.Join(errs, err)
+		}
+	}
+
+	fl.status[f] = false
+
+	return errs
+}
+
+// IsRunning checks if a feature is currently running.
+// It returns true if the feature exists in status map
+// and its status is true, and false otherwise.
+func (fl *FeatureLifecycle) IsRunning(f Feature) bool {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+
+	status, ok := fl.status[f]
+	return ok && status
+
+}
+
+// List returns a list of all features registered
+func (fl *FeatureLifecycle) List() []Feature {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+
+	return maps.Keys(fl.hooks)
+}

--- a/pkg/hive/feature_lifecycle_test.go
+++ b/pkg/hive/feature_lifecycle_test.go
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package hive
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+const (
+	feature = "feature"
+)
+
+var (
+	goodHook = cell.Hook{
+		OnStart: func(cell.HookContext) error {
+			return nil
+		},
+		OnStop: func(cell.HookContext) error {
+			return nil
+		},
+	}
+
+	failToStartHook = cell.Hook{
+		OnStart: func(cell.HookContext) error {
+			return fmt.Errorf("start failed")
+		},
+		OnStop: func(cell.HookContext) error {
+			return nil
+		},
+	}
+	failToStopHook = cell.Hook{
+		OnStart: func(cell.HookContext) error {
+			return nil
+		},
+		OnStop: func(cell.HookContext) error {
+			return fmt.Errorf("stop failed")
+		},
+	}
+)
+
+func TestFeatureLifecycle_Append(t *testing.T) {
+	testCases := []struct {
+		name          string
+		initialHooks  map[Feature][]cell.Hook
+		initialStatus map[Feature]bool
+		feature       Feature
+		hook          cell.Hook
+		wantError     string
+		wantStatus    map[Feature]bool
+	}{
+		{
+			name:          "new_feature",
+			initialHooks:  map[Feature][]cell.Hook{},
+			initialStatus: map[Feature]bool{},
+			feature:       feature,
+			hook:          goodHook,
+			wantStatus:    map[Feature]bool{feature: false},
+		},
+		{
+			name:          "existing_feature",
+			initialHooks:  map[Feature][]cell.Hook{feature: {goodHook}},
+			initialStatus: map[Feature]bool{feature: false},
+			feature:       feature,
+			hook:          goodHook,
+			wantStatus:    map[Feature]bool{feature: false},
+		},
+		{
+			name:          "running_feature",
+			initialHooks:  map[Feature][]cell.Hook{feature: {goodHook}},
+			initialStatus: map[Feature]bool{feature: true},
+			feature:       feature,
+			hook:          goodHook,
+			wantError:     "cannot add hooks to a running feature: " + feature,
+			wantStatus:    map[Feature]bool{feature: true},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fl := NewFeatureLifecycle()
+
+			fl.hooks = tc.initialHooks
+			fl.status = tc.initialStatus
+
+			err := fl.Append(tc.feature, tc.hook)
+
+			if err != nil && err.Error() != tc.wantError {
+				t.Errorf("unexpected error: got %v, want %v", err, tc.wantError)
+			}
+
+			if !reflect.DeepEqual(fl.status, tc.wantStatus) {
+				t.Errorf("unexpected status: got %v, want %v", fl.status, tc.wantStatus)
+			}
+
+		})
+	}
+}
+
+func TestFeatureLifecycle_Start(t *testing.T) {
+	testCases := []struct {
+		name          string
+		initialHooks  map[Feature][]cell.Hook
+		initialStatus map[Feature]bool
+		feature       Feature
+		wantError     string
+		wantStatus    map[Feature]bool
+	}{
+		{
+			name:          "successful",
+			initialHooks:  map[Feature][]cell.Hook{feature: {goodHook}},
+			initialStatus: map[Feature]bool{feature: false},
+			feature:       feature,
+			wantStatus:    map[Feature]bool{feature: true},
+		},
+		{
+			name:          "failing_hook",
+			initialHooks:  map[Feature][]cell.Hook{feature: {failToStartHook}},
+			initialStatus: map[Feature]bool{feature: false},
+			feature:       feature,
+			wantError:     fmt.Sprintf("starting hook for feature %s: start failed", feature),
+			wantStatus:    map[Feature]bool{feature: false},
+		},
+		{
+			name:          "already_running",
+			initialHooks:  map[Feature][]cell.Hook{feature: {goodHook}},
+			initialStatus: map[Feature]bool{feature: true},
+			feature:       feature,
+			wantError:     fmt.Sprintf("feature %s is already running", feature),
+			wantStatus:    map[Feature]bool{feature: true},
+		},
+		{
+			name: "second_hook_failing",
+			initialHooks: map[Feature][]cell.Hook{feature: {
+				goodHook,
+				failToStartHook,
+			}},
+			feature:       feature,
+			initialStatus: map[Feature]bool{feature: false},
+			wantError:     fmt.Sprintf("starting hook for feature %s: start failed", feature),
+			wantStatus:    map[Feature]bool{feature: false},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fl := NewFeatureLifecycle()
+
+			fl.hooks = tc.initialHooks
+			fl.status = tc.initialStatus
+
+			err := fl.Start(tc.feature, context.Background(), slog.Default())
+
+			if err != nil && err.Error() != tc.wantError {
+				t.Errorf("unexpected error, got: %v, want: %v", err, tc.wantError)
+			}
+			if !reflect.DeepEqual(fl.status, tc.wantStatus) {
+				t.Errorf("unexpected status, got: %v, want: %v", fl.status, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestFeatureLifecycle_Stop(t *testing.T) {
+	testCases := []struct {
+		name          string
+		initialHooks  map[Feature][]cell.Hook
+		initialStatus map[Feature]bool
+		feature       Feature
+		wantError     string
+		wantStatus    map[Feature]bool
+	}{
+		{
+			name:          "successful",
+			initialHooks:  map[Feature][]cell.Hook{feature: {goodHook}},
+			initialStatus: map[Feature]bool{feature: true},
+			feature:       feature,
+			wantStatus:    map[Feature]bool{feature: false},
+		},
+		{
+			name:          "failing_hook",
+			initialHooks:  map[Feature][]cell.Hook{feature: {failToStopHook}},
+			initialStatus: map[Feature]bool{feature: true},
+			feature:       feature,
+			wantError:     "stop failed",
+			wantStatus:    map[Feature]bool{feature: false},
+		},
+		{
+			name: "second_hook_failing",
+			initialHooks: map[Feature][]cell.Hook{feature: {
+				goodHook,
+				failToStopHook,
+			}},
+			initialStatus: map[Feature]bool{feature: true},
+			feature:       feature,
+			wantError:     "stop failed",
+			wantStatus:    map[Feature]bool{feature: false},
+		},
+		{
+			name:          "already_stopped",
+			initialHooks:  map[Feature][]cell.Hook{feature: {goodHook}},
+			initialStatus: map[Feature]bool{feature: false},
+			feature:       feature,
+			wantError:     fmt.Sprintf("feature %s is already stopped", feature),
+			wantStatus:    map[Feature]bool{feature: false},
+		},
+		{
+			name: "reverse_order",
+			initialHooks: map[Feature][]cell.Hook{feature: {
+				cell.Hook{
+					OnStop: func(cell.HookContext) error {
+						return fmt.Errorf("cell1")
+					}},
+				cell.Hook{
+					OnStop: func(cell.HookContext) error {
+						return fmt.Errorf("cell2")
+					}},
+			}},
+			initialStatus: map[Feature]bool{feature: true},
+			feature:       feature,
+			wantError:     errors.Join(fmt.Errorf("cell2"), fmt.Errorf("cell1")).Error(),
+			wantStatus:    map[Feature]bool{feature: false},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fl := NewFeatureLifecycle()
+
+			fl.hooks = tc.initialHooks
+			fl.status = tc.initialStatus
+
+			err := fl.Stop(tc.feature, context.Background(), slog.Default())
+
+			if err != nil && err.Error() != tc.wantError {
+				t.Errorf("unexpected error, got: %v, want: %v", err, tc.wantError)
+			}
+			if !reflect.DeepEqual(fl.status, tc.wantStatus) {
+				t.Errorf("unexpected status: got %v, want %v", fl.status, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestFeatureLifecycle_IsRunning(t *testing.T) {
+	testCases := []struct {
+		name          string
+		initialStatus map[Feature]bool
+		feature       Feature
+		wantIsRunning bool
+	}{
+		{
+			name:          "running",
+			initialStatus: map[Feature]bool{feature: true},
+			feature:       feature,
+			wantIsRunning: true,
+		},
+		{
+			name:          "stopped",
+			initialStatus: map[Feature]bool{feature: false},
+			feature:       feature,
+			wantIsRunning: false,
+		},
+		{
+			name:          "nonexistent",
+			initialStatus: map[Feature]bool{feature: true},
+			feature:       "another_feature",
+			wantIsRunning: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fl := NewFeatureLifecycle()
+			fl.status = tc.initialStatus
+
+			isRunning := fl.IsRunning(tc.feature)
+
+			if isRunning != tc.wantIsRunning {
+				t.Errorf("unexpected result for status, got: %v, want: %v", isRunning, tc.wantIsRunning)
+			}
+		})
+	}
+}
+
+func TestFeatureLifecycle_GetFeatures(t *testing.T) {
+	testCases := []struct {
+		name         string
+		initialHooks map[Feature][]cell.Hook
+		wantFeatures []Feature
+	}{
+		{
+			name:         "empty",
+			initialHooks: map[Feature][]cell.Hook{},
+			wantFeatures: []Feature{},
+		},
+		{
+			name: "single",
+			initialHooks: map[Feature][]cell.Hook{
+				feature: {goodHook},
+			},
+			wantFeatures: []Feature{feature},
+		},
+		{
+			name: "multiple",
+			initialHooks: map[Feature][]cell.Hook{
+				feature:           {goodHook},
+				"another_feature": {goodHook, failToStopHook, failToStartHook},
+				"third_feature":   {},
+			},
+			wantFeatures: []Feature{feature, "another_feature", "third_feature"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fl := NewFeatureLifecycle()
+			fl.hooks = tc.initialHooks
+
+			gotFeatures := fl.List()
+
+			diff := cmp.Diff(tc.wantFeatures, gotFeatures, cmpopts.SortSlices(func(x, y Feature) bool { return x < y }))
+			if diff != "" {
+				t.Errorf("unexpected features (-want, +got):\n%s", diff)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
FeatureLifecycle can be initiated or terminated based on feature names. Associated lifecycle hooks are grouped by feature, and methods are exposed to control the start and stop actions for all hooks within a feature group.

A `FeatureLifecycleManager` will be introduced in a later PR that would manage this FeatureLifecycle, so the Manager will take responsibility of dependencies between features and also handling errors during start/stop of the features. 

Related: #33502

