### PR TITLE
Update CiliumEnvoyConfig log for headless Services

### DIFF
--- a/pkg/ciliumenvoyconfig/cec_reconciler.go
+++ b/pkg/ciliumenvoyconfig/cec_reconciler.go
@@ -304,7 +304,7 @@ func (r *ciliumEnvoyConfigReconciler) syncHeadlessService(_ context.Context) err
 
 	for key, cfg := range r.configs {
 		if err := r.manager.syncCiliumEnvoyConfigService(cfg.meta.Name, cfg.meta.Namespace, cfg.spec); err != nil {
-			r.logger.WithField("key", key).WithError(err).Error("failed to sync headless service")
+			r.logger.WithField("key", key).WithError(err).Info("Failed to sync headless service, Hive will retry")
 			reconcileErr = errors.Join(reconcileErr, fmt.Errorf("failed to reconcile existing config (%s): %w", key, err))
 			continue
 		}


### PR DESCRIPTION
Hive will automatically retry these, so this does not need to be logged at Error level. Non-headless Services already behave in this way after #33266 was merged.

