### PR TITLE
datapath: Fix update to NodeAddress table and prioritize Node IP

### DIFF
--- a/pkg/datapath/tables/node_address.go
+++ b/pkg/datapath/tables/node_address.go
@@ -251,7 +251,7 @@ func (n *nodeAddressController) register() {
 				// Do an immediate update to populate the table before it is read from.
 				devices := n.Devices.All(txn)
 				for dev, _, ok := devices.Next(); ok; dev, _, ok = devices.Next() {
-					n.update(txn, nil, n.getAddressesFromDevice(dev), nil, dev.Name)
+					n.update(txn, n.getAddressesFromDevice(dev), nil, dev.Name)
 					n.updateWildcardDevice(txn, dev, false)
 				}
 				txn.Commit()
@@ -274,15 +274,11 @@ func (n *nodeAddressController) run(ctx context.Context, reporter cell.Health) e
 		for change, _, ok := n.deviceChanges.Next(); ok; change, _, ok = n.deviceChanges.Next() {
 			dev := change.Object
 
-			// Note: prefix match! existing may contain node addresses from devices with names
-			// prefixed by dev. See https://github.com/cilium/cilium/issues/29324.
-			addrIter := n.NodeAddresses.List(txn, NodeAddressDeviceNameIndex.Query(dev.Name))
-			existing := statedb.Collect(addrIter)
-			var new sets.Set[NodeAddress]
+			var new []NodeAddress
 			if !change.Deleted {
 				new = n.getAddressesFromDevice(dev)
 			}
-			n.update(txn, sets.New(existing...), new, reporter, dev.Name)
+			n.update(txn, new, reporter, dev.Name)
 			n.updateWildcardDevice(txn, dev, change.Deleted)
 		}
 		txn.Commit()
@@ -313,7 +309,7 @@ func (n *nodeAddressController) updateWildcardDevice(txn statedb.WriteTxn, dev *
 		n.NodeAddresses.Delete(txn, addr)
 	}
 
-	newAddrs := sets.New[NodeAddress]()
+	newAddrs := []NodeAddress{}
 	for _, fallback := range n.fallbackAddresses.addrs() {
 		if !fallback.IsValid() {
 			continue
@@ -324,7 +320,7 @@ func (n *nodeAddressController) updateWildcardDevice(txn statedb.WriteTxn, dev *
 			Primary:    true,
 			DeviceName: WildcardDeviceName,
 		}
-		newAddrs.Insert(nodeAddr)
+		newAddrs = append(newAddrs, nodeAddr)
 		n.NodeAddresses.Insert(txn, nodeAddr)
 	}
 
@@ -350,30 +346,32 @@ func (n *nodeAddressController) updateFallbacks(txn statedb.ReadTxn, dev *Device
 }
 
 // updates the node addresses of a single device.
-func (n *nodeAddressController) update(txn statedb.WriteTxn, existing, new sets.Set[NodeAddress], reporter cell.Health, device string) {
+func (n *nodeAddressController) update(txn statedb.WriteTxn, new []NodeAddress, reporter cell.Health, device string) {
 	updated := false
-	prefixLen := len(device)
 
-	// Insert new addresses that did not exist.
-	for addr := range new {
-		if !existing.Has(addr) {
+	// Gather the set of currently existing addresses for this device.
+	current := sets.New(statedb.Collect(
+		statedb.Map(
+			n.NodeAddresses.List(txn, NodeAddressDeviceNameIndex.Query(device)),
+			func(addr NodeAddress) netip.Addr {
+				return addr.Addr
+			}))...)
+
+	// Update the new set of addresses for this device. We try to avoid insertions when nothing has changed
+	// to avoid unnecessary wakeups to watchers of the table.
+	for _, addr := range new {
+		old, _, hadOld := n.NodeAddresses.Get(txn, NodeAddressIndex.Query(NodeAddressKey{Addr: addr.Addr, DeviceName: device}))
+		if !hadOld || old != addr {
 			updated = true
 			n.NodeAddresses.Insert(txn, addr)
 		}
+		current.Delete(addr.Addr)
 	}
 
-	// Remove addresses that were not part of the new set.
-	for addr := range existing {
-		// Ensure full device name match. 'device' may be a prefix of DeviceName, and we don't want
-		// to delete node addresses of `cilium_host` because they are not on `cilium`.
-		if prefixLen != len(addr.DeviceName) {
-			continue
-		}
-
-		if !new.Has(addr) {
-			updated = true
-			n.NodeAddresses.Delete(txn, addr)
-		}
+	// Delete the addresses no longer associated with the device.
+	for addr := range current {
+		updated = true
+		n.NodeAddresses.Delete(txn, NodeAddress{DeviceName: device, Addr: addr})
 	}
 
 	if updated {
@@ -385,7 +383,7 @@ func (n *nodeAddressController) update(txn statedb.WriteTxn, existing, new sets.
 	}
 }
 
-func (n *nodeAddressController) getAddressesFromDevice(dev *Device) sets.Set[NodeAddress] {
+func (n *nodeAddressController) getAddressesFromDevice(dev *Device) []NodeAddress {
 	if dev.Flags&net.FlagUp == 0 {
 		return nil
 	}
@@ -493,13 +491,13 @@ func (n *nodeAddressController) getAddressesFromDevice(dev *Device) sets.Set[Nod
 		}
 	}
 
-	return sets.New(addrs...)
+	return addrs
 }
 
 // showAddresses formats a Set[NodeAddress] as "1.2.3.4 (primary, nodeport), fe80::1"
-func showAddresses(addrs sets.Set[NodeAddress]) string {
+func showAddresses(addrs []NodeAddress) string {
 	ss := make([]string, 0, len(addrs))
-	for addr := range addrs {
+	for _, addr := range addrs {
 		var extras []string
 		if addr.Primary {
 			extras = append(extras, "primary")

--- a/pkg/datapath/tables/node_address.go
+++ b/pkg/datapath/tables/node_address.go
@@ -337,9 +337,7 @@ func (n *nodeAddressController) updateFallbacks(txn statedb.ReadTxn, dev *Device
 	}
 
 	fallbacks := &n.fallbackAddresses
-	if deleted && (fallbacks.ipv4.dev == dev || fallbacks.ipv6.dev == dev) {
-		// The device that was used for fallback address was removed.
-		// Clear the fallbacks and reprocess from scratch.
+	if deleted && fallbacks.fromDevice(dev) {
 		fallbacks.clear()
 		devices := n.Devices.All(txn)
 		for dev, _, ok := devices.Next(); ok; dev, _, ok = devices.Next() {
@@ -571,7 +569,27 @@ func (f *fallbackAddresses) addrs() []netip.Addr {
 	return []netip.Addr{f.ipv4.addr.Addr, f.ipv6.addr.Addr}
 }
 
+func (f *fallbackAddresses) fromDevice(dev *Device) bool {
+	return (f.ipv4.dev != nil && f.ipv4.dev.Name == dev.Name) ||
+		(f.ipv6.dev != nil && f.ipv6.dev.Name == dev.Name)
+}
+
+func (f *fallbackAddresses) clearDevice(dev *Device) {
+	// Clear the fallbacks if they were from a prior version of this device
+	// as the addresses may have been removed.
+	if f.ipv4.dev != nil && f.ipv4.dev.Name == dev.Name {
+		f.ipv4 = fallbackAddress{}
+	}
+	if f.ipv6.dev != nil && f.ipv6.dev.Name == dev.Name {
+		f.ipv6 = fallbackAddress{}
+	}
+}
+
 func (f *fallbackAddresses) update(dev *Device) (updated bool) {
+	prevIPv4, prevIPv6 := f.ipv4.addr, f.ipv6.addr
+
+	f.clearDevice(dev)
+
 	// Iterate over all addresses to see if any of them make for a better
 	// fallback address.
 	for _, addr := range dev.Addrs {
@@ -602,12 +620,11 @@ func (f *fallbackAddresses) update(dev *Device) (updated bool) {
 			better = addr.Addr.Less(fa.addr.Addr)
 		}
 		if better {
-			updated = true
 			fa.dev = dev
 			fa.addr = addr
 		}
 	}
-	return
+	return prevIPv4 != f.ipv4.addr || prevIPv6 != f.ipv6.addr
 }
 
 // Shared test address definitions

--- a/pkg/datapath/tables/node_address_test.go
+++ b/pkg/datapath/tables/node_address_test.go
@@ -692,45 +692,61 @@ func TestSortedAddresses(t *testing.T) {
 func TestFallbackAddresses(t *testing.T) {
 	var f fallbackAddresses
 
-	f.update(&Device{
+	updated := f.update(&Device{
 		Index: 2,
 		Addrs: []DeviceAddress{
 			{Addr: netip.MustParseAddr("10.0.0.1"), Scope: RT_SCOPE_SITE},
 		},
 	})
 	assert.Equal(t, f.ipv4.addr.Addr.String(), "10.0.0.1")
-	f.update(&Device{
+	assert.True(t, updated, "updated")
+
+	updated = f.update(&Device{
 		Index: 3,
 		Addrs: []DeviceAddress{
 			{Addr: netip.MustParseAddr("1001::1"), Scope: RT_SCOPE_SITE},
 		},
 	})
 	assert.Equal(t, f.ipv6.addr.Addr.String(), "1001::1")
+	assert.True(t, updated, "updated")
 
 	// Lower scope wins
-	f.update(&Device{
+	updated = f.update(&Device{
 		Index: 4,
 		Addrs: []DeviceAddress{
 			{Addr: netip.MustParseAddr("10.0.0.2"), Scope: RT_SCOPE_UNIVERSE},
 		},
 	})
 	assert.Equal(t, f.ipv4.addr.Addr.String(), "10.0.0.2")
+	assert.True(t, updated, "updated")
 
 	// Lower ifindex wins
-	f.update(&Device{
+	updated = f.update(&Device{
 		Index: 1,
 		Addrs: []DeviceAddress{
 			{Addr: netip.MustParseAddr("10.0.0.3"), Scope: RT_SCOPE_UNIVERSE},
 		},
 	})
 	assert.Equal(t, f.ipv4.addr.Addr.String(), "10.0.0.3")
+	assert.True(t, updated, "updated")
 
 	// Public wins over private
-	f.update(&Device{
+	updated = f.update(&Device{
 		Index: 5,
 		Addrs: []DeviceAddress{
 			{Addr: netip.MustParseAddr("20.0.0.1"), Scope: RT_SCOPE_SITE},
 		},
 	})
 	assert.Equal(t, f.ipv4.addr.Addr.String(), "20.0.0.1")
+	assert.True(t, updated, "updated")
+
+	// Update with the same set of addresses does nothing.
+	updated = f.update(&Device{
+		Index: 5,
+		Addrs: []DeviceAddress{
+			{Addr: netip.MustParseAddr("20.0.0.1"), Scope: RT_SCOPE_SITE},
+		},
+	})
+	assert.Equal(t, f.ipv4.addr.Addr.String(), "20.0.0.1")
+	assert.False(t, updated, "updated")
 }


### PR DESCRIPTION
When new node addresses were added after Cilium had started the update to the internal table of node addresses accidentally removed existing addresses due to wrong kind of comparison operation.

As part of fixing this issue a similar type of problem was found with update to the fallback addresses (used as backup when selecting BPF masquerading address). This commit also fixes this issue.

This only impacts users running v1.15 with the runtime device detection enabled.

The second commit adds in the prioritization of the K8s Node IP when selecting the NodeAddress. This was a semantic
difference between the old and new code and should have been retained.

Fixes: #33234 

```release-note
Fix an issue in updates to node addresses which may have caused missing NodePort frontend IP addresses. May have affected NodePort/LoadBalancer services for users running with runtime device detection enabled when node's IP addresses were changed after Cilium had started.
Node IP as defined in the Kubernetes Node is now preferred when selecting the NodePort frontend IPs.
```
