### PR TITLE
Low hanging fruit performance improvements of KVStoreMesh

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -763,6 +763,7 @@ func (e *etcdClient) DeletePrefix(ctx context.Context, path string) (err error) 
 
 // watch starts watching for changes in a prefix
 func (e *etcdClient) watch(ctx context.Context, w *Watcher) {
+	scope := GetScopeFromKey(strings.TrimRight(w.Prefix, "/"))
 	localCache := watcherCache{}
 	listSignalSent := false
 
@@ -844,7 +845,7 @@ reList:
 				Value: key.Value,
 				Typ:   t,
 			}
-			trackEventQueued(string(key.Key), t, queueStart.End(true).Total())
+			trackEventQueued(scope, t, queueStart.End(true).Total())
 		}
 
 		nextRev := revision + 1
@@ -864,7 +865,7 @@ reList:
 
 			queueStart := spanstat.Start()
 			w.Events <- event
-			trackEventQueued(k, EventTypeDelete, queueStart.End(true).Total())
+			trackEventQueued(scope, EventTypeDelete, queueStart.End(true).Total())
 		})
 
 		// Only send the list signal once
@@ -954,7 +955,7 @@ reList:
 
 					queueStart := spanstat.Start()
 					w.Events <- event
-					trackEventQueued(string(ev.Kv.Key), event.Typ, queueStart.End(true).Total())
+					trackEventQueued(scope, event.Typ, queueStart.End(true).Total())
 				}
 			}
 		}

--- a/pkg/kvstore/metrics.go
+++ b/pkg/kvstore/metrics.go
@@ -38,11 +38,11 @@ func increaseMetric(key, kind, action string, duration time.Duration, err error)
 		WithLabelValues(namespace, kind, action, outcome).Observe(duration.Seconds())
 }
 
-func trackEventQueued(key string, typ EventType, duration time.Duration) {
+func trackEventQueued(scope string, typ EventType, duration time.Duration) {
 	if !metrics.KVStoreEventsQueueDuration.IsEnabled() {
 		return
 	}
-	metrics.KVStoreEventsQueueDuration.WithLabelValues(GetScopeFromKey(key), typ.String()).Observe(duration.Seconds())
+	metrics.KVStoreEventsQueueDuration.WithLabelValues(scope, typ.String()).Observe(duration.Seconds())
 }
 
 func recordQuorumError(err string) {

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -185,16 +185,19 @@ type LocalKey interface {
 }
 
 // KVPair represents a basic implementation of the LocalKey interface
-type KVPair struct{ Key, Value string }
+type KVPair struct {
+	Key   string
+	Value []byte
+}
 
-func NewKVPair(key, value string) *KVPair { return &KVPair{Key: key, Value: value} }
+func NewKVPair(key, value string) *KVPair { return &KVPair{Key: key, Value: []byte(value)} }
 func KVPairCreator() Key                  { return &KVPair{} }
 
 func (kv *KVPair) GetKeyName() string       { return kv.Key }
-func (kv *KVPair) Marshal() ([]byte, error) { return []byte(kv.Value), nil }
+func (kv *KVPair) Marshal() ([]byte, error) { return kv.Value, nil }
 
 func (kv *KVPair) Unmarshal(key string, data []byte) error {
-	kv.Key, kv.Value = key, string(data)
+	kv.Key, kv.Value = key, data
 	return nil
 }
 

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -198,10 +198,6 @@ func (kv *KVPair) Unmarshal(key string, data []byte) error {
 	return nil
 }
 
-func (kv *KVPair) DeepKeyCopy() LocalKey {
-	return NewKVPair(kv.Key, kv.Value)
-}
-
 // JoinSharedStore creates a new shared store based on the provided
 // configuration. An error is returned if the configuration is invalid. The
 // store is initialized with the contents of the kvstore. An error is returned


### PR DESCRIPTION
Please refer to the individual commit messages for additional details.

Marked for backport to v1.16. Changes are trivial, and the initial data from the clustermesh scale tests shows a ~10% reduction in KVStoreMesh memory usage.
