### PR TITLE
endpoint: Avoid direct error comparison

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1132,7 +1132,7 @@ func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool) boo
 	err := e.policyMap.DeleteKey(policymapKey)
 	var errno unix.Errno
 	errors.As(err, &errno)
-	if err != nil && errno != unix.ENOENT {
+	if err != nil && !errors.Is(errno, unix.ENOENT) {
 		e.getLogger().WithError(err).WithField(logfields.BPFMapKey, policymapKey).Error("Failed to delete PolicyMap key")
 		return false
 	}


### PR DESCRIPTION
The returned error is actually wrapped, so direct error comparison should be avoided.

Relates: https://github.com/cilium/cilium/blob/24e85ac1a5dbcb4cec5a73890aeaa77be9656b56/pkg/bpf/map_linux.go#L962

