### PR TITLE
LocalRedirect: RedirectBackend and RedirectFront are immutable

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
@@ -145,6 +145,9 @@ spec:
                 - localEndpointSelector
                 - toPorts
                 type: object
+                x-kubernetes-validations:
+                - message: redirectBackend is immutable
+                  rule: self == oldSelf
               redirectFrontend:
                 description: RedirectFrontend specifies frontend configuration to
                   redirect traffic from. It can not be empty.
@@ -262,7 +265,11 @@ spec:
                     - serviceName
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: redirectFrontend is immutable
+                  rule: self == oldSelf
               skipRedirectFromBackend:
+                default: false
                 description: "SkipRedirectFromBackend indicates whether traffic matching
                   RedirectFrontend from RedirectBackend should skip redirection, and
                   hence the traffic will be forwarded as-is. \n The default is false
@@ -275,6 +282,9 @@ spec:
                   Instead, the matched traffic from the backends will be forwarded
                   to the original destination \"169.254.169.254:80\"."
                 type: boolean
+                x-kubernetes-validations:
+                - message: skipRedirectFromBackend is immutable
+                  rule: self == oldSelf
             required:
             - redirectBackend
             - redirectFrontend

--- a/pkg/k8s/apis/cilium.io/v2/clrp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/clrp_types.go
@@ -156,12 +156,14 @@ type CiliumLocalRedirectPolicySpec struct {
 	// It can not be empty.
 	//
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="redirectFrontend is immutable"
 	RedirectFrontend RedirectFrontend `json:"redirectFrontend"`
 
 	// RedirectBackend specifies backend configuration to redirect traffic to.
 	// It can not be empty.
 	//
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="redirectBackend is immutable"
 	RedirectBackend RedirectBackend `json:"redirectBackend"`
 
 	// SkipRedirectFromBackend indicates whether traffic matching RedirectFrontend
@@ -179,6 +181,8 @@ type CiliumLocalRedirectPolicySpec struct {
 	// destination "169.254.169.254:80".
 	//
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="skipRedirectFromBackend is immutable"
 	SkipRedirectFromBackend bool `json:"skipRedirectFromBackend"`
 
 	// Description can be used by the creator of the policy to describe the


### PR DESCRIPTION
Local Redirect Policy updates are currently not supported. If there are any changes to be made, delete the existing policy, and re-create a new one.

Refer to: https://docs.cilium.io/en/stable/network/kubernetes/local-redirect-policy/#limitations

Introducing CEL expressions to prevent users from modifying the redirectFront and redirectBackend fields

Test:
``` shell
kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/1.15.6/examples/kubernetes-local-redirect/lrp-addrmatcher.yaml
ciliumlocalredirectpolicy.cilium.io/lrp-addr created
```

Test skipRedirectFromBackend:

``` diff
diff --git a/examples/kubernetes-local-redirect/lrp-addrmatcher.yaml b/examples/kubernetes-local-redirect/lrp-addrmatcher.yaml
index 547a32a4a4..b1539d802e 100644
--- a/examples/kubernetes-local-redirect/lrp-addrmatcher.yaml
+++ b/examples/kubernetes-local-redirect/lrp-addrmatcher.yaml
@@ -3,6 +3,7 @@ kind: CiliumLocalRedirectPolicy
 metadata:
   name: "lrp-addr"
 spec:
+  skipRedirectFromBackend: true
   redirectFrontend:
     addressMatcher:
       ip: "169.254.169.254
```

```shell
# kubectl apply -f examples/kubernetes-local-redirect/lrp-addrmatcher.yaml
The CiliumLocalRedirectPolicy "lrp-addr" is invalid: spec.skipRedirectFromBackend: Invalid value: "boolean": skipRedirectFromBackend is immutable
```

Test redirectBackend:


``` diff
diff --git a/examples/kubernetes-local-redirect/lrp-addrmatcher.yaml b/examples/kubernetes-local-redirect/lrp-addrmatcher.yaml
index 547a32a4a4..964149a227 100644
--- a/examples/kubernetes-local-redirect/lrp-addrmatcher.yaml
+++ b/examples/kubernetes-local-redirect/lrp-addrmatcher.yaml
@@ -12,7 +12,7 @@ spec:
   redirectBackend:
     localEndpointSelector:
       matchLabels:
-        app: proxy
+        app: proxy-test
     toPorts:
       - port: "80"
         protocol: TCP

```



``` shell
kubectl apply -f examples/kubernetes-local-redirect/lrp-addrmatcher.yaml
The CiliumLocalRedirectPolicy "lrp-addr" is invalid: spec.redirectBackend: Invalid value: "object": redirectBackend is immutable
```



```release-note
Add kubernetes validations to ensure CiliumLocalRedirectPolicy fields are immutable as policy updates are not supported.
```
