### PR TITLE
ipsec: do not explicitly prioritize host endpoint regeneration

### DIFF
--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -307,42 +307,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState, endpoi
 		}
 	}
 
-	if option.Config.EnableIPSec {
-		// If IPsec is enabled we need to restore the host endpoint before any
-		// other endpoint, to ensure a dropless upgrade.
-		// This code can be removed in v1.15.
-		// This is necessary because we changed how the IPsec encapsulation is
-		// done. In older version, bpf_lxc would pass the outer destination IP
-		// via skb->cb to bpf_host which would write it to the outer header.
-		// In newer versions, the header is written by the kernel XFRM
-		// subsystem and bpf_host must therefore not write it. To allow for a
-		// smooth upgrade, bpf_host has been updated to handle both cases. But
-		// for that to succeed, it must be reloaded first, before the bpf_lxc
-		// programs stop writing the IP into skb->cb.
-		for _, ep := range state.restored {
-			// Cap the timeout used to wait for remote cluster synchronization
-			// to avoid blocking the agent startup, as this regeneration is
-			// performed synchronously.
-			endpointsRegenerator.CapTimeoutForSynchronousRegeneration()
-
-			if ep.IsHost() {
-				log.WithField(logfields.EndpointID, ep.ID).Info("Successfully restored endpoint. Scheduling regeneration")
-				if err := ep.RegenerateAfterRestore(endpointsRegenerator, d.bwManager, d.fetchK8sMetadataForEndpoint); err != nil {
-					log.WithField(logfields.EndpointID, ep.ID).WithError(err).Debug("error regenerating restored host endpoint")
-					epRegenerated <- false
-				} else {
-					epRegenerated <- true
-				}
-				break
-			}
-		}
-	}
-
 	for _, ep := range state.restored {
-		if ep.IsHost() && option.Config.EnableIPSec {
-			// The host endpoint was handled above.
-			continue
-		}
 		log.WithField(logfields.EndpointID, ep.ID).Info("Successfully restored endpoint. Scheduling regeneration")
 		go func(ep *endpoint.Endpoint, epRegenerated chan<- bool) {
 			if err := ep.RegenerateAfterRestore(endpointsRegenerator, d.bwManager, d.fetchK8sMetadataForEndpoint); err != nil {

--- a/pkg/endpoint/regenerator.go
+++ b/pkg/endpoint/regenerator.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/clustermesh/wait"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -51,21 +50,6 @@ func newRegenerator(in struct {
 		logger:        in.Logger,
 		cmWaitFn:      waitFn,
 		cmWaitTimeout: in.Config.Timeout(),
-	}
-}
-
-// CapTimeoutForSynchronousRegeneration caps the timeout to a value suitable in
-// case the regeneration of an endpoint needs to be performed synchronously
-// (currently required when IPSec is enabled). In particular, this is necessary
-// to not block the agent bootstrap, as that prevents the scheduling of new
-// workloads. This logic is implemented as a separate function to avoid
-// forgetting to remove it when the synchronous regeneration is removed.
-func (r *Regenerator) CapTimeoutForSynchronousRegeneration() {
-	const maxTimeout = 5 * time.Second
-	if r.cmWaitTimeout > maxTimeout {
-		r.cmWaitTimeout = maxTimeout
-		r.logger.WithField(logfields.Value, maxTimeout).
-			Info("Capped clustermesh-sync-timeout because endpoint regeneration needs to be performed synchronously")
 	}
 }
 


### PR DESCRIPTION
This code was introduced in #25735.

As described well in:

16e446c0ffd6424a1a1b737cb359c6e9ef339e3d
bpf: Support the old IP_POOLS logic in bpf_host

and

b429c42a4f8d7217cc998ffa50d0d18d9e27054b
daemon: Reload bpf_host first in case of IPsec upgrade

This code was put in place to ensure the refactored 'bpf_host' program, which supports the IP_POOLS hack upgrade compatibility, is installed before any other eBPF prog.

Now that we are N+2 versions from this introduction, and we instruct individuals to upgrade consecutively, this code can be removed.

It is possible that something in Cilium now depends on this eBPF program installation ordering. The status of CI jobs in this PR should be looked at with a keener-then-normal eye due to this possibility. 


```release-note
No longer prioritizes HostEndpoint regeneration during Cilium init. 
```