### PR TITLE
renovate: assign on auto-merge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -84,6 +84,7 @@
     "^make generate-k8s-api$",
     "^make manifests$"
   ],
+  "assignAutomerge": true,
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
Accordingly with renovate's documentation:
By default, Renovate will not assign reviewers and assignees to an automerge-enabled PR unless it fails status checks. By configuring this setting to true, Renovate will instead always assign reviewers and assignees for automerging PRs at time of creation.