### PR TITLE
Documentation: Add docs for configuring hubble metrics with TLS

### DIFF
--- a/Documentation/gettingstarted/hubble-configuration.rst
+++ b/Documentation/gettingstarted/hubble-configuration.rst
@@ -196,3 +196,50 @@ resolve this issue. Pick one of the options below:
                     --set webhook.tolerations='["operator": "Exists"]'
 
         Then configure an issuer and install Cilium.
+
+.. _hubble_configure_metrics_tls:
+
+Metrics TLS and Authentication
+===============================
+
+Starting with Cilium 1.16, Hubble supports configuring TLS on the Hubble
+metrics API in addition to the Hubble observer API.
+
+This can be done by specifying the following options to Helm at install or
+upgrade time, along with the TLS configuration options described in the
+previous section.
+
+To enable TLS on the Hubble metrics API, add the following Helm flag to your
+list of options:
+
+::
+
+    --set hubble.metrics.tls.enabled=true # Enable TLS on the Hubble metrics API
+
+If you also want to enable authentication using mTLS on the Hubble metrics API,
+first create a ConfigMap with a CA certificate to use for verifying client
+certificates:
+
+::
+
+    kubectl -n kube-system create configmap hubble-metrics-ca --from-file=ca.crt
+
+Then, add the following flags to your Helm command to enable mTLS:
+
+::
+
+    --set hubble.metrics.tls.enabled=true                       # Enable TLS on the Hubble metrics API
+    --set hubble.metrics.tls.server.mtls.enabled=true           # Enable mTLS authentication on the Hubble metrics API
+    --set hubble.metrics.tls.server.mtls.name=hubble-metrics-ca # Use the CA certificate from the ConfigMap
+
+After the configuration is applied, clients will be required to authenticate
+using a certificate signed by the configured CA certificate to access the
+Hubble metrics API.
+
+.. note::
+
+  When using TLS with the Hubble metrics API you will need to update your
+  Prometheus scrape configuration to use HTTPS by setting a ``tls_config`` and
+  provide the path to the CA certificate. When using mTLS you will also need to
+  provide a client certificate and key signed by the CA certificate for
+  Prometheus to authenticate to the Hubble metrics API.

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -706,6 +706,8 @@ The command-line options to configure them are ``--enable-hubble``,
 ``--hubble-metrics-server`` takes an ``IP:Port`` pair, but
 passing an empty IP (e.g. ``:9965``) will bind the server to all available
 interfaces. ``--hubble-metrics`` takes a comma-separated list of metrics.
+It's also possible to configure Hubble metrics to listen with TLS and
+optionally use mTLS for authentication. For details see :ref:`hubble_configure_metrics_tls`.
 
 Some metrics can take additional semicolon-separated options per metric, e.g.
 ``--hubble-metrics="dns:query;ignoreAAAA,http:destinationContext=workload-name"``


### PR DESCRIPTION
Fixes: #33066

```release-note
Document configuring hubble metrics with TLS
```
