### PR TITLE
Documentation: remove references to removed ipam_ips metric.

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -632,7 +632,6 @@ IPAM
 ======================================== ================================================================= ========== ========================================================
 Name                                     Labels                                                            Default    Description
 ======================================== ================================================================= ========== ========================================================
-``ipam_ips``                             ``type``                                                          Enabled    Number of IPs allocated
 ``ipam_ip_allocation_ops``               ``subnet_id``                                                     Enabled    Number of IP allocation operations.
 ``ipam_ip_release_ops``                  ``subnet_id``                                                     Enabled    Number of IP release operations.
 ``ipam_interface_creation_ops``          ``subnet_id``                                                     Enabled    Number of interfaces creation operations.

--- a/examples/kubernetes/addons/prometheus/monitoring-example.yaml
+++ b/examples/kubernetes/addons/prometheus/monitoring-example.yaml
@@ -8945,7 +8945,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(cilium_operator_ipam_ips) by (type)",
+              "expr": "avg(cilium_operator_ipam_used_ips) by (type)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{type}}",
@@ -8956,7 +8956,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "IP Addresses",
+          "title": "Used IP Addresses",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/install/kubernetes/cilium/files/cilium-operator/dashboards/cilium-operator-dashboard.json
+++ b/install/kubernetes/cilium/files/cilium-operator/dashboards/cilium-operator-dashboard.json
@@ -347,7 +347,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(cilium_operator_ipam_ips) by (type)",
+          "expr": "avg(cilium_operator_ipam_used_ips) by (type)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{type}}",
@@ -358,7 +358,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "IP Addresses",
+      "title": "Used IP Addresses",
       "tooltip": {
         "shared": true,
         "sort": 0,


### PR DESCRIPTION
ipam_ips was previously [deprecated](https://github.com/tommyp1ckles/cilium/blob/0013798761eec0dda0217042f6ee3ccfa857f7ff/Documentation/operations/upgrade.rst#deprecated-metrics) then removed, there are some leftover mentions of the metric. This removes those.
In example dashboards that used this metric, they are replaced with ipam_used_ips, which is the number of IPs currently in use, as known by the operators IPAM manager.