### PR TITLE
Track node labels propagated to the endpoint manager correctly (v1.15)

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -470,6 +470,11 @@ func (e *Endpoint) IsHost() bool {
 	return e.isHost
 }
 
+// SetIsHost is a convenient method to create host endpoints for testing.
+func (ep *Endpoint) SetIsHost(isHost bool) {
+	ep.isHost = isHost
+}
+
 // closeBPFProgramChannel closes the channel that signals whether the endpoint
 // has had its BPF program compiled. If the channel is already closed, this is
 // a no-op.


### PR DESCRIPTION
Cherrypicks https://github.com/cilium/cilium/pull/33511

This fixes a race condition during agent startup
where k8s node label updates are rejected
indefinitely by the host endpoint.

The current endpoint label update logic rejects
a request if any of the labels on the old node
are not present in the endpoint manager state.

For host endpoints, the k8s node label add/update
events may be missed if the k8s node watcher
initializes before the host endpoint is created.
As a result, the host endpoint labels are outdated, and all subsequent node label updates are rejected due to the aforementioned precondition check.

To resolve the issue, this commit updates the old
labels only if the current node label update is
successfully propagated to the endpoint manager.

Fixes cilium#29649

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 33511
```