### PR TITLE
renovate: do not update etcd on older branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -283,6 +283,17 @@
       ]
     },
     {
+      // Do not upgrade etcd as they have removed bash starting from v3.5.5
+      "matchDepNames": [
+        "quay.io/coreos/etcd"
+      ],
+      "allowedVersions": "<3.5.5",
+      "matchBaseBranches": [
+        "v1.14",
+        "v1.13"
+      ]
+    },
+    {
       "matchFiles": [
         "install/kubernetes/Makefile.values"
       ],


### PR DESCRIPTION
Since etcd v3.5.5, bash is no longer present on etcd images and we can't upgrade to newer versions as we still use a bash init script to setup clustermesh.