### PR TITLE
bpf: fix flaky nat test

### DIFF
--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -698,7 +698,7 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_target target = {
 	    .addr = bpf_htonl(IP_HOST),
 	    .min_port = NODEPORT_PORT_MIN_NAT - 1,
-	    .max_port = NODEPORT_PORT_MIN_NAT,
+	    .max_port = NODEPORT_PORT_MIN_NAT - 1,
 	};
 	struct ipv4_nat_entry state;
 	void *map;


### PR DESCRIPTION
We recently fixed the port allocation behaviour of the NAT helpers. Most tests were fixed to accomondate this, but
test_nat4_icmp_error_udp_egress slipped through the cracks.

Fixes: 9b6c0bddb6 ("bpf: fix __snat_clamp_port_range not using highest port")
