### PR TITLE
renovate: onboard etcd image used in integration tests

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -57,7 +57,10 @@ ifeq ($(DOCKER_IMAGE_TAG),)
     DOCKER_IMAGE_TAG=latest
 endif
 
-ETCD_IMAGE=gcr.io/etcd-development/etcd:v3.5.11@sha256:8eff25cf636711fb48426005b55fc9f4d6ffa4f38f483fa87c8cc82976347bbb
+# renovate: datasource=docker depName=gcr.io/etcd-development/etcd
+ETCD_IMAGE_VERSION = v3.5.11
+ETCD_IMAGE_SHA = sha256:8eff25cf636711fb48426005b55fc9f4d6ffa4f38f483fa87c8cc82976347bbb
+ETCD_IMAGE=gcr.io/etcd-development/etcd:$(ETCD_IMAGE_VERSION)@$(ETCD_IMAGE_SHA)
 
 CONSUL_IMAGE=consul:1.7.2
 


### PR DESCRIPTION
Tested locally:

```
{
  "depName": "gcr.io/etcd-development/etcd",
  "currentValue": "v3.5.11",
  "currentDigest": "sha256:8eff25cf636711fb48426005b55fc9f4d6ffa4f38f483fa87c8cc82976347bbb",
  "datasource": "docker",
  "replaceString": "# renovate: datasource=docker depName=gcr.io/etcd-development/etcd\nETCD_IMAGE_VERSION = v3.5.11\nETCD_IMAGE_SHA = sha256:8eff25cf636711fb48426005b55fc9f4d6ffa4f38f483fa87c8cc82976347bbb",
  "updates": [
    {
      "bucket": "latest",
      "newVersion": "v3.5.14",
      "newValue": "v3.5.14",
      "newMajor": 3,
      "newMinor": 5,
      "updateType": "patch",
      "newDigest": "sha256:e690e8c2a36f7ededaa76e2178e7492954aef33616fa30e323bc00852fdb65c2",
      "branchName": "renovate/all-dependencies"
    }
  ],
  "packageName": "gcr.io/etcd-development/etcd",
  "versioning": "docker",
  "warnings": [],
  "registryUrl": "https://gcr.io",
  "currentVersion": "v3.5.11",
  "isSingleVersion": true,
  "fixedVersion": "v3.5.11"
},
```
