### PR TITLE
gha: Add http client timeout in Ingress

### DIFF
--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -193,7 +193,7 @@ jobs:
           # Please refer to https://github.com/kubernetes-sigs/ingress-controller-conformance/pull/101 for more details.
           repository: cilium/ingress-controller-conformance
           path: ingress-controller-conformance
-          ref: ea4049969a830d3ecac0d2a9b71b254212ac4b65
+          ref: 6a193b3f73d8b1201a818bb7c8f204059b064857
           persist-credentials: false
 
       - name: Install Ingress conformance test tool
@@ -404,6 +404,7 @@ jobs:
             -ingress-class cilium \
             -wait-time-for-ingress-status 60s \
             -wait-time-for-ready 60s \
+            -http-client-timeout 60s \
             -enable-http-debug \
             -stop-on-failure
 


### PR DESCRIPTION
Conformance Ingress job is running successfully for 10+ consecutive runs (i.e. 10x5 as each consists of 5 sub-jobs).

https://github.com/cilium/cilium/actions/runs/9870615332

Fixes: https://github.com/cilium/cilium/issues/31857

