### PR TITLE
gh: cilium-config: enable IPv6 BPF Masquerade with HostFW

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -125,10 +125,6 @@ runs:
           if [ "${{ inputs.kpr }}" == "true" ]; then
             # BPF-masq requires KPR=true.
             MASQ="--helm-set=bpf.masquerade=true"
-            if [ "${{ inputs.host-fw }}" == "true" ]; then
-              # BPF IPv6 masquerade not currently supported with host firewall - GH-26074
-              MASQ="${MASQ} --helm-set=enableIPv6Masquerade=false"
-            fi
           fi
 
           EGRESS_GATEWAY=""


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/31511 enabled the combination of HostFW with IPv6 BPF Masquerading. Reflect this in the cilium-config action.
