### PR TITLE
bpf: fib: only touch ext_err on an actual error

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -123,7 +123,6 @@ nodeport_fib_lookup_and_redirect(struct __ctx_buff *ctx,
 	int ret;
 
 	ret = fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), 0);
-	*ext_err = (__s8)ret;
 
 	switch (ret) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
@@ -131,8 +130,9 @@ nodeport_fib_lookup_and_redirect(struct __ctx_buff *ctx,
 		if ((__u32)oif == fib_params->l.ifindex)
 			return CTX_ACT_OK;
 
-		return fib_do_redirect(ctx, true, fib_params, true, ext_err, &oif);
+		return fib_do_redirect(ctx, true, fib_params, true, ret, &oif, ext_err);
 	default:
+		*ext_err = (__s8)ret;
 		return DROP_NO_FIB;
 	}
 }

--- a/bpf/tests/fib_tests.c
+++ b/bpf/tests/fib_tests.c
@@ -141,7 +141,8 @@ int test1_check(struct __ctx_buff *ctx)
 				   redir_neigh_recorder.plen);
 
 		if (redir_neigh_recorder.flags != 0)
-			test_fatal("expected flags 0, got %d", flags);
+			test_fatal("expected flags 0, got %d",
+				   redir_neigh_recorder.flags);
 
 		reset_redir_neigh_recorder(&redir_neigh_recorder);
 	});
@@ -173,7 +174,8 @@ int test1_check(struct __ctx_buff *ctx)
 			test_fatal("expected plen to be 0");
 
 		if (redir_neigh_recorder.flags != 0)
-			test_fatal("expected flags 0, got %d", flags);
+			test_fatal("expected flags 0, got %d",
+				   redir_neigh_recorder.flags);
 
 		reset_redir_neigh_recorder(&redir_neigh_recorder);
 	});

--- a/bpf/tests/fib_tests.c
+++ b/bpf/tests/fib_tests.c
@@ -181,24 +181,3 @@ int test1_check(struct __ctx_buff *ctx)
 	});
 	test_finish();
 }
-
-CHECK("tc", "fib_do_redirect_sad_path")
-int test2_check(__maybe_unused struct __ctx_buff *ctx)
-{
-	test_init();
-
-	/* Confirm we return a DROP_NO_FIB for all unsupported flags. */
-	TEST("bad_flags", {
-		__s8 flag = BPF_FIB_LKUP_RET_BLACKHOLE;
-
-		for (; flag <= BPF_FIB_LKUP_RET_FRAG_NEEDED; flag++) {
-			if (flag == BPF_FIB_LKUP_RET_NO_NEIGH)
-				continue;
-
-			if (fib_do_redirect(NULL, false, NULL, true, &flag, NULL) != DROP_NO_FIB)
-				test_fatal("expected DROP_NO_FIB with flag %d", flag);
-		}
-	});
-
-	test_finish();
-}

--- a/bpf/tests/fib_tests.c
+++ b/bpf/tests/fib_tests.c
@@ -85,13 +85,14 @@ int test1_check(struct __ctx_buff *ctx)
 		__u32 ifindex_bad  = 0xDEADBEEF;
 		__u32 ifindex_good = 0xAAAAAAAA;
 		int ret = -1;
-		__s8 flags = BPF_FIB_LKUP_RET_SUCCESS;
 		struct bpf_fib_lookup_padded params = {0};
+		__s8 ext_err;
 
 		params.l.ifindex = ifindex_good;
 
-		ret = fib_do_redirect(ctx, false, &params, true, &flags,
-				      (int *)&ifindex_bad);
+		ret = fib_do_redirect(ctx, false, &params, true,
+				      BPF_FIB_LKUP_RET_SUCCESS,
+				      (int *)&ifindex_bad, &ext_err);
 		if (ret != CTX_REDIRECT_ENTERED)
 			test_fatal("did not enter ctx_redirect");
 
@@ -116,15 +117,17 @@ int test1_check(struct __ctx_buff *ctx)
 		__u32 ifindex_bad  = 0xDEADBEEF;
 		__u32 ifindex_good = 0xAAAAAAAA;
 		int ret = -1;
-		__s8 flags = BPF_FIB_LKUP_RET_NO_NEIGH;
 		struct bpf_fib_lookup_padded params = {0};
+		__s8 ext_err;
 
 		params.l.ifindex = ifindex_good;
 
 		if (!neigh_resolver_available())
 			test_fatal("expected neigh_resolver_available true");
 
-		ret = fib_do_redirect(ctx, false, &params, true, &flags, (int *)&ifindex_bad);
+		ret = fib_do_redirect(ctx, false, &params, true,
+				      BPF_FIB_LKUP_RET_NO_NEIGH,
+				      (int *)&ifindex_bad, &ext_err);
 		if (ret != REDIR_NEIGH_ENTERED)
 			test_fatal("did not enter redirect_neigh");
 
@@ -154,12 +157,14 @@ int test1_check(struct __ctx_buff *ctx)
 	TEST("lookup_no_neigh_no_fib", {
 		__u32 ifindex_good = 0xBEEFDEAD;
 		int ret = -1;
-		__s8 flags = BPF_FIB_LKUP_RET_NO_NEIGH;
+		__s8 ext_err;
 
 		if (!neigh_resolver_available())
 			test_fatal("expected neigh_resolver_available true");
 
-		ret = fib_do_redirect(ctx, false, NULL, true, &flags, (int *)&ifindex_good);
+		ret = fib_do_redirect(ctx, false, NULL, true,
+				      BPF_FIB_LKUP_RET_NO_NEIGH,
+				      (int *)&ifindex_good, &ext_err);
 		if (ret != REDIR_NEIGH_ENTERED)
 			test_fatal("did not enter redirect_neigh");
 


### PR DESCRIPTION
Fix up a minor issue in the FIB lookup/redirect code. Using the `ext_err` to transport the FIB lookup result means that we potentially report a bogus error when dropping the packet later.