### PR TITLE
ci: Set cluster id in external workloads

### DIFF
--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -205,6 +205,7 @@ jobs:
 
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set cluster.name=${{ env.clusterName }} \
+            --helm-set cluster.id=1 \
             --datapath-mode=tunnel \
             --helm-set kubeProxyReplacement=true"
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --collect-sysdump-on-failure \


### PR DESCRIPTION
With KVStoreMesh enabled by default, we rely on having cluster id.
Currently, external-workloads did not have it set in CI, which was
causing CI failure when trying to update cilium-cli containing change
from https://github.com/cilium/cilium-cli/pull/2660
