### PR TITLE
Don't create sessions when connecting to etcd in the clustermesh context 

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -678,7 +678,10 @@ func (e *etcdClient) asyncConnectEtcdClient(errChan chan<- error) {
 			continue
 
 		case EventTypeListDone:
+			// A list done event signals the initial connection, but
+			// is also not an heartbeat signal.
 			close(listDone)
+			continue
 		}
 
 		// It is tempting to compare against the heartbeat value stored in
@@ -1013,6 +1016,16 @@ func (e *etcdClient) statusChecker() {
 	statusTimer, statusTimerDone := inctimer.New()
 	defer statusTimerDone()
 
+	e.RWMutex.Lock()
+	// Ensure that lastHearbeat is always set to a non-zero value when starting
+	// the status checker, to guarantee that we can correctly compute the time
+	// difference even in case we don't receive any heartbeat event. Indeed, we
+	// want to consider that as an heartbeat failure after the usual timeout.
+	if e.lastHeartbeat.IsZero() {
+		e.lastHeartbeat = time.Now()
+	}
+	e.RWMutex.Unlock()
+
 	for {
 		newStatus := []string{}
 		ok := 0
@@ -1023,7 +1036,7 @@ func (e *etcdClient) statusChecker() {
 		lastHeartbeat := e.lastHeartbeat
 		e.RWMutex.RUnlock()
 
-		if heartbeatDelta := time.Since(lastHeartbeat); !lastHeartbeat.IsZero() && heartbeatDelta > 2*HeartbeatWriteInterval {
+		if heartbeatDelta := time.Since(lastHeartbeat); heartbeatDelta > 2*HeartbeatWriteInterval {
 			recordQuorumError("no event received")
 			quorumError = fmt.Errorf("%s since last heartbeat update has been received", heartbeatDelta)
 		}


### PR DESCRIPTION
Currently, the etcd client leverages a session to wait for the establishment of the initial connection. However, this potentially introduces a quite significant overhead in the context of clustermesh, due to the usage of short-lived (25 seconds) etcd sessions which grow in number proportionally to the Cilium agents in each given cluster, times the number of clusters in the clustermesh. Yet, these sessions, despite being renewed until the client gets closed, are never used after this initial check. 

In an effort to improve the overall clustermesh performance, and reduce the overhead introduced on the etcd instances, let's rework this logic to not depend on the creation of a session in the clustermesh context (i.e., if the lock quorum check is disabled), but rather just wait until the heartbeat watcher is started successfully (i.e., the list operation completed). 

Most notably, this (a) preserves the current behavior of the etcd client reporting readiness only once successfully
connected, (b) guarantees that there's already been an interaction with the target etcd instance (even if the session check is disabled), to ensure that its corresponding cluster ID has been retrieved if using the "clusterLock" interceptors (i.e., in the clustermesh context) and (c) prevents the client from turning ready if the heartbeat watcher cannot be started, avoiding regressions in this respect and ensuring that the status checker logic can operate correctly.