### PR TITLE
Fix Hubble drop event emitter reasons join in config

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -980,7 +980,7 @@ data:
 {{- if .Values.hubble.dropEventEmitter.enabled }}
   hubble-drop-events: "true"
   hubble-drop-events-interval: {{ .Values.hubble.dropEventEmitter.interval | quote }}
-  hubble-drop-events-reasons: {{ .Values.hubble.dropEventEmitter.reasons | join "," | quote }}
+  hubble-drop-events-reasons: {{ .Values.hubble.dropEventEmitter.reasons | join " " | quote }}
 {{- end }}
 {{- if .Values.hubble.preferIpv6 }}
   hubble-prefer-ipv6: "true"


### PR DESCRIPTION
`Viper.GetStringSlice()` uses `spf13.cast.ToStringSlice()` that relies on `strings.Fields()` to split a string into an array. `Fields()` [splits on whitespace](https://pkg.go.dev/strings#Fields), not on commas.

`hubble-drop-events-reasons` joins Helm values list elements using a comma, so the splitting doesn't work and the resulting array of reasons is invalid. No packet drop reasons match and so we get no events even when we should.

Switching to joining using a space resolves the issue.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Fix configuration generated from Helm values for `hubble-drop-events-reasons` to use a whitespace item separator
```
