### PR TITLE
clustermesh: prevent test races leveraging renameio.WriteFile

### DIFF
--- a/pkg/clustermesh/common/config_test.go
+++ b/pkg/clustermesh/common/config_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/renameio/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
@@ -31,7 +32,7 @@ var (
 func writeFile(t *testing.T, name, content string) {
 	t.Helper()
 
-	err := os.WriteFile(name, []byte(content), 0644)
+	err := renameio.WriteFile(name, []byte(content), 0644, renameio.WithTempDir(os.TempDir()))
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
This prevents race conditions in tests caused by the inotify watcher observing incomplete file writes, that can otherwise occur if using the os.WriteFile function from the standard library. This commit had been incorrectly dropped during one of the rebases of https://github.com/cilium/cilium/pull/33251, and is being reintroduced here.

<!-- Description of change -->

Fixes: #33673

```release-note
Fix race condition in clustermesh integration tests
```
