### PR TITLE
Add metric for identity GC latency.

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -420,6 +420,9 @@ Name                                     Labels                                 
 ======================================== ================================================== ========== ========================================================
 ``identity``                             ``type``                                           Enabled    Number of identities currently allocated
 ``identity_label_sources``               ``source``                                         Enabled    Number of identities which contain at least one label from the given label source
+``identity_gc_entries``                                                                     Enabled    Number of alive and deleted identities at the end of a garbage collector run
+``identity_gc_runs``                     ``outcome``                                        Enabled    Number of times identity garbage collector has run
+``identity_gc_latency``                  ``outcome``                                        Enabled    Duration of the last successful identity GC run 
 ``ipcache_errors_total``                 ``type``, ``error``                                Enabled    Number of errors interacting with the ipcache
 ``ipcache_events_total``                 ``type``                                           Enabled    Number of events interacting with the ipcache
 ======================================== ================================================== ========== ========================================================

--- a/operator/identitygc/crd_gc.go
+++ b/operator/identitygc/crd_gc.go
@@ -170,9 +170,11 @@ func (igc *GC) gc(ctx context.Context) error {
 	if ctx.Err() == nil {
 		igc.successfulRuns++
 		igc.metrics.IdentityGCRuns.WithLabelValues(LabelValueOutcomeSuccess).Set(float64(igc.successfulRuns))
+		igc.metrics.IdentityGCLatency.WithLabelValues(LabelValueOutcomeSuccess).Set(float64(time.Since(timeNow).Seconds()))
 	} else {
 		igc.failedRuns++
 		igc.metrics.IdentityGCRuns.WithLabelValues(LabelValueOutcomeFail).Set(float64(igc.failedRuns))
+		igc.metrics.IdentityGCLatency.WithLabelValues(LabelValueOutcomeFail).Set(float64(time.Since(timeNow).Seconds()))
 	}
 	aliveEntries := totalEntries - deletedEntries
 	igc.metrics.IdentityGCSize.WithLabelValues(LabelValueOutcomeAlive).Set(float64(aliveEntries))

--- a/operator/identitygc/kvstore_gc.go
+++ b/operator/identitygc/kvstore_gc.go
@@ -55,6 +55,7 @@ func (igc *GC) runKVStoreModeGC(ctx context.Context) error {
 
 			igc.failedRuns++
 			igc.metrics.IdentityGCRuns.WithLabelValues(LabelValueOutcomeFail).Set(float64(igc.failedRuns))
+			igc.metrics.IdentityGCLatency.WithLabelValues(LabelValueOutcomeFail).Set(float64(time.Since(now).Seconds()))
 		} else {
 			// Best effort to run auth identity GC
 			err = igc.runAuthGC(ctx, keysToDeletePrev)
@@ -71,6 +72,7 @@ func (igc *GC) runKVStoreModeGC(ctx context.Context) error {
 
 			igc.metrics.IdentityGCSize.WithLabelValues(LabelValueOutcomeAlive).Set(float64(gcStats.Alive))
 			igc.metrics.IdentityGCSize.WithLabelValues(LabelValueOutcomeDeleted).Set(float64(gcStats.Deleted))
+			igc.metrics.IdentityGCLatency.WithLabelValues(LabelValueOutcomeSuccess).Set(float64(time.Since(now).Seconds()))
 		}
 
 		if igc.gcInterval <= gcDuration {

--- a/operator/identitygc/metrics.go
+++ b/operator/identitygc/metrics.go
@@ -43,6 +43,12 @@ func NewMetrics() *Metrics {
 			Name:      "identity_gc_runs",
 			Help:      "The number of times identity garbage collector has run",
 		}, []string{LabelOutcome}),
+
+		IdentityGCLatency: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "identity_gc_latency",
+			Help:      "The duration of the last successful identity GC run",
+		}, []string{LabelOutcome}),
 	}
 }
 
@@ -52,4 +58,7 @@ type Metrics struct {
 
 	// IdentityGCRuns records how many times identity GC has run
 	IdentityGCRuns metric.Vec[metric.Gauge]
+
+	// IdentityGCLatency records the duration of the last successful identity GC run
+	IdentityGCLatency metric.Vec[metric.Gauge]
 }


### PR DESCRIPTION
This PR adds a metric for measuring the time taken for identity GC to run.

We have found this useful for evaluating the identity GC performance when making changes to relevant config e.g. qps throttling and moving from CRD -> kvstore etc.

Given it's a low volume operation, I've made the metric a gauge instead of a histogram so I can see the actual latency. I'm also clearing it each run and only updating on success. Happy to change any of these details if required.