### PR TITLE
bugtool: scrape heap profiles in protocol buffer format by default

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -47,7 +47,7 @@ cilium-bugtool [OPTIONS] [flags]
       --k8s-mode                             Require Kubernetes pods to be found or fail
       --k8s-namespace string                 Kubernetes namespace for Cilium pod (default "kube-system")
       --parallel-workers int                 Maximum number of parallel worker tasks, use 0 for number of CPUs
-      --pprof-debug int                      Debug pprof args (default 1)
+      --pprof-debug int                      Debug pprof args
       --pprof-port int                       Pprof port to connect to. Known Cilium component ports are agent:6060, operator:6061, apiserver:6063 (default 6060)
       --pprof-trace-seconds int              Amount of seconds used for pprof CPU traces (default 180)
   -t, --tmp string                           Path to store extracted files. Use '-' to send to stdout. (default "/tmp")

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -104,7 +104,7 @@ var (
 func init() {
 	BugtoolRootCmd.Flags().BoolVar(&archive, "archive", true, "Create archive when false skips deletion of the output directory")
 	BugtoolRootCmd.Flags().BoolVar(&getPProf, "get-pprof", false, "When set, only gets the pprof traces from the cilium-agent binary")
-	BugtoolRootCmd.Flags().IntVar(&pprofDebug, "pprof-debug", 1, "Debug pprof args")
+	BugtoolRootCmd.Flags().IntVar(&pprofDebug, "pprof-debug", 0, "Debug pprof args")
 	BugtoolRootCmd.Flags().BoolVar(&envoyDump, "envoy-dump", true, "When set, dump envoy configuration from unix socket")
 	BugtoolRootCmd.Flags().BoolVar(&envoyMetrics, "envoy-metrics", true, "When set, dump envoy prometheus metrics from unix socket")
 	BugtoolRootCmd.Flags().IntVar(&pprofPort,


### PR DESCRIPTION
By default, cilium-bugtool currently scrapes heap profiles in the legacy text format (i.e., debug=1), rather than in gzipped-compressed protocol buffer format (i.e., debug=0) [1]. Let's flip this value to use the modern format by default, as it allows to run `go tool pprof` without having to explicitly specify the target binary, and produces an output file an order of magnitude smaller, based on a local test. Additionally, this also ensures consistency with the cpu profile,    which is hardcoded to using the binary format.

\[1\]: https://pkg.go.dev/runtime/pprof#pkg-notes
