### PR TITLE
Documentation: Add --set cni.exclusive=false for Azure Chain Mode

### DIFF
--- a/Documentation/installation/cni-chaining-azure-cni.rst
+++ b/Documentation/installation/cni-chaining-azure-cni.rst
@@ -94,6 +94,7 @@ Deploy Cilium release via Helm:
      --namespace kube-system \\
      --set cni.chainingMode=generic-veth \\
      --set cni.customConf=true \\
+     --set cni.exclusive=false \\
      --set nodeinit.enabled=true \\
      --set cni.configMap=cni-configuration \\
      --set routingMode=native \\


### PR DESCRIPTION
Update cni-chaining-azure-cni.rst
Azure chain mode should follow same logic as per https://github.com/cilium/cilium/pull/23159 so that cilium in chain mode should not own /etc/cni/net.d or uninstallation will be problematic

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

Signed-off-by: Mais <8318308+Mais316@users.noreply.github.com>