### PR TITLE
bpf: Fix complexity issue failing cil_sock{4,6}_connect prog load

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -393,6 +393,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 				 * doesn't hit the reselection again.
 				 */
 				backend_id = 0;
+			barrier();
 		}
 	}
 
@@ -414,6 +415,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 		update_metrics(0, METRIC_EGRESS, REASON_LB_NO_BACKEND);
 		return -EHOSTUNREACH;
 	}
+	barrier();
 
 	if (lb4_svc_is_affinity(svc) && !backend_from_affinity)
 		lb4_update_affinity_by_netns(svc, &id, backend_id);
@@ -1079,6 +1081,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 			backend = __lb6_lookup_backend(backend_id);
 			if (!backend)
 				backend_id = 0;
+			barrier();
 		}
 	}
 
@@ -1100,6 +1103,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 		update_metrics(0, METRIC_EGRESS, REASON_LB_NO_BACKEND);
 		return -EHOSTUNREACH;
 	}
+	barrier();
 
 	if (lb6_svc_is_affinity(svc) && !backend_from_affinity)
 		lb6_update_affinity_by_netns(svc, &id, backend_id);


### PR DESCRIPTION
Fix the verifier complexity error - 

`{"level":"fatal","msg":"failed to start: daemon creation failed: error while initializing daemon: failed while reinitializing datapath: failed loading eBPF collection into the kernel: program cil_sock4_connect: load program: permission denied: 373: (07) r9 += 4: R9 pointer arithmetic on map_value_or_null prohibited, null-check it first (759 line(s) omitted)","subsys":"daemon"}
`

Dylan reported -

```
We get a map value back here https://github.com/cilium/cilium/blob/main/bpf/bpf_sock.c#L387
Which we then null-check like we are supposed to do. However, for some reason
the generated byte code does the backend->port access first
so https://github.com/cilium/cilium/blob/main/bpf/bpf_sock.c#L422 or https://github.com/cilium/cilium/blob/main/bpf/bpf_sock.c#L434
We don't have the actual bytecode at the moment, but what I suspect
 is happening is that the compiler is computing the offset of backend->port
 without accessing the memory before the null check.
 ```

Add a barrier call so that compiler doesn't reorder the memory accesses. 

Tested the fix on an AKS cluster running on BYOCNI with k8s=1.29.4 deployed by @amitmavgupta - 

```
# kubectl get pods -A -o wide
NAMESPACE     NAME                                  READY   STATUS    RESTARTS     AGE   IP             NODE                                NOMINATED NODE   READINESS GATES
kube-system   cilium-2jcrn                          1/1     Running   0            44s   10.224.0.4     aks-nodepool1-26434812-vmss000000   <none>           <none>
kube-system   cilium-7d8qp                          1/1     Running   0            44s   10.224.0.6     aks-nodepool1-26434812-vmss000002   <none>           <none>

# kubectl -n kube-system exec -it cilium-2jcrn -- cilium version
Defaulted container "cilium-agent" out of: cilium-agent, config (init), mount-cgroup (init), apply-sysctl-overwrites (init), mount-bpf-fs (init), wait-for-node-init (init), clean-cilium-state (init), install-cni-binaries (init)
Client: 1.17.0-dev 440377aa 2024-07-10T09:14:44-07:00 go version go1.22.5 linux/amd64
Daemon: 1.17.0-dev 440377aa 2024-07-10T09:14:44-07:00 go version go1.22.5 linux/amd64

```

Before:

```
# kubectl get pods -A -o wide
NAMESPACE     NAME                                  READY   STATUS             RESTARTS          AGE   IP             NODE                                NOMINATED NODE   READINESS GATES
kube-system   cilium-2sp8c                          0/1     CrashLoopBackOff   115 (15s ago)     9h    10.224.0.4     aks-nodepool1-26434812-vmss000000   <none>           <none>
kube-system   cilium-f4kgf                          0/1     CrashLoopBackOff   115 (29s ago)     9h    10.224.0.6     aks-nodepool1-26434812-vmss000002   <none>           <none>

```

Fixes: [#33545](https://github.com/cilium/cilium/issues/33545)
Reported-by: Francisco Guerrero <jsfrncscg@gmail.com>
Tested-by: Francisco Guerrero <jsfrncscg@gmail.com>

```release-note
Fix loading of program `cil_sock{4,6}_connect` due to verifier complexity issue on certain kernels.
```


