### PR TITLE
release image: Allow arbitrary pre-release identifiers

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - v1.16.[0-9]+
-      - v1.16.[0-9]+-rc.[0-9]+
+      - v1.16.[0-9]+-*
 
 permissions:
   # To be able to access the repository with `actions/checkout`


### PR DESCRIPTION
Make the filter patterns for release image tags more lenient to allow arbitrary pre-release identifiers beyond rc. We made a similar change in main branch [^1], but the change got lost when we branched v1.16.

Fixes: f5bdf28e8af1 ("Prepare v1.16 stable branch")

[^1]: https://github.com/cilium/cilium/pull/29173