### PR TITLE
policy: Keep deny entries when covered by another CIDR deny

### DIFF
--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -1366,6 +1366,10 @@ func Test_AllowAll(t *testing.T) {
 }
 
 var (
+	ruleAllowAllIngress = api.NewRule().WithIngressRules([]api.IngressRule{{
+		IngressCommonRule: api.IngressCommonRule{
+			FromEndpoints: []api.EndpointSelector{api.WildcardEndpointSelector},
+		}}}).WithEndpointSelector(api.WildcardEndpointSelector)
 	ruleL3DenyWorld = api.NewRule().WithIngressDenyRules([]api.IngressDenyRule{{
 		IngressCommonRule: api.IngressCommonRule{
 			FromEntities: api.EntitySlice{api.EntityWorld},
@@ -1456,8 +1460,8 @@ var (
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
 
-	mapKeyL3SmallerSubnetIngress = key(worldIPIdentity.Uint32(), 0, 0, trafficdirection.Ingress.Uint8())
-	mapKeyL3SmallerSubnetEgress  = key(worldIPIdentity.Uint32(), 0, 0, trafficdirection.Egress.Uint8())
+	mapKeyL3WorldIPIngress = key(worldIPIdentity.Uint32(), 0, 0, trafficdirection.Ingress.Uint8())
+	mapKeyL3WorldIPEgress  = key(worldIPIdentity.Uint32(), 0, 0, trafficdirection.Egress.Uint8())
 
 	ruleL3AllowHostEgress = api.NewRule().WithEgressRules([]api.EgressRule{{
 		EgressCommonRule: api.EgressCommonRule{
@@ -1520,6 +1524,13 @@ var (
 	mapKeyL3L4Port8080ProtoSCTPWorldSNIngress = key(worldSubnetIdentity.Uint32(), 8080, 132, trafficdirection.Ingress.Uint8())
 	mapKeyL3L4Port8080ProtoSCTPWorldSNEgress  = key(worldSubnetIdentity.Uint32(), 8080, 132, trafficdirection.Egress.Uint8())
 
+	mapKeyL3L4Port8080ProtoTCPWorldIPIngress  = key(worldIPIdentity.Uint32(), 8080, 6, trafficdirection.Ingress.Uint8())
+	mapKeyL3L4Port8080ProtoTCPWorldIPEgress   = key(worldIPIdentity.Uint32(), 8080, 6, trafficdirection.Egress.Uint8())
+	mapKeyL3L4Port8080ProtoUDPWorldIPIngress  = key(worldIPIdentity.Uint32(), 8080, 17, trafficdirection.Ingress.Uint8())
+	mapKeyL3L4Port8080ProtoUDPWorldIPEgress   = key(worldIPIdentity.Uint32(), 8080, 17, trafficdirection.Egress.Uint8())
+	mapKeyL3L4Port8080ProtoSCTPWorldIPIngress = key(worldIPIdentity.Uint32(), 8080, 132, trafficdirection.Ingress.Uint8())
+	mapKeyL3L4Port8080ProtoSCTPWorldIPEgress  = key(worldIPIdentity.Uint32(), 8080, 132, trafficdirection.Egress.Uint8())
+
 	ruleL3AllowWorldSubnet = api.NewRule().WithIngressRules([]api.IngressRule{{
 		ToPorts: api.PortRules{
 			api.PortRule{
@@ -1559,6 +1570,7 @@ var (
 			ToCIDR: api.CIDRSlice{worldIPCIDR},
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
+	mapKeyAnyIngress                        = key(0, 0, 0, trafficdirection.Ingress.Uint8())
 	mapKeyL4AnyPortProtoWorldIPIngress      = key(worldIPIdentity.Uint32(), 0, 0, trafficdirection.Ingress.Uint8())
 	mapKeyL4AnyPortProtoWorldIPEgress       = key(worldIPIdentity.Uint32(), 0, 0, trafficdirection.Egress.Uint8())
 	mapKeyL4Port8080ProtoTCPWorldIPIngress  = key(worldIPIdentity.Uint32(), 8080, 6, trafficdirection.Ingress.Uint8())
@@ -1663,27 +1675,36 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 		rules    api.Rules
 		expected MapState
 	}{
-		{"deny_world_no_labels", api.Rules{ruleL3DenyWorld, ruleL3AllowWorldIP}, newMapState(map[Key]MapStateEntry{
-			mapKeyL3WorldIngress:  mapEntryDeny,
-			mapKeyL3WorldEgress:   mapEntryDeny,
-			mapKeyL3SubnetIngress: mapEntryDeny,
-			mapKeyL3SubnetEgress:  mapEntryDeny,
-		})}, {"deny_world_with_labels", api.Rules{ruleL3DenyWorldWithLabels, ruleL3AllowWorldIP}, newMapState(map[Key]MapStateEntry{
-			mapKeyL3WorldIngress:  mapEntryWorldDenyWithLabels,
-			mapKeyL3WorldEgress:   mapEntryWorldDenyWithLabels,
-			mapKeyL3SubnetIngress: mapEntryDeny,
-			mapKeyL3SubnetEgress:  mapEntryDeny,
-		})}, {"deny_one_ip_with_a_larger_subnet", api.Rules{ruleL3DenySubnet, ruleL3AllowWorldIP}, newMapState(map[Key]MapStateEntry{
-			mapKeyL3SubnetIngress:        mapEntryDeny,
-			mapKeyL3SubnetEgress:         mapEntryDeny,
-			mapKeyL3SmallerSubnetIngress: mapEntryDeny,
-			mapKeyL3SmallerSubnetEgress:  mapEntryDeny,
-		})}, {"deny_part_of_a_subnet_with_an_ip", api.Rules{ruleL3DenySmallerSubnet, ruleL3AllowLargerSubnet}, newMapState(map[Key]MapStateEntry{
-			mapKeyL3SmallerSubnetIngress: mapEntryDeny,
-			mapKeyL3SmallerSubnetEgress:  mapEntryDeny,
-			mapKeyL3SubnetIngress:        mapEntryAllow,
-			mapKeyL3SubnetEgress:         mapEntryAllow,
-		})}, {"broad_cidr_deny_is_a_portproto_subset_of_a_specific_cidr_allow", api.Rules{ruleL3L4Port8080ProtoAnyDenyWorld, ruleL3AllowWorldIP}, newMapState(map[Key]MapStateEntry{
+		{"deny_world_no_labels", api.Rules{ruleAllowAllIngress, ruleL3DenyWorld, ruleL3AllowWorldIP}, newMapState(map[Key]MapStateEntry{
+			mapKeyAnyIngress:       mapEntryAllow,
+			mapKeyL3WorldIngress:   mapEntryDeny,
+			mapKeyL3WorldEgress:    mapEntryDeny,
+			mapKeyL3SubnetIngress:  mapEntryDeny,
+			mapKeyL3SubnetEgress:   mapEntryDeny,
+			mapKeyL3WorldIPIngress: mapEntryDeny,
+			mapKeyL3WorldIPEgress:  mapEntryDeny,
+		})}, {"deny_world_with_labels", api.Rules{ruleAllowAllIngress, ruleL3DenyWorldWithLabels, ruleL3AllowWorldIP}, newMapState(map[Key]MapStateEntry{
+			mapKeyAnyIngress:       mapEntryAllow,
+			mapKeyL3WorldIngress:   mapEntryWorldDenyWithLabels,
+			mapKeyL3WorldEgress:    mapEntryWorldDenyWithLabels,
+			mapKeyL3SubnetIngress:  mapEntryDeny,
+			mapKeyL3SubnetEgress:   mapEntryDeny,
+			mapKeyL3WorldIPIngress: mapEntryDeny,
+			mapKeyL3WorldIPEgress:  mapEntryDeny,
+		})}, {"deny_one_ip_with_a_larger_subnet", api.Rules{ruleAllowAllIngress, ruleL3DenySubnet, ruleL3AllowWorldIP}, newMapState(map[Key]MapStateEntry{
+			mapKeyAnyIngress:       mapEntryAllow,
+			mapKeyL3SubnetIngress:  mapEntryDeny,
+			mapKeyL3SubnetEgress:   mapEntryDeny,
+			mapKeyL3WorldIPIngress: mapEntryDeny,
+			mapKeyL3WorldIPEgress:  mapEntryDeny,
+		})}, {"deny_part_of_a_subnet_with_an_ip", api.Rules{ruleAllowAllIngress, ruleL3DenySmallerSubnet, ruleL3AllowLargerSubnet}, newMapState(map[Key]MapStateEntry{
+			mapKeyAnyIngress:       mapEntryAllow,
+			mapKeyL3WorldIPIngress: mapEntryDeny,
+			mapKeyL3WorldIPEgress:  mapEntryDeny,
+			mapKeyL3SubnetIngress:  mapEntryAllow,
+			mapKeyL3SubnetEgress:   mapEntryAllow,
+		})}, {"broad_cidr_deny_is_a_portproto_subset_of_a_specific_cidr_allow", api.Rules{ruleAllowAllIngress, ruleL3L4Port8080ProtoAnyDenyWorld, ruleL3AllowWorldIP}, newMapState(map[Key]MapStateEntry{
+			mapKeyAnyIngress:                          mapEntryAllow,
 			mapKeyL3L4Port8080ProtoTCPWorldIngress:    mapEntryDeny,
 			mapKeyL3L4Port8080ProtoTCPWorldEgress:     mapEntryDeny,
 			mapKeyL3L4Port8080ProtoUDPWorldIngress:    mapEntryDeny,
@@ -1696,9 +1717,16 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 			mapKeyL3L4Port8080ProtoUDPWorldSNEgress:   mapEntryDeny,
 			mapKeyL3L4Port8080ProtoSCTPWorldSNIngress: mapEntryDeny,
 			mapKeyL3L4Port8080ProtoSCTPWorldSNEgress:  mapEntryDeny,
-			mapKeyL3SmallerSubnetIngress:              mapEntryAllow,
-			mapKeyL3SmallerSubnetEgress:               mapEntryAllow,
-		})}, {"broad_cidr_allow_is_a_portproto_subset_of_a_specific_cidr_deny", api.Rules{ruleL3AllowWorldSubnet, ruleL3DenyWorldIP}, newMapState(map[Key]MapStateEntry{
+			mapKeyL3L4Port8080ProtoTCPWorldIPIngress:  mapEntryDeny,
+			mapKeyL3L4Port8080ProtoTCPWorldIPEgress:   mapEntryDeny,
+			mapKeyL3L4Port8080ProtoUDPWorldIPIngress:  mapEntryDeny,
+			mapKeyL3L4Port8080ProtoUDPWorldIPEgress:   mapEntryDeny,
+			mapKeyL3L4Port8080ProtoSCTPWorldIPIngress: mapEntryDeny,
+			mapKeyL3L4Port8080ProtoSCTPWorldIPEgress:  mapEntryDeny,
+			mapKeyL3WorldIPIngress:                    mapEntryAllow,
+			mapKeyL3WorldIPEgress:                     mapEntryAllow,
+		})}, {"broad_cidr_allow_is_a_portproto_subset_of_a_specific_cidr_deny", api.Rules{ruleAllowAllIngress, ruleL3AllowWorldSubnet, ruleL3DenyWorldIP}, newMapState(map[Key]MapStateEntry{
+			mapKeyAnyIngress:                          mapEntryAllow,
 			mapKeyL3L4Port8080ProtoTCPWorldSNIngress:  mapEntryAllow,
 			mapKeyL3L4Port8080ProtoTCPWorldSNEgress:   mapEntryAllow,
 			mapKeyL3L4Port8080ProtoUDPWorldSNIngress:  mapEntryAllow,
@@ -1713,10 +1741,12 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 			mapKeyL4Port8080ProtoUDPWorldIPEgress:     mapEntryDeny,
 			mapKeyL4Port8080ProtoSCTPWorldIPIngress:   mapEntryDeny,
 			mapKeyL4Port8080ProtoSCTPWorldIPEgress:    mapEntryDeny,
-		})}, {"named_port_world_subnet", api.Rules{ruleL3AllowWorldSubnetNamedPort}, newMapState(map[Key]MapStateEntry{
+		})}, {"named_port_world_subnet", api.Rules{ruleAllowAllIngress, ruleL3AllowWorldSubnetNamedPort}, newMapState(map[Key]MapStateEntry{
+			mapKeyAnyIngress: mapEntryAllow,
 			mapKeyL3L4NamedPortHTTPProtoTCPWorldSubNetIngress: mapEntryAllow,
 			mapKeyL3L4NamedPortHTTPProtoTCPWorldIPIngress:     mapEntryAllow,
-		})}, {"port_range_world_subnet", api.Rules{ruleL3AllowWorldSubnetPortRange}, newMapState(map[Key]MapStateEntry{
+		})}, {"port_range_world_subnet", api.Rules{ruleAllowAllIngress, ruleL3AllowWorldSubnetPortRange}, newMapState(map[Key]MapStateEntry{
+			mapKeyAnyIngress: mapEntryAllow,
 			mapKeyL3L4Port64To127ProtoTCPWorldSubNetIngress: mapEntryAllow,
 			mapKeyL3L4Port5ProtoTCPWorldSubNetIngress:       mapEntryAllow,
 			mapKeyL3L4Port6To7ProtoTCPWorldSubNetIngress:    mapEntryAllow,

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -287,16 +287,13 @@ func (e *MapStateEntry) HasDependent(key Key) bool {
 }
 
 // HasSameOwners returns true if both MapStateEntries
-// have the same owners as one another (which means that
-// one of the entries is redundant).
+// have the same owners as one another.
+// MapStateEntries are stored by value, so we do not check for nil pointers here.
 func (e *MapStateEntry) HasSameOwners(bEntry *MapStateEntry) bool {
-	if e == nil && bEntry == nil {
-		return true
-	}
 	if len(e.owners) != len(bEntry.owners) {
 		return false
 	}
-	for _, owner := range e.owners {
+	for owner := range e.owners {
 		if _, ok := bEntry.owners[owner]; !ok {
 			return false
 		}
@@ -838,6 +835,18 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 		return
 	}
 
+	// Since bpf datapath denies by default, we would only need to add deny entries to carve out
+	// more specific holes to less specific allow rules, or simply remove allow keys when a deny
+	// with the same key is added. But since we don't know if allow entries will be added later
+	// we must generally add deny entries even if there are no covering allow entries (yet).
+
+	// Datapath matches security IDs exactly, or completely wildcards them (ID == 0). Datapath
+	// has no LPM/CIDR logic for security IDs. We use LPM/CIDR logic here to find out if allow
+	// entries are "covered" by deny entries and change them to deny entries if so. We can not
+	// simply leave the allow entries off the datapath and rely on the default deny as a broad
+	// allow could be added later (e.g. an allow all-L3 rule that would match if no specific
+	// match on the left-off security ID of the deny rules exists).
+
 	// We cannot update the map while we are
 	// iterating through it, so we record the
 	// changes to be made and then apply them.
@@ -872,16 +881,49 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 						Value: l3l4DenyEntry,
 					})
 				}
-			} else if (newKey.Identity == k.Identity ||
-				identityIsSupersetOf(newKey.Identity, k.Identity, identities)) &&
-				(newKey.PortProtoIsBroader(k) || newKey.PortProtoIsEqual(k)) {
-				// If the new-entry is a superset (or equal) of the iterated-allow-entry and
-				// the new-entry has a broader (or equal) port-protocol then we
-				// should delete the iterated-allow-entry
-				deletes = append(deletes, MapChange{
-					Key: k,
-				})
+			} else if newKey.PortProtoIsBroader(k) || newKey.PortProtoIsEqual(k) {
+				// If newKey has a broader (or equal) port-protocol then we should
+				// either delete the iterated-allow-entry (if the identity is the
+				// same or the newKey is L3 wildcard), or change it to a deny entry
+				// if the newKey's identity is a superset of the iterated identity
+				// (e.g., newKey has a wider CIDR (say 10/8 covering the iterated
+				// identity of more specific CIDR (say 10.1.1.1). Note that the
+				// security identities assigned to these CIDRs have no numerical
+				// relation to each other (e.g, they could be any numbers X and Y)
+				// and the datapath does an exact match on them.
+				if newKey.Identity == 0 || newKey.Identity == k.Identity {
+					deletes = append(deletes, MapChange{
+						Key: k,
+					})
+				} else if identityIsSupersetOf(newKey.Identity, k.Identity, identities) {
+					// When newKey.Identity is not ANY and is different from the
+					// subset key, but still a superset (e.g., in CIDR sense) we
+					// must keep the subset key and make it a deny instead.
+					l3l4DenyEntry := NewMapStateEntry(newKey, newEntry.DerivedFromRules, 0, "", 0, true, DefaultAuthType, AuthTypeDisabled)
+					updates = append(updates, MapChange{
+						Add:   true,
+						Key:   k,
+						Value: l3l4DenyEntry,
+					})
+				}
+			} else if identityIsSupersetOf(newKey.Identity, k.Identity, identities) {
+				// k.PortProtoIsBroader(newKey) // due to if statements above
 
+				// Deny takes precedence for the port/proto of the newKey
+				// for each allow with broader port/proto and narrower ID.
+
+				// If newKey is a superset of the iterated allow key and newKey has
+				// a less specific port-protocol than the iterated allow key then an
+				// additional deny entry with port/proto of newKey and with the
+				// identity of the iterated allow key must be added.
+				denyKeyCpy := newKey
+				denyKeyCpy.Identity = k.Identity
+				l3l4DenyEntry := NewMapStateEntry(newKey, newEntry.DerivedFromRules, 0, "", 0, true, DefaultAuthType, AuthTypeDisabled)
+				updates = append(updates, MapChange{
+					Add:   true,
+					Key:   denyKeyCpy,
+					Value: l3l4DenyEntry,
+				})
 			}
 			return true
 		})
@@ -903,41 +945,47 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 		updates = nil
 		bailed := false
 		ms.ForEachDeny(func(k Key, v MapStateEntry) bool {
-			// Protocols and traffic directions that don't match ensure that the policies
-			// do not interact in anyway.
+			// Protocols and traffic directions that don't match ensure that the
+			// policies do not interact in anyway.
 			if newKey.TrafficDirection != k.TrafficDirection || !protocolsMatch(newKey, k) {
 				return true
 			}
 
-			if !v.HasDependent(newKey) && v.HasSameOwners(&newEntry) &&
-				(k.PortProtoIsEqual(newKey) || k.PortProtoIsBroader(newKey)) &&
-				(newKey.Identity == k.Identity ||
-					identityIsSupersetOf(k.Identity, newKey.Identity, identities)) {
-				// If this iterated-deny-entry is a supserset (or equal) of the new-entry and
-				// the iterated-deny-entry has a broader (or equal) port-protocol and
-				// the ownership between the entries is the same then we
-				// should not insert the new entry (as long as it is not one
-				// of the special L4-only denies we created to cover the special
-				// case of a superset-allow with a more specific port-protocol).
-				//
-				// NOTE: This condition could be broader to reject more deny entries,
-				// but there *may* be performance tradeoffs.
-				bailed = true
-				return false
-			} else if !newEntry.HasDependent(k) && newEntry.HasSameOwners(&v) &&
+			// A narrower of two deny keys is redundant in the datapath only if
+			// the broader ID is 0, or the IDs are the same. This is because the
+			// ID will be assigned from the ipcache and datapath has no notion
+			// of one ID being related to another (e.g., in a CIDR sense).
+			if (k.Identity == 0 || k.Identity == newKey.Identity) &&
+				(k.PortProtoIsEqual(newKey) || k.PortProtoIsBroader(newKey)) {
+				// If this iterated-deny-entry is an allow-all-L3 or has the same ID
+				// as the new-entry and the iterated-deny-entry has a broader (or
+				// equal) port-protocol it will match all the packets the newKey
+				// would, given that we do not allow more specific allow rules to be
+				// inserted.
+
+				// Identical key needs to be added if owners are different (to merge
+				// them). This has no effect on the datapath policy map but is
+				// needed for internal bookkeeping.
+				if k != newKey || v.HasSameOwners(&newEntry) {
+					bailed = true
+					return false
+				}
+			} else if (newKey.Identity == 0 || newKey.Identity == k.Identity) &&
 				(newKey.PortProtoIsEqual(k) || newKey.PortProtoIsBroader(k)) &&
-				(newKey.Identity == k.Identity ||
-					identityIsSupersetOf(newKey.Identity, k.Identity, identities)) {
-				// If this iterated-deny-entry is a subset (or equal) of the new-entry and
-				// the new-entry has a broader (or equal) port-protocol and
-				// the ownership between the entries is the same then we
-				// should delete the iterated-deny-entry (as long as it is not one
-				// of the special L4-only denies we created to cover the special
-				// case of a superset-allow with a more specific port-protocol).
-				//
-				// NOTE: This condition could be broader to reject more deny entries,
-				// but there *may* be performance tradeoffs.
+				!newEntry.HasDependent(k) {
+				// If this iterated-deny-entry is a subset (or equal) of the
+				// new-entry and the new-entry has a broader (or equal)
+				// port-protocol the newKey will match all the packets the iterated
+				// key would, given that there are no more specific or L4-only allow
+				// entries. We removed the more specific allow rules in the loop
+				// above, and added more specific deny rules if there was an L4-only
+				// allow rule. We use 'HasDependant' to figure out that 'k' must
+				// remain to take precedence over the L4-only allow key.
+
+				// Identical key would have been captured in the block above, so we
+				// do not need to check for it here.
 				updates = append(updates, MapChange{
+					Add: false,
 					Key: k,
 				})
 			}
@@ -957,6 +1005,7 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 		updates = nil
 		var dependents []MapChange
 		bailed := false
+		changeToDeny := false
 		ms.ForEachDeny(func(k Key, v MapStateEntry) bool {
 			// Protocols and traffic directions that don't match ensure that the policies
 			// do not interact in anyway.
@@ -988,15 +1037,45 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 						Value: v,
 					})
 				}
-			} else if (k.Identity == newKey.Identity ||
-				identityIsSupersetOf(k.Identity, newKey.Identity, identities)) &&
-				(k.PortProtoIsBroader(newKey) || k.PortProtoIsEqual(newKey)) &&
-				!v.HasDependent(newKey) {
-				// If the iterated-deny-entry is a superset (or equal) of the new-entry and has a
-				// broader (or equal) port-protocol than the new-entry then the new
-				// entry should not be inserted.
-				bailed = true
-				return false
+			} else if k.PortProtoIsBroader(newKey) || k.PortProtoIsEqual(newKey) {
+				if k.Identity == 0 || k.Identity == newKey.Identity {
+					// If the iterated-deny-entry is a datapath superset (or
+					// equal) of the new-entry and has a broader (or equal)
+					// port-protocol than the new-entry then the new entry
+					// should not be inserted.
+					bailed = true
+					return false
+				} else if identityIsSupersetOf(k.Identity, newKey.Identity, identities) {
+					// if newKey is not bailed due to being covered in the
+					// datapath by a deny entry, but is covered by a deny entry
+					// in the CIDR sense, we must change this allow entry to a
+					// deny entry so that the covering deny policy is honored
+					// also for this ID in the datapath.
+					changeToDeny = true
+				}
+			} else { // newKey.PortProtoIsBroader(k)
+				if identityIsSupersetOf(k.Identity, newKey.Identity, identities) {
+					// If the new-entry is a subset of the iterated-deny-entry
+					// and the new-entry has a less specific port-protocol than
+					// the iterated-deny-entry then an additional copy of the
+					// iterated-deny-entry with the identity of the new-entry
+					// must be added.
+					denyKeyCpy := k
+					denyKeyCpy.Identity = newKey.Identity
+					l3l4DenyEntry := NewMapStateEntry(k, v.DerivedFromRules, 0, "", 0, true, DefaultAuthType, AuthTypeDisabled)
+					updates = append(updates, MapChange{
+						Add:   true,
+						Key:   denyKeyCpy,
+						Value: l3l4DenyEntry,
+					})
+					// L3-only entries can be deleted incrementally so we need
+					// to track their effects on other entries so that those
+					// effects can be reverted when the identity is removed.
+					dependents = append(dependents, MapChange{
+						Key:   k,
+						Value: v,
+					})
+				}
 			}
 			return true
 		})
@@ -1009,6 +1088,14 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 				dep := dependents[i]
 				ms.addDependentOnEntry(dep.Key, dep.Value, update.Key, changes)
 			}
+		}
+		if changeToDeny {
+			newEntry.IsDeny = true
+			newEntry.ProxyPort = 0
+			newEntry.Listener = ""
+			newEntry.priority = 0
+			newEntry.hasAuthType = DefaultAuthType
+			newEntry.AuthType = AuthTypeDisabled
 		}
 		ms.authPreferredInsert(newKey, newEntry, features, changes)
 	}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -943,14 +943,15 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 			}
 			return true
 		})
+		if bailed {
+			return
+		}
 		for _, update := range updates {
 			if !update.Add {
 				ms.deleteKeyWithChanges(update.Key, nil, changes)
 			}
 		}
-		if !bailed {
-			ms.addKeyWithChanges(newKey, newEntry, changes)
-		}
+		ms.addKeyWithChanges(newKey, newEntry, changes)
 	} else {
 		// NOTE: We do not delete redundant allow entries.
 		updates = nil
@@ -999,6 +1000,9 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 			}
 			return true
 		})
+		if bailed {
+			return
+		}
 		for i, update := range updates {
 			if update.Add {
 				ms.addKeyWithChanges(update.Key, update.Value, changes)
@@ -1006,9 +1010,7 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 				ms.addDependentOnEntry(dep.Key, dep.Value, update.Key, changes)
 			}
 		}
-		if !bailed {
-			ms.authPreferredInsert(newKey, newEntry, features, changes)
-		}
+		ms.authPreferredInsert(newKey, newEntry, features, changes)
 	}
 }
 

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -3666,6 +3666,13 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
 		outcomeKeys.validatePortProto(t)
 		require.True(t, expectedKeys.Equals(outcomeKeys), "%s (MapState):\n%s", tt.name, outcomeKeys.Diff(expectedKeys))
+
+		// Test also with reverse insertion order
+		outcomeKeys = newMapState(nil)
+		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
+		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
+		outcomeKeys.validatePortProto(t)
+		require.True(t, expectedKeys.Equals(outcomeKeys), "%s (in reverse) (MapState):\n%s", tt.name, outcomeKeys.Diff(expectedKeys))
 	}
 	// Now test all cases with different traffic directions.
 	// This should result in both entries being inserted with
@@ -3690,7 +3697,14 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
 		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
 		outcomeKeys.validatePortProto(t)
-		require.EqualValuesf(t, expectedKeys, outcomeKeys, "different traffic directions %s", tt.name)
+		require.True(t, expectedKeys.Equals(outcomeKeys), "%s different traffic directions (MapState):\n%s", tt.name, outcomeKeys.Diff(expectedKeys))
+
+		// Test also with reverse insertion order
+		outcomeKeys = newMapState(nil)
+		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
+		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
+		outcomeKeys.validatePortProto(t)
+		require.True(t, expectedKeys.Equals(outcomeKeys), "%s different traffic directions (in reverse) (MapState):\n%s", tt.name, outcomeKeys.Diff(expectedKeys))
 	}
 }
 


### PR DESCRIPTION
Deny entries covered by another deny CIDR entry must be kept as they have different numerical identities in the datapath. Otherwise a later added allow-all entry could take effect if there is no specific match for the left-off identity. Simplest example of this is with L3-only deny rules and an Allow-all rule that wildcards also the L3. So for the sake if this example we only need to consider L3-identities of the CIDRs (10/8, and 10.1.1.1/32, first covering the latter), say X and Y (both nonzero) and an allow rule with ID 0 (ANY). This policy should allow all traffic that is not with an IP covered by 10/8. Since 10.1.1.1/32 is covered by 10/8 it would be tempting to not insert the rule for the ID assigned to CIDR 10.1.1.1/32 to the datapath policy map. The identities for both CIDRs are, however, present in the ipcache, so that traffic to (or from) 10.1.1.1 would be associated with ID Y, which would match the wildcard ID (0) allow rule, if a deny rule with the ID Y is not present in the datapath. Hence, we must both deny rules in to the policy map.

The above logic does not apply when the two rules in question have the same ID (but different coverage on port and protocol), or when one of them is a wildcard L3 rule (with ID 0). In that case we can leave the more deny rule covered by another off the policy map, but only if it was not needed to cover for a L4-only allow rule that still needs to take effect on all L3 identities not explicitly denied. In that case we add new L3/L4 deny entries to carve holes into the broader allow rule, and we must keep the deny rules we added for those holes even when they would otherwise be covered by a broader deny rule.

Note that a presence of a wider allow rule is not required at the time of policy map entry insertion for the above consideration to take effect. In this line of thought we could simply leave off all the deny entries if no allow entries exist, since the datapath is deny by default. This breaks down as soon as an allow rule is inserted to a now empty policy map (maybe incrementally due to an FQDN policy rule), as all the (non-inserted) deny rules would now be disregarded.

This leaves a possibility for a late-stage policy map optimization, however: If, when syncing the userspace policy map to the bpf datapath policy map, we notice that some deny entries are not covered by any wider allow entries, it would be safe to leave such entries off from the datapath policy map. We'd need to be ready to insert them before any new related allow entries are added, though.

Unit tests are adjusted, not only to include the previously missing entries, but also add "allow-all" rules for illustrative purposes so that it is easier to reason about the necessity of the added deny entries.

Fixes: #32675

Note: This is `v1.16` version of #33953