### PR TITLE
gh: nat46x64: don't set DSR dispatch mode when LB mode is SNAT

### DIFF
--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -14,8 +14,7 @@ CILIUM_EXEC="docker exec -t lb-node docker exec -t cilium-lb"
 
 CFG_COMMON=("--enable-ipv4=true" "--enable-ipv6=true" "--devices=eth0" \
             "--datapath-mode=lb-only" "--bpf-lb-external-control-plane=true" \
-	    "--bpf-lb-dsr-dispatch=ipip" "--bpf-lb-mode=snat" \
-	    "--enable-nat46x64-gateway=true")
+	    "--bpf-lb-mode=snat" "--enable-nat46x64-gateway=true")
 
 TXT_XDP_MAGLEV="Mode:XDP\tAlgorithm:Maglev\tRecorder:Disabled"
 CFG_XDP_MAGLEV=("--bpf-lb-acceleration=native" "--bpf-lb-algorithm=maglev")


### PR DESCRIPTION
Apply a small cleanup to make the config consistent. There is no point in configuring a DSR dispatch mode when the cluster is not using DSR.