### PR TITLE
daemon: improve error message when SocketLB is required

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -658,7 +658,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 			err = fmt.Errorf("BPF masquerade does not allow to specify devices via --%s (use --%s instead)",
 				option.MasqueradeInterfaces, option.Devices)
 		case option.Config.TunnelingEnabled() && !option.Config.EnableSocketLB:
-			err = fmt.Errorf("BPF masquerade requires socket-LB (--%s=\"false\")",
+			err = fmt.Errorf("BPF masquerade with tunnel routing requires socket-LB (--%s=\"true\")",
 				option.EnableSocketLB)
 		}
 		if err != nil {


### PR DESCRIPTION
Clarify that the SocketLB is only required for the combination of overlay routing and BPF masquerade. And be more helpful by saying what value needs to be set for the --bpf-lb-sock option.