### PR TITLE
daemon: Do not require socketLB for BPF masq

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -175,6 +175,7 @@ jobs:
             kpr: 'false'
             tunnel: 'geneve'
             endpoint-routes: 'true'
+            misc: 'socketLB.enabled=false,nodePort.enabled=true,bpf.masquerade=true'
 
           - name: '9'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -657,9 +657,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		case len(option.Config.MasqueradeInterfaces) > 0:
 			err = fmt.Errorf("BPF masquerade does not allow to specify devices via --%s (use --%s instead)",
 				option.MasqueradeInterfaces, option.Devices)
-		case option.Config.TunnelingEnabled() && !option.Config.EnableSocketLB:
-			err = fmt.Errorf("BPF masquerade requires socket-LB (--%s=\"false\")",
-				option.EnableSocketLB)
 		}
 		if err != nil {
 			log.WithError(err).Error("unable to initialize BPF masquerade support")


### PR DESCRIPTION
Previously, we required socketLB to be enabled in order for BPF masquerade to properly function. The reasoning was outlined in \[1\] and \[2\].

As pointed by Julian Wiedmann, \[3\] resolved the following NAT reply issue:

        On the remote node, the reply (dst=the client node IP) gets
        masqueraded by the BPF-masq feature, because we masquerade pod ->
        remote host IP in the tunnel mode (see comment in the
        "snat_v4_needed()" for the reason), and currently we don't consult
        the CT map to see whether a packet is reply.

Thus, we can remove the check.

\[1\]: https://github.com/cilium/cilium/issues/15437
\[2\]: https://github.com/cilium/cilium/commit/50e59c309e6d86adad84dc175678a91dce6def03
\[3\]: https://github.com/cilium/cilium/pull/17168

Fix #15437 
Fix #12699