### PR TITLE
gha: compress profiles archives in scale/perf tests

### DIFF
--- a/.github/actions/cl2-modules/cilium-agent-pprofs.yaml
+++ b/.github/actions/cl2-modules/cilium-agent-pprofs.yaml
@@ -20,6 +20,7 @@ steps:
           - cilium-bugtool
           - --get-pprof
           - --pprof-trace-seconds=40
+          - --archiveType=gz
           - -t=-
           timeout: 55s
 

--- a/.github/actions/cl2-modules/fqdn/modules/profiles.yaml
+++ b/.github/actions/cl2-modules/fqdn/modules/profiles.yaml
@@ -20,5 +20,6 @@ steps:
           - cilium-bugtool
           - --get-pprof
           - --pprof-trace-seconds=40
+          - --archiveType=gz
           - -t=-
           timeout: 55s


### PR DESCRIPTION
This allows to reduce the resulting size of the archive between half and one fifth of the original size, reducing the space used in the bucket, and the subsequent download time.