### PR TITLE
bpf: add ctx_load_meta_ipv6()

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -675,7 +675,7 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 	int ret, oif = 0, ohead = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
-	union v6addr addr;
+	union v6addr addr __align_stack_8 = {};
 	__s8 ext_err = 0;
 	__be16 port;
 
@@ -684,10 +684,7 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 		goto drop_err;
 	}
 
-	addr.p1 = ctx_load_meta(ctx, CB_ADDR_V6_1);
-	addr.p2 = ctx_load_meta(ctx, CB_ADDR_V6_2);
-	addr.p3 = ctx_load_meta(ctx, CB_ADDR_V6_3);
-	addr.p4 = ctx_load_meta(ctx, CB_ADDR_V6_4);
+	ctx_load_meta_ipv6(ctx, &addr, CB_ADDR_V6_1);
 
 	port = (__be16)ctx_load_meta(ctx, CB_PORT);
 
@@ -1370,16 +1367,10 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 #if DSR_ENCAP_MODE == DSR_ENCAP_IPIP
 		ctx_store_meta(ctx, CB_HINT,
 			       ((__u32)tuple->sport << 16) | tuple->dport);
-		ctx_store_meta(ctx, CB_ADDR_V6_1, tuple->daddr.p1);
-		ctx_store_meta(ctx, CB_ADDR_V6_2, tuple->daddr.p2);
-		ctx_store_meta(ctx, CB_ADDR_V6_3, tuple->daddr.p3);
-		ctx_store_meta(ctx, CB_ADDR_V6_4, tuple->daddr.p4);
+		ctx_store_meta_ipv6(ctx, CB_ADDR_V6_1, &tuple->daddr);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE || DSR_ENCAP_MODE == DSR_ENCAP_NONE
 		ctx_store_meta(ctx, CB_PORT, key->dport);
-		ctx_store_meta(ctx, CB_ADDR_V6_1, key->address.p1);
-		ctx_store_meta(ctx, CB_ADDR_V6_2, key->address.p2);
-		ctx_store_meta(ctx, CB_ADDR_V6_3, key->address.p3);
-		ctx_store_meta(ctx, CB_ADDR_V6_4, key->address.p4);
+		ctx_store_meta_ipv6(ctx, CB_ADDR_V6_1, &key->address);
 #endif /* DSR_ENCAP_MODE */
 		return tail_call_internal(ctx, CILIUM_CALL_IPV6_NODEPORT_DSR, ext_err);
 	} else {

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -23,6 +23,24 @@ bpf_clear_meta(struct __sk_buff *ctx)
 	WRITE_ONCE(ctx->tc_classid, zero);
 }
 
+static __always_inline __maybe_unused void
+ctx_store_meta_ipv6(struct __sk_buff *ctx, const __u32 off, const union v6addr *addr)
+{
+	ctx_store_meta(ctx, off, addr->p1);
+	ctx_store_meta(ctx, off + 1, addr->p2);
+	ctx_store_meta(ctx, off + 2, addr->p3);
+	ctx_store_meta(ctx, off + 3, addr->p4);
+}
+
+static __always_inline __maybe_unused void
+ctx_load_meta_ipv6(const struct __sk_buff *ctx, union v6addr *addr, const __u32 off)
+{
+	addr->p1 = ctx_load_meta(ctx, off);
+	addr->p2 = ctx_load_meta(ctx, off + 1);
+	addr->p3 = ctx_load_meta(ctx, off + 2);
+	addr->p4 = ctx_load_meta(ctx, off + 3);
+}
+
 /**
  * get_identity - returns source identity from the mark field
  *

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -11,6 +11,30 @@ bpf_clear_meta(struct xdp_md *ctx __maybe_unused)
 {
 }
 
+static __always_inline __maybe_unused void
+ctx_store_meta_ipv6(struct xdp_md *ctx __maybe_unused, const __u64 off,
+		    const union v6addr *addr)
+{
+	__u32 zero = 0, *data_meta = map_lookup_elem(&cilium_xdp_scratch, &zero);
+
+	if (always_succeeds(data_meta))
+		memcpy(&data_meta[off], addr, sizeof(*addr));
+
+	build_bug_on((off + 4) * sizeof(__u32) > META_PIVOT);
+}
+
+static __always_inline __maybe_unused void
+ctx_load_meta_ipv6(const struct xdp_md *ctx __maybe_unused,
+		   union v6addr *addr, const __u64 off)
+{
+	__u32 zero = 0, *data_meta = map_lookup_elem(&cilium_xdp_scratch, &zero);
+
+	if (always_succeeds(data_meta))
+		memcpy(addr, &data_meta[off], sizeof(*addr));
+
+	build_bug_on((off + 4) * sizeof(__u32) > META_PIVOT);
+}
+
 static __always_inline __maybe_unused int
 get_identity(struct xdp_md *ctx __maybe_unused)
 {

--- a/bpf/lib/srv6.h
+++ b/bpf/lib/srv6.h
@@ -348,21 +348,15 @@ srv6_handling(struct __ctx_buff *ctx, struct in6_addr *dst_sid)
 }
 
 static __always_inline void
-srv6_load_meta_sid(struct __ctx_buff *ctx, struct in6_addr *sid)
+srv6_load_meta_sid(struct __ctx_buff *ctx, const struct in6_addr *sid)
 {
-	sid->s6_addr32[0] = ctx_load_meta(ctx, CB_SRV6_SID_1);
-	sid->s6_addr32[1] = ctx_load_meta(ctx, CB_SRV6_SID_2);
-	sid->s6_addr32[2] = ctx_load_meta(ctx, CB_SRV6_SID_3);
-	sid->s6_addr32[3] = ctx_load_meta(ctx, CB_SRV6_SID_4);
+	ctx_load_meta_ipv6(ctx, (union v6addr *)sid, CB_SRV6_SID_1);
 }
 
 static __always_inline void
 srv6_store_meta_sid(struct __ctx_buff *ctx, const union v6addr *sid)
 {
-	ctx_store_meta(ctx, CB_SRV6_SID_1, sid->p1);
-	ctx_store_meta(ctx, CB_SRV6_SID_2, sid->p2);
-	ctx_store_meta(ctx, CB_SRV6_SID_3, sid->p3);
-	ctx_store_meta(ctx, CB_SRV6_SID_4, sid->p4);
+	ctx_store_meta_ipv6(ctx, CB_SRV6_SID_1, sid);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_SRV6_ENCAP)


### PR DESCRIPTION
Add an optimized XDP implementation to load/store IPv6 addresses. This reduces the accesses to the per-CPU map that emulates skb->cb.