### PR TITLE
[v1.16] ginkgo: use net-next configuration with 6.6 kernel

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -307,7 +307,7 @@ jobs:
           provision: 'false'
           cmd: |
             cd /host/
-            if [[ "${{ matrix.kernel }}" == bpf-next-* ]]; then
+            if [[ "${{ matrix.kernel }}" == 6.6-* ]]; then
               ./contrib/scripts/kind.sh "" 2 "" "${{ matrix.kube-image }}" "none" "${{ matrix.ip-family }}"
               kubectl label node kind-worker2 cilium.io/ci-node=kind-worker2
               # Avoid re-labeling this node by setting "node-role.kubernetes.io/controlplane"
@@ -380,7 +380,7 @@ jobs:
             kubectl get pods -A -o wide
             export K8S_NODES=2
             export NETNEXT=0
-            if [[ "${{ matrix.kernel }}" == bpf-next-* ]]; then
+            if [[ "${{ matrix.kernel }}" == 6.6-* ]]; then
                export KERNEL=net-next
                export NETNEXT=1
                export KUBEPROXY=0

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -124,7 +124,7 @@ jobs:
             encryption: 'ipsec'
             endpoint-routes: 'false'
 
-          - config: 'bpf-next'
+          - config: '6.6'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: '6.6-20240703.151759'
             kube-proxy: 'iptables'
@@ -146,7 +146,7 @@ jobs:
             mode: 'minor'
             name: '3'
 
-          - config: 'bpf-next'
+          - config: '6.6'
             mode: 'minor'
             name: '4'
 
@@ -162,7 +162,7 @@ jobs:
             mode: 'patch'
             name: '7'
 
-          - config: 'bpf-next'
+          - config: '6.6'
             mode: 'patch'
             name: '8'
 

--- a/contrib/scripts/run-gh-ginkgo-workflow.sh
+++ b/contrib/scripts/run-gh-ginkgo-workflow.sh
@@ -134,7 +134,7 @@ install_vm_dep() {
 provision_kind() {
     local kernel_tag="$1" kubernetes_image="$2" ip_family="$3"
 
-    if [[ "${kernel_tag}" == bpf-next-* ]]; then
+    if [[ "${kernel_tag}" == 6.6-* ]]; then
         ${connect} "cd /host; ./contrib/scripts/kind.sh '' 2 '' ${kubernetes_image} none ${ip_family}"
         ${connect} kubectl label node kind-worker2 cilium.io/ci-node=kind-worker2
         ${connect} kubectl label node kind-worker2 node-role.kubernetes.io/controlplane=
@@ -156,7 +156,7 @@ run_tests() {
     local NO_CILIUM_ON_NODES=""
 
     case "${kernel_tag}" in
-        bpf-next-*)
+        6.6-*)
             K8S_NODES=3
             NETNEXT=1
             KERNEL=net-next


### PR DESCRIPTION
When creating a new stable branch, we switch from using the net-next image to the latest LTS version, which is currently 6.6. This helps avoid breaking our CI process due to newer kernel versions. However, this change means some tests, which are intended to run only with net-next, are skipped. As a result, we lose coverage for these tests when we move from net-next to the 6.6 LTS version. With this commit, the Ginkgo GitHub workflow will detect if the kernel version is 6.6 and set up Ginkgo to run as if it were net-next.


Fixes https://github.com/cilium/cilium/issues/33460