### PR TITLE
Optimize deallocation of node IDs

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/cidr"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
@@ -81,7 +82,7 @@ type linuxNodeHandler struct {
 	// Node-scoped unique IDs for the nodes.
 	nodeIDsByIPs map[string]uint16
 	// reverse map of the above
-	nodeIPsByIDs map[uint16]string
+	nodeIPsByIDs map[uint16]sets.Set[string]
 
 	ipsecMetricCollector prometheus.Collector
 	ipsecMetricOnce      sync.Once
@@ -135,7 +136,7 @@ func newNodeHandler(
 		nodeMap:                nodeMap,
 		nodeIDs:                idpool.NewIDPool(minNodeID, maxNodeID),
 		nodeIDsByIPs:           map[string]uint16{},
-		nodeIPsByIDs:           map[uint16]string{},
+		nodeIPsByIDs:           map[uint16]sets.Set[string]{},
 		ipsecMetricCollector:   ipsec.NewXFRMCollector(),
 		prefixClusterMutatorFn: func(node *nodeTypes.Node) []cmtypes.PrefixClusterOpts { return nil },
 		nodeNeighborQueue:      nbq,


### PR DESCRIPTION
Currently, node IDs deallocation loops through all the known IP to IDs mappings, introducing a quite significant performance overhead on node removal when the number of known nodes (and hence mappings) is high.

Let's improve this by leveraging the reverse nodeIPsByIDs map to remove the need for looping through all mappings. To this end, let's repurpose the already existing map to actually reflect the fact that IDs to IPs are a one to many relationship, as all the IPs of a given node are associated to the same node ID.

This also ensures that correctness of the data contained in the nodeIPsByIDs map, which instead currently only included the last inserted mapping, or none if an address was subsequently removed.