### PR TITLE
clustermesh: fix rare deadlock due to race condition

### DIFF
--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -267,7 +267,7 @@ func (rc *remoteCluster) getClusterConfig(ctx context.Context, backend kvstore.B
 	rc.config = &models.RemoteClusterConfig{Required: true}
 	rc.mutex.Unlock()
 
-	cfgch := make(chan types.CiliumClusterConfig)
+	cfgch := make(chan types.CiliumClusterConfig, 1)
 	defer close(cfgch)
 
 	// We retry here rather than simply returning an error and relying on the external


### PR DESCRIPTION
The clustermesh subsystem is currently affected by a possible, although rare, race condition in the cluster config retrieval logic, which can cause a deadlock due to attempting to write to an unbuffered channel no one is receiving from anymore.

More in detail, this can happen upon context expiration, as at that point the select statement unblocks, and the function returns, with a deferred function waiting for the termination of the controller. However, the controller body may still attempt to send to the channel, if the context got canceled after having already retrieved the cluster configuration.

While extremely unlikely to occur in a production environment, this issue manifested in CI \[1\], and can be reliably reproduced adding a sleep statement before sending to the `cfgch` channel, and running the `TestClusterMeshMultipleAddRemove` test.

Let's fix this by making the channel buffered, to ensure that the controller never blocks while attempting to send to it.

\[1\]: https://github.com/cilium/cilium/actions/runs/9887657579/job/27309862099

<!-- Description of change -->

```release-note
Fix rare race condition afflicting clustermesh while stopping the retrieval of the remote cluster configuration, possibly causing a deadlock 
```
