### PR TITLE
[v1.15] ci/ipsec: add missing config for patch-upgrade test with 6.6 kernel

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -150,6 +150,10 @@ jobs:
             mode: 'patch'
             name: '7'
 
+          - config: '6.6'
+            mode: 'patch'
+            name: '8'
+
     timeout-minutes: 70
     steps:
       - name: Checkout context ref (trusted)


### PR DESCRIPTION
As the title says.