### PR TITLE
[v1.14] ci/ipsec: add missing config for patch-upgrade test with 6.6 kernel

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -155,6 +155,10 @@ jobs:
             mode: 'patch'
             name: '7'
 
+          - config: '6.6'
+            mode: 'patch'
+            name: '8'
+
     timeout-minutes: 70
     steps:
       - name: Checkout context ref


### PR DESCRIPTION
As the title says.
