### PR TITLE
[v1.15] gh/e2e: fix up config 15 to not use bpf-next

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -246,10 +246,9 @@ jobs:
             egress-gateway: 'true'
             lb-acceleration: 'testing-only'
 
-
           - name: '15'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: 'bpf-next-20240307.011705'
+            kernel: '6.6-20240703.151759'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'


### PR DESCRIPTION
For the workflows in stable branches we prefer LTS kernels.