### PR TITLE
ci: add K8s 1.30 platform testing

### DIFF
--- a/.github/actions/aws-cni/k8s-versions.yaml
+++ b/.github/actions/aws-cni/k8s-versions.yaml
@@ -1,15 +1,15 @@
 # List of k8s version for EKS tests
 ---
 include:
-  - version: "1.26"
-    region: us-west-1
   - version: "1.27"
-    region: us-east-2
+    region: us-west-1
   - version: "1.28"
+    region: us-east-2
+  - version: "1.29"
     region: ca-central-1
     default: true
     kpr: true
-  - version: "1.29"
+  - version: "1.30"
     region: us-east-1
     default: true
     wireguard: true

--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -11,3 +11,8 @@ include:
     location: eastus
     index: 3
     default: true
+  - version: "1.30"
+    location: westus3
+    index: 4
+    preview: true
+    default: true

--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -1,17 +1,17 @@
 # List of k8s version for EKS tests
 ---
 include:
-  - version: "1.26"
-    region: us-west-1
   - version: "1.27"
+    region: us-west-1
+  - version: "1.28"
     region: us-east-2
     ipsec: true
-  - version: "1.28"
+  - version: "1.29"
     region: ca-central-1
     default: true
     ipsec: true
     kpr: true
-  - version: "1.29"
+  - version: "1.30"
     region: us-east-1
     ipsec: true
     default: true

--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,16 +1,16 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.26"
+  - version: "1.27"
     zone: us-west2-c
     vmIndex: 1
-  - version: "1.27"
+  - version: "1.28"
     zone: us-west3-a
     vmIndex: 2
-  - version: "1.28"
+  - version: "1.29"
     zone: us-east4-b
     vmIndex: 3
-  - version: "1.29"
+  - version: "1.30"
     zone: us-east1-c
     vmIndex: 4
     default: true

--- a/.github/actions/setup-eks-cluster/action.yml
+++ b/.github/actions/setup-eks-cluster/action.yml
@@ -44,7 +44,7 @@ runs:
           spot: ${{ inputs.spot }}
           privateNetworking: true
           volumeType: "gp3"
-          volumeSize: 10
+          volumeSize: 20
           taints:
            - key: "node.cilium.io/agent-not-ready"
              value: "true"
@@ -56,7 +56,7 @@ runs:
           spot: ${{ inputs.spot }}
           privateNetworking: true
           volumeType: "gp3"
-          volumeSize: 10
+          volumeSize: 20
           taints:
            - key: "node.cilium.io/agent-not-ready"
              value: "true"

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -213,6 +213,12 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_PR_SP_CREDS }}
 
+      - name: Install AKS preview extension
+        if: ${{ matrix.preview }}
+        run: |
+          az extension add --name aks-preview
+          az extension update --name aks-preview
+
       - name: Create AKS cluster
         run: |
           # Create group

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -16,13 +16,13 @@ on:
       extra-args:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
-        default: '{}'
+        default: "{}"
   push:
     branches:
-      - 'renovate/main-**'
+      - "renovate/main-**"
   # Run every 6 hours
   schedule:
-    - cron:  '0 1/6 * * *'
+    - cron: "0 1/6 * * *"
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.
@@ -202,6 +202,7 @@ jobs:
             --helm-set loadBalancer.l7.backend=envoy \
             --helm-set tls.secretsBackend=k8s \
             --helm-set=bpf.monitorAggregation=none \
+            --helm-set egress-masquerade-interface=ens5 \
             --wait=false"
           if [[ "${{ matrix.ipsec }}" == "true" ]]; then
             CILIUM_INSTALL_DEFAULTS+=" --helm-set encryption.enabled=true --helm-set encryption.type=ipsec"
@@ -364,7 +365,7 @@ jobs:
         if: ${{ matrix.ipsec == true }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
-          full-test: 'true'
+          full-test: "true"
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Post-test information gathering
@@ -436,8 +437,7 @@ jobs:
         with:
           sha: ${{ inputs.SHA || github.sha }}
           status: ${{ github.event_name != 'schedule' && 'success' || 'failure' }}
-          description: 'Skipped'
-
+          description: "Skipped"
 
   cleanup:
     name: Cleanup EKS Clusters


### PR DESCRIPTION
Support for K8s 1.30 was added earlier via f2b0a66e40ef20b787fd59e08095bcc540cb087b, at which time support for K8s 1.26 was also dropped.

As usual, we update K8s versions tested on platforms now that K8s 1.30 is available on them.

In addition, we introduce the possibility to use the `aks-preview` extension for AKS CI.

(note: this PR depends on #33770 being merged first)