### PR TITLE
docs: Assume ready-to-merge is not for humans

### DIFF
--- a/Documentation/contributing/development/reviewers_committers/review_process.rst
+++ b/Documentation/contributing/development/reviewers_committers/review_process.rst
@@ -28,9 +28,8 @@ Review process
    ensure it gets reviewed and merged.
 
    If the contributor is a Cilium committer, then they are responsible for
-   getting the PR in a ready to be merged state by adding the
-   ``ready-to-merge`` label, once all reviews have been addressed and CI checks
-   are successful, so that they (or another committer) can merge the PR.
+   getting the PR ready to be merged by addressing review comments and
+   resolving all CI checks for "Required" workflows.
 
    If this PR is a backport PR (typically with the label ``kind/backport``) and
    no-one else has reviewed the PR, review the changes as a sanity check. If
@@ -153,16 +152,11 @@ that require review in the `filter <team_review_filter_>`_.
    :scale: 50%
 
 When all review objectives for all ``CODEOWNERS`` are met, all required CI
-tests have passed and a proper release label is set, you may set the
-``ready-to-merge`` label to indicate that all criteria have been met.
-Maintainer's little helper might set this label automatically if the previous
-requirements were met.
-
-+--------------------------+---------------------------+
-| Labels                   | When to set               |
-+==========================+===========================+
-| ``ready-to-merge``       | PR is ready to be merged  |
-+--------------------------+---------------------------+
+tests have passed and a proper release label is set, a PR may be merged by any
+committer with access rights to click the green merge button.
+Maintainer's little helper may set the ``ready-to-merge`` label automatically
+to recognize the state of the PR. Periodically, a rotating assigned committer
+will review the list of PRs that are marked ``ready-to-merge``.
 
 .. _committers team: https://github.com/orgs/cilium/teams/committers/members
 .. _community repository: https://github.com/cilium/community


### PR DESCRIPTION
Cilium committers today in general have access to merge PRs that both
(a) have all codeowner reviews covered for the PR, and
(b) all required workflows are passing their tests for the PR.

The committer then takes responsibility if they decide to merge the PR.
For instance, if the PR passes CI but introduces unreliability into the
testsuite, then they should be proactive about addressing any problems
introduced by the PR, preparing a revert if necessary, or facilitating
the revert if another solution cannot be proposed within a reasonable
timeframe.

Once a PR passes workflow checks and has all required codeowner
approvals, the Maintainer's Little Helper should set the
"ready-to-merge" label. @cilium/tophat will periodically review the list
of PRs that are ready to merge, and will merge them. In particular this
helps with processing contributions from members of the community
who are not committers.

We have previously experienced situations where contributors may
set the "ready-to-merge" label before the required review and testing
steps have been completed, and this can lead to breakage in the main
branch. This should be avoided wherever possible. As such, this commit
removes wording that presumes that _humans_ will set the label, and
prefers wording where it is assumed that _robots_ will set the label,
then humans may be there mostly for a sanity check.

This should help to formalize generally two expectations for PRs:
- All PRs must pass all required CI checks. Always use /test commands.
- Do not use "ready-to-merge" label as a way to bypass required checks.

There will always be exceptions to these rules, and we can deal with
those exceptions on an ad-hoc basis through communication on the PR. If
the above rules are not working very well, then we can also iterate on
the implementation of them to make them work better, for instance by
reviewing codeowners groups, adjusting required CI jobs, or making
Ariane smarter to detect required tests to skip more accurately.

Related: https://github.com/cilium/cilium/issues/32269