### PR TITLE
perf: Run cilium-cli inside Docker

### DIFF
--- a/.github/workflows/fqdn-perf.yaml
+++ b/.github/workflows/fqdn-perf.yaml
@@ -148,12 +148,6 @@ jobs:
         with:
           go-version: ${{ env.go_version }}
 
-      - name: Install Cilium CLI
-        uses: cilium/cilium-cli@1afb3ff7eb6ace8ab5f8d4d844afe02e2018bb4e # v0.16.13
-        with:
-          repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
-          release-version: ${{ env.CILIUM_CLI_VERSION }}
-
       - name: Install Kops
         uses: cilium/scale-tests-action/install-kops@dbd0721db1b3c6ef71644a7df205842252fc7c11 # main
 
@@ -185,17 +179,6 @@ jobs:
           sparse-checkout: clusterloader2
           path: perf-tests
 
-      - name: Display version info of installed tools
-        run: |
-          echo "--- go ---"
-          go version
-          echo "--- cilium-cli ---"
-          cilium version --client
-          echo "--- kops ---"
-          ./kops version
-          echo "--- gcloud ---"
-          gcloud version
-
       - name: Deploy cluster
         id: deploy-cluster
         uses: cilium/scale-tests-action/create-cluster@dbd0721db1b3c6ef71644a7df205842252fc7c11 # main
@@ -208,6 +191,24 @@ jobs:
           node_count: 2
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
           project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
+
+      - name: Install Cilium CLI
+        uses: cilium/cilium-cli@1afb3ff7eb6ace8ab5f8d4d844afe02e2018bb4e # v0.16.13
+        with:
+          skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
+          image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
+          image-tag: ${{ env.CILIUM_CLI_VERSION }}
+
+      - name: Display version info of installed tools
+        run: |
+          echo "--- go ---"
+          go version
+          echo "--- cilium-cli ---"
+          cilium version --client
+          echo "--- kops ---"
+          ./kops version
+          echo "--- gcloud ---"
+          gcloud version
 
       - name: Setup firewall rules
         uses: cilium/scale-tests-action/setup-firewall@dbd0721db1b3c6ef71644a7df205842252fc7c11 # main

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -235,13 +235,6 @@ jobs:
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo owner=${OWNER} >> $GITHUB_OUTPUT
 
-      - name: Install Cilium CLI
-        uses: cilium/cilium-cli@1afb3ff7eb6ace8ab5f8d4d844afe02e2018bb4e # v0.16.13
-        with:
-          repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
-          release-version: ${{ env.CILIUM_CLI_VERSION }}
-          ci-version: ${{ env.cilium_cli_ci_version }}
-
       - name: Set up gcloud credentials
         id: 'auth'
         uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
@@ -286,6 +279,13 @@ jobs:
         run: |
           gcloud container clusters get-credentials ${{ env.clusterName }}-${{ matrix.index }} --zone ${{ env.gcp_zone }}
 
+      - name: Install Cilium CLI
+        uses: cilium/cilium-cli@1afb3ff7eb6ace8ab5f8d4d844afe02e2018bb4e # v0.16.13
+        with:
+          skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
+          image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
+          image-tag: ${{ env.CILIUM_CLI_VERSION }}
+
       - name: Wait for images to be available
         timeout-minutes: 30
         shell: bash
@@ -316,12 +316,14 @@ jobs:
         run: |
           mkdir output
           cilium connectivity perf --duration=30s --host-net=true --pod-net=true --report-dir=./output
+          sudo chmod -R +r ./output
 
       - name: Get sysdump
         if: ${{ always() && steps.run-perf.outcome != 'skipped' && steps.run-perf.outcome != 'cancelled' }}
         run: |
           cilium status
           cilium sysdump --output-filename cilium-sysdump-final
+          sudo chmod +r cilium-sysdump-final.zip
 
       - name: Clean up GKE
         if: ${{ always() }}

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -150,12 +150,6 @@ jobs:
         with:
           go-version: ${{ env.go_version }}
 
-      - name: Install Cilium CLI
-        uses: cilium/cilium-cli@1afb3ff7eb6ace8ab5f8d4d844afe02e2018bb4e # v0.16.13
-        with:
-          repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
-          release-version: ${{ env.CILIUM_CLI_VERSION }}
-
       - name: Install Kops
         uses: cilium/scale-tests-action/install-kops@dbd0721db1b3c6ef71644a7df205842252fc7c11 # main
 
@@ -187,17 +181,6 @@ jobs:
           sparse-checkout: clusterloader2
           path: perf-tests
 
-      - name: Display version info of installed tools
-        run: |
-          echo "--- go ---"
-          go version
-          echo "--- cilium-cli ---"
-          cilium version --client
-          echo "--- kops ---"
-          ./kops version
-          echo "--- gcloud ---"
-          gcloud version
-
       - name: Deploy cluster
         id: deploy-cluster
         uses: cilium/scale-tests-action/create-cluster@dbd0721db1b3c6ef71644a7df205842252fc7c11 # main
@@ -210,6 +193,24 @@ jobs:
           node_count: 100
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
           project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
+
+      - name: Install Cilium CLI
+        uses: cilium/cilium-cli@1afb3ff7eb6ace8ab5f8d4d844afe02e2018bb4e # v0.16.13
+        with:
+          skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
+          image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
+          image-tag: ${{ env.CILIUM_CLI_VERSION }}
+
+      - name: Display version info of installed tools
+        run: |
+          echo "--- go ---"
+          go version
+          echo "--- cilium-cli ---"
+          cilium version --client
+          echo "--- kops ---"
+          ./kops version
+          echo "--- gcloud ---"
+          gcloud version
 
       - name: Create Instance Group for resource heavy deployments
         uses: cilium/scale-tests-action/create-instance-group@dbd0721db1b3c6ef71644a7df205842252fc7c11 # main
@@ -290,6 +291,7 @@ jobs:
         run: |
           cilium status
           cilium sysdump --output-filename cilium-sysdump-final
+          sudo chmod +r cilium-sysdump-final.zip
 
       - name: Cleanup cluster
         if: ${{ always() && steps.deploy-cluster.outcome != 'skipped' }}

--- a/.github/workflows/scale-test-clustermesh.yaml
+++ b/.github/workflows/scale-test-clustermesh.yaml
@@ -128,12 +128,6 @@ jobs:
         with:
           go-version: ${{ env.go_version }}
 
-      - name: Install Cilium CLI
-        uses: cilium/cilium-cli@1afb3ff7eb6ace8ab5f8d4d844afe02e2018bb4e # v0.16.13
-        with:
-          repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
-          release-version: ${{ env.CILIUM_CLI_VERSION }}
-
       - name: Install Kops
         uses: cilium/scale-tests-action/install-kops@dbd0721db1b3c6ef71644a7df205842252fc7c11 # main
 
@@ -174,17 +168,6 @@ jobs:
           sparse-checkout: cmapisrv-mock
           path: scaffolding
 
-      - name: Display version info of installed tools
-        run: |
-          echo "--- go ---"
-          go version
-          echo "--- cilium-cli ---"
-          cilium version --client
-          echo "--- kops ---"
-          ./kops version
-          echo "--- gcloud ---"
-          gcloud version
-
       - name: Deploy cluster
         id: deploy-cluster
         uses: cilium/scale-tests-action/create-cluster@dbd0721db1b3c6ef71644a7df205842252fc7c11 # main
@@ -199,6 +182,24 @@ jobs:
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
           project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
           kube_proxy_enabled: false
+
+      - name: Install Cilium CLI
+        uses: cilium/cilium-cli@1afb3ff7eb6ace8ab5f8d4d844afe02e2018bb4e # v0.16.13
+        with:
+          skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
+          image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
+          image-tag: ${{ env.CILIUM_CLI_VERSION }}
+
+      - name: Display version info of installed tools
+        run: |
+          echo "--- go ---"
+          go version
+          echo "--- cilium-cli ---"
+          cilium version --client
+          echo "--- kops ---"
+          ./kops version
+          echo "--- gcloud ---"
+          gcloud version
 
       - name: Setup firewall rules
         uses: cilium/scale-tests-action/setup-firewall@dbd0721db1b3c6ef71644a7df205842252fc7c11 # main

--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -97,12 +97,6 @@ jobs:
         with:
           go-version: ${{ env.go_version }}
 
-      - name: Install Cilium CLI
-        uses: cilium/cilium-cli@1afb3ff7eb6ace8ab5f8d4d844afe02e2018bb4e # v0.16.13
-        with:
-          repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
-          release-version: ${{ env.CILIUM_CLI_VERSION }}
-
       - name: Install Kops
         uses: cilium/scale-tests-action/install-kops@dbd0721db1b3c6ef71644a7df205842252fc7c11 # main
 
@@ -133,17 +127,6 @@ jobs:
           persist-credentials: false
           sparse-checkout: clusterloader2
           path: perf-tests
-      
-      - name: Display version info of installed tools
-        run: |
-          echo "--- go ---"
-          go version
-          echo "--- cilium-cli ---"
-          cilium version --client
-          echo "--- kops ---"
-          ./kops version
-          echo "--- gcloud ---"
-          gcloud version
 
       - name: Deploy cluster
         id: deploy-cluster
@@ -157,12 +140,30 @@ jobs:
           node_count: 1
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
           project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
-      
+
+      - name: Install Cilium CLI
+        uses: cilium/cilium-cli@1afb3ff7eb6ace8ab5f8d4d844afe02e2018bb4e # v0.16.13
+        with:
+          skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
+          image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
+          image-tag: ${{ env.CILIUM_CLI_VERSION }}
+
+      - name: Display version info of installed tools
+        run: |
+          echo "--- go ---"
+          go version
+          echo "--- cilium-cli ---"
+          cilium version --client
+          echo "--- kops ---"
+          ./kops version
+          echo "--- gcloud ---"
+          gcloud version
+
       - name: Setup firewall rules
         uses: cilium/scale-tests-action/setup-firewall@dbd0721db1b3c6ef71644a7df205842252fc7c11 # main
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
-      
+
       - name: Install Cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}


### PR DESCRIPTION
- Run cilium-cli inside a container in preparation to merge cilium-cli repo to cilium repo as proposed in CFP-25694 [^1].
- Move "Install Cilium CLI" step after the cluster creation step so that cilium-cli can access .kube/config file.
- Run chmod +r on files created inside the cilium-cli container to avoid getting permission denied errors at the "Export results and sysdump to GS bucket" step.

[^1]: https://github.com/cilium/design-cfps/pull/9