### PR TITLE
CODEOWNERS: assign etcdinit to both kvstore and clustermesh teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -488,6 +488,7 @@ Makefile* @cilium/build
 /pkg/k8s/apis/cilium.io/v2/cegp_types.go @cilium/egress-gateway
 /pkg/k8s/apis/cilium.io/v2/ @cilium/api @cilium/sig-k8s
 /pkg/kvstore/ @cilium/kvstore
+/pkg/kvstore/etcdinit @cilium/sig-clustermesh @cilium/kvstore
 /pkg/l2announcer/ @cilium/sig-agent
 /pkg/labels @cilium/sig-policy @cilium/api
 /pkg/labelsfilter @cilium/sig-policy


### PR DESCRIPTION
The etcdinit logic is used as part of the clustermesh-apiserver init container responsible for performing the etcd initialization, mainly with respect to users and roles. Hence, let's update the codeowners file to assign it to both the kvstore and clustermesh teams.
