### PR TITLE
[v1.16] ci: Add call backport label udpater workflow

### DIFF
--- a/.github/workflows/call-backport-label-updater.yaml
+++ b/.github/workflows/call-backport-label-updater.yaml
@@ -1,0 +1,44 @@
+---
+  name: Call Backport Label Updater
+  on:
+    pull_request_target:
+      types:
+        - closed
+      branches:
+        - v[0-9]+.[0-9]+
+
+  jobs:
+    get-branch:
+      name: Detect base branch
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          branch: ["1.14", "1.15", "1.16"]
+      outputs:
+          version: ${{ steps.get-branch.outputs.version }}
+      if: |
+        github.event.pull_request.merged == true &&
+        contains(github.event.pull_request.body, 'upstream-prs') &&
+        contains(join(github.event.pull_request.labels.*.name, ', '), 'backport/')
+      steps:
+        - name: Get Branch
+          id: get-branch
+          env:
+            LABELS: ${{ toJson(github.event.pull_request.labels) }}
+          run: |
+            echo "${LABELS}" | jq -c -r '.[].name' | while read -r label; do
+              if [ "${label}" = "backport/${{ matrix.branch }}" ]; then
+                echo "version=${{ matrix.branch }}" >> "$GITHUB_OUTPUT"
+                break
+              fi
+            done
+
+    call-backport-label-updater:
+      name: Update backport labels for upstream PR
+      needs: get-branch
+      if: ${{needs.get-branch.outputs.version}} != ''
+      uses: cilium/cilium/.github/workflows/update-label-backport-pr.yaml@main
+      with:
+        pr-body: ${{ github.event.pull_request.body }}
+        branch: ${{needs.get-branch.outputs.version}}
+      secrets: inherit


### PR DESCRIPTION
Add the file for the "Call Backport Label Updater". This enables the workflow that updates the backport PRs label for v1.16 stable branch.

The branch matrix has been updated to include the new stable branch.

Fixes: f5bdf28e8a ("Prepare v1.16 stable branch")

For more info about how the workflow works across the stable branches, see https://github.com/cilium/cilium/pull/29902#issuecomment-1878365319