### PR TITLE
ci: Update branch matrix list in call-backport-label-updater

### DIFF
--- a/.github/workflows/call-backport-label-updater.yaml
+++ b/.github/workflows/call-backport-label-updater.yaml
@@ -13,7 +13,7 @@
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          branch: ["1.12", "1.13", "1.14", "1.15", "1.16"]
+          branch: ["1.14", "1.15", "1.16", "1.17"]
       outputs:
           version: ${{ steps.get-branch.outputs.version }}
       if: |


### PR DESCRIPTION
In the main branch Call Backport Label Updater workflow is just a placeholder that should be copied to each new stable branch just after creation.  Doing that enables the workflow in the stable branch to automatically update the backport PRs labels once they get merged.

In order to be ready for the next stable branch (v1.17), update the list to include the last three stable versions plus v1.17.

For more info about how the workflow works across the stable branches, see https://github.com/cilium/cilium/pull/29902#issuecomment-1878365319

Related: https://github.com/cilium/release/pull/227