### PR TITLE
wireguard: minor improvements for to-wireguard program

### DIFF
--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -22,12 +22,16 @@ int cil_to_wireguard(struct __ctx_buff *ctx)
 	int __maybe_unused ret;
 	__s8 __maybe_unused ext_err = 0;
 	__u16 __maybe_unused proto = ctx_get_protocol(ctx);
-	__u32 __maybe_unused src_sec_identity = get_identity(ctx);
+	__u32 __maybe_unused src_sec_identity = UNKNOWN_ID;
+	__u32 magic = ctx->mark & MARK_MAGIC_HOST_MASK;
 
 	struct trace_ctx __maybe_unused trace = {
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = 0,
 	};
+
+	if (magic == MARK_MAGIC_IDENTITY)
+		src_sec_identity = get_identity(ctx);
 
 	bpf_clear_meta(ctx);
 

--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -36,10 +36,15 @@ int cil_to_wireguard(struct __ctx_buff *ctx)
 	bpf_clear_meta(ctx);
 
 #ifdef ENABLE_NODEPORT
+	if (magic == MARK_MAGIC_OVERLAY)
+		goto out;
+
 	ret = handle_nat_fwd(ctx, 0, proto, &trace, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
 						  CTX_ACT_DROP, METRIC_EGRESS);
+
+out:
 #endif /* ENABLE_NODEPORT */
 
 	return TC_ACT_OK;

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -70,7 +70,7 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 		 * IPv4 tunneling.
 		 */
 		if (ctx_is_overlay(ctx))
-			goto encrypt;
+			goto overlay_encrypt;
 # endif /* HAVE_ENCAP */
 
 		dst = lookup_ip4_remote_endpoint(ip4->daddr, 0);
@@ -129,9 +129,9 @@ maybe_encrypt: __maybe_unused
 	 * required.
 	 */
 	if (dst && dst->key) {
-encrypt: __maybe_unused
 		if (src)
 			set_identity_mark(ctx, src->sec_identity, MARK_MAGIC_IDENTITY);
+overlay_encrypt: __maybe_unused
 		return ctx_redirect(ctx, WG_IFINDEX, 0);
 	}
 


### PR DESCRIPTION
Fine-tune the `skb->mark` handling in `to-wireguard`.
