### PR TITLE
ci-e2e: Set up node local DNS in conformance-e2e

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -168,6 +168,7 @@ jobs:
             lb-acceleration: 'testing-only'
             ingress-controller: 'true'
             local-redirect-policy: 'true'
+            node-local-dns: 'true'
 
           - name: '8'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -429,6 +430,7 @@ jobs:
           path: untrusted
           sparse-checkout: |
             install/kubernetes/cilium
+            examples
 
       - name: Wait for images to be available
         timeout-minutes: 30
@@ -452,6 +454,15 @@ jobs:
           kubectl -n kube-system exec daemonset/cilium -- cilium-dbg status
 
           mkdir -p cilium-junits
+
+      - name: Install node local DNS
+        if: ${{ matrix.node-local-dns == 'true' }}
+        shell: bash
+        run: |
+          kubedns=$(kubectl get svc kube-dns -n kube-system -o jsonpath={.spec.clusterIP}) && sed -i "s/__PILLAR__DNS__SERVER__/$kubedns/g;" untrusted/examples/kubernetes-local-redirect/node-local-dns.yaml
+          sed -i "s/__PILLAR__UPSTREAM__SERVERS__/1.1.1.1/g;" untrusted/examples/kubernetes-local-redirect/node-local-dns.yaml
+          kubectl apply -k untrusted/examples/kubernetes-local-redirect
+          kubectl rollout status -n kube-system ds/node-local-dns
 
       - name: Run tests
         shell: bash

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -170,6 +170,8 @@ jobs:
             # Disable until https://github.com/cilium/cilium/issues/30717
             # has been resolved.
             # ingress-controller: 'true'
+            local-redirect-policy: 'true'
+            node-local-dns: 'true'
 
           - name: '8'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -391,6 +393,7 @@ jobs:
           ingress-controller: ${{ matrix.ingress-controller }}
           misc: ${{ matrix.misc || 'bpfClockProbe=false,cni.uninstall=false' }}
           ciliumendpointslice: ${{ matrix.ciliumendpointslice }}
+          local-redirect-policy: ${{ matrix.local-redirect-policy }}
           bgp-control-plane: ${{ matrix.bgp-control-plane }}
 
       - name: Derive newest Cilium installation config
@@ -414,6 +417,7 @@ jobs:
           ingress-controller: ${{ matrix.ingress-controller }}
           misc: ${{ matrix.misc || 'bpfClockProbe=false,cni.uninstall=false' }}
           ciliumendpointslice: ${{ matrix.ciliumendpointslice }}
+          local-redirect-policy: ${{ matrix.local-redirect-policy }}
           bgp-control-plane: ${{ matrix.bgp-control-plane }}
 
       - name: Set Kind params
@@ -451,6 +455,7 @@ jobs:
           path: untrusted/cilium-newest
           sparse-checkout: |
             install/kubernetes/cilium
+            examples
 
       - name: Checkout ${{ steps.vars.outputs.downgrade_version }} branch to get the Helm chart
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -482,6 +487,15 @@ jobs:
           kubectl -n kube-system exec daemonset/cilium -- cilium status
 
           mkdir -p cilium-junits
+
+      - name: Install node local DNS
+        if: ${{ matrix.node-local-dns == 'true' }}
+        shell: bash
+        run: |
+          kubedns=$(kubectl get svc kube-dns -n kube-system -o jsonpath={.spec.clusterIP}) && sed -i "s/__PILLAR__DNS__SERVER__/$kubedns/g;" untrusted/cilium-newest/examples/kubernetes-local-redirect/node-local-dns.yaml
+          sed -i "s/__PILLAR__UPSTREAM__SERVERS__/1.1.1.1/g;" untrusted/cilium-newest/examples/kubernetes-local-redirect/node-local-dns.yaml
+          kubectl apply -k untrusted/cilium-newest/examples/kubernetes-local-redirect
+          kubectl rollout status -n kube-system ds/node-local-dns
 
       - name: Start conn-disrupt-test
         shell: bash

--- a/examples/kubernetes-local-redirect/kustomization.yaml
+++ b/examples/kubernetes-local-redirect/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - node-local-dns.yaml
+  - node-local-dns-lrp.yaml
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: node-local-dns
+    patch: |-
+      - op: add
+        path: /spec/template/spec/affinity
+        value:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: cilium.io/no-schedule
+                  operator: NotIn
+                  values:
+                  - "true"


### PR DESCRIPTION
This PR introduces node local DNS with LRP in conformance-e2e following the LRP document, and run `local-redirect-policy-with-node-dns` test.

https://docs.cilium.io/en/stable/network/kubernetes/local-redirect-policy/#node-local-dns-cache