### PR TITLE
workflow: Use per-tunnel keys for the IPsec upgrade test

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -362,7 +362,7 @@ jobs:
         run: |
           kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
           kubectl create -n kube-system secret generic cilium-ipsec-keys \
-              --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
+              --from-literal=keys="3+ rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 
           mkdir -p cilium-junits
 


### PR DESCRIPTION
All users should now be using per-tunnel keys (that is, with the + sign in the IPsec secret) instead of the insecure global key. Our up/downgrade test for IPsec should therefore reflect that.