### PR TITLE
ci: allow all GKE K8s release channels

### DIFF
--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -145,7 +145,7 @@ jobs:
             VERSION=$(echo $i | jq -r '.version')
             ZONE=$(echo $i | jq -r '.zone')
             gcloud --quiet container get-server-config \
-              --flatten="channels" --filter="channels.channel=REGULAR"   \
+              --flatten="channels" \
               --format="yaml(channels.validVersions)" --zone $ZONE > /tmp/output
             if grep -q -F $VERSION /tmp/output; then
               echo "Version $VERSION is valid for zone $ZONE"

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -150,7 +150,7 @@ jobs:
             VERSION=$(echo $i | jq -r '.version')
             ZONE=$(echo $i | jq -r '.zone')
             gcloud --quiet container get-server-config \
-              --flatten="channels" --filter="channels.channel=REGULAR"   \
+              --flatten="channels" \
               --format="yaml(channels.validVersions)" --zone $ZONE > /tmp/output
             if grep -q -F $VERSION /tmp/output; then
               echo "Version $VERSION is valid for zone $ZONE"


### PR DESCRIPTION
In dd947b3a383098a5df39616a2a8850ac64072bcd, we introduced filtering of supported K8s versions for GKE, but restricted it to the regular release channel.

However, new versions of K8s are added to the rapid release channel, and older K8s versions might stick around longer in the stable release channel, and we do not specifically request any release channel to be used when we create clusters, so we want all release channels to be considered for availability in the filtering mechanism.