### PR TITLE
Makefile: Fix bench flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ GOTEST_BASE := -timeout 600s
 GOTEST_COVER_OPTS += -coverprofile=coverage.out
 BENCH_EVAL := "."
 BENCH ?= $(BENCH_EVAL)
-BENCHFLAGS_EVAL := -bench=$(BENCH) -run=^$ -benchtime=10s
+BENCHFLAGS_EVAL := -bench=$(BENCH) -run=^$$ -benchtime=10s
 BENCHFLAGS ?= $(BENCHFLAGS_EVAL)
 SKIP_KVSTORES ?= "false"
 SKIP_K8S_CODE_GEN_CHECK ?= "true"


### PR DESCRIPTION
The `$` here was not being escaped properly to send into the command,
which meant that it was dropped when passed to the underlying go bench
command. Either way it still seemed to work, but probably broke the
following benchtime flag. Fix it.

Before:

```
$ sudo -E make bench-privileged BENCH=BenchmarkMapBatchLookup TESTPKGS=pkg/maps/ctmap
PRIVILEGED_TESTS=true CGO_ENABLED=0 go test -mod=vendor -vet=all -tags=osusergo  -timeout 600s -bench=BenchmarkMapBatchLookup -run=^-benchtime=10s pkg/maps/ctmap
...
```

After:

```
$ sudo -E make bench-privileged BENCH=BenchmarkMapBatchLookup TESTPKGS=./pkg/maps/ctmap
PRIVILEGED_TESTS=true CGO_ENABLED=0 go test -mod=vendor -vet=all -tags=osusergo  -timeout 600s -bench=BenchmarkMapBatchLookup -run=^$ -benchtime=10s ./pkg/maps/ctmap
...
```
