### PR TITLE
Extended k8sServiceHost=auto options

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2357,7 +2357,15 @@
      - bool
      - ``true``
    * - :spelling:ignore:`k8sServiceHost`
-     - Kubernetes service host - use "auto" for automatic lookup from the cluster-info ConfigMap (kubeadm-based clusters only)
+     - Kubernetes service host - use "auto" for automatic lookup from the cluster-info ConfigMap
+     - string
+     - ``""``
+   * - :spelling:ignore:`k8sServiceLookupConfigMapName`
+     - When ``k8sServiceHost=auto``\ , allows to customize the configMap name. It defaults to ``cluster-info``.
+     - string
+     - ``""``
+   * - :spelling:ignore:`k8sServiceLookupNamespace`
+     - When ``k8sServiceHost=auto``\ , allows to customize the namespace that contains ``k8sServiceLookupConfigMapName``. It defaults to ``kube-public``.
      - string
      - ``""``
    * - :spelling:ignore:`k8sServicePort`

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -457,6 +457,9 @@ kubespray
 kvstore
 kvstoremesh
 kvstores
+k8sServiceHost
+k8sServiceLookupConfigMapName
+k8sServiceLookupNamespace
 lan
 latencies
 leia

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -639,7 +639,9 @@ contributors across the globe, there is almost always someone available to help.
 | k8sClientRateLimit.operator.qps | int | 100 | The sustained request rate in requests per second. |
 | k8sClientRateLimit.qps | int | 10 | The sustained request rate in requests per second. |
 | k8sNetworkPolicy.enabled | bool | `true` | Enable support for K8s NetworkPolicy |
-| k8sServiceHost | string | `""` | Kubernetes service host - use "auto" for automatic lookup from the cluster-info ConfigMap (kubeadm-based clusters only) |
+| k8sServiceHost | string | `""` | Kubernetes service host - use "auto" for automatic lookup from the cluster-info ConfigMap |
+| k8sServiceLookupConfigMapName | string | `""` | When `k8sServiceHost=auto`, allows to customize the configMap name. It defaults to `cluster-info`. |
+| k8sServiceLookupNamespace | string | `""` | When `k8sServiceHost=auto`, allows to customize the namespace that contains `k8sServiceLookupConfigMapName`. It defaults to `kube-public`. |
 | k8sServicePort | string | `""` | Kubernetes service port |
 | keepDeprecatedLabels | bool | `false` | Keep the deprecated selector labels when deploying Cilium DaemonSet. |
 | keepDeprecatedProbes | bool | `false` | Keep the deprecated probes when deploying Cilium DaemonSet |

--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -112,11 +112,16 @@ Convert a map to a comma-separated string: key1=value1,key2=value2
 {{- end -}}
 
 {{/*
-Enable automatic lookup of k8sServiceHost from the cluster-info ConfigMap (kubeadm-based clusters only)
+Enable automatic lookup of k8sServiceHost from the cluster-info ConfigMap
+When `auto`, it defaults to lookup for a `cluster-info` configmap on the `kube-public` namespace (kubeadm-based)
+To override the namespace and configMap when using `auto`:
+`.Values.k8sServiceLookupNamespace` and `.Values.k8sServiceLookupConfigMapName`
 */}}
 {{- define "k8sServiceHost" }}
   {{- if eq .Values.k8sServiceHost "auto" }}
-    {{- $configmap := (lookup "v1" "ConfigMap" "kube-public" "cluster-info") }}
+    {{- $configmapName := default "cluster-info" .Values.k8sServiceLookupConfigMapName }}
+    {{- $configmapNamespace := default "kube-public" .Values.k8sServiceLookupNamespace }}
+    {{- $configmap := (lookup "v1" "ConfigMap" $configmapNamespace $configmapName) }}
     {{- $kubeconfig := get $configmap.data "kubeconfig" }}
     {{- $k8sServer := get ($kubeconfig | fromYaml) "clusters" | mustFirst | dig "cluster" "server" "" }}
     {{- $uri := (split "https://" $k8sServer)._1 | trim }}
@@ -127,11 +132,16 @@ Enable automatic lookup of k8sServiceHost from the cluster-info ConfigMap (kubea
 {{- end }}
 
 {{/*
-Enable automatic lookup of k8sServicePort from the cluster-info ConfigMap (kubeadm-based clusters only)
+Enable automatic lookup of k8sServicePort from the cluster-info ConfigMap
+When `auto`, it defaults to lookup for a `cluster-info` configmap on the `kube-public` namespace (kubeadm-based)
+To override the namespace and configMap when using `auto`:
+`.Values.k8sServiceLookupNamespace` and `.Values.k8sServiceLookupConfigMapName`
 */}}
 {{- define "k8sServicePort" }}
   {{- if eq .Values.k8sServiceHost "auto" }}
-    {{- $configmap := (lookup "v1" "ConfigMap" "kube-public" "cluster-info") }}
+    {{- $configmapName := default "cluster-info" .Values.k8sServiceLookupConfigMapName }}
+    {{- $configmapNamespace := default "kube-public" .Values.k8sServiceLookupNamespace }}
+    {{- $configmap := (lookup "v1" "ConfigMap" $configmapNamespace $configmapName) }}
     {{- $kubeconfig := get $configmap.data "kubeconfig" }}
     {{- $k8sServer := get ($kubeconfig | fromYaml) "clusters" | mustFirst | dig "cluster" "server" "" }}
     {{- $uri := (split "https://" $k8sServer)._1 | trim }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -3774,6 +3774,18 @@
     "k8sServiceHost": {
       "type": "string"
     },
+    "k8sServiceLookupConfigMapName": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "k8sServiceLookupNamespace": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "k8sServicePort": {
       "type": [
         "string",

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -39,13 +39,23 @@ imagePullSecrets: []
 # -- (string) Kubernetes config path
 # @default -- `"~/.kube/config"`
 kubeConfigPath: ""
-# -- (string) Kubernetes service host - use "auto" for automatic lookup from the cluster-info ConfigMap (kubeadm-based clusters only)
+# -- (string) Kubernetes service host - use "auto" for automatic lookup from the cluster-info ConfigMap
 k8sServiceHost: ""
 # @schema
 # type: [string, integer]
 # @schema
 # -- (string) Kubernetes service port
 k8sServicePort: ""
+# @schema
+# type: [null, string]
+# @schema
+# -- (string) When `k8sServiceHost=auto`, allows to customize the configMap name. It defaults to `cluster-info`.
+k8sServiceLookupConfigMapName: ""
+# @schema
+# type: [null, string]
+# @schema
+# -- (string) When `k8sServiceHost=auto`, allows to customize the namespace that contains `k8sServiceLookupConfigMapName`. It defaults to `kube-public`.
+k8sServiceLookupNamespace: ""
 # -- Configure the client side rate limit for the agent
 #
 # If the amount of requests to the Kubernetes API server exceeds the configured

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -37,13 +37,23 @@ imagePullSecrets: []
 # -- (string) Kubernetes config path
 # @default -- `"~/.kube/config"`
 kubeConfigPath: ""
-# -- (string) Kubernetes service host - use "auto" for automatic lookup from the cluster-info ConfigMap (kubeadm-based clusters only)
+# -- (string) Kubernetes service host - use "auto" for automatic lookup from the cluster-info ConfigMap
 k8sServiceHost: ""
 # @schema
 # type: [string, integer]
 # @schema
 # -- (string) Kubernetes service port
 k8sServicePort: ""
+# @schema
+# type: [null, string]
+# @schema
+# -- (string) When `k8sServiceHost=auto`, allows to customize the configMap name. It defaults to `cluster-info`.
+k8sServiceLookupConfigMapName: ""
+# @schema
+# type: [null, string]
+# @schema
+# -- (string) When `k8sServiceHost=auto`, allows to customize the namespace that contains `k8sServiceLookupConfigMapName`. It defaults to `kube-public`.
+k8sServiceLookupNamespace: ""
 # -- Configure the client side rate limit for the agent
 #
 # If the amount of requests to the Kubernetes API server exceeds the configured


### PR DESCRIPTION
This commit extends the `k8sServiceHost=auto` usage to allow the user to determine the namespace and configmap to be used to retrieve the KubeAPI and KubeAPI port respectively.

This already great for kubeadm-based clusters. Therefore, exposing the configuration would allow other user cases.

The default behavior was not modified when using `k8sServiceHost=auto`.

The new introduced parameters are optional.
```release-note
helm: Allow user to configure the namespace used to look up the kube-api server address and port.
```