### PR TITLE
operator: set k8s client default rate limit to 100 QPS

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1189,8 +1189,12 @@ data:
   annotate-k8s-node: "true"
 {{- end }}
 
-  k8s-client-qps: {{ .Values.k8sClientRateLimit.qps | default $defaultK8sClientQPS | quote}}
-  k8s-client-burst: {{ .Values.k8sClientRateLimit.burst | default $defaultK8sClientBurst | quote }}
+{{- if .Values.k8sClientRateLimit.qps }}
+  k8s-client-qps: {{ .Values.k8sClientRateLimit.qps | quote}}
+{{- end }}
+{{- if .Values.k8sClientRateLimit.burst }}
+  k8s-client-burst: {{ .Values.k8sClientRateLimit.burst | quote }}
+{{- end }}
 
 {{- if and .Values.operator.setNodeTaints (not .Values.operator.removeNodeTaints) -}}
   {{ fail "Cannot have operator.setNodeTaintsMaxNodes and not operator.removeNodeTaints = false" }}

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -98,11 +98,12 @@ var (
 		// Runs the gops agent, a tool to diagnose Go processes.
 		gops.Cell(defaults.GopsPortOperator),
 
-		// Provides Clientset, API for accessing Kubernetes objects.
-		k8sClient.Cell,
-
 		// Provides a ClientBuilderFunc that can be used by other cells to create a client.
-		k8sClient.ClientBuilderCell,
+		k8sClient.OperatorClientBuilderCell,
+
+		// Provides a Clientset for accessing the Kubernetes API using the provided ClientBuilderFunc.
+		// This client is shared by controllers that do not create their own via the ClientBuilderFunc.
+		cell.Provide(func(f k8sClient.ClientBuilderFunc) (k8sClient.Clientset, error) { return f("") }),
 
 		// Provides the modular metrics registry, metric HTTP server and legacy metrics cell.
 		operatorMetrics.Cell,

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -465,13 +465,21 @@ const (
 	// policy updates are invoked.
 	PolicyTriggerInterval = 1 * time.Second
 
-	// K8sClientQPSLimit is the default qps for the k8s client. It is set to 0 because the k8s client
-	// has its own default.
-	K8sClientQPSLimit float32 = 0.0
+	// K8sClientQPSLimit is the default qps for the k8s client.
+	K8sClientQPSLimit float32 = 10.0
 
-	// K8sClientBurst is the default burst for the k8s client. It is set to 0 because the k8s client
-	// has its own default.
-	K8sClientBurst = 0
+	// K8sClientBurst is the default burst for the k8s client.
+	K8sClientBurst = 20
+
+	// OperatorK8sClientQPSLimit is the default qps for the k8s client of Cilium Operator. Since
+	// Cilium Operator replicas do not scale linearly with cluster size like Cilium Agent, it is
+	// configured with a separate default for better performance.
+	OperatorK8sClientQPSLimit float32 = 100.0
+
+	// OperatorK8sClientBurst is the default burst for the k8s client of Cilium Operator. Since
+	// Cilium Operator replicas do not scale linearly with cluster size like Cilium Agent, it is
+	// configured with a separate default for better performance.
+	OperatorK8sClientBurst = 200
 
 	// K8sServiceCacheSize is the default value for option.K8sServiceCacheSize
 	// which denotes the value of Cilium's K8s service cache size.

--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -55,12 +55,13 @@ var Cell = cell.Module(
 	cell.Provide(newClientset),
 )
 
-// client.ClientBuilderCell provides a function to create a new composite Clientset,
+// client.OperatorClientBuilderCell provides a function to create a new composite Clientset,
 // allowing a controller to use its own Clientset with a different user agent.
-var ClientBuilderCell = cell.Module(
+var OperatorClientBuilderCell = cell.Module(
 	"k8s-client-builder",
 	"Kubernetes Client Builder",
 
+	cell.Config(defaultOperatorConfig),
 	cell.Provide(NewClientBuilder),
 )
 

--- a/pkg/k8s/client/config.go
+++ b/pkg/k8s/client/config.go
@@ -57,6 +57,18 @@ var defaultConfig = Config{
 	EnableK8sAPIDiscovery:        defaults.K8sEnableAPIDiscovery,
 }
 
+var defaultOperatorConfig = Config{
+	EnableK8s:                    true,
+	K8sAPIServer:                 "",
+	K8sKubeConfigPath:            "",
+	K8sClientQPS:                 defaults.OperatorK8sClientQPSLimit,
+	K8sClientBurst:               defaults.OperatorK8sClientBurst,
+	K8sClientConnectionTimeout:   30 * time.Second,
+	K8sClientConnectionKeepAlive: 30 * time.Second,
+	K8sHeartbeatTimeout:          30 * time.Second,
+	EnableK8sAPIDiscovery:        defaults.K8sEnableAPIDiscovery,
+}
+
 func (def Config) Flags(flags *pflag.FlagSet) {
 	flags.Bool(option.EnableK8s, def.EnableK8s, "Enable the k8s clientset")
 	flags.String(option.K8sAPIServer, def.K8sAPIServer, "Kubernetes API server URL")


### PR DESCRIPTION
The K8s client for both Cilium Agent and Cilium Operator are configured with the same configmap options/flags. The default rate limit is set to 10 QPS and 20 Burst via Helm and applies to both Agent and Operator.

Since the Operator is a Deployment and does not scale linearly with cluster size like the Agent DaemonSet, the rate limit can be increased to improve performance at scale without heavily impacting control plane resources.

This commit changes the default rate limit of Cilium Operator's main K8s client to 100 QPS/200 Burst, while maintaining the same 10 QPS/20 Burst for Cilium Agent. Since both clients share the same Hive Cell and configuration flags, the default setting was moved from Helm to the `defaultConfig`.

`ClientBuilderCell` has been renamed to `OperatorClientBuilderCell` and will configure a separate default Config for Cilium Operator. Clients built for various controllers that are part of the Operator will share the same Config and benefit from the increase rate limit.

Configuring a custom rate limit via Helm will still set the rate limit for both Cilium Agent and Cilium Operator. If a separate custom rate limit is desired for the Operator, `.Values.operator.extraArgs` can be used to supply the flags directly to the deployment.

```release-note
Set a higher default rate limit for the Cilium Operator K8s client
```
